### PR TITLE
CAURA-000 docs: align README + integration guide with unified mc_ credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Get up and running in minutes — no infrastructure, automatic updates, usage an
 }
 ```
 
-> **Production / team use:** `mc_` is a tenant-level key — fine for personal use, but a fleet of agents should bind each one to its own `mca_` key for trust gating, fleet membership, and per-agent keystones. Mint per-agent keys atomically via [`POST /api/v1/admin/agent-keys/provision`](docs/integration-without-plugin.md). The MCP server accepts the agent key on either `X-API-Key: mca_…` or `Authorization: Bearer mca_…`.
+> **Production / team use:** the quickstart key above is a **tenant-scoped credential** — fine for personal use, but a fleet of agents should bind each one to its own **agent-scoped credential** for trust gating, fleet membership, and per-agent keystones. Provision agent-scoped credentials atomically via [`POST /api/v1/admin/agent-keys/provision`](docs/integration-without-plugin.md), or through the dashboard at `/settings/organization/api-credentials`. Both kinds use the `mc_` prefix on the wire — scope is bound at mint time on the credential itself. The MCP server accepts the credential on either `X-API-Key: mc_…` or `Authorization: Bearer mc_…`. *(Pre-existing `mca_…` and `mci_…` keys continue to authenticate via back-compat.)*
 >
-> Staying on `mc_` for the quickstart? Pass an explicit `agent_id` on every MCP tool call — the gateway refuses the reserved default (`mcp-agent`) on the tenant-key path.
+> Using a tenant-scoped credential? Pass an explicit `agent_id` on every MCP tool call — the gateway refuses the reserved default (`mcp-agent`) on the tenant-scoped path.
 
 ### Self-Hosted (Open Source)
 
@@ -324,7 +324,7 @@ Add MemClaw to any MCP client with one config block.
 }
 ```
 
-> For team or production use, swap the tenant `mc_` key for a per-agent `mca_` key — atomic provisioning via `POST /api/v1/admin/agent-keys/provision` mints the key + Agent row + initial trust + fleet membership in one round trip. See [`docs/integration-without-plugin.md`](docs/integration-without-plugin.md). Staying on `mc_`? Pass an explicit `agent_id` on every MCP tool call — the gateway refuses the reserved default (`mcp-agent`) on the tenant-key path.
+> For team or production use, swap the tenant-scoped key for an **agent-scoped credential** — atomic provisioning via `POST /api/v1/admin/agent-keys/provision` (or the `/settings/organization/api-credentials` wizard) mints the credential + Agent row + initial trust + fleet membership in one round trip. Both kinds use the `mc_` prefix; scope is set at mint time on the credential. See [`docs/integration-without-plugin.md`](docs/integration-without-plugin.md). Using a tenant-scoped credential? Pass an explicit `agent_id` on every MCP tool call — the gateway refuses the reserved default (`mcp-agent`) on the tenant-scoped path.
 
 **Where to add this config:**
 - **Claude Code** — `~/.claude/settings.json` under `"mcpServers"`
@@ -773,7 +773,7 @@ memclaw/
 ├── plugin/                        # OpenClaw plugin (TypeScript)
 │   └── src/
 │       ├── tools.ts               # Tool implementations
-│       ├── agent-auth.ts          # Per-agent API keys (mca_ prefix)
+│       ├── agent-auth.ts          # Per-agent credentials (agent-scoped mc_ keys)
 │       ├── context-engine.ts      # Auto-read/write lifecycle
 │       ├── heartbeat.ts           # 60s heartbeat → MemClaw API
 │       └── educate.ts             # Agent education delivery
@@ -900,7 +900,7 @@ Anything not listed above is internal and may change in any release without a ma
 - Most `/api/v1/admin/*` and all `/api/v1/testing/*` routes (the documented exception is `POST /admin/agent-keys/provision`, which is part of the stable identity-bootstrap surface — see the Agents row above)
 - The `core-storage-api` microservice (internal, not user-facing)
 - The plugin's TypeScript module structure
-- API-key prefix formats (`mc_…`, `mca_…`) — formats may evolve
+- API-key prefix formats — currently unified on `mc_…` (with legacy `mca_…` / `mci_…` aliases still accepted via back-compat); formats may continue to evolve
 
 ### Reporting breaking changes
 

--- a/docs/integration-without-plugin.md
+++ b/docs/integration-without-plugin.md
@@ -4,18 +4,23 @@
 
 **Time to first tool call:** ~5 minutes.
 
+> **One credential model.** Every API credential — tenant-scoped, agent-scoped, install, cross-tenant — uses the `mc_` prefix on the wire and lives in one underlying credential table. Scope is bound to the credential row at mint time, not encoded in the prefix. Pre-existing `mca_…` / `mci_…` keys continue to authenticate via back-compat; new mints all return `mc_…`.
+
 ---
 
 ## What you need
 
-- A tenant `mc_` key — get one from `memclaw.dev/settings/api-keys` (or self-host).
+- A tenant-scoped `mc_` credential — get one from `memclaw.dev/settings/api-keys` (or self-host).
 - An MCP client. Examples below use `mcp` (Python) and `curl`. The same flow works with `anthropic` (Python SDK's remote-MCP integration), `openai`, or any client that speaks MCP streamable-http.
 
 ---
 
-## 1. Mint a per-agent key
+## 1. Mint an agent-scoped credential
 
-Every long-lived integration should bind to a named agent identity rather than calling under the tenant key. Provision a per-agent (`mca_`) key in one round-trip; the call also creates the Agent row eagerly so subsequent trust-elevation or fleet-assignment endpoints work immediately:
+Every long-lived integration should bind to a named agent identity rather than calling under a tenant-scoped credential. Two ways:
+
+- **Dashboard (recommended for humans):** `memclaw.dev/settings/organization/api-credentials` — single-card wizard, one-time raw-key reveal, manages cross-tenant + read-scope settings.
+- **API (for scripted provisioning, shown below):** `POST /api/v1/admin/agent-keys/provision` — atomic call that creates the Agent row eagerly so subsequent trust-elevation or fleet-assignment endpoints work immediately:
 
 ```bash
 curl -X POST https://memclaw.dev/api/v1/admin/agent-keys/provision \
@@ -36,13 +41,13 @@ Response:
   "id": "…",
   "tenant_id": "…",
   "agent_id": "quote-agent-na",
-  "raw_key": "mca_…",
+  "raw_key": "mc_…",
   "agent_row_created": true,
   "created_at": "…"
 }
 ```
 
-Save `raw_key` immediately — it's only returned once. `agent_row_created: true` confirms the Agent row exists and `PATCH /agents/quote-agent-na/trust` will work without a synthetic first write.
+Save `raw_key` immediately — it's only returned once. The returned credential uses the `mc_` prefix regardless of kind; the gateway derives scope (`tenant` / `agent` / `cross-tenant`) from the credential row, not the prefix. `agent_row_created: true` confirms the Agent row exists and `PATCH /agents/quote-agent-na/trust` will work without a synthetic first write.
 
 **Optional fields** on the provision request:
 
@@ -58,7 +63,7 @@ Before making real tool calls, confirm memclaw resolves your credentials the way
 
 ```bash
 curl https://memclaw.dev/api/v1/whoami \
-  -H "X-API-Key: $MCA_AGENT_KEY"
+  -H "X-API-Key: $AGENT_KEY"
 ```
 
 ```json
@@ -70,9 +75,9 @@ curl https://memclaw.dev/api/v1/whoami \
 }
 ```
 
-If `agent_id` is `null` or doesn't match what you provisioned, your key isn't being recognized as `mca_`. Common causes:
-- You're sending the `mc_` tenant key, not the `mca_` agent key.
-- The key was revoked or rotated.
+If `agent_id` is `null` or doesn't match what you provisioned, your credential isn't recognized as agent-scoped. Common causes:
+- You're sending a tenant-scoped credential, not the agent-scoped one you provisioned.
+- The credential was revoked or rotated.
 - A proxy in front of memclaw is stripping the `X-API-Key` header.
 
 > **Latency expectation:** `POST /search` returns 23 ms p50 / 27 ms p95 warm on our reference benchmarks. Recall (`memclaw_recall` / `POST /recall`) sits in the same band — it wraps search plus a small scoring step. See [`performance.md`](performance.md) for the full numbers and methodology.
@@ -85,14 +90,14 @@ memclaw speaks MCP streamable-http at `/mcp` (the trailing slash is optional; bo
 
 ### Authentication: two headers, your choice
 
-memclaw accepts the API key on either of these — pick whichever your SDK supports:
+memclaw accepts the credential on either of these — pick whichever your SDK supports:
 
 | Header | When to use |
 |---|---|
-| `X-API-Key: mca_…` | Canonical. Use if you control the request shape. |
-| `Authorization: Bearer mca_…` | OAuth-style. Required by Anthropic's remote-MCP integration and other SDKs that only emit `Authorization` headers. |
+| `X-API-Key: mc_…` | Canonical. Use if you control the request shape. |
+| `Authorization: Bearer mc_…` | OAuth-style. Required by Anthropic's remote-MCP integration and other SDKs that only emit `Authorization` headers. |
 
-JWTs from the dashboard are also accepted via `Authorization: Bearer <jwt>`; memclaw distinguishes them by trying JWT decode first.
+Legacy `mca_…` / `mci_…` keys continue to authenticate on both headers via back-compat. JWTs from the dashboard are also accepted via `Authorization: Bearer <jwt>`; memclaw distinguishes them by trying JWT decode first.
 
 ### Python (the `mcp` library)
 
@@ -102,7 +107,7 @@ from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
 async def main():
-    headers = {"X-API-Key": "mca_..."}
+    headers = {"X-API-Key": "mc_..."}   # agent-scoped credential
     url = "https://memclaw.dev/mcp/"
 
     async with streamablehttp_client(url, headers=headers) as (read, write, _):
@@ -136,7 +141,7 @@ msg = client.messages.create(
                 "type": "url",
                 "url": "https://memclaw.dev/mcp/",
                 "name": "memclaw",
-                "authorization_token": "mca_...",
+                "authorization_token": "mc_...",   # agent-scoped credential
             }
         ]
     },
@@ -144,7 +149,7 @@ msg = client.messages.create(
 print(msg.content)
 ```
 
-The SDK forwards `authorization_token` as `Authorization: Bearer mca_…`. memclaw recognises that shape and resolves your tenant + agent identity from it.
+The SDK forwards `authorization_token` as `Authorization: Bearer mc_…`. memclaw recognises that shape and resolves your tenant + agent identity from the credential row.
 
 ---
 
@@ -172,7 +177,7 @@ If you provisioned with `initial_trust`, this step is already done — confirm w
 ## End-to-end bootstrap, one block
 
 ```bash
-TENANT_KEY=mc_...
+TENANT_KEY=mc_...   # tenant-scoped credential
 AGENT_ID="quote-agent-na"
 FLEET_ID="na-sales"
 
@@ -181,14 +186,15 @@ RESP=$(curl -s -X POST https://memclaw.dev/api/v1/admin/agent-keys/provision \
   -H "X-API-Key: $TENANT_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"agent_id\":\"$AGENT_ID\",\"initial_trust\":1,\"initial_fleet\":\"$FLEET_ID\"}")
-MCA_KEY=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin)['raw_key'])")
+AGENT_KEY=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin)['raw_key'])")
+# AGENT_KEY is an mc_… agent-scoped credential.
 
 # 2. Verify.
-curl -s https://memclaw.dev/api/v1/whoami -H "X-API-Key: $MCA_KEY"
+curl -s https://memclaw.dev/api/v1/whoami -H "X-API-Key: $AGENT_KEY"
 
 # 3. Use.
 curl -s https://memclaw.dev/api/v1/memories \
-  -H "X-API-Key: $MCA_KEY" \
+  -H "X-API-Key: $AGENT_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"tenant_id\":\"$TENANT_ID\",\"agent_id\":\"$AGENT_ID\",\"fleet_id\":\"$FLEET_ID\",\"content\":\"Hello world\"}"
 ```
@@ -212,7 +218,7 @@ Cross-agent writes of identical content no longer collide — each agent gets it
 
 - **`POST /provision` returns the raw key once.** Save it before the response goes out of scope.
 - **`PATCH /agents/{id}/trust` returns 404 immediately after provisioning.** This should not happen post-2026-05-13; if it does, the Agent row was not materialized atomically. Check `whoami` and `GET /api/v1/agents/{id}`.
-- **`/mcp` returns 401 with an `Authorization: Bearer mca_…` header but works with `X-API-Key`.** Make sure you're hitting a memclaw build dated 2026-05-13 or later — earlier builds rejected non-JWT bearer tokens.
+- **`/mcp` returns 401 with an `Authorization: Bearer mc_…` (or legacy `mca_…`) header but works with `X-API-Key`.** Make sure you're hitting a memclaw build dated 2026-05-13 or later — earlier builds rejected non-JWT bearer tokens.
 - **Streaming client hangs on initialize.** If hitting `/mcp` (no slash) caused a hang on older builds, append the trailing slash or upgrade — current builds serve both paths without redirect.
 
 ---

--- a/docs/plugin-upgrade.md
+++ b/docs/plugin-upgrade.md
@@ -39,7 +39,7 @@ curl -ks -X POST "$MEMCLAW_API_URL/api/v1/install-plugin" \
   -H "Content-Type: application/json" \
   -d '{
     "api_url":   "https://your-memclaw-server",
-    "api_key":   "mc_… or mca_…",
+    "api_key":   "mc_…",
     "fleet_id":  "your-fleet",
     "tenant_id": "your-tenant",
     "node_name": "this-node"


### PR DESCRIPTION
## Summary

Follow-up to enterprise [PR #314](https://github.com/caura-ai/caura-memclaw-enterprise/pull/314) (now merged). #314 collapsed three credential models (`mc_` tenant, `mca_` agent, `mci_` install) plus the in-flight `mcx_` cross-tenant work into one `enterprise.api_credentials` table with a single `mc_` prefix. Scope is now bound to the credential row at mint time, not encoded in the prefix.

The OSS docs were last updated for the prefix-encoded model — PRs #148 and #149 added the `mca_`-vs-`mc_` callouts that are now stale. This pass realigns the OSS-side documentation with the unified model.

## Changes

**`README.md`** (3 spots, +6/-6):
- Managed-cloud quickstart callout — `tenant-scoped` vs `agent-scoped` framing replaces `mc_` vs `mca_`. Points at both `POST /api/v1/admin/agent-keys/provision` and the new dashboard wizard `/settings/organization/api-credentials`. Notes back-compat for legacy `mca_…` / `mci_…` keys.
- MCP Configuration second callout — same reframing, terser.
- Repo-layout sidebar comment on `agent-auth.ts` — wording updated.
- Stability contract bullet on prefix formats — rephrased to reflect unification + legacy aliases.

**`docs/integration-without-plugin.md`** (+24/-19):
- New lead callout: *"One credential model"* summary.
- Section 1 retitled *"Mint an agent-scoped credential"*; adds the dashboard wizard as the recommended path for humans, keeps the API for scripted use.
- Provisioning response example: `raw_key` shows `mc_…` (was `mca_…`), with clarifying note that prefix doesn't encode scope.
- `/whoami` section: variable rename `MCA_AGENT_KEY` → `AGENT_KEY`; troubleshooting text reframed to *"isn't recognized as agent-scoped"*.
- Authentication header table: rows show `mc_…`; explicit legacy `mca_`/`mci_` back-compat note.
- Python + Anthropic SDK examples: tokens shown as `mc_…` with `# agent-scoped credential` hint comments.
- End-to-end bootstrap: variable rename `MCA_KEY` → `AGENT_KEY`.
- Common pitfalls: 401 bullet updated to `mc_` (legacy `mca_` parenthetical).

**`docs/plugin-upgrade.md`** (+1/-1):
- `install-plugin` body example: `api_key` shown as `mc_…` (was `"mc_… or mca_…"`).

## Why

PRs #148 and #149 (both merged) added great callouts steering people to agent-scoped credentials, but used the prefix-encoded vocabulary. #314 changed the underlying model. A new developer reading these docs now would see contradictions:
- README says "use `mca_` for production"
- Dashboard hands them an `mc_…` key
- They'd reasonably conclude they got the wrong kind of key.

This PR keeps every behavioural guidance from #148/#149 intact — the *agent_id required on tenant-scoped credentials* nuance is still there — but updates the vocabulary to match what the dashboard and API actually return today. Back-compat clauses are added wherever a legacy `mca_…` / `mci_…` key might still be in circulation.

## What's deliberately out of scope

- A standalone section documenting the new `read_all_org_tenants=true` capability (eToro cross-tenant use case). Mentioned briefly in the lead callout; deserves its own section once the dashboard wizard is documented end-to-end.
- The new canonical endpoint `POST /api/v1/admin/orgs/{org_id}/api-credentials`. Legacy `agent-keys/provision` still works (wire contract preserved per #314), and that's what's documented; promoting the new canonical endpoint can ride with the cross-tenant doc.
- No code changes — docs-only.

## Test plan

- [ ] README renders correctly on github.com — both callouts, repo-layout sidebar, stability bullet
- [ ] `docs/integration-without-plugin.md` renders, internal cross-links resolve (to `performance.md`)
- [ ] All remaining `mca_/mci_` references explicitly framed as legacy / back-compat (grep verified locally)
- [ ] No code or CI changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)