### PR TITLE
refactor(pipeline): migrate schedule_background_tasks onto deployment_mode (F3 Phase 2 batch 2b)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/schedule_background_tasks.py
+++ b/core-api/src/core_api/pipeline/steps/write/schedule_background_tasks.py
@@ -89,12 +89,12 @@ class ScheduleBackgroundTasks:
 
             # Path A contradiction detection (Gap 04). Only fires when an
             # inline embedding is available (OSS local + fast under
-            # ``embed_on_hot_path=True``, or strong's PR-2 force-inline).
+            # ``settings.inline_embedding``, or strong's PR-2 force-inline).
             # When ``embedding is None`` (Enterprise+fast deferred), Path A
             # fires via the ``EMBEDDED`` back-channel after ``core-worker``
             # PATCHes the embedding into the row — see the
             # ``_enrich_memory_background`` gate gated on
-            # ``not settings.embed_on_hot_path``. Each cell of the matrix
+            # ``not settings.inline_embedding``. Each cell of the matrix
             # gets exactly one Path A trigger that way.
             if embedding is not None:
                 from core_api.services.contradiction_detector import (
@@ -117,8 +117,8 @@ class ScheduleBackgroundTasks:
                 )
 
             # CAURA-594: deferred-path or inline-failure backfill — the
-            # shim publishes EMBED_REQUESTED in async mode, retries
-            # in-process when embed_on_hot_path=True.
+            # shim publishes EMBED_REQUESTED in deferred mode, retries
+            # in-process when ``settings.inline_embedding`` is True.
             if embedding is None:
                 from core_api.services.memory_service import (
                     _schedule_embed_or_reembed,
@@ -141,14 +141,15 @@ class ScheduleBackgroundTasks:
 
         # Strong mode (or no mode set): today's behavior
 
-        # CAURA-595: when ``enrich_on_hot_path=False`` the parallel
-        # embed/enrich step skipped the LLM call by design and
+        # CAURA-595: when ``settings.inline_enrichment`` is False the
+        # parallel embed/enrich step skipped the LLM call by design and
         # ``enrichment`` is None. Publish ``ENRICH_REQUESTED`` so the
-        # worker fills the row in the background. ``enrich_on_hot_path=True``
-        # already ran enrichment inline upstream; nothing to schedule.
+        # worker fills the row in the background. Inline-enrichment mode
+        # already ran enrichment upstream; nothing to schedule.
+        # F3 Phase 2 batch 2b — was ``not settings.enrich_on_hot_path``.
         if (
             enrichment is None
-            and not settings.enrich_on_hot_path
+            and not settings.inline_enrichment
             and tenant_config.enrichment_enabled
             and tenant_config.enrichment_provider != "none"
         ):
@@ -203,8 +204,8 @@ class ScheduleBackgroundTasks:
             )
 
         # CAURA-594: deferred-path or inline-failure backfill — the shim
-        # publishes EMBED_REQUESTED in async mode, retries in-process
-        # when embed_on_hot_path=True.
+        # publishes EMBED_REQUESTED in deferred mode, retries in-process
+        # when ``settings.inline_embedding`` is True.
         if embedding is None:
             from core_api.services.memory_service import (
                 _schedule_embed_or_reembed,

--- a/tests/test_enrich_off_hot_path.py
+++ b/tests/test_enrich_off_hot_path.py
@@ -181,7 +181,10 @@ async def test_hint_reembed_skipped_when_enrich_flag_off() -> None:
 
 
 async def test_strong_mode_publishes_enrich_when_flag_off() -> None:
-    """Strong-write + flag=off triggers ``_schedule_enrich_or_inline``."""
+    """Strong-write + ``deployment_mode=deferred`` triggers
+    ``_schedule_enrich_or_inline``. F3 Phase 2 batch 2b: SBT now reads
+    ``settings.inline_enrichment`` (derived from ``deployment_mode``)
+    instead of the legacy ``enrich_on_hot_path`` flag."""
     memory_id = uuid.uuid4()
     ctx = _ctx(memory_id=memory_id, write_mode="strong")
     ctx.data["enrichment"] = None  # parallel step deferred
@@ -189,8 +192,8 @@ async def test_strong_mode_publishes_enrich_when_flag_off() -> None:
     publish_spy = AsyncMock(return_value=None)
     with (
         patch(
-            "core_api.pipeline.steps.write.schedule_background_tasks.settings.enrich_on_hot_path",
-            False,
+            "core_api.pipeline.steps.write.schedule_background_tasks.settings.deployment_mode",
+            "deferred",
         ),
         patch(
             "core_api.services.memory_service._schedule_enrich_or_inline",
@@ -210,7 +213,8 @@ async def test_strong_mode_publishes_enrich_when_flag_off() -> None:
 
 
 async def test_strong_mode_no_publish_when_flag_on() -> None:
-    """Strong-write + flag=on → enrichment ran inline, no scheduling needed."""
+    """Strong-write + ``deployment_mode=inline`` → enrichment ran
+    inline, no scheduling needed."""
     memory_id = uuid.uuid4()
     ctx = _ctx(memory_id=memory_id, write_mode="strong")
     ctx.data["enrichment"] = SimpleNamespace(retrieval_hint="")  # ran inline
@@ -218,8 +222,8 @@ async def test_strong_mode_no_publish_when_flag_on() -> None:
     publish_spy = AsyncMock()
     with (
         patch(
-            "core_api.pipeline.steps.write.schedule_background_tasks.settings.enrich_on_hot_path",
-            True,
+            "core_api.pipeline.steps.write.schedule_background_tasks.settings.deployment_mode",
+            "inline",
         ),
         patch(
             "core_api.services.memory_service._schedule_enrich_or_inline",


### PR DESCRIPTION
## Summary
Second of three Phase 2 batches. One real flag read in `schedule_background_tasks.py:151` swaps from `not settings.enrich_on_hot_path` to `not settings.inline_enrichment`. Four comment blocks updated to name the new helpers.

## Production code change
- `schedule_background_tasks.py:151` — single flag read migrated. Polarity matches (helper True when inline, False when deferred — same shape as the legacy flag, opposite name).
- Four nearby comment blocks updated to reference `settings.inline_embedding` / `settings.inline_enrichment` instead of the legacy flag names. No behavior change from comments.

The legacy flags continue to back `deployment_mode` via the Phase 1 derivation validator. Phase 2c (last) migrates `memory_service.py` (7 reads); Phase 3 then deletes the legacy flags entirely.

## Test updates
Two SBT tests in `test_enrich_off_hot_path.py` (`test_strong_mode_publishes_enrich_when_flag_off` / `test_strong_mode_no_publish_when_flag_on`) migrated from patching `schedule_background_tasks.settings.enrich_on_hot_path` to patching `deployment_mode`. The "flag_on" test was passing by accident under the default container env; now patched explicitly so it continues to characterize behavior after Phase 3 removes the legacy flag.

## Test plan
- [x] 70/70 flag-touching unit tests green.
- [x] Wet-test matrix from PR #172 reproduces all 4 Phase 0 baseline cells bit-identical.
- [x] Phase 2b code verified present in the running container image BEFORE the wet test.
- [x] `ruff check` + `ruff format --check` clean.

## Remaining
- **Batch 2c** — `memory_service.py` (7 reads — the largest batch).
- **Phase 3** — delete legacy flags + `DEPLOYMENT_MODE=deferred` in `caura-memclaw-enterprise/.github/workflows/deploy-oss-services.yml:249`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)