### PR TITLE
fix(api): include visibility in GET /memories/{memory_id} response

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -571,6 +571,7 @@ async def get_memory(
             "ts_valid_start": memory.ts_valid_start.isoformat() if memory.ts_valid_start else None,
             "ts_valid_end": memory.ts_valid_end.isoformat() if memory.ts_valid_end else None,
             "status": memory.status,
+            "visibility": memory.visibility,
             "recall_count": memory.recall_count,
             "last_recalled_at": memory.last_recalled_at.isoformat() if memory.last_recalled_at else None,
             "supersedes_id": str(memory.supersedes_id) if memory.supersedes_id else None,


### PR DESCRIPTION
The single-memory GET route's hand-built JSON dict omitted the `visibility` field even though the underlying `Memory` model column is set on every row, the schema's `MemoryOut` declares it, and adjacent fields (`status`, `subject_entity_id`, etc.) are already returned. Callers reading a memory by id had no way to see which visibility tier it lives in without going through the storage API on a different port.

Wet-tested locally: write with `visibility=scope_org`, GET, the
response now contains `"visibility": "scope_org"`.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
