### PR TITLE
fix(release-please): correct openclaw.plugin.json path under the plugin package

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -43,7 +43,7 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "plugin/openclaw.plugin.json",
+          "path": "openclaw.plugin.json",
           "jsonpath": "$.version"
         }
       ]


### PR DESCRIPTION
## Summary

`release-please-config.json` for the `plugin` package had:

\`\`\`json
"plugin": {
  "release-type": "node",
  ...
  "extra-files": [
    { "type": "json", "path": "plugin/openclaw.plugin.json", "jsonpath": "\$.version" }
  ]
}
\`\`\`

For the `node` release-type, `extra-files` paths are **package-relative**, not repo-relative (only the `simple` release-type — used by the `.` package above — treats them as repo-relative).

The plugin package root is `plugin/`, so `plugin/openclaw.plugin.json` resolved to `plugin/plugin/openclaw.plugin.json` (nonexistent), and release-please silently skipped bumping it.

## Observed impact

Release-please's most recent regeneration pushed:

| File | main | release-please branch |
|---|---|---|
| `plugin/package.json` | `2.6.0` | `2.6.1` ✓ bumped |
| `plugin/openclaw.plugin.json` | `2.6.0` | `2.6.0` ✗ not bumped |

That trips the version-drift regression test added in #181 (`tests/test_plugin_source_manifest.py::test_plugin_manifest_version_matches_package_json`), so the release-please CI on the release branch fails and the release is blocked. PR #180 (`memclaw_write` output-schema fix) can't ship until the release pipeline clears.

## Fix

One line: drop the redundant `plugin/` prefix in `release-please-config.json` so the path is interpreted package-relative as required.

## Test plan

- [x] Diff is a single character change; no functional risk elsewhere
- [ ] CI green on this PR (this only touches the release-please config; no production code paths exercised)
- [ ] After merge: release-please regenerates its release PR with both `plugin/package.json` AND `plugin/openclaw.plugin.json` bumped together; the version-drift regression test passes; release ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)