### PR TITLE
CAURA-000 fix(mcp): make memclaw_write idempotent on exact-hash duplicate

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -193,6 +193,17 @@ def _refuse_default_agent_on_gateway(agent_id: str) -> str | None:
     )
 
 
+_DUPLICATE_DETAIL_RE = re.compile(r"^Duplicate memory exists:\s*(?P<id>[0-9a-fA-F-]{36})\s*$")
+
+
+def _extract_duplicate_id(detail: str) -> str | None:
+    """Parse the duplicate-memory exception detail. Returns the existing
+    memory id, or None if the format doesn't match (semantic-duplicate
+    hits use a different prefix and stay opaque to callers)."""
+    m = _DUPLICATE_DETAIL_RE.match(detail or "")
+    return m.group("id") if m else None
+
+
 def _check_auth() -> str | None:
     """Return an error string if auth fails, None if OK."""
     tid = _get_tenant()
@@ -464,6 +475,24 @@ async def memclaw_write(
             result = await create_memories_bulk(db, bulk_data, bulk_attempt_id=f"mcp:{uuid4()}")
             return _with_latency(_serialize(result), t0)
         except HTTPException as e:
+            # Idempotent retry-safe duplicate: when create_memory raises 409
+            # with the "Duplicate memory exists: <uuid>" detail (Stage 5's
+            # per-agent exact-hash dedup hit), surface a 200-shaped success
+            # envelope so callers can treat the retry as a no-op rather than
+            # an error. Semantic-duplicate hits still surface as errors —
+            # the caller wrote new content that we suppressed, which is a
+            # semantically distinct outcome.
+            if e.status_code == 409 and (existing_id := _extract_duplicate_id(str(e.detail))):
+                payload = {
+                    "status": "duplicate",
+                    "existing_id": existing_id,
+                    "agent_id": agent_id,
+                }
+                logger.info(
+                    "memclaw_write: idempotent duplicate hit existing=%s agent=%s",
+                    existing_id, agent_id,
+                )
+                return _with_latency(json.dumps(payload), t0)
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
             return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
 

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -490,7 +490,8 @@ async def memclaw_write(
                 }
                 logger.info(
                     "memclaw_write: idempotent duplicate hit existing=%s agent=%s",
-                    existing_id, agent_id,
+                    existing_id,
+                    agent_id,
                 )
                 return _with_latency(json.dumps(payload), t0)
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)

--- a/tests/test_mcp_write.py
+++ b/tests/test_mcp_write.py
@@ -124,14 +124,40 @@ async def test_write_invalid_batch_item(mcp_env):
 
 
 async def test_write_service_http_exception_becomes_envelope(mcp_env):
+    # Non-duplicate 4xx still maps to the error envelope.
     mcp_env["service"]("create_memory").side_effect = HTTPException(
-        status_code=409, detail="duplicate memory"
+        status_code=409, detail="some other conflict"
     )
     out = await mcp_server.memclaw_write(content="dup")
-    # Service-raised HTTPException maps to `Error (…): detail` (plain string
-    # plus _latency_ms), not the structured envelope above.
     assert "CONFLICT" in out
-    assert "duplicate memory" in out
+    assert "some other conflict" in out
+
+
+async def test_write_exact_duplicate_returns_idempotent_envelope(mcp_env):
+    # When the dedup gate trips (Stage 5's per-agent exact-hash dedup), the
+    # MCP write surface returns 200 with status=duplicate and the existing
+    # memory id. Lets callers safely retry without branching on 4xx codes.
+    existing_id = "11111111-2222-3333-4444-555555555555"
+    mcp_env["service"]("create_memory").side_effect = HTTPException(
+        status_code=409, detail=f"Duplicate memory exists: {existing_id}"
+    )
+    out = await mcp_server.memclaw_write(content="same content", agent_id="a1")
+    payload = parse_envelope(out)
+    assert payload["status"] == "duplicate"
+    assert payload["existing_id"] == existing_id
+    assert payload["agent_id"] == "a1"
+
+
+async def test_write_near_duplicate_still_errors(mcp_env):
+    # Semantic-duplicate (different prefix) is NOT idempotent — caller wrote
+    # new content that the service suppressed; surface as error.
+    mcp_env["service"]("create_memory").side_effect = HTTPException(
+        status_code=409,
+        detail="Near-duplicate memory exists: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    )
+    out = await mcp_server.memclaw_write(content="paraphrase")
+    assert "CONFLICT" in out
+    assert "Near-duplicate" in out
 
 
 async def test_write_auth_failure_shortcircuits(monkeypatch):


### PR DESCRIPTION
After Stage 5's per-agent dedup, a 409 on memclaw_write means the
same agent already wrote identical content — a textbook retry-safe
duplicate. Surface that case as a 200 envelope with
{status: "duplicate", existing_id, agent_id} so callers can treat
re-submitting the same payload as a no-op rather than an error.

Semantic-duplicate hits (different exception detail prefix) still
surface as 409/CONFLICT — the caller wrote NEW content that we
suppressed for similarity, which is semantically distinct from an
exact retry. The error envelope is unchanged for that path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
