### PR TITLE
CAURA-126 fix(contradiction): expand emit-memory-triple phrase coverage

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/emit_memory_triple.py
+++ b/core-api/src/core_api/pipeline/steps/write/emit_memory_triple.py
@@ -36,7 +36,31 @@ logger = logging.getLogger(__name__)
 # phrase is the split point: text before is ignored (we already have
 # the subject from entity_links), text after is normalized as the
 # object value.
+# CAURA-126 — phrase coverage expansion. Patterns are organised by
+# cluster; new clusters added 2026-05 to close the dead-code gap that
+# left ~90% of ``SINGLE_VALUE_PREDICATES`` without natural-language
+# coverage (the "release_date" bug report).
+#
+# Authoring rules to keep cross-cluster ambiguity low:
+#  - Prefer phrases that name the field explicitly ("has release
+#    date") over verbal forms ("released on") that grab too much
+#    context after the match.
+#  - One canonical predicate per semantic concept — emit the noun
+#    form (``release_date``) even when the allowlist also has the
+#    verbal form (``released_as``). Otherwise two memories carrying
+#    the same fact in different prose split across predicate columns
+#    and RDF detection silently misses them.
+#  - Use ``(?:current\s+|latest\s+|running\s+)?`` prefixes to fold
+#    qualifier variants into one row rather than adding separate
+#    patterns that would overlap.
+#  - Combine ``(?:has|has\s+a)\s+X\s+of`` and ``X\s+is`` shapes per
+#    predicate so most natural orderings are covered.
+#
+# Adding a phrase whose target predicate is NOT in
+# ``SINGLE_VALUE_PREDICATES`` is enforced impossible by the parity
+# test in tests/test_emit_memory_triple.py::TestAllowlistParity.
 _PHRASE_TO_PREDICATE: Final[list[tuple[re.Pattern[str], str]]] = [
+    # -- Original CAURA-123 cluster: location & singular roles --
     (re.compile(r"\blives\s+in\b", re.IGNORECASE), "lives_in"),
     (re.compile(r"\bis\s+located\s+in\b", re.IGNORECASE), "located_in"),
     (re.compile(r"\bis\s+based\s+in\b", re.IGNORECASE), "based_in"),
@@ -50,6 +74,148 @@ _PHRASE_TO_PREDICATE: Final[list[tuple[re.Pattern[str], str]]] = [
     (re.compile(r"\bis\s+the\s+cto\s+of\b", re.IGNORECASE), "cto_of"),
     (re.compile(r"\bis\s+the\s+cfo\s+of\b", re.IGNORECASE), "cfo_of"),
     (re.compile(r"\bis\s+renamed\s+to\b", re.IGNORECASE), "renamed_to"),
+    # -- CAURA-126 Tier 1: dates & temporal deadlines --
+    (re.compile(r"\bhas\s+release\s+date\b", re.IGNORECASE), "release_date"),
+    (re.compile(r"\brelease\s+date\s+is\b", re.IGNORECASE), "release_date"),
+    (re.compile(r"\bhas\s+launch\s+date\b", re.IGNORECASE), "launch_date"),
+    (re.compile(r"\blaunch\s+date\s+is\b", re.IGNORECASE), "launch_date"),
+    (re.compile(r"\bhas\s+go[- ]live\s+date\b", re.IGNORECASE), "go_live_date"),
+    (re.compile(r"\bgo[- ]live\s+date\s+is\b", re.IGNORECASE), "go_live_date"),
+    (re.compile(r"\bhas\s+target\s+date\b", re.IGNORECASE), "target_date"),
+    (re.compile(r"\btarget\s+date\s+is\b", re.IGNORECASE), "target_date"),
+    (re.compile(r"\bhas\s+due\s+date\b", re.IGNORECASE), "due_date"),
+    (re.compile(r"\bdue\s+date\s+is\b", re.IGNORECASE), "due_date"),
+    (re.compile(r"\bis\s+due\s+on\b", re.IGNORECASE), "due_date"),
+    (re.compile(r"\bis\s+due\s+by\b", re.IGNORECASE), "due_date"),
+    (re.compile(r"\bhas\s+start\s+date\b", re.IGNORECASE), "start_date"),
+    (re.compile(r"\bstart\s+date\s+is\b", re.IGNORECASE), "start_date"),
+    (re.compile(r"\bhas\s+end\s+date\b", re.IGNORECASE), "end_date"),
+    (re.compile(r"\bend\s+date\s+is\b", re.IGNORECASE), "end_date"),
+    (re.compile(r"\bexpires\s+on\b", re.IGNORECASE), "expiry_date"),
+    (re.compile(r"\bexpiry\s+date\s+is\b", re.IGNORECASE), "expiry_date"),
+    (re.compile(r"\bexpiration\s+date\s+is\b", re.IGNORECASE), "expiry_date"),
+    (re.compile(r"\bhas\s+deadline\b", re.IGNORECASE), "deadline"),
+    (re.compile(r"\bdeadline\s+is\b", re.IGNORECASE), "deadline"),
+    (re.compile(r"\beta\s+is\b", re.IGNORECASE), "eta"),
+    (re.compile(r"\bhas\s+eta\s+of\b", re.IGNORECASE), "eta"),
+    (re.compile(r"\bis\s+scheduled\s+for\b", re.IGNORECASE), "scheduled_for"),
+    (re.compile(r"\bis\s+rescheduled\s+to\b", re.IGNORECASE), "rescheduled_to"),
+    (re.compile(r"\bwas\s+born\s+on\b", re.IGNORECASE), "birthdate"),
+    (re.compile(r"\bdate\s+of\s+birth\s+is\b", re.IGNORECASE), "birthdate"),
+    # -- CAURA-126 Tier 2: status, state, role, priority, project --
+    (re.compile(r"\b(?:current\s+)?status\s+is\b", re.IGNORECASE), "status"),
+    (re.compile(r"\bis\s+in\s+(?:the\s+)?status\b", re.IGNORECASE), "status"),
+    (re.compile(r"\b(?:current\s+)?phase\s+is\b", re.IGNORECASE), "phase"),
+    (re.compile(r"\bis\s+in\s+(?:the\s+)?phase\b", re.IGNORECASE), "phase"),
+    (re.compile(r"\b(?:current\s+)?state\s+is\b", re.IGNORECASE), "state"),
+    (re.compile(r"\b(?:current\s+)?mode\s+is\b", re.IGNORECASE), "mode"),
+    (re.compile(r"\bis\s+in\s+(?:the\s+)?mode\b", re.IGNORECASE), "mode"),
+    (re.compile(r"\b(?:current\s+)?priority\s+is\b", re.IGNORECASE), "priority"),
+    (re.compile(r"\bhas\s+priority\b", re.IGNORECASE), "priority"),
+    (re.compile(r"\bseverity\s+is\b", re.IGNORECASE), "severity"),
+    (re.compile(r"\bhas\s+severity\b", re.IGNORECASE), "severity"),
+    (re.compile(r"\b(?:current\s+)?role\s+is\b", re.IGNORECASE), "role"),
+    (re.compile(r"\bhas\s+role\b", re.IGNORECASE), "role"),
+    (re.compile(r"\b(?:job\s+)?title\s+is\b", re.IGNORECASE), "title"),
+    (re.compile(r"\bhas\s+title\b", re.IGNORECASE), "title"),
+    (re.compile(r"\bsprint\s+is\b", re.IGNORECASE), "sprint"),
+    (re.compile(r"\bis\s+in\s+sprint\b", re.IGNORECASE), "sprint"),
+    (re.compile(r"\bmilestone\s+is\b", re.IGNORECASE), "milestone"),
+    (re.compile(r"\bhas\s+milestone\b", re.IGNORECASE), "milestone"),
+    (re.compile(r"\bepic\s+is\b", re.IGNORECASE), "epic"),
+    (re.compile(r"\bis\s+in\s+epic\b", re.IGNORECASE), "epic"),
+    # -- CAURA-126 Tier 3: money, metrics, scores, versioning --
+    (re.compile(r"\bis\s+priced\s+at\b", re.IGNORECASE), "price"),
+    (re.compile(r"\bprice\s+is\b", re.IGNORECASE), "price"),
+    (re.compile(r"\bhas\s+(?:a\s+)?price\s+of\b", re.IGNORECASE), "price"),
+    (re.compile(r"\bcost\s+is\b", re.IGNORECASE), "cost"),
+    (re.compile(r"\bhas\s+(?:a\s+)?cost\s+of\b", re.IGNORECASE), "cost"),
+    (re.compile(r"\bsalary\s+is\b", re.IGNORECASE), "salary"),
+    (re.compile(r"\bhas\s+(?:a\s+)?salary\s+of\b", re.IGNORECASE), "salary"),
+    (re.compile(r"\bbudget\s+is\b", re.IGNORECASE), "budget"),
+    (re.compile(r"\bhas\s+(?:a\s+)?budget\s+of\b", re.IGNORECASE), "budget"),
+    (re.compile(r"\b(?:annual\s+|monthly\s+)?revenue\s+is\b", re.IGNORECASE), "revenue"),
+    (re.compile(r"\bhas\s+revenue\s+of\b", re.IGNORECASE), "revenue"),
+    (re.compile(r"\bis\s+valued\s+at\b", re.IGNORECASE), "valuation"),
+    (re.compile(r"\bvaluation\s+is\b", re.IGNORECASE), "valuation"),
+    (re.compile(r"\bhas\s+valuation\s+of\b", re.IGNORECASE), "valuation"),
+    (re.compile(r"\b(?:total\s+)?funding\s+is\b", re.IGNORECASE), "funding"),
+    # ``score`` excludes compound ``X_score`` qualifiers so that
+    # "confidence score is 0.9" routes to the more specific
+    # ``confidence_score`` predicate below rather than colliding with
+    # plain ``score`` (which would mark both single matches as
+    # ambiguous and skip).
+    (
+        re.compile(
+            r"(?<!confidence\s)(?<!sentiment\s)(?<!risk\s)"
+            r"(?<!quality\s)(?<!health\s)(?<!potential\s)(?<!f1\s)"
+            r"\b(?:overall\s+|total\s+)?score\s+is\b",
+            re.IGNORECASE,
+        ),
+        "score",
+    ),
+    (
+        re.compile(
+            r"(?<!confidence\s)(?<!sentiment\s)(?<!risk\s)"
+            r"(?<!quality\s)(?<!health\s)(?<!potential\s)(?<!f1\s)"
+            r"\bhas\s+score\s+of\b",
+            re.IGNORECASE,
+        ),
+        "score",
+    ),
+    (re.compile(r"\brating\s+is\b", re.IGNORECASE), "rating"),
+    (re.compile(r"\bhas\s+rating\s+of\b", re.IGNORECASE), "rating"),
+    (re.compile(r"\brank\s+is\b", re.IGNORECASE), "rank"),
+    (re.compile(r"\bis\s+ranked\b", re.IGNORECASE), "rank"),
+    # The negative lookahead documents intent — ``confidence is`` must
+    # not fire when the immediate continuation is ``score is`` (the
+    # compound predicate). The plain pattern already wouldn't match
+    # "confidence score is" (no ``is`` directly after ``confidence``),
+    # but pinning the constraint explicitly catches a future edit
+    # that loosens ``\s+`` to ``\s*`` or similar.
+    (re.compile(r"\bconfidence\s+(?!score\s+is\b)is\b", re.IGNORECASE), "confidence"),
+    (re.compile(r"\bconfidence\s+score\s+is\b", re.IGNORECASE), "confidence_score"),
+    # Compound ``X_score`` predicates — sibling rows to the bare
+    # ``score`` patterns above, all in ``SINGLE_VALUE_PREDICATES``.
+    # The bare ``score`` patterns exclude these prefixes via
+    # negative lookbehinds; that gate is only meaningful if each
+    # compound has its own row to take the match.
+    (re.compile(r"\bpotential\s+score\s+is\b", re.IGNORECASE), "potential_score"),
+    (re.compile(r"\brisk\s+score\s+is\b", re.IGNORECASE), "risk_score"),
+    (re.compile(r"\bquality\s+score\s+is\b", re.IGNORECASE), "quality_score"),
+    (re.compile(r"\bhealth\s+score\s+is\b", re.IGNORECASE), "health_score"),
+    (re.compile(r"\bsentiment\s+score\s+is\b", re.IGNORECASE), "sentiment_score"),
+    (re.compile(r"\bf1\s+score\s+is\b", re.IGNORECASE), "f1_score"),
+    (re.compile(r"\b(?:current\s+|latest\s+|running\s+)?version\s+is\b", re.IGNORECASE), "current_version"),
+    (re.compile(r"\bis\s+on\s+version\b", re.IGNORECASE), "current_version"),
+    # -- CAURA-126 Tier 4: infra, contact, hierarchy, license/plan --
+    (re.compile(r"\bhostname\s+is\b", re.IGNORECASE), "hostname"),
+    (re.compile(r"\bhas\s+hostname\b", re.IGNORECASE), "hostname"),
+    (re.compile(r"\bcluster\s+is\b", re.IGNORECASE), "cluster"),
+    (re.compile(r"\bis\s+in\s+cluster\b", re.IGNORECASE), "cluster"),
+    (re.compile(r"\bnamespace\s+is\b", re.IGNORECASE), "namespace"),
+    (re.compile(r"\bis\s+in\s+namespace\b", re.IGNORECASE), "namespace"),
+    (re.compile(r"\bzone\s+is\b", re.IGNORECASE), "zone"),
+    (re.compile(r"\bis\s+in\s+(?:availability\s+)?zone\b", re.IGNORECASE), "zone"),
+    (re.compile(r"\bregion\s+is\b", re.IGNORECASE), "region"),
+    (re.compile(r"\bis\s+in\s+(?:the\s+)?region\b", re.IGNORECASE), "region"),
+    (re.compile(r"\bcountry\s+is\b", re.IGNORECASE), "country"),
+    (re.compile(r"\bcity\s+is\b", re.IGNORECASE), "city"),
+    (re.compile(r"\bemail\s+(?:address\s+)?is\b", re.IGNORECASE), "email"),
+    (re.compile(r"\bhas\s+email\b", re.IGNORECASE), "email"),
+    (re.compile(r"\bphone\s+(?:number\s+)?is\b", re.IGNORECASE), "phone"),
+    (re.compile(r"\bhas\s+phone\b", re.IGNORECASE), "phone"),
+    (re.compile(r"\bwebsite\s+is\b", re.IGNORECASE), "website"),
+    (re.compile(r"\bhas\s+website\b", re.IGNORECASE), "website"),
+    (re.compile(r"\bis\s+led\s+by\b", re.IGNORECASE), "led_by"),
+    (re.compile(r"\bis\s+headed\s+by\b", re.IGNORECASE), "headed_by"),
+    (re.compile(r"\bis\s+maintained\s+by\b", re.IGNORECASE), "maintained_by"),
+    (re.compile(r"\bis\s+supervised\s+by\b", re.IGNORECASE), "supervised_by"),
+    (re.compile(r"\bis\s+licensed\s+under\b", re.IGNORECASE), "license"),
+    (re.compile(r"\blicense\s+is\b", re.IGNORECASE), "license"),
+    (re.compile(r"\bis\s+on\s+(?:the\s+)?(?:subscription\s+)?plan\b", re.IGNORECASE), "subscription_plan"),
+    (re.compile(r"\bsubscription\s+plan\s+is\b", re.IGNORECASE), "subscription_plan"),
+    (re.compile(r"\btier\s+is\b", re.IGNORECASE), "tier"),
 ]
 
 _LEADING_ARTICLES = re.compile(r"^(the|a|an)\s+", re.IGNORECASE)
@@ -95,18 +261,42 @@ class EmitMemoryTriple:
                 )
             subject_entity_id = subject_links[0].entity_id
 
-            content = data.content or ""
+            # Normalise whitespace to single ASCII spaces. The score
+            # lookbehinds (``(?<!confidence\s)`` etc.) are fixed-width
+            # at one space character, so content like "confidence
+            # \tscore is 0.9" (tab between words) would otherwise
+            # bypass the lookbehind and incorrectly route to the
+            # bare ``score`` predicate. Done once at the top so all
+            # subsequent regex searches see canonical whitespace.
+            content = re.sub(r"\s+", " ", data.content or "")
             matches: list[tuple[re.Match[str], str]] = []
             for pat, predicate in _PHRASE_TO_PREDICATE:
                 m = pat.search(content)
                 if m:
                     matches.append((m, predicate))
-            if len(matches) != 1:
+            # Ambiguity is on the *predicate*, not the raw number of
+            # pattern hits. Two patterns mapping to the same canonical
+            # predicate (e.g. ``\bhas\s+release\s+date\b`` and
+            # ``\brelease\s+date\s+is\b`` both firing on
+            # "has release date is 2027") should resolve to a single
+            # emission — the predicate is unique, only the phrasing
+            # overlaps. Splitting that into ``ambiguous_predicate``
+            # used to silently drop the entire row.
+            unique_predicates = {pred for _, pred in matches}
+            if len(unique_predicates) != 1:
                 return StepResult(
                     outcome=StepOutcome.SKIPPED,
                     detail={"reason": "no_predicate_match" if not matches else "ambiguous_predicate"},
                 )
-            match, predicate = matches[0]
+            # When the same predicate is hit by multiple phrase patterns
+            # (e.g. ``\bhas\s+release\s+date\b`` and
+            # ``\brelease\s+date\s+is\b`` both fire on "has release
+            # date is 2027"), pick the match whose ``end()`` is
+            # furthest right. That's the anchor closest to the actual
+            # object — using ``matches[0]`` (table order) would leave
+            # interstitial words like "is" in the tail and pollute
+            # ``object_value``.
+            match, predicate = max(matches, key=lambda m_p: m_p[0].end())
 
             # Defensive: the allowlist parity test guards this set, but
             # belt-and-braces — never emit a predicate the detector

--- a/scripts/repro_contradictions_diagnostic.py
+++ b/scripts/repro_contradictions_diagnostic.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Diagnostic follow-up to ``repro_contradictions_not_detected.py``.
+
+Once the bug is reproduced (contradiction NOT detected for two
+conflicting release dates), this script probes the three plausible
+failure paths in isolation:
+
+    Probe A: poll ``GET /memories/{id}`` over 180s, watching for
+             ``entity_links`` to appear. If they never do → entity
+             extraction never ran (or ran but emitted nothing).
+    Probe B: ``POST /api/v1/search`` for the token. Both memories
+             should appear with high mutual similarity. If they do
+             → the embedding layer is fine and semantic detection
+             SHOULD have had a candidate pair. Failure mode is
+             downstream of the embedding/candidate-fetch step.
+    Probe C: Re-run with EXPLICIT ``entity_links=[{role:subject}]``
+             in the POST body. If THIS path produces non-empty
+             triple columns (``predicate``, ``object_value``) →
+             ``EmitMemoryTriple`` works when given subject context;
+             the bug is that ingestion never populates entity_links
+             for this content shape.
+
+Each probe is independent. Output identifies which gate the bug
+sits behind.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+import uuid
+
+import httpx
+
+
+def _env(name: str) -> str:
+    val = os.environ.get(name)
+    if not val:
+        print(f"ERROR: ${name} must be set", file=sys.stderr)
+        sys.exit(2)
+    return val
+
+
+def _ts() -> str:
+    return time.strftime("%H:%M:%S")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--max-wait", type=int, default=180, help="entity-link poll budget (s)"
+    )
+    ap.add_argument("--probe", choices=("all", "a", "b", "c"), default="all")
+    args = ap.parse_args()
+
+    base = _env("MEMCLAW_API_URL").rstrip("/")
+    key = _env("MEMCLAW_API_KEY")
+    tenant = os.environ.get("MEMCLAW_TENANT_ID")
+
+    token = f"TOKEN-{uuid.uuid4().hex[:8].upper()}"
+    agent = f"diag-contradictions-{uuid.uuid4().hex[:6]}"
+
+    print(f"env       : {base}")
+    print(f"tenant    : {tenant}")
+    print(f"token     : {token}")
+    print(f"agent     : {agent}\n")
+
+    headers = {"X-API-Key": key, "Content-Type": "application/json"}
+    client = httpx.Client(base_url=base, headers=headers, timeout=30.0)
+
+    body_common = {
+        "agent_id": agent,
+        "memory_type": "fact",
+        "visibility": "scope_team",
+        "write_mode": "strong",
+    }
+    if tenant:
+        body_common["tenant_id"] = tenant
+    qp = {"tenant_id": tenant} if tenant else {}
+
+    # Write A & B without explicit entity_links — same shape as the
+    # bug-report repro.
+    print(f"[{_ts()}] Writing A and B (no entity_links)…")
+    r = client.post(
+        "/api/v1/memories",
+        json={**body_common, "content": f"{token} has release date 2027-05-01."},
+    )
+    r.raise_for_status()
+    a = r.json()
+    r = client.post(
+        "/api/v1/memories",
+        json={**body_common, "content": f"{token} has release date 2028-10-15."},
+    )
+    r.raise_for_status()
+    b = r.json()
+    print(f"        A.id={a['id']}  B.id={b['id']}\n")
+
+    # ---- Probe A: entity_links eventually populated? ----
+    if args.probe in ("all", "a"):
+        print(f"[{_ts()}] Probe A — polling entity_links over {args.max_wait}s")
+        deadline = time.time() + args.max_wait
+        last_a_links = last_b_links = -1
+        while time.time() < deadline:
+            a_now = client.get(f"/api/v1/memories/{a['id']}", params=qp).json()
+            b_now = client.get(f"/api/v1/memories/{b['id']}", params=qp).json()
+            n_a = len(a_now.get("entity_links") or [])
+            n_b = len(b_now.get("entity_links") or [])
+            if n_a != last_a_links or n_b != last_b_links:
+                elapsed = args.max_wait - int(deadline - time.time())
+                print(
+                    f"  [{_ts()}] t={elapsed:>3}s  A.entity_links={n_a}  B.entity_links={n_b}  "
+                    f"A.subject_entity_id={a_now.get('subject_entity_id')!r}  "
+                    f"A.predicate={a_now.get('predicate')!r}  "
+                    f"A.object_value={a_now.get('object_value')!r}"
+                )
+                last_a_links, last_b_links = n_a, n_b
+                if n_a > 0 and n_b > 0:
+                    print(f"  A.entity_links payload: {a_now.get('entity_links')}")
+                    print(f"  B.entity_links payload: {b_now.get('entity_links')}")
+                    break
+            time.sleep(5)
+        else:
+            print(
+                f"  [{_ts()}] FINAL — entity_links never appeared within {args.max_wait}s."
+            )
+        print()
+
+    # ---- Probe B: search probe — do A and B even find each other? ----
+    if args.probe in ("all", "b"):
+        print(f"[{_ts()}] Probe B — POST /api/v1/search for token")
+        try:
+            # Only include ``tenant_id`` when the env actually supplied
+            # one. Posting ``"tenant_id": None`` round-trips as JSON
+            # null and would be rejected by the search route's
+            # validation as a missing field, masking the real probe
+            # outcome with a 422.
+            search_body: dict = {"query": f"{token} release date", "top_k": 10}
+            if tenant:
+                search_body["tenant_id"] = tenant
+            sresp = client.post("/api/v1/search", json=search_body)
+            sresp.raise_for_status()
+            hits = sresp.json().get("items") or []
+            print(f"  Got {len(hits)} hit(s)")
+            for h in hits:
+                if h.get("id") in (a["id"], b["id"]):
+                    label = "A" if h["id"] == a["id"] else "B"
+                    print(
+                        f"    {label}: similarity={h.get('similarity')}  score={h.get('score')}  content={h.get('content', '')[:60]!r}"
+                    )
+        except Exception as e:
+            print(f"  search FAILED: {e}")
+        print()
+
+    # ---- Probe C: re-run with explicit entity_links ----
+    if args.probe in ("all", "c"):
+        print(
+            f"[{_ts()}] Probe C — re-run with explicit entity_links=[{{role:subject}}]"
+        )
+        # Need to upsert/get an entity first. Same conditional-tenant
+        # guard as Probe B — never POST ``tenant_id: None``.
+        ent_body: dict = {"entity_type": "product", "canonical_name": token}
+        if tenant:
+            ent_body["tenant_id"] = tenant
+        eresp = client.post("/api/v1/entities/upsert", json=ent_body)
+        if eresp.status_code >= 400:
+            print(f"  entities/upsert returned {eresp.status_code}: {eresp.text[:300]}")
+        else:
+            entity = eresp.json()
+            eid = entity.get("id")
+            print(f"  Entity upserted: {eid}")
+            new_token = f"TOKEN-{uuid.uuid4().hex[:8].upper()}"
+            # Also upsert a "release date" predicate-ish entity? No — entity_links
+            # just need {entity_id, role}.
+            r = client.post(
+                "/api/v1/memories",
+                json={
+                    **body_common,
+                    "content": f"{new_token} has release date 2027-05-01.",
+                    "entity_links": [{"entity_id": eid, "role": "subject"}],
+                },
+            )
+            print(f"  Probe-C write status: {r.status_code}")
+            if r.status_code < 400:
+                cmem = r.json()
+                print(
+                    f"    id={cmem.get('id')}  predicate={cmem.get('predicate')!r}  "
+                    f"object_value={cmem.get('object_value')!r}  "
+                    f"subject_entity_id={cmem.get('subject_entity_id')!r}"
+                )
+                time.sleep(3)
+                cfetched = client.get(
+                    f"/api/v1/memories/{cmem['id']}", params=qp
+                ).json()
+                print(
+                    f"  After 3s re-read: predicate={cfetched.get('predicate')!r}  "
+                    f"object_value={cfetched.get('object_value')!r}  "
+                    f"subject_entity_id={cfetched.get('subject_entity_id')!r}  "
+                    f"entity_links={cfetched.get('entity_links')}"
+                )
+            else:
+                print(f"    body: {r.text[:300]}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repro_contradictions_not_detected.py
+++ b/scripts/repro_contradictions_not_detected.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Minimal reproduction of the ``contradictions-not-detected`` bug.
+
+Bug report (loadtest-1779685590, env=net, server v2.8.0):
+  Seeded two directly-conflicting facts about ``TOKEN-736C57D0``
+  (release date 2027-05-01 vs 2028-10-15). GET /memories/:id/contradictions
+  flagged neither.
+
+This script mirrors that exact shape against ANY environment:
+
+    1. Mint a fresh ``TOKEN-XXXXXXXX`` entity token (UUID-derived so two
+       runs never collide).
+    2. POST /memories — memory A: "<TOKEN> has release date 2027-05-01."
+    3. POST /memories — memory B: "<TOKEN> has release date 2028-10-15."
+    4. Wait N seconds for background enrichment + entity extraction +
+       contradiction detection.
+    5. GET /memories/{A}/contradictions  → expect non-empty referring to B
+       GET /memories/{B}/contradictions  → expect non-empty referring to A
+    6. GET /memories/{A}, /memories/{B} → inspect status, supersedes_id,
+       and triple columns (subject_entity_id / predicate / object_value).
+
+Exits 0 iff contradictions are detected in either direction. Otherwise
+prints a structured diagnostic dump showing exactly what the server
+reported.
+
+Usage:
+    export MEMCLAW_API_URL=https://memclaw.dev      # or https://memclaw.net
+    export MEMCLAW_API_KEY=mc_...
+    python scripts/repro_contradictions_not_detected.py
+
+    # Adjust settle time if your env's detection is slow
+    python scripts/repro_contradictions_not_detected.py --wait 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+
+import httpx
+
+
+def _env(name: str) -> str:
+    val = os.environ.get(name)
+    if not val:
+        print(f"ERROR: ${name} must be set", file=sys.stderr)
+        sys.exit(2)
+    return val
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--wait",
+        type=int,
+        default=20,
+        help="seconds to wait for async detection (default 20)",
+    )
+    ap.add_argument("--write-mode", default="strong", choices=("fast", "strong"))
+    ap.add_argument("--verbose", "-v", action="store_true")
+    ap.add_argument(
+        "--token", default=None, help="override the synthetic token (for replay)"
+    )
+    args = ap.parse_args()
+
+    base = _env("MEMCLAW_API_URL").rstrip("/")
+    key = _env("MEMCLAW_API_KEY")
+    tenant = os.environ.get("MEMCLAW_TENANT_ID")  # optional — server may infer from key
+
+    token = args.token or f"TOKEN-{uuid.uuid4().hex[:8].upper()}"
+    agent = f"repro-contradictions-{uuid.uuid4().hex[:6]}"
+
+    print(f"env       : {base}")
+    print(f"tenant    : {tenant or '(inferred from key)'}")
+    print(f"token     : {token}")
+    print(f"agent     : {agent}")
+    print(f"write_mode: {args.write_mode}")
+    print(f"wait      : {args.wait}s\n")
+
+    headers = {"X-API-Key": key, "Content-Type": "application/json"}
+    client = httpx.Client(base_url=base, headers=headers, timeout=30.0)
+
+    body_common = {
+        "agent_id": agent,
+        "memory_type": "fact",
+        "visibility": "scope_team",
+        "write_mode": args.write_mode,
+    }
+    if tenant:
+        body_common["tenant_id"] = tenant
+
+    # 1. Write memory A — earlier release date.
+    body_a = {**body_common, "content": f"{token} has release date 2027-05-01."}
+    print("[1/4] POST /api/v1/memories  (memory A: 2027-05-01)")
+    r = client.post("/api/v1/memories", json=body_a)
+    r.raise_for_status()
+    mem_a = r.json()
+    print(f"      → id={mem_a.get('id')}  status={mem_a.get('status')}")
+    if args.verbose:
+        print(f"      raw: {json.dumps(mem_a, default=str)[:400]}")
+
+    # 2. Write memory B — later release date. Direct conflict on the
+    #    same single-value predicate.
+    body_b = {**body_common, "content": f"{token} has release date 2028-10-15."}
+    print("\n[2/4] POST /api/v1/memories  (memory B: 2028-10-15)")
+    r = client.post("/api/v1/memories", json=body_b)
+    r.raise_for_status()
+    mem_b = r.json()
+    print(f"      → id={mem_b.get('id')}  status={mem_b.get('status')}")
+    if args.verbose:
+        print(f"      raw: {json.dumps(mem_b, default=str)[:400]}")
+
+    # 3. Wait for async detection (RDF compare runs inline if triples
+    #    are populated synchronously; semantic LLM check runs in a
+    #    background task after the write returns).
+    print(f"\n[3/4] Waiting {args.wait}s for async detection…")
+    time.sleep(args.wait)
+
+    # 4. Re-fetch both memories + their contradictions endpoints.
+    # All GETs scoped by tenant_id (the API requires it as a query
+    # parameter; without it, validation 422s and the response
+    # decoder silently returns ``{"detail": [...]}``). Use the
+    # tenant id returned on the write so this works even when
+    # ``MEMCLAW_TENANT_ID`` is unset.
+    print("\n[4/4] Re-fetching memories + contradictions endpoints\n")
+    qp = {"tenant_id": tenant or mem_a.get("tenant_id")}
+    a_now = client.get(f"/api/v1/memories/{mem_a['id']}", params=qp).json()
+    b_now = client.get(f"/api/v1/memories/{mem_b['id']}", params=qp).json()
+    a_contra = client.get(f"/api/v1/memories/{mem_a['id']}/contradictions", params=qp).json()
+    b_contra = client.get(f"/api/v1/memories/{mem_b['id']}/contradictions", params=qp).json()
+
+    def _summary(label: str, mem: dict) -> None:
+        print(f"  {label}.id              : {mem.get('id')}")
+        print(f"  {label}.status          : {mem.get('status')}")
+        print(f"  {label}.supersedes_id   : {mem.get('supersedes_id')}")
+        print(f"  {label}.subject_entity  : {mem.get('subject_entity_id')}")
+        print(f"  {label}.predicate       : {mem.get('predicate')!r}")
+        print(f"  {label}.object_value    : {mem.get('object_value')!r}")
+        sb = mem.get("superseded_by") or []
+        print(f"  {label}.superseded_by   : {len(sb)} entry(s)")
+        for item in sb:
+            print(f"     • {item}")
+        el = mem.get("entity_links") or []
+        print(f"  {label}.entity_links    : {len(el)} link(s)  {el}")
+
+    _summary("A", a_now)
+    print()
+    _summary("B", b_now)
+
+    def _detected(target_id: str, resp: dict) -> bool:
+        # /contradictions is documented as returning {contradictions: [...]}
+        # but call sites in algo-stress also accept {items: [...]} for
+        # forward compat — accept either.
+        items = resp.get("contradictions") or resp.get("items") or []
+        return any(
+            (it.get("memory_id") == target_id) or (it.get("id") == target_id)
+            for it in items
+        )
+
+    print("\nContradictions endpoint:")
+    print(f"  GET /memories/{mem_a['id']}/contradictions:")
+    print(f"    {json.dumps(a_contra, default=str)[:400]}")
+    print(f"  GET /memories/{mem_b['id']}/contradictions:")
+    print(f"    {json.dumps(b_contra, default=str)[:400]}")
+
+    ab_hit = _detected(mem_b["id"], a_contra)
+    ba_hit = _detected(mem_a["id"], b_contra)
+    status_hit = (a_now.get("status") in ("outdated", "conflicted")) or (
+        b_now.get("status") in ("outdated", "conflicted")
+    )
+    chain_hit = (a_now.get("supersedes_id") == mem_b["id"]) or (
+        b_now.get("supersedes_id") == mem_a["id"]
+    )
+
+    print("\nVerdict:")
+    print(f"  A/contradictions includes B? {ab_hit}")
+    print(f"  B/contradictions includes A? {ba_hit}")
+    print(f"  Either marked outdated/conflicted? {status_hit}")
+    print(f"  Either carries supersedes_id pointing at the other? {chain_hit}")
+
+    detected = ab_hit or ba_hit or status_hit or chain_hit
+    print(f"\n  ==>  CONTRADICTION DETECTED: {detected}\n")
+    return 0 if detected else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repro_contradictions_with_entity_links.py
+++ b/scripts/repro_contradictions_with_entity_links.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""CAURA-126 wet test — release-date contradiction with explicit entity_links.
+
+Reproduces the loadtest-1779685590 bug shape (two memories about the
+same token with conflicting release dates), but adds an explicit
+``entity_links=[{role:subject}]`` to the POST so the local Layer-2
+gap (entity extraction doesn't auto-populate links for token-shaped
+subjects, A5) is bypassed. This isolates Layer 1 — the phrase-table
+coverage CAURA-126 just expanded.
+
+Expected behaviour with the fix:
+    A.predicate  = "release_date"
+    B.predicate  = "release_date"
+    A.object_value = "2027-05-01" (or similar)
+    B.object_value = "2028-10-15"
+    Synchronous detector: A becomes outdated, B.supersedes_id = A.id.
+
+Usage (against local docker-compose stack with the rebuilt image):
+    python scripts/repro_contradictions_with_entity_links.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+import uuid
+
+import httpx
+
+BASE = os.environ.get("MEMCLAW_API_URL", "http://localhost:8000").rstrip("/")
+TENANT = os.environ.get("MEMCLAW_TENANT_ID", "default")  # standalone default
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--wait", type=int, default=5)
+    args = ap.parse_args()
+
+    key = os.environ.get("MEMCLAW_API_KEY", "")
+    headers = {"Content-Type": "application/json"}
+    if key:
+        headers["X-API-Key"] = key
+
+    client = httpx.Client(base_url=BASE, headers=headers, timeout=30.0)
+
+    token = f"TOKEN-{uuid.uuid4().hex[:8].upper()}"
+    suffix = uuid.uuid4().hex[:8]
+    fleet = f"caura126-fleet-{suffix}"
+    agent = f"caura126-agent-{suffix}"
+
+    print(f"env       : {BASE}")
+    print(f"tenant    : {TENANT}")
+    print(f"token     : {token}")
+    print(f"fleet     : {fleet}")
+    print(f"agent     : {agent}\n")
+
+    # 1. Upsert the subject entity once.
+    # Each ``.json()`` chain below is split into a named response +
+    # ``raise_for_status()`` so a 4xx with an error body surfaces
+    # immediately instead of producing a malformed entity / memory
+    # dict that fails later with a confusing KeyError.
+    print("[1/4] Upsert subject entity")
+    ent_resp = client.post(
+        "/api/v1/entities/upsert",
+        json={
+            "tenant_id": TENANT,
+            "fleet_id": fleet,
+            "entity_type": "product",
+            "canonical_name": token,
+        },
+    )
+    ent_resp.raise_for_status()
+    ent = ent_resp.json()
+    subject_id = ent["id"]
+    print(f"      subject_entity_id = {subject_id}\n")
+
+    body_common = {
+        "tenant_id": TENANT,
+        "fleet_id": fleet,
+        "agent_id": agent,
+        "memory_type": "fact",
+        "visibility": "scope_team",
+        "write_mode": "strong",
+        "entity_links": [{"entity_id": subject_id, "role": "subject"}],
+    }
+
+    # 2. Write memory A — earlier release date.
+    print("[2/4] Write memory A — 'has release date 2027-05-01'")
+    a_resp = client.post(
+        "/api/v1/memories",
+        json={**body_common, "content": f"{token} has release date 2027-05-01."},
+    )
+    a_resp.raise_for_status()
+    a = a_resp.json()
+    print(
+        f"      id={a['id']}  predicate={a.get('predicate')!r}  object_value={a.get('object_value')!r}\n"
+    )
+
+    # 3. Write memory B — conflicting release date.
+    print("[3/4] Write memory B — 'has release date 2028-10-15'")
+    b_resp = client.post(
+        "/api/v1/memories",
+        json={**body_common, "content": f"{token} has release date 2028-10-15."},
+    )
+    b_resp.raise_for_status()
+    b = b_resp.json()
+    print(
+        f"      id={b['id']}  predicate={b.get('predicate')!r}  object_value={b.get('object_value')!r}\n"
+    )
+
+    # 4. Wait briefly for inline detection to settle, then re-fetch.
+    print(f"[4/4] Wait {args.wait}s and re-fetch")
+    time.sleep(args.wait)
+    qp = {"tenant_id": TENANT}
+    a_now = client.get(f"/api/v1/memories/{a['id']}", params=qp).json()
+    b_now = client.get(f"/api/v1/memories/{b['id']}", params=qp).json()
+
+    def _dump(label, m):
+        print(
+            f"  {label}: status={m.get('status')!s:<11}  predicate={m.get('predicate')!r}  "
+            f"object={m.get('object_value')!r}  supersedes_id={m.get('supersedes_id')}"
+        )
+
+    print()
+    _dump("A", a_now)
+    _dump("B", b_now)
+
+    checks = {
+        "A.predicate == 'release_date'": a_now.get("predicate") == "release_date",
+        "B.predicate == 'release_date'": b_now.get("predicate") == "release_date",
+        "A.object_value populated": bool(a_now.get("object_value")),
+        "B.object_value populated": bool(b_now.get("object_value")),
+        "A.object_value != B.object_value": a_now.get("object_value")
+        != b_now.get("object_value"),
+        "A.status == 'outdated' (RDF fired)": a_now.get("status") == "outdated",
+        "B.supersedes_id == A.id": b_now.get("supersedes_id") == a["id"],
+    }
+    print("\nGates:")
+    for k, v in checks.items():
+        print(f"  {'✓' if v else '✗'}  {k}")
+
+    return 0 if all(checks.values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_emit_memory_triple.py
+++ b/tests/test_emit_memory_triple.py
@@ -108,7 +108,9 @@ class TestEmitMemoryTriple:
             # The supplied field stays exactly what the caller passed.
             assert getattr(data, untouched) == preset
             # The other two fields must NOT have been written by us.
-            other_fields = {"subject_entity_id", "predicate", "object_value"} - {untouched}
+            other_fields = {"subject_entity_id", "predicate", "object_value"} - {
+                untouched
+            }
             for f in other_fields:
                 assert getattr(data, f) is None, f"step wrote {f} on partial-supply"
 
@@ -181,7 +183,9 @@ class TestEmitMemoryTriple:
     async def test_object_bounded_to_current_sentence(self):
         # Trailing clauses must not bleed into object_value.
         sid = uuid4()
-        data = _input("Ran lives in New York. He also enjoys long walks.", subject_id=sid)
+        data = _input(
+            "Ran lives in New York. He also enjoys long walks.", subject_id=sid
+        )
         await EmitMemoryTriple().execute(_ctx(data))
         assert data.object_value == "new york"
 
@@ -206,28 +210,168 @@ class TestEmitMemoryTriple:
 
     async def test_emitted_predicate_is_in_allowlist(self):
         # Every populate path must produce a predicate the detector accepts.
+        # Covers original CAURA-123 cluster + the four CAURA-126 tiers.
         sid = uuid4()
-        for content in [
-            "X lives in Y",
-            "X is located in Y",
-            "X is based in Y",
-            "X is headquartered in Y",
-            "X reports to Y",
-            "X is managed by Y",
-            "X is owned by Y",
-            "X is assigned to Y",
-            "X is employed by Y",
-            "X is the CEO of Y",
-            "X is the CTO of Y",
-            "X is the CFO of Y",
-            "X is renamed to Y",
+        for content, expected in [
+            # -- Original CAURA-123 cluster --
+            ("X lives in Y", "lives_in"),
+            ("X is located in Y", "located_in"),
+            ("X is based in Y", "based_in"),
+            ("X is headquartered in Y", "headquartered_in"),
+            ("X reports to Y", "reports_to"),
+            ("X is managed by Y", "managed_by"),
+            ("X is owned by Y", "owned_by"),
+            ("X is assigned to Y", "assigned_to"),
+            ("X is employed by Y", "employed_by"),
+            ("X is the CEO of Y", "ceo_of"),
+            ("X is the CTO of Y", "cto_of"),
+            ("X is the CFO of Y", "cfo_of"),
+            ("X is renamed to Y", "renamed_to"),
+            # -- Tier 1: dates --
+            ("X has release date 2027-05-01", "release_date"),
+            ("X release date is 2027-05-01", "release_date"),
+            ("X has launch date 2027-05-01", "launch_date"),
+            ("X launch date is 2027-05-01", "launch_date"),
+            ("X has go-live date 2027-05-01", "go_live_date"),
+            ("X has target date 2027-05-01", "target_date"),
+            ("X has due date 2027-05-01", "due_date"),
+            ("X is due on 2027-05-01", "due_date"),
+            ("X is due by 2027-05-01", "due_date"),
+            ("X has start date 2027-05-01", "start_date"),
+            ("X has end date 2027-05-01", "end_date"),
+            ("X expires on 2027-05-01", "expiry_date"),
+            ("X has deadline 2027-05-01", "deadline"),
+            ("X ETA is 2027-05-01", "eta"),
+            ("X has ETA of 2027-05-01", "eta"),
+            ("X is scheduled for 2027-05-01", "scheduled_for"),
+            ("X is rescheduled to 2027-05-01", "rescheduled_to"),
+            ("X was born on 1990-01-01", "birthdate"),
+            # -- Tier 2: status / state / role --
+            ("X status is in_progress", "status"),
+            ("X current status is in_progress", "status"),
+            ("X phase is beta", "phase"),
+            ("X current phase is beta", "phase"),
+            ("X state is open", "state"),
+            ("X mode is debug", "mode"),
+            ("X priority is high", "priority"),
+            ("X has priority high", "priority"),
+            ("X severity is critical", "severity"),
+            ("X has severity critical", "severity"),
+            ("X role is engineer", "role"),
+            ("X has role engineer", "role"),
+            ("X title is VP", "title"),
+            ("X job title is VP", "title"),
+            ("X sprint is Sprint-7", "sprint"),
+            ("X is in sprint Sprint-7", "sprint"),
+            ("X milestone is GA", "milestone"),
+            ("X epic is checkout-redesign", "epic"),
+            ("X is in epic checkout-redesign", "epic"),
+            # -- Tier 3: money / metrics / versioning --
+            ("X is priced at 100", "price"),
+            ("X price is 100", "price"),
+            ("X has price of 100", "price"),
+            ("X cost is 50", "cost"),
+            ("X salary is 100000", "salary"),
+            ("X has budget of 1M", "budget"),
+            ("X budget is 1M", "budget"),
+            ("X revenue is 5M", "revenue"),
+            ("X annual revenue is 5M", "revenue"),
+            ("X has revenue of 5M", "revenue"),
+            ("X is valued at 10M", "valuation"),
+            ("X valuation is 10M", "valuation"),
+            ("X funding is 2M", "funding"),
+            ("X total funding is 2M", "funding"),
+            ("X score is 95", "score"),
+            ("X has score of 95", "score"),
+            ("X rating is A", "rating"),
+            ("X has rating of A", "rating"),
+            ("X rank is 3", "rank"),
+            ("X is ranked 3", "rank"),
+            ("X confidence is 0.9", "confidence"),
+            ("X confidence score is 0.9", "confidence_score"),
+            ("X potential score is 7", "potential_score"),
+            ("X risk score is 0.4", "risk_score"),
+            ("X quality score is 95", "quality_score"),
+            ("X health score is 8", "health_score"),
+            ("X sentiment score is 0.7", "sentiment_score"),
+            ("X f1 score is 0.92", "f1_score"),
+            ("X version is 2.4.0", "current_version"),
+            ("X current version is 2.4.0", "current_version"),
+            ("X is on version 2.4.0", "current_version"),
+            # -- Tier 4: infra / contact / hierarchy / license --
+            ("X hostname is host-01", "hostname"),
+            ("X has hostname host-01", "hostname"),
+            ("X cluster is prod-us", "cluster"),
+            ("X is in cluster prod-us", "cluster"),
+            ("X namespace is default", "namespace"),
+            ("X is in namespace default", "namespace"),
+            ("X zone is us-east-1a", "zone"),
+            ("X is in availability zone us-east-1a", "zone"),
+            ("X region is us-east-1", "region"),
+            ("X country is Germany", "country"),
+            ("X city is Berlin", "city"),
+            ("X email is a@b.com", "email"),
+            ("X email address is a@b.com", "email"),
+            ("X has email a@b.com", "email"),
+            ("X phone is 555-0100", "phone"),
+            ("X phone number is 555-0100", "phone"),
+            ("X website is example.com", "website"),
+            ("X is led by Alice", "led_by"),
+            ("X is headed by Alice", "headed_by"),
+            ("X is maintained by Alice", "maintained_by"),
+            ("X is supervised by Alice", "supervised_by"),
+            ("X is licensed under MIT", "license"),
+            ("X license is MIT", "license"),
+            ("X is on the plan Pro", "subscription_plan"),
+            ("X subscription plan is Pro", "subscription_plan"),
+            ("X tier is gold", "tier"),
         ]:
             data = _input(content, subject_id=sid)
             await EmitMemoryTriple().execute(_ctx(data))
-            assert data.predicate is not None, f"Failed to emit for: {content}"
+            assert data.predicate is not None, f"Failed to emit for: {content!r}"
+            assert data.predicate == expected, (
+                f"Wrong predicate for {content!r}: got {data.predicate!r}, "
+                f"expected {expected!r}"
+            )
             assert data.predicate in SINGLE_VALUE_PREDICATES, (
                 f"Emitted predicate {data.predicate!r} not in SINGLE_VALUE_PREDICATES"
             )
+
+    async def test_intra_predicate_double_match_not_ambiguous(self):
+        # CAURA-126 follow-up: when two patterns in the table match
+        # but they map to the SAME canonical predicate (e.g. the
+        # ``\bhas\s+release\s+date\b`` and ``\brelease\s+date\s+is\b``
+        # rows both fire on "has release date is 2027"), the step must
+        # NOT treat this as ambiguous and must emit. Ambiguity is on
+        # the predicate, not the number of phrase hits. The match
+        # whose ``end()`` is furthest right wins, so ``object_value``
+        # excludes interstitial words like "is".
+        sid = uuid4()
+        data = _input("Atlas has release date is 2027-05-01", subject_id=sid)
+        result = await EmitMemoryTriple().execute(_ctx(data))
+        assert result is None, (
+            f"Same-predicate double-match must emit (not skip); got {result}"
+        )
+        assert data.predicate == "release_date"
+        assert data.object_value == "2027-05-01", (
+            f"object_value must use the furthest-right match's tail "
+            f"to skip 'is'; got {data.object_value!r}"
+        )
+
+    async def test_whitespace_normalised_before_lookbehind_check(self):
+        # CAURA-126 follow-up: the score lookbehinds are fixed-width
+        # one-character (``(?<!confidence\s)``). Content with a tab
+        # between "confidence" and "score" would bypass the lookbehind
+        # and route to the bare ``score`` predicate instead of
+        # ``confidence_score``. Normalising whitespace at the top of
+        # ``execute()`` keeps the lookbehinds load-bearing.
+        sid = uuid4()
+        data = _input("Atlas confidence\tscore is 0.9", subject_id=sid)
+        await EmitMemoryTriple().execute(_ctx(data))
+        assert data.predicate == "confidence_score", (
+            f"Tab whitespace must still route to confidence_score; "
+            f"got predicate={data.predicate!r}"
+        )
 
     async def test_unexpected_error_degrades_to_skip(self):
         # A malformed input object that breaks attribute access mid-step
@@ -258,7 +402,9 @@ class TestPipelineComposition:
         names = [s.name for s in build_fast_write_pipeline()._steps]
         assert "emit_memory_triple" in names
         assert names.index("emit_memory_triple") < names.index("check_exact_duplicate")
-        assert names.index("merge_enrichment_fields") < names.index("emit_memory_triple")
+        assert names.index("merge_enrichment_fields") < names.index(
+            "emit_memory_triple"
+        )
 
     def test_strong_pipeline_includes_step(self):
         from core_api.pipeline.compositions.write import build_strong_write_pipeline
@@ -321,15 +467,11 @@ class TestTenantConfigFlag:
     def test_explicit_false_disables(self):
         from core_api.services.organization_settings import ResolvedConfig
 
-        cfg = ResolvedConfig(
-            org_settings={"write": {"triple_emission_enabled": False}}
-        )
+        cfg = ResolvedConfig(org_settings={"write": {"triple_emission_enabled": False}})
         assert cfg.triple_emission_enabled is False
 
     def test_explicit_true_enables(self):
         from core_api.services.organization_settings import ResolvedConfig
 
-        cfg = ResolvedConfig(
-            org_settings={"write": {"triple_emission_enabled": True}}
-        )
+        cfg = ResolvedConfig(org_settings={"write": {"triple_emission_enabled": True}})
         assert cfg.triple_emission_enabled is True


### PR DESCRIPTION
## Bug

Bug report (loadtest-1779685590, env=net, server v2.8.0): contradictions endpoint flagged neither of two directly-conflicting release-date memories about the same token. Reproduced on `memclaw.dev` with the same shape — same failure modes.

## Root cause (Layer 1)

CAURA-123's `EmitMemoryTriple` regex table covered only **13 phrases** (location + hierarchy + 3 C-level roles) — ~9% of the ~150 single-value predicates the *detector* knows how to conflict-check. The detector's `SINGLE_VALUE_PREDICATES` allowlist already includes `release_date`, `status`, `revenue`, `current_version`, `hostname`, etc., but the emitter had no way to *see* those predicates in free-text content. Triples never populated for business memories outside the original 13-phrase set → the deterministic RDF detection path was effectively dead for them.

## Fix

Extend the phrase table from **13 → ~85 patterns** across four tiers (all canonical predicates from the existing allowlist):

| Tier | Cluster | Predicates added |
|---|---|---|
| 1 | dates / deadlines | `release_date`, `launch_date`, `go_live_date`, `target_date`, `due_date`, `start_date`, `end_date`, `expiry_date`, `deadline`, `eta`, `scheduled_for`, `rescheduled_to`, `birthdate` |
| 2 | status / state / role / priority / project | `status`, `phase`, `state`, `mode`, `priority`, `severity`, `role`, `title`, `sprint`, `milestone`, `epic` |
| 3 | money / metrics / scores / versioning | `price`, `cost`, `salary`, `budget`, `revenue`, `valuation`, `funding`, `score`, `confidence_score`, `rating`, `rank`, `confidence`, `current_version` |
| 4 | infra / contact / hierarchy / license | `hostname`, `cluster`, `namespace`, `zone`, `region`, `country`, `city`, `email`, `phone`, `website`, `led_by`, `headed_by`, `maintained_by`, `supervised_by`, `license`, `subscription_plan`, `tier` |

## Design choices (documented in source)

- **Field-naming phrases preferred** over verbal forms — "`has release date`" over "`released on`" — to cap false-positive object extraction.
- **Canonicalize to noun forms** so two memories with the same fact in different prose don't split across predicate columns.
- **`(?:current\s+|latest\s+)?` prefixes** absorb qualifier variants into one row instead of overlapping rules.
- **Negative lookbehind on `score`** patterns excludes compound `X_score` qualifiers (`confidence_score`, etc.) — the compound predicates that have their own canonical form get their own row.

## Validation (all 5 gates green)

| Gate | What | Result |
|---|---|---|
| G1 | Allowlist parity (CI-enforced) — every emitted predicate ∈ `SINGLE_VALUE_PREDICATES` | ✅ PASS |
| G2 | ~85 new per-predicate happy-path fixtures in `test_emitted_predicate_is_in_allowlist` | ✅ PASS |
| G3 | 25 existing CAURA-123/124 emit-memory tests | ✅ PASS (unchanged) |
| G4 | Ruff format + check on touched files | ✅ Clean |
| G5 | **Wet test** against rebuilt local docker-compose with `entity_links=[{role:subject}]` | ✅ **7/7** |

**G5 detail** — exact bug-report shape (two memories conflicting on release date for the same token):
```
A.predicate  = "release_date"        ✓
B.predicate  = "release_date"        ✓
A.object_value = "2027-05-01"        ✓
B.object_value = "2028-10-15"        ✓
A.status     = "outdated" (RDF fired, no LLM call)  ✓
B.supersedes_id = A.id               ✓
```

257/257 contradiction-adjacent unit tests pass repo-wide.

## Out of scope (Layer 2 — separate PR)

Production ingestion (including the loadtest harness) writes memories **without** `entity_links`. Even with this phrase expansion, `EmitMemoryTriple` will still skip with `reason=no_subject` on bare POSTs. Auto-promoting an entity link with `role="subject"` when entity extraction yields a clear single candidate intersects audit gap A5 (extraction is unreliable on token-shaped subjects) and is the natural follow-up.

This PR is the foundation: phrase coverage is now broad enough that the Layer-2 fix actually unlocks coverage, rather than being shadowed by a 13-row phrase gap.

## Reproduction artifacts (committed for regression)

- `scripts/repro_contradictions_not_detected.py` — minimal end-to-end reproducer (5 ms write × 2 + GET).
- `scripts/repro_contradictions_diagnostic.py` — 3-probe diagnostic (which layer fails?).
- `scripts/repro_contradictions_with_entity_links.py` — Layer-1 wet test (the G5 fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)