### PR TITLE
fix(search): query classifier recall on entity-token queries (A7)

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -128,7 +128,12 @@ MIN_SEARCH_SIMILARITY = 0.3
 FRESHNESS_DECAY_DAYS = 90
 FRESHNESS_FLOOR = 0.7
 ENTITY_BOOST_FACTOR = 1.3
-ENTITY_TOKEN_MIN_LENGTH = 3
+ENTITY_TOKEN_MIN_LENGTH = 2  # A7: was 3; lowered to retain 2-char acronym
+# entities (``AI`` / ``ML`` / ``PR`` / ``UI`` / ``QA`` / ``HR`` /
+# ``UK`` / ``US``…). 2-char English fillers (``in`` / ``on`` / ``to``
+# / ``be`` / ``is``…) are already in ENTITY_STOPWORDS so the noise
+# floor is unchanged; single-letter tokens still drop via the >=2
+# check.
 ENTITY_STOPWORDS: frozenset[str] = frozenset(
     {
         # ── Determiners / articles ──

--- a/core-api/src/core_api/services/entity_tokens.py
+++ b/core-api/src/core_api/services/entity_tokens.py
@@ -40,17 +40,35 @@ def _is_hex_id(s: str) -> bool:
     return len(s) >= _HEX_ID_MIN_LENGTH and bool(_HEX_ONLY_RE.fullmatch(s))
 
 
+# ASCII apostrophe + U+2019 smart-quote possessive. Smart-quote
+# built via chr() so the source file stays pure-ASCII (ruff RUF001
+# flags raw smart quotes as ambiguous prose).
+_POSSESSIVE_SUFFIXES = ("'s", chr(0x2019) + "s")
+
+
+def _strip_possessive(s: str) -> str:
+    """Strip trailing possessive ``'s`` (ASCII apostrophe or
+    smart-quote U+2019) so ``QA's`` becomes ``QA``. The tokenizer's
+    separator class deliberately keeps apostrophes internal (to avoid
+    splitting contractions into noise like ``don`` / ``won``), but
+    possessives carry no entity-FTS signal."""
+    for suffix in _POSSESSIVE_SUFFIXES:
+        if s.endswith(suffix) and len(s) > len(suffix):
+            return s[: -len(suffix)]
+    return s
+
+
 def extract_entity_tokens(query: str) -> list[str]:
     """Return entity-FTS-ready tokens from ``query``.
 
     Splits on whitespace and internal punctuation; drops short tokens,
-    stopwords, and hex-only IDs; lowercases each surviving token so
-    callers don't have to.
+    stopwords, and hex-only IDs; strips possessive ``'s``; lowercases
+    each surviving token so callers don't have to.
     """
     return [
         lower
         for t in _TOKEN_SEP_RE.split(query)
-        if (stripped := t.strip(string.punctuation))
+        if (stripped := _strip_possessive(t.strip(string.punctuation)))
         and len(stripped) >= ENTITY_TOKEN_MIN_LENGTH
         and (lower := stripped.lower()) not in ENTITY_STOPWORDS
         and not _is_hex_id(stripped)

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2168,12 +2168,34 @@ class PostgresService:
         tenant_id: str,
         fleet_ids: list[str] | None = None,
     ) -> list[UUID]:
-        """Full-text search against the entity tsvector index."""
+        """Full-text search against the entity tsvector index.
+
+        A7: ORs tokens (any-match) instead of ANDing (all-match). The
+        AND default (``plainto_tsquery('english', " ".join(tokens))``)
+        meant a query like ``Helios telescope`` AND'd → matched only
+        entities containing BOTH terms, hiding ``Helios Robotics``
+        from the entity-lookup short-circuit. Switching to OR matches
+        any token; downstream graph expansion + memory linking +
+        ``GRAPH_MAX_EXPANDED_ENTITIES`` cap are the precision filter.
+
+        Empty token list → empty result (defensive: prior behaviour
+        passed empty string to plainto_tsquery, which returned the
+        empty tsquery and matched zero rows; explicit guard is
+        clearer).
+        """
+        if not tokens:
+            return []
         async with get_session() as session:
-            ts_query = func.plainto_tsquery("english", " ".join(tokens))
+            # OR across tokens via one plainto_tsquery per token. Each
+            # term passes through PG's ``english`` config (stem +
+            # stopword), so we don't have to escape — plainto_tsquery
+            # is the safe variant. Empty / all-stopword tokens degrade
+            # to ``''::tsquery`` and contribute False to the OR, which
+            # is correct.
+            per_token = [Entity.search_vector.op("@@")(func.plainto_tsquery("english", t)) for t in tokens]
             stmt = select(Entity.id).where(
                 Entity.tenant_id == tenant_id,
-                Entity.search_vector.op("@@")(ts_query),
+                or_(*per_token),
             )
             if fleet_ids:
                 stmt = stmt.where(or_(Entity.fleet_id.in_(fleet_ids), Entity.fleet_id.is_(None)))

--- a/tests/test_a7_classifier_recall.py
+++ b/tests/test_a7_classifier_recall.py
@@ -1,0 +1,206 @@
+"""A7 — query classifier mis-routes entity-token queries.
+
+Gap measured: strategy accuracy 0.39, entity_lookup recall 0.20.
+Entity-shaped queries fall through to semantic search instead of
+the FTS/entity-lookup short-circuit. Two root causes addressed
+here:
+
+1. **Acronym entities are dropped before they reach FTS.** The
+   tokenizer's ``ENTITY_TOKEN_MIN_LENGTH = 3`` floor silently
+   discards ``AI``, ``ML``, ``PR``, ``UI``, ``QA``, ``HR``,
+   ``UK``, ``US`` — all common 2-char entity names in real
+   queries. Lowered to 2 (still floored by the stopword filter,
+   which catches noisy 2-char words like ``in`` / ``on`` /
+   ``to`` / ``be`` / ``is``).
+
+2. **Storage FTS ANDs tokens.** ``plainto_tsquery('english', "a b
+   c")`` becomes ``a & b & c`` — matches only entities containing
+   ALL terms. For a query like "Helios telescope status",
+   tokens ``[helios, telescope, status]`` (status is stopword;
+   leaves ``[helios, telescope]``) AND'd misses the entity
+   ``Helios Robotics`` (no telescope in name). Switching to OR
+   matches on any token; the downstream graph expansion + memory
+   linking + ``GRAPH_MAX_EXPANDED_ENTITIES`` cap are the natural
+   precision filter.
+
+Conservative trade-offs:
+- Lower min_length increases the candidate token set; the stopword
+  list catches most noise.
+- OR over-matches entities but the downstream linking step's bounded
+  fan-out keeps top-K stable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer — acronym retention and 2-char stopword coverage.
+# ---------------------------------------------------------------------------
+
+
+def test_two_char_acronyms_kept():
+    """Common 2-char acronym entities reach FTS."""
+    from core_api.services.entity_tokens import extract_entity_tokens
+
+    out = extract_entity_tokens("AI roadmap")
+    assert "ai" in out, out
+
+
+def test_two_char_acronym_ml_kept():
+    from core_api.services.entity_tokens import extract_entity_tokens
+
+    assert "ml" in extract_entity_tokens("ML pipeline ownership")
+
+
+def test_two_char_acronym_pr_kept():
+    from core_api.services.entity_tokens import extract_entity_tokens
+
+    assert "pr" in extract_entity_tokens("PR review queue")
+
+
+def test_two_char_country_codes_kept():
+    from core_api.services.entity_tokens import extract_entity_tokens
+
+    # ``UK`` is sometimes an entity (UK office, UK team, etc.)
+    out = extract_entity_tokens("UK office expansion")
+    assert "uk" in out
+
+
+def test_single_char_still_dropped():
+    """``X``, ``A`` etc. are below the new floor of 2 → still dropped.
+    Keeps the tokenizer from emitting single-letter noise."""
+    from core_api.services.entity_tokens import extract_entity_tokens
+
+    out = extract_entity_tokens("X reviewed the PR")
+    assert "x" not in out
+    assert "pr" in out  # acronym retention check
+
+
+def test_two_char_english_stopwords_still_dropped():
+    """Common 2-char English words remain in the stopword list and
+    are dropped even with the new min-length floor."""
+    from core_api.services.entity_tokens import extract_entity_tokens
+
+    # ``in`` ``on`` ``to`` ``be`` ``is`` ``no`` ``of`` ``by``
+    out = extract_entity_tokens("AI is in the news on TV today")
+    # Surviving tokens: ai, news, tv. All others stopwords.
+    assert out == ["ai", "news", "tv"], out
+
+
+def test_motivating_acronym_queries_now_yield_tokens():
+    """Real-world entity queries that previously emitted ZERO tokens
+    (because all surviving content was 2-char acronyms) now emit
+    actionable tokens for FTS. ``status`` is already in
+    ENTITY_STOPWORDS so it never reaches FTS; the point is ``ai``
+    and ``qa`` (the acronyms) do."""
+    from core_api.services.entity_tokens import extract_entity_tokens
+
+    assert extract_entity_tokens("Who owns AI?") == ["owns", "ai"]
+    # ``status`` is a stopword; possessive ``'s`` stripped → ``qa`` remains.
+    assert extract_entity_tokens("What is QA's status?") == ["qa"]
+
+
+# ---------------------------------------------------------------------------
+# Storage FTS — OR-match across tokens instead of AND.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_entity_fts_or_match_returns_partial_overlap(sc):
+    """Tokens A, B sent to FTS; entity containing only A is returned.
+    With the previous AND behaviour the entity would have been hidden.
+    """
+    from uuid import uuid4
+
+    tenant = f"test-tenant-a7-or-{uuid4().hex[:8]}"
+    # Entity with canonical_name containing only "helios" (no "telescope").
+    helios = await sc.create_entity(
+        {
+            "tenant_id": tenant,
+            "entity_type": "organization",
+            "canonical_name": "helios robotics",
+        }
+    )
+    # Tokens [helios, telescope] — old AND would miss; OR finds Helios.
+    result = await sc.fts_search_entities(
+        {
+            "tenant_id": tenant,
+            "tokens": ["helios", "telescope"],
+        }
+    )
+    assert helios["id"] in result, (
+        f"Expected helios entity {helios['id']} in OR-match result; got {result}"
+    )
+
+
+@pytest.mark.integration
+async def test_entity_fts_or_match_unions_per_token_matches(sc):
+    """Two entities, each matching only one token; OR returns both."""
+    from uuid import uuid4
+
+    tenant = f"test-tenant-a7-union-{uuid4().hex[:8]}"
+    e_alpha = await sc.create_entity(
+        {
+            "tenant_id": tenant,
+            "entity_type": "organization",
+            "canonical_name": "alpha corp",
+        }
+    )
+    e_beta = await sc.create_entity(
+        {
+            "tenant_id": tenant,
+            "entity_type": "organization",
+            "canonical_name": "beta inc",
+        }
+    )
+    result = await sc.fts_search_entities(
+        {
+            "tenant_id": tenant,
+            "tokens": ["alpha", "beta"],
+        }
+    )
+    assert e_alpha["id"] in result
+    assert e_beta["id"] in result
+
+
+@pytest.mark.integration
+async def test_entity_fts_single_token_unchanged_behavior(sc):
+    """Single-token queries still work — the AND→OR change is a no-op
+    when there's only one term."""
+    from uuid import uuid4
+
+    tenant = f"test-tenant-a7-single-{uuid4().hex[:8]}"
+    e = await sc.create_entity(
+        {
+            "tenant_id": tenant,
+            "entity_type": "organization",
+            "canonical_name": "vermillion seven",
+        }
+    )
+    result = await sc.fts_search_entities(
+        {
+            "tenant_id": tenant,
+            "tokens": ["vermillion"],
+        }
+    )
+    assert e["id"] in result
+
+
+@pytest.mark.integration
+async def test_entity_fts_empty_tokens_returns_empty(sc):
+    """Defensive: empty token list → empty result, not a 500."""
+    from uuid import uuid4
+
+    tenant = f"test-tenant-a7-empty-{uuid4().hex[:8]}"
+    result = await sc.fts_search_entities(
+        {
+            "tenant_id": tenant,
+            "tokens": [],
+        }
+    )
+    assert result == []

--- a/tests/test_p0_1_entity_matching.py
+++ b/tests/test_p0_1_entity_matching.py
@@ -13,6 +13,7 @@ from core_api.constants import ENTITY_STOPWORDS, ENTITY_TOKEN_MIN_LENGTH
 # Unit tests: stopword filtering
 # ---------------------------------------------------------------------------
 
+
 def _extract_tokens(query: str) -> list[str]:
     """Replicate the token extraction logic from search_memories."""
     return [
@@ -62,12 +63,16 @@ class TestStopwordFiltering:
 
     def test_short_tokens_removed(self):
         tokens = _extract_tokens("go to db on vm")
-        # All tokens <= 2 chars should be filtered by ENTITY_TOKEN_MIN_LENGTH
-        assert "go" not in tokens
-        assert "to" not in tokens
-        assert "on" not in tokens
-        assert "db" not in tokens
-        assert "vm" not in tokens
+        # A7 (2026-05-24): ENTITY_TOKEN_MIN_LENGTH lowered to 2 to
+        # retain acronym entities (``AI`` / ``ML`` / ``PR`` / ``DB`` /
+        # ``VM``…). 2-char English fillers stay filtered via
+        # ENTITY_STOPWORDS, not the length floor.
+        assert "go" not in tokens  # stopword
+        assert "to" not in tokens  # stopword
+        assert "on" not in tokens  # stopword
+        # ``db`` and ``vm`` are now retained (legitimate acronym entities).
+        assert "db" in tokens
+        assert "vm" in tokens
 
     def test_meaningful_tokens_preserved(self):
         tokens = _extract_tokens("kubernetes deployment failed for auth-service")
@@ -99,6 +104,7 @@ class TestStopwordFiltering:
 # Integration tests: PG FTS on entities table
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.integration
 class TestEntityFTSMatching:
     """Verify PostgreSQL full-text search on the entities table."""
@@ -106,14 +112,17 @@ class TestEntityFTSMatching:
     async def _create_entity(self, db, tenant_id, name, entity_type="concept"):
         from common.models.entity import Entity
         from sqlalchemy import select, text as sql_text
+
         # Return existing entity if it already exists (unique index)
-        existing = (await db.execute(
-            select(Entity).where(
-                Entity.tenant_id == tenant_id,
-                Entity.entity_type == entity_type,
-                Entity.canonical_name == name,
+        existing = (
+            await db.execute(
+                select(Entity).where(
+                    Entity.tenant_id == tenant_id,
+                    Entity.entity_type == entity_type,
+                    Entity.canonical_name == name,
+                )
             )
-        )).scalar_one_or_none()
+        ).scalar_one_or_none()
         if existing:
             return existing
         entity = Entity(
@@ -124,15 +133,19 @@ class TestEntityFTSMatching:
         db.add(entity)
         await db.flush()
         # Manually set search_vector (normally the trigger does this)
-        await db.execute(sql_text(
-            "UPDATE entities SET search_vector = to_tsvector('english', :name) WHERE id = :id"
-        ), {"name": name, "id": entity.id})
+        await db.execute(
+            sql_text(
+                "UPDATE entities SET search_vector = to_tsvector('english', :name) WHERE id = :id"
+            ),
+            {"name": name, "id": entity.id},
+        )
         await db.flush()
         return entity
 
     async def _match_entities(self, db, tenant_id, query_tokens):
         from sqlalchemy import func, select
         from common.models.entity import Entity
+
         entity_ts_query = func.plainto_tsquery("english", " ".join(query_tokens))
         stmt = select(Entity.id, Entity.canonical_name).where(
             Entity.tenant_id == tenant_id,


### PR DESCRIPTION
## Summary

Gap A7 measured **strategy accuracy 0.39 and entity_lookup recall 0.20** — 80% of entity-shaped queries fell through to semantic search instead of taking the entity-lookup short-circuit. Two root causes addressed:

## 1. Acronym entities dropped before reaching FTS

``ENTITY_TOKEN_MIN_LENGTH = 3`` silently discarded ``AI`` / ``ML`` / ``PR`` / ``UI`` / ``QA`` / ``HR`` / ``DB`` / ``VM`` / ``UK`` / ``US`` — common 2-char entity names. Lowered to **2**. The noise floor is unchanged: 2-char English fillers (``in``, ``on``, ``to``, ``be``, ``is``…) are already in ENTITY_STOPWORDS. Single-letter tokens still drop via the ``>=2`` check.

Also added **possessive ``'s`` stripping** so ``QA's status?`` → ``qa`` (not ``qa's``). Handles both ASCII apostrophe and smart-quote U+2019.

## 2. Entity FTS ANDed tokens instead of OR

``entity_fts_search`` used ``plainto_tsquery('english', " ".join(tokens))`` → joined terms with ``&``. For ``Helios telescope`` the query became ``helios & telescope``, missing ``Helios Robotics`` (no telescope in name). **Switched to OR**: one ``plainto_tsquery`` per token, OR'd in the WHERE clause. Each term still passes through PG's ``english`` config (stem + stopword), so no escaping needed.

Precision risk (OR matches more entities) is bounded by the downstream graph expansion + memory-link filter + ``GRAPH_MAX_EXPANDED_ENTITIES = 200`` cap.

## Test plan

- [x] 11 new tests in ``tests/test_a7_classifier_recall.py``:
  - Acronym retention (AI / ML / PR / UK)
  - Single-letter still dropped
  - 2-char stopwords still dropped
  - Possessive ``'s`` stripped
  - Storage OR-match: partial-overlap match, union of per-token matches, single-token unchanged, empty defensive guard
- [x] Existing P0-1 test ``test_short_tokens_removed`` updated to match new behaviour (``db`` and ``vm`` are now retained acronyms)
- [x] Full unit suite: **2297 passed**, 0 regressions
- [x] Ruff lint + format clean

## What this doesn't do

- Doesn't measure benchmark recall directly (no LongMemEval runner integrated in CI yet — D1 territory). User-visible effect will surface when the benchmark is re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)