### PR TITLE
Revert "feat(events): EVENT_BUS_PUBSUB_MAX_MESSAGES override (CAURA-636) (#46)"

### DIFF
--- a/common/events/factory.py
+++ b/common/events/factory.py
@@ -36,9 +36,7 @@ def get_event_bus() -> EventBus:
         if backend == "inprocess":
             _bus = InProcessEventBus()
         elif backend == "pubsub":
-            project_id = os.getenv("GCP_PROJECT_ID") or os.getenv(
-                "EVENT_BUS_PROJECT_ID"
-            )
+            project_id = os.getenv("GCP_PROJECT_ID") or os.getenv("EVENT_BUS_PROJECT_ID")
             sub_prefix = os.getenv("EVENT_BUS_SUBSCRIPTION_PREFIX")
             if not project_id or not sub_prefix:
                 raise RuntimeError(
@@ -50,21 +48,7 @@ def get_event_bus() -> EventBus:
             # Pub/Sub SDK surfaces immediately instead of after the first
             # real event.
             PubSubEventBus._ensure_pubsub_sdk()
-            raw_max = os.getenv("EVENT_BUS_PUBSUB_MAX_MESSAGES")
-            if raw_max:
-                try:
-                    max_messages = int(raw_max)
-                except ValueError as exc:
-                    raise RuntimeError(
-                        f"EVENT_BUS_PUBSUB_MAX_MESSAGES must be a positive int, got {raw_max!r}"
-                    ) from exc
-                if max_messages <= 0:
-                    raise RuntimeError(
-                        f"EVENT_BUS_PUBSUB_MAX_MESSAGES must be a positive int, got {max_messages}"
-                    )
-                _bus = PubSubEventBus(project_id, sub_prefix, max_messages=max_messages)
-            else:
-                _bus = PubSubEventBus(project_id, sub_prefix)
+            _bus = PubSubEventBus(project_id, sub_prefix)
         else:
             raise ValueError(
                 f"Unknown EVENT_BUS_BACKEND {backend!r}; expected inprocess or pubsub"

--- a/tests/test_events/test_factory.py
+++ b/tests/test_events/test_factory.py
@@ -24,9 +24,7 @@ async def test_explicit_inprocess(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(bus, InProcessEventBus)
 
 
-async def test_pubsub_backend_requires_project_id(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_pubsub_backend_requires_project_id(monkeypatch: pytest.MonkeyPatch) -> None:
     await reset_event_bus_for_testing()
     monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
     monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
@@ -79,45 +77,6 @@ async def test_pubsub_backend_fails_fast_when_sdk_missing(
     monkeypatch.setattr(builtins, "__import__", blocked)
 
     with pytest.raises(RuntimeError, match="google-cloud-pubsub"):
-        get_event_bus()
-
-
-async def test_pubsub_backend_honors_max_messages_override(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    await reset_event_bus_for_testing()
-    monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
-    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
-    monkeypatch.setenv("EVENT_BUS_SUBSCRIPTION_PREFIX", "core-api")
-    monkeypatch.setenv("EVENT_BUS_PUBSUB_MAX_MESSAGES", "10")
-    bus = get_event_bus()
-    assert isinstance(bus, PubSubEventBus)
-    assert bus._max_messages == 10
-
-
-async def test_pubsub_backend_default_max_messages_when_unset(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    await reset_event_bus_for_testing()
-    monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
-    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
-    monkeypatch.setenv("EVENT_BUS_SUBSCRIPTION_PREFIX", "core-api")
-    monkeypatch.delenv("EVENT_BUS_PUBSUB_MAX_MESSAGES", raising=False)
-    bus = get_event_bus()
-    assert isinstance(bus, PubSubEventBus)
-    assert bus._max_messages == 25
-
-
-@pytest.mark.parametrize("bad", ["abc", "0", "-3", "1.5"])
-async def test_pubsub_backend_rejects_invalid_max_messages(
-    monkeypatch: pytest.MonkeyPatch, bad: str
-) -> None:
-    await reset_event_bus_for_testing()
-    monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
-    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
-    monkeypatch.setenv("EVENT_BUS_SUBSCRIPTION_PREFIX", "core-api")
-    monkeypatch.setenv("EVENT_BUS_PUBSUB_MAX_MESSAGES", bad)
-    with pytest.raises(RuntimeError, match="EVENT_BUS_PUBSUB_MAX_MESSAGES"):
         get_event_bus()
 
 


### PR DESCRIPTION
## Summary
Reverts #46 (commit `fb0104a`).

## Why
PR #46 was merged via `--admin` while the auto-review (Claude Code Review, triggered by `@claude` on the PR) was still pending. The review came back with two findings that were not addressed before merge:

1. **Medium**: no upper bound on `max_messages` — GCP Pub/Sub's `pull()` API rejects values > 1000 with `INVALID_ARGUMENT`, and `_max_messages` is passed directly through with no clamping (`pubsub.py:519-524`).
2. **Low**: duplicate `PubSubEventBus(...)` constructor call — two branches diverging only on `max_messages` will silently use stale defaults if the constructor gains parameters later.

External audit checks for unapproved commits on `main`, so this needs to be reverted through the normal review path. A follow-up PR will reintroduce the change with both review findings addressed.

## Test plan
- [x] Revert is mechanical (`git revert fb0104a`); no test changes needed
- [ ] CI green
- [ ] Approved + merged through normal protected-branch flow (no `--admin`)