### PR TITLE
feat(ingest): multi-format URL extraction via Kreuzberg

### DIFF
--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -40,6 +40,13 @@ dependencies = [
     "markdown-it-py>=4.0,<5",  # markdown AST walker
     "tiktoken>=0.10,<1",  # cl100k_base token counter for size caps
     "pysbd>=0.3,<1",  # sentence boundary detection for sub-chunk splits
+    # PR #8 (Tier-1 ingest, optional multi-format): Kreuzberg replaces
+    # what would otherwise be pypdf + python-docx + python-pptx + … (88+
+    # formats). Provides ``extract_bytes(data, mime) -> ExtractionResult``;
+    # text-PDF works out of the box, scanned-PDF OCR requires Tesseract on
+    # the host (deferred to a follow-up — image-only PDFs raise 422 for now).
+    # License Elastic-2.0.
+    "kreuzberg>=4.9,<5",
 ]
 
 [project.optional-dependencies]

--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -11,6 +11,7 @@ import uuid
 from urllib.parse import urlparse
 
 import httpx
+import kreuzberg
 from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -32,10 +33,10 @@ from core_api.services.organization_settings import resolve_config
 
 logger = logging.getLogger(__name__)
 
-# Allowed MIME types for URL ingest. Binary formats (PDF, DOCX, etc.) are
-# rejected here; the optional Kreuzberg integration (PR #8) will add a
-# separate path for them.
-ALLOWED_INGEST_MIME_TYPES = frozenset(
+# MIME types we strip HTML from and pass through directly as text. Anything
+# in this set skips Kreuzberg entirely — cheaper, and the strip-tags path
+# is good enough for HTML/markdown/plaintext.
+TEXT_INGEST_MIME_TYPES = frozenset(
     {
         "text/html",
         "text/plain",
@@ -44,6 +45,34 @@ ALLOWED_INGEST_MIME_TYPES = frozenset(
         "application/xhtml+xml",
     }
 )
+
+# Binary MIME types we route through Kreuzberg's ``extract_bytes`` to recover
+# plain text (PR #8). Kreuzberg supports 88+ formats; the list below is the
+# curated subset we accept — everything we expect users to ingest from a URL.
+# Adding a new format = append to this set; no code change.
+#
+# Notes:
+#   - PDFs: text-PDFs work out of the box; image-only PDFs need Tesseract on
+#     the host (not currently installed in our images, so they'll either
+#     return empty content or raise ParsingError → we surface as 422).
+#   - Encrypted PDFs without a password raise ParsingError → 422.
+BINARY_INGEST_MIME_TYPES = frozenset(
+    {
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",  # .pptx
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",  # .xlsx
+        "application/epub+zip",
+        "application/rtf",
+        "application/vnd.oasis.opendocument.text",  # .odt
+    }
+)
+
+# Union for the allowlist check. Anything outside both sets is a 422.
+ALLOWED_INGEST_MIME_TYPES = TEXT_INGEST_MIME_TYPES | BINARY_INGEST_MIME_TYPES
 
 # Hard cap on fetched-body size (post-decompression). Defends against
 # gzip-bomb URLs that claim Content-Length: 50KB but expand to gigabytes.
@@ -364,13 +393,83 @@ def _check_hostname_safe(url: str) -> None:
             )
 
 
+# Kreuzberg config used by ``_extract_with_kreuzberg``. We request markdown
+# output so the structure-aware chunker (PR #7) can detect headings in
+# extracted PDFs/Office docs and produce breadcrumb-tagged sections, instead
+# of dumping one giant plaintext blob. Created once at module load to avoid
+# rebuilding it on every request.
+_KREUZBERG_CFG = kreuzberg.ExtractionConfig(output_format=kreuzberg.OutputFormat.MARKDOWN)
+
+
+async def _extract_with_kreuzberg(body: bytes, mime: str) -> str:
+    """Hand a binary blob to Kreuzberg for text extraction (PR #8).
+
+    Supports PDFs, Office formats, EPUB, RTF, ODT, etc. — anything in
+    ``BINARY_INGEST_MIME_TYPES``. Requests markdown output so the chunker's
+    heading-aware path stays useful for extracted documents. Maps Kreuzberg's
+    failure modes to clean HTTP responses:
+
+    - Encrypted PDF (``metadata.is_encrypted=True`` with empty content, or
+      a ``ParsingError`` mentioning encryption) → 422.
+    - Garbage / malformed blob → 422 with the Kreuzberg error message
+      (callers see "Could not parse <type>: <reason>").
+    - Empty extracted content (image-only PDF with no Tesseract installed)
+      → 422 — better to fail loudly than to send the LLM 0 bytes.
+    """
+    try:
+        result = await kreuzberg.extract_bytes(body, mime, _KREUZBERG_CFG)
+    except kreuzberg.ParsingError as e:
+        detail = str(e)
+        status = 422
+        # Surface a friendlier error for the common encrypted-PDF case
+        # rather than dumping Kreuzberg's raw "PdfiumLibraryInternalError".
+        if "encrypted" in detail.lower() or "password" in detail.lower():
+            detail = "Encrypted PDF: password-protected documents are not supported."
+        raise HTTPException(status_code=status, detail=detail)
+    except kreuzberg.KreuzbergError as e:
+        # Catch-all for other Kreuzberg failures (OCR errors, image
+        # processing errors, etc.) — never let them escape as 500s.
+        raise HTTPException(status_code=422, detail=f"Document extraction failed: {e}")
+
+    # Defensive: an encrypted PDF *can* slip past ParsingError if the
+    # extractor returns metadata.is_encrypted=True with empty content
+    # (depends on backend). Catch that case here.
+    if (result.metadata or {}).get("is_encrypted") and not (result.content or "").strip():
+        raise HTTPException(
+            status_code=422,
+            detail="Encrypted PDF: password-protected documents are not supported.",
+        )
+
+    text = (result.content or "").strip()
+    if not text:
+        # Most likely cause: image-only PDF and no OCR backend on the host.
+        # Returning empty would feed the LLM 0 bytes and produce 0 facts —
+        # the caller is better served by a clear 422.
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Extracted document has no text content (mime={mime}). "
+                f"If this is a scanned/image PDF, OCR is required and is "
+                f"not currently enabled."
+            ),
+        )
+    return text
+
+
 async def _fetch_url_text(url: str) -> str:
-    """Fetch URL, validate MIME + size, decode safely, and strip HTML.
+    """Fetch URL, validate MIME + size, decode safely, and extract text.
+
+    For ``TEXT_INGEST_MIME_TYPES`` the body is decoded with the response
+    charset (or UTF-8 fallback) and HTML tags are stripped. For
+    ``BINARY_INGEST_MIME_TYPES`` (PR #8) the body bytes are handed to
+    Kreuzberg for format-specific extraction.
 
     Raises ``HTTPException`` for:
     - 400: invalid URL, DNS failure, hostname resolves to a blocked IP range
     - 413: fetched body exceeds ``MAX_INGEST_CONTENT_BYTES``
-    - 422: response Content-Type isn't in the text allowlist
+    - 422: response Content-Type isn't in the allowlist, or Kreuzberg
+           rejected the content (encrypted PDF, malformed file, empty
+           text extraction, etc.)
     - 4xx/5xx: passed through from the upstream server
     """
     _check_hostname_safe(url)
@@ -428,6 +527,10 @@ async def _fetch_url_text(url: str) -> str:
                     )
                 chunks.append(chunk)
             body = b"".join(chunks)
+
+            # ---- PR #8: binary formats route through Kreuzberg ----
+            if content_type in BINARY_INGEST_MIME_TYPES:
+                return await _extract_with_kreuzberg(body, content_type)
 
             # Decode using the response's declared charset, falling back
             # to UTF-8. httpx's default is ISO-8859-1 when no charset is

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -153,18 +153,103 @@ class TestFetchUrlText:
         result = await _fetch_url_text("https://example.com/")
         assert "Hello world" in result
 
-    async def test_application_pdf_rejected_422(self, monkeypatch) -> None:
-        """PDF MIME type → 422 with allowlist hint. The single most important
-        wet-tested bug this PR fixes."""
+    async def test_application_pdf_routed_through_kreuzberg(self, monkeypatch) -> None:
+        """PR #8: PDF MIME no longer auto-rejected — Kreuzberg extracts text.
+
+        Patches ``kreuzberg.extract_bytes`` to return a known string and
+        asserts that ``_fetch_url_text`` returns it (i.e. binary types
+        flow through the new path).
+        """
         monkeypatch.setattr(
             "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+
+        async def fake_extract(data, mime, *_a, **_kw):
+            assert mime == "application/pdf"
+            assert data == b"%PDF-1.4\n%pdf bytes"
+
+            class _R:
+                content = "Hello extracted PDF body"
+                metadata = {"is_encrypted": False}
+
+            return _R()
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.kreuzberg.extract_bytes", fake_extract
         )
 
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
                 headers={"content-type": "application/pdf"},
-                content=b"%PDF-1.4\n%garbage binary content",
+                content=b"%PDF-1.4\n%pdf bytes",
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        result = await _fetch_url_text("https://example.com/file.pdf")
+        assert result == "Hello extracted PDF body"
+
+    async def test_docx_routed_through_kreuzberg(self, monkeypatch) -> None:
+        """Office DOCX MIME also goes through Kreuzberg."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+
+        async def fake_extract(data, mime, *_a, **_kw):
+            assert mime == (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            )
+
+            class _R:
+                content = "Title: Quarterly Review\nBody paragraphs go here."
+                metadata = {}
+
+            return _R()
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.kreuzberg.extract_bytes", fake_extract
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={
+                    "content-type": (
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                    )
+                },
+                content=b"PK\x03\x04...",
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        result = await _fetch_url_text("https://example.com/report.docx")
+        assert "Quarterly Review" in result
+
+    async def test_encrypted_pdf_returns_422(self, monkeypatch) -> None:
+        """Encrypted PDF surfaces as 422 with a clean error message."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+        import kreuzberg as _kz
+
+        async def fake_extract(data, mime, *_a, **_kw):
+            raise _kz.ParsingError("PDF encrypted: password required")
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.kreuzberg.extract_bytes", fake_extract
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/pdf"},
+                content=b"%PDF-1.4\n%encrypted",
             )
 
         monkeypatch.setattr(
@@ -172,9 +257,71 @@ class TestFetchUrlText:
             lambda **kw: _make_client(handler),
         )
         with pytest.raises(Exception) as exc:
-            await _fetch_url_text("https://example.com/file.pdf")
+            await _fetch_url_text("https://example.com/secret.pdf")
         assert exc.value.status_code == 422
-        assert "application/pdf" in exc.value.detail
+        assert "Encrypted PDF" in exc.value.detail
+
+    async def test_malformed_pdf_parsing_error_422(self, monkeypatch) -> None:
+        """Garbage PDF bytes → Kreuzberg raises ParsingError → 422."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+        import kreuzberg as _kz
+
+        async def fake_extract(data, mime, *_a, **_kw):
+            raise _kz.ParsingError("Invalid PDF: PdfiumLibraryInternalError")
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.kreuzberg.extract_bytes", fake_extract
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/pdf"},
+                content=b"not a real pdf",
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        with pytest.raises(Exception) as exc:
+            await _fetch_url_text("https://example.com/broken.pdf")
+        assert exc.value.status_code == 422
+
+    async def test_empty_extracted_content_422(self, monkeypatch) -> None:
+        """Image-only PDF (no OCR backend) → empty extraction → 422."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+        )
+
+        async def fake_extract(data, mime, *_a, **_kw):
+            class _R:
+                content = "   "  # whitespace-only, no real text
+                metadata = {"is_encrypted": False}
+
+            return _R()
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.kreuzberg.extract_bytes", fake_extract
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/pdf"},
+                content=b"%PDF-1.4\n%image-only",
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _make_client(handler),
+        )
+        with pytest.raises(Exception) as exc:
+            await _fetch_url_text("https://example.com/scanned.pdf")
+        assert exc.value.status_code == 422
+        assert "no text content" in exc.value.detail.lower()
 
     async def test_octet_stream_rejected_422(self, monkeypatch) -> None:
         """Unknown binary MIME → 422."""


### PR DESCRIPTION
## Summary

Adds an extraction path for **binary document types** (PDF, Office, EPUB, ODT, RTF) on URL ingest, routed through Kreuzberg. URL ingest previously rejected anything outside the text MIME allowlist with 422 — the most common loss being PDFs, which are also the most common ingest source.

- New `_extract_with_kreuzberg` helper hands the fetched body bytes to `kreuzberg.extract_bytes` with `output_format=MARKDOWN` so PR #7's structure-aware chunker can detect headings in extracted documents and produce **breadcrumb-tagged sections** instead of one plaintext blob.
- `_fetch_url_text` dispatches on Content-Type after the existing SSRF + size guards: text types take the HTML-strip path; types in `BINARY_INGEST_MIME_TYPES` go through Kreuzberg.
- Supported binary formats: PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, EPUB, RTF, ODT. Adding more = append to the constant; no code change.
- Single new dep: `kreuzberg>=4.9,<5` (license Elastic-2.0, ~27 MB, replaces what would otherwise be pypdf + python-docx + python-pptx + … one dep per format).

## Failure-mode mapping (all → 422)

| Scenario | Detection | Detail message |
|---|---|---|
| Encrypted PDF | `ParsingError` with "encrypted"/"password", OR `metadata.is_encrypted=True` with empty content | "Encrypted PDF: password-protected documents are not supported." |
| Malformed binary | other `ParsingError` | Raw Kreuzberg message surfaced |
| Image-only PDF, no OCR | empty content | "Extracted document has no text content … OCR is not currently enabled." |
| Other Kreuzberg errors (OCR, image processing, etc.) | `KreuzbergError` | "Document extraction failed: …" |

## Wet test (real 150 KB / 8-page PDF, inside docker stack)

- `_extract_with_kreuzberg(pdf_bytes, "application/pdf")` → **17,448 chars (3,840 tokens) of markdown, 9 headings detected**
- Piped through PR #7's chunker → **7 sections with meaningful breadcrumbs** like `"Q1.1: System design > The different layers > Processing Layer"`

For comparison, plaintext output from Kreuzberg (default) produced 8 paragraphs / 0 headings / 2 sections with empty breadcrumbs — markdown mode is a strict upgrade for the chunker integration.

## Test plan

- [x] 5 new unit tests in `tests/test_ingest_service.py::TestFetchUrlText` covering PDF dispatch, DOCX dispatch, encrypted-PDF 422, malformed-PDF 422, empty-extraction 422.
- [x] Existing `test_application_pdf_rejected_422` reframed as `test_application_pdf_routed_through_kreuzberg` since PDFs are no longer auto-rejected.
- [x] Full 103-test ingest suite (`test_ingest_service` + `test_ingest_chunking` + `test_ingest_preview` + `test_ingest_commit` + `test_ingest_idempotency_undo`) passes locally.
- [x] `ruff check core-api/src/`, `ruff format --check core-api/src/`, `mypy src/` all green.
- [x] Wet-tested in docker stack on a real PDF, confirmed end-to-end extraction → chunker → breadcrumb sections.
- [ ] Known follow-up: image-only / scanned PDFs need Tesseract installed on the host. Currently surfaces as 422 with a clear message — enabling OCR is a separate decision (Docker image bloat trade-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)