### PR TITLE
CAURA-000 fix(mcp): accept /mcp without trailing-slash redirect

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -602,7 +602,43 @@ if _os.getenv("TESTING") == "1":
 
     app.include_router(testing_router, prefix="/api/v1")
 
-app.mount("/mcp", get_mcp_app())
+# Mount at /mcp; FastMCP's internal Route("/") handles the canonical /mcp/.
+# Bare /mcp (no trailing slash) doesn't match Mount's regex, so the parent
+# router would issue a 307 — streaming MCP clients (e.g. Anthropic's
+# remote-MCP integration) hang on the initialize handshake when a redirect
+# precedes the upgrade. The shim below forwards /mcp into the same ASGI
+# app in-process so both paths serve identically without a wire redirect.
+_mcp_asgi_app = get_mcp_app()
+app.mount("/mcp", _mcp_asgi_app)
+
+
+class _MCPNoSlashShim:
+    """Forward /mcp into the mounted MCP app in-process (no HTTP redirect)."""
+
+    # slowapi.middleware introspects ``handler.__name__`` per request — without
+    # this attribute on the instance, every /mcp call 500s with AttributeError.
+    __name__ = "_mcp_no_slash_shim"
+
+    def __init__(self, inner: ASGIApplication) -> None:
+        self._inner = inner
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        new_scope = dict(scope)
+        new_scope["path"] = "/"
+        new_scope["raw_path"] = b"/"
+        new_scope["root_path"] = scope.get("root_path", "") + "/mcp"
+        await self._inner(new_scope, receive, send)
+
+
+from starlette.routing import Route as _StarletteRoute  # noqa: E402
+
+app.router.routes.append(
+    _StarletteRoute(
+        "/mcp",
+        endpoint=_MCPNoSlashShim(_mcp_asgi_app),
+        methods=["GET", "POST", "DELETE", "OPTIONS"],
+    )
+)
 
 
 # CAURA-602: turn a silent regression into a startup crash. The

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -630,7 +630,7 @@ class _MCPNoSlashShim:
         await self._inner(new_scope, receive, send)
 
 
-from starlette.routing import Route as _StarletteRoute  # noqa: E402
+from starlette.routing import Route as _StarletteRoute
 
 app.router.routes.append(
     _StarletteRoute(

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -15,10 +15,32 @@ pytestmark = pytest.mark.asyncio
 # ── 1. MCP mount exists ──
 
 
-async def test_mcp_endpoint_exists(client):
-    """GET /mcp should not 404 — may return 405 or a protocol-specific response."""
-    resp = await client.get("/mcp")
-    assert resp.status_code != 404, f"MCP endpoint not mounted, got {resp.status_code}"
+async def test_mcp_mount_registered():
+    # Mount at /mcp handles canonical /mcp/* via FastMCP's internal Route("/").
+    from starlette.routing import Mount
+
+    from core_api.app import app
+
+    mounts = [r for r in app.router.routes if isinstance(r, Mount) and r.path == "/mcp"]
+    assert mounts, "MCP mount missing at /mcp"
+
+
+async def test_mcp_no_trailing_slash_route_registered():
+    # Streaming MCP clients hang on the initialize handshake if /mcp issues
+    # a 307/308 to /mcp/. The fix registers an exact /mcp Route that forwards
+    # into the mounted MCP ASGI app in-process so the redirect never fires.
+    from starlette.routing import Route
+
+    from core_api.app import app
+
+    bare_route = next(
+        (r for r in app.router.routes if isinstance(r, Route) and r.path == "/mcp"),
+        None,
+    )
+    assert bare_route is not None, "Bare /mcp Route missing — redirect would recur"
+    assert set(bare_route.methods or ()) >= {"GET", "POST", "DELETE"}, (
+        f"/mcp route is missing required methods: {bare_route.methods!r}"
+    )
 
 
 # ── 2. Write via API is searchable ──

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -27,12 +27,21 @@ async def test_security_headers_on_api_routes(client):
     assert "content-security-policy" in resp.headers
 
 
-async def test_security_headers_absent_on_mcp(client):
-    """MCP routes should NOT have browser security headers."""
-    resp = await client.get("/mcp")
-    # /mcp may redirect or return protocol error — either way, no security headers
-    assert "x-frame-options" not in resp.headers
-    assert "content-security-policy" not in resp.headers
+def test_security_headers_absent_on_mcp():
+    """``SecurityHeadersMiddleware`` skips MCP-path scopes by design
+    (via ``is_mcp_path``) so streaming MCP responses don't get browser
+    security headers injected. After CAURA-000-mcp-trailing-slash a
+    GET /mcp reaches the FastMCP handler in-process — which crashes
+    without the session manager (no FastAPI lifespan in TestClient),
+    so we can't exercise this via ``client.get`` anymore. Verify the
+    middleware's skip condition directly instead.
+    """
+    from core_api.constants import is_mcp_path
+
+    assert is_mcp_path("/mcp") is True
+    assert is_mcp_path("/mcp/") is True
+    assert is_mcp_path("/mcp/anything") is True
+    assert is_mcp_path("/api/v1/memories") is False
 
 
 # ResponseTimeMiddleware was removed during OSS/Enterprise split
@@ -43,12 +52,16 @@ async def test_security_headers_absent_on_mcp(client):
 
 
 async def test_mcp_auth_middleware_bearer_extraction(client):
-    """MCPAuthMiddleware should extract API key from Authorization: Bearer header."""
+    """Bearer auth works on REST routes. (The legacy "MCP mount exists"
+    half of this test was an HTTP-level GET /mcp; after the Stage 1
+    no-redirect fix it now reaches the FastMCP handler which crashes
+    without the session manager — covered structurally in
+    ``test_mcp_mount_exists`` below.)
+    """
     import uuid
     tenant_id, headers = get_test_auth()
     uid = uuid.uuid4().hex[:8]
 
-    # X-API-Key works on REST routes (baseline)
     resp1 = await client.post("/api/v1/memories", json={
         "tenant_id": tenant_id,
         "agent_id": f"bearer-test-{uid}",
@@ -57,11 +70,6 @@ async def test_mcp_auth_middleware_bearer_extraction(client):
         "content": f"baseline write [{uid}]",
     }, headers=headers)
     assert resp1.status_code == 201
-
-    # MCP mount exists and accepts requests (session manager may not be running
-    # in test fixtures, so we just verify the endpoint is mounted)
-    resp2 = await client.get("/mcp")
-    assert resp2.status_code != 404
 
 
 async def test_mcp_bearer_returns_tools(client):
@@ -74,7 +82,17 @@ async def test_mcp_bearer_returns_tools(client):
     assert resp.status_code == 200
 
 
-async def test_mcp_mount_exists(client):
-    """MCP endpoint should be mounted (not 404)."""
-    resp = await client.get("/mcp")
-    assert resp.status_code != 404, f"MCP endpoint not mounted, got {resp.status_code}"
+def test_mcp_mount_exists():
+    """MCP endpoint mount + exact-/mcp route are both registered on
+    the app router. Structural check (post Stage-1 the HTTP-level
+    GET path goes through the FastMCP handler which needs a running
+    session manager — unavailable in TestClient without lifespan).
+    """
+    from starlette.routing import Mount, Route
+
+    from core_api.app import app
+
+    mounts = [r for r in app.router.routes if isinstance(r, Mount) and r.path == "/mcp"]
+    bare_routes = [r for r in app.router.routes if isinstance(r, Route) and r.path == "/mcp"]
+    assert mounts, "MCP mount missing at /mcp"
+    assert bare_routes, "Bare-/mcp Route missing — Stage-1 redirect would recur"


### PR DESCRIPTION
Streaming MCP clients (e.g. Anthropic's remote-MCP integration in
anthropic.messages.create(mcp_servers=...)) hang on the initialize
handshake when /mcp issues a 307 to /mcp/ before the streaming
upgrade. Register an exact-match Route('/mcp') alongside the
existing Mount('/mcp', ...) so both paths serve the same MCP
handler in-process, no wire redirect.

Tests cover the structural shape; HTTP-level validation is run as
the integration smoke (POST initialize on both paths returns 200
against the enterprise dev stack).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
