### PR TITLE
feat(errors): standardize error contract across REST and MCP

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -4,7 +4,8 @@ import os as _os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -430,18 +431,83 @@ app.state.limiter = limiter
 
 
 async def _json_rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
-    # Custom handler so 429 bodies match the rest of the API's
-    # `{"detail": ...}` envelope. Re-runs slowapi's header injector so
-    # X-RateLimit-* + Retry-After still land on the response.
-    response = JSONResponse(
-        {"detail": f"Rate limit exceeded: {exc.detail}. Try again later."},
-        status_code=429,
-    )
+    # Custom handler so 429 bodies match the rest of the API's error
+    # envelope: top-level `detail` for back-compat plus the canonical
+    # `error: {code, message, details?}` field. Re-runs slowapi's header
+    # injector so X-RateLimit-* + Retry-After still land on the response.
+    from core_api.errors import make_error_payload
+
+    detail_str = f"Rate limit exceeded: {exc.detail}. Try again later."
+    body = {"detail": detail_str, **make_error_payload("RATE_LIMITED", detail_str)}
+    response = JSONResponse(body, status_code=429)
     response = request.app.state.limiter._inject_headers(response, request.state.view_rate_limit)
     return response
 
 
 app.add_exception_handler(RateLimitExceeded, _json_rate_limit_handler)
+
+
+# ── Canonical error envelope ────────────────────────────────────────
+# Every error response carries a top-level ``detail`` (legacy/back-compat)
+# AND a canonical ``error: {code, message, details?}`` envelope. New
+# clients should read ``error.code`` for machine-readable dispatch;
+# existing clients reading ``detail`` keep working.
+#
+# Callers that need a specific error code can raise:
+#     raise HTTPException(status_code=404, detail={"code": "MEMORY_NOT_FOUND",
+#                                                  "message": "...",
+#                                                  "details": {...}})
+# When ``detail`` is a string, the code is auto-derived from the status
+# via core_api.errors.STATUS_TO_CODE.
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    from core_api.errors import code_for_status, make_error_payload
+
+    raw = exc.detail
+    if isinstance(raw, dict) and "code" in raw and "message" in raw:
+        code = str(raw["code"])
+        message = str(raw["message"])
+        details = raw.get("details") if isinstance(raw.get("details"), dict) else None
+        legacy_detail: object = message
+    else:
+        code = code_for_status(exc.status_code)
+        message = str(raw) if raw is not None else ""
+        details = None
+        legacy_detail = raw  # keep original shape (string, list, dict-without-code) for back-compat
+
+    body = {"detail": legacy_detail, **make_error_payload(code, message, details)}
+    return JSONResponse(body, status_code=exc.status_code, headers=exc.headers)
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    """Replace FastAPI's default 422 body with our envelope.
+
+    FastAPI's default returns ``{"detail": [{loc, msg, type, ...}, ...]}``.
+    We keep that ``detail`` array verbatim for back-compat AND surface
+    the canonical envelope. The aggregated message joins each error's
+    ``msg`` for callers that want a single human-readable string.
+
+    ``exc.errors()`` may include non-JSON-safe values (e.g. ``ctx``
+    contains Pydantic's underlying ``ValueError`` instance for
+    ``value_error`` types). ``jsonable_encoder`` flattens those before
+    we hand off to ``JSONResponse``.
+    """
+    from fastapi.encoders import jsonable_encoder
+
+    from core_api.errors import make_error_payload
+
+    errs = jsonable_encoder(exc.errors())
+    summary = "; ".join(e.get("msg", "") for e in errs) or "validation error"
+    body = {
+        "detail": errs,  # original FastAPI shape
+        **make_error_payload("INVALID_ARGUMENTS", summary, details={"errors": errs}),
+    }
+    return JSONResponse(body, status_code=422)
+
+
 app.add_middleware(SlowAPIMiddleware)
 
 if app_settings.is_standalone:
@@ -464,11 +530,21 @@ app.add_middleware(
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
+    """Catch-all for non-HTTPException failures. Returns 500 with both
+    the back-compat ``detail`` field AND the canonical ``error`` envelope.
+    Includes ``path`` and ``error_type`` outside production for debugging.
+    """
+    from core_api.errors import make_error_payload
+
     logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
     detail = str(exc) if app_settings.environment != "production" else "Internal Server Error"
+    details: dict = {"path": request.url.path}
+    if app_settings.environment != "production":
+        details["error_type"] = type(exc).__name__
     content: dict = {
         "detail": detail,
         "path": request.url.path,
+        **make_error_payload("INTERNAL_ERROR", detail, details=details),
     }
     if app_settings.environment != "production":
         content["error_type"] = type(exc).__name__

--- a/core-api/src/core_api/errors.py
+++ b/core-api/src/core_api/errors.py
@@ -1,0 +1,70 @@
+"""Canonical error contract shared by REST and MCP surfaces.
+
+Both surfaces should return errors in the shape::
+
+    {
+      "error": {
+        "code": "<UPPER_SNAKE>",
+        "message": "<human-readable>",
+        "details": { ... optional ... }
+      }
+    }
+
+REST additionally keeps the ``detail`` top-level field for back-compat
+with existing clients that read ``response.json()["detail"]``. The
+``error`` field is the canonical surface; ``detail`` is the deprecated
+mirror.
+
+This module is import-safe: pure data, no side effects, no FastAPI
+imports — so it can be used by MCP tools, REST routes, the storage
+client, or anywhere else without dragging in a request stack.
+"""
+
+from __future__ import annotations
+
+# Mapping from HTTP status code → canonical error code. Used when callers
+# raise ``HTTPException(status_code=N, detail="...")`` without supplying an
+# explicit code. The handler in ``app.py`` derives the code from the
+# status code via this table; if a status isn't listed, it falls back to
+# ``HTTP_<status>`` (e.g. ``HTTP_418``).
+STATUS_TO_CODE: dict[int, str] = {
+    400: "BAD_REQUEST",
+    401: "UNAUTHORIZED",
+    402: "PAYMENT_REQUIRED",
+    403: "FORBIDDEN",
+    404: "NOT_FOUND",
+    405: "METHOD_NOT_ALLOWED",
+    408: "REQUEST_TIMEOUT",
+    409: "CONFLICT",
+    410: "GONE",
+    413: "PAYLOAD_TOO_LARGE",
+    415: "UNSUPPORTED_MEDIA_TYPE",
+    422: "INVALID_ARGUMENTS",
+    429: "RATE_LIMITED",
+    500: "INTERNAL_ERROR",
+    501: "NOT_IMPLEMENTED",
+    502: "UPSTREAM_ERROR",
+    503: "UNAVAILABLE",
+    504: "UPSTREAM_TIMEOUT",
+}
+
+
+def code_for_status(status: int) -> str:
+    """Return the canonical error code for an HTTP status, or HTTP_<status> if unknown."""
+    return STATUS_TO_CODE.get(status, f"HTTP_{status}")
+
+
+def make_error_payload(
+    code: str,
+    message: str,
+    details: dict | None = None,
+) -> dict:
+    """Return the canonical error envelope.
+
+    Use this from both REST and MCP error sites so the on-the-wire shape
+    is identical. ``details`` is included only when non-empty.
+    """
+    payload: dict = {"error": {"code": code, "message": message}}
+    if details:
+        payload["error"]["details"] = details
+    return payload

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -34,6 +34,7 @@ from core_api.constants import (
     VERSION,
 )
 from core_api.db.session import async_session
+from core_api.errors import code_for_status
 from core_api.repositories import memory_repo
 from core_api.schemas import BulkMemoryCreate, BulkMemoryItem, MemoryCreate, MemoryUpdate
 from core_api.services.audit_service import log_action
@@ -49,6 +50,7 @@ from core_api.services.memory_service import (
 # Re-export so existing `monkeypatch.setattr(mcp_server, "_require_trust", ...)`
 # sites in tests keep working; production callers should import ``require_trust``
 # directly from ``core_api.services.trust_service``.
+from core_api.services.trust_service import parse_trust_error
 from core_api.services.trust_service import require_trust as _require_trust
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
 
@@ -62,8 +64,31 @@ _agent_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("mcp_
 _UNAUTH = "__unauthenticated__"
 _ADMIN = "__admin__"
 _NO_AUTH = "__no_auth__"
-_AUTH_ERROR = "Error: Missing or invalid X-API-Key header. Provide a tenant-scoped API key."
-_ADMIN_ERROR = "Error: Admin/system keys cannot be used with MCP. Use a tenant-scoped API key."
+
+
+def _error_response(code: str, message: str, **details) -> str:
+    """Return the canonical MCP error envelope as a JSON string.
+
+    Shape matches the REST surface (see ``core_api.errors.make_error_payload``):
+    ``{"error": {"code": "...", "message": "...", "details": {...}}}``.
+
+    Wrap with ``_with_latency(...)`` when an in-tool latency stamp is desired —
+    ``_with_latency`` parses the JSON, appends ``_latency_ms``, and re-serializes.
+    """
+    from core_api.errors import make_error_payload
+
+    payload = make_error_payload(code, message, details=details if details else None)
+    return json.dumps(payload, default=str)
+
+
+# Pre-tool auth errors (returned directly, NOT through _with_latency, because
+# they fire before any tool work has begun).
+_AUTH_ERROR = _error_response(
+    "UNAUTHORIZED", "Missing or invalid X-API-Key header. Provide a tenant-scoped API key."
+)
+_ADMIN_ERROR = _error_response(
+    "FORBIDDEN", "Admin/system keys cannot be used with MCP. Use a tenant-scoped API key."
+)
 
 
 class MCPAuthMiddleware:
@@ -207,9 +232,19 @@ async def memclaw_recall(
     if err := _check_auth():
         return err
     if memory_type and memory_type not in MEMORY_TYPES:
-        return f"Error (422): Invalid memory_type '{memory_type}'. Must be one of: {', '.join(MEMORY_TYPES)}"
+        return _error_response(
+            "INVALID_ARGUMENTS",
+            f"Invalid memory_type '{memory_type}'. Must be one of: {', '.join(MEMORY_TYPES)}",
+            field="memory_type",
+            value=memory_type,
+        )
     if status and status not in MEMORY_STATUSES:
-        return f"Error (422): Invalid status '{status}'. Must be one of: {', '.join(MEMORY_STATUSES)}"
+        return _error_response(
+            "INVALID_ARGUMENTS",
+            f"Invalid status '{status}'. Must be one of: {', '.join(MEMORY_STATUSES)}",
+            field="status",
+            value=status,
+        )
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id  # prefer gateway-verified identity
     capped_top_k = min(top_k, MAX_SEARCH_TOP_K)
@@ -261,7 +296,7 @@ async def memclaw_recall(
             return _with_latency(json.dumps(payload, indent=2, default=str), t0)
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(f"Error ({e.status_code}): {e.detail}", t0)
+            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
 
 
 async def memclaw_write(
@@ -375,7 +410,7 @@ async def memclaw_write(
             return _with_latency(_serialize(result), t0)
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(f"Error ({e.status_code}): {e.detail}", t0)
+            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
 
 
 async def memclaw_manage(
@@ -425,7 +460,7 @@ async def memclaw_manage(
         try:
             uid = UUID(memory_id)
         except ValueError:
-            return "Error: Invalid memory_id — must be a valid UUID."
+            return _error_response("INVALID_ARGUMENTS", "Invalid memory_id — must be a valid UUID.")
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
 
@@ -433,16 +468,25 @@ async def memclaw_manage(
         try:
             if op == "bulk_delete":
                 if not memory_ids:
-                    return _with_latency("Error (422): op=bulk_delete requires non-empty 'memory_ids'.", t0)
+                    return _with_latency(
+                        _error_response(
+                            "INVALID_ARGUMENTS", "op=bulk_delete requires non-empty 'memory_ids'."
+                        ),
+                        t0,
+                    )
                 if len(memory_ids) > 1000:
                     return _with_latency(
-                        f"Error (422): op=bulk_delete capped at 1000 ids (got {len(memory_ids)}).",
+                        _error_response(
+                            "INVALID_ARGUMENTS", f"op=bulk_delete capped at 1000 ids (got {len(memory_ids)})."
+                        ),
                         t0,
                     )
                 try:
                     uids = [UUID(i) for i in memory_ids]
                 except ValueError as e:
-                    return _with_latency(f"Error (422): invalid UUID in memory_ids — {e}", t0)
+                    return _with_latency(
+                        _error_response("INVALID_ARGUMENTS", f"invalid UUID in memory_ids — {e}"), t0
+                    )
                 from datetime import UTC
                 from datetime import datetime as _dt
 
@@ -477,7 +521,7 @@ async def memclaw_manage(
 
                 this = await memory_repo.get_by_id_for_tenant(db, uid, tenant_id)
                 if not this:
-                    return _with_latency("Error: Memory not found.", t0)
+                    return _with_latency(_error_response("NOT_FOUND", "Memory not found."), t0)
 
                 # The older memory this row replaced (if any). The
                 # supersedes_id field points at the OLDER row (the
@@ -531,7 +575,7 @@ async def memclaw_manage(
             if op == "read":
                 memory = await memory_repo.get_by_id_for_tenant(db, uid, tenant_id)
                 if not memory:
-                    return _with_latency("Error: Memory not found.", t0)
+                    return _with_latency(_error_response("NOT_FOUND", "Memory not found."), t0)
                 return _with_latency(
                     json.dumps(
                         {
@@ -562,15 +606,20 @@ async def memclaw_manage(
                 )
             if op == "transition":
                 if not status:
-                    return _with_latency("Error (422): op=transition requires 'status'.", t0)
+                    return _with_latency(
+                        _error_response("INVALID_ARGUMENTS", "op=transition requires 'status'."), t0
+                    )
                 if status not in MEMORY_STATUSES:
                     return _with_latency(
-                        f"Error (422): Invalid status '{status}'. Must be one of: {', '.join(MEMORY_STATUSES)}",
+                        _error_response(
+                            "INVALID_ARGUMENTS",
+                            f"Invalid status '{status}'. Must be one of: {', '.join(MEMORY_STATUSES)}",
+                        ),
                         t0,
                     )
                 memory = await memory_repo.get_by_id_for_tenant(db, uid, tenant_id)
                 if not memory:
-                    return _with_latency("Error: Memory not found.", t0)
+                    return _with_latency(_error_response("NOT_FOUND", "Memory not found."), t0)
                 old_status = memory.status
                 await memory_repo.update_status(db, uid, status)
                 await log_action(
@@ -612,7 +661,7 @@ async def memclaw_manage(
             return _with_latency(f"Memory {memory_id} deleted.", t0)
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(f"Error ({e.status_code}): {e.detail}", t0)
+            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
 
 
 async def memclaw_entity_get(
@@ -624,7 +673,7 @@ async def memclaw_entity_get(
     try:
         uid = UUID(entity_id)
     except ValueError:
-        return "Error: Invalid entity_id — must be a valid UUID."
+        return _error_response("INVALID_ARGUMENTS", "Invalid entity_id — must be a valid UUID.")
 
     async with _mcp_session() as db:
         result = await get_entity(db, uid, _get_tenant())
@@ -665,7 +714,7 @@ async def memclaw_tune(
             similarity_blend=similarity_blend,
         )
     except (ValidationError, ValueError) as e:
-        return _with_latency(f"Error (422): {e}", t0)
+        return _with_latency(_error_response("INVALID_ARGUMENTS", f"{e}"), t0)
 
     updates = profile.model_dump(exclude_none=True)
     async with _mcp_session() as db:
@@ -685,7 +734,7 @@ async def memclaw_tune(
             return _with_latency(json.dumps({"agent_id": agent_id, "search_profile": current}, indent=2), t0)
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(f"Error ({e.status_code}): {e.detail}", t0)
+            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
 
 
 # ---------------------------------------------------------------------------
@@ -749,10 +798,7 @@ async def memclaw_doc(
     # means "search across every collection in this tenant" — the broad
     # strategy; supply collection to scope the search to just one).
     if op not in {"list_collections", "search"} and not collection:
-        return _with_latency(
-            f"Error (422): op={op} requires 'collection'.",
-            t0,
-        )
+        return _with_latency(_error_response("INVALID_ARGUMENTS", f"op={op} requires 'collection'."), t0)
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
 
@@ -773,9 +819,13 @@ async def memclaw_doc(
                 )
             if op == "write":
                 if not doc_id:
-                    return _with_latency("Error (422): op=write requires 'doc_id'.", t0)
+                    return _with_latency(
+                        _error_response("INVALID_ARGUMENTS", "op=write requires 'doc_id'."), t0
+                    )
                 if data is None:
-                    return _with_latency("Error (422): op=write requires 'data'.", t0)
+                    return _with_latency(
+                        _error_response("INVALID_ARGUMENTS", "op=write requires 'data'."), t0
+                    )
                 # Optional semantic indexing: embed data[embed_field] so the
                 # doc participates in op=search. Missing/empty source field is
                 # a caller mistake — fail loud rather than silently skip.
@@ -784,8 +834,11 @@ async def memclaw_doc(
                     source = data.get(embed_field)
                     if not isinstance(source, str) or not source.strip():
                         return _with_latency(
-                            "Error (422): op=write embed_field "
-                            f"'{embed_field}' not found in data or not a non-empty string.",
+                            _error_response(
+                                "INVALID_ARGUMENTS",
+                                f"op=write embed_field "
+                                f"'{embed_field}' not found in data or not a non-empty string.",
+                            ),
                             t0,
                         )
                     from common.embedding import get_embedding
@@ -808,7 +861,9 @@ async def memclaw_doc(
                     embedding=embedding,
                 )
                 if row is None:
-                    return _with_latency("Error: document upsert returned no rows", t0)
+                    return _with_latency(
+                        _error_response("INTERNAL_ERROR", "document upsert returned no rows"), t0
+                    )
                 await db.commit()
                 # `text("xmax")` is unlabeled in SQLAlchemy ≥ 2; access by
                 # tuple position. Returning columns are: id, created_at,
@@ -828,7 +883,9 @@ async def memclaw_doc(
                 )
             if op == "read":
                 if not doc_id:
-                    return _with_latency("Error (422): op=read requires 'doc_id'.", t0)
+                    return _with_latency(
+                        _error_response("INVALID_ARGUMENTS", "op=read requires 'doc_id'."), t0
+                    )
                 doc = await document_repo.get_by_doc_id(
                     db, tenant_id=tenant_id, collection=collection, doc_id=doc_id
                 )
@@ -867,7 +924,9 @@ async def memclaw_doc(
                 )
             if op == "search":
                 if not query or not query.strip():
-                    return _with_latency("Error (422): op=search requires a non-empty 'query'.", t0)
+                    return _with_latency(
+                        _error_response("INVALID_ARGUMENTS", "op=search requires a non-empty 'query'."), t0
+                    )
                 from common.embedding import get_embedding
 
                 query_embedding = await get_embedding(query)
@@ -912,7 +971,7 @@ async def memclaw_doc(
                 )
             # op == "delete"
             if not doc_id:
-                return _with_latency("Error (422): op=delete requires 'doc_id'.", t0)
+                return _with_latency(_error_response("INVALID_ARGUMENTS", "op=delete requires 'doc_id'."), t0)
             from sqlalchemy import delete as sa_delete
 
             from common.models.document import Document
@@ -940,10 +999,10 @@ async def memclaw_doc(
             )
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(f"Error ({e.status_code}): {e.detail}", t0)
+            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
         except Exception as e:
             logger.error("MCP doc op=%s error: %s", op, e, exc_info=True)
-            return _with_latency(f"Error: {e}", t0)
+            return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
 
 
 async def memclaw_list(
@@ -975,17 +1034,26 @@ async def memclaw_list(
     if err := _check_auth():
         return err
     if scope not in VALID_SCOPES:
-        return f"Error (422): Invalid scope '{scope}'. Must be: agent, fleet, all."
+        return _error_response("INVALID_ARGUMENTS", f"Invalid scope '{scope}'. Must be: agent, fleet, all.")
     if memory_type and memory_type not in MEMORY_TYPES:
-        return f"Error (422): Invalid memory_type '{memory_type}'. Must be one of: {', '.join(MEMORY_TYPES)}"
+        return _error_response(
+            "INVALID_ARGUMENTS",
+            f"Invalid memory_type '{memory_type}'. Must be one of: {', '.join(MEMORY_TYPES)}",
+        )
     if status and status not in MEMORY_STATUSES:
-        return f"Error (422): Invalid status '{status}'. Must be one of: {', '.join(MEMORY_STATUSES)}"
+        return _error_response(
+            "INVALID_ARGUMENTS", f"Invalid status '{status}'. Must be one of: {', '.join(MEMORY_STATUSES)}"
+        )
     if sort not in {"created_at", "weight", "recall_count"}:
-        return f"Error (422): Invalid sort '{sort}'. Must be one of: created_at, weight, recall_count."
+        return _error_response(
+            "INVALID_ARGUMENTS", f"Invalid sort '{sort}'. Must be one of: created_at, weight, recall_count."
+        )
     if order not in {"asc", "desc"}:
-        return "Error (422): order must be 'asc' or 'desc'."
+        return _error_response("INVALID_ARGUMENTS", "order must be 'asc' or 'desc'.")
     if cursor and (sort != "created_at" or order != "desc"):
-        return "Error (422): cursor pagination requires sort=created_at and order=desc."
+        return _error_response(
+            "INVALID_ARGUMENTS", "cursor pagination requires sort=created_at and order=desc."
+        )
     capped_limit = max(1, min(int(limit), 50))
 
     from datetime import datetime as _dt
@@ -997,7 +1065,10 @@ async def memclaw_list(
     agent_id = _get_agent_id() or agent_id
 
     if scope == "agent" and written_by is not None and written_by != agent_id:
-        return f"Error (422): written_by must be omitted or match your own agent_id ('{agent_id}') when scope='agent'."
+        return _error_response(
+            "INVALID_ARGUMENTS",
+            f"written_by must be omitted or match your own agent_id ('{agent_id}') when scope='agent'.",
+        )
 
     # Dynamic trust: scope='agent' requires trust ≥ 1, 'fleet'/'all' requires ≥ 2.
     min_level = 1 if scope == "agent" else 2
@@ -1005,7 +1076,7 @@ async def memclaw_list(
     async with _mcp_session() as db:
         trust, _, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
         if terr:
-            return _with_latency(terr, t0)
+            return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
 
         # scope='agent': force written_by to the caller's agent_id so they
         # can only see their own memories regardless of other filters.
@@ -1020,19 +1091,23 @@ async def memclaw_list(
             try:
                 ts_after = _dt.fromisoformat(created_after)
             except ValueError:
-                return _with_latency("Error (422): created_after must be ISO8601.", t0)
+                return _with_latency(
+                    _error_response("INVALID_ARGUMENTS", "created_after must be ISO8601."), t0
+                )
         if created_before:
             try:
                 ts_before = _dt.fromisoformat(created_before)
             except ValueError:
-                return _with_latency("Error (422): created_before must be ISO8601.", t0)
+                return _with_latency(
+                    _error_response("INVALID_ARGUMENTS", "created_before must be ISO8601."), t0
+                )
 
         c_ts = c_id = None
         if cursor:
             try:
                 c_ts, c_id = decode_cursor(cursor)
             except Exception:
-                return _with_latency("Error (422): Invalid cursor.", t0)
+                return _with_latency(_error_response("INVALID_ARGUMENTS", "Invalid cursor."), t0)
 
         rows = await memory_repo.list_by_filters(
             db,
@@ -1099,16 +1174,23 @@ async def memclaw_insights(
     # Pre-validate inputs before consuming rate-limit budget.
     if focus not in INSIGHTS_FOCUS_MODES:
         return _with_latency(
-            f"Error (422): Invalid focus '{focus}'. Must be one of: {', '.join(INSIGHTS_FOCUS_MODES)}",
+            _error_response(
+                "INVALID_ARGUMENTS",
+                f"Invalid focus '{focus}'. Must be one of: {', '.join(INSIGHTS_FOCUS_MODES)}",
+            ),
             t0,
         )
     if scope not in VALID_SCOPES:
-        return _with_latency(f"Error (422): Invalid scope '{scope}'. Must be: agent, fleet, all", t0)
+        return _with_latency(
+            _error_response("INVALID_ARGUMENTS", f"Invalid scope '{scope}'. Must be: agent, fleet, all"), t0
+        )
     if scope == "fleet" and not fleet_id:
-        return _with_latency("Error (422): fleet_id is required when scope is 'fleet'.", t0)
+        return _with_latency(
+            _error_response("INVALID_ARGUMENTS", "fleet_id is required when scope is 'fleet'."), t0
+        )
     if focus == "divergence" and scope == "agent":
         return _with_latency(
-            "Error (422): Focus 'divergence' requires scope='fleet' or scope='all'.",
+            _error_response("INVALID_ARGUMENTS", "Focus 'divergence' requires scope='fleet' or scope='all'."),
             t0,
         )
 
@@ -1118,7 +1200,7 @@ async def memclaw_insights(
     async with _mcp_session() as db:
         _, _, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
         if terr:
-            return _with_latency(terr, t0)
+            return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
         try:
             await check_and_increment(db, tenant_id, "insights")
             from core_api.services.insights_service import generate_insights
@@ -1133,10 +1215,10 @@ async def memclaw_insights(
             )
             return _with_latency(json.dumps(result, indent=2, default=str), t0)
         except HTTPException as e:
-            return _with_latency(f"Error ({e.status_code}): {e.detail}", t0)
+            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
         except Exception as e:
             logger.exception("Unhandled error in memclaw_insights")
-            return _with_latency(f"Error: {e}", t0)
+            return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
 
 
 async def memclaw_evolve(
@@ -1166,18 +1248,24 @@ async def memclaw_evolve(
     # Pre-validate inputs before consuming rate-limit budget.
     if outcome_type not in EVOLVE_OUTCOME_TYPES:
         return _with_latency(
-            (
-                f"Error (422): Invalid outcome_type '{outcome_type}'. "
-                f"Must be one of: {', '.join(EVOLVE_OUTCOME_TYPES)}"
+            _error_response(
+                "INVALID_ARGUMENTS",
+                f"Invalid outcome_type '{outcome_type}'. Must be one of: {', '.join(EVOLVE_OUTCOME_TYPES)}",
             ),
             t0,
         )
     if not outcome or not outcome.strip():
-        return _with_latency("Error (422): outcome must be a non-empty description.", t0)
+        return _with_latency(
+            _error_response("INVALID_ARGUMENTS", "outcome must be a non-empty description."), t0
+        )
     if scope not in VALID_SCOPES:
-        return _with_latency(f"Error (422): Invalid scope '{scope}'. Must be: agent, fleet, all.", t0)
+        return _with_latency(
+            _error_response("INVALID_ARGUMENTS", f"Invalid scope '{scope}'. Must be: agent, fleet, all."), t0
+        )
     if scope == "fleet" and not fleet_id:
-        return _with_latency("Error (422): fleet_id is required when scope is 'fleet'.", t0)
+        return _with_latency(
+            _error_response("INVALID_ARGUMENTS", "fleet_id is required when scope is 'fleet'."), t0
+        )
 
     # Dynamic trust: scope='agent' requires trust ≥ 1, 'fleet'/'all' requires ≥ 2.
     min_level = 1 if scope == "agent" else 2
@@ -1185,7 +1273,7 @@ async def memclaw_evolve(
     async with _mcp_session() as db:
         _, _, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
         if terr:
-            return _with_latency(terr, t0)
+            return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
         try:
             await check_and_increment(db, tenant_id, "evolve")
             from core_api.services.evolve_service import report_outcome
@@ -1202,10 +1290,10 @@ async def memclaw_evolve(
             )
             return _with_latency(json.dumps(result, indent=2, default=str), t0)
         except HTTPException as e:
-            return _with_latency(f"Error ({e.status_code}): {e.detail}", t0)
+            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
         except Exception as e:
             logger.exception("Unhandled error in memclaw_evolve")
-            return _with_latency(f"Error: {e}", t0)
+            return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
 
 
 # ── Mountable app + lifespan ──

--- a/tests/test_evolve_service.py
+++ b/tests/test_evolve_service.py
@@ -977,7 +977,7 @@ class TestMCPHandlerTrustGating:
             outcome_type="failure",
             scope="all",
         )
-        assert "Error (403)" in out
+        assert "FORBIDDEN" in out
         assert service_spy.await_count == 0
 
 
@@ -993,7 +993,7 @@ class TestMCPHandlerScopeValidation:
             outcome_type="success",
             scope="bogus",
         )
-        assert "Error (422)" in out
+        assert "INVALID_ARGUMENTS" in out
         assert "scope" in out.lower()
 
     @pytest.mark.asyncio
@@ -1006,7 +1006,7 @@ class TestMCPHandlerScopeValidation:
             scope="fleet",
             fleet_id=None,
         )
-        assert "Error (422)" in out
+        assert "INVALID_ARGUMENTS" in out
         assert "fleet_id" in out.lower()
 
 

--- a/tests/test_mcp_list.py
+++ b/tests/test_mcp_list.py
@@ -51,7 +51,7 @@ async def test_list_scope_agent_allowed_at_trust_1(mcp_env, monkeypatch):
     monkeypatch.setattr(mcp_server, "_require_trust", _trust_1)
     mcp_env["db"].execute.return_value = _mock_result([])
     out = await mcp_server.memclaw_list(agent_id="alice")  # scope='agent' by default
-    assert "Error (403)" not in out
+    assert "FORBIDDEN" not in out
     payload = parse_envelope(out)
     assert payload["scope"] == "agent"
 
@@ -66,7 +66,7 @@ async def test_list_scope_fleet_blocked_at_trust_1(mcp_env, monkeypatch):
 
     monkeypatch.setattr(mcp_server, "_require_trust", _trust_1)
     out = await mcp_server.memclaw_list(agent_id="alice", scope="fleet")
-    assert "Error (403)" in out
+    assert "FORBIDDEN" in out
     assert "trust_level=1" in out
 
 
@@ -80,19 +80,19 @@ async def test_list_scope_all_blocked_at_trust_1(mcp_env, monkeypatch):
 
     monkeypatch.setattr(mcp_server, "_require_trust", _trust_1)
     out = await mcp_server.memclaw_list(agent_id="alice", scope="all")
-    assert "Error (403)" in out
+    assert "FORBIDDEN" in out
 
 
 async def test_list_invalid_scope(mcp_env):
     out = await mcp_server.memclaw_list(scope="everywhere")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "Invalid scope" in out
 
 
 async def test_list_scope_agent_rejects_foreign_written_by(mcp_env):
     """scope='agent' + written_by != caller returns 422."""
     out = await mcp_server.memclaw_list(agent_id="alice", scope="agent", written_by="bob")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "written_by must be omitted" in out
 
 
@@ -112,56 +112,56 @@ async def test_list_scope_agent_forces_written_by(mcp_env, monkeypatch):
 
 async def test_list_invalid_memory_type(mcp_env):
     out = await mcp_server.memclaw_list(memory_type="chicken")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "Invalid memory_type 'chicken'" in out
 
 
 async def test_list_invalid_status(mcp_env):
     out = await mcp_server.memclaw_list(status="fancy")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
 
 
 async def test_list_invalid_sort(mcp_env):
     out = await mcp_server.memclaw_list(sort="content")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "Invalid sort" in out
 
 
 async def test_list_invalid_order(mcp_env):
     out = await mcp_server.memclaw_list(order="sideways")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "order must be 'asc' or 'desc'" in out
 
 
 async def test_list_cursor_with_non_default_sort_errors(mcp_env):
     out = await mcp_server.memclaw_list(cursor="x", sort="weight")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "cursor pagination requires" in out
 
 
 async def test_list_cursor_with_asc_order_errors(mcp_env):
     out = await mcp_server.memclaw_list(cursor="x", order="asc")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
 
 
 async def test_list_invalid_cursor_payload(mcp_env):
     mcp_env["db"].execute.return_value = _mock_result([])
     out = await mcp_server.memclaw_list(cursor="@@not-base64@@")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "Invalid cursor" in out
 
 
 async def test_list_invalid_created_after_iso(mcp_env):
     mcp_env["db"].execute.return_value = _mock_result([])
     out = await mcp_server.memclaw_list(created_after="not-iso")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "created_after must be ISO8601" in out
 
 
 async def test_list_invalid_created_before_iso(mcp_env):
     mcp_env["db"].execute.return_value = _mock_result([])
     out = await mcp_server.memclaw_list(created_before="not-iso")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "created_before must be ISO8601" in out
 
 

--- a/tests/test_mcp_manage.py
+++ b/tests/test_mcp_manage.py
@@ -91,7 +91,7 @@ async def test_manage_read_happy_path(mcp_env, monkeypatch):
 
 async def test_manage_transition_missing_status_errors(mcp_env):
     out = await mcp_server.memclaw_manage(op="transition", memory_id=VALID_UID)
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "op=transition requires 'status'" in out
 
 
@@ -99,7 +99,7 @@ async def test_manage_transition_invalid_status_errors(mcp_env):
     out = await mcp_server.memclaw_manage(
         op="transition", memory_id=VALID_UID, status="garbage"
     )
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "Invalid status 'garbage'" in out
 
 
@@ -165,7 +165,7 @@ async def test_manage_service_http_exception_envelope(mcp_env):
         status_code=403, detail="insufficient trust"
     )
     out = await mcp_server.memclaw_manage(op="delete", memory_id=VALID_UID)
-    assert "Error (403)" in out
+    assert "FORBIDDEN" in out
     assert "insufficient trust" in out
 
 

--- a/tests/test_mcp_recall.py
+++ b/tests/test_mcp_recall.py
@@ -86,13 +86,13 @@ async def test_recall_empty_results(mcp_env, monkeypatch):
 
 async def test_recall_invalid_memory_type_returns_422(mcp_env):
     out = await mcp_server.memclaw_recall(query="x", memory_type="garbage")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "Invalid memory_type 'garbage'" in out
 
 
 async def test_recall_invalid_status_returns_422(mcp_env):
     out = await mcp_server.memclaw_recall(query="x", status="badstatus")
-    assert "Error (422)" in out
+    assert "INVALID_ARGUMENTS" in out
     assert "Invalid status 'badstatus'" in out
 
 
@@ -123,7 +123,7 @@ async def test_recall_http_exception_becomes_error_envelope(mcp_env, monkeypatch
     monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
 
     out = await mcp_server.memclaw_recall(query="x")
-    assert "Error (429)" in out
+    assert "RATE_LIMITED" in out
     assert "rate limited" in out
 
 

--- a/tests/test_mcp_write.py
+++ b/tests/test_mcp_write.py
@@ -96,7 +96,7 @@ async def test_write_service_http_exception_becomes_envelope(mcp_env):
     out = await mcp_server.memclaw_write(content="dup")
     # Service-raised HTTPException maps to `Error (…): detail` (plain string
     # plus _latency_ms), not the structured envelope above.
-    assert "Error (409)" in out
+    assert "CONFLICT" in out
     assert "duplicate memory" in out
 
 


### PR DESCRIPTION
Both surfaces now emit the canonical envelope:

    {
      "error": {
        "code": "<UPPER_SNAKE>",
        "message": "<human-readable>",
        "details": { ... optional ... }
      }
    }

REST keeps top-level `detail` for back-compat — existing clients reading `response.json()["detail"]` continue to work; new clients should switch to `error.code` for machine-readable dispatch. MCP tools now return JSON-serialized envelopes instead of bare "Error (XXX): ..." strings; the `error.code` is the new canonical signal.

Changes:

- New module `core_api/errors.py` — `make_error_payload(code, message, details=None)` and `code_for_status(status)` (HTTP-status → UPPER_SNAKE code mapping). Pure data, no FastAPI imports, usable from REST routes, MCP tools, and standalone clients.

- `app.py`:
  - Custom `HTTPException` handler — emits `detail` (back-compat) AND `error` envelope. Supports passing an explicit code via `HTTPException(detail={"code": ..., "message": ..., "details": ...})`, otherwise auto-derives from status.
  - Custom `RequestValidationError` (FastAPI 422) handler — emits the original list-of-errors `detail` plus the canonical envelope with aggregated message and per-error details.
  - Updated `RateLimitExceeded` handler and global `Exception` handler to also emit `error`.

- `mcp_server.py`:
  - New `_error_response(code, message, **details)` helper returning canonical JSON. Composes with existing `_with_latency()` so error responses still carry `_latency_ms`.
  - All ~40 in-tool error sites ported. Cross-tool `HTTPException` bridges (`f"Error ({e.status_code}): {e.detail}"`) now use `code_for_status(e.status_code)`.
  - Trust-error bridges (`if terr: return _with_latency(terr, t0)`) now strip the legacy "Error (XXX):" prefix via `parse_trust_error()` and re-wrap as canonical FORBIDDEN.
  - `_AUTH_ERROR` / `_ADMIN_ERROR` constants are canonical envelopes (UNAUTHORIZED / FORBIDDEN).

- Tests:
  - 5 test files updated (`test_evolve_service`, `test_mcp_list`, `test_mcp_manage`, `test_mcp_recall`, `test_mcp_write`): `"Error (NNN)" in out` assertions converted to canonical-code equivalents (`"INVALID_ARGUMENTS" in out`, `"FORBIDDEN" in out`, etc.).

Out of scope (queued as follow-ups, NOT in this PR):
- `trust_service.require_trust()` still returns legacy "Error (XXX): ..." strings — used by both REST and MCP. Wrapped at MCP call sites for now; a future PR can canonicalize the source if there's appetite to touch the cross-surface helper.

Wet-tested locally:
- REST 404 (memory-not-found) → both `detail` and `error.code=NOT_FOUND` present.
- REST 422 (RequestValidationError) → original FastAPI `detail` array + canonical envelope with aggregated `message` and per-error `details.errors`.
- MCP `memclaw_manage(op="wat", ...)` → `{"error": {"code": "INVALID_ARGUMENTS", "message": "Unknown op 'wat'.", "details": {"op": "wat", "expected_ops": [...]}}, "_latency_ms": ...}`.
- MCP `memclaw_recall(memory_type="bogus")` → `{"error": {"code": "INVALID_ARGUMENTS", "message": "Invalid memory_type 'bogus'.", "details": {"field": "memory_type", "value": "bogus"}}}`.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
