### PR TITLE
fix(memories): apply visibility scoping to memory count endpoints (CAURA-000)

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -82,8 +82,22 @@ MEMORY_STATUSES_PATTERN = (
 )
 
 # ── Memory visibility levels ──
-MEMORY_VISIBILITIES = ("scope_agent", "scope_team", "scope_org")
-MEMORY_VISIBILITIES_PATTERN = r"^(scope_agent|scope_team|scope_org)$"
+# Named constants are the SoT — ``MEMORY_VISIBILITIES`` and the regex below
+# derive from them so a rename here propagates to membership checks and
+# the Pydantic pattern automatically. SQL filters and any other call
+# site should import the named constant rather than the bare string so
+# a typo turns into a NameError at import time, not a silent miss.
+MEMORY_VISIBILITY_SCOPE_AGENT = "scope_agent"
+MEMORY_VISIBILITY_SCOPE_TEAM = "scope_team"
+MEMORY_VISIBILITY_SCOPE_ORG = "scope_org"
+MEMORY_VISIBILITIES = (
+    MEMORY_VISIBILITY_SCOPE_AGENT,
+    MEMORY_VISIBILITY_SCOPE_TEAM,
+    MEMORY_VISIBILITY_SCOPE_ORG,
+)
+MEMORY_VISIBILITIES_PATTERN = (
+    f"^({MEMORY_VISIBILITY_SCOPE_AGENT}|{MEMORY_VISIBILITY_SCOPE_TEAM}|{MEMORY_VISIBILITY_SCOPE_ORG})$"
+)
 
 MAX_CONTENT_LENGTH = 10000
 CHUNKING_THRESHOLD_CHARS = 2000  # content above this triggers auto-chunking

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import httpx
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
-from sqlalchemy import func, select, tuple_, update
+from sqlalchemy import and_, func, or_, select, tuple_, update
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.exc import TimeoutError as SQLATimeoutError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,7 +17,13 @@ from common.models.memory import Memory
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings as app_settings
-from core_api.constants import DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT
+from core_api.constants import (
+    DEFAULT_LIST_LIMIT,
+    MAX_LIST_LIMIT,
+    MEMORY_VISIBILITY_SCOPE_AGENT,
+    MEMORY_VISIBILITY_SCOPE_ORG,
+    MEMORY_VISIBILITY_SCOPE_TEAM,
+)
 from core_api.db.session import get_db
 from core_api.middleware.idempotency import (
     IDEMPOTENCY_HEADER,
@@ -145,7 +151,21 @@ async def list_fleets(
         if not auth.tenant_id:
             raise HTTPException(status_code=400, detail="tenant_id is required")
         tenant_id = auth.tenant_id
-    filters = [Memory.deleted_at.is_(None), Memory.fleet_id.isnot(None)]
+    filters = [
+        Memory.deleted_at.is_(None),
+        Memory.fleet_id.isnot(None),
+        # No ``agent_id`` accepted on this route, so there's no caller
+        # identity that could legitimately see ``scope_agent`` rows.
+        # Exclude them the same way ``memory_repository.list_by_filters``
+        # does (line 137) and ``/memories/stats`` does. Without this,
+        # ``memory_count``/``agent_count`` overstate what
+        # ``GET /api/v1/memories?fleet_id=X`` would actually return.
+        # ``Memory.visibility`` is ``nullable=False`` with a server
+        # default (common/models/memory.py:62-66), so the SQL three-
+        # valued-logic pitfall (NULL != 'scope_agent' = NULL → row
+        # silently dropped) doesn't apply here.
+        Memory.visibility != MEMORY_VISIBILITY_SCOPE_AGENT,
+    ]
     if tenant_id:
         filters.append(Memory.tenant_id == tenant_id)
     rows = (
@@ -275,7 +295,35 @@ async def memory_stats(
     if fleet_id:
         filters.append(Memory.fleet_id == fleet_id)
     if agent_id:
+        # ``agent_id`` doubles as visibility identity AND author filter
+        # (mirrors ``list_memories`` above, which forwards it as both
+        # ``caller_agent_id`` and ``written_by`` to ``list_by_filters``).
+        # Mirror ``list_by_filters``'s visibility whitelist explicitly
+        # (memory_repository.py:125-134) so any future restricted
+        # visibility value (e.g. ``scope_private``) is excluded from
+        # both the list and the count, instead of recreating the
+        # count-vs-list mismatch this PR fixes.
         filters.append(Memory.agent_id == agent_id)
+        filters.append(
+            or_(
+                Memory.visibility == MEMORY_VISIBILITY_SCOPE_ORG,
+                Memory.visibility == MEMORY_VISIBILITY_SCOPE_TEAM,
+                and_(
+                    Memory.visibility == MEMORY_VISIBILITY_SCOPE_AGENT,
+                    Memory.agent_id == agent_id,
+                ),
+            )
+        )
+    else:
+        # No identified caller — exclude ``scope_agent`` rows the same
+        # way ``memory_repository.list_by_filters`` does (line 137).
+        # Without this, ``/memories/stats.total`` counts agent-scoped
+        # memories that ``/memories`` never returns, producing the
+        # count-vs-list mismatch the Prism browser surfaces (see
+        # CAURA-000-stats-visibility-scope-agent).
+        # ``Memory.visibility`` is ``nullable=False`` (see model), so
+        # ``!=`` is safe — no rows can be silently NULL-dropped here.
+        filters.append(Memory.visibility != MEMORY_VISIBILITY_SCOPE_AGENT)
     if memory_type:
         filters.append(Memory.memory_type == memory_type)
     if status:

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -118,6 +118,50 @@ async def test_list_fleets(client):
             assert f["agent_count"] == 2
 
 
+async def test_list_fleets_excludes_scope_agent(client):
+    # Regression: ``GET /api/v1/fleets`` previously had no visibility
+    # predicate, so its ``memory_count`` / ``agent_count`` overstated
+    # what ``GET /api/v1/memories?fleet_id=X`` would actually return —
+    # the same count-vs-list mismatch the Prism browser surfaced for
+    # ``/memories/stats``. The route accepts no ``agent_id``, so there
+    # is no caller identity that could legitimately see scope_agent rows.
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fid = f"fleet-vis-{tag}"
+
+    async def _post(agent: str, visibility: str, content: str) -> None:
+        resp = await client.post(
+            "/api/v1/memories",
+            json={
+                "tenant_id": tenant_id,
+                "content": f"{content} [{tag}]",
+                "agent_id": agent,
+                "fleet_id": fid,
+                "memory_type": "fact",
+                "visibility": visibility,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201, f"Write failed: {resp.text}"
+
+    await _post(f"alice-{tag}", "scope_agent", "alice private")
+    await _post(f"bob-{tag}", "scope_agent", "bob private")
+    await _post(f"shared-{tag}", "scope_org", "team-wide")
+
+    resp = await client.get(
+        f"/api/v1/fleets?tenant_id={tenant_id}",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    fleets = resp.json()
+    target = next((f for f in fleets if f["fleet_id"] == fid), None)
+    assert target is not None, f"fleet {fid} not in /fleets response"
+    # Only the scope_org memory is visible to an unidentified caller.
+    # Without the visibility filter this would be 3 / 3.
+    assert target["memory_count"] == 1
+    assert target["agent_count"] == 1
+
+
 async def test_dispatch_command(client):
     """Register node, POST command, GET commands → command appears."""
     tenant_id, headers = get_test_auth()

--- a/tests/test_api_memories.py
+++ b/tests/test_api_memories.py
@@ -485,3 +485,111 @@ async def test_memory_stats(client):
     assert "by_agent" in data
     assert data["by_type"].get("fact", 0) >= 2
     assert data["by_type"].get("episode", 0) >= 1
+
+
+async def test_memory_stats_excludes_scope_agent_when_caller_unidentified(client):
+    # Regression: ``GET /api/v1/memories/stats`` previously had no
+    # visibility predicate, so it counted ``scope_agent`` rows that
+    # ``GET /api/v1/memories`` (which mirrors
+    # ``memory_repository.list_by_filters``) excludes when no
+    # ``agent_id`` is in the URL. Result: Prism showed inflated counts
+    # alongside a list view that hid the same rows.
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet = f"stats-vis-fleet-{tag}"
+
+    async def _post(agent: str, visibility: str, content: str) -> None:
+        resp = await client.post(
+            "/api/v1/memories",
+            json={
+                "tenant_id": tenant_id,
+                "content": f"{content} [{tag}]",
+                "agent_id": agent,
+                "fleet_id": fleet,
+                "memory_type": "fact",
+                "visibility": visibility,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201, f"Write failed: {resp.text}"
+
+    await _post(f"alice-{tag}", "scope_agent", "alice private")
+    await _post(f"bob-{tag}", "scope_agent", "bob private")
+    await _post(f"shared-{tag}", "scope_org", "team-wide")
+
+    list_resp = await client.get(
+        f"/api/v1/memories?tenant_id={tenant_id}&fleet_id={fleet}",
+        headers=headers,
+    )
+    assert list_resp.status_code == 200
+    items = list_resp.json().get("items", [])
+
+    stats_resp = await client.get(
+        f"/api/v1/memories/stats?tenant_id={tenant_id}&fleet_id={fleet}",
+        headers=headers,
+    )
+    assert stats_resp.status_code == 200
+    stats = stats_resp.json()
+
+    assert stats["total"] == len(items), (
+        f"stats total ({stats['total']}) must match list length ({len(items)}); "
+        f"mismatch indicates /memories/stats is missing the visibility predicate "
+        f"that /memories applies via list_by_filters."
+    )
+    # Anchor the expected behavior: only the scope_org row is visible to
+    # an unidentified caller. If this assertion fires, the visibility
+    # contract itself has changed (not just stats vs list parity).
+    assert stats["total"] == 1, (
+        f"expected 1 visible memory (scope_org only) when no agent_id is passed, "
+        f"got {stats['total']}"
+    )
+
+
+async def test_memory_stats_with_agent_id_includes_own_scope_agent(client):
+    # Companion to the above: when ``agent_id`` IS passed, the caller can
+    # see their own ``scope_agent`` rows (mirrors list_by_filters lines
+    # 122-135). Stats must agree with the list under the same filter.
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet = f"stats-vis-own-fleet-{tag}"
+    alice = f"alice-{tag}"
+    bob = f"bob-{tag}"
+
+    async def _post(agent: str, visibility: str, content: str) -> None:
+        resp = await client.post(
+            "/api/v1/memories",
+            json={
+                "tenant_id": tenant_id,
+                "content": f"{content} [{tag}]",
+                "agent_id": agent,
+                "fleet_id": fleet,
+                "memory_type": "fact",
+                "visibility": visibility,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201, f"Write failed: {resp.text}"
+
+    await _post(alice, "scope_agent", "alice private")
+    await _post(alice, "scope_org", "alice public")
+    await _post(bob, "scope_agent", "bob private")
+
+    list_resp = await client.get(
+        f"/api/v1/memories?tenant_id={tenant_id}&fleet_id={fleet}&agent_id={alice}",
+        headers=headers,
+    )
+    assert list_resp.status_code == 200
+    items = list_resp.json().get("items", [])
+
+    stats_resp = await client.get(
+        f"/api/v1/memories/stats?tenant_id={tenant_id}&fleet_id={fleet}&agent_id={alice}",
+        headers=headers,
+    )
+    assert stats_resp.status_code == 200
+    stats = stats_resp.json()
+
+    assert stats["total"] == len(items)
+    # Both endpoints scope to "memories alice authored" (agent_id doubles
+    # as author + visibility identity), so bob's scope_agent row is
+    # excluded and alice sees both her own.
+    assert stats["total"] == 2


### PR DESCRIPTION
## Summary
Two count endpoints diverged from the tenant-facing list view by missing the visibility predicate that `memory_repository.list_by_filters` applies (line 137). Both surfaced the same user-visible symptom: the count widget showed more rows than the list view next to it.

| Endpoint | Bug | Fix |
|---|---|---|
| `GET /api/v1/memories/stats` | Counted `scope_agent` rows when no `agent_id` was in the URL | When `agent_id` omitted, append `Memory.visibility != "scope_agent"` (mirrors list endpoint). When `agent_id` present, author equality dominates — keep existing `Memory.agent_id == agent_id`. |
| `GET /api/v1/fleets` | Per-fleet `memory_count` / `agent_count` counted `scope_agent` rows | No `agent_id` accepted → unconditionally exclude `scope_agent` (the `else` branch of the stats fix). |

User-visible: in the Prism memory browser, the sidebar count showed e.g. **4** while the table rendered only **1** row.

## Diagnosis trace
- `routes/memories.py:256-311` (memory_stats) and `routes/memories.py:134-163` (list_fleets) — both apply `Memory.deleted_at.is_(None)` plus equality filters but no visibility predicate.
- `repositories/memory_repository.py:122-157` (list_by_filters) — applies the visibility predicate based on `caller_agent_id`.
- The two paths diverged precisely when the URL omits `agent_id` — the scenario Prism's default view triggers.

## Scope
Only the tenant-facing endpoints are patched. The admin variants (`/admin/memories/stats`, `/admin/fleets`) are intentionally left unscoped — they mirror `admin_list_memories` (line 1484-1548), which also ignores visibility because admins see everything by design.

## Out of scope
- `memory_count_all` / `memory_distinct_agent_count` soft-delete leak in the **public** `/api/stats` landing-page counter — a different bug on a different endpoint, addressed by branch `CAURA-000-public-counters-exclude-deleted` (commit `ff42e6f`).

## Test plan
- [x] `test_memory_stats_excludes_scope_agent_when_caller_unidentified` — writes 1 `scope_org` + 2 `scope_agent` (different agents), asserts `stats.total == len(list.items) == 1` for an unidentified caller.
- [x] `test_memory_stats_with_agent_id_includes_own_scope_agent` — asserts the agent-scoped path matches list semantics (alice sees her own `scope_org` + `scope_agent` = 2; bob's `scope_agent` excluded).
- [x] `test_list_fleets_excludes_scope_agent` — writes 2 `scope_agent` + 1 `scope_org` into one fleet, asserts `memory_count == 1` and `agent_count == 1` (was 3/3 pre-fix).
- [x] Existing `test_memory_stats` and `test_list_fleets` still pass (default `scope_team` writes are unaffected).
- [x] `ruff check` + `ruff format --check` clean on `core-api/src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)