### PR TITLE
fix(plugin-install): fetch openclaw.plugin.json instead of baking a HEREDOC

### DIFF
--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -48,9 +48,18 @@ _plugin_files = [
 # - tools.json: tool SoT, loaded by tool-specs.ts.
 # - skills/memclaw/SKILL.md: shared plugin skill, discovered by OpenClaw
 #   via openclaw.plugin.json:skills (one copy per node).
+# - openclaw.plugin.json: plugin manifest. Must be served (not baked into
+#   the install script as a HEREDOC) because the manifest changes
+#   periodically as OpenClaw evolves its plugin contract — e.g. the
+#   ``contracts.tools`` field became strictly enforced upstream on
+#   2026-05-01 (openclaw/openclaw@7641783d), and any user installing
+#   from a stale baked HEREDOC silently lost their entire MemClaw tool
+#   surface. Serving from disk keeps the manifest in lockstep with
+#   ``plugin/openclaw.plugin.json`` so the installer never falls behind.
 _plugin_root_files = {
     "tools.json",
     "skills/memclaw/SKILL.md",
+    "openclaw.plugin.json",
 }
 
 # Direct-MCP skill adapter. Lives under the repo-root ``static/`` tree
@@ -205,25 +214,19 @@ cat > "$PLUGIN_DIR/tsconfig.json" << 'TSCONFIG_EOF'
 }}
 TSCONFIG_EOF
 
-# 4. Write plugin manifest
-echo "[4/7] Writing openclaw.plugin.json..."
-cat > "$PLUGIN_DIR/openclaw.plugin.json" << MANIFEST_EOF
-{{
-  "id": "memclaw",
-  "name": "MemClaw",
-  "kind": "memory",
-  "type": "memory",
-  "version": "$MEMCLAW_VERSION",
-  "description": "Central persistent memory for OpenClaw agents — write, search, and entity lookup tools.",
-  "entry": "dist/index.js",
-  "skills": ["skills"],
-  "configSchema": {{
-    "type": "object",
-    "properties": {{}},
-    "required": []
-  }}
+# 4. Fetch plugin manifest from the server (single source of truth).
+# Previously this was a baked HEREDOC, which caused silent drift
+# whenever the canonical ``plugin/openclaw.plugin.json`` gained new
+# fields (notably ``contracts.tools``, required by OpenClaw upstream
+# from 2026-05-01) — the on-disk file in the repo had the field, but
+# the HEREDOC the installer wrote to fresh installs did not, so every
+# fresh install silently lost the tool surface. Fetching from
+# ``/plugin-source`` keeps the canonical file the only source.
+echo "[4/7] Fetching plugin manifest from $MEMCLAW_API_URL..."
+curl $CURL_INSECURE -sf "$MEMCLAW_API_URL/api/plugin-source?file=openclaw.plugin.json" > "$PLUGIN_DIR/openclaw.plugin.json" || {{
+  echo "ERROR: Could not fetch openclaw.plugin.json from $MEMCLAW_API_URL/api/plugin-source?file=openclaw.plugin.json"
+  exit 1
 }}
-MANIFEST_EOF
 
 # 5. Fetch latest plugin source from MemClaw server
 echo "[5/7] Fetching latest plugin source from $MEMCLAW_API_URL..."

--- a/tests/test_plugin_source_manifest.py
+++ b/tests/test_plugin_source_manifest.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
 
 from core_api.routes import plugin as plugin_mod
 
@@ -31,11 +30,7 @@ def _expected_source_files() -> set[str]:
     then overwrites it inline from the request's ``version`` parameter,
     but the fetch still happens for parity with the manifest).
     """
-    return {
-        p.name
-        for p in PLUGIN_SRC.glob("*.ts")
-        if not p.name.endswith(".test.ts")
-    }
+    return {p.name for p in PLUGIN_SRC.glob("*.ts") if not p.name.endswith(".test.ts")}
 
 
 def test_python_allow_list_matches_plugin_src():
@@ -81,4 +76,73 @@ def test_python_and_bash_lists_agree():
         f"_plugin_files and install-script loop disagree — "
         f"only-in-python={sorted(python_files - loop_files)}, "
         f"only-in-bash={sorted(loop_files - python_files)}."
+    )
+
+
+def test_install_script_does_not_bake_a_manifest_heredoc():
+    """The install script must NOT inline a manifest via HEREDOC.
+
+    Origin of this guard: in 2026-05 OpenClaw upstream made
+    ``contracts.tools`` strictly enforced in plugin manifests
+    (openclaw/openclaw@7641783d). caura-memclaw's
+    ``plugin/openclaw.plugin.json`` was updated to declare it, but the
+    install script's baked HEREDOC was left behind — so every fresh
+    ``curl /api/v1/install-plugin | bash`` produced a manifest without
+    ``contracts.tools``, which OpenClaw silently rejected, dropping the
+    entire MemClaw tool surface from the agent.
+
+    The structural fix was to serve the manifest via ``/plugin-source``
+    (single source of truth) and have the installer fetch it. This test
+    locks in that fix: any future regression that re-introduces an
+    inline HEREDOC for the manifest will fail here.
+    """
+    src = Path(plugin_mod.__file__).read_text(encoding="utf-8")
+    assert "MANIFEST_EOF" not in src, (
+        "Install script appears to bake openclaw.plugin.json via a HEREDOC "
+        "again. Don't — fetch from /plugin-source instead. See "
+        "_plugin_root_files in this module and the [4/7] step of the "
+        "install script template."
+    )
+
+
+def test_install_script_fetches_manifest_from_plugin_source():
+    """Step [4/7] must curl the manifest from /plugin-source."""
+    src = Path(plugin_mod.__file__).read_text(encoding="utf-8")
+    assert "/api/plugin-source?file=openclaw.plugin.json" in src, (
+        "Install script must fetch openclaw.plugin.json from "
+        "/api/plugin-source so the manifest stays in lockstep with the "
+        "canonical plugin/openclaw.plugin.json. See "
+        "test_install_script_does_not_bake_a_manifest_heredoc for context."
+    )
+
+
+def test_plugin_root_files_includes_manifest():
+    """``_plugin_root_files`` must include ``openclaw.plugin.json``."""
+    assert "openclaw.plugin.json" in plugin_mod._plugin_root_files, (
+        "openclaw.plugin.json must be in _plugin_root_files so the "
+        "/plugin-source endpoint serves it. The install script depends on "
+        "this — without it, fresh installs would fall back to a 404."
+    )
+
+
+def test_served_manifest_declares_contracts_tools():
+    """The on-disk manifest must declare ``contracts.tools``.
+
+    OpenClaw upstream rejects every ``api.registerTool`` call when this
+    field is missing (since 2026-05-01). The plugin TS suite has its
+    own drift test (tool-definitions.test.ts) that asserts the list
+    matches MEMCLAW_TOOLS exactly; this Python test only guards the
+    file-level invariant so a server-side test failure surfaces too
+    if someone deletes the field from the manifest file.
+    """
+    import json
+
+    manifest_path = REPO_ROOT / "plugin" / "openclaw.plugin.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    contracts = manifest.get("contracts", {})
+    tools = contracts.get("tools", [])
+    assert isinstance(tools, list) and len(tools) > 0, (
+        f"plugin/openclaw.plugin.json must declare contracts.tools — got "
+        f"{contracts!r}. OpenClaw rejects all api.registerTool calls "
+        "without it."
     )


### PR DESCRIPTION
## What broke

Every fresh canonical install (`curl /api/v1/install-plugin | bash`) since 2026-05-01 silently lost the entire MemClaw tool surface — 12 lines of `[plugins] plugin must declare contracts.tools before registering agent tools` per gateway startup, no MemClaw tools registered into agents.

## Why now

OpenClaw upstream changed its plugin contract on 2026-05-01 ([openclaw/openclaw@7641783d](https://github.com/openclaw/openclaw/commit/7641783d) — "fix: enforce plugin tool manifest contracts"). Manifests without `contracts.tools` started failing the `registerTool` gate strictly — previously a soft contract.

## Why caura-memclaw was broken

Two parallel "manifests":

1. `plugin/openclaw.plugin.json` (the file in the repo)
2. A HEREDOC inside `_install_plugin_script` in `core_api/routes/plugin.py`, baked into the bash installer

PR #77 added `contracts.tools` to (1). The HEREDOC at (2) was left untouched. Result: `pnpm gateway:dev` from a clone (which uses 1) worked; `curl install-plugin | bash` (which uses 2) didn't. My PR #77 e2e test path was clone-and-build, so it never exercised (2). The bug shipped.

## Structural fix

Eliminate the dual source. The install script already fetches every other plugin file (`plugin/src/*.ts`, `tools.json`, `skills/memclaw/SKILL.md`) from `/api/v1/plugin-source`. The manifest was the only file it baked inline. This PR:

1. Adds `"openclaw.plugin.json"` to `_plugin_root_files` so `/plugin-source` serves it.
2. Replaces the manifest HEREDOC at step [4/7] with a `curl` to `/api/plugin-source?file=openclaw.plugin.json`.

Now there's exactly one manifest source — the canonical file in the repo — distributed via the same path as every other plugin file. Future manifest changes reach fresh installs on the next deploy.

## Wet-tested with single-variable isolation

Reproduced the failure end-to-end against this PR's code, then verified the fix isolates to one file:

```
Before fix:
  rm -rf ~/.openclaw/plugins/memclaw
  curl /api/v1/install-plugin | bash
  openclaw gateway
  → 12 rejections, 0 tools registered

After fix (only file changed: openclaw.plugin.json on disk):
  rm -rf ~/.openclaw/plugins/memclaw
  curl /api/v1/install-plugin | bash
  openclaw gateway
  → 0 rejections, all 12 tools registered
```

73 plugin files SHA-256'd before and after — **only the manifest hash changed**. No JS/TS code changes required.

## Regression guards (4 new tests)

- `test_install_script_does_not_bake_a_manifest_heredoc` — re-introducing a baked manifest fails CI.
- `test_install_script_fetches_manifest_from_plugin_source` — locks the curl path in.
- `test_plugin_root_files_includes_manifest` — asserts the Python allowlist serves the manifest.
- `test_served_manifest_declares_contracts_tools` — asserts the on-disk manifest still declares the field. Complements the plugin TS drift test (`tool-definitions.test.ts`) that locks the list contents to `MEMCLAW_TOOLS`.

## Test plan

- [x] 7/7 `test_plugin_source_manifest.py` (4 new + 3 existing)
- [x] Wet-tested fresh install end-to-end
- [x] ruff + mypy clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)