### PR TITLE
fix(search): trust has_embedding sentinel in post-filter for FTS-only rows

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
+++ b/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
@@ -136,6 +136,7 @@ class ExecuteScoredSearch:
                                 "temporal_boost",
                                 "status_penalty",
                                 "entity_links",
+                                "has_embedding",
                             )
                         }
                     ),
@@ -148,6 +149,7 @@ class ExecuteScoredSearch:
                     recall_boost=row.get("recall_boost"),
                     temporal_boost=row.get("temporal_boost"),
                     status_penalty=row.get("status_penalty"),
+                    has_embedding=row.get("has_embedding", True),
                     entity_links=[],
                 )
             # Entity links may be inline in the row or as a nested list.

--- a/core-api/src/core_api/pipeline/steps/search/post_filter_results.py
+++ b/core-api/src/core_api/pipeline/steps/search/post_filter_results.py
@@ -18,14 +18,21 @@ class PostFilterResults:
             return StepResult(outcome=StepOutcome.SKIPPED)
 
         min_similarity = ctx.data["search_params"]["min_similarity"]
-        # Mirror the legacy path in memory_service.py: rows with vec_sim=None
-        # are FTS-only matches that must not be gated by cosine similarity.
-        # Currently unreachable in practice (the scored_search SQL requires
-        # `embedding IS NOT NULL` and the storage layer coerces None → 0.0),
-        # but kept aligned so the two search code paths never diverge if
-        # either invariant changes to preserve FTS-only rows.
+        # NULL-embedding rows reach this point only when storage admitted them
+        # via the FTS half of `embedding IS NOT NULL OR search_vector @@ query`
+        # (relaxed in CAURA-594 so writes deferred via EMBED_REQUESTED stay
+        # searchable during the embed-pending window). Storage coerces their
+        # missing cosine to a 0.0 sentinel and emits `has_embedding=False` to
+        # disambiguate that from a real orthogonal match — trust that flag
+        # here and bypass the vec_sim threshold for FTS-only rows. Without
+        # this, the entire FTS-fallback contract is silently broken for any
+        # row whose embedding hasn't been PATCHed yet by core-worker.
         filtered = [
-            row for row in ctx.data["raw_rows"] if row.vec_sim is None or float(row.vec_sim) >= min_similarity
+            row
+            for row in ctx.data["raw_rows"]
+            if (not getattr(row, "has_embedding", True))
+            or row.vec_sim is None
+            or float(row.vec_sim) >= min_similarity
         ]
         # Trim to the user-requested top_k (storage returned top_k * overfetch_factor)
         final_top_k = ctx.data.get("final_top_k")


### PR DESCRIPTION
## Summary

CAURA-594 relaxed the storage WHERE clause to admit NULL-embedding rows via FTS, so that fast-mode writes deferred via `EMBED_REQUESTED` remain searchable during the embed-pending window. Storage's side of that contract shipped correctly: NULL-embedding rows are admitted, and storage emits `has_embedding=false` to disambiguate the `vec_sim=0.0` sentinel from a genuinely orthogonal cosine match.

The API side never adopted the disambiguator. `PostFilterResults` continued to gate on `vec_sim >= min_similarity` only, dropping every NULL-embedding row regardless of FTS match — silently breaking the FTS-fallback contract for any row whose embedding hadn't been PATCHed yet by `core-worker`.

This PR makes the API side trust the existing disambiguator.

## Changes

- `core-api/.../pipeline/steps/search/post_filter_results.py` — adds a leading clause (`not getattr(row, "has_embedding", True)`) that keeps any row admitted by storage without an embedding. The `vec_sim` threshold is preserved for embedded rows. Defensive `getattr` default means rows lacking the field fall through to the existing path (back-compat).
- `core-api/.../pipeline/steps/search/execute_scored_search.py` — lifts `has_embedding` from the inner `row.Memory` namespace to the top-level row namespace, so the post-filter can read it. Also excludes it from the `Memory` namespace to avoid duplication.

## Why this isn't sufficient on its own

Wet-testing the patch against a tenant with ~300 existing embedded memories revealed a **second** issue: storage's score formula (`similarity = (1 - fts_weight) * vec_sim + fts_weight * fts_score`) suppresses NULL-embedding rows' similarity below typical embedded-row similarities, so the row is truncated by `ORDER BY score DESC LIMIT _top_k` before reaching the post-filter at all.

This PR fixes the half it claims to fix (the API-layer drop). The companion fix lives in a follow-up: storage-side similarity formula tweak so FTS-only rows compete on equal footing. The two together are needed to actually deliver the user-visible FTS-fallback experience the CAURA-594 SaaS deployment promises.

Tracking doc for the follow-up: `08-storage-score-suppresses-fts-only-rows-under-load.md` (lives with the broader fast-vs-strong gap analysis).

## Test plan

Validated against the running prod-mirror local stack (`EMBED_ON_HOT_PATH=false ENRICH_ON_HOT_PATH=false`) by constructing synthetic `raw_rows` and calling `PostFilterResults.execute()` directly. 6/6 cases pass:

- [x] FTS-only row (`has_embedding=False`, `vec_sim=0.0`) → kept
- [x] Embedded row with low cosine (`vec_sim=0.15 < 0.3`) → dropped (preserved)
- [x] Embedded row with high cosine (`vec_sim=0.5 >= 0.3`) → kept (preserved)
- [x] Row without `has_embedding` attribute, low cosine → dropped (defensive default `True`, back-compat)
- [x] Mixed bag — FTS-only kept, low-cosine dropped, high-cosine kept
- [x] `vec_sim=None` defensive path → kept (preserved)

Empirical lift verification: the same wet test showed every storage-returned row arrived at the post-filter with `has_embedding` set on the top-level namespace (confirming the `execute_scored_search.py` lift works end-to-end).

A real end-to-end FTS-search test will pass once the companion storage-side fix lands; until then, this PR is a foundational change with no user-visible behaviour delta in production (NULL-embedding rows still get truncated by storage's `LIMIT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)