### PR TITLE
feat(events): EVENT_BUS_PUBSUB_MAX_MESSAGES override (CAURA-636)

### DIFF
--- a/common/events/factory.py
+++ b/common/events/factory.py
@@ -36,7 +36,9 @@ def get_event_bus() -> EventBus:
         if backend == "inprocess":
             _bus = InProcessEventBus()
         elif backend == "pubsub":
-            project_id = os.getenv("GCP_PROJECT_ID") or os.getenv("EVENT_BUS_PROJECT_ID")
+            project_id = os.getenv("GCP_PROJECT_ID") or os.getenv(
+                "EVENT_BUS_PROJECT_ID"
+            )
             sub_prefix = os.getenv("EVENT_BUS_SUBSCRIPTION_PREFIX")
             if not project_id or not sub_prefix:
                 raise RuntimeError(
@@ -48,7 +50,21 @@ def get_event_bus() -> EventBus:
             # Pub/Sub SDK surfaces immediately instead of after the first
             # real event.
             PubSubEventBus._ensure_pubsub_sdk()
-            _bus = PubSubEventBus(project_id, sub_prefix)
+            raw_max = os.getenv("EVENT_BUS_PUBSUB_MAX_MESSAGES")
+            if raw_max:
+                try:
+                    max_messages = int(raw_max)
+                except ValueError as exc:
+                    raise RuntimeError(
+                        f"EVENT_BUS_PUBSUB_MAX_MESSAGES must be a positive int, got {raw_max!r}"
+                    ) from exc
+                if max_messages <= 0:
+                    raise RuntimeError(
+                        f"EVENT_BUS_PUBSUB_MAX_MESSAGES must be a positive int, got {max_messages}"
+                    )
+                _bus = PubSubEventBus(project_id, sub_prefix, max_messages=max_messages)
+            else:
+                _bus = PubSubEventBus(project_id, sub_prefix)
         else:
             raise ValueError(
                 f"Unknown EVENT_BUS_BACKEND {backend!r}; expected inprocess or pubsub"

--- a/tests/test_events/test_factory.py
+++ b/tests/test_events/test_factory.py
@@ -24,7 +24,9 @@ async def test_explicit_inprocess(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(bus, InProcessEventBus)
 
 
-async def test_pubsub_backend_requires_project_id(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_pubsub_backend_requires_project_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     await reset_event_bus_for_testing()
     monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
     monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
@@ -77,6 +79,45 @@ async def test_pubsub_backend_fails_fast_when_sdk_missing(
     monkeypatch.setattr(builtins, "__import__", blocked)
 
     with pytest.raises(RuntimeError, match="google-cloud-pubsub"):
+        get_event_bus()
+
+
+async def test_pubsub_backend_honors_max_messages_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await reset_event_bus_for_testing()
+    monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
+    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+    monkeypatch.setenv("EVENT_BUS_SUBSCRIPTION_PREFIX", "core-api")
+    monkeypatch.setenv("EVENT_BUS_PUBSUB_MAX_MESSAGES", "10")
+    bus = get_event_bus()
+    assert isinstance(bus, PubSubEventBus)
+    assert bus._max_messages == 10
+
+
+async def test_pubsub_backend_default_max_messages_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await reset_event_bus_for_testing()
+    monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
+    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+    monkeypatch.setenv("EVENT_BUS_SUBSCRIPTION_PREFIX", "core-api")
+    monkeypatch.delenv("EVENT_BUS_PUBSUB_MAX_MESSAGES", raising=False)
+    bus = get_event_bus()
+    assert isinstance(bus, PubSubEventBus)
+    assert bus._max_messages == 25
+
+
+@pytest.mark.parametrize("bad", ["abc", "0", "-3", "1.5"])
+async def test_pubsub_backend_rejects_invalid_max_messages(
+    monkeypatch: pytest.MonkeyPatch, bad: str
+) -> None:
+    await reset_event_bus_for_testing()
+    monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
+    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+    monkeypatch.setenv("EVENT_BUS_SUBSCRIPTION_PREFIX", "core-api")
+    monkeypatch.setenv("EVENT_BUS_PUBSUB_MAX_MESSAGES", bad)
+    with pytest.raises(RuntimeError, match="EVENT_BUS_PUBSUB_MAX_MESSAGES"):
         get_event_bus()
 
 


### PR DESCRIPTION
## Summary
- Wire `EVENT_BUS_PUBSUB_MAX_MESSAGES` into `get_event_bus()` so the Pub/Sub bus's pull batch size can be tuned without a code change. Default stays 25 (the existing constructor default).
- Validation: positive int required; non-int / non-positive values raise `RuntimeError` at boot, matching the existing factory style for `GCP_PROJECT_ID` and `EVENT_BUS_SUBSCRIPTION_PREFIX`.
- Tests cover override applied, default-when-unset, and rejection of `"abc"`, `"0"`, `"-3"`, `"1.5"`.

## Why
[CAURA-636](https://caura-ai.atlassian.net/browse/CAURA-636) — async-amplification regression. After CAURA-631 + 632 fixes recovered `noisy-neighbor-write` from 14.49x to 12.7x, the residual gap vs the 8.15x baseline is async-pipeline amplification (each write fans out to embed + enrich PATCH-backs, ~3x storage-writer ops). I want to test whether dropping the worker's `max_messages` from 25 to 10 narrows that gap before adding a per-tenant slot in the worker. This PR provides the knob.

## Test plan
- [x] `pytest tests/test_events/test_factory.py` passes locally (14 tests)
- [x] `ruff check` + `ruff format --check` clean on changed files
- [ ] CI green
- [ ] After merge: deploy worker to staging, set env var to 10, re-run loadtest, compare vs run `1777538050`

[CAURA-636]: https://caura-ai.atlassian.net/browse/CAURA-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ