### PR TITLE
feat(entity-extraction): plumb tenant_config through worker → extractor (A5c)

### DIFF
--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -68,17 +68,22 @@ async def process_entity_extraction(
     # worker service subscribes to ``Topics.Pipeline.ENTITY_EXTRACT_REQUESTED``
     # and this function becomes its handler body.
     try:
-        graph = await extract_entities_from_content(content, memory_type)
+        # A5c: resolve tenant_config BEFORE the extraction call so the
+        # tenant-level ``entity_extraction.provider`` / ``.model``
+        # overrides on ResolvedConfig actually take effect. Pre-A5c the
+        # worker passed nothing here, falling back to global settings,
+        # so per-tenant routing was dead code.
+        from core_api.services.organization_settings import resolve_config
+
+        tenant_cfg = await resolve_config(None, tenant_id)
+
+        graph = await extract_entities_from_content(content, memory_type, tenant_config=tenant_cfg)
         if not graph.entities:
             return
 
         sc = get_storage_client()
 
         try:
-            # Resolve tenant config for per-tenant blocklist
-            from core_api.services.organization_settings import resolve_config
-
-            tenant_cfg = await resolve_config(None, tenant_id)
             blocklist = tenant_cfg.entity_blocklist
 
             # Embed entity names for fuzzy resolution

--- a/tests/test_a5c_tenant_config_plumbing.py
+++ b/tests/test_a5c_tenant_config_plumbing.py
@@ -1,0 +1,151 @@
+"""A5c — plumb tenant_config through process_entity_extraction.
+
+Today (pre-A5c): the worker at ``entity_extraction_worker.py:71`` calls
+``extract_entities_from_content(content, memory_type)`` with no
+``tenant_config`` argument. ``extract_entities_from_content`` falls back
+to ``settings.entity_extraction_provider`` from global env — so the
+tenant-level ``entity_extraction.provider`` / ``.model`` overrides
+exposed by ``ResolvedConfig`` are DEAD CODE.
+
+After A5c: the worker resolves tenant_config FIRST (it already does
+this for ``entity_blocklist`` further down the function — A5c just
+moves the call up and threads the result through). Tenant overrides
+take effect; a tenant that sets ``entity_extraction.provider=gemini``
+in organisation_settings will actually route to gemini.
+
+Test pins: when the worker is invoked, ``extract_entities_from_content``
+receives a non-None ``tenant_config`` kwarg whose
+``entity_extraction_provider`` matches the resolved value. Production
+code that satisfies this test ships as ~5 LOC in
+``entity_extraction_worker.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_worker_forwards_resolved_tenant_config_to_extractor() -> None:
+    """When ``process_entity_extraction`` runs for tenant ``t-a5c`` whose
+    organisation_settings has ``entity_extraction.provider=gemini``, the
+    call to ``extract_entities_from_content`` must include
+    ``tenant_config`` with that provider visible.
+
+    Pre-A5c: worker calls extractor with no tenant_config kwarg →
+    tenant_config=None → settings.entity_extraction_provider wins →
+    gemini override silently ignored.
+    """
+    from core_api.services import entity_extraction_worker
+    from core_api.services.entity_extraction import ExtractedGraph
+
+    captured: dict = {}
+
+    async def fake_extract(content, memory_type, tenant_config=None):
+        captured["tenant_config"] = tenant_config
+        # Return empty so the worker short-circuits before hitting storage
+        # — we only need to observe what was passed IN.
+        return ExtractedGraph(entities=[], relations=[], mentions=[])
+
+    fake_cfg = MagicMock()
+    fake_cfg.entity_extraction_provider = "gemini"
+    fake_cfg.entity_extraction_model = "gemini-1.5-flash"
+    fake_cfg.entity_blocklist = frozenset()
+    fake_cfg.entity_extraction_enabled = True
+
+    fake_resolve = AsyncMock(return_value=fake_cfg)
+
+    with (
+        patch.object(
+            entity_extraction_worker,
+            "extract_entities_from_content",
+            side_effect=fake_extract,
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            fake_resolve,
+        ),
+    ):
+        await entity_extraction_worker.process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t-a5c",
+            fleet_id=None,
+            agent_id="agent-x",
+            content="Anna ships Vermillion to Pelagic.",
+            memory_type="episode",
+        )
+
+    assert "tenant_config" in captured, (
+        "extract_entities_from_content was not called — worker short-circuited "
+        "before reaching the extractor."
+    )
+    tc = captured["tenant_config"]
+    assert tc is not None, (
+        "Worker passed tenant_config=None to the extractor. The tenant-level "
+        "entity_extraction.provider override on ResolvedConfig is dead code "
+        "without this fix."
+    )
+    assert tc.entity_extraction_provider == "gemini", (
+        f"Expected resolved tenant_config with provider=gemini to reach the "
+        f"extractor; got provider={tc.entity_extraction_provider!r}. The fix "
+        f"must thread the resolved config through, not just None or a fresh "
+        f"unresolved instance."
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_still_works_when_resolve_config_returns_default() -> None:
+    """Back-compat: tenants without any entity_extraction override (provider
+    falls through to global settings) must still get a non-None tenant_config
+    passed to the extractor — and the worker must complete cleanly with no
+    entities returned.
+    """
+    from core_api.services import entity_extraction_worker
+    from core_api.services.entity_extraction import ExtractedGraph
+
+    captured: dict = {}
+
+    async def fake_extract(content, memory_type, tenant_config=None):
+        captured["tenant_config"] = tenant_config
+        return ExtractedGraph(entities=[], relations=[], mentions=[])
+
+    # Default config — provider falls back to the global setting (in practice
+    # 'openai' / 'fake' / whatever env has). We still expect the worker to
+    # pass *something*, not None, so per-tenant overrides remain wired.
+    fake_cfg = MagicMock()
+    fake_cfg.entity_extraction_provider = "openai"
+    fake_cfg.entity_extraction_model = None
+    fake_cfg.entity_blocklist = frozenset()
+    fake_cfg.entity_extraction_enabled = True
+
+    fake_resolve = AsyncMock(return_value=fake_cfg)
+
+    with (
+        patch.object(
+            entity_extraction_worker,
+            "extract_entities_from_content",
+            side_effect=fake_extract,
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            fake_resolve,
+        ),
+    ):
+        await entity_extraction_worker.process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t-default",
+            fleet_id=None,
+            agent_id="agent-x",
+            content="Some content.",
+            memory_type="fact",
+        )
+
+    tc = captured.get("tenant_config")
+    assert tc is not None, (
+        "Even with default config, worker must pass tenant_config (not None) "
+        "to keep the override channel live for future per-tenant settings."
+    )
+    assert tc.entity_extraction_provider == "openai"


### PR DESCRIPTION
## Summary
A5c — mechanical fix. The worker resolves `tenant_config` for the entity blocklist a few lines below `extract_entities_from_content`; this PR moves the `resolve_config` call up so the resolved config is also threaded into the extractor.

Pre-A5c: tenant-level `entity_extraction.provider` / `entity_extraction.model` overrides on `ResolvedConfig` were dead code — `extract_entities_from_content` received `tenant_config=None` and always fell back to global env settings.

After A5c: tenant overrides take effect; default tenants are unchanged.

## Test plan
- [x] 2/2 A5c unit tests green (red→green discipline; tests written before the move).
- [x] 19/19 adjacent unit tests green (A5a / A5b / entity-linking).
- [x] Wet test on local stack: strong-mode write produced 7 entity_links across artifact / identifier / role / person / location / event types; Path A + Path C completed cleanly.
- [x] `ruff check` + `ruff format --check` clean.

## Scope
~5 LOC code + ~150 LOC tests. No new abstractions, no behavior change for default tenants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)