### PR TITLE
fix(memory): drop unused unscoped indexes ix_memories_status + ix_memories_visibility (CAURA-629)

### DIFF
--- a/common/models/memory.py
+++ b/common/models/memory.py
@@ -103,8 +103,6 @@ class Memory(Base):
                 "deleted_at IS NULL AND client_request_id IS NOT NULL"
             ),
         ),
-        Index("ix_memories_status", "status"),
-        Index("ix_memories_visibility", "visibility"),
         Index("ix_memories_valid_range", "ts_valid_start", "ts_valid_end"),
         Index("ix_memories_subject_entity", "subject_entity_id"),
         Index("ix_memories_recall_count", "recall_count"),

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/008_drop_unscoped_memory_indexes.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/008_drop_unscoped_memory_indexes.py
@@ -1,0 +1,54 @@
+"""Drop unused unscoped indexes ``ix_memories_status`` + ``ix_memories_visibility``.
+
+CAURA-629 (2026-04-29). Both indexes were declared global (no
+``tenant_id`` prefix) but every query in the codebase that filters by
+``status`` or ``visibility`` already pre-narrows by ``tenant_id`` —
+the planner uses ``ix_memories_tenant_id`` (or one of the
+``tenant_id``-prefixed composites in ``__table_args__``) to bound the
+scan to a single tenant's ~100-1000 rows, then applies status /
+visibility as a cheap post-filter. The unscoped indexes provide no
+read benefit on any tenant-scoped query path; they only add per-row
+maintenance cost on every Memory INSERT/UPDATE.
+
+Surfaced in the CAURA-627 deep-dive (audit_log + memory write
+contention investigation, 2026-04-29) — flagged as low-risk hygiene
+the planner would already prefer to ignore.
+
+Migration semantics:
+- ``DROP INDEX CONCURRENTLY`` so AlloyDB primary keeps serving
+  writes through the operation. Non-blocking on AccessShare; only
+  takes a brief AccessExclusive flash on metadata commit.
+- ``IF EXISTS`` is belt-and-suspenders for the rare case where a
+  staging-only or test-only environment never had these indexes
+  (pre-001-bootstrap clones).
+- The downgrade recreates them ``CONCURRENTLY`` for symmetry, even
+  though they're not load-bearing — keeps the migration round-trip
+  reversible without a CONCURRENTLY-constraint surprise on rollback.
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-04-29
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "008"
+down_revision: str | None = "007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ``DROP INDEX CONCURRENTLY`` cannot run inside a transaction —
+    # alembic's autocommit_block opens its own connection scope.
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_memories_status")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_memories_visibility")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_memories_status ON memories (status)")
+        op.execute("CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_memories_visibility ON memories (visibility)")


### PR DESCRIPTION
## Summary
- Both indexes were declared **global** (no ``tenant_id`` prefix) in migration 001 but every query that filters by ``status`` or ``visibility`` already pre-narrows by ``tenant_id``. The planner uses ``ix_memories_tenant_id`` (or one of the ``tenant_id``-prefixed composites) to bound the scan to a single tenant's rows, then applies status/visibility as a cheap post-filter.
- Net effect: the unscoped indexes provide **no read benefit** on any code path; they only add per-row index maintenance on every Memory INSERT/UPDATE.
- Surfaced in the CAURA-627 deep-dive (audit_log + memory write contention investigation).

## Verification
\`\`\`bash
grep -rn "ix_memories_status\\|ix_memories_visibility" --include="*.py"
# Returns only:
#   migrations/001_initial_schema.py  (creates them — original)
#   migrations/008_drop_unscoped_memory_indexes.py  (drops them — this PR)
#   common/models/memory.py  (now just a comment reference)
# No live code, query, or test references either index name.
\`\`\`

## Migration 008 semantics
- ``DROP INDEX CONCURRENTLY`` inside alembic's ``autocommit_block`` so AlloyDB primary keeps serving writes through the operation
- ``IF EXISTS`` is belt-and-suspenders for clones that never had these indexes
- Downgrade re-creates them ``CONCURRENTLY`` for round-trip symmetry

## Expected effect
- Write throughput: marginal improvement (sub-5%) — every Memory INSERT/UPDATE skips two index updates
- Read throughput: no effect — every query that uses status/visibility is already tenant-scoped

This is a hygiene win that unblocks the larger CAURA-628 audit-batch-ingest work without introducing competing variables at deploy time.

## Test plan
- [x] 143 memory/bulk tests pass on the core-api in-memory test infra (the SQLAlchemy schema simply doesn't have those indexes anymore — tests don't care)
- [x] Storage-api integration tests: 5 passed, 2 pre-existing failures on \`main\` reproduce identically (\`test_metadata_patch_jsonb_merge\` and \`test_batch_update_status\` — unrelated to this change)
- [x] grep verified no remaining references in code/queries
- [x] Lint clean (ruff check + format)
- [ ] Staging deploy: confirm migration runs cleanly (sub-second on staging row counts; CONCURRENTLY makes it non-blocking even on bigger tables)
- [ ] Optional: \`EXPLAIN ANALYZE\` of representative tenant-scoped queries before/after to confirm planner still uses the tenant-prefixed indexes (it should — they were always preferred)

## Out of scope
- The bigger CAURA-628 (audit_log async batch ingest) — that's the actual fix for the residual noisy-neighbor write contention. This PR is the small hygiene step before it.