### PR TITLE
fix(write): str() subject_entity_id before storage POST

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
+++ b/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
@@ -57,7 +57,7 @@ class WriteMemoryRow:
             "metadata_": metadata,
             "content_hash": ch,
             "expires_at": str(data.expires_at) if data.expires_at else None,
-            "subject_entity_id": data.subject_entity_id,
+            "subject_entity_id": str(data.subject_entity_id) if data.subject_entity_id else None,
             "predicate": data.predicate,
             "object_value": data.object_value,
             "ts_valid_start": str(fields["ts_valid_start"]) if fields.get("ts_valid_start") else None,


### PR DESCRIPTION
write_memory_row passed `data.subject_entity_id` (a Pydantic-parsed `UUID` object) directly into the dict it sends to the storage HTTP client. The client uses `httpx.post(json=...)`, which falls through to stdlib `json.dumps()` — and stdlib JSON cannot serialize a UUID, so any write request that set `subject_entity_id` crashed with:

    TypeError: Object of type UUID is not JSON serializable

The pipeline step's exception left `ctx.data["memory"]` unset, and the route handler later raised `KeyError: 'memory'`, surfacing as a generic HTTP 500 to the caller.

Adjacent fields (`expires_at`, `ts_valid_start`, `ts_valid_end`) already wrap the value in `str(...)` for the same reason; this field was missed in that pattern.

The bug was latent — the MCP `memclaw_write` tool deliberately doesn't expose `subject_entity_id`, and HTTP callers who tried to set it crashed and stopped trying. So no production traffic hit this today. But it does prevent any HTTP caller from populating the RDF columns at all, which is the actual reason the path-1 contradiction detection looks dormant in practice.

Wet-tested locally:
- POST /api/v1/memories with `subject_entity_id` set → pre-fix: HTTP 500 (KeyError: 'memory') post-fix: HTTP 201, columns persisted correctly via both core-api response and storage API direct readback.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
