### PR TITLE
feat(infra): docker-compose pulls published images by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,30 @@
 IS_STANDALONE=true
 ENVIRONMENT=development
 
+# -- Image version (docker-compose only) ------------------------------------
+# Pin the published image tag pulled from ghcr.io on first ``up``.
+# Defaults to ``latest`` (the most recent stable release). Subsequent
+# ``up`` commands re-use the cached image (``pull_policy: missing``
+# in docker-compose.yml) — to fetch a newer image at the same tag, run:
+#
+#     docker compose pull && docker compose up -d
+#
+# Set to a specific version like ``v1.0.0`` for reproducibility. To
+# build from local source instead, run
+# ``docker compose up --build --no-pull``.
+#
+# MEMCLAW_VERSION is tag-only (it expands inline into ``image:`` for
+# both core-api and core-storage-api). For *digest pinning* — strict
+# supply-chain reproducibility — a single MEMCLAW_VERSION is not
+# enough: the two services have different images and therefore
+# different sha256 digests, so a shared digest would fail to pull on
+# whichever service it doesn't belong to. Pin per-service via a
+# docker-compose.override.yml that hardcodes each ``image:`` to its
+# own ``name:tag@sha256:<digest>``. Look up each service's digest with:
+#     docker buildx imagetools inspect ghcr.io/caura-ai/caura-memclaw-core-api:v1.2.3
+#     docker buildx imagetools inspect ghcr.io/caura-ai/caura-memclaw-core-storage-api:v1.2.3
+# MEMCLAW_VERSION=latest
+
 # -- Database (PostgreSQL + pgvector) ----------------------------------------
 POSTGRES_HOST=127.0.0.1
 POSTGRES_PORT=5432

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ Anthropic, Gemini, and OpenRouter don't offer embedding APIs here — pair them 
 docker compose up -d
 ```
 
+By default this **pulls the multi-arch images from `ghcr.io`** (`linux/amd64` + `linux/arm64`) on first run — takes ~30 seconds. Subsequent `up` commands re-use the cached image (no registry round-trip, works offline). To pin a specific version, set `MEMCLAW_VERSION=v1.2.3` in your `.env`. To build from local source instead (e.g. when iterating on a fork), run `docker compose up --build --no-pull`.
+
+To upgrade to a newer image at the same tag (e.g. `:latest` after we cut a new release), run `docker compose pull && docker compose up -d`. Without an explicit `pull`, the local cache wins — there's no silent version drift.
+
+> **Offline / air-gapped operation**: depending on whether the image is already cached locally:
+> - **Image cached, no network**: `docker compose up -d` works as-is — `pull_policy: missing` doesn't try to pull when the image is present. Use `docker compose up --no-pull` if you want to be explicit.
+> - **No local image, no network**: `docker compose up --build --no-pull` (build from source, don't try to pull).
+> - **Strict no-network guarantee** (e.g. an air-gapped pipeline that should never reach `ghcr.io`): drop a `docker-compose.override.yml` setting `pull_policy: never` for both services — Compose then fails fast if the image is absent rather than attempting a pull.
+
 | Service | URL |
 |---|---|
 | Core API (REST + MCP) | http://localhost:8000 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,34 @@ services:
   # ── Core Storage API (PostgreSQL CRUD) ──────────────────────────
 
   core-storage-api:
+    # Pulls the published multi-arch image from ghcr.io.
+    #
+    # ``pull_policy: missing`` is required because Compose's default
+    # when both ``image:`` and ``build:`` are present is to BUILD
+    # locally and ignore the registry — the opposite of what we want.
+    # ``missing`` pulls only when the image is absent from the local
+    # cache: first ``docker compose up`` fetches; subsequent ``up``
+    # commands re-use the cached image (fast, no registry round-trip,
+    # works offline). Crucially, this means a moving tag like
+    # ``:latest`` does NOT silently upgrade on every ``up`` — version
+    # changes are explicit. Upgrade path:
+    #
+    #     docker compose pull && docker compose up -d
+    #
+    # The ``build:`` block is for ``docker compose up --build
+    # --no-pull`` (``--no-pull`` is needed when no local image is
+    # cached and you want to build from source without network: without
+    # it, ``pull_policy: missing`` triggers a pull attempt before the
+    # build starts and fails if the registry is unreachable. When the
+    # image already exists locally, ``--build`` alone is sufficient to
+    # force a rebuild.) Compose does NOT auto-fall-back to ``build:``
+    # on pull failure; an unreachable registry hard-fails ``up`` only
+    # when no local image is cached.
+    #
+    # Pin a specific version with ``MEMCLAW_VERSION=v1.2.3`` in your
+    # ``.env``; defaults to ``latest`` for the most recent stable.
+    image: ghcr.io/caura-ai/caura-memclaw-core-storage-api:${MEMCLAW_VERSION:-latest}
+    pull_policy: missing
     build:
       context: .
       dockerfile: core-storage-api/Dockerfile
@@ -64,6 +92,10 @@ services:
   # ── Core API (main application) ─────────────────────────────────
 
   core-api:
+    # Same pull-on-first-up + ``pull_policy: missing`` pattern as
+    # core-storage-api above. See its block for the full rationale.
+    image: ghcr.io/caura-ai/caura-memclaw-core-api:${MEMCLAW_VERSION:-latest}
+    pull_policy: missing
     build:
       context: .
       dockerfile: core-api/Dockerfile


### PR DESCRIPTION
## Why

The README's Quick Start says `docker compose up -d`, which currently does a full local build (3–5 min on first run). Now that we publish multi-arch images to ghcr.io on every release ([PR #17](https://github.com/caura-ai/caura-memclaw/pull/17)), users can pull instead — same Dockerfile, same source at the same tag, ~30s instead of minutes.

## What

Adds the standard `image: + build:` Compose pattern to `core-api` and `core-storage-api`:

| Command | Behaviour |
|---|---|
| `docker compose up -d` (default) | Pulls `ghcr.io/caura-ai/caura-memclaw-*:latest` |
| `docker compose pull` | Refresh to the current published images |
| `docker compose build` | Build from local source (forks, dev) |

Tag is parameterised: `MEMCLAW_VERSION=v1.2.3` in `.env` pins a specific release. Defaults to `latest` for the most recent stable release.

## Compose verification

- `docker compose -f docker-compose.yml config --quiet` passes (compose recognises the dual image+build block).
- YAML still parses cleanly via Python yaml.
- `docker-compose.dev.yml` deliberately untouched — dev profile keeps build-only since iterating-on-source is the point.

## What stays the same

- Dockerfiles and source are identical between local-built and pulled images
- All env vars and services unchanged
- New users hitting Quick Start get the fast path automatically

## Sequencing note

This PR depends on [PR #17](https://github.com/caura-ai/caura-memclaw/pull/17) being merged + the v1.0.0 images actually being published to ghcr.io (manual workflow_dispatch with `tag=v1.0.0` and `push_latest=true`). Don't merge this PR until those images exist, or new `docker compose up` runs hit a missing image and fall back to building locally — which works but defeats the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)