### PR TITLE
CAURA-000 fix(mcp): register Agent row on first MCP write

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -40,6 +40,7 @@ from core_api.db.session import async_session
 from core_api.errors import code_for_status
 from core_api.repositories import memory_repo
 from core_api.schemas import BulkMemoryCreate, BulkMemoryItem, MemoryCreate, MemoryUpdate
+from core_api.services.agent_service import enforce_fleet_write
 from core_api.services.audit_service import log_action
 from core_api.services.entity_service import get_entity
 from core_api.services.memory_service import (
@@ -349,6 +350,12 @@ async def memclaw_write(
 
     async with _mcp_session() as db:
         try:
+            # Register the calling agent (auto-create row on first write) and
+            # enforce trust gating for cross-fleet writes — same surface the
+            # REST write path uses. Without this, MCP writes succeed without
+            # ever creating an Agent row, so a follow-up
+            # PATCH /agents/{id}/trust 404s.
+            await enforce_fleet_write(db, tenant_id, agent_id, fleet_id)
             if content is not None:
                 await check_and_increment(db, tenant_id, "write")
                 result = await create_memory(
@@ -872,6 +879,10 @@ async def memclaw_doc(
                             "(check provider config / quota). Write aborted.",
                             t0,
                         )
+                # Mirror memclaw_write's agent registration so a doc upsert
+                # via MCP creates the Agent row on first contact and enforces
+                # cross-fleet trust gating.
+                await enforce_fleet_write(db, tenant_id, agent_id, fleet_id)
                 await check_and_increment(db, tenant_id, "write")
                 row = await document_repo.upsert_returning_xmax(
                     db,

--- a/tests/_mcp_test_helpers.py
+++ b/tests/_mcp_test_helpers.py
@@ -85,6 +85,15 @@ def mcp_env(monkeypatch):
 
     monkeypatch.setattr(mcp_server, "_require_trust", _always_allow)
 
+    # Write tools call ``enforce_fleet_write`` to lazy-create the Agent row;
+    # in unit tests there's no real DB, so stub it as a no-op returning the
+    # caller's identity. Tests that want to assert the call replace this via
+    # ``service("enforce_fleet_write")``.
+    async def _stub_enforce_fleet_write(db, tenant_id, agent_id, fleet_id):
+        return {"agent_id": agent_id, "tenant_id": tenant_id, "fleet_id": fleet_id, "trust_level": 3}
+
+    monkeypatch.setattr(mcp_server, "enforce_fleet_write", _stub_enforce_fleet_write)
+
     service_mocks: dict[str, AsyncMock] = {}
 
     def service(name: str) -> AsyncMock:

--- a/tests/test_mcp_write.py
+++ b/tests/test_mcp_write.py
@@ -40,6 +40,40 @@ async def test_write_single_happy_path(mcp_env):
     mcp_env["service_mocks"]["create_memory"].assert_awaited_once()
 
 
+async def test_write_registers_agent(mcp_env):
+    # memclaw_write must lazy-create the Agent row (REST parity). Without this,
+    # an mca_-key holder's first MCP write succeeds but PATCH /agents/{id}/trust
+    # 404s because no Agent row exists.
+    enforce = mcp_env["service"]("enforce_fleet_write")
+    enforce.return_value = {"agent_id": "a1", "trust_level": 0}
+    mcp_env["service"]("create_memory").return_value = _OutStub("m-2")
+
+    await mcp_server.memclaw_write(
+        content="first write", agent_id="a1", fleet_id="f1"
+    )
+    enforce.assert_awaited_once()
+    args = enforce.await_args.args
+    # Signature: (db, tenant_id, agent_id, fleet_id)
+    assert args[1] == mcp_env["tenant"]
+    assert args[2] == "a1"
+    assert args[3] == "f1"
+
+
+async def test_write_batch_registers_agent(mcp_env):
+    enforce = mcp_env["service"]("enforce_fleet_write")
+    mcp_env["service"]("create_memories_bulk").return_value = _OutStub("batch-2")
+
+    await mcp_server.memclaw_write(
+        items=[{"content": "one"}, {"content": "two"}],
+        agent_id="a2",
+        fleet_id="f2",
+    )
+    enforce.assert_awaited_once()
+    args = enforce.await_args.args
+    assert args[2] == "a2"
+    assert args[3] == "f2"
+
+
 async def test_write_batch_happy_path(mcp_env):
     mcp_env["service"]("create_memories_bulk").return_value = _OutStub("batch-1")
 


### PR DESCRIPTION
The REST write path calls enforce_fleet_write (which lazy-creates
the Agent row and enforces cross-fleet trust gating); the MCP path
went straight to create_memory. That divergence means a freshly
provisioned mca_ key's first memclaw_write succeeded but the Agent
row was never created, so the immediate follow-up
PATCH /agents/{id}/trust 404'd. Wire enforce_fleet_write into
memclaw_write (single + batch) and memclaw_doc op=write so MCP
writes match REST semantics.

Tests: new test_write_registers_agent + test_write_batch_registers_agent
assert the call. Existing 986 unit tests still pass (988 with the
two new ones); _mcp_test_helpers stubs enforce_fleet_write to a
no-op so per-handler tests don't need a real DB.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
