### PR TITLE
fix(llm,embedding): explicit httpx.Limits on OpenAI-compatible providers (CAURA-627)

### DIFF
--- a/common/embedding/_registry.py
+++ b/common/embedding/_registry.py
@@ -11,6 +11,7 @@ and core-worker (platform-only) can use it.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from collections import OrderedDict
@@ -37,13 +38,29 @@ logger = logging.getLogger(__name__)
 # instead of pinning a 401-returning client forever. ``OrderedDict``
 # semantics: ``move_to_end`` on hit, ``popitem(last=False)`` on miss
 # when full. 256 is well above any realistic tenant count for a single
-# process; raise if that proves wrong. ``AsyncOpenAI`` doesn't require
-# explicit ``aclose`` — the GC drops the underlying httpx pool when
-# the evicted instance has no remaining refs.
+# process; raise if that proves wrong.
+#
+# Eviction must explicitly close the evicted provider's httpx pool
+# (CAURA-627). The OpenAI SDK now gets a user-provided ``http_client``
+# (set in ``OpenAIEmbeddingProvider.__init__`` so we control pool
+# sizing); per the SDK contract, user-provided clients are NOT closed
+# on SDK teardown — caller owns cleanup. ``_get_or_create_openai_provider``
+# below schedules ``aclose()`` on the evicted instance via
+# ``asyncio.create_task`` so the pool drains in the background instead
+# of leaking ``ResourceWarning`` and held connections under long-lived
+# processes that rotate keys past the cache cap.
 _OPENAI_CACHE_MAX = 256
 _openai_provider_cache: OrderedDict[tuple[str, str], OpenAIEmbeddingProvider] = (
     OrderedDict()
 )
+
+# Strong references to in-flight ``aclose()`` cleanup tasks so the GC
+# doesn't reap them mid-execution. ``asyncio.create_task`` returns a
+# task that's kept alive only by user references; without this set the
+# task could be collected before its coroutine finishes draining the
+# httpx pool. The ``add_done_callback`` removes the task from the set
+# once it completes so this doesn't grow unboundedly.
+_background_tasks: set[asyncio.Task[None]] = set()
 
 
 def _get_or_create_openai_provider(api_key: str, model: str) -> OpenAIEmbeddingProvider:
@@ -65,7 +82,21 @@ def _get_or_create_openai_provider(api_key: str, model: str) -> OpenAIEmbeddingP
     provider = OpenAIEmbeddingProvider(api_key=api_key, model=model)
     _openai_provider_cache[cache_key] = provider
     if len(_openai_provider_cache) > _OPENAI_CACHE_MAX:
-        _openai_provider_cache.popitem(last=False)
+        _, evicted = _openai_provider_cache.popitem(last=False)
+        # Schedule cleanup of the evicted provider's httpx pool. The
+        # SDK won't do it for us (we pass an explicit ``http_client``).
+        # Best-effort — bare ``except RuntimeError`` covers the rare
+        # case where the registry is exercised outside a running event
+        # loop (e.g. early startup); GC will reclaim the connections
+        # eventually but with the ``ResourceWarning`` we'd see in
+        # asyncio debug mode.
+        try:
+            loop = asyncio.get_running_loop()
+            task = loop.create_task(evicted.aclose())
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
+        except RuntimeError:
+            pass
     return provider
 
 

--- a/common/embedding/constants.py
+++ b/common/embedding/constants.py
@@ -43,3 +43,20 @@ OPENAI_REQUEST_TIMEOUT_SECONDS: float = float(
 # meaningfully extending the hot-path tail.
 EMBEDDING_RETRY_ATTEMPTS: int = int(os.environ.get("EMBEDDING_RETRY_ATTEMPTS", "2"))
 EMBEDDING_RETRY_DELAY_S: float = float(os.environ.get("EMBEDDING_RETRY_DELAY_S", "1.0"))
+
+
+# httpx pool sizing for the embedding-side OpenAI client (CAURA-627).
+# Same env var names as ``common/llm/constants.py`` so a single env
+# tunable controls both the LLM and the embedding pools. Without an
+# explicit limits arg the SDK rides httpx's default (100 max / 20
+# keepalive) which saturates under bulk-write storm fan-out (16
+# concurrent writes × 10 enrichment calls = 160 concurrent LLM
+# requests per process, well over the keepalive budget). See
+# ``common/llm/constants.py`` for full rationale.
+from common.env_utils import clamp_keepalive, read_int_env  # noqa: E402
+
+OPENAI_HTTPX_MAX_CONNECTIONS: int = read_int_env("OPENAI_HTTPX_MAX_CONNECTIONS", 200)
+OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS: int = clamp_keepalive(
+    OPENAI_HTTPX_MAX_CONNECTIONS,
+    read_int_env("OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS", 50),
+)

--- a/common/embedding/providers/openai.py
+++ b/common/embedding/providers/openai.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import httpx
 import openai
 
 from common.constants import VECTOR_DIM
 from common.embedding.constants import (
     OPENAI_EMBEDDING_MODEL,
+    OPENAI_HTTPX_MAX_CONNECTIONS,
+    OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
     OPENAI_REQUEST_TIMEOUT_SECONDS,
 )
 
@@ -26,9 +29,21 @@ class OpenAIEmbeddingProvider:
         # api.openai.com response would silently eat the worker's
         # entire ack budget. Mirrors the same env-driven default that
         # gates ``OpenAILLMProvider``.
+        #
+        # Explicit ``http_client`` with ``httpx.Limits`` sized for our
+        # bulk-write fan-out (CAURA-627). Same rationale as
+        # ``OpenAILLMProvider``: the SDK's default httpx pool (100 max
+        # / 20 keepalive) saturates under storm load and queues other
+        # tenants' embed calls at the pool layer.
         self._client = openai.AsyncOpenAI(
             api_key=api_key,
             timeout=OPENAI_REQUEST_TIMEOUT_SECONDS,
+            http_client=httpx.AsyncClient(
+                limits=httpx.Limits(
+                    max_connections=OPENAI_HTTPX_MAX_CONNECTIONS,
+                    max_keepalive_connections=OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+                ),
+            ),
         )
 
     @property
@@ -38,6 +53,16 @@ class OpenAIEmbeddingProvider:
     @property
     def model(self) -> str:
         return self._model
+
+    async def aclose(self) -> None:
+        """Close the underlying httpx pool cleanly.
+
+        Without this, ``asyncio`` debug mode emits ``ResourceWarning:
+        Unclosed <httpx.AsyncClient>`` when the provider is GC'd —
+        noisy in tests and a leak in long-lived processes that rotate
+        client instances. Idempotent; safe to call multiple times.
+        """
+        await self._client.close()
 
     async def embed(self, text: str) -> list[float]:
         """Generate an embedding vector for a single text."""

--- a/common/env_utils.py
+++ b/common/env_utils.py
@@ -1,0 +1,93 @@
+"""Tiny env-var parsing helpers shared across ``common/`` constants modules.
+
+Lives at ``common/`` (not ``common/llm/`` or ``common/embedding/``) so it
+has zero imports from peer ``common/`` subpackages — keeping the LLM
+and embedding constants modules independent of each other while letting
+them share the same defensive parsing without each module having to
+maintain its own copy. Without this, both modules would need to repeat
+the same validation logic and a bug fix in one would silently miss the
+other.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def read_int_env(name: str, default: int) -> int:
+    """Read ``name`` from the environment, parse as int, fall back on bad input.
+
+    Falls back to ``default`` and writes a warning to stderr in three
+    cases:
+
+    1. Env value is not a valid integer literal (``"200abc"``,
+       ``"25s"``, etc.) — would raise ``ValueError`` from bare
+       ``int(...)`` and crash module import.
+    2. Env value is non-positive (``"0"``, ``"-1"``) — ``int(...)``
+       accepts these but downstream consumers (``httpx.Limits``,
+       semaphore-style caps) interpret 0 / negative as "block forever"
+       or silently degrade.
+    3. ``TypeError`` from a non-string env value (defensive; shouldn't
+       happen in practice but cheap to guard).
+
+    Module-level callers can't use a logger because structured logging
+    isn't wired up yet at import time — stderr is the only universal
+    channel and shows up in Cloud Logging's ``stderr`` stream.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        print(
+            f"WARN: {name}={raw!r} is not a valid int; falling back to {default}",
+            file=sys.stderr,
+        )
+        return default
+    if value < 1:
+        print(
+            f"WARN: {name}={raw!r} must be >= 1; falling back to {default}",
+            file=sys.stderr,
+        )
+        return default
+    return value
+
+
+def clamp_keepalive(
+    max_connections: int,
+    max_keepalive: int,
+    *,
+    max_connections_var: str = "OPENAI_HTTPX_MAX_CONNECTIONS",
+    max_keepalive_var: str = "OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS",
+) -> int:
+    """Clamp ``max_keepalive`` to ``max_connections``, warning if it had to.
+
+    ``httpx.Limits`` silently clamps the keepalive value to
+    ``max_connections`` when keepalive > max — making the env var
+    misleading for an operator tuning under an incident. This helper
+    surfaces the misconfig as a stderr warning at import time and
+    applies the clamp explicitly.
+
+    Each importing module produces its own warning when misconfigured
+    (a process loading both ``common/llm/constants`` and
+    ``common/embedding/constants`` will see the warning twice). The
+    helper exists to keep the warning text + clamp logic identical
+    across modules, not to deduplicate at runtime — the env vars
+    themselves are imported once per module.
+
+    ``max_connections_var`` / ``max_keepalive_var`` keyword-only args
+    let a future provider with different env-var names (e.g. an
+    Anthropic-only or vertex-only client pool) reuse the helper with
+    accurate variable names in the warning text.
+    """
+    if max_keepalive > max_connections:
+        print(
+            f"WARN: {max_keepalive_var} ({max_keepalive}) > "
+            f"{max_connections_var} ({max_connections}); "
+            f"clamping keepalive to max_connections",
+            file=sys.stderr,
+        )
+        return max_connections
+    return max_keepalive

--- a/common/llm/constants.py
+++ b/common/llm/constants.py
@@ -47,6 +47,7 @@ LLM_RETRY_DELAY_S = 1.0
 # a cheaper / different family without a redeploy.
 LLM_FALLBACK_MODEL_OPENAI = os.environ.get("LLM_FALLBACK_MODEL_OPENAI", "gpt-5.4-nano")
 
+
 # Per-call timeout passed to the OpenAI/Anthropic/Openrouter SDK.
 # Without an explicit value the SDK rides httpx's default — long
 # enough that a single hung upstream call eats the whole enrichment
@@ -79,3 +80,26 @@ def _read_openai_request_timeout_seconds() -> float:
 
 
 OPENAI_REQUEST_TIMEOUT_SECONDS = _read_openai_request_timeout_seconds()
+
+
+# ── httpx pool sizing for OpenAI-compatible providers ────────────────
+#
+# CAURA-627: the SDK rides httpx's default (100 max_connections / 20
+# keepalive). Under bulk-write storms — 100-item batches with
+# ``BULK_ENRICHMENT_CONCURRENCY=10`` × ``per_tenant_write_concurrency=16``
+# in flight per worker — the pool saturates and queues subsequent
+# requests, including other tenants'. The defaults were sized for
+# request/response patterns where one user's bursty fan-out doesn't
+# sit on top of another tenant's traffic; our hot-path enrichment is
+# exactly that pattern.
+#
+# Sized for headroom over the worst-case fan-out per process. Env-
+# tunable so an operator can adjust during an incident (e.g. if the
+# upstream provider's per-IP cap is hit) without a redeploy.
+from common.env_utils import clamp_keepalive, read_int_env  # noqa: E402
+
+OPENAI_HTTPX_MAX_CONNECTIONS = read_int_env("OPENAI_HTTPX_MAX_CONNECTIONS", 200)
+OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS = clamp_keepalive(
+    OPENAI_HTTPX_MAX_CONNECTIONS,
+    read_int_env("OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS", 50),
+)

--- a/common/llm/providers/openai.py
+++ b/common/llm/providers/openai.py
@@ -19,9 +19,15 @@ import json
 import logging
 import time
 
+import httpx
 import openai
 
-from common.llm.constants import OPENAI_CHAT_BASE_URL, OPENAI_REQUEST_TIMEOUT_SECONDS
+from common.llm.constants import (
+    OPENAI_CHAT_BASE_URL,
+    OPENAI_HTTPX_MAX_CONNECTIONS,
+    OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+    OPENAI_REQUEST_TIMEOUT_SECONDS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,10 +54,25 @@ class OpenAILLMProvider:
         # Explicit per-call timeout — without this the SDK rides httpx's
         # default and a single hung upstream call would eat the whole
         # enrichment budget silently.
+        #
+        # Explicit ``http_client`` with ``httpx.Limits`` sized for our
+        # bulk-write fan-out (CAURA-627). The SDK's default httpx pool
+        # (100 max / 20 keepalive) saturates under storm load — 16
+        # concurrent writes × 10 enrichment calls per request = 160
+        # concurrent LLM calls per worker process, with the next
+        # tenant's traffic queueing at the pool layer. Sizing the pool
+        # 2x the worst-case fan-out keeps headroom; values are env-
+        # tunable for incident-time adjustment.
         self._client = openai.AsyncOpenAI(
             api_key=api_key,
             base_url=base_url,
             timeout=request_timeout_seconds,
+            http_client=httpx.AsyncClient(
+                limits=httpx.Limits(
+                    max_connections=OPENAI_HTTPX_MAX_CONNECTIONS,
+                    max_keepalive_connections=OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+                ),
+            ),
         )
 
     @property
@@ -61,6 +82,16 @@ class OpenAILLMProvider:
     @property
     def model(self) -> str:
         return self._model
+
+    async def aclose(self) -> None:
+        """Close the underlying httpx pool cleanly.
+
+        Without this, ``asyncio`` debug mode emits ``ResourceWarning:
+        Unclosed <httpx.AsyncClient>`` when the provider is GC'd —
+        noisy in tests and a leak in long-lived processes that rotate
+        client instances. Idempotent; safe to call multiple times.
+        """
+        await self._client.close()
 
     async def complete_json(
         self,

--- a/tests/test_embedding_registry_eviction.py
+++ b/tests/test_embedding_registry_eviction.py
@@ -1,0 +1,92 @@
+"""Test that LRU eviction in common.embedding._registry closes the evicted
+provider's httpx pool (CAURA-627 round-3).
+
+The eviction path used to drop the reference and rely on GC; with the
+explicit ``http_client=httpx.AsyncClient(...)`` we now pass to the OpenAI
+SDK, the SDK no longer owns the client teardown, so the registry must
+schedule ``aclose()`` itself on eviction.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import common.embedding._registry as registry_mod
+
+
+@pytest.mark.asyncio
+async def test_eviction_schedules_aclose_on_evicted_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the LRU cache evicts an entry, the evicted provider's
+    ``aclose()`` must be awaited so the underlying httpx pool is
+    closed cleanly. Without this, asyncio debug mode emits
+    ``ResourceWarning: Unclosed <httpx.AsyncClient>`` on every
+    eviction and the connections leak in long-lived processes."""
+    # Tighten the cache to make eviction trivially observable.
+    monkeypatch.setattr(registry_mod, "_OPENAI_CACHE_MAX", 1)
+    monkeypatch.setattr(
+        registry_mod, "_openai_provider_cache", registry_mod.OrderedDict()
+    )
+
+    # Track every provider instance we make and whether aclose was
+    # awaited. Replace the provider class with a stand-in that
+    # records the call without hitting the OpenAI SDK / network.
+    aclose_calls: list[tuple[str, str]] = []
+
+    class _FakeProvider:
+        def __init__(self, *, api_key: str, model: str) -> None:
+            self.api_key = api_key
+            self.model = model
+            self.aclose = AsyncMock(
+                side_effect=lambda: aclose_calls.append((api_key, model))
+            )  # type: ignore[arg-type]
+
+    monkeypatch.setattr(registry_mod, "OpenAIEmbeddingProvider", _FakeProvider)
+
+    # First insert — no eviction yet.
+    registry_mod._get_or_create_openai_provider("key-A", "model-1")
+    assert aclose_calls == []
+
+    # Second insert exceeds cap=1 → evicts (key-A, model-1).
+    registry_mod._get_or_create_openai_provider("key-B", "model-1")
+
+    # Yield to the event loop so the scheduled aclose() task runs.
+    import asyncio
+
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)  # belt-and-suspenders for any nested awaits
+
+    assert aclose_calls == [("key-A", "model-1")], (
+        f"expected aclose() called for evicted provider only; got {aclose_calls!r}"
+    )
+
+
+def test_eviction_outside_running_loop_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bare ``except RuntimeError`` covers callers that exercise
+    the registry outside an asyncio event loop (e.g. early-startup
+    config validation). The eviction must not crash; cleanup falls
+    through to GC in that case."""
+    monkeypatch.setattr(registry_mod, "_OPENAI_CACHE_MAX", 1)
+    monkeypatch.setattr(
+        registry_mod, "_openai_provider_cache", registry_mod.OrderedDict()
+    )
+
+    class _FakeProvider:
+        def __init__(self, *, api_key: str, model: str) -> None:
+            self.api_key = api_key
+            self.model = model
+
+        async def aclose(self) -> None:
+            pass
+
+    monkeypatch.setattr(registry_mod, "OpenAIEmbeddingProvider", _FakeProvider)
+
+    registry_mod._get_or_create_openai_provider("key-A", "model-1")
+    # No event loop running here — the second call triggers eviction
+    # and must swallow the RuntimeError from get_running_loop().
+    registry_mod._get_or_create_openai_provider("key-B", "model-1")

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,0 +1,127 @@
+"""Unit tests for common.env_utils helpers (CAURA-627)."""
+
+from __future__ import annotations
+
+import pytest
+
+from common.env_utils import clamp_keepalive, read_int_env
+
+
+def test_unset_returns_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CAURA_TEST_KEY", raising=False)
+    assert read_int_env("CAURA_TEST_KEY", 42) == 42
+
+
+def test_valid_int_returns_parsed_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CAURA_TEST_KEY", "100")
+    assert read_int_env("CAURA_TEST_KEY", 42) == 100
+
+
+def test_invalid_string_falls_back(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("CAURA_TEST_KEY", "200abc")
+    assert read_int_env("CAURA_TEST_KEY", 42) == 42
+    err = capsys.readouterr().err
+    assert "CAURA_TEST_KEY" in err
+    assert "not a valid int" in err
+    assert "42" in err  # default surfaced in the warning
+
+
+def test_unit_suffix_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``"25s"`` is the realistic copy-paste-from-config bug shape."""
+    monkeypatch.setenv("CAURA_TEST_KEY", "25s")
+    assert read_int_env("CAURA_TEST_KEY", 42) == 42
+
+
+def test_zero_falls_back(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``int("0")`` parses cleanly but ``httpx.Limits(max_connections=0)``
+    is a semaphore with zero permits — every request blocks forever.
+    The guard rejects values < 1 explicitly (CAURA-627 round-2)."""
+    monkeypatch.setenv("CAURA_TEST_KEY", "0")
+    assert read_int_env("CAURA_TEST_KEY", 42) == 42
+    err = capsys.readouterr().err
+    assert ">= 1" in err
+
+
+def test_negative_falls_back(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("CAURA_TEST_KEY", "-5")
+    assert read_int_env("CAURA_TEST_KEY", 42) == 42
+    err = capsys.readouterr().err
+    assert ">= 1" in err
+
+
+def test_one_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Boundary: 1 is the smallest valid value (httpx.Limits accepts it)."""
+    monkeypatch.setenv("CAURA_TEST_KEY", "1")
+    assert read_int_env("CAURA_TEST_KEY", 42) == 1
+
+
+def test_whitespace_around_int_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``int("  100  ")`` succeeds in Python — the env var would parse and
+    return 100, not the default. This documents that surrounding
+    whitespace is tolerated rather than rejected."""
+    monkeypatch.setenv("CAURA_TEST_KEY", "  100  ")
+    assert read_int_env("CAURA_TEST_KEY", 42) == 100
+
+
+# ─── clamp_keepalive ──────────────────────────────────────────────────
+
+
+def test_clamp_keepalive_passthrough_when_within_max(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If keepalive <= max, return keepalive unchanged with no warning."""
+    assert clamp_keepalive(max_connections=200, max_keepalive=50) == 50
+    assert capsys.readouterr().err == ""
+
+
+def test_clamp_keepalive_equal_is_passthrough(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Boundary: keepalive == max passes through silently (the docs only
+    promise warning when keepalive STRICTLY exceeds max, matching
+    httpx's actual clamp behaviour)."""
+    assert clamp_keepalive(max_connections=100, max_keepalive=100) == 100
+    assert capsys.readouterr().err == ""
+
+
+def test_clamp_keepalive_warns_and_clamps_when_above_max(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If an operator sets keepalive > max (typically by env var), we
+    return ``max_connections`` and emit a stderr warning naming both
+    values + the env var so they can self-diagnose."""
+    assert clamp_keepalive(max_connections=100, max_keepalive=500) == 100
+    err = capsys.readouterr().err
+    assert "OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS" in err
+    assert "OPENAI_HTTPX_MAX_CONNECTIONS" in err
+    assert "500" in err
+    assert "100" in err
+    assert "clamping" in err
+
+
+def test_clamp_keepalive_uses_custom_var_names_in_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A future provider with different env-var names can override the
+    var names in the warning. This regression-guards the kwargs path so
+    a refactor that drops them surfaces immediately."""
+    assert (
+        clamp_keepalive(
+            max_connections=10,
+            max_keepalive=99,
+            max_connections_var="ANTHROPIC_HTTPX_MAX_CONNECTIONS",
+            max_keepalive_var="ANTHROPIC_HTTPX_MAX_KEEPALIVE",
+        )
+        == 10
+    )
+    err = capsys.readouterr().err
+    assert "ANTHROPIC_HTTPX_MAX_KEEPALIVE" in err
+    assert "ANTHROPIC_HTTPX_MAX_CONNECTIONS" in err
+    # Verify the OpenAI defaults DON'T leak through when overrides are set.
+    assert "OPENAI_HTTPX" not in err


### PR DESCRIPTION
## Summary
- Both ``OpenAILLMProvider`` and ``OpenAIEmbeddingProvider`` were riding the SDK's default httpx pool (**100 max_connections / 20 keepalive**). Under bulk-write storm fan-out — ``per_tenant_write_concurrency=16`` × ``BULK_ENRICHMENT_CONCURRENCY=10`` = up to **160 concurrent LLM calls per worker process** from a single tenant — the pool saturates and queues subsequent requests, including other tenants'.
- This is the mechanism behind the ``noisy-neighbor-write`` HIGH finding's disproportionate cross-tenant degradation that survived the storage-pool fix in #190.
- Set explicit ``httpx.Limits(max_connections=200, max_keepalive_connections=50)`` on both providers via the ``http_client`` arg of ``AsyncOpenAI``. Env-tunable (``OPENAI_HTTPX_MAX_CONNECTIONS``, ``OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS``) for incident-time adjustment without a redeploy.

## Why these values
- max_connections=200: covers the worst-case 160-concurrent fan-out per process with ~25% headroom.
- max_keepalive_connections=50: 2.5× the default. Aggressive enough to keep TLS handshake costs down on bursts; not so aggressive that idle workers hold an unreasonable number of sockets.

Both are env vars so the values can be re-tuned post-loadtest if needed.

## What's NOT in scope
- Vertex / Gemini providers (use ``google-cloud-aiplatform`` SDK with its own connection management — different abstraction)
- Per-tenant httpx client pools (would require a tenant→client cache; deferred unless needed)

## Test plan
- [x] All 121 LLM/embedding-tagged tests pass locally
- [x] Lint clean (ruff check + format)
- [ ] After merge + OSS deploy + ``ENRICH_ON_HOT_PATH=false`` env flip on staging-memclaw-core-api → run loadtest and watch for:
  - ``noisy-neighbor-write`` drops below 5× (current 8.15×)
  - ``paraphrase_search`` p99 drops back into ≤4s neighborhood (since paraphrase uses an LLM call too)
  - ``freshness-search-never-visible`` improves further
  - No regression in single_write or bulk_write retry rates

## Related
- CAURA-627 deep-dive comment captures the full investigation
- Gotcha #15 in v0.99.0-prod-rollout.md is the previously-documented LLM-pool starvation; this PR is the actual fix