### PR TITLE
feat(fleet-stats): include agent trust_level in per-agent records

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2782,6 +2782,12 @@ class PostgresService:
             )
             agent_rows = result.all()
 
+            trust_result = await session.execute(
+                text("SELECT agent_id, trust_level FROM agents WHERE tenant_id = :tenant_id"),
+                {"tenant_id": tenant_id},
+            )
+            trust_by_id: dict[str, int] = {row.agent_id: row.trust_level for row in trust_result.all()}
+
             now = datetime.now(UTC)
             day_ago = now - timedelta(days=1)
             week_ago = now - timedelta(days=7)
@@ -2796,6 +2802,7 @@ class PostgresService:
                 agents.append(
                     {
                         "agent_id": r.agent_id,
+                        "trust_level": trust_by_id.get(r.agent_id, 1),
                         "total_memories": r.total_memories,
                         "last_write_at": last_write.isoformat() if last_write else None,
                         "total_recalls": int(r.total_recalls),
@@ -2845,6 +2852,7 @@ class PostgresService:
                         agents.append(
                             {
                                 "agent_id": aid,
+                                "trust_level": trust_by_id.get(aid, 1),
                                 "total_memories": 0,
                                 "last_write_at": None,
                                 "total_recalls": 0,


### PR DESCRIPTION
## Summary
- Adds \`trust_level\` to every per-agent record returned by \`GET /api/v1/storage/fleet/stats\`
- One extra tenant-scoped query (\`SELECT agent_id, trust_level FROM agents WHERE tenant_id = :tenant_id\`), bounded by per-tenant agent count
- Defaults to \`1\` (Standard) for agents present in \`fleet_nodes.agents_json\` but not yet upserted into \`agents\`

## Why
The Fleet Management UI shows a row per agent (status, memory counts, recall counts) but had no way to surface or edit governance state. Trust gates real behaviour — \`0\` blocks writes, \`<2\` blocks cross-fleet reads (see \`core-api/routes/memories.py:794, 1197\`). Surfacing it in fleet/stats lets the UI render it inline next to the existing per-agent fields.

Pairs with the enterprise PR that consumes this field and adds the inline editor.

## Test plan
- [ ] Verified locally: \`fleet/stats\` returns \`trust_level\` for both memory-having and node-only agents
- [ ] \`PATCH /api/v1/agents/{id}\` \`{trust_level: N}\` → reflected in next \`fleet/stats\` read
- [ ] Default of 1 returned for an agent in \`fleet_nodes.agents_json\` with no \`agents\` row
- [ ] No regression in existing \`fleet_summary\` totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)