### PR TITLE
chore(docs): finish tool-surface catch-up to 12 tools (CAURA-000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ curl -sf -H "X-API-Key: $MEMCLAW_KEY" \
 openclaw gateway restart
 ```
 
-The plugin claims the OpenClaw `memory` slot (replacing `memory-core`) and exposes the same 9 MCP tools. Full setup, agent prompts, and trust levels: [static/docs/integration-guide.md](static/docs/integration-guide.md).
+The plugin claims the OpenClaw `memory` slot (replacing `memory-core`) and exposes the same 12 MCP tools. Full setup, agent prompts, and trust levels: [static/docs/integration-guide.md](static/docs/integration-guide.md).
 
 ---
 

--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -1,5 +1,5 @@
 /**
- * MemClaw tool definitions — v1.0 consolidated surface (7 tools).
+ * MemClaw tool definitions — current surface (12 tools).
  *
  * One `createToolFromSpec(name)` factory wires together three sources:
  *

--- a/plugin/src/tools.ts
+++ b/plugin/src/tools.ts
@@ -7,9 +7,9 @@
  * MemClaw tools: …" line in the prompt section, and any downstream UI
  * that renders tools in discovery order.
  *
- * v1.0 surface: 7 tools (5 consolidated LTM + entity_get + tune).
- * Placeholders (share/insights/evolve) and STM tools are not exposed
- * via the plugin.
+ * Current surface: 12 tools — LTM (write/recall/list/manage), doc,
+ * entity_get, tune, insights, evolve, stats, share_skill, unshare_skill.
+ * STM tools are not exposed via the plugin.
  *
  * A boot-time drift check throws if this list and tools.json disagree.
  */

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -110,7 +110,7 @@ Options:
 
 Restart your agent after installing — skills are loaded at startup.
 
-Why this matters: without the skill, an agent can discover the 9 tool
+Why this matters: without the skill, an agent can discover the 12 tool
 names and their arg schemas via MCP `tools/list`, but it has no
 mental model for the two-store design (memory vs doc), the trust
 levels, or which op to reach for in an ambiguous situation. With the


### PR DESCRIPTION
## Summary

Follow-up to #73 ("catch up tool lists across docs + scripts"). That PR caught most of the docs, but missed README.md:238 and integration-guide.md:113. The plugin source headers (`tool-definitions.ts`, `tools.ts`) were also still describing the pre-stats v1.0 surface as "7 tools (5 consolidated LTM + entity_get + tune)" with a stale "share/insights/evolve are placeholders" comment — those have all been live tools since the v1.0 16→13 refactor and the `memclaw_stats` PR (#64).

## Changes

- `README.md:238` — "exposes the same 9 MCP tools" → 12 (line 307 of same file already said 12 — was self-contradicting)
- `static/docs/integration-guide.md:113` — "discover the 9 tool" → 12
- `plugin/src/tool-definitions.ts:2` — header `v1.0 consolidated surface (7 tools)` → `current surface (12 tools)`
- `plugin/src/tools.ts:10` — header `v1.0 surface: 7 tools (5 consolidated LTM + entity_get + tune)` → enumerated current 12; dropped the stale "Placeholders (share/insights/evolve) and STM tools are not exposed via the plugin" sentence (they all are now)

These are documentation/comment-only changes — no behavior change, no schema change, no test fixture impact. The 12-tool roster matches `plugin/tools.json` exactly.

## Test plan

- [ ] `grep -rE "\b(7|9) (MCP )?tool" README.md plugin/src static/docs` → nothing material
- [ ] `npm run build` in plugin/ — TypeScript still happy after header comment edits
- [ ] CI green (no functional changes; sanity check only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)