### PR TITLE
fix(core-worker): bundle Vertex SDK + improve retry log (CAURA-648)

### DIFF
--- a/common/llm/retry.py
+++ b/common/llm/retry.py
@@ -66,11 +66,12 @@ async def call_with_retry(
             if attempt < max_attempts - 1:
                 delay = base_delay * (attempt + 1)
                 logger.warning(
-                    "%s attempt %d/%d failed (%s), retrying in %.1fs",
+                    "%s attempt %d/%d failed (%s: %s), retrying in %.1fs",
                     label,
                     attempt + 1,
                     max_attempts,
                     type(exc).__name__,
+                    exc,
                     delay,
                 )
                 await asyncio.sleep(delay)

--- a/core-worker/Dockerfile
+++ b/core-worker/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY core-worker/pyproject.toml core-worker/README.md* ./core-worker/
 # Dummy src so setuptools find_packages doesn't fail
 RUN mkdir -p core-worker/src/core_worker && touch core-worker/src/core_worker/__init__.py
-RUN pip install --no-cache-dir './core-worker[pubsub]'
+RUN pip install --no-cache-dir './core-worker[pubsub,vertex]'
 
 # Copy actual source
 COPY common/ /app/common/

--- a/core-worker/pyproject.toml
+++ b/core-worker/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 # Standalone OSS installs use the in-process bus (no Pub/Sub at all —
 # core-api dispatches directly to the consumer in the same process).
 pubsub = ["google-cloud-pubsub>=2.23,<3"]
-vertex = ["google-cloud-aiplatform>=1.71,<2"]
+vertex = ["google-cloud-aiplatform>=1.71,<2", "vertexai>=1.60,<2"]
 local = ["sentence-transformers>=3.0,<4"]
 dev = [
     "core-worker[test,pubsub]",


### PR DESCRIPTION
## Summary

- core-worker prod image was missing the Vertex SDK (`google-cloud-aiplatform`, `vertexai`). With `PLATFORM_LLM_PROVIDER=vertex` set on prod, enrich-requests resolving through `get_platform_llm()` raised `ImportError` on the lazy `from vertexai.generative_models import …`, retried twice, and fell through the 3-tier chain to `FakeLLMProvider` — silently corrupting caura-ai re-enrichment metadata in the same shape as the original CAURA-643 disaster.
- Three minimal fixes: install `[pubsub,vertex]` in the worker Dockerfile, expand the `[vertex]` extra in `core-worker/pyproject.toml` to include `vertexai` (previously only `google-cloud-aiplatform` was listed; `vertex.py` imports `vertexai.generative_models`), and surface the actual exception message in the per-attempt retry WARNING log so the next regression of this shape is debuggable in seconds, not hours.

## Why this slipped through CAURA-647 / PR #74

PR #74 wired `init_platform_providers()` into the lifespan, which materializes the platform-LLM singleton from env vars. It worked — `Platform LLM: vertex/gemini-3.1-flash-lite-preview` shows up at startup on the new revision. The bug only fires later, when the SDK is actually imported (lazy in `_complete_*_sync`). The retry log line printed `(ImportError)` with no detail, so it took DB forensics to localize.

Prod damage: ~1,430 caura-ai rows were touched between publish-2 (17:13Z) and the seek-stop at 17:26:51Z and now hold FakeLLM output. After this PR deploys, a re-publish of caura-ai (4th and final attempt) will overwrite them with real Vertex Gemini output.

## Test plan

- [ ] `deploy-oss-services` rebuilds core-worker — verify `pip install … [pubsub,vertex]` succeeds in builder stage.
- [ ] On the new prod core-worker revision, startup logs show: `Platform LLM: vertex/gemini-3.1-flash-lite-preview (alpine-theory-469016-c8/global)` (no change from PR #74).
- [ ] After publishing an enrich-request, the worker log shows NO `enrichment-primary attempt 1/2 failed (ImportError: …)` lines.
- [ ] Sampled caura-ai row's `metadata.summary` is paragraph-coherent Gemini output, `llm_ms` is in the Vertex-shape range (~1-15s, not <100ms FakeLLM).
- [ ] Negative test: if I were to force an `ImportError` from a Vertex submodule, the new log line would now read `… failed (ImportError: cannot import name 'X' from 'vertexai…'), retrying in 1.0s` (with the module name visible). This is the observability win.

Closes CAURA-648.