### PR TITLE
feat(storage-api): add /_debug/pg_locks endpoint for live lock investigation (CAURA-686)

### DIFF
--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -28,6 +28,7 @@ from core_storage_api.middleware import RejectWritesOnReaderMiddleware
 from core_storage_api.routers import (
     agents_router,
     audit_router,
+    debug_router,
     documents_router,
     entities_router,
     fleet_router,
@@ -119,6 +120,11 @@ def create_app() -> FastAPI:
     app.include_router(tasks_router, prefix=prefix)
     app.include_router(idempotency_router, prefix=prefix)
     app.include_router(lifecycle_audit_router, prefix=prefix)
+    # CAURA-686: ``GET /api/v1/storage/_debug/pg_locks`` for live
+    # pg_locks / pg_stat_activity snapshots during contention triage.
+    # Behind the same private-VPC posture as everything else here —
+    # not exposed via the gateway.
+    app.include_router(debug_router, prefix=prefix)
 
     return app
 

--- a/core-storage-api/src/core_storage_api/routers/__init__.py
+++ b/core-storage-api/src/core_storage_api/routers/__init__.py
@@ -1,5 +1,6 @@
 from core_storage_api.routers.agents import router as agents_router
 from core_storage_api.routers.audit import router as audit_router
+from core_storage_api.routers.debug import router as debug_router
 from core_storage_api.routers.documents import router as documents_router
 from core_storage_api.routers.entities import router as entities_router
 from core_storage_api.routers.fleet import router as fleet_router
@@ -14,6 +15,7 @@ from core_storage_api.routers.tasks import router as tasks_router
 __all__ = [
     "agents_router",
     "audit_router",
+    "debug_router",
     "documents_router",
     "entities_router",
     "fleet_router",

--- a/core-storage-api/src/core_storage_api/routers/debug.py
+++ b/core-storage-api/src/core_storage_api/routers/debug.py
@@ -1,0 +1,151 @@
+"""Diagnostic endpoints for live DB inspection.
+
+Internal-only surface — exposed on the storage-api private VPC IP and
+gated by Cloud Run IAM. Not routed through the gateway. The endpoints
+here snapshot DB-side state (``pg_locks``, ``pg_stat_activity``,
+``pg_blocking_pids``) for triaging contention storms; they're cheap
+enough to poll at 1Hz during a controlled loadtest, but expensive
+enough to NOT wire into a routine dashboard.
+
+CAURA-686 motivation: instance-level Cloud Monitoring wait-event
+metrics (``alloydb.googleapis.com/instance/postgresql/wait_time``) tell
+you THAT row-level locks are accumulating but not WHICH query holds
+them. ``pg_stat_activity`` joined with ``pg_locks`` and
+``pg_blocking_pids`` is the canonical Postgres surface for that.
+AlloyDB Insights' per-query lock_time aggregation does NOT capture
+``Lock/transactionid`` / ``Lock/tuple`` — only LWLocks — so this
+endpoint is the only way to attribute row-lock waits to specific
+queries on AlloyDB.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core_storage_api.database.init import get_session
+
+router = APIRouter(tags=["Debug"])
+
+
+# Direct privilege check: ``pg_read_all_stats`` (PG 10+) exposes
+# other backends' query / wait_event / usename; ``pg_monitor`` is a
+# bundle that includes ``pg_read_all_stats``. Either grants the
+# visibility this endpoint needs. Asking the catalog directly is
+# cheaper and unambiguous compared to the older heuristic of
+# scanning the returned rows for non-NULL ``query``/``usename``
+# (which couldn't distinguish "no contention" from "no privilege").
+_PG_CHECK_STATS_SQL = text(
+    "SELECT pg_has_role(current_user, 'pg_read_all_stats', 'USAGE') "
+    "   OR pg_has_role(current_user, 'pg_monitor', 'USAGE') AS has_priv"
+)
+
+
+# Combines pg_stat_activity (backend state, current query, wait shape)
+# with the result of pg_blocking_pids() so each waiting backend lists
+# the pids that hold the locks it's queueing on. Filtered to only
+# rows that are either waiting OR holding a lock for a transaction
+# that has waiters — keeps the response small under steady state
+# and meaningful under a storm.
+#
+# CTE structure: ``backend_blockers`` calls ``pg_blocking_pids`` exactly
+# once per backend (it's not cheap); ``blocker_set`` collapses the union
+# of blocker pids so the final filter can do a single set lookup.
+# Replaces an earlier version that called ``pg_blocking_pids`` up to
+# five times per backend (once for ``WHERE``, once for the SELECT
+# projection, once for ``array_length`` in WHERE + SELECT, and once
+# inside the IN-list subquery).
+_PG_LOCKS_SNAPSHOT_SQL = text("""
+WITH backend_blockers AS (
+    SELECT
+        pid,
+        pg_blocking_pids(pid) AS blocked_by_pids
+    FROM pg_stat_activity
+    WHERE pid <> pg_backend_pid()
+      AND backend_type = 'client backend'
+),
+blocker_set AS (
+    SELECT DISTINCT unnest(blocked_by_pids) AS pid
+    FROM backend_blockers
+    WHERE cardinality(blocked_by_pids) > 0
+)
+SELECT
+    a.pid,
+    a.datname,
+    a.usename,
+    a.application_name,
+    a.state,
+    a.wait_event_type,
+    a.wait_event,
+    EXTRACT(EPOCH FROM (now() - a.xact_start))::float  AS xact_age_sec,
+    EXTRACT(EPOCH FROM (now() - a.query_start))::float AS query_age_sec,
+    LEFT(a.query, 240)                                  AS query,
+    bb.blocked_by_pids,
+    cardinality(bb.blocked_by_pids)                     AS blocked_by_n
+FROM pg_stat_activity a
+JOIN backend_blockers bb ON bb.pid = a.pid
+WHERE (
+    a.wait_event_type IS NOT NULL
+    OR cardinality(bb.blocked_by_pids) > 0
+    OR a.pid IN (SELECT pid FROM blocker_set)
+)
+ORDER BY a.xact_start NULLS LAST, a.pid
+""")
+
+
+@router.get("/_debug/pg_locks")
+async def pg_locks_snapshot(
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, Any]:
+    """Return waiting backends + their blocker pids.
+
+    Response shape::
+
+        {
+          "captured_at": "2026-05-25T15:42:13.456Z",
+          "pg_read_all_stats": true,
+          "rows": [
+            {
+              "pid": 12345,
+              "wait_event_type": "Lock",
+              "wait_event": "transactionid",
+              "xact_age_sec": 4.231,
+              "query": "INSERT INTO memories ...",
+              "blocked_by_pids": [12346, 12347],
+              "blocked_by_n": 2,
+              ...
+            },
+            ...
+          ]
+        }
+
+    A snapshot caller (the loadtest harness or an operator polling
+    during a contrived storm) reads ``wait_event`` + ``query`` to
+    attribute the lock to a specific statement, then chases
+    ``blocked_by_pids`` to find the blocker's query.
+
+    Requires the app DB role to have ``pg_read_all_stats``; without
+    it, ``query`` / ``usename`` / ``wait_event`` come back NULL for
+    other users' backends and the snapshot is effectively blind to
+    the actual lock holder. ``pg_read_all_stats`` in the response is
+    a direct privilege check via ``pg_has_role(current_user, ...)``
+    and is always ``True`` or ``False`` — never ``null``. ``true``
+    means the role has ``pg_read_all_stats`` (or ``pg_monitor``,
+    which includes it) and the snapshot rows carry useful query
+    text; ``false`` means the role is missing both and the rows
+    will be blind to other users' backends regardless of whether
+    contention is actually present.
+    """
+    priv_row = (await session.execute(_PG_CHECK_STATS_SQL)).one()
+    has_visibility = priv_row.has_priv
+    result = await session.execute(_PG_LOCKS_SNAPSHOT_SQL)
+    rows = [dict(row._mapping) for row in result.all()]
+    return {
+        "captured_at": datetime.now(UTC).isoformat(),
+        "pg_read_all_stats": has_visibility,
+        "rows": rows,
+    }

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -82,6 +82,42 @@ class TestHealth:
         resp = await client.get(f"{PREFIX}/healthz")
         assert resp.status_code == 200
 
+    async def test_debug_pg_locks_returns_shape(self, client: AsyncClient) -> None:
+        """GET /_debug/pg_locks returns the expected snapshot shape.
+
+        CAURA-686: the endpoint is wired up and runs the
+        ``pg_stat_activity`` + ``pg_blocking_pids`` snapshot against
+        the test DB without raising. ``rows`` may be empty when no
+        contention is happening (the normal case during a unit
+        test); the contract pinned here is the response shape,
+        not the row count.
+        """
+        resp = await client.get(f"{PREFIX}/_debug/pg_locks")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "captured_at" in body
+        assert "pg_read_all_stats" in body
+        # Direct ``pg_has_role`` privilege check — always boolean,
+        # independent of whether contention is present.
+        assert isinstance(body["pg_read_all_stats"], bool)
+        assert "rows" in body
+        assert isinstance(body["rows"], list)
+        # If any rows DO appear (e.g., the test's own connections),
+        # they must carry the documented field surface so callers
+        # (loadtest poller, operator triage) can rely on it.
+        for row in body["rows"]:
+            for key in (
+                "pid",
+                "wait_event_type",
+                "wait_event",
+                "xact_age_sec",
+                "query_age_sec",
+                "query",
+                "blocked_by_pids",
+                "blocked_by_n",
+            ):
+                assert key in row, f"missing field {key!r}; row={row!r}"
+
 
 # =====================================================================
 # Memories
@@ -635,9 +671,7 @@ class TestMemories:
         query_embedding = fake_embedding(f"q-{keyword}")
 
         # NULL-embedding row with an FTS-matching keyword.
-        payload = _memory_payload(
-            tenant_id, fleet_id, content=f"urgent dispatch {keyword} body details"
-        )
+        payload = _memory_payload(tenant_id, fleet_id, content=f"urgent dispatch {keyword} body details")
         payload["embedding"] = None
         resp = await client.post(f"{PREFIX}/memories", json=payload)
         assert resp.status_code == 200, resp.text
@@ -725,9 +759,7 @@ class TestMemories:
         # tenant_count delta is loose — fixture may already contribute the tenant.
         assert after_write == before_total + 2
         assert after_agents == before_agents + 1
-        assert (
-            await client.get(f"{PREFIX}/memories/distinct-tenants")
-        ).json()["count"] >= before_tenants
+        assert (await client.get(f"{PREFIX}/memories/distinct-tenants")).json()["count"] >= before_tenants
 
         # Soft-delete both. ``deleted_at`` is set; ``status`` flips to ``"deleted"``.
         assert (await client.delete(f"{PREFIX}/memories/{m1['id']}")).status_code == 200
@@ -1487,9 +1519,7 @@ class TestKeystones:
             params={"tenant_id": tenant_id, "fleet_id": fleet_id},
         )
         assert resp2.status_code == 200
-        scopes_no_agent = {
-            r["data"]["scope"] for r in resp2.json() if r["doc_id"] in created_doc_ids
-        }
+        scopes_no_agent = {r["data"]["scope"] for r in resp2.json() if r["doc_id"] in created_doc_ids}
         assert "agent" not in scopes_no_agent
 
     async def test_validation_rejects_bad_scope(

--- a/scripts/capture_pg_locks_during_storm.py
+++ b/scripts/capture_pg_locks_during_storm.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Poll core-storage-api's /_debug/pg_locks endpoint during a loadtest storm.
+
+CAURA-686 toolkit. The endpoint is on the writer's private VPC IP, so
+this script assumes a local proxy is forwarding it — typically::
+
+    gcloud run services proxy staging-memclaw-core-storage-writer \\
+        --port 8080 --region us-central1
+
+Then::
+
+    python3 scripts/capture_pg_locks_during_storm.py \\
+        --base http://localhost:8080 \\
+        --duration 90 \\
+        --out /tmp/pg-locks-storm.jsonl
+
+The script writes one JSON line per snapshot (one per second by default),
+each containing a timestamp + the endpoint payload. Post-process with
+``jq`` to filter the storm window, group by ``wait_event``, or chase
+``blocked_by_pids`` chains.
+
+The endpoint is intentionally separate from the gateway so it's
+reachable only via this proxy or from inside the VPC; the script is a
+thin polling loop on top of it, not a permanent surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def _snapshot(base: str, timeout: float = 5.0) -> dict:
+    """Fetch one /_debug/pg_locks payload."""
+    url = f"{base.rstrip('/')}/api/v1/storage/_debug/pg_locks"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default="http://localhost:8080",
+        help="Base URL of the local proxy to storage-api (default: http://localhost:8080)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=90,
+        help="Total seconds to poll (default: 90 — covers baseline + storm + tail)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=1.0,
+        help="Seconds between snapshots (default: 1.0)",
+    )
+    parser.add_argument(
+        "--out",
+        default="-",
+        help="Output JSONL path (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    # ``contextlib.nullcontext(sys.stdout)`` keeps the ``with`` shape
+    # consistent across stdout and a real file, and inlining ``open()``
+    # in the ``with``'s expression means the file is acquired as part
+    # of the same context — no risk of a half-open handle from a
+    # ``ctx = open(...)`` assignment outside the ``with``.
+    deadline = time.monotonic() + args.duration
+    with (
+        open(args.out, "w", buffering=1)
+        if args.out != "-"
+        else contextlib.nullcontext(sys.stdout)
+    ) as sink:
+        n_ok = 0
+        n_err = 0
+        try:
+            while time.monotonic() < deadline:
+                t0 = time.monotonic()
+                try:
+                    payload = _snapshot(args.base)
+                    sink.write(
+                        json.dumps(
+                            {
+                                "polled_at": time.time(),
+                                "rows": payload.get("rows", []),
+                                "captured_at": payload.get("captured_at"),
+                            }
+                        )
+                        + "\n"
+                    )
+                    n_ok += 1
+                except (
+                    urllib.error.URLError,
+                    urllib.error.HTTPError,
+                    TimeoutError,
+                    # ``json.JSONDecodeError`` inherits from
+                    # ``ValueError``; covers the case where the
+                    # endpoint serves a partial / malformed response
+                    # during a cold-start or proxy hiccup.
+                    ValueError,
+                ) as exc:
+                    # Endpoint may briefly fail during a cold-start or
+                    # while the proxy is reconnecting. Log to stderr
+                    # and keep going — the storm window is short and
+                    # a missed sample isn't fatal.
+                    print(f"[poll error] {exc}", file=sys.stderr)
+                    n_err += 1
+                elapsed = time.monotonic() - t0
+                sleep = args.interval - elapsed
+                if sleep > 0:
+                    time.sleep(sleep)
+        finally:
+            print(
+                f"[done] ok={n_ok} err={n_err} duration={args.duration}s",
+                file=sys.stderr,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

[CAURA-686](https://caura-ai.atlassian.net/browse/CAURA-686). Adds ``GET /api/v1/storage/_debug/pg_locks`` on core-storage-api plus a small polling script (``scripts/capture_pg_locks_during_storm.py``) to capture per-query lock-holder evidence during a contention storm.

## Why

The CAURA-682 noisy-neighbor work narrowed the remaining bottleneck to PG row-level lock contention (instance-level ``alloydb.googleapis.com/instance/postgresql/wait_time`` showed **7.4s of `Lock/transactionid` + 3.0s of `Lock/tuple` cumulative** under a 30-second storm). AlloyDB Insights' per-query aggregation only captures LWLocks; ``Lock/transactionid`` / ``Lock/tuple`` waits don't surface there. So we don't yet know *which* query is the lock holder.

The canonical Postgres surface for query-level lock attribution is ``pg_locks ∩ pg_stat_activity`` + ``pg_blocking_pids()`` — but AlloyDB's private-IP-only posture rules out direct ``psql`` from a laptop. This PR adds that surface as a thin read-only endpoint on the storage-api itself.

## What's in the PR

| File | Purpose |
|---|---|
| ``core-storage-api/.../routers/debug.py`` | New ``GET /_debug/pg_locks`` route. ~80 LOC including the SQL + docstring. Filters to backends that are either waiting OR being waited-on, returns ``wait_event_type / wait_event / xact_age_sec / query / blocked_by_pids`` per row. |
| ``core-storage-api/.../routers/__init__.py`` | Export ``debug_router`` |
| ``core-storage-api/.../app.py`` | Register the new router under ``/api/v1/storage`` |
| ``core-storage-api/tests/test_integration.py`` | One shape test in ``TestHealth`` — asserts the endpoint returns the documented payload structure and runs without raising against the test DB. |
| ``scripts/capture_pg_locks_during_storm.py`` | Thin polling loop that hits the endpoint at 1Hz, writes JSONL for later ``jq`` slicing. Documents the typical ``gcloud run services proxy`` + storm workflow. |

## Posture / security

- The endpoint is on the storage-api's private VPC IP, same as every other route there. It is NOT routed through the gateway (``memclaw.dev`` / ``memclaw.net``).
- No authentication is added — core-storage-api's existing trust boundary is the private network. To reach this endpoint externally you need ``gcloud run services proxy`` with Cloud Run IAM, which my account has on staging only.
- The response carries the first 240 chars of each waiting/holding query (``LEFT(a.query, 240)``) and Postgres ``pid``s; no user-data PII surfaces.
- Read-only — runs one ``SELECT`` per request.

## What I'll do after merge

After CAURA-683 auto-deploys this to staging:

```bash
gcloud run services proxy staging-memclaw-core-storage-writer --port 8080 --region us-central1 &
python3 scripts/capture_pg_locks_during_storm.py --base http://localhost:8080 --duration 90 --out /tmp/pg-locks-storm.jsonl
# concurrently:
python3 loadtest.py dry dev
```

Then slice the JSONL by the noisy-neighbor storm window (Phase 4b — ~test-elapsed 11:00 → 11:30 from the loadtest's stdout), identify the lock holder + blocked-by chain, and propose a targeted fix on CAURA-686. Strong candidate based on the schema + storm pattern: speculative-insertion contention on ``ix_memories_attempt_unique`` partial unique index, but I want the actual evidence before guessing.

## Test plan

- [x] ``pytest core-storage-api/tests/test_integration.py::TestHealth`` — 4/4 pass (3 existing + 1 new shape test)
- [x] ``ruff check / format --check`` clean on touched files
- [x] ``cd core-storage-api && uv run mypy src/`` — Success: no issues in 48 source files
- [ ] After merge + auto-deploy: ``curl`` the endpoint via ``gcloud run services proxy``, then run the loadtest, capture the snapshots, attribute the locks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-686]: https://caura-ai.atlassian.net/browse/CAURA-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ