### PR TITLE
feat(contradiction): back-channel idempotency on detection entry (A4 #14)

### DIFF
--- a/core-api/src/core_api/cache.py
+++ b/core-api/src/core_api/cache.py
@@ -78,6 +78,28 @@ async def cache_delete(key: str) -> bool:
         return False
 
 
+async def cache_set_nx(key: str, value: str, ttl: int) -> bool:
+    """Atomic SET-if-not-exists with TTL. Returns True iff we newly set
+    the key (i.e. the caller "owns" the lock); False if the key already
+    existed.
+
+    **Fail-open semantics**: when Redis is unavailable (``_get_redis``
+    returns ``None``) or the SET call raises, returns True. The
+    idempotency check using this helper is best-effort — losing it
+    means falling back to whatever upstream behaviour exists (e.g.
+    storage CAS guards), never silently blocking work.
+    """
+    r = await _get_redis()
+    if r is None:
+        return True
+    try:
+        result = await r.set(key, value, ex=ttl, nx=True)
+        return bool(result)
+    except Exception:
+        logger.debug("cache_set_nx failed for key=%s", key, exc_info=True)
+        return True
+
+
 # ── JSON helpers ──
 
 

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -18,6 +18,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from core_api.cache import cache_set_nx
 from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
 from core_api.constants import SINGLE_VALUE_PREDICATES
@@ -25,6 +26,35 @@ from core_api.providers._retry import call_with_fallback
 from core_api.schemas import ContradictionInfo
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# A4 #14 — back-channel idempotency for back-to-back detection invocations.
+# ---------------------------------------------------------------------------
+
+# Lock TTL. Long enough for any detection to complete (worst case
+# ~10s per candidate; ~80s for a typical batch); short enough that
+# a process crash holding the lock doesn't permanently block
+# re-detection for the same memory.
+_DETECTION_LOCK_TTL_SECONDS = 3600
+
+
+async def _acquire_path_a_lock(memory_id) -> bool:
+    """Try to acquire the Path A (semantic + RDF) idempotency lock for
+    ``memory_id``. Returns True iff this caller owns the lock and should
+    proceed; False if another caller already holds it and we should skip.
+
+    Lock is keyed per-path so Path A and Path C run independently for
+    the same memory.
+    """
+    return await cache_set_nx(f"contradiction:path_a:{memory_id}", "1", _DETECTION_LOCK_TTL_SECONDS)
+
+
+async def _acquire_path_c_lock(memory_id) -> bool:
+    """Try to acquire the Path C (entity-overlap) idempotency lock for
+    ``memory_id``. Returns True iff this caller owns the lock; False
+    means another caller already ran detection for this memory."""
+    return await cache_set_nx(f"contradiction:path_c:{memory_id}", "1", _DETECTION_LOCK_TTL_SECONDS)
 
 
 def _parse_dt(value) -> datetime | None:
@@ -117,7 +147,19 @@ async def detect_contradictions_async(
     # structlog renderer's ``extra={}`` behaviour.
     t_start = time.monotonic()
     n_conflicts = 0
+    skipped = False
     try:
+        # A4 #14 — back-channel idempotency. Both the ENRICHED and
+        # EMBEDDED handlers fire ``detect_contradictions_async`` for
+        # the same memory; whichever arrives first owns the lock and
+        # runs detection, the other skips. Fail-open: if Redis is
+        # unavailable, ``_acquire_path_a_lock`` returns True and we
+        # fall back to the prior double-detection behaviour (storage
+        # CAS still keeps writes idempotent).
+        if not await _acquire_path_a_lock(memory_id):
+            skipped = True
+            return
+
         if new_memory is None:
             sc = get_storage_client()
             new_memory = await sc.get_memory(str(memory_id))
@@ -139,9 +181,10 @@ async def detect_contradictions_async(
     finally:
         elapsed_ms = round((time.monotonic() - t_start) * 1000)
         logger.info(
-            "path_a_completed for memory %s n_conflicts=%d elapsed_ms=%d tenant_id=%s",
+            "path_a_completed for memory %s n_conflicts=%d skipped=%s elapsed_ms=%d tenant_id=%s",
             memory_id,
             n_conflicts,
+            str(skipped).lower(),
             elapsed_ms,
             tenant_id,
         )
@@ -910,7 +953,16 @@ async def detect_contradictions_by_entities_async(
     n_candidates = 0
     n_conflicts = 0
     n_retractions = 0
+    skipped = False
     try:
+        # A4 #14 — back-channel idempotency. Entity extraction can
+        # complete more than once per memory (delta re-extraction,
+        # partial retry), each completion firing Path C. First caller
+        # wins the lock; the rest skip. Fail-open on Redis outage.
+        if not await _acquire_path_c_lock(memory_id):
+            skipped = True
+            return
+
         sc = get_storage_client()
         new_memory = await sc.get_memory(str(memory_id))
         if not new_memory or new_memory.get("deleted_at") is not None:
@@ -1030,11 +1082,12 @@ async def detect_contradictions_by_entities_async(
         elapsed_ms = round((time.monotonic() - t_start) * 1000)
         logger.info(
             "path_c_completed for memory %s n_candidates=%d n_conflicts=%d "
-            "n_retractions=%d elapsed_ms=%d tenant_id=%s",
+            "n_retractions=%d skipped=%s elapsed_ms=%d tenant_id=%s",
             memory_id,
             n_candidates,
             n_conflicts,
             n_retractions,
+            str(skipped).lower(),
             elapsed_ms,
             tenant_id,
         )

--- a/tests/test_a4_14_back_channel_idempotency.py
+++ b/tests/test_a4_14_back_channel_idempotency.py
@@ -1,0 +1,333 @@
+"""A4 #14 — back-channel idempotency for contradiction detection.
+
+Context
+───────
+Path A is triggered from two events: ``Topics.Memory.ENRICHED`` and
+``Topics.Memory.EMBEDDED``. The intent is to handle whichever lands
+first; the second event is a back-channel safety net. But the current
+handlers both call ``detect_contradictions_async`` unconditionally, so
+once both events fire (the common case), the detector runs **twice**.
+Storage writes are idempotent (status revert is a no-op; supersedes
+CAS rejects subsequent sets), but each invocation re-issues every
+LLM judgement call against the candidate set — wasted API spend +
+latency.
+
+Same pattern for Path C: entity extraction can complete more than
+once per memory (re-extraction after enrichment delta, partial
+fan-out, retries), and each completion fires
+``detect_contradictions_by_entities_async`` independently. Wet test
+on 2026-05-24 observed Path C completing twice for every memory.
+
+A4 #14 adds a per-memory SETNX-based idempotency check at the
+top of each detector entry point. First caller wins and runs;
+subsequent callers within the TTL window skip with a structured log
+line. Falls back gracefully (allow detection) when Redis is
+unavailable, preserving current behaviour rather than silently
+blocking detection.
+
+Lock keys (separate per path so Path A and Path C don't block each other):
+  ``contradiction:path_a:<memory_id>``
+  ``contradiction:path_c:<memory_id>``
+
+TTL: 3600s (1h). Long enough for any detection to complete (worst
+case ~10s × N candidates); short enough that a process crash holding
+the lock doesn't permanently block re-detection.
+
+What this PR does NOT change:
+- Storage-side idempotency (CAS on supersedes_id, status writes).
+- Detection logic itself.
+- Handler-level deferral (ENRICHED handler still skips when embedding
+  missing; that's complementary, not redundant, with A4 #14).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_memory(mid: UUID, *, status: str = "active", supersedes_id=None) -> dict:
+    return {
+        "id": str(mid),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "agent_id": "a1",
+        "content": "memory content",
+        "status": status,
+        "visibility": "scope_team",
+        "supersedes_id": str(supersedes_id) if supersedes_id else None,
+        "deleted_at": None,
+        "created_at": "2026-05-24T10:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Path A — detect_contradictions_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_path_a_second_call_skips_when_lock_already_held():
+    """When the first Path A call has acquired the lock, the second
+    call MUST skip the expensive work (no ``_detect`` invocation, no
+    storage calls beyond the initial guard fetch)."""
+    from core_api.services.contradiction_detector import detect_contradictions_async
+
+    mid = uuid4()
+    new_memory = _make_memory(mid)
+
+    # Simulate a Redis lock holder by patching SETNX to return False
+    # (lock not acquired). This is what the SECOND back-channel call
+    # would see.
+    with (
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_a_lock",
+            new_callable=AsyncMock,
+            return_value=False,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._detect",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as detect_mock,
+    ):
+        await detect_contradictions_async(
+            mid, "t1", "f1", "content", [0.1] * 10, new_memory=new_memory
+        )
+
+    detect_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_path_a_first_call_runs_when_lock_acquired():
+    """The first Path A caller must acquire the lock AND run detection."""
+    from core_api.services.contradiction_detector import detect_contradictions_async
+
+    mid = uuid4()
+    new_memory = _make_memory(mid)
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_a_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._detect",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as detect_mock,
+    ):
+        await detect_contradictions_async(
+            mid, "t1", "f1", "content", [0.1] * 10, new_memory=new_memory
+        )
+
+    detect_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Path C — detect_contradictions_by_entities_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_path_c_second_call_skips_when_lock_already_held():
+    """When the first Path C call has the lock, the second skips
+    without fetching the new memory or running detection."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    mid = uuid4()
+    sc = AsyncMock()
+    sc.get_memory = AsyncMock(return_value=_make_memory(mid))
+    sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
+    sc.update_memory_status = AsyncMock()
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new_callable=AsyncMock,
+            return_value=False,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+
+    sc.find_entity_overlap_candidates.assert_not_called()
+    sc.update_memory_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_path_c_first_call_runs_when_lock_acquired():
+    """The first Path C caller acquires the lock and runs detection."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    mid = uuid4()
+    sc = AsyncMock()
+    sc.get_memory = AsyncMock(return_value=_make_memory(mid))
+    sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
+    sc.update_memory_status = AsyncMock()
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+
+    sc.find_entity_overlap_candidates.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Path A and Path C have INDEPENDENT locks — one shouldn't block the other.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_path_a_and_path_c_use_independent_locks():
+    """The two paths cover different concerns (semantic vs entity
+    overlap). Holding the Path A lock for memory X MUST NOT block
+    Path C from running on memory X (and vice versa).
+
+    Pinned via the lock key shape: ``contradiction:path_a:<mid>`` vs
+    ``contradiction:path_c:<mid>`` — different keys, different
+    SETNX calls, no shared state.
+    """
+    from core_api.services.contradiction_detector import (
+        _acquire_path_a_lock,
+        _acquire_path_c_lock,
+    )
+
+    # Both helpers exist and are callable. Pin the key separation by
+    # capturing what cache_set_nx is asked for.
+    mid = uuid4()
+    captured: list[str] = []
+
+    async def fake_set_nx(key, value, ttl):
+        captured.append(key)
+        return True
+
+    with patch(
+        "core_api.services.contradiction_detector.cache_set_nx",
+        new=fake_set_nx,
+        create=True,
+    ):
+        await _acquire_path_a_lock(mid)
+        await _acquire_path_c_lock(mid)
+
+    assert len(captured) == 2
+    assert captured[0] != captured[1], (
+        f"Path A and Path C must use distinct lock keys; got {captured}"
+    )
+    assert "path_a" in captured[0]
+    assert "path_c" in captured[1]
+    assert str(mid) in captured[0]
+    assert str(mid) in captured[1]
+
+
+# ---------------------------------------------------------------------------
+# Redis-unavailable fallback: MUST allow detection (current behavior).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_path_a_runs_when_redis_unavailable():
+    """If Redis is down, ``cache_set_nx`` returns True (fail-open)
+    so the FIRST detection still runs. Subsequent duplicates also
+    run — that's the current behavior. The idempotency is best-effort,
+    not load-bearing for correctness (storage CAS still guards)."""
+    from core_api.services.contradiction_detector import _acquire_path_a_lock
+
+    async def redis_down(key, value, ttl):
+        return True  # fail-open
+
+    with patch(
+        "core_api.services.contradiction_detector.cache_set_nx",
+        new=redis_down,
+        create=True,
+    ):
+        assert await _acquire_path_a_lock(uuid4()) is True
+
+
+# ---------------------------------------------------------------------------
+# cache_set_nx helper — return True only when the key was newly set,
+# False when it already existed, and True when Redis is unavailable.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_set_nx_returns_true_on_first_set():
+    """The first SETNX for a key returns True."""
+    from core_api.cache import cache_set_nx
+
+    redis_mock = AsyncMock()
+    redis_mock.set = AsyncMock(return_value=True)
+
+    with patch("core_api.cache._get_redis", new=AsyncMock(return_value=redis_mock)):
+        assert await cache_set_nx("test_key", "v", 60) is True
+
+    redis_mock.set.assert_called_once_with("test_key", "v", ex=60, nx=True)
+
+
+@pytest.mark.asyncio
+async def test_cache_set_nx_returns_false_when_key_already_exists():
+    """SETNX on an existing key returns False (Redis returns None)."""
+    from core_api.cache import cache_set_nx
+
+    redis_mock = AsyncMock()
+    redis_mock.set = AsyncMock(return_value=None)
+
+    with patch("core_api.cache._get_redis", new=AsyncMock(return_value=redis_mock)):
+        assert await cache_set_nx("test_key", "v", 60) is False
+
+
+@pytest.mark.asyncio
+async def test_cache_set_nx_fails_open_when_redis_unavailable():
+    """When Redis returns None from ``_get_redis`` (unavailable),
+    ``cache_set_nx`` returns True so detection still runs. We do NOT
+    want a Redis outage to silently kill contradiction detection."""
+    from core_api.cache import cache_set_nx
+
+    with patch("core_api.cache._get_redis", new=AsyncMock(return_value=None)):
+        assert await cache_set_nx("test_key", "v", 60) is True
+
+
+@pytest.mark.asyncio
+async def test_cache_set_nx_fails_open_on_exception():
+    """If the Redis SET call itself raises (transient network blip),
+    ``cache_set_nx`` swallows and returns True. Same rationale as
+    Redis-unavailable case."""
+    from core_api.cache import cache_set_nx
+
+    redis_mock = AsyncMock()
+    redis_mock.set = AsyncMock(side_effect=Exception("connection reset"))
+
+    with patch("core_api.cache._get_redis", new=AsyncMock(return_value=redis_mock)):
+        assert await cache_set_nx("test_key", "v", 60) is True


### PR DESCRIPTION
## Summary

Closes the A4 chain. Adds a Redis SETNX-based idempotency lock at the entry of both detection paths so back-channel double-firing doesn't re-issue every LLM judge call.

**Why it matters**: Path A is intentionally subscribed to both ``ENRICHED`` and ``EMBEDDED`` events so whichever lands second sees a complete row. Once both fire (the common case), the detector ran **twice** — storage CAS kept writes idempotent, but each invocation re-issued every LLM judgement against the candidate set (wasted API spend + latency). Path C had the same shape from duplicate entity-extraction completions (observed in the A4 #13 wet test).

## Design

- Add ``cache_set_nx(key, value, ttl) -> bool`` to ``cache.py`` — atomic SET-NX with TTL, **fail-open** on Redis unavailability/errors
- Lock helpers ``_acquire_path_a_lock(memory_id)`` and ``_acquire_path_c_lock(memory_id)`` — per-path keys so the two paths don't block each other
- TTL ``3600s`` — long enough for any detection (worst case ~80s); short enough that a crashed lock-holder unblocks within 1h
- New ``skipped=true|false`` field on the ``path_a_completed`` / ``path_c_completed`` completion logs for observability

The dedup is best-effort, not load-bearing for correctness — storage CAS still guards ``supersedes_id`` writes if a duplicate sneaks through (Redis flake, lock-TTL expiry mid-flight).

## Test plan

- [x] 10 new unit tests in ``tests/test_a4_14_back_channel_idempotency.py`` pin: Path A + Path C skip on lock-held, run on lock-acquired, use independent lock keys, fail-open on Redis-unavailable; ``cache_set_nx`` first-set/already-exists/unavailable/raises
- [x] Full unit suite: **2223 passed** (+10), 0 regressions
- [x] Mypy: 19 pre-existing errors, **zero new**
- [x] Ruff lint + format clean
- [x] Wet-tested locally — A4 #14 integrated, ``skipped=`` log field appears, no regressions. Duplicate firing didn't reproduce on this run (single Path A + single Path C invocation per memory); previous wet tests confirmed the duplicate pattern is real and the lock will activate when it occurs

## Closes A4 chain

| PR | Title |
|---|---|
| #171 | A4 #10 — retraction primitive |
| #185 | A4 #11 — entity-overlap query expansion (filter is dead in prod — see follow-up) |
| #186 | A4 #12 — judge returns (verdict, confidence) |
| #187 | A4 #13 — Path C retracts wrong Path A verdicts |
| **this** | A4 #14 — back-channel idempotency |

## Open follow-ups (separate PRs)

- A4 #11's ``include_supersedes`` filter is structurally inverted vs Path A's chain shape — fix or remove
- Path C judge false-positive on shared-first-name pairs (entity-extractor canonicalization) — folds into A1 #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)