### PR TITLE
[CAURA-444] feat(embedding): local embedder infra (TEI + BAAI/bge-m3) + 1024-dim schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,40 @@ EMBEDDING_PROVIDER=openai
 # Required if EMBEDDING_PROVIDER=openai or ENTITY_EXTRACTION_PROVIDER=openai
 OPENAI_API_KEY=
 
+# -- Local embedder (opt-in: BAAI/bge-m3 via TEI sidecar) -------------------
+# When you bring up the stack with ``--profile embed-local``, the
+# ``tei`` service runs HuggingFace Text Embeddings Inference with
+# ``BAAI/bge-m3`` (1024-dim, MIT, multilingual). It speaks the same
+# OpenAI-compatible API, so the existing ``EMBEDDING_PROVIDER=openai``
+# path is reused — point it at the sidecar with ``OPENAI_EMBEDDING_BASE_URL``.
+#
+# Quickstart:
+#     docker compose --profile embed-local up -d
+#     # core-api transparently embeds via tei:80 instead of api.openai.com.
+#
+# All four envs are unset by default — leave them empty to keep using
+# OpenAI's hosted embeddings. Schema is at 1024-dim (alembic 010), so a
+# matching 1024-dim model is required when self-hosting. See
+# ``docs/local-embedder.md`` for the full story (model swaps, GPU image
+# tag, instruction-aware models like Qwen3-Embedding, etc.).
+#
+# OPENAI_EMBEDDING_BASE_URL=http://tei:80/v1
+# OPENAI_EMBEDDING_MODEL=BAAI/bge-m3
+# TEI rejects the ``dimensions=`` SDK kwarg — must be false when talking to TEI.
+# OPENAI_EMBEDDING_SEND_DIMENSIONS=false
+# Optional: only set when running an instruction-aware model (Qwen3-Embedding,
+# e5-instruct). bge-m3 is symmetric — leave empty.
+# EMBEDDING_QUERY_INSTRUCTION=
+# Optional: Matryoshka truncation for native >1024-dim models against the
+# 1024 schema. bge-m3 is native 1024 — leave empty.
+# OPENAI_EMBEDDING_TRUNCATE_TO_DIM=
+
+# Compose-only knobs (read by docker-compose.yml's ``tei`` service):
+# Default CPU build; switch to ``89-1.7`` for an L4-class GPU host.
+# TEI_IMAGE_TAG=cpu-1.7
+# Default model. Change requires a re-embed when changing dim or pooling.
+# TEI_MODEL_ID=BAAI/bge-m3
+
 # -- LLM enrichment ---------------------------------------------------------
 USE_LLM_FOR_MEMORY_CREATION=true
 # Options: openai | anthropic | openrouter | gemini | fake | none

--- a/README.md
+++ b/README.md
@@ -406,6 +406,129 @@ The **reader/writer split** is an opt-in topology for high-write-rate deploys th
 
 ---
 
+## Upgrading from v1.x
+
+> **⚠️ v2.0.0 ships a destructive schema migration.** If your installation is on
+> v1.x and has any memories already stored, follow this procedure carefully — the
+> migration NULLs every existing embedding to widen the pgvector column from
+> 768 → 1024 dim. The application is designed to refuse the migration
+> automatically; you must opt in.
+
+### What changes
+
+- Default embedder model: `BAAI/bge-m3` (was: OpenAI `text-embedding-3-small`).
+  Self-hosted via the new `tei` profile in docker-compose; documented in
+  [`docs/local-embedder.md`](docs/local-embedder.md).
+- pgvector schema dim: `vector(1024)` (was: `vector(768)`).
+- Existing embeddings on `memories.embedding`, `entities.name_embedding`, and
+  `documents.embedding` are NULLed by alembic revision `012_vector_dim_1024`.
+  Re-embedding is required; until rows are re-embedded, semantic search returns
+  no results for those rows.
+
+### Procedure (OSS, docker-compose)
+
+1. **Stop the stack** so no writes happen during migration:
+   ```bash
+   docker compose down
+   ```
+
+2. **Snapshot the database.** A `pg_dump` is the safest fallback. Replace
+   `<container>` with the running PostgreSQL container name (typically
+   `caura-memclaw-db-1`):
+   ```bash
+   docker compose up -d db    # bring just the DB back
+   docker exec <container> pg_dump -U memclaw memclaw > backup-pre-v2.sql
+   docker compose down
+   ```
+
+3. **Pull the new image** and start with the migration opt-in env set. The
+   gate enforces an explicit opt-in because the migration is destructive on
+   a populated DB:
+   ```bash
+   docker compose pull
+   MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS=true docker compose up -d
+   ```
+   The `core-storage-api` container will run `alembic upgrade head` on
+   startup. The migration runs in seconds-to-minutes for typical OSS
+   workloads.
+
+4. **Verify migration completed.** Look for the line
+   `Database initialization complete` in the `core-storage-api` logs:
+   ```bash
+   docker compose logs core-storage-api | grep -i "alembic\|migration"
+   ```
+
+5. **Re-embed your data.** Two paths:
+   - **Lazy** (zero action): the application re-embeds rows on next read or
+     write that touches them. Search will return empty results for cold rows
+     until they are touched. Acceptable for low-traffic personal deployments.
+   - **Eager (recommended):** run the bundled backfill CLI. It walks every
+     memory and entity with a NULL embedding and re-embeds via the configured
+     provider. Idempotent — safe to re-run. First do a dry-run to estimate
+     scope:
+     ```bash
+     docker compose run --rm core-storage-api \
+       python -m core_storage_api.scripts.backfill_embeddings --dry-run
+     ```
+     Then the real run:
+     ```bash
+     docker compose run --rm core-storage-api \
+       python -m core_storage_api.scripts.backfill_embeddings
+     ```
+     Optional knobs: `--tenant-id <id>` (per-tenant cutover), `--batch-size N`,
+     `--max-inflight N`, `--only-table memories|entities`. Documents are NOT
+     covered (their embed-source field is per-row JSON, not a fixed column);
+     re-write any embedded documents to refresh them.
+   - **Eager (event-driven, recommended for multi-tenant production):** if you
+     run the `core-worker` service, drive the existing `EMBED_REQUESTED`
+     consumer instead. The CLI scans `WHERE embedding IS NULL` and publishes
+     one event per row, inheriting per-tenant concurrency + retry + DLQ:
+     ```bash
+     docker compose run --rm core-worker \
+       python -m core_worker.cli backfill-embeddings --dry-run
+     docker compose run --rm core-worker \
+       python -m core_worker.cli backfill-embeddings
+     ```
+     Same knobs as the standalone script (`--tenant-id`, `--batch-size`,
+     `--max-inflight`, `--dry-run`). Currently covers `memories` only.
+
+6. **Once stable, unset `MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS`** so subsequent
+   `up` commands don't carry the opt-in:
+   ```bash
+   unset MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS  # if exported in the shell
+   # or remove the line from your .env file
+   ```
+
+### What if I skip the opt-in?
+
+`core-storage-api` will refuse to start, with a clear error message reporting
+how many rows would be NULLed. The container exits non-zero; the rest of the
+stack stays healthy. No data is touched. Set the env var and retry.
+
+### Rolling back
+
+The migration has a symmetric `downgrade()`. To revert, set the env var and
+explicitly downgrade:
+
+```bash
+docker compose run --rm \
+  -e MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS=true \
+  core-storage-api alembic downgrade 009
+```
+
+This NULLs any 1024-dim embeddings written since the upgrade and widens the
+columns back to `vector(768)`. The same data-loss tradeoff applies in reverse.
+For untouched-since-upgrade installations, the simpler recovery is to restore
+the snapshot from step 2.
+
+### v1.x → v2.x compatibility for client code
+
+No public API changes. Code that reads memory embeddings via the search/recall
+endpoints is unaffected. Client code that hardcodes `768` for vector lengths
+should be updated to read `VECTOR_DIM` from `common.constants`.
+
+---
+
 ## API Reference
 
 All routes are versioned under `/api/v1/`. Interactive Swagger docs at `/api/docs`.

--- a/common/constants.py
+++ b/common/constants.py
@@ -1,7 +1,10 @@
 """DB-query constants shared between core-api and core-storage-api."""
 
 # ── Embeddings ──
-VECTOR_DIM = 768
+# Native dim of the default embedder (BAAI/bge-m3, see local-embedder docs).
+# Schema upgrade lives in alembic migration 012_vector_dim_1024.py — keep
+# this constant in lock-step with that migration.
+VECTOR_DIM = 1024
 
 # ── Write-time semantic dedup ──
 SEMANTIC_DEDUP_THRESHOLD = 0.95  # cosine similarity above this -> near-duplicate

--- a/common/embedding/__init__.py
+++ b/common/embedding/__init__.py
@@ -4,9 +4,14 @@ Public surface:
 
 * :class:`~common.embedding.protocols.EmbeddingProvider` — async protocol
   every provider implements.
-* :func:`get_embedding` / :func:`get_embeddings_batch` — service-level
-  entrypoints with retry. Backwards-compatible with the prior
-  ``core_api.services.embedding`` module.
+* :class:`~common.embedding.protocols.InstructionAwareEmbedder` — optional
+  protocol for models with asymmetric query/document encoding (Qwen3-class).
+* :func:`get_embedding` / :func:`get_embeddings_batch` /
+  :func:`get_query_embedding` — service-level entrypoints with retry.
+  ``get_query_embedding`` routes through the instruction-aware path when
+  the resolved provider implements ``InstructionAwareEmbedder``, else
+  falls back to :func:`get_embedding`'s symmetric behaviour. Backwards-
+  compatible with the prior ``core_api.services.embedding`` module.
 * :func:`get_embedding_provider` — factory.
 * :func:`init_platform_embedding` / :func:`get_platform_embedding` —
   platform-tier singleton, initialised once at service startup from
@@ -33,8 +38,12 @@ from common.embedding._platform import (
     init_platform_embedding,
 )
 from common.embedding._registry import get_embedding_provider
-from common.embedding._service import get_embedding, get_embeddings_batch
-from common.embedding.protocols import EmbeddingProvider
+from common.embedding._service import (
+    get_embedding,
+    get_embeddings_batch,
+    get_query_embedding,
+)
+from common.embedding.protocols import EmbeddingProvider, InstructionAwareEmbedder
 from common.embedding.providers.fake import (
     FakeEmbeddingProvider,
     fake_embedding,
@@ -43,11 +52,13 @@ from common.embedding.providers.fake import (
 __all__ = [
     "EmbeddingProvider",
     "FakeEmbeddingProvider",
+    "InstructionAwareEmbedder",
     "fake_embedding",
     "get_embedding",
     "get_embedding_provider",
     "get_embeddings_batch",
     "get_platform_embedding",
     "get_platform_init_errors",
+    "get_query_embedding",
     "init_platform_embedding",
 ]

--- a/common/embedding/_registry.py
+++ b/common/embedding/_registry.py
@@ -16,6 +16,7 @@ import logging
 import os
 from collections import OrderedDict
 
+from common.constants import VECTOR_DIM
 from common.embedding.constants import OPENAI_EMBEDDING_MODEL
 from common.embedding.protocols import EmbeddingProvider
 from common.embedding.providers.fake import FakeEmbeddingProvider
@@ -50,9 +51,10 @@ logger = logging.getLogger(__name__)
 # of leaking ``ResourceWarning`` and held connections under long-lived
 # processes that rotate keys past the cache cap.
 _OPENAI_CACHE_MAX = 256
-_openai_provider_cache: OrderedDict[tuple[str, str], OpenAIEmbeddingProvider] = (
-    OrderedDict()
-)
+_openai_provider_cache: OrderedDict[
+    tuple[str, str, str | None, bool, str | None, int | None],
+    OpenAIEmbeddingProvider,
+] = OrderedDict()
 
 # Strong references to in-flight ``aclose()`` cleanup tasks so the GC
 # doesn't reap them mid-execution. ``asyncio.create_task`` returns a
@@ -63,23 +65,51 @@ _openai_provider_cache: OrderedDict[tuple[str, str], OpenAIEmbeddingProvider] = 
 _background_tasks: set[asyncio.Task[None]] = set()
 
 
-def _get_or_create_openai_provider(api_key: str, model: str) -> OpenAIEmbeddingProvider:
-    """LRU-bounded ``OpenAIEmbeddingProvider`` lookup keyed on (api_key, model).
+def _get_or_create_openai_provider(
+    api_key: str,
+    model: str,
+    base_url: str | None,
+    send_dimensions: bool,
+    query_instruction: str | None,
+    truncate_to_dim: int | None,
+) -> OpenAIEmbeddingProvider:
+    """LRU-bounded ``OpenAIEmbeddingProvider`` lookup keyed on the full client
+    config tuple.
+
+    Cache key includes ``base_url`` / ``send_dimensions`` / ``query_instruction``
+    / ``truncate_to_dim`` so the same api_key can host multiple simultaneous
+    providers — e.g. real OpenAI for one tenant and a local TEI sidecar with
+    a Qwen3 instruction prefix for another — without the second silently
+    aliasing to the first cached client.
 
     Not strictly async-safe across concurrent cache misses for the same
     key — two coroutines can both observe a miss before either inserts.
     The race is harmless: the later insert overwrites the earlier with
-    a functionally identical client (same api_key + model, no per-call
-    state), and the earlier instance gets dropped on the next GC. Not
-    worth an asyncio.Lock for the cost of a duplicated TLS handshake
-    on the first concurrent miss.
+    a functionally identical client (same key tuple, no per-call state),
+    and the earlier instance gets dropped on the next GC. Not worth an
+    asyncio.Lock for the cost of a duplicated TLS handshake on the
+    first concurrent miss.
     """
-    cache_key = (api_key, model)
+    cache_key = (
+        api_key,
+        model,
+        base_url,
+        send_dimensions,
+        query_instruction,
+        truncate_to_dim,
+    )
     cached = _openai_provider_cache.get(cache_key)
     if cached is not None:
         _openai_provider_cache.move_to_end(cache_key)
         return cached
-    provider = OpenAIEmbeddingProvider(api_key=api_key, model=model)
+    provider = OpenAIEmbeddingProvider(
+        api_key=api_key,
+        model=model,
+        base_url=base_url,
+        send_dimensions=send_dimensions,
+        query_instruction=query_instruction,
+        truncate_to_dim=truncate_to_dim,
+    )
     _openai_provider_cache[cache_key] = provider
     if len(_openai_provider_cache) > _OPENAI_CACHE_MAX:
         _, evicted = _openai_provider_cache.popitem(last=False)
@@ -132,7 +162,12 @@ def get_embedding_provider(
     Raises
     ------
     ValueError
-        If the provider name is unknown.
+        If the provider name is unknown, or if the OpenAI-compatible
+        env var combination would guarantee 100% failed embed calls
+        (``base_url`` set with ``send_dimensions=true``, or
+        ``base_url`` unset with ``send_dimensions=false``), or if
+        ``OPENAI_EMBEDDING_TRUNCATE_TO_DIM`` is set to anything other
+        than ``VECTOR_DIM``, or if it is not parseable as an integer.
     """
     if name == ProviderName.FAKE:
         return FakeEmbeddingProvider()
@@ -161,7 +196,147 @@ def get_embedding_provider(
             if tenant_config is not None
             else None
         ) or OPENAI_EMBEDDING_MODEL
-        return _get_or_create_openai_provider(api_key, embed_model)
+        base_url = os.environ.get("OPENAI_EMBEDDING_BASE_URL") or None
+        # Strict bool parsing: only ``"true"`` / ``"false"`` (case-insensitive)
+        # accepted. The previous ``!= "false"`` check silently treated typos
+        # ("trun", "yes", "1") and accidental values as true, which is the
+        # wrong default direction for a flag that controls a config the
+        # registry now hard-fails on (any base_url + send_dimensions=true
+        # raises). Operators get a clear error on the parse rather than
+        # downstream on the misconfig.
+        _send_dim_raw = os.environ.get(
+            "OPENAI_EMBEDDING_SEND_DIMENSIONS", "true"
+        ).lower()
+        if _send_dim_raw not in ("true", "false"):
+            raise ValueError(
+                f"OPENAI_EMBEDDING_SEND_DIMENSIONS={_send_dim_raw!r} "
+                "must be 'true' or 'false'."
+            )
+        send_dimensions = _send_dim_raw == "true"
+        # Option B: instruction-aware query encoding. Default applied to all
+        # /api/v1/search calls; documents (writes) embed unmodified text.
+        query_instruction = os.environ.get("EMBEDDING_QUERY_INSTRUCTION") or None
+        truncate_raw = os.environ.get("OPENAI_EMBEDDING_TRUNCATE_TO_DIM")
+        # Surface the env var name in the parse error. Bare ``int(...)``
+        # raises ``ValueError: invalid literal for int() with base 10:
+        # 'foo'`` — which is true but doesn't tell the operator which
+        # knob they fat-fingered. Re-raise with the variable name and
+        # the offending value.
+        try:
+            truncate_to_dim = int(truncate_raw) if truncate_raw else None
+        except ValueError:
+            raise ValueError(
+                f"OPENAI_EMBEDDING_TRUNCATE_TO_DIM={truncate_raw!r} must be an integer"
+            ) from None
+
+        # Hot-path note. ``get_embedding_provider`` runs on every embed
+        # and search request, so we want the steady-state cache hit to
+        # be as cheap as possible — but the cache key itself includes
+        # the *parsed* env values (``send_dimensions: bool``,
+        # ``truncate_to_dim: int | None``), so the env lookups + strict
+        # bool/int parsing above ALWAYS run, regardless of cache hit
+        # or miss. They're O(microseconds) (a couple of ``os.environ``
+        # reads + a string compare + at most one ``int()``) and have
+        # been measured as below the noise floor of the embed call
+        # itself, but they're not free. The expensive structural
+        # validation — the ``base_url ⊕ send_dimensions`` raise and the
+        # ``truncate_to_dim`` vs ``VECTOR_DIM`` raise below — is what
+        # the cache lookup actually skips. On a steady-state cache hit
+        # nothing about the env-driven config has changed since the
+        # cached provider was constructed, so we don't need to re-run
+        # those structural checks. (Operators changing env vars
+        # mid-process would need to restart anyway — env parses don't
+        # invalidate cache entries.)
+        #
+        # ``_get_or_create_openai_provider`` re-does the same dict
+        # lookup on a miss — single O(1) and not worth a
+        # signature-breaking refactor.
+        cache_key = (
+            api_key,
+            embed_model,
+            base_url,
+            send_dimensions,
+            query_instruction,
+            truncate_to_dim,
+        )
+        cached = _openai_provider_cache.get(cache_key)
+        if cached is not None:
+            _openai_provider_cache.move_to_end(cache_key)
+            return cached
+
+        # ── Cache miss — first time we see this config tuple. ─────────
+        # Both misconfiguration shapes below GUARANTEE that every embed
+        # call will fail (4xx from the provider, or schema-dim mismatch
+        # at the pgvector layer). A warning + fall-through would mean:
+        # provider gets constructed, every request 4xx's, retries
+        # exhaust, ``get_embedding`` returns None, writes persist with
+        # ``embedding=NULL``, search silently broken. That's strictly
+        # worse than failing fast at construction time — the operator
+        # sees the misconfiguration on the first request rather than
+        # debugging mysteriously empty search results.
+        #
+        # Forward misconfiguration: TEI / vLLM and most OpenAI-compatible
+        # self-hosted endpoints reject the ``dimensions=`` SDK kwarg
+        # outright. Hosted ``api.openai.com`` is the only target that
+        # accepts (and requires) it.
+        if base_url and send_dimensions:
+            raise ValueError(
+                f"OPENAI_EMBEDDING_BASE_URL={base_url!r} is set but "
+                "OPENAI_EMBEDDING_SEND_DIMENSIONS is true. Most "
+                "OpenAI-compatible self-hosted endpoints (TEI, vLLM, ...) "
+                "reject the ``dimensions=`` kwarg. Set "
+                "OPENAI_EMBEDDING_SEND_DIMENSIONS=false for TEI/vLLM, or "
+                "remove OPENAI_EMBEDDING_BASE_URL to use hosted OpenAI."
+            )
+
+        # Inverse misconfiguration: hosted OpenAI (no ``base_url``) with
+        # ``send_dimensions=false``. Hosted ``api.openai.com`` honours
+        # ``dimensions=`` to truncate the model's native output down to
+        # the schema dim; omitting it returns the full native dim
+        # (1536 for ``text-embedding-3-small``, 3072 for
+        # ``text-embedding-3-large``), which pgvector rejects on every
+        # write with ``expected N dimensions, not M``.
+        if not base_url and not send_dimensions:
+            raise ValueError(
+                "OPENAI_EMBEDDING_SEND_DIMENSIONS=false but "
+                "OPENAI_EMBEDDING_BASE_URL is unset (hosted OpenAI). "
+                f"Hosted OpenAI returns model {embed_model}'s native dim "
+                "without the ``dimensions=`` kwarg (e.g. 1536 for "
+                "text-embedding-3-small), which pgvector rejects at "
+                "write time. Set OPENAI_EMBEDDING_SEND_DIMENSIONS=true "
+                "(or unset it) for the hosted OpenAI path, or set "
+                "OPENAI_EMBEDDING_BASE_URL to point at a self-hosted "
+                "endpoint that produces VECTOR_DIM-sized vectors natively."
+            )
+
+        # Matryoshka truncation: lets us run instruction-aware models with
+        # native dim > VECTOR_DIM (Qwen3-Embedding-4B is 2560-d, 8B is
+        # 4096-d) against the 1024-d schema. Qwen3-Embedding-0.6B is
+        # natively 1024-d and does NOT need this knob — leave unset.
+        # ``OpenAIEmbeddingProvider._postprocess`` slices and
+        # L2-renormalizes so cosine sim correctness is preserved.
+        #
+        # Only valid value is exactly ``VECTOR_DIM``. Anything smaller
+        # produces vectors pgvector rejects at write time (column type
+        # is ``vector(VECTOR_DIM)``); anything larger would not fit
+        # the schema column either. The knob exists to truncate a
+        # *wider* model's native output down to the schema dimension —
+        # that's the only meaningful operation. Catch the misuse here
+        # instead of letting writes 4xx in production.
+        if truncate_to_dim is not None and truncate_to_dim != VECTOR_DIM:
+            raise ValueError(
+                f"OPENAI_EMBEDDING_TRUNCATE_TO_DIM={truncate_to_dim} must equal "
+                f"VECTOR_DIM={VECTOR_DIM}; this knob is only for truncating a "
+                "wider model's native output to the schema dimension."
+            )
+        return _get_or_create_openai_provider(
+            api_key,
+            embed_model,
+            base_url,
+            send_dimensions,
+            query_instruction,
+            truncate_to_dim,
+        )
 
     if name == ProviderName.LOCAL:
         return LocalEmbedding()

--- a/common/embedding/_service.py
+++ b/common/embedding/_service.py
@@ -11,9 +11,11 @@ import asyncio
 import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
 
 from common.embedding._registry import get_embedding_provider
 from common.embedding.constants import EMBEDDING_RETRY_ATTEMPTS, EMBEDDING_RETRY_DELAY_S
+from common.embedding.protocols import InstructionAwareEmbedder
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +64,17 @@ class _EmbeddingStats:
 
 _stats = _EmbeddingStats()
 
+# One-shot misconfiguration log dedup. The registry raises ``ValueError``
+# on env-var misconfig; ``_resolve_provider_or_degrade`` catches it,
+# records a failure stat, and returns ``None``. That guard runs on
+# every embed/query request, so logging the ERROR unconditionally
+# would spam the log at request rate. Keyed on the resolved provider
+# name (``"openai"``, ``"vertex"``, …) so a multi-tenant deployment
+# misconfiguring multiple providers still warns once per provider.
+# Module-level (process-scoped); restart resets the set, which is
+# the right cadence for "operator forgot a flag" errors.
+_misconfiguration_logged: set[str] = set()
+
 
 def _resolve_provider_name(tenant_config: object | None) -> str:
     """Tenant override first, else ``EMBEDDING_PROVIDER`` env, else ``"fake"``."""
@@ -77,21 +90,146 @@ async def get_embeddings_batch(
 ) -> list[list[float]]:
     """Generate embeddings for multiple texts in a single API call.
 
-    Raises any provider-side exception. ``ValueError`` is treated as a
-    programming error and re-raised without affecting failure stats.
+    Raises on any provider-side error. Bulk callers
+    (``memory_service.create_memories_bulk``,
+    ``_reembed_batch_via_provider``) already wrap this in
+    ``try: ... except Exception:`` and fall back to per-item retries,
+    so any exception type is acceptable here — what matters is that
+    the failure stats counter increments so the registry-level
+    degraded-provider trip-wire fires consistently with the single-embed
+    paths (``get_embedding`` / ``get_query_embedding``).
+
+    Two error shapes are explicitly accounted for:
+
+    1. ``ValueError`` from ``get_embedding_provider`` — env-var
+       misconfiguration (e.g. ``OPENAI_EMBEDDING_BASE_URL`` ⊕
+       ``SEND_DIMENSIONS`` mismatch). Used to propagate as an unhandled
+       exception that bulk callers caught generically but bypassed
+       ``_stats.record_failure``, so the trip-wire never fired under
+       sustained misconfig. Now records a failure and re-raises.
+    2. Any provider-side exception from ``embed_batch`` — auth, HTTP
+       client errors, Vertex quota, etc. Same record_failure + re-raise
+       contract as before.
     """
     provider_name = _resolve_provider_name(tenant_config)
-    provider = get_embedding_provider(provider_name, tenant_config)
-
+    # Provider construction and embed dispatch are wrapped in *separate*
+    # try/excepts on purpose. Provider implementations (notably
+    # ``OpenAIEmbeddingProvider._postprocess``) raise ``ValueError`` at
+    # runtime — e.g. when the model returns fewer dimensions than
+    # ``OPENAI_EMBEDDING_TRUNCATE_TO_DIM``. That is NOT a registry
+    # misconfiguration; folding it into the misconfig branch would
+    # incorrectly route runtime data errors through the misconfig path.
+    #
+    # On a registry ``ValueError``, this path logs but does NOT claim
+    # the once-per-provider dedup gate (``_misconfiguration_logged``).
+    # Bulk-call failures cascade into the per-item ``_reembed_memory``
+    # fallback in ``memory_service``, which calls ``get_embedding`` →
+    # ``_resolve_provider_or_degrade`` → that path owns the dedup gate
+    # (and logs once with full context). If we `.add()` here, the per-
+    # item fallback's first ERROR log gets silenced as a duplicate,
+    # losing the more useful single-row attribution.
+    try:
+        provider = get_embedding_provider(provider_name, tenant_config)
+    except ValueError:
+        logger.error(
+            "Bulk embedding: provider misconfiguration",
+            exc_info=True,
+        )
+        await _stats.record_failure()
+        raise
     try:
         result = await provider.embed_batch(texts)
-        await _stats.record_success()
-        return result
-    except ValueError:
-        raise
     except Exception:
         await _stats.record_failure()
         raise
+    await _stats.record_success()
+    return result
+
+
+async def _run_with_retry(
+    make_call: Callable[[], Awaitable[list[float]]],
+    context: str,
+) -> list[float] | None:
+    """Execute *make_call* under the shared retry / stats / logging policy.
+
+    *make_call* is invoked once per attempt, so it should construct a
+    fresh coroutine each time it runs (coroutines aren't reusable across
+    awaits). Returns ``None`` after the attempt budget is exhausted —
+    callers degrade gracefully (write path persists ``embedding=NULL``;
+    search path raises 503 upstream).
+
+    *context* is a short human-readable label (``"Embedding"``,
+    ``"Query embedding"``) interpolated into the per-attempt warning
+    and the terminal error log so failures are attributable.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, EMBEDDING_RETRY_ATTEMPTS + 1):
+        try:
+            result = await make_call()
+            await _stats.record_success()
+            return result
+        # Intentionally broad: must catch all provider-specific errors during retry.
+        except Exception as exc:
+            # Capture so the terminal log below can attach the stack trace.
+            # ``exc_info=True`` outside an except block reads
+            # ``sys.exc_info()`` which has been cleared by the time the
+            # loop exits, so we have to bind the exception explicitly.
+            last_exc = exc
+            logger.warning(
+                "%s attempt %d/%d failed",
+                context,
+                attempt,
+                EMBEDDING_RETRY_ATTEMPTS,
+                exc_info=True,
+            )
+            if attempt < EMBEDDING_RETRY_ATTEMPTS:
+                await asyncio.sleep(EMBEDDING_RETRY_DELAY_S * attempt)
+    await _stats.record_failure()
+    logger.error(
+        "%s failed after %d attempts, returning None",
+        context,
+        EMBEDDING_RETRY_ATTEMPTS,
+        exc_info=last_exc,
+    )
+    return None
+
+
+async def _resolve_provider_or_degrade(
+    tenant_config: object | None,
+    context: str,
+) -> object | None:
+    """Resolve the embedding provider, mapping a misconfiguration
+    ``ValueError`` from the registry to the same ``None`` degradation
+    contract the rest of this module documents.
+
+    ``get_embedding_provider`` raises ``ValueError`` on env-var misconfig
+    (``base_url`` ⊕ ``send_dimensions`` mismatch, invalid
+    ``OPENAI_EMBEDDING_TRUNCATE_TO_DIM``, etc.). Without this guard the
+    error would propagate out of ``get_embedding`` / ``get_query_embedding``
+    and break callers that rely on "returns None on failure" — write
+    paths persist rows with ``embedding=NULL`` for later backfill, search
+    paths typically translate None → 503. Logging once at error level
+    keeps the misconfiguration visible without making the request handler
+    crash.
+    """
+    provider_name = _resolve_provider_name(tenant_config)
+    try:
+        return get_embedding_provider(provider_name, tenant_config)
+    except ValueError:
+        # Dedup: once-per-provider-name so a misconfigured deployment
+        # gets a single ERROR at first request rather than one per
+        # request. Failure stats still increment on every call, so
+        # the degraded-provider trip-wire in ``_EmbeddingStats`` still
+        # fires correctly under sustained misconfiguration.
+        if provider_name not in _misconfiguration_logged:
+            _misconfiguration_logged.add(provider_name)
+            logger.error(
+                "%s: provider misconfiguration (will not repeat); returning None",
+                context,
+                exc_info=True,
+            )
+        await _stats.record_failure()
+        return None
 
 
 async def get_embedding(
@@ -102,28 +240,61 @@ async def get_embedding(
     Caller-friendly degradation: a transient OpenAI/Vertex hiccup
     returns ``None`` rather than raising, so write paths can persist
     rows with ``embedding=NULL`` and let the async-embed worker backfill.
-    """
-    provider_name = _resolve_provider_name(tenant_config)
-    provider = get_embedding_provider(provider_name, tenant_config)
+    The same ``None`` is returned on a registry-level
+    ``ValueError`` (env-var misconfiguration) — see
+    :func:`_resolve_provider_or_degrade`.
 
-    for attempt in range(1, EMBEDDING_RETRY_ATTEMPTS + 1):
-        try:
-            result = await provider.embed(text)
-            await _stats.record_success()
-            return result
-        except (
-            Exception
-        ):  # Intentionally broad: must catch all provider-specific errors during retry
-            logger.warning(
-                "Embedding attempt %d/%d failed",
-                attempt,
-                EMBEDDING_RETRY_ATTEMPTS,
-                exc_info=True,
-            )
-            if attempt < EMBEDDING_RETRY_ATTEMPTS:
-                await asyncio.sleep(EMBEDDING_RETRY_DELAY_S * attempt)
-    await _stats.record_failure()
-    logger.error(
-        "Embedding failed after %d attempts, returning None", EMBEDDING_RETRY_ATTEMPTS
-    )
-    return None
+    This is the document/ingest path. For search-side queries that should
+    pass through an instruction-aware encoder (Qwen3-Embedding, e5-instruct,
+    etc.), use :func:`get_query_embedding` instead.
+    """
+    provider = await _resolve_provider_or_degrade(tenant_config, "Embedding")
+    if provider is None:
+        return None
+    return await _run_with_retry(lambda: provider.embed(text), "Embedding")
+
+
+async def get_query_embedding(
+    text: str,
+    tenant_config: object | None = None,
+    instruction: str | None = None,
+) -> list[float] | None:
+    """Generate a query-side embedding (instruction-aware, asymmetric).
+
+    For instruction-aware models (Qwen3-Embedding, e5-instruct, KaLM), the
+    query encoder expects a task-description prefix that documents do not
+    receive. Symmetric providers (OpenAI ``text-embedding-3-small``,
+    ``bge-m3``, ``gte-en-v1.5``, ``Fake``, ``Local``, ``Vertex``) do not
+    implement :class:`~common.embedding.protocols.InstructionAwareEmbedder`
+    — the call site below detects that and falls back to the symmetric
+    :meth:`embed` path, matching :func:`get_embedding`.
+
+    Same retry / degradation semantics as :func:`get_embedding`: returns
+    ``None`` after exhausted retries rather than raising, so search routes
+    can degrade gracefully (typically by raising 503 to the caller). The
+    same ``None`` is returned on a registry-level ``ValueError`` (env-var
+    misconfiguration).
+    """
+    provider = await _resolve_provider_or_degrade(tenant_config, "Query embedding")
+    if provider is None:
+        return None
+
+    # ``InstructionAwareEmbedder`` is an optional ``@runtime_checkable``
+    # Protocol declared in ``common.embedding.protocols`` for exactly
+    # this dispatch. Only providers backed by an instruction-aware
+    # model (e.g. ``OpenAIEmbeddingProvider`` pointed at
+    # Qwen3-Embedding) conform. ``Fake`` / ``Local`` / ``Vertex`` do
+    # not implement ``embed_query`` and the isinstance check returns
+    # False — they fall through to :meth:`embed` and silently ignore
+    # *instruction*.
+    is_instruction_aware = isinstance(provider, InstructionAwareEmbedder)
+
+    async def _call() -> list[float]:
+        # Inner ``def`` rather than a ``lambda`` so the closure captures
+        # *provider* / *text* / *instruction* with explicit ``await``
+        # ergonomics; ruff E731 disapproves of ``make_call = lambda:``.
+        if is_instruction_aware:
+            return await provider.embed_query(text, instruction)
+        return await provider.embed(text)
+
+    return await _run_with_retry(_call, "Query embedding")

--- a/common/embedding/protocols.py
+++ b/common/embedding/protocols.py
@@ -1,4 +1,25 @@
-"""Embedding-provider protocol shared across services."""
+"""Embedding-provider protocols shared across services.
+
+Two protocols, by design split:
+
+* :class:`EmbeddingProvider` — the symmetric core every provider must
+  implement (``embed``, ``embed_batch``, ``provider_name``, ``model``).
+  Conformance held by ``Fake``, ``Local``, ``Vertex``, and
+  ``OpenAIEmbeddingProvider``.
+
+* :class:`InstructionAwareEmbedder` — the optional extension for models
+  trained with asymmetric query/document encoding (Qwen3-Embedding,
+  e5-instruct, KaLM). Conformance held by ``OpenAIEmbeddingProvider``
+  only — when pointed at an instruction-aware model. Symmetric providers
+  deliberately do NOT implement this; callers (see
+  :func:`common.embedding._service.get_query_embedding`) ``hasattr``-check
+  and fall back to :meth:`EmbeddingProvider.embed`.
+
+Splitting the protocols keeps ``runtime_checkable`` honest:
+``isinstance(p, EmbeddingProvider)`` is true for every provider without
+forcing a no-op shim onto symmetric ones. The narrower protocol expresses
+real capability rather than protocol-conformance ceremony.
+"""
 
 from __future__ import annotations
 
@@ -30,4 +51,34 @@ class EmbeddingProvider(Protocol):
 
         Same dimensionality contract as :meth:`embed`.
         """
+        ...
+
+
+@runtime_checkable
+class InstructionAwareEmbedder(Protocol):
+    """Optional extension for models with asymmetric query/document encoding.
+
+    Instruction-aware embedders (Qwen3-Embedding, e5-instruct, KaLM-Gemma3,
+    …) train the query-side encoder to expect a task-description prefix
+    that documents do not receive. A provider conforming to this protocol
+    must:
+
+    * Apply the prefix on :meth:`embed_query` only — never on the
+      document path (:meth:`EmbeddingProvider.embed`).
+    * Resolve *instruction* in this order: per-call arg → constructor
+      default → no prefix (degenerates to :meth:`embed`).
+
+    Symmetric providers (``Fake``, ``Local``, ``Vertex``,
+    OpenAI ``text-embedding-3-small``, ``bge-m3``, ``gte-en-v1.5``) do
+    **not** implement this protocol. The query path
+    (:func:`common.embedding._service.get_query_embedding`) checks
+    ``isinstance(provider, InstructionAwareEmbedder)`` (or, equivalently,
+    ``hasattr(provider, "embed_query")``) and falls back to
+    :meth:`EmbeddingProvider.embed` when absent.
+    """
+
+    async def embed_query(
+        self, text: str, instruction: str | None = None
+    ) -> list[float]:
+        """Generate an embedding vector for a search-side query."""
         ...

--- a/common/embedding/providers/fake.py
+++ b/common/embedding/providers/fake.py
@@ -55,3 +55,9 @@ class FakeEmbeddingProvider:
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         """Generate deterministic embeddings for multiple texts."""
         return [fake_embedding(t) for t in texts]
+
+    # Deliberately does NOT implement ``embed_query`` —
+    # ``FakeEmbeddingProvider`` is symmetric by design (deterministic hash).
+    # The query path falls back to :meth:`embed` via the
+    # ``hasattr(provider, "embed_query")`` check in
+    # :func:`common.embedding._service.get_query_embedding`.

--- a/common/embedding/providers/local.py
+++ b/common/embedding/providers/local.py
@@ -86,3 +86,10 @@ class LocalEmbedding:
             lambda: self._model.encode(texts, normalize_embeddings=True, batch_size=32),
         )
         return vecs.tolist()
+
+    # Deliberately does NOT implement ``embed_query`` — sentence-
+    # transformers models served here (default ``BAAI/bge-base-en-v1.5``)
+    # are symmetric encoders with no query-side instruction prefix. The
+    # query path falls back to :meth:`embed` via the
+    # ``hasattr(provider, "embed_query")`` check in
+    # :func:`common.embedding._service.get_query_embedding`.

--- a/common/embedding/providers/openai.py
+++ b/common/embedding/providers/openai.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import httpx
 import openai
 
@@ -15,15 +17,44 @@ from common.embedding.constants import (
 
 
 class OpenAIEmbeddingProvider:
-    """Embedding provider using the OpenAI embeddings API."""
+    """Embedding provider using the OpenAI embeddings API.
+
+    Also serves any OpenAI-compatible endpoint (TEI, vLLM, etc.) by setting
+    ``base_url``. Supports asymmetric query/doc encoding for instruction-aware
+    embedders (Qwen3-Embedding, e5-instruct, ...) via :meth:`embed_query` and
+    the ``query_instruction`` constructor arg. Supports Matryoshka-style
+    output truncation via ``truncate_to_dim`` so models with native dim
+    larger than the pgvector column can be used without a schema migration.
+    """
 
     def __init__(
         self,
         api_key: str,
         model: str = OPENAI_EMBEDDING_MODEL,
+        base_url: str | None = None,
+        send_dimensions: bool = True,
+        query_instruction: str | None = None,
+        truncate_to_dim: int | None = None,
     ) -> None:
         self._api_key = api_key
         self._model = model
+        self._send_dimensions = send_dimensions
+        self._query_instruction = query_instruction
+        self._truncate_to_dim = truncate_to_dim
+        # Defence in depth: the registry's ``get_embedding_provider``
+        # already validates this knob before constructing a provider,
+        # but direct construction (a one-off script, a migration helper,
+        # a test that mocks the registry) bypasses that path. Without
+        # this guard, ``truncate_to_dim=512`` against a 1024-dim schema
+        # silently produces 512-element vectors that pgvector rejects
+        # at write time with a dim-mismatch error far from the original
+        # constructor call. Fail fast at construction instead.
+        if truncate_to_dim is not None and truncate_to_dim != VECTOR_DIM:
+            raise ValueError(
+                f"truncate_to_dim={truncate_to_dim} must equal "
+                f"VECTOR_DIM={VECTOR_DIM}; this knob is only for truncating a "
+                "wider model's native output to the schema dimension."
+            )
         # Explicit per-call timeout — without this the SDK rides
         # httpx's default 600s read timeout, and a single hung
         # api.openai.com response would silently eat the worker's
@@ -35,16 +66,19 @@ class OpenAIEmbeddingProvider:
         # ``OpenAILLMProvider``: the SDK's default httpx pool (100 max
         # / 20 keepalive) saturates under storm load and queues other
         # tenants' embed calls at the pool layer.
-        self._client = openai.AsyncOpenAI(
-            api_key=api_key,
-            timeout=OPENAI_REQUEST_TIMEOUT_SECONDS,
-            http_client=httpx.AsyncClient(
+        client_kwargs: dict = {
+            "api_key": api_key,
+            "timeout": OPENAI_REQUEST_TIMEOUT_SECONDS,
+            "http_client": httpx.AsyncClient(
                 limits=httpx.Limits(
                     max_connections=OPENAI_HTTPX_MAX_CONNECTIONS,
                     max_keepalive_connections=OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
                 ),
             ),
-        )
+        }
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self._client = openai.AsyncOpenAI(**client_kwargs)
 
     @property
     def provider_name(self) -> str:
@@ -64,21 +98,72 @@ class OpenAIEmbeddingProvider:
         """
         await self._client.close()
 
+    def _postprocess(self, emb: list[float]) -> list[float]:
+        # Matryoshka truncation: slice to ``truncate_to_dim`` and L2-renormalize.
+        # Models trained with MRL (Qwen3-Embedding, jina-v3, snowflake-arctic-l)
+        # produce vectors that stay coherent under truncation, but the resulting
+        # vector is no longer unit-norm — we re-normalize so cosine similarity
+        # at the pgvector layer stays correct.
+        # Explicit ``is not None`` rather than truthy check: a
+        # hypothetical ``truncate_to_dim=0`` would slip through a
+        # truthy gate as "no truncation" but is invalid configuration
+        # the registry already rejects. Be unambiguous here too.
+        if self._truncate_to_dim is not None and len(emb) > self._truncate_to_dim:
+            # Slicing a list already returns a new list — no need to
+            # wrap in ``list(...)`` (which would allocate a redundant
+            # second copy of the truncated data).
+            emb = emb[: self._truncate_to_dim]
+            n = math.sqrt(sum(x * x for x in emb))
+            if n > 0:
+                emb = [x / n for x in emb]
+        elif self._truncate_to_dim is not None and len(emb) < self._truncate_to_dim:
+            # Undersized passthrough is silently broken: returning a
+            # vector with fewer than ``truncate_to_dim`` elements would
+            # produce inserts that pgvector rejects with
+            # ``expected N dimensions, not M``. Fail fast here so the
+            # mismatch is attributable to the model+truncate config,
+            # not surfaced obliquely as a write error far downstream.
+            raise ValueError(
+                f"Model returned {len(emb)}-dim vector but truncate_to_dim="
+                f"{self._truncate_to_dim}; the configured model must produce "
+                f"at least {self._truncate_to_dim} native dimensions."
+            )
+        return emb
+
     async def embed(self, text: str) -> list[float]:
-        """Generate an embedding vector for a single text."""
-        response = await self._client.embeddings.create(
-            model=self._model,
-            input=text,
-            dimensions=VECTOR_DIM,
-        )
-        return response.data[0].embedding
+        """Generate an embedding vector for a single text (document/ingest path)."""
+        kwargs: dict = {"model": self._model, "input": text}
+        if self._send_dimensions:
+            kwargs["dimensions"] = VECTOR_DIM
+        response = await self._client.embeddings.create(**kwargs)
+        return self._postprocess(response.data[0].embedding)
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         """Generate embedding vectors for multiple texts in one call."""
-        response = await self._client.embeddings.create(
-            model=self._model,
-            input=texts,
-            dimensions=VECTOR_DIM,
-        )
+        kwargs: dict = {"model": self._model, "input": texts}
+        if self._send_dimensions:
+            kwargs["dimensions"] = VECTOR_DIM
+        response = await self._client.embeddings.create(**kwargs)
         # OpenAI returns embeddings sorted by index
-        return [item.embedding for item in sorted(response.data, key=lambda x: x.index)]
+        sorted_data = sorted(response.data, key=lambda x: x.index)
+        return [self._postprocess(item.embedding) for item in sorted_data]
+
+    async def embed_query(
+        self, text: str, instruction: str | None = None
+    ) -> list[float]:
+        """Generate an embedding vector for a search-side query.
+
+        For instruction-aware models (Qwen3-Embedding, e5-instruct), prepends
+        the resolved instruction in the convention these models were trained
+        with: ``"Instruct: <task>\\nQuery: <text>"``. The instruction is
+        resolved as: per-call *instruction* arg → constructor
+        *query_instruction* → no prefix.
+
+        For symmetric models (bge-m3, snowflake-arctic-l, gte-en-v1.5,
+        OpenAI text-embedding-3-small), pass no instruction at construction
+        time and this is equivalent to :meth:`embed`.
+        """
+        instr = instruction or self._query_instruction
+        if instr:
+            text = f"Instruct: {instr}\nQuery: {text}"
+        return await self.embed(text)

--- a/common/embedding/providers/vertex.py
+++ b/common/embedding/providers/vertex.py
@@ -75,3 +75,9 @@ class VertexEmbeddingProvider:
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         """Generate embedding vectors for multiple texts in one call."""
         return await asyncio.to_thread(self._embed_batch_sync, texts)
+
+    # Deliberately does NOT implement ``embed_query`` — Vertex's
+    # ``TextEmbeddingModel`` does not currently expose an instruction-aware
+    # mode in the SDK shape we use. The query path falls back to
+    # :meth:`embed` via the ``hasattr(provider, "embed_query")`` check in
+    # :func:`common.embedding._service.get_query_embedding`.

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -34,7 +34,7 @@ except ImportError:
         pass  # type: ignore[misc]
 
 
-from common.embedding import get_embedding, get_embeddings_batch
+from common.embedding import get_embedding, get_embeddings_batch, get_query_embedding
 from common.events import publish_memory_embed_request, publish_memory_enrich_request
 from core_api.constants import (
     BULK_EMBEDDING_TIMEOUT_SECONDS,
@@ -2584,7 +2584,14 @@ async def _get_or_cache_embedding(query: str, tenant_id: str, tenant_config):
             return json.loads(_cached_raw)
         except (ValueError, TypeError):
             pass
-    embedding = await asyncio.wait_for(get_embedding(query, tenant_config), timeout=10.0)
+    # Search-side embed uses the instruction-aware path. For symmetric
+    # models (OpenAI, bge, snowflake-m, gte-en-v1.5) this is identical to
+    # ``get_embedding(query, tenant_config)``. For instruction-aware models
+    # (Qwen3-Embedding, e5-instruct), the provider prepends the configured
+    # task instruction (env: ``EMBEDDING_QUERY_INSTRUCTION``) so the query
+    # is encoded with the same instruction prefix the model was trained on.
+    # Documents (writes) embed unmodified text.
+    embedding = await asyncio.wait_for(get_query_embedding(query, tenant_config), timeout=10.0)
     if embedding is None:
         raise ValueError("Embedding service unavailable")
     await cache_set(_cache_key, json.dumps(embedding), ttl=EMBEDDING_CACHE_TTL)

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/012_vector_dim_1024.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/012_vector_dim_1024.py
@@ -1,0 +1,276 @@
+"""Bump pgvector embedding columns from ``Vector(768)`` to ``Vector(1024)``.
+
+Follows the local-embedder bench-off (``local_emb_res/RESULTS.md``)
+that selected ``BAAI/bge-m3`` as the new default embedder. bge-m3 is
+natively 1024-dim — running it against the previous 768-dim schema
+would require Matryoshka-style truncation that loses retrieval signal
+(verified at N=30: native 1024 holds R@5 ≈ 0.96 on LongMemEval
+``single-session-user``; truncated 768 trails by ~3 pp in earlier
+spot checks).
+
+Affects three columns across two services:
+- ``memories.embedding``         — primary memory vectors
+- ``entities.name_embedding``    — canonical-name embeddings
+- ``documents.embedding``        — opt-in document semantic search
+
+Migration semantics
+-------------------
+**Existing 768-dim data is destroyed.** pgvector cannot widen a vector
+column in place — the dim is part of the column type, and a row's
+existing 768-element value is not coercible to 1024. We therefore:
+
+  1. ``DROP INDEX CONCURRENTLY`` the HNSW indexes (so ``ALTER TYPE``
+     doesn't have to rebuild them inline). Same pattern used in
+     migrations 008/009 for index churn on AlloyDB primary.
+  2. ``UPDATE ... SET <embedding column> = NULL`` for every row that
+     still has a 768-dim value. Without this, ``ALTER TYPE`` fails
+     with ``ERROR: expected 1024 dimensions, not 768``. Setting to
+     NULL is acceptable: pgvector treats NULL as "no embedding",
+     queries naturally exclude these rows from semantic search, and
+     the application re-embeds on next write.
+  3. ``ALTER TABLE ... ALTER COLUMN ... TYPE vector(1024)`` —
+     succeeds now that the column is empty.
+  4. ``CREATE INDEX CONCURRENTLY`` the HNSW indexes against the new
+     1024-dim column. Same operator (``vector_cosine_ops``) and build
+     params (``m = 16, ef_construction = 64``) as the originals in
+     001 / 003.
+
+After upgrade, all existing memories/entities/documents have NULL
+embeddings until the application re-embeds them. Two paths to recover:
+- **Lazy**: any new write or any read path that calls
+  ``get_or_cache_embedding`` will re-embed the row's content via the
+  configured TEI sidecar. Steady-state OSS deployments converge over
+  hours/days as memories are touched.
+- **Eager**: run the backfill task in ``core-worker`` (separate PR)
+  to scan rows ``WHERE embedding IS NULL`` and embed in batches.
+  Recommended for production cutovers.
+
+Operationally
+-------------
+- ``CONCURRENTLY`` keeps reads/writes serving through the index churn
+  on AlloyDB primary — same constraint that drove migrations 008/009.
+- The ``ALTER TYPE`` itself takes a brief ``ACCESS EXCLUSIVE`` lock on
+  each table. On a multi-million-row table this is sub-second once
+  the column is empty (the lock is metadata-only, no row rewrites).
+- Each ``ALTER TABLE`` is preceded by ``SET LOCAL lock_timeout = '3s'``
+  so an unfortunately-timed migration can't queue behind a long-running
+  transaction and gate every other writer for minutes. If the lock
+  isn't acquired within 3 s the statement raises ``lock_timeout`` and
+  the surrounding alembic transaction rolls back — the migration fails
+  fast and can be retried during a quieter window. ``SET LOCAL`` scopes
+  the timeout to the current transaction only, so subsequent migrations
+  inherit the cluster default.
+- ``UPDATE ... = NULL`` rewrites every affected row — long-running on
+  production-sized tables, but no exclusive lock and no app downtime.
+  Safe to run during traffic. The three UPDATEs are **committed before
+  the ALTERs** (each runs in its own auto-committed transaction via
+  ``autocommit_block``), so a ``lock_timeout`` on a later ALTER does
+  NOT roll the UPDATE work back. Retries pick up where the previous
+  run left off — the ``WHERE ... IS NOT NULL`` filter makes each
+  UPDATE idempotent, so already-NULLed rows are skipped. Without this
+  separation, a late lock_timeout would force a complete redo of the
+  UPDATEs on retry and could loop indefinitely under write load.
+
+Safety gate
+-----------
+``upgrade()`` runs a pre-flight check that aborts the migration if
+existing 768-dim rows are present and
+``MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS`` is not set to ``"true"``. On a
+fresh DB (no rows) the gate is a no-op and the migration runs
+unchanged. On a populated DB an operator must explicitly opt in by
+setting the env var for the migration run (and unset it afterwards).
+Combined with the documented backfill task, this prevents the OSS
+auto-migrate path (``core_storage_api.app.lifespan`` →
+``init_database()`` → ``alembic upgrade head``) from silently
+destroying embeddings on a ``docker compose pull && up``.
+
+The gate is **not** applied to ``downgrade()``. Downgrade is
+operator-driven (manual ``alembic downgrade``) and adding friction
+there serves no purpose; the operator running it is already in
+deliberate-recovery mode.
+
+Downgrade
+---------
+Symmetric: drop indexes, NULL the 1024-dim values, ALTER TYPE back to
+``Vector(768)``, recreate indexes. Same data-loss tradeoff in reverse.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-04-30
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "012"
+down_revision: str | None = "011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ── Pre-flight safety gate ──────────────────────────────────────
+    # This migration NULLs every existing 768-dim embedding before
+    # widening the column to vector(1024) — pgvector cannot widen a
+    # vector column in place. On a non-empty DB that's destructive
+    # and irreversible. ``core-storage-api/...app.py`` runs
+    # ``alembic upgrade head`` automatically in its FastAPI lifespan,
+    # so without this gate a ``docker compose pull && up`` on an
+    # existing install would silently destroy embeddings the moment
+    # the container starts. Refuse to proceed unless the operator has
+    # opted in explicitly via ``MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS=true``.
+    #
+    # On a fresh DB (no existing 768-dim rows), the gate is a no-op:
+    # there is nothing to destroy. The check is row-count-based, not
+    # purely env-based, so a fresh ``docker compose up`` for the first
+    # time still works without operator intervention.
+    import os
+
+    from sqlalchemy import text as _sql_text
+
+    _opt_in = os.environ.get("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", "").lower() == "true"
+    if not _opt_in:
+        bind = op.get_bind()
+        # Count rows that would be destroyed. Single round-trip; cast
+        # to ``bigint`` so sums beyond 32-bit don't overflow on very
+        # large tables. Each sub-select is independently safe to run
+        # before the schema change because the columns still exist
+        # (we haven't widened them yet).
+        existing = bind.execute(
+            _sql_text(
+                "SELECT "
+                "  (SELECT COUNT(*) FROM memories  WHERE embedding      IS NOT NULL)::bigint "
+                "+ (SELECT COUNT(*) FROM entities  WHERE name_embedding IS NOT NULL)::bigint "
+                "+ (SELECT COUNT(*) FROM documents WHERE embedding      IS NOT NULL)::bigint "
+                "AS n"
+            )
+        ).scalar_one()
+        if existing > 0:
+            raise RuntimeError(
+                f"alembic 012_vector_dim_1024 is destructive: "
+                f"{existing} row(s) currently hold 768-dim embeddings that "
+                f"will be NULL'd. To proceed, set "
+                f"MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS=true and ensure a "
+                f"backfill is queued to re-embed the rows after migration "
+                f"completes (see the 'Upgrading from v1.x' section of "
+                f"README.md). Refusing to run automatically."
+            )
+    # ────────────────────────────────────────────────────────────────
+
+    # 1. Drop HNSW indexes — must be CONCURRENTLY (read traffic stays
+    # served on AlloyDB primary). ``CONCURRENTLY`` cannot run inside a
+    # transaction, so we use alembic's autocommit_block. Same idiom as
+    # migrations 008 / 009.
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_memories_embedding_hnsw")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_documents_embedding_hnsw")
+    # ``entities.name_embedding`` has no HNSW index (per 001) — no-op.
+
+    # 2. Clear existing 768-dim values so ``ALTER TYPE`` accepts the
+    # new dim. NULL is the only value compatible with both old and
+    # new column types. Application is expected to re-embed
+    # post-migration (see module docstring).
+    #
+    # Each UPDATE runs in its own auto-committed transaction. On a
+    # multi-million-row table these rewrites can take many minutes;
+    # if a later ALTER TABLE then trips its 3 s ``lock_timeout`` and
+    # rolls back, we want the NULL-scan work *already done* to stay
+    # done. Without ``autocommit_block`` here, the entire UPDATE +
+    # ALTER chain is one alembic transaction — a lock_timeout late in
+    # the chain would discard hours of UPDATE work and force a
+    # complete redo on retry, potentially looping indefinitely under
+    # write load. The ``WHERE ... IS NOT NULL`` filter makes each
+    # UPDATE idempotent: a row already NULLed by a partial prior
+    # attempt is simply skipped on the next run.
+    with op.get_context().autocommit_block():
+        op.execute("UPDATE memories SET embedding = NULL WHERE embedding IS NOT NULL")
+        op.execute("UPDATE entities SET name_embedding = NULL WHERE name_embedding IS NOT NULL")
+        op.execute("UPDATE documents SET embedding = NULL WHERE embedding IS NOT NULL")
+
+    # 3. Widen each column to 1024 dim. Sub-second metadata-only
+    # change once the column is empty.
+    #
+    # ``SET LOCAL lock_timeout = '3s'`` before each ALTER scopes a
+    # bounded wait to the transaction: if the AccessExclusive lock
+    # can't be acquired in 3 s (because a long-running transaction
+    # holds AccessShare on the table), the statement raises
+    # ``lock_timeout`` and the migration aborts cleanly instead of
+    # queuing behind the holder and freezing every other writer in
+    # the meantime. Alembic's surrounding transaction rolls back; the
+    # migration can be retried during a quieter window.
+    op.execute("SET LOCAL lock_timeout = '3s'")
+    op.execute("ALTER TABLE memories ALTER COLUMN embedding TYPE vector(1024)")
+    op.execute("SET LOCAL lock_timeout = '3s'")
+    op.execute("ALTER TABLE entities ALTER COLUMN name_embedding TYPE vector(1024)")
+    op.execute("SET LOCAL lock_timeout = '3s'")
+    op.execute("ALTER TABLE documents ALTER COLUMN embedding TYPE vector(1024)")
+
+    # 4. Rebuild HNSW indexes against the new dim. Same operator + build
+    # params as the originals in 001 / 003.
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_memories_embedding_hnsw
+            ON memories
+            USING hnsw (embedding vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64)
+            """
+        )
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_documents_embedding_hnsw
+            ON documents
+            USING hnsw (embedding vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64)
+            WHERE embedding IS NOT NULL
+            """
+        )
+
+
+def downgrade() -> None:
+    # Mirror image of upgrade. Same data-loss tradeoff: existing
+    # 1024-dim embeddings cannot be coerced back to 768; rows are
+    # NULLed and the application is expected to re-embed against
+    # whatever 768-dim provider it switches back to.
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_memories_embedding_hnsw")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_documents_embedding_hnsw")
+
+    # Same ``autocommit_block`` rationale as upgrade: NULL-scan work
+    # commits independently so a later ALTER hitting ``lock_timeout``
+    # doesn't force the UPDATEs to re-run on retry. Idempotent under
+    # ``WHERE ... IS NOT NULL``.
+    with op.get_context().autocommit_block():
+        op.execute("UPDATE memories SET embedding = NULL WHERE embedding IS NOT NULL")
+        op.execute("UPDATE entities SET name_embedding = NULL WHERE name_embedding IS NOT NULL")
+        op.execute("UPDATE documents SET embedding = NULL WHERE embedding IS NOT NULL")
+
+    # Same ``lock_timeout`` guard as upgrade — an unfortunately-timed
+    # rollback shouldn't be able to queue behind a long-running reader
+    # and freeze the whole cluster.
+    op.execute("SET LOCAL lock_timeout = '3s'")
+    op.execute("ALTER TABLE memories ALTER COLUMN embedding TYPE vector(768)")
+    op.execute("SET LOCAL lock_timeout = '3s'")
+    op.execute("ALTER TABLE entities ALTER COLUMN name_embedding TYPE vector(768)")
+    op.execute("SET LOCAL lock_timeout = '3s'")
+    op.execute("ALTER TABLE documents ALTER COLUMN embedding TYPE vector(768)")
+
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_memories_embedding_hnsw
+            ON memories
+            USING hnsw (embedding vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64)
+            """
+        )
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_documents_embedding_hnsw
+            ON documents
+            USING hnsw (embedding vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64)
+            WHERE embedding IS NOT NULL
+            """
+        )

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -485,6 +485,69 @@ async def count_active_memories(tenant_id: str, fleet_id: str | None = None) -> 
     return {"count": count}
 
 
+@router.get("/null-embedding-ids")
+async def list_null_embedding_ids(
+    tenant_id: str,
+    limit: int = 500,
+    after: str | None = None,
+) -> dict:
+    """Page through memories where ``embedding IS NULL`` for one tenant.
+
+    Drives the event-driven embedding backfill task in core-worker
+    (``core_worker.backfill``) — the worker fetches a page of ids
+    here, calls ``GET /memories/{id}?tenant_id=...`` per row to
+    retrieve the content, then publishes one ``EMBED_REQUESTED`` event
+    per row. See ``local_emb_res/specs/C-backfill-task-pr.md``.
+
+    Each returned row carries only the **identifiers** the worker
+    needs to address the next fetch — ``id`` and ``tenant_id``. The
+    raw ``content`` and ``content_hash`` are deliberately NOT inlined
+    here. Two reasons:
+
+    1. **Defence-in-depth.** The OSS storage API has no auth
+       middleware (see ``app.py``); a successful GET on this endpoint
+       must not leak every memory's content in a single response. An
+       attacker who guesses the per-tenant id still has to issue
+       one ``GET /memories/{id}`` per row, which is rate-limitable
+       and audit-logged separately.
+    2. **Payload size.** A 5000-row page with full content can run to
+       multiple MB; ids-only keeps it deterministic and small
+       regardless of corpus shape.
+
+    Idempotent under restart: the consumer's writes flip rows from
+    NULL to non-NULL, so a re-run picks up only rows that are still
+    NULL.
+
+    ``tenant_id`` is required for the same defence-in-depth reason —
+    no un-scoped scans across all tenants. For whole-deployment
+    scans, iterate the tenant list externally and call this endpoint
+    once per tenant.
+    """
+    if limit < 1 or limit > 5000:
+        raise HTTPException(
+            status_code=422,
+            detail="limit must be in [1, 5000]",
+        )
+    after_uuid: UUID | None = None
+    if after is not None:
+        try:
+            after_uuid = UUID(after)
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail=f"after must be a UUID, got {after!r}",
+            )
+
+    rows, total_remaining = await _svc.memory_list_null_embedding_rows(
+        limit=limit, after=after_uuid, tenant_id=tenant_id
+    )
+    return {
+        "rows": [{"id": str(row_id), "tenant_id": row_tenant} for row_id, row_tenant in rows],
+        "next_after": str(rows[-1][0]) if rows else None,
+        "total_remaining": total_remaining,
+    }
+
+
 @router.get("/distinct-agents")
 async def count_distinct_agents() -> dict:
     """Global count of distinct agent identities across all memories.

--- a/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
+++ b/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
@@ -1,0 +1,426 @@
+"""Re-embed memories and entities whose embedding is NULL.
+
+Companion to alembic migration 012_vector_dim_1024. After 012 NULLs every
+existing 768-dim embedding (pgvector cannot widen a vector column in
+place), this script walks the relevant rows and re-embeds each via the
+configured embedding provider — typically the same hosted OpenAI account
+the deployment was already using, just now producing 1024-dim vectors via
+the SDK's ``dimensions=`` parameter.
+
+Standalone CLI (no event bus, no core-worker required). For OSS docker-
+compose deployments this is the recommended eager backfill path. For
+enterprise / multi-tenant production cutovers, prefer the event-driven
+backfill task in core-worker (see ``local_emb_res/specs/C-backfill-task-pr.md``).
+
+Idempotent and restartable: the WHERE clauses filter to rows with NULL
+embeddings, so a partial run can be resumed by simply re-running the
+command — already-embedded rows are skipped naturally.
+
+⚠ **Single-provider only — does NOT honour per-tenant embedding configs.**
+
+This CLI calls ``common.embedding.get_embedding(content)`` without a
+``tenant_config`` argument, which means every row — regardless of its
+``tenant_id`` — is re-embedded against the **process-level** embedding
+provider resolved from environment variables (``EMBEDDING_PROVIDER``,
+``OPENAI_*``, ``OPENAI_EMBEDDING_*``). On a multi-tenant deployment
+where individual tenants have overridden the embedding provider /
+model / base_url via ``tenant_config``, this script will silently
+re-embed those rows against the wrong provider, producing vectors
+that are **inconsistent with the rest of the tenant's data** in the
+shared embedding space. Cross-tenant search quality and per-tenant
+recall will both degrade.
+
+Threading per-tenant ``tenant_config`` here would require resolving
+each row's tenant config (DB lookup or proxy call) inside the embed
+loop, which conflicts with the "standalone, no service deps" design
+goal of this CLI.
+
+If your deployment uses per-tenant embedding overrides, **stop and
+use the event-driven backfill task in core-worker instead**:
+
+    docker compose run --rm core-worker \\
+        python -m core_worker.cli backfill-embeddings
+
+That path publishes ``EMBED_REQUESTED`` events and lets the regular
+embed worker resolve ``tenant_config`` per row, exactly matching the
+hot path. Use the ``--tenant-id`` flag below only to **scope** the
+scan to one tenant — it does not change which embedding provider
+runs the call.
+
+Usage:
+    # Run inside the docker-compose stack so envs are wired up correctly.
+    docker compose run --rm core-storage-api \\
+        python -m core_storage_api.scripts.backfill_embeddings
+
+    # Dry-run first to estimate scope (does not call OpenAI / write DB):
+    docker compose run --rm core-storage-api \\
+        python -m core_storage_api.scripts.backfill_embeddings --dry-run
+
+    # Per-tenant phasing for prod cutover safety:
+    python -m core_storage_api.scripts.backfill_embeddings --tenant-id tenant-abc
+
+Scope:
+- ``memories.embedding`` — re-embedded from ``memories.content``.
+- ``entities.name_embedding`` — re-embedded from ``entities.canonical_name``.
+- ``documents.embedding`` — NOT handled. Documents store opaque JSON and
+  the original embed source is the user-configured ``embed_field``; the
+  per-doc ``embed_field`` isn't recorded in the row. Treat documents as
+  lazy (re-write the doc with the same ``embed_field`` to re-embed) or
+  use a custom script.
+
+Exit codes:
+    0  Backfill completed (or dry-run completed).
+    1  Configuration error (missing env, DB unreachable, etc).
+    2  Embedding provider returned None on too many rows in a row
+       (probable degradation; surface and stop).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import logging
+import os
+import sys
+import time
+import uuid
+from collections.abc import AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+
+# Stop the loop if too many consecutive embed calls return None.
+# ``get_embedding`` returns None only after exhausting its retry budget,
+# so a streak of Nones means the provider is meaningfully degraded
+# rather than blipping. Better to halt and let the operator escalate
+# than to spend the next hour writing nothing.
+_MAX_CONSECUTIVE_NONES = 20
+
+
+@dataclasses.dataclass
+class _TableSpec:
+    table: str
+    embedding_column: str
+    content_column: str
+    # Whether this table soft-deletes rows via a ``deleted_at`` timestamp
+    # column. When True, the scan filter excludes soft-deleted rows so we
+    # don't waste embed calls (and provider quota) on tombstones — keeps
+    # the scope consistent with ``postgres_service.memory_list_null_embedding_rows``
+    # and the ``/null-embedding-ids`` endpoint that the event-driven
+    # backfill task uses. ``entities`` does not have a ``deleted_at``
+    # column.
+    has_deleted_at: bool = False
+
+
+_TARGETS: tuple[_TableSpec, ...] = (
+    _TableSpec(
+        table="memories",
+        embedding_column="embedding",
+        content_column="content",
+        has_deleted_at=True,
+    ),
+    _TableSpec(
+        table="entities",
+        embedding_column="name_embedding",
+        content_column="canonical_name",
+    ),
+)
+
+
+@dataclasses.dataclass
+class BackfillReport:
+    table: str
+    scanned: int
+    embedded: int
+    skipped_empty_content: int
+    none_returns: int
+    elapsed_s: float
+
+
+async def _iter_null_rows(
+    engine,
+    spec: _TableSpec,
+    *,
+    tenant_id: str | None,
+    batch_size: int,
+) -> AsyncIterator[list[tuple[uuid.UUID, str]]]:
+    """Yield batches of (id, content) for rows where the embedding is NULL.
+
+    Cursor-style pagination on ``id`` for stable resumability — the
+    consumer's writes flip ``embedding`` from NULL to non-NULL, so on a
+    re-run the same page-after-id may yield fewer rows but never
+    duplicates.
+    """
+    from sqlalchemy import text
+
+    after: uuid.UUID | None = None
+    while True:
+        params: dict = {"limit": batch_size}
+        sql = f"SELECT id, {spec.content_column} FROM {spec.table} WHERE {spec.embedding_column} IS NULL "
+        # Skip soft-deleted rows on tables that have ``deleted_at`` —
+        # consistent with ``memory_list_null_embedding_rows`` and the
+        # event-driven backfill task; otherwise we'd burn provider
+        # quota re-embedding tombstones that nothing reads.
+        if spec.has_deleted_at:
+            sql += "AND deleted_at IS NULL "
+        if tenant_id is not None:
+            sql += "AND tenant_id = :tenant_id "
+            params["tenant_id"] = tenant_id
+        if after is not None:
+            sql += "AND id > :after "
+            params["after"] = after
+        sql += "ORDER BY id LIMIT :limit"
+        async with engine.connect() as conn:
+            result = await conn.execute(text(sql), params)
+            rows = result.all()
+        if not rows:
+            return
+        yield [(row[0], row[1]) for row in rows]
+        after = rows[-1][0]
+
+
+async def _backfill_one_table(
+    engine,
+    spec: _TableSpec,
+    *,
+    tenant_id: str | None,
+    batch_size: int,
+    max_inflight: int,
+    dry_run: bool,
+) -> BackfillReport:
+    from sqlalchemy import text
+
+    from common.embedding import get_embedding
+
+    sem = asyncio.Semaphore(max_inflight)
+    started = time.monotonic()
+    scanned = embedded = skipped_empty = none_returns = 0
+    consecutive_nones = 0
+    none_lock = asyncio.Lock()
+
+    async def _embed_and_write(row_id: uuid.UUID, content: str | None) -> None:
+        nonlocal embedded, skipped_empty, none_returns, consecutive_nones
+        if not content:
+            # Defensive: ``content`` is NOT NULL on memories but is
+            # technically nullable on entities' canonical_name? No,
+            # canonical_name is also NOT NULL. Still — empty string is
+            # possible, and ``get_embedding("")`` is provider-dependent.
+            # Skip rather than ship a degenerate vector.
+            skipped_empty += 1
+            return
+        async with sem:
+            if dry_run:
+                # Count what would have been done without calling out.
+                embedded += 1
+                return
+            vec = await get_embedding(content)
+            if vec is None:
+                async with none_lock:
+                    none_returns += 1
+                    consecutive_nones += 1
+                    if consecutive_nones >= _MAX_CONSECUTIVE_NONES:
+                        raise RuntimeError(
+                            f"Embedding provider returned None on "
+                            f"{_MAX_CONSECUTIVE_NONES} consecutive rows; "
+                            "stopping. Check OPENAI_API_KEY validity, "
+                            "rate-limit headroom, and the registry warnings "
+                            "logged at startup."
+                        )
+                return
+            async with none_lock:
+                consecutive_nones = 0
+            async with engine.connect() as conn:
+                # Pass the raw ``list[float]`` — asyncpg's pgvector codec
+                # (registered globally via ``register_vector`` on the
+                # async engine) serializes the list to pgvector's binary
+                # representation. Using ``str(vec)`` would force pgvector
+                # to re-parse a Python repr (``'[0.1, 0.2, ...]'``) and
+                # crashes when the codec is registered, since the codec
+                # then expects a sequence.
+                await conn.execute(
+                    text(f"UPDATE {spec.table} SET {spec.embedding_column} = :emb WHERE id = :id"),
+                    {"emb": vec, "id": row_id},
+                )
+                await conn.commit()
+            embedded += 1
+
+    async for batch in _iter_null_rows(engine, spec, tenant_id=tenant_id, batch_size=batch_size):
+        scanned += len(batch)
+        await asyncio.gather(*(_embed_and_write(rid, c) for rid, c in batch))
+        logger.info(
+            "backfill[%s] progress: scanned=%d embedded=%d empty=%d none=%d",
+            spec.table,
+            scanned,
+            embedded,
+            skipped_empty,
+            none_returns,
+        )
+
+    return BackfillReport(
+        table=spec.table,
+        scanned=scanned,
+        embedded=embedded,
+        skipped_empty_content=skipped_empty,
+        none_returns=none_returns,
+        elapsed_s=time.monotonic() - started,
+    )
+
+
+async def run_backfill(
+    *,
+    tenant_id: str | None,
+    batch_size: int,
+    max_inflight: int,
+    dry_run: bool,
+    only_table: str | None = None,
+) -> list[BackfillReport]:
+    """Walk every NULL-embedding row in the targeted tables and re-embed.
+
+    Returns one ``BackfillReport`` per table processed.
+
+    Per-tenant embedding providers are NOT honoured — see the module
+    docstring's warning. ``tenant_id`` here scopes the SQL scan, not
+    the embedding-provider resolution; every row is embedded against
+    the process-level provider (``EMBEDDING_PROVIDER`` env, etc.).
+    Multi-tenant deployments with per-tenant overrides must use the
+    event-driven backfill task in ``core-worker`` instead.
+    """
+    from core_storage_api.database.init import get_engine
+
+    engine = get_engine()
+    reports: list[BackfillReport] = []
+    for spec in _TARGETS:
+        if only_table is not None and spec.table != only_table:
+            continue
+        logger.info(
+            "backfill[%s] starting (tenant=%s, batch=%d, max_inflight=%d, dry_run=%s)",
+            spec.table,
+            tenant_id,
+            batch_size,
+            max_inflight,
+            dry_run,
+        )
+        report = await _backfill_one_table(
+            engine,
+            spec,
+            tenant_id=tenant_id,
+            batch_size=batch_size,
+            max_inflight=max_inflight,
+            dry_run=dry_run,
+        )
+        reports.append(report)
+        logger.info(
+            "backfill[%s] done: scanned=%d embedded=%d empty=%d none=%d elapsed=%.1fs",
+            spec.table,
+            report.scanned,
+            report.embedded,
+            report.skipped_empty_content,
+            report.none_returns,
+            report.elapsed_s,
+        )
+    return reports
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="core_storage_api.scripts.backfill_embeddings")
+    p.add_argument(
+        "--tenant-id",
+        default=None,
+        help=(
+            "Restrict the SQL scan to a single tenant id. NOTE: this scopes "
+            "the rows scanned; it does NOT switch the embedding provider to "
+            "the tenant's per-tenant config. Multi-tenant deployments with "
+            "per-tenant provider overrides must use the core-worker "
+            "event-driven backfill task instead — see module docstring."
+        ),
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        help="Rows per pagination page. Default 500.",
+    )
+    p.add_argument(
+        "--max-inflight",
+        type=int,
+        default=50,
+        help="Concurrent embed calls. Default 50. Tune down if hitting "
+        "OpenAI rate limits, up if rate-limit headroom allows.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count rows that would be re-embedded; don't call the embedding provider or write to the DB.",
+    )
+    p.add_argument(
+        "--only-table",
+        choices=[s.table for s in _TARGETS],
+        default=None,
+        help="Limit to a single table (memories or entities). Default: both.",
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    return p
+
+
+async def _amain(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s | %(message)s",
+    )
+
+    # Sanity: does an embedding provider key resolve to anything?
+    if not os.environ.get("OPENAI_API_KEY") and (os.environ.get("EMBEDDING_PROVIDER", "fake") in ("openai",)):
+        logger.error(
+            "EMBEDDING_PROVIDER=openai but OPENAI_API_KEY is unset. "
+            "Set the key or change the provider before running backfill."
+        )
+        return 1
+
+    try:
+        reports = await run_backfill(
+            tenant_id=args.tenant_id,
+            batch_size=args.batch_size,
+            max_inflight=args.max_inflight,
+            dry_run=args.dry_run,
+            only_table=args.only_table,
+        )
+    except RuntimeError as e:
+        # Reserved for the "degraded provider" abort path (20 consecutive
+        # None returns from get_embedding) — tells operator monitoring
+        # this is provider-side, not local config.
+        logger.error("backfill aborted: %s", e)
+        return 2
+    except Exception as e:
+        # Anything else (DB unreachable, registry misconfig surfacing as
+        # ValueError, an asyncio cancellation, etc.) — exit 1 with a
+        # stack trace so the failure is debuggable but the script's
+        # exit code distinguishes it from the provider-degraded case.
+        logger.error(
+            "backfill aborted (configuration or unexpected error): %s",
+            e,
+            exc_info=True,
+        )
+        return 1
+
+    total_scanned = sum(r.scanned for r in reports)
+    total_embedded = sum(r.embedded for r in reports)
+    print(
+        f"backfill {'dry-run ' if args.dry_run else ''}done: "
+        f"scanned={total_scanned} embedded={total_embedded} "
+        f"({len(reports)} table(s))"
+    )
+    return 0
+
+
+def main() -> None:
+    sys.exit(asyncio.run(_amain(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1307,6 +1307,72 @@ class PostgresService:
     # F) Crystallizer hygiene
     # ------------------------------------------------------------------
 
+    async def memory_list_null_embedding_rows(
+        self,
+        *,
+        limit: int,
+        after: UUID | None = None,
+        tenant_id: str | None = None,
+    ) -> tuple[list[tuple[UUID, str]], int]:
+        """Page through memories whose ``embedding IS NULL``.
+
+        Returns ``(rows, total_remaining)``. Each row carries only the
+        identifiers the caller needs to address a follow-up fetch
+        (``id, tenant_id``). The raw ``content`` and ``content_hash``
+        are NOT included — the worker uses ``GET /memories/{id}`` per
+        row to retrieve them. This keeps the listing endpoint's
+        response small + deterministic and avoids leaking full memory
+        content via what is essentially an unauthenticated id scan
+        (the storage API has no auth middleware; see Spec I in
+        ``local_emb_res/specs/``). Cursor-style on ``id`` for stable
+        resumability under the consumer's concurrent writes flipping
+        rows from NULL to non-NULL.
+
+        ``deleted_at`` rows are excluded — re-embedding them is wasted
+        work since they're already filtered out of every read path.
+
+        ``total_remaining`` is an exact ``COUNT(*)`` of *all* rows still
+        matching the embedding-NULL + deleted-at + (optional) tenant
+        filter — i.e. it uses ``base_filters``, not ``page_filters``. The
+        cursor (``after``) is paging-only state; including it in the
+        count would shrink the reported total as the backfill walks
+        forward, which is the wrong number for the caller to drive
+        progress UI / completion logging on. Acceptable on tables up to
+        a few million rows; revisit with ``pg_class.reltuples`` if it
+        shows up in operator profiles.
+        """
+        async with get_session() as session:
+            base_filters = [
+                Memory.embedding.is_(None),
+                Memory.deleted_at.is_(None),
+            ]
+            if tenant_id is not None:
+                base_filters.append(Memory.tenant_id == tenant_id)
+
+            page_filters = list(base_filters)
+            if after is not None:
+                page_filters.append(Memory.id > after)
+
+            stmt = (
+                select(
+                    Memory.id,
+                    Memory.tenant_id,
+                )
+                .where(*page_filters)
+                .order_by(Memory.id)
+                .limit(limit)
+            )
+            rows = (await session.execute(stmt)).all()
+
+            total_remaining = (
+                await session.execute(select(func.count()).select_from(Memory).where(*base_filters))
+            ).scalar_one()
+
+            return (
+                [(r[0], r[1]) for r in rows],
+                int(total_remaining),
+            )
+
     async def memory_find_missing_embeddings(
         self,
         tenant_id: str,

--- a/core-worker/src/core_worker/backfill.py
+++ b/core-worker/src/core_worker/backfill.py
@@ -1,0 +1,154 @@
+"""Event-driven re-embedding of memories whose embedding is NULL.
+
+After alembic migration ``012_vector_dim_1024`` NULLs every 768-dim
+embedding to widen the column to 1024-dim, retrieval is broken for
+those rows until they're re-embedded. This task drives the existing
+``handle_embed_request`` consumer by publishing one
+``Topics.Memory.EMBED_REQUESTED`` event per NULL row.
+
+Two backfills exist by design:
+
+* This task — event-driven, runs in ``core-worker`` against the same
+  Pub/Sub bus as production traffic. Recommended for enterprise /
+  multi-tenant production cutovers because it inherits the consumer's
+  per-tenant concurrency, retry, and DLQ wiring.
+* A standalone script at ``core-storage-api/src/core_storage_api/scripts/
+  backfill_embeddings.py`` — direct DB writes, no event bus needed.
+  Recommended for OSS docker-compose deployments where the worker may
+  not be running.
+
+Design notes:
+
+* Idempotent: re-running picks up only still-NULL rows. The consumer's
+  writes flip them non-NULL, so a restart resumes naturally.
+* Backpressure: ``max_inflight`` caps the number of unacknowledged
+  publishes. Tune up for throughput, down to avoid swamping the
+  embedding provider or the consumer's per-tenant slots.
+* No retry / DLQ logic here — that's the consumer's job
+  (``handle_embed_request`` already raises → Pub/Sub redelivers →
+  max-delivery-attempts → DLQ).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+
+from common.events.memory_embed_publisher import publish_memory_embed_request
+from core_worker.clients.storage_client import (
+    NullEmbeddingRow,
+    get_memory,
+    get_storage_client,
+    iter_memories_with_null_embedding,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BackfillReport:
+    scanned: int
+    published: int
+    skipped_missing: int
+    elapsed_s: float
+
+
+async def run_embedding_backfill(
+    *,
+    tenant_id: str,
+    batch_size: int = 500,
+    max_inflight: int = 100,
+    dry_run: bool = False,
+) -> BackfillReport:
+    """Scan NULL-embedding memories for one tenant, publish ``EMBED_REQUESTED``.
+
+    Parameters
+    ----------
+    tenant_id:
+        **Required.** Scope the scan to a single tenant. The
+        storage-API endpoint refuses un-scoped calls because the OSS
+        storage API has no auth middleware and this path returns raw
+        memory content. For whole-deployment cutovers, the operator
+        iterates over the tenant list and invokes this function once
+        per tenant — which is also the documented prod-cutover pattern
+        (per-tenant phasing limits blast radius).
+    batch_size:
+        How many ids to fetch per storage-API page.
+    max_inflight:
+        Concurrency cap on outstanding publishes. Higher = faster but
+        risks event-bus overload and consumer lag.
+    dry_run:
+        If True, count rows that would be published. Don't publish.
+    """
+    import httpx
+
+    sem = asyncio.Semaphore(max_inflight)
+    scanned = 0
+    published = 0
+    skipped_missing = 0
+    started = time.monotonic()
+
+    async def _publish_one(row: NullEmbeddingRow) -> None:
+        nonlocal published, skipped_missing
+        async with sem:
+            # Fetch the memory's content + content_hash by id. The
+            # listing endpoint returns ids-only (defence-in-depth on
+            # the unauthenticated storage API), so the worker has to
+            # round-trip per row to read the content. With
+            # ``max_inflight`` concurrency this overlaps fully with
+            # publishing — net throughput is bounded by the storage
+            # API + event bus, not by the extra hop.
+            try:
+                memory = await get_memory(storage, memory_id=row.memory_id, tenant_id=row.tenant_id)
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 404:
+                    # Row was soft-deleted (or hard-deleted) between
+                    # the listing scan and this fetch. Don't fail the
+                    # backfill — just skip; nothing to re-embed.
+                    skipped_missing += 1
+                    return
+                raise
+            content = memory.get("content")
+            if not content:
+                # ``content`` is NOT NULL on memories, but defensive
+                # against a future schema where it might not be —
+                # skipping is safer than publishing a degenerate
+                # embed request the consumer would reject.
+                skipped_missing += 1
+                return
+            if not dry_run:
+                await publish_memory_embed_request(
+                    memory_id=row.memory_id,
+                    content=content,
+                    tenant_id=row.tenant_id,
+                    content_hash=memory.get("content_hash"),
+                )
+            published += 1
+
+    storage = get_storage_client()
+    async for batch in iter_memories_with_null_embedding(storage, tenant_id=tenant_id, batch_size=batch_size):
+        scanned += len(batch)
+        await asyncio.gather(*(_publish_one(row) for row in batch))
+        logger.info(
+            "embedding_backfill progress: scanned=%d published=%d skipped=%d",
+            scanned,
+            published,
+            skipped_missing,
+        )
+
+    elapsed = time.monotonic() - started
+    logger.info(
+        "embedding_backfill done: scanned=%d published=%d skipped=%d elapsed=%.1fs",
+        scanned,
+        published,
+        skipped_missing,
+        elapsed,
+    )
+    return BackfillReport(
+        scanned=scanned,
+        published=published,
+        skipped_missing=skipped_missing,
+        elapsed_s=elapsed,
+    )

--- a/core-worker/src/core_worker/cli.py
+++ b/core-worker/src/core_worker/cli.py
@@ -1,0 +1,86 @@
+"""Operator CLI for core-worker tasks.
+
+Usage::
+
+    python -m core_worker.cli backfill-embeddings \
+        [--tenant-id ID] [--batch-size N] [--max-inflight N] [--dry-run]
+
+The backfill subcommand drives the existing ``handle_embed_request``
+consumer: it scans memories whose ``embedding IS NULL`` (after migration
+``012_vector_dim_1024``) and publishes one ``EMBED_REQUESTED`` event per
+row. See ``core_worker.backfill`` for the design notes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from core_worker.backfill import run_embedding_backfill
+from core_worker.clients.storage_client import close_storage_client
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="core_worker.cli")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    bf = sub.add_parser(
+        "backfill-embeddings",
+        help="Re-embed memories with NULL embeddings (post-migration-012 recovery).",
+    )
+    bf.add_argument(
+        "--tenant-id",
+        required=True,
+        help=(
+            "Required. Scope the backfill to a single tenant. The "
+            "storage-API endpoint refuses un-scoped calls since the OSS "
+            "API has no auth middleware. For whole-deployment cutovers, "
+            "iterate the tenant list externally and invoke this command "
+            "once per tenant — also the documented prod-cutover pattern."
+        ),
+    )
+    bf.add_argument("--batch-size", type=int, default=500)
+    bf.add_argument("--max-inflight", type=int, default=100)
+    bf.add_argument("--dry-run", action="store_true")
+    bf.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    return p
+
+
+async def _amain(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s | %(message)s",
+    )
+    if args.cmd == "backfill-embeddings":
+        try:
+            report = await run_embedding_backfill(
+                tenant_id=args.tenant_id,
+                batch_size=args.batch_size,
+                max_inflight=args.max_inflight,
+                dry_run=args.dry_run,
+            )
+        finally:
+            # Close the singleton httpx client so the event-loop exits
+            # cleanly. Mirrors the FastAPI lifespan shutdown.
+            await close_storage_client()
+        print(
+            f"backfill {'dry-run ' if args.dry_run else ''}done: "
+            f"scanned={report.scanned} published={report.published} "
+            f"elapsed={report.elapsed_s:.1f}s"
+        )
+        return 0
+    return 1
+
+
+def main() -> None:
+    sys.exit(asyncio.run(_amain(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/core-worker/src/core_worker/clients/storage_client.py
+++ b/core-worker/src/core_worker/clients/storage_client.py
@@ -23,7 +23,8 @@ real token and the writer's ``--no-allow-unauthenticated`` accepts it.
 from __future__ import annotations
 
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
@@ -215,6 +216,104 @@ async def update_memory_embedding(
         return
     # 5xx / 429 / network → raise → consumer nacks → Pub/Sub redelivers.
     resp.raise_for_status()
+
+
+@dataclass(frozen=True)
+class NullEmbeddingRow:
+    """Identifiers for one memory row that needs re-embedding.
+
+    Carries only the fields needed to address a follow-up
+    ``GET /memories/{id}`` fetch. Raw ``content`` / ``content_hash``
+    are NOT included — the listing endpoint deliberately returns
+    ids-only (defence-in-depth on the unauthenticated storage API),
+    and the worker fetches content per row before publishing.
+    """
+
+    memory_id: UUID
+    tenant_id: str
+
+
+async def iter_memories_with_null_embedding(
+    client: httpx.AsyncClient,
+    *,
+    tenant_id: str,
+    batch_size: int = 500,
+) -> AsyncIterator[list[NullEmbeddingRow]]:
+    """Paginate memories whose ``embedding IS NULL`` for one tenant.
+
+    Yields lists of up to *batch_size* rows so the caller can publish
+    events in batches and apply backpressure. Stops when the storage
+    API reports an empty page.
+
+    Idempotent under restart: each call re-queries from the start, but
+    rows the consumer has since embedded are no longer NULL and are
+    skipped naturally by the storage-side filter.
+
+    Transient HTTP errors propagate — the operator-driven CLI prefers
+    a loud failure over a silent partial-scan.
+
+    ``tenant_id`` is **required**. The storage-API endpoint refuses
+    un-scoped requests because the OSS API has no auth middleware.
+    For whole-deployment scans, iterate the tenant list and call once
+    per tenant.
+    """
+    after: str | None = None
+    while True:
+        params: dict[str, Any] = {"limit": batch_size, "tenant_id": tenant_id}
+        if after is not None:
+            params["after"] = after
+        resp = await _signed_call(
+            client.get,
+            f"{_PREFIX}/memories/null-embedding-ids",
+            params=params,
+        )
+        resp.raise_for_status()
+        page = resp.json()
+        rows_payload = page.get("rows") or []
+        if not rows_payload:
+            # Endpoint contract: when ``rows`` is non-empty,
+            # ``next_after`` is always a UUID string (the last row's
+            # id). When ``rows`` is empty, we're done — no need for a
+            # secondary ``next_after is None`` check, which used to
+            # follow the yield below but was unreachable under the
+            # contract.
+            return
+        yield [
+            NullEmbeddingRow(
+                memory_id=UUID(r["id"]),
+                tenant_id=r["tenant_id"],
+            )
+            for r in rows_payload
+        ]
+        after = page["next_after"]
+
+
+async def get_memory(
+    client: httpx.AsyncClient,
+    *,
+    memory_id: UUID,
+    tenant_id: str,
+) -> dict:
+    """Fetch a single memory by id, scoped to ``tenant_id``.
+
+    Used by the embedding backfill worker to retrieve ``content`` +
+    ``content_hash`` after the listing endpoint hands it an id. The
+    listing path deliberately returns ids-only so this round-trip
+    here is the only place raw memory content is exposed over the
+    HTTP boundary, on a per-row basis (rate-limitable, audit-loggable
+    if the storage API later adds auth middleware).
+
+    Raises ``HTTPStatusError`` on 404 or any non-2xx — the caller
+    decides whether to skip-and-continue (the row was deleted between
+    listing and fetch) or abort.
+    """
+    resp = await _signed_call(
+        client.get,
+        f"{_PREFIX}/memories/{memory_id}",
+        params={"tenant_id": tenant_id},
+    )
+    resp.raise_for_status()
+    return resp.json()
 
 
 async def update_memory_enrichment(

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -117,11 +117,27 @@ services:
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
+      # Embedder experiment (A.5) — local TEI sidecar overrides
+      OPENAI_EMBEDDING_BASE_URL: "${OPENAI_EMBEDDING_BASE_URL:-}"
+      OPENAI_EMBEDDING_SEND_DIMENSIONS: "${OPENAI_EMBEDDING_SEND_DIMENSIONS:-true}"
+      OPENAI_EMBEDDING_MODEL: "${OPENAI_EMBEDDING_MODEL:-}"
+      # Option B (instruction-aware query encoding) and Matryoshka truncation.
+      # Default instruction applied to all /api/v1/search calls; ingest path
+      # unchanged. Truncate-to-dim lets us run native-1024/2560/4096-dim models
+      # against an unchanged 768-dim schema (Qwen3-Embedding family with MRL).
+      EMBEDDING_QUERY_INSTRUCTION: "${EMBEDDING_QUERY_INSTRUCTION:-}"
+      OPENAI_EMBEDDING_TRUNCATE_TO_DIM: "${OPENAI_EMBEDDING_TRUNCATE_TO_DIM:-}"
+      EMBEDDING_PROVIDER: "${EMBEDDING_PROVIDER:-fake}"
+      ENTITY_EXTRACTION_PROVIDER: "${ENTITY_EXTRACTION_PROVIDER:-fake}"
+      USE_LLM_FOR_MEMORY_CREATION: "${USE_LLM_FOR_MEMORY_CREATION:-false}"
     depends_on:
       core-storage-api:
         condition: service_healthy
       redis:
         condition: service_healthy
+      tei:
+        condition: service_healthy
+        required: false  # only enforced when --profile embed-local is active
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]
       interval: 15s
@@ -129,6 +145,31 @@ services:
       retries: 3
       start_period: 15s
 
+  # ── Local Embedder (opt-in via ``--profile embed-local``) ───────
+  # See docker-compose.yml for the full block + comments. This dev
+  # variant is identical so that ``--profile embed-local`` works the
+  # same way against the hot-reload stack.
+
+  tei:
+    image: ghcr.io/huggingface/text-embeddings-inference:${TEI_IMAGE_TAG:-cpu-1.7}
+    profiles: ["embed-local"]
+    command:
+      - --model-id
+      - "${TEI_MODEL_ID:-BAAI/bge-m3}"
+      - --auto-truncate
+    environment:
+      HUGGINGFACE_HUB_CACHE: /data
+    volumes:
+      - tei_cache:/data
+    healthcheck:
+      test: ["CMD", "curl", "-fs", "http://localhost:80/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    # See docker-compose.yml for the optional GPU deploy block.
+
 volumes:
   pgdata:
   redis_data:
+  tei_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,11 +114,21 @@ services:
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
+      # Local-embedder envs (consumed when ``--profile embed-local``
+      # is active; harmless when unset). See ``docs/local-embedder.md``.
+      OPENAI_EMBEDDING_BASE_URL: "${OPENAI_EMBEDDING_BASE_URL:-}"
+      OPENAI_EMBEDDING_SEND_DIMENSIONS: "${OPENAI_EMBEDDING_SEND_DIMENSIONS:-true}"
+      OPENAI_EMBEDDING_MODEL: "${OPENAI_EMBEDDING_MODEL:-}"
+      OPENAI_EMBEDDING_TRUNCATE_TO_DIM: "${OPENAI_EMBEDDING_TRUNCATE_TO_DIM:-}"
+      EMBEDDING_QUERY_INSTRUCTION: "${EMBEDDING_QUERY_INSTRUCTION:-}"
     depends_on:
       core-storage-api:
         condition: service_healthy
       redis:
         condition: service_healthy
+      tei:
+        condition: service_healthy
+        required: false  # only enforced when --profile embed-local is active
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]
       interval: 15s
@@ -126,6 +136,51 @@ services:
       retries: 3
       start_period: 15s
 
+  # ── Local Embedder (opt-in via ``--profile embed-local``) ───────
+  #
+  # HuggingFace Text Embeddings Inference server. Drop-in replacement
+  # for the OpenAI embeddings API: ``OPENAI_EMBEDDING_BASE_URL=
+  # http://tei:80/v1`` on ``core-api`` routes embeddings here instead
+  # of api.openai.com. Default model is ``BAAI/bge-m3`` (1024-dim,
+  # MIT, multilingual, no instruction prefix needed) — matches the
+  # schema set in alembic migration 012.
+  #
+  # Default image is the CPU build (``cpu-1.7``); for an L4-class
+  # GPU box, set ``TEI_IMAGE_TAG=89-1.7`` and add the deploy/gpu
+  # block (commented at the bottom of this service). See
+  # ``docs/local-embedder.md`` for hardware sizing and model swaps.
+
+  tei:
+    image: ghcr.io/huggingface/text-embeddings-inference:${TEI_IMAGE_TAG:-cpu-1.7}
+    profiles: ["embed-local"]
+    command:
+      - --model-id
+      - "${TEI_MODEL_ID:-BAAI/bge-m3}"
+      - --auto-truncate
+    environment:
+      HUGGINGFACE_HUB_CACHE: /data
+    volumes:
+      - tei_cache:/data
+    healthcheck:
+      # Generous retries: first-time model download (~2 GB for
+      # bge-m3) can take several minutes on a cold cache.
+      test: ["CMD", "curl", "-fs", "http://localhost:80/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    # Uncomment to attach a GPU (L4, A10, etc) — requires
+    # nvidia-container-toolkit on the host. Verified on L4
+    # (``g2-standard-8``) in the local-embedder bench.
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: 1
+    #           capabilities: [gpu]
+
 volumes:
   pgdata:
   redis_data:
+  tei_cache:

--- a/docs/local-embedder.md
+++ b/docs/local-embedder.md
@@ -1,0 +1,173 @@
+# Local Embedder (TEI sidecar)
+
+MemClaw can serve embeddings from a self-hosted [HuggingFace Text Embeddings
+Inference](https://github.com/huggingface/text-embeddings-inference) (TEI)
+container instead of OpenAI's hosted API. **Default model: `BAAI/bge-m3`**
+(1024-dim, MIT-licensed, multilingual, no instruction prefix needed) — matches
+the schema set in alembic migration `012_vector_dim_1024`.
+
+## TL;DR
+
+```bash
+docker compose --profile embed-local up -d
+```
+
+That's it. The `tei` service runs on the compose network, `core-api` finds it
+at `http://tei:80/v1`, embeddings stop hitting OpenAI. Set the four envs from
+`.env.example` if you want to override the model or point at an external TEI.
+
+## Why bother
+
+| | OpenAI hosted | TEI + bge-m3 (this) |
+|---|---|---|
+| Cost @ 1000 RPS | ~$10.5k/mo | ~$1.0k/mo (2× L4) |
+| Idle p50 search | ~230 ms | ~127 ms (CPU), ~50 ms (L4) |
+| Data residency | leaves your env | stays in your VPC |
+| R@5 (LongMemEval N=30) | 0.889 | 0.963 |
+| Accuracy | 86.7 % | 93.3 % |
+
+Numbers from `local_emb_res/RESULTS.md` (the bench-off that drove this default).
+
+## How it works
+
+`OpenAIEmbeddingProvider` accepts an optional `base_url`. When set, the OpenAI
+SDK routes every embed call there instead of `api.openai.com`. TEI speaks the
+same `POST /v1/embeddings` API shape, so no other code changes are required.
+
+Two flags are TEI-specific:
+
+* **`OPENAI_EMBEDDING_SEND_DIMENSIONS=false`** — TEI rejects the
+  `dimensions=` SDK kwarg. Must be `false` whenever `OPENAI_EMBEDDING_BASE_URL`
+  points at TEI. The OpenAI hosted path keeps the default `true` (dim is
+  pinned to `VECTOR_DIM`).
+* **`OPENAI_EMBEDDING_TRUNCATE_TO_DIM`** — Matryoshka-style output slice +
+  L2-renormalize. Only relevant if you swap to a model whose native dim is
+  larger than the schema (e.g. Qwen3-Embedding-0.6B = 1024, schema = 768
+  on a stale deployment). bge-m3 is native 1024 against the 1024 schema —
+  leave empty.
+
+Two are model-specific:
+
+* **`OPENAI_EMBEDDING_MODEL`** — passed to the OpenAI SDK and surfaced to TEI
+  unchanged. TEI ignores it (TEI runs whatever model `--model-id` says) but
+  the value is logged and cached on so we keep it accurate.
+* **`EMBEDDING_QUERY_INSTRUCTION`** — only set this for instruction-aware
+  models (Qwen3-Embedding, e5-instruct, KaLM). When set, the search path
+  prepends `Instruct: <task>\nQuery: <text>` to every query; the ingest path
+  is unchanged. bge-m3 is symmetric — leave empty.
+
+The full asymmetric-encoding contract is in `common/embedding/protocols.py`
+(`embed_query` vs `embed`).
+
+## Hardware sizing
+
+The compose service ships with the **CPU image** (`cpu-1.7`) by default. Good
+enough for a laptop, a small VM, or a single-tenant client. Numbers below are
+for `BAAI/bge-m3` at ~200-token average input.
+
+| Hardware | TEI image | Realistic RPS | p50 latency |
+|---|---|---|---|
+| 8 vCPU AMD (e2-standard-8) | `cpu-1.7` (default) | 200–400 | ~130 ms |
+| 8 vCPU Intel (n2-standard-8, AVX-512) | `cpu-1.7` | 400–700 | ~80 ms |
+| 1× L4 GPU (g2-standard-8) | `89-1.7` | 3,000–8,000 | ~50 ms |
+
+To switch to the GPU image, set `TEI_IMAGE_TAG=89-1.7` in `.env` **and**
+uncomment the `deploy.resources.reservations.devices` block in the `tei`
+service (or copy it into `docker-compose.override.yml`). You'll need
+[nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+on the host.
+
+For production at sustained high RPS, you want **two TEI replicas behind a
+load balancer** — see the discussion in `local_emb_res/sizing-1000rps.md`.
+A single replica's per-call latency degrades sharply under concurrent load
+(measured: 57 ms idle → 571 ms at 5×2 concurrent fan-out).
+
+## Swapping models
+
+Set `TEI_MODEL_ID` and (if needed) the four flags above. The combinations
+that work cleanly with the current 1024-dim schema:
+
+| Model | Native dim | Truncate? | Instruction? | Notes |
+|---|---|---|---|---|
+| `BAAI/bge-m3` | 1024 | no | no | **Default.** MIT, 100+ langs, 8K ctx. |
+| `Snowflake/snowflake-arctic-embed-l-v2.0` | 1024 | no | no (recommended `query:` prefix) | Apache-2.0, 74 langs. Same shape as bge-m3. |
+| `Qwen/Qwen3-Embedding-0.6B` | 1024 | no | yes | Apache-2.0, instruction-aware. Best quality for this dim, but needs GPU. |
+| `Qwen/Qwen3-Embedding-4B` | 2560 | yes (`=1024`) | yes | Truncates to 1024 via Matryoshka. L4 GPU. |
+
+If you go to a model with a different native dim (e.g. Qwen3-8B at 4096),
+either set `OPENAI_EMBEDDING_TRUNCATE_TO_DIM=1024` or migrate the schema to
+the new dim with a follow-up alembic revision.
+
+## Schema requirement
+
+> **Upgrading from v1.x?** Follow the
+> [Upgrading from v1.x](../README.md#upgrading-from-v1x) section in the
+> README first — it sequences DB snapshot, opt-in env var, and re-embed for
+> you. The bare `alembic upgrade 012` shown below is for fresh installations.
+
+The `tei` profile assumes the 1024-dim schema. If you're upgrading an existing
+768-dim deployment:
+
+```bash
+# Run the migration (NULLs existing 768-dim embeddings; re-embed required)
+docker compose run --rm core-storage-api \
+  python -m alembic upgrade 012
+```
+
+The `012` revision is **destructive** — existing 768-dim vectors cannot be
+coerced to 1024 and are set to `NULL`. The application re-embeds lazily on
+next read/write. For an eager re-embed pass, run the bundled CLI:
+
+```bash
+docker compose run --rm core-storage-api \
+  python -m core_storage_api.scripts.backfill_embeddings --dry-run
+docker compose run --rm core-storage-api \
+  python -m core_storage_api.scripts.backfill_embeddings
+```
+
+For multi-tenant production cutovers prefer the event-driven backfill task
+in `core-worker`. It scans `WHERE embedding IS NULL` and publishes one
+`EMBED_REQUESTED` event per row, inheriting the consumer's per-tenant
+concurrency, retry, and DLQ wiring:
+
+```bash
+docker compose run --rm core-worker \
+  python -m core_worker.cli backfill-embeddings --dry-run
+docker compose run --rm core-worker \
+  python -m core_worker.cli backfill-embeddings
+```
+
+Optional knobs: `--tenant-id <id>` (per-tenant cutover), `--batch-size N`,
+`--max-inflight N`, `--dry-run`. Idempotent and restartable — re-running
+picks up only rows still missing an embedding.
+
+See `core-storage-api/src/core_storage_api/database/migrations/versions/012_vector_dim_1024.py`
+for the full operational story.
+
+## Switching back to OpenAI hosted
+
+Just don't pass `--profile embed-local`. The `tei` service is profile-gated,
+so a plain `docker compose up -d` brings up the same stack as before — no
+TEI container, `core-api` falls through to the hosted OpenAI default
+(unset `OPENAI_EMBEDDING_BASE_URL`, set `OPENAI_API_KEY`).
+
+A single deployment cannot mix both — the schema dim is global. To go back
+to OpenAI's `text-embedding-3-small` (1536 → 768 truncated), you'd need to
+roll back migration `012` and re-embed.
+
+## Troubleshooting
+
+* **`tei` healthcheck fails on first boot for several minutes.** First-time
+  model download can be slow (~2 GB for bge-m3). The healthcheck has 30
+  retries and `start_period: 60s` to cover this. Subsequent boots reuse the
+  `tei_cache` volume and come up in seconds.
+* **`core-api` logs `400 Bad Request` from `/v1/embeddings`.** Check that
+  `OPENAI_EMBEDDING_SEND_DIMENSIONS=false` — TEI rejects the `dimensions=`
+  kwarg.
+* **Per-call latency jumps from ~130 ms to ~600 ms under concurrent load.**
+  Single-replica TEI queues requests in dynamic batching. Add a second
+  replica behind nginx/LB — see `local_emb_res/design_integration.md`.
+* **`413 Payload Too Large` on long writes.** The compose `command:` includes
+  `--auto-truncate` so this should not happen with bge-m3 (8K context).
+  If it does, you've swapped to a 512-ctx model — pick something else or
+  pre-chunk in the application layer.

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
 asyncio_default_test_loop_scope = session
 testpaths = tests
-pythonpath = core-api/src core-storage-api/src .
+pythonpath = core-api/src core-storage-api/src core-worker/src .
 markers =
     unit: pure algorithmic tests (no DB required)
     integration: tests requiring PostgreSQL + pgvector

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -11,6 +11,7 @@ import pytest
 from sqlalchemy import select
 
 from common.models.memory import Memory
+from core_api.constants import VECTOR_DIM
 from core_api.schemas import MemoryCreate, MemoryOut
 
 # Ensure pipeline flag is off for legacy path tests
@@ -373,7 +374,7 @@ async def test_schedule_background_tasks_fast_mode_fires_background_enrichment()
         data={
             "input": _make_input(),
             "memory": mock_memory,
-            "embedding": [0.1] * 768,
+            "embedding": [0.1] * VECTOR_DIM,
             "resolved_write_mode": "fast",
         },
         tenant_config=mock_config,
@@ -412,7 +413,7 @@ async def test_schedule_background_tasks_strong_mode_fires_entity_and_contradict
         data={
             "input": _make_input(),
             "memory": mock_memory,
-            "embedding": [0.1] * 768,
+            "embedding": [0.1] * VECTOR_DIM,
             "resolved_write_mode": "strong",
         },
         tenant_config=mock_config,

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -1,0 +1,293 @@
+"""Unit tests for the OSS embedding-backfill CLI.
+
+The script lives at ``core-storage-api/scripts/backfill_embeddings.py``
+and re-embeds rows whose embedding is NULL — the post-migration-010
+recovery path for OSS docker-compose users.
+
+These tests mock the engine + ``get_embedding`` so no real DB or
+OpenAI account is required. Integration coverage (against a real
+local Postgres + fake embedding provider) is covered by the staging
+cutover runbook (Spec E), not this PR.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _fake_engine(rows_by_query: dict[str, list[tuple]]) -> MagicMock:
+    """Build a minimal AsyncEngine stand-in that returns canned rows for
+    each ``conn.execute`` call, keyed by a fragment of the SQL.
+
+    *rows_by_query* maps "memories" / "entities" → the full row list to
+    yield in a single page. The first ``execute`` call for each table
+    returns those rows; subsequent calls return an empty list (so the
+    pagination loop terminates).
+    """
+    served: dict[str, bool] = {}
+
+    async def _execute(statement, params=None):
+        sql = str(statement).lower()
+        # UPDATE statements: pretend they succeeded.
+        if sql.startswith("update"):
+            return MagicMock()
+        # SELECT — first call per table returns rows; second returns [].
+        for key, rows in rows_by_query.items():
+            if key in sql and not served.get(key):
+                served[key] = True
+                result = MagicMock()
+                result.all = MagicMock(return_value=rows)
+                return result
+        empty = MagicMock()
+        empty.all = MagicMock(return_value=[])
+        return empty
+
+    conn = MagicMock()
+    conn.execute = AsyncMock(side_effect=_execute)
+    conn.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _connect():
+        yield conn
+
+    engine = MagicMock()
+    engine.connect = _connect
+    return engine
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_re_embeds_memories_and_entities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: each NULL-embedding row gets a re-embed call and a
+    corresponding UPDATE. Reports the right scanned/embedded counts."""
+    from core_storage_api.scripts.backfill_embeddings import run_backfill
+
+    rows = {
+        "from memories": [
+            (uuid.uuid4(), "memory content one"),
+            (uuid.uuid4(), "memory content two"),
+        ],
+        "from entities": [
+            (uuid.uuid4(), "Acme Corp"),
+        ],
+    }
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.get_engine"
+        if False
+        else "core_storage_api.database.init.get_engine",
+        lambda: _fake_engine(rows),
+    )
+
+    embed = AsyncMock(return_value=[0.1] * 1024)
+    monkeypatch.setattr("common.embedding.get_embedding", embed)
+
+    reports = await run_backfill(
+        tenant_id=None,
+        batch_size=500,
+        max_inflight=10,
+        dry_run=False,
+    )
+
+    by_table = {r.table: r for r in reports}
+    assert by_table["memories"].scanned == 2
+    assert by_table["memories"].embedded == 2
+    assert by_table["entities"].scanned == 1
+    assert by_table["entities"].embedded == 1
+    # 3 rows → 3 embed calls.
+    assert embed.await_count == 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_dry_run_skips_provider_and_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--dry-run`` counts what would have been done but doesn't call
+    the embedding provider or issue UPDATEs."""
+    from core_storage_api.scripts.backfill_embeddings import run_backfill
+
+    rows = {
+        "from memories": [(uuid.uuid4(), "x"), (uuid.uuid4(), "y")],
+        "from entities": [],
+    }
+    monkeypatch.setattr(
+        "core_storage_api.database.init.get_engine",
+        lambda: _fake_engine(rows),
+    )
+    embed = AsyncMock(return_value=[0.1] * 1024)
+    monkeypatch.setattr("common.embedding.get_embedding", embed)
+
+    reports = await run_backfill(
+        tenant_id=None, batch_size=500, max_inflight=10, dry_run=True
+    )
+
+    by_table = {r.table: r for r in reports}
+    assert by_table["memories"].scanned == 2
+    assert by_table["memories"].embedded == 2  # counted as "would have"
+    assert embed.await_count == 0  # but never actually called
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_skips_empty_content_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row with empty / None content is skipped (not re-embedded with
+    a degenerate empty-string vector). Reported under
+    ``skipped_empty_content``."""
+    from core_storage_api.scripts.backfill_embeddings import run_backfill
+
+    rows = {
+        "from memories": [
+            (uuid.uuid4(), ""),
+            (uuid.uuid4(), "real content"),
+            (uuid.uuid4(), None),
+        ],
+        "from entities": [],
+    }
+    monkeypatch.setattr(
+        "core_storage_api.database.init.get_engine",
+        lambda: _fake_engine(rows),
+    )
+    embed = AsyncMock(return_value=[0.1] * 1024)
+    monkeypatch.setattr("common.embedding.get_embedding", embed)
+
+    reports = await run_backfill(
+        tenant_id=None, batch_size=500, max_inflight=10, dry_run=False
+    )
+
+    mems = next(r for r in reports if r.table == "memories")
+    assert mems.scanned == 3
+    assert mems.embedded == 1
+    assert mems.skipped_empty_content == 2
+    assert embed.await_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_aborts_on_consecutive_provider_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``get_embedding`` returns None on too many consecutive rows,
+    the backfill raises a RuntimeError so the operator can investigate
+    rather than spending the next hour writing nothing."""
+    from core_storage_api.scripts import backfill_embeddings
+
+    n_rows = backfill_embeddings._MAX_CONSECUTIVE_NONES + 5
+    rows = {
+        "from memories": [(uuid.uuid4(), f"content {i}") for i in range(n_rows)],
+        "from entities": [],
+    }
+    monkeypatch.setattr(
+        "core_storage_api.database.init.get_engine",
+        lambda: _fake_engine(rows),
+    )
+    embed = AsyncMock(return_value=None)
+    monkeypatch.setattr("common.embedding.get_embedding", embed)
+
+    with pytest.raises(RuntimeError, match="consecutive rows"):
+        await backfill_embeddings.run_backfill(
+            tenant_id=None, batch_size=500, max_inflight=2, dry_run=False
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_only_table_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--only-table memories`` skips entities entirely (no scan, no
+    report)."""
+    from core_storage_api.scripts.backfill_embeddings import run_backfill
+
+    rows = {
+        "from memories": [(uuid.uuid4(), "m1")],
+        "from entities": [(uuid.uuid4(), "ENTITY-SHOULD-NOT-BE-PROCESSED")],
+    }
+    monkeypatch.setattr(
+        "core_storage_api.database.init.get_engine",
+        lambda: _fake_engine(rows),
+    )
+    embed = AsyncMock(return_value=[0.1] * 1024)
+    monkeypatch.setattr("common.embedding.get_embedding", embed)
+
+    reports = await run_backfill(
+        tenant_id=None,
+        batch_size=500,
+        max_inflight=10,
+        dry_run=False,
+        only_table="memories",
+    )
+
+    assert len(reports) == 1
+    assert reports[0].table == "memories"
+
+
+# ---------------------------------------------------------------------------
+# CLI exit-code coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_returns_2_on_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``RuntimeError`` from ``run_backfill`` (the "consecutive Nones"
+    abort path) maps to exit code 2 — distinguishable for monitoring as
+    "embedding provider degraded" rather than "config / unexpected"."""
+    from core_storage_api.scripts.backfill_embeddings import _amain
+
+    async def _runtime_explode(**_kw):
+        raise RuntimeError("provider returned None on 20 consecutive rows; stopping")
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.run_backfill",
+        _runtime_explode,
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    code = await _amain([])
+    assert code == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_returns_1_on_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Anything that isn't ``RuntimeError`` (DB unreachable,
+    registry-level ``ValueError`` surfacing here, asyncio cancellation,
+    etc.) maps to exit code 1 with a stack trace logged. Exit-code 1 vs
+    2 lets ops monitoring distinguish 'something else is broken' from
+    'provider degraded'."""
+    import logging
+
+    from core_storage_api.scripts.backfill_embeddings import _amain
+
+    async def _value_explode(**_kw):
+        raise ValueError("OPENAI_EMBEDDING_BASE_URL/SEND_DIMENSIONS conflict")
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.run_backfill",
+        _value_explode,
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    with caplog.at_level(
+        logging.ERROR, logger="core_storage_api.scripts.backfill_embeddings"
+    ):
+        code = await _amain([])
+
+    assert code == 1
+    assert any(
+        "configuration or unexpected error" in rec.getMessage()
+        for rec in caplog.records
+    ), "expected an ERROR log naming the broader error class"

--- a/tests/test_bulk_write.py
+++ b/tests/test_bulk_write.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 
 import pytest
 
-from core_api.constants import BULK_MAX_ITEMS, DEFAULT_MEMORY_WEIGHT
+from core_api.constants import BULK_MAX_ITEMS, DEFAULT_MEMORY_WEIGHT, VECTOR_DIM
 from core_api.schemas import (
     BulkItemResult,
     BulkMemoryCreate,
@@ -138,7 +138,7 @@ class TestBatchEmbedding:
         config.embedding_provider = "fake"
         results = await get_embeddings_batch(texts, config)
         assert len(results) == 3
-        assert all(len(e) == 768 for e in results)
+        assert all(len(e) == VECTOR_DIM for e in results)
 
     @pytest.mark.asyncio
     async def test_batch_matches_single(self):

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from core_api.constants import VECTOR_DIM
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.steps.write.parallel_embed_enrich import ParallelEmbedEnrich
 from core_api.schemas import MemoryCreate
@@ -72,7 +73,7 @@ async def test_skips_embed_when_flag_off() -> None:
         patch("core_api.pipeline.steps.write.parallel_embed_enrich.settings.embed_on_hot_path", False),
         patch(
             "core_api.pipeline.steps.write.parallel_embed_enrich.get_embedding",
-            new=AsyncMock(return_value=[0.1] * 768),
+            new=AsyncMock(return_value=[0.1] * VECTOR_DIM),
         ) as embed,
     ):
         await ParallelEmbedEnrich().execute(ctx)
@@ -83,7 +84,7 @@ async def test_skips_embed_when_flag_off() -> None:
 
 async def test_runs_embed_when_flag_on() -> None:
     ctx = _ctx()
-    fake = [0.1] * 768
+    fake = [0.1] * VECTOR_DIM
     with (
         patch("core_api.pipeline.steps.write.parallel_embed_enrich.settings.embed_on_hot_path", True),
         patch(
@@ -99,13 +100,13 @@ async def test_runs_embed_when_flag_on() -> None:
 async def test_uses_cached_embedding_even_when_flag_off() -> None:
     """A cached embedding is a pure dict lookup — there's no provider call
     to offload. The step must reuse it regardless of the flag."""
-    cached = [0.42] * 768
+    cached = [0.42] * VECTOR_DIM
     ctx = _ctx(cached_embedding=cached)
     with (
         patch("core_api.pipeline.steps.write.parallel_embed_enrich.settings.embed_on_hot_path", False),
         patch(
             "core_api.pipeline.steps.write.parallel_embed_enrich.get_embedding",
-            new=AsyncMock(return_value=[0.0] * 768),
+            new=AsyncMock(return_value=[0.0] * VECTOR_DIM),
         ) as embed,
     ):
         await ParallelEmbedEnrich().execute(ctx)
@@ -126,7 +127,7 @@ async def test_enrichment_still_runs_when_flag_off() -> None:
         patch("core_api.pipeline.steps.write.parallel_embed_enrich.settings.embed_on_hot_path", False),
         patch(
             "core_api.pipeline.steps.write.parallel_embed_enrich.get_embedding",
-            new=AsyncMock(return_value=[0.0] * 768),
+            new=AsyncMock(return_value=[0.0] * VECTOR_DIM),
         ) as embed,
         patch("core_api.services.memory_enrichment.enrich_memory", new=_enrich),
     ):
@@ -151,7 +152,7 @@ async def test_hint_reembed_skipped_when_flag_off() -> None:
         patch("core_api.pipeline.steps.write.parallel_embed_enrich.settings.embed_on_hot_path", False),
         patch(
             "core_api.pipeline.steps.write.parallel_embed_enrich.get_embedding",
-            new=AsyncMock(return_value=[0.0] * 768),
+            new=AsyncMock(return_value=[0.0] * VECTOR_DIM),
         ) as embed,
         patch("core_api.services.memory_enrichment.enrich_memory", new=_enrich),
     ):
@@ -185,7 +186,7 @@ async def test_reembed_skips_initial_sleep_when_flag_off() -> None:
 
     with (
         patch.object(memory_service.settings, "embed_on_hot_path", False),
-        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * 768)),
+        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * VECTOR_DIM)),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.memory_service.asyncio.sleep", new=_fake_sleep),
         patch.object(memory_service, "track_task"),
@@ -213,7 +214,7 @@ async def test_reembed_sleeps_on_failure_path_when_flag_on() -> None:
 
     with (
         patch.object(memory_service.settings, "embed_on_hot_path", True),
-        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * 768)),
+        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * VECTOR_DIM)),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.memory_service.asyncio.sleep", new=_fake_sleep),
         patch.object(memory_service, "track_task"),
@@ -246,7 +247,7 @@ async def test_reembed_schedules_contradiction_after_success() -> None:
 
     with (
         patch.object(memory_service.settings, "embed_on_hot_path", False),
-        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * 768)),
+        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * VECTOR_DIM)),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.memory_service.asyncio.sleep", new=_noop_sleep),
         patch.object(memory_service, "track_task"),
@@ -268,7 +269,7 @@ async def test_reembed_race_guard_fires_with_flag_on_too() -> None:
     Regression guard for a review finding."""
     from core_api.services import memory_service
 
-    hint_enhanced = [0.9] * 768  # written by _enrich_memory_background
+    hint_enhanced = [0.9] * VECTOR_DIM  # written by _enrich_memory_background
     sc = MagicMock()
     sc.get_memory = AsyncMock(
         return_value={"id": "m1", "deleted_at": None, "fleet_id": "f1", "embedding": hint_enhanced}
@@ -285,7 +286,7 @@ async def test_reembed_race_guard_fires_with_flag_on_too() -> None:
     with (
         # Flag ON — the configuration where the earlier guard was broken.
         patch.object(memory_service.settings, "embed_on_hot_path", True),
-        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * 768)),
+        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * VECTOR_DIM)),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.memory_service.asyncio.sleep", new=_noop_sleep),
         patch.object(memory_service, "track_task"),
@@ -307,7 +308,7 @@ async def test_reembed_respects_existing_embedding_from_enrich_race() -> None:
     on the existing value so coverage isn't lost."""
     from core_api.services import memory_service
 
-    existing = [0.9] * 768  # hint-enhanced embedding written by enrich
+    existing = [0.9] * VECTOR_DIM  # hint-enhanced embedding written by enrich
     sc = MagicMock()
     sc.get_memory = AsyncMock(
         return_value={"id": "m1", "deleted_at": None, "fleet_id": "f1", "embedding": existing}
@@ -335,7 +336,7 @@ async def test_reembed_respects_existing_embedding_from_enrich_race() -> None:
 
     with (
         patch.object(memory_service.settings, "embed_on_hot_path", False),
-        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * 768)),
+        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * VECTOR_DIM)),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.memory_service.asyncio.sleep", new=_noop_sleep),
         patch("core_api.services.contradiction_detector.detect_contradictions_async", new=_fake_detect),
@@ -373,7 +374,7 @@ async def test_bulk_reembed_preserves_batching() -> None:
 
     async def _fake_batch(texts, _cfg):
         batch_calls.append(len(texts))
-        return [[0.1] * 768 for _ in texts]
+        return [[0.1] * VECTOR_DIM for _ in texts]
 
     def _stub_tracked_task(coro, _name, *_a, **_k):
         coro.close()
@@ -404,8 +405,8 @@ async def test_enrich_fires_contradiction_when_overwriting_existing_embedding() 
     uncovered unless we fire contradiction detection post-enrich too."""
     from core_api.services import memory_service
 
-    raw_existing = [0.1] * 768      # already written by _reembed
-    hint_enhanced = [0.9] * 768     # enrich computes + overwrites with this
+    raw_existing = [0.1] * VECTOR_DIM      # already written by _reembed
+    hint_enhanced = [0.9] * VECTOR_DIM     # enrich computes + overwrites with this
 
     mem_row = {
         "id": "m1",
@@ -520,7 +521,7 @@ async def test_enrich_no_contradiction_when_no_prior_embedding() -> None:
     """
     from core_api.services import memory_service
 
-    hint_enhanced = [0.9] * 768
+    hint_enhanced = [0.9] * VECTOR_DIM
     mem_row = {
         "id": "m1",
         "deleted_at": None,
@@ -606,7 +607,7 @@ async def test_reembed_is_failure_fallback_triggers_backoff() -> None:
 
     with (
         patch.object(memory_service.settings, "embed_on_hot_path", False),
-        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * 768)),
+        patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=[0.1] * VECTOR_DIM)),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.memory_service.asyncio.sleep", new=_fake_sleep),
         patch.object(memory_service, "track_task"),
@@ -724,7 +725,7 @@ async def test_bulk_reembed_reschedules_items_whose_get_memory_failed() -> None:
     sc.update_embedding = AsyncMock()
 
     async def _batch(_texts, _cfg):
-        return [[0.1] * 768, [0.2] * 768]
+        return [[0.1] * VECTOR_DIM, [0.2] * VECTOR_DIM]
 
     def _fake_detect(*args, **_kwargs):
         async def _noop() -> None:
@@ -752,7 +753,7 @@ async def test_bulk_reembed_reschedules_items_whose_get_memory_failed() -> None:
         )
 
     # Item B went through the normal write pass.
-    sc.update_embedding.assert_awaited_once_with(str(mem_b_id), [0.2] * 768)
+    sc.update_embedding.assert_awaited_once_with(str(mem_b_id), [0.2] * VECTOR_DIM)
     # Item A was rescheduled as a per-item retry (reembed task) AND
     # item B scheduled contradiction detection — both tracked.
     names = [call.args[1] for call in tracked.call_args_list]
@@ -786,7 +787,7 @@ async def test_bulk_reembed_patch_failure_reschedules_item() -> None:
     sc.update_embedding = AsyncMock(side_effect=_update_embedding)
 
     async def _batch(_texts, _cfg):
-        return [[0.1] * 768, [0.2] * 768]
+        return [[0.1] * VECTOR_DIM, [0.2] * VECTOR_DIM]
 
     def _fake_detect(*args, **_kwargs):
         async def _noop() -> None:
@@ -828,8 +829,8 @@ async def test_bulk_reembed_respects_existing_embedding_per_item() -> None:
     their fresh batch-computed embedding written."""
     from core_api.services import memory_service
 
-    hint_enhanced = [0.9] * 768  # already written by _enrich_memory_background
-    fresh = [0.1] * 768          # what the bulk batch call returns
+    hint_enhanced = [0.9] * VECTOR_DIM  # already written by _enrich_memory_background
+    fresh = [0.1] * VECTOR_DIM          # what the bulk batch call returns
 
     # mem_a: enrichment already wrote an embedding (race guard should fire)
     # mem_b: still NULL (normal path should fire)
@@ -894,7 +895,7 @@ async def test_bulk_reembed_falls_back_on_length_mismatch() -> None:
     async def _short_batch(texts, _cfg):
         # Provider returned 2 embeddings for 5 inputs — real-world shape
         # when a provider partial-fails mid-batch.
-        return [[0.1] * 768 for _ in texts[:2]]
+        return [[0.1] * VECTOR_DIM for _ in texts[:2]]
 
     sc = MagicMock()
     sc.get_memory = AsyncMock(return_value={"id": "m", "deleted_at": None, "fleet_id": "f"})

--- a/tests/test_embedding_backfill.py
+++ b/tests/test_embedding_backfill.py
@@ -1,0 +1,245 @@
+"""Unit tests for the event-driven embedding backfill task.
+
+The task lives at ``core-worker/src/core_worker/backfill.py`` and drives
+the existing ``handle_embed_request`` consumer by publishing one
+``EMBED_REQUESTED`` event per memory whose ``embedding IS NULL``.
+
+Mocks the storage-client iterator + the per-row ``get_memory`` fetch
++ the embed-request publisher. No real DB or event bus. Integration
+coverage (against staging Postgres + a Pub/Sub emulator) is covered
+by the staging cutover runbook (Spec E), not this PR.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from core_worker.backfill import run_embedding_backfill
+from core_worker.clients.storage_client import NullEmbeddingRow
+
+
+def _row() -> NullEmbeddingRow:
+    return NullEmbeddingRow(memory_id=uuid.uuid4(), tenant_id="tenant-A")
+
+
+def _make_get_memory(
+    content: str = "hello", content_hash: str | None = None
+) -> AsyncMock:
+    """Build an ``AsyncMock`` for ``get_memory`` that returns a fake
+    memory dict matching the storage API's shape."""
+    return AsyncMock(return_value={"content": content, "content_hash": content_hash})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_publishes_one_event_per_null_row() -> None:
+    """Happy path: every NULL row → one ``get_memory`` fetch + one
+    ``publish_memory_embed_request`` call."""
+    rows = [_row() for _ in range(7)]
+
+    async def _fake_iter(_storage, **_kw):
+        # Two pages: 5 + 2.
+        yield rows[:5]
+        yield rows[5:]
+
+    publish = AsyncMock()
+    get_memory = _make_get_memory()
+    with (
+        patch("core_worker.backfill.iter_memories_with_null_embedding", _fake_iter),
+        patch("core_worker.backfill.publish_memory_embed_request", publish),
+        patch("core_worker.backfill.get_memory", get_memory),
+        patch("core_worker.backfill.get_storage_client", return_value=MagicMock()),
+    ):
+        report = await run_embedding_backfill(
+            tenant_id="t-1", batch_size=5, max_inflight=2
+        )
+
+    assert report.scanned == 7
+    assert report.published == 7
+    assert report.skipped_missing == 0
+    assert get_memory.await_count == 7
+    assert publish.await_count == 7
+    sample = publish.await_args_list[0].kwargs
+    assert {"memory_id", "tenant_id", "content", "content_hash"} <= set(sample)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_dry_run_fetches_content_but_does_not_publish() -> None:
+    """``--dry-run`` still does the per-row content fetch (so the report
+    accurately accounts for soft-deleted rows) but skips the publish."""
+    rows = [_row() for _ in range(3)]
+
+    async def _fake_iter(_storage, **_kw):
+        yield rows
+
+    publish = AsyncMock()
+    get_memory = _make_get_memory()
+    with (
+        patch("core_worker.backfill.iter_memories_with_null_embedding", _fake_iter),
+        patch("core_worker.backfill.publish_memory_embed_request", publish),
+        patch("core_worker.backfill.get_memory", get_memory),
+        patch("core_worker.backfill.get_storage_client", return_value=MagicMock()),
+    ):
+        report = await run_embedding_backfill(tenant_id="t-1", dry_run=True)
+
+    assert report.scanned == 3
+    assert report.published == 3  # counted as "would have"
+    assert get_memory.await_count == 3
+    assert publish.await_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_no_null_rows_returns_zero_report() -> None:
+    """No NULL rows → empty report, no fetches, no publishes, clean exit."""
+
+    async def _fake_iter(_storage, **_kw):
+        if False:  # generator with no yields
+            yield
+
+    publish = AsyncMock()
+    get_memory = _make_get_memory()
+    with (
+        patch("core_worker.backfill.iter_memories_with_null_embedding", _fake_iter),
+        patch("core_worker.backfill.publish_memory_embed_request", publish),
+        patch("core_worker.backfill.get_memory", get_memory),
+        patch("core_worker.backfill.get_storage_client", return_value=MagicMock()),
+    ):
+        report = await run_embedding_backfill(tenant_id="t-1")
+
+    assert report.scanned == 0
+    assert report.published == 0
+    assert get_memory.await_count == 0
+    assert publish.await_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_passes_tenant_filter_to_iterator() -> None:
+    """``tenant_id`` and ``batch_size`` reach the storage iterator."""
+    captured: dict = {}
+
+    async def _fake_iter(_storage, **kw):
+        captured.update(kw)
+        if False:
+            yield
+
+    with (
+        patch("core_worker.backfill.iter_memories_with_null_embedding", _fake_iter),
+        patch("core_worker.backfill.publish_memory_embed_request", AsyncMock()),
+        patch("core_worker.backfill.get_memory", _make_get_memory()),
+        patch("core_worker.backfill.get_storage_client", return_value=MagicMock()),
+    ):
+        await run_embedding_backfill(tenant_id="tenant-A", batch_size=42)
+
+    assert captured["tenant_id"] == "tenant-A"
+    assert captured["batch_size"] == 42
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_publishes_full_embed_request_payload() -> None:
+    """Each publish call receives content + hash + tenant — fetched
+    per-row from ``get_memory`` after the listing endpoint hands the
+    worker the id. Guards against regressing to a partial payload that
+    the consumer's Pydantic model would reject and burn the DLQ budget on."""
+    row = NullEmbeddingRow(memory_id=uuid.uuid4(), tenant_id="tenant-X")
+
+    async def _fake_iter(_storage, **_kw):
+        yield [row]
+
+    publish = AsyncMock()
+    get_memory = _make_get_memory(content="some memory body", content_hash="hash-abc")
+    with (
+        patch("core_worker.backfill.iter_memories_with_null_embedding", _fake_iter),
+        patch("core_worker.backfill.publish_memory_embed_request", publish),
+        patch("core_worker.backfill.get_memory", get_memory),
+        patch("core_worker.backfill.get_storage_client", return_value=MagicMock()),
+    ):
+        await run_embedding_backfill(tenant_id="t-1")
+
+    get_memory.assert_awaited_once_with(
+        get_memory.await_args.args[0],  # the storage client
+        memory_id=row.memory_id,
+        tenant_id="tenant-X",
+    )
+    publish.assert_awaited_once_with(
+        memory_id=row.memory_id,
+        content="some memory body",
+        tenant_id="tenant-X",
+        content_hash="hash-abc",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_skips_404_between_listing_and_fetch() -> None:
+    """A row that the listing endpoint reported but ``get_memory``
+    can't find (soft-/hard-deleted in the gap) is counted as
+    ``skipped_missing`` rather than failing the whole backfill."""
+    rows = [_row() for _ in range(3)]
+
+    async def _fake_iter(_storage, **_kw):
+        yield rows
+
+    publish = AsyncMock()
+
+    # Build a 404 HTTPStatusError for one of the three rows.
+    not_found = httpx.HTTPStatusError(
+        "404",
+        request=httpx.Request("GET", "http://x/memories/y"),
+        response=httpx.Response(status_code=404),
+    )
+    get_memory = AsyncMock(
+        side_effect=[
+            {"content": "first", "content_hash": None},
+            not_found,
+            {"content": "third", "content_hash": None},
+        ]
+    )
+
+    with (
+        patch("core_worker.backfill.iter_memories_with_null_embedding", _fake_iter),
+        patch("core_worker.backfill.publish_memory_embed_request", publish),
+        patch("core_worker.backfill.get_memory", get_memory),
+        patch("core_worker.backfill.get_storage_client", return_value=MagicMock()),
+    ):
+        report = await run_embedding_backfill(tenant_id="t-1")
+
+    assert report.scanned == 3
+    assert report.published == 2
+    assert report.skipped_missing == 1
+    assert publish.await_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backfill_propagates_non_404_http_errors() -> None:
+    """A 500 from the storage API is NOT silently absorbed — the
+    backfill aborts so the operator notices instead of a silent
+    long-running no-op."""
+    rows = [_row()]
+
+    async def _fake_iter(_storage, **_kw):
+        yield rows
+
+    server_error = httpx.HTTPStatusError(
+        "500",
+        request=httpx.Request("GET", "http://x/memories/y"),
+        response=httpx.Response(status_code=500),
+    )
+    get_memory = AsyncMock(side_effect=server_error)
+
+    with (
+        patch("core_worker.backfill.iter_memories_with_null_embedding", _fake_iter),
+        patch("core_worker.backfill.publish_memory_embed_request", AsyncMock()),
+        patch("core_worker.backfill.get_memory", get_memory),
+        patch("core_worker.backfill.get_storage_client", return_value=MagicMock()),
+    ):
+        with pytest.raises(httpx.HTTPStatusError):
+            await run_embedding_backfill(tenant_id="t-1")

--- a/tests/test_embedding_openai_compat.py
+++ b/tests/test_embedding_openai_compat.py
@@ -1,0 +1,722 @@
+"""Unit tests for the A.5 + Option B knobs on ``OpenAIEmbeddingProvider``.
+
+These verify the contract added in the local-embedder branch — the
+provider now also serves any OpenAI-compatible endpoint (TEI sidecar,
+vLLM, etc.) and supports asymmetric query/document encoding for
+instruction-aware models.
+
+What's covered (no network, no real OpenAI / TEI calls):
+
+* ``base_url`` is forwarded to the underlying OpenAI SDK.
+* ``send_dimensions=False`` omits the ``dimensions`` SDK kwarg
+  (TEI rejects it).
+* ``send_dimensions=True`` (default) still sends ``dimensions=VECTOR_DIM``
+  on the OpenAI hosted path.
+* ``truncate_to_dim`` slices and L2-renormalizes the model output.
+* ``embed_query`` is identical to ``embed`` when no instruction
+  resolves (symmetric models like bge-m3, OpenAI text-embedding-3-small).
+* ``embed_query`` prepends the Qwen-style ``Instruct: ...\\nQuery: ...``
+  prefix when an instruction resolves (per-call arg or constructor
+  default).
+"""
+
+from __future__ import annotations
+
+import math
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.constants import VECTOR_DIM
+from common.embedding.providers.openai import OpenAIEmbeddingProvider
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _fake_openai_response(vector: list[float]):
+    """Shape an OpenAI SDK ``embeddings.create`` response object."""
+    return SimpleNamespace(data=[SimpleNamespace(index=0, embedding=vector)])
+
+
+def _patched_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    response_vector: list[float] | None = None,
+    **provider_kwargs,
+) -> tuple[OpenAIEmbeddingProvider, MagicMock, AsyncMock]:
+    """Build an ``OpenAIEmbeddingProvider`` whose underlying
+    ``openai.AsyncOpenAI`` is fully mocked.
+
+    Returns ``(provider, async_openai_constructor_mock, embeddings_create_mock)``
+    so each test can assert against either the constructor kwargs (was
+    ``base_url`` forwarded?) or the create-call kwargs (was ``dimensions``
+    sent? was the input prefixed?).
+    """
+    if response_vector is None:
+        response_vector = [0.5] * VECTOR_DIM
+
+    embeddings_create = AsyncMock(return_value=_fake_openai_response(response_vector))
+    fake_client = MagicMock()
+    fake_client.embeddings.create = embeddings_create
+
+    async_openai_ctor = MagicMock(return_value=fake_client)
+    monkeypatch.setattr(
+        "common.embedding.providers.openai.openai.AsyncOpenAI", async_openai_ctor
+    )
+
+    provider = OpenAIEmbeddingProvider(api_key="sk-fake", **provider_kwargs)
+    return provider, async_openai_ctor, embeddings_create
+
+
+# ---------------------------------------------------------------------------
+# A.5 — base_url forwarding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_base_url_forwarded_to_async_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``base_url`` is passed through to ``openai.AsyncOpenAI`` so a TEI
+    sidecar (``http://tei:80/v1``) becomes a drop-in OpenAI replacement."""
+    _, async_openai_ctor, _ = _patched_provider(
+        monkeypatch, base_url="http://tei:80/v1"
+    )
+    kwargs = async_openai_ctor.call_args.kwargs
+    assert kwargs.get("base_url") == "http://tei:80/v1"
+
+
+@pytest.mark.unit
+def test_base_url_omitted_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``base_url`` is not given, the kwarg must not be sent
+    (would override the SDK's hosted-OpenAI default)."""
+    _, async_openai_ctor, _ = _patched_provider(monkeypatch)
+    assert "base_url" not in async_openai_ctor.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# A.5 — send_dimensions toggle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_dimensions_false_omits_dimensions_kwarg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TEI rejects ``dimensions=`` — when pointed at a TEI sidecar,
+    ``send_dimensions=False`` must drop the kwarg from every embed call."""
+    provider, _, create = _patched_provider(monkeypatch, send_dimensions=False)
+    await provider.embed("hello")
+    assert "dimensions" not in create.call_args.kwargs
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_dimensions_true_sends_vector_dim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default path (hosted OpenAI) still sends the ``dimensions``
+    kwarg pinned to the schema's ``VECTOR_DIM``."""
+    provider, _, create = _patched_provider(monkeypatch)  # default True
+    await provider.embed("hello")
+    assert create.call_args.kwargs.get("dimensions") == VECTOR_DIM
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_embed_batch_respects_send_dimensions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``embed_batch`` honours the same toggle as ``embed`` —
+    important so a TEI sidecar serves both ingest and search paths."""
+    provider, _, create = _patched_provider(monkeypatch, send_dimensions=False)
+    create.return_value = SimpleNamespace(
+        data=[
+            SimpleNamespace(index=0, embedding=[0.1] * VECTOR_DIM),
+            SimpleNamespace(index=1, embedding=[0.2] * VECTOR_DIM),
+        ]
+    )
+    await provider.embed_batch(["a", "b"])
+    assert "dimensions" not in create.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# Option B — Matryoshka truncation + L2 renormalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_truncate_to_dim_slices_and_renormalizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vectors trained with MRL (Qwen3-Embedding, jina-v3,
+    snowflake-arctic-l) stay coherent under truncation, but the
+    truncated vector is no longer unit-norm. The provider must slice
+    AND L2-renormalize so cosine similarity at the pgvector layer
+    stays correct.
+
+    ``truncate_to_dim`` must equal ``VECTOR_DIM`` (the only
+    operationally valid value — any smaller value would produce
+    vectors pgvector rejects at write time). We simulate a wider
+    model by producing a ``2 * VECTOR_DIM`` response vector so the
+    truncation has something to slice off."""
+    raw = list(range(1, 2 * VECTOR_DIM + 1))  # native dim 2*VECTOR_DIM
+    provider, _, _ = _patched_provider(
+        monkeypatch,
+        response_vector=raw,
+        truncate_to_dim=VECTOR_DIM,
+        send_dimensions=False,
+    )
+    out = await provider.embed("anything")
+
+    assert len(out) == VECTOR_DIM
+    norm = math.sqrt(sum(x * x for x in out))
+    assert math.isclose(norm, 1.0, abs_tol=1e-9)
+    # Verify proportional structure preserved: the slice is [1, 2, ..., VECTOR_DIM]
+    # → renormalised; relative ratios survive.
+    sum_sq = sum(v * v for v in range(1, VECTOR_DIM + 1))
+    expected_norm = math.sqrt(sum_sq)
+    for i, got in enumerate(out, start=1):
+        assert math.isclose(got, i / expected_norm, abs_tol=1e-9)
+
+
+@pytest.mark.unit
+def test_openai_provider_init_rejects_truncate_below_vector_dim() -> None:
+    """Defence-in-depth (the registry already validates this, but
+    direct construction shouldn't bypass it). Constructing the provider
+    with ``truncate_to_dim != VECTOR_DIM`` must raise ``ValueError``
+    immediately rather than silently producing schema-incompatible
+    vectors that pgvector rejects far from the construction site."""
+    with pytest.raises(ValueError, match="must equal VECTOR_DIM"):
+        OpenAIEmbeddingProvider(api_key="sk-test", truncate_to_dim=512)
+
+
+@pytest.mark.unit
+def test_openai_provider_init_rejects_truncate_above_vector_dim() -> None:
+    """Mirror of the below-VECTOR_DIM case — anything other than exactly
+    ``VECTOR_DIM`` is invalid."""
+    with pytest.raises(ValueError, match="must equal VECTOR_DIM"):
+        OpenAIEmbeddingProvider(api_key="sk-test", truncate_to_dim=VECTOR_DIM + 1)
+
+
+@pytest.mark.unit
+def test_openai_provider_init_accepts_truncate_equal_to_vector_dim() -> None:
+    """Exact-equality is the only operationally valid value: truncating
+    a wider model's native output (e.g. Qwen3-4B at 2560) down to the
+    schema dimension."""
+    p = OpenAIEmbeddingProvider(api_key="sk-test", truncate_to_dim=VECTOR_DIM)
+    assert p is not None
+
+
+@pytest.mark.unit
+def test_openai_provider_init_accepts_truncate_unset() -> None:
+    """``truncate_to_dim=None`` (the default) is the symmetric path —
+    no validation, no truncation, vectors pass through unchanged."""
+    p = OpenAIEmbeddingProvider(api_key="sk-test")
+    assert p is not None
+    p2 = OpenAIEmbeddingProvider(api_key="sk-test", truncate_to_dim=None)
+    assert p2 is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_truncate_to_dim_unset_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No truncation knob → vector is returned untouched
+    (no surprise renormalisation on the OpenAI hosted path)."""
+    raw = [0.3, 0.4, 0.0, 0.0]  # not unit-norm
+    provider, _, _ = _patched_provider(
+        monkeypatch, response_vector=raw, send_dimensions=False
+    )
+    out = await provider.embed("hi")
+    assert out == raw
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_truncate_to_dim_raises_on_undersized_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the configured model returns FEWER dimensions than
+    ``truncate_to_dim``, ``_postprocess`` must raise instead of
+    silently passing through. An undersized vector would make every
+    pgvector insert fail with ``expected N dimensions, not M`` —
+    failing fast in the provider attributes the error to the
+    model+truncate config rather than surfacing as a far-downstream
+    write error.
+
+    Use a half-sized response (VECTOR_DIM // 2) against
+    ``truncate_to_dim=VECTOR_DIM`` to simulate a misconfigured model
+    (e.g. operator pointed ``OPENAI_EMBEDDING_MODEL`` at a 512-d
+    legacy model while ``truncate_to_dim`` expected a wider one)."""
+    half = VECTOR_DIM // 2
+    raw = list(range(1, half + 1))
+    provider, _, _ = _patched_provider(
+        monkeypatch,
+        response_vector=raw,
+        truncate_to_dim=VECTOR_DIM,
+        send_dimensions=False,
+    )
+    with pytest.raises(ValueError) as ei:
+        await provider.embed("any")
+    msg = str(ei.value)
+    assert str(half) in msg
+    assert str(VECTOR_DIM) in msg
+    assert "must produce at least" in msg
+
+
+# ---------------------------------------------------------------------------
+# Option B — embed_query (asymmetric, instruction-aware)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_embed_query_no_instruction_passes_text_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Symmetric models (bge-m3, gte-en-v1.5, OpenAI
+    text-embedding-3-small) get no prefix — ``embed_query`` is
+    equivalent to ``embed`` when no instruction resolves."""
+    provider, _, create = _patched_provider(monkeypatch, send_dimensions=False)
+    await provider.embed_query("what is the capital of France?")
+    assert create.call_args.kwargs["input"] == "what is the capital of France?"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_embed_query_per_call_instruction_prepended(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-call ``instruction`` arg overrides the constructor default
+    and produces the Qwen-style ``Instruct: ...\\nQuery: ...`` prefix."""
+    provider, _, create = _patched_provider(monkeypatch, send_dimensions=False)
+    await provider.embed_query("paris", instruction="Retrieve relevant memories")
+    expected = "Instruct: Retrieve relevant memories\nQuery: paris"
+    assert create.call_args.kwargs["input"] == expected
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_embed_query_constructor_default_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``query_instruction=`` set at construction is the fallback
+    for any caller that doesn't override per-call. This is the
+    process-wide default plumbed via ``EMBEDDING_QUERY_INSTRUCTION``."""
+    provider, _, create = _patched_provider(
+        monkeypatch,
+        send_dimensions=False,
+        query_instruction="Default task",
+    )
+    await provider.embed_query("query body")
+    assert create.call_args.kwargs["input"] == "Instruct: Default task\nQuery: query body"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_embed_unaffected_by_query_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``embed`` (the document/ingest path) NEVER prepends the
+    instruction — that asymmetry is the whole point of Option B."""
+    provider, _, create = _patched_provider(
+        monkeypatch,
+        send_dimensions=False,
+        query_instruction="Should not appear",
+    )
+    await provider.embed("a document chunk")
+    assert create.call_args.kwargs["input"] == "a document chunk"
+
+
+# ---------------------------------------------------------------------------
+# Registry-side validation (env-driven knobs)
+# ---------------------------------------------------------------------------
+
+
+def _reset_registry_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wipe the registry's process-level OpenAI provider LRU so a test
+    sees a fresh cache-miss path. Without this, a populated cache from
+    a previous test would silently skip the validation / misconfig
+    branches a test is asserting against."""
+    import common.embedding._registry as registry_mod
+
+    monkeypatch.setattr(registry_mod, "_openai_provider_cache", OrderedDict())
+
+
+@pytest.mark.unit
+def test_registry_rejects_truncate_to_dim_above_schema_dim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``OPENAI_EMBEDDING_TRUNCATE_TO_DIM`` greater than ``VECTOR_DIM`` is
+    nonsensical — pgvector would reject the wider vector at write time.
+    The registry catches this misconfiguration up-front with a clear
+    ``ValueError`` instead of letting embed calls 4xx in production."""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_EMBEDDING_TRUNCATE_TO_DIM", str(VECTOR_DIM + 256))
+
+    with pytest.raises(ValueError, match="must equal VECTOR_DIM"):
+        get_embedding_provider("openai")
+
+
+@pytest.mark.unit
+def test_registry_rejects_truncate_to_dim_below_schema_dim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A value < ``VECTOR_DIM`` (e.g. 512) passes the naive ``> VECTOR_DIM``
+    check but produces vectors pgvector would reject because they don't
+    match the schema column dimension. The exact-equality check catches
+    this too."""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_EMBEDDING_TRUNCATE_TO_DIM", str(VECTOR_DIM - 256))
+
+    with pytest.raises(ValueError, match="must equal VECTOR_DIM"):
+        get_embedding_provider("openai")
+
+
+@pytest.mark.unit
+def test_registry_accepts_truncate_to_dim_equal_to_schema_dim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The only operationally valid value is exactly ``VECTOR_DIM``:
+    truncating a wider model's native output (e.g. Qwen3-4B at 2560)
+    down to the 1024-dim schema."""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_EMBEDDING_TRUNCATE_TO_DIM", str(VECTOR_DIM))
+
+    # Should not raise.
+    p = get_embedding_provider("openai")
+    assert p is not None
+
+
+@pytest.mark.unit
+def test_registry_validation_skipped_on_cache_hit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hot-path optimisation (Fix 1): cache lookup runs *before*
+    truncate-dim validation. Once a provider is cached, subsequent calls
+    with the same env return the cached instance without going through
+    the validation path again.
+
+    Proof: pre-populate the cache slot for a known config tuple with a
+    sentinel. The next ``get_embedding_provider`` call with that same
+    config must return the sentinel — meaning the validation +
+    construction path was never re-entered."""
+    import common.embedding._registry as registry_mod
+    from common.embedding._registry import get_embedding_provider
+    from common.embedding.constants import OPENAI_EMBEDDING_MODEL
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENAI_EMBEDDING_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_EMBEDDING_SEND_DIMENSIONS", raising=False)
+    monkeypatch.delenv("EMBEDDING_QUERY_INSTRUCTION", raising=False)
+    monkeypatch.delenv("OPENAI_EMBEDDING_TRUNCATE_TO_DIM", raising=False)
+
+    # Build the exact cache_key the registry will compute for the env
+    # above and pre-populate it with a sentinel. If validation ran on
+    # cache hit, the registry would never reach the ``return cached``
+    # branch — it'd fall through to construction and overwrite us.
+    sentinel = object()
+    cache_key = (
+        "sk-test",
+        OPENAI_EMBEDDING_MODEL,
+        None,  # base_url
+        True,  # send_dimensions (default)
+        None,  # query_instruction
+        None,  # truncate_to_dim
+    )
+    registry_mod._openai_provider_cache[cache_key] = sentinel  # type: ignore[assignment]
+
+    p = get_embedding_provider("openai")
+    assert p is sentinel, (
+        "cache hit must return without re-running validation/construction"
+    )
+
+
+@pytest.mark.unit
+def test_registry_raises_when_base_url_set_but_send_dimensions_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TEI / vLLM / most OpenAI-compatible self-hosted endpoints reject
+    the ``dimensions=`` SDK kwarg. Setting ``OPENAI_EMBEDDING_BASE_URL``
+    without flipping ``OPENAI_EMBEDDING_SEND_DIMENSIONS=false`` would
+    cause every embed call to 4xx, retries to exhaust, and writes to
+    silently persist with ``embedding=NULL``. Failing fast at provider
+    construction (raise) is strictly better than logging a warning and
+    falling through."""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_EMBEDDING_BASE_URL", "http://tei:80/v1")
+    # Default for SEND_DIMENSIONS is "true" — leave unset.
+    monkeypatch.delenv("OPENAI_EMBEDDING_SEND_DIMENSIONS", raising=False)
+
+    with pytest.raises(ValueError) as ei:
+        get_embedding_provider("openai")
+    msg = str(ei.value)
+    assert "OPENAI_EMBEDDING_BASE_URL" in msg
+    assert "SEND_DIMENSIONS" in msg
+    assert "TEI" in msg or "vLLM" in msg
+
+
+@pytest.mark.unit
+def test_registry_misconfig_raises_on_every_call_no_caching(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed construction must NOT be cached as a sentinel. Every
+    call with the misconfigured env raises freshly — operators see the
+    error on every request until they fix it, not just the first. (The
+    cache is only populated on successful construction.)"""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_EMBEDDING_BASE_URL", "http://tei:80/v1")
+    monkeypatch.delenv("OPENAI_EMBEDDING_SEND_DIMENSIONS", raising=False)
+
+    for _ in range(3):
+        with pytest.raises(ValueError):
+            get_embedding_provider("openai")
+
+
+@pytest.mark.unit
+def test_registry_raises_inverse_no_base_url_with_send_dims_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hosted OpenAI (no ``base_url``) + ``SEND_DIMENSIONS=false`` is a
+    write-time time bomb: OpenAI returns the model's native dim (1536
+    for text-embedding-3-small) and pgvector rejects every insert. The
+    registry must raise at construction so the operator catches the
+    misconfiguration before the first failed write — not log a warning
+    and let writes silently persist NULL."""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENAI_EMBEDDING_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_EMBEDDING_SEND_DIMENSIONS", "false")
+
+    with pytest.raises(ValueError) as ei:
+        get_embedding_provider("openai")
+    msg = str(ei.value)
+    assert "SEND_DIMENSIONS=false" in msg
+    assert "BASE_URL is unset" in msg
+    # Message names a concrete native-dim example so the error is
+    # actionable for an operator who hasn't memorised every model's
+    # native dim.
+    assert "1536" in msg or "text-embedding-3-small" in msg
+
+
+@pytest.mark.unit
+def test_registry_accepts_correct_tei_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``base_url`` set + ``SEND_DIMENSIONS=false`` is the correct TEI
+    configuration: no raise, provider constructs cleanly."""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_EMBEDDING_BASE_URL", "http://tei:80/v1")
+    monkeypatch.setenv("OPENAI_EMBEDDING_SEND_DIMENSIONS", "false")
+
+    p = get_embedding_provider("openai")
+    assert p is not None
+
+
+@pytest.mark.unit
+def test_registry_accepts_default_hosted_openai_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default hosted OpenAI: no base_url, send_dimensions left at its
+    default (true). The happy path — no raise, provider constructs
+    cleanly."""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENAI_EMBEDDING_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_EMBEDDING_SEND_DIMENSIONS", raising=False)
+
+    p = get_embedding_provider("openai")
+    assert p is not None
+
+
+@pytest.mark.unit
+def test_registry_truncate_to_dim_non_integer_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-integer value in ``OPENAI_EMBEDDING_TRUNCATE_TO_DIM`` must
+    raise a ``ValueError`` whose message names the env var and the
+    offending raw value, not the bare CPython
+    ``"invalid literal for int() with base 10: '...'"``. Operators
+    grep startup logs for ``OPENAI_EMBEDDING_*`` when something's
+    wrong; the parse error should be findable that way."""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_EMBEDDING_TRUNCATE_TO_DIM", "ten-twenty-four")
+
+    with pytest.raises(
+        ValueError,
+        match=r"OPENAI_EMBEDDING_TRUNCATE_TO_DIM=.*must be an integer",
+    ):
+        get_embedding_provider("openai")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("val", ["yes", "1", "trun", "0", "TRU"])
+def test_registry_rejects_non_canonical_send_dimensions_value(
+    monkeypatch: pytest.MonkeyPatch,
+    val: str,
+) -> None:
+    """Strict bool parsing for ``OPENAI_EMBEDDING_SEND_DIMENSIONS``: only
+    ``"true"`` / ``"false"`` (case-insensitive) accepted. A typo or a
+    different truthy syntax (``yes``, ``1``) must raise instead of
+    silently coercing to a default — which historically biased toward
+    ``true`` and that's the wrong default direction for a flag the
+    registry now hard-fails on."""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_EMBEDDING_SEND_DIMENSIONS", val)
+
+    with pytest.raises(
+        ValueError,
+        match=r"OPENAI_EMBEDDING_SEND_DIMENSIONS=.*must be 'true' or 'false'",
+    ):
+        get_embedding_provider("openai")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("val", ["true", "TRUE", "True", "false", "FALSE", "False"])
+def test_registry_accepts_case_insensitive_canonical_send_dimensions(
+    monkeypatch: pytest.MonkeyPatch,
+    val: str,
+) -> None:
+    """Mirror of the rejection test: the canonical bool spellings (with
+    case variation) all parse cleanly. Tied with appropriate base_url
+    config so neither misconfig branch trips."""
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_EMBEDDING_SEND_DIMENSIONS", val)
+    if val.lower() == "false":
+        # Pair with base_url so the "no base_url + send_dims=false"
+        # branch doesn't fire.
+        monkeypatch.setenv("OPENAI_EMBEDDING_BASE_URL", "http://tei:80/v1")
+    else:
+        monkeypatch.delenv("OPENAI_EMBEDDING_BASE_URL", raising=False)
+
+    p = get_embedding_provider("openai")
+    assert p is not None
+
+
+@pytest.mark.unit
+def test_registry_no_warning_when_send_dimensions_false(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The mirror case: ``base_url`` set + ``SEND_DIMENSIONS=false`` is
+    the correct TEI configuration and must NOT trigger the warning."""
+    import logging
+
+    from common.embedding._registry import get_embedding_provider
+
+    _reset_registry_state(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_EMBEDDING_BASE_URL", "http://tei:80/v1")
+    monkeypatch.setenv("OPENAI_EMBEDDING_SEND_DIMENSIONS", "false")
+
+    with caplog.at_level(logging.WARNING, logger="common.embedding._registry"):
+        get_embedding_provider("openai")
+
+    assert not any(
+        "SEND_DIMENSIONS" in rec.getMessage() for rec in caplog.records
+    ), "no SEND_DIMENSIONS warning expected when correctly set to false"
+
+
+# ---------------------------------------------------------------------------
+# Split protocols: EmbeddingProvider vs InstructionAwareEmbedder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_symmetric_providers_do_not_implement_instruction_aware() -> None:
+    """``Fake``, ``Local``, and ``Vertex`` are symmetric encoders by design
+    — they conform to :class:`EmbeddingProvider` but deliberately not to
+    :class:`InstructionAwareEmbedder`. The query path detects that and
+    falls back to :meth:`embed`."""
+    from common.embedding.protocols import (
+        EmbeddingProvider,
+        InstructionAwareEmbedder,
+    )
+    from common.embedding.providers.fake import FakeEmbeddingProvider
+
+    p = FakeEmbeddingProvider()
+    assert isinstance(p, EmbeddingProvider)
+    assert not isinstance(p, InstructionAwareEmbedder)
+    assert not hasattr(p, "embed_query")
+
+
+@pytest.mark.unit
+def test_openai_provider_implements_instruction_aware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``OpenAIEmbeddingProvider`` implements both protocols — it owns the
+    ``Instruct: ...\\nQuery: ...`` prefix logic when an instruction is
+    configured."""
+    from common.embedding.protocols import (
+        EmbeddingProvider,
+        InstructionAwareEmbedder,
+    )
+
+    p, _, _ = _patched_provider(monkeypatch)
+    assert isinstance(p, EmbeddingProvider)
+    assert isinstance(p, InstructionAwareEmbedder)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_query_embedding_falls_back_for_symmetric_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``get_query_embedding`` ``hasattr``-checks
+    :class:`InstructionAwareEmbedder` and routes symmetric providers to
+    :meth:`embed`. Verified end-to-end through the service layer with a
+    fake provider that lacks ``embed_query`` — ``instruction`` is silently
+    ignored, output equals ``embed(text)``."""
+    from common.embedding._service import get_query_embedding
+    from common.embedding.providers.fake import FakeEmbeddingProvider
+
+    fake = FakeEmbeddingProvider()
+    monkeypatch.setattr(
+        "common.embedding._service.get_embedding_provider",
+        lambda *_a, **_k: fake,
+    )
+
+    expected = await fake.embed("paris")
+    got_no_instr = await get_query_embedding("paris")
+    got_with_instr = await get_query_embedding("paris", instruction="should be ignored")
+    assert got_no_instr == expected
+    assert got_with_instr == expected

--- a/tests/test_embedding_registry_eviction.py
+++ b/tests/test_embedding_registry_eviction.py
@@ -37,7 +37,16 @@ async def test_eviction_schedules_aclose_on_evicted_provider(
     aclose_calls: list[tuple[str, str]] = []
 
     class _FakeProvider:
-        def __init__(self, *, api_key: str, model: str) -> None:
+        def __init__(
+            self,
+            *,
+            api_key: str,
+            model: str,
+            base_url: str | None = None,
+            send_dimensions: bool = True,
+            query_instruction: str | None = None,
+            truncate_to_dim: int | None = None,
+        ) -> None:
             self.api_key = api_key
             self.model = model
             self.aclose = AsyncMock(
@@ -46,12 +55,24 @@ async def test_eviction_schedules_aclose_on_evicted_provider(
 
     monkeypatch.setattr(registry_mod, "OpenAIEmbeddingProvider", _FakeProvider)
 
+    # ``_get_or_create_openai_provider`` grew four args after the
+    # local-embedder branch landed (base_url / send_dimensions /
+    # query_instruction / truncate_to_dim). Pass the no-op defaults
+    # here — eviction is keyed on the full tuple so passing identical
+    # extras across both calls keeps the test's intent (different
+    # api_keys → distinct cache slots → first one evicted).
+    _DEFAULTS = dict(
+        base_url=None,
+        send_dimensions=True,
+        query_instruction=None,
+        truncate_to_dim=None,
+    )
     # First insert — no eviction yet.
-    registry_mod._get_or_create_openai_provider("key-A", "model-1")
+    registry_mod._get_or_create_openai_provider("key-A", "model-1", **_DEFAULTS)
     assert aclose_calls == []
 
     # Second insert exceeds cap=1 → evicts (key-A, model-1).
-    registry_mod._get_or_create_openai_provider("key-B", "model-1")
+    registry_mod._get_or_create_openai_provider("key-B", "model-1", **_DEFAULTS)
 
     # Yield to the event loop so the scheduled aclose() task runs.
     import asyncio
@@ -77,7 +98,16 @@ def test_eviction_outside_running_loop_does_not_raise(
     )
 
     class _FakeProvider:
-        def __init__(self, *, api_key: str, model: str) -> None:
+        def __init__(
+            self,
+            *,
+            api_key: str,
+            model: str,
+            base_url: str | None = None,
+            send_dimensions: bool = True,
+            query_instruction: str | None = None,
+            truncate_to_dim: int | None = None,
+        ) -> None:
             self.api_key = api_key
             self.model = model
 
@@ -86,7 +116,13 @@ def test_eviction_outside_running_loop_does_not_raise(
 
     monkeypatch.setattr(registry_mod, "OpenAIEmbeddingProvider", _FakeProvider)
 
-    registry_mod._get_or_create_openai_provider("key-A", "model-1")
+    _DEFAULTS = dict(
+        base_url=None,
+        send_dimensions=True,
+        query_instruction=None,
+        truncate_to_dim=None,
+    )
+    registry_mod._get_or_create_openai_provider("key-A", "model-1", **_DEFAULTS)
     # No event loop running here — the second call triggers eviction
     # and must swallow the RuntimeError from get_running_loop().
-    registry_mod._get_or_create_openai_provider("key-B", "model-1")
+    registry_mod._get_or_create_openai_provider("key-B", "model-1", **_DEFAULTS)

--- a/tests/test_embedding_retry.py
+++ b/tests/test_embedding_retry.py
@@ -16,6 +16,7 @@ from core_api.constants import (
     EMBEDDING_REEMBED_DELAY_S,
     EMBEDDING_RETRY_ATTEMPTS,
     EMBEDDING_RETRY_DELAY_S,
+    VECTOR_DIM,
 )
 
 
@@ -87,7 +88,7 @@ async def test_success_on_second_attempt():
     """get_embedding returns a valid embedding when the second attempt succeeds."""
     from common.embedding import get_embedding
 
-    fake_vec = [0.1] * 768
+    fake_vec = [0.1] * VECTOR_DIM
     mock_provider = AsyncMock()
     mock_provider.embed = AsyncMock(side_effect=[RuntimeError("transient"), fake_vec])
     with (
@@ -127,3 +128,159 @@ async def test_fake_provider_never_returns_none():
     assert result is not None
     assert isinstance(result, list)
     assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Provider-misconfiguration degradation: ValueError from registry → None
+# ---------------------------------------------------------------------------
+
+
+def _reset_misconfig_dedup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wipe the module-level ``_misconfiguration_logged`` set so a test
+    sees a fresh "first-failure" path. Module-scoped state — without
+    this, test ordering would mask the once-per-provider dedup logic."""
+    import common.embedding._service as service_mod
+
+    monkeypatch.setattr(service_mod, "_misconfiguration_logged", set())
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_embedding_returns_none_on_registry_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the registry raises ``ValueError`` at provider construction
+    (env-var misconfig), ``get_embedding`` must map it to the documented
+    ``None`` degradation contract — write paths persist
+    ``embedding=NULL`` for backfill instead of crashing the request
+    handler. Logged at ERROR (once per provider) so the misconfig is
+    still visible."""
+    from common.embedding import get_embedding
+
+    _reset_misconfig_dedup(monkeypatch)
+
+    def _explode(*_a, **_k):
+        raise ValueError(
+            "OPENAI_EMBEDDING_BASE_URL=... is set but SEND_DIMENSIONS is true"
+        )
+
+    monkeypatch.setattr("common.embedding._service.get_embedding_provider", _explode)
+    result = await get_embedding("anything")
+    assert result is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_query_embedding_returns_none_on_registry_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mirror of the above for the query/search path. Search routes
+    typically translate ``None`` → 503; raising would crash the worker
+    instead."""
+    from common.embedding import get_query_embedding
+
+    _reset_misconfig_dedup(monkeypatch)
+
+    def _explode(*_a, **_k):
+        raise ValueError("invalid OPENAI_EMBEDDING_TRUNCATE_TO_DIM='zzz'")
+
+    monkeypatch.setattr("common.embedding._service.get_embedding_provider", _explode)
+    result = await get_query_embedding("anything")
+    assert result is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_value_error_in_provider_construction_does_not_propagate(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The degradation guard logs at ERROR level on the first failure
+    so operators see the misconfiguration in their logs — silent
+    return-None would obscure the cause."""
+    import logging
+
+    from common.embedding import get_embedding
+
+    _reset_misconfig_dedup(monkeypatch)
+
+    def _explode(*_a, **_k):
+        raise ValueError("operator forgot OPENAI_EMBEDDING_SEND_DIMENSIONS=false")
+
+    monkeypatch.setattr("common.embedding._service.get_embedding_provider", _explode)
+
+    with caplog.at_level(logging.ERROR, logger="common.embedding._service"):
+        await get_embedding("anything")
+
+    assert any(
+        "misconfiguration" in rec.getMessage() for rec in caplog.records
+    ), "expected an ERROR log naming the misconfig"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_misconfiguration_error_logged_only_once_per_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``_resolve_provider_or_degrade`` runs on every embed/query
+    request. Logging the ERROR unconditionally would spam the log at
+    request rate. The module-level ``_misconfiguration_logged`` set
+    gates the ERROR to one emit per resolved provider name per process
+    — failure stats still increment on every call so the degraded
+    trip-wire keeps working, but the log stays readable."""
+    import logging
+
+    from common.embedding import get_embedding
+
+    _reset_misconfig_dedup(monkeypatch)
+
+    def _explode(*_a, **_k):
+        raise ValueError("misconfig that would otherwise log every request")
+
+    monkeypatch.setattr("common.embedding._service.get_embedding_provider", _explode)
+
+    with caplog.at_level(logging.ERROR, logger="common.embedding._service"):
+        # Five back-to-back calls simulate five incoming requests.
+        for _ in range(5):
+            assert await get_embedding("x") is None
+
+    matches = [
+        rec for rec in caplog.records if "misconfiguration" in rec.getMessage()
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly 1 ERROR across 5 calls; got {len(matches)} "
+        f"({[r.getMessage() for r in matches]!r})"
+    )
+    # Sanity: the message tells the operator we'll be quiet from here on.
+    assert "will not repeat" in matches[0].getMessage()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_failure_stats_still_increment_under_misconfig_dedup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The log dedup must NOT short-circuit ``_stats.record_failure()``
+    — every misconfigured call still counts as a failure so the
+    degraded-provider tripwire (3 consecutive failures fires the
+    "service degraded" ERROR) keeps working."""
+    import common.embedding._service as service_mod
+    from common.embedding import get_embedding
+
+    _reset_misconfig_dedup(monkeypatch)
+    # Reset failure stats so this test owns the count.
+    monkeypatch.setattr(service_mod, "_stats", service_mod._EmbeddingStats())
+
+    def _explode(*_a, **_k):
+        raise ValueError("dedupable misconfig")
+
+    monkeypatch.setattr("common.embedding._service.get_embedding_provider", _explode)
+
+    for _ in range(4):
+        assert await get_embedding("x") is None
+
+    # All four calls bumped failure stats even though only the first
+    # one logged.
+    assert service_mod._stats.failures == 4
+    assert service_mod._stats.consecutive_failures == 4

--- a/tests/test_enrich_off_hot_path.py
+++ b/tests/test_enrich_off_hot_path.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from core_api.constants import VECTOR_DIM
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.steps.write.parallel_embed_enrich import ParallelEmbedEnrich
 from core_api.pipeline.steps.write.schedule_background_tasks import (
@@ -78,7 +79,7 @@ def _ctx(
         "input": data or _input(),
         "content_hash": "f" * 64,
         "memory": {"id": memory_id or uuid.uuid4()},
-        "embedding": [0.1] * 768,
+        "embedding": [0.1] * VECTOR_DIM,
         "resolved_write_mode": write_mode,
     }
     if cached_embedding is not None:
@@ -108,7 +109,7 @@ async def test_skips_inline_enrich_when_flag_off() -> None:
         ),
         patch(
             "core_api.pipeline.steps.write.parallel_embed_enrich.get_embedding",
-            new=AsyncMock(return_value=[0.0] * 768),
+            new=AsyncMock(return_value=[0.0] * VECTOR_DIM),
         ),
         patch(
             "core_api.services.memory_enrichment.enrich_memory",
@@ -135,7 +136,7 @@ async def test_runs_inline_enrich_when_flag_on() -> None:
         ),
         patch(
             "core_api.pipeline.steps.write.parallel_embed_enrich.get_embedding",
-            new=AsyncMock(return_value=[0.1] * 768),
+            new=AsyncMock(return_value=[0.1] * VECTOR_DIM),
         ),
         patch("core_api.services.memory_enrichment.enrich_memory", new=_enrich),
     ):
@@ -148,7 +149,7 @@ async def test_hint_reembed_skipped_when_enrich_flag_off() -> None:
     means the hint isn't available; back-channel ENRICHED consumer can
     pick it up later if high-value."""
     ctx = _ctx(enrichment=True)
-    embed_spy = AsyncMock(return_value=[0.1] * 768)
+    embed_spy = AsyncMock(return_value=[0.1] * VECTOR_DIM)
     with (
         patch(
             "core_api.pipeline.steps.write.parallel_embed_enrich.settings.enrich_on_hot_path",

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from core_api import mcp_server
+from core_api.constants import VECTOR_DIM
 from tests._mcp_test_helpers import parse_envelope, strip_latency
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
@@ -278,7 +279,7 @@ async def test_doc_write_with_embed_field_embeds_and_forwards(mcp_env, monkeypat
 
     async def fake_embed(text):
         captured["embed_text"] = text
-        return [0.1] * 768
+        return [0.1] * VECTOR_DIM
 
     monkeypatch.setattr(
         "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
@@ -296,7 +297,7 @@ async def test_doc_write_with_embed_field_embeds_and_forwards(mcp_env, monkeypat
     assert payload["ok"] is True
     assert payload["indexed"] is True
     assert captured["embed_text"] == "Some markdown body"
-    assert len(captured["embedding"]) == 768
+    assert len(captured["embedding"]) == VECTOR_DIM
 
 
 async def test_doc_write_embed_field_missing_from_data(mcp_env, monkeypatch):
@@ -306,7 +307,7 @@ async def test_doc_write_embed_field_missing_from_data(mcp_env, monkeypatch):
 
     async def should_not_embed(text):  # noqa: ARG001
         called["hit"] = True
-        return [0.0] * 768
+        return [0.0] * VECTOR_DIM
 
     monkeypatch.setattr("common.embedding.get_embedding", should_not_embed)
 
@@ -324,7 +325,7 @@ async def test_doc_write_embed_field_missing_from_data(mcp_env, monkeypatch):
 async def test_doc_write_embed_field_empty_string_is_rejected(mcp_env, monkeypatch):
     """Empty-string source is treated as missing (embedding would be noise)."""
     monkeypatch.setattr(
-        "common.embedding.get_embedding", _async_return([0.0] * 768)
+        "common.embedding.get_embedding", _async_return([0.0] * VECTOR_DIM)
     )
     out = await mcp_server.memclaw_doc(
         op="write",
@@ -368,7 +369,7 @@ async def test_doc_search_without_collection_spans_all(mcp_env, monkeypatch):
         return []
 
     monkeypatch.setattr(
-        "common.embedding.get_embedding", _async_return([0.1] * 768)
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
     monkeypatch.setattr("core_api.repositories.document_repo.search", fake_search)
 
@@ -383,7 +384,7 @@ async def test_doc_search_broad_results_include_per_row_collection(mcp_env, monk
     """Each result row must include its own `collection` so the caller can
     follow up with op=read across mixed collections."""
     monkeypatch.setattr(
-        "common.embedding.get_embedding", _async_return([0.1] * 768)
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
     pairs = [
         (_DocRow("acme", collection="customers"), 0.9),
@@ -413,7 +414,7 @@ async def test_doc_search_empty_query_rejected(mcp_env):
 async def test_doc_search_happy_path(mcp_env, monkeypatch):
     """Happy path: embedding → repo.search → results sorted by similarity."""
     monkeypatch.setattr(
-        "common.embedding.get_embedding", _async_return([0.1] * 768)
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
     pairs = [(_DocRow("acme"), 0.92), (_DocRow("initech"), 0.81)]
     monkeypatch.setattr(
@@ -435,7 +436,7 @@ async def test_doc_search_happy_path(mcp_env, monkeypatch):
 async def test_doc_search_empty_results(mcp_env, monkeypatch):
     """No indexed docs / no matches → empty list, not error."""
     monkeypatch.setattr(
-        "common.embedding.get_embedding", _async_return([0.1] * 768)
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
     monkeypatch.setattr(
         "core_api.repositories.document_repo.search", _async_return([])
@@ -455,7 +456,7 @@ async def test_doc_search_top_k_capped_at_50(mcp_env, monkeypatch):
         return []
 
     monkeypatch.setattr(
-        "common.embedding.get_embedding", _async_return([0.1] * 768)
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
     monkeypatch.setattr("core_api.repositories.document_repo.search", fake_search)
 

--- a/tests/test_migration_012_safety_gate.py
+++ b/tests/test_migration_012_safety_gate.py
@@ -1,0 +1,147 @@
+"""Pre-flight safety gate on alembic migration 012_vector_dim_1024.
+
+Verifies the gate's three behaviours:
+- Empty DB (count = 0): proceeds without env opt-in (fresh-install path).
+- Populated DB + env unset: raises RuntimeError with a clear message.
+- Populated DB + env set: proceeds.
+
+The gate is at the top of ``upgrade()``; we exercise it by importing
+the migration module and patching ``op.get_bind`` + the env via
+``monkeypatch``. No real DB connection is opened.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _load_migration():
+    """Re-import the migration module fresh.
+
+    Migration files have hyphenated filenames (``012_vector_dim_1024.py``)
+    that aren't valid Python identifiers, so we use ``importlib.util`` to
+    load by file path.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    here = Path(__file__).resolve().parent
+    repo = here.parent
+    mig_path = (
+        repo
+        / "core-storage-api"
+        / "src"
+        / "core_storage_api"
+        / "database"
+        / "migrations"
+        / "versions"
+        / "012_vector_dim_1024.py"
+    )
+    name = "_test_alembic_012_vector_dim_1024"
+    spec = importlib.util.spec_from_file_location(name, mig_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _patch_op(monkeypatch: pytest.MonkeyPatch, existing_count: int) -> None:
+    """Make ``alembic.op`` look like a no-op shim that returns
+    *existing_count* from the gate's count query, and silently accepts
+    every other call (``op.execute``, ``op.get_context``, the
+    autocommit_block context manager).
+
+    This lets ``upgrade()`` run end-to-end without touching a real DB —
+    we're only asserting on the gate's branching, not on the ALTER /
+    CREATE INDEX side effects.
+    """
+    from alembic import op as alembic_op
+
+    fake_bind = MagicMock()
+    fake_result = MagicMock()
+    fake_result.scalar_one.return_value = existing_count
+    fake_bind.execute.return_value = fake_result
+    monkeypatch.setattr(alembic_op, "get_bind", lambda: fake_bind)
+
+    # Stub out the rest of upgrade()'s side effects so the post-gate
+    # body doesn't crash on missing tables / context.
+    monkeypatch.setattr(alembic_op, "execute", lambda *_a, **_k: None)
+    fake_ctx = MagicMock()
+    cm = MagicMock()
+    cm.__enter__ = lambda *_: None
+    cm.__exit__ = lambda *_: False
+    fake_ctx.autocommit_block.return_value = cm
+    monkeypatch.setattr(alembic_op, "get_context", lambda: fake_ctx)
+
+
+@pytest.mark.unit
+def test_gate_proceeds_on_empty_db_without_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fresh install: row count == 0, env unset → upgrade() runs to
+    completion (no RuntimeError)."""
+    monkeypatch.delenv("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", raising=False)
+    _patch_op(monkeypatch, existing_count=0)
+    mig = _load_migration()
+    mig.upgrade()  # must not raise
+
+
+@pytest.mark.unit
+def test_gate_refuses_destructive_run_without_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Populated DB, env unset → RuntimeError with the row count and
+    the env var name in the message."""
+    monkeypatch.delenv("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", raising=False)
+    _patch_op(monkeypatch, existing_count=42_000)
+    mig = _load_migration()
+    with pytest.raises(RuntimeError) as ei:
+        mig.upgrade()
+    assert "42000" in str(ei.value)
+    assert "MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS" in str(ei.value)
+
+
+@pytest.mark.unit
+def test_gate_proceeds_with_explicit_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Populated DB, env set to 'true' → upgrade() proceeds."""
+    monkeypatch.setenv("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", "true")
+    _patch_op(monkeypatch, existing_count=42_000)
+    mig = _load_migration()
+    mig.upgrade()  # must not raise
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("val", ["", "yes", "1", "TRUE_BUT_TYPO", "no", "false"])
+def test_gate_treats_non_true_values_as_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+    val: str,
+) -> None:
+    """Anything other than (case-insensitive) ``"true"`` is treated as
+    opt-out, so an operator's typo doesn't accidentally green-light
+    data destruction."""
+    monkeypatch.setenv("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", val)
+    _patch_op(monkeypatch, existing_count=10)
+    mig = _load_migration()
+    with pytest.raises(RuntimeError):
+        mig.upgrade()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("val", ["true", "TRUE", "True"])
+def test_gate_accepts_case_insensitive_true(
+    monkeypatch: pytest.MonkeyPatch,
+    val: str,
+) -> None:
+    """``MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS=TRUE`` (or ``True``) opts
+    in. Operators commonly capitalize bool envs."""
+    monkeypatch.setenv("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", val)
+    _patch_op(monkeypatch, existing_count=10)
+    mig = _load_migration()
+    mig.upgrade()  # must not raise

--- a/tests/test_p2_semantic_dedup.py
+++ b/tests/test_p2_semantic_dedup.py
@@ -35,6 +35,7 @@ from core_api.constants import (
     CRYSTALLIZER_DEDUP_THRESHOLD,
     SEMANTIC_DEDUP_CANDIDATE_LIMIT,
     SEMANTIC_DEDUP_THRESHOLD,
+    VECTOR_DIM,
 )
 from common.embedding import fake_embedding
 
@@ -96,7 +97,7 @@ class TestFindSemanticDuplicateMocked:
 
         with patch("core_api.services.memory_service.get_storage_client", return_value=mock_sc):
             result = await _find_semantic_duplicate(
-                None, "tenant-1", None, [0.1] * 768,
+                None, "tenant-1", None, [0.1] * VECTOR_DIM,
             )
         assert result is None
 
@@ -110,7 +111,7 @@ class TestFindSemanticDuplicateMocked:
 
         with patch("core_api.services.memory_service.get_storage_client", return_value=mock_sc):
             result = await _find_semantic_duplicate(
-                None, "tenant-1", None, [0.1] * 768,
+                None, "tenant-1", None, [0.1] * VECTOR_DIM,
             )
         assert result is mock_memory
 
@@ -124,7 +125,7 @@ class TestFindSemanticDuplicateMocked:
 
         with patch("core_api.services.memory_service.get_storage_client", return_value=mock_sc):
             await _find_semantic_duplicate(
-                None, "tenant-1", "fleet-a", [0.1] * 768,
+                None, "tenant-1", "fleet-a", [0.1] * VECTOR_DIM,
             )
 
         call_data = mock_sc.find_semantic_duplicate.call_args[0][0]
@@ -141,7 +142,7 @@ class TestFindSemanticDuplicateMocked:
         exclude = uuid4()
         with patch("core_api.services.memory_service.get_storage_client", return_value=mock_sc):
             await _find_semantic_duplicate(
-                None, "tenant-1", None, [0.1] * 768, exclude_id=exclude,
+                None, "tenant-1", None, [0.1] * VECTOR_DIM, exclude_id=exclude,
             )
 
         call_data = mock_sc.find_semantic_duplicate.call_args[0][0]

--- a/tests/test_p5_crystallizer.py
+++ b/tests/test_p5_crystallizer.py
@@ -23,6 +23,7 @@ from core_api.constants import (
     CRYSTALLIZER_DEDUP_NEIGHBORS,
     CRYSTALLIZER_DEDUP_THRESHOLD,
     CRYSTALLIZER_MAX_DEDUP_PAIRS,
+    VECTOR_DIM,
 )
 
 
@@ -181,7 +182,7 @@ class TestBatchANNIntegration:
         )
 
     @staticmethod
-    def _fake_embedding(seed: str, dim: int = 768) -> list[float]:
+    def _fake_embedding(seed: str, dim: int = VECTOR_DIM) -> list[float]:
         """Deterministic embedding from seed string."""
         import hashlib
         import struct

--- a/tests/test_single_value_predicates.py
+++ b/tests/test_single_value_predicates.py
@@ -14,6 +14,7 @@ import pytest
 
 from core_api.constants import (
     SINGLE_VALUE_PREDICATES,
+    VECTOR_DIM,
 )
 
 
@@ -202,7 +203,7 @@ class TestRdfPathGating:
             "core_api.services.contradiction_detector.get_storage_client",
             return_value=mock_sc,
         ):
-            contradictions = await _detect(new_mem, [0.1] * 768)
+            contradictions = await _detect(new_mem, [0.1] * VECTOR_DIM)
 
         # RDF found conflict, semantic skipped
         mock_sc.find_rdf_conflicts.assert_called_once()
@@ -231,7 +232,7 @@ class TestRdfPathGating:
             "core_api.services.contradiction_detector.get_storage_client",
             return_value=mock_sc,
         ):
-            contradictions = await _detect(new_mem, [0.1] * 768)
+            contradictions = await _detect(new_mem, [0.1] * VECTOR_DIM)
 
         # RDF should NOT run for multi-value predicates; only semantic path
         mock_sc.find_rdf_conflicts.assert_not_called()
@@ -262,7 +263,7 @@ class TestRdfPathGating:
             "core_api.services.contradiction_detector.get_storage_client",
             return_value=mock_sc,
         ):
-            contradictions = await _detect(new_mem, [0.1] * 768)
+            contradictions = await _detect(new_mem, [0.1] * VECTOR_DIM)
 
         mock_sc.find_rdf_conflicts.assert_called_once()
         mock_sc.find_similar_candidates.assert_not_called()
@@ -288,7 +289,7 @@ class TestRdfPathGating:
             "core_api.services.contradiction_detector.get_storage_client",
             return_value=mock_sc,
         ):
-            contradictions = await _detect(new_mem, [0.1] * 768)
+            contradictions = await _detect(new_mem, [0.1] * VECTOR_DIM)
 
         # Only semantic path runs (no RDF triple)
         mock_sc.find_rdf_conflicts.assert_not_called()
@@ -319,7 +320,7 @@ class TestRdfPathGating:
             "core_api.services.contradiction_detector.get_storage_client",
             return_value=mock_sc,
         ):
-            contradictions = await _detect(new_mem, [0.1] * 768)
+            contradictions = await _detect(new_mem, [0.1] * VECTOR_DIM)
 
         # Only RDF query should have run — semantic skipped
         mock_sc.find_rdf_conflicts.assert_called_once()

--- a/tests/test_visibility_contradiction.py
+++ b/tests/test_visibility_contradiction.py
@@ -12,6 +12,8 @@ from uuid import uuid4
 
 import pytest
 
+from core_api.constants import VECTOR_DIM
+
 
 # ---------------------------------------------------------------------------
 # 1. Auto-chunk child visibility inheritance
@@ -178,7 +180,7 @@ class TestContradictionVisibilityScoping:
         mock_result.all.return_value = []
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        embedding = [0.1] * 768
+        embedding = [0.1] * VECTOR_DIM
         await memory_repo.find_similar_candidates(mock_db, new_memory, embedding)
 
         # Inspect the compiled SQL statement passed to db.execute
@@ -219,7 +221,7 @@ class TestContradictionVisibilityScoping:
             "core_api.services.contradiction_detector.get_storage_client",
             return_value=mock_sc,
         ):
-            embedding = [0.1] * 768
+            embedding = [0.1] * VECTOR_DIM
             await _detect(new_memory, embedding)
 
         # Verify the RDF path was invoked (single-value predicate)
@@ -292,7 +294,7 @@ class TestSupersessionFirstMatchOnly:
             "core_api.services.contradiction_detector.get_storage_client",
             return_value=mock_sc,
         ):
-            embedding = [0.1] * 768
+            embedding = [0.1] * VECTOR_DIM
             contradictions = await _detect(new_memory, embedding)
 
         # Should find 2 contradictions
@@ -365,7 +367,7 @@ class TestSupersessionFirstMatchOnly:
             new_callable=AsyncMock,
             return_value=True,
         ):
-            embedding = [0.1] * 768
+            embedding = [0.1] * VECTOR_DIM
             contradictions = await _detect(new_memory, embedding)
 
         assert len(contradictions) == 2


### PR DESCRIPTION
## Summary

Replaces OpenAI's hosted ``text-embedding-3-small`` with a self-hosted **TEI sidecar running ``BAAI/bge-m3``** as MemClaw's default embedder. Bumps the pgvector schema from 768 → 1024 dim to match bge-m3's native output. All opt-in for OSS — a plain ``docker compose up -d`` is unchanged; the new behaviour activates with ``--profile embed-local``.

Stacks the rebased ``embedder-exp-option-b`` work (A.5 + Option B + Matryoshka truncation) with new operational pieces: alembic migration, compose service, env scaffolding, unit tests, and a quickstart doc. Closes the rollout loop traced in ``local_emb_res/RESULTS.md`` (LongMemEval bench-off) and ``local_emb_res/sizing-1000rps.md`` (cost / sizing).

> Re-opened from #50 under the CI-matching branch name ``CAURA-444-local-embed-infra``. All 3 commits are DCO-signed.

## Headline numbers (LongMemEval ``single-session-user``, N=30, seed=42)

| Embedder | R@5 | Accuracy |
|---|---|---|
| OpenAI ``text-embedding-3-small`` (current default) | 0.889 | 86.7% |
| **``BAAI/bge-m3`` (this PR's new default)** | **0.963** | **93.3%** |

Compute economics at 1000 RPS sustained: ~$1k/mo on 2× L4 vs ~$10.5k/mo on OpenAI (~$114k/yr saved). Data residency: stays in-VPC.

## Three commits

1. **feat(embedding): Option B + A.5 + dev-compose Dockerfile fix** — Eyal's experiment commit, rebased onto current ``main``, conflict-resolved (httpx pool + ``base_url`` merged in ``providers/openai.py``; preserved the ``user: ${UID}:${GID}`` mapping in dev compose). Re-authored to ``ran-taig`` with ``Co-Authored-By: Eyal Blyachman`` to preserve attribution, and DCO-signed.
   - ``OpenAIEmbeddingProvider`` accepts ``base_url`` + ``send_dimensions`` so any OpenAI-compatible endpoint (TEI, vLLM) is a drop-in.
   - New ``EmbeddingProvider.embed_query(text, instruction)`` for asymmetric query/document encoding (instruction-aware models like Qwen3-Embedding).
   - Matryoshka truncation + L2-renormalization (``OPENAI_EMBEDDING_TRUNCATE_TO_DIM``).
   - ``hasattr`` guard on ``embed_query`` keeps non-instruction-aware providers (vertex, local, fake) backward-compatible without protocol breakage.

2. **feat(embedding): wire up local embedder default + 1024-dim schema**
   - **alembic 010_vector_dim_1024.py**: drops + recreates ``ix_memories_embedding_hnsw`` and ``ix_documents_embedding_hnsw`` ``CONCURRENTLY``, NULLs existing 768-dim vectors (incompatible with new dim), ALTERs three columns to ``vector(1024)``, rebuilds HNSW. Symmetric downgrade. Follows the ``CONCURRENTLY`` + ``autocommit_block`` idiom from migrations 008/009.
   - ``common/constants.py``: ``VECTOR_DIM`` 768 → 1024 with a comment tying it to migration 010.
   - ``docker-compose.yml`` + ``docker-compose.dev.yml``: profile-gated ``tei`` service (default ``BAAI/bge-m3``), env passthrough, ``tei_cache`` volume. Optional GPU deploy block included as a comment.
   - ``.env.example``: documents the four runtime envs + two compose-only knobs.
   - ``tests/test_embedding_openai_compat.py``: **11 unit tests, all passing**, covering A.5 + Option B contract (base_url forwarding, send_dimensions toggle, Matryoshka renormalization, embed_query asymmetry, instruction prefix). Pure mocks, no network.
   - ``docs/local-embedder.md``: quickstart, hardware sizing, model swap table, schema-migration note, troubleshooting.

3. **chore(tests): replace hardcoded 768 with VECTOR_DIM constant**
   - Tech-debt sweep surfaced by the dim flip. 57 hardcoded ``768`` references across 10 test files replaced with ``VECTOR_DIM`` (imported from ``core_api.constants``). Test-only, no production code change.

## ⚠️ Migration is destructive on existing 768-dim data

``alembic 010`` cannot widen a vector column in place — pgvector rejects the type change with non-NULL data. The migration NULLs every existing embedding before ``ALTER TYPE``. **All memories, entities, and documents will need re-embedding after upgrade.**

Two recovery paths:
- **Lazy** (default): the application re-embeds on next read/write touching each row. Steady-state OSS deployments converge over hours/days.
- **Eager**: a backfill task in ``core-worker`` to scan ``WHERE embedding IS NULL`` and embed in batches. **Tracked separately** — required for production cutover, not in this PR.

For the few existing OSS deployments, the team will handle migration manually (per stakeholder confirmation).

## Test plan

- [x] ``pytest tests/test_embedding_openai_compat.py -v`` → **11/11 pass** (the new unit tests).
- [x] ``pytest -m unit`` → **699 passed, 1 skipped, 6 errors**. The 6 errors are pre-existing on ``origin/main`` (verified by running the same tests against ``origin/main`` HEAD via worktree); they live in ``tests/test_pagination_tiebreaker.py`` and ``tests/test_visibility_scoping.py``, are mismarked as ``unit`` but require a real Postgres at migration ≥007. Out of scope for this PR.
- [x] Rebased onto latest ``origin/main`` → conflict-free.
- [x] DCO sign-off on all 3 commits (``ran@caura.ai``).
- [ ] ``alembic upgrade 010`` against staging — **deferred until backfill task is ready**.
- [ ] End-to-end smoke: ``docker compose --profile embed-local up -d`` + LongMemEval runner → confirm parity with the recovered N=30 numbers.

## Out of scope (follow-up PRs)

- Backfill task to re-embed existing rows post-migration.
- CI workflow update to spin up a TEI sidecar for an integration smoke test.
- Enterprise / Cloud-Run deployment (separate plan in ``local_emb_res/design_integration.md``).
- Fix-up of the 6 ``unit``-marked-but-needs-DB tests (separate hygiene PR).

## Refs

- ``local_emb_res/RESULTS.md`` — full bench numbers (Qwen3 / bge-m3 / OpenAI).
- ``local_emb_res/sizing-1000rps.md`` — fleet sizing + cost.
- ``local_emb_res/design_integration.md`` — production roadmap (Phase 1/2/3).
- ``docs/local-embedder.md`` — user-facing quickstart added in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)