### PR TITLE
feat(core-api): per-phase write-latency instrumentation (CAURA-682 Phase 1)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/parallel_embed_enrich.py
+++ b/core-api/src/core_api/pipeline/steps/write/parallel_embed_enrich.py
@@ -38,6 +38,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
+from collections.abc import Awaitable
+from typing import Any
 
 from fastapi import HTTPException
 
@@ -47,6 +50,22 @@ from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
 
 logger = logging.getLogger(__name__)
+
+
+async def _timed(awaitable: Awaitable[Any], timings: dict, key: str) -> Any:
+    """Await ``awaitable`` and record its wall-clock duration into ``timings[key]``.
+
+    Used to separate embed and enrich latencies even though ``asyncio.gather``
+    runs them concurrently — without this, a slow LLM enrichment masks the
+    embedding's own latency in the gather wall-clock. The pre-/post-await
+    `perf_counter` samples each task's own time, so values are additive but
+    not exclusive (they overlap when gather runs both).
+    """
+    t0 = time.perf_counter()
+    try:
+        return await awaitable
+    finally:
+        timings[key] = round((time.perf_counter() - t0) * 1000)
 
 
 class ParallelEmbedEnrich:
@@ -60,6 +79,10 @@ class ParallelEmbedEnrich:
         cached_embedding = ctx.data.get("cached_embedding")
         ch = ctx.data.get("content_hash")
         resolved_write_mode = ctx.data.get("resolved_write_mode")
+        # CAURA-682 Phase 1: per-phase latency capture. The summary emit
+        # lives in ``_create_memory_pipeline`` after pipeline.run; each
+        # phase deposits its duration here.
+        timings: dict = ctx.data.setdefault("phase_timings", {})
 
         # write_mode-aware deferral. See the module docstring for the
         # contracts each mode enforces. A cached embedding is a hit on
@@ -86,9 +109,14 @@ class ParallelEmbedEnrich:
             async def _return_cached():
                 return cached_embedding
 
-            embedding_task = _return_cached()
+            # ``_timed`` records a sub-millisecond duration around the
+            # trivial cache-return coroutine — that satisfies the
+            # "key present = ran inline (≈0 ms = cached)" contract for
+            # downstream log readers. Distinct from "deferred to
+            # core-worker" where the key is absent entirely.
+            embedding_task = _timed(_return_cached(), timings, "embedding_ms")
         elif not defer_embedding:
-            embedding_task = get_embedding(data.content, tenant_config)
+            embedding_task = _timed(get_embedding(data.content, tenant_config), timings, "embedding_ms")
 
         enrichment_task = None
         if (
@@ -98,8 +126,10 @@ class ParallelEmbedEnrich:
         ):
             from core_api.services.memory_enrichment import enrich_memory
 
-            enrichment_task = enrich_memory(
-                data.content, tenant_config, reference_datetime=data.reference_datetime
+            enrichment_task = _timed(
+                enrich_memory(data.content, tenant_config, reference_datetime=data.reference_datetime),
+                timings,
+                "enrichment_ms",
             )
 
         # Gather whichever subset of tasks exists; stays parallel when

--- a/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
+++ b/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
@@ -25,12 +25,23 @@ class WriteMemoryRow:
         fields = ctx.data["memory_fields"]
         metadata = fields["metadata"]
         t0 = ctx.data.get("t0", time.perf_counter())
+        # CAURA-682 Phase 1: per-phase latency capture (see
+        # ParallelEmbedEnrich). ``storage_ms`` measures just the
+        # ``create_memory`` roundtrip; ``entity_links_ms`` is the
+        # subsequent fan-out for ``data.entity_links`` (zero links →
+        # zero ms — the key is still emitted to keep field surface
+        # uniform across writes).
+        timings: dict = ctx.data.setdefault("phase_timings", {})
 
         if embedding is None:
             metadata["embedding_pending"] = True
             logger.warning("Storing memory without embedding; deferred backfill scheduled")
 
-        # Store write latency in metadata
+        # Store write latency in metadata. Despite the name, this is
+        # pipeline-start-to-pre-storage, not the storage call duration —
+        # kept as-is because metadata consumers (audit log, dashboard)
+        # depend on the contract. ``timings["storage_ms"]`` below is
+        # the new, accurately-named signal for Phase 1 measurement.
         write_ms = round((time.perf_counter() - t0) * 1000)
         metadata["write_latency_ms"] = write_ms
 
@@ -65,8 +76,11 @@ class WriteMemoryRow:
             "status": fields["status"],
             "visibility": data.visibility or "scope_team",
         }
+        storage_t0 = time.perf_counter()
         memory = await sc.create_memory(memory_data)
+        timings["storage_ms"] = round((time.perf_counter() - storage_t0) * 1000)
 
+        links_t0 = time.perf_counter()
         for link in data.entity_links:
             await sc.create_entity_link(
                 {
@@ -79,6 +93,7 @@ class WriteMemoryRow:
                     "role": link.role,
                 }
             )
+        timings["entity_links_ms"] = round((time.perf_counter() - links_t0) * 1000)
 
         detail = {
             "memory_type": fields["memory_type"],

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -332,13 +332,64 @@ async def _create_memory_pipeline(db: AsyncSession, data: MemoryCreate) -> Memor
     else:
         pipeline = build_strong_write_pipeline()
 
-    await pipeline.run(ctx)
+    # CAURA-682 Phase 1: per-phase write-latency emission. One line per
+    # write request, structured so GCP log queries can slice by tenant /
+    # phase to identify the dominant phase under noisy-neighbor load
+    # (loadtest finding ``noisy-neighbor-write``, 3.58x degradation).
+    # ``phase_timings`` keys are present only for phases that actually
+    # ran; missing key = deferred to core-worker via background topic.
+    #
+    # The emit lives in ``finally`` so timeouts — the actual
+    # noisy-neighbor failure mode (``HTTPException(504)`` from
+    # ``parallel_embed_enrich`` on ``asyncio.wait_for`` timeout) — also
+    # produce a log line with the partial timings that DID land. Without
+    # this, the worst case for diagnosis (timed-out writes) is exactly
+    # the case that produces no diagnostic signal. ``success`` lets GCP
+    # queries filter failed from successful writes.
+    _exc: BaseException | None = None
+    try:
+        try:
+            await pipeline.run(ctx)
+        except BaseException as e:
+            _exc = e
+            raise
 
-    memory = ctx.data["memory"]
-    return _memory_to_out(
-        memory,
-        entity_links=[EntityLinkOut(entity_id=link.entity_id, role=link.role) for link in data.entity_links],
-    )
+        memory = ctx.data["memory"]
+        return _memory_to_out(
+            memory,
+            entity_links=[
+                EntityLinkOut(entity_id=link.entity_id, role=link.role) for link in data.entity_links
+            ],
+        )
+    finally:
+        timings = ctx.data.get("phase_timings", {})
+        # Defensive ``.get`` — when the pipeline raised, ``ctx.data["memory"]``
+        # may not be set. Explicit ``is not None`` on ``metadata_`` so an
+        # empty dict (no flags set yet) isn't treated as falsy and
+        # fallthrough'd into ``metadata``.
+        memory = ctx.data.get("memory") or {}
+        memory_metadata = memory.get("metadata_")
+        if memory_metadata is None:
+            memory_metadata = memory.get("metadata") or {}
+        logger.info(
+            "memory_write_latency",
+            extra={
+                "path": "memory-write",
+                "tenant_id": data.tenant_id,
+                "agent_id": data.agent_id,
+                "fleet_id": data.fleet_id,
+                "write_mode": resolved_mode,
+                "embedding_ms": timings.get("embedding_ms"),
+                "enrichment_ms": timings.get("enrichment_ms"),
+                "storage_ms": timings.get("storage_ms"),
+                "entity_links_ms": timings.get("entity_links_ms"),
+                "total_ms": round((time.perf_counter() - ctx.data["t0"]) * 1000),
+                "embedding_pending": bool(memory_metadata.get("embedding_pending")),
+                "enrichment_pending": bool(memory_metadata.get("enrichment_pending")),
+                "cached_embedding": ctx.data.get("cached_embedding") is not None,
+                "success": _exc is None,
+            },
+        )
 
 
 async def _handle_auto_chunk_from_ctx(db: AsyncSession, data: MemoryCreate, ctx: object) -> MemoryOut:

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -117,6 +117,128 @@ async def test_pipeline_path_creates_memory(db):
 
 
 @pytest.mark.asyncio
+async def test_pipeline_emits_memory_write_latency_log(db, caplog):
+    """CAURA-682 Phase 1: write pipeline emits ``memory_write_latency``
+    structured log with per-phase timings + tenant_id at INFO level.
+
+    The summary log is the input to GCP-side per-tenant slice queries that
+    answer "which phase is the bottleneck under noisy-neighbor load?" —
+    so the test pins the field surface contract, not specific values.
+    """
+    import logging
+
+    from core_api.services import memory_service
+
+    original = memory_service._USE_PIPELINE_WRITE
+    memory_service._USE_PIPELINE_WRITE = True
+    try:
+        from core_api.services.memory_service import create_memory
+
+        data = _make_input(
+            content="CAURA-682 Phase 1 latency log emission test — unique content for hash dedup."
+        )
+        with caplog.at_level(logging.INFO, logger="core_api.services.memory_service"):
+            await create_memory(db, data)
+
+        latency_records = [
+            r for r in caplog.records if r.getMessage() == "memory_write_latency"
+        ]
+        assert len(latency_records) == 1, (
+            f"expected exactly one memory_write_latency log, got {len(latency_records)}"
+        )
+        record = latency_records[0]
+        # Pin the field surface so the GCP log query stays stable.
+        for key in (
+            "path",
+            "tenant_id",
+            "agent_id",
+            "fleet_id",
+            "write_mode",
+            "total_ms",
+            "embedding_pending",
+            "enrichment_pending",
+            "cached_embedding",
+        ):
+            assert hasattr(record, key), f"missing field: {key}"
+        assert record.path == "memory-write"
+        assert record.tenant_id == TENANT_ID
+        assert record.agent_id == AGENT_ID
+        assert record.fleet_id == FLEET_ID
+        assert record.write_mode in ("fast", "strong")
+        assert isinstance(record.total_ms, int)
+        assert record.total_ms >= 0
+        # Storage call always runs; per-phase keys present when the
+        # phase ran inline (may be None if deferred to core-worker).
+        assert hasattr(record, "storage_ms")
+        assert hasattr(record, "entity_links_ms")
+        assert hasattr(record, "embedding_ms")
+        assert hasattr(record, "enrichment_ms")
+        # Success path: ``success`` must be True so failed-vs-successful
+        # write filters in GCP work.
+        assert record.success is True
+    finally:
+        memory_service._USE_PIPELINE_WRITE = original
+
+
+@pytest.mark.asyncio
+async def test_pipeline_emits_latency_log_on_pipeline_failure(db, caplog):
+    """CAURA-682 Phase 1: timeouts (the actual noisy-neighbor failure mode)
+    must also produce a ``memory_write_latency`` log with ``success=False``
+    and whatever partial timings landed before the exception.
+
+    Pre-fix, the log lived after ``await pipeline.run(ctx)`` with no
+    exception handling, so a ``HTTPException(504)`` from
+    ``parallel_embed_enrich`` on ``asyncio.wait_for`` timeout skipped the
+    log entirely — the worst case for diagnosis."""
+    import logging
+    from unittest.mock import patch
+
+    from fastapi import HTTPException
+    from core_api.pipeline.runner import Pipeline
+    from core_api.services import memory_service
+
+    original = memory_service._USE_PIPELINE_WRITE
+    memory_service._USE_PIPELINE_WRITE = True
+
+    async def _boom(self, ctx):
+        # Mirrors parallel_embed_enrich's timeout shape exactly.
+        raise HTTPException(
+            status_code=504, detail="Memory write timed out (embedding/enrichment)"
+        )
+
+    try:
+        from core_api.services.memory_service import create_memory
+
+        data = _make_input(
+            content="CAURA-682 Phase 1 timeout-emits-log path — distinct content for hash uniqueness."
+        )
+        with (
+            caplog.at_level(logging.INFO, logger="core_api.services.memory_service"),
+            patch.object(Pipeline, "run", _boom),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await create_memory(db, data)
+            assert exc_info.value.status_code == 504
+
+        latency_records = [
+            r for r in caplog.records if r.getMessage() == "memory_write_latency"
+        ]
+        assert len(latency_records) == 1, (
+            f"expected exactly one memory_write_latency log on failure, got {len(latency_records)}"
+        )
+        record = latency_records[0]
+        assert record.success is False
+        assert record.tenant_id == TENANT_ID
+        # ``total_ms`` is computed in finally → must be present even when
+        # the pipeline raised before populating ``ctx.data["memory"]``.
+        assert isinstance(record.total_ms, int)
+        assert record.embedding_pending is False
+        assert record.enrichment_pending is False
+    finally:
+        memory_service._USE_PIPELINE_WRITE = original
+
+
+@pytest.mark.asyncio
 async def test_legacy_path_creates_memory(db):
     """Legacy path creates a memory and returns valid MemoryOut (baseline)."""
     from core_api.services import memory_service


### PR DESCRIPTION
## Summary

Adds one structured `INFO` log per write request — `memory_write_latency` — with **embedding / enrichment / storage / total** wall-clock durations tagged by `tenant_id`, `agent_id`, `fleet_id`, and `write_mode`. This is the input to GCP log queries that answer **"which phase is the bottleneck under noisy-neighbor load?"** — required to choose between [CAURA-682](https://caura-ai.atlassian.net/browse/CAURA-682) Phase 2 (async enrichment) and Phase 3 (containerConcurrency tightening) without guessing.

## Motivation

`report-loadtest-1779685590` finding `noisy-neighbor-write` measured **tenant B write p95: 553 ms → 1982 ms (3.58×)** under a tenant-A storm. Target ≤2.0×.

The existing per-tenant bulkhead in `core_api/middleware/per_tenant_concurrency.py` already isolates A and B's storage slots — so the leakage must be at a shared resource the bulkhead **doesn't** gate. The strongest hypothesis (matches `freshness-read-p95-slow` from the same report) is **synchronous LLM enrichment**: the loadtest's `llm_title_summary_judge` phase alone took 37.4 s wall-clock. This PR makes the hypothesis testable.

## What's logged

One line per write at INFO, sliced by tenant in GCP log queries:

| field | meaning |
|---|---|
| `path` | `"memory-write"` discriminator (matches existing search log) |
| `tenant_id`, `agent_id`, `fleet_id` | attribution |
| `write_mode` | `strong` / `fast` — controls whether enrichment is inline |
| `embedding_ms` | `get_embedding` duration; `0` on cache hit; absent if deferred |
| `enrichment_ms` | LLM title/summary/tag duration; absent if deferred |
| `storage_ms` | `sc.create_memory` + entity-link roundtrips |
| `total_ms` | route-handler-start to log-emission |
| `embedding_pending`, `enrichment_pending` | from response metadata — indicates background-worker hand-off |
| `cached_embedding` | true on content-hash cache hit |

Per-phase keys are **present only for phases that actually ran**; missing key = deferred to `core-worker` via background topic. Each `asyncio.gather` task is wrapped in a `_timed` helper so embed and enrich latencies separate even when running concurrently (gather wall-clock alone would mask one behind the other).

## Out of scope

- Changing the existing `metadata["write_latency_ms"]` (audit log + dashboard depend on it; despite the name it actually measures pipeline-start-to-pre-storage). The new `storage_ms` in the log is the accurately-named signal.
- Phase 2 (async enrichment) and Phase 3 (containerConcurrency 2→8) — separate PRs once Phase 1 data lands.

## Test plan

- [x] `uv run pytest tests/pipeline/ tests/test_write_mode_dispatch.py tests/test_mcp_write.py tests/test_bulk_write.py tests/test_write_quality_gate.py` — 78 + 58 tests pass (DB-backed integration suite included)
- [x] New `test_pipeline_emits_memory_write_latency_log` pins the log field surface (path, tenant_id, agent_id, fleet_id, write_mode, total_ms, *_pending, cached_embedding, *_ms)
- [x] `uv run ruff check / format --check` clean on touched files
- [x] `cd core-api && uv run mypy src/` — `Success: no issues found in 161 source files`
- [ ] After merge → staging: re-run noisy-neighbor loadtest scenario, query `path="memory-write"` logs sliced by `tenant_id`, confirm which phase dominates tenant B's degradation under A's storm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-682]: https://caura-ai.atlassian.net/browse/CAURA-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ