### PR TITLE
fix(storage-api): bulk-insert memory_entity_links with ON CONFLICT DO NOTHING (CAURA-686)

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -864,10 +864,8 @@ async def update_embedding(memory_id: UUID, request: Request) -> dict:
 async def update_memory_entities(memory_id: UUID, request: Request) -> dict:
     body: dict = await request.json()
     entity_links = body.get("entity_links", [])
-    for link in entity_links:
-        entity_id = UUID(link["entity_id"])
-        role = link["role"]
-        await _svc.memory_add_entity_link(memory_id, entity_id, role)
+    links = [{"entity_id": UUID(link["entity_id"]), "role": link["role"]} for link in entity_links]
+    await _svc.memory_add_entity_links(memory_id, links)
     return {"ok": True}
 
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -864,7 +864,12 @@ async def update_embedding(memory_id: UUID, request: Request) -> dict:
 async def update_memory_entities(memory_id: UUID, request: Request) -> dict:
     body: dict = await request.json()
     entity_links = body.get("entity_links", [])
-    links = [{"entity_id": UUID(link["entity_id"]), "role": link["role"]} for link in entity_links]
+    try:
+        links = [{"entity_id": UUID(link["entity_id"]), "role": link["role"]} for link in entity_links]
+    except (KeyError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if any(not isinstance(lnk["role"], str) or not lnk["role"] for lnk in links):
+        raise HTTPException(status_code=422, detail="Each entity link must have a non-empty string 'role'")
     await _svc.memory_add_entity_links(memory_id, links)
     return {"ok": True}
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -864,9 +864,11 @@ async def update_embedding(memory_id: UUID, request: Request) -> dict:
 async def update_memory_entities(memory_id: UUID, request: Request) -> dict:
     body: dict = await request.json()
     entity_links = body.get("entity_links", [])
+    if not isinstance(entity_links, list):
+        raise HTTPException(status_code=422, detail="'entity_links' must be a list")
     try:
         links = [{"entity_id": UUID(link["entity_id"]), "role": link["role"]} for link in entity_links]
-    except (KeyError, ValueError) as exc:
+    except (KeyError, ValueError, TypeError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     if any(not isinstance(lnk["role"], str) or not lnk["role"] for lnk in links):
         raise HTTPException(status_code=422, detail="Each entity link must have a non-empty string 'role'")

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1981,14 +1981,28 @@ class PostgresService:
     # H) Entity links (memory side)
     # ------------------------------------------------------------------
 
-    async def memory_add_entity_link(
+    async def memory_add_entity_links(
         self,
         memory_id: UUID,
-        entity_id: UUID,
-        role: str,
+        links: list[dict],
     ) -> None:
+        # Bulk-insert with ``ON CONFLICT (memory_id, entity_id) DO NOTHING``
+        # so two concurrent writes targeting the same ``(memory_id,
+        # entity_id)`` pair don't serialise on ``Lock/transactionid``
+        # (CAURA-686). Each ``link`` dict carries ``entity_id`` (UUID) and
+        # ``role`` (str).
+        if not links:
+            return
+        rows = [
+            {"memory_id": memory_id, "entity_id": link["entity_id"], "role": link["role"]} for link in links
+        ]
         async with get_session() as session:
-            session.add(MemoryEntityLink(memory_id=memory_id, entity_id=entity_id, role=role))
+            stmt = (
+                pg_insert(MemoryEntityLink)
+                .values(rows)
+                .on_conflict_do_nothing(index_elements=["memory_id", "entity_id"])
+            )
+            await session.execute(stmt)
 
     async def memory_get_entity_links_for_memories(
         self,

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -771,6 +771,101 @@ class TestMemories:
         assert post_total == before_total
         assert post_agents == before_agents
 
+    async def test_patch_entities_is_bulk_and_idempotent(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        # CAURA-686: ``PATCH /memories/{id}/entities`` is a single bulk
+        # ``INSERT … ON CONFLICT (memory_id, entity_id) DO NOTHING``. Two
+        # behaviours are pinned here:
+        #   1. All N links land via one PATCH — re-PATCHing the same body
+        #      is a no-op, not an ``IntegrityError`` on the PK.
+        #   2. ``ON CONFLICT DO NOTHING`` preserves the *original* role
+        #      when the same ``(memory_id, entity_id)`` is re-sent with a
+        #      different role. This is the contract the route relies on
+        #      to keep concurrent storage-api writes from serialising on
+        #      ``Lock/transactionid``.
+        mem = (
+            await client.post(
+                f"{PREFIX}/memories",
+                json=_memory_payload(tenant_id, fleet_id),
+            )
+        ).json()
+        memory_id = mem["id"]
+
+        entity_ids: list[str] = []
+        for _ in range(3):
+            entity = (
+                await client.post(
+                    f"{PREFIX}/entities",
+                    json={
+                        "tenant_id": tenant_id,
+                        "fleet_id": fleet_id,
+                        "entity_type": "person",
+                        "canonical_name": f"BulkLink-{_uid()}",
+                    },
+                )
+            ).json()
+            entity_ids.append(entity["id"])
+
+        first = [{"entity_id": eid, "role": "mentioned"} for eid in entity_ids]
+        resp = await client.patch(
+            f"{PREFIX}/memories/{memory_id}/entities",
+            json={"entity_links": first},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["ok"] is True
+
+        links_after_first = (
+            await client.post(
+                f"{PREFIX}/memories/entity-links",
+                json={"memory_ids": [memory_id]},
+            )
+        ).json()[memory_id]
+        assert sorted(link["entity_id"] for link in links_after_first) == sorted(entity_ids)
+        assert {link["role"] for link in links_after_first} == {"mentioned"}
+
+        # Re-PATCH with two old entity_ids (different role) + one new
+        # entity. The conflicting rows must be silently skipped (original
+        # role retained); the new row must be inserted.
+        new_entity = (
+            await client.post(
+                f"{PREFIX}/entities",
+                json={
+                    "tenant_id": tenant_id,
+                    "fleet_id": fleet_id,
+                    "entity_type": "person",
+                    "canonical_name": f"BulkLink-{_uid()}",
+                },
+            )
+        ).json()
+        second = [
+            {"entity_id": entity_ids[0], "role": "subject"},
+            {"entity_id": entity_ids[1], "role": "object"},
+            {"entity_id": new_entity["id"], "role": "mentioned"},
+        ]
+        resp2 = await client.patch(
+            f"{PREFIX}/memories/{memory_id}/entities",
+            json={"entity_links": second},
+        )
+        assert resp2.status_code == 200, resp2.text
+
+        final_links = (
+            await client.post(
+                f"{PREFIX}/memories/entity-links",
+                json={"memory_ids": [memory_id]},
+            )
+        ).json()[memory_id]
+        by_entity = {link["entity_id"]: link["role"] for link in final_links}
+        assert by_entity == {
+            entity_ids[0]: "mentioned",
+            entity_ids[1]: "mentioned",
+            entity_ids[2]: "mentioned",
+            new_entity["id"]: "mentioned",
+        }
+
 
 # =====================================================================
 # Entities


### PR DESCRIPTION
## Summary

Phase 2 fix for [CAURA-686](https://caura-ai.atlassian.net/browse/CAURA-686) (row-lock contention during noisy-neighbor write storms).

`PATCH /memories/{id}/entities` iterated `entity_links` in a Python `for` loop, calling the singular storage method N times — N separate transactions, each doing a bare `INSERT INTO memory_entity_links` with no `ON CONFLICT` handling. Two concurrent storage-api requests targeting the same `(memory_id, entity_id)` PK serialised on `Lock/transactionid` for the full duration of the holder's transaction.

Replace the loop with a single bulk `pg_insert(...).on_conflict_do_nothing(index_elements=["memory_id", "entity_id"])` call. Identical-row conflicts now silently skip instead of blocking, idempotent re-PATCH is a no-op, and the route makes 1 DB round trip instead of N.

## Evidence

Fresh staging `/_debug/pg_locks` capture during today's loadtest storm caught the contention chain directly: pid 646055 blocked by pid 645132 on `Lock/transactionid` for ≥3s, blocked statement was `INSERT INTO memory_entity_links (memory_id, entity_id, role) VALUES ($1::UUID, $2::UUID, $3::VARCHAR)`. Tenant B write p95 during storm: 573.1ms → 3820.7ms (6.67×), well above the ≤2× [CAURA-682](https://caura-ai.atlassian.net/browse/CAURA-682) closure target. Storm-window data attached on the Jira ticket.

The prior hypothesis on memclaw memory `45414b2b…` (`ix_memories_attempt_unique` speculative-insertion contention on the `memories` table) is **refuted** by the JSONL — different table, different lock type.

## Test plan

- [ ] CI: new `test_patch_entities_is_bulk_and_idempotent` exercises bulk-insert + conflict-skip role-preservation
- [ ] After auto-deploy to staging via [CAURA-683](https://caura-ai.atlassian.net/browse/CAURA-683): re-run `loadtest.py dry dev`
- [ ] Tenant B write storm/baseline ratio drops to ≤ 2.0× (currently 6.67×)
- [ ] Prod promotion stays gated per `loadtest-autonomy` keystone + [CAURA-676](https://caura-ai.atlassian.net/browse/CAURA-676) manual gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-686]: https://caura-ai.atlassian.net/browse/CAURA-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAURA-682]: https://caura-ai.atlassian.net/browse/CAURA-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ