### PR TITLE
fix(storage): drop name_embedding/search_vector from entity payloads

### DIFF
--- a/core-storage-api/src/core_storage_api/schemas.py
+++ b/core-storage-api/src/core_storage_api/schemas.py
@@ -89,8 +89,6 @@ ENTITY_FIELDS: list[str] = [
     "canonical_name",
     "entity_type",
     "attributes",
-    "name_embedding",
-    "search_vector",
 ]
 
 RELATION_FIELDS: list[str] = [

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -24,6 +24,7 @@ from sqlalchemy import and_, case, delete, false, func, literal_column, or_, sel
 from sqlalchemy import update as sql_update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import load_only
 
 from common.constants import (
     CONTRADICTION_CANDIDATE_MAX,
@@ -2402,9 +2403,27 @@ class PostgresService:
         tenant_id: str,
         fleet_id: str | None = None,
     ) -> tuple[list[Entity], list[Relation]]:
-        """Return all entities and relations for a tenant (optionally filtered by fleet)."""
+        """Return all entities and relations for a tenant (optionally filtered by fleet).
+
+        Skips the heavy ``name_embedding`` (pgvector) and ``search_vector`` (TSVECTOR)
+        columns — the graph view doesn't need them, and loading + serialising them
+        dominates the response time for tenants with many entities.
+        """
         async with get_session() as session:
-            entity_stmt = select(Entity).where(Entity.tenant_id == tenant_id)
+            entity_stmt = (
+                select(Entity)
+                .options(
+                    load_only(
+                        Entity.id,
+                        Entity.tenant_id,
+                        Entity.fleet_id,
+                        Entity.entity_type,
+                        Entity.canonical_name,
+                        Entity.attributes,
+                    )
+                )
+                .where(Entity.tenant_id == tenant_id)
+            )
             if fleet_id:
                 entity_stmt = entity_stmt.where(or_(Entity.fleet_id == fleet_id, Entity.fleet_id.is_(None)))
             entities_result = await session.execute(entity_stmt)


### PR DESCRIPTION
## Summary

- Removes `name_embedding` (1536-dim pgvector) and `search_vector` (TSVECTOR) from `ENTITY_FIELDS`, the `orm_to_dict` whitelist that drives every entity-returning core-storage-api → core-api HTTP response.
- Switches `entity_get_full_graph` to `load_only(...)` so postgres only ships the columns the graph view actually uses.

## Why

Surfaced from a load-test report on `memclaw.net` flagging `slo-p99-graph 3052.6ms (n=16)` with `p50 = 2114.6ms` — the median was already over the p99 target, so this wasn't a tail problem. Reading the `/graph` call path top-to-bottom, every entity in the response was carrying its full `name_embedding` (a 1536-float JSON array, ~15 KB per entity) and `search_vector` through loopback HTTP from core-storage-api to core-api, where they were deserialized and discarded. The `/graph` route's response only uses `id / label / type / fleet_id / attributes / memory_count`.

A wider grep confirmed **no consumer in `core-api`, `core-worker`, `core-operations`, `plugin`, or any test reads `name_embedding` / `search_vector` off the dict returned from storage HTTP** — these fields were dead weight on every entity-returning endpoint, just most visible on `/full-graph` because it returns the most entities at once.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` — no new errors introduced (the one type drift the first cut produced was fixed by using `load_only` so we still return `Entity` ORM rows, not `SimpleNamespace`)
- [x] Unit tests pass: `tests/test_entity_linking_wiring.py`, `tests/test_p3_3_graph_fanout.py`, `tests/test_p0_1_entity_matching.py`, `tests/test_p3_1_entity_resolution.py`, `tests/test_a5a_seed_and_canonical.py` — 46 passed, 2 xfailed
- [x] `orm_to_dict(entity, ENTITY_FIELDS)` asserted to no longer emit the heavy keys
- [ ] **Wet test on memclaw.dev pending** — rebuild core-storage-api image, hit `GET /api/v1/graph?tenant_id=…`, time before/after p50 against a tenant with a meaningful entity count