### PR TITLE
CAURA-000 docs: surface benchmark numbers + fleet thesis across README & docs

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -224,6 +224,16 @@ Then restart the server (`docker compose restart app` or re-run uvicorn).
 - No external dependencies (fake providers, no API keys needed)
 - Full read/write access to your own memory store
 
+## Performance Expectations
+
+On our reference benchmarks (warm cache, single tenant):
+
+- **Search latency:** 23 ms p50, 27 ms p95
+- **Recall accuracy:** 77.6% (LoCoMo) / 72.5% (LongMemEval), LLM-judge
+- **Token savings vs full context:** 96–98%
+
+If you see search latency materially above ~50 ms p50 after warm-up, the pgvector index is likely cold or your embedding-provider roundtrip is the bottleneck — see [`docs/performance.md`](docs/performance.md) for the methodology and the operator-scale notes.
+
 ## Full Reference
 
-For complete tool documentation with parameters, examples, memory types, status lifecycle, and best practices, see the [README](README.md) and [ARCHITECTURE_REVIEW.md](ARCHITECTURE_REVIEW.md).
+For complete tool documentation with parameters, examples, memory types, status lifecycle, and best practices, see the [README](README.md) and [ARCHITECTURE_REVIEW.md](ARCHITECTURE_REVIEW.md). For benchmark methodology and competitive context, see [`docs/performance.md`](docs/performance.md).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 <p align="center">
   <a href="#quick-start">Quick Start</a> &middot;
   <a href="#features">Features</a> &middot;
+  <a href="#performance">Performance</a> &middot;
   <a href="#mcp-model-context-protocol">MCP</a> &middot;
   <a href="#api-reference">API Reference</a> &middot;
   <a href="static/docs/integration-guide.md">Plugin Docs</a> &middot;
@@ -31,6 +32,8 @@ MemClaw is open-source memory for **multi-tenant, multi-agent** AI fleets. Your 
 Agents write plain text. MemClaw turns it into searchable, governed, self-improving memory.
 
 **One loop, three pillars: write, recall, compound** — every interaction makes the next one smarter.
+
+**Built for fleets, not single agents.** Public agent-memory benchmarks (LoCoMo, LongMemEval) measure one agent, one user, one long conversation — the single-chatbot shape. The deployment shape we see in production is the opposite: dozens or thousands of agents working on behalf of a company, sharing what they learn under governance. MemClaw is architected around that shape from day one — scoped memory, cross-agent outcome propagation, fleet-wide trust tiers — and competes on the axes that compound with agent count: latency, token efficiency, and governance. See [Performance](#performance) for the numbers, or read the [benchmarks write-up](https://memclaw.net/blog/memclaw-benchmarks).
 
 <p align="center">
   <img src="static/images/memclaw-concept.svg" alt="MemClaw — Fleet Memory that Compounds" width="700" />
@@ -270,6 +273,24 @@ The plugin claims the OpenClaw `memory` slot (replacing `memory-core`) and expos
 - **MCP server** — built-in [Model Context Protocol](https://modelcontextprotocol.io) at `/mcp` (Streamable HTTP). Connect Claude Desktop, Claude Code, Cursor, Windsurf, or any MCP client with a URL and API key
 - **Multi-provider LLM** — primary + fallback provider chain per tenant (OpenAI, Gemini, Anthropic, OpenRouter) with platform defaults for zero-config tenants
 - **Document store** — structured JSONB collections alongside semantic memories for exact-field lookups (customer records, config, task lists)
+
+---
+
+## Performance
+
+Benchmarked against the two most-cited public agent-memory benchmarks. Methodology and operator-scale context live in [`docs/performance.md`](docs/performance.md); the full write-up is on the blog.
+
+|  | LoCoMo | LongMemEval | Search latency |
+|---|---|---|---|
+| Accuracy (LLM-judge) | **77.6%** | **72.5%** | — |
+| Token savings vs full context | **96.6%** | **98.2%** | — |
+| Latency | — | — | **23 ms p50 · 27 ms p95** |
+
+Accuracy sits inside the leading cluster across the field (Mem0, Zep, MemClaw — scores cluster in a narrow band). The axes we push hardest are latency and token efficiency, because those are the ones that compound as agent count grows — a few hundred ms of search latency disappears behind one LLM call, but bills millions of times a day across a fleet.
+
+> Single-agent benchmarks can't measure cross-agent recall, outcome propagation between agents, fleet-scoped visibility, or governance-aware retrieval. Those are the questions that decide whether a memory system is *deployable* inside a company. See [`docs/performance.md`](docs/performance.md#what-these-benchmarks-cant-measure).
+
+Source: [Fast, Token-Efficient, and Built for Fleets](https://memclaw.net/blog/memclaw-benchmarks) (2026-04-19).
 
 ---
 

--- a/docs/api-surfaces.md
+++ b/docs/api-surfaces.md
@@ -5,6 +5,10 @@ They are intentionally **not symmetric**. Each serves a different audience and
 operates under different assumptions. This document records who owns what and
 when to add or move an operation.
 
+> Looking for **latency and throughput numbers** per surface? See
+> [`performance.md`](performance.md). This document is about *which surface
+> owns which operation*, not about how fast each one runs.
+
 ## Audiences
 
 | Surface | Primary audience | Trust model |

--- a/docs/integration-without-plugin.md
+++ b/docs/integration-without-plugin.md
@@ -75,6 +75,8 @@ If `agent_id` is `null` or doesn't match what you provisioned, your key isn't be
 - The key was revoked or rotated.
 - A proxy in front of memclaw is stripping the `X-API-Key` header.
 
+> **Latency expectation:** `POST /search` returns 23 ms p50 / 27 ms p95 warm on our reference benchmarks. Recall (`memclaw_recall` / `POST /recall`) sits in the same band — it wraps search plus a small scoring step. See [`performance.md`](performance.md) for the full numbers and methodology.
+
 ---
 
 ## 3. Open an MCP session

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,73 @@
+# Performance & Benchmarks
+
+Operator-grade companion to the public benchmarks write-up. The blog answers *"is this credible?"*; this document answers *"what should I expect in my system, and what can these numbers not tell me?"*
+
+## Public benchmark results
+
+|  | LoCoMo | LongMemEval | Search latency |
+|---|---|---|---|
+| Accuracy (LLM-judge) | **77.6%** | **72.5%** | — |
+| Token savings vs full context | **96.6%** | **98.2%** | — |
+| Latency | — | — | **23 ms p50 · 27 ms p95** (warm) |
+
+LoCoMo and LongMemEval are the two most-cited public agent-memory benchmarks. Both measure one agent, one user, one long conversation — the single-chatbot shape. Accuracy across the leading systems (MemClaw, Mem0, Zep) clusters in a narrow band.
+
+**Source:** [Fast, Token-Efficient, and Built for Fleets](https://memclaw.net/blog/memclaw-benchmarks) (2026-04-19).
+
+**Last updated:** 2026-04-19. These numbers move when we re-run; check the blog for the current canonical version.
+
+## What we optimize for
+
+Accuracy sits inside the leading cluster. That's not the axis we push hardest along.
+
+- **Latency** — a few hundred ms of search disappears behind one LLM call when you run one agent. The same overhead, multiplied across thousands of agents making millions of recall calls a day, decides whether a deployment is viable.
+- **Token efficiency** — recall returns the relevant slice, not the full transcript. Token savings vs sending the full context to the LLM: 96–98% on the two benchmarks. That ratio is the bill at fleet scale.
+- **Governance correctness** — write a memory at the wrong scope and you've leaked data across teams. The retrieval surface enforces scope filtering by default; the audit log records every cross-scope read.
+
+## What we measure
+
+- **Accuracy** — LLM-judge over benchmark-defined questions, not `recall@k` over a fixed gold set. The retrieval-then-answer pipeline as a whole gets the credit; this is the metric that maps to product behavior.
+- **Token efficiency** — total tokens sent to the answering LLM, divided by the same prompt + full prior context (the "no memory system" baseline).
+- **Search latency** — p50 / p95 of `POST /search` against a warm cache, single-tenant load. Cold-cache p50 is higher; we publish warm because that's the steady-state condition under real load.
+
+## What these benchmarks can't measure
+
+Single-agent benchmarks can't ask:
+
+- Did agent #17's mistake this morning prevent agents #1–#40 from repeating it this afternoon?
+- Does a new agent joining the fleet inherit what the fleet already knows, or start from zero?
+- Is a memory written by the sales fleet visible — or correctly invisible — to an agent in support?
+- Does cross-tenant data ever leak when the recall query is ambiguous?
+
+These are the questions that decide whether a memory system is deployable inside a company. MemClaw was designed around them — scoped memory (agent / fleet / cross-fleet), per-agent trust tiers, PII quarantine before cross-fleet exposure, full audit log, the `memclaw_evolve` → `memclaw_insights` outcome-propagation loop. **None of this moves a recall@k number. All of it moves whether you can deploy.**
+
+The field needs a benchmark for the fleet-shaped problem. We're working toward one. If you're thinking about this too, the [Discord](https://discord.com/invite/aNfpgfpj) is open.
+
+## How MemClaw compares
+
+For a single chatbot, the public-benchmark leaders (MemClaw, Mem0, Zep) cluster in a narrow accuracy band — the choice usually comes down to stack fit, latency, and token budget.
+
+MemClaw differentiates on the dimensions a single-agent benchmark can't see:
+
+| Dimension | Why it matters at fleet scale |
+|---|---|
+| Scoped memory (agent / fleet / cross-fleet) | A write at the wrong scope is a data leak across teams |
+| Per-agent trust tiers | Lets you trust some agents more than others without rewriting the recall path |
+| Cross-agent outcome propagation (`memclaw_evolve` → `memclaw_insights`) | One agent's mistake becomes a preventive rule the rest of the fleet sees before repeating it |
+| Latency at fleet load | 23 ms p50 search × millions of calls/day stays affordable; 250 ms doesn't |
+| Token efficiency | 96–98% savings vs full context is the bill, not a microbenchmark curiosity |
+
+## What to verify in your own deployment
+
+The published numbers are warm-cache, single-tenant, on our reference hardware. Before relying on them in capacity planning:
+
+- Run [`/whoami`](integration-without-plugin.md#2-verify-your-identity-whoami) round-trips against your deployment to anchor a baseline.
+- Hit `POST /search` under your expected concurrency to confirm latency holds — the search-path optimizer assumes a warm pgvector cache.
+- Audit `tenant_id` and `fleet_id` filtering on every recall path you care about; the test suite covers scope correctness, but your tenancy model is yours to validate.
+
+For benchmark methodology, the raw harness, and the underlying scoring code, see the [`keystone-benchmark`](https://github.com/caura-ai/keystone-benchmark) repo (in development).
+
+## Sources
+
+- **Blog write-up:** [Fast, Token-Efficient, and Built for Fleets](https://memclaw.net/blog/memclaw-benchmarks) (2026-04-19)
+- **Public benchmarks:** [LoCoMo](https://arxiv.org/abs/2402.17753), [LongMemEval](https://arxiv.org/abs/2410.10813)


### PR DESCRIPTION
## Summary

The [benchmark blog](https://memclaw.net/blog/memclaw-benchmarks) (2026-04-19) has hard numbers (77.6% / 72.5% accuracy, 96–99% token savings, 23 ms p50 search latency) and articulates the fleet-shaped thesis that justifies every feature in the docs (scoped memory, trust tiers, evolve, audit log). Until now none of that was reflected in the OSS docs — engineers evaluating MemClaw via the repo never saw the credibility evidence or the *why* behind the features.

This pass pulls the blog's evidence into the docs surface without making new claims.

## Changes

- **`README.md`**
  - New "Built for fleets, not single agents" paragraph under the hero — the *why* the existing feature list never quite makes explicit.
  - New `## Performance` section between Features and MCP, with the benchmark table + a one-sentence operator framing + link to the new doc and the blog.
  - `Performance` added to the top nav.
- **`docs/performance.md` (new)** — operator-grade companion to the blog:
  - Public benchmark table with source + last-updated date.
  - What we optimize for + what we measure (LLM-judge methodology, why not `recall@k`).
  - What these benchmarks *can't* measure (cross-agent recall, governance, scope correctness).
  - Honest competitive framing (MemClaw / Mem0 / Zep cluster on single-agent accuracy; differentiation is fleet-scale).
  - "What to verify in your own deployment" — anchors the published numbers as a starting hypothesis, not a guarantee.
- **`docs/integration-without-plugin.md`** — adds a latency-expectation callout after `/whoami` pointing to `performance.md`.
- **`docs/api-surfaces.md`** — adds a one-line pointer at the top: "this doc is about ownership, not latency — for that see `performance.md`."
- **`AGENT-INSTALL.md`** — adds a `Performance Expectations` subsection at the end with the headline numbers + a debugging hint for when latency drifts off-baseline.

## Why

Follow-up to the discussion of doc credibility gaps that motivated #148 and #149. Those PRs fixed the *auth model* documentation. This PR fixes the *evidence* documentation — a new evaluator reading the README never had to wonder if MemClaw publishes benchmarks; now they don't.

All numbers are cited from the blog with the publish date so future re-runs only need to update one place. No claims invented; the only new content beyond the blog is operator framing (what to verify, debugging hints, why each axis matters at fleet scale).

## Test plan

- [ ] README renders correctly on github.com — new Performance section, fleet-thesis paragraph, nav link
- [ ] `docs/performance.md` renders correctly with working internal anchor (`#what-these-benchmarks-cant-measure`)
- [ ] Cross-links work: `README` → `docs/performance.md`, `integration-without-plugin.md` → `performance.md`, `api-surfaces.md` → `performance.md`, `AGENT-INSTALL.md` → `performance.md`
- [ ] Blog link (`https://memclaw.net/blog/memclaw-benchmarks`) resolves
- [ ] No code or CI changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)