### PR TITLE
ci(release): retag AR images at :vX.Y.Z on GitHub Release publish (CAURA-634)

### DIFF
--- a/.github/workflows/retag-ar-on-release.yml
+++ b/.github/workflows/retag-ar-on-release.yml
@@ -1,0 +1,88 @@
+name: retag-ar-on-release
+
+# When release-please cuts a GitHub Release, this workflow re-tags the
+# already-built staging AR image with the new :vX.Y.Z tag — giving the
+# prod runbook a stable promote-this-tag handle.
+#
+# Done as a separate workflow (rather than inline in release-please.yml)
+# because release-please-action creates the GitHub Release tag via
+# GITHUB_TOKEN, which DOES trigger `on: release: published` even though
+# it does NOT trigger `on: push: tags`. Two-step "cut release then
+# retag" stays loosely coupled and survives a retag failure without
+# blocking the release-please run.
+#
+# Manual workflow_dispatch is provided for re-tagging a specific
+# version after a registry hiccup or to bootstrap a release that
+# pre-dates this workflow.
+#
+# Mirrors the enterprise pattern in caura-memclaw-enterprise/.github/
+# workflows/release-please.yml retag-images job (CAURA-630, PR #194).
+# CAURA-634.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to (re-)tag (e.g. v1.0.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AR_REPO: us-central1-docker.pkg.dev/alpine-theory-469016-c8/staging-memclaw
+
+jobs:
+  retag:
+    name: Promote staging digest to :vX.Y.Z
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve target version
+        id: vars
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+          # Strip leading "v" so we always store the bare semver, then
+          # re-add it on the AR tag for consistency with the enterprise
+          # pattern (:v1.0.0).
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: github-actions-sa@alpine-theory-469016-c8.iam.gserviceaccount.com
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
+
+      - name: Tag core-api at v${{ steps.vars.outputs.version }}
+        run: |
+          # Source = whatever :latest currently points to in AR. The
+          # staging deploy workflow on caura-memclaw-enterprise pushes
+          # both :sha and :latest on every dev push, so :latest tracks
+          # whichever OSS commit was last built into staging — which
+          # is what release-please just cut a version for.
+          SOURCE="${{ env.AR_REPO }}/core-api:latest"
+          DEST="${{ env.AR_REPO }}/core-api:v${{ steps.vars.outputs.version }}"
+          gcloud artifacts docker tags add "$SOURCE" "$DEST"
+
+      - name: Tag core-storage-api at v${{ steps.vars.outputs.version }}
+        run: |
+          SOURCE="${{ env.AR_REPO }}/core-storage-api:latest"
+          DEST="${{ env.AR_REPO }}/core-storage-api:v${{ steps.vars.outputs.version }}"
+          gcloud artifacts docker tags add "$SOURCE" "$DEST"
+
+      - name: Tag core-worker at v${{ steps.vars.outputs.version }}
+        run: |
+          SOURCE="${{ env.AR_REPO }}/core-worker:latest"
+          DEST="${{ env.AR_REPO }}/core-worker:v${{ steps.vars.outputs.version }}"
+          gcloud artifacts docker tags add "$SOURCE" "$DEST"


### PR DESCRIPTION
## Summary

Closes [CAURA-634](https://caura-ai.atlassian.net/browse/CAURA-634).

When release-please on this repo cuts a GitHub Release (e.g. `v1.0.1`), this new workflow re-tags the already-built staging AR image (currently at `:latest`) with the new `:vX.Y.Z` tag — giving the prod runbook a stable promote-this-tag handle without a `docker build` rebuild.

Mirrors the enterprise pattern from [caura-memclaw-enterprise#194](https://github.com/caura-ai/caura-memclaw-enterprise/pull/194)'s `retag-images` job.

### Why a separate workflow vs inline in `release-please.yml`?

`release-please-action` creates the GitHub Release tag via `GITHUB_TOKEN`, which **does** trigger `on: release: published` (unlike `on: push: tags`, which it doesn't). Two-step "cut release then retag" stays loosely coupled and survives a retag failure without blocking the release-please run.

### Source = `:latest`

The staging deploy workflow on `caura-memclaw-enterprise` (`deploy-oss-services.yml`) pushes both `:sha` and `:latest` on every dev push. So `:latest` tracks whichever OSS commit was last built into staging — which is what release-please just cut a version for. We tag THAT digest as `:vX.Y.Z`.

Today's manual prod cut used the same approach (`gcloud artifacts docker tags add` from a `:sha` tag); this just automates it.

### Pre-merge requirement (one-time setup)

This workflow uses the same WIF provider + SA as the enterprise repo:
- `workload_identity_provider: projects/${GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-actions/providers/github`
- `service_account: github-actions-sa@alpine-theory-469016-c8.iam.gserviceaccount.com`

For this to work in `caura-ai/caura-memclaw` (vs the enterprise repo), the WIF principal mapping needs to allow OSS repo too. If it's currently scoped to `attribute.repository=caura-ai/caura-memclaw-enterprise`, the binding needs widening or a sibling. Also need `GCP_PROJECT_NUMBER` set as a repo secret.

If either is missing the workflow fails with a clear `gcloud` error and the release-please run still succeeds — the WIF binding is a fast follow-up if needed.

## Test plan

- [ ] DCO + branch protection passes
- [ ] Manual `workflow_dispatch` against an existing release tag (e.g. `v1.0.0`) — validates auth + tagging works without waiting for next release-please cut
- [ ] After next release-please merge: confirm new release tag automatically appears on the matching AR digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-634]: https://caura-ai.atlassian.net/browse/CAURA-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ