### PR TITLE
CAURA-684 fix(search): ENTITY_LOOKUP short-circuit silently fails on …

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -208,10 +208,13 @@ class ClassifyQuery:
             if isinstance(partial, BaseException):
                 logger.warning("expand_graph failed for a fleet: %s", partial)
                 continue
-            # Storage client returns {entity_id_str: [hop, weight], ...}
+            # Storage returns {entity_id_str: {"hop": int, "weight": float}, ...}
+            # (See core-storage-api/.../routers/entities.py expand_graph route.)
+            # Positional indexing here used to ``KeyError: 0`` on every call,
+            # silently killing the ENTITY_LOOKUP short-circuit. CAURA-684.
             for eid_str, hop_weight in partial.items():
                 eid = UUID(eid_str)
-                hop, weight = hop_weight[0], hop_weight[1]
+                hop, weight = hop_weight["hop"], hop_weight["weight"]
                 if (
                     eid not in merged
                     or hop < merged[eid][0]

--- a/tests/pipeline/test_classify_query.py
+++ b/tests/pipeline/test_classify_query.py
@@ -106,7 +106,7 @@ async def test_entity_lookup_with_match(mock_get_sc):
 
     sc = _mock_sc()
     sc.fts_search_entities = AsyncMock(return_value=[eid_str])
-    sc.expand_graph = AsyncMock(return_value={eid_str: [0, 1.0]})
+    sc.expand_graph = AsyncMock(return_value={eid_str: {"hop": 0, "weight": 1.0}})
     sc.get_memory_ids_by_entity_ids = AsyncMock(
         return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
     )
@@ -143,7 +143,7 @@ async def test_entity_lookup_no_linked_memories(mock_get_sc):
 
     sc = _mock_sc()
     sc.fts_search_entities = AsyncMock(return_value=[eid_str])
-    sc.expand_graph = AsyncMock(return_value={eid_str: [0, 1.0]})
+    sc.expand_graph = AsyncMock(return_value={eid_str: {"hop": 0, "weight": 1.0}})
     sc.get_memory_ids_by_entity_ids = AsyncMock(return_value=[])
     mock_get_sc.return_value = sc
 
@@ -291,7 +291,7 @@ async def test_entity_lookup_takes_priority_over_temporal(mock_get_sc):
 
     sc = _mock_sc()
     sc.fts_search_entities = AsyncMock(return_value=[eid_str])
-    sc.expand_graph = AsyncMock(return_value={eid_str: [0, 1.0]})
+    sc.expand_graph = AsyncMock(return_value={eid_str: {"hop": 0, "weight": 1.0}})
     sc.get_memory_ids_by_entity_ids = AsyncMock(
         return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
     )
@@ -395,7 +395,7 @@ async def test_entity_lookup_takes_priority_over_recent(mock_get_sc):
 
     sc = _mock_sc()
     sc.fts_search_entities = AsyncMock(return_value=[eid_str])
-    sc.expand_graph = AsyncMock(return_value={eid_str: [0, 1.0]})
+    sc.expand_graph = AsyncMock(return_value={eid_str: {"hop": 0, "weight": 1.0}})
     sc.get_memory_ids_by_entity_ids = AsyncMock(
         return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
     )
@@ -451,8 +451,12 @@ async def test_expand_per_fleet_parallel_merges_correctly():
     sc = AsyncMock()
     sc.expand_graph = AsyncMock(
         side_effect=[
-            {str(eid_a): [0, 1.0], str(eid_b): [2, 0.5]},
-            {str(eid_a): [1, 0.8], str(eid_b): [1, 0.9], str(eid_c): [0, 1.0]},
+            {str(eid_a): {"hop": 0, "weight": 1.0}, str(eid_b): {"hop": 2, "weight": 0.5}},
+            {
+                str(eid_a): {"hop": 1, "weight": 0.8},
+                str(eid_b): {"hop": 1, "weight": 0.9},
+                str(eid_c): {"hop": 0, "weight": 1.0},
+            },
         ]
     )
 
@@ -478,7 +482,7 @@ async def test_expand_per_fleet_partial_failure():
     sc = AsyncMock()
     sc.expand_graph = AsyncMock(
         side_effect=[
-            {str(eid_a): [0, 1.0]},  # fleet 1 succeeds
+            {str(eid_a): {"hop": 0, "weight": 1.0}},  # fleet 1 succeeds
             RuntimeError("DB connection lost"),  # fleet 2 fails
         ]
     )

--- a/tests/test_entity_lookup_short_circuit.py
+++ b/tests/test_entity_lookup_short_circuit.py
@@ -1,0 +1,147 @@
+"""CAURA-684: ENTITY_LOOKUP short-circuit shape contract.
+
+Before this fix, ``ClassifyQuery._expand_per_fleet`` indexed the
+``expand_graph`` response positionally (``hop_weight[0]`` /
+``hop_weight[1]``), but storage returns ``{"hop": int, "weight": float}``
+dicts — see ``core-storage-api/.../routers/entities.py`` ``expand_graph``
+route. Every entity-token query KeyError'd at line 214, the broad
+``except Exception:`` at line 123 swallowed it, and the pipeline fell
+through to keyword/semantic search.
+
+Confirmed in prod logs before fix:
+  staging-memclaw-core-api : 1,327 occurrences / 24h
+  prod-memclaw-core-api    : 206 occurrences / 24h
+
+This test pins the dict-shape contract. It mocks storage to return the
+shape the real ``expand_graph`` route emits and asserts ``ClassifyQuery``
+selects the ENTITY_LOOKUP strategy end-to-end. ``scored_search`` is
+mocked to return memory rows directly, isolating this test from the
+separate ``_collect_memories`` payload-contract bug (omitted
+``embedding``/``query``/``search_params``) that is tracked as a follow-up.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+async def test_entity_lookup_short_circuit_fires_with_dict_shaped_expand_graph():
+    """ClassifyQuery selects ENTITY_LOOKUP when entity FTS + expand_graph
+    produce matches and ``_collect_memories`` returns rows.
+
+    The critical fixture detail is ``expand_graph`` returning
+    ``{eid_str: {"hop": 0, "weight": 1.0}}`` — the dict shape the real
+    storage route emits. The pre-fix consumer at classify_query.py:214
+    raised ``KeyError: 0`` against this shape.
+    """
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.search.classify_query import ClassifyQuery
+    from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
+
+    matched_entity_id = uuid4()
+    matched_memory_id = str(uuid4())
+
+    fake_storage = AsyncMock()
+    fake_storage.fts_search_entities = AsyncMock(return_value=[str(matched_entity_id)])
+    # Storage shape: dict with "hop" / "weight" keys. Matches
+    # core-storage-api/.../routers/entities.py expand_graph route.
+    fake_storage.expand_graph = AsyncMock(
+        return_value={str(matched_entity_id): {"hop": 0, "weight": 1.0}}
+    )
+    fake_storage.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[
+            {
+                "memory_id": matched_memory_id,
+                "entity_id": str(matched_entity_id),
+                "role": "subject",
+            }
+        ]
+    )
+    # _collect_memories' scored_search call is mocked to return rows
+    # directly. The deeper bug — payload missing embedding/query/
+    # search_params — is tracked separately; isolating this test from
+    # that contract gap lets the line-214 fix be asserted alone.
+    fake_storage.scored_search = AsyncMock(
+        return_value=[
+            {
+                "id": matched_memory_id,
+                "tenant_id": "tenant-test",
+                "content": "Heartbeat check completed",
+                "memory_type": "task",
+                "weight": 0.5,
+                "status": "active",
+                "ts_valid_start": None,
+                "ts_valid_end": None,
+                "metadata_": {},
+                "fleet_id": None,
+            }
+        ]
+    )
+
+    ctx = PipelineContext()
+    ctx.data = {
+        "query": "central control heartbeat",
+        "tenant_id": "tenant-test",
+        "search_params": {
+            "fts_weight": 0.3,
+            "graph_max_hops": 2,
+            "top_k": 5,
+        },
+        "temporal_window": None,
+    }
+
+    with patch(
+        "core_api.pipeline.steps.search.classify_query.get_storage_client",
+        return_value=fake_storage,
+    ):
+        await ClassifyQuery().execute(ctx)
+
+    plan = ctx.data.get("retrieval_plan")
+    assert plan is not None, "ClassifyQuery should always emit a retrieval_plan"
+    assert plan.strategy == RetrievalStrategy.ENTITY_LOOKUP, (
+        f"Expected ENTITY_LOOKUP short-circuit; got {plan.strategy}. "
+        "If this fails with strategy=keyword/semantic, the broad except at "
+        "classify_query.py:123 is hiding a regression — check the logs."
+    )
+    assert plan.skip_embedding is True
+    assert plan.skip_scored_search is True
+    assert str(matched_entity_id) in [str(eid) for eid in plan.matched_entity_ids]
+
+    rows = ctx.data.get("filtered_rows", [])
+    assert rows, "ENTITY_LOOKUP should populate filtered_rows for downstream steps"
+    assert rows[0].Memory.id == matched_memory_id
+
+
+async def test_expand_per_fleet_parses_dict_shape_directly():
+    """Unit-level guard on the exact line that broke: ``_expand_per_fleet``
+    must accept ``{eid_str: {"hop": int, "weight": float}}`` and return
+    a merged ``{UUID: (hop, weight)}`` mapping.
+    """
+    from core_api.pipeline.steps.search.classify_query import ClassifyQuery
+
+    eid1, eid2 = uuid4(), uuid4()
+    fake_storage = AsyncMock()
+    fake_storage.expand_graph = AsyncMock(
+        return_value={
+            str(eid1): {"hop": 0, "weight": 1.0},
+            str(eid2): {"hop": 1, "weight": 0.8},
+        }
+    )
+
+    merged = await ClassifyQuery._expand_per_fleet(
+        fake_storage,
+        seed_ids=[eid1],
+        tenant_id="tenant-test",
+        fleet_ids=None,
+        max_hops=2,
+        use_union=True,
+    )
+
+    assert merged == {eid1: (0, 1.0), eid2: (1, 0.8)}, (
+        f"Expected merged hop/weight tuples; got {merged}"
+    )


### PR DESCRIPTION
…every call

ClassifyQuery._expand_per_fleet indexed the expand_graph response positionally (hop_weight[0] / hop_weight[1]), but storage returns {"hop": int, "weight": float} dicts (see core-storage-api/.../routers/ entities.py expand_graph route). Every entity-token search KeyError'd at classify_query.py:214; the broad except Exception: at line 123 swallowed it and the pipeline fell through to keyword/semantic search.

Confirmed in prod logs (24h):
  staging-memclaw-core-api : 1,327 occurrences
  prod-memclaw-core-api    : 206 occurrences

Switch to dict-key access. Other consumer at parallel_embed_entity_boost .py:74-77 already reads the dict shape correctly — this aligns both sites on the documented storage contract.

Adds tests/test_entity_lookup_short_circuit.py with two assertions:
1. _expand_per_fleet parses the dict shape and emits {UUID: (hop, weight)}.
2. ClassifyQuery selects ENTITY_LOOKUP end-to-end against a faithful storage mock (negative control: both fail without this fix).

A separate payload-contract bug at _collect_memories (omitted embedding/query/search_params) is now reachable and tracked as a follow-up — the scored_search call in this fix's test is mocked to isolate the line-214 contract.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
