### PR TITLE
fix(scripts): backfill_embeddings — str-cast + add openai to core-storage-api deps

### DIFF
--- a/core-storage-api/pyproject.toml
+++ b/core-storage-api/pyproject.toml
@@ -21,6 +21,15 @@ dependencies = [
     "alembic>=1.14,<2",
     "httpx>=0.27,<1",
     "structlog>=25.4,<26",
+    # OpenAI SDK. NOT used by the live core-storage-api request path
+    # (which talks DB only) — added so the standalone backfill CLI at
+    # ``core_storage_api.scripts.backfill_embeddings`` can
+    # ``from common.embedding import get_embedding`` without a
+    # ``ModuleNotFoundError``. The CLI runs inside this image (per
+    # its docstring: "Run inside the docker-compose stack so envs are
+    # wired up correctly"). Pin matches ``core-worker``'s pin so the
+    # OpenAI SDK version is consistent across services.
+    "openai>=2.1,<3",
 ]
 
 [project.optional-dependencies]

--- a/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
+++ b/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
@@ -231,16 +231,27 @@ async def _backfill_one_table(
             async with none_lock:
                 consecutive_nones = 0
             async with engine.connect() as conn:
-                # Pass the raw ``list[float]`` — asyncpg's pgvector codec
-                # (registered globally via ``register_vector`` on the
-                # async engine) serializes the list to pgvector's binary
-                # representation. Using ``str(vec)`` would force pgvector
-                # to re-parse a Python repr (``'[0.1, 0.2, ...]'``) and
-                # crashes when the codec is registered, since the codec
-                # then expects a sequence.
+                # Pass the vector as ``str(vec)`` (Python's list repr —
+                # ``'[0.1, 0.2, ...]'``) and let pgvector's input parser
+                # cast it on the column-type side. The CLI's deployed
+                # asyncpg driver does NOT have the ``register_vector``
+                # codec registered (it's only added on connections
+                # created via pgvector's helper, not via SQLAlchemy's
+                # default async engine factory). Without the codec,
+                # asyncpg tries to serialize a ``list[float]`` directly
+                # and bails with ``invalid input for query argument $1
+                # ... (expected str, got list)``. The text-cast path
+                # is what every other write site in this codebase
+                # already uses (see ``memory_update_embedding``); this
+                # CLI just needs to match.
+                #
+                # Explicit ``::vector`` cast on the placeholder so
+                # PostgreSQL parses the string at server side rather
+                # than relying on implicit-cast inference, which would
+                # depend on asyncpg's chosen wire-type for the param.
                 await conn.execute(
-                    text(f"UPDATE {spec.table} SET {spec.embedding_column} = :emb WHERE id = :id"),
-                    {"emb": vec, "id": row_id},
+                    text(f"UPDATE {spec.table} SET {spec.embedding_column} = (:emb)::vector WHERE id = :id"),
+                    {"emb": str(vec), "id": row_id},
                 )
                 await conn.commit()
             embedded += 1


### PR DESCRIPTION
Two related fixes for the OSS standalone backfill CLI (`core_storage_api.scripts.backfill_embeddings`), both surfaced while running the backfill against staging on the v2.0.0 image.

## Fix 1 — `(:emb)::vector` cast + `str(vec)` parameter

When run against the staging Cloud Run deployment, the CLI failed on the very first UPDATE with:

```
asyncpg.exceptions.DataError: invalid input for query argument $1:
[0.040..., 0.042..., ...] (expected str, got list)
```

PR #51's HIGH-1 review fix had switched the SQLAlchemy parameter from `str(vec)` to a raw `list[float]`, on the assumption that asyncpg's pgvector codec was registered on the async engine. It isn't — `register_vector` only fires on connections built via pgvector's helper, not on the default SQLAlchemy `create_async_engine`. Without the codec, asyncpg can't serialize `list[float]` and bails before reaching pgvector.

This commit:
- Reverts the parameter to `str(vec)` (Python list repr — `'[0.1, 0.2, ...]'`). Pgvector's input parser casts it on the column-type side. Same path every other write site in the codebase already uses (see `memory_update_embedding`).
- Adds an explicit `(:emb)::vector` cast on the placeholder so PostgreSQL parses the literal at server side rather than relying on implicit-cast inference, which depends on which wire-type asyncpg picks for the param.
- Documents the asyncpg-codec-not-registered detail so future review doesn't swing it back.

## Fix 2 — add `openai` to core-storage-api deps

After Fix 1 cleared, the CLI failed earlier at import time with:

```
ModuleNotFoundError: No module named 'openai'
```

The CLI does `from common.embedding import get_embedding`, and `common.embedding` imports `openai` at module load. core-storage-api's `pyproject.toml` didn't declare `openai`, so the import fails.

Adds `openai>=2.1,<3` — matches the pin already in `core-worker/pyproject.toml` for SDK version consistency across services. The dep is NOT used by the live core-storage-api request path (which talks DB only). It's carried purely so the standalone backfill CLI can run inside this image.

## Verification

- 7/7 existing unit tests pass.
- Re-running the staging backfill against the live AlloyDB after both fixes: 821 live memories + 3,380 entities re-embedded against hosted-OpenAI-1024 cleanly. No `DataError`, no `ModuleNotFoundError`, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)