### PR TITLE
fix(noisy-neighbor): widen per-tenant Semaphore caps so bench loop fits

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -142,9 +142,11 @@ class Settings(BaseSettings):
     # Per-tenant in-flight concurrency caps (see
     # ``middleware/per_tenant_concurrency.py`` for full rationale).
     # Per-instance state — fleet-wide cap is roughly
-    # ``cap * max_instances``.
-    per_tenant_search_concurrency: int = 8
-    per_tenant_write_concurrency: int = 4
+    # ``cap * max_instances``. Sized to absorb routine per-tenant
+    # fan-out (the harness's microbench phase issues ~10-30 concurrent
+    # search/list ops) while still tripping under a genuine storm.
+    per_tenant_search_concurrency: int = 32
+    per_tenant_write_concurrency: int = 16
     # Deeper bulkhead at the storage roundtrip itself
     # (CAURA-602 follow-up). Smaller than the route-entry caps above
     # because each request only holds the storage slot for the actual


### PR DESCRIPTION
## Summary

Bump per-tenant in-flight concurrency caps so routine read fan-out doesn't 5xx:

- `per_tenant_search_concurrency`: **8 → 32**
- `per_tenant_write_concurrency`: **4 → 16**

The original caps (private-PR #33, commit [`1ce87b5`](https://github.com/caura-ai/caura-memclaw/commit/1ce87b5d1e95d825178c8bd0fc98c5ae72d430b4)) were sized for a writes-only storm against a single tenant. The loadtest harness's microbench phase fans 10-30 concurrent search / list / stats / entities / agents ops out within one tenant, and `8` was too low to absorb that.

## Loadtest evidence

[`loadtest-1777371451`](../loadtest/report-loadtest-1777371451.md) (post-#29 deploy of `staging-memclaw-core-api-00188-rb6`):

| op | n | failures | tail |
|---|---:|---:|---|
| `bench_search` | 100 | **25 × 500** | — |
| `bench_agents` | 100 | **19 × 500** | — |
| `bench_entities` | 100 | **19 × 500** | — |
| `bench_search_concurrent` | 60 | several | **p99 15.5 s** (target 5 s) |
| total error rate | 1613 reqs | 392 × 5xx | **25.73%** (was 14.44% pre-#33) |

The semaphore IS firing on writes (`bulk_write:429=11`), so the mechanism is sound — only the sizes were too conservative.

## Why these specific values

- **search 32**: covers a single tenant fanning 30 concurrent searches (the harness's heaviest read fan-out) without firing 429.
- **write 16**: still bites under the storm phase (tenant A storm runs at concurrency=20 for 60 s — bounded to ~16 slots per instance instead of unbounded). Per-tenant fleet-wide cap = `16 × peak_instances`; with `staging-memclaw-core-api` at peak 38 in the latest run, that's ~600 slots vs unbounded pre-#33. Tenant isolation preserved.

## What's not changing

- `per_tenant_storage_search_concurrency=4`, `per_tenant_storage_write_concurrency=2` — the deeper bulkhead at the storage roundtrip is unchanged. Those weren't observed firing incorrectly.
- `per_tenant_acquire_timeout_seconds=0.05` — unchanged.

## Test plan

- [x] `tests/test_per_tenant_concurrency.py` — 8/8 pass; tests monkeypatch their own values so default changes don't shift assertions
- [x] `ruff check`, `ruff format --check`, pre-commit clean
- [ ] Re-run staging loadtest after deploy. Expect: bench_*:500 counts → 0; total error rate → ~5-7% (the cleanup-noise-free baseline); per-tenant 429s still fire on the storm probe and on the 150-burst search probe

## Refs

- Epic: [CAURA-513](https://caura-ai.atlassian.net/browse/CAURA-513)
- Related tickets filed alongside: CAURA-612 (edge-layer rate limit), CAURA-613 (`patch-resurrects-deleted` regression), CAURA-614 (`cross_tenant_leak_own_tenant` 500), CAURA-615 (app-timeout alignment), CAURA-616 (freshness cluster)
- Prior loadtest baselines: `report-loadtest-1777332393` (pre-§8h, pre-#29), `report-loadtest-1777364035` (post-§8h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-513]: https://caura-ai.atlassian.net/browse/CAURA-513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ