### PR TITLE
fix(core-api): use CAST instead of `::uuid[]` for SQLAlchemy bind compatibility (CAURA-675)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/entity_linking/discover_cross_links.py
+++ b/core-api/src/core_api/pipeline/steps/entity_linking/discover_cross_links.py
@@ -41,7 +41,7 @@ class DiscoverCrossLinks:
                     text(f"""
                         SELECT m.id, m.content, m.embedding
                         FROM memories m
-                        WHERE m.id = ANY(:memory_ids::uuid[])
+                        WHERE m.id = ANY(CAST(:memory_ids AS uuid[]))
                           AND m.tenant_id = :tenant_id
                           AND m.deleted_at IS NULL
                           AND m.status = 'active'
@@ -93,7 +93,7 @@ class DiscoverCrossLinks:
             SELECT m.id AS memory_id,
                    e.id AS entity_id, e.canonical_name, e.attributes, e.sim
             FROM (SELECT id, embedding FROM memories
-                  WHERE id = ANY(:memory_ids::uuid[]) AND tenant_id = :tenant_id) m
+                  WHERE id = ANY(CAST(:memory_ids AS uuid[])) AND tenant_id = :tenant_id) m
             JOIN LATERAL (
                 SELECT e.id, e.canonical_name, e.attributes,
                        1 - (e.name_embedding <=> m.embedding) AS sim

--- a/core-api/src/core_api/pipeline/steps/entity_linking/infer_relations.py
+++ b/core-api/src/core_api/pipeline/steps/entity_linking/infer_relations.py
@@ -85,7 +85,7 @@ class InferRelations:
                     FROM relations
                     WHERE tenant_id = :tenant_id
                       AND relation_type = 'related_to'
-                      AND (from_entity_id = ANY(:ids::uuid[]) OR to_entity_id = ANY(:ids::uuid[]))
+                      AND (from_entity_id = ANY(CAST(:ids AS uuid[])) OR to_entity_id = ANY(CAST(:ids AS uuid[])))
                 """),
                 {
                     "tenant_id": tenant_id,

--- a/tests/pipeline/test_entity_linking.py
+++ b/tests/pipeline/test_entity_linking.py
@@ -158,9 +158,11 @@ async def test_discover_with_target_memory_ids():
     assert result.outcome == StepOutcome.SUCCESS
     assert ctx.data["links_created"] == 1
 
-    # Verify the first SQL call uses ANY(:memory_ids) not HAVING/LIMIT
+    # Targeted mode binds :memory_ids; ``::uuid[]`` form mis-parsed as a second
+    # bind in production (CAURA-675), so guard against its reintroduction.
     first_sql = str(db.execute.call_args_list[0][0][0].text)
-    assert "ANY(:memory_ids" in first_sql
+    assert ":memory_ids" in first_sql
+    assert "::uuid[]" not in first_sql
     assert "HAVING" not in first_sql
     assert "LIMIT" not in first_sql
 


### PR DESCRIPTION
## Summary

`/api/v1/admin/lifecycle/fanout/entity-link` was nacking every Pub/Sub message in prod after today's CAURA-652 / CAURA-657 rollout, with:

```
ERROR pubsub handler raised; nacking for redelivery
entity_linking_full.discover_cross_links: FAILED in 8.8ms —
sqlalchemy.dialects.postgresql.asyncpg.ProgrammingError:
<class 'asyncpg.exceptions.PostgresSyntaxError'>: syntax error at or near ":"
```

The bug has been in the code since v1.0.0 (`7456e23`) but stayed dormant because no producer was publishing to `memclaw.lifecycle.entity-link-requested` until today's prod cron came online.

### Root cause

SQLAlchemy `text()` parses `:name` binds with a regex that doesn't recognise PostgreSQL's `::` cast as a terminator. `:memory_ids::uuid[]` reads as `:memory_ids` (bind, gets translated to `$N` for asyncpg) + leftover `::uuid[]`, where `:uuid` inside the leftover matches a **second** named bind that nothing supplies. The compiled SQL handed to asyncpg ends up with `:memory_ids` un-translated alongside `tenant_id = $1`, so asyncpg hits the literal `:` and reports `syntax error at or near ":"`.

### Fix

Replace `ANY(:bind::uuid[])` → `ANY(CAST(:bind AS uuid[]))` at all three call sites:

- [`discover_cross_links.py:44`](https://github.com/caura-ai/caura-memclaw/blob/main/core-api/src/core_api/pipeline/steps/entity_linking/discover_cross_links.py#L44) — targeted-mode candidate query
- [`discover_cross_links.py:96`](https://github.com/caura-ai/caura-memclaw/blob/main/core-api/src/core_api/pipeline/steps/entity_linking/discover_cross_links.py#L96) — LATERAL JOIN entity-similarity query
- [`infer_relations.py:88`](https://github.com/caura-ai/caura-memclaw/blob/main/core-api/src/core_api/pipeline/steps/entity_linking/infer_relations.py#L88) — existing-relations bulk fetch

PostgreSQL parses `CAST(x AS uuid[])` and `x::uuid[]` to the same `TypeCast` parse node, so plan shape and index usage are unchanged. The `CAST` form just doesn't trip the SQLAlchemy bind regex.

### Test changes

[`test_entity_linking.py`](https://github.com/caura-ai/caura-memclaw/blob/main/tests/pipeline/test_entity_linking.py): updated `test_discover_with_target_memory_ids` to add an `assert "::uuid[]" not in first_sql` regression guard, and loosened the positive `ANY(:memory_ids` substring check to `":memory_ids" in first_sql` so a future refactor to `bindparam(type_=ARRAY(UUID))` doesn't break the test for non-substantive reasons.

## Out of scope (follow-ups if desired)

- `discover_cross_links.py` passes `memory_ids` as `list[str]` on line 53 (UUID-stringified) and `list[uuid.UUID]` on line 116 (raw `m.id` from query result). Same bind name, two shapes. `CAST(...)` accepts both, so it's a code-health item — small, but unrelated to the bug.
- `core-storage-api` has two `(:bind)::type` patterns ([`postgres_service.py:465`](https://github.com/caura-ai/caura-memclaw/blob/main/core-storage-api/src/core_storage_api/services/postgres_service.py#L465), [`backfill_embeddings.py:253`](https://github.com/caura-ai/caura-memclaw/blob/main/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py#L253)) using the safer parenthesized form `(:bind)::type`. They parse correctly because the parens terminate the bind name, but converting them to `CAST(...)` for codebase consistency is worth a follow-up.
- A real-PG regression test (using the `db` fixture from `tests/conftest.py:101-211`) would catch the asyncpg-level parse error that the substring assertion can't. Sibling `test_write_pipeline.py` / `test_search_pipeline.py` already use the live engine — same pattern would work here.

## Test plan

- [x] `pytest tests/pipeline/test_entity_linking.py` — 6/6 passed
- [x] `ruff check` + `ruff format --check` — clean
- [ ] Post-merge verification: prod core-api logs should stop showing `pubsub handler raised; nacking for redelivery` for the entity-link consumer once v2.3.1 (or the next release) deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)