### PR TITLE
fix(enrichment): action/episode few-shot disambiguation (A9)

### DIFF
--- a/common/enrichment/_prompts.py
+++ b/common/enrichment/_prompts.py
@@ -31,6 +31,16 @@ Analyze the following memory content and return a JSON object with these fields:
     + _TYPE_BULLETS
     + """
 
+   Action vs episode (common confusion):
+   - action — actor's own deed, first-person past tense (subject=agent).
+   - episode — observed event tied to time/place (subject=event,
+     often third-person).
+   Pairs:
+     "I deployed v2.3 to production"                 -> action
+     "The v2.3 deployment succeeded at 14:00"        -> episode
+     "Merged the auth refactor PR"                   -> action
+     "Production outage between 14:00 and 14:30"     -> episode
+
 2. "weight": float 0.0-1.0 indicating importance
    - 0.9-1.0: critical decisions, key facts with evidence, high-impact events
    - 0.7-0.8: solid facts, meaningful events, clear preferences

--- a/common/enrichment/constants.py
+++ b/common/enrichment/constants.py
@@ -61,7 +61,12 @@ MEMORY_TYPE_DESCRIPTIONS: dict[str, str] = {
         'Look for: "committed to", "promised", "guaranteed", '
         '"agreed to deliver", "pledged"'
     ),
-    "action": "concrete steps taken or being taken",
+    "action": (
+        "concrete step the actor (first-person / agent itself) took or is taking. "
+        'Past-tense first-person framing: "I deployed", "filed", "merged", '
+        '"sent". Distinct from "episode" (an observed event tied to time, '
+        "regardless of who performed it)."
+    ),
     "outcome": "results of actions, tasks, or plans",
     "cancellation": "explicit record that something was cancelled or abandoned",
     "rule": (

--- a/tests/test_a8_enrichment_tags.py
+++ b/tests/test_a8_enrichment_tags.py
@@ -86,10 +86,12 @@ def test_prompt_includes_a_tag_example():
 
 
 def test_prompt_word_count_remains_bounded():
-    """Adding the new tag guidance must not bust the existing 1100-word ceiling."""
+    """Adding tag guidance must not bust the prompt budget. Ceiling
+    raised to 1200 in A9 to cover the action/episode disambiguation
+    block + A8's tag guidance."""
     prompt = _get_prompt()
     word_count = len(prompt.split())
-    assert word_count < 1100, f"prompt is {word_count} words — too long"
+    assert word_count < 1200, f"prompt is {word_count} words — too long"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_a9_action_vs_episode.py
+++ b/tests/test_a9_action_vs_episode.py
@@ -1,0 +1,155 @@
+"""A9 — type classifier confuses ``action`` and ``episode``.
+
+Gap: 28 of ~95 misclassifications are ``action``-class; ``action``
+accounts for 30% of all type errors. Root cause: the enrichment
+prompt distinguishes neither dimension cleanly between
+
+  - **action** — the actor's own completed deed (past tense first-
+    person: "I deployed", "filed", "merged", "sent"). Subject is
+    typically the agent itself.
+
+  - **episode** — an observed event tied to time/place that the
+    actor witnessed or recorded (third-person: "the deployment
+    failed", "the meeting concluded", "outage between 14:00 and
+    14:30"). Subject is the event, not the agent.
+
+Fix: 2-3 contrastive few-shot pairs in the enrichment prompt + a
+sharpened type description so the LLM has explicit guidance on the
+dimension that disambiguates them. No schema change.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def _get_prompt() -> str:
+    from core_api.services.memory_enrichment import ENRICHMENT_PROMPT
+
+    return ENRICHMENT_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Prompt pins: action/episode disambiguation guidance is present.
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_mentions_action_vs_episode_distinction():
+    """The prompt must explicitly call out the contrast — not just
+    list both types with their generic descriptions."""
+    prompt = _get_prompt().lower()
+    # The disambiguation guidance lives in some "action vs episode"
+    # or "episode vs action" block. Accept either ordering.
+    has_disambiguation_block = (
+        "action vs episode" in prompt
+        or "episode vs action" in prompt
+        or "action versus episode" in prompt
+    )
+    assert has_disambiguation_block, (
+        "prompt must include an explicit action-vs-episode disambiguation block"
+    )
+
+
+def test_prompt_mentions_actor_or_first_person_for_action():
+    """Action's distinguishing feature is "the actor's own deed" —
+    prompt should mention first-person / actor / "I" / "my" framing
+    so the LLM can pick up the signal."""
+    prompt = _get_prompt().lower()
+    signals = [
+        "first-person",
+        "first person",
+        "actor's own",
+        "by the actor",
+        "i did",
+        '"i "',
+    ]
+    assert any(s in prompt for s in signals), (
+        f"prompt must signal first-person/actor framing for action; tried {signals}"
+    )
+
+
+def test_prompt_mentions_observed_or_witnessed_for_episode():
+    """Episode's distinguishing feature is an observed/witnessed
+    event tied to time — prompt should hint at it."""
+    prompt = _get_prompt().lower()
+    signals = [
+        "observed",
+        "witnessed",
+        "happened",
+        "occurred",
+        "third-person",
+        "third person",
+    ]
+    assert any(s in prompt for s in signals), (
+        f"prompt must signal observed/witnessed framing for episode; tried {signals}"
+    )
+
+
+def test_prompt_has_at_least_two_contrastive_examples():
+    """The gap specifies '2-3 contrastive few-shot pairs'. Check
+    that at least two example pairs (or equivalent) are present in
+    the action/episode block."""
+    prompt = _get_prompt()
+    # Heuristic: at least two arrows / colons annotating example→type
+    # in the disambiguation area. Look for phrases like ``→ action``,
+    # ``→ episode``, ``-> action``, etc.
+    import re
+
+    arrow_action = re.findall(r"(?:→|->)\s*action\b", prompt)
+    arrow_episode = re.findall(r"(?:→|->)\s*episode\b", prompt)
+    assert len(arrow_action) >= 2, f"need ≥2 action examples; got {len(arrow_action)}"
+    assert len(arrow_episode) >= 2, (
+        f"need ≥2 episode examples; got {len(arrow_episode)}"
+    )
+
+
+def test_prompt_examples_are_realistic_business_content():
+    """The examples should be the shapes that misclassify in real
+    traffic — deployments, meetings, code merges, filed reports —
+    not abstract placeholders like ``X did Y``."""
+    prompt = _get_prompt().lower()
+    realistic_terms = ["deploy", "meeting", "merge", "ship", "filed", "review"]
+    matched = [t for t in realistic_terms if t in prompt]
+    assert len(matched) >= 2, (
+        f"examples should use realistic terms; only matched {matched}"
+    )
+
+
+def test_prompt_word_count_still_bounded():
+    """A9 adds few-shot pairs (raises ceiling from 1100 → 1200 to
+    cover A8's tag guidance + A9's action/episode pairs). Keeps cost
+    bounded while permitting the new high-signal content."""
+    prompt = _get_prompt()
+    word_count = len(prompt.split())
+    assert word_count < 1200, f"prompt is {word_count} words — too long"
+
+
+# ---------------------------------------------------------------------------
+# MEMORY_TYPE_DESCRIPTIONS — action/episode descriptions sharpened so
+# the per-type bullet list rendered into the prompt carries the
+# disambiguation signal too.
+# ---------------------------------------------------------------------------
+
+
+def test_action_description_mentions_actor():
+    from common.enrichment.constants import MEMORY_TYPE_DESCRIPTIONS
+
+    desc = MEMORY_TYPE_DESCRIPTIONS["action"].lower()
+    # Must hint at "the actor did X" framing — not just "concrete steps".
+    assert "actor" in desc or "first-person" in desc or "first person" in desc, (
+        f"action description should signal actor framing; got: {desc!r}"
+    )
+
+
+def test_episode_description_mentions_observed_or_event():
+    from common.enrichment.constants import MEMORY_TYPE_DESCRIPTIONS
+
+    desc = MEMORY_TYPE_DESCRIPTIONS["episode"].lower()
+    # Original already says "events that happened" — keep that;
+    # confirm it stays event/observed-framed.
+    assert "event" in desc or "observed" in desc, (
+        f"episode description should signal observed/event framing; got: {desc!r}"
+    )

--- a/tests/test_enrichment_prompt.py
+++ b/tests/test_enrichment_prompt.py
@@ -13,12 +13,14 @@ import pytest
 # Unit tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestEnrichmentPromptSignalPhrases:
     """Verify signal phrases are present in the enrichment prompt."""
 
     def _get_prompt(self) -> str:
         from core_api.services.memory_enrichment import ENRICHMENT_PROMPT
+
         return ENRICHMENT_PROMPT
 
     def test_decision_has_signal_phrases(self):
@@ -41,12 +43,15 @@ class TestEnrichmentPromptSignalPhrases:
     def test_prompt_token_count_reasonable(self):
         """Prompt ceiling — keeps cost bounded while leaving room for small additions.
 
-        Baseline grew with retrieval_hint, atomic_facts, and the temporal
-        ts_valid_end guidance; 1100 gives ~15% headroom over today's ~942.
+        Baseline grew with retrieval_hint, atomic_facts, the temporal
+        ts_valid_end guidance, A8's tag-format guidance, and A9's
+        action/episode disambiguation pairs. Raised to 1200 (2026-05-24).
         """
         prompt = self._get_prompt()
         word_count = len(prompt.split())
-        assert word_count < 1100, f"Prompt is {word_count} words — too long, will increase cost"
+        assert word_count < 1200, (
+            f"Prompt is {word_count} words — too long, will increase cost"
+        )
 
     def test_prompt_structure_unchanged(self):
         """JSON template should still be present and valid."""
@@ -71,10 +76,12 @@ class TestEnrichmentPromptVocabularySync:
 
     def _get_prompt(self) -> str:
         from core_api.services.memory_enrichment import ENRICHMENT_PROMPT
+
         return ENRICHMENT_PROMPT
 
     def test_every_memory_type_appears_quoted_in_inline_list(self):
         from common.enrichment.constants import MEMORY_TYPES
+
         prompt = self._get_prompt()
         for t in MEMORY_TYPES:
             assert f'"{t}"' in prompt, (
@@ -84,6 +91,7 @@ class TestEnrichmentPromptVocabularySync:
 
     def test_every_memory_type_has_a_bullet(self):
         from common.enrichment.constants import MEMORY_TYPE_DESCRIPTIONS
+
         prompt = self._get_prompt()
         for name, desc in MEMORY_TYPE_DESCRIPTIONS.items():
             assert f"   - {name}: " in prompt, f"{name!r} bullet missing from prompt"
@@ -97,6 +105,7 @@ class TestEnrichmentPromptVocabularySync:
         import re
         from common.enrichment.constants import MEMORY_TYPES
         from core_api.constants import MEMORY_TYPES_PATTERN
+
         for t in MEMORY_TYPES:
             assert re.match(MEMORY_TYPES_PATTERN, t), (
                 f"{t!r} not accepted by MEMORY_TYPES_PATTERN — pattern drifted"
@@ -109,51 +118,79 @@ class TestHeuristicRegressions:
 
     def test_decision_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
+
         assert _fake_enrich("We decided to use PostgreSQL").memory_type == "decision"
         assert _fake_enrich("Team chose Redis for caching").memory_type == "decision"
         assert _fake_enrich("Management approved the budget").memory_type == "decision"
 
     def test_preference_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
+
         assert _fake_enrich("The team prefers dark mode").memory_type == "preference"
 
     def test_episode_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
+
         assert _fake_enrich("We deployed v2.3 to production").memory_type == "episode"
 
     def test_task_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
+
         assert _fake_enrich("Need to review the PR by Friday").memory_type == "task"
 
     def test_commitment_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
-        assert _fake_enrich("We committed to delivering by Q2").memory_type == "commitment"
+
+        assert (
+            _fake_enrich("We committed to delivering by Q2").memory_type == "commitment"
+        )
 
     def test_rule_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
-        assert _fake_enrich("Always notify security before deploying").memory_type == "rule"
+
+        assert (
+            _fake_enrich("Always notify security before deploying").memory_type
+            == "rule"
+        )
         assert _fake_enrich("Never store PII in Redis").memory_type == "rule"
 
     def test_cancellation_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
-        assert _fake_enrich("The project was cancelled last week").memory_type == "cancellation"
+
+        assert (
+            _fake_enrich("The project was cancelled last week").memory_type
+            == "cancellation"
+        )
 
     def test_outcome_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
-        assert _fake_enrich("The migration achieved 99.9% uptime").memory_type == "outcome"
+
+        assert (
+            _fake_enrich("The migration achieved 99.9% uptime").memory_type == "outcome"
+        )
 
     def test_fact_default(self):
         from core_api.services.memory_enrichment import _fake_enrich
+
         assert _fake_enrich("The server runs on port 8080").memory_type == "fact"
 
     def test_plan_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
+
         assert _fake_enrich("The roadmap includes three phases").memory_type == "plan"
 
     def test_intention_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
-        assert _fake_enrich("We intend to migrate to AWS next quarter").memory_type == "intention"
+
+        assert (
+            _fake_enrich("We intend to migrate to AWS next quarter").memory_type
+            == "intention"
+        )
 
     def test_action_classification(self):
         from core_api.services.memory_enrichment import _fake_enrich
-        assert _fake_enrich("I executed the database backup script").memory_type == "action"
+
+        assert (
+            _fake_enrich("I executed the database backup script").memory_type
+            == "action"
+        )


### PR DESCRIPTION
## Summary

Gap A9 measured **28 of ~95 misclassifications as ``action``-class** — ``action`` accounted for 30% of all type errors. Root cause: the enrichment prompt's per-type descriptions don't disambiguate ``action`` (actor's own deed, first-person past tense) from ``episode`` (observed event tied to time/place, often third-person).

## Fix

Two pieces:

**1. ``ENRICHMENT_PROMPT`` — disambiguation block + 2 contrastive few-shot pairs**

```
   Action vs episode (common confusion):
   - action — actor's own deed, first-person past tense (subject=agent).
   - episode — observed event tied to time/place (subject=event,
     often third-person).
   Pairs:
     "I deployed v2.3 to production"                 -> action
     "The v2.3 deployment succeeded at 14:00"        -> episode
     "Merged the auth refactor PR"                   -> action
     "Production outage between 14:00 and 14:30"     -> episode
```

**2. ``MEMORY_TYPE_DESCRIPTIONS["action"]`` sharpened** — adds explicit ``"actor / first-person past tense"`` framing alongside the original ``"concrete steps taken"``.

## Prompt budget

Per-prompt word budget raised **1100 → 1200** across all enrichment-prompt tests (covers A8's tag guidance + A9's pairs).

## Test plan

- [x] 8 new unit tests: disambiguation block present; first-person signal for action; observed/event signal for episode; ≥2 example pairs per direction; realistic business content; word budget; action description mentions actor; episode description still mentions event
- [x] Full unit suite: **2320 passed** (+8), 0 regressions
- [x] Ruff lint + format clean

## What this doesn't do

Doesn't measure benchmark misclassification rate directly (D1 territory). Effect will surface when the benchmark is re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)