### PR TITLE
feat(contradiction): Path C re-judges and retracts wrong Path A verdicts (A4 #13)

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -760,6 +760,128 @@ def _fake_contradiction_check(new_content: str, old_content: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# A4 #13 — Retraction phase: re-judge a Path A verdict with full entity
+# context and undo it via the A4 #10 storage primitive when the re-judge
+# disagrees with sufficient confidence.
+# ---------------------------------------------------------------------------
+
+
+# Minimum confidence the judge must report for a ``verdict=False`` to
+# trigger retraction. Above this we trust the "not a contradiction"
+# call; below this we leave Path A's verdict in place (the model's
+# response was malformed / unparseable — see ``_CONF_FALLBACK``).
+#
+# Gate 1 (0.60) is the canonical retraction signal: model said
+# ``contradicts=True`` with ``same_subject=False``, parser overrode
+# to False. Path A flagged on surface similarity; the entity-aware
+# judge confirmed they're different subjects. Acting on 0.60 is
+# exactly the bug A4 #13 fixes.
+RETRACTION_CONFIDENCE_THRESHOLD = 0.60
+
+
+async def _attempt_path_c_retraction(
+    sc,
+    new_memory: dict,
+    tenant_config,
+) -> bool:
+    """Re-judge whatever candidate Path A retracted; undo if the judge
+    disagrees with sufficient confidence. Returns True iff a retraction
+    was performed.
+
+    Lookup is a direct dereference of ``new_memory.supersedes_id`` —
+    bypasses A4 #11's ``include_supersedes`` filter (which is structurally
+    inverted relative to Path A's chain shape — see follow-up). Works
+    in both canonical and flipped Path A directions: the dereferenced
+    row IS the conflicted candidate in either case.
+
+    Retraction is a two-step write via A4 #10:
+      1. ``update_memory_status(candidate.id, "active")`` — revert
+         the conflicted row. Idempotent if a concurrent writer beat
+         us to it.
+      2. ``update_memory_status(new_memory.id, status,
+         unset_supersedes=True, expected_supersedes_id=candidate.id)``
+         — clear the chain edge with a CAS anchor. A 409 from the
+         storage layer means someone else mutated the chain between
+         our read and our write; we treat that as "the retraction is
+         no longer ours to do" and swallow it.
+    """
+    retraction_target_id = new_memory.get("supersedes_id")
+    if not retraction_target_id:
+        return False
+
+    candidate = await sc.get_memory(str(retraction_target_id))
+    if not candidate or candidate.get("deleted_at") is not None:
+        return False
+    # Only retract rows still in the conflicted state Path A produced.
+    # If the row has already been moved on by another writer (or by
+    # a previous Path C invocation), our retraction is no longer
+    # meaningful — skip without calling the judge.
+    if candidate.get("status") != "conflicted":
+        return False
+
+    new_content = new_memory.get("content", "") or ""
+    old_content = candidate.get("content", "") or ""
+
+    try:
+        verdict, confidence = await asyncio.wait_for(
+            _llm_contradiction_check(new_content, old_content, tenant_config),
+            timeout=10.0,
+        )
+    except (TimeoutError, Exception) as e:
+        logger.warning(
+            "Path C retraction judge failed for memory %s candidate %s: %s",
+            new_memory.get("id"),
+            candidate.get("id"),
+            e,
+        )
+        return False
+
+    if verdict:
+        # Judge agrees with Path A — real contradiction, leave it.
+        return False
+    if confidence < RETRACTION_CONFIDENCE_THRESHOLD:
+        # Heuristic fallback / malformed — don't trust ``verdict=False``.
+        logger.info(
+            "Path C retraction skipped low-confidence verdict for memory %s "
+            "candidate %s (confidence=%.2f < threshold=%.2f)",
+            new_memory.get("id"),
+            candidate.get("id"),
+            confidence,
+            RETRACTION_CONFIDENCE_THRESHOLD,
+        )
+        return False
+
+    # Two-step retraction via A4 #10.
+    await sc.update_memory_status(str(candidate.get("id")), "active")
+    try:
+        await sc.update_memory_status(
+            str(new_memory.get("id")),
+            new_memory.get("status", "active"),
+            unset_supersedes=True,
+            expected_supersedes_id=str(candidate.get("id")),
+        )
+    except Exception as e:
+        # CAS rejection (409) means another writer mutated the chain
+        # — the candidate revert above still landed (idempotent), and
+        # the chain edge is whatever the other writer chose. Don't
+        # roll the candidate back.
+        logger.warning(
+            "Path C retraction chain-clear failed for memory %s candidate %s: %s",
+            new_memory.get("id"),
+            candidate.get("id"),
+            e,
+        )
+
+    logger.info(
+        "Path C retracted Path A's verdict for memory %s: candidate %s reverted to active (confidence=%.2f)",
+        new_memory.get("id"),
+        candidate.get("id"),
+        confidence,
+    )
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Entity-based contradiction detection (post entity extraction)
 # ---------------------------------------------------------------------------
 
@@ -775,6 +897,10 @@ async def detect_contradictions_by_entities_async(
     Finds memories that share entities with the new memory and checks for
     contradictions via LLM -- catches by-the-way updates that embedding
     similarity misses.
+
+    Also re-judges any candidate Path A retracted (A4 #13). If the
+    entity-aware re-judge disagrees with Path A's verdict at sufficient
+    confidence, the retraction is undone via the A4 #10 storage primitive.
     """
     from core_api.services.organization_settings import resolve_config
 
@@ -783,6 +909,7 @@ async def detect_contradictions_by_entities_async(
     t_start = time.monotonic()
     n_candidates = 0
     n_conflicts = 0
+    n_retractions = 0
     try:
         sc = get_storage_client()
         new_memory = await sc.get_memory(str(memory_id))
@@ -790,6 +917,22 @@ async def detect_contradictions_by_entities_async(
             return
 
         tenant_config = await resolve_config(None, tenant_id)
+
+        # A4 #13 — re-judge Path A's verdict (if any) before the
+        # standard entity-overlap detection. Phases are independent:
+        # this lookup dereferences ``new_memory.supersedes_id``, while
+        # the detection phase below looks at memories that share
+        # entities with new_memory. A retraction in this phase doesn't
+        # short-circuit the detection phase — Path C may still find a
+        # different (genuine) contradiction below.
+        if await _attempt_path_c_retraction(sc, new_memory, tenant_config):
+            n_retractions = 1
+            # The new memory's ``supersedes_id`` was just cleared.
+            # Re-fetch so the detection phase below sees the fresh state.
+            refreshed = await sc.get_memory(str(memory_id))
+            if refreshed and refreshed.get("deleted_at") is None:
+                new_memory = refreshed
+
         candidates = await sc.find_entity_overlap_candidates(
             {
                 "memory_id": str(memory_id),
@@ -886,10 +1029,12 @@ async def detect_contradictions_by_entities_async(
     finally:
         elapsed_ms = round((time.monotonic() - t_start) * 1000)
         logger.info(
-            "path_c_completed for memory %s n_candidates=%d n_conflicts=%d elapsed_ms=%d tenant_id=%s",
+            "path_c_completed for memory %s n_candidates=%d n_conflicts=%d "
+            "n_retractions=%d elapsed_ms=%d tenant_id=%s",
             memory_id,
             n_candidates,
             n_conflicts,
+            n_retractions,
             elapsed_ms,
             tenant_id,
         )

--- a/tests/test_a4_13_path_c_retraction.py
+++ b/tests/test_a4_13_path_c_retraction.py
@@ -1,0 +1,421 @@
+"""A4 #13 — Path C retracts a wrong Path A verdict via the A4 #10 primitive.
+
+Context
+───────
+Path A runs first (post-commit, semantic similarity). It can wrongly
+flag a contradiction when two memories *look* similar but are actually
+about different real-world subjects (e.g. two people sharing a first
+name; a project name reused by two teams). Once flagged, the older
+candidate is marked ``conflicted`` and the new memory carries
+``supersedes_id`` pointing back at it.
+
+Path C runs later (post-entity-extraction). Now there's MORE
+information — the entity extractor has identified actual subjects
+(``MemoryEntityLink`` rows). A4 #13 has Path C re-judge the candidate
+Path A retracted, using ``_llm_contradiction_check`` (A4 #12 — returns
+``(verdict, confidence)``). If the verdict is now NOT-a-contradiction
+with sufficient confidence, Path C retracts Path A's verdict via the
+A4 #10 storage primitive (``unset_supersedes=True`` + CAS).
+
+Chain shape on entry to Path C (after wrong Path A verdict):
+  candidate.status = "conflicted",  candidate.supersedes_id = NULL
+  new_memory.status = "active",      new_memory.supersedes_id = candidate.id
+
+Retraction performs (atomically from the API caller's POV):
+  candidate.status      → "active"
+  new_memory.supersedes_id → NULL  (CAS guarded by expected=candidate.id)
+
+Confidence rubric (A4 #12):
+  0.90 — clean LLM agreement (both gates aligned)
+  0.85 — gate 2 fired (model named a non_conflict_reason)
+  0.60 — gate 1 fired (model said contradicts=True with same_subject=False)
+  0.50 — malformed / heuristic fallback
+
+Retraction acts on every ``verdict=False`` case EXCEPT malformed
+(threshold ``RETRACTION_CONFIDENCE_THRESHOLD = 0.60``). Gate 1 is the
+canonical retraction signal — the model said "different subjects" but
+its own ``contradicts=True`` was wrong; the safety gate corrected it.
+
+Why direct lookup (not via A4 #11):
+A4 #11's ``include_supersedes=True`` filter was structurally inverted
+relative to Path A's actual chain shape (see
+[[flow-debug-contradiction-chain-shape]]). Path A leaves
+``older.supersedes_id`` as NULL; the filter expected
+``older.supersedes_id == new_memory.id``, which is never written. A4
+#13 sidesteps the broken filter by dereferencing
+``new_memory.supersedes_id`` directly — one extra ``sc.get_memory(...)``
+call, works in both canonical and flipped Path A directions. Fixing or
+removing the A4 #11 filter is tracked separately
+(see [[followup-a4-11-filter-dead]]).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_memory(
+    mid: UUID, *, status: str, supersedes_id: UUID | None, content: str = "content"
+) -> dict:
+    return {
+        "id": str(mid),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "agent_id": "a1",
+        "content": content,
+        "status": status,
+        "visibility": "scope_team",
+        "supersedes_id": str(supersedes_id) if supersedes_id else None,
+        "deleted_at": None,
+        "created_at": "2026-05-24T10:00:00+00:00",
+    }
+
+
+def _mock_sc_with_retraction_setup(
+    new_id: UUID, cand_id: UUID, *, cand_status: str = "conflicted"
+) -> AsyncMock:
+    """Build a mock storage client where Path A has already retracted ``cand``
+    by ``new``: new.supersedes_id=cand, cand.status='conflicted'."""
+    sc = AsyncMock()
+    new_mem = _make_memory(
+        new_id,
+        status="active",
+        supersedes_id=cand_id,
+        content="new statement about subject X",
+    )
+    cand_mem = _make_memory(
+        cand_id,
+        status=cand_status,
+        supersedes_id=None,
+        content="old statement that looked similar but is about subject Y",
+    )
+
+    async def get_memory(mid: str) -> dict | None:
+        if mid == str(new_id):
+            return new_mem
+        if mid == str(cand_id):
+            return cand_mem
+        return None
+
+    sc.get_memory = AsyncMock(side_effect=get_memory)
+    sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
+    sc.update_memory_status = AsyncMock()
+    return sc
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Retraction fires — clean (False, 0.90) and gate-2 (False, 0.85)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retracts_when_judge_says_not_contradiction_clean_confidence():
+    """Path A flagged contradiction; Path C's judge says NOT contradiction
+    with confidence 0.90 (clean LLM agreement, both gates aligned).
+    Retraction MUST fire: candidate back to ``active``, new memory's
+    ``supersedes_id`` cleared."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    sc = _mock_sc_with_retraction_setup(new_id, cand_id)
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            new_callable=AsyncMock,
+            return_value=(False, 0.90),
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    calls = sc.update_memory_status.call_args_list
+    # 1) Candidate reverted to active.
+    assert any(c.args == (str(cand_id), "active") for c in calls), (
+        f"expected candidate reverted to active; calls={calls}"
+    )
+    # 2) New memory's supersedes_id cleared via A4 #10 (CAS by expected).
+    clear_calls = [
+        c
+        for c in calls
+        if c.args
+        and c.args[0] == str(new_id)
+        and c.kwargs.get("unset_supersedes") is True
+        and c.kwargs.get("expected_supersedes_id") == str(cand_id)
+    ]
+    assert len(clear_calls) == 1, (
+        f"expected exactly one supersedes-clear call on new memory with CAS "
+        f"anchor={cand_id}; got {calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_retracts_when_judge_says_not_contradiction_gate2_confidence():
+    """Gate 2 fired (e.g. ``refinement`` / ``temporal_supersession`` / etc.):
+    verdict=False at confidence 0.85. Retraction MUST fire."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    sc = _mock_sc_with_retraction_setup(new_id, cand_id)
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            new_callable=AsyncMock,
+            return_value=(False, 0.85),
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    assert any(
+        c.args == (str(cand_id), "active")
+        for c in sc.update_memory_status.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_retracts_on_gate1_confidence_canonical_case():
+    """Gate 1 fired — model said ``contradicts=True`` with
+    ``same_subject=False``; parser overrode to False at confidence 0.60.
+    This is the **canonical retraction case**: Path A wrongly flagged
+    on similarity; the entity-aware re-judge says "different subjects"
+    via the safety gate. Retraction MUST fire."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    sc = _mock_sc_with_retraction_setup(new_id, cand_id)
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            new_callable=AsyncMock,
+            return_value=(False, 0.60),
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    assert any(
+        c.args == (str(cand_id), "active")
+        for c in sc.update_memory_status.call_args_list
+    )
+
+
+# ---------------------------------------------------------------------------
+# Retraction does NOT fire — low confidence, judge agrees with Path A,
+# nothing to retract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_retraction_on_malformed_fallback_confidence():
+    """Confidence 0.50 = heuristic fallback / malformed LLM. We can't
+    trust verdict=False from a malformed response; leave Path A's call
+    alone."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    sc = _mock_sc_with_retraction_setup(new_id, cand_id)
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            new_callable=AsyncMock,
+            return_value=(False, 0.50),
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    # No revert-to-active call on the candidate.
+    revert_calls = [
+        c
+        for c in sc.update_memory_status.call_args_list
+        if c.args == (str(cand_id), "active")
+    ]
+    assert revert_calls == [], (
+        f"low-confidence verdict=False must NOT retract; got {revert_calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_retraction_when_judge_confirms_contradiction():
+    """Judge says verdict=True (e.g. confidence 0.90 — real contradiction).
+    Path A was right; Path C MUST leave the retraction alone."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    sc = _mock_sc_with_retraction_setup(new_id, cand_id)
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            new_callable=AsyncMock,
+            return_value=(True, 0.90),
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    revert_calls = [
+        c
+        for c in sc.update_memory_status.call_args_list
+        if c.args == (str(cand_id), "active")
+    ]
+    assert revert_calls == [], (
+        f"verdict=True must NOT retract (Path A was right); got {revert_calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pre-conditions — nothing to retract; no-op without judge invocation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_retraction_when_new_memory_has_no_supersedes_id():
+    """Path A didn't retract anything; ``new_memory.supersedes_id`` is
+    NULL. The retraction phase must be a fast no-op and MUST NOT call
+    the judge."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id = uuid4()
+    sc = AsyncMock()
+    sc.get_memory = AsyncMock(
+        return_value=_make_memory(new_id, status="active", supersedes_id=None)
+    )
+    sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
+    sc.update_memory_status = AsyncMock()
+
+    judge = AsyncMock()
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    judge.assert_not_called()
+    sc.update_memory_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_retraction_when_candidate_already_active():
+    """If the retraction candidate is already ``active`` (someone else
+    cleared it between Path A and Path C), the retraction phase MUST
+    be a no-op — we don't re-judge a row that no longer needs
+    retraction."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    # Candidate is already active — concurrent writer already retracted.
+    sc = _mock_sc_with_retraction_setup(new_id, cand_id, cand_status="active")
+
+    judge = AsyncMock()
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    judge.assert_not_called()
+    revert_calls = [
+        c
+        for c in sc.update_memory_status.call_args_list
+        if c.args == (str(cand_id), "active")
+    ]
+    assert revert_calls == []


### PR DESCRIPTION
## Summary

- Adds a **retraction phase** to ``detect_contradictions_by_entities_async`` (Path C). When Path A already flagged a candidate ``conflicted``, Path C re-judges the pair with A4 #12's ``(verdict, confidence)``-returning ``_llm_contradiction_check`` and undoes the verdict if the re-judge disagrees at sufficient confidence.
- **Threshold** ``RETRACTION_CONFIDENCE_THRESHOLD = 0.60`` — acts on every ``verdict=False`` case except the heuristic-fallback / malformed-LLM floor of 0.50. Gate 1 (model said ``contradicts=True`` with ``same_subject=False``, parser overrode to False) is the canonical retraction signal.
- Retraction is two writes via A4 #10: ``update_memory_status(candidate, "active")`` then ``update_memory_status(new_memory, ..., unset_supersedes=True, expected_supersedes_id=candidate)``. A 409 on the second is logged and swallowed (idempotent).

## Why direct lookup, not via A4 #11

I investigated A4 #11's ``include_supersedes`` filter while designing this PR (see [flow-debug-contradiction-chain-shape](https://github.com/caura-ai/caura-memclaw/blob/main/CHANGELOG.md) in the memory file). The filter is structurally inverted relative to Path A's actual chain shape — Path A leaves ``older.supersedes_id`` as NULL and only sets the edge on the newer row, but A4 #11's filter looks for ``older.supersedes_id == new_memory.id``, which is never written. A4 #11's tests pass only because they fabricate the inverse chain shape in setup.

This PR sidesteps the dead filter by dereferencing ``new_memory.supersedes_id`` directly with ``sc.get_memory(...)``. One extra round trip; works in both canonical and flipped Path A directions. **Fixing or removing A4 #11's filter is a separate follow-up PR.**

## Test plan

- [x] 7 new unit tests in ``tests/test_a4_13_path_c_retraction.py`` pin: retraction fires at 0.90 / 0.85 / 0.60; does NOT fire at 0.50 or on ``verdict=True``; no-op when ``supersedes_id`` is NULL or candidate is no longer ``conflicted``
- [x] Full unit suite: **2213 passed**, 0 new failures
- [x] Mypy: 19 pre-existing errors, **zero new errors** from this PR
- [x] Ruff lint + format clean
- [x] Wet-tested against locally-rebuilt stack with a blind-subagent corpus + a targeted high-similarity corpus. KEEP pairs (real contradictions) correctly retained. RETRACT pairs with disambiguated entities stayed clean. RETRACT pairs sharing only a first name surfaced an **adjacent issue** (Path C's judge can't distinguish them when entity extraction canonicalizes to one entity) — **not A4 #13's scope**; tracked as a follow-up (A1 #17 ``subject_entity_id`` preflight will address it)

## Follow-ups (not in this PR)

- Fix or remove A4 #11's structurally-inverted ``include_supersedes`` filter
- Path C judge false-positive on shared-first-name pairs (entity-extractor canonicalization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)