### PR TITLE
fix(audit): batch + async ingest via in-memory queue (CAURA-628)

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -194,6 +194,43 @@ async def lifespan(app):
             )
         )
 
+        # CAURA-628: bind + start the audit batch flusher. ``log_action``
+        # checks for an active queue and falls back to a synchronous
+        # POST when ``audit_queue_max_size = 0`` (kill-switch) or the
+        # queue isn't bound (early startup, tests).
+        audit_queue = None
+        if app_settings.audit_queue_max_size > 0:
+            from core_api.services.audit_queue import (
+                AuditEventQueue,
+                set_audit_queue,
+            )
+
+            async def _flush_audit_batch(events: list[dict]) -> None:
+                try:
+                    await get_storage_client().create_audit_logs_bulk(events)
+                except Exception:
+                    # Log the rich detail (event count, storage-api
+                    # correlation context) here, then re-raise so
+                    # ``_drain_and_flush`` can bump ``_failed_count``
+                    # for the dashboard. The flusher loop's outer
+                    # ``except`` will emit a generic "iteration failed;
+                    # continuing" line on top of this — slight log
+                    # noise but worth it for the failure metric.
+                    logger.exception(
+                        "audit batch flush failed (events=%d); events lost from this batch",
+                        len(events),
+                    )
+                    raise
+
+            audit_queue = AuditEventQueue(
+                max_queue_size=app_settings.audit_queue_max_size,
+                flush_threshold=app_settings.audit_queue_flush_threshold,
+                flush_interval_seconds=app_settings.audit_queue_flush_interval_seconds,
+                flush_callable=_flush_audit_batch,
+            )
+            set_audit_queue(audit_queue)
+            await audit_queue.start()
+
         # Start lifecycle automation scheduler
         from core_api.services.lifecycle_service import lifecycle_scheduler
         from core_api.tasks import cancel_all_tasks, track_task
@@ -219,11 +256,23 @@ async def lifespan(app):
         # we leak the resources the later steps would have freed.
         # Wrap each in its own try/except and continue; the
         # executor.shutdown at the end always runs.
-        for coro in [
-            event_bus.stop(),
-            cancel_all_tasks(),
-            get_storage_client().close(),
-        ]:
+        #
+        # Order matters: drain the audit queue BEFORE closing the
+        # storage client — the final flush goes through that client.
+        # Bus stop also happens before storage-client close because
+        # the bus's pull-loops may still be issuing storage calls
+        # mid-cancel.
+        shutdown_steps: list = []
+        if audit_queue is not None:
+            shutdown_steps.append(audit_queue.stop(timeout=5.0))
+        shutdown_steps.extend(
+            [
+                event_bus.stop(),
+                cancel_all_tasks(),
+                get_storage_client().close(),
+            ]
+        )
+        for coro in shutdown_steps:
             try:
                 await coro
             except Exception:

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -902,6 +902,12 @@ class CoreStorageClient:
     async def create_audit_log(self, data: dict) -> dict:
         return await self._post("/audit-logs", data)  # type: ignore[return-value]
 
+    async def create_audit_logs_bulk(self, events: list[dict]) -> dict:
+        """Batched audit insert (CAURA-628). One HTTP POST + one
+        multi-row INSERT regardless of batch size, vs N round-trips +
+        N table-lock acquisitions on the legacy single-event path."""
+        return await self._post("/audit-logs/bulk", {"events": events})  # type: ignore[return-value]
+
     async def list_audit_logs(
         self,
         tenant_id: str,

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -151,6 +151,35 @@ class Settings(BaseSettings):
     # for too long; tunable via env var so an operator can widen it
     # during a sustained outage to avoid thundering-herd retries.
     storage_network_error_retry_after_seconds: int = 5
+    # Audit-event queue tunables (CAURA-628). The queue replaces the
+    # legacy per-event audit POST with batched flushes, removing the
+    # cross-tenant table-lock contention that surfaced as the residual
+    # noisy-neighbor-write signal after the LLM-pool fix in #34 and
+    # the dead-index drop in #35.
+    #
+    # ``audit_queue_max_size``: per-process queue cap. With ~200 bytes
+    # per event, 10000 events fits in ~2 MiB. Sized well over realistic
+    # storm rate so the queue only fills if storage-api is degraded;
+    # overflow triggers a structured warning + drop counter rather
+    # than blocking the request hot path.
+    #
+    # ``audit_queue_flush_threshold``: events accumulated → flush
+    # immediately. 50 keeps the average batch comfortable for one
+    # multi-row INSERT without stalling steady-state low-volume
+    # tenants behind a long flush cadence.
+    #
+    # ``audit_queue_flush_interval_seconds``: maximum staleness for
+    # any single event before it lands in storage. 1s matches the
+    # CAURA-627 scoping recommendation; the audit_list endpoint may
+    # see up to that delay for the most recent events, which is
+    # acceptable for the post-hoc analysis paths that consume it.
+    #
+    # Setting ``audit_queue_max_size = 0`` disables the queue entirely
+    # — ``log_action`` then falls through to the legacy synchronous
+    # POST. Useful as an incident-time kill-switch without a redeploy.
+    audit_queue_max_size: int = 10000
+    audit_queue_flush_threshold: int = 50
+    audit_queue_flush_interval_seconds: float = 1.0
     # Rate limits applied per-route via slowapi decorators
     # (middleware/rate_limit.py). Syntax: "<count>/<period>" where period
     # is second | minute | hour | day.

--- a/core-api/src/core_api/services/audit_queue.py
+++ b/core-api/src/core_api/services/audit_queue.py
@@ -1,0 +1,286 @@
+"""In-memory audit-event queue + background batched flusher (CAURA-628).
+
+Pre-CAURA-628 every memory write triggered a fire-and-forget background
+task that POSTed one audit event to ``core-storage-api``. Under bulk
+storms (100-item batches x tenant A's 20-concurrent storm = up to 2000
+audit POSTs in flight) those calls saturated the storage-api per-tenant
+slot AND piled up on the AlloyDB ``audit_log`` table-level write lock,
+queueing tenant B's gentle audit traffic behind tenant A's fan-out.
+That cross-tenant queueing is the residual contention the CAURA-627
+deep-dive identified as the dominant remaining ``noisy-neighbor-write``
+cause, after the LLM-pool fix in #34 and the dead-index drop in #35.
+
+This module replaces the per-event POST with an in-memory ``asyncio``
+queue + a background flusher that batches events and writes them to a
+new ``POST /audit-logs/bulk`` endpoint. Flush triggers are first-of:
+
+  - ``audit_queue_flush_threshold`` events accumulated (50 by default)
+  - ``audit_queue_flush_interval_seconds`` elapsed since last flush (1s)
+
+Per-event memory overhead is small (~200 bytes for an audit dict at the
+default sizes), so a 10000-event cap fits in ~2 MiB per worker process —
+plenty of headroom over the realistic worst-case storm rate.
+
+Backpressure: the queue is bounded. If writers fill the queue faster
+than the flusher drains it (storage-api degraded, or a sustained burst
+larger than the cap), new events are dropped with a structured warning
+counter rather than blocking the request hot path. Audit is not on the
+critical correctness path; loss of a few events under sustained
+overload is preferable to defeating the whole point of async ingestion
+by blocking writers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AuditEventQueue:
+    """Bounded in-memory queue for audit events with a background flusher.
+
+    Lifecycle: ``start()`` from FastAPI lifespan startup,
+    ``stop(timeout=...)`` from shutdown. Both are idempotent so a
+    re-import in tests doesn't double-start the task.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_queue_size: int,
+        flush_threshold: int,
+        flush_interval_seconds: float,
+        flush_callable,  # async (events: list[dict]) -> None
+        chunk_size: int = 500,
+    ) -> None:
+        self._max_queue_size = max_queue_size
+        self._flush_threshold = flush_threshold
+        self._flush_interval = flush_interval_seconds
+        self._flush_callable = flush_callable
+        # ``chunk_size`` caps the per-call batch given to ``flush_callable``.
+        # The storage-side ``POST /audit-logs/bulk`` endpoint enforces
+        # ``_MAX_BATCH_SIZE = 500``; if the queue ever holds more than
+        # that (e.g. storage-api was degraded and the queue built up),
+        # a single uncapped flush would 422 and lose every drained
+        # event. Slicing the drained list into chunks keeps each flush
+        # call within the storage cap, and per-chunk failure isolation
+        # means a bad chunk doesn't take down the rest of the drain.
+        # Default matches the storage-side cap exactly; tests pass
+        # ``chunk_size=1`` to exercise the slicing path without
+        # depending on the storage-side constant.
+        self._chunk_size = chunk_size
+        self._queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=max_queue_size)
+        self._flusher_task: asyncio.Task[None] | None = None
+        self._stopping = asyncio.Event()
+        self._dropped_count = 0
+        self._flushed_count = 0
+        self._failed_count = 0
+        self._wake_event = asyncio.Event()  # set when threshold reached
+
+    @property
+    def dropped_count(self) -> int:
+        """Events rejected at enqueue time because the queue was full."""
+        return self._dropped_count
+
+    @property
+    def flushed_count(self) -> int:
+        """Events successfully written via the flush callable."""
+        return self._flushed_count
+
+    @property
+    def failed_count(self) -> int:
+        """Events drained from the queue but lost when the flush callable
+        raised. Distinct from ``dropped_count`` (full-queue rejection)
+        so an operator can distinguish "writers outpacing the flusher"
+        from "storage-api failing the write" in dashboards."""
+        return self._failed_count
+
+    @property
+    def queue_size(self) -> int:
+        return self._queue.qsize()
+
+    def enqueue(self, event: dict) -> None:
+        """Non-blocking enqueue. Drops + warns when the queue is full.
+
+        Synchronous (no ``await``) so callers in fire-and-forget paths
+        don't pay an extra event-loop hop. ``Queue.put_nowait`` returns
+        immediately when there's room; raises ``QueueFull`` otherwise,
+        which we map to a counter + structured warning rather than
+        propagating to the caller (audit isn't on the correctness
+        path; dropping is preferable to blocking the request).
+        """
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            self._dropped_count += 1
+            # Log every 100th drop so a sustained overload produces a
+            # finite, informative log volume rather than one line per
+            # dropped event. A single first-drop line still surfaces
+            # immediately so the issue is visible.
+            if self._dropped_count == 1 or self._dropped_count % 100 == 0:
+                logger.warning(
+                    "audit queue full; dropped %d events so far "
+                    "(max_queue_size=%d, flush behind storage-api?)",
+                    self._dropped_count,
+                    self._max_queue_size,
+                )
+            return
+        # Wake the flusher early when we reach the batch threshold so a
+        # storm doesn't have to wait for the interval timer.
+        if self._queue.qsize() >= self._flush_threshold:
+            self._wake_event.set()
+
+    async def start(self) -> None:
+        """Idempotent: a second call is a no-op."""
+        if self._flusher_task is not None and not self._flusher_task.done():
+            return
+        self._stopping.clear()
+        self._flusher_task = asyncio.create_task(self._flusher_loop(), name="audit-queue-flusher")
+
+    async def stop(self, *, timeout: float = 5.0) -> None:
+        """Signal the flusher to drain pending events and exit.
+
+        Waits up to ``timeout`` seconds for the final flush. If the
+        deadline expires (storage-api hung), the flusher task is
+        cancelled and any still-in-queue events are lost — the
+        alternative is blocking shutdown indefinitely, which would
+        block Cloud Run's revision termination and trigger
+        ``container did not stop in time`` SIGKILL anyway.
+        """
+        if self._flusher_task is None:
+            return
+        self._stopping.set()
+        self._wake_event.set()  # break the loop's wait immediately
+        try:
+            await asyncio.wait_for(self._flusher_task, timeout=timeout)
+        except TimeoutError:
+            logger.warning(
+                "audit queue flusher did not drain within %ss; cancelling",
+                timeout,
+            )
+            self._flusher_task.cancel()
+            try:
+                await self._flusher_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        finally:
+            self._flusher_task = None
+
+    async def _flusher_loop(self) -> None:
+        """Wake on threshold OR interval, drain available events, flush."""
+        while not self._stopping.is_set():
+            try:
+                # Wait for either the threshold-wake event or the
+                # interval timer, whichever fires first. ``wait_for``
+                # propagates ``TimeoutError`` on the interval path; we
+                # catch it and treat as a normal "interval flush" tick.
+                try:
+                    await asyncio.wait_for(self._wake_event.wait(), timeout=self._flush_interval)
+                except TimeoutError:
+                    pass
+                self._wake_event.clear()
+                await self._drain_and_flush()
+            except Exception:
+                # ``_drain_and_flush`` catches per-chunk flush failures
+                # internally (logs + bumps ``_failed_count``) so this
+                # ``except`` only fires on genuinely unexpected errors
+                # — queue corruption, an asyncio internal bug, etc. —
+                # not on transient storage-api blips. The loop must
+                # still survive those, since the alternative is silent
+                # audit ingestion stop.
+                logger.exception("audit flush iteration failed unexpectedly; continuing")
+
+        # Final drain on shutdown — best-effort, bounded by stop()'s
+        # outer timeout.
+        try:
+            await self._drain_and_flush()
+        except Exception:
+            logger.exception("audit shutdown flush failed")
+
+    async def _drain_and_flush(self) -> None:
+        """Drain the queue, then flush in ``chunk_size`` slices.
+
+        Slicing protects against two failure modes that a single-call
+        flush exposes:
+
+        1. Storage-side hard caps: ``POST /audit-logs/bulk`` rejects
+           batches above ``_MAX_BATCH_SIZE`` (500). Without slicing, a
+           queue that built up past 500 (storage-api outage,
+           tenant-A-storm pile-up) would have its entire drained
+           backlog rejected on the first recovery flush.
+        2. Per-chunk failure isolation: a bad chunk (one transient
+           5xx, one bad event after future relaxations) doesn't take
+           down the rest of the drain. Each chunk's success/failure
+           is counted independently in ``_flushed_count`` /
+           ``_failed_count``.
+
+        Failed chunks are NOT requeued — the closure's failure log
+        carries enough detail for an operator to correlate the loss
+        with the upstream cause; requeuing would risk an infinite
+        retry loop on a sustained outage.
+
+        ``task_done()`` is intentionally NOT called here. The
+        documented ``asyncio.Queue.join()`` contract is "wait until
+        all enqueued items have been processed" — calling
+        ``task_done()`` before the flush would let ``join()`` return
+        while events were still buffered in ``events`` and not yet
+        written to storage. Nothing in the codebase calls
+        ``queue.join()`` today; if a future caller wires it for a
+        stricter drain semantic, the right place for ``task_done()``
+        is after the per-chunk flush completes successfully (or
+        explicitly fails). Today's shutdown path uses ``stop()`` +
+        the final ``_drain_and_flush`` call, which doesn't depend on
+        the unfinished-task counter at all.
+        """
+        events: list[dict] = []
+        while True:
+            try:
+                events.append(self._queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        if not events:
+            return
+        for i in range(0, len(events), self._chunk_size):
+            chunk = events[i : i + self._chunk_size]
+            try:
+                await self._flush_callable(chunk)
+                self._flushed_count += len(chunk)
+            except Exception:
+                self._failed_count += len(chunk)
+                # Per-chunk failure logged here (in addition to the
+                # closure's rich-detail log) so a partial drain of N
+                # chunks shows N independent log lines, each naming
+                # the chunk size — a bare ``logger.exception`` from
+                # the loop's outer ``except`` would only fire once
+                # for the first failing chunk and obscure how many
+                # chunks total were lost.
+                logger.exception(
+                    "audit chunk flush failed (chunk_size=%d); events lost",
+                    len(chunk),
+                )
+
+
+# Module-level singleton bound at lifespan startup. Tests that need a
+# different instance can monkeypatch this binding directly.
+_queue_singleton: AuditEventQueue | None = None
+
+
+def get_audit_queue() -> AuditEventQueue | None:
+    """Return the active queue or ``None`` if not initialised.
+
+    ``None`` means audit ingestion is in synchronous-fallback mode —
+    callers in ``log_action`` fall back to the legacy per-event POST
+    path. Used during early startup, in tests that don't wire the
+    queue, and on the synchronous-fallback path during the dual-write
+    rollout window (so a queue-side bug can't drop audit events
+    silently).
+    """
+    return _queue_singleton
+
+
+def set_audit_queue(queue: AuditEventQueue | None) -> None:
+    """Bind / unbind the module-level singleton. Used by lifespan + tests."""
+    global _queue_singleton
+    _queue_singleton = queue

--- a/core-api/src/core_api/services/audit_service.py
+++ b/core-api/src/core_api/services/audit_service.py
@@ -1,8 +1,32 @@
+"""Audit-event ingestion entrypoint.
+
+``log_action`` is the only public surface — every memory mutation calls
+it via the configured ``ServiceHooks`` (see ``core_api.app.lifespan``).
+
+CAURA-628 (2026-04-29): the legacy shape POSTed one audit event per
+mutation directly to ``core-storage-api``. Under bulk storms that
+created up to N HTTP-POSTs-per-bulk-create on the storage-api connection
+pool + serialised tenant B's audit traffic behind tenant A's storm at
+the AlloyDB ``audit_log`` table-level write lock. ``log_action`` now
+enqueues into a process-local ``AuditEventQueue``; a background flusher
+batches events and writes them via ``POST /audit-logs/bulk``.
+
+The synchronous-POST fallback path runs when the queue is not active
+(early startup, tests that didn't wire it, intentional kill-switch via
+``set_audit_queue(None)``). That fallback preserves the legacy
+behaviour byte-for-byte so a queue-side bug can't silently drop audit
+events; an operator can fall back to the legacy path during an incident
+without a redeploy.
+"""
+
+from __future__ import annotations
+
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core_api.clients.storage_client import get_storage_client
+from core_api.services.audit_queue import get_audit_queue
 
 
 async def log_action(
@@ -15,15 +39,30 @@ async def log_action(
     resource_id: UUID | None = None,
     detail: dict | None = None,
 ) -> None:
+    """Record an audit event. Async-batched via queue when available;
+    falls through to a synchronous POST otherwise.
+
+    ``db`` is unused (audit persistence is owned by the storage layer)
+    but kept in the signature for back-compat with the ``ServiceHooks``
+    contract — callers pass it through; switching them all to drop the
+    arg is a separate, scoped change.
+    """
+    payload = {
+        "tenant_id": tenant_id,
+        "agent_id": agent_id,
+        "action": action,
+        "resource_type": resource_type,
+        "resource_id": str(resource_id) if resource_id else None,
+        "detail": detail,
+    }
+    queue = get_audit_queue()
+    if queue is not None:
+        # Non-blocking enqueue. Overflow is mapped to a structured
+        # warning + drop counter inside the queue — the request hot
+        # path stays fast even when storage-api is degraded.
+        queue.enqueue(payload)
+        return
+
+    # Fallback: synchronous POST. Same shape as pre-CAURA-628.
     sc = get_storage_client()
-    await sc.create_audit_log(
-        {
-            "tenant_id": tenant_id,
-            "agent_id": agent_id,
-            "action": action,
-            "resource_type": resource_type,
-            "resource_id": str(resource_id) if resource_id else None,
-            "detail": detail,
-        }
-    )
-    # Note: the storage API handles persistence; no separate commit needed.
+    await sc.create_audit_log(payload)

--- a/core-storage-api/src/core_storage_api/routers/audit.py
+++ b/core-storage-api/src/core_storage_api/routers/audit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 
 from core_storage_api.schemas import AUDIT_LOG_FIELDS, orm_to_dict
 from core_storage_api.services.postgres_service import PostgresService
@@ -12,22 +12,136 @@ from core_storage_api.services.postgres_service import PostgresService
 router = APIRouter(prefix="/audit-logs", tags=["Audit"])
 _svc = PostgresService()
 
+# Required keys on every audit event. Missing any of these used to
+# raise ``KeyError`` deep in ``audit_add_batch`` (and silently lose
+# every other event in the same drained batch); validating at the
+# boundary turns a 500 into a 422 with an actionable index + field
+# list, and protects already-drained valid events from collateral
+# loss.
+_REQUIRED_AUDIT_FIELDS = frozenset({"tenant_id", "action", "resource_type"})
+
+# Hard ceiling on the bulk endpoint so a buggy or malicious caller
+# can't bypass core-api's ``audit_queue_flush_threshold`` (50 default)
+# and submit millions of rows in one INSERT. 500 is a generous
+# multiple of the default flush_threshold and keeps any single INSERT
+# bounded for predictable AlloyDB transaction time.
+_MAX_BATCH_SIZE = 500
+
+
+def _parse_resource_id(rid: object) -> UUID | None:
+    """``UUID(rid)`` with a 422 on a malformed input.
+
+    Pre-422 a malformed ``resource_id`` raised ``ValueError`` and
+    propagated as a 500. On the bulk path that meant one bad event
+    crashed the whole batch — every other valid event drained from
+    the queue alongside it was lost.
+    """
+    if rid is None:
+        return None
+    try:
+        return UUID(rid)  # type: ignore[arg-type]
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid resource_id UUID: {rid!r}",
+        ) from exc
+
 
 @router.post("")
 async def create_audit_log(request: Request) -> dict:
     body: dict = await request.json()
-    resource_id = body.get("resource_id")
-    if resource_id is not None:
-        resource_id = UUID(resource_id)
     await _svc.audit_add(
         tenant_id=body["tenant_id"],
         agent_id=body.get("agent_id"),
         action=body["action"],
         resource_type=body["resource_type"],
-        resource_id=resource_id,
+        resource_id=_parse_resource_id(body.get("resource_id")),
         detail=body.get("detail"),
     )
     return {"ok": True}
+
+
+@router.post("/bulk")
+async def create_audit_logs_bulk(request: Request) -> dict:
+    """Batched audit insert (CAURA-628).
+
+    Accepts ``{"events": [<event>, ...]}`` and persists them in a
+    single multi-row INSERT — one table-lock acquisition + one
+    AlloyDB round-trip regardless of batch size. The legacy per-event
+    endpoint (``POST /audit-logs``) kept for the synchronous-fallback
+    path in core-api's ``log_action``; once core-api is on the queue
+    path everywhere, the legacy endpoint can be retired in a separate
+    cycle.
+
+    Validation happens at the boundary so malformed events surface as
+    422 before the database session opens — protects valid events in
+    the same batch from being rolled back. Order:
+
+      1. Reject non-list payloads.
+      2. Reject batch sizes above ``_MAX_BATCH_SIZE``.
+      3. Walk every event: collect required-field-missing AND
+         malformed-``resource_id`` errors, then raise once with the
+         full list. Caller fixes the whole bad set in one round-trip
+         instead of having to play whack-a-mole one event at a time.
+    """
+    body: dict = await request.json()
+    events = body.get("events") or []
+    # Guard the type explicitly — without this, ``len(events)`` would
+    # raise ``TypeError`` on a non-list (e.g. a caller mis-shaping the
+    # payload as ``{"events": {"0": {...}}}``) and propagate as a 500.
+    if not isinstance(events, list):
+        raise HTTPException(
+            status_code=422,
+            detail=f"'events' must be a list, got {type(events).__name__!r}",
+        )
+    if len(events) > _MAX_BATCH_SIZE:
+        raise HTTPException(
+            status_code=422,
+            detail=(f"Batch too large: {len(events)} events (max {_MAX_BATCH_SIZE})"),
+        )
+    # Pass 1: collect all validation errors. Doing this in two passes
+    # (validate, then normalise) means a caller submitting 50 events
+    # with 3 bad fields gets all 3 errors back in one 422 — no
+    # round-trip-per-fix.
+    errors: list[dict] = []
+    for i, event in enumerate(events):
+        # Per-element type guard: the outer ``isinstance(events, list)``
+        # check above only confirms the container is a list; JSON
+        # arrays can hold arbitrary types, so a payload like
+        # ``{"events": [null, "oops", 123]}`` would crash with
+        # ``AttributeError`` on ``event.keys()`` below and propagate
+        # as a 500. Surface as 422 with a typed error so the caller
+        # can self-diagnose.
+        if not isinstance(event, dict):
+            errors.append(
+                {
+                    "index": i,
+                    "error": (f"event must be an object, got {type(event).__name__!r}"),
+                }
+            )
+            continue
+        missing = _REQUIRED_AUDIT_FIELDS - event.keys()
+        if missing:
+            errors.append({"index": i, "missing_fields": sorted(missing)})
+        rid = event.get("resource_id")
+        if rid is not None:
+            try:
+                UUID(str(rid))
+            except (ValueError, TypeError):
+                errors.append({"index": i, "invalid_resource_id": repr(rid)})
+    if errors:
+        raise HTTPException(status_code=422, detail=errors)
+    # Pass 2: normalise. ``resource_id`` already validated above so
+    # ``UUID(rid)`` here is just the type conversion — no error path.
+    normalised: list[dict] = []
+    for event in events:
+        normalised_event = dict(event)
+        rid = normalised_event.get("resource_id")
+        if rid is not None:
+            normalised_event["resource_id"] = UUID(rid)
+        normalised.append(normalised_event)
+    await _svc.audit_add_batch(normalised)
+    return {"ok": True, "count": len(normalised)}
 
 
 @router.get("")

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2953,6 +2953,37 @@ class PostgresService:
                 )
             )
 
+    async def audit_add_batch(self, events: list[dict]) -> None:
+        """Persist N audit events in one transaction with one INSERT
+        statement (CAURA-628).
+
+        ``session.add_all`` issues a single multi-row INSERT to
+        Postgres, vs ``audit_add`` which opens one transaction +
+        acquires the table write lock once per event. Reducing N
+        per-event lock acquisitions to one batched acquisition is the
+        whole point of the CAURA-628 refactor; the per-event legacy
+        path is preserved for the synchronous-fallback case in
+        core-api's ``log_action``.
+
+        Empty ``events`` short-circuits without touching the
+        database — saves a no-op session open under the audit
+        flusher's interval-driven empty ticks.
+        """
+        if not events:
+            return
+        async with get_session() as session:
+            session.add_all(
+                AuditLog(
+                    tenant_id=event["tenant_id"],
+                    agent_id=event.get("agent_id"),
+                    action=event["action"],
+                    resource_type=event["resource_type"],
+                    resource_id=event.get("resource_id"),
+                    detail=event.get("detail"),
+                )
+                for event in events
+            )
+
     async def audit_list_by_tenant(
         self,
         tenant_id: str,

--- a/tests/test_audit_queue.py
+++ b/tests/test_audit_queue.py
@@ -1,0 +1,310 @@
+"""Tests for core_api.services.audit_queue (CAURA-628).
+
+Covers the in-memory queue + background flusher behaviours that
+``log_action`` relies on:
+
+- enqueue is non-blocking and triggers a flush when the threshold is
+  reached
+- the interval timer also triggers a flush even if the threshold
+  hasn't been hit (steady-state low-volume tenants)
+- shutdown drains pending events
+- queue overflow drops + warns rather than blocking the request hot
+  path
+- flush failures don't kill the loop
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from core_api.services.audit_queue import AuditEventQueue
+
+
+@pytest.mark.asyncio
+async def test_enqueue_triggers_flush_at_threshold() -> None:
+    """When the queue reaches ``flush_threshold``, the flusher wakes
+    immediately rather than waiting for the interval timer."""
+    flushed_batches: list[list[dict]] = []
+
+    async def flush(events: list[dict]) -> None:
+        flushed_batches.append(events)
+
+    q = AuditEventQueue(
+        max_queue_size=100,
+        flush_threshold=3,
+        flush_interval_seconds=10.0,  # well past the threshold trigger
+        flush_callable=flush,
+    )
+    await q.start()
+    try:
+        for i in range(3):
+            q.enqueue({"i": i})
+        # Yield enough cycles for the threshold-wake → drain → flush
+        # callable to run. Two await sleeps cover the wake_event ->
+        # _drain_and_flush path.
+        for _ in range(5):
+            await asyncio.sleep(0)
+    finally:
+        await q.stop()
+
+    # All 3 events landed in (typically) one batch — but the test
+    # is robust to the flusher waking mid-enqueue and producing
+    # multiple batches; what matters is total count.
+    total = sum(len(b) for b in flushed_batches)
+    assert total == 3, f"expected 3 events flushed; got {total} via {flushed_batches!r}"
+
+
+@pytest.mark.asyncio
+async def test_interval_flush_fires_below_threshold() -> None:
+    """Steady-state low-volume tenants must still see their events
+    written — the interval timer flushes pending events even when
+    the threshold isn't hit."""
+    flushed_batches: list[list[dict]] = []
+
+    async def flush(events: list[dict]) -> None:
+        flushed_batches.append(events)
+
+    q = AuditEventQueue(
+        max_queue_size=100,
+        flush_threshold=100,  # never reached in this test
+        flush_interval_seconds=0.05,
+        flush_callable=flush,
+    )
+    await q.start()
+    try:
+        q.enqueue({"only": True})
+        # Wait two interval ticks so the flusher has time to wake on
+        # the timeout path and flush the single event.
+        await asyncio.sleep(0.15)
+    finally:
+        await q.stop()
+
+    total = sum(len(b) for b in flushed_batches)
+    assert total == 1, (
+        f"expected the single event to be flushed; got {flushed_batches!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_drains_pending_events() -> None:
+    """Graceful shutdown must flush whatever is in the queue, not just
+    cancel the loop and lose pending events."""
+    flushed_batches: list[list[dict]] = []
+
+    async def flush(events: list[dict]) -> None:
+        flushed_batches.append(events)
+
+    q = AuditEventQueue(
+        max_queue_size=100,
+        flush_threshold=1000,  # avoid threshold-wake interference
+        flush_interval_seconds=10.0,  # avoid interval-wake interference
+        flush_callable=flush,
+    )
+    await q.start()
+    q.enqueue({"shutdown_pending": True})
+    # No await — go straight to stop() so the event is still in queue.
+    await q.stop()
+
+    total = sum(len(b) for b in flushed_batches)
+    assert total == 1, (
+        f"shutdown drain must flush pending events; got {flushed_batches!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_overflow_drops_and_increments_counter() -> None:
+    """When the queue is full, enqueue drops the new event and bumps
+    the dropped counter — must NOT raise (audit isn't on the
+    correctness path; dropping > blocking the request hot path)."""
+
+    async def flush(events: list[dict]) -> None:
+        pass
+
+    q = AuditEventQueue(
+        max_queue_size=2,
+        flush_threshold=1000,
+        flush_interval_seconds=1000.0,
+        flush_callable=flush,
+    )
+    # Don't start the flusher — we want the queue to actually fill.
+    q.enqueue({"i": 0})
+    q.enqueue({"i": 1})
+    assert q.queue_size == 2
+    assert q.dropped_count == 0
+
+    q.enqueue({"i": 2})  # full
+    q.enqueue({"i": 3})  # still full
+
+    assert q.queue_size == 2
+    assert q.dropped_count == 2
+
+
+@pytest.mark.asyncio
+async def test_flush_callable_failure_does_not_kill_loop() -> None:
+    """A flush callable that raises on the first call must not stop
+    the flusher — subsequent enqueues should still be flushed when
+    the callable starts working again. This is the operational
+    invariant: storage-api blips don't compound into total audit
+    loss. Also verifies ``flushed_count`` and ``failed_count`` are
+    incremented separately so dashboards can distinguish the two."""
+    call_count = 0
+    flushed_batches: list[list[dict]] = []
+
+    async def flush(events: list[dict]) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("simulated storage-api blip")
+        flushed_batches.append(events)
+
+    q = AuditEventQueue(
+        max_queue_size=100,
+        flush_threshold=1,  # flush on every enqueue
+        flush_interval_seconds=10.0,
+        flush_callable=flush,
+    )
+    await q.start()
+    try:
+        q.enqueue({"will_fail": True})  # triggers raise
+        # Give the flusher a chance to log + continue.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        q.enqueue({"will_succeed": True})
+        for _ in range(5):
+            await asyncio.sleep(0)
+    finally:
+        await q.stop()
+
+    assert call_count >= 2, "flusher must have made a 2nd attempt after the failure"
+    # The second event must reach the success path.
+    flat = [e for batch in flushed_batches for e in batch]
+    assert any(e.get("will_succeed") for e in flat), (
+        f"recovery flush must include the second event; got {flushed_batches!r}"
+    )
+    # The first event was drained but lost; the second was written.
+    # Counters split so dashboards can tell the two apart.
+    assert q.failed_count == 1, f"expected 1 failed event; got {q.failed_count}"
+    assert q.flushed_count == 1, f"expected 1 flushed event; got {q.flushed_count}"
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent() -> None:
+    """Re-starting an already-running queue must not double-spawn the
+    flusher task — the lifespan re-import path in tests would
+    otherwise leak a second loop."""
+
+    async def flush(events: list[dict]) -> None:
+        pass
+
+    q = AuditEventQueue(
+        max_queue_size=100,
+        flush_threshold=10,
+        flush_interval_seconds=10.0,
+        flush_callable=flush,
+    )
+    await q.start()
+    try:
+        first_task = q._flusher_task  # type: ignore[attr-defined]
+        await q.start()  # second call
+        second_task = q._flusher_task  # type: ignore[attr-defined]
+        assert first_task is second_task
+    finally:
+        await q.stop()
+
+
+@pytest.mark.asyncio
+async def test_drain_chunks_above_chunk_size() -> None:
+    """``_drain_and_flush`` must slice the drained list into
+    ``chunk_size`` batches so the storage-side ``_MAX_BATCH_SIZE=500``
+    cap is never exceeded — even when the queue built up far past
+    that during a storage-api outage. With ``chunk_size=2`` and 5
+    enqueued events, the flusher must call the callable 3 times
+    (sizes 2, 2, 1), not once with size 5."""
+    flushed_batches: list[list[dict]] = []
+
+    async def flush(events: list[dict]) -> None:
+        flushed_batches.append(list(events))
+
+    q = AuditEventQueue(
+        max_queue_size=100,
+        flush_threshold=1000,  # avoid threshold-wake interference
+        flush_interval_seconds=10.0,  # avoid interval-wake interference
+        flush_callable=flush,
+        chunk_size=2,
+    )
+    await q.start()
+    for i in range(5):
+        q.enqueue({"i": i})
+    # Trigger one drain via shutdown — the threshold/interval timers
+    # are both far away so this is the cleanest path to flush.
+    await q.stop()
+
+    sizes = [len(b) for b in flushed_batches]
+    assert sizes == [2, 2, 1], (
+        f"expected 3 chunks of sizes [2, 2, 1] from chunk_size=2; got {sizes!r}"
+    )
+    assert q.flushed_count == 5
+
+
+@pytest.mark.asyncio
+async def test_chunk_failure_does_not_drop_other_chunks() -> None:
+    """Per-chunk failure isolation: when chunk 1 of N fails, the
+    remaining chunks must still flush. ``_failed_count`` increments
+    by the failed chunk's size; ``_flushed_count`` increments by the
+    successful chunks' sizes."""
+    seen_chunks: list[list[dict]] = []
+
+    async def flush(events: list[dict]) -> None:
+        seen_chunks.append(list(events))
+        # Fail the second chunk only.
+        if len(seen_chunks) == 2:
+            raise RuntimeError("simulated mid-drain blip")
+
+    q = AuditEventQueue(
+        max_queue_size=100,
+        flush_threshold=1000,
+        flush_interval_seconds=10.0,
+        flush_callable=flush,
+        chunk_size=2,
+    )
+    await q.start()
+    for i in range(6):
+        q.enqueue({"i": i})
+    await q.stop()
+
+    assert len(seen_chunks) == 3, (
+        f"all 3 chunks must reach the callable even though chunk 2 raised; "
+        f"got {seen_chunks!r}"
+    )
+    assert q.flushed_count == 4, f"chunks 1+3 flushed = 4 events; got {q.flushed_count}"
+    assert q.failed_count == 2, f"chunk 2 failed = 2 events; got {q.failed_count}"
+
+
+@pytest.mark.asyncio
+async def test_stop_with_hung_flusher_falls_back_to_cancel() -> None:
+    """If the flush callable hangs past the stop() timeout, the queue
+    must cancel the task rather than block shutdown indefinitely.
+    Cloud Run will SIGKILL on container-stop timeout otherwise."""
+
+    flush_started = asyncio.Event()
+
+    async def hung_flush(events: list[dict]) -> None:
+        flush_started.set()
+        await asyncio.sleep(60)  # never returns within the test
+
+    q = AuditEventQueue(
+        max_queue_size=100,
+        flush_threshold=1,
+        flush_interval_seconds=10.0,
+        flush_callable=hung_flush,
+    )
+    await q.start()
+    q.enqueue({"hangs": True})
+    # Wait for the flusher to actually enter the hung callable.
+    await flush_started.wait()
+    # stop() must return within a small multiple of its own timeout
+    # rather than waiting for the hung sleep.
+    await asyncio.wait_for(q.stop(timeout=0.1), timeout=2.0)


### PR DESCRIPTION
## Summary
- The substantive fix for the residual ``noisy-neighbor-write`` cross-tenant contention identified in CAURA-627 deep-dive (after #34 LLM-pool fix + #35 dead-index drop).
- Replaces the per-event audit POST (one HTTP roundtrip + one AlloyDB ``audit_log`` table-lock acquisition per audit) with a process-local ``asyncio.Queue`` + background batched flusher (one HTTP roundtrip + one multi-row INSERT per up-to-50-event batch).
- Tenant B's gentle audit traffic no longer queues behind tenant A's bulk-storm fan-out at the storage-api / AlloyDB layer.

## Architecture

\`\`\`
            BEFORE                                        AFTER
   ─────────────────────────                  ─────────────────────────────────────
   request handler                            request handler
       │                                          │
       └─ track_task(log_action(...))             └─ AuditEventQueue.enqueue()  (sync, O(1))
              │                                          │
              └─ HTTP POST /audit-logs                   ▼
                     │  (×N per bulk)             ┌──────────────┐
                     ▼                            │ flusher loop │  (one task per process)
              core-storage /audit_add             │  - threshold │
              SESSION + INSERT                    │  - interval  │
              (×N table-lock acquires)            └──────┬───────┘
                                                         │
                                                         ▼
                                           HTTP POST /audit-logs/bulk
                                           SESSION + add_all() multi-row INSERT
                                           (1 table-lock acquire per batch)
\`\`\`

## What ships
| Layer | Change |
|---|---|
| **core-api** | New ``services/audit_queue.py`` (queue + flusher); ``log_action`` enqueues; lifespan binds + drains; storage client gains ``create_audit_logs_bulk``; 3 new ``Settings`` env knobs |
| **core-storage-api** | New ``POST /audit-logs/bulk`` endpoint; ``audit_add_batch`` service method using ``session.add_all`` |
| **tests** | ``test_audit_queue.py`` — 7 unit tests covering threshold/interval/shutdown/overflow/failure/idempotent-start/hung-flusher |

## Operational tunables (env-tunable, no redeploy)
| Setting | Default | Purpose |
|---|---|---|
| ``AUDIT_QUEUE_MAX_SIZE`` | 10000 | Per-process queue cap (~2 MiB at default event size). **Set to 0 to disable the queue** → \`log_action\` falls through to the legacy synchronous path. Incident kill-switch. |
| ``AUDIT_QUEUE_FLUSH_THRESHOLD`` | 50 | Events accumulated → flush immediately |
| ``AUDIT_QUEUE_FLUSH_INTERVAL_SECONDS`` | 1.0 | Max staleness before any single event flushes |

## Backwards compat
- ``log_action(db, *, ...)`` signature unchanged. Existing test sites that ``patch(...)`` it keep working.
- Legacy single-event ``POST /audit-logs`` endpoint untouched — it's the synchronous-fallback target.
- Audit-list freshness lag bounded by flush interval (~1s). Acceptable for ``crystallizer_service`` + ``/audit-logs`` list (post-hoc analysis paths; not real-time).

## Expected loadtest impact
- ``noisy-neighbor-write`` (current 8.15×, target ≤2×) — should drop materially. The fan-out from N audit POSTs to 1 batch is the residual cause CAURA-627 isolated.
- ``bulk_write`` retry rate (current 26%, all 429s) — may improve marginally as the storage-api connection pool sees less audit-side pressure.
- Other metrics — should be steady or marginally better.

## Test plan
- [x] 7/7 new audit-queue unit tests pass (threshold, interval, drain, overflow, recovery, idempotent start, hung-flusher cancel)
- [x] 168 audit/memory/bulk tests pass — no regressions
- [x] ruff check + format clean
- [ ] Staging deploy → loadtest → expect ``noisy-neighbor-write`` to drop below 5×
- [ ] If regression: ``AUDIT_QUEUE_MAX_SIZE=0`` env var falls back to legacy synchronous path with no redeploy

## Out of scope
- Durability: events in flight at process kill are lost. Acceptable for audit (post-hoc analysis); if durability becomes critical later, swap the in-memory queue for a Pub/Sub publisher (same shape, different transport).
- Retiring the legacy ``POST /audit-logs`` endpoint — kept for synchronous fallback during the rollout window. Can retire in a separate cycle once the queue path is proven across multiple loadtests.