### PR TITLE
fix(entity-extraction): deterministic seed + first-seen canonical preservation (A5a)

### DIFF
--- a/common/llm/providers/openai.py
+++ b/common/llm/providers/openai.py
@@ -114,18 +114,31 @@ class OpenAILLMProvider:
         prompt: str,
         *,
         temperature: float = 0.0,
+        seed: int | None = None,
     ) -> dict:
         """Send a prompt and return a parsed JSON dict.
 
         Uses ``response_format={"type": "json_object"}`` to enforce JSON output.
+
+        ``seed`` (A5 #2): when provided, forwarded to OpenAI's chat
+        completions API for response determinism. ``temperature=0.0`` is
+        not sufficient on its own — small models (gpt-class -nano) still
+        sample non-deterministically without a seed. Callers that need
+        repeatable output across retries (entity extraction, dedup
+        disambiguation) should pass a stable seed derived from the
+        prompt. Omit (or pass ``None``) for vanilla non-deterministic
+        completion.
         """
         t0 = time.perf_counter()
-        response = await self._client.chat.completions.create(
-            model=self._model,
-            messages=[{"role": "user", "content": prompt}],
-            response_format={"type": "json_object"},
-            temperature=temperature,
-        )
+        create_kwargs: dict = {
+            "model": self._model,
+            "messages": [{"role": "user", "content": prompt}],
+            "response_format": {"type": "json_object"},
+            "temperature": temperature,
+        }
+        if seed is not None:
+            create_kwargs["seed"] = seed
+        response = await self._client.chat.completions.create(**create_kwargs)
         llm_ms = int((time.perf_counter() - t0) * 1000)
         logger.info(
             "OpenAI-compatible complete_json (%s) took %dms",

--- a/core-api/src/core_api/services/entity_extraction.py
+++ b/core-api/src/core_api/services/entity_extraction.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import zlib
 
 from pydantic import BaseModel
 
@@ -92,7 +93,14 @@ async def extract_entities_from_content(
 
     async def _do_extract(llm: LLMProvider) -> ExtractedGraph:
         prompt = EXTRACTION_PROMPT.format(memory_type=memory_type, content=content)
-        raw = await llm.complete_json(prompt)
+        # Stable seed per prompt (A5 #2): without it, gpt-5.4-nano returns
+        # different entity sets / types across retries on identical content
+        # (e.g., "helios-9" → 'technology' on one call, 'project' on the
+        # next). CRC32 of the encoded prompt gives a deterministic 32-bit
+        # integer that survives process restarts — unlike ``hash()`` which
+        # is salted per-process for str inputs.
+        seed = zlib.crc32(prompt.encode("utf-8"))
+        raw = await llm.complete_json(prompt, seed=seed)
         return ExtractedGraph(**raw)
 
     extraction_model = (

--- a/core-api/src/core_api/services/entity_service.py
+++ b/core-api/src/core_api/services/entity_service.py
@@ -80,10 +80,16 @@ async def upsert_entity(
             aliases.append(data.canonical_name)
         merged_attrs["_aliases"] = aliases
 
-        # Promote longer (more specific) name as canonical
+        # First-seen wins (A5 #3). The previous "promote longer name as
+        # canonical" rule actively turned hallucinated suffixes into the
+        # canonical row — e.g., the LLM returns ``globex industries`` for
+        # content that says only ``Globex``, embedding similarity merges
+        # the two, and the canonical permanently becomes ``globex
+        # industries``. Cross-link discovery then surfaces false overlaps
+        # against every other ``Globex`` mention. Alternative surface
+        # forms are still preserved via the ``_aliases`` list above so
+        # they remain searchable / discoverable.
         new_canonical = existing_name
-        if len(data.canonical_name) > len(existing_name):
-            new_canonical = data.canonical_name
 
         update_data: dict = {
             "entity_type": data.entity_type,

--- a/tests/test_a5a_seed_and_canonical.py
+++ b/tests/test_a5a_seed_and_canonical.py
@@ -1,0 +1,261 @@
+"""A5a — two surgical fixes for entity-extraction reliability.
+
+These tests are written BEFORE the code changes so they cannot be
+biased toward whatever the implementation happens to do. They will
+FAIL against current main (red). Implementation makes them PASS (green).
+
+Changes pinned by these tests
+─────────────────────────────
+1. **OpenAI `complete_json` accepts and forwards a `seed=` kwarg**
+   (``common/llm/providers/openai.py``). Addresses A5 symptom #2 —
+   non-determinism across retries. ``temperature=0.0`` alone is not
+   sufficient on gpt-class small models without a seed.
+
+2. **`upsert_entity` preserves the first-seen canonical name** when
+   a longer alternative arrives via embedding-similarity resolution
+   (``core_api/services/entity_service.py``). The current "longer
+   name = canonical" rule actively promotes hallucinated suffixes
+   (A5 symptom #3 — e.g., LLM hallucinates ``globex industries`` for
+   content saying only ``Globex``, and the canonical is permanently
+   overwritten). The alternative surface form is still tracked via
+   the ``_aliases`` list, so it remains searchable; it just stops
+   being the canonical.
+
+Both changes are surgical (~2-line diffs each). The matching code
+changes land in the same PR after these tests are red.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Change 1 — seed forwarding through OpenAILLMProvider.complete_json
+# ---------------------------------------------------------------------------
+
+
+async def test_complete_json_forwards_seed_when_provided() -> None:
+    """When the caller passes ``seed=42`` to ``complete_json``, that exact
+    value must reach the OpenAI client's ``chat.completions.create`` call.
+
+    Today: ``complete_json`` does not accept a ``seed`` kwarg — calling
+    with ``seed=42`` raises ``TypeError: got unexpected keyword``. After
+    the fix: signature gains ``seed: int | None = None`` and the value
+    is included in the ``create(...)`` kwargs only when not None.
+    """
+    from common.llm.providers.openai import OpenAILLMProvider
+
+    provider = OpenAILLMProvider(api_key="sk-test", model="gpt-test")
+
+    # Mock the SDK call surface so no network IO happens.
+    mock_create = AsyncMock(
+        return_value=MagicMock(
+            choices=[MagicMock(message=MagicMock(content='{"ok": true}'))],
+        )
+    )
+    with patch.object(provider._client.chat.completions, "create", mock_create):
+        await provider.complete_json("test prompt", seed=42)
+
+    assert mock_create.call_count == 1
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs.get("seed") == 42, (
+        f"Expected seed=42 forwarded to OpenAI client, got kwargs={list(kwargs.keys())}"
+    )
+
+
+async def test_complete_json_omits_seed_when_none() -> None:
+    """Backward compatibility: callers that don't pass a seed should not
+    see a ``seed`` kwarg sent to the OpenAI client (passing ``seed=None``
+    to the OpenAI SDK is accepted but redundant; we keep the call shape
+    clean to match today's behaviour for un-seeded calls)."""
+    from common.llm.providers.openai import OpenAILLMProvider
+
+    provider = OpenAILLMProvider(api_key="sk-test", model="gpt-test")
+
+    mock_create = AsyncMock(
+        return_value=MagicMock(
+            choices=[MagicMock(message=MagicMock(content='{"ok": true}'))],
+        )
+    )
+    with patch.object(provider._client.chat.completions, "create", mock_create):
+        await provider.complete_json("test prompt")
+
+    kwargs = mock_create.call_args.kwargs
+    # Either seed not present, or explicitly None — both acceptable. The
+    # important thing is no ACCIDENTAL seed leak from a previous call.
+    assert kwargs.get("seed") is None, (
+        f"Expected seed=None or absent when caller didn't supply one; got seed={kwargs.get('seed')!r}"
+    )
+
+
+async def test_extract_entities_uses_stable_seed() -> None:
+    """The entity-extraction wrapper must pass a stable seed to the LLM so
+    the same content produces the same entity set across retries.
+
+    After the fix, ``_do_extract`` inside ``extract_entities_from_content``
+    derives a deterministic seed from the prompt (e.g., hash) and passes
+    it to ``complete_json``. Two calls with identical content → identical
+    ``seed=`` argument seen by the provider.
+
+    We don't pin the EXACT seed value (implementation may choose
+    ``hash(prompt) & 0xFFFFFFFF`` or a fixed constant — either works);
+    we only require *stability* and *non-None*.
+    """
+    from common.llm.providers.openai import OpenAILLMProvider
+    from core_api.services.entity_extraction import extract_entities_from_content
+
+    seeds_seen: list[int | None] = []
+
+    async def fake_complete_json(self, prompt: str, **kwargs):
+        seeds_seen.append(kwargs.get("seed"))
+        return {"entities": [], "relations": []}
+
+    # Patch the provider's complete_json so we observe the seed kwarg
+    # without doing real network IO.
+    with (
+        patch.object(OpenAILLMProvider, "complete_json", fake_complete_json),
+        patch(
+            "common.llm.registry.get_llm_provider",
+            return_value=OpenAILLMProvider(api_key="sk-test", model="gpt-test"),
+        ),
+        patch(
+            "core_api.services.entity_extraction.settings.entity_extraction_provider",
+            "openai",
+        ),
+    ):
+        await extract_entities_from_content("Anna ships Vermillion to Pelagic.", "fact")
+        await extract_entities_from_content("Anna ships Vermillion to Pelagic.", "fact")
+
+    assert len(seeds_seen) == 2, f"Expected 2 LLM calls, got {len(seeds_seen)}"
+    assert seeds_seen[0] is not None, (
+        "Extraction must pass a non-None seed for determinism"
+    )
+    assert seeds_seen[0] == seeds_seen[1], (
+        f"Same content must produce the same seed across calls; "
+        f"got {seeds_seen[0]} != {seeds_seen[1]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Change 2 — upsert_entity preserves first-seen canonical name
+# ---------------------------------------------------------------------------
+
+
+async def _make_entity_upsert(canonical_name: str, entity_type: str = "organization"):
+    """Convenience builder matching today's EntityUpsert shape."""
+    from core_api.schemas import EntityUpsert
+
+    return EntityUpsert(
+        tenant_id="t-a5",
+        fleet_id="f-a5",
+        entity_type=entity_type,
+        canonical_name=canonical_name,
+    )
+
+
+async def test_upsert_preserves_canonical_when_longer_alternative_arrives() -> None:
+    """The hallucinated-suffix case (A5 symptom #3).
+
+    Setup: an entity ``globex`` already exists (created by an earlier
+    upsert). The LLM later returns ``globex industries`` for content
+    that only mentions ``Globex``. Phase 2 embedding similarity links
+    the two (cosine ≥ 0.85). The canonical_name of the stored entity
+    must REMAIN ``globex``; ``globex industries`` is recorded as an
+    alias only.
+
+    Pre-fix (current main): canonical is promoted to ``globex industries``
+    because of the ``if len(new) > len(existing)`` rule, producing
+    permanent damage to the entity row.
+
+    Post-fix: first-seen wins. Alias list contains both forms.
+    """
+    from core_api.services.entity_service import upsert_entity
+
+    existing_entity = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "tenant_id": "t-a5",
+        "fleet_id": "f-a5",
+        "entity_type": "organization",
+        "canonical_name": "globex",
+        "attributes": {},
+    }
+
+    sc = MagicMock()
+    sc.find_exact_entity = AsyncMock(return_value=None)
+    sc.find_by_embedding_similarity = AsyncMock(
+        return_value=[{**existing_entity, "similarity": 0.95}]
+    )
+    sc.update_entity = AsyncMock(
+        side_effect=lambda eid, data: {**existing_entity, **data}
+    )
+    sc.create_entity = AsyncMock()
+
+    with patch("core_api.services.entity_service.get_storage_client", return_value=sc):
+        result = await upsert_entity(
+            None,
+            await _make_entity_upsert("globex industries"),
+            name_embedding=[0.1] * 1536,
+        )
+
+    sc.update_entity.assert_called_once()
+    _, update_data = sc.update_entity.call_args.args
+    assert update_data["canonical_name"] == "globex", (
+        f"First-seen canonical must be preserved; the longer 'globex industries' "
+        f"was promoted, producing {update_data['canonical_name']!r}"
+    )
+    assert result.canonical_name == "globex"
+
+    # Alias list must include both surface forms so the longer one
+    # remains searchable / discoverable.
+    aliases = set(update_data["attributes"].get("_aliases", []))
+    assert {"globex", "globex industries"}.issubset(aliases), (
+        f"Both surface forms must be tracked as aliases; got {aliases}"
+    )
+
+
+async def test_upsert_preserves_canonical_when_shorter_alternative_arrives() -> None:
+    """Symmetric sanity check. If existing canonical is ``globex industries``
+    and a shorter ``globex`` arrives later, canonical must also stay as
+    the first-seen value (``globex industries``).
+
+    Today the longer-wins rule happens to do the right thing here by
+    coincidence (existing wins because it's longer). After the fix, the
+    behaviour is principled (first-seen wins) rather than accidental.
+    """
+    from core_api.services.entity_service import upsert_entity
+
+    existing_entity = {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "tenant_id": "t-a5",
+        "fleet_id": "f-a5",
+        "entity_type": "organization",
+        "canonical_name": "globex industries",
+        "attributes": {},
+    }
+
+    sc = MagicMock()
+    sc.find_exact_entity = AsyncMock(return_value=None)
+    sc.find_by_embedding_similarity = AsyncMock(
+        return_value=[{**existing_entity, "similarity": 0.95}]
+    )
+    sc.update_entity = AsyncMock(
+        side_effect=lambda eid, data: {**existing_entity, **data}
+    )
+    sc.create_entity = AsyncMock()
+
+    with patch("core_api.services.entity_service.get_storage_client", return_value=sc):
+        await upsert_entity(
+            None,
+            await _make_entity_upsert("globex"),
+            name_embedding=[0.1] * 1536,
+        )
+
+    _, update_data = sc.update_entity.call_args.args
+    assert update_data["canonical_name"] == "globex industries", (
+        "Symmetric case: first-seen 'globex industries' must remain canonical"
+    )

--- a/tests/test_p3_1_entity_resolution.py
+++ b/tests/test_p3_1_entity_resolution.py
@@ -5,14 +5,20 @@ Unit tests validate:
 - Exact match still takes priority (Phase 1 short-circuits)
 - Entity type guard: same name different type → no merge
 - Alias tracking: merged entity has _aliases containing both names
-- Canonical name promotion: longer name replaces shorter one
+- Canonical preservation (A5a): first-seen canonical wins. The previous
+  "longer name promoted as canonical" rule actively turned hallucinated
+  suffixes into permanent canonical names (e.g., LLM hallucinating
+  "globex industries" for content saying only "Globex" produced a
+  permanent corruption); see commit history for A5a context.
 - No embedding → no fuzzy check (graceful skip)
 
 Integration tests verify:
 - Insert "john smith" twice → exact match, same entity
 - Insert "john smith", then "jon smith" (similar embedding) → fuzzy match, same entity
 - Insert "john smith" (person), then "john smith" (technology) → different entities
-- Insert "john smith", then "dr. john smith" → fuzzy match, canonical promoted
+- Insert "john smith", then "dr. john smith" → fuzzy match; canonical
+  stays as "john smith" (first-seen wins); "dr. john smith" lives in
+  the aliases list and remains searchable.
 - Insert "alice smith", then "bob smith" → different entities (distance too large)
 - Alias list grows correctly over multiple merges
 """
@@ -184,29 +190,21 @@ class TestAliasTracking:
         assert "John Smith" in aliases
         assert "J. Smith" in aliases
 
-    def test_longer_name_promoted(self):
-        """Longer incoming name should become canonical."""
+    def test_first_seen_canonical_preserved_when_longer_arrives(self):
+        """A5a: first-seen wins. When a longer alternative form arrives via
+        fuzzy match, the existing canonical name is preserved. The longer
+        form is tracked in the alias list above so it remains searchable."""
         existing_name = "J. Smith"
-        incoming_name = "Dr. John Smith"
+        # incoming_name preserved as an alias, not as the canonical
+        result = existing_name  # production rule in entity_service.upsert_entity
+        assert result == "J. Smith"
 
-        # The rule: if incoming is longer, promote it
-        if len(incoming_name) > len(existing_name):
-            result = incoming_name
-        else:
-            result = existing_name
-
-        assert result == "Dr. John Smith"
-
-    def test_shorter_name_not_promoted(self):
-        """Shorter incoming name should NOT replace longer existing."""
+    def test_first_seen_canonical_preserved_when_shorter_arrives(self):
+        """A5a: symmetric case. Shorter incoming name does NOT downgrade the
+        existing canonical. This case was already correct under the old
+        longer-wins rule by coincidence; now it's principled."""
         existing_name = "Dr. John Smith"
-        incoming_name = "John"
-
-        if len(incoming_name) > len(existing_name):
-            result = incoming_name
-        else:
-            result = existing_name
-
+        result = existing_name
         assert result == "Dr. John Smith"
 
 
@@ -283,8 +281,13 @@ class TestEntityResolutionIntegration:
         assert e1.id != e2.id
 
     @pytest.mark.asyncio
-    async def test_canonical_name_promoted(self, db, tenant_id, fleet_id):
-        """Insert 'john smith', then 'dr. john smith' → merged, canonical promoted."""
+    async def test_canonical_name_preserves_first_seen(self, db, tenant_id, fleet_id):
+        """A5a: insert 'john smith', then 'dr. john smith' → merged via fuzzy
+        match; canonical stays as 'john smith' (first-seen wins). The
+        previous behaviour promoted the longer name as canonical, which
+        actively turned hallucinated LLM suffixes into permanent
+        canonical names. 'dr. john smith' is now tracked as an alias
+        and remains searchable."""
         emb1 = fake_embedding("john smith")
         e1 = await self._insert_entity(
             db, tenant_id, fleet_id, "person", "john smith", emb1
@@ -296,7 +299,10 @@ class TestEntityResolutionIntegration:
         )
 
         assert e1.id == e2.id
-        assert e2.canonical_name == "dr. john smith"
+        assert e2.canonical_name == "john smith"
+        # Longer surface form is preserved as an alias.
+        aliases = (e2.attributes or {}).get("_aliases", [])
+        assert "dr. john smith" in aliases
 
     @pytest.mark.asyncio
     async def test_distant_names_not_merged(self, db, tenant_id, fleet_id):


### PR DESCRIPTION
## Summary

Two surgical fixes for entity-extraction reliability (issue **A5a**), both pinned by **tests written before the code changes** to avoid implementation-bias.

Closes 2 of 5 A5 structural symptoms identified in the cross-issue analysis:
- A5 symptom #2 — non-determinism across retries
- A5 symptom #3 — hallucinated canonical-name promotion

The other 3 A5 symptoms (closed type vocab, role misclassification, no coreference) move to follow-up PRs A5b + A5c.

## Changes

### 1. `complete_json` accepts a `seed=` kwarg (`common/llm/providers/openai.py`)

```python
async def complete_json(self, prompt: str, *, temperature: float = 0.0, seed: int | None = None) -> dict:
    ...
    if seed is not None:
        create_kwargs["seed"] = seed
    response = await self._client.chat.completions.create(**create_kwargs)
```

`temperature=0.0` alone is not sufficient on small models (gpt-class -nano) — they still sample non-deterministically. OpenAI's `seed` parameter is the official knob.

### 2. Entity extraction derives a stable seed (`core-api/.../services/entity_extraction.py`)

```python
seed = zlib.crc32(prompt.encode("utf-8"))
raw = await llm.complete_json(prompt, seed=seed)
```

`zlib.crc32` is cross-process deterministic (unlike Python's `hash()`, which is salted per-process via `PYTHONHASHSEED` for str inputs). Same content → same seed across deploys.

Local repro of A5 symptom #2 from the deep-dive: identical content produced `helios-9 = technology` on one write and `helios-9 = project` on the next. With seed, same input → same output.

### 3. `upsert_entity` preserves first-seen canonical name (`core-api/.../services/entity_service.py`)

```diff
-# Promote longer (more specific) name as canonical
-new_canonical = existing_name
-if len(data.canonical_name) > len(existing_name):
-    new_canonical = data.canonical_name
+# First-seen wins (A5 #3). The previous "promote longer name as
+# canonical" rule actively turned hallucinated suffixes into the
+# canonical row — e.g., LLM hallucinates "globex industries" for
+# content that says only "Globex", embedding similarity merges
+# the two, canonical becomes "globex industries" permanently.
+new_canonical = existing_name
```

The alternative surface form is still tracked via the `_aliases` list above (unchanged), so it remains searchable / discoverable; it just stops being the canonical row.

Symmetric case (existing canonical longer, shorter arrives later) was already correct by coincidence under longer-wins; now it's principled — both cases reduce to "first-seen wins."

## Test discipline (red → green)

`tests/test_a5a_seed_and_canonical.py` was written **before** the code changes. Initial run against unmodified main:

```
FAILED test_complete_json_forwards_seed_when_provided        — TypeError: unexpected kwarg 'seed'
FAILED test_extract_entities_uses_stable_seed                — same, in the extraction wrapper
FAILED test_upsert_preserves_canonical_when_longer_arrives   — longer name promoted
PASSED test_complete_json_omits_seed_when_none               — non-regression guard
PASSED test_upsert_preserves_canonical_when_shorter_arrives  — non-regression guard
```

After the 3 code edits:
```
5 passed in 0.44s
```

Also ran 155 existing tests across the related surfaces (provider protocols, entity linking, entity blocklist, entity tokens, contradiction providers). All pass. No regressions.

## What this doesn't fix

- A5 #1 (zero entities for ID-shaped subjects) — deferred to A5b (prompt + schema)
- A5 #4 (role misclassification: ceo/engineer → person) — deferred to A5b
- A5 #5 (no coreference output) — deferred to A5b
- F5 (memclaw.dev silent extraction observed during 2026-05-17 wet test) — pending environment confirmation; the symptom is observable on memclaw.dev but local extraction works correctly with valid OpenAI key. Likely a prod config/secrets issue, not a code defect.

Local stack reproduces both the seed determinism win and the canonical-preservation win after the changes; staging deploy will widen visibility once this lands.

## Backwards compatibility

- `complete_json` callers without `seed=` see no behaviour change (kwarg defaults to None, omitted from the OpenAI client call).
- `upsert_entity` callers see no API change. Existing entity rows are unaffected (only future merges differ). Aliases continue to work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)