### PR TITLE
feat: memory retention purge on top of lifecycle Pub/Sub fanout (CAURA-656)

### DIFF
--- a/common/events/__init__.py
+++ b/common/events/__init__.py
@@ -22,6 +22,7 @@ from common.events.inprocess import InProcessEventBus
 from common.events.lifecycle_publishers import (
     publish_archive_expired_request,
     publish_archive_stale_request,
+    publish_purge_soft_deleted_request,
 )
 from common.events.memory_embed_publisher import publish_memory_embed_request
 from common.events.memory_enrich_publisher import publish_memory_enrich_request
@@ -44,6 +45,7 @@ __all__ = [
     "get_event_bus",
     "publish_archive_expired_request",
     "publish_archive_stale_request",
+    "publish_purge_soft_deleted_request",
     "publish_memory_embed_request",
     "publish_memory_enrich_request",
     "publish_memory_enriched",

--- a/common/events/lifecycle_archive_request.py
+++ b/common/events/lifecycle_archive_request.py
@@ -1,8 +1,11 @@
-"""Typed payload for the ``memclaw.lifecycle.<action>-requested`` topics
-(CAURA-655). Both ``archive-expired`` and ``archive-stale`` share this
-model — the consumer's per-action behaviour is parameterised by the
-topic, not by payload fields. ``audit_id`` ties the message back to
-the row pre-published by the core-api fanout endpoint.
+"""Typed payloads for ``memclaw.lifecycle.<action>-requested`` topics.
+
+Both archive ops (CAURA-655) share one model — the per-action
+behaviour is parameterised by the topic, not by payload fields.
+``LifecycleRequestBase`` exposes the four fields every lifecycle
+payload carries; per-action subclasses (e.g.
+:class:`~common.events.lifecycle_purge_request.LifecyclePurgeRequest`)
+add their action-specific fields without redefining the shared ones.
 """
 
 from __future__ import annotations
@@ -10,10 +13,25 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict
 
 
-class LifecycleArchiveRequest(BaseModel):
+class LifecycleRequestBase(BaseModel):
+    """Fields every lifecycle Pub/Sub payload carries: the audit-row
+    pointer (``audit_id``), the org scope (``org_id``), provenance
+    (``triggered_by``), and an optional fleet narrowing.
+
+    The shared handler reads only these fields and is generic over
+    subclasses. New actions extend by subclassing and adding their
+    own action-specific Pydantic fields.
+    """
+
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     audit_id: int
     org_id: str
     triggered_by: str
     fleet_id: str | None = None
+
+
+class LifecycleArchiveRequest(LifecycleRequestBase):
+    """No additional fields beyond the base — both archive ops are
+    keyed entirely by their topic, with no per-action data.
+    """

--- a/common/events/lifecycle_handlers.py
+++ b/common/events/lifecycle_handlers.py
@@ -1,4 +1,5 @@
-"""Consumers for ``memclaw.lifecycle.<action>-requested`` topics (CAURA-655).
+"""Consumers for ``memclaw.lifecycle.<action>-requested`` topics
+(CAURA-655 archive ops, CAURA-656 purge-soft-deleted op).
 
 Lives in ``common/`` rather than under either service so the same code
 runs in both deployments:
@@ -9,7 +10,9 @@ runs in both deployments:
 
 The handler delegates the two storage round-trips it needs (run the
 SQL primitive, finalise the audit row) to a small adapter the host
-service supplies via :func:`register_consumers`.
+service supplies via :func:`register_consumers`. Per-action ops bind
+their own primitive callable + payload class at registration time so
+the dispatch never branches on a string.
 """
 
 from __future__ import annotations
@@ -23,14 +26,18 @@ from pydantic import ValidationError
 
 from common.events.base import Event
 from common.events.factory import get_event_bus
-from common.events.lifecycle_archive_request import LifecycleArchiveRequest
+from common.events.lifecycle_archive_request import (
+    LifecycleArchiveRequest,
+    LifecycleRequestBase,
+)
+from common.events.lifecycle_purge_request import LifecyclePurgeRequest
 from common.events.topics import Topics
 
 logger = logging.getLogger(__name__)
 
 
 class LifecycleStorageAdapter(Protocol):
-    """Two-method shape the lifecycle handlers need.
+    """Three-method shape the lifecycle handlers need.
 
     All methods are async and call core-storage-api over HTTP. Hosts
     inject their own implementation so this module stays free of any
@@ -40,6 +47,10 @@ class LifecycleStorageAdapter(Protocol):
     async def archive_expired(self, *, org_id: str, fleet_id: str | None) -> int: ...
 
     async def archive_stale(self, *, org_id: str, fleet_id: str | None) -> int: ...
+
+    async def purge_soft_deleted(
+        self, *, org_id: str, fleet_id: str | None, retention_days: int
+    ) -> int: ...
 
     async def update_lifecycle_audit_row(
         self,
@@ -51,25 +62,34 @@ class LifecycleStorageAdapter(Protocol):
     ) -> None: ...
 
 
-_ArchiveFn = Callable[..., Awaitable[int]]
+# Callable parameters are contravariant: an op that accepts a
+# ``LifecycleArchiveRequest`` (subclass) is NOT assignable to a
+# ``Callable[[LifecycleRequestBase], ...]``. Use ``...`` so the
+# registered closures (each with its own subclass-typed argument)
+# satisfy the alias without a ``# type: ignore``. ``_run_action``
+# never inspects ``run_op``'s parameter type itself — the caller
+# always passes the correctly-shaped request — so the looser alias
+# carries no runtime risk.
+_OpFn = Callable[..., Awaitable[int]]
 
 
-async def _run_archive(
+async def _run_action(
     event: Event,
     *,
     adapter: LifecycleStorageAdapter,
-    archive_fn: _ArchiveFn,
+    payload_cls: type[LifecycleRequestBase],
+    run_op: _OpFn,
+    stats_key: str,
     action: str,
 ) -> None:
-    """Shared body for both archive handlers — bound to a specific
+    """Shared body for every lifecycle action — bound to a specific
     primitive at registration time so this function never branches on
-    a string. The SQL archive ops are naturally idempotent so Pub/Sub
-    redelivery is safe to run more than once; each delivery attempt
-    updates the SAME audit row (the row id rides in the event payload
-    and is pre-created by the fanout endpoint before publish).
+    a string. SQL ops are naturally idempotent so Pub/Sub redelivery
+    is safe; each delivery attempt updates the SAME audit row (the
+    row id rides in the payload, pre-created by the fanout endpoint).
     """
     try:
-        request = LifecycleArchiveRequest(**event.payload)
+        request = payload_cls(**event.payload)
     except ValidationError:
         logger.exception(
             "dropping malformed lifecycle-request payload",
@@ -81,36 +101,35 @@ async def _run_archive(
         )
         return
 
+    audit_id = request.audit_id
+    org_id = request.org_id
+    triggered_by = request.triggered_by
+
     # Best-effort in_progress mark: 404 means the audit row was pruned
     # between fanout and consume. Continue anyway so the SQL primitive
     # still runs — dropping would silently skip an op the operator
     # asked for.
     try:
-        await adapter.update_lifecycle_audit_row(request.audit_id, status="in_progress")
+        await adapter.update_lifecycle_audit_row(audit_id, status="in_progress")
     except Exception:
         logger.warning(
             "lifecycle audit in_progress update failed; continuing",
             exc_info=True,
-            extra={"audit_id": request.audit_id, "action": action},
+            extra={"audit_id": audit_id, "action": action},
         )
 
     try:
-        count = await archive_fn(org_id=request.org_id, fleet_id=request.fleet_id)
+        count = await run_op(request)
     except Exception as exc:
-        # Mark the row failed so observers can distinguish a stuck
-        # ``in_progress`` (worker crashed mid-run) from a finished-with-
-        # error op. Truncated to keep the row bounded; full traceback
-        # is in the worker logs.
-        #
-        # Wrap the audit update in its own guard: if it raises, the
-        # outer ``raise`` below would never run and the original archive
+        # Wrap the failure update in its own guard: if it raises, the
+        # outer ``raise`` below would never run and the original op
         # exception would be silently replaced by the audit error,
         # leaving the row stuck in ``in_progress`` indistinguishable
         # from a crashed worker. Log and continue so the original
         # always surfaces.
         try:
             await adapter.update_lifecycle_audit_row(
-                request.audit_id,
+                audit_id,
                 status="failure",
                 error_message=str(exc)[:500],
             )
@@ -118,7 +137,7 @@ async def _run_archive(
             logger.warning(
                 "lifecycle audit failure update failed; row stuck in_progress",
                 exc_info=True,
-                extra={"audit_id": request.audit_id, "action": action},
+                extra={"audit_id": audit_id, "action": action},
             )
         # Re-raise so the bus nacks → Pub/Sub redelivers (subject to
         # max-delivery-attempts → DLQ). The ``failure`` row above is
@@ -126,44 +145,74 @@ async def _run_archive(
         raise
 
     await adapter.update_lifecycle_audit_row(
-        request.audit_id,
+        audit_id,
         status="success",
-        stats={"archived": count},
+        stats={stats_key: count},
     )
 
     logger.info(
         "lifecycle %s processed",
         action,
         extra={
-            "audit_id": request.audit_id,
-            "org_id": request.org_id,
-            "triggered_by": request.triggered_by,
-            "archived": count,
+            "audit_id": audit_id,
+            "org_id": org_id,
+            "triggered_by": triggered_by,
+            stats_key: count,
         },
     )
 
 
 def register_consumers(adapter: LifecycleStorageAdapter) -> None:
-    """Subscribe both archive handlers, each closing over the adapter
-    method that runs its primitive. Call once at app startup, before
-    ``bus.start()``.
+    """Subscribe every lifecycle action handler. Per-action ops are
+    bound here as closures over the adapter so :func:`_run_action`
+    receives a no-arg-ish callable + payload class. Call once at app
+    startup, before ``bus.start()``.
     """
+
+    async def archive_expired_op(req: LifecycleArchiveRequest) -> int:
+        return await adapter.archive_expired(org_id=req.org_id, fleet_id=req.fleet_id)
+
+    async def archive_stale_op(req: LifecycleArchiveRequest) -> int:
+        return await adapter.archive_stale(org_id=req.org_id, fleet_id=req.fleet_id)
+
+    async def purge_op(req: LifecyclePurgeRequest) -> int:
+        return await adapter.purge_soft_deleted(
+            org_id=req.org_id,
+            fleet_id=req.fleet_id,
+            retention_days=req.retention_days,
+        )
+
     bus = get_event_bus()
     bus.subscribe(
         Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED,
         partial(
-            _run_archive,
+            _run_action,
             adapter=adapter,
-            archive_fn=adapter.archive_expired,
+            payload_cls=LifecycleArchiveRequest,
+            run_op=archive_expired_op,
+            stats_key="archived",
             action="archive-expired",
         ),
     )
     bus.subscribe(
         Topics.Lifecycle.ARCHIVE_STALE_REQUESTED,
         partial(
-            _run_archive,
+            _run_action,
             adapter=adapter,
-            archive_fn=adapter.archive_stale,
+            payload_cls=LifecycleArchiveRequest,
+            run_op=archive_stale_op,
+            stats_key="archived",
             action="archive-stale",
+        ),
+    )
+    bus.subscribe(
+        Topics.Lifecycle.PURGE_SOFT_DELETED_REQUESTED,
+        partial(
+            _run_action,
+            adapter=adapter,
+            payload_cls=LifecyclePurgeRequest,
+            run_op=purge_op,
+            stats_key="deleted",
+            action="purge-soft-deleted",
         ),
     )

--- a/common/events/lifecycle_publishers.py
+++ b/common/events/lifecycle_publishers.py
@@ -9,27 +9,18 @@ from __future__ import annotations
 
 from common.events.base import Event
 from common.events.factory import get_event_bus
-from common.events.lifecycle_archive_request import LifecycleArchiveRequest
+from common.events.lifecycle_archive_request import (
+    LifecycleArchiveRequest,
+    LifecycleRequestBase,
+)
+from common.events.lifecycle_purge_request import LifecyclePurgeRequest
 from common.events.topics import Topics
 
 
-async def _publish(
-    topic: str,
-    *,
-    audit_id: int,
-    org_id: str,
-    triggered_by: str,
-    fleet_id: str | None,
-) -> None:
-    payload = LifecycleArchiveRequest(
-        audit_id=audit_id,
-        org_id=org_id,
-        triggered_by=triggered_by,
-        fleet_id=fleet_id,
-    )
+async def _publish(topic: str, payload: LifecycleRequestBase) -> None:
     event = Event(
         event_type=topic,
-        tenant_id=org_id,
+        tenant_id=payload.org_id,
         payload=payload.model_dump(mode="json"),
     )
     await get_event_bus().publish(topic, event)
@@ -44,10 +35,12 @@ async def publish_archive_expired_request(
 ) -> None:
     await _publish(
         Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED,
-        audit_id=audit_id,
-        org_id=org_id,
-        triggered_by=triggered_by,
-        fleet_id=fleet_id,
+        LifecycleArchiveRequest(
+            audit_id=audit_id,
+            org_id=org_id,
+            triggered_by=triggered_by,
+            fleet_id=fleet_id,
+        ),
     )
 
 
@@ -60,8 +53,30 @@ async def publish_archive_stale_request(
 ) -> None:
     await _publish(
         Topics.Lifecycle.ARCHIVE_STALE_REQUESTED,
-        audit_id=audit_id,
-        org_id=org_id,
-        triggered_by=triggered_by,
-        fleet_id=fleet_id,
+        LifecycleArchiveRequest(
+            audit_id=audit_id,
+            org_id=org_id,
+            triggered_by=triggered_by,
+            fleet_id=fleet_id,
+        ),
+    )
+
+
+async def publish_purge_soft_deleted_request(
+    *,
+    audit_id: int,
+    org_id: str,
+    triggered_by: str,
+    retention_days: int,
+    fleet_id: str | None = None,
+) -> None:
+    await _publish(
+        Topics.Lifecycle.PURGE_SOFT_DELETED_REQUESTED,
+        LifecyclePurgeRequest(
+            audit_id=audit_id,
+            org_id=org_id,
+            triggered_by=triggered_by,
+            fleet_id=fleet_id,
+            retention_days=retention_days,
+        ),
     )

--- a/common/events/lifecycle_purge_request.py
+++ b/common/events/lifecycle_purge_request.py
@@ -1,0 +1,28 @@
+"""Typed payload for ``memclaw.lifecycle.purge-soft-deleted-requested``
+(CAURA-656). Diverges from
+:class:`~common.events.lifecycle_archive_request.LifecycleArchiveRequest`
+by carrying ``retention_days`` — the per-org policy snapshot that the
+fanout endpoint reads from organization_settings at cron-tick time and
+bakes into each per-org message. Consumer trusts the value (no
+re-fetch), so a settings change between fanout and consume uses the
+snapshot from the previous tick — acceptable for daily cadence.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from common.events.lifecycle_archive_request import LifecycleRequestBase
+
+# Inclusive range applied at three boundaries: the org-settings PUT
+# validator, this Pydantic field, and the storage-side primitive's
+# default. One source of truth so a future widening only touches one
+# constant.
+MEMORY_RETENTION_MIN_DAYS = 1
+MEMORY_RETENTION_MAX_DAYS = 30
+
+
+class LifecyclePurgeRequest(LifecycleRequestBase):
+    retention_days: int = Field(
+        ge=MEMORY_RETENTION_MIN_DAYS, le=MEMORY_RETENTION_MAX_DAYS
+    )

--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -41,6 +41,7 @@ class Lifecycle(enum.StrEnum):
     # and lets each action evolve its payload independently.
     ARCHIVE_EXPIRED_REQUESTED = "memclaw.lifecycle.archive-expired-requested"
     ARCHIVE_STALE_REQUESTED = "memclaw.lifecycle.archive-stale-requested"
+    PURGE_SOFT_DELETED_REQUESTED = "memclaw.lifecycle.purge-soft-deleted-requested"
 
 
 class Topics:

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 
+from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
 from core_api.clients.identity_token import evict as _evict_id_token
 from core_api.clients.identity_token import fetch_auth_header
 from core_api.config import settings
@@ -378,6 +379,18 @@ class CoreStorageClient:
             data["fleet_id"] = fleet_id
         result = await self._post("/memories/archive-stale", data)
         return result.get("count", 0)  # type: ignore[union-attr]
+
+    async def purge_soft_deleted(
+        self,
+        tenant_id: str,
+        fleet_id: str | None = None,
+        retention_days: int = MEMORY_RETENTION_MAX_DAYS,
+    ) -> int:
+        data: dict[str, Any] = {"tenant_id": tenant_id, "retention_days": retention_days}
+        if fleet_id is not None:
+            data["fleet_id"] = fleet_id
+        result = await self._post("/memories/purge-soft-deleted", data)
+        return result.get("deleted", 0)  # type: ignore[union-attr]
 
     async def count_active(self, tenant_id: str, fleet_id: str | None = None) -> int:
         params: dict[str, Any] = {"tenant_id": tenant_id}

--- a/core-api/src/core_api/routes/lifecycle.py
+++ b/core-api/src/core_api/routes/lifecycle.py
@@ -27,23 +27,30 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from common.events import (
     publish_archive_expired_request,
     publish_archive_stale_request,
+    publish_purge_soft_deleted_request,
+)
+from common.events.lifecycle_purge_request import (
+    MEMORY_RETENTION_MAX_DAYS,
+    MEMORY_RETENTION_MIN_DAYS,
 )
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
 from core_api.db.session import async_session
-from core_api.services.lifecycle_audit import audit_begin
-from core_api.services.tenants import list_active_tenant_ids
+from core_api.services.lifecycle_audit import audit_begin, resolve_publisher_kwargs
+from core_api.services.tenants import (
+    list_active_tenant_ids,
+    list_tenants_with_any_memory,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Admin", "Lifecycle"])
 
-# Whitelist of action names → publisher.  CAURA-657 will extend with
-# ``crystallize`` and ``entity-link`` once their consumers exist.
 _PublisherFn = Callable[..., Awaitable[None]]
 _ACTION_PUBLISHERS: dict[str, _PublisherFn] = {
     "archive-expired": publish_archive_expired_request,
     "archive-stale": publish_archive_stale_request,
+    "purge-soft-deleted": publish_purge_soft_deleted_request,
 }
 
 # Cap on concurrent per-org ``audit_begin + publish`` pairs in the
@@ -54,6 +61,18 @@ _ACTION_PUBLISHERS: dict[str, _PublisherFn] = {
 # enough that the storage-writer pool is never saturated by fanout
 # traffic alone (the same pool serves the live request path).
 _FANOUT_CONCURRENCY = 50
+
+
+async def _list_tenants_for_action(action: str, db) -> list[str]:
+    """Discovery query for the fanout — purge is the odd action here:
+    its target is orgs with SOFT-DELETED memories, so the
+    deleted_at-IS-NULL filter that archive uses would silently drop
+    the orgs we most need to run against (an org that 100%-soft-
+    deleted its memories).
+    """
+    if action == "purge-soft-deleted":
+        return await list_tenants_with_any_memory(db)
+    return await list_active_tenant_ids(db)
 
 
 def _resolve_publisher(action: str) -> _PublisherFn:
@@ -73,6 +92,7 @@ async def _trigger_one(
     triggered_by: str,
     publisher: _PublisherFn,
     fleet_id: str | None = None,
+    extra_kwargs: dict | None = None,
 ) -> int:
     """Pre-publish the audit row, then publish the per-org Pub/Sub
     message. Returns the new audit_id.
@@ -81,6 +101,11 @@ async def _trigger_one(
     ``pending`` row pointing at the operator's request — observable as
     a row that never advances. Reverse ordering would let the consumer
     receive a message referencing an id that doesn't exist.
+
+    ``extra_kwargs`` carries action-specific publisher kwargs (e.g.
+    ``retention_days`` for purge). The publisher's Pydantic payload
+    enforces ``extra='forbid'`` so a wrong-action kwarg fails fast at
+    publish rather than producing a silent no-op message.
     """
     storage = get_storage_client()
     audit_id = await audit_begin(
@@ -94,6 +119,7 @@ async def _trigger_one(
         org_id=org_id,
         triggered_by=triggered_by,
         fleet_id=fleet_id,
+        **(extra_kwargs or {}),
     )
     return audit_id
 
@@ -118,25 +144,23 @@ async def fanout_lifecycle_action(
     publisher = _resolve_publisher(action)
 
     async with async_session() as db:
-        org_ids = await list_active_tenant_ids(db)
+        org_ids = await _list_tenants_for_action(action, db)
 
     # Fan out concurrently with a semaphore cap (see _FANOUT_CONCURRENCY)
     # so a deployment with N orgs doesn't fire N simultaneous storage
     # round-trips. ``return_exceptions=True`` keeps the
-    # one-bad-org-must-not-abort-the-rest invariant: per-iteration try/
-    # except in a serial loop did the same job, but the cron tick used
-    # to scale O(N) in wall time * per-org publish latency. The cron
-    # re-runs on the configured cadence so a partial failure here is
-    # always recoverable on the next tick.
+    # one-bad-org-must-not-abort-the-rest invariant.
     sem = asyncio.Semaphore(_FANOUT_CONCURRENCY)
 
     async def _bounded_trigger(org_id: str) -> int:
         async with sem:
+            extra = await resolve_publisher_kwargs(action, org_id)
             return await _trigger_one(
                 action=action,
                 org_id=org_id,
                 triggered_by="core-operations",
                 publisher=publisher,
+                extra_kwargs=extra or None,
             )
 
     results = await asyncio.gather(
@@ -209,6 +233,47 @@ async def trigger_lifecycle_action(
             detail="'fleet_id' must be a string when provided",
         )
 
+    # Manual route lets the operator override per-org settings via
+    # body keys (dry-running a different ``retention_days`` without
+    # touching the persisted setting). Without an override, fall back
+    # to the same per-action resolver the cron path uses. Range
+    # validation is delegated to the publisher's Pydantic payload —
+    # single source of truth with the storage-side primitive.
+    extra_kwargs = await resolve_publisher_kwargs(action, org_id)
+    body_retention = body.get("retention_days")
+    if body_retention is not None:
+        # Gate on action FIRST: archive-expired / archive-stale
+        # publishers don't accept ``retention_days``, so an unfiltered
+        # body kwarg would propagate through ``extra_kwargs`` and cause
+        # a TypeError → 500 inside ``publisher(**extra_kwargs)``. Worse,
+        # ``audit_begin`` runs before that splat, so each such request
+        # would also leave a ``pending`` audit row that never advances.
+        # Fail at the route boundary with a 422 before ``audit_begin``.
+        if action != "purge-soft-deleted":
+            raise HTTPException(
+                status_code=422,
+                detail="'retention_days' is only valid for the 'purge-soft-deleted' action",
+            )
+        # ``isinstance(True, int)`` is True; carve bools out so a body
+        # of ``{"retention_days": true}`` is rejected loudly.
+        if not isinstance(body_retention, int) or isinstance(body_retention, bool):
+            raise HTTPException(
+                status_code=422,
+                detail="'retention_days' must be an integer when provided",
+            )
+        # Range-check at the route boundary — without it, an out-of-
+        # range value reaches the publisher's Pydantic payload and
+        # raises ValidationError, which the global catch-all maps to
+        # 500 instead of the 422 the caller would expect.
+        if not (MEMORY_RETENTION_MIN_DAYS <= body_retention <= MEMORY_RETENTION_MAX_DAYS):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"'retention_days' must be in [{MEMORY_RETENTION_MIN_DAYS}, {MEMORY_RETENTION_MAX_DAYS}]"
+                ),
+            )
+        extra_kwargs["retention_days"] = body_retention
+
     triggered_by = f"manual:{auth.user_id}" if auth.user_id else "manual:admin-key"
     audit_id = await _trigger_one(
         action=action,
@@ -216,5 +281,6 @@ async def trigger_lifecycle_action(
         triggered_by=triggered_by,
         publisher=publisher,
         fleet_id=fleet_id,
+        extra_kwargs=extra_kwargs or None,
     )
     return {"action": action, "org_id": org_id, "audit_id": audit_id}

--- a/core-api/src/core_api/services/lifecycle_audit.py
+++ b/core-api/src/core_api/services/lifecycle_audit.py
@@ -1,6 +1,7 @@
-"""Tiny wrappers around the lifecycle_audit storage routes (CAURA-655).
+"""Helpers around the lifecycle_audit storage routes + per-action
+publisher kwargs (CAURA-655 / CAURA-656).
 
-Two helpers, one for each transition:
+Three helpers:
 
 * :func:`audit_begin` — creates a ``pending`` row and returns its id.
   Called by the fanout endpoint just before each per-org Pub/Sub
@@ -9,6 +10,9 @@ Two helpers, one for each transition:
   :class:`LifecycleStorageAdapter` shape the shared handler expects.
   Used in OSS standalone where core-api itself subscribes to the
   in-process bus (no separate worker process).
+* :func:`resolve_publisher_kwargs` — per-action settings → publisher
+  kwarg map (e.g. CAURA-656 purge needs ``retention_days`` from each
+  org's ``lifecycle.memory_retention_days`` setting).
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ from __future__ import annotations
 from common.events.lifecycle_handlers import LifecycleStorageAdapter
 from core_api.clients.storage_client import CoreStorageClient
 from core_api.constants import LIFECYCLE_STALE_ARCHIVE_WEIGHT
+from core_api.services.organization_settings import resolve_config
 
 
 async def audit_begin(
@@ -47,6 +52,9 @@ class _CoreApiLifecycleAdapter:
     async def archive_stale(self, *, org_id: str, fleet_id: str | None) -> int:
         return await self._storage.archive_stale(org_id, fleet_id, max_weight=LIFECYCLE_STALE_ARCHIVE_WEIGHT)
 
+    async def purge_soft_deleted(self, *, org_id: str, fleet_id: str | None, retention_days: int) -> int:
+        return await self._storage.purge_soft_deleted(org_id, fleet_id, retention_days=retention_days)
+
     async def update_lifecycle_audit_row(
         self,
         audit_id: int,
@@ -62,3 +70,15 @@ class _CoreApiLifecycleAdapter:
 
 def make_storage_adapter(storage: CoreStorageClient) -> LifecycleStorageAdapter:
     return _CoreApiLifecycleAdapter(storage)
+
+
+async def resolve_publisher_kwargs(action: str, org_id: str) -> dict:
+    """Per-action settings → publisher-kwarg map. Empty for actions
+    that don't read org settings. Lives in the service layer rather
+    than the route so the consumer-side adapter never accidentally
+    takes a settings dependency.
+    """
+    if action == "purge-soft-deleted":
+        config = await resolve_config(None, org_id)
+        return {"retention_days": config.memory_retention_days}
+    return {}

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -30,6 +30,10 @@ from sqlalchemy import func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from common.events.lifecycle_purge_request import (
+    MEMORY_RETENTION_MAX_DAYS,
+    MEMORY_RETENTION_MIN_DAYS,
+)
 from common.models.organization_settings import OrganizationSettings, OrganizationSettingsAudit
 from common.provider_names import ProviderName
 from core_api.config import settings as global_settings
@@ -75,6 +79,13 @@ DEFAULT_SETTINGS: dict = {
     },
     "lifecycle": {
         "lifecycle_automation_enabled": None,
+        # Days to keep soft-deleted memories before they're physically
+        # purged (CAURA-656). Daily cron reads this per-org and runs
+        # ``purge-soft-deleted``. ``None`` means "use the global
+        # default" (30 — see ResolvedConfig.memory_retention_days).
+        # Range constrained to 1-30 by the validator below; the UI
+        # numeric input mirrors that range.
+        "memory_retention_days": None,
     },
     "entity_linking": {
         "auto_entity_linking_enabled": None,
@@ -276,15 +287,30 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "crystallizer.auto_crystallize": bool,
     "dedup.semantic_dedup_enabled": bool,
     "lifecycle.lifecycle_automation_enabled": bool,
+    "lifecycle.memory_retention_days": int,
     "entity_linking.auto_entity_linking_enabled": bool,
     "chunking.auto_chunk_enabled": bool,
     "agents.require_agent_approval": bool,
     "entity_blocklist": list,
 }
 
+# Inclusive range constraints applied AFTER type validation. Listed
+# separately rather than encoded in ``_LEAF_TYPES`` so types stay
+# Python-class types (cleanly testable with ``isinstance``). Range
+# constants are imported from the publisher-side payload so a future
+# widening only needs to touch one source of truth.
+_LEAF_RANGES: dict[str, tuple[int, int]] = {
+    "lifecycle.memory_retention_days": (
+        MEMORY_RETENTION_MIN_DAYS,
+        MEMORY_RETENTION_MAX_DAYS,
+    ),
+}
+
 
 def _validate_leaf_types(payload: dict, prefix: str = "") -> None:
-    """Raise ``ValueError`` if any leaf value has the wrong Python type."""
+    """Raise ``ValueError`` if any leaf value has the wrong Python type
+    or falls outside its declared inclusive range.
+    """
     for k, v in payload.items():
         path = f"{prefix}{k}"
         if isinstance(v, dict):
@@ -298,6 +324,10 @@ def _validate_leaf_types(payload: dict, prefix: str = "") -> None:
                     else " or ".join(t.__name__ for t in expected)
                 )
                 raise ValueError(f"Settings key {path!r} must be {type_name}, got {type(v).__name__}")
+            if path in _LEAF_RANGES:
+                lo, hi = _LEAF_RANGES[path]
+                if not (lo <= v <= hi):
+                    raise ValueError(f"Settings key {path!r} must be in [{lo}, {hi}], got {v!r}")
 
 
 class ResolvedConfig:
@@ -450,6 +480,18 @@ class ResolvedConfig:
     def lifecycle_automation_enabled(self) -> bool:
         val = self._ts.get("lifecycle", {}).get("lifecycle_automation_enabled")
         return val if val is not None else True
+
+    @property
+    def memory_retention_days(self) -> int:
+        """Days to keep soft-deleted memories before they're purged
+        (CAURA-656). Default 30 matches the UI numeric input's upper
+        bound — generous on the safe side; an org tightens it down to
+        as low as 1 day if their compliance posture demands it. The
+        validator on settings PUT already constrains the override to
+        [1, 30].
+        """
+        val = self._ts.get("lifecycle", {}).get("memory_retention_days")
+        return val if val is not None else 30
 
     # Entity linking
     @property

--- a/core-api/src/core_api/services/tenants.py
+++ b/core-api/src/core_api/services/tenants.py
@@ -11,11 +11,23 @@ from common.models.memory import Memory
 async def list_active_tenant_ids(db: AsyncSession) -> list[str]:
     """Distinct ``tenant_id`` from non-soft-deleted memories.
 
-    OSS-standalone resolves to one id (the standalone tenant). Enterprise
-    sees one row per tenant with live memories. Multi-tenant orgs share an
-    org_id only at the enterprise side, so OSS-side fanout issues one
-    message per tenant — cross-tenant rollups can come later if a shared
-    lifecycle policy becomes a thing.
+    Use for archive ops — orgs with no live memories have nothing to
+    archive. CAURA-656 purge needs the broader variant below: an org
+    that soft-deleted all its memories is exactly who we want to purge.
     """
     result = await db.execute(select(Memory.tenant_id).where(Memory.deleted_at.is_(None)).distinct())
+    return sorted([row[0] for row in result.all()])
+
+
+async def list_tenants_with_any_memory(db: AsyncSession) -> list[str]:
+    """Distinct ``tenant_id`` from EVERY memory row, including
+    soft-deleted ones (CAURA-656 purge fanout target).
+
+    The narrower :func:`list_active_tenant_ids` filters
+    ``deleted_at IS NULL`` and would silently skip an org whose
+    memories are 100% soft-deleted — exactly the population the purge
+    op needs to run against, so the daily cron would never reclaim
+    their storage.
+    """
+    result = await db.execute(select(Memory.tenant_id).distinct())
     return sorted([row[0] for row in result.all()])

--- a/core-operations/src/core_operations/app.py
+++ b/core-operations/src/core_operations/app.py
@@ -27,15 +27,19 @@ from fastapi import FastAPI, HTTPException
 from common.structlog_config import configure_logging
 from core_operations.config import settings
 from core_operations.scheduler import scheduler
-from core_operations.tasks import run_archive_expired_tick, run_archive_stale_tick
+from core_operations.tasks import (
+    run_archive_expired_tick,
+    run_archive_stale_tick,
+    run_purge_soft_deleted_tick,
+)
 
 logger = logging.getLogger(__name__)
 
 
 def _register_scheduled_tasks() -> None:
-    # CAURA-655: each archival op gets its own registration so an
-    # outage on one can't silently mask the other; their audit rows
-    # stay independent. CAURA-656 will add ``purge-soft-deleted`` here.
+    # Each lifecycle op gets its own registration so an outage on one
+    # can't silently mask the others; their audit rows stay
+    # independent.
     scheduler.register(
         "lifecycle-archive-expired",
         settings.lifecycle_archive_interval_seconds,
@@ -45,6 +49,11 @@ def _register_scheduled_tasks() -> None:
         "lifecycle-archive-stale",
         settings.lifecycle_archive_interval_seconds,
         run_archive_stale_tick,
+    )
+    scheduler.register(
+        "lifecycle-purge-soft-deleted",
+        settings.lifecycle_purge_interval_seconds,
+        run_purge_soft_deleted_tick,
     )
 
 

--- a/core-operations/src/core_operations/config.py
+++ b/core-operations/src/core_operations/config.py
@@ -42,6 +42,11 @@ class Settings(BaseSettings):
     # — e.g. ``security_audit.schedule_cron`` — still live on the
     # enterprise scheduler.
     lifecycle_archive_interval_seconds: float = 24 * 3600
+    # Separate cadence for purge — operationally a different concern
+    # (compliance-driven retention vs. staleness archival), so an
+    # operator can dial purge less frequently or to a different cycle
+    # without touching archive. Default matches archive (daily).
+    lifecycle_purge_interval_seconds: float = 24 * 3600
 
 
 settings = Settings()  # type: ignore[call-arg]

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -74,3 +74,12 @@ async def run_archive_expired_tick() -> None:
 
 async def run_archive_stale_tick() -> None:
     await _fire_fanout("archive-stale")
+
+
+async def run_purge_soft_deleted_tick() -> None:
+    """Hard-delete soft-deleted memories older than each org's
+    ``lifecycle.memory_retention_days`` setting. The per-org settings
+    snapshot happens inside the core-api fanout endpoint, not here —
+    core-operations stays oblivious of org concepts.
+    """
+    await _fire_fanout("purge-soft-deleted")

--- a/core-operations/tests/test_tasks.py
+++ b/core-operations/tests/test_tasks.py
@@ -99,6 +99,18 @@ async def test_archive_stale_tick_hits_correct_path(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
+async def test_purge_soft_deleted_tick_hits_correct_path(monkeypatch: pytest.MonkeyPatch):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    response = _StubResponse(200, {"action": "purge-soft-deleted", "published": 2, "failed": 0})
+    async with _patch_client(monkeypatch, response=response) as stub:
+        await tasks.run_purge_soft_deleted_tick()
+
+    assert stub.calls[0][0].endswith("/admin/lifecycle/fanout/purge-soft-deleted")
+
+
+@pytest.mark.asyncio
 async def test_tick_swallows_non_2xx(monkeypatch: pytest.MonkeyPatch):
     """A non-2xx response must not raise — the scheduler retries on the
     next tick anyway, and re-raising would just produce duplicate

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -8,6 +8,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
 
+from common.events.lifecycle_purge_request import (
+    MEMORY_RETENTION_MAX_DAYS,
+    MEMORY_RETENTION_MIN_DAYS,
+)
 from core_storage_api.observability import bind_timer, log_request
 from core_storage_api.schemas import MEMORY_FIELDS, orm_to_dict
 from core_storage_api.services.postgres_service import PostgresService
@@ -409,6 +413,53 @@ async def archive_stale_low_weight(request: Request) -> dict:
         batch_size=body.get("batch_size", 500),
     )
     return {"count": count}
+
+
+@router.post("/purge-soft-deleted")
+async def purge_soft_deleted(request: Request) -> dict:
+    """Hard-delete soft-deleted memories older than ``retention_days``
+    (CAURA-656). The retention window is policy, not state — the caller
+    decides how long ``deleted_at IS NOT NULL`` rows stick around for
+    undo / forensics. ``retention_days`` defaults to 30 to match the
+    organization-settings default.
+    """
+    body: dict = await request.json()
+    # Validate the inputs that drive the SQL primitive's WHERE clause.
+    # ``tenant_id`` missing would 500 on a KeyError; ``retention_days=0``
+    # produces ``deleted_at < NOW()`` (matches every soft-deleted row,
+    # nullifying the retention window); ``batch_size`` 0 silently
+    # no-ops every tick (Postgres LIMIT 0) and -1 unbounds the
+    # delete. Each failure mode would be a real outage from the
+    # consumer's perspective; surface as 422 at the boundary.
+    tenant_id = body.get("tenant_id")
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_id' is required and must be a non-empty string",
+        )
+    batch_size = body.get("batch_size", 500)
+    if not isinstance(batch_size, int) or isinstance(batch_size, bool) or batch_size < 1:
+        raise HTTPException(
+            status_code=422,
+            detail="'batch_size' must be a positive integer",
+        )
+    retention_days = body.get("retention_days", MEMORY_RETENTION_MAX_DAYS)
+    if (
+        not isinstance(retention_days, int)
+        or isinstance(retention_days, bool)
+        or not (MEMORY_RETENTION_MIN_DAYS <= retention_days <= MEMORY_RETENTION_MAX_DAYS)
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail=f"'retention_days' must be in [{MEMORY_RETENTION_MIN_DAYS}, {MEMORY_RETENTION_MAX_DAYS}]",
+        )
+    count = await _svc.memory_purge_soft_deleted(
+        tenant_id=tenant_id,
+        fleet_id=body.get("fleet_id"),
+        retention_days=retention_days,
+        batch_size=batch_size,
+    )
+    return {"deleted": count}
 
 
 # ------------------------------------------------------------------

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -37,6 +37,7 @@ from common.constants import (
     SEMANTIC_DEDUP_THRESHOLD,
     TYPE_DECAY_DAYS,
 )
+from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
 from common.models import (
     Agent,
     AuditLog,
@@ -1226,6 +1227,49 @@ class PostgresService:
                       AND weight < :max_weight
                       AND status = 'active'
                       AND deleted_at IS NULL
+                    LIMIT :batch_size
+                )
+                RETURNING id
+            """),
+                params,
+            )
+            return len(result.all())
+
+    async def memory_purge_soft_deleted(
+        self,
+        tenant_id: str,
+        fleet_id: str | None = None,
+        retention_days: int = MEMORY_RETENTION_MAX_DAYS,
+        batch_size: int = 500,
+    ) -> int:
+        """Hard-delete soft-deleted memories whose ``deleted_at`` is older
+        than ``retention_days``. Soft-deletes (CAURA-656) keeps rows
+        addressable for a grace period before they're physically removed,
+        so a misclick or buggy client can be undone for ``retention_days``
+        days. After that window the row is gone for good — including its
+        embedding, entity links, and idempotency response cache lines
+        (cascaded by their FKs to ``memories.id``).
+        """
+        async with get_session() as session:
+            params: dict = {
+                "tenant_id": tenant_id,
+                "retention_days": retention_days,
+                "batch_size": batch_size,
+            }
+            fleet_clause = ""
+            if fleet_id:
+                fleet_clause = "AND fleet_id = :fleet_id"
+                params["fleet_id"] = fleet_id
+
+            result = await session.execute(
+                text(f"""
+                DELETE FROM memories
+                WHERE id IN (
+                    SELECT id FROM memories
+                    WHERE tenant_id = :tenant_id
+                      {fleet_clause}
+                      AND deleted_at IS NOT NULL
+                      AND deleted_at < NOW() - INTERVAL '1 day' * :retention_days
                     LIMIT :batch_size
                 )
                 RETURNING id

--- a/core-worker/src/core_worker/clients/storage_client.py
+++ b/core-worker/src/core_worker/clients/storage_client.py
@@ -369,6 +369,32 @@ async def archive_stale(
     return resp.json().get("count", 0)
 
 
+async def purge_soft_deleted(
+    client: httpx.AsyncClient,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    retention_days: int,
+) -> int:
+    """Run the storage-side ``memory_purge_soft_deleted`` SQL primitive.
+
+    ``retention_days`` is REQUIRED — it rides along in the Pub/Sub
+    payload, snapshot at fanout time from the org's
+    ``lifecycle.memory_retention_days`` setting. Defaulting it on this
+    side would mask a publisher bug that forgot to bake the value in.
+    """
+    body: dict[str, Any] = {"tenant_id": tenant_id, "retention_days": retention_days}
+    if fleet_id is not None:
+        body["fleet_id"] = fleet_id
+    resp = await _signed_call(
+        client.post,
+        f"{_PREFIX}/memories/purge-soft-deleted",
+        json=body,
+    )
+    resp.raise_for_status()
+    return resp.json().get("deleted", 0)
+
+
 async def update_lifecycle_audit_row(
     client: httpx.AsyncClient,
     audit_id: int,

--- a/core-worker/src/core_worker/lifecycle.py
+++ b/core-worker/src/core_worker/lifecycle.py
@@ -14,6 +14,7 @@ from core_worker.clients.storage_client import (
     archive_expired,
     archive_stale,
     get_storage_client,
+    purge_soft_deleted,
     update_lifecycle_audit_row,
 )
 
@@ -24,6 +25,14 @@ class _CoreWorkerLifecycleAdapter:
 
     async def archive_stale(self, *, org_id: str, fleet_id: str | None) -> int:
         return await archive_stale(get_storage_client(), tenant_id=org_id, fleet_id=fleet_id)
+
+    async def purge_soft_deleted(self, *, org_id: str, fleet_id: str | None, retention_days: int) -> int:
+        return await purge_soft_deleted(
+            get_storage_client(),
+            tenant_id=org_id,
+            fleet_id=fleet_id,
+            retention_days=retention_days,
+        )
 
     async def update_lifecycle_audit_row(
         self,

--- a/tests/test_lifecycle_automation.py
+++ b/tests/test_lifecycle_automation.py
@@ -81,6 +81,10 @@ class TestLifecycleTopics:
             Topics.Lifecycle.ARCHIVE_STALE_REQUESTED
             == "memclaw.lifecycle.archive-stale-requested"
         )
+        assert (
+            Topics.Lifecycle.PURGE_SOFT_DELETED_REQUESTED
+            == "memclaw.lifecycle.purge-soft-deleted-requested"
+        )
 
     def test_topic_strenum_format(self):
         from common.events.topics import Topics
@@ -92,3 +96,51 @@ class TestLifecycleTopics:
             f"{Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED}"
             == "memclaw.lifecycle.archive-expired-requested"
         )
+
+
+@pytest.mark.unit
+class TestMemoryRetentionSettings:
+    """CAURA-656: org-level memory_retention_days setting + validator."""
+
+    def test_default_is_30(self):
+        from core_api.services.organization_settings import ResolvedConfig
+
+        config = ResolvedConfig({})
+        assert config.memory_retention_days == 30
+
+    def test_override_within_range(self):
+        from core_api.services.organization_settings import ResolvedConfig
+
+        config = ResolvedConfig({"lifecycle": {"memory_retention_days": 7}})
+        assert config.memory_retention_days == 7
+
+    def test_default_settings_has_retention_key(self):
+        from core_api.services.organization_settings import DEFAULT_SETTINGS
+
+        assert "memory_retention_days" in DEFAULT_SETTINGS["lifecycle"]
+
+    def test_validator_rejects_out_of_range_low(self):
+        from core_api.services.organization_settings import _validate_leaf_types
+
+        with pytest.raises(ValueError, match=r"\[1, 30\]"):
+            _validate_leaf_types({"lifecycle": {"memory_retention_days": 0}})
+
+    def test_validator_rejects_out_of_range_high(self):
+        from core_api.services.organization_settings import _validate_leaf_types
+
+        with pytest.raises(ValueError, match=r"\[1, 30\]"):
+            _validate_leaf_types({"lifecycle": {"memory_retention_days": 31}})
+
+    def test_validator_rejects_non_int(self):
+        from core_api.services.organization_settings import _validate_leaf_types
+
+        with pytest.raises(ValueError, match="must be int"):
+            _validate_leaf_types({"lifecycle": {"memory_retention_days": "30"}})
+
+    def test_validator_accepts_in_range(self):
+        from core_api.services.organization_settings import _validate_leaf_types
+
+        # Should not raise.
+        _validate_leaf_types({"lifecycle": {"memory_retention_days": 1}})
+        _validate_leaf_types({"lifecycle": {"memory_retention_days": 30}})
+        _validate_leaf_types({"lifecycle": {"memory_retention_days": 15}})

--- a/tests/test_lifecycle_handlers.py
+++ b/tests/test_lifecycle_handlers.py
@@ -1,4 +1,4 @@
-"""Unit tests for the shared lifecycle archive consumers (CAURA-655).
+"""Unit tests for the shared lifecycle action consumers (CAURA-655 + CAURA-656).
 
 The handlers live in ``common/events/lifecycle_handlers.py`` so both
 core-api (OSS standalone) and core-worker (SaaS) register the same
@@ -9,13 +9,14 @@ covered by integration tests elsewhere.
 
 from __future__ import annotations
 
-import pytest
-
 from functools import partial
+
+import pytest
 
 from common.events.base import Event
 from common.events.lifecycle_archive_request import LifecycleArchiveRequest
-from common.events.lifecycle_handlers import _run_archive
+from common.events.lifecycle_handlers import _run_action
+from common.events.lifecycle_purge_request import LifecyclePurgeRequest
 from common.events.topics import Topics
 
 
@@ -25,25 +26,35 @@ class _FakeAdapter:
         *,
         expired_count: int = 7,
         stale_count: int = 4,
-        raise_on_archive: Exception | None = None,
+        purged_count: int = 5,
+        raise_on_op: Exception | None = None,
     ):
         self.expired_count = expired_count
         self.stale_count = stale_count
-        self.raise_on_archive = raise_on_archive
-        self.archive_calls: list[tuple[str, str, str | None]] = []
+        self.purged_count = purged_count
+        self.raise_on_op = raise_on_op
+        self.archive_calls: list[tuple[str, str, str | None, int | None]] = []
         self.audit_calls: list[tuple[int, str, dict | None, str | None]] = []
 
     async def archive_expired(self, *, org_id: str, fleet_id: str | None) -> int:
-        self.archive_calls.append(("expired", org_id, fleet_id))
-        if self.raise_on_archive is not None:
-            raise self.raise_on_archive
+        self.archive_calls.append(("expired", org_id, fleet_id, None))
+        if self.raise_on_op is not None:
+            raise self.raise_on_op
         return self.expired_count
 
     async def archive_stale(self, *, org_id: str, fleet_id: str | None) -> int:
-        self.archive_calls.append(("stale", org_id, fleet_id))
-        if self.raise_on_archive is not None:
-            raise self.raise_on_archive
+        self.archive_calls.append(("stale", org_id, fleet_id, None))
+        if self.raise_on_op is not None:
+            raise self.raise_on_op
         return self.stale_count
+
+    async def purge_soft_deleted(
+        self, *, org_id: str, fleet_id: str | None, retention_days: int
+    ) -> int:
+        self.archive_calls.append(("purge", org_id, fleet_id, retention_days))
+        if self.raise_on_op is not None:
+            raise self.raise_on_op
+        return self.purged_count
 
     async def update_lifecycle_audit_row(
         self,
@@ -56,7 +67,7 @@ class _FakeAdapter:
         self.audit_calls.append((audit_id, status, stats, error_message))
 
 
-def _event(
+def _archive_event(
     topic: str,
     *,
     audit_id: int = 42,
@@ -72,22 +83,77 @@ def _event(
     return Event(event_type=topic, payload=payload)
 
 
-def _bind(adapter: _FakeAdapter, *, action: str):
-    """Mirror what register_consumers() does at app startup — bind the
-    adapter and the per-action archive callable into the dispatch."""
-    archive_fn = (
-        adapter.archive_expired
-        if action == "archive-expired"
-        else adapter.archive_stale
+def _purge_event(
+    *,
+    audit_id: int = 99,
+    org_id: str = "tenant-x",
+    fleet_id: str | None = None,
+    retention_days: int = 14,
+) -> Event:
+    payload = LifecyclePurgeRequest(
+        audit_id=audit_id,
+        org_id=org_id,
+        triggered_by="test",
+        fleet_id=fleet_id,
+        retention_days=retention_days,
+    ).model_dump(mode="json")
+    return Event(
+        event_type=Topics.Lifecycle.PURGE_SOFT_DELETED_REQUESTED,
+        payload=payload,
     )
-    return partial(_run_archive, adapter=adapter, archive_fn=archive_fn, action=action)
+
+
+def _bind(adapter: _FakeAdapter, *, action: str):
+    """Mirror what ``register_consumers`` does at app startup — bind
+    the adapter and the per-action archive callable into the dispatch
+    via :func:`functools.partial`. Single helper so adding a new
+    action only requires extending the lookup table.
+    """
+    if action == "archive-expired":
+
+        async def _op(req: LifecycleArchiveRequest) -> int:
+            return await adapter.archive_expired(
+                org_id=req.org_id, fleet_id=req.fleet_id
+            )
+
+        payload_cls: type = LifecycleArchiveRequest
+        stats_key = "archived"
+    elif action == "archive-stale":
+
+        async def _op(req: LifecycleArchiveRequest) -> int:
+            return await adapter.archive_stale(org_id=req.org_id, fleet_id=req.fleet_id)
+
+        payload_cls = LifecycleArchiveRequest
+        stats_key = "archived"
+    elif action == "purge-soft-deleted":
+
+        async def _op(req: LifecyclePurgeRequest) -> int:
+            return await adapter.purge_soft_deleted(
+                org_id=req.org_id,
+                fleet_id=req.fleet_id,
+                retention_days=req.retention_days,
+            )
+
+        payload_cls = LifecyclePurgeRequest
+        stats_key = "deleted"
+    else:
+        raise ValueError(f"unknown action {action!r}")
+
+    return partial(
+        _run_action,
+        adapter=adapter,
+        payload_cls=payload_cls,
+        run_op=_op,
+        stats_key=stats_key,
+        action=action,
+    )
 
 
 @pytest.mark.asyncio
 async def test_archive_expired_success_marks_audit_progress_then_success():
     adapter = _FakeAdapter(expired_count=11)
     handler = _bind(adapter, action="archive-expired")
-    await handler(_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
+    await handler(_archive_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
     # Order matters: in_progress must land BEFORE the storage primitive
     # so observers can distinguish a stuck-in-progress run from a
     # never-started one.
@@ -97,25 +163,39 @@ async def test_archive_expired_success_marks_audit_progress_then_success():
     assert final[0] == 42
     assert final[2] == {"archived": 11}
     assert final[3] is None
-    assert adapter.archive_calls == [("expired", "tenant-x", None)]
+    assert adapter.archive_calls == [("expired", "tenant-x", None, None)]
 
 
 @pytest.mark.asyncio
 async def test_archive_stale_dispatches_to_stale_primitive():
     adapter = _FakeAdapter(stale_count=3)
     handler = _bind(adapter, action="archive-stale")
-    await handler(_event(Topics.Lifecycle.ARCHIVE_STALE_REQUESTED, fleet_id="fleet-1"))
-    assert adapter.archive_calls == [("stale", "tenant-x", "fleet-1")]
+    await handler(
+        _archive_event(Topics.Lifecycle.ARCHIVE_STALE_REQUESTED, fleet_id="fleet-1")
+    )
+    assert adapter.archive_calls == [("stale", "tenant-x", "fleet-1", None)]
     assert adapter.audit_calls[-1] == (42, "success", {"archived": 3}, None)
+
+
+@pytest.mark.asyncio
+async def test_purge_soft_deleted_forwards_retention_days_and_uses_deleted_stats_key():
+    adapter = _FakeAdapter(purged_count=8)
+    handler = _bind(adapter, action="purge-soft-deleted")
+    await handler(_purge_event(retention_days=7, fleet_id="fleet-2"))
+    # The op was called with retention_days from the payload.
+    assert adapter.archive_calls == [("purge", "tenant-x", "fleet-2", 7)]
+    # Stats key is 'deleted', not 'archived' — the only per-action
+    # divergence in the success branch.
+    assert adapter.audit_calls[-1] == (99, "success", {"deleted": 8}, None)
 
 
 @pytest.mark.asyncio
 async def test_archive_failure_marks_audit_failure_and_reraises():
     err = RuntimeError("storage down")
-    adapter = _FakeAdapter(raise_on_archive=err)
+    adapter = _FakeAdapter(raise_on_op=err)
     handler = _bind(adapter, action="archive-expired")
     with pytest.raises(RuntimeError, match="storage down"):
-        await handler(_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
+        await handler(_archive_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
     statuses = [c[1] for c in adapter.audit_calls]
     assert statuses == ["in_progress", "failure"]
     final = adapter.audit_calls[-1]
@@ -126,9 +206,9 @@ async def test_archive_failure_marks_audit_failure_and_reraises():
 @pytest.mark.asyncio
 async def test_failure_audit_update_error_does_not_swallow_original():
     """If the audit-row failure update itself raises, the original
-    archive exception must still propagate. Otherwise the row would
-    sit in ``in_progress`` indefinitely AND Pub/Sub would see the wrong
-    exception (audit-update flake instead of the real archive failure).
+    op exception must still propagate. Otherwise the row would sit
+    in ``in_progress`` indefinitely AND Pub/Sub would see the wrong
+    exception (audit-update flake instead of the real op failure).
     """
 
     class _FlakyAuditAdapter(_FakeAdapter):
@@ -144,16 +224,16 @@ async def test_failure_audit_update_error_does_not_swallow_original():
             if status == "failure":
                 raise RuntimeError("audit endpoint down")
 
-    adapter = _FlakyAuditAdapter(raise_on_archive=RuntimeError("storage down"))
+    adapter = _FlakyAuditAdapter(raise_on_op=RuntimeError("storage down"))
     handler = _bind(adapter, action="archive-expired")
     with pytest.raises(RuntimeError, match="storage down"):
-        await handler(_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
+        await handler(_archive_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
     statuses = [c[1] for c in adapter.audit_calls]
     assert statuses == ["in_progress", "failure"]
 
 
 @pytest.mark.asyncio
-async def test_malformed_payload_is_acked_dropped():
+async def test_malformed_archive_payload_is_acked_dropped():
     adapter = _FakeAdapter()
     handler = _bind(adapter, action="archive-expired")
     bad_event = Event(
@@ -161,7 +241,39 @@ async def test_malformed_payload_is_acked_dropped():
         payload={"audit_id": "not-an-int"},
     )
     await handler(bad_event)
-    # No archive call, no audit-row PATCH — the message gets dropped
-    # cleanly so a poison message can't loop the subscription.
+    assert adapter.archive_calls == []
+    assert adapter.audit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_malformed_purge_payload_is_acked_dropped():
+    """Purge payload requires retention_days in [1, 30]. A missing
+    field or out-of-range value must drop the message rather than
+    leak a 500 / nack-loop.
+    """
+    adapter = _FakeAdapter()
+    handler = _bind(adapter, action="purge-soft-deleted")
+    # Missing retention_days entirely.
+    bad_event = Event(
+        event_type=Topics.Lifecycle.PURGE_SOFT_DELETED_REQUESTED,
+        payload={
+            "audit_id": 1,
+            "org_id": "tenant-x",
+            "triggered_by": "test",
+        },
+    )
+    await handler(bad_event)
+    # retention_days out of range — bumps against the Field(le=30)
+    # constraint in LifecyclePurgeRequest.
+    out_of_range = Event(
+        event_type=Topics.Lifecycle.PURGE_SOFT_DELETED_REQUESTED,
+        payload={
+            "audit_id": 2,
+            "org_id": "tenant-x",
+            "triggered_by": "test",
+            "retention_days": 99,
+        },
+    )
+    await handler(out_of_range)
     assert adapter.archive_calls == []
     assert adapter.audit_calls == []


### PR DESCRIPTION
## Summary

Third lifecycle action — \`purge-soft-deleted\` — on top of the [CAURA-655](https://caura-ai.atlassian.net/browse/CAURA-655) Pub/Sub fanout pipeline. Hard-deletes soft-deleted memories older than each org's \`lifecycle.memory_retention_days\` setting (1-30 days, default 30).

## Pipeline

\`\`\`
core-operations cron (daily, third tick)
  → POST /api/v1/admin/lifecycle/fanout/purge-soft-deleted
  → core-api: per-org → snapshot retention_days from org settings,
     pre-publish audit row, publish memclaw.lifecycle.purge-soft-deleted-requested
  → core-worker consumes → POST /memories/purge-soft-deleted
  → updates lifecycle_audit row with stats.deleted = N
\`\`\`

Settings are snapshot at fanout time and ride along in the Pub/Sub payload — the consumer trusts the value rather than re-fetching, so a settings change between cron tick and consume uses the snapshot from the previous tick (acceptable for daily cadence).

## Refactors driven by simplify + bot review

The new payload created an opportunity to clean up things CAURA-655 left behind:

- **\`LifecycleRequestBase\`** introduced; both archive and purge payloads inherit. Drops the \`# type: ignore[attr-defined]\` triplet in \`_run_action\` (audit_id / org_id / triggered_by are now properly typed).
- **\`_publish_archive\` → \`_publish\`**: generalised to take any \`LifecycleRequestBase\` payload.
- **Dropped \`_ACTIONS_NEEDING_CONFIG\` frozenset** — redundant once \`resolve_publisher_kwargs\` returns \`{}\` for actions with no per-org settings.
- **\`resolve_publisher_kwargs\` moved** from \`routes/lifecycle.py\` → \`services/lifecycle_audit.py\` (the route shouldn't own settings-resolution logic).
- **\`MEMORY_RETENTION_MIN/MAX_DAYS\` constants** in \`lifecycle_purge_request.py\`; imported into the org-settings \`_LEAF_RANGES\` validator. Single source of truth across publisher, validator, and storage primitive.
- **\`list_tenants_with_any_memory\` discovery query**: an org whose memories are 100% soft-deleted (the exact target of purge!) was being silently excluded by the archive-style \`deleted_at IS NULL\` filter. Critical correctness fix.
- **Three test bind helpers consolidated** into one parametrized \`_bind(adapter, action=...)\`.

## New surface

- \`Topics.Lifecycle.PURGE_SOFT_DELETED_REQUESTED\`
- \`LifecyclePurgeRequest\` payload (frozen, \`extra='forbid'\`, retention_days \`ge=1, le=30\`)
- \`publish_purge_soft_deleted_request\` publisher
- \`LifecycleStorageAdapter.purge_soft_deleted\` protocol method (core-api + core-worker adapters both implement)
- \`memory_purge_soft_deleted\` SQL primitive in postgres_service.py
- \`POST /memories/purge-soft-deleted\` route on core-storage-api
- \`memory_retention_days\` field in DEFAULT_SETTINGS["lifecycle"] + \`ResolvedConfig.memory_retention_days\` property
- Third \`scheduler.register\` entry in core-operations + \`run_purge_soft_deleted_tick\`

## Out of scope

- Frontend UI for the numeric input on \`/settings/organization\` — deferred to enterprise as a separate concern.
- Bulk pre-fetch of org settings during fanout — TTLCache (5-min) covers steady-state cadence; daily cron's cold-fill is acceptable. Flag for the infra-monitoring epic if the >10k-org case becomes real.

## Test plan

- [x] \`pytest tests/test_lifecycle_handlers.py tests/test_lifecycle_automation.py tests/test_entity_linking_wiring.py\` — 30 pass
- [x] \`pytest core-operations/tests/\` — 17 pass
- [x] ruff check + format clean
- [ ] Review automated bot pass(es)
- [ ] After core-operations deploy + enterprise bootstrap script run + frontend UI: full \`lifecycle_smoke.py --env staging\` covering all three actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-655]: https://caura-ai.atlassian.net/browse/CAURA-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ