### PR TITLE
test(search): regression test for soft-delete exclusion in scored search (CAURA-000)

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -106,8 +106,10 @@ class Settings(BaseSettings):
     db_max_overflow: int = 50
     cors_origins: str = "http://localhost:3000"
     # Request-wide budget enforced by RequestTimeoutMiddleware. 45s fits
-    # comfortably under the 60s LB cap and 300s Cloud Run platform ceiling,
-    # so a hung handler cannot keep a request slot past this.
+    # comfortably under the 120s gateway/Cloud Run cap (CAURA-623 raised
+    # the nginx ``proxy_read_timeout`` from 60s to 120s; the staging
+    # core-api Cloud Run service is also pinned to 120s at the platform
+    # level), so a hung handler cannot keep a request slot past this.
     #
     # Residual risk: asyncio.timeout cancels the coroutine task but cannot
     # cancel sync threads started via asyncio.to_thread (Vertex / Gemini
@@ -125,8 +127,10 @@ class Settings(BaseSettings):
     # enforce this longer budget themselves; the per-attempt unique
     # constraint on ``memories.client_request_id`` makes a 504-here
     # retry-safe at the row level. p95 today is ~42s under load, so
-    # 90s is roughly 2x headroom while staying well under the 300s
-    # Cloud Run platform ceiling.
+    # 90s is roughly 2x headroom while staying 30s below the 120s
+    # Cloud Run platform timeout (CAURA-623 — earlier comment cited
+    # the 300s unconfigured default before the platform service was
+    # pinned at 120s).
     bulk_request_timeout_seconds: float = 90.0
     # Per-phase cap on the storage roundtrip inside
     # ``create_memories_bulk`` (CAURA-599). Embedding and enrichment

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -322,21 +322,53 @@ class TestSearchPipelineEndToEnd:
         # path already has its own deleted-row test in
         # tests/test_p2_semantic_dedup.py::test_deleted_memory_doesnt_block;
         # this closes the parallel gap on the scored-search read path.
+        #
+        # Note: the deleted row is created with ``deleted_at`` ALREADY
+        # set, matching the dedup-side test's helper. A post-insert
+        # ``UPDATE memories SET deleted_at = ...`` via the per-test
+        # ``db`` fixture is invisible to the storage-api ASGI bridge:
+        # ``db`` runs the outer transaction in
+        # ``join_transaction_mode="create_savepoint"`` (conftest
+        # ``db`` fixture), so its commits land at a savepoint inside a
+        # never-committed outer transaction — a separate connection
+        # (which the storage app's session_factory checks out from the
+        # same engine) never sees the change.
+        from core_api.clients.storage_client import get_storage_client
         from core_api.services.memory_service import search_memories
 
-        deleted_mem = await _insert_memory(
-            db, tenant_id, "kubernetes pod restart troubleshooting guide", weight=0.7
-        )
-        live_mem = await _insert_memory(
-            db, tenant_id, "kubernetes pod restart common causes summary", weight=0.7
-        )
+        sc = get_storage_client()
 
-        await db.execute(
-            update(Memory)
-            .where(Memory.id == deleted_mem["id"])
-            .values(deleted_at=datetime.now(timezone.utc))
+        async def _seed(content: str, *, deleted: bool) -> dict:
+            payload = {
+                "tenant_id": tenant_id,
+                "fleet_id": None,
+                "agent_id": "scored-search-soft-delete",
+                "memory_type": "fact",
+                "content": content,
+                "weight": 0.7,
+                "embedding": fake_embedding(content),
+                "content_hash": _hash(tenant_id, None, content),
+                "status": "active",
+                "visibility": "scope_team",
+            }
+            if deleted:
+                payload["deleted_at"] = datetime.now(timezone.utc).isoformat()
+            mem = await sc.create_memory(payload)
+            await db.execute(
+                text(
+                    "UPDATE memories SET search_vector = to_tsvector('english', :content) WHERE id = :id"
+                ),
+                {"content": content, "id": mem["id"]},
+            )
+            await db.commit()
+            return mem
+
+        deleted_mem = await _seed(
+            "kubernetes pod restart troubleshooting guide", deleted=True
         )
-        await db.commit()
+        live_mem = await _seed(
+            "kubernetes pod restart common causes summary", deleted=False
+        )
 
         results = await search_memories(db, tenant_id, "kubernetes pod restart")
 

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -314,3 +314,36 @@ class TestSearchPipelineEndToEnd:
         assert len(results) >= 1
         # Memory 2 should win: fresher, recently recalled, entity-boosted
         # Memory 1's high weight and stale recall count shouldn't dominate
+
+    async def test_scored_search_excludes_soft_deleted(self, db, tenant_id):
+        # Regression guard for the parallel ``deleted_at IS NULL`` filter
+        # sites in core-storage-api/services/postgres_service.py
+        # (memory_scored_search at line 857 today). The semantic-dedup
+        # path already has its own deleted-row test in
+        # tests/test_p2_semantic_dedup.py::test_deleted_memory_doesnt_block;
+        # this closes the parallel gap on the scored-search read path.
+        from core_api.services.memory_service import search_memories
+
+        deleted_mem = await _insert_memory(
+            db, tenant_id, "kubernetes pod restart troubleshooting guide", weight=0.7
+        )
+        live_mem = await _insert_memory(
+            db, tenant_id, "kubernetes pod restart common causes summary", weight=0.7
+        )
+
+        await db.execute(
+            update(Memory)
+            .where(Memory.id == deleted_mem["id"])
+            .values(deleted_at=datetime.now(timezone.utc))
+        )
+        await db.commit()
+
+        results = await search_memories(db, tenant_id, "kubernetes pod restart")
+
+        result_ids = {str(r.id) for r in results}
+        assert str(deleted_mem["id"]) not in result_ids, (
+            "soft-deleted memory leaked into scored search results"
+        )
+        assert str(live_mem["id"]) in result_ids, (
+            "live memory was not returned by scored search"
+        )


### PR DESCRIPTION
## Summary
Adds a regression test asserting that the scored-search read path (`memory_scored_search` in `core-storage-api/services/postgres_service.py`, line 857) does not return soft-deleted rows.

The four parallel `deleted_at IS NULL` filter sites in `postgres_service.py` (lines 562, 857, 1137, 1336) made an oversight on any single one easy to ship. The semantic-dedup path already has a counterpart test (`test_p2_semantic_dedup.py::test_deleted_memory_doesnt_block`); this PR adds the equivalent on the most user-visible read path.

Also refreshes two stale `300s Cloud Run platform ceiling` comments in `core-api/config.py` to reflect the live 120s shape (CAURA-623 raised the nginx gateway from 60s to 120s; the staging core-api Cloud Run service is also pinned at 120s at the platform level).

## Diagnosis
- The "vector search doesn't filter soft deleted memories" bug claim was investigated against `main` — code was already correct on all four paths.
- Test coverage gap on the **scored search** path — only dedup had a regression test.

## Scope
- New: `test_scored_search_excludes_soft_deleted` in `tests/test_integration_search.py`.
- Comment-only refresh in `core-api/src/core_api/config.py` (no behavior change).

## Test plan
- [x] `ruff check` + `ruff format --check` clean on `core-api/src/`.
- [x] `pytest --collect-only tests/test_integration_search.py` collects 8 tests (was 7).
- [ ] Test runs green in CI (requires the integration db fixtures — validated locally only at collection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)