### PR TITLE
fix(ingest): warn-and-continue on per-fact commit failure (P1.C-lite)

### DIFF
--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -474,14 +474,30 @@ async def ingest_commit(db: AsyncSession, request: IngestCommitRequest) -> dict:
         )
 
     # ----- P1.3: parallel strong-mode writes -----
+    # ----- P1.C-lite: warn-and-continue on per-fact failure -----
+    # Outcomes returned by ``_write_one`` and aggregated after gather.
+    # Encoded as ints because gather's collection ordering doesn't matter
+    # here — we only need totals.
+    _OUTCOME_CREATED = 1
+    _OUTCOME_DUPLICATE = 0
+    _OUTCOME_ERRORED = -1
+
     sem = asyncio.Semaphore(_COMMIT_CONCURRENCY)
 
-    async def _write_one(fact) -> int:
-        """Return 1 on create, 0 on 409, raise on other failures.
+    async def _write_one(idx: int, fact) -> int:
+        """Always returns; never raises.
 
-        Errors from ``create_memory`` that aren't 409 propagate out of
-        ``asyncio.gather`` and abort the batch. Tier-1 P1.C-lite (next
-        PR) softens that to per-fact warn-and-continue.
+        Returns one of: ``_OUTCOME_CREATED`` (created+1),
+        ``_OUTCOME_DUPLICATE`` (409 from create_memory, skipped+1),
+        ``_OUTCOME_ERRORED`` (any other failure — logged with run_id +
+        fact index for manual cleanup, errored+1).
+
+        P1.C-lite: pre-PR, any non-409 exception escaped out of gather
+        and aborted the whole batch, leaving 0..N-1 memories already
+        persisted under the run_id with no per-fact telemetry. Now each
+        fact's outcome is captured independently; the run_id stamps
+        whatever did land so it can be cleaned up via bulk-delete or
+        the upcoming POST /ingest/undo/{run_id} (PR #6).
         """
         # P1.2: provenance precedence — caller-supplied request.url wins
         # (dashboard back-compat), else use the fact's own source_uri
@@ -505,24 +521,50 @@ async def ingest_commit(db: AsyncSession, request: IngestCommitRequest) -> dict:
         async with sem:
             try:
                 await create_memory(db, mem_data)
-                return 1
+                return _OUTCOME_CREATED
             except HTTPException as e:
                 if e.status_code == 409:
-                    return 0
-                raise
+                    return _OUTCOME_DUPLICATE
+                logger.exception(
+                    "ingest_commit: fact[%d] write failed with HTTP %d "
+                    "(run_id=%s) — tagged for manual cleanup",
+                    idx,
+                    e.status_code,
+                    run_id,
+                )
+                return _OUTCOME_ERRORED
+            except Exception:
+                logger.exception(
+                    "ingest_commit: fact[%d] write raised (run_id=%s) — tagged for manual cleanup",
+                    idx,
+                    run_id,
+                )
+                return _OUTCOME_ERRORED
 
-    results = await asyncio.gather(*(_write_one(f) for f in survivors))
-    created = sum(results)
-    skipped_in_loop = len(survivors) - created
+    results = await asyncio.gather(*(_write_one(i, f) for i, f in enumerate(survivors)))
+    created = sum(1 for r in results if r == _OUTCOME_CREATED)
+    skipped_in_loop = sum(1 for r in results if r == _OUTCOME_DUPLICATE)
+    errored = sum(1 for r in results if r == _OUTCOME_ERRORED)
     skipped = pre_dedup_skipped + skipped_in_loop
     ingest_ms = int((time.perf_counter() - t0) * 1000)
 
+    if errored:
+        logger.warning(
+            "ingest_commit: run_id=%s had %d errored fact(s) — "
+            "find them in the logs above, or DELETE FROM memories WHERE "
+            "ingest_run_id='%s' to wipe partial batch",
+            run_id,
+            errored,
+            run_id,
+        )
+
     logger.info(
-        "ingest_commit: run_id=%s facts=%d created=%d skipped=%d (pre_dedup=%d, 409=%d) in %dms",
+        "ingest_commit: run_id=%s facts=%d created=%d skipped=%d errored=%d (pre_dedup=%d, 409=%d) in %dms",
         run_id,
         len(facts),
         created,
         skipped,
+        errored,
         pre_dedup_skipped,
         skipped_in_loop,
         ingest_ms,
@@ -533,6 +575,7 @@ async def ingest_commit(db: AsyncSession, request: IngestCommitRequest) -> dict:
         "facts_extracted": len(facts),
         "memories_created": created,
         "skipped_duplicates": skipped,
+        "errored": errored,
         "run_id": run_id,
         "ingest_ms": ingest_ms,
     }

--- a/tests/test_ingest_commit.py
+++ b/tests/test_ingest_commit.py
@@ -49,6 +49,11 @@ def captured(monkeypatch):
         bulk_find_result={},
         write_delay_ms=0,
         write_409_for=set(),
+        # P1.C-lite (PR #4): map of content_hash → exception_to_raise. Lets a
+        # test simulate non-409 failures on specific facts. Use HTTPException
+        # for HTTP-coded errors, or any other Exception subclass for generic
+        # runtime errors.
+        write_raise_for={},
     )
 
     async def fake_resolve_config(db, tenant_id):
@@ -72,12 +77,15 @@ def captured(monkeypatch):
         state.writes.append(data)
         if state.write_delay_ms:
             await asyncio.sleep(state.write_delay_ms / 1000.0)
-        # Simulate 409 from inside create_memory when configured
         from fastapi import HTTPException
 
         from core_api.services.memory_service import _content_hash as ch_fn
 
         h = ch_fn(data.tenant_id, data.fleet_id, data.content)
+        # Configured generic / non-409 error → raise it (P1.C-lite test path)
+        if h in state.write_raise_for:
+            raise state.write_raise_for[h]
+        # Simulate 409 from inside create_memory when configured
         if h in state.write_409_for:
             raise HTTPException(status_code=409, detail="duplicate")
         return SimpleNamespace(id="00000000-0000-0000-0000-000000000000")
@@ -393,3 +401,129 @@ async def test_valid_suggested_types_pass_through(captured):
     )
     result = await ingest_service.ingest_commit(db=None, request=req)
     assert result["memories_created"] == len(MEMORY_TYPES)
+
+
+# ---------------------------------------------------------------------------
+# PR #4 — P1.C-lite warn-and-continue on commit failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_non_409_http_error_increments_errored_not_raises(captured, caplog):
+    """A 5xx (or any non-409 HTTPException) on one fact is captured, logged
+    with run_id + fact index, and the response carries an ``errored`` count.
+    Pre-PR: this would raise out of gather and abort the entire batch."""
+    import logging
+
+    from fastapi import HTTPException
+
+    from core_api.services.memory_service import _content_hash
+
+    facts = ["good fact A", "BAD will 502", "good fact B"]
+    captured.write_raise_for = {
+        _content_hash("t1", None, facts[1]): HTTPException(
+            status_code=502, detail="upstream barfed"
+        ),
+    }
+
+    req = _request("t1", *facts)
+    with caplog.at_level(logging.WARNING, logger="core_api.services.ingest_service"):
+        result = await ingest_service.ingest_commit(db=None, request=req)
+
+    # The good facts went through; the bad one didn't blow up the batch
+    assert result["memories_created"] == 2
+    assert result["skipped_duplicates"] == 0
+    assert result["errored"] == 1
+    # Log mentions the run_id + the fact index (P1.C-lite runbook hook)
+    assert result["run_id"] in caplog.text
+    assert "fact[1]" in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_generic_exception_logs_and_increments_errored(captured, caplog):
+    """RuntimeError (or any non-HTTPException) on one fact is captured too,
+    not just HTTPException-shaped failures."""
+    import logging
+
+    from core_api.services.memory_service import _content_hash
+
+    facts = ["good", "boom", "also good"]
+    captured.write_raise_for = {
+        _content_hash("t1", None, "boom"): RuntimeError("storage_client TCP reset"),
+    }
+
+    req = _request("t1", *facts)
+    with caplog.at_level(logging.WARNING, logger="core_api.services.ingest_service"):
+        result = await ingest_service.ingest_commit(db=None, request=req)
+
+    assert result["memories_created"] == 2
+    assert result["errored"] == 1
+    assert "fact[1]" in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mixed_outcomes_all_three_counted_correctly(captured):
+    """5 facts: 2 created, 1 dup (409), 1 errored, 1 pre-dedup-filtered."""
+    from fastapi import HTTPException
+
+    from core_api.services.memory_service import _content_hash
+
+    facts = ["fact-a", "fact-b", "fact-c", "fact-d", "fact-e"]
+    # fact-a hits pre-loop dedup (already in storage)
+    captured.bulk_find_result = {_content_hash("t1", None, "fact-a")}
+    # fact-b 409s inside create_memory (race with concurrent writer)
+    captured.write_409_for = {_content_hash("t1", None, "fact-b")}
+    # fact-c errors with a 5xx
+    captured.write_raise_for = {
+        _content_hash("t1", None, "fact-c"): HTTPException(
+            status_code=503, detail="db down"
+        ),
+    }
+    # fact-d, fact-e succeed
+
+    req = _request("t1", *facts)
+    result = await ingest_service.ingest_commit(db=None, request=req)
+
+    assert result["facts_extracted"] == 5
+    assert result["memories_created"] == 2  # d, e
+    assert result["skipped_duplicates"] == 2  # a (pre-dedup), b (in-loop 409)
+    assert result["errored"] == 1  # c
+    # Total accounting: created + skipped + errored = facts_extracted
+    assert (
+        result["memories_created"] + result["skipped_duplicates"] + result["errored"]
+        == result["facts_extracted"]
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_all_facts_error_does_not_raise(captured):
+    """When every single write fails, the batch still returns — empty
+    errored=N is the contract, not raise."""
+    from core_api.services.memory_service import _content_hash
+
+    facts = ["f1", "f2", "f3"]
+    captured.write_raise_for = {
+        _content_hash("t1", None, c): RuntimeError(f"fail {c}") for c in facts
+    }
+
+    req = _request("t1", *facts)
+    result = await ingest_service.ingest_commit(db=None, request=req)
+
+    assert result["memories_created"] == 0
+    assert result["skipped_duplicates"] == 0
+    assert result["errored"] == 3
+    # Importantly, the response was generated — the function didn't raise
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_response_always_carries_errored_field(captured):
+    """``errored`` is a stable response field even when zero."""
+    req = _request("t1", "f1")
+    result = await ingest_service.ingest_commit(db=None, request=req)
+    assert "errored" in result
+    assert result["errored"] == 0


### PR DESCRIPTION
## Summary

When ``ingest_commit`` is writing N facts in parallel and **one** fails with anything other than a 409, the whole batch used to blow up — the request returned 500, but 0..N-1 facts had already been persisted under the run_id with no per-fact telemetry. Now each fact fails independently, gets logged with run_id + fact index, and the response gains a stable ``errored`` counter. Part of the Tier-1 ingest sprint (follows #115, #117, #120).

## Related Issue

N/A — internal Tier-1 plan tracker.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## The change

**Response contract** (adds one field, breaks nothing):

\`\`\`jsonc
{
  "memories_created": 5,
  "skipped_duplicates": 2,
  "errored": 1,         // ← new, always present
  "run_id": "..."
}
\`\`\`

**Per-fact behavior**:
- 409 from \`create_memory\` → ``skipped_duplicates`` (unchanged)
- Any other HTTPException → logged with run_id + fact index, ``errored`` += 1, batch continues
- Any non-HTTP Exception → same as above
- Pre-PR: any non-409 escaped out of \`asyncio.gather\` and aborted the entire batch → 500 response, partial writes orphaned in DB

**Log lines**:
- INFO summary now includes \`errored=N\`
- WARNING when \`errored > 0\`: \`"run_id=X had E errored fact(s) — find them in the logs above, or DELETE FROM memories WHERE ingest_run_id='X' to wipe partial batch"\`

## What it's NOT

Not full transactional rollback. If 3 of 10 facts fail, the 7 that succeeded stay in the DB tagged with \`ingest_run_id\`. Runbook is \"DELETE by run_id\". Full transactional commit is a Tier-3 follow-up — defer until partial-write incidents become a support load.

## How Has This Been Tested?

**Unit tests (5 new, 62 total in 0.7s):**
- \`test_non_409_http_error_increments_errored_not_raises\` — HTTPException 502 on one fact → 2 created, 1 errored, batch did not raise
- \`test_generic_exception_logs_and_increments_errored\` — RuntimeError on one fact → same outcome
- \`test_mixed_outcomes_all_three_counted_correctly\` — 5 facts spanning pre-dedup, 409, error, and success; accounting checks all 4 totals match
- \`test_all_facts_error_does_not_raise\` — 3-of-3 errors still returns a response
- \`test_response_always_carries_errored_field\` — \`errored\` is a stable response key, present even when zero

**Wet test on live local stack:**
- Happy path: 1 fact in 9.7s, response has \`\"errored\": 0\` ✓
- 409 path: re-commit same fact → \`created=0 skipped=1 errored=0\` ✓
- Log line format includes \`errored=N (pre_dedup=N, 409=N)\` ✓

## Checklist

- [x] DCO sign-off applied
- [x] Tests added covering all 4 outcome paths
- [x] \`ruff check\` and \`ruff format --check\` pass
- [x] \`mypy\` passes on changed files
- [x] \`pytest tests/test_ingest_*\` passes locally (62 passed)
- [ ] Documentation — N/A, internal behavior
- [ ] CHANGELOG — release-please picks it up from the commit subject

## Additional Notes

- Backward compatible. Existing callers ignore the new \`errored\` field.
- No DB migration, no new deps.
- Builds on #117 (parallel commit loop) and #120 (validators). Branched off latest \`main\` after both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)