### PR TITLE
feat(contradiction): widen _llm_contradiction_check to (verdict, confidence) (A4 #12)

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -372,7 +372,12 @@ async def _detect(
                         result,
                     )
                     continue
-                if result:
+                # A4 #12 — judge now returns (verdict, confidence).
+                # Path A continues to gate only on verdict at this site;
+                # A4 #13 will introduce confidence-weighted vetoes on
+                # Path C's else-branch.
+                verdict, _confidence = result  # type: ignore[misc]
+                if verdict:
                     # CAURA-125 — symmetric attribution; see RDF path
                     # above for the rationale.
                     older = _pick_older(candidate, new_memory)
@@ -635,6 +640,58 @@ def _parse_contradiction_response(raw: dict) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# A4 #12 — Confidence-scored judge wrapper around the bool parser.
+# ---------------------------------------------------------------------------
+
+
+# Confidence rubric (see ``tests/test_a4_12_contradiction_judge_confidence.py``
+# for the per-branch pin):
+#   0.90 — Clean LLM agreement (both gates aligned with the verdict).
+#   0.85 — Gate 2 fired (model itself named a non-conflict pattern,
+#          parser overrode contradicts=true to false).
+#   0.60 — Gate 1 fired (model's same_subject contradicted its
+#          contradicts=true; parser overrode to false).
+#   0.50 — Malformed / unparseable response (parser conservative-default).
+_CONF_CLEAN = 0.90
+_CONF_GATE2 = 0.85
+_CONF_GATE1 = 0.60
+_CONF_FALLBACK = 0.50
+
+
+def _judge_contradiction(raw) -> tuple[bool, float]:
+    """A4 #12 — wrap ``_parse_contradiction_response`` with a confidence
+    score derived from the model's own coherence.
+
+    Callers (A4 #13 retraction's confidence-weighted veto, A1 #16
+    dedup danger-zone judge) use the score to decide whether the
+    final verdict is trustworthy enough to act on. Verdict semantics
+    are identical to ``_parse_contradiction_response``; this is purely
+    additive on top.
+    """
+    if not isinstance(raw, dict) or not raw:
+        return False, _CONF_FALLBACK
+
+    verdict = _parse_contradiction_response(raw)
+    same_subject = raw.get("same_subject") is True
+    model_contradicts = raw.get("contradicts") is True
+    raw_ncr = raw.get("non_conflict_reason")
+    non_conflict_reason = raw_ncr if isinstance(raw_ncr, str) else None
+
+    if model_contradicts and not same_subject:
+        # Gate 1 fired — model said contradicts=true but its own
+        # same_subject said false. Internal inconsistency → lower trust.
+        return verdict, _CONF_GATE1
+    if model_contradicts and non_conflict_reason in NON_CONFLICT_REASONS:
+        # Gate 2 fired — model recognised a non-conflict pattern AND
+        # said contradicts=true. The pattern-recognition signal is
+        # what we trust — high confidence in NOT-a-contradiction.
+        return verdict, _CONF_GATE2
+    # Either contradicts=False with consistent ancillary fields, or
+    # contradicts=True with both gates aligned. Clean case.
+    return verdict, _CONF_CLEAN
+
+
+# ---------------------------------------------------------------------------
 # Multi-provider LLM contradiction check with fallback chain
 # ---------------------------------------------------------------------------
 
@@ -643,19 +700,18 @@ async def _llm_contradiction_check(
     new_content: str,
     old_content: str,
     tenant_config=None,
-) -> bool:
+) -> tuple[bool, float]:
     """Ask the LLM whether two texts contradict each other.
+
+    Returns ``(verdict, confidence)`` — see ``_judge_contradiction`` for
+    the rubric. A4 #12 widened this from ``bool`` so downstream
+    consumers (A4 #13 retraction, A1 #16 dedup judge) can gate
+    decisions on the model's coherence.
 
     Uses the standard 3-tier fallback chain:
     1. Try the configured provider (with retry)
     2. Try the configured fallback provider (via resolve_fallback)
     3. Fall back to negation-word heuristic
-
-    Note: the previous implementation tried ALL providers with valid
-    credentials before falling back to the heuristic. This was replaced
-    with the standard single-fallback pattern for consistency across
-    services. The heuristic fallback (step 3) is now reachable, which
-    it previously was not due to the FakeLLMProvider short-circuit bug.
     """
     provider_name = (
         tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
@@ -663,14 +719,14 @@ async def _llm_contradiction_check(
 
     prompt = CONTRADICTION_PROMPT.format(new_content=new_content[:500], old_content=old_content[:500])
 
-    async def _do_check(llm) -> bool:
+    async def _do_check(llm) -> tuple[bool, float]:
         raw = await llm.complete_json(prompt)
-        return _parse_contradiction_response(raw)
+        return _judge_contradiction(raw)
 
     return await call_with_fallback(
         primary_provider_name=provider_name,
         call_fn=_do_check,
-        fake_fn=lambda: _fake_contradiction_check(new_content, old_content),
+        fake_fn=lambda: (_fake_contradiction_check(new_content, old_content), _CONF_FALLBACK),
         tenant_config=tenant_config,
         service_label="contradiction",
         model_attr="entity_extraction_model",
@@ -768,7 +824,11 @@ async def detect_contradictions_by_entities_async(
                     result,
                 )
                 continue
-            if result:
+            # A4 #12 — judge now returns (verdict, confidence).
+            # Path C continues to gate only on verdict at this site;
+            # A4 #13 will introduce confidence-weighted vetoes here.
+            verdict, _confidence = result  # type: ignore[misc]
+            if verdict:
                 # CAURA-125 — symmetric attribution; see RDF path for
                 # the rationale. First match sets supersedes_id on the
                 # newer row (most relevant — candidates are ordered by

--- a/tests/test_a4_12_contradiction_judge_confidence.py
+++ b/tests/test_a4_12_contradiction_judge_confidence.py
@@ -1,0 +1,210 @@
+"""A4 #12 — ``_llm_contradiction_check`` returns ``(verdict, confidence)``.
+
+Pattern-Y enabler: the same LLM-judges-pair-returns-verdict-with-
+confidence shape gets reused by A4 #13 (Path C retraction's
+confidence-weighted veto) and by A1 #16 (dedup danger-zone judge).
+This PR widens the return type and pins a confidence score derived
+from the model's own coherence — high when the response is internally
+consistent, lower when the parser's safety gates had to override the
+raw verdict.
+
+Confidence rubric (all in [0.0, 1.0]):
+
+  0.90 — Clean LLM agreement: ``same_subject`` matches the verdict
+         direction, ``non_conflict_reason`` is ``"none"`` (or the
+         model said ``contradicts=False`` against a recognised
+         non-conflict shape — both gates aligned).
+  0.85 — Gate 2 fired: model said ``contradicts=True`` AND named a
+         recognised ``non_conflict_reason`` from
+         ``NON_CONFLICT_REASONS``. Parser overrides to False. The
+         model's own pattern recognition flagged the non-conflict
+         shape — high trust in NOT-a-contradiction.
+  0.60 — Gate 1 fired: model said ``contradicts=True`` with
+         ``same_subject=False``. Parser overrides to False. The
+         model contradicted itself between the two fields — lower
+         trust.
+  0.50 — Heuristic fallback or unparseable response. Low trust,
+         downstream callers should hesitate.
+
+Tests pin both the return shape (tuple) and the per-branch confidence
+values. They FAIL against current main (function still returns bool).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Return-shape tests
+# ---------------------------------------------------------------------------
+
+
+def test_judge_returns_tuple_bool_float() -> None:
+    """``_judge_contradiction`` is the new (verdict, confidence) helper."""
+    from core_api.services.contradiction_detector import _judge_contradiction
+
+    out = _judge_contradiction(
+        {
+            "same_subject": True,
+            "contradicts": True,
+            "non_conflict_reason": "none",
+            "subject_a": "x",
+            "subject_b": "x",
+            "reason": "test",
+        }
+    )
+    assert isinstance(out, tuple)
+    assert len(out) == 2
+    verdict, confidence = out
+    assert isinstance(verdict, bool)
+    assert isinstance(confidence, float)
+    assert 0.0 <= confidence <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Confidence rubric — per-branch
+# ---------------------------------------------------------------------------
+
+
+def test_clean_agreement_high_confidence() -> None:
+    """Same_subject=True + contradicts=True + non_conflict_reason='none'
+    → model committed fully → 0.90."""
+    from core_api.services.contradiction_detector import _judge_contradiction
+
+    verdict, conf = _judge_contradiction(
+        {
+            "same_subject": True,
+            "contradicts": True,
+            "non_conflict_reason": "none",
+        }
+    )
+    assert verdict is True
+    assert conf == pytest.approx(0.90)
+
+
+def test_clean_not_contradiction_high_confidence() -> None:
+    """Same_subject=True + contradicts=False + non_conflict_reason='none'.
+    Model said no conflict directly; nothing in the response is
+    inconsistent. Same confidence as clean-True case."""
+    from core_api.services.contradiction_detector import _judge_contradiction
+
+    verdict, conf = _judge_contradiction(
+        {
+            "same_subject": True,
+            "contradicts": False,
+            "non_conflict_reason": "none",
+        }
+    )
+    assert verdict is False
+    assert conf == pytest.approx(0.90)
+
+
+def test_gate2_fired_returns_high_confidence_not_contradiction() -> None:
+    """Model said contradicts=True AND named a non-conflict pattern.
+    Parser overrides to False; the model's own pattern recognition
+    flagged the not-contradiction shape — high trust in the final
+    NOT-contradiction verdict."""
+    from core_api.services.contradiction_detector import _judge_contradiction
+
+    verdict, conf = _judge_contradiction(
+        {
+            "same_subject": True,
+            "contradicts": True,
+            "non_conflict_reason": "temporal_supersession",
+        }
+    )
+    assert verdict is False
+    assert conf == pytest.approx(0.85)
+
+
+def test_gate1_fired_returns_medium_confidence_not_contradiction() -> None:
+    """Model said contradicts=True with same_subject=False. Parser
+    overrides to False — but the model's response was internally
+    inconsistent (cross-subject hallucinated contradiction), so
+    confidence is lower."""
+    from core_api.services.contradiction_detector import _judge_contradiction
+
+    verdict, conf = _judge_contradiction(
+        {
+            "same_subject": False,
+            "contradicts": True,
+            "non_conflict_reason": "none",
+        }
+    )
+    assert verdict is False
+    assert conf == pytest.approx(0.60)
+
+
+def test_clean_not_contradiction_cross_subject_high_confidence() -> None:
+    """Same_subject=False + contradicts=False — model agreed with itself
+    on cross-subject ⇒ no contradiction. Clean case."""
+    from core_api.services.contradiction_detector import _judge_contradiction
+
+    verdict, conf = _judge_contradiction(
+        {
+            "same_subject": False,
+            "contradicts": False,
+            "non_conflict_reason": "none",
+        }
+    )
+    assert verdict is False
+    assert conf == pytest.approx(0.90)
+
+
+def test_malformed_response_low_confidence() -> None:
+    """Non-dict / missing keys → conservative False with low confidence.
+    Downstream callers can use this floor to gate "don't act on
+    untrustworthy verdicts"."""
+    from core_api.services.contradiction_detector import _judge_contradiction
+
+    verdict, conf = _judge_contradiction("not a dict")  # type: ignore[arg-type]
+    assert verdict is False
+    assert conf == pytest.approx(0.50)
+
+    verdict, conf = _judge_contradiction({})  # empty dict — also unparseable
+    assert verdict is False
+    assert conf == pytest.approx(0.50)
+
+
+# ---------------------------------------------------------------------------
+# Caller-facing contract — _llm_contradiction_check returns the tuple
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_llm_contradiction_check_returns_tuple() -> None:
+    """The async entry point ``_llm_contradiction_check`` (called from
+    ``detect_contradictions_async`` and
+    ``detect_contradictions_by_entities_async``) returns the same
+    ``(verdict, confidence)`` tuple."""
+    from unittest.mock import AsyncMock, patch
+
+    from core_api.services.contradiction_detector import _llm_contradiction_check
+
+    fake_llm = AsyncMock()
+    fake_llm.complete_json = AsyncMock(
+        return_value={
+            "same_subject": True,
+            "contradicts": True,
+            "non_conflict_reason": "none",
+            "subject_a": "alice",
+            "subject_b": "alice",
+            "reason": "lives in different cities",
+        }
+    )
+
+    async def fake_call_with_fallback(**kw):
+        return await kw["call_fn"](fake_llm)
+
+    with patch(
+        "core_api.services.contradiction_detector.call_with_fallback",
+        new=AsyncMock(side_effect=fake_call_with_fallback),
+    ):
+        result = await _llm_contradiction_check("A says X", "B says Y")
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    verdict, confidence = result
+    assert verdict is True
+    assert confidence == pytest.approx(0.90)

--- a/tests/test_contradiction_direction_invariance.py
+++ b/tests/test_contradiction_direction_invariance.py
@@ -320,7 +320,8 @@ class TestSemanticAttributionDirection:
             ),
             patch(
                 "core_api.services.contradiction_detector._llm_contradiction_check",
-                AsyncMock(return_value=True),
+                # A4 #12 — judge returns (verdict, confidence) tuple.
+                AsyncMock(return_value=(True, 0.90)),
             ),
         ):
             await _detect(new, [0.1] * VECTOR_DIM)
@@ -359,7 +360,8 @@ class TestSemanticAttributionDirection:
             ),
             patch(
                 "core_api.services.contradiction_detector._llm_contradiction_check",
-                AsyncMock(return_value=True),
+                # A4 #12 — judge returns (verdict, confidence) tuple.
+                AsyncMock(return_value=(True, 0.90)),
             ),
         ):
             await _detect(new, [0.1] * VECTOR_DIM)
@@ -420,7 +422,8 @@ class TestNoConflictNoSupersession:
             ),
             patch(
                 "core_api.services.contradiction_detector._llm_contradiction_check",
-                AsyncMock(return_value=False),
+                # A4 #12 — judge returns (verdict, confidence) tuple.
+                AsyncMock(return_value=(False, 0.90)),
             ),
         ):
             await _detect(new, [0.1] * VECTOR_DIM)
@@ -699,7 +702,8 @@ class TestFlippedSkipsExistingSupersedesId:
             ),
             patch(
                 "core_api.services.contradiction_detector._llm_contradiction_check",
-                AsyncMock(return_value=True),
+                # A4 #12 — judge returns (verdict, confidence) tuple.
+                AsyncMock(return_value=(True, 0.90)),
             ),
         ):
             with caplog.at_level("WARNING"):

--- a/tests/test_contradiction_providers.py
+++ b/tests/test_contradiction_providers.py
@@ -158,7 +158,13 @@ class TestResolveOpenAICompatible:
 
 @pytest.mark.unit
 class TestFallbackChain:
-    """Verify the fallback chain in _llm_contradiction_check."""
+    """Verify the fallback chain in _llm_contradiction_check.
+
+    A4 #12 — judge now returns ``(verdict, confidence)``. These tests
+    pin only the verdict bool; the heuristic fallback always emits
+    confidence=0.50 (see ``_CONF_FALLBACK``), exercised in the A4 #12
+    test module's malformed-response case.
+    """
 
     @pytest.mark.asyncio
     async def test_none_provider_returns_false(self):
@@ -166,7 +172,8 @@ class TestFallbackChain:
 
         config = MagicMock()
         config.entity_extraction_provider = "none"
-        assert await _llm_contradiction_check("a", "b", config) is False
+        verdict, _conf = await _llm_contradiction_check("a", "b", config)
+        assert verdict is False
 
     @pytest.mark.asyncio
     async def test_fake_provider_uses_heuristic(self):
@@ -175,12 +182,10 @@ class TestFallbackChain:
         config = MagicMock()
         config.entity_extraction_provider = "fake"
         # No negation difference → False
-        assert (
-            await _llm_contradiction_check(
-                "the system is running", "the system is fast", config
-            )
-            is False
+        verdict, _conf = await _llm_contradiction_check(
+            "the system is running", "the system is fast", config
         )
+        assert verdict is False
 
     @pytest.mark.asyncio
     async def test_fake_provider_triggers_heuristic_via_fallback(self):
@@ -193,12 +198,12 @@ class TestFallbackChain:
         config.openai_api_key = None  # no credentials -> FakeLLMProvider
 
         # Negation difference → heuristic returns True
-        result = await _llm_contradiction_check(
+        verdict, _conf = await _llm_contradiction_check(
             "the system is not running and it crashed",
             "the system is running and it works fine",
             config,
         )
-        assert result is True
+        assert verdict is True
 
     @pytest.mark.asyncio
     async def test_no_credentials_heuristic_returns_false(self):
@@ -213,10 +218,10 @@ class TestFallbackChain:
         config.openrouter_api_key = None
 
         # No negation → heuristic returns False
-        result = await _llm_contradiction_check(
+        verdict, _conf = await _llm_contradiction_check(
             "the system works", "the system is fine", config
         )
-        assert result is False
+        assert verdict is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_contradiction_subject_gate.py
+++ b/tests/test_contradiction_subject_gate.py
@@ -208,6 +208,9 @@ async def _run_check_with_payload(payload: dict) -> bool:
     but bypass the provider-resolution / fallback chain by stubbing
     ``call_with_fallback`` to invoke the supplied ``call_fn`` against a
     ``_StubLLM(payload)``. This exercises the full prompt-format → parse path.
+
+    Returns just the verdict bool (A4 #12 widened the underlying return
+    to ``(verdict, confidence)``; these tests pin parser behaviour only).
     """
 
     async def fake_call_with_fallback(*, call_fn, **_kwargs):
@@ -217,10 +220,11 @@ async def _run_check_with_payload(payload: dict) -> bool:
         "core_api.services.contradiction_detector.call_with_fallback",
         side_effect=fake_call_with_fallback,
     ):
-        return await _llm_contradiction_check(
+        verdict, _confidence = await _llm_contradiction_check(
             new_content="ignored — stub returns payload directly",
             old_content="ignored — stub returns payload directly",
         )
+        return verdict
 
 
 @pytest.mark.unit

--- a/tests/test_p1_contradiction.py
+++ b/tests/test_p1_contradiction.py
@@ -250,7 +250,8 @@ class TestSupersessionSemantics:
         ), patch(
             "core_api.services.contradiction_detector._llm_contradiction_check",
             new_callable=AsyncMock,
-            return_value=True,
+            # A4 #12 — judge returns (verdict, confidence) tuple.
+            return_value=(True, 0.90),
         ):
             contradictions = await _detect(new_memory, [0.1] * 10)
 
@@ -307,7 +308,8 @@ class TestSupersessionSemantics:
             patch(
                 "core_api.services.contradiction_detector._llm_contradiction_check",
                 new_callable=AsyncMock,
-                return_value=True,
+                # A4 #12 — judge returns (verdict, confidence) tuple.
+                return_value=(True, 0.90),
             ),
         ):
             contradictions = await _detect(new_memory, [0.1] * 10)

--- a/tests/test_visibility_contradiction.py
+++ b/tests/test_visibility_contradiction.py
@@ -365,7 +365,8 @@ class TestSupersessionFirstMatchOnly:
         ), patch(
             "core_api.services.contradiction_detector._llm_contradiction_check",
             new_callable=AsyncMock,
-            return_value=True,
+            # A4 #12 — judge returns (verdict, confidence) tuple.
+            return_value=(True, 0.90),
         ):
             embedding = [0.1] * VECTOR_DIM
             contradictions = await _detect(new_memory, embedding)


### PR DESCRIPTION
## Summary

- Add ``_judge_contradiction(raw) -> tuple[bool, float]`` helper that wraps the existing ``_parse_contradiction_response`` parser with a confidence score derived from the model's own coherence
- Change ``_llm_contradiction_check`` signature from ``-> bool`` to ``-> tuple[bool, float]`` — Path A (similarity-based) and Path C (entity-overlap) callers unpack ``verdict, _confidence = result`` and continue gating on the verdict only
- Confidence rubric: **0.90** clean agreement, **0.85** gate 2 fired (model named ``non_conflict_reason``), **0.60** gate 1 fired (``contradicts=True`` with ``same_subject=False``), **0.50** heuristic fallback / malformed

## Why this PR

Sets up two downstream PRs in the A4 + A1 stack:
- **A4 #13** Path C retraction veto — when Path C finds a candidate that Path A already marked conflicted, the new entity-overlap judge will weigh confidence against the retraction threshold rather than always firing
- **A1 #16** dedup danger-zone judge — same tuple-returning shape gets reused in the two-tier dedup decision

This PR is mechanically a refactor. Verdict semantics are identical to before; the boolean half of the tuple is exactly what the function used to return. No behavior changes at the two existing call sites.

## Test plan

- [x] 8 new unit tests in ``tests/test_a4_12_contradiction_judge_confidence.py`` pin the per-branch confidence rubric and the tuple return shape
- [x] 5 existing test files updated to mock/unpack the new tuple shape (``test_contradiction_direction_invariance``, ``test_contradiction_providers``, ``test_contradiction_subject_gate``, ``test_p1_contradiction``, ``test_visibility_contradiction``)
- [x] Full unit suite: **2206 passed**, 0 new failures
- [x] Mypy: same 19 pre-existing errors, **zero new errors** from this PR
- [x] Ruff lint + format clean on touched files
- [x] **Wet-tested locally** end-to-end: ``Alice in Berlin → Alice in Tokyo`` still flips the older memory to ``conflicted`` with the newer ``supersedes_id`` correctly populated; search filters the conflicted row out of recall results

🤖 Generated with [Claude Code](https://claude.com/claude-code)