### PR TITLE
fix(entities): align read contract with memories — widen to readable_tenant_ids

### DIFF
--- a/core-api/src/core_api/routes/entities.py
+++ b/core-api/src/core_api/routes/entities.py
@@ -15,6 +15,7 @@ from core_api.schemas import (
     RelationUpsert,
     RelationUpsertOut,
 )
+from core_api.services.audit_service import log_cross_tenant_read
 from core_api.services.entity_service import get_entity, upsert_entity, upsert_relation
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
 
@@ -31,15 +32,33 @@ async def list_entities(
     search: str | None = Query(default=None),
     limit: int = Query(default=DEFAULT_ENTITY_LIMIT, ge=1, le=MAX_LIST_LIMIT),
     auth: AuthContext = Depends(get_auth_context),
+    db: AsyncSession = Depends(get_db),
 ):
-    """List all entities for a tenant."""
-    auth.enforce_tenant(tenant_id)
+    """List all entities for a tenant.
+
+    Reads widen across the caller's ``readable_tenant_ids`` set when the
+    requested ``tenant_id`` is in that set — the same contract memory
+    reads use (see ``routes/memories.py:list_memories``). Cross-tenant
+    reads emit a ``cross_tenant_read`` audit event TO the source tenant
+    so per-tenant audit-log queries surface "who read FROM my tenant".
+    """
+    auth.enforce_readable_tenant(tenant_id)
     sc = get_storage_client()
     entities = await sc.list_entities(tenant_id, fleet_id=fleet_id, limit=limit)
 
     # Count linked memories per entity
     eids = [e.get("id", "") for e in entities]
     memory_counts_raw = await sc.count_memories_per_entity(tenant_id, eids) if eids else {}
+
+    if auth.is_cross_tenant_read and tenant_id != auth.tenant_id:
+        await log_cross_tenant_read(
+            db,
+            home_tenant_id=auth.tenant_id,
+            home_agent_id=auth.agent_id,
+            source_tenants=[tenant_id],
+            surface="rest_entities_list",
+            result_count_by_tenant={tenant_id: len(entities)},
+        )
 
     return [
         {
@@ -60,9 +79,15 @@ async def get_graph(
     tenant_id: str = Query(...),
     fleet_id: str | None = Query(default=None),
     auth: AuthContext = Depends(get_auth_context),
+    db: AsyncSession = Depends(get_db),
 ):
-    """Return full knowledge graph (entities + relations) for a tenant."""
-    auth.enforce_tenant(tenant_id)
+    """Return full knowledge graph (entities + relations) for a tenant.
+
+    Matches the read-widening contract used by memory reads — cross-tenant
+    credentials may inspect the graph of any tenant in
+    ``readable_tenant_ids``. Audited to the source tenant.
+    """
+    auth.enforce_readable_tenant(tenant_id)
 
     sc = get_storage_client()
     graph = await sc.get_full_graph(tenant_id, fleet_id)
@@ -73,6 +98,16 @@ async def get_graph(
     logger.info(
         f"Graph query: tenant={tenant_id} fleet={fleet_id} → {len(entities)} entities, {len(relations)} relations"
     )
+
+    if auth.is_cross_tenant_read and tenant_id != auth.tenant_id:
+        await log_cross_tenant_read(
+            db,
+            home_tenant_id=auth.tenant_id,
+            home_agent_id=auth.agent_id,
+            source_tenants=[tenant_id],
+            surface="rest_graph",
+            result_count_by_tenant={tenant_id: len(entities) + len(relations)},
+        )
 
     # Memory counts per entity
     eids = [e.get("id", "") for e in entities]
@@ -126,10 +161,22 @@ async def get_entity_route(
     auth: AuthContext = Depends(get_auth_context),
     db: AsyncSession = Depends(get_db),
 ):
-    auth.enforce_tenant(tenant_id)
+    """Fetch a single entity. Mirrors ``GET /memories/{memory_id}`` —
+    reads widen via ``readable_tenant_ids``; foreign-tenant reads are
+    audited to the source tenant."""
+    auth.enforce_readable_tenant(tenant_id)
     entity = await get_entity(db, entity_id, tenant_id)
     if not entity:
         raise HTTPException(status_code=404, detail="Entity not found")
+    if auth.is_cross_tenant_read and tenant_id != auth.tenant_id:
+        await log_cross_tenant_read(
+            db,
+            home_tenant_id=auth.tenant_id,
+            home_agent_id=auth.agent_id,
+            source_tenants=[tenant_id],
+            surface="rest_entity_get",
+            result_count_by_tenant={tenant_id: 1},
+        )
     return entity
 
 

--- a/tests/test_entity_routes_cross_tenant.py
+++ b/tests/test_entity_routes_cross_tenant.py
@@ -1,0 +1,281 @@
+"""Unit tests for the cross-tenant read contract on entity routes (#24).
+
+Previously ``routes/entities.py`` used ``enforce_tenant`` on every read
+endpoint, which silently blocked cross-tenant credentials from reading
+sibling tenants' entities — even though ``routes/memories.py`` already
+widens memory reads via ``enforce_readable_tenant``. The fix aligns the
+contract: ``list_entities``, ``get_graph``, and ``get_entity_route``
+now use ``enforce_readable_tenant`` and emit a ``cross_tenant_read``
+audit event when the requested tenant differs from the caller's home.
+
+Write routes (``upsert_entity_route``, ``upsert_relation_route``)
+intentionally retain ``enforce_tenant`` — writes pin to home_tenant.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+
+from core_api.auth import AuthContext
+from core_api.routes import entities as entities_routes
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _auth(home: str = "tenant-home", readable: list[str] | None = None) -> AuthContext:
+    """Build a non-admin AuthContext. Pass ``readable=["tenant-home",
+    "tenant-other"]`` to model a cross-tenant credential."""
+    return AuthContext(
+        tenant_id=home,
+        is_admin=False,
+        agent_id="test-agent",
+        readable_tenant_ids=readable,
+    )
+
+
+def _patch_storage(
+    monkeypatch, entities: list[dict] | None = None, graph: dict | None = None
+):
+    """Stub get_storage_client() so route handlers don't touch the network."""
+    sc = MagicMock(name="storage_client")
+    sc.list_entities = AsyncMock(return_value=entities if entities is not None else [])
+    sc.count_memories_per_entity = AsyncMock(return_value={})
+    sc.get_full_graph = AsyncMock(
+        return_value=graph if graph is not None else {"entities": [], "relations": []}
+    )
+    monkeypatch.setattr(entities_routes, "get_storage_client", lambda: sc)
+    return sc
+
+
+def _patch_audit(monkeypatch) -> AsyncMock:
+    """Stub log_cross_tenant_read with an AsyncMock so tests can assert
+    on emission shape."""
+    spy = AsyncMock(name="log_cross_tenant_read")
+    monkeypatch.setattr(entities_routes, "log_cross_tenant_read", spy)
+    return spy
+
+
+# ---------------------------------------------------------------------------
+# Contract drift fix — list_entities
+# ---------------------------------------------------------------------------
+
+
+async def test_list_entities_single_tenant_blocked_from_foreign(monkeypatch):
+    """A single-tenant credential still gets 403 when reading a
+    different tenant — the gate moved from ``enforce_tenant`` to
+    ``enforce_readable_tenant`` but the readable set for a single-tenant
+    key is exactly ``[home_tenant]``, so foreign reads still fail."""
+    _patch_storage(monkeypatch)
+    auth = _auth(home="tenant-A")  # readable = ["tenant-A"]
+    with pytest.raises(HTTPException) as exc:
+        await entities_routes.list_entities(
+            tenant_id="tenant-B",
+            fleet_id=None,
+            entity_type=None,
+            search=None,
+            limit=50,
+            auth=auth,
+            db=MagicMock(),
+        )
+    assert exc.value.status_code == 403
+
+
+async def test_list_entities_cross_tenant_credential_allowed(monkeypatch):
+    """A cross-tenant credential CAN now read sibling tenants — the
+    behaviour that was previously broken (entity reads blocked while
+    memory reads worked)."""
+    sc = _patch_storage(monkeypatch, entities=[{"id": "e1", "tenant_id": "tenant-B"}])
+    spy = _patch_audit(monkeypatch)
+    auth = _auth(home="tenant-A", readable=["tenant-A", "tenant-B"])
+
+    result = await entities_routes.list_entities(
+        tenant_id="tenant-B",
+        fleet_id=None,
+        entity_type=None,
+        search=None,
+        limit=50,
+        auth=auth,
+        db=MagicMock(),
+    )
+    assert sc.list_entities.await_count == 1
+    assert isinstance(result, list) and len(result) == 1
+    # Cross-tenant read emits an audit event TO the source tenant.
+    spy.assert_awaited_once()
+    kwargs = spy.await_args.kwargs
+    assert kwargs["home_tenant_id"] == "tenant-A"
+    assert kwargs["source_tenants"] == ["tenant-B"]
+    assert kwargs["surface"] == "rest_entities_list"
+    assert kwargs["result_count_by_tenant"] == {"tenant-B": 1}
+
+
+async def test_list_entities_home_tenant_does_not_audit(monkeypatch):
+    """Reading the home tenant must NOT emit a cross_tenant_read event
+    even if the credential is technically cross-tenant capable — the
+    audit is for the act of reading FROM a sibling, not from home."""
+    _patch_storage(monkeypatch)
+    spy = _patch_audit(monkeypatch)
+    auth = _auth(home="tenant-A", readable=["tenant-A", "tenant-B"])
+
+    await entities_routes.list_entities(
+        tenant_id="tenant-A",
+        fleet_id=None,
+        entity_type=None,
+        search=None,
+        limit=50,
+        auth=auth,
+        db=MagicMock(),
+    )
+    spy.assert_not_awaited()
+
+
+async def test_list_entities_single_tenant_does_not_audit(monkeypatch):
+    """A single-tenant credential reading its own tenant must not
+    emit an audit event. ``is_cross_tenant_read`` is False for it."""
+    _patch_storage(monkeypatch)
+    spy = _patch_audit(monkeypatch)
+    auth = _auth(home="tenant-A")  # readable = ["tenant-A"]
+
+    await entities_routes.list_entities(
+        tenant_id="tenant-A",
+        fleet_id=None,
+        entity_type=None,
+        search=None,
+        limit=50,
+        auth=auth,
+        db=MagicMock(),
+    )
+    spy.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Contract drift fix — get_graph
+# ---------------------------------------------------------------------------
+
+
+async def test_get_graph_cross_tenant_credential_allowed(monkeypatch):
+    sc = _patch_storage(
+        monkeypatch,
+        graph={"entities": [{"id": "e1"}], "relations": [{"id": "r1"}]},
+    )
+    spy = _patch_audit(monkeypatch)
+    auth = _auth(home="tenant-A", readable=["tenant-A", "tenant-B"])
+
+    await entities_routes.get_graph(
+        tenant_id="tenant-B",
+        fleet_id=None,
+        auth=auth,
+        db=MagicMock(),
+    )
+    assert sc.get_full_graph.await_count == 1
+    spy.assert_awaited_once()
+    assert spy.await_args.kwargs["surface"] == "rest_graph"
+    # Count is entities + relations, mirroring the audit surface contract.
+    assert spy.await_args.kwargs["result_count_by_tenant"] == {"tenant-B": 2}
+
+
+async def test_get_graph_single_tenant_blocked_from_foreign(monkeypatch):
+    _patch_storage(monkeypatch)
+    auth = _auth(home="tenant-A")
+    with pytest.raises(HTTPException) as exc:
+        await entities_routes.get_graph(
+            tenant_id="tenant-B",
+            fleet_id=None,
+            auth=auth,
+            db=MagicMock(),
+        )
+    assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Contract drift fix — get_entity_route (single item)
+# ---------------------------------------------------------------------------
+
+
+_FAKE_ENTITY_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+async def test_get_entity_cross_tenant_credential_allowed(monkeypatch):
+    """Single-item entity GET widens to readable_tenant_ids — matches
+    ``GET /memories/{memory_id}`` widening."""
+    spy = _patch_audit(monkeypatch)
+    fake_entity = MagicMock(name="entity")
+    monkeypatch.setattr(
+        entities_routes, "get_entity", AsyncMock(return_value=fake_entity)
+    )
+    auth = _auth(home="tenant-A", readable=["tenant-A", "tenant-B"])
+
+    result = await entities_routes.get_entity_route(
+        entity_id=_FAKE_ENTITY_ID,
+        tenant_id="tenant-B",
+        auth=auth,
+        db=MagicMock(),
+    )
+    assert result is fake_entity
+    spy.assert_awaited_once()
+    assert spy.await_args.kwargs["surface"] == "rest_entity_get"
+    assert spy.await_args.kwargs["result_count_by_tenant"] == {"tenant-B": 1}
+
+
+async def test_get_entity_not_found_does_not_audit(monkeypatch):
+    """A 404 must not emit a cross_tenant_read event — auditing a
+    non-existent entity would leak the existence of entities by their
+    presence/absence in the audit log."""
+    spy = _patch_audit(monkeypatch)
+    monkeypatch.setattr(entities_routes, "get_entity", AsyncMock(return_value=None))
+    auth = _auth(home="tenant-A", readable=["tenant-A", "tenant-B"])
+
+    with pytest.raises(HTTPException) as exc:
+        await entities_routes.get_entity_route(
+            entity_id=_FAKE_ENTITY_ID,
+            tenant_id="tenant-B",
+            auth=auth,
+            db=MagicMock(),
+        )
+    assert exc.value.status_code == 404
+    spy.assert_not_awaited()
+
+
+async def test_get_entity_single_tenant_blocked_from_foreign(monkeypatch):
+    monkeypatch.setattr(entities_routes, "get_entity", AsyncMock())
+    auth = _auth(home="tenant-A")
+    with pytest.raises(HTTPException) as exc:
+        await entities_routes.get_entity_route(
+            entity_id=_FAKE_ENTITY_ID,
+            tenant_id="tenant-B",
+            auth=auth,
+            db=MagicMock(),
+        )
+    assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Write paths remain pinned to home_tenant
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_entity_route_still_uses_enforce_tenant():
+    """The write path must NOT have widened — confirm by reading the
+    handler source. Belt-and-braces guard against future refactors that
+    might over-broaden the alignment to write paths."""
+    import inspect
+
+    src = inspect.getsource(entities_routes.upsert_entity_route)
+    assert "enforce_tenant" in src
+    assert "enforce_readable_tenant" not in src
+
+
+def test_upsert_relation_route_still_uses_enforce_tenant():
+    import inspect
+
+    src = inspect.getsource(entities_routes.upsert_relation_route)
+    assert "enforce_tenant" in src
+    assert "enforce_readable_tenant" not in src


### PR DESCRIPTION
## Summary

External audit finding #24: `routes/entities.py` reads used `enforce_tenant`, while `routes/memories.py` reads used `enforce_readable_tenant`. A cross-tenant credential could read sibling tenants' memories but not their entities — a silent asymmetry between two halves of the same knowledge graph.

Aligned by widening the three entity GET endpoints:

| Endpoint | Before | After |
|---|---|---|
| `GET /entities` | `enforce_tenant` | `enforce_readable_tenant` + `cross_tenant_read` audit |
| `GET /graph` | `enforce_tenant` | `enforce_readable_tenant` + `cross_tenant_read` audit |
| `GET /entities/{id}` | `enforce_tenant` | `enforce_readable_tenant` + `cross_tenant_read` audit (only when 200) |

Write paths (`upsert_entity_route`, `upsert_relation_route`) intentionally keep `enforce_tenant` — writes still pin to `home_tenant`.

## Audit shape

Mirrors `routes/memories.py`'s existing convention:

```
log_cross_tenant_read(
    home_tenant_id=auth.tenant_id,
    home_agent_id=auth.agent_id,
    source_tenants=[<requested tenant>],
    surface="rest_entities_list" | "rest_graph" | "rest_entity_get",
    result_count_by_tenant={<requested tenant>: <count>},
)
```

The single-item GET only audits on 200 — a 404 would leak the existence of an entity by presence/absence in the audit log.

## Tests

`tests/test_entity_routes_cross_tenant.py` (11 cases):

- Single-tenant credential still 403s on foreign reads (negative path).
- Cross-tenant credential gets 200 + audit (the bug fix).
- Home-tenant read does not emit an audit event.
- Single-tenant credential reading its own tenant does not emit an audit event.
- Per-route coverage: list, graph, single-item.
- 404 single-item read suppresses the audit event.
- Belt-and-braces guard tests asserting write routes still use `enforce_tenant`.

All 142 MCP tests pass; full suite **2367 tests** green.

## Wet test

Local stack rebuilt and exercised end-to-end via direct route invocation in the running core-api container:

- ✅ single-tenant credential → 403 on foreign read (unchanged)
- ✅ cross-tenant credential → 200 on sibling read (was 403)
- ✅ audit event emitted with correct `surface` and `source_tenants`
- ✅ home-tenant read does NOT emit audit
- ✅ graph endpoint widened + audited

Also confirmed home-tenant read still returns 200 via the live gateway with the bootstrap user.

## Test plan

- [x] Unit tests pass (`pytest tests/test_entity_routes_cross_tenant.py -q`)
- [x] Full pytest suite green (2367 tests)
- [x] `ruff check` + `ruff format --check` pass on touched files
- [x] Local wet test: cross-tenant reads succeed + audit fires; single-tenant 403s unchanged