### PR TITLE
CAURA-000 feat(api): GET /api/v1/whoami identity probe

### DIFF
--- a/core-api/src/core_api/routes/health.py
+++ b/core-api/src/core_api/routes/health.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, Request, Response
 from starlette.status import HTTP_503_SERVICE_UNAVAILABLE
 
 from common.events.factory import get_event_bus
@@ -27,6 +27,46 @@ router = APIRouter(tags=["System"])
 @router.get("/version")
 async def version():
     return {"version": VERSION}
+
+
+@router.get("/whoami")
+async def whoami(request: Request) -> dict:
+    """Identity probe — returns the caller's resolved (tenant_id, agent_id)
+    along with the resolution source. A single round-trip answers ~80% of
+    "is my integration wired correctly?" debugging during plugin / SDK
+    bootstrap (friction §2.1, §2.8 / Stage 7).
+
+    Resolution priority mirrors MCPAuthMiddleware:
+      gateway-header — X-Tenant-ID (and optionally X-Agent-ID) injected
+                       by the enterprise gateway after auth_request
+      standalone     — settings.is_standalone fixed tenant
+      anonymous      — no auth resolved (caller will hit 401 on first
+                       write; this endpoint stays open as a probe)
+    """
+    tenant_id = request.headers.get("x-tenant-id")
+    agent_id = request.headers.get("x-agent-id")
+    if tenant_id:
+        return {
+            "tenant_id": tenant_id,
+            "agent_id": agent_id,
+            "auth_source": "gateway-header",
+            "via_gateway": True,
+        }
+    if settings.is_standalone:
+        from core_api.standalone import get_standalone_tenant_id
+
+        return {
+            "tenant_id": get_standalone_tenant_id(),
+            "agent_id": None,
+            "auth_source": "standalone",
+            "via_gateway": False,
+        }
+    return {
+        "tenant_id": None,
+        "agent_id": None,
+        "auth_source": "anonymous",
+        "via_gateway": False,
+    }
 
 
 @router.get("/tool-descriptions")

--- a/tests/test_api_whoami.py
+++ b/tests/test_api_whoami.py
@@ -1,0 +1,42 @@
+"""E2E ``/api/v1/whoami`` — identity probe for SDK bootstrap debugging."""
+
+from __future__ import annotations
+
+
+async def test_whoami_with_gateway_headers(client):
+    # Gateway-routed path: X-Tenant-ID (+ optional X-Agent-ID) injected by
+    # auth_validate → returned verbatim with auth_source=gateway-header.
+    resp = await client.get(
+        "/api/v1/whoami",
+        headers={"X-Tenant-ID": "probe-tenant", "X-Agent-ID": "probe-agent"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["tenant_id"] == "probe-tenant"
+    assert data["agent_id"] == "probe-agent"
+    assert data["auth_source"] == "gateway-header"
+    assert data["via_gateway"] is True
+
+
+async def test_whoami_with_tenant_only(client):
+    # mc_ tenant-key path: gateway sets X-Tenant-ID but no X-Agent-ID.
+    resp = await client.get(
+        "/api/v1/whoami",
+        headers={"X-Tenant-ID": "probe-tenant"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tenant_id"] == "probe-tenant"
+    assert data["agent_id"] is None
+    assert data["auth_source"] == "gateway-header"
+
+
+async def test_whoami_standalone_or_anonymous(client):
+    # No gateway headers — tests run in standalone (auto-resolves) or
+    # anonymous mode. Either way the endpoint must return 200 and a
+    # structured envelope, never 401: it's a debug probe.
+    resp = await client.get("/api/v1/whoami")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["via_gateway"] is False
+    assert data["auth_source"] in {"standalone", "anonymous"}


### PR DESCRIPTION
Friction §2.1 + §2.8 / Stage 7 — single round-trip probe that
returns the caller's resolved (tenant_id, agent_id, auth_source) so
SDK developers can verify their integration without instrumenting
a memclaw_write + GET /agents flow.

FastMCP 1.27 doesn't expose a clean hook for injecting per-session
metadata into serverInfo at initialize, so this ships as a REST
endpoint for now. The path lives on the auth_request-gated /api/v1/
prefix — by design, since the friction case is "is my key actually
recognized?", which requires going through the auth surface.

Sample response (gateway path):
  GET /api/v1/whoami
    X-API-Key: mca_...
  → {"tenant_id": "...", "agent_id": "agent-na",
     "auth_source": "gateway-header", "via_gateway": true}

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
