### PR TITLE
fix(crystallizer): /latest 404→200 null on empty (CAURA-646)

### DIFF
--- a/core-api/src/core_api/routes/crystallizer.py
+++ b/core-api/src/core_api/routes/crystallizer.py
@@ -155,12 +155,27 @@ async def get_latest_report(
     tenant_id: str = Query(...),
     auth: AuthContext = Depends(get_auth_context),
 ):
-    """Get the most recent completed crystallization report for a tenant."""
+    """Get the most recent completed crystallization report for a tenant.
+
+    Returns ``200`` with the report body when a completed report exists;
+    returns ``200`` with body ``null`` when the tenant has none yet. The
+    URL itself is the well-defined "give me my latest report" resource —
+    the fact that no completed report exists yet is *empty state*, not a
+    missing resource. ``404`` would conflate the two and force every
+    client to special-case it as "actually empty"; see CAURA-646. The
+    sibling ``/crystallize/reports/{report_id}`` keeps its 404 because
+    *that* endpoint genuinely points at an opaque id that may not exist.
+    """
     auth.enforce_tenant(tenant_id)
     sc = get_storage_client()
     report = await sc.get_latest_report(tenant_id)
-    if not report:
-        raise HTTPException(status_code=404, detail="No completed reports found")
+    # Identity check, not truthiness — the storage client's contract is
+    # ``dict | None``. ``not {}`` would also be True, which would
+    # silently null-return an empty (but otherwise valid) report dict
+    # if storage ever changed to return ``{}`` instead of ``None`` on a
+    # miss. ``is None`` is the precise guard the contract supports.
+    if report is None:
+        return None
     return {
         "id": str(report.get("id", "")),
         "tenant_id": report.get("tenant_id"),

--- a/tests/test_api_crystallizer.py
+++ b/tests/test_api_crystallizer.py
@@ -1,7 +1,5 @@
 """E2E crystallizer (memory analysis) tests through HTTP API."""
 
-import pytest
-
 from tests.conftest import get_test_auth, get_admin_headers, uid as _uid
 
 
@@ -165,6 +163,36 @@ async def test_get_report_not_found(client):
         headers=headers,
     )
     assert resp.status_code == 404
+
+
+async def test_get_latest_report_empty_returns_200_null(client):
+    """GET /api/crystallize/latest returns 200 with body ``null`` when the
+    tenant has no completed reports — empty state, not a missing resource.
+
+    Regression for CAURA-646: previously returned 404 + ``NOT_FOUND``,
+    forcing every client to special-case 404 as "actually empty". The
+    URL itself ("the tenant's latest report") is well-defined; only the
+    optional value behind it is unset, so 200 + ``null`` is the correct
+    contract. The sibling ``/reports/{report_id}`` (above) still 404s
+    because that endpoint genuinely points at an opaque id.
+    """
+    # Use a unique per-test tenant id — ``get_test_auth()`` returns
+    # the shared ``"default"`` tenant, which is contaminated with
+    # completed reports from earlier tests in this file. The admin
+    # API key bypasses ``enforce_tenant``, so an arbitrary tenant_id
+    # routes through cleanly without auth wiring.
+    fresh_tenant = f"caura-646-empty-{_uid()}"
+    _, headers = get_test_auth()
+    resp = await client.get(
+        f"/api/v1/crystallize/latest?tenant_id={fresh_tenant}",
+        headers=headers,
+    )
+    assert resp.status_code == 200, (
+        f"Expected 200 (empty state) but got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json() is None, (
+        f"Expected null body for empty state, got {resp.json()!r}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the API contract for `GET /api/v1/crystallize/latest` so it returns **200 with body `null`** when a tenant has no completed reports yet, instead of a 404.

## Why

The 404 conflated:

- **Resource doesn't exist** — the URL doesn't map to anything (genuine 404)
- **Empty state** — the resource exists as a concept; it just has no value yet

For a tenant-scoped "give me my latest of $X" endpoint, the URL is well-defined; only the optional value behind it is unset → 200 + `null` is correct. 404 stays for `/crystallize/reports/{report_id}` because *that* endpoint genuinely points at an opaque id that may not exist.

Real prod report today: a user hitting `/api/crystallize/latest?tenant_id=eldad` got a 404 in their network tab. Dashboard had to special-case it via `String(e).includes('404')` → `setLatest(null)`.

## Change

`core-api/src/core_api/routes/crystallizer.py`:

- Replace `raise HTTPException(404, ...)` with `return None`. FastAPI emits `null` body with 200.
- Expanded docstring spells out empty-state vs missing-resource so the next reader doesn't re-introduce the 404 thinking it's "more REST-y".

## Test

`tests/test_api_crystallizer.py::test_get_latest_report_empty_returns_200_null` — fresh tenant (per-test unique id), assert 200 + `json() is None`. Passes locally.

Existing `test_get_report_not_found` for `/reports/{id}` unchanged and still passes — that 404 is the genuine-missing-resource case.

## Test plan

- [x] `pytest tests/test_api_crystallizer.py::test_get_latest_report_empty_returns_200_null -v` — passes
- [x] `pytest tests/test_api_crystallizer.py::test_get_report_not_found -v` — still passes
- [x] `ruff check` + `ruff format --check` — clean
- [ ] CI green
- [ ] Frontend's `includes('404')` simplification (separate small PR if desired — existing branch still works since 200+null falls through `setLatest(data)` with `data=null`)

## Out of scope

Other `/latest`-shaped endpoints with the same pattern (e.g. `/security-audit/latest` if present, `/contradictions/latest`). Separate sweep — file as found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)