### PR TITLE
chore(docs): catch up tool lists across docs + scripts (12 tools)

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -193,8 +193,11 @@ Once connected via MCP or the OpenClaw plugin, you have these tools:
 | `memclaw_tune` | Adjust per-agent search parameters (top_k, min_similarity, graph hops, blend weights) |
 | `memclaw_insights` | Analyze the store; focus: `contradictions`, `failures`, `stale`, `divergence`, `patterns`, `discover`. Persists findings as `insight` memories |
 | `memclaw_evolve` | Report a real-world outcome (success/failure/partial) against recalled memories — adjusts weights, auto-generates preventive rules (Karpathy Loop) |
+| `memclaw_stats` | Aggregate counts: total + breakdowns by `type`, `agent`, `status`. Read-only |
+| `memclaw_share_skill` | Share a SKILL.md with the fleet. Default publishes to the catalog (semantic-searchable); `install_on_fleet=true` also auto-installs on every fleet node |
+| `memclaw_unshare_skill` | Remove a shared skill. Default removes from catalog only; `unshare_from_fleet=true` also rms the local SKILL.md on fleet nodes |
 
-The plugin surfaces all 9 tools; MCP exposes the same set.
+The plugin surfaces all 12 tools; MCP exposes the same set.
 
 ## Enable Real LLM Enrichment (optional)
 
@@ -214,7 +217,7 @@ Then restart the server (`docker compose restart app` or re-run uvicorn).
 
 - A local MemClaw server with full API + MCP
 - A single-tenant standalone setup (or admin-keyed multi-tenant, depending on which path you picked)
-- 9 tools ready to use (6 memory ops + 1 document store op + 2 Karpathy Loop ops)
+- 12 tools ready to use (6 memory ops + 1 document store op + 2 Karpathy Loop ops + stats + skill share/unshare)
 - PostgreSQL with pgvector for semantic search
 - No external dependencies (fake providers, no API keys needed)
 - Full read/write access to your own memory store

--- a/scripts/mcp_tool_smoke.py
+++ b/scripts/mcp_tool_smoke.py
@@ -2,9 +2,9 @@
 """End-to-end smoke for every MCP tool against a live enterprise stack.
 
 Complements trust_matrix_e2e.py: that one proves trust gating, this one
-proves each of the nine plugin-exposed tools actually performs its
-advertised operation with realistic arguments. Reports per-tool PASS /
-FAIL / SKIP with a one-line reason each.
+proves each plugin-exposed tool actually performs its advertised
+operation with realistic arguments. Reports per-tool PASS / FAIL / SKIP
+with a one-line reason each.
 
 Expects /tmp/e2e.env (written by the E2E register step) containing::
 
@@ -12,6 +12,7 @@ Expects /tmp/e2e.env (written by the E2E register step) containing::
     KEY=...
     JWT=...
 """
+
 from __future__ import annotations
 
 import json
@@ -39,8 +40,8 @@ TENANT = ENV["TENANT_ID"]
 KEY = ENV["KEY"]
 FLEET = "smoke-fleet"
 
-GATEWAY = "http://localhost"         # nginx
-CORE_API = "http://localhost:8000"   # direct core-api (MCP lives here)
+GATEWAY = "http://localhost"  # nginx
+CORE_API = "http://localhost:8000"  # direct core-api (MCP lives here)
 
 
 def http(method: str, url: str, body=None, headers=None):
@@ -220,7 +221,12 @@ def main():
         ),
         (
             "memclaw_insights",
-            {"agent_id": agent, "fleet_id": FLEET, "focus": "patterns", "scope": "agent"},
+            {
+                "agent_id": agent,
+                "fleet_id": FLEET,
+                "focus": "patterns",
+                "scope": "agent",
+            },
         ),
         (
             "memclaw_evolve",
@@ -230,6 +236,24 @@ def main():
                 "outcome": "Smoke test confirmed the tool flow is reachable.",
                 "outcome_type": "success",
             },
+        ),
+        (
+            "memclaw_stats",
+            {"agent_id": agent, "fleet_id": FLEET, "scope": "agent"},
+        ),
+        (
+            "memclaw_share_skill",
+            {
+                "agent_id": agent,
+                "name": "smoke-skill",
+                "description": "Smoke-test skill — auto-published, not installed.",
+                "content": "# smoke-skill\n\nProbe content.\n",
+                "target_fleet_id": FLEET,
+            },
+        ),
+        (
+            "memclaw_unshare_skill",
+            {"agent_id": agent, "name": "smoke-skill"},
         ),
     ]
 
@@ -241,7 +265,9 @@ def main():
         passed += int(ok)
         failed += int(not ok)
         snippet = detail.replace("\n", " ")[:110]
-        print(f"  {'PASS' if ok else 'FAIL':4s}  {tool:<{width}} {verdict:<12} {snippet}")
+        print(
+            f"  {'PASS' if ok else 'FAIL':4s}  {tool:<{width}} {verdict:<12} {snippet}"
+        )
 
     print()
     print(f"Summary: {passed}/{len(tests)} tools passed, {failed} failed.")

--- a/scripts/wet-test-install.sh
+++ b/scripts/wet-test-install.sh
@@ -168,7 +168,7 @@ if [[ -f "$OPENCLAW_CONFIG" ]]; then
     const tools = [
       'memclaw_recall','memclaw_write','memclaw_manage','memclaw_doc',
       'memclaw_list','memclaw_entity_get','memclaw_tune','memclaw_insights',
-      'memclaw_evolve'
+      'memclaw_evolve','memclaw_stats','memclaw_share_skill','memclaw_unshare_skill'
     ];
     for (const t of tools) {
       if (!config.tools.alsoAllow.includes(t)) config.tools.alsoAllow.push(t);

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -43,9 +43,12 @@ Tool descriptions are derived from the tool registry (`core-api/src/core_api/too
 | `memclaw_tune` | Yes | Yes | Tune per-agent retrieval parameters (top_k, min_similarity, fts_weight, freshness, recall boost, graph hops, similarity blend) |
 | `memclaw_insights` | Yes | Yes | Analyze the memory store. `focus`: `contradictions`, `failures`, `stale`, `divergence`, `patterns`, `discover`. `scope`: `agent`, `fleet`, `all`. Findings persist as `insight`-type memories (Karpathy Loop reflection step) |
 | `memclaw_evolve` | Yes | Yes | Record a real-world outcome (`success` / `failure` / `partial`) against recalled memories — adjusts weights, auto-generates preventive rules on failure (Karpathy Loop feedback edge) |
+| `memclaw_stats` | Yes | Yes | Aggregate counts of memories: total + breakdowns by `type`, `agent`, `status`. Read-only — useful for dashboards (REST) and agent self-introspection (MCP) |
+| `memclaw_share_skill` | Yes | Yes | Share a `SKILL.md` artifact with the fleet. Default publishes to the catalog (semantic-searchable via `GET /skills?query=`); `install_on_fleet=true` also queues `install_skill` fleet commands so every node materialises the skill locally for OpenClaw discovery |
+| `memclaw_unshare_skill` | Yes | Yes | Remove a shared skill. Default removes from the catalog only; `unshare_from_fleet=true` also queues `uninstall_skill` per fleet node so plugins delete the local `SKILL.md` |
 
-- **MCP (9 tools):** Full surface. Used by individual developers via Claude Desktop, Claude Code, Cursor, etc.
-- **OpenClaw plugin (9 tools):** Same set. Claims the exclusive `memory` slot, replacing `memory-core`. Includes ContextEngine lifecycle, heartbeat, and auto-education.
+- **MCP (12 tools):** Full surface. Used by individual developers via Claude Desktop, Claude Code, Cursor, etc.
+- **OpenClaw plugin (12 tools):** Same set. Claims the exclusive `memory` slot, replacing `memory-core`. Includes ContextEngine lifecycle, heartbeat, and auto-education.
 
 ---
 
@@ -119,19 +122,22 @@ in the first place.
 
 ### Available tools
 
-The MCP server exposes 9 tools that clients discover automatically. Descriptions are canonical — served from `GET /api/tool-descriptions`, derived from the tool registry (`core-api/src/core_api/tools/_registry.py`).
+The MCP server exposes 12 tools that clients discover automatically. Descriptions are canonical — served from `GET /api/tool-descriptions`, derived from the tool registry (`core-api/src/core_api/tools/_registry.py`).
 
 | Tool | Purpose |
 |---|---|
 | `memclaw_write` | Store a memory. Single write (`content`) or batch (`items` ≤100). LLM auto-infers type, title, summary, tags, embedding. Long content auto-chunked |
 | `memclaw_recall` | Hybrid semantic + keyword search with graph-enhanced retrieval. `include_brief=true` returns an LLM-summarized context paragraph. Supports `fleet_ids` |
-| `memclaw_manage` | Per-memory lifecycle, op-dispatched: `read`, `update`, `transition`, `delete`. Re-embeds on content updates |
+| `memclaw_manage` | Per-memory lifecycle, op-dispatched: `read`, `update`, `transition`, `delete`, `bulk_delete`, `lineage`. Re-embeds on content updates |
 | `memclaw_list` | Non-semantic enumeration — filter by type/status/agent/weight/date, sort, cursor-paginate (trust ≥ 2) |
-| `memclaw_doc` | Document CRUD, op-dispatched: `write`, `read`, `query`, `delete` on named JSON collections |
+| `memclaw_doc` | Document CRUD, op-dispatched: `write`, `read`, `query`, `delete`, `list_collections`, `search` (semantic) on named JSON collections |
 | `memclaw_entity_get` | Look up an entity by UUID — returns linked memories and relationships |
 | `memclaw_tune` | Tune per-agent retrieval parameters (top_k, min_similarity, fts_weight, freshness, recall boost, graph hops, similarity blend) |
 | `memclaw_insights` | Analyze the store. Focus: `contradictions`, `failures`, `stale`, `divergence`, `patterns`, `discover`. Persists findings as `insight` memories |
 | `memclaw_evolve` | Report an outcome (success/failure/partial) against recalled memories — adjusts weights, generates preventive rules on failure |
+| `memclaw_stats` | Aggregate counts: total + breakdowns by `type`, `agent`, `status`. Read-only |
+| `memclaw_share_skill` | Share a `SKILL.md` with the fleet. Default publishes to the catalog (semantic-searchable); `install_on_fleet=true` also auto-installs on every fleet node |
+| `memclaw_unshare_skill` | Remove a shared skill. Default removes from catalog only; `unshare_from_fleet=true` also rms the local `SKILL.md` on fleet nodes |
 
 ### Auth
 
@@ -271,7 +277,7 @@ The node will appear in the Fleet page (`/ui/fleet.html`) within 60 seconds.
 
 ### Plugin internals
 
-The plugin registers 9 tools and runs several lifecycle systems:
+The plugin registers 12 tools and runs several lifecycle systems:
 
 - **ContextEngine** — 7 lifecycle hooks: `bootstrap` (smoke test), `ingest` (message buffering + persistence), `assemble` (token-budget-aware recall injection), `compact` (persist summaries), `afterTurn` (auto-write turn summaries), `prepareSubagentSpawn`, `onSubagentEnded`
 - **Memory runtime** — API-backed `search()` and `get()` replacing file-based `memory-core`

--- a/tests/test_mcp_token_budget.py
+++ b/tests/test_mcp_token_budget.py
@@ -20,9 +20,8 @@ tiktoken = pytest.importorskip("tiktoken")
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
-# Current measured count is 4462 tokens (11 tools, post-share_skill).
-# Ceiling gives ~12% headroom for 1-2 more tools or description tweaks
-# before the gate trips. Raise intentionally when the surface grows.
+# Current measured count is 4796 tokens (12 tools, post-unshare_skill).
+# Ceiling gives ~4% headroom — raise intentionally when the surface grows.
 CEILING_TOKENS = 5000
 
 


### PR DESCRIPTION
## Summary

Multi-PR drift cleanup. `memclaw_stats` (#64), `memclaw_share_skill`, and `memclaw_unshare_skill` (#68) were added to the MCP/plugin surface but several docs and scripts still listed only the original 9 tools, or missed op-dispatch additions. CI snapshot tests catch registry drift but not these prose / install-script references.

## Files updated

| File | What was stale |
|---|---|
| `AGENT-INSTALL.md` | Tool table missing 3 tools; "all 9 tools" / "9 tools ready to use" mentions |
| `static/docs/integration-guide.md` | Two tool tables missing 3 tools; four "9 tools" prose mentions; missing `bulk_delete`/`lineage` on manage and `list_collections`/`search` on doc |
| `scripts/wet-test-install.sh` | OpenClaw allowlist install missed the 3 new tool names — fresh installs had tools registered but blocked by allowlist |
| `scripts/mcp_tool_smoke.py` | Added smoke probes for stats / share_skill / unshare_skill; fixed "nine plugin-exposed tools" docstring |
| `tests/test_mcp_token_budget.py` | Comment said "11 tools, 4462 tokens"; now 12 tools, 4796 tokens (no test logic change, only comment) |

## Out of scope

**Enterprise frontend drift** (`caura-memclaw-enterprise`) — `mcp-tools/page.tsx`, `for-agents-page.tsx`, `site/app/page.tsx`, `llms-full.txt`, `fleet/page.tsx`, `e2e/mcp.spec.ts` use pre-consolidation tool names entirely (`memclaw_search`, `memclaw_brief`, `memclaw_update`, `memclaw_delete`, `memclaw_transition`, `memclaw_doc_write/get/query/delete`, `memclaw_write_bulk`). Those tools no longer exist on the OSS surface. This is a deeper drift problem and needs a focused review of whether the enterprise pages document a different surface intentionally or are simply stale. **Not fixed here** — flagging for separate triage.

**Intentional stale fixtures** — `plugin/src/educate.test.ts` "9 tools" / "10 tools" string literals are part of the legacy-paragraph cleanup-regex tests. Left alone.

## Tests

- 22/22 server snapshots ✅
- 99/99 plugin TS ✅
- ruff + format clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)