### PR TITLE
feat(ingest): salience score + tightened extraction prompt (A1 + A5)

### DIFF
--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -67,6 +67,18 @@ _INGEST_MAX_CONTENT_CHARS = 50_000
 # 'hi'"). We short-circuit instead and return ``skipped_reason``.
 _INGEST_MIN_CONTENT_CHARS = 20
 
+# A1: drop extracted facts whose LLM-emitted salience falls below this floor.
+# Lower-numbered = essential standalone fact, higher number toward 1.0. The
+# 0.5 threshold is empirically anchored — adjustable via tenant config in a
+# follow-up if needed.
+_SALIENCE_FLOOR = 0.5
+
+# Minimum word count for a kept fact. A5 forbids the LLM from emitting these
+# in the first place, but real-world prompts still produce short fragments;
+# the validator drops them. "≥ 5 words" is the boundary — anything shorter
+# is almost always a heading, label, or one-word fragment.
+_MIN_FACT_WORDS = 5
+
 # Drop facts that describe the input itself rather than extracting from it.
 # These show up when the LLM has nothing real to chunk — typical on short
 # inputs that slipped past ``_INGEST_MIN_CONTENT_CHARS``. Belt-and-braces
@@ -82,22 +94,77 @@ _META_FACT_RE = re.compile(
 )
 
 CHUNKING_PROMPT = """\
-Extract discrete, atomic facts from the following content.
-Each fact should be a single claim that can stand alone as a memory.
+Extract discrete, atomic facts from the following content for storage in an
+agent's long-term memory. Each fact must stand on its own when retrieved
+later without the surrounding document.
 
-Guidelines:
-- Extract 5-20 facts depending on content length
-- Be specific: include names, numbers, dates, decisions
-- Each fact: one claim, not a paragraph
-- Suggest a memory_type for each: fact, decision, preference, task, plan, episode, semantic, intention, commitment, action, outcome, cancellation
-- Do NOT produce meta-facts that describe the input itself. Avoid claims like "The content begins with...", "The provided text says...", "This document is about...". Extract facts FROM the content, not facts ABOUT the content.
+## Rules
+
+1. **Self-contained.** Every fact must be understandable without the original
+   document. Resolve pronouns, references, and "the" + ambiguous noun against
+   the document. "He shipped it" is bad; "Bob shipped v2.3 of the SDK on
+   March 15" is good.
+
+2. **Atomic.** One claim per fact. A sentence containing "X happened and Y
+   was decided" becomes two facts unless one of them is trivial.
+
+3. **No duplicates or near-duplicates.** If the document repeats a claim,
+   emit it once. If two paragraphs say the same thing in different words,
+   emit it once. Better to under-extract than to clone.
+
+4. **Substantive only.** At least 5 words per fact. No UI labels ("Learn
+   more", "Subscribe"), no headings ("Section 3"), no boilerplate ("All
+   rights reserved"), no questions, no TODOs without an answer.
+
+5. **No meta-facts.** Do not describe the input itself. Avoid claims like
+   "The content begins with...", "The provided text says...", "This
+   document is about...". Extract facts FROM the content, not facts ABOUT
+   the content.
+
+6. **Salience score** (0.0 to 1.0). Rate how essential each fact is for
+   later recall. Use this scale:
+     - 1.0 = critical, would be sorely missed if absent
+     - 0.7 = useful specifics: names, numbers, dates, decisions, outcomes
+     - 0.5 = relevant but not load-bearing
+     - 0.3 = arguably extractable but mostly noise
+     - 0.0 = filler / restatement
+   Be honest. Anything below 0.5 will be dropped automatically.
+
+7. **memory_type.** Pick the most specific tag. When in doubt prefer the
+   left option in each pair:
+     - fact         — a stable proposition about the world ("Iron melts at 1538°C")
+     - decision     — a chosen course of action by an identified actor
+     - task         — work item assigned but not yet finished
+     - plan         — intended future action stated as plan
+     - outcome      — past event/result; if you'd write "X happened" or "Y
+                      was completed", use this (not "fact")
+     - preference   — a stated like/dislike
+     - intention    — what someone aims to do
+     - commitment   — explicit promise
+     - action       — something done (granular than outcome)
+     - episode      — narrative event tied to a specific moment
+     - semantic     — definitional/conceptual relationship
+     - cancellation — explicit revocation of a prior plan/commitment
+
+## Quantity guidance
+
+Extract 5-20 facts depending on content length. Err toward fewer, higher-
+salience facts over many low-salience ones.
+
 {focus_instruction}
 
-Content:
+## Content
+
 {content}
 
-Return ONLY valid JSON object with a "facts" key containing an array:
-{{"facts": [{{"content": "...", "suggested_type": "fact"}}, ...]}}
+## Output
+
+Return ONLY a valid JSON object with a "facts" key. Each item:
+
+{{"facts": [
+  {{"content": "...", "suggested_type": "fact", "salience": 0.9}},
+  ...
+]}}
 """
 
 
@@ -149,23 +216,58 @@ async def _chunk_content(
                 raw = v
                 break
     dropped_meta = 0
+    dropped_low_salience = 0
+    dropped_short = 0
     for item in raw:
         if not isinstance(item, dict) or not item.get("content"):
             continue
         body = str(item["content"]).strip()
+
+        # P2.4: drop facts that describe the input rather than extract
+        # from it. Prompt forbids them but the LLM still produces them
+        # occasionally — especially on short/trivial input.
         if _META_FACT_RE.search(body):
-            # P2.4: drop facts that describe the input rather than extract
-            # from it. Prompt forbids them but the LLM still produces them
-            # occasionally — especially on short/trivial input.
             dropped_meta += 1
             continue
+
+        # A5: drop sub-5-word fragments. Prompt forbids them but the LLM
+        # still emits short headings/labels on noisy inputs.
+        if len(body.split()) < _MIN_FACT_WORDS:
+            dropped_short += 1
+            continue
+
+        # A1: drop low-salience facts. The LLM emits a per-fact 0-1
+        # salience score (see CHUNKING_PROMPT); anything below the floor
+        # is dropped without ever reaching the write pipeline.
+        salience_raw = item.get("salience")
+        try:
+            salience = float(salience_raw) if salience_raw is not None else None
+        except (TypeError, ValueError):
+            salience = None
+        if salience is not None and salience < _SALIENCE_FLOOR:
+            dropped_low_salience += 1
+            continue
+
         st = item.get("suggested_type", "fact")
         if st not in MEMORY_TYPES:
             st = "fact"
-        facts.append({"content": body, "suggested_type": st})
 
-    if dropped_meta:
-        logger.info("ingest: dropped %d meta-fact(s) from extraction output", dropped_meta)
+        fact_out: dict = {"content": body, "suggested_type": st}
+        # Surface salience on the returned fact when present, so the
+        # caller (preview UI / agent) can sort / threshold / display it.
+        # Existing callers ignore the new field — backward compatible.
+        if salience is not None:
+            fact_out["salience"] = salience
+        facts.append(fact_out)
+
+    if dropped_meta or dropped_low_salience or dropped_short:
+        logger.info(
+            "ingest: filtered %d fact(s) from extraction output (meta=%d, low_salience=%d, short=%d)",
+            dropped_meta + dropped_low_salience + dropped_short,
+            dropped_meta,
+            dropped_low_salience,
+            dropped_short,
+        )
 
     return facts
 

--- a/tests/test_ingest_preview.py
+++ b/tests/test_ingest_preview.py
@@ -284,3 +284,229 @@ async def test_chunk_content_filters_meta_facts(monkeypatch):
     assert all("The provided content" not in c for c in contents)
     assert all("This document describes" not in c for c in contents)
     assert len(facts) == 2
+
+
+# ---------------------------------------------------------------------------
+# PR #5 — A1 salience floor + A5 short-fact + prompt tightening
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_salience_floor_drops_low_score_facts(monkeypatch):
+    """Facts with salience below 0.5 are filtered out by the validator (A1)."""
+
+    async def fake(*, primary_provider_name, call_fn, fake_fn, **kw):
+        return {
+            "facts": [
+                {
+                    "content": "The Eiffel Tower stands 330 meters tall.",
+                    "suggested_type": "fact",
+                    "salience": 0.9,
+                },
+                {
+                    "content": "Some boilerplate phrasing appears in the document.",
+                    "suggested_type": "fact",
+                    "salience": 0.2,  # below floor
+                },
+                {
+                    "content": "Mercury orbits the Sun every 88 days.",
+                    "suggested_type": "fact",
+                    "salience": 0.7,
+                },
+                {
+                    "content": "A trivial restatement of earlier material happens.",
+                    "suggested_type": "fact",
+                    "salience": 0.3,  # below floor
+                },
+            ]
+        }
+
+    monkeypatch.setattr(ingest_service, "call_with_fallback", fake)
+    tc = SimpleNamespace(enrichment_provider="fake")
+    facts = await ingest_service._chunk_content("dummy", tenant_config=tc)
+
+    assert len(facts) == 2
+    assert all(f["salience"] >= ingest_service._SALIENCE_FLOOR for f in facts)
+    contents = {f["content"] for f in facts}
+    assert "The Eiffel Tower stands 330 meters tall." in contents
+    assert "Mercury orbits the Sun every 88 days." in contents
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_salience_exactly_at_floor_is_kept(monkeypatch):
+    """The threshold is strict less-than — 0.5 exactly survives."""
+
+    async def fake(*, primary_provider_name, call_fn, fake_fn, **kw):
+        return {
+            "facts": [
+                {
+                    "content": "A fact sitting exactly at the salience floor.",
+                    "suggested_type": "fact",
+                    "salience": 0.5,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(ingest_service, "call_with_fallback", fake)
+    tc = SimpleNamespace(enrichment_provider="fake")
+    facts = await ingest_service._chunk_content("dummy", tenant_config=tc)
+    assert len(facts) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_missing_salience_does_not_drop_fact_backward_compat(monkeypatch):
+    """If the LLM (or an old prompt) omits salience, the fact passes through.
+    Important during the prompt rollout window — don't accidentally drop
+    everything because the model didn't include the new field yet."""
+
+    async def fake(*, primary_provider_name, call_fn, fake_fn, **kw):
+        return {
+            "facts": [
+                {
+                    "content": "A solid fact without salience scoring.",
+                    "suggested_type": "fact",
+                },
+            ]
+        }
+
+    monkeypatch.setattr(ingest_service, "call_with_fallback", fake)
+    tc = SimpleNamespace(enrichment_provider="fake")
+    facts = await ingest_service._chunk_content("dummy", tenant_config=tc)
+    assert len(facts) == 1
+    assert "salience" not in facts[0]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_malformed_salience_does_not_drop_fact(monkeypatch):
+    """LLM occasionally emits garbage in the salience field (string, null).
+    Parser fails gracefully and falls back to 'no salience filter applied'."""
+
+    async def fake(*, primary_provider_name, call_fn, fake_fn, **kw):
+        return {
+            "facts": [
+                {
+                    "content": "This fact carries a non-numeric salience field.",
+                    "suggested_type": "fact",
+                    "salience": "high",
+                },
+                {
+                    "content": "This fact carries an explicit null salience value.",
+                    "suggested_type": "fact",
+                    "salience": None,
+                },
+            ]
+        }
+
+    monkeypatch.setattr(ingest_service, "call_with_fallback", fake)
+    tc = SimpleNamespace(enrichment_provider="fake")
+    facts = await ingest_service._chunk_content("dummy", tenant_config=tc)
+    assert len(facts) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_short_fact_filter_drops_sub_5_words(monkeypatch):
+    """A5: facts with fewer than 5 words are dropped — likely headings/labels."""
+
+    async def fake(*, primary_provider_name, call_fn, fake_fn, **kw):
+        return {
+            "facts": [
+                {"content": "Learn more", "suggested_type": "fact", "salience": 0.9},
+                {"content": "Section 3", "suggested_type": "fact", "salience": 0.9},
+                {
+                    "content": "Iron melts at 1538 Celsius.",
+                    "suggested_type": "fact",
+                    "salience": 0.9,
+                },
+                {"content": "Yes", "suggested_type": "fact", "salience": 0.9},
+                {
+                    "content": "The user can pay via credit card or wire transfer.",
+                    "suggested_type": "fact",
+                    "salience": 0.9,
+                },
+            ]
+        }
+
+    monkeypatch.setattr(ingest_service, "call_with_fallback", fake)
+    tc = SimpleNamespace(enrichment_provider="fake")
+    facts = await ingest_service._chunk_content("dummy", tenant_config=tc)
+
+    contents = {f["content"] for f in facts}
+    assert "Iron melts at 1538 Celsius." in contents
+    assert "The user can pay via credit card or wire transfer." in contents
+    assert "Learn more" not in contents
+    assert "Section 3" not in contents
+    assert "Yes" not in contents
+    assert len(facts) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_all_three_filters_compose(monkeypatch, caplog):
+    """Meta-fact + short + low-salience filters all apply to one batch.
+    Confirms the validator counts each drop reason separately in the log."""
+    import logging
+
+    async def fake(*, primary_provider_name, call_fn, fake_fn, **kw):
+        return {
+            "facts": [
+                {
+                    "content": "Mercury orbits the Sun every 88 days.",
+                    "suggested_type": "fact",
+                    "salience": 0.9,
+                },
+                {
+                    "content": "The provided content consists of trivia.",
+                    "suggested_type": "fact",
+                    "salience": 0.9,
+                },
+                {"content": "Mars red", "suggested_type": "fact", "salience": 0.9},
+                {
+                    "content": "Some boilerplate phrasing appears here.",
+                    "suggested_type": "fact",
+                    "salience": 0.2,
+                },
+                {
+                    "content": "Venus has the longest day in the solar system.",
+                    "suggested_type": "fact",
+                    "salience": 0.85,
+                },
+            ]
+        }
+
+    monkeypatch.setattr(ingest_service, "call_with_fallback", fake)
+    tc = SimpleNamespace(enrichment_provider="fake")
+    with caplog.at_level(logging.INFO, logger="core_api.services.ingest_service"):
+        facts = await ingest_service._chunk_content("dummy", tenant_config=tc)
+
+    assert len(facts) == 2
+    assert "meta=1" in caplog.text
+    assert "low_salience=1" in caplog.text
+    assert "short=1" in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_salience_field_surfaces_on_returned_facts(monkeypatch):
+    """Kept facts retain their salience score on the output. Callers
+    (preview UI, agents) can sort/display/threshold further."""
+
+    async def fake(*, primary_provider_name, call_fn, fake_fn, **kw):
+        return {
+            "facts": [
+                {
+                    "content": "Iron melts at 1538 Celsius.",
+                    "suggested_type": "fact",
+                    "salience": 0.85,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(ingest_service, "call_with_fallback", fake)
+    tc = SimpleNamespace(enrichment_provider="fake")
+    facts = await ingest_service._chunk_content("dummy", tenant_config=tc)
+    assert facts[0]["salience"] == 0.85


### PR DESCRIPTION
## Summary

Two changes to LLM-driven fact extraction that together act as the highest-leverage quality lever in the Tier-1 plan. Per the 3-agent fresh-design synthesis, an AI lab measured 8% → 34% recall-utility from a salience floor alone. Part of the Tier-1 ingest sprint (follows #115, #117, #120, #123).

## Related Issue

N/A — internal Tier-1 plan tracker.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## What's in this PR

**A1 — Salience score (0.0 to 1.0) per fact**
CHUNKING_PROMPT now requires each fact emit a \`salience\` value scoring how essential it is for later recall. Validator drops facts below 0.5 (\`_SALIENCE_FLOOR\`) so low-value items never reach the write pipeline. Returned facts surface salience for caller-side sorting/threshold-tightening.

Tolerant fallback: missing salience → fact passes through (backward-compat for the prompt-rollout window). Malformed salience (string, null) also passes — graceful tolerance of LLM JSON variance.

**A5 — Tightened extraction prompt (eyeball-tuned, NOT formal eval)**
Rewrote CHUNKING_PROMPT with 7 explicit rules:
- Self-contained sentences (resolve pronouns/anaphora against the doc)
- One atomic claim per fact
- No duplicate / near-duplicate facts (anti-fragmentation)
- ≥ 5 words per fact (no UI labels, no headings, no boilerplate)
- No meta-facts
- Pinned memory_type table with disambiguation examples
- Salience-rating scale with concrete thresholds

Belt-and-braces validator: facts under 5 words dropped by \`_MIN_FACT_WORDS\` even when the prompt-side rule slips.

## How Has This Been Tested?

**Unit tests (7 new, 69 total ingest tests passing in ~1s):**
- \`test_salience_floor_drops_low_score_facts\` — 0.2, 0.3 below floor → dropped
- \`test_salience_exactly_at_floor_is_kept\` — strict less-than boundary
- \`test_missing_salience_does_not_drop_fact_backward_compat\`
- \`test_malformed_salience_does_not_drop_fact\` — string/null tolerated
- \`test_short_fact_filter_drops_sub_5_words\` — "Learn more", "Section 3", "Yes" all dropped
- \`test_all_three_filters_compose\` — meta + low-salience + short in one batch, separate log counters
- \`test_salience_field_surfaces_on_returned_facts\`

**Wet test signal #1 — anti-fragmentation on the 3 canonical fixtures:**

| File | Pre-PR-#5 facts | Post-PR-#5 facts | Δ |
|---|---:|---:|---:|
| short.md (553 chars)  | 9  | 8  | -11% |
| medium.md (4315 chars) | 26 | 24 | -8% |
| long.md (83798 chars, repetitive content) | 27 | **14** | **-48%** ⭐ |

Salience scores from gpt-5.4-nano were in 0.50–0.95 range on all 3 fixtures (mean 0.71–0.77). Type diversity preserved: short/medium kept 4 distinct types each.

**Wet test signal #2 — cross-format variance reduction:**

Re-ran the 4-format comparison test (same content as .md / .txt / .pdf / .docx) used to surface Bug B from the cross-format memory:

| format | Pre-PR-#5 facts | Post-PR-#5 facts | Δ |
|---|---:|---:|---:|
| md   | 35 | 30 | -5  |
| txt  | 33 | 31 | -2  |
| pdf  | 37 | 29 | -8  |
| docx | 43 | **26** | **-17** ⭐ |

**Spread (max − min) / min: 30% → 19%.**

The docx outlier (textutil \`\t•\t\` bullet over-fragmentation) dropped the most — the new prompt's "no near-duplicates" + "≥ 5 words" + "no UI labels" rules specifically defang it.

## What's deliberately deferred

- **Formal N=50 eval set** — Tier-2 work. The eyeball-tune-on-fixtures approach is what the Tier-1 plan called for.
- **Recall-utility benchmark** (the 8% → 34% production metric) — needs a labeled query corpus and \`/recall\` integration. Tier-2.
- **\`tags\` field still null on every persisted memory** — pre-existing enrichment-LLM defect, not in PR #5 scope. Tracked in the in-flight memory.

## Checklist

- [x] DCO sign-off applied
- [x] Tests added covering salience floor + boundary + backward-compat + malformed + short-fact + composition + surfacing
- [x] \`ruff check\` and \`ruff format --check\` pass
- [x] \`mypy\` passes on changed files
- [x] \`pytest\` passes locally (69 ingest tests in ~1s)
- [ ] Documentation — N/A, internal behavior
- [ ] CHANGELOG — release-please picks it up from the commit subject

## Additional Notes

- Backward compatible. Existing callers that ignore the new \`salience\` field on facts see no behavior change.
- No DB migration, no new deps.
- Builds on #120 (validators) and #123 (warn-and-continue). Branched off latest \`main\` after #123 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)