### PR TITLE
fix(contradiction): preserve direction invariant on re-fired detection

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -12,6 +12,7 @@ Multi-provider support:
 
 import asyncio
 import logging
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,6 +24,39 @@ from core_api.providers._retry import call_with_fallback
 from core_api.schemas import ContradictionInfo
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_dt(value) -> datetime | None:
+    """Best-effort parse of an ISO datetime string or pass-through datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def _candidate_is_older(candidate: dict, new_memory: dict) -> bool:
+    """Return True only if ``candidate`` was created strictly before ``new_memory``.
+
+    Enforces the supersession-direction invariant: ``NEW.supersedes_id = OLD.id``
+    (CAURA-000). Detection has four call sites, two of them event-driven
+    (``MemoryEnriched`` / ``MemoryEmbedded`` consumers), so it can fire on a row
+    long after that row was written — by which time newer contradicting rows
+    may exist. Without this guard, the detector would happily mark the newer
+    candidate as ``outdated`` and write ``older.supersedes_id = newer.id``,
+    inverting the chain and producing cycles like ``A → B → A``.
+
+    If either timestamp is missing or unparseable we conservatively return
+    False — a missed detection is cheaper than a corrupted chain.
+    """
+    cand_dt = _parse_dt(candidate.get("created_at"))
+    new_dt = _parse_dt(new_memory.get("created_at"))
+    if cand_dt is None or new_dt is None:
+        return False
+    return cand_dt < new_dt
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +184,10 @@ async def _detect(
             exclude_id=str(memory_id),
         )
         for old in rdf_conflicts:
+            if not _candidate_is_older(old, new_memory):
+                # Skip: candidate is newer than us. Marking it outdated and
+                # writing our supersedes_id at it would invert direction.
+                continue
             old_id = old.get("id")
             # Mark old memory as outdated via storage client
             await sc.update_memory_status(str(old_id), "outdated")
@@ -214,6 +252,9 @@ async def _detect(
                     )
                     continue
                 if result:
+                    if not _candidate_is_older(candidate, new_memory):
+                        # Same direction-invariant guard as path 1.
+                        continue
                     cand_id = candidate.get("id")
                     # Mark candidate as conflicted via storage client
                     await sc.update_memory_status(str(cand_id), "conflicted")
@@ -389,6 +430,9 @@ async def detect_contradictions_by_entities_async(
                 )
                 continue
             if result:
+                if not _candidate_is_older(candidate, new_memory):
+                    # Same direction-invariant guard as paths 1 and 2.
+                    continue
                 cand_id = candidate.get("id")
                 await sc.update_memory_status(str(cand_id), "conflicted")
                 if not found:

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -566,7 +566,13 @@ async def update_memory_status(memory_id: UUID, request: Request) -> dict:
     supersedes_id = body.get("supersedes_id")
     # Update status
     await _svc.memory_update_status(memory_id, status)
-    # If supersedes_id is provided, also set that field via a direct update
+    # If supersedes_id is provided, also set that field via a direct update.
+    # Compare-and-swap (``WHERE supersedes_id IS NULL``) makes this idempotent:
+    # the first detection to land owns the chain, later re-fires on the same
+    # row become no-ops at the DB. Pairs with the created_at direction
+    # invariant in core_api.services.contradiction_detector to defend the
+    # CAURA-000 ``NEW.supersedes_id = OLD.id`` rule against re-fired
+    # detection on already-resolved memories (consumer-event paths).
     if supersedes_id is not None:
         from sqlalchemy import update as sql_update
 
@@ -575,7 +581,9 @@ async def update_memory_status(memory_id: UUID, request: Request) -> dict:
 
         async with get_session() as session:
             await session.execute(
-                sql_update(Memory).where(Memory.id == memory_id).values(supersedes_id=UUID(supersedes_id))
+                sql_update(Memory)
+                .where(Memory.id == memory_id, Memory.supersedes_id.is_(None))
+                .values(supersedes_id=UUID(supersedes_id))
             )
     return {"ok": True}
 

--- a/tests/test_p1_contradiction.py
+++ b/tests/test_p1_contradiction.py
@@ -119,6 +119,7 @@ class TestSupersessionSemantics:
             "content": "Alice lives in Tel Aviv",
             "status": "active",
             "object_value": "Tel Aviv",
+            "created_at": "2026-04-29T11:00:00+00:00",
         }
 
         new_memory = {
@@ -131,6 +132,7 @@ class TestSupersessionSemantics:
             "content": "Alice lives in Haifa",
             "supersedes_id": None,
             "status": "active",
+            "created_at": "2026-04-29T12:00:00+00:00",
         }
 
         mock_sc = AsyncMock()
@@ -165,12 +167,14 @@ class TestSupersessionSemantics:
             "content": "Alice lives in Tel Aviv",
             "status": "active",
             "object_value": "Tel Aviv",
+            "created_at": "2026-04-29T10:00:00+00:00",
         }
         old_mem_2 = {
             "id": old_id_2,
             "content": "Alice lives in Jerusalem",
             "status": "active",
             "object_value": "Jerusalem",
+            "created_at": "2026-04-29T11:00:00+00:00",
         }
 
         new_memory = {
@@ -183,6 +187,7 @@ class TestSupersessionSemantics:
             "content": "Alice lives in Haifa",
             "supersedes_id": None,
             "status": "active",
+            "created_at": "2026-04-29T12:00:00+00:00",
         }
 
         mock_sc = AsyncMock()
@@ -219,6 +224,7 @@ class TestSupersessionSemantics:
             "id": old_id,
             "content": "Redis cache hit ratio is 95%",
             "status": "active",
+            "created_at": "2026-04-29T11:00:00+00:00",
         }
 
         new_memory = {
@@ -231,6 +237,7 @@ class TestSupersessionSemantics:
             "content": "Redis cache hit ratio is not 95% anymore",
             "supersedes_id": None,
             "status": "active",
+            "created_at": "2026-04-29T12:00:00+00:00",
         }
 
         mock_sc = AsyncMock()
@@ -266,11 +273,13 @@ class TestSupersessionSemantics:
             "id": old_id_1,
             "content": "The project deadline is Friday",
             "status": "active",
+            "created_at": "2026-04-29T10:00:00+00:00",
         }
         old_mem_2 = {
             "id": old_id_2,
             "content": "The project deadline is Thursday",
             "status": "active",
+            "created_at": "2026-04-29T11:00:00+00:00",
         }
 
         new_memory = {
@@ -283,6 +292,7 @@ class TestSupersessionSemantics:
             "content": "The project deadline is Monday",
             "supersedes_id": None,
             "status": "active",
+            "created_at": "2026-04-29T12:00:00+00:00",
         }
 
         mock_sc = AsyncMock()

--- a/tests/test_single_value_predicates.py
+++ b/tests/test_single_value_predicates.py
@@ -169,6 +169,7 @@ def _make_memory(**kwargs):
         "deleted_at": None,
         "visibility": kwargs.get("visibility", "scope_team"),
         "supersedes_id": None,
+        "created_at": kwargs.get("created_at", "2026-04-29T12:00:00+00:00"),
     }
 
 
@@ -190,6 +191,7 @@ class TestRdfPathGating:
             predicate="lives_in",
             object_value="Tel Aviv",
             subject_entity_id=subject_id,
+            created_at="2026-04-29T11:00:00+00:00",
         )
 
         mock_sc = AsyncMock()
@@ -249,6 +251,7 @@ class TestRdfPathGating:
             predicate="Lives_In",
             object_value="Tel Aviv",
             subject_entity_id=subject_id,
+            created_at="2026-04-29T11:00:00+00:00",
         )
 
         mock_sc = AsyncMock()
@@ -305,6 +308,7 @@ class TestRdfPathGating:
             predicate="scored",
             object_value="6.2",
             subject_entity_id=subject_id,
+            created_at="2026-04-29T11:00:00+00:00",
         )
 
         mock_sc = AsyncMock()

--- a/tests/test_visibility_contradiction.py
+++ b/tests/test_visibility_contradiction.py
@@ -259,12 +259,14 @@ class TestSupersessionFirstMatchOnly:
             "content": "X lives in Tel Aviv",
             "status": "active",
             "object_value": "Tel Aviv",
+            "created_at": "2026-04-29T10:00:00+00:00",
         }
         old_mem_2 = {
             "id": old_id_2,
             "content": "X lives in Jerusalem",
             "status": "active",
             "object_value": "Jerusalem",
+            "created_at": "2026-04-29T11:00:00+00:00",
         }
 
         new_memory = {
@@ -279,6 +281,7 @@ class TestSupersessionFirstMatchOnly:
             "status": "active",
             "visibility": "scope_team",
             "supersedes_id": None,
+            "created_at": "2026-04-29T12:00:00+00:00",
         }
 
         mock_sc = AsyncMock()
@@ -326,11 +329,13 @@ class TestSupersessionFirstMatchOnly:
             "id": old_id_1,
             "content": "The project deadline is Friday",
             "status": "active",
+            "created_at": "2026-04-29T10:00:00+00:00",
         }
         old_mem_2 = {
             "id": old_id_2,
             "content": "The project deadline is Thursday",
             "status": "active",
+            "created_at": "2026-04-29T11:00:00+00:00",
         }
 
         new_memory = {
@@ -345,6 +350,7 @@ class TestSupersessionFirstMatchOnly:
             "status": "active",
             "visibility": "scope_team",
             "supersedes_id": None,
+            "created_at": "2026-04-29T12:00:00+00:00",
         }
 
         mock_sc = AsyncMock()


### PR DESCRIPTION
`detect_contradictions_async` is reachable from four call sites — the write pipeline (`schedule_background_tasks.py`), the inline path in `memory_service.py`, and two consumer event handlers (`MemoryEnriched`, `MemoryEmbedded`). The detector treats its `memory_id` argument as "the new memory" by positional convention, unconditionally writing `memory_id.supersedes_id = candidate.id` when the LLM/RDF check fires.

That convention is safe at write time, but the consumer entry points can re-fire detection on the same row long after write — for example when a delayed enrichment retry re-publishes `MemoryEnriched`. By that point newer contradicting rows may exist, so the detector picks one of *them* as a "candidate" and writes:

    older.status        = "outdated" / "conflicted"
    older.supersedes_id = newer.id

inverting CAURA-000's `NEW.supersedes_id = OLD.id` rule. Two such re-fires on a pair (A, B) produce a cycle: `A.supersedes_id = B`, `B.supersedes_id = A`. The single-hop successor lookup at search time terminates, but the chain is logically broken — both rows in the pair end up `conflicted`, neither canonically "current."

This commit adds two layers of defense.

(1) Direction invariant in the detector. A small helper `_candidate_is_older(candidate, new_memory)` parses both `created_at` timestamps and returns True only when the candidate is strictly older. Each of the three detection paths (RDF, semantic, entity-overlap) skips the iteration when this is False, so neither the candidate's status nor `new_memory.supersedes_id` is touched when re-firing on the older side of an existing pair. If either timestamp is missing/unparseable we conservatively skip — a missed detection is cheaper than a corrupted chain.

(2) Compare-and-swap in the storage UPDATE. The
`PATCH /memories/{id}/status` route now sets `supersedes_id` only when the row's current value `IS NULL`. First detection to land owns the chain; later writers become idempotent no-ops at the DB. Backstops the detector guard against any future call site that might bypass it.

Wet-tested locally:
- Write A then B (negation), confirm CAURA-000 baseline: A.status=conflicted, supersedes_id=null
    B.status=active,    supersedes_id=A.id
- Re-fire `detect_contradictions_async(memory_id=A.id, …)` directly
  via in-container python — simulating a late event redelivery on
  the older row.
- Post re-fire (with this fix): both rows unchanged. Pre-fix would
  have flipped B to `conflicted` and set A.supersedes_id = B.id.

Distinct from H3 (concurrent paths racing within a single detection run). This is original-detection vs re-fired-detection across unbounded time, with a much wider race window.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
