### PR TITLE
feat(config): add deployment_mode setting alongside legacy flags (F3 Phase 1)

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -74,6 +74,21 @@ class Settings(BaseSettings):
     # Set the env override ``ENRICH_ON_HOT_PATH=false`` on the SaaS
     # deploy.
     enrich_on_hot_path: bool = True
+    # F3 Phase 1 — single per-deploy mode that supersedes the legacy
+    # ``embed_on_hot_path`` + ``enrich_on_hot_path`` pair.
+    #
+    # - ``"inline"``   : both embed + enrich run on the request path
+    #                    (OSS local default — no worker fleet required)
+    # - ``"deferred"`` : both deferred to ``core-worker`` via Pub/Sub
+    #                    (SaaS prod default — sub-2s p99 SLA)
+    #
+    # When unset (``None``), the derivation validator below populates
+    # this from the legacy flags and emits a deprecation warning if the
+    # two flags disagree. F3 Phase 3 removes the legacy flags entirely;
+    # this becomes the only per-deploy control. ``write_mode=strong``
+    # on a per-request basis continues to force inline regardless of
+    # ``deployment_mode`` (CAURA-229 contract, preserved by PR #151).
+    deployment_mode: Literal["inline", "deferred"] | None = None
     # Outer cap on the inline embed+enrich gather in ParallelEmbedEnrich.
     # Was hardcoded at 20.0 — too tight under load once embedding moved
     # off the hot path (CAURA-594) and enrichment LLM became the sole
@@ -439,6 +454,58 @@ class Settings(BaseSettings):
                     "enrichment."
                 )
         return self
+
+    @model_validator(mode="after")
+    def _derive_deployment_mode(self) -> "Settings":
+        """F3 Phase 1 — derive ``deployment_mode`` from legacy flags when unset.
+
+        Rules:
+          ``(T, T)`` → ``"inline"``
+          ``(F, F)`` → ``"deferred"``
+          asymmetric → ``"deferred"`` + WARNING. Conservative default —
+            silently exposing un-enriched rows under an "inline"
+            deployment shape is worse than under-delivering and
+            surfacing the misconfig via the warning.
+
+        When the operator sets ``DEPLOYMENT_MODE`` explicitly, that
+        value wins; legacy flags are ignored for derivation. The
+        legacy flags themselves stay readable until F3 Phase 3
+        removes them — 18 call sites across 3 files migrate to
+        ``inline_embedding`` / ``inline_enrichment`` helpers below
+        during F3 Phase 2.
+        """
+        if self.deployment_mode is not None:
+            return self  # explicit operator override wins
+
+        if self.embed_on_hot_path and self.enrich_on_hot_path:
+            derived = "inline"
+        elif not self.embed_on_hot_path and not self.enrich_on_hot_path:
+            derived = "deferred"
+        else:
+            derived = "deferred"
+            logger.warning(
+                "Asymmetric legacy flag pair: embed_on_hot_path=%s "
+                "enrich_on_hot_path=%s. F3 Phase 0 audit confirmed no "
+                "environment intentionally uses this combination. "
+                "Defaulting deployment_mode='deferred'. Set "
+                "DEPLOYMENT_MODE=inline|deferred explicitly to silence "
+                "this warning; the legacy flags are removed in F3 "
+                "Phase 3.",
+                self.embed_on_hot_path,
+                self.enrich_on_hot_path,
+            )
+        object.__setattr__(self, "deployment_mode", derived)
+        return self
+
+    @property
+    def inline_embedding(self) -> bool:
+        """True iff the resolved deployment mode runs embedding inline."""
+        return self.deployment_mode == "inline"
+
+    @property
+    def inline_enrichment(self) -> bool:
+        """True iff the resolved deployment mode runs enrichment inline."""
+        return self.deployment_mode == "inline"
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 

--- a/tests/test_f3_phase1_deployment_mode.py
+++ b/tests/test_f3_phase1_deployment_mode.py
@@ -1,0 +1,213 @@
+"""F3 Phase 1 — ``deployment_mode`` setting with legacy-flag derivation.
+
+Phase 1 adds the new ``deployment_mode: Literal["inline","deferred"]``
+setting alongside the existing ``embed_on_hot_path`` and
+``enrich_on_hot_path`` flags. No call site moves yet — every reader
+of the legacy flags stays as-is. The new setting + two helpers are
+the source of truth Phases 2+3 migrate onto.
+
+Derivation rules (when ``DEPLOYMENT_MODE`` is unset)
+────────────────────────────────────────────────────
+- ``(embed=True,  enrich=True)``   → ``"inline"``   (OSS local default)
+- ``(embed=False, enrich=False)``  → ``"deferred"`` (SaaS prod default)
+- ``(embed=False, enrich=True)``   → log a WARNING + choose ``"deferred"``
+  (conservative — never silently expose un-enriched rows to OSS users)
+- ``(embed=True,  enrich=False)``  → log a WARNING + choose ``"deferred"``
+
+When ``DEPLOYMENT_MODE`` IS set explicitly (``"inline"`` | ``"deferred"``):
+- the explicit value wins; legacy flags are ignored for derivation
+  purposes. The legacy flags themselves stay readable until Phase 3.
+
+Helpers
+───────
+- ``settings.inline_embedding``  → True iff effective mode is ``"inline"``
+- ``settings.inline_enrichment`` → True iff effective mode is ``"inline"``
+
+Tests pinned BEFORE the implementation. They FAIL against current
+main (no ``deployment_mode`` field, no helpers). Implementation makes
+them pass without breaking any of the ~28 existing flag-touching
+tests.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+def _make_settings(**overrides):
+    """Construct a fresh Settings() with the given fields overridden.
+
+    Pydantic-Settings reads env at construction. To avoid pollution
+    from the surrounding process env, we pass the overrides explicitly
+    and assert behavior on the resulting instance.
+    """
+    from core_api.config import Settings
+
+    return Settings(**overrides)
+
+
+# ---------------------------------------------------------------------------
+# deployment_mode field exists and accepts the two literal values
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_mode_field_exists_with_default_none() -> None:
+    """The setting must exist on Settings. Default is ``None`` so the
+    derivation validator runs and pulls the value from legacy flags."""
+    s = _make_settings(embed_on_hot_path=True, enrich_on_hot_path=True)
+    assert hasattr(s, "deployment_mode")
+
+
+def test_deployment_mode_accepts_inline() -> None:
+    s = _make_settings(deployment_mode="inline")
+    assert s.deployment_mode == "inline"
+
+
+def test_deployment_mode_accepts_deferred() -> None:
+    s = _make_settings(deployment_mode="deferred")
+    assert s.deployment_mode == "deferred"
+
+
+def test_deployment_mode_rejects_garbage() -> None:
+    """Pydantic must reject unknown literals at construction so a typo
+    in an env file becomes a startup error, not silent fallback."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        _make_settings(deployment_mode="async")
+
+
+# ---------------------------------------------------------------------------
+# Derivation when deployment_mode is None
+# ---------------------------------------------------------------------------
+
+
+def test_derives_inline_from_both_flags_true() -> None:
+    """(T, T) — OSS local canonical."""
+    s = _make_settings(embed_on_hot_path=True, enrich_on_hot_path=True)
+    assert s.deployment_mode == "inline"
+
+
+def test_derives_deferred_from_both_flags_false() -> None:
+    """(F, F) — SaaS prod canonical."""
+    s = _make_settings(embed_on_hot_path=False, enrich_on_hot_path=False)
+    assert s.deployment_mode == "deferred"
+
+
+def test_derives_deferred_from_asymmetric_embed_off_enrich_on(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(F, T) — asymmetric. Per Phase 0 finding + user confirmation, no
+    real environment uses this. Conservative default: ``deferred`` (worse
+    to silently expose un-enriched rows as 'OSS inline' than to under-
+    deliver and surface the misconfig in the deprecation warning)."""
+    caplog.set_level(logging.WARNING)
+    s = _make_settings(embed_on_hot_path=False, enrich_on_hot_path=True)
+    assert s.deployment_mode == "deferred"
+
+    msgs = " ".join(rec.message for rec in caplog.records)
+    assert "deployment_mode" in msgs.lower() or "asymmetric" in msgs.lower(), (
+        f"Asymmetric flag pair must emit a deprecation/derivation warning. "
+        f"Caplog: {[r.message for r in caplog.records]!r}"
+    )
+
+
+def test_derives_deferred_from_asymmetric_embed_on_enrich_off(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(T, F) — also asymmetric, same conservative default + warning."""
+    caplog.set_level(logging.WARNING)
+    s = _make_settings(embed_on_hot_path=True, enrich_on_hot_path=False)
+    assert s.deployment_mode == "deferred"
+
+    msgs = " ".join(rec.message for rec in caplog.records)
+    assert "deployment_mode" in msgs.lower() or "asymmetric" in msgs.lower()
+
+
+def test_explicit_deployment_mode_inline_wins_over_legacy_flags() -> None:
+    """Explicit setting beats legacy flags. A deploy setting
+    ``DEPLOYMENT_MODE=inline`` with stale ``EMBED_ON_HOT_PATH=false``
+    overrides the derivation. This is how Phase 3 migrates ops cleanly."""
+    s = _make_settings(
+        deployment_mode="inline",
+        embed_on_hot_path=False,
+        enrich_on_hot_path=False,
+    )
+    assert s.deployment_mode == "inline"
+
+
+def test_explicit_deployment_mode_deferred_wins_over_legacy_flags() -> None:
+    s = _make_settings(
+        deployment_mode="deferred",
+        embed_on_hot_path=True,
+        enrich_on_hot_path=True,
+    )
+    assert s.deployment_mode == "deferred"
+
+
+# ---------------------------------------------------------------------------
+# Helper properties — single source of truth for callers
+# ---------------------------------------------------------------------------
+
+
+def test_inline_embedding_true_when_inline() -> None:
+    s = _make_settings(embed_on_hot_path=True, enrich_on_hot_path=True)
+    assert s.deployment_mode == "inline"
+    assert s.inline_embedding is True
+
+
+def test_inline_embedding_false_when_deferred() -> None:
+    s = _make_settings(embed_on_hot_path=False, enrich_on_hot_path=False)
+    assert s.deployment_mode == "deferred"
+    assert s.inline_embedding is False
+
+
+def test_inline_enrichment_true_when_inline() -> None:
+    s = _make_settings(embed_on_hot_path=True, enrich_on_hot_path=True)
+    assert s.inline_enrichment is True
+
+
+def test_inline_enrichment_false_when_deferred() -> None:
+    s = _make_settings(embed_on_hot_path=False, enrich_on_hot_path=False)
+    assert s.inline_enrichment is False
+
+
+def test_helpers_follow_explicit_deployment_mode() -> None:
+    """When deployment_mode is set explicitly, the helpers reflect IT,
+    not the legacy flags. This is the contract Phase 2 migrates callers
+    onto."""
+    s = _make_settings(
+        deployment_mode="inline",
+        embed_on_hot_path=False,
+        enrich_on_hot_path=False,
+    )
+    assert s.inline_embedding is True
+    assert s.inline_enrichment is True
+
+    s = _make_settings(
+        deployment_mode="deferred",
+        embed_on_hot_path=True,
+        enrich_on_hot_path=True,
+    )
+    assert s.inline_embedding is False
+    assert s.inline_enrichment is False
+
+
+# ---------------------------------------------------------------------------
+# Legacy flags untouched — readers continue to work as before
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_flags_remain_readable_after_phase1() -> None:
+    """Phase 1 does NOT remove the legacy flags. Existing call sites
+    (18 branches across 3 files per the Phase 0 inventory) all still
+    read them. They are removed in Phase 3."""
+    s = _make_settings(embed_on_hot_path=False, enrich_on_hot_path=False)
+    assert s.embed_on_hot_path is False
+    assert s.enrich_on_hot_path is False
+
+    s = _make_settings(embed_on_hot_path=True, enrich_on_hot_path=True)
+    assert s.embed_on_hot_path is True
+    assert s.enrich_on_hot_path is True


### PR DESCRIPTION
## Summary
F3 Phase 1 — purely additive. No call site moved, no legacy flag removed, no observable behavior changed. Adds the new `deployment_mode` setting + derivation + helpers that Phase 2 will migrate call sites onto.

## What's in this PR
- **`deployment_mode: Literal["inline","deferred"] | None`** on `Settings`. Operators can set `DEPLOYMENT_MODE` explicitly; when unset, a model_validator derives it from the legacy flag pair.
- **`_derive_deployment_mode`** validator: `(T,T)→inline`, `(F,F)→deferred`, asymmetric→`deferred`+WARNING (the warning names both flag values, tells the operator to set `DEPLOYMENT_MODE` explicitly, and notes that the legacy flags are dropped in Phase 3).
- **`settings.inline_embedding`** and **`settings.inline_enrichment`** properties — both `True iff deployment_mode == "inline"`. The 18 legacy-flag readers in `parallel_embed_enrich.py` / `schedule_background_tasks.py` / `memory_service.py` migrate onto these in Phase 2.

## Test plan
- [x] 16/16 new Phase 1 unit tests green (red→green discipline).
- [x] 71/71 flag-touching tests across the codebase green — no regression in `test_write_mode_dispatch.py` / `test_embed_off_hot_path.py` / `test_enrich_off_hot_path.py` / `test_fast_branch_fan_out.py` / `test_consumer_enriched.py` / `test_f3_asymmetric_canary.py`.
- [x] Wet-test matrix from PR #172 reproduces all four cells bit-identical to the Phase 0 baseline.
- [x] Asymmetric env (`EMBED=false ENRICH=true`) wet-tested: warning fires, derived mode is `deferred`, helpers return False.
- [x] `ruff check` + `ruff format --check` clean.

## Phase 2 preview
Three batches sized by file, gated on the same characterization suite + wet-test matrix after each batch:
1. `parallel_embed_enrich.py` (6 branches)
2. `schedule_background_tasks.py` (5 branches)
3. `memory_service.py` (7 branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)