### PR TITLE
chore(release): remove release-as=2.0.0 pin now that v2.0.0 has shipped

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,7 +13,6 @@
     ".": {
       "release-type": "simple",
       "package-name": "caura-memclaw",
-      "release-as": "2.0.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         "VERSION",


### PR DESCRIPTION
## Why

#62 added `"release-as": "2.0.0"` to `release-please-config.json` to force the next release to v2.0.0 (the `BREAKING CHANGE:` footer was dropped from #51's squash-merge so release-please had calculated v1.1.0). The pin is **sticky** — every subsequent release-please run reuses 2.0.0 as the target version regardless of conventional-commit signals.

v2.0.0 has now been cut and tagged: https://github.com/caura-ai/caura-memclaw/releases/tag/v2.0.0

This PR removes the pin so future releases calculate normally.

## What's in the diff

A single-line deletion in `release-please-config.json` (json-validated):

```json
".": {
  "release-type": "simple",
  "package-name": "caura-memclaw",
  "release-as": "2.0.0",          ← deleted
  "changelog-path": "CHANGELOG.md",
  ...
}
```

## What restores after merge

Normal SemVer calculation:
- `feat:` → minor bump (2.1.0)
- `fix:` → patch (2.0.1)
- `BREAKING CHANGE:` or `feat!:` → major (3.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)