### PR TITLE
chore(release): pin next release to v2.0.0 via config (replaces #61 attempt)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,7 @@
     ".": {
       "release-type": "simple",
       "package-name": "caura-memclaw",
+      "release-as": "2.0.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         "VERSION",


### PR DESCRIPTION
## Why

#61 tried to fix the v1.1.0 vs v2.0.0 issue with an empty commit carrying a `Release-As: 2.0.0` footer. release-please did **not** parse it (workflow ran successfully but #49 still shows 1.1.0). Empty commits are commonly skipped by release-please's commit walker.

This PR uses the **documented config-level mechanism**: adds `"release-as": "2.0.0"` to the package config in `release-please-config.json`. On the next release-please workflow run, the open release PR (#49) refreshes to show **v2.0.0**.

## What's in the diff

A single line added to `release-please-config.json` (json-validated, formatting preserved):

```json
".": {
  "release-type": "simple",
  "package-name": "caura-memclaw",
  "release-as": "2.0.0",          ← new
  "changelog-path": "CHANGELOG.md",
  ...
}
```

## ⚠ Follow-up required after #49 merges

The `release-as` directive is sticky — until removed, every subsequent release-please run pins the version to 2.0.0. After #49 is merged and the v2.0.0 tag is cut, **open a small follow-up PR removing the `release-as` line** so v2.0.1 / v2.1.0 / etc. calculate normally going forward.

## Sequencing

1. Merge **this PR** → release-please re-runs.
2. **#49 refreshes from `1.1.0` → `2.0.0`.** Watch for the title/body update (~1 min after this PR merges).
3. Merge **#49** → `v2.0.0` tag is cut, images published to ghcr.io.
4. Open a small follow-up PR removing the `release-as` line.

## Closes / supersedes

- Replaces #61 (the empty-commit attempt). Close #61 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)