### PR TITLE
fix(write): close fast-branch coverage holes + add always-fire detection logs

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/schedule_background_tasks.py
+++ b/core-api/src/core_api/pipeline/steps/write/schedule_background_tasks.py
@@ -28,7 +28,14 @@ class ScheduleBackgroundTasks:
         resolved_write_mode = ctx.data.get("resolved_write_mode")
         memory_id = memory["id"] if isinstance(memory, dict) else memory.id
 
-        # Fast mode: defer enrichment + entity extraction + contradiction to background
+        # Fast mode fan-out. The fast branch returns BEFORE the strong-mode
+        # entity-extraction + Path A blocks below, so historically each had
+        # to be wired through ``_enrich_memory_background`` indirectly —
+        # which left coverage holes (Gap 01: Enterprise+fast lost entity
+        # extraction; Gap 04: OSS+fast lost Path A) because the indirect
+        # chain didn't actually fire in every flag profile. Closes both
+        # gaps by mirroring the strong branch's direct fan-out below for
+        # extraction and Path A.
         if resolved_write_mode == "fast":
             if tenant_config.enrichment_enabled:
                 from core_api.services.memory_service import (
@@ -53,6 +60,62 @@ class ScheduleBackgroundTasks:
                         data.tenant_id,
                     )
                 )
+
+            # Entity extraction (Gap 01). Extraction reads only ``content`` —
+            # no dependency on the embedding being available — so it fires
+            # regardless of embed deferral. ``_enrich_memory_background``
+            # may also fire extraction in some profiles (OSS+fast inline
+            # path); ``process_entity_extraction`` is idempotent
+            # (``find_entity_link`` short-circuits link creation) so the
+            # potential second fire is a wasted LLM call, not a data
+            # integrity issue. Cleaning up the redundant fire is a
+            # follow-up once ``_enrich_memory_background`` is decomposed.
+            if tenant_config.entity_extraction_enabled:
+                track_task(
+                    tracked_task(
+                        process_entity_extraction(
+                            memory_id,
+                            data.tenant_id,
+                            data.fleet_id,
+                            data.agent_id,
+                            data.content,
+                            data.memory_type,
+                        ),
+                        "entity_extraction",
+                        memory_id,
+                        data.tenant_id,
+                    )
+                )
+
+            # Path A contradiction detection (Gap 04). Only fires when an
+            # inline embedding is available (OSS local + fast under
+            # ``embed_on_hot_path=True``, or strong's PR-2 force-inline).
+            # When ``embedding is None`` (Enterprise+fast deferred), Path A
+            # fires via the ``EMBEDDED`` back-channel after ``core-worker``
+            # PATCHes the embedding into the row — see the
+            # ``_enrich_memory_background`` gate gated on
+            # ``not settings.embed_on_hot_path``. Each cell of the matrix
+            # gets exactly one Path A trigger that way.
+            if embedding is not None:
+                from core_api.services.contradiction_detector import (
+                    detect_contradictions_async,
+                )
+
+                track_task(
+                    tracked_task(
+                        detect_contradictions_async(
+                            memory_id,
+                            data.tenant_id,
+                            data.fleet_id,
+                            data.content,
+                            embedding,
+                        ),
+                        "contradiction_detection",
+                        memory_id,
+                        data.tenant_id,
+                    )
+                )
+
             # CAURA-594: deferred-path or inline-failure backfill — the
             # shim publishes EMBED_REQUESTED in async mode, retries
             # in-process when embed_on_hot_path=True.

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -12,6 +12,7 @@ Multi-provider support:
 
 import asyncio
 import logging
+import time
 from datetime import datetime
 from uuid import UUID
 
@@ -88,6 +89,14 @@ async def detect_contradictions_async(
     """
     from core_api.services.organization_settings import resolve_config
 
+    # Always-fire completion log (Gap 06): without this, "function ran and
+    # found nothing" is indistinguishable from "function never fired" — the
+    # exact failure mode that hid Gap 01 and Gap 04 for weeks. Memory id is
+    # in the message string itself (rather than ``extra``) so a plain
+    # ``grep path_a_completed <memory_id>`` works regardless of the
+    # structlog renderer's ``extra={}`` behaviour.
+    t_start = time.monotonic()
+    n_conflicts = 0
     try:
         if new_memory is None:
             sc = get_storage_client()
@@ -97,6 +106,7 @@ async def detect_contradictions_async(
 
         tenant_config = await resolve_config(None, tenant_id)
         contradictions = await _detect(new_memory, embedding, tenant_config)
+        n_conflicts = len(contradictions) if contradictions else 0
 
         if contradictions:
             logger.info(
@@ -106,6 +116,15 @@ async def detect_contradictions_async(
             )
     except Exception:
         logger.exception("Async contradiction detection failed for memory %s", memory_id)
+    finally:
+        elapsed_ms = round((time.monotonic() - t_start) * 1000)
+        logger.info(
+            "path_a_completed for memory %s n_conflicts=%d elapsed_ms=%d tenant_id=%s",
+            memory_id,
+            n_conflicts,
+            elapsed_ms,
+            tenant_id,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +411,11 @@ async def detect_contradictions_by_entities_async(
     """
     from core_api.services.organization_settings import resolve_config
 
+    # Always-fire completion log (Gap 06) — see ``detect_contradictions_async``
+    # above for the rationale. Same memory-id-in-message convention.
+    t_start = time.monotonic()
+    n_candidates = 0
+    n_conflicts = 0
     try:
         sc = get_storage_client()
         new_memory = await sc.get_memory(str(memory_id))
@@ -408,6 +432,7 @@ async def detect_contradictions_by_entities_async(
                 "visibility": new_memory.get("visibility", "scope_team"),
             }
         )
+        n_candidates = len(candidates) if candidates else 0
         if not candidates:
             return
 
@@ -445,6 +470,7 @@ async def detect_contradictions_by_entities_async(
                         supersedes_id=str(cand_id),
                     )
                 found = True
+                n_conflicts += 1
                 logger.info(
                     "Entity-based contradiction: %s conflicted by %s",
                     cand_id,
@@ -452,6 +478,16 @@ async def detect_contradictions_by_entities_async(
                 )
     except Exception:
         logger.exception("Entity-based contradiction detection failed for %s", memory_id)
+    finally:
+        elapsed_ms = round((time.monotonic() - t_start) * 1000)
+        logger.info(
+            "path_c_completed for memory %s n_candidates=%d n_conflicts=%d elapsed_ms=%d tenant_id=%s",
+            memory_id,
+            n_candidates,
+            n_conflicts,
+            elapsed_ms,
+            tenant_id,
+        )
 
 
 # Backward-compat re-exports for tests

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -126,7 +126,9 @@ async def test_legacy_path_creates_memory(db):
     try:
         from core_api.services.memory_service import create_memory
 
-        data = _make_input(content="Legacy path baseline test memory — unique content to avoid hash collision with pipeline path test.")
+        data = _make_input(
+            content="Legacy path baseline test memory — unique content to avoid hash collision with pipeline path test."
+        )
         result = await create_memory(db, data)
 
         assert isinstance(result, MemoryOut)
@@ -352,8 +354,15 @@ async def test_merge_enrichment_no_pending_in_strong_mode():
 
 
 @pytest.mark.asyncio
-async def test_schedule_background_tasks_fast_mode_fires_background_enrichment():
-    """ScheduleBackgroundTasks fires _enrich_memory_background in fast mode."""
+async def test_schedule_background_tasks_fast_mode_fires_full_fan_out():
+    """ScheduleBackgroundTasks fast branch fires background enrichment +
+    entity extraction + Path A contradiction detection.
+
+    Pre-Gap-01/04 fix: fast mode only fired background_enrichment and
+    relied on ``_enrich_memory_background`` to chain into the others —
+    a chain that didn't fire in every flag profile (Enterprise+fast lost
+    entity extraction, OSS+fast lost Path A). The fast branch now fires
+    each directly, mirroring the strong branch's symmetric fan-out."""
     from core_api.pipeline.context import PipelineContext
     from core_api.pipeline.steps.write.schedule_background_tasks import (
         ScheduleBackgroundTasks,
@@ -386,8 +395,10 @@ async def test_schedule_background_tasks_fast_mode_fires_background_enrichment()
         step = ScheduleBackgroundTasks()
         await step.execute(ctx)
 
-    # Should fire background_enrichment, NOT entity_extraction or contradiction directly
-    assert mock_track.call_count == 1  # only background_enrichment
+    # 3 tracked tasks: background_enrichment + entity_extraction + Path A.
+    # Embed-reembed is NOT scheduled here because embedding is present.
+    # Detailed per-task wiring is covered in tests/test_fast_branch_fan_out.py.
+    assert mock_track.call_count == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_fast_branch_fan_out.py
+++ b/tests/test_fast_branch_fan_out.py
@@ -1,0 +1,251 @@
+"""ScheduleBackgroundTasks fast-branch fan-out (closes Gaps 01 + 04).
+
+The fast branch returns BEFORE the strong branch's entity-extraction +
+Path A blocks. Historically each had to be wired through
+``_enrich_memory_background`` indirectly, which left coverage holes:
+
+- **Gap 01**: Enterprise+fast wrote rows with zero entity_links because
+  the deferred-enrich worker handler doesn't fire
+  ``process_entity_extraction`` and nothing further in the chain does
+  either.
+- **Gap 04**: OSS+fast lost Path A because the gate inside
+  ``_enrich_memory_background`` (``not settings.embed_on_hot_path``)
+  evaluated False in the OSS profile.
+
+These tests pin the new direct fan-out in the fast branch as a
+regression guard.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core_api.constants import VECTOR_DIM
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.write.schedule_background_tasks import (
+    ScheduleBackgroundTasks,
+)
+from core_api.schemas import MemoryCreate
+
+pytestmark = pytest.mark.asyncio
+
+
+TENANT_ID = f"test-fast-fanout-{uuid.uuid4().hex[:8]}"
+
+
+def _input() -> MemoryCreate:
+    return MemoryCreate(
+        tenant_id=TENANT_ID,
+        fleet_id="f",
+        agent_id="a",
+        content="A test memory long enough to pass any content-length gate.",
+        persist=True,
+        entity_links=[],
+    )
+
+
+def _tenant_config(
+    *, entity_extraction: bool = True, enrichment: bool = True
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        enrichment_enabled=enrichment,
+        enrichment_provider="fake" if enrichment else "none",
+        entity_extraction_enabled=entity_extraction,
+    )
+
+
+def _ctx(
+    *,
+    embedding: list[float] | None,
+    entity_extraction: bool = True,
+    enrichment: bool = True,
+    memory_id: uuid.UUID | None = None,
+) -> PipelineContext:
+    return PipelineContext(
+        db=AsyncMock(),
+        data={
+            "input": _input(),
+            "memory": {"id": memory_id or uuid.uuid4()},
+            "embedding": embedding,
+            "enrichment": None,
+            "resolved_write_mode": "fast",
+            "content_hash": "f" * 64,
+        },
+        tenant_config=_tenant_config(
+            entity_extraction=entity_extraction, enrichment=enrichment
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gap 01 — entity extraction fires from the fast branch directly
+# ---------------------------------------------------------------------------
+
+
+async def test_fast_fires_entity_extraction_when_enabled() -> None:
+    """Closes Gap 01: prior to this PR, Enterprise+fast wrote rows with
+    zero entity_links because nothing in the fast chain fired extraction.
+    Now the fast branch fires it directly, mirroring the strong branch."""
+    ctx = _ctx(embedding=[0.1] * VECTOR_DIM)
+    extract_spy = AsyncMock(return_value=None)
+    with (
+        patch(
+            "core_api.pipeline.steps.write.schedule_background_tasks.process_entity_extraction",
+            new=extract_spy,
+        ),
+        patch(
+            "core_api.services.memory_service._schedule_enrich_or_inline",
+            new=AsyncMock(),
+        ),
+        patch(
+            "core_api.services.contradiction_detector.detect_contradictions_async",
+            new=AsyncMock(),
+        ),
+    ):
+        await ScheduleBackgroundTasks().execute(ctx)
+
+    extract_spy.assert_called_once()
+
+
+async def test_fast_skips_entity_extraction_when_disabled() -> None:
+    """Tenant-level kill-switch must still work."""
+    ctx = _ctx(embedding=[0.1] * VECTOR_DIM, entity_extraction=False)
+    extract_spy = AsyncMock(return_value=None)
+    with (
+        patch(
+            "core_api.pipeline.steps.write.schedule_background_tasks.process_entity_extraction",
+            new=extract_spy,
+        ),
+        patch(
+            "core_api.services.memory_service._schedule_enrich_or_inline",
+            new=AsyncMock(),
+        ),
+        patch(
+            "core_api.services.contradiction_detector.detect_contradictions_async",
+            new=AsyncMock(),
+        ),
+    ):
+        await ScheduleBackgroundTasks().execute(ctx)
+
+    extract_spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Gap 04 — Path A fires from the fast branch when embedding is present
+# ---------------------------------------------------------------------------
+
+
+async def test_fast_fires_path_a_when_embedding_present() -> None:
+    """Closes Gap 04: OSS+fast (embedding inline because
+    ``embed_on_hot_path=True``) must fire Path A. The pre-PR-3 path
+    through ``_enrich_memory_background`` was gated on
+    ``not settings.embed_on_hot_path``, so OSS+fast never got Path A."""
+    ctx = _ctx(embedding=[0.1] * VECTOR_DIM)
+    contradiction_spy = AsyncMock(return_value=None)
+    with (
+        patch(
+            "core_api.services.contradiction_detector.detect_contradictions_async",
+            new=contradiction_spy,
+        ),
+        patch(
+            "core_api.pipeline.steps.write.schedule_background_tasks.process_entity_extraction",
+            new=AsyncMock(),
+        ),
+        patch(
+            "core_api.services.memory_service._schedule_enrich_or_inline",
+            new=AsyncMock(),
+        ),
+    ):
+        await ScheduleBackgroundTasks().execute(ctx)
+
+    contradiction_spy.assert_called_once()
+
+
+async def test_fast_skips_path_a_when_embedding_none() -> None:
+    """When embedding is None (Enterprise+fast deferred), Path A is NOT
+    fired from the fast branch. The ``EMBEDDED`` back-channel will fire
+    it after core-worker PATCHes the row. Firing here would either
+    crash (no embedding to pass) or duplicate the back-channel firing."""
+    ctx = _ctx(embedding=None)
+    contradiction_spy = AsyncMock(return_value=None)
+    reembed_spy = AsyncMock(return_value=None)
+    with (
+        patch(
+            "core_api.services.contradiction_detector.detect_contradictions_async",
+            new=contradiction_spy,
+        ),
+        patch(
+            "core_api.pipeline.steps.write.schedule_background_tasks.process_entity_extraction",
+            new=AsyncMock(),
+        ),
+        patch(
+            "core_api.services.memory_service._schedule_enrich_or_inline",
+            new=AsyncMock(),
+        ),
+        patch(
+            "core_api.services.memory_service._schedule_embed_or_reembed",
+            new=reembed_spy,
+        ),
+    ):
+        await ScheduleBackgroundTasks().execute(ctx)
+
+    contradiction_spy.assert_not_called()
+    # And the re-embed shim is scheduled instead — preserves existing flow.
+    reembed_spy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Preserves existing fast-branch behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_fast_still_schedules_enrichment() -> None:
+    """The pre-PR-3 enrichment scheduling is unchanged — fast mode
+    always defers LLM enrichment (PR 2 contract), and this branch is
+    what completes the deferral via the bus or in-process shim."""
+    ctx = _ctx(embedding=[0.1] * VECTOR_DIM)
+    enrich_spy = AsyncMock(return_value=None)
+    with (
+        patch(
+            "core_api.services.memory_service._schedule_enrich_or_inline",
+            new=enrich_spy,
+        ),
+        patch(
+            "core_api.pipeline.steps.write.schedule_background_tasks.process_entity_extraction",
+            new=AsyncMock(),
+        ),
+        patch(
+            "core_api.services.contradiction_detector.detect_contradictions_async",
+            new=AsyncMock(),
+        ),
+    ):
+        await ScheduleBackgroundTasks().execute(ctx)
+
+    enrich_spy.assert_called_once()
+
+
+async def test_fast_skips_enrichment_when_disabled() -> None:
+    """Tenant-level enrichment kill-switch must still skip scheduling."""
+    ctx = _ctx(embedding=[0.1] * VECTOR_DIM, enrichment=False)
+    enrich_spy = AsyncMock(return_value=None)
+    with (
+        patch(
+            "core_api.services.memory_service._schedule_enrich_or_inline",
+            new=enrich_spy,
+        ),
+        patch(
+            "core_api.pipeline.steps.write.schedule_background_tasks.process_entity_extraction",
+            new=AsyncMock(),
+        ),
+        patch(
+            "core_api.services.contradiction_detector.detect_contradictions_async",
+            new=AsyncMock(),
+        ),
+    ):
+        await ScheduleBackgroundTasks().execute(ctx)
+
+    enrich_spy.assert_not_called()


### PR DESCRIPTION
## Summary

Closes three related gaps from the fast-vs-strong investigation. Each was a coverage hole that a future characterization test would have caught — bundling them keeps the surface tight (one PR per gap would be three rounds of CI for ~50 lines of code).

| Gap | Fixed |
|---|---|
| **01** — Enterprise+fast wrote rows with zero entity_links | fast branch of `ScheduleBackgroundTasks` now fires `process_entity_extraction` directly, mirroring the strong branch |
| **04** — OSS+fast lost Path A contradiction detection | fast branch now fires `detect_contradictions_async` directly when embedding is present; back-channel still fires it when embedding is None (Enterprise+fast) |
| **06** — Path A/Path C only logged on conflicts found | both detection functions now emit `path_a_completed` / `path_c_completed` log lines at end (via try/finally) so "ran and found nothing" is distinguishable from "never fired" |

## Diff shape

- `schedule_background_tasks.py` — fast branch grows two new blocks (entity extraction + Path A direct fire). Both gated on the same tenant flags + embedding state as their strong-branch equivalents. ~40 lines.
- `contradiction_detector.py` — two `t_start = time.monotonic()` / `try/finally` wrappings, each emitting one new log line with `memory_id` in the message string itself (independent of structlog's `extra={}` behaviour — see Gap 05). ~12 lines.
- `tests/test_fast_branch_fan_out.py` — new 6-case characterization test.

## Idempotency / double-firing

- `process_entity_extraction` is idempotent: `find_entity_link` short-circuits link creation at `entity_extraction_worker.py:122-126`. The OSS+fast profile may have `_enrich_memory_background` fire extraction a second time — wasted LLM call, no data damage. Cleaning that up is a follow-up once `_enrich_memory_background` is decomposed.
- `detect_contradictions_async` writes via `update_memory_status` which is idempotent (same status → same row state). The fast-branch trigger is gated `if embedding is not None`, so Enterprise+fast (embedding deferred) only ever fires it via the EMBEDDED back-channel — single fire.

## Test plan

6 new unit tests (`tests/test_fast_branch_fan_out.py`):

- [x] Fast + `entity_extraction_enabled=True` → `process_entity_extraction` called
- [x] Fast + `entity_extraction_enabled=False` → not called (kill-switch preserved)
- [x] Fast + embedding present → `detect_contradictions_async` called (Gap 04)
- [x] Fast + embedding=None → `detect_contradictions_async` NOT called, `_schedule_embed_or_reembed` IS called (preserves existing flow)
- [x] Fast + `enrichment_enabled=True` → enrichment still scheduled (PR 2 contract preserved)
- [x] Fast + `enrichment_enabled=False` → enrichment skipped (kill-switch preserved)

Empirical end-to-end against the local enterprise stack with prod-mirror flags:

- Strong write → `path_a_completed for memory <id> n_conflicts=0 elapsed_ms=9 tenant_id=dev-41fddf` ✓
- Fast write → `Entity extraction complete for memory <id>: 3 entities, 2 relations` ✓ (was absent pre-PR-3 — Gap 01 fixed) + `path_c_completed for memory <id> n_candidates=0 n_conflicts=0 elapsed_ms=5 tenant_id=dev-41fddf` ✓
- Fast write + Path A in logs: correctly absent (embedding=None in prod-mirror; back-channel handles this cell)

## Sequenced with PRs #150 + #151

Together these three PRs deliver Goals 1 + 2 from the fast-vs-strong gap analysis: fast mode is actually fast with full post-commit coverage, strong mode is actually thorough with semantic-dedup restored, FTS-fallback works for the embed-pending window. Goal 3 (longer-term refactor consolidating the flag axes) remains as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)