### PR TITLE
test(f3): phase 0 — pin asymmetric branch + wet-test matrix runner

### DIFF
--- a/scripts/_f3_wet_test_observer.py
+++ b/scripts/_f3_wet_test_observer.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""F3 Phase 0 observer — write a memory + capture observable state.
+
+Driven by ``scripts/f3_wet_test_matrix.sh``. Reads two args:
+    cell_name  — "inline" | "deferred"
+    output_dir — path to write the JSON record to
+
+Assumes the local stack is up, ``/tmp/local-dev.token`` exists, and
+the core-api container is the one named below.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import uuid
+import sys
+import time
+import urllib.request
+
+CONTAINER_CORE_API = "caura-memclaw-enterprise-core-api-1"
+CONTAINER_POSTGRES = "caura-memclaw-enterprise-postgres-1"
+TENANT = "dev-41fddf"
+
+
+def write_memory(content: str, agent: str, mode: str = "strong") -> dict:
+    with open("/tmp/local-dev.token") as f:
+        token = f.read().strip()
+    req = urllib.request.Request(
+        "http://localhost/api/v1/memories",
+        data=json.dumps(
+            {
+                "content": content,
+                "tenant_id": TENANT,
+                "agent_id": agent,
+                "write_mode": mode,
+            }
+        ).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read())
+
+
+def psql(sql: str) -> str:
+    """Run a `-tAc` query against the local Postgres container."""
+    out = subprocess.run(
+        [
+            "docker",
+            "exec",
+            CONTAINER_POSTGRES,
+            "psql",
+            "-U",
+            "memclaw",
+            "-d",
+            "memclaw",
+            "-tAc",
+            sql,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+def grep_logs_for(memory_id: str) -> list[str]:
+    out = subprocess.run(
+        ["docker", "logs", CONTAINER_CORE_API, "--since", "3m"],
+        capture_output=True,
+        text=True,
+    )
+    keep = []
+    for line in (out.stdout + out.stderr).splitlines():
+        if memory_id in line and any(
+            marker in line
+            for marker in ("EMBED_REQUESTED", "ENRICH_REQUESTED", "publish_memory")
+        ):
+            keep.append(line.strip())
+    return keep[:20]
+
+
+def env_inside_container(var: str) -> str:
+    out = subprocess.run(
+        ["docker", "exec", CONTAINER_CORE_API, "sh", "-c", f'echo "${{{var}:-unset}}"'],
+        capture_output=True,
+        text=True,
+    )
+    return out.stdout.strip()
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("usage: _f3_wet_test_observer.py <cell_name> <output_dir> [mode]")
+        return 2
+    cell = sys.argv[1]
+    out_dir = sys.argv[2]
+    mode = sys.argv[3] if len(sys.argv) > 3 else "strong"
+    os.makedirs(out_dir, exist_ok=True)
+
+    embed_env = env_inside_container("EMBED_ON_HOT_PATH")
+    enrich_env = env_inside_container("ENRICH_ON_HOT_PATH")
+    print(
+        f"=== CELL: {cell}  in-container: EMBED_ON_HOT_PATH={embed_env}  "
+        f"ENRICH_ON_HOT_PATH={enrich_env} ==="
+    )
+
+    # uuid in content so prior runs don't 409 us out via semantic dedup
+    # (the inline cell embeds + checks for near-duplicates inline).
+    nonce = uuid.uuid4().hex[:10]
+    content = (
+        f"F3 Phase 0 {cell}-{mode} {nonce}: Alma Reyes shipped Helios-{nonce} "
+        f"to the Aurora squad on May {nonce}."
+    )
+    print(f"writing memory (mode={mode})...")
+    resp = write_memory(content, f"f3-{cell}-{mode}", mode)
+    mid = resp.get("id")
+    if not mid:
+        print(f"WRITE FAILED: {resp}")
+        return 1
+    print(f"wrote memory {mid}; sleeping 20s for async settle")
+    time.sleep(20)
+
+    record: dict = {
+        "cell": cell,
+        "mode": mode,
+        "memory_id": mid,
+        "env": {"EMBED_ON_HOT_PATH": embed_env, "ENRICH_ON_HOT_PATH": enrich_env},
+        "response": {
+            "title": resp.get("title"),
+            "memory_type": resp.get("memory_type"),
+            "weight": resp.get("weight"),
+            "status": resp.get("status"),
+            "summary_present": bool((resp.get("metadata") or {}).get("summary")),
+            "tags_present": bool((resp.get("metadata") or {}).get("tags")),
+        },
+        "db": {
+            "embedding_is_null": psql(
+                f"SELECT embedding IS NULL FROM memories WHERE id='{mid}';"
+            )
+            == "t",
+            "title": psql(f"SELECT title FROM memories WHERE id='{mid}';") or None,
+            "memory_type": psql(f"SELECT memory_type FROM memories WHERE id='{mid}';")
+            or None,
+            "status": psql(f"SELECT status FROM memories WHERE id='{mid}';") or None,
+            "summary_present": psql(
+                f"SELECT (metadata->>'summary') IS NOT NULL "
+                f"FROM memories WHERE id='{mid}';"
+            )
+            == "t",
+            "tags_present": psql(
+                f"SELECT json_array_length(COALESCE(metadata->'tags','[]'::json)) > 0 "
+                f"FROM memories WHERE id='{mid}';"
+            )
+            == "t",
+        },
+        "publishes_observed_in_logs": grep_logs_for(mid),
+    }
+
+    out_path = os.path.join(out_dir, f"{cell}-{mode}.json")
+    with open(out_path, "w") as f:
+        json.dump(record, f, indent=2, default=str)
+
+    print(f"\n=== observed: {out_path} ===")
+    print(json.dumps(record, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/f3_wet_test_matrix.sh
+++ b/scripts/f3_wet_test_matrix.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# F3 Phase 0 — wet-test the two canonical cells of the
+# (embed_on_hot_path × enrich_on_hot_path) matrix end-to-end against
+# the local stack, capturing observable state as a golden record.
+#
+# Phase 0 deliverable: this run on `main` produces baseline JSON
+# under `.f3-phase0-baseline/` that Phase 3 must reproduce after the
+# deployment_mode swap.
+#
+# Usage:
+#   scripts/f3_wet_test_matrix.sh                 # full matrix
+#   scripts/f3_wet_test_matrix.sh inline          # just the (T,T) cell
+#   scripts/f3_wet_test_matrix.sh deferred        # just the (F,F) cell
+#
+# Pre-reqs:
+#   - Enterprise stack up via memclaw-local-dev skill
+#   - Real OPENAI_API_KEY in caura-memclaw/.env so embed + enrich actually fire
+#   - User authenticated (/tmp/local-dev.token, /tmp/local-dev.cookies)
+#
+# Env-flag override strategy: the script writes a temporary
+# `.env.f3-override` file alongside the user's .env, ordered AFTER it
+# on the --env-file chain so the override's values win. The file is
+# removed on exit; the user's .env is never touched.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENT_DIR="${REPO_ROOT}/../caura-memclaw-enterprise"
+ENV_FILE="${REPO_ROOT}/.env"
+COMPOSE_OVERRIDE="${ENT_DIR}/docker-compose.override.yml"
+OUTPUT_DIR="${REPO_ROOT}/.f3-phase0-baseline"
+OBSERVER="${REPO_ROOT}/scripts/_f3_wet_test_observer.py"
+
+mkdir -p "${OUTPUT_DIR}"
+trap 'rm -f "${COMPOSE_OVERRIDE}"' EXIT
+
+restart_with_flags() {
+  local embed="$1"
+  local enrich="$2"
+  # docker compose auto-loads `docker-compose.override.yml` from the
+  # project dir if present. We write one that injects the two flags
+  # into core-api's env block, then tear it down on EXIT.
+  cat > "${COMPOSE_OVERRIDE}" <<EOF
+services:
+  core-api:
+    environment:
+      EMBED_ON_HOT_PATH: "${embed}"
+      ENRICH_ON_HOT_PATH: "${enrich}"
+EOF
+  cd "${ENT_DIR}"
+  TESTING=1 docker compose \
+    --env-file "${ENV_FILE}" \
+    up -d --no-deps --force-recreate core-api \
+    > /dev/null 2>&1
+  cd - > /dev/null
+
+  # Wait for the stack to respond at all. /api/auth/me through the
+  # gateway proves nginx is routing; we'll probe a /memories endpoint
+  # right after to be sure core-api itself is serving.
+  local attempts=0
+  while ! curl -fsS -o /dev/null -m 2 http://localhost/api/auth/me \
+        -b /tmp/local-dev.cookies 2>/dev/null; do
+    sleep 1
+    attempts=$((attempts+1))
+    if [ "$attempts" -gt 45 ]; then
+      echo "auth service did not respond within 45s after env flip"
+      return 1
+    fi
+  done
+  # Confirm core-api itself is serving (not just the auth service).
+  attempts=0
+  while [ "$(curl -s -o /dev/null -w '%{http_code}' \
+             -H "Authorization: Bearer $(cat /tmp/local-dev.token 2>/dev/null || echo x)" \
+             http://localhost/api/v1/memories?limit=1)" = "502" ]; do
+    sleep 1
+    attempts=$((attempts+1))
+    if [ "$attempts" -gt 45 ]; then
+      echo "core-api still 502 after 45s"
+      return 1
+    fi
+  done
+
+  local got
+  got=$(docker exec caura-memclaw-enterprise-core-api-1 \
+        sh -c 'echo "EMBED=${EMBED_ON_HOT_PATH:-unset} ENRICH=${ENRICH_ON_HOT_PATH:-unset}"')
+  printf '  in-container: %s\n' "${got}"
+}
+
+# Refresh auth (bootstrap is idempotent; cookie/token may have expired).
+EMAIL="dev@example.com" "${HOME}/.claude/skills/memclaw-local-dev/bootstrap.sh" \
+  > /dev/null 2>&1 || true
+
+run_cell() {
+  # Run BOTH write_mode=strong and write_mode=fast under the same
+  # env-flag pair. The strong runs prove the CAURA-229 contract is
+  # preserved (strong always inline regardless of flags); the fast
+  # runs are where the flags actually steer observable behavior.
+  local cell="$1" embed="$2" enrich="$3"
+  printf '\n=== restart core-api with EMBED=%s ENRICH=%s ===\n' "${embed}" "${enrich}"
+  restart_with_flags "${embed}" "${enrich}"
+  python3 "${OBSERVER}" "${cell}" "${OUTPUT_DIR}" strong
+  python3 "${OBSERVER}" "${cell}" "${OUTPUT_DIR}" fast
+}
+
+case "${1:-all}" in
+  inline)   run_cell inline   true  true  ;;
+  deferred) run_cell deferred false false ;;
+  all)
+    run_cell inline   true  true
+    run_cell deferred false false
+    ;;
+  *)
+    echo "usage: $0 [inline|deferred|all]"
+    exit 2
+    ;;
+esac
+
+printf '\nbaseline captured under %s\n' "${OUTPUT_DIR}"
+ls -la "${OUTPUT_DIR}"

--- a/tests/test_f3_asymmetric_canary.py
+++ b/tests/test_f3_asymmetric_canary.py
@@ -1,0 +1,259 @@
+"""F3 Phase 0 — pin the ONE branch we intentionally drop in Phase 3.
+
+Background
+──────────
+F3 replaces the two global flags ``embed_on_hot_path`` and
+``enrich_on_hot_path`` with a single ``deployment_mode: Literal[
+"inline", "deferred"]`` knob. The deploy YAML proves prod is always
+``(False, False)``; OSS local defaults to ``(True, True)``; user
+confirmed no environment uses the asymmetric combinations.
+
+The subagent inventory (2026-05-19) identified exactly one production
+branch whose existence ONLY makes sense in the asymmetric state:
+
+    core-api/src/core_api/services/memory_service.py:2158
+        if embedding is not None and not settings.embed_on_hot_path:
+            ... fire Path A contradiction detection ...
+
+This branch lives INSIDE ``_enrich_memory_background`` (the inline-
+enrich code path, gated by ``enrich_on_hot_path=True``). It only does
+real work when ``embed_on_hot_path=False`` AND the embed-worker has
+already PATCHed an embedding into the row by the time enrichment
+finishes — i.e. the ``(enrich=inline, embed=deferred)`` race window.
+
+Why this test exists
+────────────────────
+It is the CANARY for Phase 3's intentional capability loss. Today the
+branch fires; Phase 3 deletes both the branch and this test in one
+commit, with a code comment marking the deliberate scope reduction.
+Pinning the current behavior here means a reviewer can see precisely
+what's being dropped and why — not a quiet `git rm`.
+
+The existing characterization coverage for the canonical cells lives
+in (not duplicated here):
+  - ``tests/test_write_mode_dispatch.py`` (strong + fast × T,T/F,F)
+  - ``tests/test_embed_off_hot_path.py``
+  - ``tests/test_enrich_off_hot_path.py``
+  - ``tests/test_fast_branch_fan_out.py``
+  - ``tests/test_consumer_enriched.py``
+
+These all stay green through Phase 1+2+3.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _enrichment_result() -> SimpleNamespace:
+    """Minimal EnrichmentResult-shaped object the post-LLM block reads."""
+    return SimpleNamespace(
+        memory_type=None,
+        weight=None,
+        title=None,
+        summary=None,
+        tags=None,
+        retrieval_hint=None,
+        contains_pii=None,
+        pii_types=None,
+        ts_valid_start=None,
+        ts_valid_end=None,
+        status=None,
+        llm_ms=None,
+        atomic_facts=[],
+    )
+
+
+def _row_with_embedding(embedding: list[float] | None) -> dict:
+    """Storage-row shape the in-function code reads after the PATCH."""
+    return {
+        "id": str(uuid4()),
+        "deleted_at": None,
+        "memory_type": "fact",
+        "weight": 0.5,
+        "status": "active",
+        "metadata_": {},
+        "metadata": None,
+        "ts_valid_start": None,
+        "ts_valid_end": None,
+        "embedding": embedding,
+    }
+
+
+async def test_asymmetric_branch_fires_contradiction_when_embed_deferred_and_worker_patched_first() -> (
+    None
+):
+    """The Phase-3-doomed branch at memory_service.py:2158.
+
+    Setup matches the only state where it does real work:
+    - ``enrich_on_hot_path=True``  → inline enrich path runs
+    - ``embed_on_hot_path=False``  → without this flag asymmetry, the
+      branch would never fire (the ``not settings.embed_on_hot_path``
+      guard would be False)
+    - ``storage_client.get_memory`` returns a row whose ``embedding``
+      column is non-None — simulating the embed-worker having already
+      PATCHed the row by the time inline enrichment lands here.
+
+    Expectation: ``detect_contradictions_async`` is scheduled via
+    ``track_task``. THIS IS THE BEHAVIOR WE INTENTIONALLY LOSE IN
+    F3 PHASE 3. The test (and the branch) are deleted together.
+    """
+    from core_api.services.memory_service import _enrich_memory_background
+
+    memory_id = uuid4()
+    embedding = [0.1] * 1536
+
+    fake_tenant_config = SimpleNamespace(
+        enrichment_enabled=True,
+        entity_extraction_enabled=False,
+    )
+    fake_sc = MagicMock()
+    fake_sc.get_memory = AsyncMock(return_value=_row_with_embedding(embedding))
+    fake_sc._patch = AsyncMock()
+    fake_sc.update_memory_status = AsyncMock()
+
+    track_task = MagicMock()
+    detect_contradictions_async = MagicMock(return_value="coro-sentinel")
+    tracked_task = MagicMock(side_effect=lambda coro, label, *_a, **_k: (label, coro))
+
+    with (
+        patch(
+            "core_api.services.memory_service.settings.embed_on_hot_path",
+            False,
+        ),
+        patch(
+            "core_api.services.memory_service.settings.enrich_on_hot_path",
+            True,
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(return_value=fake_tenant_config),
+        ),
+        patch(
+            "core_api.services.memory_enrichment.enrich_memory",
+            new=AsyncMock(return_value=_enrichment_result()),
+        ),
+        patch(
+            "core_api.services.memory_service.get_storage_client",
+            return_value=fake_sc,
+        ),
+        patch(
+            "core_api.services.memory_service.track_task",
+            new=track_task,
+        ),
+        patch(
+            "core_api.services.task_tracker.tracked_task",
+            new=tracked_task,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.detect_contradictions_async",
+            new=detect_contradictions_async,
+        ),
+    ):
+        await _enrich_memory_background(
+            memory_id=memory_id,
+            content="A test memory for the asymmetric canary.",
+            tenant_id="t-f3-canary",
+            fleet_id=None,
+            agent_id="a",
+        )
+
+    # The branch must have fired: detect_contradictions_async was called
+    # with the worker-PATCHed embedding, then wrapped in tracked_task
+    # under the SaaS-mode label, then handed to track_task.
+    detect_contradictions_async.assert_called_once()
+    args = detect_contradictions_async.call_args.args
+    assert args[0] == memory_id
+    assert args[1] == "t-f3-canary"
+    assert args[4] == embedding, (
+        "branch must pass the embedding it observed on the worker-PATCHed row"
+    )
+
+    labels_scheduled = [call.args[0][0] for call in track_task.call_args_list]
+    assert "contradiction_detection_saas" in labels_scheduled, (
+        f"track_task must receive a tracked_task labelled 'contradiction_detection_saas' "
+        f"(the asymmetric-branch label). Got labels: {labels_scheduled}. "
+        f"If this assertion fails, the branch at memory_service.py:2158 was "
+        f"removed or moved — confirm intent before deleting this canary."
+    )
+
+
+async def test_asymmetric_branch_does_not_fire_when_both_flags_true() -> None:
+    """Negative pin: the canonical OSS-inline cell. ``embed_on_hot_path=True``
+    means ``not settings.embed_on_hot_path`` is False, so the branch
+    short-circuits. ``detect_contradictions_async`` is NOT called from
+    this path — the OSS hot path already fired its own Path A via
+    ``ScheduleBackgroundTasks``.
+    """
+    from core_api.services.memory_service import _enrich_memory_background
+
+    memory_id = uuid4()
+
+    fake_tenant_config = SimpleNamespace(
+        enrichment_enabled=True,
+        entity_extraction_enabled=False,
+    )
+    fake_sc = MagicMock()
+    fake_sc.get_memory = AsyncMock(return_value=_row_with_embedding([0.2] * 1536))
+    fake_sc._patch = AsyncMock()
+    fake_sc.update_memory_status = AsyncMock()
+
+    track_task = MagicMock()
+    detect_contradictions_async = MagicMock(return_value="coro-sentinel")
+    tracked_task = MagicMock(side_effect=lambda coro, label, *_a, **_k: (label, coro))
+
+    with (
+        patch(
+            "core_api.services.memory_service.settings.embed_on_hot_path",
+            True,
+        ),
+        patch(
+            "core_api.services.memory_service.settings.enrich_on_hot_path",
+            True,
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(return_value=fake_tenant_config),
+        ),
+        patch(
+            "core_api.services.memory_enrichment.enrich_memory",
+            new=AsyncMock(return_value=_enrichment_result()),
+        ),
+        patch(
+            "core_api.services.memory_service.get_storage_client",
+            return_value=fake_sc,
+        ),
+        patch(
+            "core_api.services.memory_service.track_task",
+            new=track_task,
+        ),
+        patch(
+            "core_api.services.task_tracker.tracked_task",
+            new=tracked_task,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.detect_contradictions_async",
+            new=detect_contradictions_async,
+        ),
+    ):
+        await _enrich_memory_background(
+            memory_id=memory_id,
+            content="A test memory for the canonical-cell negative pin.",
+            tenant_id="t-f3-canary",
+            fleet_id=None,
+            agent_id="a",
+        )
+
+    detect_contradictions_async.assert_not_called()
+    labels_scheduled = [call.args[0][0] for call in track_task.call_args_list]
+    assert "contradiction_detection_saas" not in labels_scheduled, (
+        f"In the canonical (True, True) cell the asymmetric branch must "
+        f"NOT fire. The OSS hot path already fired its own Path A. "
+        f"Got labels: {labels_scheduled}."
+    )


### PR DESCRIPTION
## Summary
F3 Phase 0 — the **conviction gate** before any production-code change. F3 will replace `embed_on_hot_path` + `enrich_on_hot_path` with a single `deployment_mode` setting; this PR locks in the current observable behavior so Phases 1-3 can prove they preserve it.

## What's in this PR
- **`tests/test_f3_asymmetric_canary.py`** — pinned characterization tests for the ONE asymmetric branch we know we're dropping in Phase 3 (`memory_service.py:2158`). Positive pin + negative pin. These tests are deleted in Phase 3 with the branch, by design.
- **`scripts/f3_wet_test_matrix.sh`** + **`scripts/_f3_wet_test_observer.py`** — end-to-end runner that, per `(cell × write_mode)`, injects the flag pair via a temporary `docker-compose.override.yml`, recreates `core-api`, writes a memory, and captures observable state (response shape, DB row, log publishes) to `.f3-phase0-baseline/<cell>-<mode>.json`.

## Phase 0 baseline (captured on main, 2026-05-19)
- `inline + strong` → response = DB; LLM fields populated; embedding non-null.
- `inline + fast` → response empty (CAURA-229: no LLM on fast response path); DB fills within ~5s.
- `deferred + strong` → IDENTICAL to inline+strong — confirms PR #151's CAURA-229 restoration. Strong forces inline regardless of flags.
- `deferred + fast` → response empty AND DB embedding still NULL after 20s settle (no core-worker subscriber in local stack to consume `EMBED_REQUESTED` / `ENRICH_REQUESTED`).

Phase 3 must reproduce all four (minus the asymmetric canary). Any drift = F3 broke behavior.

## What this PR is NOT
- Not a code change to `core-api` / `core-storage-api` production code.
- Not a deletion of any existing test. The flag-touching tests in `tests/test_write_mode_dispatch.py`, `test_embed_off_hot_path.py`, `test_enrich_off_hot_path.py`, `test_fast_branch_fan_out.py`, `test_consumer_enriched.py` (~28 tests across 5 files) cover the canonical cells at the step level and stay green through every later phase.

## Test plan
- [x] Both canary tests green on `main`.
- [x] Wet-test matrix run captures all four cells; output committed to PR description above.
- [x] `ruff check` + `ruff format --check` clean.

## Next phases (locked in `memory/fast-vs-strong-investigation.md`)
- **Phase 1** — add `deployment_mode` setting alongside legacy flags; derive default at startup with deprecation warning on asymmetric combos.
- **Phase 2** — migrate the 18 call sites in three file-sized batches (`parallel_embed_enrich.py` / `schedule_background_tasks.py` / `memory_service.py`).
- **Phase 3** — delete the legacy flags + the asymmetric branch + this canary test in one PR. Update deploy YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)