### PR TITLE
refactor: rename tenant_settings → organization_settings (CAURA-654)

### DIFF
--- a/common/events/memory_enrich_publisher.py
+++ b/common/events/memory_enrich_publisher.py
@@ -38,7 +38,7 @@ async def publish_memory_enrich_request(
     ``tenant_config`` is a ``ResolvedConfig``-shaped object (or ``None``).
     The publisher reads the enrichment-relevant attributes off it and
     packs them into the payload so the worker doesn't need to import
-    ``core_api.services.tenant_settings``.
+    ``core_api.services.organization_settings``.
 
     ``agent_provided_fields`` lists the row's columns the agent set
     explicitly at write time. The worker uses it to skip overwriting

--- a/common/models/organization_settings.py
+++ b/common/models/organization_settings.py
@@ -1,4 +1,11 @@
-"""Per-tenant settings storage: live overrides + append-only audit trail."""
+"""Per-organization settings storage: live overrides + append-only audit trail.
+
+Renamed from ``tenant_settings`` in CAURA-654. The keying column is
+``org_id`` (text); semantically the value is the organization
+identifier in enterprise deployments and the tenant identifier
+acting as an implicit single-org key in OSS-standalone deployments
+(no ``organizations`` table in pure OSS).
+"""
 
 from datetime import datetime
 
@@ -9,12 +16,12 @@ from sqlalchemy.orm import Mapped, mapped_column
 from common.models.base import Base
 
 
-class TenantSettings(Base):
-    """Live tenant overrides — one row per tenant, JSONB holds only overrides."""
+class OrganizationSettings(Base):
+    """Live organization overrides — one row per org, JSONB holds only overrides."""
 
-    __tablename__ = "tenant_settings"
+    __tablename__ = "organization_settings"
 
-    tenant_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    org_id: Mapped[str] = mapped_column(Text, primary_key=True)
     settings: Mapped[dict] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )
@@ -26,20 +33,20 @@ class TenantSettings(Base):
     )
 
 
-class TenantSettingsAudit(Base):
+class OrganizationSettingsAudit(Base):
     """Append-only per-change audit trail. One row per PUT /settings that changes a value."""
 
-    __tablename__ = "tenant_settings_audit"
+    __tablename__ = "organization_settings_audit"
     __table_args__ = (
         Index(
-            "idx_tenant_settings_audit_tenant_created",
-            "tenant_id",
+            "idx_organization_settings_audit_org_created",
+            "org_id",
             text("created_at DESC"),
         ),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
-    tenant_id: Mapped[str] = mapped_column(Text, nullable=False)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False)
     changed_by: Mapped[str | None] = mapped_column(Text)
     diff: Mapped[dict] = mapped_column(JSONB, nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -288,7 +288,7 @@ class Settings(BaseSettings):
 
     # Security audit — scheduler + threshold alerts. Enterprise-only feature;
     # OSS standalone deployments can leave these at defaults (all off).
-    # Per-tenant overrides live in tenant_settings.security_audit.
+    # Per-org overrides live in organization_settings.security_audit.
     security_audit_schedule_enabled: bool = False
     security_audit_schedule_cron: str = "0 2 * * *"  # daily 02:00 by default
     security_audit_alerts_enabled: bool = False

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -253,7 +253,7 @@ async def memclaw_recall(
         try:
             await check_and_increment(db, tenant_id, "search")
             from core_api.repositories import agent_repo
-            from core_api.services.tenant_settings import resolve_config
+            from core_api.services.organization_settings import resolve_config
 
             config = await resolve_config(db, tenant_id)
             _ag = await agent_repo.get_by_id(db, agent_id, tenant_id)
@@ -726,7 +726,7 @@ async def memclaw_tune(
             current = (agent.get("search_profile") if isinstance(agent, dict) else agent.search_profile) or {}
             if updates:
                 current.update(updates)
-                from core_api.services.tenant_settings import validate_search_profile
+                from core_api.services.organization_settings import validate_search_profile
 
                 current = validate_search_profile(current)
                 await agent_repo.update_search_profile(db, agent.id, current)

--- a/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
+++ b/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
@@ -22,7 +22,7 @@ class ResolveSearchProfile:
         return "resolve_search_profile"
 
     async def execute(self, ctx: PipelineContext) -> StepResult | None:
-        from core_api.services.tenant_settings import validate_search_profile
+        from core_api.services.organization_settings import validate_search_profile
 
         search_profile = ctx.data.get("search_profile")
         sp = validate_search_profile(search_profile) if search_profile else {}

--- a/core-api/src/core_api/pipeline/steps/write/load_tenant_config.py
+++ b/core-api/src/core_api/pipeline/steps/write/load_tenant_config.py
@@ -12,7 +12,7 @@ class LoadTenantConfig:
         return "load_tenant_config"
 
     async def execute(self, ctx: PipelineContext) -> StepResult | None:
-        from core_api.services.tenant_settings import resolve_config
+        from core_api.services.organization_settings import resolve_config
 
         data = ctx.data["input"]
         tenant_config = await resolve_config(ctx.require_db, data.tenant_id)

--- a/core-api/src/core_api/routes/agents.py
+++ b/core-api/src/core_api/routes/agents.py
@@ -7,7 +7,7 @@ from core_api.db.session import get_db
 from core_api.schemas import AgentOut, AgentTrustUpdate, SearchProfileUpdate
 from core_api.services.agent_service import update_trust_level
 from core_api.services.audit_service import log_action
-from core_api.services.tenant_settings import validate_search_profile
+from core_api.services.organization_settings import validate_search_profile
 
 router = APIRouter(tags=["Admin"])
 

--- a/core-api/src/core_api/routes/crystallizer.py
+++ b/core-api/src/core_api/routes/crystallizer.py
@@ -54,7 +54,7 @@ async def trigger_crystallization(
 ):
     """Trigger crystallization for a tenant (analysis + auto-curate)."""
     auth.enforce_tenant(body.tenant_id)
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     config = await resolve_config(db, body.tenant_id)
     report_id = await run_crystallization(
@@ -80,7 +80,7 @@ async def trigger_crystallization_all(
     tenant_ids = [get_standalone_tenant_id()]
     reports = []
     for tid in tenant_ids:
-        from core_api.services.tenant_settings import resolve_config
+        from core_api.services.organization_settings import resolve_config
 
         config = await resolve_config(db, tid)
         report_id = await run_crystallization(

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -777,7 +777,7 @@ async def _write_memory_inner(
     db: AsyncSession,
     idem: IdempotencyGuard | None,
 ):
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     write_config = await resolve_config(db, body.tenant_id)
     agent = await get_or_create_agent(
@@ -1198,7 +1198,7 @@ async def _search_inner(
     if usage:
         response.headers["X-RateLimit-Limit"] = str(usage.get("limit", "unlimited"))
         response.headers["X-RateLimit-Remaining"] = str(usage.get("remaining", "unlimited"))
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     t_start = time.perf_counter()
     success = True

--- a/core-api/src/core_api/routes/settings.py
+++ b/core-api/src/core_api/routes/settings.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core_api.auth import AuthContext, get_auth_context
 from core_api.db.session import get_db
-from core_api.services.tenant_settings import (
+from core_api.services.organization_settings import (
     PROVIDER_OPTIONS,
     get_settings_for_display,
     update_settings,

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -86,7 +86,7 @@ async def detect_contradictions_async(
     so a soft-delete that landed AFTER the caller's fetch but BEFORE
     detection runs cleanly aborts.
     """
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     try:
         if new_memory is None:
@@ -390,7 +390,7 @@ async def detect_contradictions_by_entities_async(
     contradictions via LLM -- catches by-the-way updates that embedding
     similarity misses.
     """
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     try:
         sc = get_storage_client()

--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -267,7 +267,7 @@ async def _run_crystallization(
     hygiene: dict,
 ) -> dict:
     """Identify clusters of noisy/redundant memories and crystallize them via LLM."""
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     config = await resolve_config(db, tenant_id)
 

--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -76,7 +76,7 @@ async def process_entity_extraction(
 
         try:
             # Resolve tenant config for per-tenant blocklist
-            from core_api.services.tenant_settings import resolve_config
+            from core_api.services.organization_settings import resolve_config
 
             tenant_cfg = await resolve_config(None, tenant_id)
             blocklist = tenant_cfg.entity_blocklist

--- a/core-api/src/core_api/services/evolve_service.py
+++ b/core-api/src/core_api/services/evolve_service.py
@@ -339,7 +339,7 @@ async def _generate_rule(
     """
     from core_api.clients.storage_client import get_storage_client
     from core_api.providers._retry import call_with_fallback
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     sc = get_storage_client()
     config = await resolve_config(db, tenant_id)

--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -111,7 +111,7 @@ async def _fetch_url_text(url: str) -> str:
 
 async def ingest_preview(db: AsyncSession, request: IngestRequest) -> dict:
     """Preview mode: extract facts from URL or text without writing anything."""
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     tenant_config = await resolve_config(db, request.tenant_id)
 

--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -919,7 +919,7 @@ async def generate_insights(
         }
 
     # 2. Resolve tenant config for LLM provider
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     config = await resolve_config(db, tenant_id)
 

--- a/core-api/src/core_api/services/lifecycle_service.py
+++ b/core-api/src/core_api/services/lifecycle_service.py
@@ -25,7 +25,7 @@ async def lifecycle_scheduler() -> None:
 
 async def _run_lifecycle_cycle() -> None:
     """Run lifecycle automation for all tenants."""
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
     from core_api.standalone import get_standalone_tenant_id
 
     tenant_ids = [get_standalone_tenant_id()]
@@ -53,7 +53,7 @@ async def run_lifecycle_for_tenant(
     stale_count = await _archive_stale_memories(tenant_id, fleet_id)
 
     crystal_triggered = False
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     config = await resolve_config(None, tenant_id)
 

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -235,7 +235,7 @@ async def _create_memory_pipeline(db: AsyncSession, data: MemoryCreate) -> Memor
         build_strong_write_pipeline,
     )
     from core_api.pipeline.context import PipelineContext
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     # STM branch: bypass tenant config resolution and LTM pipelines entirely
     if data.write_mode == "stm":
@@ -498,7 +498,7 @@ async def _create_memory_legacy(db: AsyncSession, data: MemoryCreate) -> MemoryO
     sc = get_storage_client()
     t0 = time.perf_counter()
     # -- Resolve per-tenant LLM config (falls back to global) --
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     tenant_config = await resolve_config(db, data.tenant_id)
 
@@ -969,7 +969,7 @@ async def create_memories_bulk(
     }
 
     # -- Resolve per-tenant config once --
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     tenant_config = await resolve_config(db, data.tenant_id)
 
@@ -1635,7 +1635,7 @@ async def _reembed_memory(
     delay — thundering herd.
     """
     from core_api.constants import EMBEDDING_REEMBED_DELAY_S
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     if settings.embed_on_hot_path or is_failure_fallback:
         # Two paths land here: pre-offload legacy behaviour (flag on,
@@ -1743,7 +1743,7 @@ async def _reembed_memories_bulk(
     some rows without embeddings forever.
     """
     from core_api.services.contradiction_detector import detect_contradictions_async
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     if not items:
         return
@@ -1939,8 +1939,8 @@ async def _enrich_memory_background(
     as sub-tasks.
     """
     from core_api.services.memory_enrichment import enrich_memory
+    from core_api.services.organization_settings import resolve_config
     from core_api.services.task_tracker import tracked_task
-    from core_api.services.tenant_settings import resolve_config
 
     try:
         tenant_config = await resolve_config(None, tenant_id)
@@ -2252,7 +2252,7 @@ async def update_memory(
     agent_id: str | None = None,
 ) -> MemoryOut:
     """Update a memory. Re-embeds and re-extracts entities if content changes."""
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     sc = get_storage_client()
     mem = await sc.get_memory_for_tenant(tenant_id, str(memory_id))
@@ -3000,7 +3000,7 @@ async def _search_memories_legacy(
     sc = get_storage_client()
 
     # Resolve per-agent search profile with fallback to constants
-    from core_api.services.tenant_settings import validate_search_profile
+    from core_api.services.organization_settings import validate_search_profile
 
     sp = validate_search_profile(search_profile) if search_profile else {}
     _top_k = sp.get("top_k", top_k)

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -1,16 +1,22 @@
-"""Per-tenant settings — storage + resolution.
+"""Per-organization settings — storage + resolution.
 
-Settings are stored as a JSONB blob in ``tenant_settings`` (one row per tenant,
-overrides only). Every update additionally writes a flat diff to
-``tenant_settings_audit`` for attribution and history.
+Settings are stored as a JSONB blob in ``organization_settings`` (one row
+per organization, overrides only). Every update additionally writes a flat
+diff to ``organization_settings_audit`` for attribution and history.
 
 Resolution order for any value:
-    tenant override (cached) → global env default (``core_api.config.Settings``)
+    org override (cached) → global env default (``core_api.config.Settings``)
     → hardcoded Pydantic default
 
-Reads go through a per-process ``TTLCache`` (5-min TTL). Writes invalidate the
-local cache entry immediately; other workers catch up on TTL expiry. Cross-worker
-invalidation is tracked as a follow-up (see CAURA-571).
+The function parameters here are still named ``tenant_id`` for call-site
+back-compat (CAURA-654) — the value is treated as the org-key internally.
+In OSS-standalone the tenant_id IS the org_id (single implicit org per
+tenant); in enterprise callers should pass the actual org_id (parameter
+rename to ``org_id`` is a follow-up that will touch ~20 call sites).
+
+Reads go through a per-process ``TTLCache`` (5-min TTL). Writes invalidate
+the local cache entry immediately; other workers catch up on TTL expiry.
+Cross-worker invalidation is tracked as a follow-up (see CAURA-571).
 """
 
 from __future__ import annotations
@@ -24,7 +30,7 @@ from sqlalchemy import func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from common.models.tenant_settings import TenantSettings, TenantSettingsAudit
+from common.models.organization_settings import OrganizationSettings, OrganizationSettingsAudit
 from common.provider_names import ProviderName
 from core_api.config import settings as global_settings
 
@@ -178,7 +184,7 @@ def _remap_vertex(provider: str) -> str:
     return provider
 
 
-# ── TTL cache: tenant_id → settings dict ──
+# ── TTL cache: org_id → settings dict ──
 #
 # Per-process cache; each uvicorn worker has its own. Staleness across workers
 # is bounded by the TTL (5 min). Writes on the current worker invalidate
@@ -295,10 +301,19 @@ def _validate_leaf_types(payload: dict, prefix: str = "") -> None:
 
 
 class ResolvedConfig:
-    """Resolves LLM/feature config from tenant overrides + global fallbacks."""
+    """Resolves LLM/feature config from organization overrides + global fallbacks."""
 
-    def __init__(self, tenant_settings: dict | None = None):
-        self._ts = tenant_settings or {}
+    def __init__(
+        self,
+        org_settings: dict | None = None,
+        tenant_settings: dict | None = None,
+    ):
+        # ``tenant_settings`` is a back-compat alias for callers that
+        # still pass the pre-CAURA-654 keyword. Silently absorbs them
+        # rather than raising TypeError; consistent with the module
+        # docstring's promise to keep call-site signatures stable until
+        # the parameter rename follow-up lands.
+        self._ts = org_settings or tenant_settings or {}
 
     # Enrichment
     @property
@@ -588,7 +603,7 @@ def validate_search_profile(profile: dict) -> dict:
 def invalidate_cache(tenant_id: str) -> None:
     """Evict a tenant's cached settings. Exposed for tests + future NOTIFY hook."""
     _settings_cache.pop(tenant_id, None)
-    logger.info("tenant_settings cache invalidated for %s", tenant_id)
+    logger.info("organization_settings cache invalidated for %s", tenant_id)
 
 
 async def resolve_config(db: AsyncSession | None, tenant_id: str) -> ResolvedConfig:
@@ -620,7 +635,7 @@ async def get_raw_settings(db: AsyncSession | None, tenant_id: str) -> dict:
     """
     cached = _settings_cache.get(tenant_id)
     if cached is not None:
-        logger.debug("tenant_settings cache hit for %s", tenant_id)
+        logger.debug("organization_settings cache hit for %s", tenant_id)
         return cached
 
     if db is None:
@@ -637,11 +652,13 @@ async def get_raw_settings(db: AsyncSession | None, tenant_id: str) -> dict:
 
 
 async def _load_and_cache(db: AsyncSession, tenant_id: str) -> dict:
-    result = await db.execute(select(TenantSettings.settings).where(TenantSettings.tenant_id == tenant_id))
+    result = await db.execute(
+        select(OrganizationSettings.settings).where(OrganizationSettings.org_id == tenant_id)
+    )
     row = result.scalar_one_or_none()
     resolved = row if isinstance(row, dict) else {}
     _settings_cache[tenant_id] = resolved
-    logger.info("tenant_settings cache miss for %s; loaded from DB and cached", tenant_id)
+    logger.info("organization_settings cache miss for %s; loaded from DB and cached", tenant_id)
     return resolved
 
 
@@ -674,7 +691,9 @@ async def update_settings(
     # stale cache entry, and this path is rare compared to reads.
     # FOR UPDATE prevents lost-update races under concurrent writes for the same tenant.
     result = await db.execute(
-        select(TenantSettings.settings).where(TenantSettings.tenant_id == tenant_id).with_for_update()
+        select(OrganizationSettings.settings)
+        .where(OrganizationSettings.org_id == tenant_id)
+        .with_for_update()
     )
     current_row = result.scalar_one_or_none()
     current: dict = current_row if isinstance(current_row, dict) else {}
@@ -690,18 +709,18 @@ async def update_settings(
     # inserts (no row yet) use JSONB || to merge at the DB level so two racing
     # inserts don't silently overwrite each other. The shallow || merge is safe
     # because top-level schema keys (enrichment, recall, …) are independent.
-    upsert = pg_insert(TenantSettings).values(tenant_id=tenant_id, settings=merged)
+    upsert = pg_insert(OrganizationSettings).values(org_id=tenant_id, settings=merged)
     await db.execute(
         upsert.on_conflict_do_update(
-            index_elements=["tenant_id"],
+            index_elements=["org_id"],
             set_={
-                "settings": text("tenant_settings.settings || EXCLUDED.settings"),
+                "settings": text("organization_settings.settings || EXCLUDED.settings"),
                 "updated_at": func.now(),
             },
         )
     )
     await db.execute(
-        pg_insert(TenantSettingsAudit).values(tenant_id=tenant_id, changed_by=changed_by, diff=diff)
+        pg_insert(OrganizationSettingsAudit).values(org_id=tenant_id, changed_by=changed_by, diff=diff)
     )
     await db.commit()
 

--- a/core-api/src/core_api/services/recall_service.py
+++ b/core-api/src/core_api/services/recall_service.py
@@ -85,7 +85,7 @@ async def recall(
     t0 = time.perf_counter()
 
     # Search for relevant memories
-    from core_api.services.tenant_settings import resolve_config
+    from core_api.services.organization_settings import resolve_config
 
     config = await resolve_config(db, tenant_id)
     diagnostic_ctx: dict = {} if diagnostic else {}

--- a/core-storage-api/src/core_storage_api/database/migrations/env.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/env.py
@@ -25,7 +25,7 @@ from common.models.analysis_report import CrystallizationReport  # noqa: F401
 from common.models.fleet import FleetNode, FleetCommand  # noqa: F401
 from common.models.document import Document  # noqa: F401
 from common.models.background_task import BackgroundTaskLog  # noqa: F401
-from common.models.tenant_settings import TenantSettings, TenantSettingsAudit  # noqa: F401
+from common.models.organization_settings import OrganizationSettings, OrganizationSettingsAudit  # noqa: F401
 from sqlalchemy.ext.asyncio import create_async_engine
 
 

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/014_rename_tenant_settings_to_organization_settings.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/014_rename_tenant_settings_to_organization_settings.py
@@ -1,0 +1,156 @@
+"""Rename ``tenant_settings`` and ``tenant_settings_audit`` to
+``organization_settings`` and ``organization_settings_audit``, swapping
+the keying column from ``tenant_id`` to ``org_id``.
+
+Why. All current settings (crystallizer, security_audit, lifecycle,
+etc.) are conceptually per-organization. The legacy per-tenant table
+holds zero rows in prod (verified empirically) and the admin UI is
+already org-scoped. Moving storage to match the conceptual model now
+avoids a fan-out / migration story later when settings become
+populated.
+
+OSS-standalone compatibility. Pure-OSS deployments don't have an
+``organizations`` table — that's an enterprise-side concept. The
+``org_id`` column stays ``text`` (matching today's ``tenant_id text``
+shape) with NO foreign-key constraint, so the schema works in both:
+
+* OSS standalone: callers pass ``tenant_id`` as the org-key (single
+  implicit org per tenant — no real org concept exists).
+* Enterprise: callers pass the real ``org_id`` (string-form UUID from
+  the user's auth context); multiple member tenants under the same org
+  share one settings row, which is the desired behaviour.
+
+Migration shape: rename → create → copy → drop. Even though prod has
+zero rows today, the pattern is data-preserving by construction so any
+local/dev DB with overrides survives the upgrade. Each step:
+
+  1. Rename ``tenant_settings`` → ``tenant_settings_old`` (and audit
+     siblings). The rename is atomic and preserves data and indexes.
+  2. Create the new ``organization_settings`` / ``..._audit`` tables.
+  3. ``INSERT … SELECT`` from the renamed legacy tables — no-op when
+     empty, copies rows verbatim when present. The audit table's
+     ``id`` is intentionally not preserved so the new table starts
+     its sequence at 1; audit ordering is via ``created_at`` and
+     nothing references ``audit.id`` as a foreign key.
+  4. Drop the renamed legacy tables. Whole migration is one
+     transaction (alembic default), so a failure between any two
+     steps rolls back cleanly.
+
+``downgrade()`` is symmetric — rename forward → create legacy → copy
+back → drop forward — so time-travel testing works either direction.
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-05-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "014"
+down_revision: str | None = "013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE tenant_settings RENAME TO tenant_settings_old")
+    op.execute("ALTER TABLE tenant_settings_audit RENAME TO tenant_settings_audit_old")
+    op.execute(
+        "ALTER INDEX idx_tenant_settings_audit_tenant_created "
+        "RENAME TO idx_tenant_settings_audit_old_tenant_created"
+    )
+
+    op.create_table(
+        "organization_settings",
+        sa.Column("org_id", sa.Text(), primary_key=True),
+        sa.Column("settings", JSONB, nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_table(
+        "organization_settings_audit",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("changed_by", sa.Text()),
+        sa.Column("diff", JSONB, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.execute(
+        "CREATE INDEX idx_organization_settings_audit_org_created "
+        "ON organization_settings_audit (org_id, created_at DESC)"
+    )
+
+    op.execute(
+        "INSERT INTO organization_settings (org_id, settings, updated_at) "
+        "SELECT tenant_id, settings, updated_at FROM tenant_settings_old"
+    )
+    op.execute(
+        "INSERT INTO organization_settings_audit (org_id, changed_by, diff, created_at) "
+        "SELECT tenant_id, changed_by, diff, created_at FROM tenant_settings_audit_old"
+    )
+
+    op.drop_table("tenant_settings_audit_old")
+    op.drop_table("tenant_settings_old")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE organization_settings RENAME TO organization_settings_old")
+    op.execute("ALTER TABLE organization_settings_audit RENAME TO organization_settings_audit_old")
+    op.execute(
+        "ALTER INDEX idx_organization_settings_audit_org_created "
+        "RENAME TO idx_organization_settings_audit_old_org_created"
+    )
+
+    op.create_table(
+        "tenant_settings",
+        sa.Column("tenant_id", sa.Text(), primary_key=True),
+        sa.Column("settings", JSONB, nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_table(
+        "tenant_settings_audit",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("changed_by", sa.Text()),
+        sa.Column("diff", JSONB, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.execute(
+        "CREATE INDEX idx_tenant_settings_audit_tenant_created "
+        "ON tenant_settings_audit (tenant_id, created_at DESC)"
+    )
+
+    op.execute(
+        "INSERT INTO tenant_settings (tenant_id, settings, updated_at) "
+        "SELECT org_id, settings, updated_at FROM organization_settings_old"
+    )
+    op.execute(
+        "INSERT INTO tenant_settings_audit (tenant_id, changed_by, diff, created_at) "
+        "SELECT org_id, changed_by, diff, created_at FROM organization_settings_audit_old"
+    )
+
+    op.drop_table("organization_settings_audit_old")
+    op.drop_table("organization_settings_old")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def _import_all_models():
     import common.models.fleet  # noqa: F401
     import common.models.document  # noqa: F401
     import common.models.background_task  # noqa: F401
-    import common.models.tenant_settings  # noqa: F401
+    import common.models.organization_settings  # noqa: F401
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -9,7 +9,7 @@ Unit tests validate:
 import pytest
 
 from core_api.constants import CHUNKING_THRESHOLD_CHARS, MAX_CONTENT_LENGTH
-from core_api.services.tenant_settings import DEFAULT_SETTINGS, ResolvedConfig
+from core_api.services.organization_settings import DEFAULT_SETTINGS, ResolvedConfig
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_contradiction_providers.py
+++ b/tests/test_contradiction_providers.py
@@ -229,24 +229,24 @@ class TestTenantSettingsKeys:
     """Verify ResolvedConfig has anthropic/openrouter key properties."""
 
     def test_anthropic_key_from_settings(self):
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
 
         config = ResolvedConfig({"api_keys": {}})
         # Falls back to global (None or empty string)
         assert not config.anthropic_api_key
 
     def test_openrouter_key_from_settings(self):
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
 
         config = ResolvedConfig({"api_keys": {}})
         assert config.openrouter_api_key is None
 
     def test_has_anthropic_property(self):
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
 
         assert hasattr(ResolvedConfig, "anthropic_api_key")
 
     def test_has_openrouter_property(self):
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
 
         assert hasattr(ResolvedConfig, "openrouter_api_key")

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -190,7 +190,7 @@ async def test_reembed_skips_initial_sleep_when_flag_off() -> None:
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.memory_service.asyncio.sleep", new=_fake_sleep),
         patch.object(memory_service, "track_task"),
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memory(uuid.uuid4(), "hello", TENANT_ID)
     assert slept == [], "flag-off path must not sleep before the first embed attempt"
@@ -218,7 +218,7 @@ async def test_reembed_sleeps_on_failure_path_when_flag_on() -> None:
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.memory_service.asyncio.sleep", new=_fake_sleep),
         patch.object(memory_service, "track_task"),
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memory(uuid.uuid4(), "hello", TENANT_ID)
     assert slept and slept[0] == EMBEDDING_REEMBED_DELAY_S
@@ -252,7 +252,7 @@ async def test_reembed_schedules_contradiction_after_success() -> None:
         patch("core_api.services.memory_service.asyncio.sleep", new=_noop_sleep),
         patch.object(memory_service, "track_task"),
         patch.object(memory_service, "tracked_task", new=MagicMock(side_effect=_stub_tracked_task)) as tracked,
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memory(uuid.uuid4(), "hello", TENANT_ID)
 
@@ -291,7 +291,7 @@ async def test_reembed_race_guard_fires_with_flag_on_too() -> None:
         patch("core_api.services.memory_service.asyncio.sleep", new=_noop_sleep),
         patch.object(memory_service, "track_task"),
         patch.object(memory_service, "tracked_task", new=MagicMock(side_effect=_stub_tracked_task)) as tracked,
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memory(uuid.uuid4(), "hello", TENANT_ID)
 
@@ -342,7 +342,7 @@ async def test_reembed_respects_existing_embedding_from_enrich_race() -> None:
         patch("core_api.services.contradiction_detector.detect_contradictions_async", new=_fake_detect),
         patch.object(memory_service, "track_task"),
         patch.object(memory_service, "tracked_task", new=MagicMock(side_effect=_stub_tracked_task)) as tracked,
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memory(uuid.uuid4(), "hello", TENANT_ID)
 
@@ -387,7 +387,7 @@ async def test_bulk_reembed_preserves_batching() -> None:
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch.object(memory_service, "track_task"),
         patch.object(memory_service, "tracked_task", new=MagicMock(side_effect=_stub_tracked_task)) as tracked,
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memories_bulk(items, TENANT_ID)
 
@@ -481,7 +481,7 @@ async def test_enrich_fires_contradiction_when_overwriting_existing_embedding() 
             new=MagicMock(side_effect=_stub_tracked_task),
         ) as tracked,
         patch(
-            "core_api.services.tenant_settings.resolve_config",
+            "core_api.services.organization_settings.resolve_config",
             new=AsyncMock(
                 return_value=SimpleNamespace(
                     enrichment_enabled=True,
@@ -565,7 +565,7 @@ async def test_enrich_no_contradiction_when_no_prior_embedding() -> None:
             new=MagicMock(side_effect=_stub_tracked_task),
         ) as tracked,
         patch(
-            "core_api.services.tenant_settings.resolve_config",
+            "core_api.services.organization_settings.resolve_config",
             new=AsyncMock(
                 return_value=SimpleNamespace(
                     enrichment_enabled=True,
@@ -611,7 +611,7 @@ async def test_reembed_is_failure_fallback_triggers_backoff() -> None:
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.memory_service.asyncio.sleep", new=_fake_sleep),
         patch.object(memory_service, "track_task"),
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memory(
             uuid.uuid4(), "hello", TENANT_ID, is_failure_fallback=True
@@ -650,7 +650,7 @@ async def test_bulk_reembed_fallback_passes_is_failure_fallback() -> None:
         patch.object(memory_service, "_reembed_memory", new=_capture),
         patch.object(memory_service, "track_task"),
         patch.object(memory_service, "tracked_task", new=MagicMock(side_effect=_stub_tracked_task)),
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         items = [(uuid.uuid4(), f"m{i}") for i in range(3)]
         await memory_service._reembed_memories_bulk(items, TENANT_ID)
@@ -693,7 +693,7 @@ async def test_bulk_reembed_fallback_catches_unexpected_exception_types() -> Non
         patch.object(memory_service, "_reembed_memory", new=_capture),
         patch.object(memory_service, "track_task"),
         patch.object(memory_service, "tracked_task", new=MagicMock(side_effect=_stub_tracked_task)),
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         items = [(uuid.uuid4(), f"m{i}") for i in range(3)]
         await memory_service._reembed_memories_bulk(items, TENANT_ID)
@@ -746,7 +746,7 @@ async def test_bulk_reembed_reschedules_items_whose_get_memory_failed() -> None:
         # binding (not a local re-import like _enrich_memory_background),
         # so we patch memory_service.tracked_task directly.
         patch.object(memory_service, "tracked_task", new=MagicMock(side_effect=_stub_tracked_task)) as tracked,
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memories_bulk(
             [(mem_a_id, "body a"), (mem_b_id, "body b")], TENANT_ID
@@ -805,7 +805,7 @@ async def test_bulk_reembed_patch_failure_reschedules_item() -> None:
         patch("core_api.services.contradiction_detector.detect_contradictions_async", new=_fake_detect),
         patch.object(memory_service, "track_task"),
         patch.object(memory_service, "tracked_task", new=MagicMock(side_effect=_stub_tracked_task)) as tracked,
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memories_bulk(
             [(mem_a_id, "body a"), (mem_b_id, "body b")], TENANT_ID
@@ -869,7 +869,7 @@ async def test_bulk_reembed_respects_existing_embedding_per_item() -> None:
         patch("core_api.services.contradiction_detector.detect_contradictions_async", new=_fake_detect),
         patch.object(memory_service, "track_task"),
         patch.object(memory_service, "tracked_task", new=MagicMock(side_effect=_stub_tracked_task)),
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memories_bulk(
             [(mem_a_id, "body a"), (mem_b_id, "body b")], TENANT_ID
@@ -912,7 +912,7 @@ async def test_bulk_reembed_falls_back_on_length_mismatch() -> None:
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch.object(memory_service, "track_task"),
         patch.object(memory_service, "tracked_task", new=MagicMock(side_effect=_stub_tracked_task)) as tracked,
-        patch("core_api.services.tenant_settings.resolve_config", new=AsyncMock(return_value=None)),
+        patch("core_api.services.organization_settings.resolve_config", new=AsyncMock(return_value=None)),
     ):
         await memory_service._reembed_memories_bulk(items, TENANT_ID)
 

--- a/tests/test_entity_linking_wiring.py
+++ b/tests/test_entity_linking_wiring.py
@@ -35,7 +35,7 @@ def _fake_config(**overrides):
 
 @pytest.mark.asyncio
 @patch("core_api.services.lifecycle_service.get_storage_client")
-@patch("core_api.services.tenant_settings.resolve_config", new_callable=AsyncMock)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
 async def test_lifecycle_runs_entity_linking_when_enabled(
     mock_resolve,
     mock_sc_factory,
@@ -76,7 +76,7 @@ async def test_lifecycle_runs_entity_linking_when_enabled(
 
 @pytest.mark.asyncio
 @patch("core_api.services.lifecycle_service.get_storage_client")
-@patch("core_api.services.tenant_settings.resolve_config", new_callable=AsyncMock)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
 async def test_lifecycle_skips_entity_linking_when_disabled(
     mock_resolve,
     mock_sc_factory,
@@ -117,7 +117,7 @@ async def test_lifecycle_skips_entity_linking_when_disabled(
     "core_api.services.entity_extraction_worker.extract_entities_from_content",
     new_callable=AsyncMock,
 )
-@patch("core_api.services.tenant_settings.resolve_config", new_callable=AsyncMock)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
 async def test_extraction_triggers_cross_links_when_enabled(
     mock_resolve,
     mock_extract,
@@ -187,7 +187,7 @@ async def test_extraction_triggers_cross_links_when_enabled(
     "core_api.services.entity_extraction_worker.extract_entities_from_content",
     new_callable=AsyncMock,
 )
-@patch("core_api.services.tenant_settings.resolve_config", new_callable=AsyncMock)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
 async def test_extraction_skips_cross_links_when_disabled(
     mock_resolve,
     mock_extract,
@@ -256,7 +256,7 @@ async def test_extraction_skips_cross_links_when_disabled(
     "core_api.services.entity_extraction_worker.extract_entities_from_content",
     new_callable=AsyncMock,
 )
-@patch("core_api.services.tenant_settings.resolve_config", new_callable=AsyncMock)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
 async def test_extraction_cross_link_failure_is_nonfatal(
     mock_resolve,
     mock_extract,

--- a/tests/test_lifecycle_automation.py
+++ b/tests/test_lifecycle_automation.py
@@ -40,22 +40,22 @@ class TestLifecycleTenantSettings:
     """Verify lifecycle tenant setting integration."""
 
     def test_enabled_by_default(self):
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
         config = ResolvedConfig({})
         assert config.lifecycle_automation_enabled is True
 
     def test_can_be_disabled(self):
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
         config = ResolvedConfig({"lifecycle": {"lifecycle_automation_enabled": False}})
         assert config.lifecycle_automation_enabled is False
 
     def test_explicitly_enabled(self):
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
         config = ResolvedConfig({"lifecycle": {"lifecycle_automation_enabled": True}})
         assert config.lifecycle_automation_enabled is True
 
     def test_default_settings_has_lifecycle_section(self):
-        from core_api.services.tenant_settings import DEFAULT_SETTINGS
+        from core_api.services.organization_settings import DEFAULT_SETTINGS
         assert "lifecycle" in DEFAULT_SETTINGS
         assert "lifecycle_automation_enabled" in DEFAULT_SETTINGS["lifecycle"]
 

--- a/tests/test_mcp_recall.py
+++ b/tests/test_mcp_recall.py
@@ -40,7 +40,7 @@ async def test_recall_happy_path(mcp_env, monkeypatch):
 
     # Patch the late-imported config/profile dependencies.
     monkeypatch.setattr(
-        "core_api.services.tenant_settings.resolve_config",
+        "core_api.services.organization_settings.resolve_config",
         _fake_resolve_config,
     )
     monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
@@ -60,7 +60,7 @@ async def test_recall_with_include_brief(mcp_env, monkeypatch):
     brief_mock = _fake_async_return({"summary": "alice onboarded last quarter"})
     monkeypatch.setattr("core_api.services.recall_service.recall", brief_mock)
     monkeypatch.setattr(
-        "core_api.services.tenant_settings.resolve_config", _fake_resolve_config
+        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
     )
     monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
 
@@ -75,7 +75,7 @@ async def test_recall_with_include_brief(mcp_env, monkeypatch):
 async def test_recall_empty_results(mcp_env, monkeypatch):
     mcp_env["service"]("search_memories").return_value = []
     monkeypatch.setattr(
-        "core_api.services.tenant_settings.resolve_config", _fake_resolve_config
+        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
     )
     monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
 
@@ -103,7 +103,7 @@ async def test_recall_top_k_is_capped(mcp_env, monkeypatch):
     search_mock = mcp_env["service"]("search_memories")
     search_mock.return_value = []
     monkeypatch.setattr(
-        "core_api.services.tenant_settings.resolve_config", _fake_resolve_config
+        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
     )
     monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
 
@@ -118,7 +118,7 @@ async def test_recall_http_exception_becomes_error_envelope(mcp_env, monkeypatch
         status_code=429, detail="rate limited"
     )
     monkeypatch.setattr(
-        "core_api.services.tenant_settings.resolve_config", _fake_resolve_config
+        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
     )
     monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
 

--- a/tests/test_organization_settings_storage.py
+++ b/tests/test_organization_settings_storage.py
@@ -1,12 +1,12 @@
-"""Storage, cache, and ResolvedConfig tests for tenant_settings service."""
+"""Storage, cache, and ResolvedConfig tests for organization_settings service."""
 
 import uuid
 
 import pytest
 from sqlalchemy import text
 
-from core_api.services import tenant_settings as ts_svc
-from core_api.services.tenant_settings import (
+from core_api.services import organization_settings as ts_svc
+from core_api.services.organization_settings import (
     DEFAULT_SETTINGS,
     ResolvedConfig,
     _deep_merge,
@@ -181,8 +181,8 @@ async def test_audit_row_written_on_change(db):
 
     result = await db.execute(
         text(
-            "SELECT changed_by, diff FROM tenant_settings_audit "
-            "WHERE tenant_id = :tid ORDER BY created_at DESC LIMIT 1"
+            "SELECT changed_by, diff FROM organization_settings_audit "
+            "WHERE org_id = :tid ORDER BY created_at DESC LIMIT 1"
         ),
         {"tid": tid},
     )
@@ -198,7 +198,7 @@ async def test_audit_no_row_on_noop(db):
     await update_settings(db, tid, {"enrichment": {"provider": "vertex"}})
 
     before = await db.execute(
-        text("SELECT count(*) FROM tenant_settings_audit WHERE tenant_id = :tid"),
+        text("SELECT count(*) FROM organization_settings_audit WHERE org_id = :tid"),
         {"tid": tid},
     )
     before_count = before.scalar() or 0
@@ -207,7 +207,7 @@ async def test_audit_no_row_on_noop(db):
     await update_settings(db, tid, {"enrichment": {"provider": "vertex"}})
 
     after = await db.execute(
-        text("SELECT count(*) FROM tenant_settings_audit WHERE tenant_id = :tid"),
+        text("SELECT count(*) FROM organization_settings_audit WHERE org_id = :tid"),
         {"tid": tid},
     )
     after_count = after.scalar() or 0

--- a/tests/test_p2_semantic_dedup.py
+++ b/tests/test_p2_semantic_dedup.py
@@ -154,17 +154,17 @@ class TestSemanticDedupToggle:
     """Verify per-tenant toggle via ResolvedConfig."""
 
     def test_default_enabled(self):
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
         cfg = ResolvedConfig({})
         assert cfg.semantic_dedup_enabled is True
 
     def test_explicitly_disabled(self):
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
         cfg = ResolvedConfig({"dedup": {"semantic_dedup_enabled": False}})
         assert cfg.semantic_dedup_enabled is False
 
     def test_explicitly_enabled(self):
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
         cfg = ResolvedConfig({"dedup": {"semantic_dedup_enabled": True}})
         assert cfg.semantic_dedup_enabled is True
 

--- a/tests/test_platform_providers.py
+++ b/tests/test_platform_providers.py
@@ -502,7 +502,7 @@ class TestPlatformSecurity:
         monkeypatch.setattr(cfg, "settings", cfg.Settings())
         monkeypatch.setattr(cfg.settings, "openai_api_key", None)
 
-        from core_api.services.tenant_settings import ResolvedConfig
+        from core_api.services.organization_settings import ResolvedConfig
 
         config = ResolvedConfig({})
         # ResolvedConfig.openai_api_key reads tenant settings then global settings

--- a/tests/test_runtime_imports.py
+++ b/tests/test_runtime_imports.py
@@ -18,7 +18,7 @@ import pytest
     "module_path",
     [
         # Home of the cachetools.TTLCache import that got broken.
-        "core_api.services.tenant_settings",
+        "core_api.services.organization_settings",
         # App bootstrap — imports most routers transitively.
         "core_api.app",
         # MCP server — registers every tool spec at import time, any


### PR DESCRIPTION
## Summary

- Storage rename only: `tenant_settings` / `tenant_settings_audit` → `organization_settings` / `organization_settings_audit`. Settings are conceptually per-organization (admin UI is org-scoped); the legacy per-tenant table holds 0 rows in prod, so the migration is a clean drop+recreate.
- `org_id` column intentionally typed as `text` with NO foreign-key constraint — pure-OSS deployments don't have an `organizations` table (enterprise-only concept). The `text` shape works in both: OSS-standalone passes `tenant_id` as the implicit org-key; enterprise passes the real org_id.
- ~22 lazy-import call sites updated mechanically to point at `core_api.services.organization_settings`. Public function parameter names stay `tenant_id` for back-compat; renaming those is a follow-up that touches every call site (out of scope here to keep the diff scoped).

## Changes

- **Migration 014** (`core-storage-api/src/core_storage_api/database/migrations/versions/014_rename_tenant_settings_to_organization_settings.py`): drop legacy tables + indexes, create new shape, downgrade restores legacy.
- **Model**: `common/models/tenant_settings.py` → `organization_settings.py`; classes `TenantSettings(Audit)` → `OrganizationSettings(Audit)`; column `tenant_id` → `org_id`.
- **Service**: `core-api/src/core_api/services/tenant_settings.py` → `organization_settings.py`; `ResolvedConfig.__init__(tenant_settings=…)` → `org_settings=…` (verified zero keyword call sites); cache log lines re-keyed to "organization_settings cache". Internal queries updated to `OrganizationSettings.org_id`.
- **22 consumers** in `core-api/` had their import path flipped (mechanical).
- **Test**: `test_tenant_settings_storage.py` → `test_organization_settings_storage.py` with raw-SQL `tenant_settings_audit` queries updated to `organization_settings_audit`.
- One stale docstring reference in `common/events/memory_enrich_publisher.py` updated.

## Why this shape (not a bigger refactor)

Two things deliberately stay as today's shape:

1. **Function parameters keep the name `tenant_id`**. Renaming them to `org_id` requires updating ~20 call sites that pass `auth.tenant_id`, plus ensuring `auth.org_id` is populated everywhere (including OSS-standalone middleware). Doing it here would balloon the PR without changing behavior; the empty prod table makes the semantic difference invisible today. Landing the rename now sets up the storage; the call-site migration is a follow-up.
2. **`org_id` is `text`, no FK**. The `organizations` table is enterprise-only — pure-OSS migrations don't create it. A FK would break OSS-standalone deployments at migration time.

## Test plan

- [ ] CI passes (ruff, mypy, pytest, alembic upgrade head from a fresh DB).
- [ ] `pytest tests/test_organization_settings_storage.py` runs green — covers cache lifecycle, audit row creation, no-op-skip, ResolvedConfig fallbacks.
- [ ] Manual smoke after deploy: `GET /settings` returns the merged display view; `PUT /settings` writes a row in the new `organization_settings` table.

## Out of scope

- Function parameter rename `tenant_id` → `org_id` across ~20 call sites — separate follow-up.
- FastAPI route handler names `get_tenant_settings` / `update_tenant_settings` — cosmetic; HTTP path stays /settings.
- `auth.org_id` propagation end-to-end (so call sites pass the org-key directly).

Closes CAURA-654.