### PR TITLE
feat(evolve): surface rule-synthesis skip reason on every path (A10)

### DIFF
--- a/core-api/src/core_api/services/evolve_service.py
+++ b/core-api/src/core_api/services/evolve_service.py
@@ -30,6 +30,39 @@ from core_api.utils.sanitize import sanitize_content as _sanitize_content
 logger = logging.getLogger(__name__)
 
 
+# A10 — slugs identifying every silent-exit path on the rule synthesis
+# flow. Callers (the harness, the dashboard, an operator inspecting
+# ``report_outcome`` results) read these from the response's
+# ``rule_skipped_reason`` field instead of grep'ing log strings, so
+# downstream tooling can pattern-match without parsing prose.
+RULE_SKIP_REASONS: tuple[str, ...] = (
+    "not_failure_or_partial",  # success outcomes don't generate rules
+    "no_related_ids",  # failure/partial but no memories supplied
+    "no_memories_fetched",  # every storage fetch failed
+    "llm_failed",  # provider raised or returned non-dict
+    "below_confidence_threshold",  # rule generated but conf < threshold
+    "persist_failed",  # _persist_rule returned None
+)
+
+
+def _log_rule_skip(reason: str, tenant_id: str, outcome_type: str, **extra) -> None:
+    """Always-fire log line for an evolve rule-synthesis skip.
+
+    Mirrors the ``path_a_completed`` / ``path_c_completed`` pattern in
+    ``contradiction_detector.py`` (Gap 06): the reason slug lives in
+    the message string itself so a plain
+    ``grep evolve_rule_skipped <reason>`` works regardless of the
+    structlog renderer's ``extra={}`` handling."""
+    extras = " ".join(f"{k}={v}" for k, v in extra.items() if v is not None)
+    logger.info(
+        "evolve_rule_skipped reason=%s tenant_id=%s outcome_type=%s %s",
+        reason,
+        tenant_id,
+        outcome_type,
+        extras,
+    )
+
+
 # -- Delta map ----------------------------------------------------------------
 
 _DELTA_MAP = {
@@ -332,10 +365,17 @@ async def _generate_rule(
     related_ids: list[str],
     agent_id: str,
     fleet_id: str | None,
-) -> dict | None:
+) -> tuple[str | None, dict | None]:
     """Ask LLM to generate a preventive rule from a failure/partial outcome.
 
-    Returns dict with {condition, action, confidence, reasoning} or None on failure.
+    Returns ``(skip_reason, rule)``:
+      - ``(None, {...})`` on success
+      - ``(<RULE_SKIP_REASONS slug>, None)`` on any silent-exit path
+
+    A10 widened the return from ``dict | None`` to the tuple so callers
+    (``report_outcome``) can propagate the specific reason out to the
+    response + structured log instead of conflating "no candidates",
+    "LLM blew up", and "fetched zero memories" into a single None.
     """
     from core_api.clients.storage_client import get_storage_client
     from core_api.providers._retry import call_with_fallback
@@ -370,7 +410,7 @@ async def _generate_rule(
         memories_text_lines.append(f"- (id:{mid_str}) [{mtype}] {title}: {content} [weight: {weight:.2f}]")
 
     if not memories_text_lines:
-        return None
+        return ("no_memories_fetched", None)
 
     memories_text = "\n".join(memories_text_lines)
     # Escape user-controlled braces before .format() — both outcome (agent input)
@@ -400,10 +440,10 @@ async def _generate_rule(
         )
     except Exception:
         logger.exception("evolve: rule generation failed")
-        return None
+        return ("llm_failed", None)
 
     if not isinstance(raw, dict):
-        return None
+        return ("llm_failed", None)
 
     # LLMs occasionally return confidence as None, a string like "high", or
     # omit it entirely. Coerce defensively to avoid TypeError/ValueError
@@ -413,12 +453,15 @@ async def _generate_rule(
     except (TypeError, ValueError):
         confidence = 0.0
 
-    return {
-        "condition": str(raw.get("condition", ""))[:500],
-        "action": str(raw.get("action", ""))[:500],
-        "confidence": confidence,
-        "reasoning": str(raw.get("reasoning", ""))[:500],
-    }
+    return (
+        None,
+        {
+            "condition": str(raw.get("condition", ""))[:500],
+            "action": str(raw.get("action", ""))[:500],
+            "confidence": confidence,
+            "reasoning": str(raw.get("reasoning", ""))[:500],
+        },
+    )
 
 
 # -- Persist ------------------------------------------------------------------
@@ -629,9 +672,20 @@ async def report_outcome(
     # doing it first means Phase 2's row locks are held for DB round-trips only,
     # never across HTTP/LLM I/O. The rule prompt only needs memory content for
     # context — it has no dependency on the updated weights.
-    rule_result = None
-    if outcome_type in ("failure", "partial") and related_ids:
-        rule_result = await _generate_rule(
+    #
+    # A10 — track the specific skip reason through every silent-exit
+    # branch so the response carries it back to the caller (and a
+    # structured log line lets operators bisect by reason).
+    rule_result: dict | None = None
+    rule_skipped_reason: str | None = None
+    if outcome_type not in ("failure", "partial"):
+        rule_skipped_reason = "not_failure_or_partial"
+        _log_rule_skip(rule_skipped_reason, tenant_id, outcome_type)
+    elif not related_ids:
+        rule_skipped_reason = "no_related_ids"
+        _log_rule_skip(rule_skipped_reason, tenant_id, outcome_type)
+    else:
+        gen_reason, rule_result = await _generate_rule(
             db,
             tenant_id,
             outcome,
@@ -640,6 +694,9 @@ async def report_outcome(
             agent_id,
             fleet_id,
         )
+        if gen_reason is not None:
+            rule_skipped_reason = gen_reason
+            _log_rule_skip(rule_skipped_reason, tenant_id, outcome_type)
 
     # Phase 2: Adjust weights atomically. Row locks are acquired and released
     # entirely within this block — no long-running work runs while locks are held.
@@ -653,8 +710,22 @@ async def report_outcome(
     # Phase 3: Persist rule memory if confidence meets threshold. outcome_id
     # is not known yet; it is backfilled in Phase 5 after the outcome exists.
     rule_memory_id: str | None = None
-    if rule_result and rule_result.get("confidence", 0) >= EVOLVE_RULE_CONFIDENCE_THRESHOLD:
-        rule_memory_id = await _persist_rule(db, tenant_id, agent_id, fleet_id, rule_result, scope=scope)
+    if rule_result is not None:
+        confidence = rule_result.get("confidence", 0)
+        if confidence < EVOLVE_RULE_CONFIDENCE_THRESHOLD:
+            rule_skipped_reason = "below_confidence_threshold"
+            _log_rule_skip(
+                rule_skipped_reason,
+                tenant_id,
+                outcome_type,
+                confidence=confidence,
+                threshold=EVOLVE_RULE_CONFIDENCE_THRESHOLD,
+            )
+        else:
+            rule_memory_id = await _persist_rule(db, tenant_id, agent_id, fleet_id, rule_result, scope=scope)
+            if rule_memory_id is None:
+                rule_skipped_reason = "persist_failed"
+                _log_rule_skip(rule_skipped_reason, tenant_id, outcome_type)
 
     # Phase 4: Persist outcome memory — records rule_memory_id and the IDs
     # that actually got their weights updated.
@@ -727,6 +798,11 @@ async def report_outcome(
         ]
         if rule_memory_id and rule_result
         else [],
+        # A10 — see ``RULE_SKIP_REASONS`` for the slug taxonomy. None
+        # means a rule was generated; a slug names the silent-exit
+        # path that fired. Mirrors the always-fire log line emitted
+        # alongside.
+        "rule_skipped_reason": rule_skipped_reason,
         "out_of_scope_count": out_of_scope_count,
         "evolve_ms": int((time.perf_counter() - t0) * 1000),
     }

--- a/tests/test_a10_evolve_rule_skipped_reason.py
+++ b/tests/test_a10_evolve_rule_skipped_reason.py
@@ -1,0 +1,251 @@
+"""A10 — rule synthesis silent-skip observability.
+
+Gap measured: ``rules_synthesized = 0`` end-to-end. The harness
+instrument was fixed, but ``evolve_service`` has five silent-exit
+paths where rule synthesis short-circuits without saying why:
+
+  1. ``outcome_type != failure|partial`` OR ``not related_ids``
+  2. all related memories failed to fetch
+  3. LLM returned a non-dict response
+  4. LLM raised
+  5. confidence below ``EVOLVE_RULE_CONFIDENCE_THRESHOLD``
+  6. ``_persist_rule`` raised
+
+Each path silently returns ``rules_generated=[]`` with no signal for
+operators. A10 makes every skip path:
+
+  - **Log a structured line** of the form
+    ``evolve_rule_skipped reason=<slug> tenant_id=<tid> outcome_id=<oid>``
+    (matches the Gap-06 always-fire completion-log pattern from
+    contradiction_detector).
+  - **Populate a new ``rule_skipped_reason`` field** on the
+    ``report_outcome`` response so callers / the harness can read the
+    skip cause without parsing logs.
+
+The actual rule-generation logic is unchanged — this PR is pure
+observability. Once visible, the root cause of zero rules in any
+given run can be localised in seconds (currently requires bisecting
+the worker path).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Constants — the exact reason slugs that callers may pattern-match on.
+# ---------------------------------------------------------------------------
+
+
+def test_rule_skip_reason_constants_defined():
+    """A central enum of skip reasons so callers can pattern-match
+    instead of grep'ing log strings."""
+    from core_api.services.evolve_service import RULE_SKIP_REASONS
+
+    # All six known silent-exit paths plus None-for-success.
+    for slug in (
+        "not_failure_or_partial",
+        "no_related_ids",
+        "no_memories_fetched",
+        "llm_failed",
+        "below_confidence_threshold",
+        "persist_failed",
+    ):
+        assert slug in RULE_SKIP_REASONS
+
+
+# ---------------------------------------------------------------------------
+# Service contract — ``report_outcome`` returns rule_skipped_reason.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_response_includes_rule_skipped_reason_field():
+    """Every call to ``report_outcome`` returns a ``rule_skipped_reason``
+    key. None means "rule was generated"; a slug means "skipped because"."""
+    from core_api.services.evolve_service import report_outcome
+
+    db = AsyncMock()
+    with (
+        patch(
+            "core_api.services.evolve_service._adjust_weights",
+            new=AsyncMock(return_value=([], [])),
+        ),
+        patch(
+            "core_api.services.evolve_service._persist_outcome",
+            new=AsyncMock(return_value="00000000-0000-0000-0000-000000000001"),
+        ),
+    ):
+        result = await report_outcome(
+            db,
+            tenant_id="t1",
+            outcome="passing test",
+            outcome_type="success",  # success → not_failure_or_partial
+            related_ids=None,
+            agent_id="a1",
+        )
+
+    assert "rule_skipped_reason" in result
+
+
+# ---------------------------------------------------------------------------
+# Per-path reason coverage.
+# ---------------------------------------------------------------------------
+
+
+async def _run(outcome_type, related_ids=None, **patches):
+    """Invoke ``report_outcome`` with sensible-default mocks; allow tests
+    to override any internal via ``patches``."""
+    from core_api.services.evolve_service import report_outcome
+
+    db = AsyncMock()
+    base_patches = {
+        "_filter_by_scope": AsyncMock(return_value=(related_ids or [], 0)),
+        "_adjust_weights": AsyncMock(return_value=([], [])),
+        "_persist_outcome": AsyncMock(
+            return_value="00000000-0000-0000-0000-000000000001"
+        ),
+    }
+    base_patches.update(patches)
+    cm = []
+    for name, mock in base_patches.items():
+        cm.append(patch(f"core_api.services.evolve_service.{name}", new=mock))
+    with patch.multiple(
+        "core_api.services.evolve_service",
+        **{k: v for k, v in base_patches.items()},
+    ):
+        return await report_outcome(
+            db,
+            tenant_id="t1",
+            outcome="report",
+            outcome_type=outcome_type,
+            related_ids=related_ids,
+            agent_id="a1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_skip_reason_not_failure_or_partial_on_success():
+    """``success`` outcomes never generate rules. Report the reason
+    explicitly so a curious operator can confirm it's by design."""
+    result = await _run("success")
+    assert result["rule_skipped_reason"] == "not_failure_or_partial"
+    assert result["rules_generated"] == []
+
+
+@pytest.mark.asyncio
+async def test_skip_reason_no_related_ids_on_failure_without_ids():
+    """``failure`` with empty ``related_ids`` — gate at evolve_service:633."""
+    result = await _run("failure", related_ids=None)
+    assert result["rule_skipped_reason"] == "no_related_ids"
+
+
+@pytest.mark.asyncio
+async def test_skip_reason_no_related_ids_on_partial_without_ids():
+    result = await _run("partial", related_ids=None)
+    assert result["rule_skipped_reason"] == "no_related_ids"
+
+
+@pytest.mark.asyncio
+async def test_skip_reason_no_memories_fetched_when_all_fetch_fail():
+    """All ``sc.get_memory_for_tenant`` calls failed → ``_generate_rule``
+    returns ``None`` with reason."""
+    result = await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000aaa"],
+        _generate_rule=AsyncMock(return_value=("no_memories_fetched", None)),
+    )
+    assert result["rule_skipped_reason"] == "no_memories_fetched"
+    assert result["rules_generated"] == []
+
+
+@pytest.mark.asyncio
+async def test_skip_reason_llm_failed_on_non_dict_response():
+    result = await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000aaa"],
+        _generate_rule=AsyncMock(return_value=("llm_failed", None)),
+    )
+    assert result["rule_skipped_reason"] == "llm_failed"
+
+
+@pytest.mark.asyncio
+async def test_skip_reason_below_confidence_threshold():
+    """Judge returned valid rule but ``confidence < 0.5``. Currently
+    silently drops; A10 surfaces it."""
+    rule_low_conf = {
+        "condition": "if X",
+        "action": "do Y",
+        "confidence": 0.3,
+        "reasoning": "...",
+    }
+    result = await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000aaa"],
+        _generate_rule=AsyncMock(return_value=(None, rule_low_conf)),
+    )
+    assert result["rule_skipped_reason"] == "below_confidence_threshold"
+
+
+@pytest.mark.asyncio
+async def test_skip_reason_persist_failed_when_persist_returns_none():
+    rule_ok = {
+        "condition": "if X",
+        "action": "do Y",
+        "confidence": 0.9,
+        "reasoning": "...",
+    }
+    result = await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000aaa"],
+        _generate_rule=AsyncMock(return_value=(None, rule_ok)),
+        _persist_rule=AsyncMock(return_value=None),
+    )
+    assert result["rule_skipped_reason"] == "persist_failed"
+
+
+@pytest.mark.asyncio
+async def test_skip_reason_none_on_successful_rule_generation():
+    """Happy path: rule generated, persisted. ``rule_skipped_reason`` is
+    None and ``rules_generated`` has one entry."""
+    rule_ok = {
+        "condition": "if X",
+        "action": "do Y",
+        "confidence": 0.9,
+        "reasoning": "...",
+    }
+    result = await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000aaa"],
+        _generate_rule=AsyncMock(return_value=(None, rule_ok)),
+        _persist_rule=AsyncMock(return_value="00000000-0000-0000-0000-000000000bbb"),
+    )
+    assert result["rule_skipped_reason"] is None
+    assert len(result["rules_generated"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Structured log assertions — operators can grep ``evolve_rule_skipped``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_structured_log_emitted_on_skip(caplog):
+    """A skip emits one ``evolve_rule_skipped`` log line carrying the
+    reason slug + tenant_id. Mirrors the ``path_a_completed`` /
+    ``path_c_completed`` always-fire log pattern."""
+    import logging
+
+    caplog.set_level(logging.INFO, logger="core_api.services.evolve_service")
+    await _run("success")  # not_failure_or_partial
+    matching = [r for r in caplog.records if "evolve_rule_skipped" in r.message]
+    assert len(matching) == 1, (
+        f"expected one skip log; got {[r.message for r in caplog.records]}"
+    )
+    assert "not_failure_or_partial" in matching[0].message

--- a/tests/test_evolve_service.py
+++ b/tests/test_evolve_service.py
@@ -445,7 +445,8 @@ async def test_evolve_generate_rule_returns_valid_structure(db, sc):
 
     from core_api.services.evolve_service import _generate_rule
 
-    rule = await _generate_rule(
+    # A10: _generate_rule now returns (skip_reason, rule_dict) tuple.
+    reason, rule = await _generate_rule(
         db,
         tenant_id=tenant_id,
         outcome=f"Failed because of bad info [{tag}]",
@@ -456,6 +457,7 @@ async def test_evolve_generate_rule_returns_valid_structure(db, sc):
     )
 
     # FakeLLMProvider.complete_json returns {} — _generate_rule sanitizes to valid structure
+    assert reason is None, f"unexpected skip reason: {reason}"
     assert rule is not None
     assert "condition" in rule
     assert "action" in rule


### PR DESCRIPTION
## Summary

Gap A10 measured ``rules_synthesized = 0`` end-to-end. The harness instrument bug was fixed, but ``evolve_service`` has **six silent-exit paths** where rule synthesis short-circuits without saying why:

| # | Path | Site |
|---|---|---|
| 1 | ``outcome_type != failure\|partial`` | gate |
| 2 | ``not related_ids`` | gate |
| 3 | all related memories failed to fetch | inside ``_generate_rule`` |
| 4 | LLM returned non-dict (or raised) | inside ``_generate_rule`` |
| 5 | confidence below threshold | after ``_generate_rule`` |
| 6 | ``_persist_rule`` returned None | after persist |

Each silently returned ``rules_generated=[]`` with no signal.

## Fix (pure observability — no logic change)

- New module-level ``RULE_SKIP_REASONS`` tuple — canonical slug taxonomy
- ``_generate_rule`` return type widened: ``dict | None`` → ``(skip_reason: str | None, rule_dict: dict | None)``
- ``_log_rule_skip(reason, tenant_id, outcome_type, **extra)`` helper emits ``evolve_rule_skipped reason=<slug>`` log lines (mirrors the Gap-06 always-fire pattern in contradiction_detector)
- ``report_outcome`` response gains ``rule_skipped_reason`` — ``None`` when a rule was generated; a slug from ``RULE_SKIP_REASONS`` otherwise

Callers / the harness / dashboards can now introspect why rule synthesis was skipped without parsing logs.

## Test plan

- [x] 11 new unit tests: enum slugs defined; response field present; each of six skip paths sets the correct slug; success-path leaves it None; structured log line emitted with reason in message
- [x] ``tests/test_evolve_service.py::test_evolve_generate_rule_returns_valid_structure`` updated to unpack the new tuple shape
- [x] Full unit suite: **2331 passed** (+11), 0 regressions
- [x] Ruff lint + format clean

## What this doesn't do

Doesn't change rule synthesis logic or the confidence threshold. Once the harness re-runs and the skip reason surfaces, the root cause (e.g. "every run hits ``below_confidence_threshold``" vs "every run hits ``no_related_ids``") can be acted on in a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)