### PR TITLE
CAURA-679 fix(storage): NULL-embedding rows rank on fts_score alone

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -677,8 +677,7 @@ class PostgresService:
         # through the similarity blend into `score`, and PostgreSQL's
         # default `ORDER BY score DESC` sorts NULLS FIRST — putting
         # every unembedded row at the TOP of results. The CASE forces
-        # a numeric value (0.0 — the blend's identity element so NULL
-        # rows rank on fts_score alone) and also short-circuits so
+        # a numeric value (0.0) and also short-circuits so
         # cosine_distance isn't even evaluated for NULL rows.
         # `has_embedding` below is the authoritative NULL-vs-orthogonal
         # signal for callers — `vec_sim == 0.0` is ambiguous with a
@@ -696,7 +695,24 @@ class PostgresService:
         raw_fts = func.ts_rank_cd(Memory.search_vector, ts_query)
         fts_score = (raw_fts / (1.0 + raw_fts)).label("fts_score")
 
-        similarity = ((1.0 - _fts_weight) * vec_sim + _fts_weight * fts_score).label("similarity")
+        # CAURA-679: NULL-embedding rows fall back to `fts_score` alone
+        # rather than the `(1 - w) * 0 + w * fts_score` haircut that
+        # the unconditional blend would apply. The haircut multiplies
+        # the FTS signal by `fts_weight` (≤1), so an FTS-matching but
+        # unembedded row could rank below noise-floor-cosine embedded
+        # rows (vec_sim ~0.15-0.20 from high-dim sphere clustering),
+        # which then drop it past the `LIMIT top_k * overfetch_factor`
+        # cutoff. This protects the FTS-fallback contract for both the
+        # CAURA-594 deferred-embed window and any case where the embed
+        # worker fails permanently — the row stays discoverable rather
+        # than silently undiscoverable.
+        similarity = case(
+            (
+                Memory.embedding.is_not(None),
+                (1.0 - _fts_weight) * vec_sim + _fts_weight * fts_score,
+            ),
+            else_=fts_score,
+        ).label("similarity")
 
         anchor = func.greatest(
             Memory.created_at,

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -609,6 +609,87 @@ class TestMemories:
                 f"query={blank_query!r} must not admit any NULL-embedding rows"
             )
 
+    async def test_scored_search_null_embedding_similarity_invariant_to_fts_weight(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """CAURA-679: NULL-embedding rows rank on ``fts_score`` alone — the
+        ``fts_weight`` haircut no longer applies. The old unconditional
+        ``(1 - w) * vec_sim + w * fts_score`` blend, combined with the
+        ``vec_sim = 0.0`` sentinel for NULL rows, made NULL-row similarity
+        scale linearly with ``w``: at ``w = 0.3`` it was ``0.3 * fts_score``,
+        at ``w = 0.7`` it was ``0.7 * fts_score``. That haircut let
+        noise-floor-cosine embedded rows (``vec_sim`` ~0.15-0.20 from
+        high-dim sphere clustering) beat unembedded FTS matches on rank
+        and slip past ``LIMIT top_k * overfetch_factor``.
+
+        The ``CASE`` on ``similarity`` falls back to ``fts_score`` when
+        ``embedding IS NULL``, so identical NULL rows produce identical
+        ``similarity`` across any ``fts_weight``. This test pins that
+        invariance — under the old blend the two values would differ by
+        a factor of ``w_high / w_low``.
+        """
+        keyword = f"caura679_{_uid()}"
+        query_embedding = fake_embedding(f"q-{keyword}")
+
+        # NULL-embedding row with an FTS-matching keyword.
+        payload = _memory_payload(
+            tenant_id, fleet_id, content=f"urgent dispatch {keyword} body details"
+        )
+        payload["embedding"] = None
+        resp = await client.post(f"{PREFIX}/memories", json=payload)
+        assert resp.status_code == 200, resp.text
+        memory_id = resp.json()["id"]
+
+        def make_body(fts_weight: float) -> dict:
+            return {
+                "tenant_id": tenant_id,
+                "embedding": query_embedding,
+                "query": keyword,
+                "fleet_ids": [fleet_id],
+                "top_k": 10,
+                "search_params": {
+                    "fts_weight": fts_weight,
+                    "freshness_floor": 0.5,
+                    "freshness_decay_days": 30.0,
+                    "recall_boost_cap": 2.0,
+                    "recall_decay_window_days": 7.0,
+                    "similarity_blend": 0.7,
+                },
+            }
+
+        resp_low = await client.post(f"{PREFIX}/memories/scored-search", json=make_body(0.3))
+        assert resp_low.status_code == 200, resp_low.text
+        resp_high = await client.post(f"{PREFIX}/memories/scored-search", json=make_body(0.7))
+        assert resp_high.status_code == 200, resp_high.text
+
+        row_low = next(r for r in resp_low.json() if r["id"] == memory_id)
+        row_high = next(r for r in resp_high.json() if r["id"] == memory_id)
+
+        # Sanity: still the NULL-embedding row, vec_sim still coalesced
+        # to the 0.0 sentinel (the CASE on `similarity` doesn't touch
+        # the CASE on `vec_sim`).
+        assert row_low["has_embedding"] is False
+        assert row_low["vec_sim"] == 0.0
+        assert row_high["has_embedding"] is False
+        assert row_high["vec_sim"] == 0.0
+
+        # FTS contributes a real signal — sanity that the keyword
+        # actually matched (else the assertion below is vacuous).
+        assert row_low["similarity"] > 0.0
+
+        # The defining assertion: similarity is invariant under
+        # fts_weight changes for NULL rows. Under the OLD blend,
+        # similarity_high / similarity_low would equal 0.7 / 0.3 ≈ 2.33.
+        assert row_low["similarity"] == pytest.approx(row_high["similarity"], rel=1e-9), (
+            "NULL-embedding similarity must not depend on fts_weight under CAURA-679; "
+            f"got similarity@w=0.3={row_low['similarity']}, "
+            f"similarity@w=0.7={row_high['similarity']} "
+            f"(old-blend ratio would be 0.7/0.3 ≈ 2.33)"
+        )
+
     async def test_public_counters_exclude_soft_deleted(
         self,
         client: AsyncClient,


### PR DESCRIPTION
The scored-search CTE blended `(1 - w) * vec_sim + w * fts_score` unconditionally. For NULL-embedding rows (CAURA-594 deferred-embed window, or any case where the embed worker fails), the `vec_sim = 0.0` sentinel left `similarity = w * fts_score` — a hidden `w` haircut that let noise-floor-cosine embedded rows beat unembedded FTS matches and slip past `LIMIT top_k * overfetch_factor`.

Wrap the similarity expression in a CASE so NULL rows score on `fts_score` alone. PR #150's post-filter is what kept these rows discoverable via `has_embedding`; this protects them at the rank-by- score stage as well, end-to-end. Defensive against permanent embedder failure: rows stay searchable instead of silently undiscoverable.

Tradeoff: a row's similarity can step down (not up) when the embed worker patches it if the resulting vec_sim turns out to be low. Brief NULL-window rank instability vs. the current silent-drop pathology — the former is observable and self-correcting; the latter is invisible.

Adds regression test asserting `similarity` is invariant under `fts_weight` for NULL rows (under the old blend it would scale linearly with `w`).

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
