### PR TITLE
fix(storage): align core-storage-api DB pool defaults with platform-storage (5+5)

### DIFF
--- a/core-storage-api/src/core_storage_api/config.py
+++ b/core-storage-api/src/core_storage_api/config.py
@@ -22,8 +22,22 @@ class Settings(BaseSettings):
     # we route.
     database_url: str = "postgresql+asyncpg://memclaw:changeme@localhost:5432/memclaw"
     read_database_url: str = ""
-    db_pool_size: int = 20
-    db_max_overflow: int = 20
+    # 5+5 matches the post-PR-#166 ``platform-storage-api`` defaults so
+    # both services share the same pool sizing without per-environment
+    # env-var overrides. Pre-this-fix the source defaults were 20+20,
+    # which staging worked around with ``--remove-env-vars`` /
+    # explicit env-var overrides on the writer + reader Cloud Run
+    # services; the mismatch was a footgun for fresh deploys (a new
+    # operator would inherit the 20+20 source default and silently
+    # over-allocate against AlloyDB's connection ceiling, which we
+    # observed on loadtest-1777301515 as
+    # ``asyncpg.TooManyConnectionsError`` during the storm window).
+    # Operators that genuinely need a larger pool can still set
+    # ``DB_POOL_SIZE`` / ``DB_MAX_OVERFLOW`` explicitly; the source
+    # default is now the safe baseline rather than a value that
+    # requires environment-side correction.
+    db_pool_size: int = 5
+    db_max_overflow: int = 5
     db_pool_timeout: int = 60
     db_pool_recycle: int = 1800
 


### PR DESCRIPTION
## Summary

Lowers `db_pool_size` / `db_max_overflow` source defaults in `core-storage-api/config.py` from 20+20 to 5+5, matching `platform-storage-api` after PR #166. Staging is already running 5+5 via env-var overrides; the source-level mismatch was a fresh-deploy footgun — any new operator (or a clean redeploy) inherits the 20+20 source default and silently over-allocates against AlloyDB's connection ceiling.

Loadtest-1777301515's storm window surfaced this as `asyncpg.TooManyConnectionsError` on the storage-writer. The CAURA-602 silent-create work in #23 closes the symptom path (committed-but-unacked rows on retry); this PR closes the root by sizing the pool correctly out of the box.

## Test plan

- [x] No code/behavior change beyond the default values; existing tests are unaffected.
- [ ] After merge + deploy: drop the `DB_POOL_SIZE=5` / `DB_MAX_OVERFLOW=5` env-var overrides on `staging-memclaw-core-storage-writer` and `staging-memclaw-core-storage-reader` (per the prod-rollout runbook §7e). The new source default makes them no-ops.
- [ ] After staging confirmation: same env-var cleanup on the prod writer + reader during Phase B rollout.

## Notes

Operators that need a larger pool still set `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` explicitly — only the source default changes.

Pairs with [#24](https://github.com/caura-ai/caura-memclaw/pull/24) (per-tenant storage bulkhead, draft) which approaches the same noisy-neighbor surface from the application layer; this PR addresses the infrastructure-default layer. Independent — both can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)