### PR TITLE
feat(memories): add run_id query filter to /api/memories

### DIFF
--- a/core-api/src/core_api/repositories/memory_repository.py
+++ b/core-api/src/core_api/repositories/memory_repository.py
@@ -93,6 +93,7 @@ class MemoryRepository:
         written_by: str | None = None,
         memory_type: str | None = None,
         status: str | None = None,
+        run_id: str | None = None,
         weight_min: float | None = None,
         weight_max: float | None = None,
         created_after: datetime | None = None,
@@ -145,6 +146,11 @@ class MemoryRepository:
             stmt = stmt.where(Memory.memory_type == memory_type)
         if status:
             stmt = stmt.where(Memory.status == status)
+        if run_id is not None:
+            # Indexed by ``ix_memories_run_id (tenant_id, run_id)`` — drives
+            # the "show me memories from this ingest batch" filter used by
+            # the dashboard Past Uploads tab.
+            stmt = stmt.where(Memory.run_id == run_id)
         if weight_min is not None:
             stmt = stmt.where(Memory.weight >= weight_min)
         if weight_max is not None:

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -213,6 +213,7 @@ async def list_memories(
     memory_type: str | None = Query(default=None),
     status: str | None = Query(default=None),
     visibility: str | None = Query(default=None),
+    run_id: str | None = Query(default=None),
     cursor: str | None = Query(default=None),
     sort: str = Query(
         default="created_at",
@@ -275,6 +276,7 @@ async def list_memories(
         written_by=agent_id,  # author filter (same param)
         memory_type=memory_type,
         status=status,
+        run_id=run_id,
         include_deleted=include_deleted,
         sort=sort,
         order=order,


### PR DESCRIPTION
## Summary

Pure additive. `GET /api/memories?...&run_id=<uuid>` filters the listing to memories from one ingest batch. Backed by the `ix_memories_run_id (tenant_id, run_id) WHERE run_id IS NOT NULL` index added in #134, so the filter is a single index seek even on multi-million-row tenants.

Plumbed through `memory_repository.list_by_filters` (new `run_id` kwarg). All other filters unchanged.

## Why

Unblocks the dashboard's **Past Uploads → Prism click-through path** (caura-memclaw-enterprise companion PR): clicking a row on the new Past Uploads tab navigates to `/prism?run_id=<uuid>` and the memory table filters server-side instead of fetching everything and filtering in the browser. Per-batch view becomes O(N_batch), not O(N_tenant).

## Test plan

- [x] `ruff check`, `mypy src/` clean.
- [x] Full ingest test suite (93 tests) passes — no regressions to existing filters.
- [x] **Wet test** on canonical local stack:
  - `GET /api/memories?tenant_id=...&run_id=<known-run-id>` → exactly the 4 memories from that ingest batch ✓
  - `GET /api/memories?tenant_id=...&run_id=<bogus-uuid>` → 0 ✓
- No new tests for the param itself — the change is one `if` in the repo, behavior exercised end-to-end by the wet test. If filter-combination coverage becomes a need, `tests/test_memory_repository.py` is the place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)