### PR TITLE
CAURA-111 fix(contradiction): subject-equality gate in LLM prompt + parser

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -305,22 +305,90 @@ async def _detect(
 CONTRADICTION_PROMPT = """\
 You are a contradiction detector for a business memory system.
 
-Given two memory statements, determine if they CONTRADICT each other.
-Contradiction means they cannot both be true at the same time.
+Two statements contradict ONLY IF they make incompatible claims about the
+SAME real-world subject. Different subjects -> NOT a contradiction, even if
+the predicates look opposite or the statements look semantically similar.
 
 Statement A (NEW): {new_content}
 
 Statement B (EXISTING): {old_content}
 
-Rules:
-- Updates/corrections ARE contradictions (e.g., "X lives in Tel Aviv" vs "X lives in Haifa")
-- More specific versions of the same fact are NOT contradictions
-- Complementary information is NOT a contradiction
-- Different topics are NOT contradictions
+Follow these steps in order:
 
-Reply with ONLY a JSON object:
-{{"contradicts": true/false, "reason": "brief explanation"}}
+1. Extract subject_a: the entity Statement A is primarily about
+   (person, company, project, product, etc.). Use a short noun phrase.
+2. Extract subject_b: the entity Statement B is primarily about.
+3. Decide same_subject. Set true ONLY when subject_a and subject_b refer
+   to the SAME real-world entity. Treat these as same_subject=true:
+     - exact name match
+     - known alias / nickname / abbreviation of the same entity
+     - role description and proper name referring to the same individual
+       in context (e.g., "the CEO" and "Sarah Johnson" when context makes
+       it unambiguous)
+     - pronoun resolved unambiguously to the other statement's subject
+   Treat these as same_subject=false:
+     - two different people who share a first name or last name
+     - two different companies, products, projects, or teams
+     - any case where you are not confident the subjects are the same entity
+4. Decide contradicts:
+   - If same_subject is false, contradicts MUST be false.
+   - If same_subject is true, contradicts is true ONLY when the two
+     statements assert mutually exclusive states about that subject
+     referring to the same time frame.
+   - Updates / corrections about the same subject ARE contradictions
+     (e.g., "X lives in Tel Aviv" vs "X lives in Haifa").
+   - More specific versions of the same fact are NOT contradictions.
+   - Complementary information is NOT a contradiction.
+   - Two state claims about the same subject are NOT a contradiction ONLY
+     when BOTH statements explicitly reference non-overlapping past time
+     periods (e.g., "X lived in Tel Aviv from 2010 to 2014" vs "X lived in
+     Haifa from 2015 to 2018" — both can be historically true). In every
+     other case, including when only one statement carries a date stamp,
+     conflicting same-subject state claims ARE contradictions; do not
+     speculate that one might describe a future state that resolves the
+     conflict.
+
+Reply with ONLY a JSON object, no prose, no markdown fences:
+{{"subject_a": "<short noun phrase>",
+  "subject_b": "<short noun phrase>",
+  "same_subject": true/false,
+  "contradicts": true/false,
+  "reason": "one short phrase referencing the subjects and the conflict (or its absence)"}}
 """
+
+
+def _parse_contradiction_response(raw: dict) -> bool:
+    """Apply the structured-output safety gate.
+
+    The prompt requires the model to commit to ``same_subject`` before
+    ``contradicts``. If ``same_subject`` is false (or missing), ``contradicts``
+    MUST be false regardless of what the model emitted — this guards against
+    cross-subject false positives even when the model returns an inconsistent
+    combination. Missing keys are treated as false (conservative default).
+    """
+    if not isinstance(raw, dict):
+        return False
+    # Identity check against True — anything else (False, missing, the JSON
+    # string "false", numbers, None) is conservatively treated as False.
+    # ``bool("false")`` is True in Python, so a model returning the string
+    # "false" instead of the boolean would have silently bypassed the gate.
+    same_subject = raw.get("same_subject") is True
+    contradicts = raw.get("contradicts") is True
+    if contradicts and not same_subject:
+        logger.warning(
+            "Contradiction model returned contradicts=true with same_subject=false; "
+            "overriding to false. subject_a=%r subject_b=%r reason=%r",
+            raw.get("subject_a"),
+            raw.get("subject_b"),
+            raw.get("reason"),
+        )
+        return False
+    # The dangerous (contradicts=True, same_subject=False) case was handled
+    # above. Returning ``contradicts`` is therefore equivalent to
+    # ``same_subject and contradicts``: if contradicts is False the result
+    # is False either way; if contradicts is True we only reach this line
+    # when same_subject is True.
+    return contradicts
 
 
 # ---------------------------------------------------------------------------
@@ -354,7 +422,7 @@ async def _llm_contradiction_check(
 
     async def _do_check(llm) -> bool:
         raw = await llm.complete_json(prompt)
-        return bool(raw.get("contradicts", False))
+        return _parse_contradiction_response(raw)
 
     return await call_with_fallback(
         primary_provider_name=provider_name,

--- a/scripts/wet_test_contradiction_prompt.py
+++ b/scripts/wet_test_contradiction_prompt.py
@@ -1,0 +1,320 @@
+"""Wet test for the CAURA-111 contradiction-detection prompt fix.
+
+Hits a real LLM with the actual ``CONTRADICTION_PROMPT`` from
+``core_api.services.contradiction_detector`` and runs it over a curated
+list of memory pairs covering:
+
+  - The documented cross-subject false-positive shapes that motivated the fix
+    (Sarah Johnson / David Patel, Daniel Cohen / Daniel Levi).
+  - Genuine same-subject contradictions (must still fire).
+  - Same-subject complementary facts (must NOT fire).
+  - More-specific-version cases (must NOT fire).
+
+For each pair the script prints:
+  - Raw model JSON (so you can inspect subject_a / subject_b / same_subject /
+    contradicts / reason).
+  - The parser verdict from the real ``_parse_contradiction_response`` —
+    proves the hard gate behaves end-to-end.
+  - Whether the case matches its expected verdict.
+
+Two providers are supported. Each uses the same JSON-output, temperature=0.0
+configuration the codebase uses in production:
+
+  OpenAI Chat Completions   — ``response_format={"type": "json_object"}``
+  Gemini Developer API      — ``response_mime_type="application/json"``
+                              (matches ``common.llm.providers.gemini``)
+
+Usage:
+    # OpenAI (default)
+    export OPENAI_API_KEY=sk-...
+    python scripts/wet_test_contradiction_prompt.py
+    python scripts/wet_test_contradiction_prompt.py --model gpt-4o-mini
+
+    # Gemini
+    export GEMINI_API_KEY=...
+    python scripts/wet_test_contradiction_prompt.py --provider gemini
+    python scripts/wet_test_contradiction_prompt.py --provider gemini --model gemini-2.5-flash
+
+    # Repeat all cases for variance check (temp=0 so deltas are model-side noise)
+    python scripts/wet_test_contradiction_prompt.py --runs 3
+
+The script is a standalone diagnostic tool. It does NOT replace the unit
+tests in ``tests/test_contradiction_subject_gate.py`` — those exercise the
+parser hard-gate deterministically. This script exercises the *prompt*
+against a real model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+
+# Make core-api, core-storage-api, core-worker, and the repo root importable
+# without installing the packages. Mirrors pytest.ini's pythonpath.
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+for sub in ("core-api/src", "core-storage-api/src", "core-worker/src", "."):
+    sys.path.insert(0, os.path.join(ROOT, sub))
+
+from core_api.services.contradiction_detector import (  # noqa: E402
+    CONTRADICTION_PROMPT,
+    _parse_contradiction_response,
+)
+
+# SDKs are imported lazily inside the provider-specific call paths so that
+# you only need the SDK for the provider you actually use.
+
+
+@dataclass(frozen=True)
+class Case:
+    label: str
+    new_content: str
+    old_content: str
+    expected: bool  # True = should be flagged as contradiction
+    note: str
+
+
+CASES: list[Case] = [
+    # ----- Documented cross-subject false positives (must NOT fire) -----
+    Case(
+        label="sarah_vs_david_pref_1",
+        new_content="Sarah Johnson prefers iced coffee in the morning.",
+        old_content="David Patel prefers hot tea in the morning.",
+        expected=False,
+        note="Different people, opposite-looking preferences.",
+    ),
+    Case(
+        label="sarah_vs_david_pref_2",
+        new_content="Sarah Johnson does not like working from the office.",
+        old_content="David Patel likes working from the office.",
+        expected=False,
+        note="Different people, polar opposite predicate.",
+    ),
+    Case(
+        label="daniel_cohen_vs_daniel_levi_role",
+        new_content="Daniel Cohen joined Acme as Head of Engineering.",
+        old_content="Daniel Levi left Acme as Head of Engineering last quarter.",
+        expected=False,
+        note="Shared first name, different individuals.",
+    ),
+    Case(
+        label="daniel_cohen_vs_daniel_levi_location",
+        new_content="Daniel Cohen relocated to Tel Aviv.",
+        old_content="Daniel Levi relocated to Berlin.",
+        expected=False,
+        note="Shared first name, non-conflicting facts.",
+    ),
+    # ----- Genuine same-subject contradictions (MUST fire) -----
+    Case(
+        label="alice_current_address_conflict",
+        new_content="Alice lives in Haifa.",
+        old_content="Alice lives in Tel Aviv.",
+        expected=True,
+        note="Same person, two undated current-state claims — must conflict.",
+    ),
+    Case(
+        label="acme_ship_date_slip",
+        new_content="Acme's Project Falcon ships in Q4 2026.",
+        old_content="Acme's Project Falcon ships in Q2 2026.",
+        expected=True,
+        note="Same project, ship-date slip — true contradiction.",
+    ),
+    # ----- Genuinely historical, non-overlapping periods (must NOT fire) -----
+    Case(
+        label="historical_residence_not_contradiction",
+        new_content="Alice lived in Haifa from 2010 to 2014.",
+        old_content="Alice lived in Tel Aviv from 2015 to 2018.",
+        expected=False,
+        note="Non-overlapping past periods — both historically true.",
+    ),
+    # ----- Same-subject complementary facts (must NOT fire) -----
+    Case(
+        label="alice_two_facts",
+        new_content="Alice was promoted to Senior Engineer last month.",
+        old_content="Alice has been on the platform team since 2024.",
+        expected=False,
+        note="Same person, complementary facts.",
+    ),
+    Case(
+        label="more_specific_not_contradiction",
+        new_content="Alice lives in Tel Aviv on Rothschild Boulevard.",
+        old_content="Alice lives in Tel Aviv.",
+        expected=False,
+        note="More specific version of the same fact.",
+    ),
+]
+
+
+DEFAULT_MODEL = {
+    "openai": "gpt-4o-mini",
+    "gemini": "gemini-2.5-flash",
+}
+
+
+def _build_openai_caller(model: str):
+    try:
+        from openai import OpenAI
+    except ImportError:
+        print("ERROR: openai SDK not installed. Run: pip install openai", file=sys.stderr)
+        sys.exit(2)
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        print("ERROR: set OPENAI_API_KEY in your environment", file=sys.stderr)
+        sys.exit(2)
+    client = OpenAI(api_key=api_key)
+
+    def _call(prompt: str) -> dict:
+        resp = client.chat.completions.create(
+            model=model,
+            temperature=0.0,
+            response_format={"type": "json_object"},
+            messages=[{"role": "user", "content": prompt}],
+        )
+        content = resp.choices[0].message.content or "{}"
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            return {"_raw": content, "_parse_error": True}
+
+    return _call
+
+
+def _build_gemini_caller(model: str):
+    """Build a caller that mirrors common/llm/providers/gemini.py:
+    Developer API key auth, response_mime_type=application/json, temperature=0.0.
+    """
+    try:
+        from google import genai
+        from google.genai import types
+    except ImportError:
+        print(
+            "ERROR: google-genai SDK not installed. Run: pip install google-genai",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        print(
+            "ERROR: set GEMINI_API_KEY (or GOOGLE_API_KEY) in your environment",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    client = genai.Client(api_key=api_key)
+
+    def _call(prompt: str) -> dict:
+        response = client.models.generate_content(
+            model=model,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                response_mime_type="application/json",
+                temperature=0.0,
+            ),
+        )
+        try:
+            text = response.text or ""
+        except ValueError as exc:
+            return {"_raw": "", "_parse_error": True, "_provider_error": str(exc)}
+        if not text:
+            return {"_raw": "", "_parse_error": True, "_provider_error": "empty content"}
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return {"_raw": text, "_parse_error": True}
+        if not isinstance(parsed, dict):
+            return {"_raw": text, "_parse_error": True, "_shape": type(parsed).__name__}
+        return parsed
+
+    return _call
+
+
+def call_model(caller, new_content: str, old_content: str) -> dict:
+    """Call the real LLM with the actual CONTRADICTION_PROMPT in JSON mode.
+
+    The [:500] truncation is intentional — it mirrors the production call
+    site in ``_llm_contradiction_check`` (contradiction_detector.py), which
+    truncates each statement to 500 chars before formatting the prompt.
+    Keeping the same slice here means the wet test exercises the exact
+    prompt shape production sends to the model.
+    """
+    prompt = CONTRADICTION_PROMPT.format(
+        new_content=new_content[:500],
+        old_content=old_content[:500],
+    )
+    return caller(prompt)
+
+
+def run_once(caller, provider: str, model: str, *, run_id: int) -> tuple[int, int]:
+    """Run all cases once. Returns (passed, failed)."""
+    passed = 0
+    failed = 0
+    print(f"\n{'=' * 78}\nRUN {run_id}  provider={provider}  model={model}\n{'=' * 78}")
+    for case in CASES:
+        t0 = time.perf_counter()
+        raw = call_model(caller, case.new_content, case.old_content)
+        latency_ms = int((time.perf_counter() - t0) * 1000)
+        verdict = _parse_contradiction_response(raw)
+        ok = verdict == case.expected
+        passed += int(ok)
+        failed += int(not ok)
+
+        status = "PASS" if ok else "FAIL"
+        print(f"\n[{status}] {case.label}  ({latency_ms} ms)")
+        print(f"  note          : {case.note}")
+        print(f"  new (A)       : {case.new_content}")
+        print(f"  old (B)       : {case.old_content}")
+        print(f"  expected      : contradiction={case.expected}")
+        print(f"  model JSON    : {json.dumps(raw, ensure_ascii=False)}")
+        print(f"  parser verdict: {verdict}")
+        if not ok:
+            print(f"  >>> MISMATCH: expected {case.expected}, got {verdict}")
+    print(f"\nRun {run_id} summary: {passed}/{passed + failed} passed")
+    return passed, failed
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--provider",
+        choices=("openai", "gemini"),
+        default="openai",
+        help="LLM provider (default: openai)",
+    )
+    ap.add_argument(
+        "--model",
+        default=None,
+        help="Model id; default depends on --provider "
+        f"({DEFAULT_MODEL['openai']} for openai, {DEFAULT_MODEL['gemini']} for gemini)",
+    )
+    ap.add_argument("--runs", type=int, default=1, help="Repeat all cases N times")
+    args = ap.parse_args()
+
+    model = args.model or DEFAULT_MODEL[args.provider]
+    if args.provider == "openai":
+        caller = _build_openai_caller(model)
+    elif args.provider == "gemini":
+        caller = _build_gemini_caller(model)
+    else:  # unreachable due to argparse choices
+        raise ValueError(f"unknown provider: {args.provider}")
+
+    total_pass = 0
+    total_fail = 0
+    for run_id in range(1, args.runs + 1):
+        p, f = run_once(caller, args.provider, model, run_id=run_id)
+        total_pass += p
+        total_fail += f
+
+    print(f"\n{'=' * 78}")
+    print(
+        f"OVERALL: {total_pass}/{total_pass + total_fail} passed across "
+        f"{args.runs} run(s), {len(CASES)} cases each  "
+        f"[provider={args.provider} model={model}]"
+    )
+    print(f"{'=' * 78}")
+    return 0 if total_fail == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_contradiction_subject_gate.py
+++ b/tests/test_contradiction_subject_gate.py
@@ -1,0 +1,274 @@
+"""CAURA-111: Subject-equality gate in the contradiction-detection prompt.
+
+The old prompt asked the LLM "do these contradict?" without requiring the
+model to first check whether the two memories share a subject. That allowed
+cross-subject false positives whenever two memories of *different* subjects
+sat close in embedding space (e.g., "Sarah Johnson prefers X" vs
+"David Patel prefers not-X", or "Daniel Cohen joined Acme" vs
+"Daniel Levi left Acme").
+
+The fix has two parts, both covered here:
+
+  1. The prompt forces structured output with ``subject_a``, ``subject_b``,
+     ``same_subject``, ``contradicts``, ``reason``.
+  2. ``_parse_contradiction_response`` enforces a hard gate: if the model
+     ever returns ``contradicts=true`` while ``same_subject=false``, the
+     parser overrides to False. This is defense-in-depth — the prompt
+     should prevent the inconsistent combo, but if a future prompt
+     regression or model quirk produces it, the parser still blocks the
+     cross-subject false positive from reaching the caller.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core_api.services.contradiction_detector import (
+    CONTRADICTION_PROMPT,
+    _llm_contradiction_check,
+    _parse_contradiction_response,
+)
+
+
+# ---------------------------------------------------------------------------
+# Parser hard-gate — pure function, no LLM
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestParseContradictionResponse:
+    """The parser must enforce ``same_subject AND contradicts`` semantics."""
+
+    def test_same_subject_and_contradicts_returns_true(self):
+        assert _parse_contradiction_response({
+            "subject_a": "Alice",
+            "subject_b": "Alice",
+            "same_subject": True,
+            "contradicts": True,
+            "reason": "Alice's stated city changed from Tel Aviv to Haifa.",
+        }) is True
+
+    def test_same_subject_no_contradiction_returns_false(self):
+        assert _parse_contradiction_response({
+            "subject_a": "Alice",
+            "subject_b": "Alice",
+            "same_subject": True,
+            "contradicts": False,
+            "reason": "Same subject, complementary facts.",
+        }) is False
+
+    def test_different_subjects_no_contradiction_returns_false(self):
+        assert _parse_contradiction_response({
+            "subject_a": "Sarah Johnson",
+            "subject_b": "David Patel",
+            "same_subject": False,
+            "contradicts": False,
+            "reason": "Different people; preferences about different subjects.",
+        }) is False
+
+    def test_hard_gate_blocks_inconsistent_combination(self):
+        """The Sarah/David failure mode: model emits contradicts=true even
+        though same_subject=false. The parser MUST override to False."""
+        assert _parse_contradiction_response({
+            "subject_a": "Sarah Johnson",
+            "subject_b": "David Patel",
+            "same_subject": False,
+            "contradicts": True,  # model misbehavior
+            "reason": "opposite preferences (wrong — different subjects)",
+        }) is False
+
+    def test_missing_same_subject_treated_as_false(self):
+        """Conservative default: missing key -> not a contradiction."""
+        assert _parse_contradiction_response({
+            "contradicts": True,
+            "reason": "no same_subject field",
+        }) is False
+
+    def test_missing_contradicts_treated_as_false(self):
+        assert _parse_contradiction_response({
+            "same_subject": True,
+        }) is False
+
+    def test_empty_dict_returns_false(self):
+        assert _parse_contradiction_response({}) is False
+
+    def test_non_dict_input_returns_false(self):
+        """Defensive: malformed JSON, None, etc., must not crash or pass."""
+        assert _parse_contradiction_response(None) is False  # type: ignore[arg-type]
+        assert _parse_contradiction_response("contradicts") is False  # type: ignore[arg-type]
+        assert _parse_contradiction_response(["contradicts", True]) is False  # type: ignore[arg-type]
+
+    def test_string_false_does_not_bypass_gate(self):
+        """A model returning the JSON STRING "false" (instead of the boolean
+        false) must not be coerced to truthy. ``bool("false")`` is True in
+        Python; the parser must use an identity check against True to avoid
+        silently letting cross-subject false positives through."""
+        # Both fields as the string "false" — must read as False.
+        assert _parse_contradiction_response({
+            "subject_a": "X",
+            "subject_b": "Y",
+            "same_subject": "false",
+            "contradicts": "false",
+            "reason": "model emitted strings instead of booleans",
+        }) is False
+        # The dangerous shape: model says same_subject=false (string) but
+        # also contradicts=true (string). Without identity check this would
+        # have been read as same_subject=True AND contradicts=True -> True.
+        assert _parse_contradiction_response({
+            "subject_a": "Sarah",
+            "subject_b": "David",
+            "same_subject": "false",
+            "contradicts": "true",
+            "reason": "would have leaked through bool() coercion",
+        }) is False
+        # Non-True truthy values must also not pass.
+        assert _parse_contradiction_response({
+            "same_subject": 1,
+            "contradicts": 1,
+        }) is False
+
+
+# ---------------------------------------------------------------------------
+# Prompt content — structural invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPromptContent:
+    """Lock in the structural properties of the new prompt so a future edit
+    cannot silently regress the subject-equality contract."""
+
+    def test_prompt_has_required_placeholders(self):
+        assert "{new_content}" in CONTRADICTION_PROMPT
+        assert "{old_content}" in CONTRADICTION_PROMPT
+
+    def test_prompt_requires_all_structured_fields(self):
+        for key in ("subject_a", "subject_b", "same_subject", "contradicts", "reason"):
+            assert key in CONTRADICTION_PROMPT, f"prompt missing required field: {key}"
+
+    def test_prompt_states_different_subjects_rule(self):
+        """The core rule that prevents cross-subject false positives."""
+        text = CONTRADICTION_PROMPT.lower()
+        assert "different subjects" in text
+        assert "not a contradiction" in text or "not_a_contradiction" in text
+
+    def test_prompt_warns_about_shared_first_or_last_name(self):
+        """The Daniel Cohen / Daniel Levi failure mode is named explicitly."""
+        text = CONTRADICTION_PROMPT.lower()
+        assert "first name" in text or "last name" in text
+
+    def test_prompt_forbids_markdown_fences(self):
+        """JSON-only output protects the downstream parser."""
+        assert "no markdown fences" in CONTRADICTION_PROMPT.lower()
+
+    def test_prompt_keeps_legacy_update_rule(self):
+        """Updates / corrections about the same subject ARE contradictions —
+        regression guard so we don't over-correct in the opposite direction."""
+        text = CONTRADICTION_PROMPT.lower()
+        assert "updates" in text or "corrections" in text
+
+    def test_prompt_temporal_rule_is_exception_based(self):
+        """The temporal rule must put the burden on the historical exception
+        (both statements must explicitly reference non-overlapping past
+        periods) and must forbid the model from speculating that a date
+        stamp marks a future state which resolves the conflict. Locks in
+        the post-wet-test refinement so the rule can't silently revert to
+        the looser NLI-style 'different time periods are not contradictions'
+        framing that misfired in the Gemini wet test."""
+        text = CONTRADICTION_PROMPT.lower()
+        assert (
+            "non-overlapping" in text or "historically true" in text
+        ), "temporal rule must carve out genuinely historical periods only"
+        assert (
+            "speculate" in text or "future" in text
+        ), "temporal rule must forbid future-state speculation that dissolves conflicts"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end gate via _llm_contradiction_check with a stub LLM
+# ---------------------------------------------------------------------------
+
+
+class _StubLLM:
+    """Minimal LLM provider that returns a canned JSON response."""
+
+    provider_name = "stub"
+    model = "stub"
+    is_fake = False
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    async def complete_json(self, prompt: str, *, temperature: float = 0.0) -> dict:
+        return self._payload
+
+
+async def _run_check_with_payload(payload: dict) -> bool:
+    """Invoke ``_llm_contradiction_check`` with the real ``_do_check`` body
+    but bypass the provider-resolution / fallback chain by stubbing
+    ``call_with_fallback`` to invoke the supplied ``call_fn`` against a
+    ``_StubLLM(payload)``. This exercises the full prompt-format → parse path.
+    """
+
+    async def fake_call_with_fallback(*, call_fn, **_kwargs):
+        return await call_fn(_StubLLM(payload))
+
+    with patch(
+        "core_api.services.contradiction_detector.call_with_fallback",
+        side_effect=fake_call_with_fallback,
+    ):
+        return await _llm_contradiction_check(
+            new_content="ignored — stub returns payload directly",
+            old_content="ignored — stub returns payload directly",
+        )
+
+
+@pytest.mark.unit
+class TestLlmContradictionCheckEndToEnd:
+    """End-to-end: parser hard-gate must hold through the real call path."""
+
+    async def test_sarah_vs_david_blocked_even_if_model_says_contradicts(self):
+        """Documented failure pair #1. Even if the model emits the
+        inconsistent ``contradicts=true`` for a clearly cross-subject pair,
+        the parser blocks it."""
+        result = await _run_check_with_payload({
+            "subject_a": "Sarah Johnson",
+            "subject_b": "David Patel",
+            "same_subject": False,
+            "contradicts": True,
+            "reason": "model misbehavior — opposite predicates, different people",
+        })
+        assert result is False
+
+    async def test_daniel_cohen_vs_daniel_levi_blocked(self):
+        """Documented failure pair #2. Shared first name, different people."""
+        result = await _run_check_with_payload({
+            "subject_a": "Daniel Cohen",
+            "subject_b": "Daniel Levi",
+            "same_subject": False,
+            "contradicts": True,
+            "reason": "model misbehavior — shared first name, different individuals",
+        })
+        assert result is False
+
+    async def test_genuine_same_subject_contradiction_still_fires(self):
+        """Regression guard the other way: a real same-subject update must
+        still be flagged as a contradiction."""
+        result = await _run_check_with_payload({
+            "subject_a": "Alice",
+            "subject_b": "Alice",
+            "same_subject": True,
+            "contradicts": True,
+            "reason": "Alice moved from Tel Aviv to Haifa.",
+        })
+        assert result is True
+
+    async def test_same_subject_complementary_not_contradiction(self):
+        result = await _run_check_with_payload({
+            "subject_a": "Alice",
+            "subject_b": "Alice",
+            "same_subject": True,
+            "contradicts": False,
+            "reason": "Both facts about Alice; complementary.",
+        })
+        assert result is False


### PR DESCRIPTION
## Summary

- The contradiction-detection LLM prompt previously asked the model only "do these contradict?" — no requirement to verify the two memories shared a subject. When embeddings were similar but subjects differed, the model flagged `<subject> <verb> <opposite-predicate>` shapes as contradictions: 5/5 false positives on Sarah Johnson / David Patel, 3/3 on Daniel Cohen / Daniel Levi.
- New prompt forces structured output with `subject_a`, `subject_b`, `same_subject`, `contradicts`, `reason`, and walks the model through subject extraction → same-subject decision → contradiction decision as numbered steps tied 1:1 to JSON fields (no free-form CoT — keeps the alignment-first structure from the Stanford NLI literature without the variance penalty flagged in Meincke / Mollick et al. 2025).
- New `_parse_contradiction_response` adds a defensive hard gate: if the model ever returns `contradicts=true` with `same_subject=false`, the parser overrides to `False` and logs at WARNING. Cross-subject false positives are blocked twice — by the prompt rules and by the parser.

## Scope

- One module touched: `core-api/src/core_api/services/contradiction_detector.py` (~70 LOC).
- No schema change, no DB migration, no API change.
- `complete_json` default temperature is already `0.0` across all providers (verified in `common/llm/protocols.py`, `providers/openai.py`, `providers/gemini.py`, `providers/vertex.py`) — no temperature change needed.
- Zero-shot prompt with rule illustrations only; deferring few-shot examples until/unless regression tests show residual misses (avoids overfitting to the specific failure-pair shape).

## Test plan

- [x] 18 new unit tests in `tests/test_contradiction_subject_gate.py`:
  - Parser hard-gate across 8 input shapes (same+contradicts, same+no, different+no, **different+contradicts overridden**, missing keys, empty dict, non-dict input).
  - Prompt content invariants (placeholders, required JSON fields, different-subjects rule, shared-first/last-name guidance, JSON-only output, legacy update-rule retained).
  - End-to-end via stubbed LLM for both documented failure pairs (Sarah/David, Daniel Cohen/Daniel Levi) plus same-subject true-positive and same-subject complementary-facts regression guards.
- [x] All 56 existing contradiction unit tests still pass (`test_p1_contradiction.py`, `test_contradiction_providers.py`, `test_contradiction_batch.py`, `test_visibility_contradiction.py`).
- [ ] Reviewer: confirm any tenant-specific prompt overrides (if such mechanism exists) still load correctly with the new fields.
- [ ] Reviewer: confirm provider JSON parsers (OpenAI / Anthropic / Gemini / Vertex) handle the additional fields without truncation in production traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)