### PR TITLE
fix(mcp): disable auto-generated output schema on tool registrations

### DIFF
--- a/core-api/src/core_api/tools/_builders.py
+++ b/core-api/src/core_api/tools/_builders.py
@@ -24,10 +24,21 @@ def mcp_register(mcp, spec: ToolSpec) -> None:
 
     No-op when `spec.handler is None` (Phase 1 of the refactor — handlers
     still live in `mcp_server.py`'s `@mcp.tool` decorators).
+
+    Handlers are annotated `-> str` but their error paths return
+    `CallToolResult` via `_as_error_result` to preserve the unified
+    error-envelope clients parse from `content[0].text`. With structured
+    output enabled, FastMCP would auto-generate a `{result: str}` schema
+    from the `-> str` annotation and reject the `CallToolResult` at
+    validation time, so disable it here.
     """
     if spec.handler is None:
         return
-    mcp.tool(name=spec.name, description=spec.description)(spec.handler)
+    mcp.tool(
+        name=spec.name,
+        description=spec.description,
+        structured_output=False,  # mcp>=1.10 (PR #993); current pin >=1.26 covers it
+    )(spec.handler)
 
 
 def _python_type_name(annotation: Any) -> str:

--- a/core-api/src/core_api/tools/_types.py
+++ b/core-api/src/core_api/tools/_types.py
@@ -16,8 +16,15 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Literal
 
-HandlerFn = Callable[..., Awaitable[str]]
-"""All MCP tool handlers are async and return a JSON-or-text string."""
+from mcp.types import CallToolResult
+
+HandlerFn = Callable[..., Awaitable[str | CallToolResult]]
+"""Async; success returns a string, errors return ``CallToolResult`` via
+``_as_error_result``. Type checkers accept ``CallToolResult`` on any path —
+returning it from a success branch silently sets ``isError=True`` for
+clients; enforce the split in code review. Registration sets
+``structured_output=False`` to accept this union — see ``mcp_register``
+in ``_builders.py``."""
 
 
 ImplStatus = Literal["live", "reserved", "deprecated"]

--- a/tests/_mcp_test_helpers.py
+++ b/tests/_mcp_test_helpers.py
@@ -36,47 +36,39 @@ def strip_latency(result: Any) -> str:
     return _LATENCY_SUFFIX_RE.sub("", as_text(result))
 
 
-def parse_envelope(result: Any) -> dict[str, Any]:
-    """Parse a JSON response (error envelope or payload) from a handler.
-
-    Accepts:
-      - ``str`` — the success-path return shape (and the legacy shape
-        for error returns before CAURA-000 FRICTION-REPORT-V3 B2 wired
-        errors through CallToolResult).
-      - ``CallToolResult`` — the post-B2 error shape. ``isError=True``
-        is implied for any caller that reaches a parsed envelope this
-        way; the JSON content lives in ``content[0].text``.
-
-    Handlers that wrap JSON get a top-level ``_latency_ms`` key merged
-    in; we strip it so tests can assert on the semantic payload.
-    """
-    from mcp.types import CallToolResult, TextContent
-
-    if isinstance(result, CallToolResult):
-        text = (
-            result.content[0].text if isinstance(result.content[0], TextContent) else ""
-        )
-        data = json.loads(text)
-    else:
-        data = json.loads(result)
-    if isinstance(data, dict):
-        data.pop("_latency_ms", None)
-    return data
-
-
 def as_text(result: Any) -> str:
     """Return the textual content of a handler result regardless of
     shape — used for tests that ``assert "X" in out``. Pre-B2 (FRICTION-
     REPORT-V3) handlers returned strings for both success and error;
-    post-B2 the error path returns a ``CallToolResult``. This helper
-    bridges the two so the substring-check idiom keeps working.
+    post-B2 the error path returns a ``CallToolResult``. ``mcp.call_tool``
+    callers may also see a bare ``Sequence[ContentBlock]`` when the handler
+    returned a string that FastMCP wrapped into text content. This helper
+    bridges all three so the substring-check idiom keeps working.
     """
     from mcp.types import CallToolResult, TextContent
 
     if isinstance(result, CallToolResult):
         first = result.content[0] if result.content else None
         return first.text if isinstance(first, TextContent) else ""
+    if isinstance(result, (list, tuple)) and result:
+        first = result[0]
+        return first.text if isinstance(first, TextContent) else ""
     return result if isinstance(result, str) else str(result)
+
+
+def parse_envelope(result: Any) -> dict[str, Any]:
+    """Parse a JSON response (error envelope or payload) from a handler.
+
+    Delegates text extraction to ``as_text`` so all three shapes —
+    ``str``, ``CallToolResult``, and ``Sequence[ContentBlock]`` — are
+    handled uniformly. Handlers that wrap JSON get a top-level
+    ``_latency_ms`` key merged in; we strip it so tests can assert on
+    the semantic payload.
+    """
+    data = json.loads(as_text(result))
+    if isinstance(data, dict):
+        data.pop("_latency_ms", None)
+    return data
 
 
 def is_error_envelope(result: Any) -> bool:

--- a/tests/fixtures/tools_list_baseline_v1.json
+++ b/tests/fixtures/tools_list_baseline_v1.json
@@ -140,19 +140,7 @@
       "title": "memclaw_docArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_docOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -176,19 +164,7 @@
       "title": "memclaw_entity_getArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_entity_getOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -259,19 +235,7 @@
       "title": "memclaw_evolveArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_evolveOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -320,19 +284,7 @@
       "title": "memclaw_insightsArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_insightsOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -367,19 +319,7 @@
       "title": "memclaw_keystonesArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_keystonesOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -500,19 +440,7 @@
       "title": "memclaw_keystones_setArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_keystones_setOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -681,19 +609,7 @@
       "title": "memclaw_listArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_listOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -837,19 +753,7 @@
       "title": "memclaw_manageArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_manageOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -946,19 +850,7 @@
       "title": "memclaw_recallArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_recallOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -1031,19 +923,7 @@
       "title": "memclaw_statsArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_statsOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -1182,19 +1062,7 @@
       "title": "memclaw_tuneArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_tuneOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,
@@ -1364,19 +1232,7 @@
       "title": "memclaw_writeArguments",
       "type": "object"
     },
-    "outputSchema": {
-      "properties": {
-        "result": {
-          "title": "Result",
-          "type": "string"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "memclaw_writeOutput",
-      "type": "object"
-    },
+    "outputSchema": null,
     "icons": null,
     "annotations": null,
     "meta": null,

--- a/tests/test_mcp_call_tool_e2e.py
+++ b/tests/test_mcp_call_tool_e2e.py
@@ -1,0 +1,113 @@
+"""End-to-end tests that exercise ``mcp.call_tool(...)`` — the FastMCP
+surface used by every real MCP client.
+
+These tests close the gap that let the structured-output-schema bug ship:
+the rest of the unit suite invokes handler coroutines directly (e.g.
+``await mcp_server.memclaw_write(...)``), which skips
+``FuncMetadata.convert_result`` and never exercises FastMCP's output-schema
+validation. The bug lived there: when a tool registered with
+``structured_output`` enabled returned a ``CallToolResult`` on its error
+path, ``convert_result`` called ``output_model.model_validate(
+result.structuredContent)`` against the ``None`` default and raised
+``"1 validation error for <tool>Output ... input_value=None"`` — masking
+the legitimate error envelope.
+
+The ``call_tool`` path matches what JSON-RPC ``tools/call`` runs, so a
+green test here is the same guarantee a remote MCP client gets.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_api import mcp_server
+from tests._mcp_test_helpers import as_text, parse_envelope
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_auth_error_returns_clean_envelope(monkeypatch):
+    """Regression test for the structured-output mismatch.
+
+    ``_check_auth`` returns a pre-baked ``CallToolResult(isError=True)``
+    on auth failure. Pre-fix, ``mcp.call_tool`` raised
+    ``ToolError("Error executing tool memclaw_write: 1 validation error
+    for memclaw_writeOutput ... input_value=None")`` and the legitimate
+    UNAUTHORIZED envelope was lost. Post-fix
+    (``structured_output=False`` on registration), the CallToolResult
+    flows through ``convert_result`` untouched.
+    """
+    monkeypatch.setattr(mcp_server, "_check_auth", lambda: mcp_server._AUTH_ERROR)
+
+    result = await mcp_server.mcp.call_tool(
+        "memclaw_write",
+        {"content": "test memory body", "agent_id": "claude-eldad"},
+    )
+
+    assert "validation error" not in as_text(result), (
+        "FastMCP's output-schema validation leaked into the response. "
+        "Re-enable `structured_output=False` on `mcp_register` "
+        "(core_api/tools/_builders.py)."
+    )
+    envelope = parse_envelope(result)
+    assert envelope["error"]["code"] == "UNAUTHORIZED"
+
+
+@pytest.mark.asyncio
+async def test_admin_key_refusal_returns_clean_envelope(monkeypatch):
+    """Same regression coverage for ``_ADMIN_ERROR`` — the other module-level
+    pre-baked CallToolResult that ``_check_auth`` can hand back.
+    """
+    monkeypatch.setattr(mcp_server, "_check_auth", lambda: mcp_server._ADMIN_ERROR)
+
+    result = await mcp_server.mcp.call_tool(
+        "memclaw_keystones_set",
+        {
+            "op": "set",
+            "doc_id": "probe",
+            "title": "probe",
+            "content": "probe",
+            "scope": "agent",
+            "agent_id": "claude-eldad",
+            "weight": "low",
+        },
+    )
+
+    assert "validation error" not in as_text(result)
+    envelope = parse_envelope(result)
+    assert envelope["error"]["code"] == "FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_invalid_args_returns_clean_envelope(monkeypatch):
+    """The ``_with_latency(_error_response(...))`` → ``_as_error_result``
+    path is the other major source of CallToolResult returns. Calling
+    ``memclaw_write`` with neither ``content`` nor ``items`` triggers it
+    via the in-handler INVALID_ARGUMENTS branch.
+    """
+    monkeypatch.setattr(mcp_server, "_check_auth", lambda: None)
+
+    result = await mcp_server.mcp.call_tool("memclaw_write", {})
+
+    assert "validation error" not in as_text(result)
+    envelope = parse_envelope(result)
+    assert envelope["error"]["code"] == "INVALID_ARGUMENTS"
+
+
+@pytest.mark.asyncio
+async def test_no_tool_has_structured_output_schema():
+    """Belt-and-braces guard: if a future contributor flips
+    ``structured_output`` back on (or registers a tool that bypasses
+    ``mcp_register``), this test fails before the bug ships. Without
+    ``structured_output=False`` every tool gets an auto-generated
+    ``{result: str}`` output schema that rejects ``CallToolResult``
+    returns at ``convert_result`` time.
+    """
+    tools = await mcp_server.mcp.list_tools()
+    offenders = [t.name for t in tools if t.outputSchema is not None]
+    assert not offenders, (
+        f"Tools with an output schema present: {offenders}. The unified "
+        f"error-envelope contract requires `structured_output=False` on "
+        f"every registration — see core_api/tools/_builders.py:mcp_register."
+    )


### PR DESCRIPTION
## Summary
- **Bug:** `memclaw_write` and `memclaw_keystones_set` return `1 validation error for <tool>Output ... input_value=None` when called via the gateway with a tenant-scope key + default `agent_id=mcp-agent`. The legitimate `MISSING_AGENT_ID` envelope from `_refuse_default_agent_on_gateway` gets swallowed.
- **Root cause:** FastMCP auto-generates `{result: str}` output schema from each tool's `-> str` annotation. Error paths return `CallToolResult` via `_as_error_result` (the unified error-envelope contract clients parse from `content[0].text`), which fails the auto-schema validation. Read-only tools didn't hit this because their non-error returns are plain JSON strings.
- **Fix:** Pass `structured_output=False` at the single registration point in `mcp_register`. The auto-schema was misleading anyway — the `result` string is itself JSON with rich structure inside, not the bare string the schema claimed. Test baseline regenerated; MCP+tool suite stays 171/171.

## Test plan
- [x] `pytest tests/test_tool_descriptions_regression.py tests/test_mcp_token_budget.py tests/test_mcp_write.py tests/test_mcp_keystones.py tests/test_mcp_iserror_propagation.py` — 47/47 pass locally
- [x] Broader `pytest -k 'mcp or tool'` — 171/171 pass locally
- [x] `ruff check` + `ruff format --check` on the changed file — clean
- [ ] After staging deploy: call `memclaw_write` via MCP with a tenant-scope key + default `agent_id=mcp-agent` → expect a proper JSON `MISSING_AGENT_ID` envelope in `content[0].text` and `isError=true` (instead of the pydantic validation message)
- [ ] After staging deploy: call `memclaw_write` with `agent_id=<real>` → expect a successful write and `content[0].text` containing the new memory JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)