### PR TITLE
CAURA-000 fix(dedup): scope content-hash dedup by agent_id

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -278,10 +278,16 @@ class CoreStorageClient:
         tenant_id: str,
         content_hash: str,
         fleet_id: str | None = None,
+        agent_id: str | None = None,
     ) -> dict | None:
         params: dict[str, Any] = {"tenant_id": tenant_id, "content_hash": content_hash}
         if fleet_id is not None:
             params["fleet_id"] = fleet_id
+        if agent_id is not None:
+            # Per-agent dedup scope (Stage 5 / friction §2.8): cross-agent
+            # writes of identical content no longer collide. Omit to
+            # preserve legacy fleet-wide dedup.
+            params["agent_id"] = agent_id
         # Write-path exact-hash dedup gate — stale replica data here would
         # let a just-written duplicate slip through. Pair with
         # bulk_find_by_content_hashes and find_semantic_duplicate.
@@ -319,13 +325,17 @@ class CoreStorageClient:
         self,
         tenant_id: str,
         hashes: list[str],
+        fleet_id: str | None = None,
+        agent_id: str | None = None,
     ) -> dict[str, dict]:
         """Look up existing rows by content_hash for the dedup gate.
 
         Returns ``{content_hash: {"id": str, "client_request_id": str | None}}``.
         ``client_request_id`` lets the bulk path tell ``duplicate_attempt``
         (the caller's own retry) apart from ``duplicate_content``
-        (different attempt, same content).
+        (different attempt, same content). ``agent_id`` scopes the lookup
+        per-agent (Stage 5) so a batch from agent-A and a batch from
+        agent-B in the same fleet don't collide on identical content.
 
         Explicit ``read=False``: this is the dedup lookup called inline
         during bulk writes. Routing to a read replica risks missing a
@@ -334,9 +344,14 @@ class CoreStorageClient:
         Not relying on the default so a future flip of _post's default
         can't silently re-route it.
         """
+        body: dict[str, Any] = {"tenant_id": tenant_id, "hashes": hashes}
+        if fleet_id is not None:
+            body["fleet_id"] = fleet_id
+        if agent_id is not None:
+            body["agent_id"] = agent_id
         result = await self._post(
             "/memories/bulk-by-content-hashes",
-            {"tenant_id": tenant_id, "hashes": hashes},
+            body,
             read=False,
         )
         return result  # type: ignore[return-value]

--- a/core-api/src/core_api/pipeline/steps/write/check_exact_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/check_exact_duplicate.py
@@ -1,4 +1,6 @@
-"""CheckExactDuplicate — reject if content_hash already exists in tenant+fleet."""
+"""CheckExactDuplicate — reject if content_hash already exists for the
+same (tenant, fleet, agent). Stage 5: per-agent dedup so cross-agent
+writes of identical content no longer collide (friction §2.8)."""
 
 from __future__ import annotations
 
@@ -23,6 +25,7 @@ class CheckExactDuplicate:
             data.tenant_id,
             ch,
             fleet_id=data.fleet_id,
+            agent_id=data.agent_id,
         )
         if dup:
             raise HTTPException(

--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -975,7 +975,16 @@ async def ingest_commit(db: AsyncSession, request: IngestCommitRequest) -> dict:
     if hashes:
         try:
             sc = get_storage_client()
-            existing = await sc.bulk_find_by_content_hashes(request.tenant_id, hashes)
+            # Stage 5: scope dedup to (tenant, fleet, agent) so an ingest
+            # run by one agent doesn't silently dedup against another agent's
+            # identical content. Falls back to (tenant, fleet) when agent_id
+            # is omitted.
+            existing = await sc.bulk_find_by_content_hashes(
+                request.tenant_id,
+                hashes,
+                fleet_id=request.fleet_id,
+                agent_id=request.agent_id,
+            )
         except Exception:
             # Fail-open: if the dedup query fails, fall through to the
             # per-fact path. ``create_memory`` still 409s exact dups, so

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -744,11 +744,14 @@ async def _create_memory_legacy(db: AsyncSession, data: MemoryCreate) -> MemoryO
             return _dict_to_memory_out(parent)
 
     # -- Persist path --
-    # Dedup: check for exact content match within tenant+fleet
+    # Dedup: check for exact content match within tenant+fleet, scoped to
+    # the writing agent. Cross-agent writes of identical content should
+    # succeed as distinct observations — friction §2.8 / Stage 5.
     dup = await sc.find_by_content_hash(
         data.tenant_id,
         ch,
         fleet_id=data.fleet_id,
+        agent_id=data.agent_id,
     )
     if dup:
         raise HTTPException(
@@ -1034,9 +1037,14 @@ async def create_memories_bulk(
 
     existing_hashes: dict[str, dict] = {}
     if hashes:
+        # Stage 5: scope bulk dedup to (tenant, fleet, agent) so a batch
+        # from agent-A and a batch from agent-B in the same fleet don't
+        # collide on identical content.
         existing_hashes = await sc.bulk_find_by_content_hashes(
             data.tenant_id,
             hashes,
+            fleet_id=data.fleet_id,
+            agent_id=data.agent_id,
         )
 
     # -- Also detect intra-batch duplicates (same content appearing twice) --

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -260,8 +260,11 @@ async def find_by_content_hash(
     tenant_id: str,
     content_hash: str,
     fleet_id: str | None = None,
+    agent_id: str | None = None,
 ) -> dict:
-    memory = await _svc.memory_find_by_content_hash(tenant_id, content_hash, fleet_id)
+    memory = await _svc.memory_find_by_content_hash(
+        tenant_id, content_hash, fleet_id, agent_id=agent_id
+    )
     if memory is None:
         raise HTTPException(status_code=404, detail="Memory not found by content hash")
     return orm_to_dict(memory, MEMORY_FIELDS)
@@ -298,12 +301,15 @@ async def bulk_find_by_content_hashes(request: Request) -> dict:
     See ``memory_bulk_find_by_content_hashes`` for why
     ``client_request_id`` is part of the response — the upstream bulk
     route uses it to distinguish ``duplicate_attempt`` from
-    ``duplicate_content`` (CAURA-602).
+    ``duplicate_content`` (CAURA-602). ``agent_id`` (optional) scopes
+    the dedup lookup per Stage 5.
     """
     body: dict = await request.json()
     result = await _svc.memory_bulk_find_by_content_hashes(
         tenant_id=body["tenant_id"],
         hashes=body["hashes"],
+        fleet_id=body.get("fleet_id"),
+        agent_id=body.get("agent_id"),
     )
     return {ch: {"id": str(v["id"]), "client_request_id": v["client_request_id"]} for ch, v in result.items()}
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -262,9 +262,7 @@ async def find_by_content_hash(
     fleet_id: str | None = None,
     agent_id: str | None = None,
 ) -> dict:
-    memory = await _svc.memory_find_by_content_hash(
-        tenant_id, content_hash, fleet_id, agent_id=agent_id
-    )
+    memory = await _svc.memory_find_by_content_hash(tenant_id, content_hash, fleet_id, agent_id=agent_id)
     if memory is None:
         raise HTTPException(status_code=404, detail="Memory not found by content hash")
     return orm_to_dict(memory, MEMORY_FIELDS)

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -493,7 +493,12 @@ class PostgresService:
         tenant_id: str,
         content_hash: str,
         fleet_id: str | None = None,
+        agent_id: str | None = None,
     ) -> Memory | None:
+        # ``agent_id`` scopes the dedup match: two different agents writing
+        # identical content in the same fleet should both succeed (they are
+        # independent observations). Omitted → legacy tenant+fleet+content
+        # scope, which silently collides cross-agent.
         async with get_session() as session:
             stmt = select(Memory).where(
                 Memory.tenant_id == tenant_id,
@@ -504,6 +509,8 @@ class PostgresService:
                 stmt = stmt.where(Memory.fleet_id == fleet_id)
             else:
                 stmt = stmt.where(Memory.fleet_id.is_(None))
+            if agent_id is not None:
+                stmt = stmt.where(Memory.agent_id == agent_id)
             return (await session.execute(stmt)).scalar_one_or_none()
 
     async def memory_find_duplicate_hash(
@@ -512,6 +519,7 @@ class PostgresService:
         content_hash: str,
         fleet_id: str | None = None,
         exclude_id: UUID | None = None,
+        agent_id: str | None = None,
     ) -> UUID | None:
         async with get_session() as session:
             stmt = select(Memory.id).where(
@@ -523,6 +531,8 @@ class PostgresService:
                 stmt = stmt.where(Memory.fleet_id == fleet_id)
             else:
                 stmt = stmt.where(Memory.fleet_id.is_(None))
+            if agent_id is not None:
+                stmt = stmt.where(Memory.agent_id == agent_id)
             if exclude_id is not None:
                 stmt = stmt.where(Memory.id != exclude_id)
             return (await session.execute(stmt)).scalar_one_or_none()
@@ -588,6 +598,7 @@ class PostgresService:
         tenant_id: str,
         hashes: list[str],
         fleet_id: str | None = None,
+        agent_id: str | None = None,
     ) -> dict[str, dict]:
         """Map ``content_hash → {id, client_request_id}`` for existing rows.
 
@@ -598,6 +609,9 @@ class PostgresService:
         (``duplicate_attempt``); any other match is a different
         attempt's content (``duplicate_content``). NULL on legacy rows
         written before the column existed.
+
+        ``agent_id`` scopes the dedup lookup so cross-agent writes of
+        identical content no longer collide (Stage 5 / friction §2.8).
         """
         async with get_session() as session:
             stmt = select(Memory.content_hash, Memory.id, Memory.client_request_id).where(
@@ -609,6 +623,8 @@ class PostgresService:
                 stmt = stmt.where(Memory.fleet_id == fleet_id)
             else:
                 stmt = stmt.where(Memory.fleet_id.is_(None))
+            if agent_id is not None:
+                stmt = stmt.where(Memory.agent_id == agent_id)
             rows = (await session.execute(stmt)).all()
             return {row[0]: {"id": row[1], "client_request_id": row[2]} for row in rows}
 

--- a/tests/test_ingest_commit.py
+++ b/tests/test_ingest_commit.py
@@ -187,7 +187,8 @@ async def test_parent_document_skipped_when_zero_created(captured):
         "_ALL_": True,
     }
 
-    async def fake_bulk_find_all_existing(tenant_id, hashes):
+    async def fake_bulk_find_all_existing(tenant_id, hashes, *, fleet_id=None, agent_id=None):
+        # Stage 5 added per-agent dedup; accept the new kwargs.
         return {h: {"id": "x", "client_request_id": None} for h in hashes}
 
     captured.bulk_find_calls = []

--- a/tests/test_ingest_commit.py
+++ b/tests/test_ingest_commit.py
@@ -64,7 +64,10 @@ def captured(monkeypatch):
             default_write_mode="fast",
         )
 
-    async def fake_bulk_find(tenant_id, hashes):
+    async def fake_bulk_find(tenant_id, hashes, *, fleet_id=None, agent_id=None):
+        # ``fleet_id`` and ``agent_id`` were added in Stage 5 so cross-agent
+        # writes of identical content no longer collide; tests can still
+        # ignore them, but the signature must accept them.
         state.bulk_find_calls.append((tenant_id, list(hashes)))
         # Mimic the storage_client contract: dict[content_hash, {"id": str, ...}]
         return {


### PR DESCRIPTION
The exact-match dedup gate previously keyed on (tenant_id, fleet_id,
content_hash); two distinct agents writing identical content into
the same fleet would collide with a 409, even though they're
independent observations from different identities. Per friction
report §2.8 and the bug repro from the crm-demo team this is the
smoking gun behind "same memory UUID returned for admin-agent and
quote-agent-na on first-write registration."

Plumb agent_id through:
  core-storage-api  POST /memories/by-content-hash & /bulk-by-content-hashes
                    + postgres_service.memory_find_by_content_hash
                    + memory_find_duplicate_hash
                    + memory_bulk_find_by_content_hashes
  core-api          storage_client.find_by_content_hash
                    + bulk_find_by_content_hashes (+ fleet_id forwarding)
                    + memory_service create_memory dedup gate
                    + memory_service bulk dedup gate
                    + ingest_service bulk dedup gate
                    + pipeline step CheckExactDuplicate

agent_id is OPTIONAL on every layer so legacy callers that don't
pass it preserve the old behaviour; new memclaw callers always
pass data.agent_id. No data migration needed: the row's content_hash
column is unchanged (still tenant+fleet+content-deterministic), only
the dedup-query WHERE clause picks up an extra AND.

Embedding cache (find_embedding_by_content_hash) is intentionally
NOT scoped by agent_id — embeddings are content-deterministic, so
sharing the cache across agents is correct and saves redundant
embed calls.

Smoke (local enterprise stack, REST path):
  agent A writes "X" in fleet F  → 201
  agent B writes "X" in fleet F  → 201 (was 409 before Stage 5)
  agent A writes "X" again       → 409 (same-agent dup correctly caught)

Tests: ingest fixture updated to accept new kwargs. All 989 OSS unit
tests pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
