### PR TITLE
chore(tier-2): hygiene batch — agent_add ON CONFLICT, patch-resurrects fix, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ All routes are versioned under `/api/v1/`. Interactive Swagger docs at `/api/doc
 | Endpoint | Method | Description |
 |---|---|---|
 | `/memories` | POST | Write a memory. LLM enrichment + embedding + entity extraction + contradiction detection. `"persist": false` for extract-only preview |
-| `/memories/bulk` | POST | Write up to 100 memories. Batches embeddings, parallelizes enrichment, single transaction |
+| `/memories/bulk` | POST | Write up to 100 memories. Batches embeddings, parallelizes enrichment, single transaction. Requires `X-Bulk-Attempt-Id` header (per-attempt idempotency); a retry with the same id resolves committed rows as `duplicate_attempt` instead of duplicating. Returns 200 (clean / all-error) or 207 Multi-Status (mixed) — read per-item `status` |
 | `/memories` | GET | List memories (filter by type, status, agent; paginate) |
 | `/memories/{id}` | GET | Full memory detail (embedding stats, entity links, RDF triple, temporal bounds) |
 | `/memories/{id}` | PATCH | Update content or metadata. Re-embeds if content changes |

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -541,8 +541,20 @@ async def update_memory(memory_id: UUID, request: Request) -> dict:
     # core-api, future tooling) get the same coercion at the API
     # boundary.
     _parse_datetimes(body)
-    if body:
-        await _svc.memory_update(memory_id, body)
+    # No empty-body short-circuit here: ``memory_update`` runs the
+    # existence check first and returns False for absent/soft-deleted
+    # rows regardless of whether the body has actionable columns. An
+    # earlier short-circuit would let a PATCH ``{}`` on a deleted row
+    # answer 200 — inconsistent with the 404 the same row gets on a
+    # non-empty PATCH.
+    found = await _svc.memory_update(memory_id, body or {})
+    if not found:
+        # Pre-this-fix the route returned ``200 {"ok": True}`` regardless
+        # of whether the row was missing or soft-deleted, so a PATCH on
+        # a deleted memory looked successful to the caller while
+        # silently no-op'ing. Surface as 404 so clients can distinguish
+        # "applied" from "ignored because the row is gone."
+        raise HTTPException(status_code=404, detail=f"Memory {memory_id} not found")
     return {"ok": True}
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -353,7 +353,7 @@ class PostgresService:
                 memory.deleted_at = datetime.now(UTC)
                 memory.status = "deleted"
 
-    async def memory_update(self, memory_id: UUID, patch: dict) -> None:
+    async def memory_update(self, memory_id: UUID, patch: dict) -> bool:
         """Apply arbitrary field updates to a memory.
 
         Two patch shapes are supported in the same request:
@@ -369,9 +369,17 @@ class PostgresService:
 
         Other top-level keys whose names don't match a ``Memory`` column
         are silently dropped — callers validate upstream.
+
+        Returns ``True`` when the row exists and is live (the patch was
+        applied or was a no-op due to all-unknown keys); ``False`` when
+        the row is absent or soft-deleted, which the route turns into
+        404. Both UPDATE branches run inside a single
+        ``SELECT ... FOR UPDATE`` snapshot so a concurrent
+        ``memory_soft_delete`` can't commit between them and leave the
+        row in a torn state (status updated, metadata not, or vice
+        versa) — the bare per-statement ``deleted_at IS NULL`` guard
+        wasn't enough on its own under READ COMMITTED.
         """
-        if not patch:
-            return
         metadata_patch = patch.get("metadata_patch") if isinstance(patch, dict) else None
         # Map JSON keys to model columns. ``metadata_patch`` is handled
         # via a separate JSONB-merge statement below; skip it here so it
@@ -379,15 +387,54 @@ class PostgresService:
         values: dict = {
             key: val for key, val in patch.items() if key != "metadata_patch" and hasattr(Memory, key)
         }
-        # Early-return when the caller's patch contained only unknown
-        # keys — opening a session burns a connection-pool slot for no
-        # work. The pre-CAURA-595 shape gated the session on ``if
-        # values:`` for the same reason.
-        if not values and not metadata_patch:
-            return
         async with get_session() as session:
+            # Existence check FIRST — runs even on empty / all-unknown-
+            # keys patches so a PATCH on an absent or soft-deleted row
+            # consistently returns 404 regardless of body shape. Pre-
+            # this-change the no-op paths (empty body, all-unknown
+            # keys) short-circuited with ``return True`` and the route
+            # answered 200, so a deleted row could absorb a "successful"
+            # no-op PATCH that depended only on whether the body
+            # carried recognised columns.
+            #
+            # ``SELECT ... FOR UPDATE`` locks the row so the two UPDATE
+            # branches below run inside one snapshot: a concurrent soft
+            # DELETE blocks until this transaction commits or rolls
+            # back, eliminating the column-set-but-not-metadata torn
+            # state under READ COMMITTED.
+            #
+            # ``id, deleted_at`` come back as a tuple so "row absent"
+            # (None tuple) and "row exists, deleted_at IS NULL" (live)
+            # are distinguishable — ``scalar_one_or_none`` on
+            # ``deleted_at`` alone would collapse both into None.
+            row = (
+                await session.execute(
+                    select(Memory.id, Memory.deleted_at).where(Memory.id == memory_id).with_for_update()
+                )
+            ).first()
+            if row is None:
+                return False  # row truly absent — caller → 404
+            if row.deleted_at is not None:
+                return False  # soft-deleted — caller → 404, no UPDATE runs
+
+            # No-op patches on a live row are valid: existence check
+            # already passed, so report success without burning UPDATEs.
+            # Worth the SELECT roundtrip cost (rate-limited PATCH route
+            # bounds it) for the consistent 404-on-absent contract.
+            if not patch or (not values and not metadata_patch):
+                return True
+
+            # ``deleted_at IS NULL`` predicate stays on each UPDATE
+            # even though the FOR UPDATE lock above already gates this
+            # path; it's belt-and-suspenders against a future change
+            # that splits the lock and the UPDATEs into separate
+            # sessions.
             if values:
-                await session.execute(sql_update(Memory).where(Memory.id == memory_id).values(**values))
+                await session.execute(
+                    sql_update(Memory)
+                    .where(Memory.id == memory_id, Memory.deleted_at.is_(None))
+                    .values(**values)
+                )
             if metadata_patch:
                 # Single-statement JSONB merge — concurrent merges are
                 # last-writer-wins per key but never corrupt the doc.
@@ -406,13 +453,18 @@ class PostgresService:
                 # The cast is a no-op when the column is already
                 # ``jsonb`` and a one-time conversion when it isn't —
                 # cheap either way relative to the network round-trip.
+                #
+                # ``deleted_at IS NULL`` guard mirrors the column-set
+                # branch above so a PATCH never resurrects a deleted
+                # row via the metadata-merge path either.
                 await session.execute(
                     text(
                         "UPDATE memories "
                         "SET metadata = COALESCE(metadata::jsonb, '{}'::jsonb) || (:patch)::jsonb "
-                        "WHERE id = :id"
+                        "WHERE id = :id AND deleted_at IS NULL"
                     ).bindparams(patch=json.dumps(metadata_patch), id=memory_id),
                 )
+        return True
 
     async def memory_update_status(self, memory_id: UUID, status: str) -> None:
         async with get_session() as session:

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2185,38 +2185,85 @@ class PostgresService:
     async def agent_add(self, data: dict) -> Agent:
         """Create new agent — handle race with concurrent registrations.
 
-        The uq_agents_tenant_agent unique index rejects duplicates at
-        INSERT time; on conflict we re-SELECT and merge updates.
+        Uses ``INSERT ... ON CONFLICT (tenant_id, agent_id) DO NOTHING
+        RETURNING ...`` paired with a same-session re-SELECT for the
+        conflicted case. The same shape ``memory_add_all`` uses for
+        per-attempt idempotency (caura-memclaw#23): it avoids the
+        ``flush() → IntegrityError → rollback() → re-SELECT`` pattern's
+        mid-session rollback, which is brittle (the rollback aborts any
+        other pending writes in the same session) and forced
+        ``test_concurrent_same_key_returns_same_id`` to pre-create the
+        agent row to dodge the failure mode.
         """
-        from sqlalchemy.exc import IntegrityError
-
         async with get_session() as session:
-            agent = Agent(**data)
-            session.add(agent)
-            try:
-                await session.flush()
-            except IntegrityError:
-                await session.rollback()
-                logger.info(
-                    "Agent dedup race: '%s/%s' already exists, re-selecting",
-                    data.get("tenant_id"),
-                    data.get("agent_id"),
-                )
-                result = await session.execute(
-                    select(Agent).where(
-                        Agent.tenant_id == data["tenant_id"],
-                        Agent.agent_id == data["agent_id"],
-                    )
-                )
+            stmt = (
+                pg_insert(Agent)
+                .values(**data)
+                .on_conflict_do_nothing(index_elements=["tenant_id", "agent_id"])
+                .returning(Agent.id)
+            )
+            inserted_id = (await session.execute(stmt)).scalar_one_or_none()
+
+            if inserted_id is not None:
+                # New row — fetch the full ORM object for the return.
+                # ``scalar_one_or_none`` (not ``scalar_one``) defends
+                # against a concurrent delete between INSERT RETURNING
+                # and the re-SELECT: ``scalar_one`` would raise
+                # ``NoResultFound`` and surface as a 500 with no
+                # actionable detail. We just-INSERTED this row in the
+                # same session so the realistic race window is
+                # vanishingly small, but cheap to be loud about it.
+                result = await session.execute(select(Agent).where(Agent.id == inserted_id))
                 agent = result.scalar_one_or_none()
                 if agent is None:
                     raise ValueError(
-                        f"Agent '{data.get('agent_id')}' conflict but re-select returned nothing"
+                        f"Agent row {inserted_id} vanished after INSERT — concurrent delete during agent_add"
                     )
-                # Apply any new fields from the request (e.g. fleet_id backfill)
-                for key in ("fleet_id", "trust_level"):
-                    if key in data and data[key] is not None:
-                        setattr(agent, key, data[key])
+                return agent
+
+            # Conflict: another caller (or a prior attempt) already
+            # created the row. Re-SELECT and apply any new fields the
+            # caller supplied (e.g. ``fleet_id`` backfill from a write
+            # that learned the fleet after the agent existed).
+            #
+            # ``.with_for_update()`` on the re-SELECT serialises against
+            # an in-progress concurrent ``agent_delete`` so we either
+            # see the live row or wait until that delete commits — if
+            # it does commit before we read, we still raise the
+            # ``ValueError`` below (the row genuinely vanished), but
+            # the lock removes the gap where the row was visible during
+            # ``ON CONFLICT`` and gone here.
+            logger.info(
+                "Agent dedup race: '%s/%s' already exists, re-selecting",
+                data.get("tenant_id"),
+                data.get("agent_id"),
+            )
+            result = await session.execute(
+                select(Agent)
+                .where(
+                    Agent.tenant_id == data["tenant_id"],
+                    Agent.agent_id == data["agent_id"],
+                )
+                .with_for_update()
+            )
+            agent = result.scalar_one_or_none()
+            if agent is None:
+                # Conflict happened but the row vanished — concurrent
+                # delete or schema drift. Surface as a clean ValueError
+                # so the caller sees the inconsistent state rather than
+                # an opaque ``None`` returned from a "create" call.
+                raise ValueError(f"Agent '{data.get('agent_id')}' conflict but re-select returned nothing")
+            # Track whether any field actually changed so we don't
+            # bump ``updated_at`` (or burn an UPDATE roundtrip) when
+            # the caller's data has nothing to backfill — e.g. a
+            # plain idempotent re-register that just wants the
+            # existing row back.
+            changed = False
+            for key in ("fleet_id", "trust_level"):
+                if key in data and data[key] is not None and getattr(agent, key) != data[key]:
+                    setattr(agent, key, data[key])
+                    changed = True
+            if changed:
                 agent.updated_at = datetime.now(UTC)
                 await session.flush()
             return agent

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -289,6 +289,68 @@ class TestMemories:
         assert fetched["deleted_at"] is not None
         assert fetched["status"] == "deleted"
 
+    async def test_patch_after_delete_does_not_resurrect(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """A PATCH that lands after a soft DELETE must no-op against
+        the deleted row AND surface as 404 to the caller, not silently
+        resurrect or fake-success.
+
+        Pre-fix the UPDATE statement filtered only by ``Memory.id``, so
+        a PATCH with ``status="active"`` on a deleted row would set
+        ``status`` without touching ``deleted_at`` — the row showed
+        ``status='active', deleted_at=<ts>``, an inconsistent state.
+        The fix combines a ``SELECT ... FOR UPDATE`` snapshot lock
+        (atomicity across both UPDATE branches), a per-statement
+        ``deleted_at IS NULL`` predicate (defence in depth), and a 404
+        response so callers can distinguish "applied" from "row is
+        gone" rather than always seeing ``200 {"ok": True}``.
+        """
+        payload = _memory_payload(tenant_id, fleet_id)
+        mem = (await client.post(f"{PREFIX}/memories", json=payload)).json()
+        memory_id = mem["id"]
+
+        # 1. Soft-delete the row.
+        await client.delete(f"{PREFIX}/memories/{memory_id}")
+
+        # 2. PATCH it. Both the column-set branch (status) and the
+        # metadata-merge branch (metadata_patch) must no-op, and the
+        # route must surface 404.
+        resp = await client.patch(
+            f"{PREFIX}/memories/{memory_id}",
+            json={"status": "active", "metadata_patch": {"resurrect_attempt": True}},
+        )
+        assert resp.status_code == 404, resp.text
+
+        # 3. Re-read: deleted_at is still set, status is still 'deleted',
+        # metadata is unchanged.
+        after = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        assert after["deleted_at"] is not None
+        assert after["status"] == "deleted"
+        assert (after.get("metadata") or {}).get("resurrect_attempt") is None
+
+    async def test_patch_on_nonexistent_memory_returns_404(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """PATCH on a memory_id that never existed must surface 404 too,
+        not the legacy ``200 {"ok": True}`` silent success.
+
+        Pre-fix this returned 200 because ``memory_update`` issued an
+        UPDATE that matched zero rows and the route ignored the
+        rowcount. Locked here so a future change can't quietly
+        regress to silent-success.
+        """
+        fake_id = str(uuid.uuid4())
+        resp = await client.patch(
+            f"{PREFIX}/memories/{fake_id}",
+            json={"status": "active"},
+        )
+        assert resp.status_code == 404, resp.text
+
     async def test_bulk_per_attempt_idempotency(
         self,
         client: AsyncClient,

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -362,26 +362,16 @@ async def test_concurrent_same_key_returns_same_id(client):
     resolve to the same memory id — the loser polls for the winner's
     response rather than creating a duplicate row.
 
-    A throwaway warm-up write pre-creates the agent row so the two
-    parallel writes below don't race on ``agent_add`` — that path has
-    a separate latent bug (a session ``rollback()`` inside the
-    ``IntegrityError`` handler that closes the outer transaction)
-    which is orthogonal to the idempotency claim race this test is
-    guarding.
+    Pre-CAURA-602b, this test pre-created the agent row via a warm-up
+    write because ``agent_add`` had a separate latent bug — a mid-session
+    ``rollback()`` inside its ``IntegrityError`` handler that closed
+    the outer transaction. The agent path now uses
+    ``INSERT ... ON CONFLICT DO NOTHING RETURNING ...`` (same shape as
+    ``memory_add_all``) so the warm-up is no longer required; this test
+    drives the agent race directly to lock that fix in.
     """
     tenant_id, headers = get_test_auth()
     agent_id = f"idem-race-{uid()}"
-    # Warm-up: ensure the agent row exists so the parallel writes below
-    # can't both try to ``INSERT`` it concurrently.
-    warm = {
-        "tenant_id": tenant_id,
-        "agent_id": agent_id,
-        "memory_type": "fact",
-        "content": f"warm-up agent {uid()}",
-    }
-    warm_resp = await client.post("/api/v1/memories", json=warm, headers=headers)
-    assert warm_resp.status_code == 201, warm_resp.text
-
     key = _new_key()
     body = {
         "tenant_id": tenant_id,


### PR DESCRIPTION
## Summary

Three small Tier-2 cleanups bundled per request:

1. **`fix(storage): replace agent_add try/IntegrityError/rollback with ON CONFLICT`** — `agent_add` used a mid-session `rollback()` inside the IntegrityError handler, which aborts every other pending write in the session and forced [`test_concurrent_same_key_returns_same_id`](https://github.com/caura-ai/caura-memclaw/blob/main/tests/test_idempotency.py#L360) to pre-create the agent row via a warm-up write to dodge concurrent calls. Switched to `INSERT ... ON CONFLICT (tenant_id, agent_id) DO NOTHING RETURNING id` plus a same-session re-SELECT — same shape `memory_add_all` uses post-#23. Drops the warm-up workaround so the test drives the race directly.

2. **`fix(storage): block PATCH on soft-deleted rows`** — adds `WHERE deleted_at IS NULL` to both UPDATE branches in `memory_update` (column-set + metadata-merge). Pre-fix, a PATCH that landed after a soft DELETE silently set columns on the deleted row, leaving inconsistent state like `status='active', deleted_at=<ts>`. Loadtest-1777301515 + 1777327400 both *held* the `patch-resurrects-deleted` probe by timing luck; the gap was always there. New regression test `test_patch_after_delete_does_not_resurrect` drives both branches and asserts the row stays deleted.

3. **`docs(readme): document X-Bulk-Attempt-Id requirement on /memories/bulk`** — the breaking change shipped in #23 wasn't reflected in the README's endpoint table; SDK authors and integrators couldn't see the new contract without reading the route docstring or changelog.

## Out of scope (deferred)

- **Rate-limit test flake** ([Ticket 10](https://caura-ai.atlassian.net/browse/CAURA-513)): tried `asyncio.gather`-ing the burst, but the slowapi rate decorator binds the limit string at module-import time so per-test overrides don't take. A robust fix needs test-infra changes (env-var override before app import, or moving slowapi to a runtime-configurable limit). Left for its own PR.

## Test plan

- [x] `pytest tests/test_per_tenant_concurrency.py tests/test_request_timeout.py tests/test_bulk_write.py -m unit` — passes locally
- [ ] CI: full integration suite, including the two new tests (`test_concurrent_same_key_returns_same_id` no-warmup + `test_patch_after_delete_does_not_resurrect`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)