### PR TITLE
fix(version-compat): bump MIN_RECOMMENDED_PLUGIN_VERSION to 2.6.2

### DIFF
--- a/core-api/src/core_api/version_compat.py
+++ b/core-api/src/core_api/version_compat.py
@@ -6,7 +6,7 @@ We log a warning when a heartbeat reports a plugin older than the minimum
 recommended version; no hard rejection — operators decide when to upgrade.
 """
 
-MIN_RECOMMENDED_PLUGIN_VERSION = "2.5.0"
+MIN_RECOMMENDED_PLUGIN_VERSION = "2.6.2"
 
 
 def _parse(v: str) -> tuple[int, ...]:


### PR DESCRIPTION
Without this bump, v2.6.0 / v2.6.1 nodes never auto-upgrade to v2.6.2 because the heartbeat handler gates auto-deploy on `plugin_version < MIN_RECOMMENDED_PLUGIN_VERSION` and the previous floor of 2.5.0 left them above the threshold.

Observed end-to-end during v2.8.0 staging on erni-onprem: a node on plugin 2.6.0 heartbeating against a server serving plugin 2.6.2 sources, no deploy command queued.

After this fix, passive heartbeat-driven auto-upgrade fires for nodes on 2.6.0 / 2.6.1. The dashboard 'Update Plugin' button continued to work throughout (it bypasses this gate).

## Test plan
- Hot-patch erni-onprem core-api with the same value, send fake heartbeat with plugin_version=2.6.0, observe deploy command queued in response.
- After backend-v2.9.1 ships via release-please, re-tag enterprise onprem-v2.8.1 and verify on erni-onprem from clean image.