### PR TITLE
feat(events): EVENT_BUS_PUBSUB_MAX_MESSAGES override (CAURA-636) — v2

### DIFF
--- a/common/events/factory.py
+++ b/common/events/factory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import threading
+from typing import Any
 
 from common.events.base import EventBus
 from common.events.inprocess import InProcessEventBus
@@ -36,19 +37,39 @@ def get_event_bus() -> EventBus:
         if backend == "inprocess":
             _bus = InProcessEventBus()
         elif backend == "pubsub":
-            project_id = os.getenv("GCP_PROJECT_ID") or os.getenv("EVENT_BUS_PROJECT_ID")
+            project_id = os.getenv("GCP_PROJECT_ID") or os.getenv(
+                "EVENT_BUS_PROJECT_ID"
+            )
             sub_prefix = os.getenv("EVENT_BUS_SUBSCRIPTION_PREFIX")
             if not project_id or not sub_prefix:
                 raise RuntimeError(
                     "EVENT_BUS_BACKEND=pubsub requires GCP_PROJECT_ID (or "
                     "EVENT_BUS_PROJECT_ID) and EVENT_BUS_SUBSCRIPTION_PREFIX"
                 )
+            kwargs: dict[str, Any] = {}
+            raw_max = os.getenv("EVENT_BUS_PUBSUB_MAX_MESSAGES")
+            if raw_max:
+                try:
+                    max_messages = int(raw_max)
+                except ValueError as exc:
+                    raise RuntimeError(
+                        f"EVENT_BUS_PUBSUB_MAX_MESSAGES must be a positive int <= 1000, got {raw_max!r}"
+                    ) from exc
+                # Pub/Sub's ``pull()`` API rejects ``max_messages > 1000`` with
+                # INVALID_ARGUMENT at first pull. Fail fast at boot instead so
+                # a typo in the env var doesn't surface as a runtime error
+                # mid-traffic.
+                if not 1 <= max_messages <= 1000:
+                    raise RuntimeError(
+                        f"EVENT_BUS_PUBSUB_MAX_MESSAGES must be a positive int <= 1000, got {raw_max!r}"
+                    )
+                kwargs["max_messages"] = max_messages
             # Fail fast at factory resolution (service boot) rather than on
             # first publish, so a misconfigured deploy that's missing the
             # Pub/Sub SDK surfaces immediately instead of after the first
             # real event.
             PubSubEventBus._ensure_pubsub_sdk()
-            _bus = PubSubEventBus(project_id, sub_prefix)
+            _bus = PubSubEventBus(project_id, sub_prefix, **kwargs)
         else:
             raise ValueError(
                 f"Unknown EVENT_BUS_BACKEND {backend!r}; expected inprocess or pubsub"

--- a/tests/test_events/test_factory.py
+++ b/tests/test_events/test_factory.py
@@ -24,7 +24,9 @@ async def test_explicit_inprocess(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(bus, InProcessEventBus)
 
 
-async def test_pubsub_backend_requires_project_id(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_pubsub_backend_requires_project_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     await reset_event_bus_for_testing()
     monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
     monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
@@ -77,6 +79,58 @@ async def test_pubsub_backend_fails_fast_when_sdk_missing(
     monkeypatch.setattr(builtins, "__import__", blocked)
 
     with pytest.raises(RuntimeError, match="google-cloud-pubsub"):
+        get_event_bus()
+
+
+async def test_pubsub_backend_honors_max_messages_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await reset_event_bus_for_testing()
+    monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
+    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+    monkeypatch.setenv("EVENT_BUS_SUBSCRIPTION_PREFIX", "core-api")
+    monkeypatch.setenv("EVENT_BUS_PUBSUB_MAX_MESSAGES", "10")
+    bus = get_event_bus()
+    assert isinstance(bus, PubSubEventBus)
+    assert bus._max_messages == 10
+
+
+async def test_pubsub_backend_default_max_messages_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await reset_event_bus_for_testing()
+    monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
+    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+    monkeypatch.setenv("EVENT_BUS_SUBSCRIPTION_PREFIX", "core-api")
+    monkeypatch.delenv("EVENT_BUS_PUBSUB_MAX_MESSAGES", raising=False)
+    bus = get_event_bus()
+    assert isinstance(bus, PubSubEventBus)
+    assert bus._max_messages == 25
+
+
+async def test_pubsub_backend_accepts_max_messages_upper_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await reset_event_bus_for_testing()
+    monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
+    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+    monkeypatch.setenv("EVENT_BUS_SUBSCRIPTION_PREFIX", "core-api")
+    monkeypatch.setenv("EVENT_BUS_PUBSUB_MAX_MESSAGES", "1000")
+    bus = get_event_bus()
+    assert isinstance(bus, PubSubEventBus)
+    assert bus._max_messages == 1000
+
+
+@pytest.mark.parametrize("bad", ["abc", "0", "-3", "1.5", "1001"])
+async def test_pubsub_backend_rejects_invalid_max_messages(
+    monkeypatch: pytest.MonkeyPatch, bad: str
+) -> None:
+    await reset_event_bus_for_testing()
+    monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
+    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+    monkeypatch.setenv("EVENT_BUS_SUBSCRIPTION_PREFIX", "core-api")
+    monkeypatch.setenv("EVENT_BUS_PUBSUB_MAX_MESSAGES", bad)
+    with pytest.raises(RuntimeError, match="EVENT_BUS_PUBSUB_MAX_MESSAGES"):
         get_event_bus()
 
 


### PR DESCRIPTION
## Summary
Reintroduces the env-var override reverted in #47, with both Claude review findings from #46 addressed.

- Wire `EVENT_BUS_PUBSUB_MAX_MESSAGES` into `get_event_bus()` so the Pub/Sub bus's pull batch size can be tuned without a code change. Default stays 25 (the existing `PubSubEventBus.__init__` default).
- **Review fix #1 (Medium)**: Add upper-bound check (`<= 1000`). GCP Pub/Sub's `pull()` API rejects `max_messages > 1000` with `INVALID_ARGUMENT`. Without this check, a typo would surface as a runtime error at first pull instead of failing fast at boot.
- **Review fix #2 (Low)**: Unify the two `PubSubEventBus(...)` branches into a single kwargs-splat call. Future constructor params will no longer silently use stale defaults in one branch.
- Validation raises `RuntimeError` at boot for non-int / non-positive / over-1000 values, matching the existing factory style for `GCP_PROJECT_ID` and `EVENT_BUS_SUBSCRIPTION_PREFIX`.

## Tests
- 16 tests pass (`pytest tests/test_events/test_factory.py`)
- New cases: override-applied, default-when-unset, upper-bound (1000) accepted, parametrized rejection of `\"abc\"`, `\"0\"`, `\"-3\"`, `\"1.5\"`, `\"1001\"`.

## Why
[CAURA-636](https://caura-ai.atlassian.net/browse/CAURA-636) — async-amplification regression. After CAURA-631 + 632 fixes recovered \`noisy-neighbor-write\` from 14.49x to 12.7x, the residual gap vs the 8.15x baseline is async-pipeline amplification (each write fans out to embed + enrich PATCH-backs, ~3x storage-writer ops). I want to test whether dropping the worker's \`max_messages\` from 25 to 10 narrows that gap before adding a per-tenant slot in the worker. This PR provides the knob.

## Process note
Previous PR #46 was merged via \`--admin\` while the auto-review was still pending; #47 reverted it. This v2 will go through normal review/merge — please review, no admin-merge.

## Test plan
- [x] \`pytest tests/test_events/test_factory.py\` passes locally (16 tests)
- [x] \`ruff check\` + \`ruff format --check\` clean on changed files
- [ ] Auto-review (Claude Code Review) green
- [ ] Approved + merged through normal protected-branch flow
- [ ] After merge: deploy worker to staging, set env var to 10, re-run loadtest, compare vs run \`1777538050\`

[CAURA-636]: https://caura-ai.atlassian.net/browse/CAURA-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ