### PR TITLE
chore(release-please): pin bootstrap-sha to pre-#131 commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "separate-pull-requests": false,
+  "bootstrap-sha": "868da80d108573f259dae74f7c4330f23f614e86",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "draft": false,


### PR DESCRIPTION
## Why

PR #131 split release-please into two packages (\`.\` backend / \`plugin\`) and flipped \`include-component-in-tag: true\`. Result: the new tag formats are \`backend-vX.Y.Z\` and \`plugin-vX.Y.Z\` — neither of which exist yet in repo history.

When release-please ran on \`main\` immediately after #131 merged, it couldn't find any prior \`backend-v*\` / \`plugin-v*\` tag, fell back to scanning the **entire repo history**, and rolled every conventional commit since the repo's start into the Release PR. The candidate version became **3.0.0** for both packages, driven by an already-shipped \`BREAKING CHANGE\` in #128 (\`feat(doc)!: drop embed_field\`) plus dozens of older feats/fixes.

See the current state of PR #121 (\`chore: release main\`) — both component sections list commits from #4 to #129 as if they're new.

## What this does

Pins \`bootstrap-sha\` to \`868da80d108573f259dae74f7c4330f23f614e86\` — the commit on main **before** #131 was merged. release-please ignores commits before this SHA when computing the next version.

After this merges, the next Release PR run should propose:
- \`backend\`: 2.5.0 → 2.6.0 (one \`feat:\` — #131 itself touches \`core-api/\`)
- \`plugin\`: 2.5.0 → 2.6.0 (one \`feat:\` — #131 also touches \`plugin/src/version.ts\`)

Plus the small \`/status\` extension included in #131 doesn't add a separate bump (same PR).

## Cleanup

Once the first Release PR opens with the correct version targets, this \`bootstrap-sha\` line can be removed (its job is done — once \`backend-v2.6.0\` / \`plugin-v2.6.0\` tags exist, release-please scans from those instead). A small follow-up PR removing it is fine, or leave it; it's harmless after the fact.

## Test plan

- [ ] Merge this PR.
- [ ] Watch \`.github/workflows/release-please.yml\` re-run on the next push to \`main\`.
- [ ] Verify PR #121 (\`chore: release main\`) updates to target \`backend: 2.6.0\` + \`plugin: 2.6.0\` with a short commit list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)