### PR TITLE
chore(docs): sweep mca_/mci_/mcx_ comments to unified-credential vocabulary

### DIFF
--- a/core-api/src/core_api/auth.py
+++ b/core-api/src/core_api/auth.py
@@ -72,10 +72,12 @@ class AuthContext:
         # deletes (so users can reduce usage) and reads.
         self.is_read_only = is_read_only
         # True when the gateway authenticated the call with a memclawd
-        # install credential (mci_ prefix). Drives bulk-write relaxation
-        # for broker-mode callers — they don't drive an
-        # ``X-Bulk-Attempt-Id`` header and don't have an ``agent_id``
-        # on the wire.
+        # install credential (kind=install_credential; HMAC-derived
+        # ``mci_v1_`` prefix on the wire — intentional carve-out from
+        # the unified ``mc_`` surface for retry idempotency). Drives
+        # bulk-write relaxation for broker-mode callers — they don't
+        # drive an ``X-Bulk-Attempt-Id`` header and don't have an
+        # ``agent_id`` on the wire.
         self.is_install_credential = is_install_credential
         self.install_uuid = install_uuid
         # Tenants this caller may READ from. Always non-empty when tenant_id
@@ -249,7 +251,8 @@ async def get_auth_context(
     key: str | None = Security(api_key_header),
 ) -> AuthContext:
     admin_key = get_admin_key()
-    # Enterprise gateway injects X-Agent-ID when caller uses an mca_ agent key.
+    # Enterprise gateway injects X-Agent-ID when the caller's credential
+    # is agent-scoped (kind=agent_key).
     agent_id = request.headers.get("x-agent-id") or None
     # Enterprise gateway injects X-Org-Read-Only: true when the org has
     # exceeded plan limits after a subscription cancellation. In standalone

--- a/core-api/src/core_api/routes/keystones.py
+++ b/core-api/src/core_api/routes/keystones.py
@@ -109,8 +109,9 @@ def _resolve_caller_identity(auth: AuthContext, x_agent_id: str | None) -> tuple
     """Return ``(caller_agent_id, verified)`` for the request.
 
     ``verified=True`` means the gateway cryptographically established
-    the caller's agent identity (an agent-scoped API key like ``mca_…``
-    populated ``auth.agent_id``). ``verified=False`` means the identity
+    the caller's agent identity (an agent-scoped credential whose
+    ``kind=agent_key`` populated ``auth.agent_id``). ``verified=False``
+    means the identity
     is asserted via the ``X-Agent-ID`` header alone — which is what
     happens when a non-agent-scoped (admin / tenant) key is in use.
     Unverified identities are still accepted but with stricter trust

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -921,8 +921,9 @@ async def write_memories_bulk(
     auth.enforce_usage_limits()
     auth.enforce_tenant(body.tenant_id)
 
-    # Broker (mci_ install credential) calls don't carry an attempt id
-    # header or an ``agent_id`` body field — the broker's own per-
+    # Broker (kind=install_credential, ``mci_v1_…`` wire prefix) calls
+    # don't carry an attempt id header or an ``agent_id`` body field
+    # — the broker's own per-
     # session ``client_hash`` de-dup is the design contract per
     # cloud-data-plane.md §2.4 (gap G3). Server-derive a per-request
     # attempt id and attribute writes to the install. Non-broker

--- a/plugin/src/agent-auth.ts
+++ b/plugin/src/agent-auth.ts
@@ -1,9 +1,11 @@
 /**
  * Agent authentication broker for MemClaw plugin.
  *
- * Auto-provisions per-agent API keys (mca_ prefix) using the tenant key
- * (mc_ prefix) as a bootstrap credential. Keys are cached in memory and
- * persisted to a local secrets file (mode 600).
+ * Auto-provisions agent-scoped credentials using the tenant-scoped key
+ * as a bootstrap credential. Both kinds share the `mc_` prefix on the
+ * wire; the credential's kind (tenant vs agent) is bound at mint time.
+ * Keys are cached in memory and persisted to a local secrets file
+ * (mode 600).
  *
  * Flow:
  *   1. resolveAgentKey(agentId) checks in-memory cache
@@ -97,8 +99,10 @@ async function provisionAgentKey(
 /**
  * Resolve the API key for a specific agent.
  *
- * Returns the per-agent mca_ key if available/provisionable,
- * or null to fall back to the tenant mc_ key.
+ * Returns the agent-scoped credential if available/provisionable,
+ * or null to fall back to the tenant-scoped key. Both share the
+ * `mc_` wire prefix; the resolved kind drives the X-Agent-ID
+ * injection at the gateway.
  */
 export async function resolveAgentKey(
   agentId: string,

--- a/plugin/src/transport.ts
+++ b/plugin/src/transport.ts
@@ -39,7 +39,7 @@ export async function apiCall(
     }
   }
 
-  // Resolve per-agent key (mca_) or fall back to tenant key (mc_)
+  // Resolve agent-scoped credential, or fall back to the tenant-scoped key
   const effectiveAgentId = agentId || (body?.agent_id as string) || (query?.agent_id as string);
   let effectiveKey = MEMCLAW_API_KEY;
   if (effectiveAgentId) {

--- a/tests/test_api_keystones.py
+++ b/tests/test_api_keystones.py
@@ -309,7 +309,7 @@ async def test_set_agent_scope_self_unverified_rejected(client):
     bumps the floor to ≥ 2; a trust-1 agent attempting self-author
     through this path is rejected. To exercise the legitimate
     self-author tier in production, callers need a gateway-verified
-    agent identity (e.g. an ``mca_*`` agent-scoped key)."""
+    agent identity (an agent-scoped credential, kind=agent_key)."""
     tenant_id, headers = get_test_auth()
     tag = _uid()
     agent_id = f"self-{tag}"

--- a/tests/test_auth_context.py
+++ b/tests/test_auth_context.py
@@ -131,7 +131,8 @@ def test_enforce_write_scope_blocks_read_only_scopes():
 def test_enforce_read_only_blocks_scope_restricted_keys():
     """The write-side aggregate gate at every endpoint head — demo +
     scope are both checked in one call so existing handlers don't need
-    per-site changes to honor mcx_ read-only credentials."""
+    per-site changes to honor read-only cross-tenant credentials
+    (kind=cross_tenant with the ``write`` capability omitted)."""
     ctx = AuthContext(
         tenant_id="t1",
         scopes={"recall", "search", "memories_read", "documents_read"},

--- a/tests/test_mcp_write.py
+++ b/tests/test_mcp_write.py
@@ -10,6 +10,7 @@ Covers:
 - Service ``HTTPException`` → ``Error (…)`` envelope.
 - Auth failure short-circuits.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -42,15 +43,13 @@ async def test_write_single_happy_path(mcp_env):
 
 async def test_write_registers_agent(mcp_env):
     # memclaw_write must lazy-create the Agent row (REST parity). Without this,
-    # an mca_-key holder's first MCP write succeeds but PATCH /agents/{id}/trust
-    # 404s because no Agent row exists.
+    # an agent-scoped credential holder's first MCP write succeeds but
+    # PATCH /agents/{id}/trust 404s because no Agent row exists.
     enforce = mcp_env["service"]("enforce_fleet_write")
     enforce.return_value = {"agent_id": "a1", "trust_level": 0}
     mcp_env["service"]("create_memory").return_value = _OutStub("m-2")
 
-    await mcp_server.memclaw_write(
-        content="first write", agent_id="a1", fleet_id="f1"
-    )
+    await mcp_server.memclaw_write(content="first write", agent_id="a1", fleet_id="f1")
     enforce.assert_awaited_once()
     args = enforce.await_args.args
     # Signature: (db, tenant_id, agent_id, fleet_id)
@@ -77,9 +76,7 @@ async def test_write_batch_registers_agent(mcp_env):
 async def test_write_batch_happy_path(mcp_env):
     mcp_env["service"]("create_memories_bulk").return_value = _OutStub("batch-1")
 
-    out = await mcp_server.memclaw_write(
-        items=[{"content": "one"}, {"content": "two"}]
-    )
+    out = await mcp_server.memclaw_write(items=[{"content": "one"}, {"content": "two"}])
     payload = parse_envelope(out)
     assert payload["id"] == "batch-1"
     mcp_env["service_mocks"]["create_memories_bulk"].assert_awaited_once()
@@ -115,9 +112,7 @@ async def test_write_batch_too_large(mcp_env):
 
 async def test_write_invalid_batch_item(mcp_env):
     """Item without ``content`` trips BulkMemoryItem validation → INVALID_BATCH_ITEM."""
-    out = await mcp_server.memclaw_write(
-        items=[{"content": "good"}, {"weight": 0.5}]
-    )
+    out = await mcp_server.memclaw_write(items=[{"content": "good"}, {"weight": 0.5}])
     payload = parse_envelope(out)
     assert payload["error"]["code"] == "INVALID_BATCH_ITEM"
     assert payload["error"]["details"]["received_count"] == 2


### PR DESCRIPTION
## Summary

Comment-only sweep across files the post-#314 audit flagged as still describing the legacy prefix-encoded model. Follow-up to #161 (which fixed the user-facing MISSING_AGENT_ID error string). No behavior change.

- `core_api/auth.py` — `is_install_credential` docstring describes the carve-out explicitly; X-Agent-ID header note now says "agent-scoped credential" instead of "mca_ agent key"
- `core_api/routes/keystones.py` — `_resolve_caller_identity` docstring tidied
- `core_api/routes/memories.py` — broker-write comment names `kind=install_credential` + `mci_v1_` wire prefix explicitly
- `plugin/src/agent-auth.ts` / `transport.ts` — JSDoc + inline comments use "agent-scoped credential" / "tenant-scoped key" with the shared-prefix callout
- Three test docstrings updated (`test_api_keystones.py`, `test_auth_context.py`, `test_mcp_write.py`)

All remaining `mca_/mci_/mcx_` literals in the tree are intentional (back-compat parentheticals in README/docs already shipped via #160, or explicit references to the `mci_v1_` wire prefix in carve-out explanations).

## Test plan

- [ ] CI green (ruff, mypy, format, pytest) — comments + docstrings only; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)