### PR TITLE
feat(plugin): synthesize skill frontmatter + anchor catalog discovery

### DIFF
--- a/plugin/src/educate.ts
+++ b/plugin/src/educate.ts
@@ -407,10 +407,11 @@ outcome MUST produce a write. No write = not done. Checkpoint every
 blocker · commitment · config change · error pattern · skill created
 or updated. If in doubt: write.
 
-**Skills** (reusable team knowledge: runbooks, recipes, playbooks).
-Catalog is \`collection=skills\` — never \`runbooks\` etc. Check
-(\`memclaw_doc op=query collection=skills\`); share back
-(\`op=write collection=skills doc_id=<slug>\`).
+**Skills** (team knowledge: runbooks, recipes, playbooks). Catalog
+is \`collection=skills\`. Search first
+(\`memclaw_doc op=search collection=skills\`) — \`memclaw_recall\`
+is for YOUR memories, not shared. Share via \`op=write
+collection=skills doc_id=<slug>\`.
 
 Before your first MemClaw call this session, read
 \`skills/memclaw/SKILL.md\` for tool signatures, capture cadences

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -43,7 +43,21 @@ const { reconcileSkills, PROTECTED_SKILLS } = await import("./reconcile-skills.j
 const SKILLS_ROOT = join(tmpHome, ".openclaw", "plugins", "memclaw", "skills");
 
 let originalFetch: typeof fetch;
-let mockCatalog: Array<{ doc_id: string; data: { content: string } }>;
+type MockCatalogEntry = {
+  doc_id: string;
+  data: { name?: string; description?: string; content: string };
+};
+let mockCatalog: MockCatalogEntry[];
+
+/**
+ * Wrap a content body with the same frontmatter the reconciler would
+ * synthesise. Used by tests that need disk state to *exactly match*
+ * what the reconciler will write (so convergence tests don't see a
+ * spurious update on every tick).
+ */
+function withSynthFrontmatter(name: string, description: string, body: string): string {
+  return `---\nname: ${name}\ndescription: "${description}"\n---\n\n${body}`;
+}
 
 function installMockFetch(): void {
   originalFetch = globalThis.fetch;
@@ -116,9 +130,9 @@ describe("reconcileSkills", () => {
   test("invariant 2: cold start pulls every catalog skill", async () => {
     plantOnDisk("memclaw"); // only the bundled skill
     mockCatalog = [
-      { doc_id: "git-rebase-safety", data: { content: "# rebase safely\n" } },
-      { doc_id: "deploy-runbook",    data: { content: "# deploy steps\n" } },
-      { doc_id: "incident-triage",   data: { content: "# triage\n" } },
+      { doc_id: "git-rebase-safety", data: { name: "git-rebase-safety", description: "rebase steps",   content: "# rebase safely\n" } },
+      { doc_id: "deploy-runbook",    data: { name: "deploy-runbook",    description: "deploy steps",   content: "# deploy steps\n" } },
+      { doc_id: "incident-triage",   data: { name: "incident-triage",   description: "triage steps",   content: "# triage\n" } },
     ];
 
     const summary = await reconcileSkills();
@@ -128,16 +142,20 @@ describe("reconcileSkills", () => {
     ]);
     assert.deepEqual(summary.added.sort(), ["deploy-runbook", "git-rebase-safety", "incident-triage"]);
     assert.deepEqual(summary.removed, []);
-    assert.equal(readSkill("git-rebase-safety"), "# rebase safely\n");
+    // Frontmatter synthesised from data.{name, description}; body preserved.
+    const written = readSkill("git-rebase-safety");
+    assert.match(written, /^---\nname: git-rebase-safety\ndescription: "rebase steps"\n---\n\n# rebase safely\n$/);
   });
 
   test("invariant 3: convergence — adds B, removes C, in one tick", async () => {
     plantOnDisk("memclaw");
-    plantOnDisk("skill-a", "# A from catalog\n");
+    // Plant skill-a with the EXACT content the reconciler would write,
+    // so the no-op-on-match path stays quiet for it.
+    plantOnDisk("skill-a", withSynthFrontmatter("skill-a", "alpha", "# A from catalog\n"));
     plantOnDisk("skill-c", "# C — orphan\n");
     mockCatalog = [
-      { doc_id: "skill-a", data: { content: "# A from catalog\n" } },
-      { doc_id: "skill-b", data: { content: "# B — newly shared\n" } },
+      { doc_id: "skill-a", data: { name: "skill-a", description: "alpha", content: "# A from catalog\n" } },
+      { doc_id: "skill-b", data: { name: "skill-b", description: "bravo — newly shared", content: "# B — newly shared\n" } },
     ];
 
     const summary = await reconcileSkills();
@@ -150,7 +168,7 @@ describe("reconcileSkills", () => {
   test("invariant 4: re-running with no changes is a no-op", async () => {
     plantOnDisk("memclaw");
     mockCatalog = [
-      { doc_id: "skill-a", data: { content: "# A\n" } },
+      { doc_id: "skill-a", data: { name: "skill-a", description: "alpha", content: "# A\n" } },
     ];
 
     const first = await reconcileSkills();
@@ -160,15 +178,15 @@ describe("reconcileSkills", () => {
     assert.deepEqual(second.added, []);
     assert.deepEqual(second.removed, []);
     // The skill on disk hasn't been overwritten (same content → skipped)
-    assert.equal(readSkill("skill-a"), "# A\n");
+    assert.equal(readSkill("skill-a"), withSynthFrontmatter("skill-a", "alpha", "# A\n"));
   });
 
   test("invariant 5: unsafe slug from catalog is skipped, never lands on disk", async () => {
     plantOnDisk("memclaw");
     mockCatalog = [
-      { doc_id: "../etc/passwd", data: { content: "exploit\n" } },
-      { doc_id: "Capitalized",   data: { content: "uppercase rejected\n" } },
-      { doc_id: "valid-slug",    data: { content: "# valid\n" } },
+      { doc_id: "../etc/passwd", data: { name: "x", description: "exploit",     content: "exploit\n" } },
+      { doc_id: "Capitalized",   data: { name: "x", description: "uppercase",   content: "rejected\n" } },
+      { doc_id: "valid-slug",    data: { name: "valid-slug", description: "ok", content: "# valid\n" } },
     ];
 
     const summary = await reconcileSkills();
@@ -180,18 +198,65 @@ describe("reconcileSkills", () => {
     assert.ok(!existsSync(join(tmpHome, "etc", "passwd")));
   });
 
-  test("catalog returns missing/empty content → row skipped, others applied", async () => {
+  test("catalog returns missing content/description → row skipped, others applied", async () => {
     plantOnDisk("memclaw");
     mockCatalog = [
-      { doc_id: "no-content", data: {} as { content: string } }, // explicitly empty
-      { doc_id: "good",       data: { content: "# good\n" } },
+      { doc_id: "no-content",     data: { name: "x", description: "ok" } as MockCatalogEntry["data"] },
+      { doc_id: "no-description", data: { name: "x",                       content: "# body\n" } as MockCatalogEntry["data"] },
+      { doc_id: "good",           data: { name: "good", description: "ok", content: "# good\n" } },
     ];
 
     const summary = await reconcileSkills();
 
     assert.deepEqual(listSkillDirs(), ["good", "memclaw"]);
     assert.deepEqual(summary.added, ["good"]);
-    assert.equal(summary.skipped.length, 1);
+    assert.equal(summary.skipped.length, 2);
+  });
+
+  test("frontmatter synthesis: plain markdown gets name+description prepended for OpenClaw discovery", async () => {
+    plantOnDisk("memclaw");
+    mockCatalog = [
+      {
+        doc_id: "git-rebase-safety",
+        data: {
+          name: "git-rebase-safety",
+          description: "Safely rebase a feature branch — quotes \"and\" backslashes \\ get escaped",
+          content: "# Body\n\nStep 1.\n",
+        },
+      },
+    ];
+
+    await reconcileSkills();
+
+    const written = readSkill("git-rebase-safety");
+    // YAML frontmatter present; description double-quoted with escapes intact.
+    assert.match(
+      written,
+      /^---\nname: git-rebase-safety\ndescription: "Safely rebase a feature branch — quotes \\"and\\" backslashes \\\\ get escaped"\n---\n\n/,
+    );
+    // Original body preserved after the fence
+    assert.ok(written.endsWith("# Body\n\nStep 1.\n"));
+  });
+
+  test("frontmatter passthrough: skill content that already starts with --- is left untouched", async () => {
+    plantOnDisk("memclaw");
+    const authorContent =
+      "---\nname: my-skill\ndescription: hand-authored\nuser-invocable: true\n---\n\n# Body\n";
+    mockCatalog = [
+      {
+        doc_id: "authored",
+        data: {
+          name: "should-be-ignored",
+          description: "should-be-ignored",
+          content: authorContent,
+        },
+      },
+    ];
+
+    await reconcileSkills();
+
+    // Author's frontmatter wins — reconciler doesn't double-prepend.
+    assert.equal(readSkill("authored"), authorContent);
   });
 
   test("catalog query failure → fail open: existing skills preserved", async () => {
@@ -215,12 +280,12 @@ describe("reconcileSkills", () => {
     plantOnDisk("memclaw");
     plantOnDisk("skill-a", "# stale local edits\n");
     mockCatalog = [
-      { doc_id: "skill-a", data: { content: "# canonical from catalog\n" } },
+      { doc_id: "skill-a", data: { name: "skill-a", description: "alpha", content: "# canonical from catalog\n" } },
     ];
 
     await reconcileSkills();
 
-    assert.equal(readSkill("skill-a"), "# canonical from catalog\n");
+    assert.equal(readSkill("skill-a"), withSynthFrontmatter("skill-a", "alpha", "# canonical from catalog\n"));
   });
 });
 

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -107,18 +107,37 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
   //    Phase B ``memclaw_doc op=write collection=skills`` rule, so
   //    every doc_id we see here should already be safe — but defense
   //    in depth: re-validate before touching the filesystem.
+  //
+  //    OpenClaw's skill loader rejects any SKILL.md without YAML
+  //    frontmatter declaring ``name`` and ``description`` (it returns
+  //    null in ``loadSingleSkillDirectory`` when either is missing,
+  //    silently filtering the skill out of the agent's tool palette).
+  //    Skills uploaded via ``memclaw_doc op=write collection=skills``
+  //    typically supply ``data.{name, description, content}`` as
+  //    separate fields with the content being plain markdown — so the
+  //    reconciler synthesises frontmatter from ``data.name`` and
+  //    ``data.description`` before writing, unless the content already
+  //    starts with a ``---`` fence (in which case the author's own
+  //    frontmatter is preserved).
   const desired = new Map<string, string>();
   for (const doc of catalog) {
     const slug = typeof doc.doc_id === "string" ? doc.doc_id : "";
-    const content =
-      doc.data && typeof doc.data["content"] === "string"
-        ? (doc.data["content"] as string)
+    const data = doc.data ?? {};
+    const rawContent =
+      typeof data["content"] === "string" ? (data["content"] as string) : "";
+    const description =
+      typeof data["description"] === "string"
+        ? (data["description"] as string).trim()
         : "";
-    if (!slug || !isSafeSlug(slug) || !content) {
+    const name =
+      typeof data["name"] === "string" && (data["name"] as string).trim()
+        ? (data["name"] as string).trim()
+        : slug;
+    if (!slug || !isSafeSlug(slug) || !rawContent || !description) {
       summary.skipped.push(slug || "<missing>");
       continue;
     }
-    desired.set(slug, content);
+    desired.set(slug, ensureFrontmatter(rawContent, name, description));
   }
 
   // 3. Read disk. Skip non-directories so a stray file in
@@ -197,4 +216,44 @@ const SAFE_SLUG_RE = /^[a-z0-9][a-z0-9._-]{0,99}$/;
 
 function isSafeSlug(s: string): boolean {
   return SAFE_SLUG_RE.test(s);
+}
+
+const FRONTMATTER_FENCE_RE = /^---\r?\n/;
+
+/**
+ * Synthesise YAML frontmatter from the catalog row when the body
+ * doesn't already include it. OpenClaw's skill loader silently filters
+ * any SKILL.md whose frontmatter is missing ``name`` or ``description``
+ * (see ``plugin-sdk/src/agents/skills/...loadSingleSkillDirectory``),
+ * so a reconciled skill without frontmatter would land on disk yet
+ * never appear in the agent's tool palette.
+ *
+ * Authors who upload skills with their own frontmatter in
+ * ``data.content`` get pass-through (we detect the leading ``---``
+ * fence and don't touch the body). Authors who upload plain markdown
+ * (the common case for ``memclaw_doc op=write collection=skills``) get
+ * frontmatter prepended from ``data.name`` and ``data.description``.
+ *
+ * Description is YAML-escaped — wrapped in double quotes with embedded
+ * quotes/backslashes escaped — so a multi-word description with
+ * punctuation can't trip the YAML parser.
+ */
+function ensureFrontmatter(
+  rawContent: string,
+  name: string,
+  description: string,
+): string {
+  if (FRONTMATTER_FENCE_RE.test(rawContent)) return rawContent;
+  const escapedDescription = description
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+  // Single-line YAML strings — safe across the slug + description
+  // shapes the server already enforces (description ≤ 500 chars per
+  // skill_service validation, no newlines accepted).
+  const fm =
+    "---\n" +
+    `name: ${name}\n` +
+    `description: "${escapedDescription}"\n` +
+    "---\n\n";
+  return fm + rawContent;
 }


### PR DESCRIPTION
Two follow-ups to Phase A (#94), driven by the 2026-05-06 wet-test findings on the local memclaw.dev replica. Closes follow-up tasks #30 and #31.

## 1. Reconciler synthesizes SKILL.md frontmatter (was task #30)

OpenClaw's skill loader silently filters any SKILL.md whose YAML frontmatter is missing `name` or `description`. Skills uploaded via `memclaw_doc op=write collection=skills` typically supply `data.{name, description, content}` separately with content being plain markdown — so a reconciled skill landed on disk but never appeared in the agent's tool palette.

Fix: `ensureFrontmatter()` synthesizes a frontmatter block from `data.name` and `data.description` before writing, unless the content already starts with a `---` fence (preserves any hand-authored frontmatter).

Description is YAML-escaped (double-quoted, embedded `\` and `"` doubled) so multi-word descriptions with punctuation can't trip the YAML parser.

## 2. AGENTS.md anchors search-the-catalog as primary discovery (was task #31)

Phase B's prose taught agents to share via `memclaw_doc op=write collection=skills` (worked: Agent 1 picked the right collection 13/13 times in the wet test). But Agent 2's instinct for "see if there's anything written down" was 3× `memclaw_recall` (memory search), 0× `memclaw_doc op=search collection=skills`.

New text leads with "search the catalog FIRST" and explicitly distinguishes `memclaw_recall` (YOUR memories) from skills (shared team knowledge). Within the existing 1500-char AGENTS.md budget (1497/1500).

## Tests

2 new reconciler tests:
- frontmatter synthesis: plain markdown gets name+description prepended, YAML escape verified
- frontmatter passthrough: content starting with `---` left untouched (no double-prepend)

Existing reconciler tests updated to include `name` + `description` in mock catalog rows (otherwise they'd be skipped per Phase B's auto-default + new frontmatter requirement).

Plugin test suite: **176 pass / 0 fail** (was 174, +2 new).

## Wet-test caveat — NEW finding worth filing as a follow-up

While verifying end-to-end on the local stack, an unrelated phenomenon surfaced: when the OpenClaw gateway is running, SKILL.md files appear to be **reverted to body-only after the reconciler writes the frontmatter+body version**. The reconciler keeps "updating" each tick because the on-disk content drifts back to body-only between ticks.

Standalone (gateway-dead) reconciler runs DO produce the correct 154-byte frontmatter+body file and it stays put. So this PR's synthesis logic is sound; some other writer in the gateway process strips the frontmatter back. I couldn't find the writer in `/opt/homebrew/lib/node_modules/openclaw/dist/`; the chokidar skill watcher only fires snapshot-version bumps, doesn't write.

Until that's tracked down, the user-visible end-to-end ("Agent 2 sees Agent 1's reconciled skill in its tool palette") still won't pass — but for a different reason than what this PR fixes. The synthesis is necessary but not sufficient.

## Test plan

- [ ] CI green
- [ ] Deploy to memclaw.dev
- [ ] Re-run the two-agent wet test on memclaw.dev — confirm the synthesis produces correct frontmatter on disk
- [ ] Separately track the gateway-stripping mystery as a new task

🤖 Generated with [Claude Code](https://claude.com/claude-code)