### PR TITLE
fix(core-api): align write/query embedding surface (CAURA-222)

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -82,10 +82,6 @@ class Settings(BaseSettings):
     # breaching the 45s outer request budget. Must stay below
     # ``request_timeout_seconds`` so this fires first.
     enrichment_inline_timeout_seconds: float = 35.0
-    # Inner timeout for the optional hint-based re-embed roundtrip after
-    # enrichment lands a retrieval_hint. Pure quality-vs-latency knob;
-    # only fires when ``embed_on_hot_path`` is True.
-    enrichment_hint_reembed_timeout_seconds: float = 10.0
     # Per-call timeout passed to the AsyncOpenAI client (covers both LLM
     # enrichment and embedding providers). Without an explicit value the
     # SDK rides httpx's default — long enough that a single hung upstream

--- a/core-api/src/core_api/pipeline/steps/write/parallel_embed_enrich.py
+++ b/core-api/src/core_api/pipeline/steps/write/parallel_embed_enrich.py
@@ -12,10 +12,13 @@ enrichment call too. The strong-write pipeline persists the row with
 agent-provided values + schema defaults for the LLM-derived columns
 (``memory_type`` / ``weight`` / ``status``); ``ScheduleBackgroundTasks``
 publishes ``Topics.Memory.ENRICH_REQUESTED`` and ``core-worker``
-PATCHes the enrichment fields back. Hint-based re-embed is also
-deferred — when both flags are off, we accept the small recall hit on
-the initial embed and let the back-channel ENRICHED consumer trigger
-a follow-up re-embed if the hint is high-value.
+PATCHes the enrichment fields back. Hint-based re-embed is DISABLED
+(CAURA-222): writes used to embed
+``compose_embedding_text(content, retrieval_hint)`` while queries embed
+raw text, producing a write/query surface asymmetry that capped recall
+across dedup, entity-lookup, and search ranking. Until a symmetric
+reintroduction lands, both the hot-path here and the background
+re-embed in ``_enrich_memory_background`` embed raw ``content``.
 """
 
 from __future__ import annotations
@@ -102,29 +105,16 @@ class ParallelEmbedEnrich:
         embedding = next(result_iter) if embedding_task is not None else None
         enrichment = next(result_iter) if enrichment_task is not None else None
 
-        # Hint re-embed uses enrichment output to improve retrieval
-        # quality (e.g. "business milestone" query vs "signed first
-        # client" content) via a second embed call. Pointless when
-        # we're already deferring the first one — accept the small
-        # quality regression for the latency win.
-        if (
-            not defer_embedding
-            and cached_embedding is None
-            and enrichment is not None
-            and getattr(enrichment, "retrieval_hint", "")
-        ):
-            from core_api.services.memory_enrichment import compose_embedding_text
-
-            composed = compose_embedding_text(data.content, enrichment.retrieval_hint)
-            try:
-                hint_embedding = await asyncio.wait_for(
-                    get_embedding(composed, tenant_config),
-                    timeout=settings.enrichment_hint_reembed_timeout_seconds,
-                )
-                if hint_embedding is not None:
-                    embedding = hint_embedding
-            except TimeoutError:
-                logger.warning("hint re-embed timed out; keeping content-only embedding")
+        # Hint re-embed disabled (CAURA-222): writes embedded
+        # `compose_embedding_text(content, retrieval_hint)` —
+        # "[Retrieval hint]: ...\n\n<content>" — while queries embed raw
+        # text. Identical content↔query produced cosine ~0.69 instead of
+        # ~1.0, capping recall across dedup, entity_lookup, and search
+        # ranking. The background hint re-embed in
+        # `_enrich_memory_background` (memory_service._enrich_memory_background)
+        # required the same fix; it now also embeds raw `content`. Both
+        # sides — hot path and background — embed raw `content` to match
+        # the search surface (raw query through `get_query_embedding`).
 
         ctx.data["embedding"] = embedding
         ctx.data["enrichment"] = enrichment

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -1991,8 +1991,8 @@ async def _enrich_memory_background(
             if enrichment.pii_types:
                 meta["pii_types"] = enrichment.pii_types
         if enrichment.retrieval_hint:
-            # Persisted for debugging / auditability; not used at query time
-            # (the hint already shaped the embedding).
+            # Persisted for debugging / auditability only; no longer used
+            # to shape the embedding (see CAURA-222).
             meta["retrieval_hint"] = enrichment.retrieval_hint
         # Temporal resolution
         if mem.get("ts_valid_start") is None and enrichment.ts_valid_start:
@@ -2020,93 +2020,33 @@ async def _enrich_memory_background(
                 await sc.update_memory_status(str(memory_id), status_val)
 
         embedding = mem.get("embedding")
-        pre_hint_embedding = embedding  # snapshot for the contradiction race-check below
         memory_type = patch.get("memory_type") or mem.get("memory_type")
 
-        # Re-embed with the enricher's retrieval_hint (if any) so the final
-        # embedding captures the memory's semantic essence in query-aligned
-        # vocabulary, not just the raw content surface.  No-op when the
-        # enricher returned an empty hint.
-        hint = getattr(enrichment, "retrieval_hint", "") or ""
-        if hint:
-            from core_api.services.memory_enrichment import compose_embedding_text
-
-            composed = compose_embedding_text(content, hint)
-            try:
-                new_embedding = await get_embedding(composed, tenant_config=tenant_config)
-            except (TimeoutError, ValueError, RuntimeError, OpenAIError, GoogleAPIError):
-                new_embedding = None
-                logger.warning(
-                    "hint re-embed failed for memory %s, keeping content-only embedding",
-                    memory_id,
-                    exc_info=True,
-                )
-            if new_embedding is not None:
-                try:
-                    await sc.update_embedding(str(memory_id), new_embedding)
-                    embedding = new_embedding
-                    logger.info("Background hint re-embed succeeded for memory %s", memory_id)
-                    # Contradiction coverage for the hint-enhanced embedding.
-                    # This branch is the SaaS-mode (embed_on_hot_path=False)
-                    # half of a flag-mutually-exclusive pair — the OSS-mode
-                    # half lives at the bottom of this function and fires
-                    # whenever ``embedding is not None and embed_on_hot_path``.
-                    # Splitting on the flag avoids a double-fire when both
-                    # branches would otherwise run on the same hint-enhanced
-                    # vector.
-                    #
-                    # SaaS-mode shape: ``core-worker`` may have already PATCH-ed
-                    # an embedding before enrich's hint-reembed lands. The
-                    # worker does NOT fire contradiction detection (CAURA-594
-                    # follow-up gap), so when ``pre_hint_embedding is not None``
-                    # — meaning the worker beat enrich to the row — the
-                    # hint-enhanced overwrite is the only chance to attach
-                    # contradiction coverage at all. When pre_hint_embedding
-                    # is None, the worker hasn't won the race yet; firing
-                    # here would still help, but the worker's eventual PATCH
-                    # would silently overwrite our hint-enhanced vector
-                    # without re-firing contradiction — that's the documented
-                    # SaaS-mode coverage gap.
-                    if not settings.embed_on_hot_path and pre_hint_embedding is not None:
-                        from core_api.services.contradiction_detector import (
-                            detect_contradictions_async,
-                        )
-
-                        track_task(
-                            tracked_task(
-                                detect_contradictions_async(
-                                    memory_id,
-                                    tenant_id,
-                                    fleet_id,
-                                    content,
-                                    new_embedding,
-                                ),
-                                "contradiction_detection_post_enrich",
-                                memory_id,
-                                tenant_id,
-                            )
-                        )
-                except (TimeoutError, ValueError, RuntimeError, OpenAIError, GoogleAPIError):
-                    logger.exception("Background hint re-embed update failed for memory %s", memory_id)
+        # Hint-based re-embed removed (CAURA-222): the hot path embeds raw
+        # ``content`` and the search side embeds raw query, so the stored
+        # vector is already on the correct surface by the time enrichment
+        # finishes. Re-embedding ``content`` here would just produce an
+        # identical vector — wasted provider call and DB write. The
+        # SaaS-mode contradiction-coverage branch that lived inside this
+        # block is gone with it; OSS-mode contradiction detection still
+        # fires below on the stored embedding.
 
         # Atomic-fact fan-out: if the enricher detected 2+ independent claims in
         # this turn, create a child memory for each so queries targeting a
-        # specific fact retrieve it directly.  Each child gets its own
-        # hint-enriched embedding.  Failures here are non-fatal to the parent.
+        # specific fact retrieve it directly. Children embed raw
+        # ``fact_content`` (not hint-prefixed) to keep the same write/query
+        # surface as the search side — see CAURA-222. Failures here are
+        # non-fatal to the parent.
         atomic_facts = getattr(enrichment, "atomic_facts", None) or []
         if len(atomic_facts) >= 1:
-            from core_api.services.memory_enrichment import compose_embedding_text
-
             parent_ts_start = mem.get("ts_valid_start")
             parent_visibility = mem.get("visibility") or "scope_team"
             parent_weight = patch.get("weight") or mem.get("weight") or 0.5
             fanout_created = 0
             for fact in atomic_facts:
                 fact_content = fact.content
-                fact_hint = fact.retrieval_hint or ""
-                fact_embed_text = compose_embedding_text(fact_content, fact_hint)
                 try:
-                    child_embedding = await get_embedding(fact_embed_text, tenant_config=tenant_config)
+                    child_embedding = await get_embedding(fact_content, tenant_config=tenant_config)
                 except (TimeoutError, ValueError, RuntimeError, OpenAIError, GoogleAPIError):
                     logger.warning(
                         "atomic-fact embed failed for memory %s (skipping this fact)",
@@ -2120,7 +2060,7 @@ async def _enrich_memory_background(
                 child_meta = {
                     "parent_memory_id": str(memory_id),
                     "source": "atomic_fact_fanout",
-                    "retrieval_hint": fact_hint,
+                    "retrieval_hint": fact.retrieval_hint or "",
                 }
                 # Intentionally NOT wrapped in ``per_tenant_storage_slot``
                 # (CAURA-602 follow-up): this site runs inside
@@ -2183,23 +2123,31 @@ async def _enrich_memory_background(
                     tenant_id,
                 )
             )
-        # OSS-mode (embed_on_hot_path=True) half of the flag-mutually-
-        # exclusive contradiction-coverage pair (the SaaS-mode half is
-        # the ``not embed_on_hot_path and pre_hint_embedding is not None``
-        # branch inside the hint-reembed block above). In OSS mode the
-        # inline write path already fired contradiction once on the
-        # pre-hint embedding via ScheduleBackgroundTasks — this fire
-        # covers the post-hint-reembed final value. On the inline-failure
-        # path, _reembed_memory's race guard handles its own
-        # contradiction call, so we don't double-fire.
+        # SaaS-mode contradiction detection. Only fires when
+        # ``embed_on_hot_path=False``: in OSS mode the hot path already
+        # fired ``contradiction_detection`` via ScheduleBackgroundTasks
+        # on the same embedding (post-CAURA-222 there's no hint re-embed
+        # generating a different vector here, so re-firing would just
+        # duplicate the LLM check work — state is idempotent because the
+        # detector only writes via ``update_memory_status``).
         #
-        # CAURA-594 gap (SaaS, embed_on_hot_path=False): when enrich
-        # beats core-worker (pre_hint_embedding is None, but worker
-        # eventually overwrites with raw-content), neither branch
-        # fires. Tracked as a follow-up — adding a
-        # ``Topics.Memory.EMBEDDED`` consumer back in core-api (or
-        # running contradiction detection inside the worker) closes it.
-        if embedding is not None and settings.embed_on_hot_path:
+        # On the OSS inline-embed-failure path, ``_reembed_memory``'s
+        # race guard fires its own contradiction call when the retry
+        # succeeds, so the OSS-mode coverage hole is also closed there.
+        #
+        # In SaaS mode, ``handle_memory_embedded`` and
+        # ``handle_memory_enriched`` consumers also fire contradiction
+        # when their respective worker PATCHes land. This in-process
+        # branch covers the case where ``enrich_on_hot_path=True`` AND
+        # ``embed_on_hot_path=False`` AND the embed worker has already
+        # PATCH-ed the row by the time we reach this point.
+        #
+        # CAURA-594 remaining gap (full SaaS, both flags off): when
+        # enrich runs before core-worker's embed PATCH lands, the
+        # ``embedding is not None`` guard skips this branch and the
+        # ``handle_memory_embedded`` consumer takes over when the
+        # worker's later EMBEDDED publish fires.
+        if embedding is not None and not settings.embed_on_hot_path:
             from core_api.services.contradiction_detector import detect_contradictions_async
 
             track_task(
@@ -2211,7 +2159,7 @@ async def _enrich_memory_background(
                         content,
                         embedding,
                     ),
-                    "contradiction_detection",
+                    "contradiction_detection_saas",
                     memory_id,
                     tenant_id,
                 )

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -398,15 +398,26 @@ async def test_bulk_reembed_preserves_batching() -> None:
     assert names == ["contradiction_detection_post_reembed"] * 5
 
 
-async def test_enrich_fires_contradiction_when_overwriting_existing_embedding() -> None:
-    """Flow B2: _reembed_memory wrote raw embedding first and fired
-    contradiction on it. _enrich_memory_background overwrites with the
-    hint-enhanced vector — the stored (final) embedding would be
-    uncovered unless we fire contradiction detection post-enrich too."""
+async def test_enrich_fires_contradiction_on_existing_embedding_in_saas_mode() -> None:
+    """SaaS-mode (embed_on_hot_path=False) contradiction coverage.
+
+    Pre-CAURA-222 this path did a hint re-embed and fired
+    ``contradiction_detection_post_enrich`` on the hint-enhanced vector.
+    The hint re-embed is gone (caused write/query surface asymmetry —
+    see CAURA-222), but SaaS-mode contradiction coverage was preserved
+    by adding a dedicated ``contradiction_detection_saas`` branch at
+    the bottom of ``_enrich_memory_background``.
+
+    Expected behavior now:
+      - No ``update_embedding`` call from this function (worker owns
+        the stored vector).
+      - Contradiction detection fires once with task name
+        ``contradiction_detection_saas`` against the embedding read
+        from storage at the top of the function.
+    """
     from core_api.services import memory_service
 
-    raw_existing = [0.1] * VECTOR_DIM      # already written by _reembed
-    hint_enhanced = [0.9] * VECTOR_DIM     # enrich computes + overwrites with this
+    raw_existing = [0.1] * VECTOR_DIM  # already written by core-worker
 
     mem_row = {
         "id": "m1",
@@ -456,21 +467,11 @@ async def test_enrich_fires_contradiction_when_overwriting_existing_embedding() 
         coro.close()
         return None
 
-    # _enrich_memory_background calls get_embedding(composed_content, ...)
-    # for the hint re-embed.
-    async def _embed(*_a, **_k):
-        return hint_enhanced
-
     with (
         patch.object(memory_service.settings, "embed_on_hot_path", False),
-        patch.object(memory_service, "get_embedding", new=AsyncMock(side_effect=_embed)),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.contradiction_detector.detect_contradictions_async", new=_fake_detect),
         patch("core_api.services.memory_enrichment.enrich_memory", new=AsyncMock(return_value=enrichment)),
-        patch(
-            "core_api.services.memory_enrichment.compose_embedding_text",
-            side_effect=lambda content, hint: f"{content} [hint: {hint}]",
-        ),
         patch.object(memory_service, "track_task"),
         # NB: patch the SOURCE (task_tracker.tracked_task) rather than
         # memory_service.tracked_task — _enrich_memory_background does a
@@ -495,16 +496,16 @@ async def test_enrich_fires_contradiction_when_overwriting_existing_embedding() 
             uuid.uuid4(), "hello", TENANT_ID, "f1", "a"
         )
 
-    # The hint-enhanced embedding was written to the row.
-    sc.update_embedding.assert_awaited_once()
-    assert sc.update_embedding.await_args.args[1] == hint_enhanced
-    # Contradiction detection fires on the hint-enhanced embedding
-    # (otherwise the stored vector would be uncovered).
+    # No hint re-embed roundtrip → no update_embedding call from enrich
+    # (the worker owns the stored vector under embed_on_hot_path=False).
+    sc.update_embedding.assert_not_awaited()
+    # SaaS-mode contradiction detection fires on the embedding read
+    # from storage at the top of the function.
     names = [call.args[1] for call in tracked.call_args_list]
-    assert "contradiction_detection_post_enrich" in names
-    # And the detection target was the HINT-ENHANCED embedding, not the
-    # stale raw one — arg[4] in detect_contradictions_async.
-    assert any(call[4] == hint_enhanced for call in detect_calls)
+    assert "contradiction_detection_saas" in names
+    assert "contradiction_detection_post_enrich" not in names
+    # arg[4] in detect_contradictions_async is the embedding.
+    assert any(call[4] == raw_existing for call in detect_calls)
 
 
 async def test_enrich_no_contradiction_when_no_prior_embedding() -> None:

--- a/tests/test_enrichment_inline_timeout.py
+++ b/tests/test_enrichment_inline_timeout.py
@@ -8,8 +8,6 @@ hot path (CAURA-594) and enrichment LLM became the sole occupant.
 Verifies:
   - ``settings.enrichment_inline_timeout_seconds`` is the value passed
     to ``asyncio.wait_for`` (no longer the hardcoded 20.0).
-  - ``settings.enrichment_hint_reembed_timeout_seconds`` is the value
-    passed to the hint re-embed wait_for.
   - The Settings model validator rejects ordering inversions that would
     let the inner cap miss the outer request budget.
 """


### PR DESCRIPTION
## Summary

Removes the hint-prefix re-embed in `parallel_embed_enrich.py` so writes persist the **same surface** the search path embeds.

The write path was calling `compose_embedding_text(data.content, enrichment.retrieval_hint)` — which prepends `\"[Retrieval hint]: <hint>\\n\\n\"` to the content — and overwriting the content-only vector. The search path embeds the raw query through `get_query_embedding`. Same model (text-embedding-3-small / 1536d), different input — so identical content↔query produced cosine **0.693** instead of ~1.0.

## Evidence

algo-stress run \`20260507T153129Z-76c172\` on staging tenant \`ran-507cb7\`. The probe writes a fixed string then immediately searches for the byte-identical string; top hit IS the just-written memory but cosine = 0.693.

A single defect explains three independent measured regressions, all of which bottom out on a cosine threshold:

| metric | before | target |
|---|---:|---:|
| `embed.stability_top1_similarity` | 0.693 | ≥ 0.95 |
| `dedup.paraphrase.detected_rate` | 0/80 | ≥ 0.85 |
| `ranking.recall@20` | 0.512 | ≥ 0.80 |
| `ranking.ndcg@10` | 0.363 | ≥ 0.60 |
| `dispatcher.entity_lookup.recall` | 0.20 | ≥ 0.70 |

When stored vectors lived on the hint-prefixed surface and query vectors lived on the raw surface, every threshold (semantic_dedup floor, dispatcher entity gating, search `min_similarity` / blend weights) was being evaluated on a corrupted axis. Restoring surface symmetry restores the full ~[0,1] cosine dynamic range and lifts all three components together.

## Change

`core-api/src/core_api/pipeline/steps/write/parallel_embed_enrich.py`: removed lines 105–127 (the post-enrichment hint re-embed block). Writes now persist the content-only embedding produced at line 61.

No changes to:
- `min_similarity` / dedup floor / blend weights — root fix, not a threshold mask.
- Embedding model — `text-embedding-3-small` / 1536d preserved per CLAUDE.md.
- Schema, endpoints, or abstractions.
- The `retrieval_hint` enrichment field, prompt, validator, or `compose_embedding_text` helper — they stay as metadata and as a future building block (see *Future work* below).

## What I checked (other paths preserving the issue)

Audited every `get_embedding` / `provider.embed` / `compose_embedding_text` site in `core-api`, `core-worker`, `core-storage-api`, and `common`:

**Symmetric (raw content/query) — OK:**
- \`parallel_embed_enrich.py:61\` (after fix)
- \`memory_service.py:526\` (memory write)
- \`memory_service.py:1654\` (\`_reembed_after_delay\` background retry)
- \`memory_service.py:2280\` (manual update path)
- \`core-worker/consumer.py:158\` (async EMBED_REQUESTED backfill — embeds \`request.content\` raw)
- \`core-storage-api/scripts/backfill_embeddings.py:217\` (CLI backfill)
- \`mcp_server.py:846/932\`, \`routes/documents.py:280\` (document write/search both use \`get_embedding\` — symmetric pair on the document collection)
- \`memory_service.py:2594\` (\`get_query_embedding\` — symmetric provider falls through to \`embed\`)

**Still asymmetric — known follow-ups (same root pattern, intentionally out of scope for this PR per \"single-line fix at root\"):**
- \`memory_service.py:2030–2046\` — SaaS-mode background hint re-embed inside \`_enrich_memory_background\`. Fires when \`embed_on_hot_path=False\`. Will overwrite the content-only embedding with \`compose_embedding_text(content, hint)\` and re-introduce the asymmetry for SaaS deployments.
- \`memory_service.py:2095–2123\` — atomic-fact fan-out. Each child memory's stored embedding is \`compose_embedding_text(fact_content, fact_hint)\`, so atomic-fact children carry the asymmetry even after this fix.

These should be fixed in a follow-up PR (CAURA-222-followup) so SaaS-mode and atomic-fact children land on the same surface as the OSS hot path. The fix is the same shape — drop the \`compose_embedding_text\` wrap and embed raw content. They are split out to keep this PR minimal and easy to revert.

## Future work — re-introducing the hint mechanism *symmetrically*

The hint mechanism's intent was correct: bridge the **semantic gap** between content vocabulary (\"I signed a contract with my first client\") and query vocabulary (\"business milestone\"). The bug was that only the write side got the prefix.

A symmetric reintroduction has at least three viable shapes — each is a separate design decision:

1. **Two-vector store** — keep the raw \`embedding\` column for surface-form recall, add a \`hint_embedding\` column populated from \`compose_embedding_text(content, hint)\`. Search ranks against both and takes \`max\` (or a weighted blend). Pros: preserves both axes, no query-side changes needed. Cons: schema migration, doubles storage and embedding cost per memory.
2. **Query-side hint synthesis** — at query time, ask a small fast LLM to expand the query into both raw and significance-framed forms, embed both, max over candidates. Pros: no schema change, write path stays raw. Cons: per-query LLM latency on the hot search path, cache invalidation complexity.
3. **Decoder-symmetric framing** — instead of a prefix marker, use the same instruction-aware encoder protocol the project already has (\`get_query_embedding\` / \`InstructionAwareEmbedder\`). Document side encodes with a *passage* instruction, query side with a *query* instruction. Requires moving to an instruction-aware embedding model, which is gated by CLAUDE.md's \`text-embedding-3-small\` mandate.

A future PR rebuilding this should pick one explicitly, document the choice, and add an algo-stress test that asserts \`embed.stability_top1_similarity ≥ 0.95\` so this regression cannot return.

## Test plan

- [ ] CI passes on this branch.
- [ ] Existing tests \`tests/test_retrieval_hint.py\` still pass (they cover \`compose_embedding_text\`, the validator, and prompt rules — all unchanged).
- [ ] Existing tests \`tests/test_embed_off_hot_path.py\` reviewed: cases that asserted the hot-path hint-enhanced overwrite (e.g. \"hint re-embed on hot path overwrites raw embedding\") need updating to assert raw-content embedding instead. Reviewer please flag if I should include those test edits in this PR.
- [ ] Deploy to staging \`memclaw.dev\`.
- [ ] Drain tenant \`ran-507cb7\`: \`python -m scripts.drain_tenant\`.
- [ ] Re-run algo-stress: \`python -m runners.all --only embed_stability --only dedup --only search_ranking --only query_classify\`.
- [ ] Verify metric table targets above are met.
- [ ] Verify \`dedup.topical_similar\` / unrelated **false-merge stays at 0%** — removing the prefix moves to a stricter axis but I want this confirmed empirically before merge.

## Rollout

- Backwards-compatible at the storage layer: existing rows still have hint-prefixed vectors; new writes produce raw-content vectors. They will coexist and the recall floor will lift gradually as fresh writes accumulate.
- For a clean recall lift across the full corpus, run \`core-storage-api/scripts/backfill_embeddings.py\` after merge to re-embed historical rows on the raw surface. This is optional and can be done lazily.

---