### PR TITLE
CAURA-000 docs(readme): note mc_ tenant-key path requires explicit agent_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Get up and running in minutes — no infrastructure, automatic updates, usage an
 ```
 
 > **Production / team use:** `mc_` is a tenant-level key — fine for personal use, but a fleet of agents should bind each one to its own `mca_` key for trust gating, fleet membership, and per-agent keystones. Mint per-agent keys atomically via [`POST /api/v1/admin/agent-keys/provision`](docs/integration-without-plugin.md). The MCP server accepts the agent key on either `X-API-Key: mca_…` or `Authorization: Bearer mca_…`.
+>
+> Staying on `mc_` for the quickstart? Pass an explicit `agent_id` on every MCP tool call — the gateway refuses the reserved default (`mcp-agent`) on the tenant-key path.
 
 ### Self-Hosted (Open Source)
 
@@ -301,7 +303,7 @@ Add MemClaw to any MCP client with one config block.
 }
 ```
 
-> For team or production use, swap the tenant `mc_` key for a per-agent `mca_` key — atomic provisioning via `POST /api/v1/admin/agent-keys/provision` mints the key + Agent row + initial trust + fleet membership in one round trip. See [`docs/integration-without-plugin.md`](docs/integration-without-plugin.md).
+> For team or production use, swap the tenant `mc_` key for a per-agent `mca_` key — atomic provisioning via `POST /api/v1/admin/agent-keys/provision` mints the key + Agent row + initial trust + fleet membership in one round trip. See [`docs/integration-without-plugin.md`](docs/integration-without-plugin.md). Staying on `mc_`? Pass an explicit `agent_id` on every MCP tool call — the gateway refuses the reserved default (`mcp-agent`) on the tenant-key path.
 
 **Where to add this config:**
 - **Claude Code** — `~/.claude/settings.json` under `"mcpServers"`


### PR DESCRIPTION
## Summary

Follow-up to #148. Add one sentence to each of the two `mc_` callouts in the README pointing out that tool calls on the tenant-key path must include an explicit `agent_id` — the gateway refuses the reserved default (`mcp-agent`).

## Why

#148 added great callouts steering team/production users to `mca_` keys + atomic provisioning, but left the quickstart `mc_` path silent on the default-agent refuse behavior implemented in `mcp_server._refuse_default_agent_on_gateway`. A developer who follows the README quickstart literally and tries their first MCP tool call hits `MISSING_AGENT_ID` with no docs hint that the fix is to pass `agent_id="…"` on the call. Hit this firsthand while building a Streamlit demo against the quickstart key path.

This is the smallest possible delta that closes the residual quickstart gotcha without re-litigating PR #148's framing (which correctly steers serious users to `mca_`).

## Test plan

- [ ] README renders on github.com — no Markdown breakage in either callout
- [ ] Existing link to `docs/integration-without-plugin.md` still resolves
- [ ] No code or CI changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)