### PR TITLE
fix(contradiction): scope candidate fetch by writer visibility

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -188,6 +188,10 @@ async def _detect(
                 "tenant_id": tenant_id,
                 "fleet_id": new_memory.get("fleet_id"),
                 "embedding": embedding,
+                # Scope candidates to the writer's visibility tier — prevents
+                # scope_org/scope_agent writes from being marked as superseding
+                # scope_team memories (cross-scope chain pollution).
+                "visibility": new_memory.get("visibility", "scope_team"),
             }
         )
         if candidates:
@@ -359,6 +363,8 @@ async def detect_contradictions_by_entities_async(
                 "memory_id": str(memory_id),
                 "tenant_id": tenant_id,
                 "fleet_id": fleet_id,
+                # Same visibility scoping as the semantic path above.
+                "visibility": new_memory.get("visibility", "scope_team"),
             }
         )
         if not candidates:

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -210,6 +210,7 @@ async def find_entity_overlap_candidates(request: Request) -> list[dict]:
         memory_id=UUID(body["memory_id"]),
         tenant_id=body["tenant_id"],
         fleet_id=body.get("fleet_id"),
+        visibility=body.get("visibility", "scope_team"),
         limit=body.get("limit", 8),
     )
     return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1041,12 +1041,15 @@ class PostgresService:
         memory_id: UUID,
         tenant_id: str,
         fleet_id: str | None = None,
+        visibility: str = "scope_team",
         limit: int = CONTRADICTION_CANDIDATE_MAX,
     ) -> list[Memory]:
         """Find active memories sharing entities with the given memory by entity name.
 
         Joins through Entity.canonical_name to find overlap. When fleet_id is
-        provided, candidates are scoped to the same fleet.
+        provided, candidates are scoped to the same fleet. ``visibility``
+        scopes candidates to the writer's visibility tier so a scope_org
+        write can't be linked into a scope_team chain (and vice versa).
         """
         async with get_session() as session:
             # Subquery: canonical names of entities linked to the target memory
@@ -1079,6 +1082,7 @@ class PostgresService:
                     Memory.id != memory_id,
                     Memory.deleted_at.is_(None),
                     Memory.status.in_(("active", "confirmed", "pending")),
+                    Memory.visibility == visibility,
                     *([Memory.fleet_id == fleet_id] if fleet_id else []),
                 )
                 .group_by(Memory.id)


### PR DESCRIPTION
The semantic and entity-overlap contradiction paths fetched candidates without forwarding the writer's `visibility`. The storage layer fell back to its default ("scope_team"), which had two consequences:

1. scope_org and scope_agent peers were invisible to each other — real contradictions silently missed.
2. A scope_org write whose content was similar to an existing scope_team memory could be marked as superseding it (its `supersedes_id` would point into a scope_team chain). That is a visibility-boundary violation: scope_org rows linked into scope_team supersession chains.

This change forwards `new_memory.visibility` from
`detect_contradictions_async` and `detect_contradictions_by_entities_async` into both `find_similar_candidates` and the new `visibility` parameter on `find_entity_overlap_candidates` (which previously had no visibility predicate at all). The storage layer applies `Memory.visibility == visibility`, mirroring the pattern already in `find_similar_candidates`.

Wet-tested locally:
- A_team (scope_team), A_org (scope_org peer), B_org (scope_org write contradicting A_org).
- After fix: A_org becomes `conflicted`, B_org.supersedes_id points to A_org. A_team stays `active` with no incoming link. Pre-fix, A_org was untouched and B_org.supersedes_id pointed at A_team.

Note: scope_agent semantics still rely on strict
`Memory.visibility == visibility` equality, so a scope_agent writer will currently match other agents' scope_agent rows in the same tenant. Worth a follow-up adding `caller_agent_id` to both candidate queries and applying the same visibility predicate used in `memory_repository`. Out of scope here to keep this PR focused on the cross-scope pollution issue.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
