### PR TITLE
fix(search): drop UUID/hex fragments before entity FTS roundtrip

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -12,14 +12,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-import string
 import types
 from uuid import UUID
 
 from core_api.clients.storage_client import get_storage_client
 from core_api.constants import (
-    ENTITY_STOPWORDS,
-    ENTITY_TOKEN_MIN_LENGTH,
     FTS_WEIGHT_BOOSTED,
     GRAPH_HOP_BOOST,
     GRAPH_MAX_BOOSTED_MEMORIES,
@@ -33,6 +30,7 @@ from core_api.pipeline.steps.search.retrieval_types import (
     RetrievalStrategy,
 )
 from core_api.schemas import EntityLinkOut
+from core_api.services.entity_tokens import extract_entity_tokens
 
 _GRAPH_HOP_BOOST_FALLBACK = GRAPH_HOP_BOOST[max(GRAPH_HOP_BOOST)]
 
@@ -70,14 +68,7 @@ class ClassifyQuery:
         graph_max_hops: int = sp["graph_max_hops"]
         top_k: int = sp["top_k"]
 
-        # Tokenize, strip punctuation, and filter to meaningful tokens.
-        tokens = [
-            stripped
-            for t in query.split()
-            if (stripped := t.strip(string.punctuation))
-            and len(stripped) >= ENTITY_TOKEN_MIN_LENGTH
-            and stripped.lower() not in ENTITY_STOPWORDS
-        ]
+        tokens = extract_entity_tokens(query)
 
         if tokens:
             try:

--- a/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
+++ b/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
@@ -14,14 +14,13 @@ from fastapi import HTTPException
 
 from core_api.clients.storage_client import get_storage_client
 from core_api.constants import (
-    ENTITY_STOPWORDS,
-    ENTITY_TOKEN_MIN_LENGTH,
     GRAPH_HOP_BOOST,
     GRAPH_MAX_BOOSTED_MEMORIES,
     RECALL_BOOST_CAP,
 )
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepOutcome, StepResult
+from core_api.services.entity_tokens import extract_entity_tokens
 from core_api.services.memory_service import _get_or_cache_embedding
 
 logger = logging.getLogger(__name__)
@@ -49,11 +48,7 @@ async def _entity_boost_via_storage(
             entity_hops = precomputed_hops
             matched_entity_ids = [eid for eid, (hop, _w) in entity_hops.items() if hop == 0]
         else:
-            tokens = [
-                t.lower()
-                for t in query.split()
-                if len(t) >= ENTITY_TOKEN_MIN_LENGTH and t.lower() not in ENTITY_STOPWORDS
-            ]
+            tokens = extract_entity_tokens(query)
             if not tokens:
                 return boosted_memory_ids, memory_boost_factor
 

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import httpx
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
-from sqlalchemy import func, select, tuple_
+from sqlalchemy import func, select, tuple_, update
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.exc import TimeoutError as SQLATimeoutError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -439,8 +439,6 @@ async def bulk_delete_by_ids(
     db: AsyncSession = Depends(get_db),
 ):
     """Soft-delete memories by a list of IDs."""
-    from sqlalchemy import update
-
     tenant_id = body.get("tenant_id")
     ids = body.get("ids", [])
     if not tenant_id:

--- a/core-api/src/core_api/services/entity_tokens.py
+++ b/core-api/src/core_api/services/entity_tokens.py
@@ -1,0 +1,57 @@
+"""Tokenizer for entity FTS lookups.
+
+Shared by every call site that feeds ``fts_search_entities``: the
+``ClassifyQuery`` pipeline step, ``_entity_boost_pipeline`` in
+``memory_service``, and the ``ParallelEmbedEntityBoost`` pipeline step.
+Keeping one tokenizer means a single place to harden against
+UUID-fragment / content-hash leaks into the entity FTS index — the
+``empty-query-nonempty`` loadtest finding came from each site
+calling ``query.split()`` independently and sending unbroken
+hyphenated strings to storage, which then re-tokenised server-side
+on punctuation and matched UUID chunks against indexed entities.
+"""
+
+from __future__ import annotations
+
+import re
+import string
+
+from core_api.constants import ENTITY_STOPWORDS, ENTITY_TOKEN_MIN_LENGTH
+
+# Internal punctuation splits before storage-side FTS sees the string.
+# ``_`` is intentionally excluded from the separator class so snake_case
+# entity names (``project_alpha``, ``api_key``) reach FTS as a single
+# token; UUIDs use hyphens, which is what the empty-query-nonempty
+# loadtest probe surfaced.
+_TOKEN_SEP_RE = re.compile(r"[\s\-/.,;:!?()\[\]{}]+")
+_HEX_ONLY_RE = re.compile(r"[0-9a-f]+", re.IGNORECASE)
+_HEX_ID_MIN_LENGTH = 8
+
+
+def _is_hex_id(s: str) -> bool:
+    """True for UUID segments / content hashes / oid-style IDs.
+
+    The 8-char floor sits above the longest common all-hex English word
+    (~6 chars: ``decade``, ``facade``), so shorter all-hex words like
+    ``cafe`` / ``face`` / ``dead`` / ``beef`` are kept. 4-char UUID
+    segments (``e29b``, ``41d4`` …) also survive — an acceptable
+    trade-off, since they won't match real entity names downstream.
+    """
+    return len(s) >= _HEX_ID_MIN_LENGTH and bool(_HEX_ONLY_RE.fullmatch(s))
+
+
+def extract_entity_tokens(query: str) -> list[str]:
+    """Return entity-FTS-ready tokens from ``query``.
+
+    Splits on whitespace and internal punctuation; drops short tokens,
+    stopwords, and hex-only IDs; lowercases each surviving token so
+    callers don't have to.
+    """
+    return [
+        lower
+        for t in _TOKEN_SEP_RE.split(query)
+        if (stripped := t.strip(string.punctuation))
+        and len(stripped) >= ENTITY_TOKEN_MIN_LENGTH
+        and (lower := stripped.lower()) not in ENTITY_STOPWORDS
+        and not _is_hex_id(stripped)
+    ]

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -73,6 +73,7 @@ from core_api.schemas import (
     MemoryUpdate,
 )
 from core_api.services.entity_extraction_worker import process_entity_extraction
+from core_api.services.entity_tokens import extract_entity_tokens
 from core_api.services.hooks import get_hooks
 from core_api.services.task_tracker import tracked_task
 
@@ -2599,11 +2600,7 @@ async def _entity_boost_pipeline(
             entity_hops = precomputed_hops
             matched_entity_ids = [eid for eid, (hop, _w) in entity_hops.items() if hop == 0]
         else:
-            tokens = [
-                t.lower()
-                for t in query.split()
-                if len(t) >= ENTITY_TOKEN_MIN_LENGTH and t.lower() not in ENTITY_STOPWORDS
-            ]
+            tokens = extract_entity_tokens(query)
             if not tokens:
                 return boosted_memory_ids, memory_boost_factor
 

--- a/tests/pipeline/test_classify_query.py
+++ b/tests/pipeline/test_classify_query.py
@@ -107,13 +107,19 @@ async def test_entity_lookup_with_match(mock_get_sc):
     sc = _mock_sc()
     sc.fts_search_entities = AsyncMock(return_value=[eid_str])
     sc.expand_graph = AsyncMock(return_value={eid_str: [0, 1.0]})
-    sc.get_memory_ids_by_entity_ids = AsyncMock(return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}])
-    sc.scored_search = AsyncMock(return_value=[{
-        "id": mid_str,
-        "tenant_id": "t1",
-        "content": "Alice test memory",
-        "memory_type": "fact",
-    }])
+    sc.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
+    )
+    sc.scored_search = AsyncMock(
+        return_value=[
+            {
+                "id": mid_str,
+                "tenant_id": "t1",
+                "content": "Alice test memory",
+                "memory_type": "fact",
+            }
+        ]
+    )
     mock_get_sc.return_value = sc
 
     step = ClassifyQuery()
@@ -177,6 +183,66 @@ async def test_empty_query():
     assert plan.strategy == RetrievalStrategy.SEMANTIC_SEARCH
 
 
+@pytest.mark.asyncio
+@patch("core_api.pipeline.steps.search.classify_query.get_storage_client")
+async def test_uuid_laden_gibberish_drops_hex_fragments(mock_get_sc):
+    """Hex chunks inside hyphenated tokens must not reach entity FTS."""
+    sc = _mock_sc()
+    mock_get_sc.return_value = sc
+
+    hex_chunk = "deadbeefcafe1234deadbeefcafe1234"
+    ctx = _make_ctx(f"xyzzyzombie-{hex_chunk}-FLIBBERTYJIBBET")
+
+    step = ClassifyQuery()
+    await step.execute(ctx)
+
+    sent_tokens = sc.fts_search_entities.await_args.args[0]["tokens"]
+    assert hex_chunk not in sent_tokens
+    assert "xyzzyzombie" in sent_tokens
+    assert "flibbertyjibbet" in sent_tokens
+
+
+@pytest.mark.asyncio
+@patch("core_api.pipeline.steps.search.classify_query.get_storage_client")
+async def test_internal_punctuation_splits_tokens(mock_get_sc):
+    """Hyphenated phrases split client-side, not via storage FTS re-tokenisation."""
+    sc = _mock_sc()
+    mock_get_sc.return_value = sc
+
+    ctx = _make_ctx("USA-based,research/scribe")
+
+    step = ClassifyQuery()
+    await step.execute(ctx)
+
+    sent_tokens = sc.fts_search_entities.await_args.args[0]["tokens"]
+    assert "usa" in sent_tokens
+    assert "based" in sent_tokens
+    assert "research" in sent_tokens
+    assert "scribe" in sent_tokens
+
+
+@pytest.mark.asyncio
+@patch("core_api.pipeline.steps.search.classify_query.get_storage_client")
+async def test_uuid_query_long_hex_segments_dropped(mock_get_sc):
+    """A pasted UUID — segments ≥8 chars are dropped (UUID-shaped), shorter
+    segments survive (collide with real English words like ``cafe``).
+    With no entity match the query falls through to SEMANTIC_SEARCH."""
+    sc = _mock_sc()
+    mock_get_sc.return_value = sc
+
+    ctx = _make_ctx("550e8400-e29b-41d4-a716-446655440000")
+
+    step = ClassifyQuery()
+    await step.execute(ctx)
+
+    sent_tokens = sc.fts_search_entities.await_args.args[0]["tokens"]
+    assert "550e8400" not in sent_tokens
+    assert "446655440000" not in sent_tokens
+    assert sent_tokens == ["e29b", "41d4", "a716"]
+    plan: RetrievalPlan = ctx.data["retrieval_plan"]
+    assert plan.strategy == RetrievalStrategy.SEMANTIC_SEARCH
+
+
 # ---------------------------------------------------------------------------
 # TEMPORAL routing tests
 # ---------------------------------------------------------------------------
@@ -226,13 +292,19 @@ async def test_entity_lookup_takes_priority_over_temporal(mock_get_sc):
     sc = _mock_sc()
     sc.fts_search_entities = AsyncMock(return_value=[eid_str])
     sc.expand_graph = AsyncMock(return_value={eid_str: [0, 1.0]})
-    sc.get_memory_ids_by_entity_ids = AsyncMock(return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}])
-    sc.scored_search = AsyncMock(return_value=[{
-        "id": mid_str,
-        "tenant_id": "t1",
-        "content": "Alice temporal test",
-        "memory_type": "fact",
-    }])
+    sc.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
+    )
+    sc.scored_search = AsyncMock(
+        return_value=[
+            {
+                "id": mid_str,
+                "tenant_id": "t1",
+                "content": "Alice temporal test",
+                "memory_type": "fact",
+            }
+        ]
+    )
     mock_get_sc.return_value = sc
 
     ctx = _make_ctx("Alice", temporal_window=timedelta(days=7))
@@ -324,13 +396,19 @@ async def test_entity_lookup_takes_priority_over_recent(mock_get_sc):
     sc = _mock_sc()
     sc.fts_search_entities = AsyncMock(return_value=[eid_str])
     sc.expand_graph = AsyncMock(return_value={eid_str: [0, 1.0]})
-    sc.get_memory_ids_by_entity_ids = AsyncMock(return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}])
-    sc.scored_search = AsyncMock(return_value=[{
-        "id": mid_str,
-        "tenant_id": "t1",
-        "content": "Alice recent test",
-        "memory_type": "fact",
-    }])
+    sc.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
+    )
+    sc.scored_search = AsyncMock(
+        return_value=[
+            {
+                "id": mid_str,
+                "tenant_id": "t1",
+                "content": "Alice recent test",
+                "memory_type": "fact",
+            }
+        ]
+    )
     mock_get_sc.return_value = sc
 
     ctx = _make_ctx("what was I doing with Alice")
@@ -371,10 +449,12 @@ async def test_expand_per_fleet_parallel_merges_correctly():
     eid_c = uuid.uuid4()
 
     sc = AsyncMock()
-    sc.expand_graph = AsyncMock(side_effect=[
-        {str(eid_a): [0, 1.0], str(eid_b): [2, 0.5]},
-        {str(eid_a): [1, 0.8], str(eid_b): [1, 0.9], str(eid_c): [0, 1.0]},
-    ])
+    sc.expand_graph = AsyncMock(
+        side_effect=[
+            {str(eid_a): [0, 1.0], str(eid_b): [2, 0.5]},
+            {str(eid_a): [1, 0.8], str(eid_b): [1, 0.9], str(eid_c): [0, 1.0]},
+        ]
+    )
 
     result = await ClassifyQuery._expand_per_fleet(
         sc=sc,
@@ -396,10 +476,12 @@ async def test_expand_per_fleet_partial_failure():
     eid_a = uuid.uuid4()
 
     sc = AsyncMock()
-    sc.expand_graph = AsyncMock(side_effect=[
-        {str(eid_a): [0, 1.0]},  # fleet 1 succeeds
-        RuntimeError("DB connection lost"),  # fleet 2 fails
-    ])
+    sc.expand_graph = AsyncMock(
+        side_effect=[
+            {str(eid_a): [0, 1.0]},  # fleet 1 succeeds
+            RuntimeError("DB connection lost"),  # fleet 2 fails
+        ]
+    )
 
     result = await ClassifyQuery._expand_per_fleet(
         sc=sc,
@@ -429,7 +511,10 @@ async def test_collect_memories_caps_entity_ids():
     sc.scored_search = AsyncMock(return_value=[])
 
     result = await ClassifyQuery._collect_memories(
-        sc=sc, entity_hops=entity_hops, tenant_id="t1", top_k=10,
+        sc=sc,
+        entity_hops=entity_hops,
+        tenant_id="t1",
+        top_k=10,
     )
 
     sc.get_memory_ids_by_entity_ids.assert_called_once()

--- a/tests/test_entity_tokens.py
+++ b/tests/test_entity_tokens.py
@@ -1,0 +1,85 @@
+"""Unit tests for ``core_api.services.entity_tokens.extract_entity_tokens``.
+
+Mirrors the integration-level checks in ``tests/pipeline/test_classify_query.py``
+but at the helper level so all three call sites that consume it
+(``ClassifyQuery``, ``_entity_boost_pipeline``, ``ParallelEmbedEntityBoost``)
+are covered by a single source of truth.
+"""
+
+from __future__ import annotations
+
+from core_api.services.entity_tokens import extract_entity_tokens
+
+
+def test_simple_query_unchanged():
+    assert extract_entity_tokens("Alice and Bob") == ["alice", "bob"]
+
+
+def test_drops_stopwords_and_short_tokens():
+    # "the" is a stopword; "of" is too short.
+    assert extract_entity_tokens("the home of Alice") == ["home", "alice"]
+
+
+def test_internal_punctuation_splits():
+    assert extract_entity_tokens("USA-based,research/scribe") == [
+        "usa",
+        "based",
+        "research",
+        "scribe",
+    ]
+
+
+def test_hex_only_fragments_dropped():
+    hex_chunk = "deadbeefcafe1234deadbeefcafe1234"
+    assert extract_entity_tokens(f"xyzzy-{hex_chunk}-FLIBBERTY") == [
+        "xyzzy",
+        "flibberty",
+    ]
+
+
+def test_short_hex_english_words_kept():
+    """All-hex words below the 8-char floor are real entity names, not IDs."""
+    assert extract_entity_tokens("cafe face dead beef decade facade") == [
+        "cafe",
+        "face",
+        "dead",
+        "beef",
+        "decade",
+        "facade",
+    ]
+
+
+def test_hyphenated_uuid_partially_filtered():
+    """8/12-char UUID segments dropped; the three 4-char ones survive."""
+    assert extract_entity_tokens("550e8400-e29b-41d4-a716-446655440000") == [
+        "e29b",
+        "41d4",
+        "a716",
+    ]
+
+
+def test_tokens_are_lowercased():
+    """Centralised normalisation: callers no longer need their own .lower()."""
+    assert extract_entity_tokens("MixedCase QUERY tokens") == [
+        "mixedcase",
+        "query",
+        "tokens",
+    ]
+
+
+def test_snake_case_identifiers_kept_intact():
+    """Underscore is not a token separator: snake_case names stay whole."""
+    assert extract_entity_tokens("project_alpha api_key") == [
+        "project_alpha",
+        "api_key",
+    ]
+
+
+def test_empty_query_yields_empty_list():
+    assert extract_entity_tokens("") == []
+
+
+def test_quotes_and_apostrophes_stripped_via_string_punctuation():
+    # ``string.punctuation`` strip catches residual quotes the splitter
+    # doesn't tokenise on (apostrophes, quotation marks).
+    assert extract_entity_tokens("'Alice'") == ["alice"]


### PR DESCRIPTION
## Summary

- Extracts a shared `extract_entity_tokens(query)` helper that splits on whitespace **and** internal punctuation, then drops short tokens, stopwords, and hex-only fragments (UUIDs / content hashes / oid-style IDs).
- Uses the helper from **all three** entity-FTS call sites — pre-fix each rolled its own `query.split()` and only one (or none) would have been hardened by a localised patch.
- Drive-by: hoists `from sqlalchemy import update` out of `bulk_delete_by_ids` (`[Top-level imports only]`).

Closes the `empty-query-nonempty` finding in [report-loadtest-1777332393](../loadtest/report-loadtest-1777332393.md): the gibberish probe `xyzzy-{uuid_hex}-jibbet` was returning 1 hit on the larger-graph tenant because the unbroken token reached storage-side FTS, which re-tokenised on punctuation and matched UUID chunks against indexed entities.

## Refactored sites

- `core_api.pipeline.steps.search.classify_query.ClassifyQuery`
- `core_api.pipeline.steps.search.parallel_embed_entity_boost._entity_boost_via_storage`
- `core_api.services.memory_service._entity_boost_pipeline`

## Test plan

- [x] `tests/test_entity_tokens.py` — helper unit tests (7 cases)
- [x] `tests/pipeline/test_classify_query.py` — 3 new behavioural tests (loadtest probe, hyphenated phrase, pure-UUID query) + all 22 pre-existing tests still pass
- [x] `ruff check`, `ruff format --check`, pre-commit all green
- [ ] Re-run staging loadtest after merge — `empty-query-nonempty` finding should be absent for both tenants.

## Out of scope (separate work)

- Item F (move single-write enrichment off the hot path) is **already implemented in code** (`config.py:76` `enrich_on_hot_path` flag + `ScheduleBackgroundTasks` publishing `Topics.Memory.ENRICH_REQUESTED`). Staging is just running the OSS default `True`. Will be flipped via `gcloud run services update` separately, after verifying `core-worker` consumes the topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)