### PR TITLE
test(plugin): expand 'all tool cards' SKILL.md test from 9 to 12 (CAURA-000)

### DIFF
--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -1127,12 +1127,13 @@ describe("shared SKILL.md (plugin/skills/memclaw/SKILL.md)", () => {
     assert.ok(skill.includes("### Error codes"), "missing ### Error codes");
   });
 
-  test("all 9 tool cards are present in SKILL.md", () => {
+  test("all 12 tool cards are present in SKILL.md", () => {
     const skill = readSharedSkill();
     for (const tool of [
       "memclaw_recall", "memclaw_write", "memclaw_manage", "memclaw_list",
       "memclaw_doc", "memclaw_entity_get", "memclaw_tune",
       "memclaw_insights", "memclaw_evolve",
+      "memclaw_stats", "memclaw_share_skill", "memclaw_unshare_skill",
     ]) {
       assert.ok(
         skill.includes(`**\`${tool}(`) || skill.includes(`\`${tool}(`),


### PR DESCRIPTION
## Summary

`educate.test.ts:1130` asserts SKILL.md contains a tool card for each tool in a hardcoded list — but the list only enumerated 9 of the 12 canonical tools. The test would silently pass even if `memclaw_stats` / `memclaw_share_skill` / `memclaw_unshare_skill` cards went missing from SKILL.md. Adding the 3 missing tools and renaming the test.

## What is *not* changed

The other `9 tools` / `10 tools` / `13 tools` strings in this test file are intentional legacy fixtures:

- `educate.test.ts:541` — v0.98.5 stale install fixture for the `writeEducationFiles` splice migration
- `educate.test.ts:639` — same migration test
- `educate.test.ts:810, 828, 952, 1010` — input data for `cleanupStaleHeartbeatEducation` (the function exists specifically to remove legacy "N tools" paragraphs from existing installs)
- `educate.test.ts:838-849` — explicitly tests N drift (`for (const n of [7, 9, 10, 13, 99])`)

Those are correct as-is.

## Test plan

- [ ] `npm test` in `plugin/` — the renamed test still passes (all 12 cards already exist in SKILL.md per #75)
- [ ] If we delete a card from SKILL.md the test now fails (the previous version wouldn't have caught the 3 newer tools)