### PR TITLE
ci(release-please): mint App token so release PRs trigger CI/dco

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,16 +20,24 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Mint an installation token from the org's deploy GitHub App.
+      # The default GITHUB_TOKEN can't trigger downstream workflows
+      # on PRs it creates (GitHub's anti-loop guard), so PRs opened
+      # by release-please with the default token never run CI / dco —
+      # branch protection sees zero required-checks history and the
+      # merge gate stays BLOCKED forever even after approval. An
+      # App-minted token is treated as an external user → triggers
+      # workflows as expected.
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
-          # GITHUB_TOKEN is sufficient for opening release PRs and
-          # cutting GitHub Releases. Note: tags created via this token
-          # do NOT trigger downstream `on: release` or `on: push: tags`
-          # workflows (GitHub's loop prevention). When/if we add an
-          # auto-publish-to-npm or auto-publish-to-PyPI flow that must
-          # fire on release, swap this for a PAT or App token stored
-          # as secrets.RELEASE_PLEASE_TOKEN.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Fixes the root cause behind PR #92 (v2.1.0 release) sitting BLOCKED indefinitely with `mergeable: MERGEABLE`, `reviewDecision: APPROVED`, and **zero status checks ever run**: PRs opened by release-please-action with `secrets.GITHUB_TOKEN` don't trigger downstream workflows (GitHub's anti-loop guard), so `ci.yml` and the DCO check never fire on them. Branch protection on `main` requires both, so the merge button stays disabled forever.

Mints an installation token from the org-level deploy GitHub App (`DEPLOY_APP_ID` / `DEPLOY_APP_PRIVATE_KEY`) and passes it to release-please-action instead. App-minted tokens are treated as external by GitHub, so PRs they open trigger `ci.yml` and `dco` normally.

## Required GitHub App permissions

The App referenced by these org secrets needs:
- `contents: write` (push branches, create tags)
- `pull_requests: write` (open / update release PRs)
- `issues: write` (manage `autorelease: pending` / `autorelease: tagged` labels)

If release-please starts failing on missing permission after this merges, the fix is a UI-only change in the org's GitHub App settings — no code change needed.

## Existing PR #92

This change won't auto-fix [#92](https://github.com/caura-ai/caura-memclaw/pull/92) (it was already opened with GITHUB_TOKEN, so its check history is missing). Two options for that one PR specifically:

- Empty-commit nudge: `gh pr checkout 92 && git commit --allow-empty -m "ci: re-trigger" -s && git push`
- Admin-merge: `gh pr merge 92 --admin --squash`

After this PR lands, **future** release-please PRs will go through CI normally.

## Test plan

- [ ] After merge, the next push to `main` triggers `release-please.yml`
- [ ] release-please opens / updates a release PR using the App token
- [ ] CI workflows (`ci.yml`, DCO) run on that PR automatically
- [ ] Approving the PR + waiting for checks = green merge button (no more BLOCKED state)

## Mirror

A matching change is on the enterprise side in [Ent #252](https://github.com/caura-ai/caura-memclaw-enterprise/pull/252).