### PR TITLE
ci: publish multi-arch Docker images to ghcr.io on release

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,141 @@
+name: publish-docker
+
+# Builds and publishes the core-api and core-storage-api container images
+# to GitHub Container Registry (ghcr.io) on every published GitHub Release.
+#
+# release-please cuts the GitHub Release on release-PR merge — that fires
+# this workflow. Multi-arch (linux/amd64, linux/arm64). Tags are derived
+# from the release version: vX.Y.Z, vX.Y, vX, plus ``latest`` for stable
+# (non-prerelease) releases.
+#
+# Manual workflow_dispatch is provided for re-publishing a specific tag
+# without re-cutting the release (e.g. recovering from a transient
+# registry outage).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to (re-)publish (e.g. v1.0.0)"
+        required: true
+        type: string
+      push_latest:
+        description: "Also push :latest (only safe if this IS the current latest release — recovery flag)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      # All-or-nothing publish: if one image fails, abort the other so
+      # we don't ship a release where (e.g.) core-api:v1.0.0 exists in
+      # the registry but core-storage-api:v1.0.0 doesn't — a state that
+      # would silently break ``docker compose up`` for that version.
+      # The operator triages the failure, fixes it, and re-runs via
+      # workflow_dispatch with the same tag for atomicity.
+      fail-fast: true
+      matrix:
+        include:
+          - name: core-api
+            dockerfile: core-api/Dockerfile
+          - name: core-storage-api
+            dockerfile: core-storage-api/Dockerfile
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # On a ``release`` event, ``github.ref_name`` is the tag (e.g.
+      # v1.0.0) and metadata-action's default semver derivation works.
+      # On a ``workflow_dispatch`` rerun, ``github.ref_name`` is the
+      # branch (e.g. main), so semver derivation would break. Resolve
+      # the effective tag explicitly here and feed it to metadata-action
+      # below so the workflow behaves identically across both event
+      # types.
+      #
+      # Context expressions are routed via env: rather than inlined into
+      # the script body — GitHub-recommended pattern that prevents shell
+      # injection if a tag-like input ever contains shell metacharacters.
+      - name: Resolve effective tag
+        id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "tag=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Fail-fast on malformed workflow_dispatch input (e.g. "latest",
+      # "main", or a typo). metadata-action's semver derivation would
+      # otherwise produce confusing tags or no tags at all. Release-event
+      # tags come pre-validated by GitHub's release-creation flow, so
+      # this gate is workflow_dispatch-only.
+      - name: Validate tag format
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          # Accept ``vMAJOR.MINOR.PATCH`` with an optional pre-release
+          # (``-rc.1``) or PEP 440 dev/post (``.dev0``) suffix. End-anchored
+          # so ``v1.0.0garbage`` is rejected. ``+build.metadata`` is
+          # deliberately excluded — ``+`` is not a valid Docker tag char.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][a-zA-Z0-9._-]+)?$ ]]; then
+            echo "::error::inputs.tag must be a semver tag starting with 'v' (got: $TAG)"
+            exit 1
+          fi
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/caura-memclaw-${{ matrix.name }}
+          # ``latest`` defaults to release-event-only — a
+          # workflow_dispatch with an older tag must not silently rewind
+          # ``latest``. For the recovery use case (e.g. transient
+          # registry outage when the release event fired), the dispatch
+          # input ``push_latest`` is an explicit opt-in.
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.resolve.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.resolve.outputs.tag }}
+            type=semver,pattern={{major}},value=${{ steps.resolve.outputs.tag }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.push_latest == 'true' }}
+          labels: |
+            org.opencontainers.image.title=caura-memclaw-${{ matrix.name }}
+            org.opencontainers.image.description=MemClaw ${{ matrix.name }} — fleet memory for AI agents
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Build and push (${{ matrix.name }})
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/README.md
+++ b/README.md
@@ -358,6 +358,17 @@ installs; skip this step.
 
 The recommended way to run MemClaw is via Docker Compose (see [Quick Start](#quick-start)). This gives you a production-ready PostgreSQL + pgvector + Redis + API stack with a single command.
 
+### Published container images
+
+Each release publishes multi-arch (linux/amd64, linux/arm64) images to [GitHub Container Registry](https://github.com/orgs/caura-ai/packages):
+
+```
+ghcr.io/caura-ai/caura-memclaw-core-api:v1.0.0
+ghcr.io/caura-ai/caura-memclaw-core-storage-api:v1.0.0
+```
+
+Tags follow SemVer with floating aliases — `:v1`, `:v1.0`, `:v1.0.0`, plus `:latest` for the latest stable release. Pull them in your own compose file or Kubernetes manifests instead of building from source.
+
 <a id="manual-deployment"></a>
 
 ### Manual deployment (without Docker)


### PR DESCRIPTION
Adds the publish-docker workflow that fires on every published GitHub Release. See diff for full description.

Re-opened after the repo recreate (delete + push from bundle); the original PR #30 was lost when the previous repo was deleted as part of the security cleanup. Same content, same branch HEAD.