### PR TITLE
perf(recall): add stampede guard to query-embedding cache

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2560,6 +2560,22 @@ def _normalize_query_for_cache(query: str) -> str:
     return re.sub(r"\s+", " ", query.strip().lower())
 
 
+# Per-process stampede guard for cold-cache embed calls. Maps cache-key to
+# the in-flight Future producing the embedding. When N concurrent callers
+# miss the cache for the same key, the first arrival registers the Future
+# and fires the embed call; subsequent arrivals find the Future and await
+# its result instead of each issuing their own OpenAI round-trip.
+#
+# Scope is intentionally per-process: a Redis-side lock would coordinate
+# across replicas but the latency floor of the read path is already a
+# single embed call per cold key per replica, and the stampede pattern
+# observed in production is dominated by the same client issuing N
+# parallel recalls (e.g. fan-out probe, agent batch) hitting the same
+# replica. Cache_set still happens, so once any replica completes the
+# embed, the next request — local OR remote — finds it in Redis.
+_inflight_embeddings: dict[str, asyncio.Future] = {}
+
+
 async def _get_or_cache_embedding(query: str, tenant_id: str, tenant_config):
     """Get embedding from cache or generate it.
 
@@ -2567,6 +2583,11 @@ async def _get_or_cache_embedding(query: str, tenant_id: str, tenant_config):
     migration doesn't surface stale cached embeddings to the new schema;
     old entries with a mismatched dim become unreachable under the new
     key and expire naturally via ``EMBEDDING_CACHE_TTL``.
+
+    Concurrent cold-cache callers for the same key share a single
+    ``get_query_embedding`` round-trip via ``_inflight_embeddings`` —
+    measured 3-second tail spread on 5 parallel novel-query recalls
+    pre-fix; post-fix all callers join the leader's future.
     """
     from core_api.cache import cache_get, cache_set
 
@@ -2588,18 +2609,45 @@ async def _get_or_cache_embedding(query: str, tenant_id: str, tenant_config):
             return json.loads(_cached_raw)
         except (ValueError, TypeError):
             pass
-    # Search-side embed uses the instruction-aware path. For symmetric
-    # models (OpenAI, bge, snowflake-m, gte-en-v1.5) this is identical to
-    # ``get_embedding(query, tenant_config)``. For instruction-aware models
-    # (Qwen3-Embedding, e5-instruct), the provider prepends the configured
-    # task instruction (env: ``EMBEDDING_QUERY_INSTRUCTION``) so the query
-    # is encoded with the same instruction prefix the model was trained on.
-    # Documents (writes) embed unmodified text.
-    embedding = await asyncio.wait_for(get_query_embedding(query, tenant_config), timeout=10.0)
-    if embedding is None:
-        raise ValueError("Embedding service unavailable")
-    await cache_set(_cache_key, json.dumps(embedding), ttl=EMBEDDING_CACHE_TTL)
-    return embedding
+
+    # Cold cache: check whether another coroutine is already producing
+    # this embedding. If so, await its result. Otherwise become the
+    # leader, register the future, and fire the embed call.
+    inflight = _inflight_embeddings.get(_cache_key)
+    if inflight is not None:
+        return await inflight
+
+    loop = asyncio.get_running_loop()
+    fut: asyncio.Future = loop.create_future()
+    _inflight_embeddings[_cache_key] = fut
+    try:
+        # Search-side embed uses the instruction-aware path. For symmetric
+        # models (OpenAI, bge, snowflake-m, gte-en-v1.5) this is identical to
+        # ``get_embedding(query, tenant_config)``. For instruction-aware models
+        # (Qwen3-Embedding, e5-instruct), the provider prepends the configured
+        # task instruction (env: ``EMBEDDING_QUERY_INSTRUCTION``) so the query
+        # is encoded with the same instruction prefix the model was trained on.
+        # Documents (writes) embed unmodified text.
+        embedding = await asyncio.wait_for(get_query_embedding(query, tenant_config), timeout=10.0)
+        if embedding is None:
+            raise ValueError("Embedding service unavailable")
+        await cache_set(_cache_key, json.dumps(embedding), ttl=EMBEDDING_CACHE_TTL)
+        fut.set_result(embedding)
+        return embedding
+    except BaseException as exc:
+        # Propagate to every waiter so they raise consistently rather
+        # than hanging forever on a fulfilled-never future. BaseException
+        # catches CancelledError too — leaking a cancelled future would
+        # otherwise strand every joiner. The leader re-raises after the
+        # finally block.
+        if not fut.done():
+            fut.set_exception(exc)
+        raise
+    finally:
+        # Drop the inflight slot only after the future has been resolved.
+        # A late arrival that read the slot before this pop still gets
+        # the cached future and awaits its already-resolved state.
+        _inflight_embeddings.pop(_cache_key, None)
 
 
 async def _entity_boost_pipeline(

--- a/tests/test_query_embedding_stampede_guard.py
+++ b/tests/test_query_embedding_stampede_guard.py
@@ -1,0 +1,245 @@
+"""Concurrency tests for the query-embedding cache stampede guard (P4).
+
+Wet-tested on memclaw.dev before the fix: 5 parallel recalls with a novel
+query produced a 3-second tail spread (5.67s → 8.70s) — each request
+independently issued its own ``get_query_embedding`` round-trip and
+serialized on the embedding provider's HTTP client pool.
+
+The fix in ``memory_service._get_or_cache_embedding`` registers a
+process-local ``asyncio.Future`` per cache-key in ``_inflight_embeddings``
+so concurrent cold-cache callers share a single embed round-trip.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from core_api.services import memory_service
+
+pytestmark = [pytest.mark.unit]
+
+
+_FAKE_EMBED = [0.1] * 8
+
+
+@pytest.fixture(autouse=True)
+def _clear_inflight():
+    """Ensure inflight dict is empty across tests — otherwise a prior
+    test that ended on an unresolved future would deadlock the next."""
+    memory_service._inflight_embeddings.clear()
+    yield
+    memory_service._inflight_embeddings.clear()
+
+
+async def test_concurrent_cold_misses_share_one_embed_call():
+    """The smoking gun: N parallel callers, one upstream embed call."""
+    embed_calls = 0
+
+    async def _slow_embed(query, tenant_config):
+        nonlocal embed_calls
+        embed_calls += 1
+        # Simulate the multi-second latency of a real OpenAI round-trip
+        # so the stampede window is wide enough for all N callers to
+        # arrive before the leader resolves its future.
+        await asyncio.sleep(0.05)
+        return _FAKE_EMBED
+
+    async def _miss(_key):
+        return None
+
+    async def _noop_set(_key, _value, ttl=0):
+        return None
+
+    with (
+        patch.object(memory_service, "get_query_embedding", new=_slow_embed),
+        patch("core_api.cache.cache_get", new=_miss),
+        patch("core_api.cache.cache_set", new=_noop_set),
+    ):
+        results = await asyncio.gather(
+            *[
+                memory_service._get_or_cache_embedding("novel query", "tenant-A", None)
+                for _ in range(10)
+            ]
+        )
+
+    assert embed_calls == 1, f"stampede: {embed_calls} upstream calls"
+    # Every caller received the same embedding.
+    for r in results:
+        assert r == _FAKE_EMBED
+
+
+async def test_different_queries_get_independent_futures():
+    """Distinct cache keys must NOT share a future — otherwise queries
+    would block each other on unrelated work."""
+    embed_calls = 0
+
+    async def _embed(query, tenant_config):
+        nonlocal embed_calls
+        embed_calls += 1
+        await asyncio.sleep(0.02)
+        return _FAKE_EMBED
+
+    async def _miss(_key):
+        return None
+
+    async def _noop_set(_key, _value, ttl=0):
+        return None
+
+    with (
+        patch.object(memory_service, "get_query_embedding", new=_embed),
+        patch("core_api.cache.cache_get", new=_miss),
+        patch("core_api.cache.cache_set", new=_noop_set),
+    ):
+        await asyncio.gather(
+            memory_service._get_or_cache_embedding("query A", "tenant-A", None),
+            memory_service._get_or_cache_embedding("query B", "tenant-A", None),
+            memory_service._get_or_cache_embedding("query C", "tenant-A", None),
+        )
+
+    assert embed_calls == 3, "distinct queries should produce distinct embed calls"
+
+
+async def test_cache_hit_skips_inflight_path_entirely():
+    """A warm cache must short-circuit before the inflight check — no
+    future registration, no contention with concurrent cold misses."""
+    embed_calls = 0
+
+    async def _embed(query, tenant_config):
+        nonlocal embed_calls
+        embed_calls += 1
+        return _FAKE_EMBED
+
+    cached_payload = "[0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]"
+
+    async def _hit(_key):
+        return cached_payload
+
+    async def _noop_set(_key, _value, ttl=0):
+        return None
+
+    with (
+        patch.object(memory_service, "get_query_embedding", new=_embed),
+        patch("core_api.cache.cache_get", new=_hit),
+        patch("core_api.cache.cache_set", new=_noop_set),
+    ):
+        result = await memory_service._get_or_cache_embedding(
+            "warm query", "tenant-A", None
+        )
+
+    assert embed_calls == 0
+    assert result == _FAKE_EMBED
+    # Inflight map stays empty when the lookup hits cache.
+    assert memory_service._inflight_embeddings == {}
+
+
+async def test_inflight_slot_cleared_on_success():
+    """After a successful resolution the slot must be removed so a
+    subsequent cold call with the same key starts a fresh future
+    (rather than awaiting a stale completed one indefinitely held)."""
+
+    async def _embed(query, tenant_config):
+        return _FAKE_EMBED
+
+    async def _miss(_key):
+        return None
+
+    async def _noop_set(_key, _value, ttl=0):
+        return None
+
+    with (
+        patch.object(memory_service, "get_query_embedding", new=_embed),
+        patch("core_api.cache.cache_get", new=_miss),
+        patch("core_api.cache.cache_set", new=_noop_set),
+    ):
+        await memory_service._get_or_cache_embedding("q", "tenant-A", None)
+        assert memory_service._inflight_embeddings == {}
+        # A second call also clears.
+        await memory_service._get_or_cache_embedding("q", "tenant-A", None)
+        assert memory_service._inflight_embeddings == {}
+
+
+async def test_exception_propagates_to_all_waiters():
+    """If the leader's embed call raises, every waiter must see the
+    same exception — otherwise N waiters would hang forever on an
+    unresolved future."""
+    leader_started = asyncio.Event()
+
+    async def _failing_embed(query, tenant_config):
+        leader_started.set()
+        await asyncio.sleep(0.02)
+        raise RuntimeError("upstream embed failed")
+
+    async def _miss(_key):
+        return None
+
+    async def _noop_set(_key, _value, ttl=0):
+        return None
+
+    with (
+        patch.object(memory_service, "get_query_embedding", new=_failing_embed),
+        patch("core_api.cache.cache_get", new=_miss),
+        patch("core_api.cache.cache_set", new=_noop_set),
+    ):
+        results = await asyncio.gather(
+            *[
+                memory_service._get_or_cache_embedding("doomed", "tenant-A", None)
+                for _ in range(5)
+            ],
+            return_exceptions=True,
+        )
+
+    assert len(results) == 5
+    # Every caller saw an exception. Leader raises RuntimeError directly;
+    # waiters await the future and see the same RuntimeError it carries.
+    for r in results:
+        assert isinstance(r, RuntimeError)
+        assert str(r) == "upstream embed failed"
+    # And the inflight slot is cleared so the next call doesn't await a
+    # rejected ghost future.
+    assert memory_service._inflight_embeddings == {}
+
+
+async def test_timeout_propagates_to_all_waiters():
+    """get_query_embedding is wrapped in asyncio.wait_for(timeout=10).
+    A timeout on the leader must also propagate."""
+
+    async def _hangs(query, tenant_config):
+        # The wait_for(timeout=10) wrapper inside _get_or_cache_embedding
+        # is too slow for a unit test, so make our embed take longer
+        # than that. We instead monkeypatch the wait_for timeout itself
+        # for this case via a faster stub.
+        await asyncio.sleep(2.0)
+        return _FAKE_EMBED
+
+    async def _miss(_key):
+        return None
+
+    async def _noop_set(_key, _value, ttl=0):
+        return None
+
+    # Patch wait_for to a 50ms timeout so the test completes quickly.
+    real_wait_for = asyncio.wait_for
+
+    async def _fast_wait_for(coro, timeout):
+        return await real_wait_for(coro, 0.05)
+
+    with (
+        patch.object(memory_service, "get_query_embedding", new=_hangs),
+        patch("core_api.cache.cache_get", new=_miss),
+        patch("core_api.cache.cache_set", new=_noop_set),
+        patch("core_api.services.memory_service.asyncio.wait_for", new=_fast_wait_for),
+    ):
+        results = await asyncio.gather(
+            *[
+                memory_service._get_or_cache_embedding("slow", "tenant-A", None)
+                for _ in range(3)
+            ],
+            return_exceptions=True,
+        )
+
+    for r in results:
+        assert isinstance(r, asyncio.TimeoutError)
+    assert memory_service._inflight_embeddings == {}


### PR DESCRIPTION
## Summary

External audit finding **P4**: `_get_or_cache_embedding` in `services/memory_service.py:2563-2602` has no per-key dedup on the cold-cache path. N concurrent recalls for the same novel query each issue their own `get_query_embedding` round-trip and serialize on the embedding provider's HTTP client pool.

## Wet-test signature

Reproduced on memclaw.dev before the fix — 5 parallel recalls with a brand-new query:

```
trial 4: 5.67s
trial 3: 5.73s
trial 5: 5.76s
trial 2: 6.67s
trial 1: 8.70s
wall-clock: 8.84s
```

3-second tail spread. Under a stampede guard one leader pays the embed cost and the rest join its future — a tight cluster instead.

## Fix

Process-local `dict[str, asyncio.Future]` keyed by cache-key in `_inflight_embeddings`:

1. Warm cache (Redis hit) — short-circuits before the inflight check, unchanged.
2. Cold miss + no inflight future — create future, fire `get_query_embedding`, set result.
3. Cold miss + inflight future exists — `await inflight`, get the leader's result.

Exceptions (including `TimeoutError` from the existing 10s `wait_for`) propagate to every waiter via `fut.set_exception(...)`. The leader pops the inflight slot in `finally` so a follow-on cold call with the same key starts a fresh future rather than awaiting a stale completed one.

## Scope decision: per-process, not per-replica

A Redis SETNX lock would coordinate across replicas, but the observed stampede pattern is one client issuing N parallel recalls hitting the same replica. Once any replica completes the embed, Redis hosts the result for the next request — local or remote. The added complexity of a distributed lock isn't justified by the data.

## Tests

`tests/test_query_embedding_stampede_guard.py` (6 cases):

- 10 concurrent cold misses → exactly 1 upstream embed call
- Distinct queries → distinct embed calls (no false sharing)
- Cache hit bypasses the inflight path entirely (no slot churn)
- Inflight slot cleared after success
- Exception propagates to all 5 concurrent waiters with same message
- TimeoutError propagates to all waiters

All 142 MCP tests pass; full suite **2380 tests** green.

## Live-container wet test

After rebuilding the local stack with the fix:

```
$ docker compose exec core-api python <stampede-probe.py>
10 parallel callers → 1 upstream embed call(s)
PASS: stampede guard active in live image
```

End-to-end recall via the gateway also exercised — the live behavior tracks the unit-test contract.

## Test plan

- [x] Unit tests pass (`pytest tests/test_query_embedding_stampede_guard.py -q`)
- [x] Full pytest suite green (2380 tests)
- [x] `ruff check` + `ruff format --check` pass on touched files
- [x] Local wet test: in-container probe confirms 10 callers → 1 embed call
- [x] Existing cache-dim-versioning test still passes (no regression on the warm-cache path)

## Follow-up (not in this PR)

Audit P3 — `_mcp_session()` wraps the entire MCP tool body across 7 sites, holding a pooled DB connection during multi-second LLM round-trips in `memclaw_recall`, `memclaw_insights`, `memclaw_evolve`. Will land as a separate PR (recall path refactor to close the session before the LLM call) so this perf win can ship independently.