### PR TITLE
fix(plugin): close install-script alsoAllow drift + manifest version drift (CAURA-444)

### DIFF
--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -503,7 +503,7 @@ if (!config.plugins.load.paths.includes(pluginDir)) config.plugins.load.paths.pu
 
 if (!config.tools) config.tools = {{}};
 if (!Array.isArray(config.tools.alsoAllow)) config.tools.alsoAllow = [];
-const tools = ['memclaw_recall','memclaw_write','memclaw_manage','memclaw_doc','memclaw_list','memclaw_entity_get','memclaw_tune','memclaw_insights','memclaw_evolve','memclaw_stats'];
+const tools = ['memclaw_recall','memclaw_write','memclaw_manage','memclaw_doc','memclaw_list','memclaw_entity_get','memclaw_tune','memclaw_insights','memclaw_evolve','memclaw_stats','memclaw_keystones'];
 for (const t of tools) {{
   if (!config.tools.alsoAllow.includes(t)) config.tools.alsoAllow.push(t);
 }}

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memclaw",
   "name": "MemClaw",
   "kind": "memory",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Central persistent memory for OpenClaw agents — write, search, and entity lookup tools.",
   "entry": "dist/index.js",
   "skills": [

--- a/tests/test_plugin_source_manifest.py
+++ b/tests/test_plugin_source_manifest.py
@@ -11,6 +11,7 @@ This test keeps them in lockstep with `plugin/src/*.ts`.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -197,4 +198,78 @@ def test_served_manifest_declares_contracts_tools():
         f"plugin/openclaw.plugin.json must declare contracts.tools — got "
         f"{contracts!r}. OpenClaw rejects all api.registerTool calls "
         "without it."
+    )
+
+
+def test_install_script_alsoAllow_lockstep():
+    """The install script's hardcoded ``alsoAllow`` array MUST match
+    ``contracts.tools`` in ``plugin/openclaw.plugin.json`` (and, transitively,
+    ``MEMCLAW_TOOLS`` in ``plugin/src/tools.ts`` — the TS-side boot-time
+    drift check enforces that direction; this Python test pins the
+    cross-language symmetry).
+
+    Drift this guards: pre-fix the install script's ``alsoAllow`` was
+    written by hand at ``plugin.py:506`` and shipped 10 entries — missing
+    ``memclaw_keystones``. Every fresh ``curl /api/install-plugin | bash``
+    install wrote that 10-tool list into ``~/.openclaw/openclaw.json``, and
+    OpenClaw silently refused every ``memclaw_keystones`` invocation
+    because it wasn't in the allowed set. The plugin's boot log emitted a
+    warning, but operators don't read gateway.log, so the keystone tool
+    was effectively disabled on every fresh-installed node.
+
+    ``memclaw_keystones_set`` is intentionally NOT in the install-script's
+    ``alsoAllow`` because ``tools.json`` marks it ``plugin_exposed: false``
+    — it is the admin authoring path, served only via MCP (memclaw_server)
+    and never exposed to OpenClaw-side agents. The two sides of this test
+    deliberately use the SAME canonical source (``contracts.tools``) so a
+    future plugin_exposed flip is picked up automatically.
+    """
+    src = Path(plugin_mod.__file__).read_text(encoding="utf-8")
+    m = re.search(r"const tools = \[(.*?)\];", src, re.DOTALL)
+    assert m, (
+        "Could not find ``const tools = [...]`` in the install-script template. "
+        "If you renamed the variable, update this test's regex."
+    )
+    install_tools = [s.strip().strip("'\"") for s in m.group(1).split(",")]
+    install_tools = [t for t in install_tools if t]  # drop trailing-comma empties
+
+    manifest_path = REPO_ROOT / "plugin" / "openclaw.plugin.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    contracts_tools = manifest["contracts"]["tools"]
+
+    assert install_tools == contracts_tools, (
+        f"install-script alsoAllow drift — \n"
+        f"  install-script: {install_tools}\n"
+        f"  contracts.tools: {contracts_tools}\n"
+        f"missing-from-install={sorted(set(contracts_tools) - set(install_tools))}, "
+        f"extra-in-install={sorted(set(install_tools) - set(contracts_tools))}. "
+        "Both lists must hold every ``plugin_exposed: true`` tool from "
+        "``plugin/tools.json`` in the same order."
+    )
+
+
+def test_plugin_manifest_version_matches_package_json():
+    """``openclaw.plugin.json:version`` must match ``plugin/package.json:version``.
+
+    The two are read by different downstream surfaces:
+      - ``package.json:version`` is what ``_plugin_version()`` (in
+        ``core_api/routes/plugin.py``) returns; the heartbeat auto-upgrade
+        trigger and the install script's stamped ``MEMCLAW_PLUGIN_VERSION``
+        derive from this side.
+      - ``openclaw.plugin.json:version`` is what OpenClaw reads when
+        loading the plugin and what any plugin-info UI renders to operators.
+
+    Drift this guards: ``openclaw.plugin.json`` was at "2.5.0" while
+    ``package.json`` was at "2.6.0" on main 2026-05-20. A node fresh-installed
+    via the install script ended up with two different version labels in
+    its own directory, depending on which file the inspecting tool happened
+    to read.
+    """
+
+
+    pkg = json.loads((REPO_ROOT / "plugin" / "package.json").read_text(encoding="utf-8"))
+    mfst = json.loads((REPO_ROOT / "plugin" / "openclaw.plugin.json").read_text(encoding="utf-8"))
+    assert pkg["version"] == mfst["version"], (
+        f"version drift — package.json={pkg['version']!r}, "
+        f"openclaw.plugin.json={mfst['version']!r}. Bump both in lockstep."
     )


### PR DESCRIPTION
## Summary

Two independent drift bugs found on \`origin/main\`, both shipping together:

| # | Bug | File | Effect |
|---|---|---|---|
| 1 | Install-script \`alsoAllow\` missing \`memclaw_keystones\` | \`core-api/.../plugin.py:506\` | Every fresh \`curl /api/install-plugin \| bash\` writes a 10-tool \`alsoAllow\` into \`~/.openclaw/openclaw.json\`, locking agents out of the keystone tool. Plugin's boot drift-check warns (\`2 of 11 tools not in tools.alsoAllow\`) but operators don't see it. |
| 2 | \`openclaw.plugin.json:version\` stale at \`"2.5.0"\` while \`package.json\` was bumped to \`"2.6.0"\` | \`plugin/openclaw.plugin.json\` | Auto-deploy machinery (reads \`package.json\`) is unaffected, but plugin-info UI / \`openclaw plugins list\` / audit logs show \`2.5.0\`. |

## Scope decision: \`memclaw_keystones_set\` stays out

\`plugin/tools.json\` marks \`memclaw_keystones_set\` as \`plugin_exposed: false\` — it's the admin authoring path served via MCP only, deliberately NOT exposed to OpenClaw-side agents (it would let trust ≥ 2 agents write governance rules without the MCP auth layer). The \`plugin/src/tools.ts\` boot-time drift check enforces \`MEMCLAW_TOOLS\` ≡ \`plugin_exposed: true\` entries, so the install-script's \`alsoAllow\` must mirror the same 11 tools — no more, no less.

## Drift tests added

In \`tests/test_plugin_source_manifest.py\`:

- **\`test_install_script_alsoAllow_lockstep\`** — asserts the install-script's hardcoded tools array equals \`contracts.tools\` byte-for-byte, in the same order. Future drift on either side trips this test on the next change.
- **\`test_plugin_manifest_version_matches_package_json\`** — asserts \`openclaw.plugin.json:version\` ≡ \`package.json:version\`. The two are read by different downstream surfaces (auto-deploy → package.json; OpenClaw runtime + UI → openclaw.plugin.json) and must move in lockstep.

## Test plan

- [x] \`uv --directory core-api run pytest tests/test_plugin_source_manifest.py\` — 10/10 pass (incl. 2 new)
- [x] \`uv --directory core-api run pytest tests/test_fleet_heartbeat_auto_upgrade.py\` — 39/39 pass
- [x] \`cd plugin && npm test\` — 226/226 pass
- [x] \`ruff format --check src/\` clean
- [x] \`ruff check src/core_api/routes/plugin.py\` clean
- [ ] Verify on a fresh-install node post-merge: \`grep memclaw_keystones ~/.openclaw/openclaw.json\` — should show the tool in \`tools.alsoAllow\`

## Related

Found by inspection while re-running the CAURA-444 wet test on \`openclaw-test-ran\` (the plugin's boot log emits \`WARNING: 2 of 11 tools not in tools.alsoAllow — agents cannot use: memclaw_stats, memclaw_keystones\` which is what surfaced this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)