### PR TITLE
CAURA-000 fix(fleet): block auto-deploy below MIN_AUTO_DEPLOY_PLUGIN_VERSION

### DIFF
--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -248,7 +248,7 @@ KNOWN_BROKEN_DEPLOY_VERSIONS: frozenset[str] = frozenset({"2.3.0"})
 # has not yet been cut into any released plugin tag. The first tagged
 # release that includes it (expected ``2.6.0``) will be the first
 # safe-to-auto-deploy version. Until that exists, every released
-# plugin (0.98.x / 2.0–2.5) needs a one-time manual re-install before
+# plugin (0.98.x / 2.0-2.5) needs a one-time manual re-install before
 # auto-deploy can take over.
 MIN_AUTO_DEPLOY_PLUGIN_VERSION: str = "2.6.0"
 

--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -218,16 +218,39 @@ async def delete_fleet(
 
 # CAURA-444 — plugin auto-upgrade. Versions whose deploy machinery is
 # itself broken; we never queue auto-deploy for these because the plugin
-# would loop. Each entry comes off the list once every node in the wild
-# has been manually upgraded past it.
+# would loop or land in a partially-deployed state. Each entry comes off
+# the list once every node in the wild has been manually upgraded past it.
 #
 # 2.3.0: hardcoded srcFiles list drifted from backend (15 vs 22 files);
 #        prebuild references a monorepo path missing on flat installs,
 #        so version.ts is never refreshed and PLUGIN_VERSION reports
-#        stale. Fixed structurally in 2.4.0 (manifest fetch + version
-#        stamp). Operators must manually upgrade 2.3.0 nodes once;
-#        auto-upgrade resumes from 2.4.0.
+#        stale.
 KNOWN_BROKEN_DEPLOY_VERSIONS: frozenset[str] = frozenset({"2.3.0"})
+
+# Floor below which auto-deploy is unsafe regardless of version-specific
+# brokenness above. Pre-manifest-aware plugins fetch source via their
+# own hardcoded ``FALLBACK_SRC_FILES`` (set at release time); any file
+# the backend later adds (e.g. ``keystones.ts``, statically imported
+# by ``context-engine.ts``) is never pulled, the post-deploy build
+# completes but ``dist/`` imports a missing module, and the plugin
+# is terminal on the next OpenClaw restart — same recovery as
+# KNOWN_BROKEN_DEPLOY_VERSIONS (manual re-install via
+# ``/api/v1/install-plugin``).
+#
+# Bump this constant in lockstep with each plugin release that adds a
+# new must-fetch source file. The plugin's ``FALLBACK_SRC_FILES`` array
+# in ``plugin/src/heartbeat.ts`` is the source of truth for what an
+# old client knows to fetch; mismatch with the backend's
+# ``_plugin_files`` in ``core_api/routes/plugin.py`` is what makes the
+# upgrade partial.
+#
+# As of CAURA-444 (this commit): manifest-aware deploy is on main but
+# has not yet been cut into any released plugin tag. The first tagged
+# release that includes it (expected ``2.6.0``) will be the first
+# safe-to-auto-deploy version. Until that exists, every released
+# plugin (0.98.x / 2.0–2.5) needs a one-time manual re-install before
+# auto-deploy can take over.
+MIN_AUTO_DEPLOY_PLUGIN_VERSION: str = "2.6.0"
 
 # Cap how far into the future a node can defer its own auto-upgrade.
 # Pre-cap a misbehaving / malicious plugin could send
@@ -321,6 +344,9 @@ async def _maybe_queue_auto_upgrade(
 
     - missing or unparseable plugin_version
     - plugin_version >= MIN_RECOMMENDED_PLUGIN_VERSION (no upgrade needed)
+    - plugin_version < MIN_AUTO_DEPLOY_PLUGIN_VERSION (pre-manifest-aware;
+      old client can't fetch new files, so auto-deploy would leave it
+      partially upgraded and unable to load)
     - plugin_version is in KNOWN_BROKEN_DEPLOY_VERSIONS
     - node has signalled cooldown via ``deploy_blocked_until``
     - tenant has explicitly disabled auto-upgrade
@@ -344,6 +370,21 @@ async def _maybe_queue_auto_upgrade(
     if not body.plugin_version:
         return False
     if not _semver_lt(body.plugin_version, target_version):
+        return False
+    # Pre-manifest-aware floor — old clients fetch source from their own
+    # hardcoded list and silently miss files added in later releases,
+    # which leaves dist/ importing modules that aren't on disk. Same
+    # recovery as KNOWN_BROKEN_DEPLOY_VERSIONS: manual re-install via
+    # ``/api/v1/install-plugin``.
+    if _semver_lt(body.plugin_version, MIN_AUTO_DEPLOY_PLUGIN_VERSION):
+        logger.info(
+            "fleet.heartbeat: skipping auto-upgrade for node=%s on "
+            "pre-manifest-aware version %s (manual re-install required; "
+            "floor=%s)",
+            body.node_name,
+            body.plugin_version,
+            MIN_AUTO_DEPLOY_PLUGIN_VERSION,
+        )
         return False
     if body.plugin_version in KNOWN_BROKEN_DEPLOY_VERSIONS:
         logger.info(

--- a/tests/test_fleet_heartbeat_auto_upgrade.py
+++ b/tests/test_fleet_heartbeat_auto_upgrade.py
@@ -240,6 +240,9 @@ async def test_maybe_queue_auto_upgrade_ignores_absurd_block_cap(monkeypatch):
     the upgrade.
     """
     monkeypatch.setattr(fleet_mod, "MIN_RECOMMENDED_PLUGIN_VERSION", "2.4.0")
+    # Disable the pre-manifest-aware floor for this test — we're
+    # exercising the absurd-block-cap branch, not the new gate.
+    monkeypatch.setattr(fleet_mod, "MIN_AUTO_DEPLOY_PLUGIN_VERSION", "0.0.0")
 
     async def _enabled(_db, _tid):
         return True
@@ -286,6 +289,74 @@ async def test_maybe_queue_auto_upgrade_skips_when_already_pending(monkeypatch):
     assert sc.created_commands == []
 
 
+# ---------------------------------------------------------------------------
+# MIN_AUTO_DEPLOY_PLUGIN_VERSION — pre-manifest-aware floor (CAURA-000)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stale_version", ["0.98.4", "2.0.0", "2.3.0", "2.4.0", "2.5.0"])
+async def test_maybe_queue_auto_upgrade_skips_pre_manifest_aware(monkeypatch, stale_version):
+    """Pre-manifest-aware floor blocks every released plugin tag.
+
+    The hardcoded fallback file list in those releases doesn't include
+    files added in later releases (e.g. keystones.ts), so auto-deploy
+    leaves the plugin unable to load. Same recovery path as
+    KNOWN_BROKEN_DEPLOY_VERSIONS — operator runs the install one-liner.
+    """
+    monkeypatch.setattr(fleet_mod, "MIN_RECOMMENDED_PLUGIN_VERSION", "2.6.0")
+    monkeypatch.setattr(fleet_mod, "MIN_AUTO_DEPLOY_PLUGIN_VERSION", "2.6.0")
+
+    async def _enabled(_db, _tid):
+        return True
+
+    monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
+    sc = _FakeStorage()
+    await fleet_mod._maybe_queue_auto_upgrade(
+        db=None, sc=sc, body=_body(stale_version),
+        pending_commands=sc.pending_commands, node_id="node-uuid-1",
+    )
+    assert sc.created_commands == [], (
+        f"Expected no deploy queued for pre-manifest-aware {stale_version!r}; "
+        f"got {sc.created_commands!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_maybe_queue_auto_upgrade_allowed_at_or_above_floor(monkeypatch):
+    """A plugin at the floor exact version OR above is eligible for
+    auto-deploy (subject to other gates). Asserts the floor is < rather
+    than <=, so floor versions can still be pushed forward."""
+    # Target is higher than floor — there's a real upgrade to issue.
+    monkeypatch.setattr(fleet_mod, "MIN_RECOMMENDED_PLUGIN_VERSION", "2.6.1")
+    monkeypatch.setattr(fleet_mod, "MIN_AUTO_DEPLOY_PLUGIN_VERSION", "2.6.0")
+
+    async def _enabled(_db, _tid):
+        return True
+
+    monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
+    sc = _FakeStorage()
+    await fleet_mod._maybe_queue_auto_upgrade(
+        db=None, sc=sc, body=_body("2.6.0"),
+        pending_commands=sc.pending_commands, node_id="node-uuid-1",
+    )
+    assert len(sc.created_commands) == 1, (
+        f"Expected deploy queued for floor version 2.6.0; got {sc.created_commands!r}"
+    )
+    assert sc.created_commands[0]["command"] == "deploy"
+
+
+def test_min_auto_deploy_constant_shape():
+    """The floor is a string-shaped semver and stays a module-level
+    constant so operators can find / bump it without searching the file.
+    """
+    assert isinstance(fleet_mod.MIN_AUTO_DEPLOY_PLUGIN_VERSION, str)
+    parts = fleet_mod.MIN_AUTO_DEPLOY_PLUGIN_VERSION.split(".")
+    assert len(parts) >= 2
+    for p in parts:
+        assert p.isdigit(), f"Non-numeric segment in floor: {p!r}"
+
+
 def test_has_recent_deploy_from_list_handles_non_dict_entries():
     """Pre-fix ``(c or {}).get(...)`` raised AttributeError on a truthy
     non-dict element (string, number, list). The isinstance guard
@@ -314,6 +385,9 @@ def test_has_recent_deploy_from_list_handles_non_dict_entries():
 async def test_maybe_queue_auto_upgrade_queues_deploy_for_old_version(monkeypatch):
     """Happy path: enabled, not blocked, no pending, valid old version → queue."""
     monkeypatch.setattr(fleet_mod, "MIN_RECOMMENDED_PLUGIN_VERSION", "2.4.0")
+    # Disable the pre-manifest-aware floor for this test — happy-path coverage
+    # is for an already-manifest-aware client; the new floor has its own tests.
+    monkeypatch.setattr(fleet_mod, "MIN_AUTO_DEPLOY_PLUGIN_VERSION", "0.0.0")
 
     async def _enabled(_db, _tid):
         return True


### PR DESCRIPTION
Pre-manifest-aware plugins (every released tag from 0.98.x through
2.5.0) fetch source via their own hardcoded FALLBACK_SRC_FILES list,
set at release time. When the backend adds a new must-fetch file
(e.g. keystones.ts in CAURA-444), an auto-deploy on those clients
completes the per-file pull for files in the old list, rebuilds dist/,
and leaves the new code importing a module that was never fetched.
Result: dist/context-engine.js → import './keystones.js' → ERR_MODULE_
NOT_FOUND on the next OpenClaw restart. Plugin terminal; recovery is
the same manual re-install path as KNOWN_BROKEN_DEPLOY_VERSIONS.

The prior comment on KNOWN_BROKEN_DEPLOY_VERSIONS asserted that 2.4.0
fixed this structurally; verified against v2.4.0 and v2.5.0 tags —
neither has the manifest fetch in plugin/src/heartbeat.ts. The fix
landed on main HEAD only (this branch's parent) and has not yet been
cut into any released plugin tag.

Add MIN_AUTO_DEPLOY_PLUGIN_VERSION="2.6.0" as a separate gate from
KNOWN_BROKEN_DEPLOY_VERSIONS (which stays for version-specific defects
above the floor). Operator bumps the constant in lockstep with each
release that adds a new must-fetch file. Until the first manifest-
aware plugin is released, the floor stays at "2.6.0" and every
released plugin needs one manual re-install before auto-deploy can
take over.

Tests: parametrize the new gate over 0.98.4 / 2.0.0 / 2.3.0 / 2.4.0
/ 2.5.0 — all skipped. 2.6.0 at the floor with a higher target is
still queued. Existing happy-path + absurd-block-cap tests now
monkeypatch the floor to "0.0.0" so they exercise the original
intent without triggering the new gate.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
