### PR TITLE
fix(logging): route uvicorn / fastmcp / mcp / slowapi to root formatter (CAURA-588)

### DIFF
--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -214,6 +214,112 @@ def configure_logging(
         _configured = True
 
 
+# Names of third-party loggers that install their own (typically stderr,
+# plain-text) handlers OR set ``propagate=False``, bypassing the root
+# ``ProcessorFormatter`` without explicit re-routing. CAURA-588.
+#
+# Ordering caveat: ``_route_third_party_to_root`` only re-routes loggers
+# whose libraries have already initialised them at call time. uvicorn's
+# ``Config.configure_logging()`` runs at server start; if our
+# ``configure_logging()`` is called at module import (the typical app.py
+# path), the uvicorn loggers may not yet have their handlers when we
+# iterate. The function logs a debug line in that case so the caller can
+# move the call into an ASGI lifespan startup handler if production logs
+# show un-rerouted output.
+_THIRD_PARTY_LOGGERS_TO_REROUTE: tuple[str, ...] = (
+    # uvicorn ships three loggers with propagate=False + own StreamHandlers
+    # via uvicorn.config.LOGGING_CONFIG.
+    "uvicorn",
+    "uvicorn.access",
+    "uvicorn.error",
+    # FastMCP / underlying mcp library register their own stream handler.
+    "fastmcp",
+    "mcp",
+    # slowapi (rate-limit middleware) — included defensively. Some versions
+    # install their own handler when rate-limit decisions are configured to
+    # log; on versions that don't, the rerouting is a harmless no-op (no
+    # snapshotted handlers, level untouched).
+    "slowapi",
+)
+
+# Pre-config state for each rerouted logger (handlers, propagate, level).
+# Captured by ``_route_third_party_to_root`` on first invocation and
+# replayed by ``_reset_for_testing`` so test fixtures can return to a
+# state structurally identical to import-time. Handlers are *not* closed
+# in the route-to-root path so the snapshot retains usable handler objects
+# for restore — Python's GC handles FD release when the logger no longer
+# references them after the next reset.
+_third_party_logger_original_state: dict[
+    str, tuple[list[logging.Handler], bool, int]
+] = {}
+
+
+def _route_third_party_to_root() -> None:
+    """Strip third-party loggers' own handlers and force propagation to root.
+
+    Without this, uvicorn access/error and FastMCP server lines bypass the
+    root ``ProcessorFormatter`` and emit as unstructured plain text at
+    DEFAULT severity in Cloud Logging — breaking severity filtering and
+    audit log searches. After this runs, those lines flow through the
+    same JSON formatter as application logs.
+
+    Only resets the level when the library actually had its own handlers
+    — otherwise the level was an operator-/library-configured filter
+    relative to root (e.g. ``uvicorn --log-level warning``) and we mustn't
+    silently widen it.
+    """
+    for name in _THIRD_PARTY_LOGGERS_TO_REROUTE:
+        lg = logging.getLogger(name)
+        # Skip iff the snapshot says we already did the work (had handlers
+        # captured). Lets a re-call (e.g. from an ASGI lifespan startup
+        # after uvicorn initialised) idempotently no-op.
+        already_rerouted = name in _third_party_logger_original_state and bool(
+            _third_party_logger_original_state[name][0]
+        )
+        if already_rerouted:
+            continue
+        # Library may not have initialised this logger yet — there's nothing
+        # to reroute right now. Don't snapshot the empty state (would freeze
+        # us into "no work to do" forever) and warn the operator at WARNING
+        # so they notice in Cloud Logging if a uvicorn-fronted service is
+        # calling configure_logging at module import (before uvicorn's own
+        # ``Config.configure_logging`` runs at server start).
+        if not lg.handlers and lg.propagate:
+            logging.getLogger(__name__).warning(
+                "logger %r has no own handlers at rerouting time; rerouting was a no-op (library may not be imported yet — call _route_third_party_to_root from an ASGI lifespan startup handler if this is a uvicorn-fronted service)",
+                name,
+            )
+            continue
+        # First effective call. Snapshot the pre-reroute state so
+        # ``_reset_for_testing`` can restore. Handlers retained for the
+        # process lifetime — bounded for the listed libraries (uvicorn /
+        # fastmcp / mcp / slowapi only install StreamHandlers pointing at
+        # stderr, ~kilobytes total) so no FD-leak risk.
+        if name not in _third_party_logger_original_state:
+            _third_party_logger_original_state[name] = (
+                list(lg.handlers),
+                lg.propagate,
+                lg.level,
+            )
+        had_own_handlers = bool(_third_party_logger_original_state[name][0])
+        # Remove the library's own handlers without closing them. Closing
+        # would invalidate the snapshot's handler objects — ``_reset_for_testing``
+        # restores from that snapshot, and a closed FileHandler/SocketHandler
+        # silently emits nothing.
+        for h in list(lg.handlers):
+            lg.removeHandler(h)
+        lg.propagate = True
+        # Reset level only when the library installed its own handlers — in
+        # that case the level was the library's filter on its own log path
+        # (which we just removed) and resetting to NOTSET delegates filtering
+        # to root. If the library *didn't* install handlers but we got here
+        # via ``propagate=False`` (intentional library suppression that we're
+        # flipping), leave the level alone so the operator's filter intent is
+        # preserved.
+        if had_own_handlers:
+            lg.setLevel(logging.NOTSET)
+
+
 def _reset_for_testing() -> None:
     """Clear the idempotency guard so tests can reconfigure with new settings.
 
@@ -261,6 +367,26 @@ def _reset_for_testing() -> None:
         # silent divergence from production behavior.
         for dep in ("httpx", "httpcore", "google.auth", "google.auth.transport"):
             logging.getLogger(dep).setLevel(logging.NOTSET)
+        # Restore third-party loggers to pre-config state from the snapshot
+        # captured by ``_route_third_party_to_root``. Best-effort: any
+        # FileHandler / SocketHandler that was closed during stripping won't
+        # actually write again, but the logger's ``handlers``, ``propagate``,
+        # and ``level`` attributes are restored to their pre-config shape so
+        # tests observing logger structure see what they would have seen
+        # before ``configure_logging`` ran.
+        for name, (
+            handlers,
+            propagate,
+            level,
+        ) in _third_party_logger_original_state.items():
+            lg = logging.getLogger(name)
+            for h in list(lg.handlers):
+                lg.removeHandler(h)
+            for h in handlers:
+                lg.addHandler(h)
+            lg.propagate = propagate
+            lg.setLevel(level)
+        _third_party_logger_original_state.clear()
         _configured = False
         _configured_environment = None
         _configured_log_level = None
@@ -312,10 +438,10 @@ def _configure_logging_impl(
 
     # Route stdlib logging (SQLAlchemy, httpx, …) through the same processor
     # chain so their output also carries GCP severity labels instead of
-    # landing as unstructured DEFAULT-severity text. Uvicorn installs its
-    # own handlers with propagate=False on `uvicorn` and `uvicorn.access`,
-    # so its lines bypass this handler — worth a follow-up if we want those
-    # in GCP format too.
+    # landing as unstructured DEFAULT-severity text. Uvicorn and FastMCP
+    # install their own handlers with ``propagate=False`` and bypass the
+    # root handler — ``_route_third_party_to_root`` (called below) reverses
+    # that so their access/error lines also flow through the formatter.
     foreign_pre_chain: list[Any] = _base_processors()
     # add_logger_name surfaces the originating stdlib logger (`sqlalchemy.engine`,
     # `httpx`, …) as the `logger` field — useful in both dev and prod. Keep
@@ -430,3 +556,5 @@ def _configure_logging_impl(
     if logging.DEBUG < min_level < logging.WARNING:
         for dep in ("httpx", "httpcore", "google.auth", "google.auth.transport"):
             logging.getLogger(dep).setLevel(logging.WARNING)
+
+    _route_third_party_to_root()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
-from common.structlog_config import _map_to_gcp_severity, _rename_event_to_message
+import logging
+
+from common.structlog_config import (
+    _THIRD_PARTY_LOGGERS_TO_REROUTE,
+    _map_to_gcp_severity,
+    _rename_event_to_message,
+    _route_third_party_to_root,
+    _third_party_logger_original_state,
+)
 
 
 def test_map_to_gcp_severity_adds_matching_label() -> None:
@@ -81,3 +89,71 @@ def test_rename_event_to_message_event_none_produces_empty_message() -> None:
     # Emit an empty string so the GCP entry still has a `message` summary.
     result = _rename_event_to_message(None, "info", {"event": None})
     assert result == {"message": ""}
+
+
+# ─── _route_third_party_to_root ─────────────────────────────────────────
+
+
+def test_route_third_party_to_root_clears_handlers_and_enables_propagation() -> None:
+    """Each rerouted logger ends with handlers=[] and propagate=True so its
+    lines flow through the root ProcessorFormatter."""
+    # Pre-populate one of the listed loggers with a fake handler + propagate=False
+    # to simulate uvicorn / fastmcp's shipped state.
+    target = logging.getLogger(_THIRD_PARTY_LOGGERS_TO_REROUTE[0])
+    fake_handler = logging.NullHandler()
+    target.addHandler(fake_handler)
+    target.propagate = False
+    try:
+        _route_third_party_to_root()
+        assert fake_handler not in target.handlers
+        assert target.propagate is True
+    finally:
+        # Restore for any subsequent test that touches this logger.
+        target.propagate = True
+
+
+def test_route_third_party_to_root_is_idempotent() -> None:
+    """Calling twice doesn't change state on the second call (already-rerouted
+    loggers stay handler-less, propagate stays True)."""
+    _route_third_party_to_root()
+    snapshot = {
+        name: (
+            list(logging.getLogger(name).handlers),
+            logging.getLogger(name).propagate,
+        )
+        for name in _THIRD_PARTY_LOGGERS_TO_REROUTE
+    }
+    _route_third_party_to_root()
+    for name in _THIRD_PARTY_LOGGERS_TO_REROUTE:
+        lg = logging.getLogger(name)
+        assert list(lg.handlers) == snapshot[name][0]
+        assert lg.propagate == snapshot[name][1]
+
+
+def test_route_third_party_to_root_preserves_operator_set_level_when_no_handlers() -> (
+    None
+):
+    """If a logger has no own handlers, its level was set by the operator
+    relative to root (e.g. ``uvicorn --log-level warning``). Don't silently
+    reset to NOTSET — that would flood Cloud Logging with previously
+    suppressed access logs."""
+    target = logging.getLogger(_THIRD_PARTY_LOGGERS_TO_REROUTE[0])
+    # Clear leaked snapshot state from earlier tests so this test sees a
+    # genuinely-empty handler list at snapshot time. Without this, a prior
+    # test's snapshot of ``[NullHandler]`` would make this run go through
+    # the rerouting path that resets the level — masking the regression
+    # this test is supposed to catch.
+    _third_party_logger_original_state.clear()
+    for h in list(target.handlers):
+        target.removeHandler(h)
+    target.propagate = True
+    target.setLevel(logging.WARNING)
+    try:
+        _route_third_party_to_root()
+        assert target.level == logging.WARNING, (
+            "operator-set level should not be silently reset to NOTSET when "
+            "the library hadn't installed its own handlers"
+        )
+    finally:
+        target.setLevel(logging.NOTSET)
+        _third_party_logger_original_state.clear()


### PR DESCRIPTION
## Summary

Add `_route_third_party_to_root()` (called from `configure_logging`) that strips the library-installed handlers from `uvicorn`, `uvicorn.access`, `uvicorn.error`, `fastmcp`, `mcp`, and `slowapi`, and sets `propagate=True` so their lines flow through the root `ProcessorFormatter`.

## Why

Without this, those loggers ship with `propagate=False` and their own stream handler — so their access / error lines bypass the GCP-severity-aware JSON formatter that `configure_logging` installs on the root logger. They land in Cloud Logging as plain text at DEFAULT severity, breaking severity filtering and audit-log searches by severity.

The existing comment in `common/structlog_config.py` already flagged this as a known limitation ("Uvicorn installs its own handlers with propagate=False on `uvicorn` and `uvicorn.access`, so its lines bypass this handler — worth a follow-up").

## What's not changed

- The existing `_silence_noisy_dependency_loggers` block (httpx / google.auth / google.auth.transport at WARNING when min_level is INFO) — that's about level filtering, separate concern.
- No log-volume change. Same lines still emitted; they now carry GCP severity labels.

## Test plan

- [x] 2 new tests in `tests/test_logging.py`: handler-cleared + idempotency
- [x] All 12 tests pass; ruff + format clean

## Refs

- Epic: [CAURA-513](https://caura-ai.atlassian.net/browse/CAURA-513)
- Ticket: [CAURA-588](https://caura-ai.atlassian.net/browse/CAURA-588)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-513]: https://caura-ai.atlassian.net/browse/CAURA-513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ