### PR TITLE
fix(write): skip embedding-cache lookup when embedding is deferred (CAURA-682)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/compute_content_hash.py
+++ b/core-api/src/core_api/pipeline/steps/write/compute_content_hash.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from core_api.clients.storage_client import get_storage_client
+from core_api.config import settings
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
 from core_api.services.memory_service import _content_hash
@@ -23,9 +24,13 @@ class ComputeContentHash:
         ch = _content_hash(data.tenant_id, data.fleet_id, data.content) if data.persist else None
         ctx.data["content_hash"] = ch
 
-        # Check for existing embedding from duplicate content (saves LLM call)
+        # The lookup only matters when ``ParallelEmbedEnrich`` will run
+        # ``get_embedding`` inline — its ``cached_embedding`` short-circuit
+        # has no effect when embedding is deferred to ``core-worker``,
+        # which performs its own content-hash dedup. Skip the request-
+        # path roundtrip in that case.
         cached_embedding = None
-        if ch:
+        if ch and settings.inline_embedding:
             sc = get_storage_client()
             cached_embedding = await sc.find_embedding_by_content_hash(
                 data.tenant_id,

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -63,6 +63,67 @@ async def test_validate_step_rejects_short_content():
 
 
 @pytest.mark.asyncio
+async def test_compute_content_hash_skips_cache_lookup_when_embedding_deferred(
+    monkeypatch,
+):
+    """CAURA-682 / CAURA-685: ComputeContentHash must NOT call
+    ``sc.find_embedding_by_content_hash`` when ``settings.inline_embedding``
+    is False (the SaaS / staging default). The cache lookup is only
+    useful to bypass an inline ``get_embedding`` call; when embedding is
+    deferred to ``core-worker``, the lookup is wasted work AND under
+    storm load (noisy-neighbor scenario) it observed p95 of ~17.8 s on
+    staging — the single step that dominated the write degradation."""
+    from unittest.mock import AsyncMock, patch
+    from core_api.config import settings
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.write.compute_content_hash import ComputeContentHash
+
+    # ``inline_embedding`` is a derived property from ``deployment_mode``.
+    monkeypatch.setattr(settings, "deployment_mode", "deferred")
+    ctx = PipelineContext(db=AsyncMock(), data={"input": _make_input()})
+
+    mock_sc = AsyncMock()
+    with patch(
+        "core_api.pipeline.steps.write.compute_content_hash.get_storage_client",
+        return_value=mock_sc,
+    ):
+        await ComputeContentHash().execute(ctx)
+
+    mock_sc.find_embedding_by_content_hash.assert_not_called()
+    # Hash is still computed; just the lookup is skipped.
+    assert ctx.data["content_hash"] is not None
+    assert ctx.data["cached_embedding"] is None
+
+
+@pytest.mark.asyncio
+async def test_compute_content_hash_still_looks_up_when_embedding_inline(
+    monkeypatch,
+):
+    """OSS-standalone (``inline_embedding=True``) preserves the optimization
+    — the cache lookup still runs so a duplicate-content write skips the
+    inline ``get_embedding`` call. Regression guard for the path the
+    deferred-mode fix MUST NOT break."""
+    from unittest.mock import AsyncMock, patch
+    from core_api.config import settings
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.write.compute_content_hash import ComputeContentHash
+
+    monkeypatch.setattr(settings, "deployment_mode", "inline")
+    ctx = PipelineContext(db=AsyncMock(), data={"input": _make_input()})
+
+    mock_sc = AsyncMock()
+    mock_sc.find_embedding_by_content_hash.return_value = [0.1, 0.2, 0.3]
+    with patch(
+        "core_api.pipeline.steps.write.compute_content_hash.get_storage_client",
+        return_value=mock_sc,
+    ):
+        await ComputeContentHash().execute(ctx)
+
+    mock_sc.find_embedding_by_content_hash.assert_called_once()
+    assert ctx.data["cached_embedding"] == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.asyncio
 async def test_apply_enrichment_step_defaults():
     """MergeEnrichmentFields applies correct defaults when no enrichment."""
     from unittest.mock import AsyncMock


### PR DESCRIPTION
## Summary

[CAURA-682](https://caura-ai.atlassian.net/browse/CAURA-682). Removes the request-path call to ``sc.find_embedding_by_content_hash`` when ``settings.inline_embedding`` is False (the SaaS / staging ``DEPLOYMENT_MODE=deferred`` default).

## Root cause (Phase 1.5 measurement)

After [PR #209](https://github.com/caura-ai/caura-memclaw/pull/209) made stdlib ``extra={...}`` fields reach GCP, the pipeline-runner's built-in per-step timing logs became queryable. Slicing them during the noisy-neighbor storm window:

| Step | n | p50 | p95 | max |
|---|---:|---:|---:|---:|
| **``compute_content_hash``** | 4 | **79.5 ms** | **17,844.8 ms** | **17,844.8 ms** |
| write_memory_row | 3 | 37.5 ms | 38.9 ms | 38.9 ms |
| check_exact_duplicate | 3 | 30.5 ms | 37.1 ms | 37.1 ms |
| load_tenant_config | 4 | 0.02 ms | 0.10 ms | 0.10 ms |
| (all others) | — | <0.1 ms | <0.1 ms | <0.1 ms |

One step out of nine accounts for the entire write degradation. ``compute_content_hash``'s only meaningful work is an HTTP roundtrip to ``core-storage-api`` for ``find_embedding_by_content_hash`` — and that endpoint specifically is taking up to 17.8 s under storm load. ``check_exact_duplicate`` uses the same storage_client, same connection pool, but its endpoint (``find_by_content_hash``) stays at ~37 ms.

The storage-api slowness is filed separately as **[CAURA-685](https://caura-ai.atlassian.net/browse/CAURA-685)** for investigation.

## Why this is safe

The cache lookup's only effect is to populate ``ctx.data["cached_embedding"]``, which ``ParallelEmbedEnrich`` consults to bypass the inline ``get_embedding`` call. Under ``DEPLOYMENT_MODE=deferred``:

- ``settings.inline_embedding`` is False
- ``ParallelEmbedEnrich`` publishes ``Topics.Memory.EMBED_REQUESTED`` and skips the inline call regardless of ``cached_embedding``
- ``core-worker`` runs the embedding job and does its OWN content-hash dedup before calling the LLM

So the request-path lookup saves **nothing** for deferred-mode deployments. It was costing every write the storage-api roundtrip — which is normally cheap but becomes ~18 s under load.

OSS-standalone (``DEPLOYMENT_MODE=inline``, ``inline_embedding=True``) keeps the optimization — covered by the new regression test.

## Initial Phase 3 hypothesis was wrong

Earlier in this investigation I bumped ``containerConcurrency`` from 2 to 8 on staging-memclaw-core-api, expecting it to cut Cloud Run cold-start cost. Result was *worse*: write degradation went from 7.79× to 9.44× because the autoscaler under-scaled (10 instances vs the previous run's 41) and 80 slots couldn't absorb the 150-burst. **Reverted to cc=2.**

The bimodal ``total_ms`` I was seeing wasn't cold-start at all — it was request-path waiting on ``storage_client``'s slow roundtrip, evenly distributed across all 10 instances. Phase 1.5 step-level slicing made that obvious in one query.

## Test plan

- [x] ``uv run pytest tests/pipeline/`` — 81/81 pass (79 existing + 2 new for compute_content_hash deferred / inline paths)
- [x] ``uv run ruff check / format --check`` clean
- [x] ``cd core-api && uv run mypy src/`` — 161 source files, clean
- [ ] After merge → auto-deploy via CAURA-683 webhook → re-run ``python loadtest.py dry dev`` → verify tenant B write p95 storm/baseline ratio drops to ≤2.0×
- [ ] CAURA-685 remains open — storage-api slowness still affects core-worker dedup + any future caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-682]: https://caura-ai.atlassian.net/browse/CAURA-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAURA-685]: https://caura-ai.atlassian.net/browse/CAURA-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ