### PR TITLE
fix(audit): per-tenant slot in batch flusher to stop bulk_write contention (CAURA-631)

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -57,6 +57,15 @@ from core_api.routes.settings import router as settings_router
 from core_api.routes.stats import router as stats_router
 from core_api.routes.stm import router as stm_router
 
+# CAURA-631: sentinel bucket for audit events that arrive without a
+# ``tenant_id`` field. Routed through the per-tenant flusher's
+# group-by step then explicitly skipped (events are unattributable, so
+# we'd be writing them to the wrong tenant's audit log otherwise).
+# Identity sentinel (``object()``) rather than a string so a tenant
+# whose actual ID happens to be a debug-style label can't accidentally
+# match it and get its events silently dropped.
+_UNKNOWN_TENANT_SENTINEL: object = object()
+
 _SECURITY_HEADERS = {
     "strict-transport-security": "max-age=63072000; includeSubDomains; preload",
     "x-content-type-options": "nosniff",
@@ -208,15 +217,9 @@ async def lifespan(app):
             )
 
             async def _flush_one_tenant(tid: str, tevs: list[dict]) -> None:
-                # Sentinel bucket for events without a tenant_id — log + skip
-                # rather than failing the whole batch (CAURA-631 review).
-                if tid == "_UNKNOWN_TENANT_":
-                    logger.warning(
-                        "audit batch contained %d events with no tenant_id; "
-                        "skipping write (events unattributable)",
-                        len(tevs),
-                    )
-                    return
+                # Caller separates the sentinel bucket out before scheduling
+                # ``_flush_one_tenant`` over real tenants only, so ``tid`` is
+                # always a real tenant ID here — no sentinel branch needed.
                 try:
                     async with per_tenant_storage_slot("storage_write", tid):
                         await get_storage_client().create_audit_logs_bulk(tevs)
@@ -240,30 +243,117 @@ async def lifespan(app):
                 #
                 # Per-tenant failures don't abort sibling tenants;
                 # ``return_exceptions=True`` lets every group's outcome land,
-                # then we re-raise the last error so ``_drain_and_flush`` can
-                # bump ``_failed_count``. Slightly over-reports failures when
-                # one tenant succeeds and another fails in the same chunk —
-                # acceptable vs silently swallowing errors. Per-tenant detail
-                # is logged inside ``_flush_one_tenant`` either way.
-                by_tenant: dict[str, list[dict]] = {}
+                # then we re-raise the last error and attach the actually-failed
+                # event count via ``failed_event_count`` so ``_drain_and_flush``
+                # can credit the surviving tenants to ``_flushed_count`` instead
+                # of marking the whole chunk lost.
+                by_tenant: dict[str | object, list[dict]] = {}
                 for ev in events:
                     # ``.get()`` so a malformed event missing tenant_id can't
                     # KeyError out the whole batch — bucket it under the
                     # sentinel and skip the storage write for that bucket.
-                    tenant_id = ev.get("tenant_id") or "_UNKNOWN_TENANT_"
+                    tenant_id = ev.get("tenant_id") or _UNKNOWN_TENANT_SENTINEL
                     by_tenant.setdefault(tenant_id, []).append(ev)
 
+                # Pop sentinel events (no tenant_id) before fan-out: log them
+                # once + skip the storage write, but don't include them in the
+                # gather. Removes the dead sentinel branch from
+                # ``_flush_one_tenant`` and keeps ``total_failed_events`` /
+                # ``len(tasks)`` accurate to "events that were actually
+                # attempted to write."
+                #
+                # Stash the count on the closure so ``_drain_and_flush`` can
+                # subtract it from ``_flushed_count`` after the call —
+                # otherwise dropped sentinel events would be silently
+                # credited as flushed, inflating the dashboard. Assigned
+                # unconditionally on every entry so a stale value from a
+                # previous call can't bleed through.
+                sentinel_evs = by_tenant.pop(_UNKNOWN_TENANT_SENTINEL, [])
+                _flush_audit_batch._sentinel_count = len(sentinel_evs)  # type: ignore[attr-defined]
+                if sentinel_evs:
+                    logger.warning(
+                        "audit batch contained %d events with no tenant_id; "
+                        "skipping write (events unattributable)",
+                        len(sentinel_evs),
+                    )
+
+                # Sentinel was already popped above, so every remaining
+                # key is a real tenant string. Runtime check (not
+                # ``assert``) so the guard fires under ``python -O`` too —
+                # surfaces a future bug that lets a non-string key sneak
+                # in instead of silently dropping that group's events.
+                if not all(isinstance(tid, str) for tid in by_tenant):
+                    raise RuntimeError("unexpected non-string tenant key in by_tenant after sentinel pop")
+                tasks: list[tuple[str, list[dict]]] = list(by_tenant.items())  # type: ignore[arg-type]
                 results = await asyncio.gather(
-                    *(_flush_one_tenant(tid, tevs) for tid, tevs in by_tenant.items()),
+                    *(_flush_one_tenant(tid, tevs) for tid, tevs in tasks),
                     return_exceptions=True,
                 )
-                errors = [r for r in results if isinstance(r, BaseException)]
+
+                # Three buckets to handle every BaseException class without
+                # silent drops:
+                #   - ``cancel_errors``: ``asyncio.CancelledError`` (BaseException,
+                #     not Exception). Asyncio cancellation MUST propagate with
+                #     highest priority — silencing it under a co-occurring
+                #     regular exception breaks shutdown semantics.
+                #   - ``other_base``: ``SystemExit`` / ``KeyboardInterrupt`` /
+                #     future ``BaseExceptionGroup`` etc. Re-raise as-is for the
+                #     queue's outer handler — never silently drop.
+                #   - ``errors``: regular ``Exception`` subclasses. Carry the
+                #     actionable Sentry-grade traceback. Raised last.
+                cancel_errors = [r for r in results if isinstance(r, asyncio.CancelledError)]
+                errors = [r for r in results if isinstance(r, Exception)]
+                other_base = [
+                    r
+                    for r in results
+                    if isinstance(r, BaseException)
+                    and not isinstance(r, Exception)
+                    and not isinstance(r, asyncio.CancelledError)
+                ]
+
+                # Count actually-lost events across all failure buckets.
+                # ``_drain_and_flush`` reads ``failed_event_count`` from the
+                # raised exception to keep ``_flushed_count`` /
+                # ``_failed_count`` accounting accurate when only some
+                # tenants in the chunk fail.
+                total_failed_events = sum(
+                    len(tevs)
+                    for (_tid, tevs), r in zip(tasks, results, strict=True)
+                    if isinstance(r, BaseException)
+                )
+
+                # Priority order: cancel → other_base → errors. Cancellation
+                # wins so shutdown signals propagate even if a co-occurring
+                # storage error tries to mask them. ``failed_event_count`` is
+                # attached to every raise path so ``_drain_and_flush``'s
+                # accounting stays accurate regardless of which path fires.
+                if cancel_errors:
+                    e_cancel = cancel_errors[-1]
+                    e_cancel.failed_event_count = total_failed_events  # type: ignore[attr-defined]
+                    raise e_cancel
+                if other_base:
+                    e_base = other_base[-1]
+                    e_base.failed_event_count = total_failed_events  # type: ignore[attr-defined]
+                    raise e_base
                 if errors:
-                    # ``with_traceback`` preserves the original failure stack
-                    # so APM / Sentry shows the storage-call frame, not just
-                    # the re-raise site.
-                    last_error = errors[-1]
-                    raise last_error.with_traceback(last_error.__traceback__)
+                    # Single-tenant failure: re-raise the underlying error
+                    # directly so callers see the original storage-call
+                    # frame in Sentry without an extra wrapping layer.
+                    # Multi-tenant failure: wrap in ``ExceptionGroup`` so
+                    # every tenant's traceback is preserved (Sentry groups
+                    # them, incident replay sees them all). Without the
+                    # group the ``errors[-1]``-only path silently dropped
+                    # all but the last tenant's stack.
+                    if len(errors) == 1:
+                        last_error = errors[-1]
+                        last_error.failed_event_count = total_failed_events  # type: ignore[attr-defined]
+                        raise last_error
+                    eg = ExceptionGroup(
+                        f"audit batch flush failed for {len(errors)} tenants",
+                        errors,
+                    )
+                    eg.failed_event_count = total_failed_events  # type: ignore[attr-defined]
+                    raise eg
 
             audit_queue = AuditEventQueue(
                 max_queue_size=app_settings.audit_queue_max_size,

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os as _os
 from contextlib import asynccontextmanager
@@ -33,6 +34,7 @@ from core_api.clients.storage_client import get_storage_client
 from core_api.constants import VERSION, is_mcp_path
 from core_api.consumer import register_consumers
 from core_api.mcp_server import get_mcp_app, mcp_lifespan
+from core_api.middleware.per_tenant_concurrency import per_tenant_storage_slot
 from core_api.middleware.rate_limit import limiter
 from core_api.middleware.request_timeout import (
     _TIMEOUT_OPT_OUT_PATHS,
@@ -205,22 +207,63 @@ async def lifespan(app):
                 set_audit_queue,
             )
 
-            async def _flush_audit_batch(events: list[dict]) -> None:
+            async def _flush_one_tenant(tid: str, tevs: list[dict]) -> None:
+                # Sentinel bucket for events without a tenant_id — log + skip
+                # rather than failing the whole batch (CAURA-631 review).
+                if tid == "_UNKNOWN_TENANT_":
+                    logger.warning(
+                        "audit batch contained %d events with no tenant_id; "
+                        "skipping write (events unattributable)",
+                        len(tevs),
+                    )
+                    return
                 try:
-                    await get_storage_client().create_audit_logs_bulk(events)
+                    async with per_tenant_storage_slot("storage_write", tid):
+                        await get_storage_client().create_audit_logs_bulk(tevs)
                 except Exception:
-                    # Log the rich detail (event count, storage-api
-                    # correlation context) here, then re-raise so
-                    # ``_drain_and_flush`` can bump ``_failed_count``
-                    # for the dashboard. The flusher loop's outer
-                    # ``except`` will emit a generic "iteration failed;
-                    # continuing" line on top of this — slight log
-                    # noise but worth it for the failure metric.
                     logger.exception(
-                        "audit batch flush failed (events=%d); events lost from this batch",
-                        len(events),
+                        "audit batch flush failed for tenant=%s (events=%d); "
+                        "events lost from this tenant's slice",
+                        tid,
+                        len(tevs),
                     )
                     raise
+
+            async def _flush_audit_batch(events: list[dict]) -> None:
+                # Group by tenant + flush concurrently with per-tenant storage
+                # slot (cap=2) gating each group. Without the slot the flusher
+                # hoards storage-writer pool slots while ``/memories/bulk``
+                # requests queue, producing the 72% bulk_write 429 spike from
+                # loadtest 1777462612 (CAURA-631). Concurrent fan-out keeps
+                # flush latency bounded to the slowest tenant rather than
+                # serialising over them.
+                #
+                # Per-tenant failures don't abort sibling tenants;
+                # ``return_exceptions=True`` lets every group's outcome land,
+                # then we re-raise the last error so ``_drain_and_flush`` can
+                # bump ``_failed_count``. Slightly over-reports failures when
+                # one tenant succeeds and another fails in the same chunk —
+                # acceptable vs silently swallowing errors. Per-tenant detail
+                # is logged inside ``_flush_one_tenant`` either way.
+                by_tenant: dict[str, list[dict]] = {}
+                for ev in events:
+                    # ``.get()`` so a malformed event missing tenant_id can't
+                    # KeyError out the whole batch — bucket it under the
+                    # sentinel and skip the storage write for that bucket.
+                    tenant_id = ev.get("tenant_id") or "_UNKNOWN_TENANT_"
+                    by_tenant.setdefault(tenant_id, []).append(ev)
+
+                results = await asyncio.gather(
+                    *(_flush_one_tenant(tid, tevs) for tid, tevs in by_tenant.items()),
+                    return_exceptions=True,
+                )
+                errors = [r for r in results if isinstance(r, BaseException)]
+                if errors:
+                    # ``with_traceback`` preserves the original failure stack
+                    # so APM / Sentry shows the storage-call frame, not just
+                    # the re-raise site.
+                    last_error = errors[-1]
+                    raise last_error.with_traceback(last_error.__traceback__)
 
             audit_queue = AuditEventQueue(
                 max_queue_size=app_settings.audit_queue_max_size,

--- a/core-api/src/core_api/services/audit_queue.py
+++ b/core-api/src/core_api/services/audit_queue.py
@@ -247,19 +247,71 @@ class AuditEventQueue:
             try:
                 await self._flush_callable(chunk)
                 self._flushed_count += len(chunk)
-            except Exception:
-                self._failed_count += len(chunk)
-                # Per-chunk failure logged here (in addition to the
-                # closure's rich-detail log) so a partial drain of N
-                # chunks shows N independent log lines, each naming
-                # the chunk size — a bare ``logger.exception`` from
-                # the loop's outer ``except`` would only fire once
-                # for the first failing chunk and obscure how many
-                # chunks total were lost.
-                logger.exception(
-                    "audit chunk flush failed (chunk_size=%d); events lost",
-                    len(chunk),
-                )
+                # CAURA-631: callables that drop sentinel events (e.g. audit
+                # events without ``tenant_id``) stash the dropped count on
+                # themselves so we don't silently credit them as flushed.
+                # Defaults to 0 for callables that don't use this protocol.
+                self._flushed_count -= getattr(self._flush_callable, "_sentinel_count", 0)
+            except BaseException as exc:
+                # CAURA-631: when the callable handles per-tenant flushes
+                # and only some sub-groups fail, it sets ``failed_event_count``
+                # on the raised exception so we credit the actually-failed
+                # events to ``_failed_count`` and the rest to
+                # ``_flushed_count``. Falls back to ``len(chunk)`` for
+                # legacy callables that don't carry the attribute, matching
+                # the original whole-chunk-failed accounting.
+                #
+                # ``BaseException`` (not ``Exception``) so the accounting
+                # block runs for ``CancelledError`` / ``SystemExit`` /
+                # ``BaseExceptionGroup`` paths too — the per-tenant flusher
+                # explicitly attaches ``failed_event_count`` on those raises
+                # and we'd otherwise bypass them entirely. We re-raise after
+                # accounting so propagation semantics are preserved (the
+                # outer flusher loop's ``except Exception`` then handles
+                # regular errors and lets BaseExceptions escape unchanged).
+                if isinstance(exc, Exception):
+                    failed = getattr(exc, "failed_event_count", len(chunk))
+                else:
+                    # External CancelledError / SystemExit injected at the
+                    # ``await self._flush_callable(chunk)`` suspension point
+                    # has no ``failed_event_count`` attribute — the per-
+                    # tenant flusher's raises always do, but a cancellation
+                    # delivered before the flusher returns doesn't. Default
+                    # to 0 instead of ``len(chunk)`` so a clean shutdown
+                    # doesn't produce a spurious failure-spike on the
+                    # dashboard. The events themselves stay in the queue
+                    # (or are silently lost depending on shutdown ordering),
+                    # but their disposition is "unknown", not "failed".
+                    failed = getattr(exc, "failed_event_count", 0)
+                self._failed_count += failed
+                self._flushed_count += len(chunk) - failed
+                # Same sentinel correction as the success path: dropped
+                # sentinel events were neither flushed nor failed, so back
+                # them out of the surviving-events credit.
+                self._flushed_count -= getattr(self._flush_callable, "_sentinel_count", 0)
+                if isinstance(exc, Exception):
+                    # Per-chunk failure logged here (in addition to the
+                    # closure's rich-detail log) so a partial drain of N
+                    # chunks shows N independent log lines, each naming
+                    # the chunk size — a bare ``logger.exception`` from
+                    # the loop's outer ``except`` would only fire once
+                    # for the first failing chunk and obscure how many
+                    # chunks total were lost. Per-chunk failure isolation
+                    # contract: regular ``Exception`` is caught here and
+                    # the loop continues to the next chunk (covered by
+                    # ``test_chunk_failure_does_not_drop_other_chunks``).
+                    logger.exception(
+                        "audit chunk flush failed (chunk_size=%d, failed_events=%d); events lost",
+                        len(chunk),
+                        failed,
+                    )
+                else:
+                    # ``CancelledError`` / ``SystemExit`` /
+                    # ``BaseExceptionGroup`` etc — re-raise so shutdown
+                    # signals propagate. Per-chunk isolation only applies
+                    # to regular ``Exception``; a cancellation pre-empts
+                    # the whole drain loop intentionally.
+                    raise
 
 
 # Module-level singleton bound at lifespan startup. Tests that need a


### PR DESCRIPTION
## Summary

Closes [CAURA-631](https://caura-ai.atlassian.net/browse/CAURA-631).

CAURA-628 (PR #36) added an `asyncio.Queue` + background flusher that batches audit events into `POST /audit-logs/bulk`. Loadtest 1777462612 surfaced a regression: `bulk_write` 429 retries jumped from **26% baseline → 72%** with the batch path live, dropping to 18% with the `AUDIT_QUEUE_MAX_SIZE=0` kill-switch.

## Root cause

`_flush_audit_batch` calls `create_audit_logs_bulk()` **without acquiring the per-tenant storage slot** that `/memories/bulk` respects (cap=2 per tenant, see `memory_service.py:369/455/641`). Both share the same httpx pool (100 max / 50 keepalive) and the same storage-api writer pool. Under tenant-A storm the flusher hoards storage connections that `/memories/bulk` requests need; the per-tenant request slot's 50ms timeout fires; clients see 429s.

The kill-switch fixed it because with the queue disabled, audit events fall back to legacy synchronous per-event POSTs that fire inline in the request context — already governed by rate-limit + request-timeout middleware.

## Fix

Group the flush chunk by `tenant_id`, then acquire `per_tenant_storage_slot("storage_write", tenant_id)` per group before the storage call. Each tenant's audit slice now queues fairly behind that tenant's own `/memories/bulk` requests instead of hoarding pool slots.

Per-tenant flush failures don't abort sibling tenants; only the last error is re-raised so `_drain_and_flush` still bumps `_failed_count`. Slightly over-reports failures when one tenant succeeds and another fails in the same chunk — acceptable vs silently swallowing errors. Per-tenant detail logged for forensics either way.

## Test plan

- [ ] DCO + CI pass
- [ ] Existing `tests/test_audit_queue.py` continues to pass — the fix is in the closure `app.py` passes as `flush_callable`; the queue's contract (fan-out chunks to the callable, count successes/failures) is unchanged
- [ ] After staging deploy: re-run the loadtest harness with `AUDIT_QUEUE_MAX_SIZE` ON (default), expect `bulk_write` retries to drop from 72% to ≤26% (matching kill-switch)
- [ ] If validated on staging: prod can drop the `AUDIT_QUEUE_MAX_SIZE=0` env var that's currently overriding

## Validation experiments

| run | AUDIT_QUEUE | observed bulk_write 429 |
|---|---|---|
| 1777411213 baseline (pre-CAURA-628) | n/a (sync POSTs) | 26% |
| 1777462612 (CAURA-628 live) | enabled | 72% |
| 1777463809 (kill-switch) | disabled | 18% |
| **post-merge re-run** | enabled | **expect ≤26%** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-631]: https://caura-ai.atlassian.net/browse/CAURA-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ