### PR TITLE
docs: complete local-embedder coverage (P0 fixes, GPU, README integration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ from [Conventional Commits](https://www.conventionalcommits.org/).
 
 ## [2.0.0](https://github.com/caura-ai/caura-memclaw/compare/v1.0.1...v2.0.0) (2026-05-03)
 
+> ⚠️ **BREAKING CHANGE — local embedder + 1024-dim schema migration.**
+> v2.0.0 introduces a self-hosted embedder profile (`BAAI/bge-m3` via HuggingFace
+> TEI sidecar — see [`docs/local-embedder.md`](docs/local-embedder.md)) and
+> migrates the pgvector schema from 768-dim to 1024-dim (alembic
+> `012_vector_dim_1024`). Existing installations must opt in via
+> `MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS=true` and re-embed afterward — see
+> [README "Upgrading from v1.x"](README.md#upgrading-from-v1x) for the
+> procedure. Fresh installs are unaffected.
+
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Get up and running in minutes — no infrastructure, automatic updates, usage an
 The fastest path is Docker Compose — one command brings up Postgres + pgvector + Redis + the API.
 
 > **Prefer not to use Docker?** Skip to [Manual deployment (Python + Postgres)](#manual-deployment) below for the bare-Python path.
+>
+> **No cloud API key, no external calls?** v2.0+ supports a self-hosted local embedder (`BAAI/bge-m3` via HuggingFace TEI) — see [`docs/local-embedder.md`](docs/local-embedder.md). The setup below walks through the OpenAI default; the local-embedder doc walks through the alternative.
 
 #### Prerequisites
 
@@ -99,8 +101,16 @@ OPENAI_API_KEY=sk-...
 
 > Without any AI keys the stack still starts — dummy providers return non-semantic embeddings, useful for testing the API surface.
 
+> 💡 **Want zero cloud API calls?** v2.0+ ships a self-hosted embedder
+> profile (`BAAI/bge-m3` on a [HuggingFace TEI](https://github.com/huggingface/text-embeddings-inference)
+> sidecar). Bring up the stack with `docker compose --profile embed-local up -d`
+> and set the four `OPENAI_EMBEDDING_*` envs from `.env.example` — see
+> [`docs/local-embedder.md`](docs/local-embedder.md) for the full setup.
+> Combined with `IS_STANDALONE=true` (below) this is a fully self-contained
+> deployment with no external API calls.
+
 <details>
-<summary>Other providers (Gemini, Anthropic, OpenRouter)</summary>
+<summary>Other providers (Gemini, Anthropic, OpenRouter, self-hosted)</summary>
 
 | Provider | `.env` settings | Required key |
 |---|---|---|
@@ -108,8 +118,9 @@ OPENAI_API_KEY=sk-...
 | **Google Gemini** | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=gemini` | `GEMINI_API_KEY` + `OPENAI_API_KEY` |
 | **Anthropic** | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=anthropic` | `ANTHROPIC_API_KEY` + `OPENAI_API_KEY` |
 | **OpenRouter** | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=openrouter` | `OPENROUTER_API_KEY` + `OPENAI_API_KEY` |
+| **Self-hosted (TEI / bge-m3)** | `--profile embed-local` + `OPENAI_EMBEDDING_BASE_URL=http://tei:80/v1`<br>+ `OPENAI_EMBEDDING_MODEL=BAAI/bge-m3`<br>+ `OPENAI_EMBEDDING_SEND_DIMENSIONS=false` | none — runs locally |
 
-Anthropic, Gemini, and OpenRouter don't offer embedding APIs here — pair them with OpenAI for embeddings. You can mix providers freely. Gemini uses the [Google AI Studio](https://aistudio.google.com/) key-auth Developer API (no GCP project/ADC required).
+Anthropic, Gemini, and OpenRouter don't offer embedding APIs here — pair them with OpenAI (or with TEI) for embeddings. You can mix providers freely. Gemini uses the [Google AI Studio](https://aistudio.google.com/) key-auth Developer API (no GCP project/ADC required). The self-hosted TEI row keeps `EMBEDDING_PROVIDER=openai` because TEI speaks the same OpenAI-compatible API; see [`docs/local-embedder.md`](docs/local-embedder.md) for hardware sizing, GPU setup, and model swapping.
 
 </details>
 
@@ -170,6 +181,8 @@ OSS supports three auth paths. Pick one and add it to your `.env`, then `docker 
 IS_STANDALONE=true
 ```
 No API key required for REST. MCP still expects a non-empty `X-API-Key` header — any value works.
+
+> Pair Standalone mode with `--profile embed-local` (see [`docs/local-embedder.md`](docs/local-embedder.md)) for a fully self-contained deployment: no admin keys, no external API calls, all embeddings computed locally. Useful for offline / air-gapped environments and personal-laptop installs.
 
 **Admin key** — multi-tenant with full access:
 ```env

--- a/docs/local-embedder.md
+++ b/docs/local-embedder.md
@@ -8,13 +8,56 @@ the schema set in alembic migration `012_vector_dim_1024`.
 
 ## TL;DR
 
+Two steps — set the four envs in `.env`, then bring up the stack with the profile:
+
+```env
+# .env
+EMBEDDING_PROVIDER=openai
+OPENAI_EMBEDDING_BASE_URL=http://tei:80/v1
+OPENAI_EMBEDDING_MODEL=BAAI/bge-m3
+OPENAI_EMBEDDING_SEND_DIMENSIONS=false
+```
+
 ```bash
 docker compose --profile embed-local up -d
 ```
 
-That's it. The `tei` service runs on the compose network, `core-api` finds it
-at `http://tei:80/v1`, embeddings stop hitting OpenAI. Set the four envs from
-`.env.example` if you want to override the model or point at an external TEI.
+The `tei` service starts on the compose network at `http://tei:80`. With the
+four envs set, `core-api` routes embedding calls there instead of
+`api.openai.com`. Without those envs, the TEI container runs but is unused —
+`core-api` falls through to hosted OpenAI. **Both pieces are required.**
+
+## Verify it's working
+
+After `up -d`, confirm TEI is actually being hit:
+
+```bash
+# Watch TEI's request log live. Embed calls show up here in real time.
+docker compose --profile embed-local logs -f tei
+```
+
+In another terminal, fire one write → search round-trip:
+
+> These examples assume `IS_STANDALONE=true` in `.env` (see the
+> [Auth modes](../README.md#self-hosted-open-source) section in README).
+> Replace `standalone` with your actual API key if you're using `ADMIN_API_KEY`
+> or `MEMCLAW_API_KEY` instead, and add `tenant_id` matching your setup.
+
+```bash
+curl -fsS -X POST http://localhost:8000/api/v1/memories \
+  -H "X-API-Key: standalone" -H "content-type: application/json" \
+  -d '{"tenant_id":"default","content":"smoke check for local embedder"}'
+
+curl -fsS -X POST http://localhost:8000/api/v1/search \
+  -H "X-API-Key: standalone" -H "content-type: application/json" \
+  -d '{"tenant_id":"default","query":"smoke check","top_k":5}'
+```
+
+You should see two `POST /v1/embeddings` lines in the TEI log (one for the
+write's content, one for the search's query) and a non-empty `memories`
+array in the search response. If the TEI log stays silent during your
+calls, double-check the four envs were picked up — `core-api` is silently
+hitting OpenAI.
 
 ## Why bother
 
@@ -26,7 +69,8 @@ at `http://tei:80/v1`, embeddings stop hitting OpenAI. Set the four envs from
 | R@5 (LongMemEval N=30) | 0.889 | 0.963 |
 | Accuracy | 86.7 % | 93.3 % |
 
-Numbers from `local_emb_res/RESULTS.md` (the bench-off that drove this default).
+Numbers from the local-embedder bench-off (LongMemEval `single-session-user`,
+N=30, seed=42) that drove this default.
 
 ## How it works
 
@@ -42,9 +86,8 @@ Two flags are TEI-specific:
   pinned to `VECTOR_DIM`).
 * **`OPENAI_EMBEDDING_TRUNCATE_TO_DIM`** — Matryoshka-style output slice +
   L2-renormalize. Only relevant if you swap to a model whose native dim is
-  larger than the schema (e.g. Qwen3-Embedding-0.6B = 1024, schema = 768
-  on a stale deployment). bge-m3 is native 1024 against the 1024 schema —
-  leave empty.
+  larger than the schema (e.g. Qwen3-Embedding-4B = 2560, schema = 1024).
+  bge-m3 is native 1024 against the 1024 schema — leave empty.
 
 Two are model-specific:
 
@@ -59,28 +102,155 @@ Two are model-specific:
 The full asymmetric-encoding contract is in `common/embedding/protocols.py`
 (`embed_query` vs `embed`).
 
-## Hardware sizing
+## Hardware sizing (CPU)
 
 The compose service ships with the **CPU image** (`cpu-1.7`) by default. Good
 enough for a laptop, a small VM, or a single-tenant client. Numbers below are
-for `BAAI/bge-m3` at ~200-token average input.
+for `BAAI/bge-m3` at ~200-token average input, idle (single-call) latency.
 
 | Hardware | TEI image | Realistic RPS | p50 latency |
 |---|---|---|---|
-| 8 vCPU AMD (e2-standard-8) | `cpu-1.7` (default) | 200–400 | ~130 ms |
+| 4 vCPU laptop class (M-series, Ryzen 7, etc.) | `cpu-1.7` | 50–150 | ~250 ms |
+| 8 vCPU AMD (e2-standard-8) | `cpu-1.7` | 200–400 | ~130 ms |
 | 8 vCPU Intel (n2-standard-8, AVX-512) | `cpu-1.7` | 400–700 | ~80 ms |
 | 1× L4 GPU (g2-standard-8) | `89-1.7` | 3,000–8,000 | ~50 ms |
 
-To switch to the GPU image, set `TEI_IMAGE_TAG=89-1.7` in `.env` **and**
-uncomment the `deploy.resources.reservations.devices` block in the `tei`
-service (or copy it into `docker-compose.override.yml`). You'll need
-[nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
-on the host.
-
-For production at sustained high RPS, you want **two TEI replicas behind a
-load balancer** — see the discussion in `local_emb_res/sizing-1000rps.md`.
 A single replica's per-call latency degrades sharply under concurrent load
-(measured: 57 ms idle → 571 ms at 5×2 concurrent fan-out).
+(measured: 57 ms idle → 571 ms at 5×2 concurrent fan-out on CPU).
+
+For production at sustained ≥ 200 RPS you want **two TEI replicas behind a
+load balancer**. Cost reference: 2× L4 on `g2-standard-8` runs ~$1k/mo
+on-demand, ~$650/mo with committed-use discount, and holds p99 < 200 ms at
+1000 RPS sustained. See the GPU section below for setup.
+
+## GPU acceleration
+
+The default `tei` image is CPU-only. To enable a GPU you need three things:
+the right TEI image tag for your GPU, host-side NVIDIA plumbing, and the
+Compose `deploy:` block.
+
+### 1. Pick the right TEI image tag
+
+HuggingFace publishes per-architecture builds. Using the wrong tag either
+fails to pull or runtime-crashes on first embed. Find your GPU's compute
+capability at <https://developer.nvidia.com/cuda-gpus>, then pick:
+
+| GPU | Compute cap | TEI tag |
+|---|---|---|
+| T4 (g4-class) | sm_75 | `turing-1.7` |
+| A10, RTX 3090 | sm_86 | `86-1.7` |
+| A100, RTX A6000 | sm_80 | `1.7` (the "default CUDA" tag) |
+| **L4, RTX 4090** | sm_89 | `89-1.7` — verified in this repo's bench |
+| H100 | sm_90 | `hopper-1.7` |
+
+### 2. Host requirements
+
+- **NVIDIA driver 535+** (CUDA 12.4 compatible). Older drivers start the
+  container but fail on first embed call. Verify with `nvidia-smi` on the
+  host.
+- **[nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)**
+  installed. Verify with:
+  ```bash
+  docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi
+  ```
+  Should print the host's GPU table. If not, finish the toolkit install
+  before continuing.
+
+### 3. Set the image tag in `.env`
+
+```env
+TEI_IMAGE_TAG=89-1.7   # or your GPU's tag from the table above
+```
+
+### 4. Uncomment the `deploy:` block in `docker-compose.yml`
+
+(Or copy this same block into a `docker-compose.override.yml` so you don't
+modify the tracked file.)
+
+```yaml
+services:
+  tei:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+```
+
+Plain `docker compose up` honours this block — no Swarm mode needed.
+
+### 5. Restart with the GPU image
+
+```bash
+docker compose --profile embed-local up -d --force-recreate tei
+```
+
+The first start downloads the bge-m3 weights (~2 GB) and may take several
+minutes. The healthcheck has 30 retries + `start_period: 60s` to cover this;
+subsequent starts reuse the `tei_cache` volume and come up in seconds.
+
+### 6. Verify the GPU is actually being used
+
+```bash
+docker compose --profile embed-local exec tei nvidia-smi
+```
+
+You should see a `python` (or `text-embeddings-inference`) process holding
+~2 GB of GPU memory. If `nvidia-smi` errors with "command not found" or the
+process list is empty, the container is on CPU mode — re-check steps 2–4.
+The most common silent fallback is forgetting step 4 (`deploy:` block stays
+commented out → Compose ignores GPU, container runs CPU-only on the GPU
+image, which works but at ~CPU speed).
+
+### Memory + multi-replica
+
+bge-m3 is ~2 GB on GPU. An L4 (24 GB) or A10 (24 GB) has plenty of headroom,
+so you can run **multiple TEI replicas on one GPU** if you're concurrency-
+bound rather than throughput-bound (a single replica saturates batching at
+~5–10 concurrent in-flight embed calls). Each replica needs its own
+container, port mapping, and entry in `OPENAI_EMBEDDING_BASE_URL` (or a
+load balancer in front of them).
+
+### Production / Kubernetes
+
+Production GPU deployments typically use Kubernetes with the [NVIDIA GPU
+Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html)
+on a dedicated node pool. Compose `deploy:` doesn't apply; the equivalent
+manifest:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tei
+spec:
+  replicas: 2
+  template:
+    spec:
+      nodeSelector: { cloud.google.com/gke-accelerator: nvidia-l4 }
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: tei
+          image: ghcr.io/huggingface/text-embeddings-inference:89-1.7
+          args: [--model-id=BAAI/bge-m3, --port=80, --auto-truncate]
+          ports: [{ containerPort: 80 }]
+          resources:
+            limits: { nvidia.com/gpu: 1 }
+          readinessProbe:
+            httpGet: { path: /health, port: 80 }
+            initialDelaySeconds: 60   # cold model download
+            periodSeconds: 10
+            failureThreshold: 30
+```
+
+Front it with a `Service` of type `ClusterIP` (or internal `LoadBalancer`
+inside a private VPC) and point `OPENAI_EMBEDDING_BASE_URL` at that Service's
+DNS name (e.g. `http://tei.default.svc.cluster.local:80/v1`).
 
 ## Swapping models
 
@@ -100,65 +270,54 @@ the new dim with a follow-up alembic revision.
 
 ## Schema requirement
 
-> **Upgrading from v1.x?** Follow the
-> [Upgrading from v1.x](../README.md#upgrading-from-v1x) section in the
-> README first — it sequences DB snapshot, opt-in env var, and re-embed for
-> you. The bare `alembic upgrade 012` shown below is for fresh installations.
+The `tei` profile assumes the 1024-dim schema introduced in v2.0.0 (alembic
+revision `012_vector_dim_1024`). Two cases:
 
-The `tei` profile assumes the 1024-dim schema. If you're upgrading an existing
-768-dim deployment:
+**Fresh install.** No action — the schema is created at 1024-dim on first
+container start. Just bring the stack up per the [TL;DR](#tldr) above.
 
-```bash
-# Pre-flight first — read-only readout of how many rows will be NULL'd,
-# rough wall-clock estimate, and the exact opt-in command to run next.
-docker compose run --rm core-storage-api \
-  python -m core_storage_api.scripts.preflight_012
+**Upgrading from v1.x.** This is destructive — every existing 768-dim
+embedding is set to `NULL` so the column can be widened to 1024-dim.
+**Follow the canonical procedure in the README's
+[Upgrading from v1.x](../README.md#upgrading-from-v1x) section** — it
+sequences DB snapshot, opt-in env var, migration trigger, and re-embed in
+the order that won't lose data.
 
-# Run the migration (NULLs existing 768-dim embeddings; re-embed required)
-docker compose run --rm core-storage-api \
-  python -m alembic upgrade 012
-```
-
-The `012` revision is **destructive** — existing 768-dim vectors cannot be
-coerced to 1024 and are set to `NULL`. The application re-embeds lazily on
-next read/write. For an eager re-embed pass, run the bundled CLI:
-
-```bash
-docker compose run --rm core-storage-api \
-  python -m core_storage_api.scripts.backfill_embeddings --dry-run
-docker compose run --rm core-storage-api \
-  python -m core_storage_api.scripts.backfill_embeddings
-```
-
-For multi-tenant production cutovers prefer the event-driven backfill task
-in `core-worker`. It scans `WHERE embedding IS NULL` and publishes one
-`EMBED_REQUESTED` event per row, inheriting the consumer's per-tenant
-concurrency, retry, and DLQ wiring:
-
-```bash
-docker compose run --rm core-worker \
-  python -m core_worker.cli backfill-embeddings --dry-run
-docker compose run --rm core-worker \
-  python -m core_worker.cli backfill-embeddings
-```
-
-Optional knobs: `--tenant-id <id>` (per-tenant cutover), `--batch-size N`,
-`--max-inflight N`, `--dry-run`. Idempotent and restartable — re-running
-picks up only rows still missing an embedding.
-
-See `core-storage-api/src/core_storage_api/database/migrations/versions/012_vector_dim_1024.py`
-for the full operational story.
+The procedure expects you to run a stand-alone backfill CLI to re-embed
+existing rows (`python -m core_storage_api.scripts.backfill_embeddings`)
+after the migration completes. Both the OSS standalone CLI and the
+event-driven `core-worker` task work; the README documents both. For
+multi-tenant production cutovers prefer the event-driven path.
 
 ## Switching back to OpenAI hosted
 
-Just don't pass `--profile embed-local`. The `tei` service is profile-gated,
-so a plain `docker compose up -d` brings up the same stack as before — no
-TEI container, `core-api` falls through to the hosted OpenAI default
-(unset `OPENAI_EMBEDDING_BASE_URL`, set `OPENAI_API_KEY`).
+Just unset `OPENAI_EMBEDDING_BASE_URL` (and the three other `OPENAI_EMBEDDING_*`
+envs from the TL;DR) in your `.env` and restart `core-api`:
 
-A single deployment cannot mix both — the schema dim is global. To go back
-to OpenAI's `text-embedding-3-small` (1536 → 768 truncated), you'd need to
-roll back migration `012` and re-embed.
+```bash
+docker compose up -d --force-recreate core-api
+```
+
+You stay on the 1024-dim schema. OpenAI's `text-embedding-3-small` supports
+`dimensions=1024` natively (Matryoshka — produced by truncating from the
+model's native 1536-dim and L2-renormalizing on OpenAI's side). Setting
+`OPENAI_EMBEDDING_SEND_DIMENSIONS=true` (the default when `BASE_URL` is
+unset) tells the SDK to request 1024-dim output. So:
+
+- **Schema dim is global** — all embeddings in the DB are 1024-dim regardless
+  of which provider produced them.
+- **Provider switch is just an env-var change** — no migration, no re-embed
+  required (though you may want to re-embed for vector-space consistency
+  if you've been writing under a different vendor — re-run
+  `python -m core_storage_api.scripts.backfill_embeddings` after switching).
+
+To stop the unused TEI container too, drop the `--profile embed-local` flag
+on the next `up`:
+
+```bash
+docker compose down
+docker compose up -d   # no profile = no TEI sidecar
+```
 
 ## Troubleshooting
 
@@ -171,8 +330,33 @@ roll back migration `012` and re-embed.
   kwarg.
 * **Per-call latency jumps from ~130 ms to ~600 ms under concurrent load.**
   Single-replica TEI queues requests in dynamic batching. Add a second
-  replica behind nginx/LB — see `local_emb_res/design_integration.md`.
+  replica behind nginx/LB.
 * **`413 Payload Too Large` on long writes.** The compose `command:` includes
   `--auto-truncate` so this should not happen with bge-m3 (8K context).
   If it does, you've swapped to a 512-ctx model — pick something else or
   pre-chunk in the application layer.
+* **`up -d` succeeds but TEI is silent on every embed call.** `core-api`
+  is hitting OpenAI, not TEI. The four `OPENAI_EMBEDDING_*` envs aren't
+  set — re-check your `.env` (or the host shell — `docker compose config`
+  shows the resolved values).
+* **GPU image runs at CPU speed.** The `deploy:` block in `docker-compose.yml`
+  is still commented out. Uncomment it (or use `docker-compose.override.yml`)
+  per [GPU step 4](#4-uncomment-the-deploy-block-in-docker-composeyml).
+* **`exec tei nvidia-smi` errors with "command not found".** The CPU image
+  is running. Check `TEI_IMAGE_TAG` in `.env` matches a GPU tag from the
+  table.
+* **TEI container starts but errors on first embed call: `CUDA error`.**
+  Host driver is too old. Verify with `nvidia-smi` on the host; upgrade to
+  535+.
+
+## Compatibility
+
+* **Any OpenAI-compatible embedding endpoint works at the `OPENAI_EMBEDDING_BASE_URL`
+  slot** — vLLM's OpenAI-compat server, llama.cpp's `server` binary,
+  OpenRouter (for hosted models), Together AI, etc. The flags documented
+  above (`SEND_DIMENSIONS`, `MODEL`, `QUERY_INSTRUCTION`, `TRUNCATE_TO_DIM`)
+  cover most differences between back-ends. TEI is the recommended default
+  because it's the most mature open-source option for the bge-m3 default.
+* **The OpenClaw plugin works transparently** regardless of which embedder
+  is configured — it talks to MemClaw's REST API, which doesn't expose
+  the embedder choice. No plugin-side configuration needed.


### PR DESCRIPTION
Comprehensive docs pass for the v2.0 local-embedder feature, addressing all gaps surfaced by a post-staging-cutover audit. Single PR, three files.

## Why

A new user trying to enable the local embedder following the existing docs would hit ≥ 5 issues that would either silently misroute traffic to OpenAI, or crash with cryptic errors. The headline feature of v2.0.0 also has zero mention in the v2.0.0 CHANGELOG entry.

## What — by file

### `README.md` (+17 / -7)
- **Self-Hosted intro callout**: one-line note that v2.0+ supports a local embedder, with a link.
- **Quick Start "Set your AI provider" block**: new tip box pointing at the `--profile embed-local` path for users who don't want any cloud API key.
- **"Other providers" table**: new row `Self-hosted (TEI / bge-m3)` listing the four required envs.
- **Auth modes**: one-line note that Standalone + `--profile embed-local` = fully self-contained (no admin keys, no external API calls).

### `docs/local-embedder.md` (+260 / -68)
- **TL;DR**: rewrite to show the four envs FIRST, then the compose command. Drop the misleading "That's it" sentence that implied the profile alone was enough.
- **New "Verify it's working" subsection**: `docker compose logs -f tei` + write→search smoke pair. Closes the silent-fallback gap (where envs aren't set and core-api hits OpenAI silently).
- **Hardware sizing**: add 4-vCPU laptop-class row (was missing). Replace `local_emb_res/sizing-1000rps.md` pointer (internal research, not in OSS) with inlined cost + RPS numbers.
- **GPU acceleration**: was a 7-line paragraph; now a ~70-line subsection with:
  - Per-architecture TEI image tag table (T4 / A10 / A100 / L4 / H100). Previously only L4 was documented.
  - Host requirements (NVIDIA driver 535+, nvidia-container-toolkit verification).
  - Step-by-step enable + restart.
  - Verification command (`docker compose exec tei nvidia-smi`).
  - Memory + multi-replica note (bge-m3 is ~2 GB → multiple replicas per L4 fit).
  - Kubernetes manifest sketch for production deployments (Compose `deploy:` doesn't apply outside Compose).
- **"Schema requirement"**: drop the broken `python -m alembic upgrade 012` command (fails in OSS image — no `alembic.ini` on disk). Point at README's "Upgrading from v1.x" canonical procedure instead.
- **"Switching back to OpenAI hosted"**: correct the misclaim that switching back requires rolling back the migration. `text-embedding-3-small` supports `dimensions=1024` via SDK kwarg; switch is just an env-var change.
- **Troubleshooting**: 4 new entries (silent core-api→OpenAI fallback; GPU image at CPU speed; `nvidia-smi` not found; CUDA error on first call).
- **New "Compatibility" section**: any OpenAI-compatible endpoint (vLLM, llama.cpp, OpenRouter) works at the `OPENAI_EMBEDDING_BASE_URL` slot. OpenClaw plugin is embedder-transparent.

### `CHANGELOG.md` (+9 / 0)
One-paragraph banner at the top of the v2.0.0 entry calling out the local-embedder feature + 1024-dim schema migration. release-please's auto-generated bullets dropped this (PR #51's squash-merge dropped the conventional-commit subject); the banner makes the breaking change discoverable without rewriting the bullets below.

## Out of scope (deliberate)

| Item | Why deferred |
|---|---|
| `core-storage-api` `openai` dep fix | Separate — PR #65 |
| `migrate-db.yml` OSS step fix | Separate — PR #220 (caura-memclaw-enterprise) |
| `.env.example` single-toggle env | Bigger change to docker-compose env mapping |
| OpenClaw plugin docs deeper integration | Plugin docs live in `plugin/` directory |
| README's broader "embedding providers" rework | This PR's row addition is targeted enough |

## Soft dependency

This PR's docs assume `core-storage-api`'s `openai` dep is available (i.e. v2.0.1+ image, after PR #65 merges). Until then, a v2.0.0 user running the documented backfill commands hits `ModuleNotFoundError: No module named 'openai'`. Per the audit discussion, the chosen path is to land #65 first; if this PR somehow merges first, we'd see a brief window where docs reference commands that don't run on v2.0.0. Low risk — #65 is in review and small.

## Test plan

- [ ] Markdown rendering check on GitHub preview.
- [ ] Internal-link sanity:
  - `[Upgrading from v1.x](../README.md#upgrading-from-v1x)` → resolves to README L422 section.
  - `[TL;DR](#tldr)` → resolves to docs/local-embedder.md L9.
  - `[GPU step 4](#4-uncomment-the-deploy-block-in-docker-composeyml)` → resolves to docs/local-embedder.md L182.
- [ ] A new user following the rewritten TL;DR + "Verify it's working" steps end-to-end on a clean clone should see two `POST /v1/embeddings` lines in `docker compose logs -f tei` after one write→search round-trip.
- [ ] CI green (no code changed; doc-only PR — should pass quickly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)