### PR TITLE
refactor(memory_service): migrate 7 legacy flag reads onto deployment_mode (F3 Phase 2c)

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -982,7 +982,7 @@ async def create_memories_bulk(
     # that will surface as an error anyway.
     valid_indices = [i for i in range(n) if i not in short_content_errors]
     embeddings: list = [None] * n
-    if valid_indices and settings.embed_on_hot_path:
+    if valid_indices and settings.inline_embedding:
         try:
             async with asyncio.timeout(BULK_EMBEDDING_TIMEOUT_SECONDS):
                 valid_embeddings = await get_embeddings_batch(
@@ -994,13 +994,13 @@ async def create_memories_bulk(
             embeddings[item_idx] = valid_embeddings[emb_pos]
 
     enrichments: list = [None] * n
-    # CAURA-595: ``enrich_on_hot_path=False`` defers the LLM call to
+    # CAURA-595: ``deployment_mode=deferred`` defers the LLM call to
     # ``core-worker``; the bulk-persist loop below still proceeds with
     # all-None enrichments and the publish happens post-persist (one
     # event per successfully-created row).
     if (
         valid_indices
-        and settings.enrich_on_hot_path
+        and settings.inline_enrichment
         and tenant_config.enrichment_enabled
         and tenant_config.enrichment_provider != "none"
     ):
@@ -1378,9 +1378,9 @@ async def create_memories_bulk(
         # LLM provider for entity extraction + enrichment).
         from core_api.services.contradiction_detector import detect_contradictions_async
 
-        # CAURA-595: per-row enrich publishes when the flag is off.
+        # CAURA-595: per-row enrich publishes when deployment_mode is deferred.
         defer_enrich_publish = (
-            not settings.enrich_on_hot_path
+            not settings.inline_enrichment
             and tenant_config.enrichment_enabled
             and tenant_config.enrichment_provider != "none"
         )
@@ -1492,13 +1492,15 @@ async def _schedule_embed_or_reembed(
 ) -> None:
     """Backfill the embedding for a memory persisted with ``embedding=NULL``.
 
-    True (OSS, no worker fleet): in-process retry via :func:`_reembed_memory`.
-    False (SaaS): publish ``EMBED_REQUESTED``; ``core-worker`` PATCHes
-    the row. ``content_hash`` is used by the worker to short-circuit
-    the provider call when the same content was already embedded for
-    this tenant — pass it whenever the caller has it in scope.
+    Inline mode (OSS, no worker fleet): in-process retry via
+    :func:`_reembed_memory`.
+    Deferred mode (SaaS): publish ``EMBED_REQUESTED``; ``core-worker``
+    PATCHes the row. ``content_hash`` is used by the worker to short-
+    circuit the provider call when the same content was already
+    embedded for this tenant — pass it whenever the caller has it in
+    scope.
     """
-    if settings.embed_on_hot_path:
+    if settings.inline_embedding:
         await _reembed_memory(memory_id, content, tenant_id)
     else:
         await publish_memory_embed_request(
@@ -1585,11 +1587,13 @@ async def _schedule_enrich_or_inline(
 ) -> None:
     """Enrichment counterpart of :func:`_schedule_embed_or_reembed`.
 
-    True (OSS / pre-CAURA-595 default): run enrichment as an in-process
-    background task in core-api via :func:`_enrich_memory_background`.
-    False (CAURA-595 SaaS): publish ``ENRICH_REQUESTED``; ``core-worker``
-    consumes the event, runs the LLM, and PATCHes the enrichment fields
-    back. The worker also emits ``ENRICHED`` after the PATCH lands.
+    Inline mode (OSS / pre-CAURA-595 default): run enrichment as an
+    in-process background task in core-api via
+    :func:`_enrich_memory_background`.
+    Deferred mode (CAURA-595 SaaS): publish ``ENRICH_REQUESTED``;
+    ``core-worker`` consumes the event, runs the LLM, and PATCHes the
+    enrichment fields back. The worker also emits ``ENRICHED`` after
+    the PATCH lands.
 
     ``agent_provided_fields`` is forwarded so the worker doesn't
     overwrite anything the agent set explicitly at write time —
@@ -1597,7 +1601,7 @@ async def _schedule_enrich_or_inline(
     ``model_dump(exclude_none=True)`` and would otherwise downgrade
     those columns on every redelivery.
     """
-    if settings.enrich_on_hot_path:
+    if settings.inline_enrichment:
         # NOTE: ``agent_provided_fields`` and ``reference_datetime``
         # are intentionally NOT forwarded to ``_enrich_memory_background``.
         # The inline path pre-dates these concepts and uses an
@@ -1646,10 +1650,10 @@ async def _reembed_memory(
     from core_api.constants import EMBEDDING_REEMBED_DELAY_S
     from core_api.services.organization_settings import resolve_config
 
-    if settings.embed_on_hot_path or is_failure_fallback:
-        # Two paths land here: pre-offload legacy behaviour (flag on,
+    if settings.inline_embedding or is_failure_fallback:
+        # Two paths land here: pre-offload legacy behaviour (inline mode,
         # this coroutine only runs on provider failure) and CAURA-594
-        # batch-fallback (flag off but the batch just failed). Both
+        # batch-fallback (deferred mode but the batch just failed). Both
         # want the backoff.
         await asyncio.sleep(EMBEDDING_REEMBED_DELAY_S)
     try:
@@ -2131,31 +2135,27 @@ async def _enrich_memory_background(
                     tenant_id,
                 )
             )
-        # SaaS-mode contradiction detection. Only fires when
-        # ``embed_on_hot_path=False``: in OSS mode the hot path already
-        # fired ``contradiction_detection`` via ScheduleBackgroundTasks
-        # on the same embedding (post-CAURA-222 there's no hint re-embed
-        # generating a different vector here, so re-firing would just
-        # duplicate the LLM check work — state is idempotent because the
-        # detector only writes via ``update_memory_status``).
+        # F3 Phase 2c — name swapped from legacy ``settings.embed_on_hot_path``
+        # to ``settings.inline_embedding`` (same value via the
+        # ``deployment_mode`` derivation). This branch is the asymmetric
+        # race guard documented in ``tests/test_f3_asymmetric_canary.py``:
+        # post-Phase-2c the helpers co-vary, so under both canonical
+        # cells the branch is unreachable in any real deployment (inline
+        # mode: ``_enrich_memory_background`` enters AND ``inline_embedding=True``
+        # → guard short-circuits; deferred mode: ``_schedule_enrich_or_inline``
+        # publishes instead of entering this function). F3 Phase 3 deletes
+        # the entire branch + the canary test.
         #
-        # On the OSS inline-embed-failure path, ``_reembed_memory``'s
-        # race guard fires its own contradiction call when the retry
-        # succeeds, so the OSS-mode coverage hole is also closed there.
+        # SaaS-mode contradiction detection (historical). On the OSS
+        # inline-embed-failure path, ``_reembed_memory``'s race guard fires
+        # its own contradiction call when the retry succeeds, so the
+        # OSS-mode coverage hole is also closed there.
         #
         # In SaaS mode, ``handle_memory_embedded`` and
-        # ``handle_memory_enriched`` consumers also fire contradiction
-        # when their respective worker PATCHes land. This in-process
-        # branch covers the case where ``enrich_on_hot_path=True`` AND
-        # ``embed_on_hot_path=False`` AND the embed worker has already
-        # PATCH-ed the row by the time we reach this point.
-        #
-        # CAURA-594 remaining gap (full SaaS, both flags off): when
-        # enrich runs before core-worker's embed PATCH lands, the
-        # ``embedding is not None`` guard skips this branch and the
-        # ``handle_memory_embedded`` consumer takes over when the
-        # worker's later EMBEDDED publish fires.
-        if embedding is not None and not settings.embed_on_hot_path:
+        # ``handle_memory_enriched`` consumers fire contradiction when
+        # their respective worker PATCHes land, covering both canonical
+        # states without this branch.
+        if embedding is not None and not settings.inline_embedding:
             from core_api.services.contradiction_detector import detect_contradictions_async
 
             track_task(

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -204,7 +204,7 @@ async def test_reembed_skips_initial_sleep_when_flag_off() -> None:
     sc.update_embedding = AsyncMock()
 
     with (
-        patch.object(memory_service.settings, "embed_on_hot_path", False),
+        patch.object(memory_service.settings, "deployment_mode", "deferred"),
         patch.object(
             memory_service,
             "get_embedding",
@@ -219,7 +219,9 @@ async def test_reembed_skips_initial_sleep_when_flag_off() -> None:
         ),
     ):
         await memory_service._reembed_memory(uuid.uuid4(), "hello", TENANT_ID)
-    assert slept == [], "flag-off path must not sleep before the first embed attempt"
+    assert slept == [], (
+        "deferred-mode path must not sleep before the first embed attempt"
+    )
     sc.update_embedding.assert_awaited_once()
 
 
@@ -493,7 +495,7 @@ async def test_bulk_reembed_preserves_batching() -> None:
 
 
 async def test_enrich_fires_contradiction_on_existing_embedding_in_saas_mode() -> None:
-    """SaaS-mode (embed_on_hot_path=False) contradiction coverage.
+    """SaaS-mode (``deployment_mode=deferred``) contradiction coverage.
 
     Pre-CAURA-222 this path did a hint re-embed and fired
     ``contradiction_detection_post_enrich`` on the hint-enhanced vector.
@@ -501,6 +503,13 @@ async def test_enrich_fires_contradiction_on_existing_embedding_in_saas_mode() -
     see CAURA-222), but SaaS-mode contradiction coverage was preserved
     by adding a dedicated ``contradiction_detection_saas`` branch at
     the bottom of ``_enrich_memory_background``.
+
+    Post-F3-Phase-2c the branch is reachable only by directly invoking
+    ``_enrich_memory_background`` while ``deployment_mode=deferred`` —
+    in real deployments ``_schedule_enrich_or_inline`` publishes
+    instead of entering this function. The branch + this test are
+    deleted in F3 Phase 3 alongside ``test_f3_asymmetric_canary``;
+    see that file's docstring for the full F3 plan context.
 
     Expected behavior now:
       - No ``update_embedding`` call from this function (worker owns
@@ -562,7 +571,7 @@ async def test_enrich_fires_contradiction_on_existing_embedding_in_saas_mode() -
         return None
 
     with (
-        patch.object(memory_service.settings, "embed_on_hot_path", False),
+        patch.object(memory_service.settings, "deployment_mode", "deferred"),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch(
             "core_api.services.contradiction_detector.detect_contradictions_async",
@@ -1125,7 +1134,7 @@ async def test_shim_publishes_event_when_flag_off() -> None:
     memory_id = uuid.uuid4()
 
     with (
-        patch.object(memory_service.settings, "embed_on_hot_path", False),
+        patch.object(memory_service.settings, "deployment_mode", "deferred"),
         patch(
             "common.events.memory_embed_publisher.get_event_bus",
             return_value=fake_bus,

--- a/tests/test_enrich_off_hot_path.py
+++ b/tests/test_enrich_off_hot_path.py
@@ -275,7 +275,7 @@ async def test_schedule_enrich_publishes_when_flag_off() -> None:
     tc = _tenant_config()
 
     with (
-        patch.object(memory_service.settings, "enrich_on_hot_path", False),
+        patch.object(memory_service.settings, "deployment_mode", "deferred"),
         patch.object(memory_service, "publish_memory_enrich_request", new=publish_spy),
         patch.object(memory_service, "_enrich_memory_background", new=bg_spy),
     ):

--- a/tests/test_f3_asymmetric_canary.py
+++ b/tests/test_f3_asymmetric_canary.py
@@ -122,14 +122,21 @@ async def test_asymmetric_branch_fires_contradiction_when_embed_deferred_and_wor
     detect_contradictions_async = MagicMock(return_value="coro-sentinel")
     tracked_task = MagicMock(side_effect=lambda coro, label, *_a, **_k: (label, coro))
 
+    # F3 Phase 2c renamed the legacy flag reads to ``settings.inline_*``
+    # helpers (derived from ``deployment_mode``). The two axes co-vary
+    # under the helpers, so the asymmetric ``(False_embed, True_enrich)``
+    # state is no longer expressible by patching legacy flags. We patch
+    # ``deployment_mode="deferred"`` so ``inline_embedding=False`` →
+    # ``not inline_embedding=True`` → branch at memory_service.py:2162
+    # fires. In real deployments the function this drives
+    # (``_enrich_memory_background``) is never CALLED when
+    # ``deployment_mode=deferred`` because ``_schedule_enrich_or_inline``
+    # publishes instead. The canary is artificial by design — it pins
+    # the branch's shape so Phase 3 can delete it confidently.
     with (
         patch(
-            "core_api.services.memory_service.settings.embed_on_hot_path",
-            False,
-        ),
-        patch(
-            "core_api.services.memory_service.settings.enrich_on_hot_path",
-            True,
+            "core_api.services.memory_service.settings.deployment_mode",
+            "deferred",
         ),
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -185,10 +192,12 @@ async def test_asymmetric_branch_fires_contradiction_when_embed_deferred_and_wor
 
 
 async def test_asymmetric_branch_does_not_fire_when_both_flags_true() -> None:
-    """Negative pin: the canonical OSS-inline cell. ``embed_on_hot_path=True``
-    means ``not settings.embed_on_hot_path`` is False, so the branch
-    short-circuits. ``detect_contradictions_async`` is NOT called from
-    this path — the OSS hot path already fired its own Path A via
+    """Negative pin: the canonical OSS-inline cell. Under
+    ``deployment_mode=inline``, ``inline_embedding=True`` →
+    ``not inline_embedding`` is False, so the branch at
+    memory_service.py:2162 short-circuits.
+    ``detect_contradictions_async`` is NOT called from this path — the
+    OSS hot path already fired its own Path A via
     ``ScheduleBackgroundTasks``.
     """
     from core_api.services.memory_service import _enrich_memory_background
@@ -210,12 +219,8 @@ async def test_asymmetric_branch_does_not_fire_when_both_flags_true() -> None:
 
     with (
         patch(
-            "core_api.services.memory_service.settings.embed_on_hot_path",
-            True,
-        ),
-        patch(
-            "core_api.services.memory_service.settings.enrich_on_hot_path",
-            True,
+            "core_api.services.memory_service.settings.deployment_mode",
+            "inline",
         ),
         patch(
             "core_api.services.organization_settings.resolve_config",


### PR DESCRIPTION
## Summary
Third and final Phase 2 batch. Migrates the last 7 legacy flag reads in `memory_service.py` onto the `inline_embedding` / `inline_enrichment` helpers. After this PR, **zero production code reads the legacy flags** — only the Phase 1 derivation validator references them at startup.

## Production code change
7 reads + 4 comment-name updates across `memory_service.py`:
- Line 985 — `bulk_write` inline-embed gate
- Line 1003 — `bulk_write` inline-enrich gate
- Line 1383 — `bulk_write` per-row publish gate
- Line 1501 — `_schedule_embed_or_reembed` shim
- Line 1600 — `_schedule_enrich_or_inline` shim
- Line 1649 — `_reembed_memory` retry-backoff gate
- Line 2158 — `_enrich_memory_background` asymmetric race guard (the canary-pinned branch). Verbatim retained; Phase 3 deletes branch + canary together.

The asymmetric branch's comment block updated to explicitly name the Phase-3 deletion plan, so reviewers see the intent.

## Test migrations
- 3 tests in `test_embed_off_hot_path.py` / `test_enrich_off_hot_path.py` swapped from legacy flags to `deployment_mode`.
- Both canary tests in `test_f3_asymmetric_canary.py` migrated. Docstrings explicitly call out that the asymmetric `(False_embed, True_enrich)` state is no longer expressible via real settings — the canary is now artificial by design and exists solely as the Phase-3 deletion marker.

## Test plan
- [x] 77/77 flag-touching unit tests green.
- [x] Phase 2c code verified present in the running container image (8 occurrences in `/app/.../memory_service.py`).
- [x] Wet-test matrix reproduces all 4 cells bit-identical to Phase 0 baseline.
- [x] `ruff check` + `ruff format --check` clean.

## Phase 3 preview
Pure deletion PR after this lands:
- Remove `embed_on_hot_path` + `enrich_on_hot_path` from `Settings`.
- Delete the Phase 1 derivation validator.
- Delete the asymmetric branch at `memory_service.py:2158` + both canary tests.
- Switch deploy YAML from `EMBED_ON_HOT_PATH=false,ENRICH_ON_HOT_PATH=false` to `DEPLOYMENT_MODE=deferred`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)