### PR TITLE
fix(ingest): preserve uploaded filename in source_uri

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1353,6 +1353,13 @@ async def ingest_file_endpoint(
     kwargs: dict = {"tenant_id": tenant_id, "content": text, "focus": focus, "fleet_id": fleet_id}
     if agent_id is not None:
         kwargs["agent_id"] = agent_id
+    # Preserve the original filename as ``upload:<filename>`` so each
+    # resulting memory's ``source_uri`` says where it came from instead
+    # of the generic ``"text-input"`` marker. ``file.filename`` can be
+    # absent / empty when the client doesn't send a multipart name, in
+    # which case we fall back to a generic ``"upload"`` label.
+    filename = (file.filename or "").strip() or None
+    kwargs["source_uri"] = f"upload:{filename}" if filename else "upload"
     req = IngestRequest(**kwargs)
     return await ingest_preview(db, req)
 

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -352,6 +352,13 @@ class IngestRequest(BaseModel):
     url: str | None = None
     content: str | None = None
     focus: str | None = None
+    # Optional caller-supplied source label. Used by the multipart upload
+    # endpoint (``/ingest/file``) to thread ``upload:<filename>`` through
+    # so the per-fact ``source_uri`` carries the original filename instead
+    # of being stamped as the generic ``"text-input"`` marker. When
+    # absent, ``ingest_preview`` falls back to ``url`` (URL ingest) or
+    # ``"text-input"`` (pasted content) — unchanged behavior.
+    source_uri: str | None = None
 
 
 class IngestFact(BaseModel):

--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -646,7 +646,12 @@ async def ingest_preview(db: AsyncSession, request: IngestRequest) -> dict:
     # — the chunker handles arbitrarily large docs up to ``DOC_HARD_TOKEN_LIMIT``).
     # If a prior ingest of identical content already exists for this tenant,
     # return the cached facts straight from those memories — no LLM call.
-    source_uri_default = url or "text-input"
+    # Per-fact source_uri precedence:
+    #   1. Caller-supplied ``request.source_uri`` — used by ``/ingest/file``
+    #      to thread ``upload:<filename>`` through so the filename survives.
+    #   2. URL the body was fetched from.
+    #   3. ``"text-input"`` marker for pasted-content / no-source ingests.
+    source_uri_default = request.source_uri or url or "text-input"
     doc_hash = _doc_hash(request.tenant_id, content)
     cached_memories = await _find_prior_ingest_by_doc_hash(db, request.tenant_id, doc_hash)
     if cached_memories:

--- a/tests/test_ingest_file_endpoint.py
+++ b/tests/test_ingest_file_endpoint.py
@@ -129,6 +129,23 @@ class TestIngestFileEndpoint:
         called_req = preview_mock.call_args.args[1]
         assert "# Title" in called_req.content
         assert "\n\n" in called_req.content
+        # Filename survives as upload:<name> on source_uri so each derived
+        # memory carries its origin (not the generic "text-input" marker).
+        assert called_req.source_uri == "upload:doc.md"
+
+    def test_upload_with_whitespace_only_filename_falls_back(self, monkeypatch) -> None:
+        """When the client sends a whitespace-only filename, source_uri
+        should fall back to the bare ``"upload"`` marker — not
+        ``upload:    `` (which would render as just the prefix in the UI)."""
+        client, preview_mock = _build_app(monkeypatch)
+        resp = client.post(
+            "/api/v1/ingest/file",
+            files={"file": ("   ", b"some plain text content here", "text/plain")},
+            data={"tenant_id": "t1"},
+        )
+        assert resp.status_code == 200, resp.text
+        called_req = preview_mock.call_args.args[1]
+        assert called_req.source_uri == "upload"
 
     def test_uploads_csv_preserves_rows(self, monkeypatch) -> None:
         client, preview_mock = _build_app(monkeypatch)
@@ -143,6 +160,29 @@ class TestIngestFileEndpoint:
         # Row breaks must survive — otherwise the LLM sees one mashed line.
         assert "\n" in called_req.content
         assert called_req.content == "a,b\n1,2\n3,4"
+
+    def test_pdf_upload_sets_upload_filename_source_uri(self, monkeypatch) -> None:
+        """Filename of a binary upload also survives via Kreuzberg dispatch."""
+
+        async def fake_extract(data, mime, *_a, **_kw):
+            class _R:
+                content = "Extracted body."
+                metadata = {"is_encrypted": False}
+
+            return _R()
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.kreuzberg.extract_bytes", fake_extract
+        )
+        client, preview_mock = _build_app(monkeypatch)
+        resp = client.post(
+            "/api/v1/ingest/file",
+            files={"file": ("report.pdf", b"%PDF-1.4\nbytes", "application/pdf")},
+            data={"tenant_id": "t1"},
+        )
+        assert resp.status_code == 200, resp.text
+        called_req = preview_mock.call_args.args[1]
+        assert called_req.source_uri == "upload:report.pdf"
 
     def test_uploads_pdf_routes_through_kreuzberg(self, monkeypatch) -> None:
         """PDFs (and other binary MIMEs) hand off to Kreuzberg."""

--- a/tests/test_ingest_preview.py
+++ b/tests/test_ingest_preview.py
@@ -99,6 +99,24 @@ async def test_source_uri_stamped_url(fake_chunker, fake_tenant_config, monkeypa
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_source_uri_request_override_beats_default(fake_chunker, fake_tenant_config):
+    """When the caller passes ``request.source_uri`` (used by /ingest/file to
+    thread ``upload:<filename>`` through), every fact's source_uri reflects
+    that override instead of the generic ``text-input`` marker."""
+    req = IngestRequest(
+        tenant_id="t1",
+        content="A meaningful sentence about distributed systems.",
+        source_uri="upload:report.pdf",
+    )
+    resp = await ingest_service.ingest_preview(db=None, request=req)
+
+    assert resp["facts"]
+    for f in resp["facts"]:
+        assert f["source_uri"] == "upload:report.pdf"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_existing_source_uri_in_fact_not_overwritten(fake_chunker, fake_tenant_config):
     """``setdefault`` shouldn't clobber a source_uri the chunker explicitly set
     (defensive — current chunker doesn't, but the contract should hold)."""


### PR DESCRIPTION
## Summary

Before this fix, every memory derived from a multipart file upload carried `source_uri="text-input"` — the same marker used for pasted text — so the **filename was dropped on the floor**. URL ingest preserved the URL, pasted-content was correctly opaque, but file uploads (the very feature we just shipped in #130) couldn't be traced back to their origin file on the per-fact level.

## Three small touches

1. **`IngestRequest`** gains an optional `source_uri: str | None` field. When set, it wins over `url` and the `"text-input"` fallback — pure addition, no behavior change for existing callers.
2. **`ingest_preview`** updates `source_uri_default` to read `request.source_uri or url or "text-input"`. Pasted-content and URL paths are unchanged.
3. **`ingest_file_endpoint`** stamps `source_uri=f"upload:{filename}"` (or just `"upload"` for the rare filename-less envelope), so every fact from a `.pdf` / `.docx` / `.csv` / `.md` upload carries e.g. `upload:report.pdf` through preview, commit, and into `metadata.ingest_url` on the persisted memory.

## Why now

This unblocks the dashboard's new Source column (caura-memclaw-enterprise#285). Previously every uploaded-file memory looked identical to every pasted-text memory in the column because both stamped the same generic `"text-input"` marker. With this fix the dashboard can render the actual filename underneath the `INGEST` badge — clicking it (future PR) becomes a meaningful "show all memories from `report.pdf`" filter.

## Test plan

- [x] 1 new unit test in `test_ingest_preview.py`: `test_source_uri_request_override_beats_default` — verifies `IngestRequest.source_uri` overrides `text-input` on every returned fact.
- [x] 1 new test in `test_ingest_file_endpoint.py`: `test_uploads_text_markdown` extended to assert `called_req.source_uri == "upload:doc.md"`.
- [x] 1 new test: `test_pdf_upload_sets_upload_filename_source_uri` — verifies the binary-via-Kreuzberg path also threads the filename.
- [x] 1 edge case: `test_upload_with_whitespace_only_filename_falls_back` — whitespace-only filename → `"upload"` (not `"upload:   "` rendering as just the prefix in UI).
- [x] All 126 ingest tests pass; `ruff check`, `ruff format --check`, `mypy src/` clean.
- [x] **Wet test**: uploaded `notes.md` via `POST /api/ingest/file` in the canonical local stack → 4 facts returned, each with `source_uri="upload:notes.md"`.

## Follow-ups (out of scope, ready when you are)

- **(2) Parent Document record per ingest batch** — write one `documents` row per upload with `collection="ingest-sources"`, `doc_id=<run_id>`, `data={filename, summary, doc_hash, memory_count, ...}`. Adds a queryable, searchable record linking a batch of facts back to its source file.
- **(3) Dashboard Documents tab** — list ingest batches with click-through to their member memories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)