### PR TITLE
fix(plugin): auto-fill target_fleet_id on skill share/unshare

### DIFF
--- a/plugin/src/tool-definitions.test.ts
+++ b/plugin/src/tool-definitions.test.ts
@@ -147,6 +147,22 @@ describe("createToolFromSpec factory", () => {
     assert.ok(list.properties.include_deleted);
   });
 
+  test("memclaw_share_skill does NOT require target_fleet_id (auto-filled by enrichBody)", () => {
+    // The plugin auto-fills ``target_fleet_id`` from MEMCLAW_FLEET_ID
+    // when the agent omits it (the common case for single-fleet
+    // installs). Making the field required would force every share to
+    // repeat the local fleet name and produce "I guessed wrong" bugs
+    // when the agent doesn't know its own fleet — silently storing
+    // the skill under the wrong fleet, invisible to teammates.
+    const share = createToolFromSpec("memclaw_share_skill").parameters as any;
+    assert.ok(
+      !share.required.includes("target_fleet_id"),
+      "target_fleet_id must NOT be in required (auto-filled by enrichBody)",
+    );
+    assert.deepEqual(share.required, ["name", "description", "content"]);
+    assert.ok(share.properties.target_fleet_id);
+  });
+
   test("description falls back to tools.json value when no live override", () => {
     // `getToolDescription` reads from the shared cache in env.ts. On a
     // fresh import (no /tool-descriptions fetch yet), the fallback should

--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -55,6 +55,14 @@ async function enrichBody(
   if (!body.tenant_id) body.tenant_id = await ensureTenantId();
   if (!body.agent_id && MEMCLAW_AGENT_ID) body.agent_id = MEMCLAW_AGENT_ID;
   if (!body.fleet_id && MEMCLAW_FLEET_ID) body.fleet_id = MEMCLAW_FLEET_ID;
+  // ``target_fleet_id`` is the routing key for skill-sharing tools
+  // (memclaw_share_skill / memclaw_unshare_skill). Auto-fill from the
+  // plugin's local fleet config when the agent omits it — agents on a
+  // single fleet shouldn't have to repeat it on every share, and
+  // making them guess produces silent visibility bugs (skill stored
+  // under the wrong fleet, invisible to teammates' queries). Explicit
+  // values (intentional cross-fleet shares) are respected.
+  if (!body.target_fleet_id && MEMCLAW_FLEET_ID) body.target_fleet_id = MEMCLAW_FLEET_ID;
   return body;
 }
 
@@ -270,12 +278,12 @@ const PARAM_SCHEMAS: Record<string, Record<string, unknown>> = {
 
   memclaw_share_skill: {
     type: "object",
-    required: ["name", "description", "content", "target_fleet_id"],
+    required: ["name", "description", "content"],
     properties: {
       name: { type: "string", description: "Skill name (lowercase, [a-z0-9._-], 1-100 chars). Doubles as on-disk directory name and the upsert key." },
       description: { type: "string", description: "One-line summary used for browse/search (1-500 chars)." },
       content: { type: "string", description: "Full SKILL.md markdown body." },
-      target_fleet_id: { type: "string", description: "Fleet the skill is scoped to (catalog tag and, if install_on_fleet=true, the install target)." },
+      target_fleet_id: { type: "string", description: "Fleet the skill is scoped to. Auto-filled from your local fleet config when omitted; specify explicitly only for cross-fleet shares." },
       install_on_fleet: { type: "boolean", description: "False (default): publish to catalog only. True: also auto-install on every node in target_fleet_id." },
       agent_id: { type: "string", description: "Author agent (recorded on the doc)." },
       target_agent_ids: { type: "array", items: { type: "string" }, description: "Optional list of recipient agent_ids — informational only in v1." },
@@ -289,7 +297,7 @@ const PARAM_SCHEMAS: Record<string, Record<string, unknown>> = {
     properties: {
       name: { type: "string", description: "Skill name (must match the share)." },
       unshare_from_fleet: { type: "boolean", description: "False (default): catalog-only removal. True: also rm SKILL.md on every fleet node (requires target_fleet_id)." },
-      target_fleet_id: { type: "string", description: "Required when unshare_from_fleet=true." },
+      target_fleet_id: { type: "string", description: "Required when unshare_from_fleet=true. Auto-filled from your local fleet config when omitted." },
       agent_id: { type: "string", description: "Caller agent." },
     },
   },


### PR DESCRIPTION
## Summary

Follow-up to #68. Auto-fills `target_fleet_id` from the plugin's local `MEMCLAW_FLEET_ID` env var when the agent omits it on `memclaw_share_skill` / `memclaw_unshare_skill`.

**The bug:** in #68, `target_fleet_id` was marked **required** in plugin `PARAM_SCHEMAS`. Agents on a single fleet had to repeat the fleet name on every share — and agents that didn't know their own fleet ended up guessing (e.g. `"default"`), silently storing the skill under the wrong fleet and breaking teammates' discovery queries.

## Why the obvious one-liner doesn't work

A reviewer suggested a one-liner in `enrichBody`:
```ts
if (!body.target_fleet_id && MEMCLAW_FLEET_ID) body.target_fleet_id = MEMCLAW_FLEET_ID;
```
But the field was **required** in the schema, so JSON-schema validation runs before `enrichBody` and forces the agent to produce a non-empty value. The condition would never fire. The reviewer self-acknowledged this in their caveat.

## The actual fix

Two changes:

1. **`enrichBody`** — auto-fill `target_fleet_id` alongside `tenant_id`, `agent_id`, `fleet_id`. Only fires when the agent omits it (explicit cross-fleet shares respected).

2. **`PARAM_SCHEMAS.memclaw_share_skill`** — drop `target_fleet_id` from `required`. Otherwise the auto-fill never reaches an empty field. (`memclaw_unshare_skill` was already optional.)

Server-side `SkillShareRequest` Pydantic model **still requires** `target_fleet_id`, so direct-MCP users without a plugin config get a clear 422 if they omit it.

## What this doesn't break

- Intentional cross-fleet shares — agents pass `target_fleet_id` explicitly when it's not their own fleet
- Direct-MCP users (Claude Code, Codex direct) — server validation still kicks in
- Existing share calls — already passing `target_fleet_id` continue to work unchanged

## Test plan

- [x] New test: `target_fleet_id` is not in `required` for `memclaw_share_skill`
- [x] Plugin TS suite: 99/99 passing
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)