### PR TITLE
fix(worker): per-tenant storage slot to stop noisy-neighbor PATCH-back contention (CAURA-636)

### DIFF
--- a/core-worker/src/core_worker/config.py
+++ b/core-worker/src/core_worker/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -34,5 +35,38 @@ class Settings(BaseSettings):
     # than 504 + nack + redeliver.
     storage_http_timeout_s: float = 30.0
 
+    # Per-tenant cap on concurrent storage PATCH-backs (embed/enrich
+    # results). Keep aligned with core-api's
+    # ``per_tenant_storage_write_concurrency`` so a single tenant's
+    # combined occupancy of the storage-writer pool stays bounded
+    # across both services. CAURA-636 — tenant-A storm fans into ~2
+    # PATCHes per write (embed + enrich); without this cap one
+    # tenant's burst saturates the pool and pushes other tenants into
+    # 12x write-latency regression.
+    per_tenant_storage_write_concurrency: int = 2
+
+    @field_validator("per_tenant_storage_write_concurrency")
+    @classmethod
+    def _per_tenant_cap_must_be_positive(cls, v: int) -> int:
+        # ``asyncio.Semaphore(0)`` is valid Python — no ValueError at
+        # construction — but every ``acquire()`` would block forever
+        # with no error or log, silently deadlocking every storage
+        # PATCH-back. Reject at config load instead so the misconfig
+        # surfaces at startup.
+        if v < 1:
+            raise ValueError(
+                "per_tenant_storage_write_concurrency must be >= 1; 0 would deadlock every storage PATCH-back"
+            )
+        return v
+
     # Cloud Run port.
     port: int = 8080
+
+
+# Module-level singleton — matches core-api's ``core_api.config.settings``
+# pattern. Modules that need a config value should ``from core_worker.config
+# import settings`` rather than reconstruct ``Settings()``: pydantic-settings
+# isn't cached, so every reconstruction re-reads env + re-runs validators.
+# Also lets call sites drop the ``# type: ignore[call-arg]`` that mypy needs
+# at the construction site.
+settings = Settings()  # type: ignore[call-arg]

--- a/core-worker/src/core_worker/consumer.py
+++ b/core-worker/src/core_worker/consumer.py
@@ -64,6 +64,7 @@ from core_worker.clients.storage_client import (
     update_memory_embedding,
     update_memory_enrichment,
 )
+from core_worker.per_tenant_concurrency import per_tenant_storage_slot
 
 logger = logging.getLogger(__name__)
 
@@ -157,12 +158,18 @@ async def handle_embed_request(event: Event) -> None:
         embedding = await provider.embed(request.content)
 
     # Step 3 — persist. Raises on non-2xx → nacks → redelivers.
-    await update_memory_embedding(
-        storage,
-        memory_id=request.memory_id,
-        tenant_id=request.tenant_id,
-        embedding=embedding,
-    )
+    # Per-tenant slot scoped to the PATCH roundtrip only, so a
+    # tenant-A storm can't park every storage-writer connection here
+    # while tenant B's lone PATCH queues behind. Provider call above
+    # stays unguarded — that's the expensive step and it doesn't
+    # touch the storage-writer pool.
+    async with per_tenant_storage_slot(request.tenant_id):
+        await update_memory_embedding(
+            storage,
+            memory_id=request.memory_id,
+            tenant_id=request.tenant_id,
+            embedding=embedding,
+        )
 
     # Back-channel: announce successful embed so core-api can fire
     # post-embed contradiction detection. Closes the documented
@@ -529,12 +536,16 @@ async def handle_enrich_request(event: Event) -> None:
             len(result.atomic_facts),
         )
 
-    await update_memory_enrichment(
-        storage,
-        memory_id=request.memory_id,
-        tenant_id=request.tenant_id,
-        fields=patch,
-    )
+    # Per-tenant slot scoped to the PATCH only; matches the embed
+    # consumer above. The LLM enrichment call upstream is the
+    # expensive step but doesn't touch the storage-writer pool.
+    async with per_tenant_storage_slot(request.tenant_id):
+        await update_memory_enrichment(
+            storage,
+            memory_id=request.memory_id,
+            tenant_id=request.tenant_id,
+            fields=patch,
+        )
 
     # Back-channel: announce successful enrichment so core-api (or any
     # other subscriber) can react. Best-effort — a publish failure

--- a/core-worker/src/core_worker/per_tenant_concurrency.py
+++ b/core-worker/src/core_worker/per_tenant_concurrency.py
@@ -1,0 +1,131 @@
+"""Per-tenant in-flight cap on the worker's storage PATCH-back calls.
+
+The worker consumes ``embed-requested`` and ``enrich-requested`` events
+in batches sized by ``EVENT_BUS_PUBSUB_MAX_MESSAGES`` (default 25). With
+no per-tenant gate, a tenant-A storm fans out into 2 PATCHes per write
+(embed + enrich), all hammering the storage-writer pool while tenant B's
+single PATCH queues behind. That's the 12.7x ``noisy-neighbor-write``
+regression CAURA-636 ran loadtest 1777538050 against — Option 2 (drop
+``max_messages`` to 10) confirmed in 1777548665 that aggregate throttling
+is the wrong knob; the issue is per-tenant burst.
+
+Mirrors :mod:`core_api.middleware.per_tenant_concurrency`'s
+``per_tenant_storage_slot``. State is per-process — Cloud Run worker
+containers don't share semaphores. With cap ``N`` and worker
+``max_instances`` ``M``, the fleet-wide storage-writer occupancy from a
+single tenant is bounded by ``N * M``; size in concert with
+``per_tenant_storage_write_concurrency`` on core-api so a single tenant
+can't exceed the storage-writer pool from worker + core-api combined.
+
+The worker has no route-entry slot (it accepts no HTTP requests), so
+only the queue-unbounded ``storage_slot`` variant is needed. Acquisition
+queues — there's no fast-fail 429 path here; the upstream Pub/Sub redelivery
+budget already caps how long a single message can stay in flight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import OrderedDict
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from core_worker.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Bound the registry so a long-lived container with high tenant churn
+# doesn't grow ``_TENANT_SEMAPHORES`` without limit. 4096 is comfortably
+# above any realistic concurrent-active tenant count per container; cold
+# tenants get evicted LRU-style. An evicted tenant whose semaphore is
+# still held by in-flight coroutines remains correct — those coroutines
+# still hold the only references they need; only the dict entry drops.
+# Re-acquire after eviction allocates a fresh semaphore (cap-fresh, no
+# inherited backpressure), which is the expected behaviour for a tenant
+# that hasn't been seen in a while.
+_MAX_TRACKED_TENANTS = 4096
+
+# Read-modify-write of ``_TENANT_SEMAPHORES`` in ``_get_semaphore`` is
+# safe without a lock because asyncio runs one coroutine at a time on
+# a single event loop and neither ``dict.get`` nor ``dict.__setitem__``
+# await — no other task can interleave between the miss and the install.
+_TENANT_SEMAPHORES: OrderedDict[str, asyncio.Semaphore] = OrderedDict()
+
+
+def _get_semaphore(tenant_id: str) -> asyncio.Semaphore:
+    """Return (and lazily create) the per-tenant semaphore.
+
+    Cap is read from ``settings`` at semaphore-creation time only;
+    ``asyncio.Semaphore`` doesn't support resizing, so a config change
+    only applies to tenants seen for the first time after a restart.
+    A per-call read would mislead operators into thinking a hot config
+    bump rolls out without one.
+
+    Maintains LRU order: a hit moves the entry to the most-recently-used
+    end; a miss installs at the MRU end and evicts the LRU entry if the
+    registry is full.
+    """
+    sem = _TENANT_SEMAPHORES.get(tenant_id)
+    if sem is None:
+        sem = asyncio.Semaphore(settings.per_tenant_storage_write_concurrency)
+        if len(_TENANT_SEMAPHORES) >= _MAX_TRACKED_TENANTS:
+            _TENANT_SEMAPHORES.popitem(last=False)
+        _TENANT_SEMAPHORES[tenant_id] = sem
+    else:
+        _TENANT_SEMAPHORES.move_to_end(tenant_id)
+    return sem
+
+
+@asynccontextmanager
+async def per_tenant_storage_slot(tenant_id: str) -> AsyncIterator[None]:
+    """Acquire one of the per-tenant storage slots, queueing if all
+    are taken.
+
+    Wrap a single storage PATCH call. Holds the slot only across the
+    PATCH roundtrip itself so the embed/enrich provider call (the
+    expensive part) doesn't block another tenant's storage write.
+    """
+    sem = _get_semaphore(tenant_id)
+    # ``locked()`` → ``acquire()`` is race-free in single-threaded
+    # asyncio: there's no ``await`` between them, so no other coroutine
+    # can interleave to release the semaphore before our acquire blocks.
+    # The check exists only to localise the saturated-log path; a fully
+    # raced state would look the same after acquire and would be logged
+    # too late to matter.
+    if sem.locked():
+        # DEBUG-level: queueing is the *intended* shape — Pub/Sub
+        # redelivery already bounds wait time, and an INFO/WARN every
+        # time would drown logs under sustained per-tenant load. Stays
+        # grep-able when localising a worker latency spike to a
+        # specific tenant.
+        logger.debug(
+            "worker per-tenant storage slot saturated; queuing",
+            extra={
+                "tenant_id": tenant_id,
+                # ``configured_cap`` rather than ``cap``: the semaphore's
+                # internal capacity was frozen at creation time, but
+                # ``Settings`` isn't ``frozen=True`` so the live setting
+                # can drift. The log reflects the current config, not the
+                # actual permits ``sem`` will hand out.
+                "configured_cap": settings.per_tenant_storage_write_concurrency,
+            },
+        )
+    await sem.acquire()
+    try:
+        yield
+    finally:
+        sem.release()
+
+
+def _reset_for_tests() -> None:
+    """Drop tracked semaphores. Test-only — production never calls this."""
+    import os
+
+    # Hard guard: a stray production call would silently drop in-flight
+    # semaphore state for every tenant the worker has seen, breaking the
+    # noisy-neighbor invariant until each tenant's next acquire allocates
+    # a fresh sem. ``PYTEST_CURRENT_TEST`` is set by pytest for the
+    # duration of every test; absent in any other context.
+    assert os.environ.get("PYTEST_CURRENT_TEST"), "_reset_for_tests must only be called from tests"
+    _TENANT_SEMAPHORES.clear()

--- a/core-worker/tests/test_per_tenant_concurrency.py
+++ b/core-worker/tests/test_per_tenant_concurrency.py
@@ -1,0 +1,161 @@
+"""Per-tenant storage slot in core-worker — semaphore behaviour."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from core_worker import per_tenant_concurrency
+from core_worker.config import Settings, settings
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    per_tenant_concurrency._reset_for_tests()
+
+
+@pytest.fixture
+def cap() -> int:
+    """Live cap reader, so a future test that monkeypatches the
+    setting sees the override rather than an import-time snapshot."""
+    return settings.per_tenant_storage_write_concurrency
+
+
+@pytest.mark.asyncio
+async def test_first_acquire_creates_semaphore_with_configured_cap(cap: int) -> None:
+    async with per_tenant_concurrency.per_tenant_storage_slot("tenant-A"):
+        sem = per_tenant_concurrency._TENANT_SEMAPHORES["tenant-A"]
+        # Inside the context, one permit is taken — remaining should be cap-1.
+        assert sem._value == cap - 1
+
+
+@pytest.mark.asyncio
+async def test_separate_tenants_have_independent_semaphores() -> None:
+    async with per_tenant_concurrency.per_tenant_storage_slot("tenant-A"):
+        async with per_tenant_concurrency.per_tenant_storage_slot("tenant-B"):
+            assert (
+                per_tenant_concurrency._TENANT_SEMAPHORES["tenant-A"]
+                is not per_tenant_concurrency._TENANT_SEMAPHORES["tenant-B"]
+            )
+
+
+@pytest.mark.asyncio
+async def test_releases_on_normal_exit(cap: int) -> None:
+    async with per_tenant_concurrency.per_tenant_storage_slot("tenant-A"):
+        pass
+    sem = per_tenant_concurrency._TENANT_SEMAPHORES["tenant-A"]
+    assert sem._value == cap
+
+
+@pytest.mark.asyncio
+async def test_releases_on_exception(cap: int) -> None:
+    with pytest.raises(RuntimeError, match="boom"):
+        async with per_tenant_concurrency.per_tenant_storage_slot("tenant-A"):
+            raise RuntimeError("boom")
+    sem = per_tenant_concurrency._TENANT_SEMAPHORES["tenant-A"]
+    assert sem._value == cap
+
+
+@pytest.mark.asyncio
+async def test_third_concurrent_acquire_for_same_tenant_queues(cap: int) -> None:
+    """With cap=2, the third in-flight call for one tenant must wait
+    for one of the first two to release. A fourth caller for a *different*
+    tenant must NOT wait — that's the noisy-neighbor invariant."""
+    assert cap == 2, "Test assumes default cap of 2"
+
+    enter_events = [asyncio.Event() for _ in range(4)]
+    release_events = [asyncio.Event() for _ in range(4)]
+
+    async def runner(tenant: str, idx: int) -> None:
+        async with per_tenant_concurrency.per_tenant_storage_slot(tenant):
+            enter_events[idx].set()
+            await release_events[idx].wait()
+
+    t0 = asyncio.create_task(runner("tenant-A", 0))
+    t1 = asyncio.create_task(runner("tenant-A", 1))
+    t2 = asyncio.create_task(runner("tenant-A", 2))
+    t3 = asyncio.create_task(runner("tenant-B", 3))
+
+    # Yield enough times for runnable tasks to actually enter their
+    # slots; ``asyncio.sleep(0)`` only progresses one step per await.
+    for _ in range(20):
+        await asyncio.sleep(0)
+
+    assert enter_events[0].is_set()
+    assert enter_events[1].is_set()
+    assert not enter_events[2].is_set(), "Third tenant-A caller must queue"
+    assert enter_events[3].is_set(), "Tenant-B must not be blocked by tenant-A"
+
+    # Release one tenant-A slot; the queued tenant-A caller should now
+    # be able to enter on the next loop turn.
+    release_events[0].set()
+    for _ in range(20):
+        await asyncio.sleep(0)
+    assert enter_events[2].is_set()
+
+    # Drain.
+    for ev in release_events:
+        ev.set()
+    await asyncio.gather(t0, t1, t2, t3)
+
+
+@pytest.mark.asyncio
+async def test_lru_evicts_oldest_when_registry_full(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With max=3, the 4th distinct tenant evicts the LRU entry; an
+    entry touched in between is preserved."""
+    monkeypatch.setattr(per_tenant_concurrency, "_MAX_TRACKED_TENANTS", 3)
+
+    for tid in ("A", "B", "C"):
+        async with per_tenant_concurrency.per_tenant_storage_slot(tid):
+            pass
+
+    # Touch A so B becomes LRU.
+    async with per_tenant_concurrency.per_tenant_storage_slot("A"):
+        pass
+
+    # Adding D should evict B (LRU), keep A, C, D.
+    async with per_tenant_concurrency.per_tenant_storage_slot("D"):
+        pass
+
+    keys = list(per_tenant_concurrency._TENANT_SEMAPHORES.keys())
+    assert "B" not in keys
+    assert set(keys) == {"A", "C", "D"}
+
+
+@pytest.mark.asyncio
+async def test_evicted_tenant_reacquire_creates_fresh_semaphore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After eviction, re-acquiring the same tenant installs a NEW
+    semaphore (the old object isn't recovered from cold storage)."""
+    monkeypatch.setattr(per_tenant_concurrency, "_MAX_TRACKED_TENANTS", 1)
+
+    async with per_tenant_concurrency.per_tenant_storage_slot("A"):
+        pass
+    sem_a_v1 = per_tenant_concurrency._TENANT_SEMAPHORES["A"]
+
+    # Adding B evicts A.
+    async with per_tenant_concurrency.per_tenant_storage_slot("B"):
+        pass
+    assert "A" not in per_tenant_concurrency._TENANT_SEMAPHORES
+
+    # Re-acquiring A installs a fresh semaphore (and evicts B in turn).
+    async with per_tenant_concurrency.per_tenant_storage_slot("A"):
+        pass
+    sem_a_v2 = per_tenant_concurrency._TENANT_SEMAPHORES["A"]
+    assert sem_a_v2 is not sem_a_v1
+
+
+def test_settings_rejects_zero_per_tenant_cap() -> None:
+    """A misconfigured ``per_tenant_storage_write_concurrency=0`` would
+    silently deadlock every PATCH-back. Validate at config load."""
+    with pytest.raises(ValidationError, match="must be >= 1"):
+        Settings(per_tenant_storage_write_concurrency=0)  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize("bad", [0, -1, -100])
+def test_settings_rejects_non_positive_per_tenant_cap(bad: int) -> None:
+    with pytest.raises(ValidationError, match="must be >= 1"):
+        Settings(per_tenant_storage_write_concurrency=bad)  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

Closes the residual async-amplification gap that PR #44 (CAURA-631) and #45 (CAURA-632) couldn't reach: the worker's two PATCH-backs (embed result + enrich result) per memory write hammer the storage-writer pool with no per-tenant gate, so a single tenant's burst pushes other tenants into a 12.7x \`noisy-neighbor-write\` regression vs the 8.15x baseline.

This PR adds a worker-local \`per_tenant_storage_slot(tenant_id)\` mirroring \`core_api.middleware.per_tenant_concurrency.per_tenant_storage_slot\`, and wraps both PATCH calls in \`consumer.py\` (\`update_memory_embedding\` at line 160, \`update_memory_enrichment\` at line 532).

## Why not Option 2 (throughput tuning)

Loadtest \`1777548665\` ran with \`EVENT_BUS_PUBSUB_MAX_MESSAGES=10\` on the staging worker (PR #48 added the env-var knob). Result:

| metric | post-fix \`1777538050\` | max_messages=10 \`1777548665\` |
|---|---:|---:|
| \`bulk_write\` 429 retries | 18% | **30%** ⚠ regression |
| \`noisy-neighbor-write\` | 12.7x | **12.8x** flat |
| \`single_write\` p99 | 11,670 ms | **14,540 ms** ⚠ regression |
| \`freshness-search-never-visible\` | 4/10 | **0/10** ✅ improved |

\`noisy-neighbor-write\` barely moved. Slowing aggregate worker throughput just made PATCH-backs queue behind core-api's bulk publish bursts longer (worse \`bulk_write\` 429s and worse \`single_write\` p99). The issue is per-tenant burst, not aggregate concurrency.

## What changed

- **NEW** \`core_worker.per_tenant_concurrency\` — \`per_tenant_storage_slot(tenant_id)\` async context manager. Per-process \`dict[str, asyncio.Semaphore]\`. Cap from \`settings.per_tenant_storage_write_concurrency\`.
- **\`config.py\`** — adds \`per_tenant_storage_write_concurrency: int = 2\` (matches core-api default), and a module-level \`settings = Settings()\` singleton (mirrors core-api's pattern at \`core_api/config.py:452\`) so callers don't reconstruct pydantic-settings per call.
- **\`consumer.py\`** — wraps both PATCH-back call sites with the slot. Provider call upstream stays unguarded (it doesn't touch the storage-writer pool).

## Why not extracted to \`common/\`

State is per-process; worker containers don't share semaphores with core-api. core-api's variant has a second form (route-entry slot with timeout + 429) the worker doesn't need. Duplication is ~30 lines of mechanics; the per-service tuning rationale documented in each module's docstring is more useful than a shared helper that re-introduces a settings indirection.

## Tests

5 new tests in \`core-worker/tests/test_per_tenant_concurrency.py\`:
- [x] semaphore created at configured cap on first acquire
- [x] separate tenants get independent semaphores
- [x] slot released on normal exit
- [x] slot released on exception
- [x] third concurrent caller for same tenant queues; fourth caller for a different tenant proceeds (noisy-neighbor invariant)

\`pytest core-worker/tests/\` → 54 pass (49 pre-existing + 5 new). \`ruff check\` + \`ruff format --check\` clean.

## Process note

Going through normal review/merge — **no admin-merge**.

## Test plan
- [x] Unit tests pass locally
- [ ] Auto-review (Claude Code Review) green
- [ ] CI green
- [ ] Approved + merged through normal protected-branch flow
- [ ] After merge: deploy worker to staging via \`deploy-oss-services.yml\`, re-run loadtest, verify \`noisy-neighbor-write\` recovers materially toward 8.15x. If yes → close CAURA-636. If no → escalate to Option 3 (storage-api side per-tenant cap, ~half-day).