### PR TITLE
fix(ingest): harden URL fetch (Content-Type allowlist + size cap + SS…

### DIFF
--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -1,10 +1,14 @@
 """Document/URL ingestion: extract atomic facts via LLM, preview, and commit as memories."""
 
+import ipaddress
 import logging
 import re
+import socket
 import time
 import uuid
+from urllib.parse import urlparse
 
+import httpx
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,6 +19,30 @@ from core_api.schemas import IngestCommitRequest, IngestRequest, MemoryCreate
 from core_api.services.memory_service import create_memory
 
 logger = logging.getLogger(__name__)
+
+# Allowed MIME types for URL ingest. Binary formats (PDF, DOCX, etc.) are
+# rejected here; the optional Kreuzberg integration (PR #8) will add a
+# separate path for them.
+ALLOWED_INGEST_MIME_TYPES = frozenset(
+    {
+        "text/html",
+        "text/plain",
+        "text/markdown",
+        "text/x-markdown",
+        "application/xhtml+xml",
+    }
+)
+
+# Hard cap on fetched-body size (post-decompression). Defends against
+# gzip-bomb URLs that claim Content-Length: 50KB but expand to gigabytes.
+MAX_INGEST_CONTENT_BYTES = 200_000
+
+# Explicit deny-list for cloud-metadata service IPs that aren't always
+# caught by ipaddress.is_link_local (AWS 169.254.169.254 IS link-local;
+# GCP metadata at metadata.google.internal resolves to 169.254.169.254 too;
+# Azure uses the same IP). Listed defensively even though is_link_local
+# covers them.
+_CLOUD_METADATA_IPS = frozenset({"169.254.169.254", "fd00:ec2::254"})
 
 CHUNKING_PROMPT = """\
 Extract discrete, atomic facts from the following content.
@@ -89,21 +117,128 @@ async def _chunk_content(
     return facts
 
 
+def _is_blocked_ip(addr: str) -> bool:
+    """Return True if the address falls in a range we must not fetch from.
+
+    Covers RFC1918 private ranges, loopback, link-local (incl. AWS/GCP/Azure
+    metadata IPs), multicast, and reserved. IPv6 unique-local fc00::/7 is
+    classified as private by the ipaddress module.
+    """
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _check_hostname_safe(url: str) -> None:
+    """Resolve the URL's hostname and reject if it points at private infra.
+
+    Light-weight SSRF defense. Does NOT handle DNS rebinding between this
+    resolution and the actual TCP connect — that's a Tier 3 hardening item.
+    Covers the accidental-misuse case (localhost, RFC1918, cloud metadata).
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname
+    if not host:
+        raise HTTPException(status_code=400, detail=f"Invalid URL: no hostname in {url!r}")
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as e:
+        raise HTTPException(status_code=400, detail=f"DNS resolution failed for {host}: {e}")
+    for family, _, _, _, sockaddr in infos:
+        addr = str(sockaddr[0])
+        if _is_blocked_ip(addr) or addr in _CLOUD_METADATA_IPS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Blocked: {host} resolves to {addr} (private/loopback/link-local/metadata)",
+            )
+
+
 async def _fetch_url_text(url: str) -> str:
-    """Fetch URL and strip HTML to plain text."""
-    import httpx
+    """Fetch URL, validate MIME + size, decode safely, and strip HTML.
+
+    Raises ``HTTPException`` for:
+    - 400: invalid URL, DNS failure, hostname resolves to a blocked IP range
+    - 413: fetched body exceeds ``MAX_INGEST_CONTENT_BYTES``
+    - 422: response Content-Type isn't in the text allowlist
+    - 4xx/5xx: passed through from the upstream server
+    """
+    _check_hostname_safe(url)
 
     async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
-        resp = await client.get(url)
-        resp.raise_for_status()
+        async with client.stream("GET", url) as resp:
+            resp.raise_for_status()
 
-    html = resp.text
+            # Re-validate the FINAL host post-redirect (the upstream may
+            # have redirected us to a private host). httpx exposes the
+            # ultimate URL via resp.url; ``follow_redirects=True`` already
+            # walked the chain.
+            _check_hostname_safe(str(resp.url))
 
-    # Strip HTML tags to get plain text
+            # MIME allowlist on the final response, not the initial request.
+            content_type = resp.headers.get("content-type", "").split(";")[0].strip().lower()
+            if content_type and content_type not in ALLOWED_INGEST_MIME_TYPES:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Unsupported content type: {content_type}. "
+                        f"Allowed: {sorted(ALLOWED_INGEST_MIME_TYPES)}"
+                    ),
+                )
+
+            # Pre-check Content-Length if the server bothered to send it.
+            # Saves us from downloading anything when the server is honest.
+            cl_header = resp.headers.get("content-length")
+            if cl_header:
+                try:
+                    if int(cl_header) > MAX_INGEST_CONTENT_BYTES:
+                        raise HTTPException(
+                            status_code=413,
+                            detail=(f"Content too large: {cl_header} bytes (max {MAX_INGEST_CONTENT_BYTES})"),
+                        )
+                except ValueError:
+                    # Malformed Content-Length — fall through to streaming.
+                    pass
+
+            # Stream the body, abort if it exceeds the cap after
+            # decompression. httpx transparently decompresses gzip/br
+            # within ``aiter_bytes`` so this measures decompressed bytes
+            # (gzip-bomb guard).
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in resp.aiter_bytes():
+                total += len(chunk)
+                if total > MAX_INGEST_CONTENT_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            f"Content too large: exceeded {MAX_INGEST_CONTENT_BYTES} bytes "
+                            f"after decompression"
+                        ),
+                    )
+                chunks.append(chunk)
+            body = b"".join(chunks)
+
+            # Decode using the response's declared charset, falling back
+            # to UTF-8. httpx's default is ISO-8859-1 when no charset is
+            # advertised, which mojibakes any UTF-8 page that omits a
+            # charset declaration.
+            encoding = resp.charset_encoding or "utf-8"
+            html = body.decode(encoding, errors="replace")
+
+    # Strip HTML tags to get plain text. (BeautifulSoup-based extraction
+    # ships in a later PR; this regex is the same as before.)
     text = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL | re.IGNORECASE)
     text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.DOTALL | re.IGNORECASE)
     text = re.sub(r"<[^>]+>", " ", text)
-    # Collapse whitespace
     text = re.sub(r"\s+", " ", text).strip()
 
     return text
@@ -120,6 +255,10 @@ async def ingest_preview(db: AsyncSession, request: IngestRequest) -> dict:
     if url:
         try:
             content = await _fetch_url_text(url)
+        except HTTPException:
+            # Preserve the specific 400/413/422 from _fetch_url_text — these
+            # carry meaningful status codes the caller needs to see.
+            raise
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Failed to fetch URL: {e}")
     elif request.content:

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -1,0 +1,304 @@
+"""Tests for the URL-fetch hardening introduced in PR #1.
+
+Covers:
+- P1.1 Content-Type allowlist + post-redirect re-validation
+- P1.1 Content-Length pre-check (413)
+- P1.1 Streaming abort on decompressed bytes (gzip-bomb guard)
+- P2.5 UTF-8 charset fallback (no ISO-8859-1 mojibake)
+- P1.A-lite Hostname IP blacklist
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from core_api.services.ingest_service import (
+    MAX_INGEST_CONTENT_BYTES,
+    _check_hostname_safe,
+    _fetch_url_text,
+    _is_blocked_ip,
+)
+
+# Capture the un-patched factories. The tests monkeypatch
+# ``ingest_service.httpx.AsyncClient`` to substitute a MockTransport-backed
+# client, so we need direct references to the originals to avoid recursion
+# when our helper itself wants to build a mock client.
+_real_AsyncClient = httpx.AsyncClient
+_real_MockTransport = httpx.MockTransport
+
+
+# ---------------------------------------------------------------------------
+# P1.A-lite — hostname IP blacklist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBlockedIPClassification:
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "127.0.0.1",  # loopback
+            "10.0.0.5",  # RFC1918 private
+            "172.16.0.1",  # RFC1918 private
+            "192.168.1.1",  # RFC1918 private
+            "169.254.169.254",  # AWS/GCP/Azure metadata (link-local)
+            "::1",  # IPv6 loopback
+            "fc00::1",  # IPv6 unique-local
+            "fe80::1",  # IPv6 link-local
+            "0.0.0.0",  # unspecified
+        ],
+    )
+    def test_blocked_ranges_are_rejected(self, addr: str) -> None:
+        assert _is_blocked_ip(addr) is True
+
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "1.1.1.1",  # Cloudflare DNS
+            "8.8.8.8",  # Google DNS
+            "93.184.216.34",  # example.com
+            "2606:4700:4700::1111",  # public IPv6
+        ],
+    )
+    def test_public_addresses_pass(self, addr: str) -> None:
+        assert _is_blocked_ip(addr) is False
+
+    def test_invalid_string_returns_false(self) -> None:
+        # Defensive: non-IP strings shouldn't raise, just say "not blocked"
+        assert _is_blocked_ip("not-an-ip") is False
+
+
+@pytest.mark.unit
+class TestHostnameSafetyCheck:
+    def test_rejects_localhost_url(self) -> None:
+        with (
+            pytest.raises(httpx.HTTPError) if False else pytest.raises(Exception) as exc
+        ):
+            _check_hostname_safe("http://127.0.0.1:8000/health")
+        # The exception is a starlette HTTPException — check the status_code attr
+        assert exc.value.status_code == 400
+        assert "127.0.0.1" in exc.value.detail
+
+    def test_rejects_rfc1918_hostname(self) -> None:
+        # Use the explicit IP as the hostname — getaddrinfo will return it back
+        with pytest.raises(Exception) as exc:
+            _check_hostname_safe("http://10.0.0.5/")
+        assert exc.value.status_code == 400
+
+    def test_rejects_metadata_ip(self) -> None:
+        with pytest.raises(Exception) as exc:
+            _check_hostname_safe("http://169.254.169.254/latest/meta-data/")
+        assert exc.value.status_code == 400
+
+    def test_rejects_invalid_url(self) -> None:
+        with pytest.raises(Exception) as exc:
+            _check_hostname_safe("not-a-valid-url")
+        assert exc.value.status_code == 400
+        assert "no hostname" in exc.value.detail.lower()
+
+    def test_public_hostname_passes(self) -> None:
+        # Mock getaddrinfo to avoid hitting real DNS in unit tests
+        with patch(
+            "core_api.services.ingest_service.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, 0, 0, "", ("1.1.1.1", 0))],
+        ):
+            # Should not raise
+            _check_hostname_safe("https://example.com/page")
+
+
+# ---------------------------------------------------------------------------
+# P1.1 — Content-Type allowlist + size guard + streaming
+# P2.5 — UTF-8 encoding fallback
+# ---------------------------------------------------------------------------
+
+
+def _make_client(handler) -> httpx.AsyncClient:
+    """Helper: build an httpx client with a MockTransport for in-process testing.
+
+    Uses the captured-at-import-time httpx references so it keeps working
+    even after a test monkeypatches ``ingest_service.httpx.AsyncClient``.
+    """
+    return _real_AsyncClient(
+        transport=_real_MockTransport(handler),
+        follow_redirects=True,
+        timeout=30.0,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestFetchUrlText:
+    async def test_text_html_succeeds(self, monkeypatch) -> None:
+        """text/html with UTF-8 body returns extracted text."""
+        # Skip the SSRF check by patching it (the URL we pass is public-ish)
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                content=b"<html><body><p>Hello world.</p></body></html>",
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        result = await _fetch_url_text("https://example.com/")
+        assert "Hello world" in result
+
+    async def test_application_pdf_rejected_422(self, monkeypatch) -> None:
+        """PDF MIME type → 422 with allowlist hint. The single most important
+        wet-tested bug this PR fixes."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/pdf"},
+                content=b"%PDF-1.4\n%garbage binary content",
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        with pytest.raises(Exception) as exc:
+            await _fetch_url_text("https://example.com/file.pdf")
+        assert exc.value.status_code == 422
+        assert "application/pdf" in exc.value.detail
+
+    async def test_octet_stream_rejected_422(self, monkeypatch) -> None:
+        """Unknown binary MIME → 422."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/octet-stream"},
+                content=b"\x00" * 100,
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        with pytest.raises(Exception) as exc:
+            await _fetch_url_text("https://example.com/data")
+        assert exc.value.status_code == 422
+
+    async def test_content_length_precheck_413(self, monkeypatch) -> None:
+        """Honest Content-Length header > cap → 413 before downloading."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+        oversized = str(MAX_INGEST_CONTENT_BYTES + 1)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            # Headers claim it's large; we should reject without reading the body
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html", "content-length": oversized},
+                content=b"x" * 10,  # body itself is small; pre-check should fire first
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        with pytest.raises(Exception) as exc:
+            await _fetch_url_text("https://example.com/")
+        assert exc.value.status_code == 413
+        assert oversized in exc.value.detail
+
+    async def test_streaming_abort_on_oversize_body(self, monkeypatch) -> None:
+        """Body exceeds cap mid-stream → 413 (gzip-bomb guard)."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+        oversize_body = b"x" * (MAX_INGEST_CONTENT_BYTES + 5_000)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            # No content-length header; force streaming path
+            return httpx.Response(
+                200, headers={"content-type": "text/html"}, content=oversize_body
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        with pytest.raises(Exception) as exc:
+            await _fetch_url_text("https://example.com/")
+        assert exc.value.status_code == 413
+
+    async def test_under_cap_succeeds(self, monkeypatch) -> None:
+        """Body comfortably under cap → success."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/plain"},
+                content=b"short content here",
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        result = await _fetch_url_text("https://example.com/")
+        assert "short content here" in result
+
+    async def test_utf8_body_with_no_charset_header(self, monkeypatch) -> None:
+        """P2.5: UTF-8 body without a charset declaration should NOT mojibake."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+        # Japanese characters in UTF-8, no charset in Content-Type
+        body = "<html><body>こんにちは世界</body></html>".encode("utf-8")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, headers={"content-type": "text/html"}, content=body
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        result = await _fetch_url_text("https://example.com/")
+        assert "こんにちは世界" in result
+
+    async def test_markdown_mime_allowed(self, monkeypatch) -> None:
+        """text/markdown is explicitly in the allowlist."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/markdown"},
+                content=b"# Title\n\nBody.",
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        result = await _fetch_url_text("https://example.com/doc.md")
+        assert "Title" in result
+        assert "Body" in result


### PR DESCRIPTION
…RF + UTF-8)

Closes three wet-tested production bugs in the ingest URL-fetch path:

P1.1 — Content-Type allowlist + size cap + streaming abort
  - Reject MIME types outside {text/html, text/plain, text/markdown, text/x-markdown, application/xhtml+xml} with 422. Previously, a `https://...dummy.pdf` URL returned 200 with 17 hallucinated facts extracted from raw PDF binary (e.g. "the PDF header is %PDF-1.4").
  - Re-validate Content-Type on the FINAL post-redirect response, not on the request URL.
  - Pre-check Content-Length header (413 before download when honest).
  - Stream body via client.stream() and abort at 200 KB measured on decompressed bytes — gzip-bomb guard. 413 mid-stream.

P2.5 — UTF-8 charset fallback
  - Decode via `resp.charset_encoding or "utf-8"` with errors="replace". httpx's default fallback is ISO-8859-1, which mojibakes UTF-8 pages that omit a charset declaration (common for many non-Latin sites).

P1.A-lite — Hostname IP blacklist (light SSRF defense)
  - Resolve hostname via socket.getaddrinfo before connecting; reject if any A/AAAA falls in RFC1918 private, loopback, link-local (incl. 169.254.169.254 / cloud metadata), unique-local IPv6, multicast, reserved, or unspecified.
  - Re-validate post-redirect using resp.url.
  - Does NOT cover DNS rebinding between resolution and connect — that's a Tier 3 hardening item (full SSRF transport). This covers the accidental-misuse case: localhost, RFC1918, EC2 IMDS.

Wet-test results (against live local stack):
  - PDF URL: 200 + 17 garbage facts in 4.6s   →   422 in 0.26s ✓
  - localhost URL: 400 (only by accident — 404 path) → 400 "Blocked: ..." in 0.008s ✓
  - 169.254.169.254 URL: would fetch EC2 IMDS → 400 "Blocked: ..." in 0.004s ✓
  - Public HTML URL: 200 (regression check)   →   200 + facts ✓
  - Plain content (no URL): 200               →   200 + facts ✓

Tests: 27 unit tests, all passing. New file: tests/test_ingest_service.py.

Also moves the lazy `import httpx` from inside _fetch_url_text to module level so monkeypatching for tests works without recursion guards. httpx is already a hard dep of core-api.

The `ingest_preview` caller previously caught all exceptions including HTTPException and re-wrapped as 400, swallowing the new 413/422 status codes — now passes HTTPException through unchanged.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
