### PR TITLE
fix(rest): /memories list + stats widen by explicit user input, not post-default tenant_id

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -241,6 +241,11 @@ async def list_memories(
     works with ``sort=created_at&order=desc``. Offset pagination works with any
     sort order.
     """
+    # Capture whether the caller explicitly pinned tenant_id BEFORE we
+    # default it to home below. This drives the cross-tenant widening
+    # decision: pinned → single-tenant scope; omitted + cross-tenant
+    # credential → widen across the readable set.
+    tenant_id_explicit = bool(tenant_id)
     if tenant_id:
         auth.enforce_readable_tenant(tenant_id)
     elif not auth.is_admin:
@@ -291,7 +296,7 @@ async def list_memories(
         cursor_ts=c_ts,
         cursor_id=c_id,
         readable_tenant_ids=(
-            auth.readable_tenant_ids if auth.is_cross_tenant_read and not tenant_id else None
+            auth.readable_tenant_ids if auth.is_cross_tenant_read and not tenant_id_explicit else None
         ),
     )
 
@@ -305,7 +310,7 @@ async def list_memories(
 
     # Cross-tenant audit (F2): count per-tenant from served rows.
     source_tenants = auth.source_tenants_for_audit()
-    if source_tenants and auth.is_cross_tenant_read and not tenant_id:
+    if source_tenants and auth.is_cross_tenant_read and not tenant_id_explicit:
         counts: dict[str, int] = {}
         for row in rows[:limit]:
             rt = getattr(row, "tenant_id", None)
@@ -334,6 +339,7 @@ async def memory_stats(
     auth: AuthContext = Depends(get_auth_context),
     db: AsyncSession = Depends(get_db),
 ):
+    tenant_id_explicit = bool(tenant_id)
     if tenant_id:
         auth.enforce_readable_tenant(tenant_id)
     elif not auth.is_admin:
@@ -356,7 +362,7 @@ async def memory_stats(
             # cross-tenant read AND didn't pin tenant_id. Pinning to a
             # specific tenant returns just that tenant's stats.
             readable_tenant_ids=(
-                auth.readable_tenant_ids if auth.is_cross_tenant_read and not tenant_id else None
+                auth.readable_tenant_ids if auth.is_cross_tenant_read and not tenant_id_explicit else None
             ),
         )
     except (OperationalError, SQLATimeoutError):


### PR DESCRIPTION
## Summary

Follow-up to #164. Caught on the post-deploy smoke pass on memclaw.dev.

The widening guard

```python
readable_tenant_ids=(
    auth.readable_tenant_ids
    if auth.is_cross_tenant_read and not tenant_id
    else None
)
```

is always false because the route's earlier \`elif not auth.is_admin\` branch defaults \`tenant_id = auth.tenant_id\` BEFORE the widening check fires. A cross-tenant credential calling \`GET /memories\` without an explicit \`tenant_id\` query parameter ended up filtered to home only.

### Repro (pre-fix, on staging post-#164)

Credential: \`mc_1Q9JwwT…\` (READ-ALL, home=\`sdfdf-c3fd8c\`, org has 6 tenants):

| Endpoint | Expected | Actual (pre-fix) |
|---|---|---|
| \`GET /documents/collections?tenant_id=sdfdf-c3fd8c\` | 5 collections across siblings | ✅ 5 (widening works — explicit body.tenant_id) |
| \`GET /memories?limit=100\` (no tenant_id) | aggregate across the 6 tenants | ❌ 2 (home only) |
| \`GET /memories/stats\` (no tenant_id) | total + by_tenant breakdown | ❌ total=2, by_tenant=None |

### Fix

Capture \`tenant_id_explicit = bool(tenant_id)\` BEFORE the elif default, then guard the widening on that variable. Same shape applied to both \`list_memories\` and \`memory_stats\`.

Other widened surfaces (\`/documents/*\`, \`/search\`, \`/recall\`, MCP tools) take \`tenant_id\` from the request body or the gateway-plumbed context-var and don't have the post-default trap — they widen correctly today.

## Test plan

- [x] Existing \`tests/test_cross_tenant_auth.py\` still passes (14/14)
- [ ] CI green
- [ ] Re-run smoke on memclaw.dev with READ-ALL credential: \`GET /memories?limit=100\` returns aggregate across all 6 tenants; \`GET /memories/stats\` returns \`by_tenant\` breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)