### PR TITLE
feat: skills as documents (Phase A) — plugin reconciler

### DIFF
--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -41,6 +41,7 @@ _plugin_files = [
     "health.ts",
     "install-id.ts",
     "identity.ts",
+    "reconcile-skills.ts",
 ]
 
 
@@ -230,7 +231,7 @@ curl $CURL_INSECURE -sf "$MEMCLAW_API_URL/api/plugin-source?file=openclaw.plugin
 
 # 5. Fetch latest plugin source from MemClaw server
 echo "[5/7] Fetching latest plugin source from $MEMCLAW_API_URL..."
-for srcfile in index.ts prompt-section.ts tools.ts tool-specs.ts version.ts env.ts transport.ts validation.ts config.ts paths.ts logger.ts resolve-agent.ts tool-definitions.ts deploy.ts heartbeat.ts educate.ts context-engine.ts agent-auth.ts health.ts install-id.ts identity.ts; do
+for srcfile in index.ts prompt-section.ts tools.ts tool-specs.ts version.ts env.ts transport.ts validation.ts config.ts paths.ts logger.ts resolve-agent.ts tool-definitions.ts deploy.ts heartbeat.ts educate.ts context-engine.ts agent-auth.ts health.ts install-id.ts identity.ts reconcile-skills.ts; do
   curl $CURL_INSECURE -sf "$MEMCLAW_API_URL/api/plugin-source?file=$srcfile" > "$PLUGIN_DIR/src/$srcfile" || {{
     echo "ERROR: Could not fetch $srcfile from $MEMCLAW_API_URL/api/plugin-source?file=$srcfile"
     exit 1

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -15,7 +15,7 @@
     "prebuild": "bash ../scripts/gen-version.sh",
     "build": "tsc",
     "dev": "bash ../scripts/gen-version.sh && tsc --watch",
-    "test": "tsc && node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js"
+    "test": "tsc && node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js"
   },
   "devDependencies": {
     "@types/node": "^25.4.0",

--- a/plugin/src/educate.ts
+++ b/plugin/src/educate.ts
@@ -407,9 +407,10 @@ outcome MUST produce a write. No write = not done. Checkpoint every
 blocker · commitment · config change · error pattern · skill created
 or updated. If in doubt: write.
 
-**Skills.** Check the catalog (\`memclaw_doc op=query collection=skills\`)
-before improvising. Share back via \`memclaw_doc op=write collection=skills
-doc_id=<slug>\` — never just forget to share.
+**Skills** (reusable team knowledge: runbooks, recipes, playbooks).
+Catalog is \`collection=skills\` — never \`runbooks\` etc. Check
+(\`memclaw_doc op=query collection=skills\`); share back
+(\`op=write collection=skills doc_id=<slug>\`).
 
 Before your first MemClaw call this session, read
 \`skills/memclaw/SKILL.md\` for tool signatures, capture cadences

--- a/plugin/src/heartbeat.ts
+++ b/plugin/src/heartbeat.ts
@@ -51,6 +51,7 @@ import {
 import { logError } from "./logger.js";
 import { getInstallId } from "./install-id.js";
 import { getDisplayName } from "./identity.js";
+import { reconcileSkills } from "./reconcile-skills.js";
 
 let heartbeatCount = 0;
 let bakCleanupDone = false;
@@ -78,6 +79,15 @@ function cleanupStaleBackups(): void {
 export async function sendHeartbeat(): Promise<void> {
   cleanupStaleBackups();
   if (!MEMCLAW_TENANT_ID || !MEMCLAW_NODE_NAME) return;
+
+  // Skill reconciler — converge plugin/skills/ with the catalog before
+  // anything else. Failures are non-fatal (best-effort distribution).
+  // Replaces the dropped install_skill / uninstall_skill push commands.
+  try {
+    await reconcileSkills();
+  } catch (e: unknown) {
+    logError("reconcileSkills failed", e);
+  }
 
   const pluginDir = getPluginDir();
 

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for ``reconcileSkills`` — the Phase A plugin-side skill reconciler.
+ *
+ * Locked-in invariants:
+ *
+ *   1. **Bundled skill protected** — empty catalog must NEVER delete
+ *      the bundled ``memclaw`` skill, even though it isn't a catalog
+ *      row. Wiping it on every fresh-tenant heartbeat would be
+ *      catastrophic — the skill is the agent's onboarding doc.
+ *   2. **Cold start pulls everything** — fresh node with only the
+ *      bundled ``memclaw`` skill must materialise every catalog skill
+ *      on first heartbeat.
+ *   3. **Convergence after offline period** — skills present in catalog
+ *      but missing from disk get added; skills on disk but absent from
+ *      catalog get removed (subject to invariant #1). Two changes in
+ *      the same tick → both applied.
+ *   4. **Idempotent** — re-running with no changes is a no-op (no
+ *      writes, no deletes, no spurious mtime bumps).
+ *   5. **Bad slug from server is rejected client-side** — defense in
+ *      depth: even if the server validation regresses, an unsafe slug
+ *      (path traversal etc.) must NOT land on disk.
+ */
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Set env BEFORE importing reconcile-skills.js — module reads from
+// process.env at import time via env.ts.
+process.env.MEMCLAW_API_KEY = "mc_test_key_for_reconcile_tests";
+process.env.MEMCLAW_API_URL = "http://localhost:8000";
+process.env.MEMCLAW_TENANT_ID = "t_test";
+
+// Redirect HOME so getPluginDir() returns a tmpdir instead of a real
+// ~/.openclaw — keeps the test from touching the dev's plugin install.
+const originalHome = process.env.HOME;
+const tmpHome = mkdtempSync(join(tmpdir(), "reconcile-skills-test-home-"));
+process.env.HOME = tmpHome;
+
+const { reconcileSkills, PROTECTED_SKILLS } = await import("./reconcile-skills.js");
+
+const SKILLS_ROOT = join(tmpHome, ".openclaw", "plugins", "memclaw", "skills");
+
+let originalFetch: typeof fetch;
+let mockCatalog: Array<{ doc_id: string; data: { content: string } }>;
+
+function installMockFetch(): void {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.endsWith("/api/v1/documents/query")) {
+      return new Response(JSON.stringify({ documents: mockCatalog }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(`unexpected url: ${url}`, { status: 500 });
+  }) as typeof fetch;
+}
+
+function restoreFetch(): void {
+  globalThis.fetch = originalFetch;
+}
+
+function resetSkillsDir(): void {
+  if (existsSync(SKILLS_ROOT)) {
+    rmSync(SKILLS_ROOT, { recursive: true, force: true });
+  }
+}
+
+function plantOnDisk(slug: string, content = "# bundled\n"): void {
+  const dir = join(SKILLS_ROOT, slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), content, "utf-8");
+}
+
+function listSkillDirs(): string[] {
+  if (!existsSync(SKILLS_ROOT)) return [];
+  return readdirSync(SKILLS_ROOT).sort();
+}
+
+function readSkill(slug: string): string {
+  return readFileSync(join(SKILLS_ROOT, slug, "SKILL.md"), "utf-8");
+}
+
+describe("reconcileSkills", () => {
+  beforeEach(() => {
+    resetSkillsDir();
+    installMockFetch();
+    mockCatalog = [];
+  });
+
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  test("invariant 1: bundled `memclaw` skill is never deleted (empty catalog)", async () => {
+    plantOnDisk("memclaw", "# bundled onboarding skill — should survive\n");
+    plantOnDisk("foo", "# orphan from a previous unshared skill\n");
+    mockCatalog = []; // empty catalog
+
+    const summary = await reconcileSkills();
+
+    assert.deepEqual(listSkillDirs(), ["memclaw"]); // foo gone, memclaw stays
+    assert.deepEqual(summary.removed, ["foo"]);
+    assert.deepEqual(summary.protected, ["memclaw"]);
+    // Bundled content must be untouched
+    assert.match(readSkill("memclaw"), /should survive/);
+  });
+
+  test("PROTECTED_SKILLS is exported and contains memclaw", () => {
+    assert.ok(PROTECTED_SKILLS.has("memclaw"));
+  });
+
+  test("invariant 2: cold start pulls every catalog skill", async () => {
+    plantOnDisk("memclaw"); // only the bundled skill
+    mockCatalog = [
+      { doc_id: "git-rebase-safety", data: { content: "# rebase safely\n" } },
+      { doc_id: "deploy-runbook",    data: { content: "# deploy steps\n" } },
+      { doc_id: "incident-triage",   data: { content: "# triage\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    assert.deepEqual(listSkillDirs(), [
+      "deploy-runbook", "git-rebase-safety", "incident-triage", "memclaw",
+    ]);
+    assert.deepEqual(summary.added.sort(), ["deploy-runbook", "git-rebase-safety", "incident-triage"]);
+    assert.deepEqual(summary.removed, []);
+    assert.equal(readSkill("git-rebase-safety"), "# rebase safely\n");
+  });
+
+  test("invariant 3: convergence — adds B, removes C, in one tick", async () => {
+    plantOnDisk("memclaw");
+    plantOnDisk("skill-a", "# A from catalog\n");
+    plantOnDisk("skill-c", "# C — orphan\n");
+    mockCatalog = [
+      { doc_id: "skill-a", data: { content: "# A from catalog\n" } },
+      { doc_id: "skill-b", data: { content: "# B — newly shared\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    assert.deepEqual(listSkillDirs(), ["memclaw", "skill-a", "skill-b"]);
+    assert.deepEqual(summary.added, ["skill-b"]);
+    assert.deepEqual(summary.removed, ["skill-c"]);
+  });
+
+  test("invariant 4: re-running with no changes is a no-op", async () => {
+    plantOnDisk("memclaw");
+    mockCatalog = [
+      { doc_id: "skill-a", data: { content: "# A\n" } },
+    ];
+
+    const first = await reconcileSkills();
+    const second = await reconcileSkills();
+
+    assert.deepEqual(first.added, ["skill-a"]);
+    assert.deepEqual(second.added, []);
+    assert.deepEqual(second.removed, []);
+    // The skill on disk hasn't been overwritten (same content → skipped)
+    assert.equal(readSkill("skill-a"), "# A\n");
+  });
+
+  test("invariant 5: unsafe slug from catalog is skipped, never lands on disk", async () => {
+    plantOnDisk("memclaw");
+    mockCatalog = [
+      { doc_id: "../etc/passwd", data: { content: "exploit\n" } },
+      { doc_id: "Capitalized",   data: { content: "uppercase rejected\n" } },
+      { doc_id: "valid-slug",    data: { content: "# valid\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    assert.deepEqual(listSkillDirs(), ["memclaw", "valid-slug"]);
+    assert.deepEqual(summary.added, ["valid-slug"]);
+    assert.equal(summary.skipped.length, 2);
+    // No traversal artefact created
+    assert.ok(!existsSync(join(tmpHome, "etc", "passwd")));
+  });
+
+  test("catalog returns missing/empty content → row skipped, others applied", async () => {
+    plantOnDisk("memclaw");
+    mockCatalog = [
+      { doc_id: "no-content", data: {} as { content: string } }, // explicitly empty
+      { doc_id: "good",       data: { content: "# good\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    assert.deepEqual(listSkillDirs(), ["good", "memclaw"]);
+    assert.deepEqual(summary.added, ["good"]);
+    assert.equal(summary.skipped.length, 1);
+  });
+
+  test("catalog query failure → fail open: existing skills preserved", async () => {
+    plantOnDisk("memclaw");
+    plantOnDisk("skill-a", "# from previous tick\n");
+    // Replace fetch with a thrower
+    globalThis.fetch = (async () => {
+      throw new TypeError("fetch failed");
+    }) as typeof fetch;
+
+    const summary = await reconcileSkills();
+
+    // Disk untouched
+    assert.deepEqual(listSkillDirs(), ["memclaw", "skill-a"]);
+    assert.equal(summary.catalogCount, 0);
+    assert.deepEqual(summary.added, []);
+    assert.deepEqual(summary.removed, []);
+  });
+
+  test("content drift on disk → reconciler overwrites with catalog version", async () => {
+    plantOnDisk("memclaw");
+    plantOnDisk("skill-a", "# stale local edits\n");
+    mockCatalog = [
+      { doc_id: "skill-a", data: { content: "# canonical from catalog\n" } },
+    ];
+
+    await reconcileSkills();
+
+    assert.equal(readSkill("skill-a"), "# canonical from catalog\n");
+  });
+});
+
+// Restore HOME after the suite so subsequent test files (run in
+// the same process under --test-isolation=none) see the real value.
+process.on("exit", () => {
+  process.env.HOME = originalHome;
+  try {
+    rmSync(tmpHome, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -1,0 +1,200 @@
+/**
+ * Plugin-side skill reconciler — Phase A of the skills-as-documents
+ * migration.
+ *
+ * On every heartbeat, mirror the visible ``collection=skills`` catalog
+ * onto ``plugin/skills/<slug>/SKILL.md`` on local disk. Replaces the
+ * dropped ``install_skill`` / ``uninstall_skill`` fleet commands (which
+ * were Phase B's removed push-mode behaviour).
+ *
+ * Properties:
+ *
+ * - **Declarative**: the catalog row IS the source of truth; the
+ *   reconciler only converges the on-disk view.
+ * - **Self-healing**: missed heartbeats catch up on the next tick.
+ *   No queue, no "lost install command" failure mode.
+ * - **Idempotent**: re-running is a no-op when disk already matches.
+ * - **Pull-everything-visible** (locked in 2026-05-05): tenant + fleet
+ *   visibility scoping happens at the catalog query layer, so the
+ *   reconciler doesn't need its own opt-in flag. Skills the agent's
+ *   fleet can see → on disk; can't see → not on disk.
+ *
+ * Failure mode: fail open. If the catalog query throws (network,
+ * server, schema), the reconciler logs and returns; existing on-disk
+ * skills are preserved untouched. The heartbeat loop continues.
+ */
+
+import {
+  existsSync, mkdirSync, readdirSync, readFileSync,
+  rmSync, statSync, writeFileSync,
+} from "fs";
+import { join } from "path";
+
+import { apiCall } from "./transport.js";
+import { MEMCLAW_TENANT_ID, MEMCLAW_FLEET_ID } from "./env.js";
+import { getPluginDir } from "./config.js";
+import { logError } from "./logger.js";
+
+/**
+ * Bundled skills shipped with the plugin install. Never deleted by
+ * reconciliation, even when the catalog returns no rows (a fresh
+ * tenant or a fleet with zero shared skills should NOT wipe the
+ * agent's onboarding skill).
+ */
+export const PROTECTED_SKILLS: ReadonlySet<string> = new Set(["memclaw"]);
+
+interface CatalogDoc {
+  doc_id?: string;
+  data?: Record<string, unknown>;
+}
+
+interface ReconcileSummary {
+  catalogCount: number;
+  added: string[];
+  removed: string[];
+  skipped: string[];   // catalog entries with bad shape (no doc_id / no content)
+  protected: string[]; // catalog-absent but not deleted
+}
+
+/**
+ * Mirror the catalog onto ``plugin/skills/``. Returns a summary for
+ * tests / logging; never throws.
+ */
+export async function reconcileSkills(): Promise<ReconcileSummary> {
+  const summary: ReconcileSummary = {
+    catalogCount: 0,
+    added: [],
+    removed: [],
+    skipped: [],
+    protected: [],
+  };
+
+  if (!MEMCLAW_TENANT_ID) {
+    // No tenant resolved — heartbeat already short-circuits in this
+    // case, but the reconciler is called independently in tests.
+    return summary;
+  }
+
+  // 1. Fetch the catalog. Visibility filtering (fleet_id) happens
+  //    server-side; we just pass our local fleet binding through.
+  let catalog: CatalogDoc[];
+  try {
+    const resp = (await apiCall(
+      "POST",
+      "/documents/query",
+      {
+        tenant_id: MEMCLAW_TENANT_ID,
+        collection: "skills",
+        fleet_id: MEMCLAW_FLEET_ID || undefined,
+        where: {},
+        limit: 1000,
+      },
+    )) as { documents?: CatalogDoc[] } | CatalogDoc[];
+    catalog = Array.isArray(resp)
+      ? resp
+      : Array.isArray(resp?.documents)
+        ? resp.documents
+        : [];
+  } catch (e: unknown) {
+    logError("reconcileSkills: catalog query failed", e);
+    return summary;
+  }
+  summary.catalogCount = catalog.length;
+
+  // 2. Build the desired state from the catalog. Skip rows missing
+  //    doc_id or content — they can't be materialised. Slug
+  //    validation (filesystem-safe) was enforced server-side by the
+  //    Phase B ``memclaw_doc op=write collection=skills`` rule, so
+  //    every doc_id we see here should already be safe — but defense
+  //    in depth: re-validate before touching the filesystem.
+  const desired = new Map<string, string>();
+  for (const doc of catalog) {
+    const slug = typeof doc.doc_id === "string" ? doc.doc_id : "";
+    const content =
+      doc.data && typeof doc.data["content"] === "string"
+        ? (doc.data["content"] as string)
+        : "";
+    if (!slug || !isSafeSlug(slug) || !content) {
+      summary.skipped.push(slug || "<missing>");
+      continue;
+    }
+    desired.set(slug, content);
+  }
+
+  // 3. Read disk. Skip non-directories so a stray file in
+  //    plugin/skills/ doesn't get treated as a managed slug.
+  const skillsRoot = join(getPluginDir(), "skills");
+  if (!existsSync(skillsRoot)) {
+    mkdirSync(skillsRoot, { recursive: true });
+  }
+  const onDisk = new Set<string>();
+  try {
+    for (const name of readdirSync(skillsRoot)) {
+      try {
+        if (statSync(join(skillsRoot, name)).isDirectory()) {
+          onDisk.add(name);
+        }
+      } catch {
+        // stat failure on one entry is non-fatal for the rest
+      }
+    }
+  } catch (e: unknown) {
+    logError("reconcileSkills: failed to read skills directory", e);
+    return summary;
+  }
+
+  // 4. Apply diff. Order: removals first, then writes — so a rename
+  //    (slug A → slug B) lands cleanly even if the operator does both
+  //    in the same heartbeat window.
+  for (const slug of onDisk) {
+    if (desired.has(slug)) continue;
+    if (PROTECTED_SKILLS.has(slug)) {
+      summary.protected.push(slug);
+      continue;
+    }
+    try {
+      rmSync(join(skillsRoot, slug), { recursive: true, force: true });
+      summary.removed.push(slug);
+      console.log(`[memclaw] Reconciler removed orphan skill: ${slug}`);
+    } catch (e: unknown) {
+      logError(`reconcileSkills: rm failed for ${slug}`, e);
+    }
+  }
+  for (const [slug, content] of desired) {
+    const dir = join(skillsRoot, slug);
+    const target = join(dir, "SKILL.md");
+    // Skip writes when the on-disk content already matches the
+    // catalog's content — keeps mtime stable and avoids spamming
+    // OpenClaw's skill-watch reload path on every heartbeat.
+    if (existsSync(target)) {
+      try {
+        if (readFileSync(target, "utf-8") === content) continue;
+      } catch {
+        // Read failure → fall through and overwrite
+      }
+    }
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(target, content, "utf-8");
+      summary.added.push(slug);
+      console.log(
+        `[memclaw] Reconciler ${onDisk.has(slug) ? "updated" : "pulled"} skill: ${slug}`,
+      );
+    } catch (e: unknown) {
+      logError(`reconcileSkills: write failed for ${slug}`, e);
+    }
+  }
+
+  return summary;
+}
+
+// Mirrors ``core_api.routes.documents._SKILL_SLUG_RE`` /
+// ``mcp_server._SKILL_SLUG_RE``. Defense in depth — server already
+// validates this on upsert, but the reconciler interpolates the slug
+// into a filesystem path so a regression on either side shouldn't be
+// able to land an unsafe directory name on disk.
+const SAFE_SLUG_RE = /^[a-z0-9][a-z0-9._-]{0,99}$/;
+
+function isSafeSlug(s: string): boolean {
+  return SAFE_SLUG_RE.test(s);
+}

--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -175,7 +175,20 @@ const PARAM_SCHEMAS: Record<string, Record<string, unknown>> = {
           "optional for search (omit to search every collection in the tenant) and list_collections.",
       },
       doc_id: { type: "string", description: "Required for op=write|read|delete" },
-      data: { type: "object", description: "Required for op=write" },
+      data: {
+        type: "object",
+        description:
+          "Required for op=write. JSON object with the document body — agent-defined keys " +
+          "(e.g. {name, description, content} for skills, or any shape for custom collections).",
+        // ``additionalProperties: true`` is JSON Schema's default but OpenClaw's
+        // gateway-side AJV validator runs in strict mode (which silently flips
+        // it to false for any object schema lacking explicit ``properties``).
+        // Without this, every plugin-routed ``memclaw_doc op=write`` call from
+        // an agent fails with "data: must not have additional properties" —
+        // surfaced wet-testing the Phase B skill-share flow on memclaw.dev
+        // (2026-05-06).
+        additionalProperties: true,
+      },
       where: { type: "object", description: "For op=query — field equality filters" },
       order_by: { type: "string", description: "For op=query" },
       order: { type: "string", enum: ["asc", "desc"], description: "For op=query" },


### PR DESCRIPTION
## Summary

Phase A of the skills-as-documents migration. Restores the fleet auto-install behaviour that Phase B temporarily dropped — declaratively, via a plugin-side reconciler, instead of the dropped `install_skill` / `uninstall_skill` push commands.

Plus two follow-ups surfaced when wet-testing Phase B on memclaw.dev with an OpenClaw agent.

## What's in

### 1. Plugin-side reconciler (`plugin/src/reconcile-skills.ts`)

On every heartbeat, mirror the visible `collection=skills` catalog onto `plugin/skills/<slug>/SKILL.md` on local disk.

- **Declarative**: the catalog row IS the source of truth.
- **Self-healing**: missed heartbeats catch up on the next tick — no queue, no "lost install command" failure mode.
- **Idempotent**: same content on disk → no write (mtime stable, no spurious OpenClaw skill-watch reload).
- **Pull-everything-visible** (Option C, locked 2026-05-05): tenant + fleet visibility happens at the catalog query layer; the reconciler doesn't need its own opt-in flag.
- **Fail open**: catalog query throws → log + return; existing on-disk skills preserved.
- **Bundled `memclaw` skill protected** from deletion regardless of catalog state.
- **Slug re-validation client-side** (defense in depth) before interpolating into a filesystem path.

Wired into `sendHeartbeat()` at the top of each tick.

### 2. `memclaw_doc.data` schema fix (Phase B follow-up)

OpenClaw's gateway-side AJV validator runs in strict mode, which silently flips `additionalProperties` to `false` for object schemas missing explicit `properties`. Without an explicit `additionalProperties: true`, every plugin-routed `memclaw_doc op=write` call failed with `"data: must not have additional properties"` — discovered running an OpenClaw agent against memclaw.dev's Phase B surface (2026-05-06).

This blocked **all** agent-driven document writes, not just skills.

### 3. `AGENTS.md` linguistic tightening (Phase B follow-up)

Phase B's prose said "share via `memclaw_doc op=write collection=skills`" but didn't anchor *which* collection. When asked to "share a runbook", gpt-4o-mini routed to a custom `collection=runbooks` instead of `collection=skills`. Tightened to lead with the named collection and explicitly call out reusable knowledge synonyms.

Within the existing 1500-char `AGENTS.md` budget (1472/1500).

## Tests

9 new tests in `plugin/src/reconcile-skills.test.ts`:

- [x] Bundled `memclaw` skill never deleted (empty catalog)
- [x] Cold start pulls every catalog entry
- [x] Convergence: adds B, removes orphan C in one tick
- [x] Idempotency: re-running with no changes is a no-op
- [x] Unsafe slug from server is rejected client-side, never hits disk
- [x] Missing/empty content rows skipped without breaking others
- [x] Catalog query failure → fail open, existing skills preserved
- [x] Content drift → reconciler overwrites with catalog version

Plugin test suite: **174 pass / 0 fail** (was 165, +9).

Reconciler is registered in `_plugin_files` and the install script's bash `for srcfile in …` loop so fresh `curl … | bash` installs include it.

## Pre-existing failures NOT caused by this PR

`test_api_documents_skills.py::test_skills_collection_accepts_safe_slugs` and `::test_skills_collection_auto_defaults_embed_field` fail with `expected 768 dimensions, not 1024` — confirmed pre-existing on `main` by stashing this branch's changes and reproducing. Unrelated to Phase A; should be a separate PR for the embedding-dim mismatch.

## Test plan

- [ ] CI green
- [ ] Deploy to memclaw.dev, run two-agent OpenClaw wet test (skill share via Agent 1 → Agent 2 finds it via reconciler on next heartbeat)
- [ ] Verify the bundled `memclaw` skill survives a `docker compose down -v` + fresh start
- [ ] Confirm `memclaw_doc op=write` from an OpenClaw plugin agent now succeeds (was 422 before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)