### PR TITLE
fix(core-worker): init platform LLM singleton on lifespan startup (CAURA-647)

### DIFF
--- a/core-worker/src/core_worker/app.py
+++ b/core-worker/src/core_worker/app.py
@@ -5,9 +5,17 @@ Consumer-only service — no business HTTP routes, just ``/healthz`` +
 
 Lifespan ordering:
 1. ``configure_logging`` reads env BEFORE any module that emits log records.
-2. ``init_platform_embedding`` materialises the platform-tier provider
-   singleton from ``PLATFORM_EMBEDDING_*`` env vars. Done eagerly so a
-   bad config fails the readiness probe instead of nacking every event.
+2. ``init_platform_providers`` materialises BOTH platform-tier singletons:
+   the embedding provider from ``PLATFORM_EMBEDDING_*`` and the LLM
+   provider from ``PLATFORM_LLM_*``. Done eagerly so a bad config fails
+   the readiness probe instead of nacking every event. Both are needed:
+   ``handle_embed_request`` consults the embedding singleton;
+   ``handle_enrich_request`` falls through to the LLM singleton when the
+   request payload has no tenant-key for the resolved provider (CAURA-647
+   — pre-fix, the worker only inited embedding, so any payload that
+   resolved to ``ProviderName.OPENAI`` without a tenant openai key fell
+   straight through to FakeLLMProvider, silently corrupting the
+   re-enrichment path).
 3. ``register_consumers`` wires ``handle_embed_request`` against
    ``Topics.Memory.EMBED_REQUESTED``.
 4. ``bus.start()`` spawns Pub/Sub pull loops (no-op for inprocess bus).
@@ -24,9 +32,9 @@ from collections.abc import AsyncIterator
 
 from fastapi import FastAPI, HTTPException
 
-from common.embedding import init_platform_embedding
 from common.events.base import EventBus
 from common.events.factory import get_event_bus
+from common.llm import init_platform_providers
 from common.structlog_config import configure_logging
 from core_worker.clients.storage_client import close_storage_client, get_storage_client
 from core_worker.config import Settings
@@ -66,10 +74,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     logger.info("Starting core-worker", extra={"environment": settings.environment})
 
-    # Eager platform-embedding init so a bad PLATFORM_EMBEDDING_* config
-    # fails the readiness probe (handle_embed_request returns early when
-    # the singleton is None — CAURA-594 worker is platform-only by design).
-    init_platform_embedding()
+    # Eager platform-provider init: builds BOTH the embedding and LLM
+    # singletons from ``PLATFORM_EMBEDDING_*`` / ``PLATFORM_LLM_*``. The
+    # LLM half is what ``handle_enrich_request`` falls through to when
+    # a request payload's resolved provider has no tenant key — without
+    # it the enrichment path silently drops to ``FakeLLMProvider``
+    # (CAURA-647). A bad PLATFORM_* config fails the readiness probe
+    # rather than nacking every event.
+    init_platform_providers()
 
     # Bind the consumer to its dependencies before subscribing — the
     # subscribe must happen BEFORE bus.start() because the Pub/Sub

--- a/core-worker/tests/test_lifespan_platform_init.py
+++ b/core-worker/tests/test_lifespan_platform_init.py
@@ -1,0 +1,56 @@
+"""Regression: lifespan must init BOTH platform singletons (CAURA-647).
+
+Pre-fix the worker called only ``init_platform_embedding`` on startup,
+so the LLM singleton (built from ``PLATFORM_LLM_*``) stayed ``None``
+even when the env was correctly configured. Any enrich-request whose
+payload resolved to ``ProviderName.OPENAI`` (the default when the
+publisher omits ``enrichment_provider``) without a tenant openai key
+hit ``get_llm_provider("openai")`` → no key → ``get_platform_llm()``
+returned ``None`` → ``FakeLLMProvider``. The drift-recovery re-enrich
+on caura-ai (post-CAURA-641) silently corrupted ~5,000 rows before the
+bug surfaced.
+
+This test pins the invariant: opening the lifespan must call the
+combined ``init_platform_providers`` (which calls both
+``init_platform_embedding`` and the LLM init), not the embedding-only
+shim.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from core_worker.app import create_app
+
+
+def test_lifespan_calls_init_platform_providers():
+    """Opening the FastAPI app's lifespan must invoke
+    :func:`common.llm.init_platform_providers` exactly once.
+
+    The earlier code path called ``init_platform_embedding`` only —
+    fine for embeds (the dedicated embedding singleton was built), but
+    the LLM half of the platform tier was never materialised, so any
+    enrichment fall-through to platform-LLM returned ``None`` and the
+    enrichment service silently dropped to FakeLLMProvider.
+    """
+    bus = MagicMock()
+    bus.start = AsyncMock(return_value=None)
+    bus.stop = AsyncMock(return_value=None)
+    bus.is_healthy = True
+
+    with (
+        patch("core_worker.app.init_platform_providers") as init_mock,
+        patch("core_worker.app.configure_consumer"),
+        patch("core_worker.app.register_consumers"),
+        patch("core_worker.app.get_event_bus", return_value=bus),
+        patch("core_worker.app.close_storage_client", new=AsyncMock()),
+    ):
+        app = create_app()
+        # Use TestClient as a context manager to trigger the lifespan
+        # startup/shutdown without binding to a real port.
+        with TestClient(app):
+            pass
+
+        init_mock.assert_called_once_with()


### PR DESCRIPTION
## Summary

`core-worker/app.py` was calling `init_platform_embedding()` only — which builds the embedding singleton from `PLATFORM_EMBEDDING_*` but leaves the LLM singleton (built from `PLATFORM_LLM_*`) uninitialised. `handle_embed_request` works because it talks to the embedding singleton directly; `handle_enrich_request` does not — its fallback chain ends at `get_platform_llm()`, which returned `None`, and the registry silently dropped the call to `FakeLLMProvider` instead of using the configured platform LLM.

## How it bit prod

Surfaced during CAURA-643 option-3 re-enrichment of `caura-ai` (post-CAURA-641 drift recovery). With `PLATFORM_LLM_PROVIDER=vertex` and the project / model / location all correctly set on `prod-memclaw-core-worker`, every published enrich-request **still went through `FakeLLMProvider`** — the keyword heuristic re-derived `memory_type` / `summary` / `title` for ~5,000 rows before the bug was caught.

## Fix

```python
# Before
from common.embedding import init_platform_embedding
...
init_platform_embedding()

# After
from common.llm import init_platform_providers
...
init_platform_providers()  # builds BOTH platform singletons
```

Plus the lifespan comment block rewritten to call out the LLM-init invariant explicitly — the prior text described the embedding singleton as if it were the only platform tier the worker needed, which is exactly the assumption that produced the bug.

## Regression test

`core-worker/tests/test_lifespan_platform_init.py::test_lifespan_calls_init_platform_providers` — mocks the lifespan deps and asserts `init_platform_providers` is called exactly once on FastAPI startup. Direct guard against re-narrowing the lifespan back to embedding-only.

## Test plan

- [x] `pytest core-worker/tests/test_lifespan_platform_init.py -v` — passes
- [x] `pytest core-worker/tests/` — 60 pass (1 pre-existing failure unrelated to this PR)
- [x] `ruff check` + `ruff format --check` — clean
- [ ] CI green
- [ ] Once merged + deployed: re-publish enrich events for caura-ai → expect Vertex calls in worker logs (no `FakeLLMProvider` fallback warnings)

## Out of scope (CAURA-643 follow-up)

- Reconciling the ~5,000 already-fake-enriched caura-ai rows (PITR-restore or re-run option 3 after this fix lands)
- Sweep of other consumer-only services for the same lifespan gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)