### PR TITLE
feat(enrichment): consolidate memory-type vocabulary as single source of truth (CAURA-000)

### DIFF
--- a/common/enrichment/_prompts.py
+++ b/common/enrichment/_prompts.py
@@ -5,35 +5,31 @@ The prompt is the source of truth for the LLM's output schema; tests
 exercise it directly (see ``tests/services/test_memory_enrichment.py``)
 and ``EnrichmentResult`` mirrors it field-for-field.
 
-Adding a new memory type or status requires synchronised updates to:
-
-* ``common/enrichment/constants.py`` (vocabulary tuples)
-* this module (prompt vocabulary list)
-* ``common/enrichment/schema.py`` (Pydantic defaults)
-* ``core_api.constants`` re-exports + storage CHECK constraint
+The ``memory_type`` vocabulary list and per-type bullets are rendered
+from :data:`common.enrichment.constants.MEMORY_TYPE_DESCRIPTIONS` at
+import time, so adding a type there propagates here automatically.
 """
 
 from __future__ import annotations
 
-ENRICHMENT_PROMPT = """\
+from common.enrichment.constants import MEMORY_TYPE_DESCRIPTIONS, MEMORY_TYPES
+
+_TYPES_INLINE = ", ".join(f'"{name}"' for name in MEMORY_TYPES)
+_TYPE_BULLETS = "\n".join(
+    f"   - {name}: {desc}" for name, desc in MEMORY_TYPE_DESCRIPTIONS.items()
+)
+
+ENRICHMENT_PROMPT = (
+    """\
 You are a memory classifier for a business agent memory system.
 
 Analyze the following memory content and return a JSON object with these fields:
 
-1. "memory_type": one of "fact", "episode", "decision", "preference", "task", "semantic", "intention", "plan", "commitment", "action", "outcome", "cancellation", "rule"
-   - fact: durable knowledge, statements of truth, technical details
-   - episode: events that happened, deployments, meetings, incidents
-   - decision: choices made with reasoning, architecture decisions, approvals. Look for: "decided to", "chose", "going with", "agreed to", "approved", "selected", "opted for", "settled on"
-   - preference: user/org preferences, likes, dislikes, style choices
-   - task: work items, assignments, things to do
-   - semantic: conceptual/definitional knowledge, taxonomy entries
-   - intention: stated goals or aims not yet acted on
-   - plan: structured sequences of steps to achieve a goal
-   - commitment: promises or obligations made to others. Look for: "committed to", "promised", "guaranteed", "agreed to deliver", "pledged"
-   - action: concrete steps taken or being taken
-   - outcome: results of actions, tasks, or plans
-   - cancellation: explicit record that something was cancelled or abandoned
-   - rule: prescriptive directive, policy, or constraint. Look for: "always", "never", "must", "do not", "whenever", "policy", "guideline"
+1. "memory_type": one of """
+    + _TYPES_INLINE
+    + "\n"
+    + _TYPE_BULLETS
+    + """
 
 2. "weight": float 0.0-1.0 indicating importance
    - 0.9-1.0: critical decisions, key facts with evidence, high-impact events
@@ -126,3 +122,4 @@ Return ONLY valid JSON (no markdown fences):
 Content:
 {content}
 """
+)

--- a/common/enrichment/constants.py
+++ b/common/enrichment/constants.py
@@ -9,29 +9,85 @@ matching pattern + UI updates in core-api.
 
 from __future__ import annotations
 
-# Canonical memory-type vocabulary the enrichment LLM is constrained
-# to choose from. Adding a new type requires updating the prompt
-# (``common/enrichment/_prompts.py``), the storage schema's CHECK
-# constraint, ``MEMORY_TYPES_PATTERN`` in ``core_api.constants``, and
-# any UI that switches on type.
-MEMORY_TYPES = (
-    "fact",
-    "episode",
-    "decision",
-    "preference",
-    "task",
-    "semantic",
-    "intention",
-    "plan",
-    "commitment",
-    "action",
-    "outcome",
-    "cancellation",
-    "rule",
-    "insight",
+from enum import Enum
+
+
+class MemoryType(str, Enum):
+    """Typed enum for the memory-type vocabulary.
+
+    Inheriting from ``str`` keeps full backward compatibility with the
+    string-based call sites: ``MemoryType.FACT == "fact"`` is True,
+    dict lookup with the enum hashes the same as the literal, JSON
+    serialisation emits the bare string, and SQLAlchemy reads of a
+    ``Text`` column coerce cleanly via Pydantic.
+    """
+
+    FACT = "fact"
+    EPISODE = "episode"
+    DECISION = "decision"
+    PREFERENCE = "preference"
+    TASK = "task"
+    SEMANTIC = "semantic"
+    INTENTION = "intention"
+    PLAN = "plan"
+    COMMITMENT = "commitment"
+    ACTION = "action"
+    OUTCOME = "outcome"
+    CANCELLATION = "cancellation"
+    RULE = "rule"
+    INSIGHT = "insight"
+
+
+# LLM-facing description for each ``MemoryType``. Kept str-keyed so a
+# direct lookup with either a literal string ("fact") or the enum member
+# (``MemoryType.FACT``, which IS a string) both succeed. Enrichment
+# prompt rendering and DX surfaces (OpenAPI descriptions, console
+# tooltips) read from here.
+MEMORY_TYPE_DESCRIPTIONS: dict[str, str] = {
+    "fact": "durable knowledge, statements of truth, technical details",
+    "episode": "events that happened, deployments, meetings, incidents",
+    "decision": (
+        "choices made with reasoning, architecture decisions, approvals. "
+        'Look for: "decided to", "chose", "going with", "agreed to", '
+        '"approved", "selected", "opted for", "settled on"'
+    ),
+    "preference": "user/org preferences, likes, dislikes, style choices",
+    "task": "work items, assignments, things to do",
+    "semantic": "conceptual/definitional knowledge, taxonomy entries",
+    "intention": "stated goals or aims not yet acted on",
+    "plan": "structured sequences of steps to achieve a goal",
+    "commitment": (
+        "promises or obligations made to others. "
+        'Look for: "committed to", "promised", "guaranteed", '
+        '"agreed to deliver", "pledged"'
+    ),
+    "action": "concrete steps taken or being taken",
+    "outcome": "results of actions, tasks, or plans",
+    "cancellation": "explicit record that something was cancelled or abandoned",
+    "rule": (
+        "prescriptive directive, policy, or constraint. "
+        'Look for: "always", "never", "must", "do not", "whenever", '
+        '"policy", "guideline"'
+    ),
+    "insight": (
+        "novel finding, learned lesson, or pattern observed across memories — "
+        "persist results of reflection/analysis steps here so future runs build on them"
+    ),
+}
+
+MEMORY_TYPES = tuple(t.value for t in MemoryType)
+
+# Import-time guard: enum and description dict must agree, otherwise
+# the prompt renderer will silently emit a bullet without a heading or
+# a heading without a description. Catching here gives a loud import
+# error rather than mysterious LLM behaviour.
+assert set(MEMORY_TYPES) == set(MEMORY_TYPE_DESCRIPTIONS.keys()), (
+    "MemoryType enum and MEMORY_TYPE_DESCRIPTIONS keys are out of sync: "
+    f"enum-only={set(MEMORY_TYPES) - set(MEMORY_TYPE_DESCRIPTIONS)}, "
+    f"dict-only={set(MEMORY_TYPE_DESCRIPTIONS) - set(MEMORY_TYPES)}"
 )
 
-DEFAULT_MEMORY_TYPE = "fact"
+DEFAULT_MEMORY_TYPE = MemoryType.FACT.value
 
 # Status vocabulary — the enrichment LLM may downgrade a write to e.g.
 # ``cancelled`` or ``conflicted`` based on the prompt's classification

--- a/common/enrichment/schema.py
+++ b/common/enrichment/schema.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
-from common.enrichment.constants import DEFAULT_MEMORY_TYPE
+from common.enrichment.constants import MemoryType
 
 
 class AtomicFact(BaseModel):
@@ -30,7 +30,7 @@ class AtomicFact(BaseModel):
     """
 
     content: str
-    suggested_type: str = DEFAULT_MEMORY_TYPE
+    suggested_type: MemoryType = MemoryType.FACT
     retrieval_hint: str = ""
 
 
@@ -43,7 +43,7 @@ class EnrichmentResult(BaseModel):
     defaults for the heuristic fallback path).
     """
 
-    memory_type: str = DEFAULT_MEMORY_TYPE
+    memory_type: MemoryType = MemoryType.FACT
     weight: float = 0.7
     title: str = ""
     summary: str = ""

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -26,7 +26,9 @@ from common.enrichment.constants import (  # noqa: F401
     DEFAULT_MEMORY_TYPE,
     DEFAULT_MEMORY_WEIGHT,
     MEMORY_STATUSES,
+    MEMORY_TYPE_DESCRIPTIONS,
     MEMORY_TYPES,
+    MemoryType,
 )
 
 # Re-export LLM provider constants from common.llm (CAURA-595).
@@ -66,11 +68,9 @@ EMBEDDING_REEMBED_BATCH_SIZE = 50
 EMBEDDING_CACHE_TTL = 259200  # 3 days — embeddings are deterministic per model+query
 
 # ── Memory ──
-MEMORY_TYPES_PATTERN = (
-    r"^(fact|episode|decision|preference"
-    r"|task|semantic|intention|plan"
-    r"|commitment|action|outcome|cancellation|rule|insight)$"
-)
+# Derived from MEMORY_TYPES (the SoT) so adding a new type in
+# common/enrichment/constants.py propagates here without hand-editing.
+MEMORY_TYPES_PATTERN = "^(" + "|".join(MEMORY_TYPES) + ")$"
 MEMORY_TYPES_DESCRIPTION = (
     "Memory type. Auto-classified by LLM if omitted. Valid values: " + ", ".join(MEMORY_TYPES) + "."
 )

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -31,9 +31,7 @@ class MemoryCreate(BaseModel):
     tenant_id: str
     fleet_id: str | None = None
     agent_id: str
-    memory_type: MemoryType | None = Field(
-        default=None, description=MEMORY_TYPES_DESCRIPTION
-    )
+    memory_type: MemoryType | None = Field(default=None, description=MEMORY_TYPES_DESCRIPTION)
     content: str = Field(min_length=1, max_length=MAX_CONTENT_LENGTH)
     weight: float | None = Field(default=None, ge=0.0, le=1.0)
     source_uri: str | None = None
@@ -63,9 +61,7 @@ class MemoryCreate(BaseModel):
 class BulkMemoryItem(BaseModel):
     """Single item in a bulk write request. tenant_id/fleet_id/agent_id inherited from parent."""
 
-    memory_type: MemoryType | None = Field(
-        default=None, description=MEMORY_TYPES_DESCRIPTION
-    )
+    memory_type: MemoryType | None = Field(default=None, description=MEMORY_TYPES_DESCRIPTION)
     content: str = Field(min_length=1, max_length=MAX_CONTENT_LENGTH)
     weight: float | None = Field(default=None, ge=0.0, le=1.0)
     source_uri: str | None = None
@@ -154,9 +150,7 @@ class RedistributeResponse(BaseModel):
 
 class MemoryUpdate(BaseModel):
     content: str | None = Field(default=None, min_length=1, max_length=MAX_CONTENT_LENGTH)
-    memory_type: MemoryType | None = Field(
-        default=None, description=MEMORY_TYPES_DESCRIPTION
-    )
+    memory_type: MemoryType | None = Field(default=None, description=MEMORY_TYPES_DESCRIPTION)
     weight: float | None = Field(default=None, ge=0.0, le=1.0)
     title: str | None = None
     status: str | None = Field(default=None, pattern=MEMORY_STATUSES_PATTERN)

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -14,9 +14,9 @@ from core_api.constants import (
     MAX_TRUST_LEVEL,
     MEMORY_STATUSES_PATTERN,
     MEMORY_TYPES_DESCRIPTION,
-    MEMORY_TYPES_PATTERN,
     MEMORY_VISIBILITIES_PATTERN,
     MIN_TRUST_LEVEL,
+    MemoryType,
 )
 
 # --- Memory ---
@@ -31,8 +31,8 @@ class MemoryCreate(BaseModel):
     tenant_id: str
     fleet_id: str | None = None
     agent_id: str
-    memory_type: str | None = Field(
-        default=None, pattern=MEMORY_TYPES_PATTERN, description=MEMORY_TYPES_DESCRIPTION
+    memory_type: MemoryType | None = Field(
+        default=None, description=MEMORY_TYPES_DESCRIPTION
     )
     content: str = Field(min_length=1, max_length=MAX_CONTENT_LENGTH)
     weight: float | None = Field(default=None, ge=0.0, le=1.0)
@@ -63,8 +63,8 @@ class MemoryCreate(BaseModel):
 class BulkMemoryItem(BaseModel):
     """Single item in a bulk write request. tenant_id/fleet_id/agent_id inherited from parent."""
 
-    memory_type: str | None = Field(
-        default=None, pattern=MEMORY_TYPES_PATTERN, description=MEMORY_TYPES_DESCRIPTION
+    memory_type: MemoryType | None = Field(
+        default=None, description=MEMORY_TYPES_DESCRIPTION
     )
     content: str = Field(min_length=1, max_length=MAX_CONTENT_LENGTH)
     weight: float | None = Field(default=None, ge=0.0, le=1.0)
@@ -154,8 +154,8 @@ class RedistributeResponse(BaseModel):
 
 class MemoryUpdate(BaseModel):
     content: str | None = Field(default=None, min_length=1, max_length=MAX_CONTENT_LENGTH)
-    memory_type: str | None = Field(
-        default=None, pattern=MEMORY_TYPES_PATTERN, description=MEMORY_TYPES_DESCRIPTION
+    memory_type: MemoryType | None = Field(
+        default=None, description=MEMORY_TYPES_DESCRIPTION
     )
     weight: float | None = Field(default=None, ge=0.0, le=1.0)
     title: str | None = None
@@ -285,9 +285,8 @@ class SearchRequest(BaseModel):
     fleet_ids: list[str] | None = None
     query: str = Field(min_length=1, max_length=MAX_QUERY_LENGTH)
     filter_agent_id: str | None = None
-    memory_type_filter: str | None = Field(
+    memory_type_filter: MemoryType | None = Field(
         default=None,
-        pattern=MEMORY_TYPES_PATTERN,
         description="Filter results to a single memory type. " + MEMORY_TYPES_DESCRIPTION,
     )
     status_filter: str | None = Field(default=None, pattern=MEMORY_STATUSES_PATTERN)

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/012_memory_type_check_constraint.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/012_memory_type_check_constraint.py
@@ -1,0 +1,78 @@
+"""Add CHECK constraint on ``memories.memory_type`` to enforce the
+vocabulary at the database layer.
+
+Why this exists. ``memory_type`` is constrained at the application
+layer in two places: the Pydantic regex ``MEMORY_TYPES_PATTERN`` on
+the API, and the LLM enrichment prompt's vocabulary list. Both are
+bypassable — raw SQL backfills, ad-hoc bulk imports, future services
+written against the storage tier directly, all of them can write any
+string. This migration makes the DB the final guardrail so an invalid
+``memory_type`` becomes an INSERT-time error instead of a row that
+silently survives until somebody queries it.
+
+This is a SNAPSHOT. Migrations are immutable historical artefacts —
+do NOT import ``MEMORY_TYPES`` from Python constants here, even
+though the values agree today. When a new type lands in
+``common/enrichment/constants.py`` the contract is to also write a
+new migration that drops this constraint and recreates it with the
+expanded list. The frozen literal below is what tells future readers
+"these were the 14 types accepted as of revision 012".
+
+Lock posture. ``ADD CONSTRAINT ... NOT VALID`` takes a brief ACCESS
+EXCLUSIVE lock and is near-instant; new writes are checked from then
+on. ``VALIDATE CONSTRAINT`` then scans existing rows under a SHARE
+UPDATE EXCLUSIVE lock — reads and normal writes are not blocked.
+If a pre-existing row violates the constraint, VALIDATE raises and
+the migration aborts; that is the desired loud failure (the operator
+must reconcile the bad row before re-running). On a clean DB both
+steps complete in a few ms.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-05-03
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "012"
+down_revision: str | None = "011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Frozen snapshot of valid ``memory_type`` values as of this revision.
+# See the module docstring for why this is a literal and not an import.
+_VALID_MEMORY_TYPES_012: tuple[str, ...] = (
+    "fact",
+    "episode",
+    "decision",
+    "preference",
+    "task",
+    "semantic",
+    "intention",
+    "plan",
+    "commitment",
+    "action",
+    "outcome",
+    "cancellation",
+    "rule",
+    "insight",
+)
+
+_CONSTRAINT_NAME = "memories_memory_type_check"
+
+
+def upgrade() -> None:
+    values_sql = ", ".join(f"'{t}'" for t in _VALID_MEMORY_TYPES_012)
+    op.execute(
+        f"ALTER TABLE memories "
+        f"ADD CONSTRAINT {_CONSTRAINT_NAME} "
+        f"CHECK (memory_type IN ({values_sql})) NOT VALID"
+    )
+    op.execute(f"ALTER TABLE memories VALIDATE CONSTRAINT {_CONSTRAINT_NAME}")
+
+
+def downgrade() -> None:
+    op.execute(f"ALTER TABLE memories DROP CONSTRAINT IF EXISTS {_CONSTRAINT_NAME}")

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/013_memory_type_check_constraint.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/013_memory_type_check_constraint.py
@@ -16,7 +16,7 @@ though the values agree today. When a new type lands in
 ``common/enrichment/constants.py`` the contract is to also write a
 new migration that drops this constraint and recreates it with the
 expanded list. The frozen literal below is what tells future readers
-"these were the 14 types accepted as of revision 012".
+"these were the 14 types accepted as of revision 013".
 
 Lock posture. ``ADD CONSTRAINT ... NOT VALID`` takes a brief ACCESS
 EXCLUSIVE lock and is near-instant; new writes are checked from then
@@ -27,8 +27,8 @@ the migration aborts; that is the desired loud failure (the operator
 must reconcile the bad row before re-running). On a clean DB both
 steps complete in a few ms.
 
-Revision ID: 012
-Revises: 011
+Revision ID: 013
+Revises: 012
 Create Date: 2026-05-03
 """
 
@@ -36,15 +36,15 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "012"
-down_revision: str | None = "011"
+revision: str = "013"
+down_revision: str | None = "012"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
 # Frozen snapshot of valid ``memory_type`` values as of this revision.
 # See the module docstring for why this is a literal and not an import.
-_VALID_MEMORY_TYPES_012: tuple[str, ...] = (
+_VALID_MEMORY_TYPES_013: tuple[str, ...] = (
     "fact",
     "episode",
     "decision",
@@ -65,7 +65,7 @@ _CONSTRAINT_NAME = "memories_memory_type_check"
 
 
 def upgrade() -> None:
-    values_sql = ", ".join(f"'{t}'" for t in _VALID_MEMORY_TYPES_012)
+    values_sql = ", ".join(f"'{t}'" for t in _VALID_MEMORY_TYPES_013)
     op.execute(
         f"ALTER TABLE memories "
         f"ADD CONSTRAINT {_CONSTRAINT_NAME} "

--- a/tests/test_enrichment_prompt.py
+++ b/tests/test_enrichment_prompt.py
@@ -58,6 +58,52 @@ class TestEnrichmentPromptSignalPhrases:
 
 
 @pytest.mark.unit
+class TestEnrichmentPromptVocabularySync:
+    """Prompt vocabulary must stay in lock-step with ``MEMORY_TYPES``.
+
+    Lives here because the prompt was the original drift site: ``insight``
+    was added to the tuple but missed in the prompt's hardcoded list,
+    causing the LLM to never emit that type. The renderer in
+    ``common/enrichment/_prompts.py`` now derives both the inline list
+    and the bullet descriptions from ``MEMORY_TYPE_DESCRIPTIONS``, and
+    these tests guard that contract.
+    """
+
+    def _get_prompt(self) -> str:
+        from core_api.services.memory_enrichment import ENRICHMENT_PROMPT
+        return ENRICHMENT_PROMPT
+
+    def test_every_memory_type_appears_quoted_in_inline_list(self):
+        from common.enrichment.constants import MEMORY_TYPES
+        prompt = self._get_prompt()
+        for t in MEMORY_TYPES:
+            assert f'"{t}"' in prompt, (
+                f"memory_type {t!r} missing from inline list — prompt vocabulary "
+                "drifted from MEMORY_TYPES"
+            )
+
+    def test_every_memory_type_has_a_bullet(self):
+        from common.enrichment.constants import MEMORY_TYPE_DESCRIPTIONS
+        prompt = self._get_prompt()
+        for name, desc in MEMORY_TYPE_DESCRIPTIONS.items():
+            assert f"   - {name}: " in prompt, f"{name!r} bullet missing from prompt"
+            # First clause of the description should also land verbatim
+            first_clause = desc.split(".")[0].split(",")[0].strip()
+            assert first_clause in prompt, (
+                f"{name!r} description first clause not found in prompt: {first_clause!r}"
+            )
+
+    def test_pattern_matches_every_memory_type(self):
+        import re
+        from common.enrichment.constants import MEMORY_TYPES
+        from core_api.constants import MEMORY_TYPES_PATTERN
+        for t in MEMORY_TYPES:
+            assert re.match(MEMORY_TYPES_PATTERN, t), (
+                f"{t!r} not accepted by MEMORY_TYPES_PATTERN — pattern drifted"
+            )
+
+
+@pytest.mark.unit
 class TestHeuristicRegressions:
     """Ensure keyword heuristic still classifies all types correctly after prompt changes."""
 


### PR DESCRIPTION
## Summary

Memory-type vocabulary was defined in three places that had to be hand-kept in sync — and had silently drifted: `insight` was added to `MEMORY_TYPES` and the Pydantic regex but never made it into the LLM prompt's hardcoded list, so the enricher could never produce `insight`-typed memories even though the rest of the stack accepted them.

This PR collapses the duplication into a single source of truth and adds a DB-level guardrail so the same class of drift cannot recur silently.

## Three-layer fix

### 1. Prompt drift (the live bug)
- `MEMORY_TYPE_DESCRIPTIONS` in `common/enrichment/constants.py` is now the SoT for both the vocabulary and the per-type LLM-facing description.
- The enrichment prompt's inline list and bullet section are rendered from this dict at import time — `insight` now appears in both.
- `MEMORY_TYPES_PATTERN` in `core_api.constants` is derived from `MEMORY_TYPES` (mirroring the pattern already used by `MEMORY_VISIBILITIES_PATTERN`).
- Three new tests in `test_enrichment_prompt.py` (`TestEnrichmentPromptVocabularySync`) assert the prompt stays in lock-step with `MEMORY_TYPES` so this drift cannot recur silently.

### 2. DB-level enforcement
- New Alembic migration **`013_memory_type_check_constraint.py`** adds a `CHECK` constraint on `memories.memory_type` enumerating the 14 valid values.
- Uses `ADD CONSTRAINT … NOT VALID` + `VALIDATE CONSTRAINT` so the upgrade does **not** take a long ACCESS EXCLUSIVE lock; existing rows are validated under SHARE UPDATE EXCLUSIVE which does not block reads/writes.
- The migration freezes the value list as a literal (rather than importing `MEMORY_TYPES`) per the immutable-snapshot norm — adding a new type henceforth requires both a constants entry **and** a follow-up migration.
- Originally numbered 012; renumbered to 013 after `012_vector_dim_1024` (#51) landed on `main` mid-PR.

### 3. Type safety
- New `MemoryType(str, Enum)` in `common/enrichment/constants.py`; `MEMORY_TYPES` is now derived from it.
- Import-time assertion catches `enum`/`description-dict` skew.
- Pydantic input fields (`MemoryCreate`, `BulkMemoryItem`, `MemoryUpdate`, `SearchRequest.memory_type_filter`) and the enrichment output schemas (`EnrichmentResult`, `AtomicFact`) are typed as `MemoryType`.
- `str` inheritance preserves backward compatibility with all existing string-based call sites; OpenAPI now emits proper `enum` arrays in place of regex patterns.
- `MemoryOut` keeps `str` for resilience against historical rows that might carry vocabulary outside the current set; the new CHECK constraint enforces validity going forward.

## Test plan

- [x] `pytest tests/test_enrichment_prompt.py tests/test_rule_type.py tests/test_atomic_facts.py tests/test_retrieval_hint.py tests/test_enrichment_ts_valid_end.py tests/test_enrichment_reference_date.py` — 90 pass
- [x] Targeted memory-/enrichment-/schema-related tests — 363 pass
- [x] `ruff check` clean across all changed files
- [x] Pydantic round-trip: string input, enum input, invalid value rejection, JSON serialisation, `==`-comparison with bare strings all behave as expected
- [x] Migration module loads cleanly; frozen snapshot matches live `MEMORY_TYPES` at write time
- [ ] Run migration on a staging DB (operator, before deploy)
- [ ] Confirm any pre-existing rows with invalid `memory_type` are reconciled before VALIDATE runs (operator)

## Notes for reviewers

- Two commits: the consolidation and a follow-up rename to 013. Squash-merge produces one clean commit.
- No behavioural change for valid inputs; only invalid memory-type writes (which were undefined behaviour at the storage tier) become loud errors.
- The 4 unrelated `test_pre_public_cleanup_regressions.py` failures locally are caused by upstream's bge-m3 PR requiring a TEI sidecar that isn't running in dev — not introduced by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)