### PR TITLE
chore(core-api): CAURA-222 follow-up — drop dead helper, add stability test, extend backfill

### DIFF
--- a/common/enrichment/__init__.py
+++ b/common/enrichment/__init__.py
@@ -7,9 +7,6 @@ Public surface:
 * :func:`enrich_memory` — async entrypoint with 3-tier fallback.
 * :func:`fake_enrich` — keyword heuristic fallback used as the
   ``"fake"`` provider and last-resort safety net.
-* :func:`compose_embedding_text` — content + retrieval hint composer
-  used by both the write-path embedding call and the post-enrichment
-  re-embedding step.
 * Constants: :data:`MEMORY_TYPES`, :data:`MEMORY_STATUSES`,
   :data:`DEFAULT_MEMORY_TYPE`, :data:`DEFAULT_MEMORY_WEIGHT`.
 
@@ -35,7 +32,6 @@ from common.enrichment.constants import (
 )
 from common.enrichment.schema import AtomicFact, EnrichmentResult
 from common.enrichment.service import (
-    compose_embedding_text,
     enrich_memory,
     fake_enrich,
 )
@@ -47,7 +43,6 @@ __all__ = [
     "MEMORY_TYPES",
     "AtomicFact",
     "EnrichmentResult",
-    "compose_embedding_text",
     "enrich_memory",
     "fake_enrich",
 ]

--- a/common/enrichment/service.py
+++ b/common/enrichment/service.py
@@ -4,9 +4,6 @@
 Public surface:
 
 * :func:`enrich_memory` — async entrypoint with 3-tier fallback.
-* :func:`compose_embedding_text` — helper used both pre- and post-
-  enrichment to assemble the text fed to the embedding model
-  (content + retrieval hint).
 * :func:`fake_enrich` — keyword-heuristic fallback used both as the
   ``"fake"`` provider and as the last-resort safety net.
 
@@ -34,30 +31,6 @@ from common.llm.retry import call_with_fallback
 from common.provider_names import ProviderName
 
 logger = logging.getLogger(__name__)
-
-
-def compose_embedding_text(content: str, retrieval_hint: str | None) -> str:
-    """Build the text fed to the embedding model.
-
-    Combines the raw memory content with the enricher-produced retrieval
-    hint (a short phrase capturing the memory's semantic essence in
-    query-aligned vocabulary). The hint attacks the semantic-gap failure
-    mode — the common case where a memory's content uses surface
-    vocabulary ("I signed a contract with my first client") but users
-    look it up via significance vocabulary ("business milestone").
-
-    If the hint is empty or missing, returns the content unchanged so
-    existing memories without hints embed exactly as before.
-    """
-    if retrieval_hint:
-        hint = retrieval_hint.strip()
-        if hint:
-            # Prefix the hint so it gets higher positional salience in the
-            # embedding model than a trailing footer would. Empirically,
-            # trailing hints on long content get diluted by token-count
-            # dominance of the body.
-            return f"[Retrieval hint]: {hint}\n\n{content}"
-    return content
 
 
 def _parse_temporal(val: str) -> datetime | None:

--- a/common/events/memory_enriched.py
+++ b/common/events/memory_enriched.py
@@ -41,9 +41,9 @@ class MemoryEnriched(BaseModel):
 
     memory_id: UUID
     tenant_id: str
-    # Carried so the re-embed consumer doesn't need a storage GET round
-    # trip just to feed ``compose_embedding_text``. Same trade we made
-    # for ``MemoryEmbedRequest.content``.
+    # Carried so the back-channel consumer doesn't need a storage GET
+    # round trip just to dispatch contradiction detection. Same trade
+    # we made for ``MemoryEmbedRequest.content``.
     content: str = Field(min_length=1)
     # Empty string when the enricher produced no useful hint —
     # back-channel consumers should short-circuit on falsy.

--- a/core-api/src/core_api/services/memory_enrichment.py
+++ b/core-api/src/core_api/services/memory_enrichment.py
@@ -21,7 +21,6 @@ from common.enrichment.schema import AtomicFact
 from common.enrichment.schema import EnrichmentResult as MemoryEnrichment
 from common.enrichment.service import (
     _validate_enrichment,  # noqa: F401  # re-export for legacy tests; not in __all__
-    compose_embedding_text,
     enrich_memory,
 )
 from common.enrichment.service import (
@@ -37,6 +36,5 @@ __all__ = [
     "_call_with_retry",
     "_fake_enrich",
     "call_with_fallback",
-    "compose_embedding_text",
     "enrich_memory",
 ]

--- a/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
+++ b/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
@@ -59,6 +59,12 @@ Usage:
     # Per-tenant phasing for prod cutover safety:
     python -m core_storage_api.scripts.backfill_embeddings --tenant-id tenant-abc
 
+    # CAURA-222 recovery: re-embed memories whose stored vector was
+    # produced under the old hint-prefixed write path. Targets rows
+    # with non-empty ``metadata.retrieval_hint``; entities are skipped.
+    python -m core_storage_api.scripts.backfill_embeddings \\
+        --rewrite-hint-prefixed --tenant-id tenant-abc --dry-run
+
 Scope:
 - ``memories.embedding`` — re-embedded from ``memories.content``.
 - ``entities.name_embedding`` — re-embedded from ``entities.canonical_name``.
@@ -111,6 +117,12 @@ class _TableSpec:
     # backfill task uses. ``entities`` does not have a ``deleted_at``
     # column.
     has_deleted_at: bool = False
+    # JSONB metadata column used by the ``rewrite_hint_prefixed`` scan
+    # to filter on ``->>'retrieval_hint'``. ``None`` for tables that
+    # don't carry hint metadata (entities) — the hint-rewrite call site
+    # asserts this is set so a misconfigured spec fails loudly rather
+    # than emitting SQL against a nonexistent column.
+    metadata_column: str | None = None
 
 
 _TARGETS: tuple[_TableSpec, ...] = (
@@ -119,6 +131,7 @@ _TARGETS: tuple[_TableSpec, ...] = (
         embedding_column="embedding",
         content_column="content",
         has_deleted_at=True,
+        metadata_column="metadata_",
     ),
     _TableSpec(
         table="entities",
@@ -138,26 +151,59 @@ class BackfillReport:
     elapsed_s: float
 
 
-async def _iter_null_rows(
+async def _iter_rows(
     engine,
     spec: _TableSpec,
     *,
     tenant_id: str | None,
     batch_size: int,
+    rewrite_hint_prefixed: bool,
 ) -> AsyncIterator[list[tuple[uuid.UUID, str]]]:
-    """Yield batches of (id, content) for rows where the embedding is NULL.
+    """Yield batches of (id, content) for rows that need (re-)embedding.
+
+    Two scan modes:
+      - Default: rows where the embedding is NULL (post-12 backfill,
+        also covers any other source of missing vectors).
+      - ``rewrite_hint_prefixed=True``: rows whose stored vector was
+        produced under the pre-CAURA-222 hint-prefixed write path
+        (``"[Retrieval hint]: <hint>\\n\\n<content>"``). Selector is
+        ``embedding IS NOT NULL AND metadata_->>'retrieval_hint'`` is
+        non-empty. Only ``memories`` carries hint metadata; the
+        ``entities`` table is skipped at the call site.
 
     Cursor-style pagination on ``id`` for stable resumability — the
-    consumer's writes flip ``embedding`` from NULL to non-NULL, so on a
-    re-run the same page-after-id may yield fewer rows but never
-    duplicates.
+    consumer's writes flip the row's match condition (NULL → non-NULL,
+    or rewrite the embedding while metadata stays put), so on a re-run
+    the same page-after-id may yield fewer rows but never duplicates.
+    Hint-prefixed mode is the exception: a re-run after a successful
+    rewrite would re-match the same rows, since metadata.retrieval_hint
+    is intentionally preserved for auditability. The recommended
+    operational pattern is a single forward pass per tenant followed
+    by the embed-stability probe to verify; see PR description.
     """
     from sqlalchemy import text
 
     after: uuid.UUID | None = None
     while True:
         params: dict = {"limit": batch_size}
-        sql = f"SELECT id, {spec.content_column} FROM {spec.table} WHERE {spec.embedding_column} IS NULL "
+        sql = f"SELECT id, {spec.content_column} FROM {spec.table} WHERE "
+        if rewrite_hint_prefixed:
+            # Rewrite mode: target rows that were embedded with the
+            # pre-CAURA-222 hint prefix. The metadata key is preserved
+            # as auditability ground truth — we use it as the selector
+            # for which rows need rewriting.
+            if spec.metadata_column is None:
+                raise ValueError(
+                    f"rewrite_hint_prefixed scan requires a metadata column on "
+                    f"_TableSpec.table={spec.table!r}; got metadata_column=None"
+                )
+            sql += (
+                f"{spec.embedding_column} IS NOT NULL "
+                f"AND {spec.metadata_column} ? 'retrieval_hint' "
+                f"AND COALESCE({spec.metadata_column}->>'retrieval_hint', '') <> '' "
+            )
+        else:
+            sql += f"{spec.embedding_column} IS NULL "
         # Skip soft-deleted rows on tables that have ``deleted_at`` —
         # consistent with ``memory_list_null_embedding_rows`` and the
         # event-driven backfill task; otherwise we'd burn provider
@@ -188,6 +234,7 @@ async def _backfill_one_table(
     batch_size: int,
     max_inflight: int,
     dry_run: bool,
+    rewrite_hint_prefixed: bool,
 ) -> BackfillReport:
     from sqlalchemy import text
 
@@ -256,7 +303,13 @@ async def _backfill_one_table(
                 await conn.commit()
             embedded += 1
 
-    async for batch in _iter_null_rows(engine, spec, tenant_id=tenant_id, batch_size=batch_size):
+    async for batch in _iter_rows(
+        engine,
+        spec,
+        tenant_id=tenant_id,
+        batch_size=batch_size,
+        rewrite_hint_prefixed=rewrite_hint_prefixed,
+    ):
         scanned += len(batch)
         await asyncio.gather(*(_embed_and_write(rid, c) for rid, c in batch))
         logger.info(
@@ -285,8 +338,26 @@ async def run_backfill(
     max_inflight: int,
     dry_run: bool,
     only_table: str | None = None,
+    rewrite_hint_prefixed: bool = False,
 ) -> list[BackfillReport]:
-    """Walk every NULL-embedding row in the targeted tables and re-embed.
+    """Walk targeted rows and (re-)embed them according to the selected scan mode.
+
+    Two modes:
+
+    - Default (``rewrite_hint_prefixed=False``): scan rows where
+      ``embedding IS NULL`` and embed them from ``content`` /
+      ``canonical_name``. This is the post-migration-012 recovery
+      path for OSS docker-compose users, and also covers any other
+      source of missing vectors (failed inline embeds, etc.).
+
+    - Hint-prefixed rewrite (``rewrite_hint_prefixed=True``): scan
+      rows where ``embedding IS NOT NULL`` AND
+      ``metadata.retrieval_hint`` is non-empty — rows written under
+      the pre-CAURA-222 hint-prefixed write path — and re-embed them
+      from raw ``content`` to align with the search-side surface.
+      One-off recall recovery after CAURA-222 has deployed; new
+      writes already land on the raw-content surface. Entities are
+      skipped in this mode (no hint metadata exists there).
 
     Returns one ``BackfillReport`` per table processed.
 
@@ -304,13 +375,22 @@ async def run_backfill(
     for spec in _TARGETS:
         if only_table is not None and spec.table != only_table:
             continue
+        if rewrite_hint_prefixed and spec.table != "memories":
+            # Only memories carry ``metadata.retrieval_hint``; skip
+            # other tables silently to keep the CLI a single command.
+            logger.info(
+                "backfill[%s] skipped under --rewrite-hint-prefixed (no hint metadata on this table)",
+                spec.table,
+            )
+            continue
         logger.info(
-            "backfill[%s] starting (tenant=%s, batch=%d, max_inflight=%d, dry_run=%s)",
+            "backfill[%s] starting (tenant=%s, batch=%d, max_inflight=%d, dry_run=%s, mode=%s)",
             spec.table,
             tenant_id,
             batch_size,
             max_inflight,
             dry_run,
+            "rewrite-hint-prefixed" if rewrite_hint_prefixed else "null-embedding",
         )
         report = await _backfill_one_table(
             engine,
@@ -319,6 +399,7 @@ async def run_backfill(
             batch_size=batch_size,
             max_inflight=max_inflight,
             dry_run=dry_run,
+            rewrite_hint_prefixed=rewrite_hint_prefixed,
         )
         reports.append(report)
         logger.info(
@@ -365,6 +446,19 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Count rows that would be re-embedded; don't call the embedding provider or write to the DB.",
     )
     p.add_argument(
+        "--rewrite-hint-prefixed",
+        action="store_true",
+        help=(
+            "Re-embed memories rows that were written under the pre-CAURA-222 "
+            "hint-prefixed write path (selector: embedding IS NOT NULL AND "
+            "metadata.retrieval_hint is non-empty). Only the ``memories`` "
+            "table is processed in this mode; entities are skipped. Use after "
+            "the CAURA-222 fix has deployed to recover recall on existing "
+            "rows. Combine with --tenant-id and --dry-run for a phased "
+            "rollout."
+        ),
+    )
+    p.add_argument(
         "--only-table",
         choices=[s.table for s in _TARGETS],
         default=None,
@@ -393,6 +487,30 @@ async def _amain(argv: list[str]) -> int:
         )
         return 1
 
+    # --rewrite-hint-prefixed is intentionally non-idempotent: the
+    # selector keys on metadata.retrieval_hint, which the rewrite
+    # preserves for auditability, so every re-run will re-match (and
+    # re-embed) the same rows. Surface this loudly before a live run
+    # so an operator who re-invokes the command doesn't silently burn
+    # provider quota on a no-op rewrite. Dry-run is fine — no provider
+    # call, no DB write.
+    if args.rewrite_hint_prefixed and not args.dry_run:
+        print(
+            "WARNING: --rewrite-hint-prefixed is NOT idempotent. "
+            "metadata.retrieval_hint is preserved as auditability ground "
+            "truth, so every re-run will re-match and re-embed the same "
+            "rows — burning provider quota on no-op rewrites. Intended "
+            "as a single forward pass per tenant; verify scope with "
+            "--dry-run first.",
+            file=sys.stderr,
+        )
+        print("Starting in 5 s — press Ctrl-C to abort.", file=sys.stderr)
+        # ``await asyncio.sleep`` rather than ``time.sleep`` so we don't
+        # block the event loop. Functionally equivalent for the 5s
+        # operator grace window — Ctrl-C cancels the sleep on either
+        # path and the script exits before any provider call.
+        await asyncio.sleep(5)
+
     try:
         reports = await run_backfill(
             tenant_id=args.tenant_id,
@@ -400,6 +518,7 @@ async def _amain(argv: list[str]) -> int:
             max_inflight=args.max_inflight,
             dry_run=args.dry_run,
             only_table=args.only_table,
+            rewrite_hint_prefixed=args.rewrite_hint_prefixed,
         )
     except RuntimeError as e:
         # Reserved for the "degraded provider" abort path (20 consecutive

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -291,3 +291,285 @@ async def test_amain_returns_1_on_unexpected_exception(
         "configuration or unexpected error" in rec.getMessage()
         for rec in caplog.records
     ), "expected an ERROR log naming the broader error class"
+
+
+# ---------------------------------------------------------------------------
+# CAURA-222: --rewrite-hint-prefixed mode
+# ---------------------------------------------------------------------------
+
+
+def _capturing_engine(
+    rows_by_query: dict[str, list[tuple]],
+) -> tuple[MagicMock, list[str]]:
+    """Like ``_fake_engine`` but also records every SQL string executed,
+    so tests can assert on the WHERE clause shape under different modes."""
+    captured_sql: list[str] = []
+    served: dict[str, bool] = {}
+
+    async def _execute(statement, params=None):
+        sql = str(statement)
+        captured_sql.append(sql)
+        sql_lower = sql.lower()
+        if sql_lower.startswith("update"):
+            return MagicMock()
+        for key, rows in rows_by_query.items():
+            if key in sql_lower and not served.get(key):
+                served[key] = True
+                result = MagicMock()
+                result.all = MagicMock(return_value=rows)
+                return result
+        empty = MagicMock()
+        empty.all = MagicMock(return_value=[])
+        return empty
+
+    conn = MagicMock()
+    conn.execute = AsyncMock(side_effect=_execute)
+    conn.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _connect():
+        yield conn
+
+    engine = MagicMock()
+    engine.connect = _connect
+    return engine, captured_sql
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rewrite_hint_prefixed_targets_memories_with_hint_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--rewrite-hint-prefixed scans rows where embedding IS NOT NULL
+    and metadata.retrieval_hint is non-empty. The default mode's
+    embedding-IS-NULL filter must NOT appear in this scan."""
+    from core_storage_api.scripts.backfill_embeddings import run_backfill
+
+    rows = {
+        "from memories": [
+            (uuid.uuid4(), "memory previously embedded with a hint prefix"),
+        ],
+    }
+    engine, captured_sql = _capturing_engine(rows)
+    monkeypatch.setattr("core_storage_api.database.init.get_engine", lambda: engine)
+    embed = AsyncMock(return_value=[0.4] * 1024)
+    monkeypatch.setattr("common.embedding.get_embedding", embed)
+
+    reports = await run_backfill(
+        tenant_id=None,
+        batch_size=500,
+        max_inflight=10,
+        dry_run=False,
+        rewrite_hint_prefixed=True,
+    )
+
+    by_table = {r.table: r for r in reports}
+    assert "memories" in by_table
+    assert by_table["memories"].scanned == 1
+    assert by_table["memories"].embedded == 1
+    assert embed.await_count == 1
+
+    # Verify the SQL filter shape on the SELECT against memories.
+    select_against_memories = [
+        s
+        for s in captured_sql
+        if "select" in s.lower() and "from memories" in s.lower()
+    ]
+    assert select_against_memories, "no SELECT against memories was emitted"
+    sql = select_against_memories[0].lower()
+    assert "embedding is not null" in sql
+    assert "metadata_ ? 'retrieval_hint'" in sql
+    assert "metadata_->>'retrieval_hint'" in sql
+    # Default-mode selector must NOT be present.
+    assert "embedding is null" not in sql
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rewrite_hint_prefixed_skips_entities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entities don't carry retrieval_hint metadata, so the hint-rewrite
+    mode skips them — even if rows exist on that table, they shouldn't
+    produce a report or burn embed calls."""
+    from core_storage_api.scripts.backfill_embeddings import run_backfill
+
+    rows = {
+        "from memories": [(uuid.uuid4(), "memory with hint")],
+        "from entities": [(uuid.uuid4(), "Acme Corp")],
+    }
+    engine, captured_sql = _capturing_engine(rows)
+    monkeypatch.setattr("core_storage_api.database.init.get_engine", lambda: engine)
+    embed = AsyncMock(return_value=[0.5] * 1024)
+    monkeypatch.setattr("common.embedding.get_embedding", embed)
+
+    reports = await run_backfill(
+        tenant_id=None,
+        batch_size=500,
+        max_inflight=10,
+        dry_run=False,
+        rewrite_hint_prefixed=True,
+    )
+
+    by_table = {r.table: r for r in reports}
+    assert set(by_table.keys()) == {"memories"}
+    # The entities table should not have been queried at all in this mode.
+    assert not any("from entities" in s.lower() for s in captured_sql)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_default_mode_uses_null_embedding_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Belt-and-braces: the existing IS-NULL scan path is unchanged when
+    --rewrite-hint-prefixed is not set. Pinned here so the new mode's
+    branching can't silently break the default."""
+    from core_storage_api.scripts.backfill_embeddings import run_backfill
+
+    rows = {
+        "from memories": [(uuid.uuid4(), "x")],
+        "from entities": [],
+    }
+    engine, captured_sql = _capturing_engine(rows)
+    monkeypatch.setattr("core_storage_api.database.init.get_engine", lambda: engine)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", AsyncMock(return_value=[0.1] * 1024)
+    )
+
+    await run_backfill(
+        tenant_id=None,
+        batch_size=500,
+        max_inflight=10,
+        dry_run=False,
+    )
+
+    select_against_memories = [
+        s
+        for s in captured_sql
+        if "select" in s.lower() and "from memories" in s.lower()
+    ]
+    assert select_against_memories
+    sql = select_against_memories[0].lower()
+    assert "embedding is null" in sql
+    # Hint-rewrite mode markers must be absent.
+    assert "retrieval_hint" not in sql
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_warns_on_non_idempotent_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Live --rewrite-hint-prefixed runs must surface the non-idempotent
+    nature loudly on stderr AND give the operator a 5s grace window to
+    Ctrl-C before the run starts. retrieval_hint metadata is preserved
+    by the rewrite, so every re-run re-matches and re-embeds the same
+    rows — silent on that fact would let an operator burn provider
+    quota on no-op repeats."""
+    from core_storage_api.scripts.backfill_embeddings import _amain
+
+    async def _noop_run(**_kw):
+        return []
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.run_backfill", _noop_run
+    )
+    # Mock the grace-period sleep so the test doesn't actually wait 5s.
+    sleeps: list[float] = []
+
+    async def _record_sleep(secs: float) -> None:
+        sleeps.append(secs)
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.asyncio.sleep",
+        _record_sleep,
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    code = await _amain(["--rewrite-hint-prefixed"])
+    captured = capsys.readouterr()
+
+    assert code == 0
+    assert "NOT idempotent" in captured.err
+    assert "metadata.retrieval_hint" in captured.err
+    # Operator grace window: warning fires, then a 5s pause before
+    # any provider call, so a fat-fingered re-invocation can be
+    # caught with Ctrl-C.
+    assert "Starting in 5 s" in captured.err
+    assert sleeps == [5]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_no_warning_on_dry_run_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--dry-run + --rewrite-hint-prefixed does not call the provider
+    or write anything, so the non-idempotency warning + grace pause
+    would just be noise — suppress both for the scope-estimation use
+    case."""
+    from core_storage_api.scripts.backfill_embeddings import _amain
+
+    async def _noop_run(**_kw):
+        return []
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.run_backfill", _noop_run
+    )
+    sleeps: list[float] = []
+
+    async def _record_sleep(secs: float) -> None:
+        sleeps.append(secs)
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.asyncio.sleep",
+        _record_sleep,
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    code = await _amain(["--rewrite-hint-prefixed", "--dry-run"])
+    captured = capsys.readouterr()
+
+    assert code == 0
+    assert "NOT idempotent" not in captured.err
+    assert "Starting in 5 s" not in captured.err
+    assert sleeps == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_no_warning_on_default_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default null-embedding scan IS idempotent (writes flip rows from
+    NULL to non-NULL, so re-runs see strictly fewer rows). The warning
+    and the grace pause must be scoped to --rewrite-hint-prefixed only."""
+    from core_storage_api.scripts.backfill_embeddings import _amain
+
+    async def _noop_run(**_kw):
+        return []
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.run_backfill", _noop_run
+    )
+    sleeps: list[float] = []
+
+    async def _record_sleep(secs: float) -> None:
+        sleeps.append(secs)
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.asyncio.sleep",
+        _record_sleep,
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    code = await _amain([])
+    captured = capsys.readouterr()
+
+    assert code == 0
+    assert "NOT idempotent" not in captured.err
+    assert sleeps == []

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -556,10 +556,6 @@ async def test_enrich_no_contradiction_when_no_prior_embedding() -> None:
         patch.object(memory_service, "get_embedding", new=AsyncMock(return_value=hint_enhanced)),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch("core_api.services.memory_enrichment.enrich_memory", new=AsyncMock(return_value=enrichment)),
-        patch(
-            "core_api.services.memory_enrichment.compose_embedding_text",
-            side_effect=lambda content, hint: content,
-        ),
         patch.object(memory_service, "track_task"),
         patch(
             "core_api.services.task_tracker.tracked_task",

--- a/tests/test_embed_stability.py
+++ b/tests/test_embed_stability.py
@@ -1,0 +1,304 @@
+"""Regression tests for write/query embedding-surface symmetry (CAURA-222).
+
+Pre-CAURA-222, the write pipeline embedded
+``compose_embedding_text(content, retrieval_hint)`` —
+``"[Retrieval hint]: <hint>\\n\\n<content>"`` — while the search path
+embedded raw query text. Identical content↔query produced cosine ~0.69
+instead of ~1.0, capping recall across dedup, entity-lookup, and search
+ranking (algo-stress run 20260507T153129Z-76c172).
+
+The fix aligned both sides on raw text. These tests are the load-
+bearing assertion that prevents the asymmetry from coming back: any
+future change that prepends, appends, or otherwise transforms the text
+on one side without doing the same on the other will trip these tests.
+
+Three surfaces are pinned:
+
+1. Hot-path write (``ParallelEmbedEnrich``) — embed input must equal
+   the raw memory content even when enrichment yields a retrieval_hint.
+2. Atomic-fact fan-out (``_enrich_memory_background``) — child embed
+   input must equal the raw ``fact.content``.
+3. End-to-end symmetry — for byte-identical content/query, the write
+   and search paths feed the embedding model the same string, so a
+   deterministic embedder produces the same vector (cosine == 1.0).
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core_api.constants import VECTOR_DIM
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.write.parallel_embed_enrich import ParallelEmbedEnrich
+from core_api.schemas import MemoryCreate
+
+pytestmark = pytest.mark.asyncio
+
+
+TENANT_ID = f"test-embed-stability-{uuid.uuid4().hex[:8]}"
+CONTENT = "Algo-stress embedding-stability probe — fixed string."
+
+
+def _input(content: str = CONTENT) -> MemoryCreate:
+    return MemoryCreate(
+        tenant_id=TENANT_ID,
+        fleet_id="f",
+        agent_id="a",
+        content=content,
+        persist=True,
+        entity_links=[],
+    )
+
+
+def _ctx(*, enrichment: bool = True) -> PipelineContext:
+    tenant_config = SimpleNamespace(
+        enrichment_enabled=enrichment,
+        enrichment_provider="fake" if enrichment else "none",
+    )
+    return PipelineContext(
+        db=AsyncMock(),
+        data={"input": _input(), "content_hash": "f" * 64},
+        tenant_config=tenant_config,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Hot-path write embeds raw content even when enrichment yields a hint
+# ---------------------------------------------------------------------------
+
+
+async def test_hot_path_embeds_raw_content_when_enrichment_yields_hint() -> None:
+    """The write pipeline must NOT prefix or otherwise transform the text
+    fed to the embedding model, regardless of what enrichment returns.
+
+    A pre-CAURA-222 regression would re-embed
+    ``"[Retrieval hint]: <hint>\\n\\n<content>"`` here and store the
+    hint-prefixed vector. Search-side embeds raw query text, so the
+    surfaces would diverge → cosine collapse → recall ceiling.
+    """
+    embed_inputs: list[str] = []
+
+    async def _spy_embed(text: str, *_a, **_k):
+        embed_inputs.append(text)
+        return [0.1] * VECTOR_DIM
+
+    enrichment_result = SimpleNamespace(
+        retrieval_hint="business milestone: signed first client",
+    )
+
+    async def _enrich(*_a, **_k):
+        return enrichment_result
+
+    with (
+        patch(
+            "core_api.pipeline.steps.write.parallel_embed_enrich.settings.embed_on_hot_path",
+            True,
+        ),
+        patch(
+            "core_api.pipeline.steps.write.parallel_embed_enrich.get_embedding",
+            new=_spy_embed,
+        ),
+        patch("core_api.services.memory_enrichment.enrich_memory", new=_enrich),
+    ):
+        await ParallelEmbedEnrich().execute(_ctx(enrichment=True))
+
+    # Exactly one embed call, with raw content. Any prefix marker
+    # (e.g. "[Retrieval hint]:") or the hint string itself appearing in
+    # the embed input is the asymmetry returning.
+    assert len(embed_inputs) == 1, (
+        f"expected one embed call, got {len(embed_inputs)} — a second call "
+        f"likely indicates a hint re-embed has been re-introduced"
+    )
+    assert embed_inputs[0] == CONTENT
+    assert "[Retrieval hint]" not in embed_inputs[0]
+    assert "business milestone" not in embed_inputs[0]
+
+
+# ---------------------------------------------------------------------------
+# 2. Atomic-fact children embed raw fact_content
+# ---------------------------------------------------------------------------
+
+
+async def test_atomic_fact_children_embed_raw_fact_content() -> None:
+    """Atomic-fact fan-out children must embed raw ``fact.content``, not
+    a hint-prefixed composition. Same rationale as the hot path: the
+    search side embeds raw query text, so children that get persisted
+    on a different surface lose recall on queries targeting their
+    specific claim.
+    """
+    from core_api.services import memory_service
+
+    embed_inputs: list[str] = []
+
+    async def _spy_embed(text: str, *_a, **_k):
+        embed_inputs.append(text)
+        return [0.2] * VECTOR_DIM
+
+    fact_a = SimpleNamespace(
+        content="Anniversary is July 22.",
+        retrieval_hint="anniversary date",
+        suggested_type="fact",
+    )
+    fact_b = SimpleNamespace(
+        content="Kitchen faucet started leaking.",
+        retrieval_hint="home maintenance issue",
+        suggested_type="episode",
+    )
+    enrichment = SimpleNamespace(
+        memory_type="fact",
+        weight=None,
+        title=None,
+        summary=None,
+        tags=None,
+        llm_ms=None,
+        contains_pii=False,
+        pii_types=None,
+        retrieval_hint="",
+        ts_valid_start=None,
+        ts_valid_end=None,
+        status=None,
+        atomic_facts=[fact_a, fact_b],
+    )
+
+    mem_row = {
+        "id": "m1",
+        "deleted_at": None,
+        "fleet_id": "f1",
+        "embedding": [0.0] * VECTOR_DIM,
+        "memory_type": "fact",
+        "weight": 0.5,
+        "status": "active",
+        "ts_valid_start": None,
+        "ts_valid_end": None,
+        "metadata_": {},
+        "visibility": "scope_team",
+    }
+    sc = MagicMock()
+    sc.get_memory = AsyncMock(return_value=mem_row)
+    sc.update_embedding = AsyncMock()
+    sc.update_memory_status = AsyncMock()
+    sc.create_memory = AsyncMock()
+    sc._patch = AsyncMock()
+
+    def _stub_tracked_task(coro, _name, *_a, **_k):
+        coro.close()
+        return None
+
+    with (
+        patch.object(memory_service.settings, "embed_on_hot_path", True),
+        patch.object(memory_service, "get_embedding", new=_spy_embed),
+        patch.object(memory_service, "get_storage_client", return_value=sc),
+        patch(
+            "core_api.services.memory_enrichment.enrich_memory",
+            new=AsyncMock(return_value=enrichment),
+        ),
+        patch.object(memory_service, "track_task"),
+        patch(
+            "core_api.services.task_tracker.tracked_task",
+            new=MagicMock(side_effect=_stub_tracked_task),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    enrichment_enabled=True,
+                    enrichment_provider="fake",
+                    entity_extraction_enabled=False,
+                )
+            ),
+        ),
+    ):
+        await memory_service._enrich_memory_background(
+            uuid.uuid4(), "parent content", TENANT_ID, "f1", "a"
+        )
+
+    # One embed call per fact, each with the fact's raw content.
+    assert embed_inputs == [fact_a.content, fact_b.content], (
+        f"atomic-fact embed inputs {embed_inputs!r} — expected raw "
+        f"fact.content with no hint prefix"
+    )
+    for inp in embed_inputs:
+        assert "[Retrieval hint]" not in inp
+        assert "anniversary date" not in inp
+        assert "home maintenance issue" not in inp
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end symmetry: write surface == query surface for identical text
+# ---------------------------------------------------------------------------
+
+
+async def test_write_and_query_embed_identical_input_for_identical_text() -> None:
+    """The load-bearing CAURA-222 assertion: for byte-identical content
+    and query, the embed inputs on the write and search paths must be
+    equal. With a deterministic embedder, equal inputs → equal vectors
+    → cosine == 1.0.
+
+    A new write transformation (e.g. a re-introduced hint prefix, a new
+    document-side instruction prefix, normalization) without a matching
+    query-side change will diverge the two recorded inputs and trip
+    this test.
+    """
+    from core_api.services import memory_service
+
+    write_embed_inputs: list[str] = []
+    query_embed_inputs: list[str] = []
+
+    async def _spy_write_embed(text: str, *_a, **_k):
+        write_embed_inputs.append(text)
+        return [0.3] * VECTOR_DIM
+
+    async def _spy_query_embed(text: str, *_a, **_k):
+        query_embed_inputs.append(text)
+        return [0.3] * VECTOR_DIM
+
+    enrichment_result = SimpleNamespace(
+        retrieval_hint="business milestone: signed first client",
+    )
+
+    async def _enrich(*_a, **_k):
+        return enrichment_result
+
+    # Bypass the redis-backed query-embedding cache so the spy fires.
+    async def _cache_miss(*_a, **_k):
+        return None
+
+    async def _cache_set(*_a, **_k):
+        return None
+
+    with (
+        patch(
+            "core_api.pipeline.steps.write.parallel_embed_enrich.settings.embed_on_hot_path",
+            True,
+        ),
+        patch(
+            "core_api.pipeline.steps.write.parallel_embed_enrich.get_embedding",
+            new=_spy_write_embed,
+        ),
+        patch("core_api.services.memory_enrichment.enrich_memory", new=_enrich),
+        patch.object(memory_service, "get_query_embedding", new=_spy_query_embed),
+        patch("core_api.cache.cache_get", new=_cache_miss),
+        patch("core_api.cache.cache_set", new=_cache_set),
+    ):
+        # Write side
+        await ParallelEmbedEnrich().execute(_ctx(enrichment=True))
+        # Search side — same text
+        await memory_service._get_or_cache_embedding(
+            CONTENT,
+            TENANT_ID,
+            tenant_config=None,
+        )
+
+    assert len(write_embed_inputs) == 1
+    assert len(query_embed_inputs) == 1
+    assert write_embed_inputs[0] == query_embed_inputs[0], (
+        f"write embed input {write_embed_inputs[0]!r} != "
+        f"query embed input {query_embed_inputs[0]!r} — surfaces have "
+        f"diverged; CAURA-222 asymmetry is back"
+    )
+    # And both equal the raw input — no transformation on either side.
+    assert write_embed_inputs[0] == CONTENT

--- a/tests/test_retrieval_hint.py
+++ b/tests/test_retrieval_hint.py
@@ -1,10 +1,12 @@
-"""Tests for the retrieval_hint feature in memory_enrichment.
+"""Tests for the retrieval_hint metadata field.
 
 Covers:
   - Validator round-trips retrieval_hint; trims whitespace; caps length.
-  - Prompt contains the new retrieval_hint rule + concrete examples.
-  - compose_embedding_text appends hint when present, returns content
-    unchanged when empty/missing.
+  - Prompt contains the retrieval_hint rule + concrete examples.
+
+The hint is persisted in metadata (debugging / auditability) but no
+longer participates in embedding composition — see CAURA-222 and the
+follow-up that removed ``compose_embedding_text`` entirely.
 """
 
 from __future__ import annotations
@@ -12,7 +14,6 @@ from __future__ import annotations
 from core_api.services.memory_enrichment import (
     ENRICHMENT_PROMPT,
     _validate_enrichment,
-    compose_embedding_text,
 )
 
 
@@ -91,30 +92,3 @@ class TestPromptContainsHintRule:
     def test_prompt_includes_business_milestone_example(self):
         # This is the example modeled after the eac54add failure case.
         assert "business milestone" in ENRICHMENT_PROMPT
-
-
-# ---------------------------------------------------------------------------
-# compose_embedding_text
-# ---------------------------------------------------------------------------
-
-
-class TestComposeEmbeddingText:
-    def test_with_hint_appends_marker(self):
-        out = compose_embedding_text(
-            content="I signed a contract with my first client today.",
-            retrieval_hint="business milestone: signed first client",
-        )
-        assert "I signed a contract" in out
-        assert "[Retrieval hint]: business milestone: signed first client" in out
-
-    def test_empty_hint_returns_content_unchanged(self):
-        content = "Some memory content."
-        assert compose_embedding_text(content, "") == content
-
-    def test_none_hint_returns_content_unchanged(self):
-        content = "Some memory content."
-        assert compose_embedding_text(content, None) == content
-
-    def test_whitespace_only_hint_returns_content_unchanged(self):
-        content = "Some memory content."
-        assert compose_embedding_text(content, "   ") == content


### PR DESCRIPTION
## Summary

Three small follow-ups to PR #104 (CAURA-222 write/query embedding-surface alignment), bundled into one PR. None change production logic — they close the loop on cleanup, regression coverage, and operational tooling that was intentionally deferred to keep #104 minimal.

1. **Delete `compose_embedding_text` and unwire re-exports.** Zero production call sites since #104.
2. **Add `tests/test_embed_stability.py` regression suite.** Pins write/query surface symmetry so the asymmetry can't return silently.
3. **Extend the embedding-backfill CLI with `--rewrite-hint-prefixed`.** One-shot recall-recovery mode for tenants whose existing rows were embedded under the old hint-prefixed write path.

## 1. Drop `compose_embedding_text`

After #104 removed every production call site, the helper, its re-exports, and the `TestComposeEmbeddingText` class were dead weight. Removed:

- `common/enrichment/service.py` — function definition.
- `common/enrichment/__init__.py` — import + `__all__` entry.
- `core-api/src/core_api/services/memory_enrichment.py` — re-export.
- `tests/test_retrieval_hint.py::TestComposeEmbeddingText` — the class.
- `tests/test_embed_off_hot_path.py` — leftover mock that was a no-op since #104.

Kept on purpose:

- The `retrieval_hint` LLM field, prompt validator (\`tests/test_retrieval_hint.py::TestValidatorRetrievalHint\` and \`TestPromptContainsHintRule\` stay).
- `metadata.retrieval_hint` persistence — auditability and the selector for the backfill mode below.
- The historical-context comments in \`parallel_embed_enrich.py\` and \`memory_enriched.py\`.

If the symmetric reintroduction work (the future PR I drafted as part of #104) goes with Option A (two-vector store), it'll add a new helper rather than reviving this one — the old prefix shape is documented as the failure mode in the test suite below, not as a building block.

## 2. Regression test — `tests/test_embed_stability.py`

Three tests, deterministic spies on the embedding providers — no network, no DB, no CI infra dependencies:

| Test | Pins |
|---|---|
| `test_hot_path_embeds_raw_content_when_enrichment_yields_hint` | `ParallelEmbedEnrich` calls embedder exactly once with raw content even when enrichment yields a `retrieval_hint`. Catches re-introduced hint prefixes on the write hot path. |
| `test_atomic_fact_children_embed_raw_fact_content` | Atomic-fact fan-out children pass `fact.content` (not `compose_embedding_text(fact_content, fact_hint)`) to the embedder. |
| `test_write_and_query_embed_identical_input_for_identical_text` | **Load-bearing**: write and search paths feed the embedder byte-identical strings for byte-identical content/query. Any future divergence — re-introduced prefix, document-side instruction without a query-side counterpart, normalization on one side — trips this test. |

The third test is the one I'd want to see in any future PR that touches embedding text construction. It mocks `get_embedding` (write side) and `get_query_embedding` (search side) with recording spies, exercises both paths with the same input string, and asserts the recorded inputs are equal.

## 3. Backfill CLI — `--rewrite-hint-prefixed`

New mode in \`core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py\` for one-off recall recovery on tenants that already have rows embedded under the old surface.

**Selector:**
```sql
WHERE embedding IS NOT NULL
  AND metadata_ ? 'retrieval_hint'
  AND COALESCE(metadata_->>'retrieval_hint', '') <> ''
  AND deleted_at IS NULL
```

Default IS-NULL scan path unchanged — the new flag branches inside `_iter_rows`. Entities are skipped silently in this mode (no hint metadata exists there). Per-tenant phasing via `--tenant-id` and `--dry-run` still apply.

**Usage:**
```
# Dry-run scope estimate per tenant:
docker compose run --rm core-storage-api \
  python -m core_storage_api.scripts.backfill_embeddings \
    --rewrite-hint-prefixed --tenant-id tenant-abc --dry-run

# Actual rewrite:
docker compose run --rm core-storage-api \
  python -m core_storage_api.scripts.backfill_embeddings \
    --rewrite-hint-prefixed --tenant-id tenant-abc
```

Three new tests cover this:
- `test_rewrite_hint_prefixed_targets_memories_with_hint_metadata` — asserts the SQL filter shape.
- `test_rewrite_hint_prefixed_skips_entities` — entities table is not even queried.
- `test_default_mode_uses_null_embedding_filter` — pins the default mode's WHERE shape so the new branching can't silently break the original CLI.

**Caveats called out in the existing module docstring still apply:**
- Standalone CLI runs against the process-level embedding provider; it does NOT honour per-tenant overrides. Multi-tenant prod with per-tenant overrides should still use the event-driven `core-worker backfill-embeddings` task. `--tenant-id` here scopes the SQL scan, not the provider resolution.
- A re-run of `--rewrite-hint-prefixed` will re-match the same rows because `metadata.retrieval_hint` is intentionally preserved (auditability). Operational pattern is one forward pass per tenant, then the embed-stability probe to verify, then move on.

## Test plan

- [x] `pytest tests/test_embed_stability.py tests/test_embed_off_hot_path.py tests/test_retrieval_hint.py tests/test_backfill_embeddings.py` — 43 passed locally.
- [x] `ruff format --check` clean on all touched paths.
- [x] `ruff check` clean on all touched paths.
- [ ] CI green.
- [ ] After merge: dry-run the new backfill mode against staging \`memclaw.dev\` tenant \`ran-507cb7\` to validate the SQL selector against real metadata shape; expected scope = paragraph-or-longer memories that were enriched on a deploy where the hint re-embed fired.

## Rollout

Independent of any production deploy — this PR is purely additive (regression test + cleanup + new opt-in CLI flag). Default backfill behavior, write path, and search path are all byte-identical to post-#104 main.

The recall recovery itself (running `--rewrite-hint-prefixed` against existing data) is a separate operational decision, owner-driven per-tenant, with the dry-run cost gate built into the existing CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)