### PR TITLE
feat(recall): exclude superseded memories from default search results

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -901,9 +901,7 @@ class PostgresService:
             # ranking with stale claims agents shouldn't act on. Callers
             # that need to inspect superseded rows pass an explicit
             # ``status_filter`` to override.
-            scored_stmt = scored_stmt.where(
-                Memory.status.notin_(("outdated", "conflicted"))
-            )
+            scored_stmt = scored_stmt.where(Memory.status.notin_(("outdated", "conflicted")))
         if valid_at:
             from datetime import date as _date_type
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -893,6 +893,17 @@ class PostgresService:
             scored_stmt = scored_stmt.where(Memory.memory_type == memory_type_filter)
         if status_filter:
             scored_stmt = scored_stmt.where(Memory.status == status_filter)
+        else:
+            # Exclude superseded memories from default search results. The
+            # contradiction detector marks the older row ``outdated`` (RDF
+            # path) or ``conflicted`` (semantic path) and points the newer
+            # one at it via ``supersedes_id``. Surfacing both would dilute
+            # ranking with stale claims agents shouldn't act on. Callers
+            # that need to inspect superseded rows pass an explicit
+            # ``status_filter`` to override.
+            scored_stmt = scored_stmt.where(
+                Memory.status.notin_(("outdated", "conflicted"))
+            )
         if valid_at:
             from datetime import date as _date_type
 

--- a/plugin/skills/memclaw/SKILL.md
+++ b/plugin/skills/memclaw/SKILL.md
@@ -203,7 +203,10 @@ your first MemClaw call in a session.
 **`memclaw_recall(query, top_k=5, include_brief=false, memory_type=?, status=?, filter_agent_id=?, fleet_ids=?)`**
 Hybrid semantic+keyword search. For metadata browse → `memclaw_list`;
 for a known id → `memclaw_manage(op="read")`. `include_brief=true` adds
-an LLM-summarized paragraph.
+an LLM-summarized paragraph. Superseded memories (`status` ∈
+{outdated, conflicted}) are excluded by default — pass `status` explicitly
+(e.g. `status="conflicted"`) to inspect the chain; the pipeline then also
+auto-injects the winning successor.
 
 **`memclaw_write(content=? | items=?, visibility="scope_team", memory_type=?, weight=?, metadata=?, write_mode="auto", source_uri=?, run_id=?)`**
 Provide exactly one of `content` / `items`. Server auto-classifies.

--- a/plugin/skills/memclaw/SKILL.md
+++ b/plugin/skills/memclaw/SKILL.md
@@ -205,8 +205,7 @@ Hybrid semantic+keyword search. For metadata browse → `memclaw_list`;
 for a known id → `memclaw_manage(op="read")`. `include_brief=true` adds
 an LLM-summarized paragraph. Superseded memories (`status` ∈
 {outdated, conflicted}) are excluded by default — pass `status` explicitly
-(e.g. `status="conflicted"`) to inspect the chain; the pipeline then also
-auto-injects the winning successor.
+(e.g. `status="conflicted"`) to inspect the chain.
 
 **`memclaw_write(content=? | items=?, visibility="scope_team", memory_type=?, weight=?, metadata=?, write_mode="auto", source_uri=?, run_id=?)`**
 Provide exactly one of `content` / `items`. Server auto-classifies.


### PR DESCRIPTION
## Summary

`memclaw_recall` and `POST /api/v1/search` now omit memories with `status` in `{outdated, conflicted}` unless the caller passes an explicit `status_filter` / `status`.

## Why

The contradiction detector marks the older row `outdated` (RDF path) or `conflicted` (semantic path) and points the newer row at it via `supersedes_id`. Surfacing both rows in default semantic search dilutes ranking with stale claims agents shouldn't act on — and the existing 0.5× score penalty wasn't enough to keep them out of the top-k for tightly-clustered embeddings.

## Implementation

A single conditional branch in the storage-layer scored search:

```diff
        if status_filter:
            scored_stmt = scored_stmt.where(Memory.status == status_filter)
+       else:
+           scored_stmt = scored_stmt.where(
+               Memory.status.notin_(("outdated", "conflicted"))
+           )
```

The escape hatch is unchanged — pass `status_filter="conflicted"` (or `"outdated"`) to inspect the chain. As a side benefit, the existing successor-injection logic in `pipeline/steps/search/load_and_serialize.py` now activates exactly when callers ask for those statuses, so they see both the superseded row and the winning successor in one response.

The pre-existing 0.5× `status_penalty` factor in the scoring expression becomes dormant under the new default (rows are filtered before scoring) but is kept for the case where a caller mixes statuses via explicit `status_filter`.

`SKILL.md` tool card for `memclaw_recall` updated to document the new default and the opt-in path.

## What's NOT changed

- `memclaw_list` (non-semantic browse) is unaffected — different code path; deliberate, since browse is "show me everything that matches my filters."
- `memclaw_manage op=read` is unaffected — direct ID lookup.
- Soft-deleted rows (`deleted_at IS NOT NULL`) were already excluded unconditionally; that stays.
- `compute_memory_stats` is unaffected — it still counts superseded rows under their respective statuses.

## Test plan

- [x] Default recall on a tenant with two conflicting "Alice lives in X" memories returns only the active winner.
- [x] `status_filter="conflicted"` returns both the conflicted row and its auto-injected active successor.
- [x] No existing tests assert that superseded rows appear in search results (grepped `tests/` for status-equals-outdated/conflicted assertions in search context — none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)