### PR TITLE
fix(mcp): wire read-only scope gate and reset ContextVars per request

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -190,17 +190,24 @@ class MCPAuthMiddleware:
             # for credentials authorized to read beyond their home tenant
             # (cross-tenant agent keys). Absent / empty headers leave the
             # context vars at their single-tenant defaults.
+            # Always reset both context vars at the start of every request,
+            # not just when the header is present. ContextVars set inside a
+            # prior request can survive into the next request when the
+            # underlying ASGI task is reused or the var was never assigned a
+            # token-based reset. An absent header means "single-tenant /
+            # full-scope" — make that explicit so a previous request's
+            # cross-tenant read-set or read-only scope cannot bleed through.
             readable_header = headers.get(b"x-readable-tenant-ids", b"").decode()
-            if readable_header:
-                _readable_tenant_ids_var.set([t.strip() for t in readable_header.split(",") if t.strip()])
+            _readable_tenant_ids_var.set(
+                [t.strip() for t in readable_header.split(",") if t.strip()] if readable_header else None
+            )
             # X-Capabilities is canonical from the unified auth-api;
             # X-Key-Scopes is accepted as a back-compat alias during
             # the gateway rollout window.
             caps_header = (
                 headers.get(b"x-capabilities", b"").decode() or headers.get(b"x-key-scopes", b"").decode()
             )
-            if caps_header:
-                _scopes_var.set({s.strip() for s in caps_header.split(",") if s.strip()})
+            _scopes_var.set({s.strip() for s in caps_header.split(",") if s.strip()} if caps_header else None)
 
         await self.app(scope, receive, send)
 
@@ -288,6 +295,33 @@ def _check_auth() -> CallToolResult | None:
     if tid in (_ADMIN, _NO_AUTH):
         return _ADMIN_ERROR
     return None
+
+
+_READ_ONLY_ERROR = _as_error_result(
+    _error_response(
+        "FORBIDDEN",
+        "This credential is scope-limited to read operations. "
+        "Provision a credential with the 'write' capability "
+        "(POST /api/v1/admin/agent-keys/provision, or via the dashboard at "
+        "Settings → Organization → API Credentials) to perform write actions.",
+    )
+)
+
+
+def _check_write_scope() -> CallToolResult | None:
+    """Return a pre-baked FORBIDDEN ``CallToolResult`` if the active
+    credential lacks the 'write' capability, ``None`` otherwise. Mirrors
+    ``_check_auth()`` so write tools can guard themselves with:
+
+        if err := _check_write_scope(): return err
+
+    A ``None`` scope set means "legacy / full-scope key" and is allowed
+    (back-compat for credentials minted before scopes existed). Only an
+    explicitly-set scope set without 'write' triggers the block.
+    """
+    if _is_write_allowed():
+        return None
+    return _READ_ONLY_ERROR
 
 
 @contextlib.asynccontextmanager
@@ -508,6 +542,8 @@ async def memclaw_write(
     t0 = time.perf_counter()
     if err := _check_auth():
         return err
+    if err := _check_write_scope():
+        return err
     if (content is None) == (items is None):
         return _with_latency(
             json.dumps(
@@ -669,6 +705,10 @@ async def memclaw_manage(
             ),
             t0,
         )
+    # Mutating ops gated by the credential scope set; read/lineage stay open
+    # to read-only keys.
+    if op in {"update", "transition", "delete", "bulk_delete"} and (err := _check_write_scope()):
+        return err
     # bulk_delete uses memory_ids (list); all other ops use memory_id (single UUID).
     # Validate accordingly so a missing memory_id on bulk_delete doesn't fail with
     # a misleading "Invalid UUID" error.
@@ -918,6 +958,8 @@ async def memclaw_tune(
     t0 = time.perf_counter()
     if err := _check_auth():
         return err
+    if err := _check_write_scope():
+        return err
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
 
@@ -1022,6 +1064,10 @@ async def memclaw_doc(
     # strategy; supply collection to scope the search to just one).
     if op not in {"list_collections", "search"} and not collection:
         return _with_latency(_error_response("INVALID_ARGUMENTS", f"op={op} requires 'collection'."), t0)
+    # Write/delete are gated by the credential scope set; read/query/list/search
+    # remain available to read-only keys.
+    if op in {"write", "delete"} and (err := _check_write_scope()):
+        return err
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
     # Refuse the default identity for write ops on the gateway path; read-only
@@ -1683,6 +1729,8 @@ async def memclaw_evolve(
     t0 = time.perf_counter()
     if err := _check_auth():
         return err
+    if err := _check_write_scope():
+        return err
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
 
@@ -1877,6 +1925,8 @@ async def memclaw_keystones_set(
     """
     t0 = time.perf_counter()
     if err := _check_auth():
+        return err
+    if err := _check_write_scope():
         return err
     if op not in {"set", "delete"}:
         return _with_latency(

--- a/tests/test_mcp_write_scope_gate.py
+++ b/tests/test_mcp_write_scope_gate.py
@@ -1,0 +1,322 @@
+"""Unit tests for the read-only scope gate on MCP write tools (B2)
+and the ASGI ContextVars hygiene fix in ``MCPAuthMiddleware`` (#32).
+
+The audit found ``_is_write_allowed()`` defined but never invoked, so a
+credential whose ``X-Capabilities`` set excluded ``write`` could still
+mutate state through every MCP write surface. These tests assert that
+every write tool now refuses such credentials with a FORBIDDEN envelope
+(``isError=True``).
+
+It also covers the middleware: prior to the fix, ``_readable_tenant_ids_var``
+and ``_scopes_var`` were only set when their respective request headers
+were present. With shared ASGI tasks or context inheritance, a follow-on
+request that omitted the headers could see the prior request's values.
+The middleware now resets both vars on every request.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_api import mcp_server
+from tests._mcp_test_helpers import is_error_envelope, parse_envelope
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# _check_write_scope() — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_check_write_scope_passes_for_legacy_none_scope(monkeypatch):
+    """Legacy credentials minted before scopes existed surface as
+    ``_get_scopes() is None`` — the gate must let them through to avoid
+    breaking back-compat for keys provisioned pre-rollout."""
+    monkeypatch.setattr(mcp_server, "_get_scopes", lambda: None)
+    assert mcp_server._check_write_scope() is None
+
+
+def test_check_write_scope_passes_with_write_capability(monkeypatch):
+    monkeypatch.setattr(mcp_server, "_get_scopes", lambda: {"read", "write"})
+    assert mcp_server._check_write_scope() is None
+
+
+def test_check_write_scope_blocks_read_only(monkeypatch):
+    monkeypatch.setattr(mcp_server, "_get_scopes", lambda: {"read"})
+    result = mcp_server._check_write_scope()
+    assert result is not None
+    assert is_error_envelope(result)
+
+
+def test_check_write_scope_blocks_empty_scope_set(monkeypatch):
+    """An explicitly-empty scope set means the credential carries no
+    capabilities — must be refused, not interpreted as legacy."""
+    monkeypatch.setattr(mcp_server, "_get_scopes", lambda: set())
+    result = mcp_server._check_write_scope()
+    assert result is not None
+    assert is_error_envelope(result)
+
+
+# ---------------------------------------------------------------------------
+# Each write tool refuses a read-only credential
+# ---------------------------------------------------------------------------
+
+
+def _force_read_only(monkeypatch):
+    """Pin the active credential to a read-only scope set for the duration
+    of the test. ``_get_scopes`` is the only seam the gate consults."""
+    monkeypatch.setattr(mcp_server, "_get_scopes", lambda: {"read"})
+
+
+async def test_memclaw_write_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_write(content="should never persist")
+    assert is_error_envelope(out)
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "FORBIDDEN"
+    # No service call should have fired.
+    assert "create_memory" not in mcp_env["service_mocks"]
+
+
+async def test_memclaw_write_batch_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_write(items=[{"content": "x"}, {"content": "y"}])
+    assert is_error_envelope(out)
+    assert "create_memories_bulk" not in mcp_env["service_mocks"]
+
+
+async def test_memclaw_evolve_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_evolve(outcome="x", outcome_type="success")
+    assert is_error_envelope(out)
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "FORBIDDEN"
+
+
+async def test_memclaw_tune_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_tune(top_k=10)
+    assert is_error_envelope(out)
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "FORBIDDEN"
+
+
+async def test_memclaw_keystones_set_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_keystones_set(
+        op="set", doc_id="rule-1", title="t", content="c", scope="tenant", weight="low"
+    )
+    assert is_error_envelope(out)
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "FORBIDDEN"
+
+
+async def test_memclaw_manage_delete_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_manage(
+        op="delete", memory_id="11111111-1111-1111-1111-111111111111"
+    )
+    assert is_error_envelope(out)
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "FORBIDDEN"
+
+
+async def test_memclaw_manage_bulk_delete_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_manage(
+        op="bulk_delete",
+        memory_ids=["11111111-1111-1111-1111-111111111111"],
+    )
+    assert is_error_envelope(out)
+
+
+async def test_memclaw_manage_update_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_manage(
+        op="update",
+        memory_id="11111111-1111-1111-1111-111111111111",
+        content="new content",
+    )
+    assert is_error_envelope(out)
+
+
+async def test_memclaw_manage_transition_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_manage(
+        op="transition",
+        memory_id="11111111-1111-1111-1111-111111111111",
+        status="archived",
+    )
+    assert is_error_envelope(out)
+
+
+async def test_memclaw_doc_write_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_doc(
+        op="write", collection="things", doc_id="d1", data={"k": "v"}
+    )
+    assert is_error_envelope(out)
+
+
+async def test_memclaw_doc_delete_blocked_for_read_only(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    out = await mcp_server.memclaw_doc(op="delete", collection="things", doc_id="d1")
+    assert is_error_envelope(out)
+
+
+# ---------------------------------------------------------------------------
+# Read-only credentials are still allowed for read ops
+# ---------------------------------------------------------------------------
+
+
+async def test_memclaw_manage_read_does_not_invoke_write_gate(mcp_env, monkeypatch):
+    """``op=read`` is a query path — the gate should never fire here.
+    We assert by spying on ``_check_write_scope`` and confirming it
+    was not called. The handler may still fail downstream (mocked DB
+    isn't awaitable), but the gate check happens before any DB work."""
+    _force_read_only(monkeypatch)
+    calls: list[None] = []
+
+    def _spy():
+        calls.append(None)
+        return None
+
+    monkeypatch.setattr(mcp_server, "_check_write_scope", _spy)
+    try:
+        await mcp_server.memclaw_manage(
+            op="read", memory_id="11111111-1111-1111-1111-111111111111"
+        )
+    except Exception:
+        # Downstream DB mocking issues are irrelevant — we only assert
+        # whether the gate fired, which is decided well before the call
+        # graph reaches the repository.
+        pass
+    assert calls == [], "write-scope gate fired on a read op"
+
+
+async def test_memclaw_doc_read_does_not_invoke_write_gate(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    calls: list[None] = []
+
+    def _spy():
+        calls.append(None)
+        return None
+
+    monkeypatch.setattr(mcp_server, "_check_write_scope", _spy)
+    try:
+        await mcp_server.memclaw_doc(op="read", collection="things", doc_id="d1")
+    except Exception:
+        pass
+    assert calls == [], "write-scope gate fired on a doc-read op"
+
+
+async def test_memclaw_doc_query_does_not_invoke_write_gate(mcp_env, monkeypatch):
+    _force_read_only(monkeypatch)
+    calls: list[None] = []
+
+    def _spy():
+        calls.append(None)
+        return None
+
+    monkeypatch.setattr(mcp_server, "_check_write_scope", _spy)
+    try:
+        await mcp_server.memclaw_doc(op="query", collection="things", where={"k": "v"})
+    except Exception:
+        pass
+    assert calls == [], "write-scope gate fired on a doc-query op"
+
+
+# ---------------------------------------------------------------------------
+# Middleware ContextVars hygiene (#32)
+# ---------------------------------------------------------------------------
+
+
+async def _call_middleware(headers: list[tuple[bytes, bytes]]):
+    """Invoke ``MCPAuthMiddleware`` once with a synthetic ASGI scope so
+    we can observe the context-var state it leaves behind. The downstream
+    app is a no-op — we only care about the side effects of the middleware
+    on ``_scopes_var`` / ``_readable_tenant_ids_var``."""
+
+    async def _noop_app(scope, receive, send):
+        return None
+
+    async def _recv():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    sends: list[dict] = []
+
+    async def _send(message):
+        sends.append(message)
+
+    mw = mcp_server.MCPAuthMiddleware(_noop_app)
+    scope = {"type": "http", "headers": headers}
+    await mw(scope, _recv, _send)
+
+
+async def test_middleware_resets_scopes_when_header_absent_after_present():
+    """First request sets ``X-Capabilities: read`` — gate should refuse
+    writes. Second request omits the header — scopes must reset to
+    ``None`` so the next caller's full-scope key is honored."""
+    # Before any request: known starting state.
+    mcp_server._scopes_var.set(None)
+    mcp_server._readable_tenant_ids_var.set(None)
+
+    # Request 1: read-only credential.
+    await _call_middleware(
+        [
+            (b"x-api-key", b"some-key"),
+            (b"x-tenant-id", b"tenant-A"),
+            (b"x-capabilities", b"read"),
+        ]
+    )
+    assert mcp_server._get_scopes() == {"read"}
+    assert mcp_server._is_write_allowed() is False
+
+    # Request 2: header omitted entirely — must NOT inherit "read" scope.
+    await _call_middleware(
+        [
+            (b"x-api-key", b"some-key"),
+            (b"x-tenant-id", b"tenant-B"),
+        ]
+    )
+    assert mcp_server._get_scopes() is None
+    assert mcp_server._is_write_allowed() is True
+
+
+async def test_middleware_resets_readable_tenants_when_header_absent_after_present():
+    mcp_server._scopes_var.set(None)
+    mcp_server._readable_tenant_ids_var.set(None)
+
+    await _call_middleware(
+        [
+            (b"x-api-key", b"some-key"),
+            (b"x-tenant-id", b"tenant-A"),
+            (b"x-readable-tenant-ids", b"tenant-A,tenant-B,tenant-C"),
+        ]
+    )
+    assert mcp_server._get_readable_tenants() == ["tenant-A", "tenant-B", "tenant-C"]
+
+    # Second request without the header: must reset, not inherit.
+    await _call_middleware(
+        [
+            (b"x-api-key", b"some-key"),
+            (b"x-tenant-id", b"tenant-D"),
+        ]
+    )
+    assert mcp_server._get_readable_tenants() == []
+
+
+async def test_middleware_honors_x_key_scopes_alias():
+    """The X-Key-Scopes header is the back-compat alias for X-Capabilities
+    during the gateway rollout. It must populate the same context var."""
+    mcp_server._scopes_var.set(None)
+
+    await _call_middleware(
+        [
+            (b"x-api-key", b"some-key"),
+            (b"x-tenant-id", b"tenant-A"),
+            (b"x-key-scopes", b"read"),
+        ]
+    )
+    assert mcp_server._get_scopes() == {"read"}


### PR DESCRIPTION
## Summary

External audit found two related MCP-server defects in `core-api/src/core_api/mcp_server.py`:

- **B2 — write-scope gate dead.** `_is_write_allowed()` was defined at line 227 but had **zero call sites**. A credential whose `X-Capabilities` set excluded `write` could still mutate state through every MCP write surface.
- **#32 — ContextVars hygiene.** `_readable_tenant_ids_var` and `_scopes_var` were set in `MCPAuthMiddleware` only when their respective headers were present. A follow-on request that omitted the header could observe a prior request's value if the async task reused the context.

## Changes

- New `_check_write_scope()` helper, sibling of `_check_auth()`, returns a pre-baked `FORBIDDEN` `CallToolResult(isError=True)` if the active credential lacks `write` capability. Legacy keys (scope set `None`) keep the prior full-scope behavior — only an explicit scope set without `write` is refused.
- Wired into the six write surfaces:
  - `memclaw_write`
  - `memclaw_evolve`
  - `memclaw_tune`
  - `memclaw_keystones_set`
  - `memclaw_doc` (only `op in {write, delete}`)
  - `memclaw_manage` (only `op in {update, transition, delete, bulk_delete}`)
- Read paths on dispatched tools (`memclaw_doc` read/query/list/search; `memclaw_manage` read/lineage) intentionally bypass the gate so read-only credentials retain full access.
- `MCPAuthMiddleware` now resets both `_readable_tenant_ids_var` and `_scopes_var` to `None`/empty on every request, regardless of header presence.

## Tests

`tests/test_mcp_write_scope_gate.py` (21 cases):

- Direct unit tests on `_check_write_scope` for legacy/empty/`{read}`/`{read,write}` scope sets.
- Per-tool refusal tests for all six write surfaces.
- "Read ops do not invoke the write gate" spy tests for `memclaw_manage` and `memclaw_doc`.
- Middleware reset tests: `X-Capabilities`, `X-Readable-Tenant-IDs`, and the `X-Key-Scopes` back-compat alias.

All 142 MCP tests pass; full suite (2354 tests) green.

## Wet test

Local stack rebuilt and run end-to-end:

- ✅ Read-only credential (`X-Capabilities: read`) → `FORBIDDEN` + `isError=True`
- ✅ Full-scope credential → write succeeds (memory created)
- ✅ Middleware: read-only header set on request 1 → next request without header reads `_scopes_var = None`
- ✅ `X-Readable-Tenant-IDs` reset across requests
- ✅ `X-Key-Scopes` alias honored

## Test plan

- [x] Unit tests pass (`pytest tests/test_mcp_write_scope_gate.py -q`)
- [x] Full MCP suite green (142 tests)
- [x] Full pytest suite green (2354 tests)
- [x] `ruff check` + `ruff format --check` pass on touched files
- [x] Local wet test: read-only credential refused, full-scope credential writes succeed, middleware resets between requests