### PR TITLE
docs: align tool count to 10 in README and integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ curl -sf -H "X-API-Key: $MEMCLAW_KEY" \
 openclaw gateway restart
 ```
 
-The plugin claims the OpenClaw `memory` slot (replacing `memory-core`) and exposes the same 12 MCP tools. Full setup, agent prompts, and trust levels: [static/docs/integration-guide.md](static/docs/integration-guide.md).
+The plugin claims the OpenClaw `memory` slot (replacing `memory-core`) and exposes the same 10 MCP tools. Full setup, agent prompts, and trust levels: [static/docs/integration-guide.md](static/docs/integration-guide.md).
 
 ---
 

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -110,7 +110,7 @@ Options:
 
 Restart your agent after installing — skills are loaded at startup.
 
-Why this matters: without the skill, an agent can discover the 12 tool
+Why this matters: without the skill, an agent can discover the 10 tool
 names and their arg schemas via MCP `tools/list`, but it has no
 mental model for the two-store design (memory vs doc), the trust
 levels, or which op to reach for in an ambiguous situation. With the


### PR DESCRIPTION
## Summary
- Two stale references still claimed "12 MCP tools" after the 2026-05 migration that consolidated skill sharing into `memclaw_doc` with `collection="skills"`.
- The current surface is 10 tools, already correct in `plugin/src/tools.ts` and the in-page tools table at `integration-guide.md:125`.

## Test plan
- [ ] Visual review of `README.md` and `static/docs/integration-guide.md`
- [ ] No other "12 tools" / "twelve tools" references remain (`grep -rn -iE "twelve|\b12\s+(memclaw|mcp|tool)"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)