### PR TITLE
fix(core-storage): exclude soft-deleted from public /stats counters

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1254,19 +1254,32 @@ class PostgresService:
             return result.scalar() or 0
 
     async def memory_count_all(self) -> int:
+        # Exclude soft-deleted rows so the public counter matches the live,
+        # queryable footprint — same predicate every other count in this
+        # file uses. Without the filter, tombstoned tenant clean-ups inflate
+        # the number by an order of magnitude on busy environments.
         async with get_read_session() as session:
-            result = await session.scalar(select(func.count()).select_from(Memory))
+            result = await session.scalar(
+                select(func.count())
+                .select_from(Memory)
+                .where(Memory.deleted_at.is_(None))
+            )
             return result or 0
 
     async def memory_distinct_agent_count(self) -> int:
         """Count distinct agent identities across all memories in all tenants.
 
         Powers the public Agents counter — reflects actual agent *activity*
-        (wrote at least one memory) rather than provisioned API keys.
+        (wrote at least one memory) rather than provisioned API keys. Agents
+        whose memories have all been soft-deleted are excluded so the count
+        tracks live activity, not historical churn.
         """
         async with get_session() as session:
             result = await session.scalar(
-                select(func.count(func.distinct(Memory.agent_id))).where(Memory.agent_id.isnot(None))
+                select(func.count(func.distinct(Memory.agent_id))).where(
+                    Memory.agent_id.isnot(None),
+                    Memory.deleted_at.is_(None),
+                )
             )
             return result or 0
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1260,9 +1260,7 @@ class PostgresService:
         # the number by an order of magnitude on busy environments.
         async with get_read_session() as session:
             result = await session.scalar(
-                select(func.count())
-                .select_from(Memory)
-                .where(Memory.deleted_at.is_(None))
+                select(func.count()).select_from(Memory).where(Memory.deleted_at.is_(None))
             )
             return result or 0
 


### PR DESCRIPTION
## Summary

The unauth'd `/api/stats` endpoint that backs the marketing-site landing page counters (Memories / Agents) reads `memory_count_all()` and `memory_distinct_agent_count()` in `core-storage-api`. Both functions were the **only counts in `postgres_service.py` that did not filter `deleted_at IS NULL`**, so they reported soft-deleted rows alongside live ones.

Verified against staging (`memclaw-staging` Cloud SQL, `enterprise.tenants` + `public.memories` schemas) with a one-shot read-only query:

```
memories_total              | 71010
memories_active             |  7125
memories_soft_deleted       | 63885
agents_distinct_all         |   198
agents_distinct_active_only |   173
```

So the homepage was over-reporting Memories by ~9× and Agents by ~14% on staging today. Prod has the same code path, so the same shape of inflation applies (current prod `/api/stats` returns `memory_count: 53124` — real active subset is much smaller).

This PR adds `Memory.deleted_at.is_(None)` to both queries, matching the predicate already used by every other count in the same file. After this lands, the public number tracks the live, queryable footprint instead of historical churn.

## Test plan

- [ ] Merge to `main` → wait for the public OSS release / staging deploy of `core-storage-api`.
- [ ] `curl https://memclaw.dev/api/stats` should return `memory_count` ≈ 7,125 and `agent_count` ≈ 173 (was 71,010 / 198).
- [ ] Visit `https://memclaw.dev/` and confirm the MEMORIES card drops to ~7K and AGENTS to ~173. TENANTS card stays at 641 (unaffected — different endpoint, no soft-delete column on that table).
- [ ] Spot-check that scoped counts (`memory_count_active(tenant_id, …)`) are unchanged — they already filtered correctly, no behaviour change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)