### PR TITLE
fix(mcp): wrap 5 raw-string error returns in _error_response (audit B4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,25 @@ jobs:
       - name: Run Ruff formatter check (core-storage-api)
         run: uv run ruff format --check core-storage-api/src/
 
+      - name: Guard against raw-string MCP error returns (audit B4 / CAURA-000 #147)
+        # MCP tool handlers must build error envelopes via ``_error_response(...)``
+        # so ``_with_latency`` can flip ``CallToolResult.isError = True``. Raw
+        # ``"Error: ..."`` / ``"Error (NNN): ..."`` returns slip past the
+        # JSON-shape detector and reach the client as ``isError=False`` —
+        # the exact regression we keep closing. Fail CI if any reappear.
+        run: |
+          # Match both double- and single-quoted forms, with optional f-string
+          # prefix. ``grep -n`` prefixes each hit with ``LINE:`` so the
+          # comment-skip filter anchors on ``^[0-9]+:\s*#``.
+          if grep -nE '[f]?"Error(:| \()' core-api/src/core_api/mcp_server.py | grep -vE '^[0-9]+:\s*#'; then
+            echo "::error::Raw-string MCP error return found (double-quote). Use _error_response(code, message) instead — see tests/test_mcp_iserror_propagation.py."
+            exit 1
+          fi
+          if grep -nE "[f]?'Error(:| \()" core-api/src/core_api/mcp_server.py | grep -vE '^[0-9]+:\s*#'; then
+            echo "::error::Raw-string MCP error return found (single-quote). Use _error_response(code, message) instead — see tests/test_mcp_iserror_propagation.py."
+            exit 1
+          fi
+
       - name: Run mypy (core-api)
         run: cd core-api && uv run mypy src/
 

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -910,7 +910,11 @@ async def memclaw_manage(
                     fields["source_uri"] = source_uri
                 if not fields:
                     return _with_latency(
-                        "Error: No fields to update. Provide at least one field to change.", t0
+                        _error_response(
+                            "INVALID_ARGUMENTS",
+                            "No fields to update. Provide at least one field to change.",
+                        ),
+                        t0,
                     )
                 await check_and_increment(db, tenant_id, "write")
                 result = await update_memory(db, uid, tenant_id, MemoryUpdate(**fields), agent_id=agent_id)
@@ -1145,8 +1149,11 @@ async def memclaw_doc(
                     embedding = await get_embedding(source)
                     if embedding is None:
                         return _with_latency(
-                            "Error: embedding provider returned no vector "
-                            "(check provider config / quota). Write aborted.",
+                            _error_response(
+                                "UPSTREAM_ERROR",
+                                "Embedding provider returned no vector "
+                                "(check provider config / quota). Write aborted.",
+                            ),
                             t0,
                         )
                 # Mirror memclaw_write's agent registration so a doc upsert
@@ -1240,8 +1247,11 @@ async def memclaw_doc(
                 query_embedding = await get_embedding(query)
                 if query_embedding is None:
                     return _with_latency(
-                        "Error: embedding provider returned no vector "
-                        "(check provider config / quota). Search aborted.",
+                        _error_response(
+                            "UPSTREAM_ERROR",
+                            "Embedding provider returned no vector "
+                            "(check provider config / quota). Search aborted.",
+                        ),
                         t0,
                     )
                 capped_top_k = max(1, min(top_k, 50))
@@ -1682,8 +1692,10 @@ async def memclaw_insights(
         _, not_found, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
         if not_found:
             return _with_latency(
-                f"Error (403): Agent '{agent_id}' is not registered. "
-                "Register the agent by writing one memory first.",
+                _error_response(
+                    "FORBIDDEN",
+                    f"Agent '{agent_id}' is not registered. Register the agent by writing one memory first.",
+                ),
                 t0,
             )
         if terr:
@@ -1769,8 +1781,10 @@ async def memclaw_evolve(
         _, not_found, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
         if not_found:
             return _with_latency(
-                f"Error (403): Agent '{agent_id}' is not registered. "
-                "Register the agent by writing one memory first.",
+                _error_response(
+                    "FORBIDDEN",
+                    f"Agent '{agent_id}' is not registered. Register the agent by writing one memory first.",
+                ),
                 t0,
             )
         if terr:

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -358,7 +358,7 @@ async def test_doc_write_embedding_provider_failure_aborts(mcp_env, monkeypatch)
         doc_id="d",
         data={"summary": "valid summary string"},
     )
-    assert "embedding provider returned no vector" in strip_latency(out)
+    assert "embedding provider returned no vector" in strip_latency(out).lower()
 
 
 # ---------------------------------------------------------------------------
@@ -476,7 +476,7 @@ async def test_doc_search_embedding_provider_failure_aborts(mcp_env, monkeypatch
     """Provider failure → no search attempt, caller sees a clear error."""
     monkeypatch.setattr("common.embedding.get_embedding", _async_return(None))
     out = await mcp_server.memclaw_doc(op="search", collection="c", query="anything")
-    assert "embedding provider returned no vector" in strip_latency(out)
+    assert "embedding provider returned no vector" in strip_latency(out).lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_iserror_propagation.py
+++ b/tests/test_mcp_iserror_propagation.py
@@ -94,3 +94,102 @@ async def test_success_path_unchanged(mcp_env, monkeypatch):
     assert isinstance(out, str), f"success path must stay str, got {type(out).__name__}"
     payload = parse_envelope(out)
     assert "error" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Codebase-audit 2026-05-19 finding B4 — 5 raw-string ``"Error: ..."`` returns
+# in ``mcp_server.py`` previously slipped past ``_with_latency``'s JSON-shape
+# detection and reached the MCP client as ``isError=False``. After the fix
+# all 5 sites must produce structured envelopes with ``isError=True``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_b4_manage_update_no_fields_sets_iserror(mcp_env):
+    """``memclaw_manage(op='update')`` with no field args is the
+    ``"Error: No fields to update..."`` site."""
+    out = await mcp_server.memclaw_manage(
+        op="update",
+        memory_id="00000000-0000-0000-0000-000000000001",
+    )
+    assert is_error_envelope(out), f"expected isError=True, got {out!r}"
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert "No fields to update" in payload["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_b4_doc_write_no_embedding_sets_iserror(mcp_env, monkeypatch):
+    """``memclaw_doc(op='write', ...)`` when the embedding provider returns
+    ``None`` is the ``"Error: embedding provider returned no vector ...
+    Write aborted."`` site."""
+    import common.embedding as _emb
+
+    async def _no_vector(_text: str):
+        return None
+
+    monkeypatch.setattr(_emb, "get_embedding", _no_vector)
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="notes",
+        doc_id="d1",
+        data={"summary": "hello"},
+    )
+    assert is_error_envelope(out), f"expected isError=True, got {out!r}"
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "UPSTREAM_ERROR"
+    assert "Write aborted" in payload["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_b4_doc_search_no_embedding_sets_iserror(mcp_env, monkeypatch):
+    """``memclaw_doc(op='search', ...)`` when the embedding provider returns
+    ``None`` is the ``"Error: embedding provider returned no vector ...
+    Search aborted."`` site."""
+    import common.embedding as _emb
+
+    async def _no_vector(_text: str):
+        return None
+
+    monkeypatch.setattr(_emb, "get_embedding", _no_vector)
+    out = await mcp_server.memclaw_doc(op="search", query="anything")
+    assert is_error_envelope(out), f"expected isError=True, got {out!r}"
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "UPSTREAM_ERROR"
+    assert "Search aborted" in payload["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_b4_insights_unregistered_agent_sets_iserror(mcp_env, monkeypatch):
+    """``memclaw_insights`` with ``_require_trust`` returning ``not_found=True``
+    is one of the two ``"Error (403): Agent ... is not registered"`` sites."""
+
+    async def _not_found(db, tenant_id, agent_id, min_level):
+        return 0, True, None
+
+    monkeypatch.setattr(mcp_server, "_require_trust", _not_found)
+    out = await mcp_server.memclaw_insights(focus="patterns", scope="agent")
+    assert is_error_envelope(out), f"expected isError=True, got {out!r}"
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "FORBIDDEN"
+    assert "is not registered" in payload["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_b4_evolve_unregistered_agent_sets_iserror(mcp_env, monkeypatch):
+    """``memclaw_evolve`` with ``_require_trust`` returning ``not_found=True``
+    is the second ``"Error (403): Agent ... is not registered"`` site."""
+
+    async def _not_found(db, tenant_id, agent_id, min_level):
+        return 0, True, None
+
+    monkeypatch.setattr(mcp_server, "_require_trust", _not_found)
+    out = await mcp_server.memclaw_evolve(
+        outcome="shipped a thing",
+        outcome_type="success",
+        scope="agent",
+    )
+    assert is_error_envelope(out), f"expected isError=True, got {out!r}"
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "FORBIDDEN"
+    assert "is not registered" in payload["error"]["message"]


### PR DESCRIPTION
## Summary

- Five MCP tool sites in `mcp_server.py` returned raw `"Error: ..."` / `f"Error (403): ..."` strings through `_with_latency`. The wrapper only flips `CallToolResult.isError=True` when the payload parses as a JSON dict with an `error` key — raw strings fell through and reached clients as `isError=False`. CAURA-000 #147 had closed an earlier batch of these; codebase audit 2026-05-19 re-surfaced it (finding B4). Validation against `main` found 5 sites (not 2 as the audit reported).
- All 5 sites now build the canonical envelope via `_error_response(code, message)`:

  | Site | Code |
  |---|---|
  | `memclaw_manage` op=update no-fields | `INVALID_ARGUMENTS` |
  | `memclaw_doc` op=write embed→None | `UPSTREAM_ERROR` |
  | `memclaw_doc` op=search embed→None | `UPSTREAM_ERROR` |
  | `memclaw_insights` unregistered agent | `FORBIDDEN` |
  | `memclaw_evolve` unregistered agent | `FORBIDDEN` |

- Added a CI grep guard against `"Error:` / `"Error (` literals in `mcp_server.py` so the pattern can't return a third time.

## Test plan

- [x] 5 new tests in `tests/test_mcp_iserror_propagation.py`, one per fixed site, asserting `is_error_envelope(out) is True` and the expected error code.
- [x] Full MCP unit-test sweep: `pytest tests/test_mcp_iserror_propagation.py tests/test_mcp_doc.py tests/test_mcp_manage.py tests/test_mcp_call_tool_e2e.py tests/test_mcp_list.py tests/test_mcp_recall.py tests/test_mcp_keystones.py tests/test_direct_mcp_skill.py` — 115/115 pass.
- [x] Ruff lint + format clean on the touched files.
- [x] Local check of the new CI step: `grep -nE '"Error:|"Error \(|f"Error:|f"Error \('` against `mcp_server.py` returns empty.
- [x] Two pre-existing assertions in `test_mcp_doc.py` adjusted to `.lower()` to match the new sentence-cased envelope message (otherwise unchanged in substance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)