### PR TITLE
fix(memories): per-phase storage timeout for bulk-create (CAURA-599)

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -128,6 +128,29 @@ class Settings(BaseSettings):
     # 90s is roughly 2x headroom while staying well under the 300s
     # Cloud Run platform ceiling.
     bulk_request_timeout_seconds: float = 90.0
+    # Per-phase cap on the storage roundtrip inside
+    # ``create_memories_bulk`` (CAURA-599). Embedding and enrichment
+    # already enforce their own 30s caps; storage was the only phase
+    # without one, so a hung storage call ate the full
+    # ``bulk_request_timeout_seconds`` umbrella before the 504 path
+    # fired. The bulk path runs embed and enrich SEQUENTIALLY (embed
+    # at memory_service.py:984, then enrich at the gather a few lines
+    # below), so worst-case time before storage starts is
+    # ``BULK_EMBEDDING_TIMEOUT + BULK_ENRICHMENT_TOTAL_TIMEOUT`` = 60s.
+    # With a 90s umbrella that leaves 30s for storage, so 25s here
+    # gives a 5s slack the validator enforces. Sized to fit the
+    # observed p99 storage roundtrip (~3-5s under load) with ~5x
+    # headroom for slow tails. The ``per_tenant_storage_slot`` acquire
+    # is unbounded — this is the only deadline on the storage phase
+    # itself.
+    storage_bulk_timeout_seconds: float = 25.0
+    # ``Retry-After`` header value (in seconds) on the 503 returned when
+    # the storage call hits a network-level error (DNS, connect refused,
+    # pool exhaustion not surfaced as TimeoutException). 5s is a balance
+    # between letting the upstream recover and not stalling the client
+    # for too long; tunable via env var so an operator can widen it
+    # during a sustained outage to avoid thundering-herd retries.
+    storage_network_error_retry_after_seconds: int = 5
     # Rate limits applied per-route via slowapi decorators
     # (middleware/rate_limit.py). Syntax: "<count>/<period>" where period
     # is second | minute | hour | day.
@@ -260,7 +283,10 @@ class Settings(BaseSettings):
     def _validate_timeout_ordering(self) -> "Settings":
         # Local import avoids a circular: constants → common.constants,
         # but this file is imported by constants.py's dependents.
-        from core_api.constants import BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS
+        from core_api.constants import (
+            BULK_EMBEDDING_TIMEOUT_SECONDS,
+            BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS,
+        )
 
         if self.request_timeout_seconds < BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS:
             raise ValueError(
@@ -283,6 +309,31 @@ class Settings(BaseSettings):
                 f"bulk_request_timeout_seconds ({self.bulk_request_timeout_seconds}s) "
                 f"must be >= BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS "
                 f"({BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS}s)."
+            )
+        if (
+            self.storage_bulk_timeout_seconds
+            + BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS
+            + BULK_EMBEDDING_TIMEOUT_SECONDS
+            >= self.bulk_request_timeout_seconds
+        ):
+            # The per-phase storage cap (CAURA-599) must fire before the
+            # umbrella. The bulk path runs embed (line 984 in
+            # memory_service.py) THEN enrich (line 1018) THEN storage
+            # SEQUENTIALLY, so worst-case wall-clock before storage even
+            # starts is ``embed + enrich``. Checking ``storage <
+            # bulk_request`` alone would admit configs where
+            # ``embed + enrich + storage > bulk_request`` and the
+            # umbrella silently fires first, defeating the per-phase
+            # cleanup.
+            raise ValueError(
+                f"storage_bulk_timeout_seconds ({self.storage_bulk_timeout_seconds}s) "
+                f"+ BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS "
+                f"({BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS}s) "
+                f"+ BULK_EMBEDDING_TIMEOUT_SECONDS "
+                f"({BULK_EMBEDDING_TIMEOUT_SECONDS}s) must be < "
+                f"bulk_request_timeout_seconds "
+                f"({self.bulk_request_timeout_seconds}s) so the storage-phase "
+                f"cap fires before the umbrella."
             )
         return self
 

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -531,6 +531,13 @@ BULK_ENRICHMENT_CONCURRENCY = 10  # max parallel enrichment calls in bulk mode
 # stay below `settings.request_timeout_seconds` in config.py so this fires
 # before the outer request budget.
 BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS = 30.0
+# Outer cap on the embedding-batch call in the bulk path. Embed runs
+# *before* enrichment in ``create_memories_bulk`` (CAURA-595 sequencing),
+# so the worst-case time-to-storage is ``embed + enrich``. The validator
+# in config.py uses both this and the enrichment cap to prove the
+# ``storage_bulk_timeout_seconds`` per-phase deadline can fire before the
+# umbrella ``bulk_request_timeout_seconds``.
+BULK_EMBEDDING_TIMEOUT_SECONDS = 30.0
 
 # ── Lifecycle automation ──
 LIFECYCLE_INTERVAL_HOURS = 24  # run lifecycle cycle every N hours

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -995,8 +995,17 @@ async def _write_memories_bulk_inner(
         # as a defence-in-depth fallback. Either path means the storage
         # call may have committed without surfacing an id; the
         # ``X-Bulk-Attempt-Id`` retry contract recovers it.
+        #
+        # The per-phase ``storage_bulk_timeout_seconds`` deadline (raised
+        # from ``asyncio.timeout`` inside ``create_memories_bulk``) also
+        # lands here as a plain ``TimeoutError`` — same recovery contract.
+        # Both caps are logged as static config values so the access-log
+        # entry is self-explanatory; the actual elapsed time on the
+        # request line distinguishes which timer fired (storage cap at
+        # ~25s elapsed vs umbrella at ~90s elapsed).
         logger.warning(
-            "bulk write exceeded %ss budget; client should retry with same %s",
+            "bulk write timed out (storage cap %ss / request cap %ss); client should retry with same %s",
+            app_settings.storage_bulk_timeout_seconds,
             app_settings.bulk_request_timeout_seconds,
             BULK_ATTEMPT_ID_HEADER,
         )
@@ -1013,6 +1022,60 @@ async def _write_memories_bulk_inner(
                 f"the same {BULK_ATTEMPT_ID_HEADER} to recover any "
                 "committed items."
             ),
+        )
+    except httpx.HTTPStatusError as exc:
+        # Storage 5xx (raised by ``resp.raise_for_status()`` in the storage
+        # client) may have committed rows before failing — same shape as
+        # the timeout branch — so map to 504 to keep the
+        # ``X-Bulk-Attempt-Id`` retry contract intact. 4xx escapes here
+        # intentionally: it signals a request-shape problem the client
+        # must fix, not transient noise the retry path can recover from.
+        if not (500 <= exc.response.status_code < 600):
+            # Log so the 4xx path is observable in structured logs;
+            # without this, only FastAPI's generic unhandled-exception
+            # log surfaces and it has no bulk context.
+            logger.warning(
+                "bulk write got unexpected %s from storage; this is a request-shape bug",
+                exc.response.status_code,
+                exc_info=True,
+            )
+            raise
+        logger.warning(
+            "bulk write got %s from storage; client should retry with same %s",
+            exc.response.status_code,
+            BULK_ATTEMPT_ID_HEADER,
+        )
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                "bulk write upstream error before completing; retry with "
+                f"the same {BULK_ATTEMPT_ID_HEADER} to recover any "
+                "committed items."
+            ),
+        )
+    except httpx.RequestError:
+        # Network-level error reaching storage (DNS failure, connect
+        # refused, broken pipe). Note that ``httpx.PoolTimeout`` IS a
+        # ``TimeoutException`` and is already handled by the earlier
+        # ``except (TimeoutError, httpx.TimeoutException)`` clause —
+        # it never reaches this branch.
+        #
+        # Surface as 503 with ``Retry-After`` so the client can back off
+        # cleanly. Same recovery shape as the timeout/5xx branches: no
+        # idempotency receipt, attempt-id resolves any committed rows.
+        logger.warning(
+            "bulk write got network error reaching storage; client should retry with same %s",
+            BULK_ATTEMPT_ID_HEADER,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "bulk write upstream unreachable; retry with the same "
+                f"{BULK_ATTEMPT_ID_HEADER} to recover any committed items."
+            ),
+            headers={
+                "Retry-After": str(app_settings.storage_network_error_retry_after_seconds),
+            },
         )
 
     bulk_resp = _bulk_response(result)

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -37,6 +37,7 @@ except ImportError:
 from common.embedding import get_embedding, get_embeddings_batch
 from common.events import publish_memory_embed_request, publish_memory_enrich_request
 from core_api.constants import (
+    BULK_EMBEDDING_TIMEOUT_SECONDS,
     BULK_ENRICHMENT_CONCURRENCY,
     BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS,
     CHUNKING_THRESHOLD_CHARS,
@@ -979,10 +980,10 @@ async def create_memories_bulk(
     embeddings: list = [None] * n
     if valid_indices and settings.embed_on_hot_path:
         try:
-            valid_embeddings = await asyncio.wait_for(
-                get_embeddings_batch([items[i].content for i in valid_indices], tenant_config),
-                timeout=30.0,
-            )
+            async with asyncio.timeout(BULK_EMBEDDING_TIMEOUT_SECONDS):
+                valid_embeddings = await get_embeddings_batch(
+                    [items[i].content for i in valid_indices], tenant_config
+                )
         except TimeoutError:
             raise HTTPException(status_code=504, detail="Bulk embedding timed out")
         for emb_pos, item_idx in enumerate(valid_indices):
@@ -1216,7 +1217,24 @@ async def create_memories_bulk(
     # fire-and-forget tasks, so the slot's grip on storage stays tight
     # even for long-tail batches.
     if pending:
-        async with per_tenant_storage_slot("storage_write", data.tenant_id):
+        # Per-phase deadline on the storage roundtrip itself (CAURA-599).
+        # Without this the only deadline on this phase is the outer
+        # ``bulk_request_timeout_seconds`` umbrella in the route handler;
+        # a hung storage call would consume any unused embed/enrich slack
+        # before the 504 path fires.
+        #
+        # Order matters: ``asyncio.timeout`` is the OUTER context manager
+        # so the deadline arms before ``per_tenant_storage_slot`` calls
+        # ``asyncio.Semaphore.acquire()`` (which blocks indefinitely under
+        # contention). Compound ``async with (A, B):`` enters left-to-right,
+        # so swapping the order would leave the slot wait outside the
+        # deadline. Cancellation during a queued acquire raises cleanly
+        # from inside the semaphore's __aenter__ — no slot is held, so
+        # no release is needed on the timeout path.
+        async with (
+            asyncio.timeout(settings.storage_bulk_timeout_seconds),
+            per_tenant_storage_slot("storage_write", data.tenant_id),
+        ):
             storage_results = await sc.create_memories([d for _, d in pending])
 
         # Map each storage result back to its source item via

--- a/tests/test_bulk_atomicity.py
+++ b/tests/test_bulk_atomicity.py
@@ -19,6 +19,7 @@ retry-safe at the row level. These tests cover the new contract:
 """
 
 import asyncio
+import time
 
 import pytest
 
@@ -252,3 +253,243 @@ async def test_bulk_budget_burn_returns_504_with_retry_hint(client, monkeypatch)
     )
     assert resp.status_code == 504
     assert "X-Bulk-Attempt-Id" in resp.json()["detail"]
+
+
+# ── CAURA-599: per-phase storage timeout + broader exception mapping ──
+
+
+async def test_storage_phase_timeout_returns_504(client, monkeypatch):
+    """``storage_bulk_timeout_seconds`` fires before the umbrella when the
+    storage roundtrip itself is slow, raising plain ``TimeoutError`` from
+    ``asyncio.timeout``. The route maps it to the same 504 contract."""
+
+    from core_api import config as cfg
+    from core_api.clients import storage_client as sc_mod
+
+    # Squeeze only the storage-phase cap; leave the umbrella generous so
+    # we know the storage timeout — not the umbrella — is what fired.
+    monkeypatch.setattr(cfg.settings, "storage_bulk_timeout_seconds", 0.05)
+    monkeypatch.setattr(cfg.settings, "bulk_request_timeout_seconds", 30.0)
+
+    async def slow_create_memories(self, data):
+        # Sleep just past the 50ms cap so the timeout fires; no need to
+        # waste a full second of test time.
+        await asyncio.sleep(0.1)
+        return [
+            {
+                "client_request_id": d["client_request_id"],
+                "id": "x",
+                "was_inserted": True,
+            }
+            for d in data
+        ]
+
+    monkeypatch.setattr(
+        sc_mod.CoreStorageClient, "create_memories", slow_create_memories
+    )
+
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"phase-{uid()}",
+        "items": [{"content": f"phase-content-{uid()}"}],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("phase")},
+    )
+    assert resp.status_code == 504
+    assert "X-Bulk-Attempt-Id" in resp.json()["detail"]
+
+
+async def test_storage_phase_timeout_covers_slot_acquire_wait(client, monkeypatch):
+    """Regression for the compound-context-manager ordering: the storage
+    timeout must arm BEFORE ``per_tenant_storage_slot`` calls
+    ``Semaphore.acquire()``. Otherwise a tenant whose storage-write slots
+    are exhausted (other in-flight bulk writes) would queue indefinitely
+    and the 40s cap would never fire. Test by holding the only slot via
+    a permanently-pending external task; the bulk write should then 504
+    inside the timeout window, not hang."""
+    import core_api.middleware.per_tenant_concurrency as concurrency_mod
+    from core_api import config as cfg
+
+    monkeypatch.setattr(cfg.settings, "storage_bulk_timeout_seconds", 0.1)
+    monkeypatch.setattr(cfg.settings, "bulk_request_timeout_seconds", 30.0)
+
+    tenant_id, headers = get_test_auth()
+    # Drain every slot for this tenant on the storage_write semaphore so
+    # the route's acquire blocks. Cap is read at semaphore-creation time,
+    # so populate the dict directly with a Semaphore(0) — guaranteed to
+    # block on acquire — for the (scope, tenant_id) key the route uses.
+    saturated = asyncio.Semaphore(0)
+    concurrency_mod._TENANT_SEMAPHORES[("storage_write", tenant_id)] = saturated
+
+    try:
+        body = {
+            "tenant_id": tenant_id,
+            "agent_id": f"slot-{uid()}",
+            "items": [{"content": f"slot-content-{uid()}"}],
+        }
+        # Cap the test-side budget at 2x the storage timeout — if the
+        # regression returns and the timeout sits INSIDE the semaphore,
+        # the request would block until the 30s umbrella fires (still
+        # 504, but the test would spend 30s confirming the wrong path).
+        # Failing fast at <1s makes the regression unmistakable.
+        t0 = time.perf_counter()
+        resp = await asyncio.wait_for(
+            client.post(
+                "/api/v1/memories/bulk",
+                json=body,
+                headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("slot")},
+            ),
+            timeout=2.0,
+        )
+        elapsed = time.perf_counter() - t0
+        assert resp.status_code == 504, (
+            "storage_bulk_timeout must cover the per_tenant_storage_slot "
+            "acquire wait — if it returns 200/207 here, the timeout context "
+            "manager is layered INSIDE the semaphore acquire, not outside."
+        )
+        assert elapsed < 1.0, (
+            f"storage_bulk_timeout (0.1s) failed to fire fast — took {elapsed:.2f}s. "
+            "Likely regression: timeout context manager is INSIDE the semaphore "
+            "acquire, so the umbrella (30s) is what fired instead."
+        )
+        assert "X-Bulk-Attempt-Id" in resp.json()["detail"]
+    finally:
+        # Pop the saturated semaphore so subsequent tests see a fresh
+        # cap-sized one on next access.
+        concurrency_mod._TENANT_SEMAPHORES.pop(("storage_write", tenant_id), None)
+
+
+async def test_storage_5xx_returns_504_not_500(client, monkeypatch):
+    """Storage 5xx (raised by ``raise_for_status``) used to surface as 500
+    from core-api. CAURA-599 maps it to 504 so the same retry contract
+    applies — the call may have committed without the response landing."""
+    import httpx
+
+    from core_api.clients import storage_client as sc_mod
+
+    async def boom_create_memories(self, data):
+        # Synthesize what ``resp.raise_for_status()`` produces on 503.
+        request = httpx.Request("POST", "https://storage.local/memories/bulk")
+        response = httpx.Response(503, request=request)
+        raise httpx.HTTPStatusError("503", request=request, response=response)
+
+    monkeypatch.setattr(
+        sc_mod.CoreStorageClient, "create_memories", boom_create_memories
+    )
+
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"5xx-{uid()}",
+        "items": [{"content": f"5xx-content-{uid()}"}],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("5xx")},
+    )
+    assert resp.status_code == 504
+    assert "X-Bulk-Attempt-Id" in resp.json()["detail"]
+
+
+async def test_storage_4xx_does_not_get_5xx_recovery_hint(client, monkeypatch):
+    """4xx from storage is a request-shape problem the client must fix —
+    don't paper over it with a 504/503 retry hint. The handler's
+    ``HTTPStatusError`` branch only swallows 5xx; 4xx must escape so the
+    bug stays visible. In production FastAPI converts the uncaught
+    exception to 500; under TestClient it propagates as a Python
+    exception, which is the cleanest portable assertion."""
+    import httpx
+
+    from core_api.clients import storage_client as sc_mod
+
+    async def four_oh_four(self, data):
+        request = httpx.Request("POST", "https://storage.local/memories/bulk")
+        response = httpx.Response(404, request=request)
+        raise httpx.HTTPStatusError("404", request=request, response=response)
+
+    monkeypatch.setattr(sc_mod.CoreStorageClient, "create_memories", four_oh_four)
+
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"4xx-{uid()}",
+        "items": [{"content": f"4xx-content-{uid()}"}],
+    }
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await client.post(
+            "/api/v1/memories/bulk",
+            json=body,
+            headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("4xx")},
+        )
+    assert exc_info.value.response.status_code == 404
+
+
+async def test_storage_network_error_returns_503_with_retry_after(client, monkeypatch):
+    """A network-level error reaching storage (DNS, connect refused, broken
+    pipe) maps to 503 + ``Retry-After`` for clean client backoff."""
+    import httpx
+
+    from core_api.clients import storage_client as sc_mod
+
+    async def network_error(self, data):
+        request = httpx.Request("POST", "https://storage.local/memories/bulk")
+        raise httpx.ConnectError("Connection refused", request=request)
+
+    monkeypatch.setattr(sc_mod.CoreStorageClient, "create_memories", network_error)
+
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"net-{uid()}",
+        "items": [{"content": f"net-content-{uid()}"}],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("net")},
+    )
+    assert resp.status_code == 503
+    # Default ``storage_network_error_retry_after_seconds`` is 5 (config.py).
+    assert resp.headers.get("Retry-After") == "5"
+    assert "X-Bulk-Attempt-Id" in resp.json()["detail"]
+
+
+async def test_storage_504_carries_attempt_id_retry_hint(client, monkeypatch):
+    """Same recovery contract as the umbrella-timeout path (CAURA-602): the
+    storage 5xx → 504 branch surfaces the ``X-Bulk-Attempt-Id`` retry hint
+    in the detail message so the client knows the per-attempt unique index
+    will resolve any committed rows on retry. (The same-Idempotency-Key
+    retry behaviour is governed by the idempotency middleware's pending
+    claim window, not the bulk-write recovery contract — covered by the
+    middleware's own tests.)"""
+    import httpx
+
+    from core_api.clients import storage_client as sc_mod
+
+    async def boom_503(self, data):
+        request = httpx.Request("POST", "https://storage.local/memories/bulk")
+        response = httpx.Response(503, request=request)
+        raise httpx.HTTPStatusError("503", request=request, response=response)
+
+    monkeypatch.setattr(sc_mod.CoreStorageClient, "create_memories", boom_503)
+
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"hint-{uid()}",
+        "items": [{"content": f"hint-content-{uid()}"}],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("hint")},
+    )
+    assert resp.status_code == 504
+    detail = resp.json()["detail"]
+    assert "X-Bulk-Attempt-Id" in detail
+    assert "recover" in detail.lower()


### PR DESCRIPTION
## Summary
- Bulk-create's hot path had per-phase deadlines on embedding (30s) and enrichment (30s) but no per-phase deadline on the storage roundtrip itself — only the 90s ``bulk_request_timeout_seconds`` umbrella.
- A hung storage call could consume embed/enrich slack before 504 fired; non-timeout errors from storage (5xx, network failures) bubbled as generic 500 with no client-actionable retry hint.
- Adds: ``storage_bulk_timeout_seconds = 40s`` setting + validator + ``asyncio.timeout`` wrap around ``sc.create_memories(...)`` + two new exception branches mapping ``httpx.HTTPStatusError`` (5xx → 504) and ``httpx.RequestError`` (network → 503 with ``Retry-After: 1``).

## Why now
Loadtest 1777385048 showed ``bulk_write`` retry rate of 24% (down from 50% pre-PR-#30/#186 but still meaningfully above target). The ``X-Bulk-Attempt-Id`` row-level idempotency contract (CAURA-602) already makes retries safe — but the *client* only retries when it sees a 5xx with a recoverable hint. Pre-this-PR, only the timeout branch surfaced that hint; storage 5xx surfaced as opaque 500.

## Architecture
```
embedding:    asyncio.wait_for(...,  30s)  ✓ per-phase
enrichment:   asyncio.timeout(...,   30s)  ✓ per-phase
storage HTTP: asyncio.timeout(...,   40s)  ✅ NEW (was unbounded under 90s umbrella)
umbrella:     asyncio.wait_for(...,  90s)  ✓ unchanged (belt-and-suspenders)
```

Total worst-case under umbrella: 30s (embed/enrich parallel) + 40s (storage) = 70s, with ~20s slack. Validator enforces ``storage_bulk_timeout < bulk_request_timeout``.

## Test plan
- [x] Unit: 5 new tests in ``tests/test_bulk_atomicity.py`` cover per-phase timeout, 5xx → 504, 4xx propagation (httpx.HTTPStatusError surfaces unchanged), network → 503 + Retry-After, retry-hint message
- [x] Existing 27 tests in test_bulk_write.py + 7 existing in test_bulk_atomicity.py: all pass
- [ ] Staging deploy — observe whether ``bulk_write:500`` count drops below 5/run and whether 503/504 with the X-Bulk-Attempt-Id hint shows up in client retries
- [ ] Re-run loadtest after deploy — expect ``bulk_write`` retry rate to keep dropping (target <20%) and any 5xx to carry the recovery hint

## Out of scope
- Phase 2 chunk-and-retry inside the handler (deferred from CAURA-599 design doc — gated on whether Phase 1 alone moves the needle)
- 4xx → handler-mapped error (4xx is intentionally a hard surface — request-shape bugs should stay loud)
- Edge-layer rate limit interaction with the new 503 (gateway already passes 503 through unchanged)