### PR TITLE
fix(ingest): validators + URL provenance (P1.2/P2.1/P2.3/P2.4/P1.E)

### DIFF
--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -357,6 +357,13 @@ class IngestRequest(BaseModel):
 class IngestFact(BaseModel):
     content: str
     suggested_type: str = DEFAULT_MEMORY_TYPE
+    # Provenance: ``ingest_preview`` stamps this on every fact it returns
+    # (the URL it fetched from, or "text-input" for a pasted body). When
+    # the caller round-trips the preview output straight to commit without
+    # explicitly re-passing ``url``, this is the only thing that lets us
+    # persist the right ``source_uri``. ``IngestCommitRequest.url`` still
+    # wins if provided (dashboard back-compat).
+    source_uri: str | None = None
 
 
 class IngestCommitRequest(BaseModel):

--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -53,6 +53,34 @@ _CLOUD_METADATA_IPS = frozenset({"169.254.169.254", "fd00:ec2::254"})
 # Bounded to avoid hammering the LLM provider with rate-limit failures.
 _COMMIT_CONCURRENCY = 4
 
+# Maximum content length the LLM sees. Inputs longer than this get
+# truncated; ``ingest_preview`` reports the post-truncate length as
+# ``content_length`` and sets ``truncated: true`` + ``original_length``
+# so callers know the input was clipped. (Previously ``content_length``
+# returned the pre-truncate length, lying about what the LLM actually
+# processed.)
+_INGEST_MAX_CONTENT_CHARS = 50_000
+
+# Minimum content length before we'll even call the LLM. Whitespace-only
+# inputs and trivially short ones ("hi") used to burn a real LLM call
+# producing useless meta-facts ("The content begins with the greeting
+# 'hi'"). We short-circuit instead and return ``skipped_reason``.
+_INGEST_MIN_CONTENT_CHARS = 20
+
+# Drop facts that describe the input itself rather than extracting from it.
+# These show up when the LLM has nothing real to chunk — typical on short
+# inputs that slipped past ``_INGEST_MIN_CONTENT_CHARS``. Belt-and-braces
+# with the prompt guidance below.
+_META_FACT_RE = re.compile(
+    r"^\s*(?:"
+    r"the\s+(?:provided|user|input)\s+(?:content|text|document)"  # "the provided content"
+    r"|this\s+(?:content|text|document)"  # "this document describes"
+    r"|the\s+content\s+(?:begins|starts|consists|is)"  # "the content begins"
+    r"|the\s+(?:document|text)\s+(?:provided|given|describes|is)"  # "the document describes"
+    r")",
+    re.IGNORECASE,
+)
+
 CHUNKING_PROMPT = """\
 Extract discrete, atomic facts from the following content.
 Each fact should be a single claim that can stand alone as a memory.
@@ -62,6 +90,7 @@ Guidelines:
 - Be specific: include names, numbers, dates, decisions
 - Each fact: one claim, not a paragraph
 - Suggest a memory_type for each: fact, decision, preference, task, plan, episode, semantic, intention, commitment, action, outcome, cancellation
+- Do NOT produce meta-facts that describe the input itself. Avoid claims like "The content begins with...", "The provided text says...", "This document is about...". Extract facts FROM the content, not facts ABOUT the content.
 {focus_instruction}
 
 Content:
@@ -83,7 +112,13 @@ async def _chunk_content(
     focus: str | None = None,
     tenant_config=None,
 ) -> list[dict]:
-    """Extract atomic facts from text via LLM."""
+    """Extract atomic facts from text via LLM.
+
+    Caller is responsible for truncation before calling — see
+    ``_INGEST_MAX_CONTENT_CHARS`` and ``ingest_preview``. This function
+    just builds the prompt, calls the LLM, validates the JSON shape,
+    and drops meta-facts (P2.4).
+    """
     provider_name = (
         tenant_config.enrichment_provider if tenant_config else None
     ) or settings.entity_extraction_provider
@@ -92,9 +127,7 @@ async def _chunk_content(
     if focus:
         focus_instruction = f"Focus on facts relevant to {focus}. Deprioritize unrelated details."
 
-    # Truncate very long content to avoid token limits
-    content = text[:50_000]
-    prompt = CHUNKING_PROMPT.format(content=content, focus_instruction=focus_instruction)
+    prompt = CHUNKING_PROMPT.format(content=text, focus_instruction=focus_instruction)
 
     async def _do_chunk(llm):
         return await llm.complete_json(prompt)
@@ -108,20 +141,31 @@ async def _chunk_content(
     )
 
     # Validate: must be a list of objects with "content"
-    facts = []
+    facts: list[dict] = []
     if isinstance(raw, dict):
         # Handle {"facts": [...]} wrapper
         for v in raw.values():
             if isinstance(v, list):
                 raw = v
                 break
+    dropped_meta = 0
     for item in raw:
         if not isinstance(item, dict) or not item.get("content"):
+            continue
+        body = str(item["content"]).strip()
+        if _META_FACT_RE.search(body):
+            # P2.4: drop facts that describe the input rather than extract
+            # from it. Prompt forbids them but the LLM still produces them
+            # occasionally — especially on short/trivial input.
+            dropped_meta += 1
             continue
         st = item.get("suggested_type", "fact")
         if st not in MEMORY_TYPES:
             st = "fact"
-        facts.append({"content": str(item["content"]).strip(), "suggested_type": st})
+        facts.append({"content": body, "suggested_type": st})
+
+    if dropped_meta:
+        logger.info("ingest: dropped %d meta-fact(s) from extraction output", dropped_meta)
 
     return facts
 
@@ -254,9 +298,18 @@ async def _fetch_url_text(url: str) -> str:
 
 
 async def ingest_preview(db: AsyncSession, request: IngestRequest) -> dict:
-    """Preview mode: extract facts from URL or text without writing anything."""
-    from core_api.services.organization_settings import resolve_config
+    """Preview mode: extract facts from URL or text without writing anything.
 
+    Response fields:
+      url             — echoed from the request (None when content was pasted)
+      content_length  — length of the string the LLM actually saw (post-truncate, P2.1)
+      truncated       — True iff input exceeded _INGEST_MAX_CONTENT_CHARS (P2.1)
+      original_length — pre-truncate length, only present when truncated=True (P2.1)
+      facts           — list of {content, suggested_type, source_uri}
+      chunk_ms        — LLM round-trip duration; 0 when short-circuited
+      skipped_reason  — only present when no LLM call happened
+                        ("content_too_short" today; future reasons may surface)
+    """
     tenant_config = await resolve_config(db, request.tenant_id)
 
     # Get content
@@ -275,6 +328,34 @@ async def ingest_preview(db: AsyncSession, request: IngestRequest) -> dict:
     else:
         raise HTTPException(status_code=400, detail="Either url or content is required")
 
+    # ---- P2.1: honest truncation reporting ----
+    original_length = len(content)
+    truncated = original_length > _INGEST_MAX_CONTENT_CHARS
+    if truncated:
+        content = content[:_INGEST_MAX_CONTENT_CHARS]
+
+    # ---- P2.3: whitespace / too-short short-circuit ----
+    # Avoid burning an LLM call on input that can't produce meaningful
+    # facts. The cap is generous (20 chars after strip()) so any
+    # legitimate ingest still hits the LLM.
+    source_uri_default = url or "text-input"
+    if len(content.strip()) < _INGEST_MIN_CONTENT_CHARS:
+        logger.info(
+            "ingest_preview: short-circuited (content too short: %d chars stripped)",
+            len(content.strip()),
+        )
+        response: dict = {
+            "url": url,
+            "content_length": len(content),
+            "facts": [],
+            "chunk_ms": 0,
+            "skipped_reason": "content_too_short",
+        }
+        if truncated:
+            response["truncated"] = True
+            response["original_length"] = original_length
+        return response
+
     # Extract facts via LLM
     t0 = time.perf_counter()
     try:
@@ -284,12 +365,21 @@ async def ingest_preview(db: AsyncSession, request: IngestRequest) -> dict:
         raise HTTPException(status_code=500, detail=f"Fact extraction failed: {e}")
     chunk_ms = int((time.perf_counter() - t0) * 1000)
 
-    return {
+    # P1.2: stamp source_uri on every fact so the commit path doesn't need
+    # the caller to re-pass ``url``. Callers can still override per-fact.
+    for f in facts:
+        f.setdefault("source_uri", source_uri_default)
+
+    response = {
         "url": url,
         "content_length": len(content),
         "facts": facts,
         "chunk_ms": chunk_ms,
     }
+    if truncated:
+        response["truncated"] = True
+        response["original_length"] = original_length
+    return response
 
 
 async def ingest_commit(db: AsyncSession, request: IngestCommitRequest) -> dict:
@@ -320,8 +410,25 @@ async def ingest_commit(db: AsyncSession, request: IngestCommitRequest) -> dict:
        on the shared session.
     """
     run_id = request.run_id or str(uuid.uuid4())
-    source_uri = request.url or "text-input"
+    # Caller-supplied url wins (dashboard back-compat). When the caller
+    # round-trips preview output without re-passing url, each fact carries
+    # its own source_uri (P1.2 — stamped by ingest_preview).
+    request_url_override = request.url
     facts = list(request.facts)
+
+    # ---- P1.E: validate suggested_type before any work ----
+    # Without this, a forged/malformed suggested_type leaks all the way to
+    # MemoryCreate and surfaces as a Pydantic ValidationError → 500. Catch
+    # it here with a clean 422 listing the offending values.
+    bad = [(i, f.suggested_type) for i, f in enumerate(facts) if f.suggested_type not in MEMORY_TYPES]
+    if bad:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid suggested_type on facts {[i for i, _ in bad]}: "
+                f"{[t for _, t in bad]}. Allowed: {sorted(MEMORY_TYPES)}"
+            ),
+        )
 
     t0 = time.perf_counter()
 
@@ -376,19 +483,23 @@ async def ingest_commit(db: AsyncSession, request: IngestCommitRequest) -> dict:
         ``asyncio.gather`` and abort the batch. Tier-1 P1.C-lite (next
         PR) softens that to per-fact warn-and-continue.
         """
+        # P1.2: provenance precedence — caller-supplied request.url wins
+        # (dashboard back-compat), else use the fact's own source_uri
+        # (stamped by preview), else fall back to "text-input".
+        effective_source = request_url_override or fact.source_uri or "text-input"
         mem_data = MemoryCreate(
             tenant_id=request.tenant_id,
             fleet_id=request.fleet_id,
             agent_id=request.agent_id,
             memory_type=fact.suggested_type,
             content=fact.content,
-            source_uri=source_uri,
+            source_uri=effective_source,
             run_id=run_id,
             write_mode="strong",
             metadata={
                 "source": "ingest",
                 "ingest_run_id": run_id,
-                "ingest_url": request.url or None,
+                "ingest_url": request_url_override or fact.source_uri or None,
             },
         )
         async with sem:

--- a/tests/test_ingest_commit.py
+++ b/tests/test_ingest_commit.py
@@ -265,14 +265,131 @@ async def test_in_loop_409_still_counts_as_skipped(captured):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_url_provenance_passes_into_metadata(captured):
-    """If commit body carries url, source_uri + metadata.ingest_url use it.
-
-    (PR #3 will switch to per-fact source_uri; PR #2 keeps the request-level
-    field. This test pins current behavior so PR #3's change is intentional.)
-    """
+async def test_url_provenance_request_level_wins(captured):
+    """Caller-supplied request.url wins for back-compat with the dashboard."""
     req = _request("t1", "f1", url="https://example.com/doc.md")
     await ingest_service.ingest_commit(db=None, request=req)
 
     assert captured.writes[0].source_uri == "https://example.com/doc.md"
     assert captured.writes[0].metadata["ingest_url"] == "https://example.com/doc.md"
+
+
+# ---------------------------------------------------------------------------
+# PR #3 — P1.2 per-fact source_uri precedence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_per_fact_source_uri_used_when_no_request_url(captured):
+    """If the caller round-trips preview output without re-passing url, each
+    fact's own ``source_uri`` (stamped by preview) is honored."""
+    from core_api.schemas import IngestCommitRequest, IngestFact
+
+    req = IngestCommitRequest(
+        tenant_id="t1",
+        facts=[
+            IngestFact(
+                content="Fact A from URL",
+                suggested_type="fact",
+                source_uri="https://example.com/doc1",
+            ),
+            IngestFact(
+                content="Fact B from URL",
+                suggested_type="fact",
+                source_uri="https://example.com/doc1",
+            ),
+        ],
+    )
+    await ingest_service.ingest_commit(db=None, request=req)
+
+    for w in captured.writes:
+        assert w.source_uri == "https://example.com/doc1"
+        assert w.metadata["ingest_url"] == "https://example.com/doc1"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_request_url_overrides_fact_source_uri(captured):
+    """If both request.url and fact.source_uri are set, request.url wins
+    (dashboard back-compat — the form's url state is authoritative)."""
+    from core_api.schemas import IngestCommitRequest, IngestFact
+
+    req = IngestCommitRequest(
+        tenant_id="t1",
+        url="https://override.example/canonical",
+        facts=[
+            IngestFact(
+                content="Fact",
+                suggested_type="fact",
+                source_uri="https://stamped-by-preview/old",
+            ),
+        ],
+    )
+    await ingest_service.ingest_commit(db=None, request=req)
+
+    assert captured.writes[0].source_uri == "https://override.example/canonical"
+    assert (
+        captured.writes[0].metadata["ingest_url"]
+        == "https://override.example/canonical"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_text_input_fallback_when_neither_set(captured):
+    """Neither request.url nor fact.source_uri → 'text-input'."""
+    req = _request("t1", "plain content fact")  # _request doesn't set source_uri
+    await ingest_service.ingest_commit(db=None, request=req)
+
+    assert captured.writes[0].source_uri == "text-input"
+    assert captured.writes[0].metadata["ingest_url"] is None
+
+
+# ---------------------------------------------------------------------------
+# PR #3 — P1.E suggested_type validation at commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_invalid_suggested_type_raises_422_before_any_work(captured):
+    """A forged or garbage suggested_type → 422 with the offending value, BEFORE
+    we touch the dedup query or create_memory. Pre-PR #3 this leaked all the
+    way to MemoryCreate's enum validation and surfaced as a 500."""
+    from fastapi import HTTPException
+
+    from core_api.schemas import IngestCommitRequest, IngestFact
+
+    req = IngestCommitRequest(
+        tenant_id="t1",
+        facts=[
+            IngestFact(content="Real fact 1", suggested_type="fact"),
+            IngestFact(content="Garbage", suggested_type="🦀garbage"),
+            IngestFact(content="Real fact 2", suggested_type="decision"),
+        ],
+    )
+    with pytest.raises(HTTPException) as exc:
+        await ingest_service.ingest_commit(db=None, request=req)
+
+    assert exc.value.status_code == 422
+    assert "🦀garbage" in exc.value.detail
+    assert "[1]" in exc.value.detail  # index 1 is the bad one
+    # No writes happened
+    assert captured.writes == []
+    assert captured.bulk_find_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_valid_suggested_types_pass_through(captured):
+    """All known MEMORY_TYPES pass the gate."""
+    from core_api.constants import MEMORY_TYPES
+    from core_api.schemas import IngestCommitRequest, IngestFact
+
+    req = IngestCommitRequest(
+        tenant_id="t1",
+        facts=[IngestFact(content=f"Fact {t}", suggested_type=t) for t in MEMORY_TYPES],
+    )
+    result = await ingest_service.ingest_commit(db=None, request=req)
+    assert result["memories_created"] == len(MEMORY_TYPES)

--- a/tests/test_ingest_preview.py
+++ b/tests/test_ingest_preview.py
@@ -1,0 +1,286 @@
+"""Tests for ingest_preview validator + provenance changes in PR #3.
+
+Covers:
+- P1.2 ``source_uri`` stamping on every preview fact
+- P2.1 ``content_length`` reflects post-truncate; ``truncated`` + ``original_length`` flags
+- P2.3 Whitespace / too-short content short-circuit (no LLM)
+- P2.4 Meta-fact regex filter inside ``_chunk_content``
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from core_api.schemas import IngestRequest
+from core_api.services import ingest_service
+
+
+@pytest.fixture
+def fake_chunker(monkeypatch):
+    """Stand in for ``_chunk_content`` — record what was passed, return canned facts.
+
+    Returns a SimpleNamespace with:
+      - ``calls``: list[(text_arg, focus_arg)]
+      - ``return_facts``: list[dict] — what to return on next call (configurable)
+    """
+    state = SimpleNamespace(
+        calls=[],
+        return_facts=[{"content": "default test fact", "suggested_type": "fact"}],
+    )
+
+    async def _fake(text, focus=None, tenant_config=None):
+        state.calls.append((text, focus))
+        return list(state.return_facts)
+
+    monkeypatch.setattr(ingest_service, "_chunk_content", _fake)
+    return state
+
+
+@pytest.fixture
+def fake_tenant_config(monkeypatch):
+    """Stub resolve_config so preview doesn't need a real DB session."""
+
+    async def _fake(db, tenant_id):
+        return SimpleNamespace(
+            enrichment_provider="fake",
+            enrichment_enabled=False,
+            default_write_mode="fast",
+        )
+
+    monkeypatch.setattr(ingest_service, "resolve_config", _fake)
+
+
+# ---------------------------------------------------------------------------
+# P1.2 — source_uri stamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_source_uri_stamped_text_input(fake_chunker, fake_tenant_config):
+    """When the caller passes ``content`` (not url), every returned fact carries
+    ``source_uri='text-input'``."""
+    req = IngestRequest(
+        tenant_id="t1", content="A meaningful sentence about distributed systems."
+    )
+    fake_chunker.return_facts = [
+        {"content": "Fact A", "suggested_type": "fact"},
+        {"content": "Fact B", "suggested_type": "decision"},
+    ]
+    resp = await ingest_service.ingest_preview(db=None, request=req)
+
+    assert len(resp["facts"]) == 2
+    for f in resp["facts"]:
+        assert f["source_uri"] == "text-input"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_source_uri_stamped_url(fake_chunker, fake_tenant_config, monkeypatch):
+    """When the caller passes ``url``, every fact carries that URL as ``source_uri``."""
+
+    async def _stub_fetch(url):
+        return "Fetched body content with enough characters to clear the short-circuit."
+
+    monkeypatch.setattr(ingest_service, "_fetch_url_text", _stub_fetch)
+    req = IngestRequest(tenant_id="t1", url="https://example.com/article")
+    resp = await ingest_service.ingest_preview(db=None, request=req)
+
+    assert resp["facts"]
+    for f in resp["facts"]:
+        assert f["source_uri"] == "https://example.com/article"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_existing_source_uri_in_fact_not_overwritten(
+    fake_chunker, fake_tenant_config
+):
+    """``setdefault`` shouldn't clobber a source_uri the chunker explicitly set
+    (defensive — current chunker doesn't, but the contract should hold)."""
+    fake_chunker.return_facts = [
+        {
+            "content": "Fact with explicit provenance",
+            "suggested_type": "fact",
+            "source_uri": "custom://override",
+        }
+    ]
+    req = IngestRequest(tenant_id="t1", content="A meaningful sentence here.")
+    resp = await ingest_service.ingest_preview(db=None, request=req)
+
+    assert resp["facts"][0]["source_uri"] == "custom://override"
+
+
+# ---------------------------------------------------------------------------
+# P2.1 — content_length truth + truncated flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_content_length_under_cap_no_truncated_flag(
+    fake_chunker, fake_tenant_config
+):
+    """Input well under cap → content_length = len(input), no truncated flag."""
+    text = "A" * 5_000
+    req = IngestRequest(tenant_id="t1", content=text)
+    resp = await ingest_service.ingest_preview(db=None, request=req)
+
+    assert resp["content_length"] == 5_000
+    assert "truncated" not in resp
+    assert "original_length" not in resp
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_content_length_over_cap_truncated_with_original(
+    fake_chunker, fake_tenant_config
+):
+    """Input over cap → content_length = cap, truncated=True, original_length=full."""
+    full_text = "X" * 80_000
+    req = IngestRequest(tenant_id="t1", content=full_text)
+    resp = await ingest_service.ingest_preview(db=None, request=req)
+
+    assert resp["content_length"] == ingest_service._INGEST_MAX_CONTENT_CHARS  # 50_000
+    assert resp["truncated"] is True
+    assert resp["original_length"] == 80_000
+    # And the chunker only got the truncated content
+    text_passed, _ = fake_chunker.calls[-1]
+    assert len(text_passed) == ingest_service._INGEST_MAX_CONTENT_CHARS
+
+
+# ---------------------------------------------------------------------------
+# P2.3 — short-circuit on whitespace / too-short content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content",
+    ["", "    ", "  \n\n\t  ", "hi", "ok", "x" * 19],
+)
+async def test_short_circuit_skips_llm(fake_chunker, fake_tenant_config, content):
+    """Whitespace-only or sub-MIN content returns immediately with skipped_reason."""
+    # Need to bypass IngestRequest's own validation by giving SOMETHING non-None.
+    # Empty string is allowed by Pydantic; shorter inputs hit the short-circuit.
+    if not content:
+        # empty string → IngestPreview's own 400 path, not the short-circuit
+        return
+    req = IngestRequest(tenant_id="t1", content=content)
+    resp = await ingest_service.ingest_preview(db=None, request=req)
+
+    assert resp["facts"] == []
+    assert resp["chunk_ms"] == 0
+    assert resp["skipped_reason"] == "content_too_short"
+    # The LLM (fake_chunker) was NEVER called
+    assert fake_chunker.calls == [], (
+        f"_chunk_content was called for short-circuited input {content!r}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_short_circuit_threshold_boundary(fake_chunker, fake_tenant_config):
+    """Exactly MIN chars → goes to LLM (boundary is < not <=)."""
+    content = "x" * ingest_service._INGEST_MIN_CONTENT_CHARS  # exactly 20
+    req = IngestRequest(tenant_id="t1", content=content)
+    resp = await ingest_service.ingest_preview(db=None, request=req)
+
+    assert "skipped_reason" not in resp
+    assert fake_chunker.calls, "Expected _chunk_content to be called at threshold"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_short_circuit_returns_truncated_flag_too(
+    fake_chunker, fake_tenant_config
+):
+    """A pathological caller could submit truncatable + tiny-after-strip input.
+    The skipped_reason response still surfaces the truncated/original_length flags."""
+    # ~60k chars of all whitespace — meaningful pre-strip but useless to LLM
+    content = " " * 60_000
+    req = IngestRequest(tenant_id="t1", content=content)
+    resp = await ingest_service.ingest_preview(db=None, request=req)
+
+    assert resp["skipped_reason"] == "content_too_short"
+    assert resp["truncated"] is True
+    assert resp["original_length"] == 60_000
+
+
+# ---------------------------------------------------------------------------
+# P2.4 — meta-fact filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_meta_fact_regex_drops_self_referential():
+    """The regex matches obvious meta-fact patterns. Tested directly because
+    _chunk_content's behavior is easier to verify on the raw filter."""
+    drop_these = [
+        "The provided content consists of the word 'hi'.",
+        "The content begins with the greeting 'hi'.",
+        "The content starts with the PDF header '%PDF-1.4'.",
+        "The user text is short.",
+        "This text is about climate change.",
+        "This content describes a meeting.",
+        "  The provided text says nothing.",  # leading whitespace ok
+        "the input content is malformed",  # case insensitive
+    ]
+    for body in drop_these:
+        assert ingest_service._META_FACT_RE.search(body), f"Should match: {body!r}"
+
+    keep_these = [
+        "The user can paste any text into the box.",  # 'the user' but not meta
+        "The book costs €30.",
+        "Sarah will write the migration script.",
+        "The Eiffel Tower stands 330 meters tall.",
+        # NB: "The content of the agreement was disputed in court." would be
+        # ambiguous; with our current regex, "the content of" doesn't match
+        # because it's not followed by begins/starts/consists/is. Verify.
+        "The content of the agreement was disputed in court.",
+    ]
+    for body in keep_these:
+        assert not ingest_service._META_FACT_RE.search(body), (
+            f"Should NOT match: {body!r}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_chunk_content_filters_meta_facts(monkeypatch):
+    """End-to-end: _chunk_content drops meta-fact items but keeps real ones."""
+
+    async def fake_with_fallback(*, primary_provider_name, call_fn, fake_fn, **kw):
+        # Return a mix of meta-facts and real facts
+        return {
+            "facts": [
+                {
+                    "content": "The Eiffel Tower stands 330 meters tall.",
+                    "suggested_type": "fact",
+                },
+                {
+                    "content": "The provided content consists of two paragraphs.",
+                    "suggested_type": "fact",
+                },
+                {"content": "Iron melts at 1538 Celsius.", "suggested_type": "fact"},
+                {
+                    "content": "This document describes a project plan.",
+                    "suggested_type": "fact",
+                },
+            ]
+        }
+
+    monkeypatch.setattr(ingest_service, "call_with_fallback", fake_with_fallback)
+    tenant_config = SimpleNamespace(enrichment_provider="fake")
+    facts = await ingest_service._chunk_content("dummy", tenant_config=tenant_config)
+
+    contents = [f["content"] for f in facts]
+    assert "The Eiffel Tower stands 330 meters tall." in contents
+    assert "Iron melts at 1538 Celsius." in contents
+    # Meta-facts dropped
+    assert all("The provided content" not in c for c in contents)
+    assert all("This document describes" not in c for c in contents)
+    assert len(facts) == 2


### PR DESCRIPTION
## Summary

Five small but tightly-coupled fixes to ingest correctness — preview/commit validators + per-fact URL provenance. Part of the Tier-1 ingest sprint (follows #115 and #117).

## Related Issue

N/A — internal Tier-1 plan tracker.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## What's in this PR

**P1.2 — URL provenance round-trips through preview → commit**
`IngestFact` gains `source_uri: str | None`. `ingest_preview` stamps every returned fact with the URL (or `"text-input"`). `ingest_commit` reads `fact.source_uri` per fact. Caller-supplied `request.url` still wins (dashboard back-compat). Fixes the bug where a non-dashboard caller round-tripping the preview payload would lose the URL — every memory persisted as `source_uri="text-input"`.

**P2.1 — `content_length` reflects what the LLM actually saw**
Truncation moved from inside `_chunk_content` (a local var) to `ingest_preview`. Response now has `content_length` (post-truncate), `truncated: bool`, and `original_length` (only when truncated). Pre-PR: 64500-char input got `content_length=64500`, but the LLM only saw 50000.

**P2.3 — Short-circuit before LLM on whitespace / too-short content**
If `len(content.strip()) < 20`, return immediately with `facts=[]`, `chunk_ms=0`, `skipped_reason="content_too_short"`. Pre-PR: `{"content": "hi"}` → 1.4s LLM call returning a hallucinated meta-fact.

**P2.4 — Meta-fact regex filter in `_chunk_content`**
Post-LLM, drop facts whose content describes the input itself ("The provided content...", "This document describes...", "The content begins with..."). Defense-in-depth with a new prompt line.

**P1.E — Validate `suggested_type ∈ MEMORY_TYPES` at commit time**
Closes the asymmetry where preview validated and commit didn't. A forged/malformed `suggested_type` previously leaked to `MemoryCreate` and surfaced as a 500 after 8s. Now: clean 422 in 10ms with the offending indices + values listed.

## How Has This Been Tested?

**Unit tests (57 total, 20 new in this PR):**
- `tests/test_ingest_preview.py` (NEW, 14 tests) — covers P1.2 stamping, P2.1 truncation/flags, P2.3 short-circuit + boundary, P2.4 meta-fact regex (drop list and keep list)
- `tests/test_ingest_commit.py` (+6 tests) — covers P1.2 per-fact precedence (3 scenarios) and P1.E validation (invalid + all-valid types)

Run locally:
~~~
pytest tests/test_ingest_service.py tests/test_ingest_preview.py tests/test_ingest_commit.py -q
# → 57 passed in ~0.8s
~~~

**Wet tests on the live local stack** (PR #1 + #2 + this PR):
| Scenario | Before | After |
|---|---|---|
| 85k content | `content_length: 85000` (lies) | `content_length: 50000, truncated: True, original_length: 85000` |
| `"hi"` | 1.4s LLM → meta-fact persisted | 10ms, no LLM, `skipped_reason="content_too_short"` |
| Whitespace | 672ms LLM, 0 facts | 0ms, no LLM, `skipped_reason="content_too_short"` |
| URL preview → all 21 facts | no `source_uri` | every fact has `source_uri=<URL>` |
| Forged `suggested_type` | 500 in 8s | 422 in 10ms with allowed-types listed |
| URL preview → commit (no re-pass) | memories show `source_uri="text-input"` | all 21 memories show `source_uri=<URL>` |

## Checklist

- [x] I have read CONTRIBUTING.md (DCO etc.)
- [x] Added tests covering all 5 changes
- [x] \`ruff check\` and \`ruff format --check\` pass
- [x] \`mypy\` passes on changed files (one pre-existing error on a different line was not introduced by this PR)
- [x] \`pytest\` passes locally
- [ ] Documentation update — N/A, internal behavior only
- [ ] CHANGELOG — let release-please handle from the commit subject

## Additional Notes

- Backward compatible: dashboard's `body.url` path still wins over fact-level source_uri.
- Builds on #115 (URL fetch hardening) and #117 (strong-mode + dedup). Branched off latest \`main\` after #117 merged; no conflict expected.
- New optional response fields: \`truncated\`, \`original_length\`, \`skipped_reason\`. Existing fields unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)