### PR TITLE
feat(dedup): CheckSemanticDuplicate dispatches LLM judge in danger band (A1 #16)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/check_semantic_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/check_semantic_duplicate.py
@@ -1,4 +1,17 @@
-"""CheckSemanticDuplicate — reject near-duplicates via pgvector cosine similarity."""
+"""CheckSemanticDuplicate — two-tier dedup gate (A1 #16).
+
+Decision band (cosine similarity to nearest stored memory; see
+``common.constants`` for the thresholds added in A1 #15):
+
+  similarity ≥ SEMANTIC_DEDUP_AUTO_THRESHOLD  → 409 auto-reject (no LLM)
+  JUDGE ≤ sim < AUTO                          → LLM judge decides
+  similarity < SEMANTIC_DEDUP_JUDGE_THRESHOLD → accept (no candidate
+                                                surfaced from storage)
+
+The judge call is gated on ``DEDUP_JUDGE_CONFIDENCE_THRESHOLD`` so a
+malformed/heuristic-fallback response (confidence 0.50) cannot 409 a
+legitimate write — only a confident "this IS a duplicate" call does.
+"""
 
 from __future__ import annotations
 
@@ -7,8 +20,16 @@ import time
 
 from fastapi import HTTPException
 
+from common.constants import (
+    SEMANTIC_DEDUP_AUTO_THRESHOLD,
+    SEMANTIC_DEDUP_JUDGE_THRESHOLD,
+)
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepOutcome, StepResult
+from core_api.services.dedup_judge import (
+    DEDUP_JUDGE_CONFIDENCE_THRESHOLD,
+    _llm_dedup_check,
+)
 from core_api.services.memory_service import _find_semantic_duplicate
 
 logger = logging.getLogger(__name__)
@@ -30,19 +51,49 @@ class CheckSemanticDuplicate:
             return StepResult(outcome=StepOutcome.SKIPPED)
 
         t_dedup = time.perf_counter()
+        # Surface candidates down to the JUDGE band so this step can
+        # decide auto-reject vs judge-dispatch vs accept by tier.
         sem_dup = await _find_semantic_duplicate(
             ctx.require_db,
             data.tenant_id,
             data.fleet_id,
             embedding,
             visibility=data.visibility or "scope_team",
+            min_similarity=SEMANTIC_DEDUP_JUDGE_THRESHOLD,
         )
-        dedup_ms = round((time.perf_counter() - t_dedup) * 1000, 1)
-        metadata["semantic_dedup_ms"] = dedup_ms
+        metadata["semantic_dedup_ms"] = round((time.perf_counter() - t_dedup) * 1000, 1)
 
-        if sem_dup:
+        if sem_dup is None:
+            return None
+
+        sem_dup_dict = sem_dup if isinstance(sem_dup, dict) else None
+        candidate_id = sem_dup_dict.get("id") if sem_dup_dict else getattr(sem_dup, "id", None)
+        similarity = float(sem_dup_dict.get("similarity", 0.0)) if sem_dup_dict else 0.0
+
+        if similarity >= SEMANTIC_DEDUP_AUTO_THRESHOLD:
+            # Auto-reject band — no LLM call.
             raise HTTPException(
                 status_code=409,
-                detail=f"Near-duplicate memory exists: {sem_dup['id'] if isinstance(sem_dup, dict) else sem_dup.id}",
+                detail=f"Near-duplicate memory exists: {candidate_id}",
             )
+
+        # Judge band — dispatch the LLM judge with A4 #12's
+        # (verdict, confidence) shape via ``_llm_dedup_check``.
+        candidate_content = sem_dup_dict.get("content", "") if sem_dup_dict else ""
+        new_content = data.content if hasattr(data, "content") else ""
+
+        t_judge = time.perf_counter()
+        is_dup, confidence = await _llm_dedup_check(new_content, candidate_content, tenant_config)
+        metadata["dedup_judge_ms"] = round((time.perf_counter() - t_judge) * 1000, 1)
+        metadata["dedup_judge_confidence"] = confidence
+        metadata["dedup_candidate_similarity"] = similarity
+
+        if is_dup and confidence >= DEDUP_JUDGE_CONFIDENCE_THRESHOLD:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Near-duplicate memory exists: {candidate_id}",
+            )
+
+        # Either judge said not a duplicate, or said duplicate at low
+        # confidence — accept the write.
         return None

--- a/core-api/src/core_api/services/dedup_judge.py
+++ b/core-api/src/core_api/services/dedup_judge.py
@@ -1,0 +1,131 @@
+"""A1 #16 — LLM judge for the dedup danger zone.
+
+Two-tier dedup (see ``common.constants.SEMANTIC_DEDUP_AUTO_THRESHOLD``
+and ``SEMANTIC_DEDUP_JUDGE_THRESHOLD``, both added in A1 #15):
+
+  similarity ≥ AUTO   → auto-reject 409 (no LLM)
+  JUDGE ≤ sim < AUTO  → call ``_llm_dedup_check`` to decide
+  similarity < JUDGE  → accept (no candidate surfaced)
+
+This module owns the judge. ``CheckSemanticDuplicate`` (the pipeline
+step) imports ``_llm_dedup_check`` and gates the 409 on its return.
+
+The judge returns ``(is_duplicate, confidence)`` mirroring A4 #12's
+``_llm_contradiction_check``. Confidence rubric is simpler here — the
+prompt has no safety gates (no subject extraction, no non-conflict
+reason taxonomy), so:
+
+  0.90 — Clean response (``is_duplicate`` is a bool, ``reason`` is a
+         non-empty string).
+  0.50 — Malformed / unparseable / heuristic fallback.
+
+Callers gate 409 on a configurable confidence threshold so a flaky
+LLM response doesn't 409 a legitimate write.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core_api.config import settings
+from core_api.providers._retry import call_with_fallback
+
+logger = logging.getLogger(__name__)
+
+
+# Confidence rubric. See module docstring for the rationale.
+_CONF_CLEAN = 0.90
+_CONF_FALLBACK = 0.50
+
+
+DEDUP_PROMPT = """\
+You are a deduplication judge for a personal memory system.
+
+Two short statements are about to be stored. Decide whether they
+encode the SAME memory (i.e. one is a duplicate or trivial paraphrase
+of the other) or DIFFERENT memories (even if they overlap in topic).
+
+Statement A (NEW): {new_content}
+Statement B (EXISTING): {old_content}
+
+Return STRICT JSON with no surrounding prose:
+{{
+  "is_duplicate": true|false,
+  "reason": "<one short clause>"
+}}
+
+A is a duplicate of B iff a reasonable reader would consider the two
+interchangeable carriers of the same fact. Refinements that ADD new
+information are NOT duplicates. Different subjects are NOT duplicates
+even if their predicates match.
+"""
+
+
+def _judge_dedup(raw) -> tuple[bool, float]:
+    """Parse the LLM response into ``(is_duplicate, confidence)``.
+
+    Conservative defaults: anything that doesn't look like a well-formed
+    ``{is_duplicate: bool, reason: str}`` dict → ``(False, 0.50)``.
+    Downstream callers gate 409 on confidence, so this floor means a
+    flaky response will not 409 a legitimate write.
+    """
+    if not isinstance(raw, dict):
+        return False, _CONF_FALLBACK
+
+    is_dup_raw = raw.get("is_duplicate")
+    reason_raw = raw.get("reason")
+    if not isinstance(is_dup_raw, bool):
+        return False, _CONF_FALLBACK
+    if not isinstance(reason_raw, str) or not reason_raw.strip():
+        return False, _CONF_FALLBACK
+    return is_dup_raw, _CONF_CLEAN
+
+
+def _fake_dedup_check(new_content: str, old_content: str) -> bool:
+    """Heuristic fallback when no LLM credentials are available.
+
+    Conservative: only flags as duplicate when the two strings are
+    near-identical after whitespace normalisation. Real dedup judgement
+    is best deferred to the LLM; this exists so the pipeline doesn't
+    raise on test/CI environments without credentials.
+    """
+    return " ".join(new_content.split()).lower() == " ".join(old_content.split()).lower()
+
+
+async def _llm_dedup_check(
+    new_content: str,
+    old_content: str,
+    tenant_config=None,
+) -> tuple[bool, float]:
+    """Ask the LLM whether two texts are duplicates.
+
+    Returns ``(is_duplicate, confidence)`` — see ``_judge_dedup`` for
+    the rubric. Uses the same 3-tier fallback chain as
+    ``_llm_contradiction_check``: configured provider → fallback
+    provider → heuristic.
+    """
+    provider_name = (
+        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
+    )
+
+    prompt = DEDUP_PROMPT.format(new_content=new_content[:500], old_content=old_content[:500])
+
+    async def _do_check(llm) -> tuple[bool, float]:
+        raw = await llm.complete_json(prompt)
+        return _judge_dedup(raw)
+
+    return await call_with_fallback(
+        primary_provider_name=provider_name,
+        call_fn=_do_check,
+        fake_fn=lambda: (_fake_dedup_check(new_content, old_content), _CONF_FALLBACK),
+        tenant_config=tenant_config,
+        service_label="dedup",
+        model_attr="entity_extraction_model",
+        timeout=10.0,
+    )
+
+
+# Below this, callers must NOT 409 — even if ``is_duplicate=True``.
+# Set at gate-1 / gate-2 confidence floor so heuristic fallbacks and
+# malformed responses don't sink legitimate writes.
+DEDUP_JUDGE_CONFIDENCE_THRESHOLD = 0.60

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -111,21 +111,30 @@ async def _find_semantic_duplicate(
     embedding: list[float],
     exclude_id: UUID | None = None,
     visibility: str | None = None,
+    min_similarity: float | None = None,
 ) -> dict | None:
     """Find a near-duplicate memory via cosine similarity.
 
-    Returns the closest match above SEMANTIC_DEDUP_THRESHOLD, or None.
+    Returns the closest match above the threshold (or ``None``). The
+    returned dict carries a ``similarity`` field — added in A1 #16 so
+    two-tier callers can dispatch by score.
+
+    ``min_similarity`` defaults to ``SEMANTIC_DEDUP_THRESHOLD`` (0.95)
+    via the storage layer for back-compat. A1 #16's
+    ``CheckSemanticDuplicate`` pipeline step passes
+    ``SEMANTIC_DEDUP_JUDGE_THRESHOLD`` to surface the judge band.
     """
     sc = get_storage_client()
-    return await sc.find_semantic_duplicate(
-        {
-            "tenant_id": tenant_id,
-            "fleet_id": fleet_id,
-            "embedding": embedding,
-            "exclude_id": str(exclude_id) if exclude_id else None,
-            "visibility": visibility,
-        }
-    )
+    payload: dict = {
+        "tenant_id": tenant_id,
+        "fleet_id": fleet_id,
+        "embedding": embedding,
+        "exclude_id": str(exclude_id) if exclude_id else None,
+        "visibility": visibility,
+    }
+    if min_similarity is not None:
+        payload["min_similarity"] = min_similarity
+    return await sc.find_semantic_duplicate(payload)
 
 
 def _dict_to_memory_out(

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -197,16 +197,22 @@ async def scored_search(request: Request) -> list[dict]:
 @router.post("/semantic-duplicate")
 async def find_semantic_duplicate(request: Request) -> dict:
     body: dict = await request.json()
-    memory = await _svc.memory_find_semantic_duplicate(
+    result = await _svc.memory_find_semantic_duplicate(
         tenant_id=body["tenant_id"],
         fleet_id=body.get("fleet_id"),
         embedding=body["embedding"],
         exclude_id=UUID(body["exclude_id"]) if body.get("exclude_id") else None,
         visibility=body.get("visibility"),
+        min_similarity=body.get("min_similarity"),
     )
-    if memory is None:
+    if result is None:
         raise HTTPException(status_code=404, detail="No semantic duplicate found")
-    return orm_to_dict(memory, MEMORY_FIELDS)
+    memory, similarity = result
+    payload = orm_to_dict(memory, MEMORY_FIELDS)
+    # A1 #16 — surface the score so the dispatching pipeline step can
+    # pick auto-reject vs judge-dispatch vs accept by tier.
+    payload["similarity"] = similarity
+    return payload
 
 
 @router.post("/entity-overlap-candidates")

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -562,7 +562,21 @@ class PostgresService:
         embedding: list[float],
         exclude_id: UUID | None = None,
         visibility: str | None = None,
-    ) -> Memory | None:
+        min_similarity: float | None = None,
+    ) -> tuple[Memory, float] | None:
+        """Find the closest memory above ``min_similarity``.
+
+        ``min_similarity`` (A1 #16): cosine-similarity cutoff applied
+        in SQL. Defaults to ``SEMANTIC_DEDUP_THRESHOLD`` (0.95) for
+        back-compat with single-tier callers; A1 #16's tier-dispatching
+        pipeline step passes ``SEMANTIC_DEDUP_JUDGE_THRESHOLD`` (0.85)
+        so candidates in the judge band become visible.
+
+        Returns ``(memory, similarity)`` or ``None``. The similarity
+        field is what callers use to decide auto-reject vs judge-dispatch
+        vs accept (see ``check_semantic_duplicate.py``).
+        """
+        threshold = min_similarity if min_similarity is not None else SEMANTIC_DEDUP_THRESHOLD
         async with get_session() as session:
             distance = Memory.embedding.cosine_distance(embedding)
             similarity = (1.0 - distance).label("similarity")
@@ -575,7 +589,7 @@ class PostgresService:
                     Memory.status.in_(("active", "confirmed", "pending")),
                     Memory.embedding.is_not(None),
                 )
-                .where((1.0 - distance) >= SEMANTIC_DEDUP_THRESHOLD)
+                .where((1.0 - distance) >= threshold)
                 .order_by(distance)
                 .limit(SEMANTIC_DEDUP_CANDIDATE_LIMIT)
             )
@@ -591,7 +605,9 @@ class PostgresService:
 
             result = await session.execute(stmt)
             row = result.first()
-            return row.Memory if row else None
+            if row is None:
+                return None
+            return row.Memory, float(row.similarity)
 
     async def memory_bulk_find_by_content_hashes(
         self,

--- a/tests/test_a1_16_dedup_judge_dispatch.py
+++ b/tests/test_a1_16_dedup_judge_dispatch.py
@@ -1,0 +1,287 @@
+"""A1 #16 — CheckSemanticDuplicate dispatches the LLM judge in the
+danger zone defined by A1 #15.
+
+Decision band (from A1 #15):
+  similarity ≥ AUTO (0.97)        → auto-reject 409 (no LLM call)
+  JUDGE ≤ similarity < AUTO       → LLM judge decides (this PR)
+  similarity < JUDGE (0.85)       → accept (no candidate returned at all)
+
+The judge call mirrors A4 #12's pattern: a thin parser returns
+``(is_duplicate, confidence)`` and an async wrapper threads through
+``call_with_fallback`` for provider failover. Confidence below
+``DEDUP_JUDGE_CONFIDENCE_THRESHOLD`` causes the write to be accepted
+even when ``is_duplicate=True`` — a malformed/heuristic-fallback
+response shouldn't 409 a legitimate write.
+
+Tests cover:
+- ``_judge_dedup`` parser confidence rubric (clean/malformed)
+- ``_llm_dedup_check`` returns the tuple
+- ``CheckSemanticDuplicate`` dispatches by tier, calling the judge
+  only in the danger band and gating 409s on confidence
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Parser: _judge_dedup(raw) → (is_duplicate, confidence)
+# ---------------------------------------------------------------------------
+
+
+def test_judge_dedup_clean_true():
+    """``is_duplicate=true`` with non-empty reason → clean response, high
+    confidence."""
+    from core_api.services.dedup_judge import _judge_dedup
+
+    out = _judge_dedup({"is_duplicate": True, "reason": "trivial paraphrase"})
+    assert isinstance(out, tuple)
+    verdict, conf = out
+    assert verdict is True
+    assert conf == pytest.approx(0.90)
+
+
+def test_judge_dedup_clean_false():
+    """``is_duplicate=false`` with reason → clean, high confidence."""
+    from core_api.services.dedup_judge import _judge_dedup
+
+    verdict, conf = _judge_dedup({"is_duplicate": False, "reason": "refinement"})
+    assert verdict is False
+    assert conf == pytest.approx(0.90)
+
+
+def test_judge_dedup_malformed_returns_low_confidence():
+    """Non-dict or empty / missing fields → conservative False with
+    fallback confidence floor."""
+    from core_api.services.dedup_judge import _judge_dedup
+
+    for raw in (None, "not a dict", {}, {"reason": "missing is_duplicate"}):
+        verdict, conf = _judge_dedup(raw)  # type: ignore[arg-type]
+        assert verdict is False
+        assert conf == pytest.approx(0.50)
+
+
+# ---------------------------------------------------------------------------
+# Async wrapper: _llm_dedup_check returns the same tuple.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_llm_dedup_check_returns_tuple():
+    from core_api.services.dedup_judge import _llm_dedup_check
+
+    fake_llm = AsyncMock()
+    fake_llm.complete_json = AsyncMock(
+        return_value={"is_duplicate": True, "reason": "exact paraphrase"}
+    )
+
+    async def fake_call_with_fallback(**kw):
+        return await kw["call_fn"](fake_llm)
+
+    with patch(
+        "core_api.services.dedup_judge.call_with_fallback",
+        new=AsyncMock(side_effect=fake_call_with_fallback),
+    ):
+        result = await _llm_dedup_check("new text", "old text")
+
+    assert isinstance(result, tuple)
+    verdict, conf = result
+    assert verdict is True
+    assert conf == pytest.approx(0.90)
+
+
+# ---------------------------------------------------------------------------
+# CheckSemanticDuplicate dispatch: tier logic
+# ---------------------------------------------------------------------------
+
+
+def _build_ctx(*, dedup_enabled: bool = True):
+    """Minimal fake PipelineContext exercising the step's actual code path."""
+    ctx = MagicMock()
+    ctx.tenant_config = MagicMock(semantic_dedup_enabled=dedup_enabled)
+    ctx.data = {
+        "input": MagicMock(
+            tenant_id="t1",
+            fleet_id="f1",
+            visibility="scope_team",
+        ),
+        "embedding": [0.1] * 10,
+        "memory_fields": {"metadata": {}},
+    }
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_auto_reject_skips_llm_judge():
+    """When ``_find_semantic_duplicate`` returns a candidate with
+    similarity ≥ AUTO (0.97), the step MUST raise 409 immediately
+    without calling the judge."""
+    from fastapi import HTTPException
+
+    from core_api.pipeline.steps.write.check_semantic_duplicate import (
+        CheckSemanticDuplicate,
+    )
+
+    ctx = _build_ctx()
+    candidate = {"id": "00000000-0000-0000-0000-000000000001", "similarity": 0.98}
+
+    judge = AsyncMock()
+    with (
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._find_semantic_duplicate",
+            new=AsyncMock(return_value=candidate),
+        ),
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._llm_dedup_check",
+            new=judge,
+        ),
+    ):
+        step = CheckSemanticDuplicate()
+        with pytest.raises(HTTPException) as ei:
+            await step.execute(ctx)
+
+    assert ei.value.status_code == 409
+    judge.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_judge_band_calls_llm_and_rejects_on_high_confidence_duplicate():
+    """JUDGE ≤ similarity < AUTO → LLM judge is called; if it returns
+    ``is_duplicate=True`` with confidence ≥ threshold, 409."""
+    from fastapi import HTTPException
+
+    from core_api.pipeline.steps.write.check_semantic_duplicate import (
+        CheckSemanticDuplicate,
+    )
+
+    ctx = _build_ctx()
+    candidate = {"id": "00000000-0000-0000-0000-000000000002", "similarity": 0.91}
+
+    with (
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._find_semantic_duplicate",
+            new=AsyncMock(return_value=candidate),
+        ),
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._llm_dedup_check",
+            new=AsyncMock(return_value=(True, 0.90)),
+        ),
+    ):
+        step = CheckSemanticDuplicate()
+        with pytest.raises(HTTPException) as ei:
+            await step.execute(ctx)
+
+    assert ei.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_judge_band_accepts_when_judge_says_not_duplicate():
+    """Judge says ``is_duplicate=False`` → write is accepted."""
+    from core_api.pipeline.steps.write.check_semantic_duplicate import (
+        CheckSemanticDuplicate,
+    )
+
+    ctx = _build_ctx()
+    candidate = {"id": "00000000-0000-0000-0000-000000000003", "similarity": 0.90}
+
+    with (
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._find_semantic_duplicate",
+            new=AsyncMock(return_value=candidate),
+        ),
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._llm_dedup_check",
+            new=AsyncMock(return_value=(False, 0.90)),
+        ),
+    ):
+        step = CheckSemanticDuplicate()
+        # No exception → accept.
+        result = await step.execute(ctx)
+        assert result is None  # CheckSemanticDuplicate returns None on accept
+
+
+@pytest.mark.asyncio
+async def test_judge_band_accepts_on_low_confidence_even_if_verdict_duplicate():
+    """``is_duplicate=True`` with confidence < threshold (e.g. heuristic
+    fallback at 0.50) → write is accepted. We don't 409 a legitimate
+    write on a malformed-LLM response."""
+    from core_api.pipeline.steps.write.check_semantic_duplicate import (
+        CheckSemanticDuplicate,
+    )
+
+    ctx = _build_ctx()
+    candidate = {"id": "00000000-0000-0000-0000-000000000004", "similarity": 0.93}
+
+    with (
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._find_semantic_duplicate",
+            new=AsyncMock(return_value=candidate),
+        ),
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._llm_dedup_check",
+            new=AsyncMock(return_value=(True, 0.50)),  # low confidence
+        ),
+    ):
+        step = CheckSemanticDuplicate()
+        assert await step.execute(ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_no_candidate_returned_skips_llm_judge_and_accepts():
+    """When ``_find_semantic_duplicate`` returns None (nothing above
+    the JUDGE threshold), the step accepts without calling the judge."""
+    from core_api.pipeline.steps.write.check_semantic_duplicate import (
+        CheckSemanticDuplicate,
+    )
+
+    ctx = _build_ctx()
+    judge = AsyncMock()
+    with (
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._find_semantic_duplicate",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._llm_dedup_check",
+            new=judge,
+        ),
+    ):
+        step = CheckSemanticDuplicate()
+        assert await step.execute(ctx) is None
+        judge.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dedup_disabled_skips_all():
+    """When ``tenant_config.semantic_dedup_enabled`` is False, neither
+    the find nor the judge are called. Existing back-compat contract."""
+    from core_api.pipeline.steps.write.check_semantic_duplicate import (
+        CheckSemanticDuplicate,
+    )
+
+    ctx = _build_ctx(dedup_enabled=False)
+    find = AsyncMock()
+    judge = AsyncMock()
+    with (
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._find_semantic_duplicate",
+            new=find,
+        ),
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._llm_dedup_check",
+            new=judge,
+        ),
+    ):
+        step = CheckSemanticDuplicate()
+        result = await step.execute(ctx)
+
+    find.assert_not_called()
+    judge.assert_not_called()
+    # ``execute`` returns a SKIPPED outcome in this branch.
+    assert result is not None


### PR DESCRIPTION
> Stacked on #190 (A1 #15). Will rebase to ``main`` once #190 merges.

## Summary

Replaces the single-tier dedup gate (≥ 0.95 cosine → 409) with a three-tier decision band using A1 #15's constants and A4 #12's ``(verdict, confidence)`` LLM-judge pattern.

```
similarity ≥ 0.97 (AUTO)       → 409 auto-reject (no LLM)
0.85 ≤ sim < 0.97 (JUDGE band) → _llm_dedup_check decides
similarity < 0.85               → accept (no candidate surfaced)
```

The 409 in the judge band is gated on confidence ``≥ 0.60`` so a heuristic-fallback verdict (0.50) won't 409 a legitimate write.

## New module: ``core_api.services.dedup_judge``

Mirrors A4 #12's ``_llm_contradiction_check`` exactly:

- ``_judge_dedup(raw) -> (is_duplicate, confidence)`` — 0.90 clean, 0.50 fallback
- ``_llm_dedup_check(new, old, tenant_config) -> (bool, float)`` — 3-tier provider fallback (configured → fallback → heuristic)
- ``DEDUP_JUDGE_CONFIDENCE_THRESHOLD = 0.60``

## Storage-side

- ``memory_find_semantic_duplicate`` gains optional ``min_similarity`` (defaults to ``SEMANTIC_DEDUP_THRESHOLD=0.95`` for back-compat; pipeline step calls with 0.85 to surface the judge band)
- Returns ``(Memory, similarity)``; router exposes ``similarity`` in the response dict so the dispatcher can pick a tier

Legacy callers in ``memory_service`` keep single-tier 0.95 — A1 #17 will migrate them.

## Test plan

- [x] 10 new unit tests in ``tests/test_a1_16_dedup_judge_dispatch.py``: parser rubric, ``_llm_dedup_check`` tuple, all three tier branches, low-confidence-doesn't-reject, dedup-disabled-skips
- [x] Full unit suite: **2241 passed** (+10), 0 regressions
- [x] Mypy parity: zero new errors
- [x] Ruff lint + format clean
- [x] **Wet-tested locally** with a blind 8-pair corpus (3 paraphrases / 3 refinements / 2 unrelated overlap):

| Cat | Result | Tier |
|---|---|---|
| A (paraphrases) | 3/3 auto-rejected, no judge metadata | AUTO band |
| B (refinements) | 3/3 accepted via judge (sim 0.85-0.91, judge_ms ~750-900ms, conf=0.9) | JUDGE band, LLM correctly said not-dup |
| C (unrelated overlap) | 2/2 accepted, no judge metadata | Below JUDGE floor |

All three tiers exercised end-to-end with real LLM. **8/8 pass.**

## Pipeline coverage

``CheckSemanticDuplicate`` runs in ``persist`` and ``strong`` modes. Fast mode (default) skips semantic dedup entirely, so default writes are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)