### PR TITLE
feat: lifecycle ops Pub/Sub fanout via core-operations (CAURA-655)

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -361,3 +361,12 @@ SINGLE_VALUE_PREDICATES: frozenset[str] = frozenset(
         "office",
     }
 )
+
+# ── Lifecycle automation (CAURA-655) ──
+# Weight threshold for archive-stale: memories below this with zero
+# recalls are eligible for archival. Lives in common/ so the threshold
+# is shared between core-api's adapter (synchronous OSS standalone path)
+# and core-worker's storage helper (SaaS Pub/Sub consumer path).
+# Diverging values would silently produce different archive footprints
+# across the two deployment modes.
+LIFECYCLE_STALE_ARCHIVE_WEIGHT: float = 0.3

--- a/common/events/__init__.py
+++ b/common/events/__init__.py
@@ -19,6 +19,10 @@ from common.events.base import (
 )
 from common.events.factory import get_event_bus
 from common.events.inprocess import InProcessEventBus
+from common.events.lifecycle_publishers import (
+    publish_archive_expired_request,
+    publish_archive_stale_request,
+)
 from common.events.memory_embed_publisher import publish_memory_embed_request
 from common.events.memory_enrich_publisher import publish_memory_enrich_request
 from common.events.memory_enriched_publisher import publish_memory_enriched
@@ -38,6 +42,8 @@ __all__ = [
     "PubSubEventBus",
     "Topics",
     "get_event_bus",
+    "publish_archive_expired_request",
+    "publish_archive_stale_request",
     "publish_memory_embed_request",
     "publish_memory_enrich_request",
     "publish_memory_enriched",

--- a/common/events/lifecycle_archive_request.py
+++ b/common/events/lifecycle_archive_request.py
@@ -1,0 +1,19 @@
+"""Typed payload for the ``memclaw.lifecycle.<action>-requested`` topics
+(CAURA-655). Both ``archive-expired`` and ``archive-stale`` share this
+model — the consumer's per-action behaviour is parameterised by the
+topic, not by payload fields. ``audit_id`` ties the message back to
+the row pre-published by the core-api fanout endpoint.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class LifecycleArchiveRequest(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    audit_id: int
+    org_id: str
+    triggered_by: str
+    fleet_id: str | None = None

--- a/common/events/lifecycle_handlers.py
+++ b/common/events/lifecycle_handlers.py
@@ -1,0 +1,169 @@
+"""Consumers for ``memclaw.lifecycle.<action>-requested`` topics (CAURA-655).
+
+Lives in ``common/`` rather than under either service so the same code
+runs in both deployments:
+
+* SaaS — core-worker subscribes (``EVENT_BUS_BACKEND=pubsub``).
+* OSS standalone — core-api subscribes against the in-process bus
+  (no separate worker process to consume the in-memory queue).
+
+The handler delegates the two storage round-trips it needs (run the
+SQL primitive, finalise the audit row) to a small adapter the host
+service supplies via :func:`register_consumers`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from functools import partial
+from typing import Protocol
+
+from pydantic import ValidationError
+
+from common.events.base import Event
+from common.events.factory import get_event_bus
+from common.events.lifecycle_archive_request import LifecycleArchiveRequest
+from common.events.topics import Topics
+
+logger = logging.getLogger(__name__)
+
+
+class LifecycleStorageAdapter(Protocol):
+    """Two-method shape the lifecycle handlers need.
+
+    All methods are async and call core-storage-api over HTTP. Hosts
+    inject their own implementation so this module stays free of any
+    core-api / core-worker imports.
+    """
+
+    async def archive_expired(self, *, org_id: str, fleet_id: str | None) -> int: ...
+
+    async def archive_stale(self, *, org_id: str, fleet_id: str | None) -> int: ...
+
+    async def update_lifecycle_audit_row(
+        self,
+        audit_id: int,
+        *,
+        status: str,
+        stats: dict | None = None,
+        error_message: str | None = None,
+    ) -> None: ...
+
+
+_ArchiveFn = Callable[..., Awaitable[int]]
+
+
+async def _run_archive(
+    event: Event,
+    *,
+    adapter: LifecycleStorageAdapter,
+    archive_fn: _ArchiveFn,
+    action: str,
+) -> None:
+    """Shared body for both archive handlers — bound to a specific
+    primitive at registration time so this function never branches on
+    a string. The SQL archive ops are naturally idempotent so Pub/Sub
+    redelivery is safe to run more than once; each delivery attempt
+    updates the SAME audit row (the row id rides in the event payload
+    and is pre-created by the fanout endpoint before publish).
+    """
+    try:
+        request = LifecycleArchiveRequest(**event.payload)
+    except ValidationError:
+        logger.exception(
+            "dropping malformed lifecycle-request payload",
+            extra={
+                "event_type": event.event_type,
+                "event_id": str(event.event_id),
+                "dropped": True,
+            },
+        )
+        return
+
+    # Best-effort in_progress mark: 404 means the audit row was pruned
+    # between fanout and consume. Continue anyway so the SQL primitive
+    # still runs — dropping would silently skip an op the operator
+    # asked for.
+    try:
+        await adapter.update_lifecycle_audit_row(request.audit_id, status="in_progress")
+    except Exception:
+        logger.warning(
+            "lifecycle audit in_progress update failed; continuing",
+            exc_info=True,
+            extra={"audit_id": request.audit_id, "action": action},
+        )
+
+    try:
+        count = await archive_fn(org_id=request.org_id, fleet_id=request.fleet_id)
+    except Exception as exc:
+        # Mark the row failed so observers can distinguish a stuck
+        # ``in_progress`` (worker crashed mid-run) from a finished-with-
+        # error op. Truncated to keep the row bounded; full traceback
+        # is in the worker logs.
+        #
+        # Wrap the audit update in its own guard: if it raises, the
+        # outer ``raise`` below would never run and the original archive
+        # exception would be silently replaced by the audit error,
+        # leaving the row stuck in ``in_progress`` indistinguishable
+        # from a crashed worker. Log and continue so the original
+        # always surfaces.
+        try:
+            await adapter.update_lifecycle_audit_row(
+                request.audit_id,
+                status="failure",
+                error_message=str(exc)[:500],
+            )
+        except Exception:
+            logger.warning(
+                "lifecycle audit failure update failed; row stuck in_progress",
+                exc_info=True,
+                extra={"audit_id": request.audit_id, "action": action},
+            )
+        # Re-raise so the bus nacks → Pub/Sub redelivers (subject to
+        # max-delivery-attempts → DLQ). The ``failure`` row above is
+        # the durable record (when the update succeeded).
+        raise
+
+    await adapter.update_lifecycle_audit_row(
+        request.audit_id,
+        status="success",
+        stats={"archived": count},
+    )
+
+    logger.info(
+        "lifecycle %s processed",
+        action,
+        extra={
+            "audit_id": request.audit_id,
+            "org_id": request.org_id,
+            "triggered_by": request.triggered_by,
+            "archived": count,
+        },
+    )
+
+
+def register_consumers(adapter: LifecycleStorageAdapter) -> None:
+    """Subscribe both archive handlers, each closing over the adapter
+    method that runs its primitive. Call once at app startup, before
+    ``bus.start()``.
+    """
+    bus = get_event_bus()
+    bus.subscribe(
+        Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED,
+        partial(
+            _run_archive,
+            adapter=adapter,
+            archive_fn=adapter.archive_expired,
+            action="archive-expired",
+        ),
+    )
+    bus.subscribe(
+        Topics.Lifecycle.ARCHIVE_STALE_REQUESTED,
+        partial(
+            _run_archive,
+            adapter=adapter,
+            archive_fn=adapter.archive_stale,
+            action="archive-stale",
+        ),
+    )

--- a/common/events/lifecycle_publishers.py
+++ b/common/events/lifecycle_publishers.py
@@ -1,0 +1,67 @@
+"""Publishers for ``memclaw.lifecycle.<action>-requested`` topics (CAURA-655).
+
+Both publishers share one payload type (:class:`LifecycleArchiveRequest`)
+and differ only in the topic — the consumer dispatches on the topic
+constant the bus already exposes per-handler.
+"""
+
+from __future__ import annotations
+
+from common.events.base import Event
+from common.events.factory import get_event_bus
+from common.events.lifecycle_archive_request import LifecycleArchiveRequest
+from common.events.topics import Topics
+
+
+async def _publish(
+    topic: str,
+    *,
+    audit_id: int,
+    org_id: str,
+    triggered_by: str,
+    fleet_id: str | None,
+) -> None:
+    payload = LifecycleArchiveRequest(
+        audit_id=audit_id,
+        org_id=org_id,
+        triggered_by=triggered_by,
+        fleet_id=fleet_id,
+    )
+    event = Event(
+        event_type=topic,
+        tenant_id=org_id,
+        payload=payload.model_dump(mode="json"),
+    )
+    await get_event_bus().publish(topic, event)
+
+
+async def publish_archive_expired_request(
+    *,
+    audit_id: int,
+    org_id: str,
+    triggered_by: str,
+    fleet_id: str | None = None,
+) -> None:
+    await _publish(
+        Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED,
+        audit_id=audit_id,
+        org_id=org_id,
+        triggered_by=triggered_by,
+        fleet_id=fleet_id,
+    )
+
+
+async def publish_archive_stale_request(
+    *,
+    audit_id: int,
+    org_id: str,
+    triggered_by: str,
+    fleet_id: str | None = None,
+) -> None:
+    await _publish(
+        Topics.Lifecycle.ARCHIVE_STALE_REQUESTED,
+        audit_id=audit_id,
+        org_id=org_id,
+        triggered_by=triggered_by,
+        fleet_id=fleet_id,
+    )

--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -34,6 +34,15 @@ class Pipeline(enum.StrEnum):
     ENTITY_EXTRACTED = "memclaw.pipeline.entity-extracted"
 
 
+class Lifecycle(enum.StrEnum):
+    # One topic per action — matches the `memclaw.memory.embed-requested`
+    # vs `memclaw.memory.enrich-requested` convention. Keeping each
+    # operation on its own topic gives clean per-subscription filtering
+    # and lets each action evolve its payload independently.
+    ARCHIVE_EXPIRED_REQUESTED = "memclaw.lifecycle.archive-expired-requested"
+    ARCHIVE_STALE_REQUESTED = "memclaw.lifecycle.archive-stale-requested"
+
+
 class Topics:
     """Namespaced facade so call sites keep the ergonomic form
     `Topics.Memory.CREATED` instead of importing each inner enum."""
@@ -41,3 +50,4 @@ class Topics:
     Memory = Memory
     Audit = Audit
     Pipeline = Pipeline
+    Lifecycle = Lifecycle

--- a/common/models/__init__.py
+++ b/common/models/__init__.py
@@ -8,6 +8,7 @@ from common.models.document import Document
 from common.models.entity import Entity, MemoryEntityLink, Relation
 from common.models.fleet import FleetCommand, FleetNode
 from common.models.idempotency import IdempotencyResponse
+from common.models.lifecycle_audit import LifecycleAudit
 from common.models.memory import Memory
 
 __all__ = [
@@ -21,6 +22,7 @@ __all__ = [
     "FleetCommand",
     "FleetNode",
     "IdempotencyResponse",
+    "LifecycleAudit",
     "Memory",
     "MemoryEntityLink",
     "Relation",

--- a/common/models/lifecycle_audit.py
+++ b/common/models/lifecycle_audit.py
@@ -1,0 +1,47 @@
+"""Per-fanout audit row for OSS scheduled lifecycle operations (CAURA-655).
+
+One row is pre-published in the core-api fanout endpoint with
+``status='pending'`` before the per-org Pub/Sub message goes out. The
+core-worker consumer flips it to ``in_progress`` on receipt and to
+``success`` / ``failure`` on completion. DLQ'd or never-consumed
+messages remain observable as ``pending`` rows past their expected
+finish time.
+
+``org_id`` is ``text`` and unconstrained — pure-OSS deployments key by
+the standalone tenant id, enterprise deployments by the real org id.
+Same shape as ``organization_settings.org_id`` (CAURA-654).
+"""
+
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, Index, Text, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from common.models.base import Base
+
+
+class LifecycleAudit(Base):
+    __tablename__ = "lifecycle_audit"
+    __table_args__ = (
+        Index(
+            "idx_lifecycle_audit_org_action_started",
+            "org_id",
+            "action",
+            text("started_at DESC"),
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False)
+    action: Mapped[str] = mapped_column(Text, nullable=False)
+    triggered_by: Mapped[str] = mapped_column(Text, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'pending'")
+    )
+    stats: Mapped[dict | None] = mapped_column(JSONB)
+    error_message: Mapped[str | None] = mapped_column(Text)

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -50,6 +50,7 @@ from core_api.routes.evolve import router as evolve_router
 from core_api.routes.fleet import router as fleet_router
 from core_api.routes.health import router as health_router
 from core_api.routes.insights import router as insights_router
+from core_api.routes.lifecycle import router as lifecycle_router
 from core_api.routes.memories import admin_memories_router
 from core_api.routes.memories import router as memories_router
 from core_api.routes.plugin import plugin_bootstrap_router
@@ -366,11 +367,7 @@ async def lifespan(app):
             set_audit_queue(audit_queue)
             await audit_queue.start()
 
-        # Start lifecycle automation scheduler
-        from core_api.services.lifecycle_service import lifecycle_scheduler
-        from core_api.tasks import cancel_all_tasks, track_task
-
-        track_task(lifecycle_scheduler())
+        from core_api.tasks import cancel_all_tasks
 
         # ``register_consumers`` must run before ``bus.start`` — the
         # Pub/Sub backend spawns pull loops from the handler registry
@@ -379,7 +376,25 @@ async def lifespan(app):
         # standalone) makes ``start`` a no-op so this wiring is
         # harmless there.
         register_consumers()
+
         event_bus = get_event_bus()
+
+        # CAURA-655: lifecycle archive consumers run in core-worker on
+        # SaaS, but in OSS standalone there is no separate worker
+        # process — the in-process bus dispatches to whoever subscribes
+        # in this same Python process. Register here only when the
+        # backend is in-process so SaaS doesn't end up with both
+        # core-api AND core-worker running each archive twice.
+        from common.events.inprocess import InProcessEventBus
+
+        if isinstance(event_bus, InProcessEventBus):
+            from common.events.lifecycle_handlers import (
+                register_consumers as register_lifecycle_consumers,
+            )
+            from core_api.services.lifecycle_audit import make_storage_adapter
+
+            register_lifecycle_consumers(make_storage_adapter(get_storage_client()))
+
         await event_bus.start()
 
         yield
@@ -570,6 +585,7 @@ app.include_router(stm_router, prefix="/api/v1")
 app.include_router(insights_router, prefix="/api/v1")
 app.include_router(evolve_router, prefix="/api/v1")
 app.include_router(skills_router, prefix="/api/v1")
+app.include_router(lifecycle_router, prefix="/api/v1")
 
 # Test-only endpoints (time-warp, etc.) — only registered when TESTING=1
 if _os.getenv("TESTING") == "1":

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -933,6 +933,44 @@ class CoreStorageClient:
         return await self._get_list("/audit-logs", **params)
 
     # =====================================================================
+    # Lifecycle audit (CAURA-655)
+    # =====================================================================
+
+    async def create_lifecycle_audit_row(
+        self,
+        *,
+        org_id: str,
+        action: str,
+        triggered_by: str,
+    ) -> int:
+        """Pre-publish a ``pending`` audit row for one Pub/Sub message.
+
+        The fanout endpoint calls this immediately before each per-org
+        publish so the consumer has a stable id to finalise.
+        """
+        result = await self._post(
+            "/lifecycle-audit",
+            {"org_id": org_id, "action": action, "triggered_by": triggered_by},
+        )
+        return result["audit_id"]  # type: ignore[index]
+
+    async def update_lifecycle_audit_row(
+        self,
+        audit_id: int,
+        *,
+        status: str,
+        stats: dict | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        """Flip the row to ``in_progress``, ``success``, or ``failure``."""
+        body: dict[str, Any] = {"status": status}
+        if stats is not None:
+            body["stats"] = stats
+        if error_message is not None:
+            body["error_message"] = error_message
+        await self._patch(f"/lifecycle-audit/{audit_id}", body)
+
+    # =====================================================================
     # Reports
     # =====================================================================
 

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -11,6 +11,7 @@ from common.constants import (  # noqa: F401
     ENTITY_RESOLUTION_CANDIDATE_LIMIT,
     GRAPH_MAX_EXPANDED_ENTITIES,
     GRAPH_MAX_HOPS,
+    LIFECYCLE_STALE_ARCHIVE_WEIGHT,
     RECALL_BOOST_SCALE,
     RELATION_TYPE_WEIGHTS,
     SEMANTIC_DEDUP_CANDIDATE_LIMIT,
@@ -565,7 +566,10 @@ BULK_EMBEDDING_TIMEOUT_SECONDS = 30.0
 # ── Lifecycle automation ──
 LIFECYCLE_INTERVAL_HOURS = 24  # run lifecycle cycle every N hours
 LIFECYCLE_BATCH_SIZE = 500  # max memories per status transition batch
-LIFECYCLE_STALE_ARCHIVE_WEIGHT = 0.3  # weight threshold for stale archival
+# ``LIFECYCLE_STALE_ARCHIVE_WEIGHT`` is re-exported from
+# ``common.constants`` (see top of this file) — canonical location is
+# ``common`` so core-worker can read the same value without depending
+# on core-api.
 
 # ── Entity extraction quality filter ──
 MIN_ENTITY_NAME_LENGTH = 2  # single-char "entities" are never meaningful

--- a/core-api/src/core_api/protocols.py
+++ b/core-api/src/core_api/protocols.py
@@ -169,7 +169,12 @@ class StorageBackend(Protocol):
 
 @runtime_checkable
 class JobQueue(Protocol):
-    """Pluggable async job/task queue (Redis, Cloud Tasks, in-memory, etc.)."""
+    """Pluggable async job/task queue (Redis, Cloud Tasks, in-memory, etc.).
+
+    Cron-style scheduling moved to the dedicated ``core-operations``
+    service in CAURA-655 — the queue is now purely a fire-and-forget
+    primitive.
+    """
 
     async def enqueue(
         self,
@@ -182,20 +187,6 @@ class JobQueue(Protocol):
         *func* is an async callable. The queue implementation decides
         whether to run it in-process (``asyncio.create_task``) or
         serialize and dispatch to a worker (arq, Cloud Tasks, etc.).
-        """
-        ...
-
-    async def schedule(
-        self,
-        func: Any,
-        *,
-        cron: str,
-    ) -> None:
-        """Register a callable to run on a cron schedule.
-
-        The cron expression follows standard 5-field format.
-        In-process implementations may use ``asyncio.sleep`` loops;
-        distributed implementations may delegate to arq or APScheduler.
         """
         ...
 

--- a/core-api/src/core_api/providers/inprocess_queue.py
+++ b/core-api/src/core_api/providers/inprocess_queue.py
@@ -3,14 +3,17 @@
 Implements the ``JobQueue`` protocol using fire-and-forget
 ``asyncio.Task`` objects.  Suitable for single-process deployments
 where an external broker (Redis / RabbitMQ) is not needed.
+
+Pre-CAURA-655 this module also exposed a cron-style ``schedule()``
+method backed by an internal ``_ticker`` task. The only caller was
+the in-process lifecycle scheduler that has since moved to
+``core-operations``; the scheduler bits are gone.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import re
-import time
 import uuid
 from typing import Any
 
@@ -22,12 +25,6 @@ class InProcessQueue:
 
     def __init__(self) -> None:
         self._tasks: set[asyncio.Task] = set()
-        self._scheduled: list[tuple[Any, int, float]] = []  # (func, interval, last_run)
-        self._ticker_task: asyncio.Task | None = None
-
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
 
     async def enqueue(self, func: Any, *args: Any, **kwargs: Any) -> str:
         """Fire-and-forget *func* as a background task."""
@@ -38,63 +35,9 @@ class InProcessQueue:
         logger.debug("Enqueued job %s", job_id)
         return job_id
 
-    async def schedule(self, func: Any, *, cron: str) -> None:
-        """Register *func* to run on a cron-like interval."""
-        interval = self._parse_cron_interval(cron)
-        self._scheduled.append((func, interval, time.monotonic()))
-        if self._ticker_task is None or self._ticker_task.done():
-            self._ticker_task = asyncio.create_task(self._ticker())
-        logger.info("Scheduled job every %ds (cron: %s)", interval, cron)
-
     async def shutdown(self) -> None:
-        """Cancel all tracked and scheduled tasks."""
-        if self._ticker_task and not self._ticker_task.done():
-            self._ticker_task.cancel()
+        """Cancel all tracked tasks."""
         for task in list(self._tasks):
             task.cancel()
-        all_tasks = list(self._tasks)
-        if self._ticker_task:
-            all_tasks.append(self._ticker_task)
-        if all_tasks:
-            await asyncio.gather(*all_tasks, return_exceptions=True)
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    def _parse_cron_interval(self, cron: str) -> int:
-        """Convert a simple cron expression to an interval in seconds."""
-        cron = cron.strip()
-
-        # */N * * * *  ->  every N minutes
-        m = re.fullmatch(r"\*/(\d+)\s+\*\s+\*\s+\*\s+\*", cron)
-        if m:
-            return int(m.group(1)) * 60
-
-        # 0 */N * * *  ->  every N hours
-        m = re.fullmatch(r"0\s+\*/(\d+)\s+\*\s+\*\s+\*", cron)
-        if m:
-            return int(m.group(1)) * 3600
-
-        # 0 0 * * *  ->  daily
-        if re.fullmatch(r"0\s+0\s+\*\s+\*\s+\*", cron):
-            return 86400
-
-        logger.warning("Unrecognised cron expression %r; defaulting to 3600s", cron)
-        return 3600
-
-    async def _ticker(self) -> None:
-        """Wake every 60 s and fire any scheduled functions whose interval has elapsed."""
-        while True:
-            try:
-                await asyncio.sleep(60)
-                now = time.monotonic()
-                for idx, (func, interval, last_run) in enumerate(self._scheduled):
-                    if now - last_run >= interval:
-                        await self.enqueue(func)
-                        self._scheduled[idx] = (func, interval, now)
-            except asyncio.CancelledError:
-                return
-            except Exception:
-                logger.exception("Ticker iteration failed, retrying in 5s")
-                await asyncio.sleep(5)
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)

--- a/core-api/src/core_api/routes/lifecycle.py
+++ b/core-api/src/core_api/routes/lifecycle.py
@@ -1,0 +1,220 @@
+"""Admin endpoints for OSS scheduled lifecycle operations (CAURA-655).
+
+Two flavours per action — ``archive-expired`` and ``archive-stale``:
+
+* ``POST /admin/lifecycle/fanout/<action>`` — cron-fired entry point.
+  Lists every tenant with live memories, pre-publishes one audit row
+  per tenant, and publishes one Pub/Sub message per tenant.
+
+* ``POST /admin/lifecycle/<action>`` — manual single-tenant trigger.
+  Body ``{"org_id": "..."}``. Same downstream code path as the fanout
+  loop body — both converge at one ``audit_begin + publish`` pair.
+
+Auth: admin-key only (``auth.enforce_admin``). The fanout route is
+called by ``core-operations`` over the network with the configured
+``CORE_API_ADMIN_API_KEY``; the manual route is for operator curl /
+admin UI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from common.events import (
+    publish_archive_expired_request,
+    publish_archive_stale_request,
+)
+from core_api.auth import AuthContext, get_auth_context
+from core_api.clients.storage_client import get_storage_client
+from core_api.db.session import async_session
+from core_api.services.lifecycle_audit import audit_begin
+from core_api.services.tenants import list_active_tenant_ids
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Admin", "Lifecycle"])
+
+# Whitelist of action names → publisher.  CAURA-657 will extend with
+# ``crystallize`` and ``entity-link`` once their consumers exist.
+_PublisherFn = Callable[..., Awaitable[None]]
+_ACTION_PUBLISHERS: dict[str, _PublisherFn] = {
+    "archive-expired": publish_archive_expired_request,
+    "archive-stale": publish_archive_stale_request,
+}
+
+# Cap on concurrent per-org ``audit_begin + publish`` pairs in the
+# fanout loop. Each pair = 1 HTTP POST to core-storage-api + 1 Pub/Sub
+# publish; without the cap, a deployment with thousands of orgs would
+# fire that many simultaneous round-trips on a single cron tick. 50 is
+# a generous default — enough that small deploys never queue, low
+# enough that the storage-writer pool is never saturated by fanout
+# traffic alone (the same pool serves the live request path).
+_FANOUT_CONCURRENCY = 50
+
+
+def _resolve_publisher(action: str) -> _PublisherFn:
+    publisher = _ACTION_PUBLISHERS.get(action)
+    if publisher is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"unknown lifecycle action {action!r}; valid: {sorted(_ACTION_PUBLISHERS)}",
+        )
+    return publisher
+
+
+async def _trigger_one(
+    *,
+    action: str,
+    org_id: str,
+    triggered_by: str,
+    publisher: _PublisherFn,
+    fleet_id: str | None = None,
+) -> int:
+    """Pre-publish the audit row, then publish the per-org Pub/Sub
+    message. Returns the new audit_id.
+
+    The audit row goes out FIRST so a publish failure leaves a
+    ``pending`` row pointing at the operator's request — observable as
+    a row that never advances. Reverse ordering would let the consumer
+    receive a message referencing an id that doesn't exist.
+    """
+    storage = get_storage_client()
+    audit_id = await audit_begin(
+        storage,
+        action=action,
+        org_id=org_id,
+        triggered_by=triggered_by,
+    )
+    await publisher(
+        audit_id=audit_id,
+        org_id=org_id,
+        triggered_by=triggered_by,
+        fleet_id=fleet_id,
+    )
+    return audit_id
+
+
+@router.post("/admin/lifecycle/fanout/{action}")
+async def fanout_lifecycle_action(
+    action: str,
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict:
+    """Cron entry point — publish one message per active org.
+
+    Caller is ``core-operations`` (``triggered_by='core-operations'``).
+    Returns ``{"action", "published", "failed"}`` — counts only, no
+    per-org id list, so the response stays bounded at scale.
+
+    The DB session is opened locally and released BEFORE the
+    ``asyncio.gather`` fan-out so a slow per-org Pub/Sub publish can't
+    park a connection for the whole loop. The fan-out only needs the
+    org list, not the session.
+    """
+    auth.enforce_admin()
+    publisher = _resolve_publisher(action)
+
+    async with async_session() as db:
+        org_ids = await list_active_tenant_ids(db)
+
+    # Fan out concurrently with a semaphore cap (see _FANOUT_CONCURRENCY)
+    # so a deployment with N orgs doesn't fire N simultaneous storage
+    # round-trips. ``return_exceptions=True`` keeps the
+    # one-bad-org-must-not-abort-the-rest invariant: per-iteration try/
+    # except in a serial loop did the same job, but the cron tick used
+    # to scale O(N) in wall time * per-org publish latency. The cron
+    # re-runs on the configured cadence so a partial failure here is
+    # always recoverable on the next tick.
+    sem = asyncio.Semaphore(_FANOUT_CONCURRENCY)
+
+    async def _bounded_trigger(org_id: str) -> int:
+        async with sem:
+            return await _trigger_one(
+                action=action,
+                org_id=org_id,
+                triggered_by="core-operations",
+                publisher=publisher,
+            )
+
+    results = await asyncio.gather(
+        *(_bounded_trigger(org_id) for org_id in org_ids),
+        return_exceptions=True,
+    )
+
+    published = 0
+    failed = 0
+    for org_id, outcome in zip(org_ids, results, strict=True):
+        if isinstance(outcome, BaseException):
+            logger.exception(
+                "lifecycle fanout: failed to trigger one org; continuing",
+                exc_info=outcome,
+                extra={"action": action, "org_id": org_id},
+            )
+            failed += 1
+            continue
+        published += 1
+
+    logger.info(
+        "lifecycle fanout dispatched",
+        extra={
+            "action": action,
+            "org_count": len(org_ids),
+            "published": published,
+            "failed": failed,
+        },
+    )
+    return {"action": action, "published": published, "failed": failed}
+
+
+@router.post("/admin/lifecycle/{action}")
+async def trigger_lifecycle_action(
+    action: str,
+    request: Request,
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict:
+    """Manual single-org trigger.
+
+    Body: ``{"org_id": "...", "fleet_id": "..." (optional)}``. Same
+    downstream as the fanout-loop body. ``triggered_by`` records who
+    initiated: ``manual:<user-id>`` if the auth context carries a user,
+    else ``manual:admin-key`` for raw curl.
+    """
+    auth.enforce_admin()
+    publisher = _resolve_publisher(action)
+
+    # ``request.json()`` raises ``JSONDecodeError`` on a malformed body;
+    # without the guard FastAPI's catch-all maps it to 500. Surface as
+    # 422 so the caller can self-diagnose.
+    try:
+        body: dict = await request.json()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="request body must be valid JSON",
+        ) from exc
+
+    org_id = body.get("org_id")
+    if not isinstance(org_id, str) or not org_id:
+        raise HTTPException(
+            status_code=422,
+            detail="'org_id' must be a non-empty string",
+        )
+    fleet_id = body.get("fleet_id")
+    if fleet_id is not None and not isinstance(fleet_id, str):
+        raise HTTPException(
+            status_code=422,
+            detail="'fleet_id' must be a string when provided",
+        )
+
+    triggered_by = f"manual:{auth.user_id}" if auth.user_id else "manual:admin-key"
+    audit_id = await _trigger_one(
+        action=action,
+        org_id=org_id,
+        triggered_by=triggered_by,
+        publisher=publisher,
+        fleet_id=fleet_id,
+    )
+    return {"action": action, "org_id": org_id, "audit_id": audit_id}

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -64,6 +64,7 @@ from core_api.services.memory_service import (
     soft_delete_memory,
     update_memory,
 )
+from core_api.services.tenants import list_active_tenant_ids
 from core_api.services.usage_service import bulk_check_and_increment, check_and_increment
 
 logger = logging.getLogger(__name__)
@@ -1442,8 +1443,7 @@ async def admin_list_tenants(
 ):
     """Admin: list all tenant IDs that have memories."""
     auth.enforce_admin()
-    result = await db.execute(select(Memory.tenant_id).where(Memory.deleted_at.is_(None)).distinct())
-    return sorted([row[0] for row in result.all()])
+    return await list_active_tenant_ids(db)
 
 
 @admin_memories_router.get("/admin/fleets")

--- a/core-api/src/core_api/services/lifecycle_audit.py
+++ b/core-api/src/core_api/services/lifecycle_audit.py
@@ -1,0 +1,64 @@
+"""Tiny wrappers around the lifecycle_audit storage routes (CAURA-655).
+
+Two helpers, one for each transition:
+
+* :func:`audit_begin` — creates a ``pending`` row and returns its id.
+  Called by the fanout endpoint just before each per-org Pub/Sub
+  publish, so the published event carries the row id.
+* :func:`make_storage_adapter` — wraps the storage client into the
+  :class:`LifecycleStorageAdapter` shape the shared handler expects.
+  Used in OSS standalone where core-api itself subscribes to the
+  in-process bus (no separate worker process).
+"""
+
+from __future__ import annotations
+
+from common.events.lifecycle_handlers import LifecycleStorageAdapter
+from core_api.clients.storage_client import CoreStorageClient
+from core_api.constants import LIFECYCLE_STALE_ARCHIVE_WEIGHT
+
+
+async def audit_begin(
+    storage: CoreStorageClient,
+    *,
+    action: str,
+    org_id: str,
+    triggered_by: str,
+) -> int:
+    return await storage.create_lifecycle_audit_row(org_id=org_id, action=action, triggered_by=triggered_by)
+
+
+class _CoreApiLifecycleAdapter:
+    """Adapt :class:`CoreStorageClient` to :class:`LifecycleStorageAdapter`.
+
+    The shared handler's protocol takes ``org_id`` (the project's
+    canonical key for org-scoped operations); the storage client's
+    archive primitives still call the column ``tenant_id``. Translate
+    at the boundary so the rename can land here without churning every
+    call site of the storage client.
+    """
+
+    def __init__(self, storage: CoreStorageClient) -> None:
+        self._storage = storage
+
+    async def archive_expired(self, *, org_id: str, fleet_id: str | None) -> int:
+        return await self._storage.archive_expired(org_id, fleet_id)
+
+    async def archive_stale(self, *, org_id: str, fleet_id: str | None) -> int:
+        return await self._storage.archive_stale(org_id, fleet_id, max_weight=LIFECYCLE_STALE_ARCHIVE_WEIGHT)
+
+    async def update_lifecycle_audit_row(
+        self,
+        audit_id: int,
+        *,
+        status: str,
+        stats: dict | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        await self._storage.update_lifecycle_audit_row(
+            audit_id, status=status, stats=stats, error_message=error_message
+        )
+
+
+def make_storage_adapter(storage: CoreStorageClient) -> LifecycleStorageAdapter:
+    return _CoreApiLifecycleAdapter(storage)

--- a/core-api/src/core_api/services/lifecycle_service.py
+++ b/core-api/src/core_api/services/lifecycle_service.py
@@ -1,71 +1,64 @@
-"""Lifecycle automation — periodic archival of expired and stale memories."""
+"""Crystallize + entity-link execution for one tenant.
 
-import asyncio
+Pre-CAURA-655 this module also held the periodic scheduler loop and
+the SQL-only archive-expired / archive-stale primitives. Both moved
+out:
+
+* The scheduler is gone — ``core-operations`` fires the operations on
+  cron, fanning out per-org Pub/Sub messages via core-api's
+  ``/admin/lifecycle/fanout/<action>`` endpoints (CAURA-655).
+* ``archive-expired`` and ``archive-stale`` are now their own per-org
+  messages consumed in core-worker via
+  ``common.events.lifecycle_handlers``.
+
+What's left here is the LLM-heavy half — crystallize and entity-link —
+that still needs core-api's pipeline machinery. CAURA-657 will lift
+this onto its own Pub/Sub topics; until then ``run_lifecycle_for_tenant``
+remains the single entry point for that work.
+
+Note on import shape: ``get_storage_client`` is imported at the top of
+this module so unit tests can patch
+``core_api.services.lifecycle_service.get_storage_client`` directly.
+``resolve_config`` and ``async_session`` are imported lazily inside the
+function body so the same tests can patch them at their *source*
+namespaces — the existing test convention this module pre-dates.
+"""
+
+from __future__ import annotations
+
 import logging
 
 from core_api.clients.storage_client import get_storage_client
-from core_api.constants import (
-    LIFECYCLE_INTERVAL_HOURS,
-    LIFECYCLE_STALE_ARCHIVE_WEIGHT,
-)
 
 logger = logging.getLogger(__name__)
-
-
-async def lifecycle_scheduler() -> None:
-    """Background scheduler: runs lifecycle automation on an interval."""
-    logger.info("Lifecycle scheduler started (interval=%dh)", LIFECYCLE_INTERVAL_HOURS)
-    while True:
-        await asyncio.sleep(LIFECYCLE_INTERVAL_HOURS * 3600)
-        try:
-            await _run_lifecycle_cycle()
-        except Exception:
-            logger.exception("Lifecycle cycle failed")
-
-
-async def _run_lifecycle_cycle() -> None:
-    """Run lifecycle automation for all tenants."""
-    from core_api.services.organization_settings import resolve_config
-    from core_api.standalone import get_standalone_tenant_id
-
-    tenant_ids = [get_standalone_tenant_id()]
-
-    for tid in tenant_ids:
-        try:
-            config = await resolve_config(None, tid)
-            if not config.lifecycle_automation_enabled:
-                continue
-            stats = await run_lifecycle_for_tenant(tid)
-            if stats["expired_archived"] or stats["stale_archived"] or stats.get("entity_linking"):
-                logger.info("Lifecycle for tenant=%s: %s", tid, stats)
-        except Exception:
-            logger.exception("Lifecycle failed for tenant %s", tid)
 
 
 async def run_lifecycle_for_tenant(
     tenant_id: str,
     fleet_id: str | None = None,
-    # Legacy db param kept for call-site compat — unused, storage client handles DB.
+    # Legacy db param kept for call-site compat — unused, the pipeline
+    # opens its own session.
     db=None,
 ) -> dict:
-    """Execute lifecycle transitions for a tenant. Returns stats."""
-    expired_count = await _archive_expired_memories(tenant_id, fleet_id)
-    stale_count = await _archive_stale_memories(tenant_id, fleet_id)
+    """Run the LLM-heavy lifecycle steps for one tenant.
 
-    crystal_triggered = False
+    Returns a stats dict with ``crystallization_triggered`` and
+    ``entity_linking`` keys; the SQL-only archive counts that used to
+    live here moved to the consumer-side audit row's ``stats`` field.
+    """
     from core_api.services.organization_settings import resolve_config
 
     config = await resolve_config(None, tenant_id)
 
+    crystal_triggered = False
     if config.auto_crystallize_enabled:
-        total = await _count_active_memories(tenant_id, fleet_id)
-        if total > 1000:
-            from core_api.services.crystallizer_service import run_crystallization
+        from core_api.services.crystallizer_service import run_crystallization
 
+        total = await get_storage_client().count_active(tenant_id, fleet_id)
+        if total > 1000:
             await run_crystallization(None, tenant_id, fleet_id, trigger="lifecycle")
             crystal_triggered = True
 
-    # Entity linking — discover cross-links for under-connected memories
     entity_linking_stats: dict = {}
     if config.auto_entity_linking_enabled:
         try:
@@ -98,26 +91,6 @@ async def run_lifecycle_for_tenant(
             )
 
     return {
-        "expired_archived": expired_count,
-        "stale_archived": stale_count,
         "crystallization_triggered": crystal_triggered,
         "entity_linking": entity_linking_stats,
     }
-
-
-async def _archive_expired_memories(tenant_id: str, fleet_id: str | None = None) -> int:
-    """Transition expired-but-active memories to 'outdated'."""
-    sc = get_storage_client()
-    return await sc.archive_expired(tenant_id, fleet_id)
-
-
-async def _archive_stale_memories(tenant_id: str, fleet_id: str | None = None) -> int:
-    """Archive old, never-recalled, low-weight memories."""
-    sc = get_storage_client()
-    return await sc.archive_stale(tenant_id, fleet_id, max_weight=LIFECYCLE_STALE_ARCHIVE_WEIGHT)
-
-
-async def _count_active_memories(tenant_id: str, fleet_id: str | None = None) -> int:
-    """Count active non-deleted memories for a tenant."""
-    sc = get_storage_client()
-    return await sc.count_active(tenant_id, fleet_id)

--- a/core-api/src/core_api/services/tenants.py
+++ b/core-api/src/core_api/services/tenants.py
@@ -1,0 +1,21 @@
+"""Tenant-listing helpers shared by admin endpoints (CAURA-655)."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from common.models.memory import Memory
+
+
+async def list_active_tenant_ids(db: AsyncSession) -> list[str]:
+    """Distinct ``tenant_id`` from non-soft-deleted memories.
+
+    OSS-standalone resolves to one id (the standalone tenant). Enterprise
+    sees one row per tenant with live memories. Multi-tenant orgs share an
+    org_id only at the enterprise side, so OSS-side fanout issues one
+    message per tenant — cross-tenant rollups can come later if a shared
+    lifecycle policy becomes a thing.
+    """
+    result = await db.execute(select(Memory.tenant_id).where(Memory.deleted_at.is_(None)).distinct())
+    return sorted([row[0] for row in result.all()])

--- a/core-operations/src/core_operations/app.py
+++ b/core-operations/src/core_operations/app.py
@@ -27,14 +27,25 @@ from fastapi import FastAPI, HTTPException
 from common.structlog_config import configure_logging
 from core_operations.config import settings
 from core_operations.scheduler import scheduler
+from core_operations.tasks import run_archive_expired_tick, run_archive_stale_tick
 
 logger = logging.getLogger(__name__)
 
 
 def _register_scheduled_tasks() -> None:
-    # CAURA-655: scheduler.register("lifecycle", LIFECYCLE_INTERVAL_S, run_lifecycle_tick)
-    # CAURA-656: scheduler.register("memory_retention", 24*3600, run_memory_retention_tick)
-    pass
+    # CAURA-655: each archival op gets its own registration so an
+    # outage on one can't silently mask the other; their audit rows
+    # stay independent. CAURA-656 will add ``purge-soft-deleted`` here.
+    scheduler.register(
+        "lifecycle-archive-expired",
+        settings.lifecycle_archive_interval_seconds,
+        run_archive_expired_tick,
+    )
+    scheduler.register(
+        "lifecycle-archive-stale",
+        settings.lifecycle_archive_interval_seconds,
+        run_archive_stale_tick,
+    )
 
 
 @contextlib.asynccontextmanager
@@ -65,6 +76,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
         logger.info("Shutting down core-operations (standalone)")
         return
+
+    if not settings.core_api_admin_api_key:
+        # Surface the misconfig at startup so operators see it
+        # immediately, not after the first cron tick fires and 401s
+        # against core-api hours later.
+        logger.warning(
+            "CORE_API_ADMIN_API_KEY is unset; every fanout POST will be "
+            "unauthorised. Set the env var before the next cron interval.",
+        )
 
     _register_scheduled_tasks()
     await scheduler.start()

--- a/core-operations/src/core_operations/config.py
+++ b/core-operations/src/core_operations/config.py
@@ -30,5 +30,18 @@ class Settings(BaseSettings):
 
     storage_http_timeout_s: float = 30.0
 
+    # CAURA-655: core-operations doesn't talk to the DB directly — its
+    # cron ticks POST to core-api's ``/admin/lifecycle/fanout/<action>``
+    # endpoints, which do the org enumeration and Pub/Sub publish.
+    core_api_url: str = "http://oss-core-api:8000"
+    core_api_admin_api_key: str = ""
+
+    # Daily cadence for the SQL-only archive operations. Per-org
+    # scheduling isn't supported here (single global tick fans out to
+    # every active org); enterprise's per-org configurable cadences
+    # — e.g. ``security_audit.schedule_cron`` — still live on the
+    # enterprise scheduler.
+    lifecycle_archive_interval_seconds: float = 24 * 3600
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -1,0 +1,76 @@
+"""Scheduled task callables for core-operations (CAURA-655).
+
+Each tick is intentionally dumb: POST to core-api's fanout endpoint
+with the configured admin key. core-api owns org enumeration, audit
+pre-publish, and Pub/Sub publication; this service is just the cron
+trigger so it doesn't need DB access or org concepts.
+
+Each cron registration is its own action — never a single umbrella
+``run-cycle`` — so an outage on one operation can't silently take down
+the others, and per-action audit rows stay independent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from core_operations.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def _fire_fanout(action: str) -> None:
+    """POST ``/admin/lifecycle/fanout/<action>``. A non-2xx response
+    logs and returns; the scheduler retries on the next tick, so
+    re-raising would just produce duplicate stack traces.
+    """
+    url = f"{settings.core_api_url.rstrip('/')}/api/v1/admin/lifecycle/fanout/{action}"
+    headers: dict[str, str] = {}
+    if settings.core_api_admin_api_key:
+        headers["X-API-Key"] = settings.core_api_admin_api_key
+    else:
+        # Missing admin key would 401 every fanout silently — log so the
+        # operator can see why all subsequent ticks fail.
+        logger.warning(
+            "core-operations: CORE_API_ADMIN_API_KEY unset; fanout will be unauthorised",
+            extra={"action": action},
+        )
+
+    timeout = httpx.Timeout(settings.storage_http_timeout_s)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            resp = await client.post(url, headers=headers)
+        except httpx.HTTPError:
+            logger.exception(
+                "lifecycle fanout POST failed",
+                extra={"action": action, "url": url},
+            )
+            return
+    if resp.status_code >= 400:
+        logger.error(
+            "lifecycle fanout returned non-2xx; will retry next tick",
+            extra={
+                "action": action,
+                "status_code": resp.status_code,
+                "body": resp.text[:500],
+            },
+        )
+        return
+    body = resp.json()
+    logger.info(
+        "lifecycle fanout fired",
+        extra={
+            "action": action,
+            "published": body.get("published"),
+        },
+    )
+
+
+async def run_archive_expired_tick() -> None:
+    await _fire_fanout("archive-expired")
+
+
+async def run_archive_stale_tick() -> None:
+    await _fire_fanout("archive-stale")

--- a/core-operations/tests/test_tasks.py
+++ b/core-operations/tests/test_tasks.py
@@ -1,0 +1,121 @@
+"""Smoke tests for core-operations cron-tick fanout (CAURA-655)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+
+from core_operations import tasks
+from core_operations.config import settings
+
+
+class _StubResponse:
+    def __init__(self, status_code: int, body: dict[str, Any] | str) -> None:
+        self.status_code = status_code
+        self._body = body
+        self.text = body if isinstance(body, str) else ""
+
+    def json(self) -> dict[str, Any]:
+        if isinstance(self._body, str):
+            raise ValueError("not json")
+        return self._body
+
+
+class _StubAsyncClient:
+    """Minimal httpx.AsyncClient drop-in. ``post`` returns the
+    response queued at construction; ``raise_on_post`` simulates a
+    network error.
+    """
+
+    def __init__(
+        self,
+        *,
+        response: _StubResponse | None = None,
+        raise_on_post: Exception | None = None,
+    ) -> None:
+        self._response = response
+        self._raise = raise_on_post
+        self.calls: list[tuple[str, dict | None]] = []
+
+    async def __aenter__(self) -> _StubAsyncClient:
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+    async def post(self, url: str, *, headers: dict | None = None) -> _StubResponse:
+        self.calls.append((url, headers))
+        if self._raise is not None:
+            raise self._raise
+        assert self._response is not None
+        return self._response
+
+
+@asynccontextmanager
+async def _patch_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    response: _StubResponse | None = None,
+    raise_on_post: Exception | None = None,
+) -> AsyncIterator[_StubAsyncClient]:
+    stub = _StubAsyncClient(response=response, raise_on_post=raise_on_post)
+    monkeypatch.setattr(
+        tasks.httpx,
+        "AsyncClient",
+        lambda *a, **kw: stub,
+    )
+    yield stub
+
+
+@pytest.mark.asyncio
+async def test_archive_expired_tick_posts_to_fanout(monkeypatch: pytest.MonkeyPatch):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    response = _StubResponse(200, {"action": "archive-expired", "published": 3, "failed": 0})
+    async with _patch_client(monkeypatch, response=response) as stub:
+        await tasks.run_archive_expired_tick()
+
+    assert len(stub.calls) == 1
+    url, headers = stub.calls[0]
+    assert url == "http://core-api/api/v1/admin/lifecycle/fanout/archive-expired"
+    assert headers == {"X-API-Key": "admin-key-xyz"}
+
+
+@pytest.mark.asyncio
+async def test_archive_stale_tick_hits_correct_path(monkeypatch: pytest.MonkeyPatch):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    response = _StubResponse(200, {"action": "archive-stale", "published": 0, "failed": 0})
+    async with _patch_client(monkeypatch, response=response) as stub:
+        await tasks.run_archive_stale_tick()
+
+    assert stub.calls[0][0].endswith("/admin/lifecycle/fanout/archive-stale")
+
+
+@pytest.mark.asyncio
+async def test_tick_swallows_non_2xx(monkeypatch: pytest.MonkeyPatch):
+    """A non-2xx response must not raise — the scheduler retries on the
+    next tick anyway, and re-raising would just produce duplicate
+    stack traces in the on-call channel without changing behaviour.
+    """
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    response = _StubResponse(503, "upstream timeout")
+    async with _patch_client(monkeypatch, response=response):
+        await tasks.run_archive_expired_tick()  # no raise
+
+
+@pytest.mark.asyncio
+async def test_tick_swallows_network_error(monkeypatch: pytest.MonkeyPatch):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    async with _patch_client(monkeypatch, raise_on_post=httpx.ConnectError("offline")):
+        await tasks.run_archive_expired_tick()  # no raise

--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -33,6 +33,7 @@ from core_storage_api.routers import (
     fleet_router,
     health_router,
     idempotency_router,
+    lifecycle_audit_router,
     memories_router,
     reports_router,
     tasks_router,
@@ -115,6 +116,7 @@ def create_app() -> FastAPI:
     app.include_router(reports_router, prefix=prefix)
     app.include_router(tasks_router, prefix=prefix)
     app.include_router(idempotency_router, prefix=prefix)
+    app.include_router(lifecycle_audit_router, prefix=prefix)
 
     return app
 

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/015_lifecycle_audit.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/015_lifecycle_audit.py
@@ -1,0 +1,62 @@
+"""Create the ``lifecycle_audit`` table for CAURA-655.
+
+One row per scheduled lifecycle invocation (per-org, per-action). The
+core-api fanout endpoint pre-publishes a row with ``status='pending'``
+before each per-org Pub/Sub message; the core-worker consumer flips
+the row to ``in_progress`` on receipt and ``success`` / ``failure`` on
+completion. The table makes lost (DLQ'd / never-consumed) messages
+recoverable: they stay ``pending`` past their expected finish time.
+
+``org_id`` is plain ``text`` (no FK) — same shape as
+``organization_settings.org_id`` from CAURA-654 — so the schema works
+in pure-OSS (key = standalone tenant id) and enterprise (key = real
+org id) deployments without a separate orgs table dependency.
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-05-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "015"
+down_revision: str | None = "014"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "lifecycle_audit",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("action", sa.Text(), nullable=False),
+        sa.Column("triggered_by", sa.Text(), nullable=False),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("finished_at", sa.DateTime(timezone=True)),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("stats", JSONB),
+        sa.Column("error_message", sa.Text()),
+    )
+    op.execute(
+        "CREATE INDEX idx_lifecycle_audit_org_action_started "
+        "ON lifecycle_audit (org_id, action, started_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("lifecycle_audit")

--- a/core-storage-api/src/core_storage_api/routers/__init__.py
+++ b/core-storage-api/src/core_storage_api/routers/__init__.py
@@ -5,6 +5,7 @@ from core_storage_api.routers.entities import router as entities_router
 from core_storage_api.routers.fleet import router as fleet_router
 from core_storage_api.routers.health import router as health_router
 from core_storage_api.routers.idempotency import router as idempotency_router
+from core_storage_api.routers.lifecycle_audit import router as lifecycle_audit_router
 from core_storage_api.routers.memories import router as memories_router
 from core_storage_api.routers.reports import router as reports_router
 from core_storage_api.routers.tasks import router as tasks_router
@@ -17,6 +18,7 @@ __all__ = [
     "fleet_router",
     "health_router",
     "idempotency_router",
+    "lifecycle_audit_router",
     "memories_router",
     "reports_router",
     "tasks_router",

--- a/core-storage-api/src/core_storage_api/routers/lifecycle_audit.py
+++ b/core-storage-api/src/core_storage_api/routers/lifecycle_audit.py
@@ -1,0 +1,74 @@
+"""Lifecycle audit endpoints (CAURA-655).
+
+Two routes back the per-fanout audit row referenced in the operations
+architecture: ``POST`` creates a ``pending`` row and returns its id;
+``PATCH`` flips the row to ``in_progress`` (worker on receipt) or
+``success`` / ``failure`` (worker on completion). Lives here, not in
+core-api, to preserve the "no DB outside core-storage-api" rule —
+both core-api and core-worker call these via their existing
+storage_clients.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from core_storage_api.services.postgres_service import PostgresService
+
+router = APIRouter(prefix="/lifecycle-audit", tags=["Lifecycle"])
+_svc = PostgresService()
+
+_VALID_STATUSES = frozenset({"in_progress", "success", "failure"})
+
+
+@router.post("")
+async def create_lifecycle_audit(request: Request) -> dict:
+    """Create a ``pending`` row. Body: ``{org_id, action, triggered_by}``."""
+    try:
+        body: dict = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail="request body must be valid JSON") from exc
+    missing = {"org_id", "action", "triggered_by"} - body.keys()
+    if missing:
+        raise HTTPException(
+            status_code=422,
+            detail=f"missing required fields: {sorted(missing)}",
+        )
+    audit_id = await _svc.lifecycle_audit_create(
+        org_id=body["org_id"],
+        action=body["action"],
+        triggered_by=body["triggered_by"],
+    )
+    return {"audit_id": audit_id}
+
+
+@router.patch("/{audit_id}")
+async def update_lifecycle_audit(audit_id: int, request: Request) -> dict:
+    """Update status (+ optional stats / error_message). Body:
+    ``{status, stats?, error_message?}``. ``finished_at`` is stamped
+    server-side when ``status`` is terminal (``success``/``failure``).
+    """
+    try:
+        body: dict = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail="request body must be valid JSON") from exc
+    status = body.get("status")
+    if status not in _VALID_STATUSES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"status must be one of {sorted(_VALID_STATUSES)}, got {status!r}",
+        )
+    result = await _svc.lifecycle_audit_finalize(
+        audit_id,
+        status=status,
+        stats=body.get("stats"),
+        error_message=body.get("error_message"),
+    )
+    if result is False:
+        raise HTTPException(status_code=404, detail=f"lifecycle_audit {audit_id} not found")
+    # ``True`` (updated) and ``None`` (no-op against an already-success
+    # row — a Pub/Sub redelivery of an acked message) both return 200.
+    # The no-op path used to share the 404 branch, which produced
+    # spurious "not found" warnings in the consumer's logs on every
+    # redelivery of a successful message.
+    return {"ok": True, "noop": result is None}

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -47,6 +47,7 @@ from common.models import (
     FleetCommand,
     FleetNode,
     IdempotencyResponse,
+    LifecycleAudit,
     Memory,
     MemoryEntityLink,
     Relation,
@@ -3117,6 +3118,103 @@ class PostgresService:
                 q = q.where(AuditLog.created_at > since)
             result = await session.execute(q)
             return list(result.scalars().all())
+
+    # ══════════════════════════════════════════════════════════════════════
+    #  LIFECYCLE AUDIT (CAURA-655)
+    # ══════════════════════════════════════════════════════════════════════
+
+    async def lifecycle_audit_create(
+        self,
+        *,
+        org_id: str,
+        action: str,
+        triggered_by: str,
+    ) -> int:
+        """Insert a ``status='pending'`` row and return its id.
+
+        Called by the core-api fanout endpoint just before publishing
+        each per-org Pub/Sub message — the id rides along in the
+        envelope so the consumer can finalise the same row on
+        completion.
+        """
+        async with get_session() as session:
+            row = LifecycleAudit(
+                org_id=org_id,
+                action=action,
+                triggered_by=triggered_by,
+            )
+            session.add(row)
+            await session.flush()
+            return row.id
+
+    async def lifecycle_audit_finalize(
+        self,
+        audit_id: int,
+        *,
+        status: str,
+        stats: dict | None = None,
+        error_message: str | None = None,
+    ) -> bool | None:
+        """Set terminal-or-progress state on the row.
+
+        Tri-state return distinguishes the two ``rowcount==0`` cases:
+        * ``True``  — row updated.
+        * ``None``  — row exists but is already at ``status='success'``
+          (the sticky-success gate skipped the UPDATE). A no-op, NOT
+          an error — typically a Pub/Sub redelivery of an already-
+          acked successful message.
+        * ``False`` — row not found at all (pruned, or a buggy
+          publisher invented an id).
+
+        ``finished_at`` is only stamped on terminal status values so the
+        ``in_progress`` transition leaves the row addressable for a
+        later success/failure update.
+        """
+        values: dict = {"status": status}
+        if status in ("success", "failure"):
+            values["finished_at"] = func.now()
+        elif status == "in_progress":
+            # Pub/Sub redelivery after a prior ``failure`` re-enters this
+            # method with status="in_progress"; without the explicit NULL
+            # the row would carry the previous attempt's ``finished_at``,
+            # and any query using ``finished_at IS NOT NULL`` to find
+            # completed rows would misclassify the retrying row.
+            values["finished_at"] = None
+        if stats is not None:
+            values["stats"] = stats
+        if error_message is not None:
+            values["error_message"] = error_message
+        if status == "success":
+            # A redelivery that recovered from a prior ``failure`` must
+            # not leave the failure's ``error_message`` lingering on a
+            # now-successful row.
+            values["error_message"] = None
+        async with get_session() as session:
+            # ``success`` is sticky — once a row reaches it, no
+            # subsequent transition (Pub/Sub redelivery of an already-
+            # acked-but-late-acked message) can downgrade or overwrite
+            # it. Without this, a redelivery would re-enter as
+            # ``in_progress`` → re-run the (idempotent) archive
+            # primitive that returns 0 → clobber the original
+            # ``stats.archived`` count with 0. Failure recovery
+            # (failure → in_progress → success) still works because
+            # ``failure`` is NOT gated.
+            stmt = (
+                sql_update(LifecycleAudit)
+                .where(LifecycleAudit.id == audit_id)
+                .where(LifecycleAudit.status != "success")
+                .values(**values)
+            )
+            result = await session.execute(stmt)
+            if result.rowcount > 0:  # type: ignore[attr-defined]
+                return True
+            # rowcount==0 has two causes — disambiguate so the router
+            # can return 200 for the no-op (already-success) path
+            # instead of a misleading 404 that would surface as a
+            # spurious "audit row not found" warning on every Pub/Sub
+            # redelivery of an acked-but-late-acked successful message.
+            exists = await session.scalar(select(LifecycleAudit.id).where(LifecycleAudit.id == audit_id))
+            return None if exists else False
 
     # ══════════════════════════════════════════════════════════════════════
     #  REPORTS (CrystallizationReport)

--- a/core-worker/src/core_worker/app.py
+++ b/core-worker/src/core_worker/app.py
@@ -34,12 +34,16 @@ from fastapi import FastAPI, HTTPException
 
 from common.events.base import EventBus
 from common.events.factory import get_event_bus
+from common.events.lifecycle_handlers import (
+    register_consumers as register_lifecycle_consumers,
+)
 from common.llm import init_platform_providers
 from common.structlog_config import configure_logging
 from core_worker.clients.storage_client import close_storage_client, get_storage_client
 from core_worker.config import Settings
 from core_worker.consumer import configure as configure_consumer
 from core_worker.consumer import register_consumers
+from core_worker.lifecycle import make_storage_adapter as make_lifecycle_adapter
 
 settings = Settings()  # type: ignore[call-arg]
 
@@ -88,6 +92,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # backend spawns pull loops based on the current handler registry.
     configure_consumer(get_storage_client)
     register_consumers()
+
+    # CAURA-655: lifecycle archive consumers share the same Pub/Sub
+    # transport. Adapter wraps the worker's httpx storage client into
+    # the shape the shared handler expects.
+    register_lifecycle_consumers(make_lifecycle_adapter())
 
     _event_bus = get_event_bus()
     await _event_bus.start()

--- a/core-worker/src/core_worker/clients/storage_client.py
+++ b/core-worker/src/core_worker/clients/storage_client.py
@@ -30,6 +30,7 @@ from uuid import UUID
 
 import httpx
 
+from common.constants import LIFECYCLE_STALE_ARCHIVE_WEIGHT
 from core_worker.clients.identity_token import evict as _evict_id_token
 from core_worker.clients.identity_token import fetch_auth_header
 
@@ -314,6 +315,89 @@ async def get_memory(
     )
     resp.raise_for_status()
     return resp.json()
+
+
+async def archive_expired(
+    client: httpx.AsyncClient,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+) -> int:
+    """Run the storage-side ``memory_archive_expired`` SQL primitive.
+
+    Returns the row count flipped from ``active`` to ``outdated``;
+    surfaced as ``stats.archived`` on the lifecycle_audit row.
+    """
+    body: dict[str, Any] = {"tenant_id": tenant_id}
+    if fleet_id is not None:
+        body["fleet_id"] = fleet_id
+    resp = await _signed_call(
+        client.post,
+        f"{_PREFIX}/memories/archive-expired",
+        json=body,
+    )
+    resp.raise_for_status()
+    return resp.json().get("count", 0)
+
+
+async def archive_stale(
+    client: httpx.AsyncClient,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+) -> int:
+    """Run the storage-side ``memory_archive_stale`` SQL primitive.
+
+    ``max_weight`` is sent explicitly so the cron-driven worker path
+    matches the synchronous code path's threshold rather than relying
+    on the storage server's default to stay aligned. The shared
+    constant lives in :mod:`common.constants` so core-api's adapter
+    and this worker can't silently diverge.
+    """
+    body: dict[str, Any] = {
+        "tenant_id": tenant_id,
+        "max_weight": LIFECYCLE_STALE_ARCHIVE_WEIGHT,
+    }
+    if fleet_id is not None:
+        body["fleet_id"] = fleet_id
+    resp = await _signed_call(
+        client.post,
+        f"{_PREFIX}/memories/archive-stale",
+        json=body,
+    )
+    resp.raise_for_status()
+    return resp.json().get("count", 0)
+
+
+async def update_lifecycle_audit_row(
+    client: httpx.AsyncClient,
+    audit_id: int,
+    *,
+    status: str,
+    stats: dict | None = None,
+    error_message: str | None = None,
+) -> None:
+    """PATCH the lifecycle_audit row created by core-api fanout."""
+    body: dict[str, Any] = {"status": status}
+    if stats is not None:
+        body["stats"] = stats
+    if error_message is not None:
+        body["error_message"] = error_message
+    resp = await _signed_call(
+        client.patch,
+        f"{_PREFIX}/lifecycle-audit/{audit_id}",
+        json=body,
+    )
+    if resp.status_code == 404:
+        # Audit row pruned or never created. The shared handler decides
+        # whether to log + continue (in_progress) or surface (final).
+        logger.warning(
+            "lifecycle_audit %s not found on PATCH (status=%s)",
+            audit_id,
+            status,
+        )
+        return
+    resp.raise_for_status()
 
 
 async def update_memory_enrichment(

--- a/core-worker/src/core_worker/lifecycle.py
+++ b/core-worker/src/core_worker/lifecycle.py
@@ -1,0 +1,46 @@
+"""Adapter wiring core-worker's httpx storage client into the shared
+:class:`common.events.lifecycle_handlers.LifecycleStorageAdapter`
+protocol (CAURA-655).
+
+The worker's storage_client is module-level functions, not a class, so
+this thin object does the binding once at startup and exposes the
+three methods the shared handler needs.
+"""
+
+from __future__ import annotations
+
+from common.events.lifecycle_handlers import LifecycleStorageAdapter
+from core_worker.clients.storage_client import (
+    archive_expired,
+    archive_stale,
+    get_storage_client,
+    update_lifecycle_audit_row,
+)
+
+
+class _CoreWorkerLifecycleAdapter:
+    async def archive_expired(self, *, org_id: str, fleet_id: str | None) -> int:
+        return await archive_expired(get_storage_client(), tenant_id=org_id, fleet_id=fleet_id)
+
+    async def archive_stale(self, *, org_id: str, fleet_id: str | None) -> int:
+        return await archive_stale(get_storage_client(), tenant_id=org_id, fleet_id=fleet_id)
+
+    async def update_lifecycle_audit_row(
+        self,
+        audit_id: int,
+        *,
+        status: str,
+        stats: dict | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        await update_lifecycle_audit_row(
+            get_storage_client(),
+            audit_id,
+            status=status,
+            stats=stats,
+            error_message=error_message,
+        )
+
+
+def make_storage_adapter() -> LifecycleStorageAdapter:
+    return _CoreWorkerLifecycleAdapter()

--- a/tests/test_lifecycle_automation.py
+++ b/tests/test_lifecycle_automation.py
@@ -1,35 +1,27 @@
-"""Fix #10: Lifecycle automation — scheduled archival of expired/stale memories.
+"""Lifecycle automation — settings + the surviving crystallize+entity-link
+service entry point.
 
-Unit tests validate:
-- Lifecycle constants
-- Tenant setting defaults and overrides
-- Archive logic contracts
+Pre-CAURA-655 this file also asserted the in-process scheduler interval
+constant; the scheduler moved to core-operations and the constant is
+no longer load-bearing on core-api. Cron cadence now lives on
+``core_operations.config.Settings.lifecycle_archive_interval_seconds``.
 """
 
 import pytest
 
 from core_api.constants import (
     LIFECYCLE_BATCH_SIZE,
-    LIFECYCLE_INTERVAL_HOURS,
     LIFECYCLE_STALE_ARCHIVE_WEIGHT,
 )
 
 
 @pytest.mark.unit
 class TestLifecycleConstants:
-    """Verify lifecycle constant values."""
-
-    def test_interval_hours(self):
-        assert LIFECYCLE_INTERVAL_HOURS == 24
-
     def test_batch_size(self):
         assert LIFECYCLE_BATCH_SIZE == 500
 
     def test_stale_archive_weight(self):
         assert LIFECYCLE_STALE_ARCHIVE_WEIGHT == 0.3
-
-    def test_interval_reasonable(self):
-        assert 1 <= LIFECYCLE_INTERVAL_HOURS <= 168  # 1h to 1 week
 
     def test_batch_size_reasonable(self):
         assert 50 <= LIFECYCLE_BATCH_SIZE <= 5000
@@ -37,40 +29,66 @@ class TestLifecycleConstants:
 
 @pytest.mark.unit
 class TestLifecycleTenantSettings:
-    """Verify lifecycle tenant setting integration."""
-
     def test_enabled_by_default(self):
         from core_api.services.organization_settings import ResolvedConfig
+
         config = ResolvedConfig({})
         assert config.lifecycle_automation_enabled is True
 
     def test_can_be_disabled(self):
         from core_api.services.organization_settings import ResolvedConfig
+
         config = ResolvedConfig({"lifecycle": {"lifecycle_automation_enabled": False}})
         assert config.lifecycle_automation_enabled is False
 
-    def test_explicitly_enabled(self):
-        from core_api.services.organization_settings import ResolvedConfig
-        config = ResolvedConfig({"lifecycle": {"lifecycle_automation_enabled": True}})
-        assert config.lifecycle_automation_enabled is True
-
     def test_default_settings_has_lifecycle_section(self):
         from core_api.services.organization_settings import DEFAULT_SETTINGS
+
         assert "lifecycle" in DEFAULT_SETTINGS
         assert "lifecycle_automation_enabled" in DEFAULT_SETTINGS["lifecycle"]
 
 
 @pytest.mark.unit
 class TestLifecycleServiceImports:
-    """Verify lifecycle service module is importable and has expected functions."""
-
     def test_module_importable(self):
         from core_api.services import lifecycle_service  # noqa: F401
 
-    def test_has_scheduler(self):
-        from core_api.services.lifecycle_service import lifecycle_scheduler
-        assert callable(lifecycle_scheduler)
-
     def test_has_run_for_tenant(self):
         from core_api.services.lifecycle_service import run_lifecycle_for_tenant
+
         assert callable(run_lifecycle_for_tenant)
+
+    def test_scheduler_is_gone(self):
+        # Guard against the loop sneaking back in. The
+        # core-operations service owns the cron now; resurrecting the
+        # in-process loop here would re-create the double-scheduling
+        # situation CAURA-655 set out to remove.
+        from core_api.services import lifecycle_service
+
+        assert not hasattr(lifecycle_service, "lifecycle_scheduler")
+
+
+@pytest.mark.unit
+class TestLifecycleTopics:
+    def test_topic_strings(self):
+        from common.events.topics import Topics
+
+        assert (
+            Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED
+            == "memclaw.lifecycle.archive-expired-requested"
+        )
+        assert (
+            Topics.Lifecycle.ARCHIVE_STALE_REQUESTED
+            == "memclaw.lifecycle.archive-stale-requested"
+        )
+
+    def test_topic_strenum_format(self):
+        from common.events.topics import Topics
+
+        # ``StrEnum`` so f-strings see the literal value, not the
+        # ``Lifecycle.ARCHIVE_EXPIRED_REQUESTED`` repr — same invariant
+        # the embed/enrich topics rely on for Pub/Sub's ``topic_path``.
+        assert (
+            f"{Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED}"
+            == "memclaw.lifecycle.archive-expired-requested"
+        )

--- a/tests/test_lifecycle_handlers.py
+++ b/tests/test_lifecycle_handlers.py
@@ -1,0 +1,167 @@
+"""Unit tests for the shared lifecycle archive consumers (CAURA-655).
+
+The handlers live in ``common/events/lifecycle_handlers.py`` so both
+core-api (OSS standalone) and core-worker (SaaS) register the same
+code. These tests exercise the full success/failure paths against an
+in-memory fake adapter — the real adapters are thin httpx wrappers
+covered by integration tests elsewhere.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from functools import partial
+
+from common.events.base import Event
+from common.events.lifecycle_archive_request import LifecycleArchiveRequest
+from common.events.lifecycle_handlers import _run_archive
+from common.events.topics import Topics
+
+
+class _FakeAdapter:
+    def __init__(
+        self,
+        *,
+        expired_count: int = 7,
+        stale_count: int = 4,
+        raise_on_archive: Exception | None = None,
+    ):
+        self.expired_count = expired_count
+        self.stale_count = stale_count
+        self.raise_on_archive = raise_on_archive
+        self.archive_calls: list[tuple[str, str, str | None]] = []
+        self.audit_calls: list[tuple[int, str, dict | None, str | None]] = []
+
+    async def archive_expired(self, *, org_id: str, fleet_id: str | None) -> int:
+        self.archive_calls.append(("expired", org_id, fleet_id))
+        if self.raise_on_archive is not None:
+            raise self.raise_on_archive
+        return self.expired_count
+
+    async def archive_stale(self, *, org_id: str, fleet_id: str | None) -> int:
+        self.archive_calls.append(("stale", org_id, fleet_id))
+        if self.raise_on_archive is not None:
+            raise self.raise_on_archive
+        return self.stale_count
+
+    async def update_lifecycle_audit_row(
+        self,
+        audit_id: int,
+        *,
+        status: str,
+        stats: dict | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        self.audit_calls.append((audit_id, status, stats, error_message))
+
+
+def _event(
+    topic: str,
+    *,
+    audit_id: int = 42,
+    org_id: str = "tenant-x",
+    fleet_id: str | None = None,
+) -> Event:
+    payload = LifecycleArchiveRequest(
+        audit_id=audit_id,
+        org_id=org_id,
+        triggered_by="test",
+        fleet_id=fleet_id,
+    ).model_dump(mode="json")
+    return Event(event_type=topic, payload=payload)
+
+
+def _bind(adapter: _FakeAdapter, *, action: str):
+    """Mirror what register_consumers() does at app startup — bind the
+    adapter and the per-action archive callable into the dispatch."""
+    archive_fn = (
+        adapter.archive_expired
+        if action == "archive-expired"
+        else adapter.archive_stale
+    )
+    return partial(_run_archive, adapter=adapter, archive_fn=archive_fn, action=action)
+
+
+@pytest.mark.asyncio
+async def test_archive_expired_success_marks_audit_progress_then_success():
+    adapter = _FakeAdapter(expired_count=11)
+    handler = _bind(adapter, action="archive-expired")
+    await handler(_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
+    # Order matters: in_progress must land BEFORE the storage primitive
+    # so observers can distinguish a stuck-in-progress run from a
+    # never-started one.
+    statuses = [c[1] for c in adapter.audit_calls]
+    assert statuses == ["in_progress", "success"]
+    final = adapter.audit_calls[-1]
+    assert final[0] == 42
+    assert final[2] == {"archived": 11}
+    assert final[3] is None
+    assert adapter.archive_calls == [("expired", "tenant-x", None)]
+
+
+@pytest.mark.asyncio
+async def test_archive_stale_dispatches_to_stale_primitive():
+    adapter = _FakeAdapter(stale_count=3)
+    handler = _bind(adapter, action="archive-stale")
+    await handler(_event(Topics.Lifecycle.ARCHIVE_STALE_REQUESTED, fleet_id="fleet-1"))
+    assert adapter.archive_calls == [("stale", "tenant-x", "fleet-1")]
+    assert adapter.audit_calls[-1] == (42, "success", {"archived": 3}, None)
+
+
+@pytest.mark.asyncio
+async def test_archive_failure_marks_audit_failure_and_reraises():
+    err = RuntimeError("storage down")
+    adapter = _FakeAdapter(raise_on_archive=err)
+    handler = _bind(adapter, action="archive-expired")
+    with pytest.raises(RuntimeError, match="storage down"):
+        await handler(_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
+    statuses = [c[1] for c in adapter.audit_calls]
+    assert statuses == ["in_progress", "failure"]
+    final = adapter.audit_calls[-1]
+    assert final[3] == "storage down"
+    assert final[2] is None  # no stats on failure path
+
+
+@pytest.mark.asyncio
+async def test_failure_audit_update_error_does_not_swallow_original():
+    """If the audit-row failure update itself raises, the original
+    archive exception must still propagate. Otherwise the row would
+    sit in ``in_progress`` indefinitely AND Pub/Sub would see the wrong
+    exception (audit-update flake instead of the real archive failure).
+    """
+
+    class _FlakyAuditAdapter(_FakeAdapter):
+        async def update_lifecycle_audit_row(
+            self,
+            audit_id: int,
+            *,
+            status: str,
+            stats: dict | None = None,
+            error_message: str | None = None,
+        ) -> None:
+            self.audit_calls.append((audit_id, status, stats, error_message))
+            if status == "failure":
+                raise RuntimeError("audit endpoint down")
+
+    adapter = _FlakyAuditAdapter(raise_on_archive=RuntimeError("storage down"))
+    handler = _bind(adapter, action="archive-expired")
+    with pytest.raises(RuntimeError, match="storage down"):
+        await handler(_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
+    statuses = [c[1] for c in adapter.audit_calls]
+    assert statuses == ["in_progress", "failure"]
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_is_acked_dropped():
+    adapter = _FakeAdapter()
+    handler = _bind(adapter, action="archive-expired")
+    bad_event = Event(
+        event_type=Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED,
+        payload={"audit_id": "not-an-int"},
+    )
+    await handler(bad_event)
+    # No archive call, no audit-row PATCH — the message gets dropped
+    # cleanly so a poison message can't loop the subscription.
+    assert adapter.archive_calls == []
+    assert adapter.audit_calls == []

--- a/tests/test_provider_protocols.py
+++ b/tests/test_provider_protocols.py
@@ -399,9 +399,6 @@ class _FakeJobQueue:
     async def enqueue(self, func, *args, **kwargs):
         return "job-1"
 
-    async def schedule(self, func, *, cron):
-        pass
-
 
 class _FakeIdentityResolver:
     async def resolve(self, context):


### PR DESCRIPTION
## Summary

- Replaces the in-process daily lifecycle loop in core-api with a per-action Pub/Sub fanout pipeline rooted in `core-operations`.
- New OSS-DB table `lifecycle_audit` (one row per scheduled invocation) makes lost / DLQ'd messages observable.
- Each archival operation gets its own cron registration, fanout endpoint, audit-action label, and Pub/Sub topic — pattern to be reused by [CAURA-656](https://caura-ai.atlassian.net/browse/CAURA-656) (memory retention) and [CAURA-657](https://caura-ai.atlassian.net/browse/CAURA-657) (crystallize + entity-link migration).

## Architecture

```
core-operations cron (per-action, daily)
   │  POST /admin/lifecycle/fanout/<action>  (admin-key auth)
   ▼
core-api fanout endpoint
  - lists active orgs (shared list_active_tenant_ids helper)
  - per org (asyncio.gather): pre-publishes audit row (status=pending) + publishes per-org event
   │  memclaw.lifecycle.<action>-requested  (Pub/Sub or in-process bus)
   ▼
core-worker (or core-api in OSS standalone)
  - update audit row → in_progress
  - call core-storage-api archive primitive
  - update audit row → success/failure with stats
```

OSS standalone uses the in-process bus and registers the consumer in core-api itself (no separate worker process). SaaS subscribes only on core-worker so each archive runs once.

## Scope

- `archive-expired` and `archive-stale` end-to-end (SQL-only, naturally idempotent under Pub/Sub redelivery).
- Crystallize + entity-link deferred to [CAURA-657](https://caura-ai.atlassian.net/browse/CAURA-657) — they need core-api's pipeline machinery and explicit dedup. Surviving `run_lifecycle_for_tenant()` in `lifecycle_service.py` is the seam CAURA-657 will subscribe to its own topic.

## Other

- New `lifecycle_audit` table (migration 015), accessed only via core-storage-api routes — preserves the no-DB-outside-storage-api invariant.
- `Topics.Lifecycle` `StrEnum` added in `common/events/topics.py`.
- `InProcessQueue._scheduled` / `_ticker` / `schedule()` and `JobQueue.schedule()` protocol entry retired (only caller was the now-removed in-process loop).
- Companion enterprise PR: [caura-memclaw-enterprise#?](https://github.com/caura-ai/caura-memclaw-enterprise) provisions the new topics, subscriptions, DLQs, and IAM bindings.

## Test plan

- [x] `pytest tests/test_lifecycle_handlers.py tests/test_lifecycle_automation.py` — 15 unit tests covering success / failure / poison-message paths and topic invariants
- [x] `pytest core-operations/tests/` — scheduler harness + tick fanout HTTP behaviour
- [x] `pytest tests/test_provider_protocols.py` — confirms `JobQueue.schedule()` removal didn't break protocol conformance
- [ ] Review automated bot pass(es)
- [ ] Staging deploy + manual fanout via `curl -XPOST $URL/api/v1/admin/lifecycle/fanout/archive-expired`; verify per-org audit rows transition pending → in_progress → success, and stats carry the archived count
- [ ] Loadtest: confirm core-operations cron fires once per day in staging and the fanout response shows expected `published` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-656]: https://caura-ai.atlassian.net/browse/CAURA-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAURA-657]: https://caura-ai.atlassian.net/browse/CAURA-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAURA-657]: https://caura-ai.atlassian.net/browse/CAURA-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ