### PR TITLE
CAURA-000 fix(api): drop /agents/{id} alias for /trust

### DIFF
--- a/core-api/src/core_api/routes/agents.py
+++ b/core-api/src/core_api/routes/agents.py
@@ -136,27 +136,6 @@ async def patch_agent_tune(
     return AgentOut.model_validate(agent)
 
 
-@router.patch("/agents/{agent_id}", response_model=AgentOut)
-async def patch_agent(
-    agent_id: str,
-    body: AgentTrustUpdate,
-    tenant_id: str = Query(...),
-    auth: AuthContext = Depends(get_auth_context),
-    db: AsyncSession = Depends(get_db),
-):
-    """Update an agent's trust level (alias for /agents/{id}/trust)."""
-    auth.enforce_tenant(tenant_id)
-    agent = await update_trust_level(
-        db,
-        tenant_id,
-        agent_id,
-        body.trust_level,
-        fleet_id=body.fleet_id,
-    )
-    await db.commit()
-    return AgentOut.model_validate(agent)
-
-
 @router.delete("/agents/{agent_id}", status_code=204)
 async def delete_agent(
     agent_id: str,

--- a/tests/test_api_agents.py
+++ b/tests/test_api_agents.py
@@ -64,7 +64,7 @@ async def test_agent_created_on_memory_write(client):
 
 
 async def test_update_agent_trust_level(client):
-    """PATCH /api/agents/{agent_id}?tenant_id=X updates the trust level."""
+    """PATCH /api/agents/{agent_id}/trust?tenant_id=X updates the trust level."""
     tenant_id, headers = get_test_auth()
     tag = _uid()
     agent_name = f"agent-{tag}"
@@ -73,9 +73,9 @@ async def test_update_agent_trust_level(client):
                         f"A fact about trust levels for testing [{tag}]",
                         agent_id=agent_name, fleet_id=f"fleet-{tag}")
 
-    # Update trust level to 3
+    # Update trust level to 3 via the canonical /trust route.
     resp = await client.patch(
-        f"/api/v1/agents/{agent_name}?tenant_id={tenant_id}",
+        f"/api/v1/agents/{agent_name}/trust?tenant_id={tenant_id}",
         json={"trust_level": 3},
         headers=headers,
     )

--- a/tests/test_api_keystones.py
+++ b/tests/test_api_keystones.py
@@ -42,7 +42,7 @@ async def _seed_trusted_agent(client, tenant_id, headers, agent_id, fleet_id):
     )
     assert resp.status_code == 201, resp.text
     bump = await client.patch(
-        f"/api/v1/agents/{agent_id}?tenant_id={tenant_id}",
+        f"/api/v1/agents/{agent_id}/trust?tenant_id={tenant_id}",
         json={"trust_level": 2},
         headers=headers,
     )


### PR DESCRIPTION
The alias at PATCH /api/v1/agents/{id} (added as a back-compat
convenience) shipped alongside the canonical /agents/{id}/trust
route and caused real confusion during onboarding: the friction
report (§2.3) traced an early bootstrap dead-end to picking the
alias path. Both routes 404 in the same way when the Agent row
doesn't yet exist, so it's easy to misattribute the 404 to a
routing bug rather than the underlying missing-row problem.

The alias has no external callers (plugin + dashboard + docs all
target /trust; only one test was on the alias path, now migrated).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
