### PR TITLE
feat(dedup,contradiction): subject_entity_id preflight gate (A1 #17)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/check_semantic_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/check_semantic_duplicate.py
@@ -1,4 +1,5 @@
-"""CheckSemanticDuplicate — two-tier dedup gate (A1 #16).
+"""CheckSemanticDuplicate — two-tier dedup gate (A1 #16) with subject
+preflight (A1 #17).
 
 Decision band (cosine similarity to nearest stored memory; see
 ``common.constants`` for the thresholds added in A1 #15):
@@ -7,6 +8,13 @@ Decision band (cosine similarity to nearest stored memory; see
   JUDGE ≤ sim < AUTO                          → LLM judge decides
   similarity < SEMANTIC_DEDUP_JUDGE_THRESHOLD → accept (no candidate
                                                 surfaced from storage)
+
+A1 #17 inserts a deterministic gate between the AUTO band and the
+judge call: if the new memory and candidate have non-NULL but
+distinct ``subject_entity_id`` values, they're about different
+real-world subjects → accept the write, no LLM. The auto band still
+fires regardless of subject IDs (near-identical embedding is a stronger
+signal than the extractor's entity assignment).
 
 The judge call is gated on ``DEDUP_JUDGE_CONFIDENCE_THRESHOLD`` so a
 malformed/heuristic-fallback response (confidence 0.50) cannot 409 a
@@ -31,6 +39,7 @@ from core_api.services.dedup_judge import (
     _llm_dedup_check,
 )
 from core_api.services.memory_service import _find_semantic_duplicate
+from core_api.services.subject_preflight import _subjects_differ_with_certainty
 
 logger = logging.getLogger(__name__)
 
@@ -71,11 +80,29 @@ class CheckSemanticDuplicate:
         similarity = float(sem_dup_dict.get("similarity", 0.0)) if sem_dup_dict else 0.0
 
         if similarity >= SEMANTIC_DEDUP_AUTO_THRESHOLD:
-            # Auto-reject band — no LLM call.
+            # Auto-reject band — no LLM call. A1 #17's subject preflight
+            # is intentionally bypassed here: near-identical embeddings
+            # are a stronger signal than the entity extractor's subject
+            # assignment, so we don't second-guess auto-reject on the
+            # basis of subject_entity_id disagreement.
             raise HTTPException(
                 status_code=409,
                 detail=f"Near-duplicate memory exists: {candidate_id}",
             )
+
+        # A1 #17 — subject preflight. If both rows carry a non-NULL
+        # ``subject_entity_id`` and those IDs differ, the pair is
+        # definitionally about different subjects: skip the judge
+        # and accept the write. Falls through to the judge in the
+        # common case where the new memory's subject_entity_id is
+        # still NULL (entity extraction is async / post-commit) OR
+        # both subjects match.
+        new_subject = getattr(data, "subject_entity_id", None)
+        candidate_subject = sem_dup_dict.get("subject_entity_id") if sem_dup_dict else None
+        if _subjects_differ_with_certainty(new_subject, candidate_subject):
+            metadata["dedup_subject_preflight"] = "skipped_judge_subjects_differ"
+            metadata["dedup_candidate_similarity"] = similarity
+            return None
 
         # Judge band — dispatch the LLM judge with A4 #12's
         # (verdict, confidence) shape via ``_llm_dedup_check``.

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -24,6 +24,7 @@ from core_api.config import settings
 from core_api.constants import SINGLE_VALUE_PREDICATES
 from core_api.providers._retry import call_with_fallback
 from core_api.schemas import ContradictionInfo
+from core_api.services.subject_preflight import _subjects_differ_with_certainty
 
 logger = logging.getLogger(__name__)
 
@@ -996,6 +997,31 @@ async def detect_contradictions_by_entities_async(
         )
         n_candidates = len(candidates) if candidates else 0
         if not candidates:
+            return
+
+        # A1 #17 — subject preflight. Drop candidates whose
+        # ``subject_entity_id`` is non-NULL AND differs from the new
+        # memory's: they're definitionally about different subjects,
+        # so the LLM judge would be (1) at risk of a false-positive
+        # contradiction call when entities share canonical names like
+        # "priya" but resolve to distinct entity rows (see
+        # ``followup-path-c-judge-first-name-collisions``) and (2)
+        # wasteful API spend regardless. Candidates with NULL
+        # ``subject_entity_id`` on either side fall through unchanged.
+        new_subject = new_memory.get("subject_entity_id")
+        filtered_candidates = [
+            c
+            for c in candidates
+            if not _subjects_differ_with_certainty(new_subject, c.get("subject_entity_id"))
+        ]
+        n_preflight_skipped = len(candidates) - len(filtered_candidates)
+        candidates = filtered_candidates
+        if not candidates:
+            logger.info(
+                "Path C preflight skipped all %d candidates for memory %s (distinct subject_entity_id)",
+                n_preflight_skipped,
+                memory_id,
+            )
             return
 
         new_content = new_memory.get("content", "")

--- a/core-api/src/core_api/services/subject_preflight.py
+++ b/core-api/src/core_api/services/subject_preflight.py
@@ -1,0 +1,34 @@
+"""A1 #17 — deterministic subject-entity preflight.
+
+A small helper used as a fast gate BEFORE the LLM judge in both
+``CheckSemanticDuplicate`` (dedup) and ``detect_contradictions_by_entities_async``
+(Path C contradiction). When both sides of a (new memory, candidate)
+pair have a non-NULL ``subject_entity_id`` AND those IDs differ, the
+pair is definitionally about different real-world subjects — no
+judge call needed.
+
+This is also the cheapest path to closing the Path C
+first-name-collision follow-up (see ``followup-path-c-judge-first-name-collisions``
+memory). The entity extractor produces distinct entity rows for two
+memories that happen to share a canonical name like "priya"; A1 #17
+catches the (subject_a != subject_b) signal those rows carry and
+short-circuits the false-positive judge call.
+
+Conservative: only the symmetric ``both-non-null AND differ`` case
+fires. Either side missing → caller falls through to the judge.
+"""
+
+from __future__ import annotations
+
+
+def _subjects_differ_with_certainty(left, right) -> bool:
+    """Return True iff both ``left`` and ``right`` are present (non-None)
+    AND they refer to different subject entities.
+
+    Accepts ``str`` or ``UUID``; compares by string form so callers
+    don't need to normalise. Any None / falsy on either side returns
+    False — i.e. "we can't tell deterministically, so fall through".
+    """
+    if left is None or right is None:
+        return False
+    return str(left) != str(right)

--- a/tests/test_a1_17_subject_entity_preflight.py
+++ b/tests/test_a1_17_subject_entity_preflight.py
@@ -1,0 +1,497 @@
+"""A1 #17 — subject_entity_id preflight gate.
+
+A deterministic gate that fires BEFORE the LLM judge in both
+``CheckSemanticDuplicate`` (A1 #16) and Path C
+(``detect_contradictions_by_entities_async``, A4 #13).
+
+When the new memory and a candidate both have a non-NULL
+``subject_entity_id`` AND those IDs differ, they're definitionally
+about different real-world subjects. The judge call is skipped:
+
+  - Dedup gate: skip judge, accept the write
+  - Path C gate: skip judge, no contradiction
+
+Why this fixes the Path C first-name-collision follow-up:
+The entity extractor links each memory to its OWN entity row even
+when several memories share a canonical name like "priya". Two
+memories about different Priyas → two distinct ``subject_entity_id``
+values → A1 #17's gate fires → no false contradiction.
+
+What it doesn't fix: when the extractor canonicalizes two genuinely
+different subjects to one entity row. That requires either better
+entity disambiguation (extractor-side) or a prompt that knows about
+first-name collisions. A1 #17's gate just plugs the leak where the
+data IS available.
+
+Conservative: only the symmetric ``both-non-null AND differ`` case
+fires. If either side is NULL (entity extraction hasn't run yet, or
+the extractor produced no subject), the gate does nothing — the LLM
+judge runs as before.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# _subjects_differ_with_certainty — the shared helper.
+# ---------------------------------------------------------------------------
+
+
+def test_helper_returns_true_when_both_present_and_differ():
+    """Both rows have ``subject_entity_id`` set; the IDs differ. The
+    gate MUST fire (return True so callers know to skip the judge)."""
+    from core_api.services.subject_preflight import _subjects_differ_with_certainty
+
+    a = "11111111-1111-1111-1111-111111111111"
+    b = "22222222-2222-2222-2222-222222222222"
+    assert _subjects_differ_with_certainty(a, b) is True
+
+
+def test_helper_returns_false_when_both_same():
+    """Same ``subject_entity_id`` → could be a genuine same-subject
+    pair → don't skip the judge."""
+    from core_api.services.subject_preflight import _subjects_differ_with_certainty
+
+    sid = "11111111-1111-1111-1111-111111111111"
+    assert _subjects_differ_with_certainty(sid, sid) is False
+
+
+def test_helper_returns_false_when_left_is_none():
+    """One side missing → can't make the determination."""
+    from core_api.services.subject_preflight import _subjects_differ_with_certainty
+
+    assert (
+        _subjects_differ_with_certainty(None, "11111111-1111-1111-1111-111111111111")
+        is False
+    )
+
+
+def test_helper_returns_false_when_right_is_none():
+    from core_api.services.subject_preflight import _subjects_differ_with_certainty
+
+    assert (
+        _subjects_differ_with_certainty("11111111-1111-1111-1111-111111111111", None)
+        is False
+    )
+
+
+def test_helper_returns_false_when_both_none():
+    """Both missing (write-time, before any entity extraction) → don't
+    skip; fall through to the judge."""
+    from core_api.services.subject_preflight import _subjects_differ_with_certainty
+
+    assert _subjects_differ_with_certainty(None, None) is False
+
+
+def test_helper_accepts_uuid_objects_too():
+    """Callers might pass UUID instances rather than strings; the
+    helper compares by string form so both shapes work."""
+    from uuid import UUID
+
+    from core_api.services.subject_preflight import _subjects_differ_with_certainty
+
+    a = UUID("11111111-1111-1111-1111-111111111111")
+    b = UUID("22222222-2222-2222-2222-222222222222")
+    assert _subjects_differ_with_certainty(a, b) is True
+    assert _subjects_differ_with_certainty(a, a) is False
+    # Cross-shape: str + UUID with same value still match.
+    assert _subjects_differ_with_certainty(str(a), a) is False
+
+
+# ---------------------------------------------------------------------------
+# Dedup gate — CheckSemanticDuplicate skips judge when subjects differ.
+# ---------------------------------------------------------------------------
+
+
+def _build_ctx(*, subject_entity_id=None):
+    from unittest.mock import MagicMock
+
+    ctx = MagicMock()
+    ctx.tenant_config = MagicMock(semantic_dedup_enabled=True)
+    ctx.data = {
+        "input": MagicMock(
+            tenant_id="t1",
+            fleet_id="f1",
+            visibility="scope_team",
+            subject_entity_id=subject_entity_id,
+            content="new statement",
+        ),
+        "embedding": [0.1] * 10,
+        "memory_fields": {"metadata": {}},
+    }
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_dedup_skips_judge_when_subjects_differ():
+    """JUDGE-band candidate but distinct subject IDs → A1 #17 skips
+    the LLM call. Write is accepted; no 409."""
+    from unittest.mock import AsyncMock, patch
+
+    from core_api.pipeline.steps.write.check_semantic_duplicate import (
+        CheckSemanticDuplicate,
+    )
+
+    new_subject = "11111111-1111-1111-1111-111111111111"
+    cand_subject = "22222222-2222-2222-2222-222222222222"
+    ctx = _build_ctx(subject_entity_id=new_subject)
+    candidate = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "similarity": 0.91,
+        "content": "candidate statement",
+        "subject_entity_id": cand_subject,
+    }
+
+    judge = AsyncMock()
+    with (
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._find_semantic_duplicate",
+            new=AsyncMock(return_value=candidate),
+        ),
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._llm_dedup_check",
+            new=judge,
+        ),
+    ):
+        step = CheckSemanticDuplicate()
+        result = await step.execute(ctx)
+
+    assert result is None  # accepted
+    judge.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dedup_calls_judge_when_subjects_match():
+    """Same ``subject_entity_id`` → fall through to the existing
+    A1 #16 judge dispatch."""
+    from unittest.mock import AsyncMock, patch
+
+    from core_api.pipeline.steps.write.check_semantic_duplicate import (
+        CheckSemanticDuplicate,
+    )
+
+    same = "11111111-1111-1111-1111-111111111111"
+    ctx = _build_ctx(subject_entity_id=same)
+    candidate = {
+        "id": "00000000-0000-0000-0000-000000000002",
+        "similarity": 0.91,
+        "content": "candidate statement",
+        "subject_entity_id": same,
+    }
+
+    judge = AsyncMock(return_value=(False, 0.90))
+    with (
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._find_semantic_duplicate",
+            new=AsyncMock(return_value=candidate),
+        ),
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._llm_dedup_check",
+            new=judge,
+        ),
+    ):
+        step = CheckSemanticDuplicate()
+        await step.execute(ctx)
+
+    judge.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dedup_calls_judge_when_one_side_missing_subject():
+    """Either side NULL → can't make a deterministic call; fall
+    through to the judge. This is the common case at write-time
+    when entity extraction hasn't populated subject_entity_id yet."""
+    from unittest.mock import AsyncMock, patch
+
+    from core_api.pipeline.steps.write.check_semantic_duplicate import (
+        CheckSemanticDuplicate,
+    )
+
+    ctx = _build_ctx(subject_entity_id=None)  # new side has no subject
+    candidate = {
+        "id": "00000000-0000-0000-0000-000000000003",
+        "similarity": 0.91,
+        "content": "candidate statement",
+        "subject_entity_id": "11111111-1111-1111-1111-111111111111",
+    }
+
+    judge = AsyncMock(return_value=(False, 0.90))
+    with (
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._find_semantic_duplicate",
+            new=AsyncMock(return_value=candidate),
+        ),
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._llm_dedup_check",
+            new=judge,
+        ),
+    ):
+        step = CheckSemanticDuplicate()
+        await step.execute(ctx)
+
+    judge.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dedup_auto_band_still_rejects_regardless_of_subject():
+    """Subjects differ AND similarity ≥ AUTO (0.97): A1 #17's gate is
+    PRE-judge but auto-reject is an even-higher-confidence call (exact
+    or near-exact text). Don't override it — keep the 409.
+
+    Rationale: similarity ≥ 0.97 means the texts are near-identical at
+    the embedding level. If the entity extractor produced different
+    subject IDs for near-identical text, the extractor is more likely
+    wrong than the embedding. Don't second-guess the auto band."""
+    from unittest.mock import AsyncMock, patch
+
+    from fastapi import HTTPException
+
+    from core_api.pipeline.steps.write.check_semantic_duplicate import (
+        CheckSemanticDuplicate,
+    )
+
+    ctx = _build_ctx(subject_entity_id="11111111-1111-1111-1111-111111111111")
+    candidate = {
+        "id": "00000000-0000-0000-0000-000000000004",
+        "similarity": 0.98,  # auto band
+        "content": "near-identical content",
+        "subject_entity_id": "22222222-2222-2222-2222-222222222222",
+    }
+
+    judge = AsyncMock()
+    with (
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._find_semantic_duplicate",
+            new=AsyncMock(return_value=candidate),
+        ),
+        patch(
+            "core_api.pipeline.steps.write.check_semantic_duplicate._llm_dedup_check",
+            new=judge,
+        ),
+    ):
+        step = CheckSemanticDuplicate()
+        with pytest.raises(HTTPException) as ei:
+            await step.execute(ctx)
+
+    assert ei.value.status_code == 409
+    judge.assert_not_called()  # auto band → no LLM
+
+
+# ---------------------------------------------------------------------------
+# Path C gate — detect_contradictions_by_entities_async filters candidates
+# with distinct subject_entity_ids before the LLM batch.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_path_c_filters_candidates_with_distinct_subject():
+    """The entity-overlap query returns memories sharing a canonical
+    name like "priya"; A1 #17 filters out those whose subject_entity_id
+    differs from the new memory's BEFORE building the LLM batch.
+    Closes the Path C first-name-collision follow-up from the A4 #13
+    wet test."""
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    mid = uuid4()
+    new_subject = "11111111-1111-1111-1111-111111111111"
+    candidate_subject = "22222222-2222-2222-2222-222222222222"
+
+    new_memory = {
+        "id": str(mid),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "content": "Priya joined the Berlin office",
+        "subject_entity_id": new_subject,
+        "supersedes_id": None,
+        "deleted_at": None,
+        "status": "active",
+        "visibility": "scope_team",
+    }
+    distinct_subject_candidate = {
+        "id": str(uuid4()),
+        "content": "Priya left for Bangalore",
+        "subject_entity_id": candidate_subject,  # different Priya
+        "status": "active",
+        "created_at": "2026-05-20T10:00:00+00:00",
+    }
+
+    sc = AsyncMock()
+    sc.get_memory = AsyncMock(return_value=new_memory)
+    sc.find_entity_overlap_candidates = AsyncMock(
+        return_value=[distinct_subject_candidate]
+    )
+    sc.update_memory_status = AsyncMock()
+
+    judge = AsyncMock()
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            new=judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "core_api.services.contradiction_detector._attempt_path_c_retraction",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+
+    # Judge skipped because subjects differ.
+    judge.assert_not_called()
+    # No retraction / contradiction writes.
+    for c in sc.update_memory_status.call_args_list:
+        assert "conflicted" not in c.args, f"unexpected contradiction write: {c}"
+
+
+@pytest.mark.asyncio
+async def test_path_c_calls_judge_when_subjects_match():
+    """Candidate with matching ``subject_entity_id`` → the preflight
+    does not fire; LLM judge runs (existing A4 #13 behaviour)."""
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    mid = uuid4()
+    shared_subject = "11111111-1111-1111-1111-111111111111"
+
+    new_memory = {
+        "id": str(mid),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "content": "Yuki Tanaka is the CTO",
+        "subject_entity_id": shared_subject,
+        "supersedes_id": None,
+        "deleted_at": None,
+        "status": "active",
+        "visibility": "scope_team",
+    }
+    matching_subject_candidate = {
+        "id": str(uuid4()),
+        "content": "Yuki Tanaka left the company",
+        "subject_entity_id": shared_subject,  # same Yuki
+        "status": "active",
+        "created_at": "2026-05-20T10:00:00+00:00",
+    }
+
+    sc = AsyncMock()
+    sc.get_memory = AsyncMock(return_value=new_memory)
+    sc.find_entity_overlap_candidates = AsyncMock(
+        return_value=[matching_subject_candidate]
+    )
+    sc.update_memory_status = AsyncMock()
+
+    judge = AsyncMock(return_value=(False, 0.90))
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            new=judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "core_api.services.contradiction_detector._attempt_path_c_retraction",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+
+    judge.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_path_c_falls_through_when_new_memory_has_no_subject():
+    """``new_memory.subject_entity_id`` is NULL (e.g. enrichment didn't
+    set it) → preflight does NOT filter anything; LLM judge runs on
+    every candidate."""
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    mid = uuid4()
+    new_memory = {
+        "id": str(mid),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "content": "some statement",
+        "subject_entity_id": None,  # no subject → can't preflight
+        "supersedes_id": None,
+        "deleted_at": None,
+        "status": "active",
+        "visibility": "scope_team",
+    }
+    candidate = {
+        "id": str(uuid4()),
+        "content": "candidate statement",
+        "subject_entity_id": "11111111-1111-1111-1111-111111111111",
+        "status": "active",
+        "created_at": "2026-05-20T10:00:00+00:00",
+    }
+
+    sc = AsyncMock()
+    sc.get_memory = AsyncMock(return_value=new_memory)
+    sc.find_entity_overlap_candidates = AsyncMock(return_value=[candidate])
+    sc.update_memory_status = AsyncMock()
+
+    judge = AsyncMock(return_value=(False, 0.90))
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            new=judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "core_api.services.contradiction_detector._attempt_path_c_retraction",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+
+    judge.assert_called_once()


### PR DESCRIPTION
## Summary

Adds a deterministic gate that fires BEFORE the LLM judge in both ``CheckSemanticDuplicate`` (A1 #16 dedup) and Path C (A4 #13 contradiction). When the new memory and a candidate both have non-NULL ``subject_entity_id`` AND those IDs differ, they're definitionally about different subjects — no judge call needed.

Closes (partially) the [Path C first-name-collision follow-up](https://github.com/caura-ai/caura-memclaw/issues) surfaced by the A4 #13 wet test.

## New helper

``core_api.services.subject_preflight._subjects_differ_with_certainty(a, b) -> bool``
- Accepts ``str | UUID | None`` on both sides
- Returns True only when both non-None and differ by string form
- Conservative: any NULL on either side → False → fall through to judge

## Wiring

**Dedup** (``CheckSemanticDuplicate``):
- Preflight runs AFTER the auto-reject band but BEFORE the judge
- Auto-reject still fires regardless of subjects (near-identical embedding is a stronger signal than the extractor's subject assignment)

**Path C** (``detect_contradictions_by_entities_async``):
- Filters candidates returned by ``find_entity_overlap_candidates`` to drop those with distinct ``subject_entity_id`` BEFORE building the LLM judge batch

## Known limitation (surfaced by the wet test)

``subject_entity_id`` is populated by ``EmitMemoryTriple`` only when callers provide ``entity_links[role=subject]`` AND the content matches a narrow predicate regex (``lives_in``, ``located_in``, ...). Most agent writes hit neither → ``subject_entity_id`` is NULL on the stored row → preflight doesn't fire.

The gate is shipped and correct. Populating ``subject_entity_id`` during async entity extraction is a separate follow-up tracked in the memory system (``followup-populate-subject-entity-id-during-extraction``).

## Test plan

- [x] 13 new unit tests in ``tests/test_a1_17_subject_entity_preflight.py``: helper rubric (both-differ/both-same/one-None/both-None/UUID-shape) + dedup gate + Path C gate (filter / fall-through / new-memory-missing)
- [x] Full unit suite: **2254 passed** (+13), 0 regressions
- [x] Mypy parity: 19 pre-existing, zero new
- [x] Ruff lint + format clean
- [x] Wet-tested locally with 3 first-name-collision pairs: 2/3 pass. The 1 failure (Project Lighthouse) is because ``subject_entity_id`` is NULL on those rows — the gate has nothing to act on (known limitation, see above)

## A1 chain context

| PR | Title |
|---|---|
| #190 | A1 #15 — two-tier dedup constants |
| #192 | A1 #16 — judge-band dispatch in CheckSemanticDuplicate |
| this | A1 #17 — subject_entity_id preflight |
| next | A1 #18 — dashboard review queue |

## Follow-up tracked

- Populate ``subject_entity_id`` during async entity extraction so the A1 #17 gate has data to act on. Will close the Path C first-name-collision follow-up end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)