### PR TITLE
CAURA-000 fix(mcp): refuse "mcp-agent" default on gateway-routed writes

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -64,10 +64,16 @@ logger = logging.getLogger(__name__)
 
 _tenant_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("mcp_tenant_id")
 _agent_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("mcp_agent_id", default=None)
+# True iff X-Tenant-ID arrived as a request header (gateway-routed). On that
+# path the gateway is the source of truth for identity; falling back to the
+# literal "mcp-agent" tool-param default would silently attribute every write
+# from a tenant-key holder to a single shared identity (friction §2.8 / Stage 6b).
+_via_gateway_var: contextvars.ContextVar[bool] = contextvars.ContextVar("mcp_via_gateway", default=False)
 
 _UNAUTH = "__unauthenticated__"
 _ADMIN = "__admin__"
 _NO_AUTH = "__no_auth__"
+_DEFAULT_AGENT_ID = "mcp-agent"
 
 
 def _error_response(code: str, message: str, **details) -> str:
@@ -118,7 +124,9 @@ class MCPAuthMiddleware:
             tenant_header = headers.get(b"x-tenant-id", b"").decode()
             if tenant_header:
                 _tenant_id_var.set(tenant_header)
+                _via_gateway_var.set(True)
             else:
+                _via_gateway_var.set(False)
                 api_key = headers.get(b"x-api-key", b"").decode()
                 if not api_key:
                     auth_header = headers.get(b"authorization", b"").decode()
@@ -152,6 +160,36 @@ def _get_tenant() -> str:
 def _get_agent_id() -> str | None:
     """Return the verified agent_id from X-Agent-ID header, or None."""
     return _agent_id_var.get(None)
+
+
+def _refuse_default_agent_on_gateway(agent_id: str) -> str | None:
+    """When the request came through the enterprise gateway (X-Tenant-ID set)
+    and the gateway didn't inject X-Agent-ID (mc_ tenant-key path), the caller
+    must supply a real agent_id. Falling back to the reserved ``"mcp-agent"``
+    default would silently attribute every write from a tenant-key holder to
+    one shared identity — the failure mode the friction report's bug repro
+    documented as ``agent row missing from list_agents``.
+
+    Returns an error envelope if the call should be refused; ``None`` to proceed.
+    Standalone, admin, and gateway-routed mca_-key paths are unaffected:
+    standalone uses a stable single-tenant identity, admin is a system caller,
+    and an mca_ key resolves X-Agent-ID via auth_validate so this guard never
+    fires for it.
+    """
+    if not _via_gateway_var.get(False):
+        return None
+    if _get_agent_id() is not None:
+        return None
+    if agent_id != _DEFAULT_AGENT_ID:
+        return None
+    return _error_response(
+        "MISSING_AGENT_ID",
+        f"Writes via the gateway with a tenant ({'mc_'}) key must specify an "
+        "agent_id explicitly; the reserved default '"
+        f"{_DEFAULT_AGENT_ID}' is not accepted on this path. Either pass "
+        "agent_id=<your-agent-name> or use an mca_ per-agent key whose "
+        "identity the gateway will inject for you.",
+    )
 
 
 def _check_auth() -> str | None:
@@ -346,6 +384,8 @@ async def memclaw_write(
         )
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
+    if refuse := _refuse_default_agent_on_gateway(agent_id):
+        return _with_latency(refuse, t0)
 
     async with _mcp_session() as db:
         try:
@@ -810,6 +850,11 @@ async def memclaw_doc(
         return _with_latency(_error_response("INVALID_ARGUMENTS", f"op={op} requires 'collection'."), t0)
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
+    # Refuse the default identity for write ops on the gateway path; read-only
+    # ops don't carry the same attribution risk.
+    if op == "write":
+        if refuse := _refuse_default_agent_on_gateway(agent_id):
+            return _with_latency(refuse, t0)
 
     from core_api.repositories import document_repo
 

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -852,9 +852,8 @@ async def memclaw_doc(
     agent_id = _get_agent_id() or agent_id
     # Refuse the default identity for write ops on the gateway path; read-only
     # ops don't carry the same attribution risk.
-    if op == "write":
-        if refuse := _refuse_default_agent_on_gateway(agent_id):
-            return _with_latency(refuse, t0)
+    if op == "write" and (refuse := _refuse_default_agent_on_gateway(agent_id)):
+        return _with_latency(refuse, t0)
 
     from core_api.repositories import document_repo
 

--- a/tests/test_mcp_write.py
+++ b/tests/test_mcp_write.py
@@ -139,6 +139,47 @@ async def test_write_passes_fleet_id_kwarg_through(mcp_env):
     assert model.fleet_id == "caura-rnd-fleet"
 
 
+async def test_write_refuses_default_agent_on_gateway(mcp_env):
+    # Gateway-routed request + tenant key (no X-Agent-ID injection) + caller
+    # left agent_id at the default → MISSING_AGENT_ID. Standalone (default
+    # in tests) is unaffected.
+    mcp_env["service"]("create_memory").return_value = _OutStub("m-x")
+    from core_api import mcp_server
+
+    token = mcp_server._via_gateway_var.set(True)
+    try:
+        out = await mcp_server.memclaw_write(content="anything")
+    finally:
+        mcp_server._via_gateway_var.reset(token)
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "MISSING_AGENT_ID"
+    # Create wasn't called because we short-circuited.
+    mcp_env["service_mocks"]["create_memory"].assert_not_awaited()
+
+
+async def test_write_explicit_agent_on_gateway_allowed(mcp_env):
+    # Same gateway-routed path, but caller passed an explicit agent_id —
+    # the guard doesn't fire and the write proceeds.
+    mcp_env["service"]("create_memory").return_value = _OutStub("m-y")
+    from core_api import mcp_server
+
+    token = mcp_server._via_gateway_var.set(True)
+    try:
+        out = await mcp_server.memclaw_write(content="hi", agent_id="real-agent")
+    finally:
+        mcp_server._via_gateway_var.reset(token)
+    payload = parse_envelope(out)
+    assert payload["id"] == "m-y"
+
+
+async def test_write_default_agent_in_standalone_ok(mcp_env):
+    # Standalone (no gateway) keeps the default-identity ergonomics.
+    mcp_env["service"]("create_memory").return_value = _OutStub("m-z")
+    out = await mcp_server.memclaw_write(content="hi")
+    payload = parse_envelope(out)
+    assert payload["id"] == "m-z"
+
+
 async def test_write_without_fleet_id_persists_null(mcp_env):
     """Absent ``fleet_id`` → model carries ``None``. This is the current
     server-side behavior; pairs with the skill guidance that tells


### PR DESCRIPTION
When a request arrives via the enterprise gateway with a tenant
(``mc_``) key, X-Tenant-ID is set but X-Agent-ID is not — the gateway
only injects the agent identity for ``mca_`` per-agent keys. Today
the write tools silently fall back to the reserved default
``agent_id="mcp-agent"`` from the tool param, so every write from a
tenant-key holder lands under the same shared identity (the failure
mode the friction-report repro flagged at step [4] "rows matching
agent: 0").

Track gateway-routedness via a new context var ``_via_gateway_var``
set in MCPAuthMiddleware when X-Tenant-ID is present. ``memclaw_write``
and ``memclaw_doc op=write`` now refuse with MISSING_AGENT_ID if the
caller is gateway-routed AND ``X-Agent-ID`` wasn't injected AND
``agent_id`` is the literal default. Standalone, admin, and gateway
+ ``mca_`` paths are unaffected (the first two never set
``_via_gateway_var``; the third resolves X-Agent-ID).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
