### PR TITLE
feat(storage): bulk endpoints for P1/P2/P5 perf fixes (foundation)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -743,6 +743,26 @@ class CoreStorageClient:
     async def batch_update_status(self, data: dict) -> dict:
         return await self._post("/memories/batch-update-status", data)  # type: ignore[return-value]
 
+    async def bulk_get_memories(
+        self,
+        ids: list[str],
+        tenant_id: str | None = None,
+    ) -> list[dict | None]:
+        """Fetch many memories in one round-trip; order matches input ``ids``.
+
+        Missing rows (deleted, nonexistent, or — when ``tenant_id`` is
+        provided — cross-tenant) come back as ``None`` in the same slot
+        rather than being dropped from the list. Lets callers zip the
+        response back to their original id list. Capped at 1000 ids
+        server-side; callers needing more must chunk client-side.
+        """
+        payload: dict[str, Any] = {"ids": ids}
+        if tenant_id is not None:
+            payload["tenant_id"] = tenant_id
+        return await self._post(  # type: ignore[return-value]
+            "/memories/bulk-get", payload, read=True
+        )
+
     # =====================================================================
     # Entities
     # =====================================================================
@@ -790,6 +810,37 @@ class CoreStorageClient:
         return await self._post(  # type: ignore[return-value]
             "/entities/embedding-similarity",
             payload,
+        )
+
+    async def bulk_upsert_entities(self, items: list[dict]) -> list[dict]:
+        """Apply many entity create / update operations in one round-trip.
+
+        Companion to ``bulk_resolve_entities``. Per-item shape and
+        response semantics documented at ``/entities/bulk-upsert``.
+        """
+        return await self._post(  # type: ignore[return-value]
+            "/entities/bulk-upsert", {"items": items}
+        )
+
+    async def bulk_resolve_entities(
+        self,
+        tenant_id: str,
+        items: list[dict],
+        threshold: float,
+        candidate_limit: int = 3,
+    ) -> list[dict | None]:
+        """Resolve many entities in one round-trip. See
+        ``/entities/bulk-resolve`` for the per-item payload + response
+        shape. The caller computes attribute merges from the response
+        and follows up with ``bulk_upsert_entities``."""
+        payload: dict[str, Any] = {
+            "tenant_id": tenant_id,
+            "items": items,
+            "threshold": threshold,
+            "candidate_limit": candidate_limit,
+        }
+        return await self._post(  # type: ignore[return-value]
+            "/entities/bulk-resolve", payload, read=True
         )
 
     async def fts_search_entities(self, data: dict) -> list[str]:
@@ -862,6 +913,18 @@ class CoreStorageClient:
 
     async def create_entity_link(self, data: dict) -> dict:
         return await self._post("/entities/links", data)  # type: ignore[return-value]
+
+    async def bulk_upsert_entity_links(self, items: list[dict]) -> list[dict]:
+        """Idempotently create many memory→entity links in one round-trip.
+
+        Per-item: ``{"input_idx", "memory_id", "entity_id", "role"}``.
+        Response aligned to input with ``{"input_idx", "memory_id",
+        "entity_id", "role", "created": bool}``. ``created=False`` means
+        the link already existed (its prior role preserved).
+        """
+        return await self._post(  # type: ignore[return-value]
+            "/entities/links/bulk", {"items": items}
+        )
 
     async def get_memory_ids_by_entity_ids(
         self,

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -19,6 +19,32 @@ router = APIRouter(prefix="/entities", tags=["Entities"])
 _svc = PostgresService()
 
 
+def _validate_input_idxs(items: list[dict]) -> None:
+    """Ensure each bulk-endpoint item has a unique, in-range ``input_idx``.
+
+    The two bulk endpoints (``/bulk-upsert``, ``/bulk-resolve``) place
+    their response into ``results[item["input_idx"]]``. An out-of-range
+    ``input_idx`` would crash with IndexError → 500; a duplicate would
+    overwrite an earlier slot and return a list shorter than the input.
+    Validate both up-front so the failure mode is a clear 422 rather
+    than a stack trace.
+    """
+    idxs: set[int] = set()
+    for i, item in enumerate(items):
+        raw = item.get("input_idx")
+        if not isinstance(raw, int) or raw < 0 or raw >= len(items):
+            raise HTTPException(
+                status_code=422,
+                detail=f"item {i}: input_idx must be int in [0, {len(items)})",
+            )
+        if raw in idxs:
+            raise HTTPException(
+                status_code=422,
+                detail=f"item {i}: duplicate input_idx {raw}",
+            )
+        idxs.add(raw)
+
+
 # ------------------------------------------------------------------
 # Entity CRUD (collection-level)
 # ------------------------------------------------------------------
@@ -97,6 +123,172 @@ async def resolve_entity_candidates(request: Request) -> list[dict]:
     return out
 
 
+@router.post("/bulk-upsert")
+async def bulk_upsert_entities(request: Request) -> list[dict]:
+    """Apply many entity create/update operations in one round-trip.
+
+    Companion to ``/entities/bulk-resolve`` — caller takes the resolve
+    output, runs the client-side merge (first-seen-wins canonical,
+    accumulate aliases), then sends the resulting create/update plan
+    here.
+
+    Per-item shape: ``{"input_idx", "action": "create"|"update",
+    "entity_id"?, "tenant_id", "fleet_id", "entity_type",
+    "canonical_name", "attributes", "name_embedding"?}``.
+
+    Response is aligned to input order. ``action`` in the response
+    reflects what actually happened:
+
+    - ``"created"``: INSERT succeeded
+    - ``"updated"``: UPDATE matched
+    - ``"merged"``: INSERT lost a race; the row that won was updated
+      with this caller's attributes (mirrors ``entity_add``'s recovery)
+    - ``"missing"``: UPDATE didn't match (entity_id deleted between
+      resolve and upsert)
+
+    Cap: 500 items per request.
+    """
+    body: dict = await request.json()
+    items = body.get("items", [])
+    if not isinstance(items, list):
+        raise HTTPException(status_code=422, detail="'items' must be a list")
+    if len(items) > 500:
+        raise HTTPException(
+            status_code=422,
+            detail=f"bulk-upsert capped at 500 items (got {len(items)})",
+        )
+    # Validate required per-item fields up-front so a missing key
+    # surfaces as a 422 instead of an uncaught KeyError → 500 inside
+    # the service. ``action`` is checked separately below.
+    _REQUIRED_BASE = {"tenant_id", "entity_type", "canonical_name", "attributes"}
+    for item in items:
+        missing = _REQUIRED_BASE - item.keys()
+        if missing:
+            raise HTTPException(
+                status_code=422,
+                detail=(f"item at input_idx {item.get('input_idx')!r} missing fields: {sorted(missing)}"),
+            )
+    _validate_input_idxs(items)
+    # Validate per-item action + update preconditions up-front. The
+    # service partitions on action ∈ {"create", "update"}; unknown
+    # values would otherwise be silently dropped (response shorter
+    # than input), and a missing entity_id on action="update" would
+    # crash inside the service with a KeyError → 500.
+    for item in items:
+        if item.get("action") not in {"create", "update"}:
+            raise HTTPException(
+                status_code=422,
+                detail=(f"invalid action {item.get('action')!r} at input_idx {item.get('input_idx')!r}"),
+            )
+        if item.get("action") == "update":
+            eid_raw = item.get("entity_id")
+            if not eid_raw:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"action='update' requires 'entity_id' at input_idx {item.get('input_idx')!r}",
+                )
+            # Validate UUID shape at the router boundary — without this
+            # a non-UUID ``entity_id`` would crash inside the service
+            # (``UUID(eid)``) and surface via the generic 500 fallback.
+            try:
+                UUID(eid_raw)
+            except (ValueError, AttributeError):
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"invalid entity_id UUID at input_idx {item.get('input_idx')!r}",
+                )
+    try:
+        return await _svc.entity_bulk_upsert(items)
+    except (ValueError, KeyError):
+        # The service no longer raises ValueError for the TOCTOU race
+        # (it reports ``action="missing"`` instead). Any ValueError /
+        # KeyError reaching here is an internal inconsistency, not a
+        # client-resolvable conflict — 500 is the honest status. Use a
+        # generic detail so internals (raw item dicts, traceback bits)
+        # don't leak across the API boundary; the real cause is in the
+        # server logs.
+        raise HTTPException(status_code=500, detail="internal entity upsert error")
+
+
+@router.post("/bulk-resolve")
+async def bulk_resolve_entities(request: Request) -> list[dict | None]:
+    """Resolve many entities in one round-trip using the same precedence
+    as ``entity_service.upsert_entity`` (Phase 1 exact → Phase 2 cosine).
+
+    Body shape::
+
+        {
+          "tenant_id": "...",
+          "threshold": 0.85,                 # required, no server-side default
+          "items": [
+            {"input_idx": 0, "fleet_id": null, "canonical_name": "...",
+             "entity_type": "...", "name_embedding": [...] | null},
+            ...
+          ]
+        }
+
+    Response is a list aligned to ``input_idx``: each element is either
+    ``null`` (no match) or ``{"entity_id", "canonical_name", "attributes",
+    "matched_by": "exact" | "similarity", "similarity": float}``. Callers
+    use the ``matched_by`` field to decide whether to take the update path
+    (with client-side attribute merge) or the create path in a follow-up
+    ``/entities/bulk-upsert`` call.
+
+    Cap: 500 items per request. Bigger batches risk pushing the Phase 1
+    OR-of-ANDs plan into a seq scan; chunk client-side if you need more.
+    """
+    body: dict = await request.json()
+    items = body.get("items", [])
+    if not isinstance(items, list):
+        raise HTTPException(status_code=422, detail="'items' must be a list")
+    if len(items) > 500:
+        raise HTTPException(
+            status_code=422,
+            detail=f"bulk-resolve capped at 500 items (got {len(items)})",
+        )
+    if "tenant_id" not in body:
+        raise HTTPException(status_code=422, detail="'tenant_id' is required")
+    if "threshold" not in body:
+        raise HTTPException(status_code=422, detail="'threshold' is required")
+    # Validate required per-item fields up-front so a missing key
+    # surfaces as a 422 instead of an uncaught KeyError inside the
+    # service. ``name_embedding`` is optional (skips Phase 2).
+    _REQUIRED_RESOLVE = {"canonical_name", "entity_type"}
+    for item in items:
+        missing = _REQUIRED_RESOLVE - item.keys()
+        if missing:
+            raise HTTPException(
+                status_code=422,
+                detail=(f"item at input_idx {item.get('input_idx')!r} missing fields: {sorted(missing)}"),
+            )
+    _validate_input_idxs(items)
+
+    # Numeric coercion before the service call so a non-numeric value
+    # from the client surfaces as a 422 rather than an uncaught
+    # ValueError/TypeError → 500.
+    try:
+        threshold = float(body["threshold"])
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=422,
+            detail=f"'threshold' must be numeric (got {body['threshold']!r})",
+        )
+    try:
+        candidate_limit = int(body.get("candidate_limit", 3))
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=422,
+            detail=f"'candidate_limit' must be int (got {body.get('candidate_limit')!r})",
+        )
+
+    return await _svc.entity_bulk_resolve(
+        tenant_id=body["tenant_id"],
+        items=items,
+        threshold=threshold,
+        candidate_limit=candidate_limit,
+    )
+
+
 # ------------------------------------------------------------------
 # Graph
 # ------------------------------------------------------------------
@@ -170,6 +362,55 @@ async def create_memory_entity_link(request: Request) -> dict:
     body: dict = await request.json()
     link = await _svc.entity_add_entity_link(body)
     return orm_to_dict(link, MEMORY_ENTITY_LINK_FIELDS)
+
+
+@router.post("/links/bulk")
+async def bulk_upsert_memory_entity_links(request: Request) -> list[dict]:
+    """Idempotently create many memory→entity links in one round-trip.
+
+    Body: ``{"items": [{"input_idx", "memory_id", "entity_id", "role"}, ...]}``.
+    Response is aligned to input order with ``{"input_idx", "memory_id",
+    "entity_id", "role", "created": bool}`` — ``created=False`` means a
+    row with the same ``(memory_id, entity_id)`` PK already existed and
+    its prior ``role`` is preserved (matches today's find-then-create
+    flow which never overwrites role).
+
+    Cap: 500 items per request.
+    """
+    body: dict = await request.json()
+    items = body.get("items", [])
+    if not isinstance(items, list):
+        raise HTTPException(status_code=422, detail="'items' must be a list")
+    if len(items) > 500:
+        raise HTTPException(
+            status_code=422,
+            detail=f"bulk-links capped at 500 items (got {len(items)})",
+        )
+    # Validate required per-item fields up-front so a missing key
+    # surfaces as a 422 instead of an uncaught KeyError inside the
+    # service.
+    _REQUIRED_LINK = {"memory_id", "entity_id", "role"}
+    for item in items:
+        missing = _REQUIRED_LINK - item.keys()
+        if missing:
+            raise HTTPException(
+                status_code=422,
+                detail=(f"item at input_idx {item.get('input_idx')!r} missing fields: {sorted(missing)}"),
+            )
+    # UUID shape validation at the router boundary — without this a
+    # malformed ``memory_id`` / ``entity_id`` would crash inside the
+    # service's ``UUID(...)`` call and surface as an uncaught 500.
+    for item in items:
+        for field in ("memory_id", "entity_id"):
+            try:
+                UUID(item[field])
+            except (ValueError, AttributeError):
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"invalid {field} UUID at input_idx {item.get('input_idx')!r}",
+                )
+    _validate_input_idxs(items)
+    return await _svc.entity_bulk_upsert_links(items)
 
 
 @router.get("/links/find")

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -301,6 +301,55 @@ async def find_duplicate_hash(
     return {"memory_id": str(dup_id)}
 
 
+@router.post("/bulk-get")
+async def bulk_get_memories(request: Request) -> list[dict | None]:
+    """Fetch many memories by id in a single round-trip.
+
+    Body: ``{"ids": ["uuid", ...], "tenant_id": "..." (optional)}``.
+
+    Returns a list of memory dicts in the **same order** as the input ids,
+    with ``null`` for ids that don't exist (or are soft-deleted, or — if
+    ``tenant_id`` is provided — belong to a different tenant). Order
+    preservation matters: callers (e.g. crystallizer archive sweep) zip
+    the response back to their original id list.
+
+    Tenant filter is optional to mirror the single-row ``GET /memories/{id}``
+    contract. Callers that need tenant safety supply ``tenant_id``; the
+    request fails open per-row (returns ``null``) when an id belongs to a
+    different tenant, never with a 4xx.
+
+    Cap: 1000 ids per request to bound query plan size and response payload.
+    """
+    body: dict = await request.json()
+    raw_ids = body.get("ids", [])
+    if not isinstance(raw_ids, list):
+        raise HTTPException(status_code=422, detail="'ids' must be a list")
+    if len(raw_ids) > 1000:
+        raise HTTPException(
+            status_code=422,
+            detail=f"bulk-get capped at 1000 ids (got {len(raw_ids)})",
+        )
+    if not raw_ids:
+        return []
+
+    try:
+        uids = [UUID(i) for i in raw_ids]
+    except (ValueError, TypeError) as e:
+        raise HTTPException(status_code=422, detail=f"invalid UUID in ids: {e}")
+
+    tenant_filter = body.get("tenant_id")
+    by_id = await _svc.memory_get_memories_by_ids(uids)
+
+    out: list[dict | None] = []
+    for uid in uids:
+        mem = by_id.get(uid)
+        if mem is None or (tenant_filter is not None and mem.tenant_id != tenant_filter):
+            out.append(None)
+        else:
+            out.append(orm_to_dict(mem, MEMORY_FIELDS))
+    return out
+
+
 @router.post("/bulk-by-content-hashes")
 async def bulk_find_by_content_hashes(request: Request) -> dict:
     """Wire format: ``{content_hash: {id, client_request_id}}``.
@@ -401,10 +450,73 @@ async def get_entity_links_for_memories(request: Request) -> dict:
 
 @router.post("/batch-update-status")
 async def batch_update_status(request: Request) -> dict:
+    """Apply status (and optional supersedes-id) updates to many memories.
+
+    Per-row payload:
+      - ``memory_id`` (required), ``status`` (required)
+      - ``supersedes_id`` (optional, UUID): set the pointer to this id
+      - ``unset_supersedes`` (optional, bool): clear the pointer; takes
+        precedence over ``supersedes_id`` if both are present
+      - ``expected_supersedes_id`` (optional, UUID): CAS gate — skip the
+        row unless its current ``supersedes_id`` matches this value
+
+    Backward-compatible with the prior 2-field shape — rows containing
+    only ``memory_id`` + ``status`` behave exactly as before.
+
+    Returns ``{"ok": True, "skipped": [memory_id, ...]}`` listing rows
+    that failed the CAS gate (or pointed at a deleted / nonexistent id).
+    Callers that don't use the CAS field can safely ignore ``skipped``.
+    """
     body: dict = await request.json()
+
+    # Two passes: validate everything FIRST, then execute. A malformed
+    # item in the middle of the batch would otherwise commit rows
+    # 0..K-1 before the 422 lands, leaving the caller no receipt of
+    # what got written. The validation pass is O(N) memory + zero DB
+    # work, so the cost is negligible compared to the partial-commit
+    # surprise it prevents.
+    parsed: list[tuple[UUID, str, UUID | None, bool, UUID | None]] = []
     for item in body.get("updates", []):
-        await _svc.memory_update_status(UUID(item["memory_id"]), item["status"])
-    return {"ok": True}
+        try:
+            sup_id = item.get("supersedes_id")
+            exp_sup_id = item.get("expected_supersedes_id")
+            parsed.append(
+                (
+                    UUID(item["memory_id"]),
+                    item["status"],
+                    UUID(sup_id) if sup_id else None,
+                    bool(item.get("unset_supersedes", False)),
+                    UUID(exp_sup_id) if exp_sup_id else None,
+                )
+            )
+        except (ValueError, KeyError) as exc:
+            # ``ValueError`` from ``UUID(...)`` includes the raw input
+            # in its message ("badly formed hexadecimal UUID string: ...")
+            # — surfacing ``exc`` verbatim would echo the offending
+            # value back across the API boundary. Use a generic
+            # field-hint instead.
+            field_hint = "memory_id or status" if isinstance(exc, KeyError) else "a UUID field"
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"invalid update item "
+                    f"(memory_id={item.get('memory_id', '?')!r}): "
+                    f"{type(exc).__name__} in {field_hint}"
+                ),
+            )
+
+    skipped: list[str] = []
+    for mid, new_status, sup_uuid, unset_sup, exp_sup_uuid in parsed:
+        ok = await _svc.memory_update_status(
+            mid,
+            new_status,
+            supersedes_id=sup_uuid,
+            unset_supersedes=unset_sup,
+            expected_supersedes_id=exp_sup_uuid,
+        )
+        if not ok:
+            skipped.append(str(mid))
+    return {"ok": True, "skipped": skipped}
 
 
 # ------------------------------------------------------------------
@@ -825,8 +937,12 @@ async def update_memory_status(memory_id: UUID, request: Request) -> dict:
                 )
         return {"ok": True}
 
-    # Set or status-only paths
-    await _svc.memory_update_status(memory_id, status)
+    # Set or status-only paths. ``memory_update_status`` returns False
+    # when the target row doesn't exist (or was already deleted); surface
+    # as 404 so the caller doesn't silently treat a no-op as success.
+    ok = await _svc.memory_update_status(memory_id, status)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"memory {memory_id} not found")
 
     if supersedes_id is not None:
         # Set path: compare-and-swap against NULL — the first detection

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -20,9 +20,10 @@ from types import SimpleNamespace
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, case, delete, false, func, literal_column, or_, select, text
+from sqlalchemy import and_, case, delete, false, func, literal_column, or_, select, text, tuple_
 from sqlalchemy import update as sql_update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import load_only
 
@@ -470,9 +471,48 @@ class PostgresService:
                 )
         return True
 
-    async def memory_update_status(self, memory_id: UUID, status: str) -> None:
+    async def memory_update_status(
+        self,
+        memory_id: UUID,
+        status: str,
+        *,
+        supersedes_id: UUID | None = None,
+        unset_supersedes: bool = False,
+        expected_supersedes_id: UUID | None = None,
+    ) -> bool:
+        """Update a memory's ``status`` and optionally (re)set ``supersedes_id``.
+
+        Args:
+            memory_id: Target row.
+            status: New status value.
+            supersedes_id: If provided, set ``supersedes_id`` to this UUID.
+                Ignored when ``unset_supersedes`` is True.
+            unset_supersedes: If True, clear ``supersedes_id`` to NULL.
+                Takes precedence over ``supersedes_id``.
+            expected_supersedes_id: Optional CAS gate — only update if the
+                row's current ``supersedes_id`` matches this value. Used by
+                the contradiction-retraction path so a concurrent writer
+                that already cleared / changed the pointer doesn't get
+                clobbered.
+
+        Returns:
+            True if the row was updated, False if the ``expected_supersedes_id``
+            CAS check failed (or the row id doesn't exist). Existing callers
+            ignore the return value — adding it is backward-compatible.
+        """
+        values: dict[str, Any] = {"status": status}
+        if unset_supersedes:
+            values["supersedes_id"] = None
+        elif supersedes_id is not None:
+            values["supersedes_id"] = supersedes_id
+
         async with get_session() as session:
-            await session.execute(sql_update(Memory).where(Memory.id == memory_id).values(status=status))
+            stmt = sql_update(Memory).where(Memory.id == memory_id)
+            if expected_supersedes_id is not None:
+                stmt = stmt.where(Memory.supersedes_id == expected_supersedes_id)
+            stmt = stmt.values(**values)
+            result = await session.execute(stmt)
+            return (result.rowcount or 0) > 0  # type: ignore[attr-defined]
 
     async def memory_update_embedding(
         self,
@@ -2062,7 +2102,10 @@ class PostgresService:
                 Entity.entity_type == entity_type,
                 Entity.canonical_name == canonical_name,
             )
-            if fleet_id:
+            # ``is not None`` rather than truthy so an empty-string
+            # ``fleet_id`` matches an empty-string column value instead
+            # of silently routing to the IS NULL branch.
+            if fleet_id is not None:
                 stmt = stmt.where(Entity.fleet_id == fleet_id)
             else:
                 stmt = stmt.where(Entity.fleet_id.is_(None))
@@ -2095,13 +2138,331 @@ class PostgresService:
                 .order_by(distance)
                 .limit(limit)
             )
-            if fleet_id:
+            # ``is not None`` rather than truthy so an empty-string
+            # ``fleet_id`` matches an empty-string column value instead
+            # of silently routing to the IS NULL branch.
+            if fleet_id is not None:
                 stmt = stmt.where(Entity.fleet_id == fleet_id)
             else:
                 stmt = stmt.where(Entity.fleet_id.is_(None))
 
             result = await session.execute(stmt)
             return list(result.all())  # type: ignore[arg-type]
+
+    async def entity_bulk_resolve(
+        self,
+        tenant_id: str,
+        items: list[dict],
+        threshold: float,
+        candidate_limit: int = ENTITY_RESOLUTION_CANDIDATE_LIMIT,
+    ) -> list[dict | None]:
+        """Bulk version of the two-phase resolution in entity_service.upsert_entity.
+
+        Replicates the same precedence — Phase 1 exact match by
+        ``(tenant_id, fleet_id, canonical_name, entity_type)``; Phase 2
+        embedding cosine similarity (top-N by distance, first ≥ threshold
+        wins) — but in one round-trip and one DB connection. Phase 1 is
+        a single batched SELECT keyed by row tuple; Phase 2 issues one
+        similarity SELECT per unresolved item with a non-null embedding,
+        all sharing the same session.
+
+        Each input item: ``{"input_idx": int, "fleet_id": str|None,
+        "canonical_name": str, "entity_type": str, "name_embedding":
+        list[float]|None}``. Returns a list aligned to input order where
+        each element is either ``None`` (no match) or
+        ``{"entity_id", "canonical_name", "attributes", "matched_by",
+        "similarity"}`` — ``matched_by`` ∈ {"exact", "similarity"}.
+
+        Threshold is required, not defaulted — the resolution rule lives
+        in the core-api layer; the storage service is the executor.
+        """
+        if not items:
+            return []
+
+        out: list[dict | None] = [None] * len(items)
+
+        async with get_read_session() as session:
+            # Phase 1: one batched SELECT keyed by row tuple. We can't
+            # use SQL VALUES/JOIN here because (canonical_name, entity_type,
+            # fleet_id) includes a nullable column, so build an OR-of-ANDs
+            # of the input tuples. Single round-trip, single plan.
+
+            # Group items by their (canonical_name, entity_type, fleet_id)
+            # so a duplicate tuple in the input batch only triggers one
+            # comparison; map back to input idxs at the end.
+            tuple_to_idxs: dict[tuple[str, str, str | None], list[int]] = {}
+            for it in items:
+                key = (
+                    it["canonical_name"],
+                    it["entity_type"],
+                    it.get("fleet_id"),
+                )
+                tuple_to_idxs.setdefault(key, []).append(it["input_idx"])
+
+            # SQLAlchemy ``tuple_(...).in_(...)`` doesn't honor NULL
+            # equality, so split into the with-fleet and no-fleet halves.
+            with_fleet = [k for k in tuple_to_idxs if k[2] is not None]
+            no_fleet = [k for k in tuple_to_idxs if k[2] is None]
+
+            exact_rows: list[Entity] = []
+            if with_fleet:
+                stmt = select(Entity).where(
+                    Entity.tenant_id == tenant_id,
+                    tuple_(Entity.canonical_name, Entity.entity_type, Entity.fleet_id).in_(with_fleet),
+                )
+                exact_rows.extend((await session.execute(stmt)).scalars().all())
+            if no_fleet:
+                stmt = select(Entity).where(
+                    Entity.tenant_id == tenant_id,
+                    Entity.fleet_id.is_(None),
+                    tuple_(Entity.canonical_name, Entity.entity_type).in_([(k[0], k[1]) for k in no_fleet]),
+                )
+                exact_rows.extend((await session.execute(stmt)).scalars().all())
+
+            matched_idxs: set[int] = set()
+            for row in exact_rows:
+                key = (row.canonical_name, row.entity_type, row.fleet_id)
+                for idx in tuple_to_idxs.get(key, []):
+                    out[idx] = {
+                        "entity_id": str(row.id),
+                        "canonical_name": row.canonical_name,
+                        "attributes": row.attributes or {},
+                        "matched_by": "exact",
+                        "similarity": 1.0,
+                    }
+                    matched_idxs.add(idx)
+
+            # Phase 2: per-unmatched-item similarity SELECT, all in this
+            # session. N queries one HTTP — the win is HTTP-roundtrip
+            # elimination, not query count. Items without a name_embedding
+            # skip Phase 2 (mirrors ``entity_service.upsert_entity`` line 46).
+            for it in items:
+                idx = it["input_idx"]
+                if idx in matched_idxs:
+                    continue
+                emb = it.get("name_embedding")
+                if emb is None:
+                    continue
+                distance = Entity.name_embedding.cosine_distance(emb)
+                sim_col = (1.0 - distance).label("similarity")
+                stmt = (
+                    select(Entity, sim_col)
+                    .where(
+                        Entity.tenant_id == tenant_id,
+                        Entity.entity_type == it["entity_type"],
+                        Entity.name_embedding.isnot(None),
+                    )
+                    .order_by(distance)
+                    .limit(candidate_limit)
+                )
+                # Mirror Phase 1's None-vs-value semantics so an empty-
+                # string ``fleet_id`` doesn't silently route to IS NULL.
+                if it.get("fleet_id") is not None:
+                    stmt = stmt.where(Entity.fleet_id == it["fleet_id"])
+                else:
+                    stmt = stmt.where(Entity.fleet_id.is_(None))
+
+                rows = (await session.execute(stmt)).all()
+                for entity, sim in rows:
+                    if float(sim) >= threshold:
+                        out[idx] = {
+                            "entity_id": str(entity.id),
+                            "canonical_name": entity.canonical_name,
+                            "attributes": entity.attributes or {},
+                            "matched_by": "similarity",
+                            "similarity": float(sim),
+                        }
+                        break
+
+        return out
+
+    async def entity_bulk_upsert(self, items: list[dict]) -> list[dict]:
+        """Apply many entity create / update operations in one round-trip.
+
+        Each input item:
+          - ``input_idx``: int (preserved in response)
+          - ``action``: "create" | "update"
+          - ``entity_id``: UUID (required when action="update")
+          - ``tenant_id``, ``fleet_id``, ``entity_type``, ``canonical_name``,
+            ``attributes`` (dict), ``name_embedding`` (list[float] | None)
+
+        Returns aligned list: ``{"input_idx", "entity_id", "action"}``.
+        ``action`` in the response reflects what actually happened:
+        ``"created"`` (INSERT succeeded), ``"updated"`` (UPDATE matched),
+        or ``"merged"`` (INSERT race lost → ON CONFLICT DO UPDATE picked
+        up the prior row; same outcome as today's IntegrityError recovery
+        in ``entity_add``).
+
+        Caller pre-computed the merged attributes from ``bulk_resolve_entities``
+        output — server side does not re-merge. Concurrent writers between
+        resolve and upsert have the same lost-update window as today's
+        serial path (find_exact → update_entity); see crystallizer
+        cluster-locking notes for the full race story.
+        """
+        if not items:
+            return []
+
+        # Partition by action; updates and creates each use a per-item
+        # session (for FK-error isolation — a constraint error on item
+        # N must not roll back items 0..N-1). Per-row sessions for both
+        # paths cost connection pool checkouts but stay within one HTTP
+        # — same big win.
+        results: list[dict | None] = [None] * len(items)
+
+        updates = [it for it in items if it["action"] == "update"]
+        creates = [it for it in items if it["action"] == "create"]
+
+        # Per-item sessions so a constraint error on item N doesn't roll
+        # back items 0..N-1. The HTTP-roundtrip win is what matters; per-
+        # item session checkout cost is negligible.
+        for item in updates:
+            eid = item["entity_id"]
+            if not isinstance(eid, UUID):
+                eid = UUID(eid)
+            values: dict[str, Any] = {
+                "entity_type": item["entity_type"],
+                "canonical_name": item["canonical_name"],
+                "attributes": item["attributes"],
+            }
+            if item.get("name_embedding") is not None:
+                values["name_embedding"] = item["name_embedding"]
+            async with get_session() as session:
+                # ``tenant_id`` in the WHERE so a cross-tenant ``entity_id``
+                # (caller bug or hostile input) is treated as "missing"
+                # rather than silently updating someone else's row.
+                upd = await session.execute(
+                    sql_update(Entity)
+                    .where(Entity.id == eid, Entity.tenant_id == item["tenant_id"])
+                    .values(**values)
+                )
+                # rowcount==0 means the entity_id no longer exists, was
+                # deleted, or belongs to a different tenant. All three
+                # surface as ``missing`` so the caller can disambiguate
+                # from ``updated``.
+                results[item["input_idx"]] = {
+                    "input_idx": item["input_idx"],
+                    "entity_id": str(eid),
+                    "action": "missing" if (upd.rowcount or 0) == 0 else "updated",  # type: ignore[attr-defined]
+                }
+
+        for item in creates:
+            # The natural-key unique index is functional (``lower(canonical_name)``,
+            # ``COALESCE(fleet_id, '')``), which SQLAlchemy's ON CONFLICT helpers
+            # can't target via the column list, so we use the read-then-write
+            # shape with TOCTOU recovery. The recovery folds SELECT + UPDATE
+            # into one writer session to guarantee read-your-writes against
+            # the row we just collided with.
+
+            # Step 1: was it already there before we tried? Determines the
+            # response ``action`` field even when we win the insert race.
+            existed_before = await self.entity_find_exact(
+                tenant_id=item["tenant_id"],
+                entity_type=item["entity_type"],
+                canonical_name=item["canonical_name"],
+                fleet_id=item.get("fleet_id"),
+            )
+
+            merge_values: dict[str, Any] = {"attributes": item["attributes"]}
+            if item.get("name_embedding") is not None:
+                merge_values["name_embedding"] = item["name_embedding"]
+
+            if existed_before is not None:
+                # Pre-existing → apply caller's merged attributes. If the
+                # row got deleted between our SELECT and UPDATE (a narrow
+                # but real window), ``entity_update`` returns None — surface
+                # as "missing" rather than reporting a "merged" that didn't
+                # actually happen.
+                updated = await self.entity_update(existed_before.id, merge_values)
+                results[item["input_idx"]] = {
+                    "input_idx": item["input_idx"],
+                    "entity_id": str(existed_before.id),
+                    "action": "missing" if updated is None else "merged",
+                }
+                continue
+
+            # Step 2: insert; on IntegrityError another writer raced us
+            # between Step 1 and now. Recover by re-SELECT + UPDATE in
+            # a single writer session — guarantees read-your-writes against
+            # the row we just collided with, and avoids the prior
+            # two-session window where the racing writer could DELETE
+            # between our SELECT and our UPDATE.
+            payload: dict[str, Any] = {
+                "tenant_id": item["tenant_id"],
+                "fleet_id": item.get("fleet_id"),
+                "entity_type": item["entity_type"],
+                "canonical_name": item["canonical_name"],
+                "attributes": item["attributes"],
+            }
+            if item.get("name_embedding") is not None:
+                payload["name_embedding"] = item["name_embedding"]
+
+            try:
+                async with get_session() as session:
+                    new_entity = Entity(**payload)
+                    session.add(new_entity)
+                    await session.flush()
+                    new_id = new_entity.id
+                results[item["input_idx"]] = {
+                    "input_idx": item["input_idx"],
+                    "entity_id": str(new_id),
+                    "action": "created",
+                }
+            except IntegrityError:
+                # TOCTOU recovery — SELECT + UPDATE in one writer session.
+                logger.info(
+                    "Entity bulk-upsert race: '%s' created concurrently, re-selecting",
+                    item["canonical_name"],
+                )
+                async with get_session() as session:
+                    sel = select(Entity).where(
+                        Entity.tenant_id == item["tenant_id"],
+                        Entity.entity_type == item["entity_type"],
+                        func.lower(Entity.canonical_name) == item["canonical_name"].lower(),
+                    )
+                    if item.get("fleet_id") is not None:
+                        sel = sel.where(Entity.fleet_id == item["fleet_id"])
+                    else:
+                        sel = sel.where(Entity.fleet_id.is_(None))
+                    racy_existing = (await session.execute(sel)).scalar_one_or_none()
+
+                    if racy_existing is None:
+                        # The row that conflicted with us was deleted in
+                        # the microseconds between our IntegrityError and
+                        # the recovery SELECT. Surface as "missing"; the
+                        # caller can retry the whole flow if they care.
+                        results[item["input_idx"]] = {
+                            "input_idx": item["input_idx"],
+                            "entity_id": None,
+                            "action": "missing",
+                        }
+                    else:
+                        # Defence-in-depth ``tenant_id`` guard on the
+                        # recovery UPDATE — the SELECT above already
+                        # filters by tenant, but pinning the UPDATE
+                        # WHERE too keeps the invariant local to the
+                        # write statement (a future refactor of the
+                        # SELECT can't accidentally let a cross-tenant
+                        # row slip through).
+                        upd = await session.execute(
+                            sql_update(Entity)
+                            .where(
+                                Entity.id == racy_existing.id,
+                                Entity.tenant_id == item["tenant_id"],
+                            )
+                            .values(**merge_values)
+                        )
+                        # rowcount==0 here means the row was deleted
+                        # between our SELECT and UPDATE inside the SAME
+                        # session — vanishingly unlikely but report
+                        # consistently as "missing".
+                        results[item["input_idx"]] = {
+                            "input_idx": item["input_idx"],
+                            "entity_id": str(racy_existing.id),
+                            "action": "missing" if (upd.rowcount or 0) == 0 else "merged",  # type: ignore[attr-defined]
+                        }
+
+        # All slots filled (we partitioned over all items); filter for mypy.
+        return [r for r in results if r is not None]
 
     async def entity_list(
         self,
@@ -2540,6 +2901,91 @@ class PostgresService:
             session.add(link)
             await session.flush()
             return link
+
+    async def entity_bulk_upsert_links(self, items: list[dict]) -> list[dict]:
+        """Idempotently create many memory→entity links in one statement.
+
+        Each input item: ``{"input_idx", "memory_id", "entity_id", "role"}``.
+        Returns aligned list with ``{"input_idx", "memory_id", "entity_id",
+        "role", "created": bool}``. ``created=False`` means a row with the
+        same composite PK ``(memory_id, entity_id)`` already existed;
+        its ``role`` is preserved (mirrors today's ``find_entity_link``
+        → ``create_entity_link`` flow which skips on a hit).
+
+        Cap enforced at the router level.
+        """
+        if not items:
+            return []
+
+        # Composite PK is (memory_id, entity_id); ``role`` is not part of
+        # the unique key. INSERT ... ON CONFLICT DO UPDATE with the
+        # no-op SET (``role = memory_entity_links.role``) is the standard
+        # trick that lets RETURNING fire on both branches so we can
+        # detect insert-vs-existed via the ``xmax`` system column.
+        #
+        # Per-item sessions: an FK violation (memory_id or entity_id
+        # pointing at a deleted/nonexistent row) on item N would
+        # otherwise roll back items 0..N-1 in a shared transaction.
+        # Keyed by ``input_idx`` rather than (mid, eid) so a caller
+        # accidentally sending the same pair twice doesn't lose the
+        # second slot's result to map overwrite.
+        idx_to_result: dict[int, dict[str, Any]] = {}
+
+        for it in items:
+            mid = it["memory_id"]
+            eid = it["entity_id"]
+            if not isinstance(mid, UUID):
+                mid = UUID(mid)
+            if not isinstance(eid, UUID):
+                eid = UUID(eid)
+            ins_stmt = (
+                pg_insert(MemoryEntityLink)
+                .values(memory_id=mid, entity_id=eid, role=it["role"])
+                .on_conflict_do_update(
+                    index_elements=[
+                        MemoryEntityLink.memory_id,
+                        MemoryEntityLink.entity_id,
+                    ],
+                    set_={"role": MemoryEntityLink.role},
+                )
+                .returning(
+                    MemoryEntityLink.memory_id,
+                    MemoryEntityLink.entity_id,
+                    MemoryEntityLink.role,
+                    literal_column("xmax"),
+                )
+            )
+            try:
+                async with get_session() as session:
+                    row = (await session.execute(ins_stmt)).one()
+                # xmax=0 ⇒ INSERT inserted; non-zero ⇒ existing row hit
+                # by the DO UPDATE no-op.
+                idx_to_result[it["input_idx"]] = {
+                    "input_idx": it["input_idx"],
+                    "memory_id": str(mid),
+                    "entity_id": str(eid),
+                    "role": row[2],
+                    "created": int(row[3]) == 0,
+                }
+            except IntegrityError:
+                # FK violation on memory_id or entity_id — report per-row
+                # so the caller can continue processing the other links
+                # rather than losing the whole batch.
+                logger.warning(
+                    "Entity link bulk-upsert FK violation: memory_id=%s entity_id=%s",
+                    mid,
+                    eid,
+                )
+                idx_to_result[it["input_idx"]] = {
+                    "input_idx": it["input_idx"],
+                    "memory_id": str(mid),
+                    "entity_id": str(eid),
+                    "role": it["role"],
+                    "created": False,
+                    "error": "fk_violation",
+                }
+
+        return [idx_to_result[it["input_idx"]] for it in items]
 
     async def entity_delete_entity_links(
         self,

--- a/tests/test_storage_bulk_endpoints.py
+++ b/tests/test_storage_bulk_endpoints.py
@@ -1,0 +1,1064 @@
+"""Integration tests for the storage-side bulk endpoints added in PR1.
+
+Covers four new (and one widened) endpoints used by the P1 / P2 / P5
+performance overhaul:
+
+- ``POST /memories/batch-update-status`` — widened with per-row
+  ``supersedes_id`` / ``unset_supersedes`` / ``expected_supersedes_id``
+- ``POST /memories/bulk-get`` — ordered list with ``None`` for missing
+- ``POST /entities/bulk-resolve`` — Phase 1 + Phase 2 in one round-trip
+- ``POST /entities/bulk-upsert`` — create + update + race-merge in one txn
+- ``POST /entities/links/bulk`` — idempotent link upsert via ON CONFLICT
+
+Tests run against the in-process ``core-storage-api`` ASGI app wired by
+``_patch_storage_client`` in conftest.py — backed by the same test
+postgres the rest of the suite uses.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from core_api.constants import VECTOR_DIM
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _t() -> str:
+    """Unique tenant id per test, so concurrent suite runs don't collide."""
+    return f"test-tenant-bulk-{uuid4().hex[:8]}"
+
+
+async def _write_memory(sc, tenant_id: str, content: str = "hello world") -> dict:
+    """Create a memory and return the storage-side dict."""
+    return await sc.create_memory(
+        {
+            "tenant_id": tenant_id,
+            "agent_id": "test-agent",
+            "content": content,
+            "memory_type": "fact",
+            "embedding": [0.1] * VECTOR_DIM,
+            "weight": 0.5,
+        }
+    )
+
+
+# ============================================================================
+# /memories/batch-update-status — widened with supersedes fields
+# ============================================================================
+
+
+async def test_batch_update_status_backward_compat_2field_shape(sc):
+    """Pre-PR1 payload shape — ``{memory_id, status}`` per row — keeps
+    working unchanged. Guards against breakage of the existing zero
+    callers in tree + any deployed consumer not yet updated."""
+    tid = _t()
+    a = await _write_memory(sc, tid, "fact A")
+    b = await _write_memory(sc, tid, "fact B")
+
+    result = await sc.batch_update_status(
+        {
+            "updates": [
+                {"memory_id": a["id"], "status": "archived"},
+                {"memory_id": b["id"], "status": "conflicted"},
+            ]
+        }
+    )
+    assert result["ok"] is True
+    assert result["skipped"] == []
+
+    a_post = await sc.get_memory(a["id"])
+    b_post = await sc.get_memory(b["id"])
+    assert a_post["status"] == "archived"
+    assert b_post["status"] == "conflicted"
+
+
+async def test_batch_update_status_sets_supersedes(sc):
+    tid = _t()
+    older = await _write_memory(sc, tid, "older fact")
+    newer = await _write_memory(sc, tid, "newer fact")
+
+    result = await sc.batch_update_status(
+        {
+            "updates": [
+                {"memory_id": older["id"], "status": "conflicted"},
+                {
+                    "memory_id": newer["id"],
+                    "status": "active",
+                    "supersedes_id": older["id"],
+                },
+            ]
+        }
+    )
+    assert result["ok"] is True
+    assert result["skipped"] == []
+
+    newer_post = await sc.get_memory(newer["id"])
+    assert newer_post["status"] == "active"
+    assert str(newer_post["supersedes_id"]) == str(older["id"])
+
+
+async def test_batch_update_status_unset_supersedes(sc):
+    tid = _t()
+    older = await _write_memory(sc, tid, "older")
+    newer = await _write_memory(sc, tid, "newer")
+    # First set the pointer via the single-row PATCH so the unset case
+    # has something to clear.
+    await sc.update_memory_status(newer["id"], "active", supersedes_id=older["id"])
+
+    result = await sc.batch_update_status(
+        {
+            "updates": [
+                {
+                    "memory_id": newer["id"],
+                    "status": "active",
+                    "unset_supersedes": True,
+                },
+            ]
+        }
+    )
+    assert result["ok"] is True
+
+    newer_post = await sc.get_memory(newer["id"])
+    assert newer_post["supersedes_id"] is None
+
+
+async def test_batch_update_status_cas_skip_on_mismatch(sc):
+    """``expected_supersedes_id`` is a CAS gate — a stale caller view
+    must not clobber a row that's been updated by another writer."""
+    tid = _t()
+    older = await _write_memory(sc, tid, "older")
+    newer = await _write_memory(sc, tid, "newer")
+    other = await _write_memory(sc, tid, "third")
+    # Row currently points at ``other``.
+    await sc.update_memory_status(newer["id"], "conflicted", supersedes_id=other["id"])
+
+    # Caller's stale view: thinks the row points at ``older``.
+    result = await sc.batch_update_status(
+        {
+            "updates": [
+                {
+                    "memory_id": newer["id"],
+                    "status": "active",
+                    "unset_supersedes": True,
+                    "expected_supersedes_id": older["id"],
+                },
+            ]
+        }
+    )
+    # CAS gate fires: row reported as skipped, status untouched.
+    assert newer["id"] in result["skipped"]
+    newer_post = await sc.get_memory(newer["id"])
+    assert newer_post["status"] == "conflicted"
+    assert str(newer_post["supersedes_id"]) == str(other["id"])
+
+
+# ============================================================================
+# /memories/bulk-get — order preservation, None for missing, tenant filter
+# ============================================================================
+
+
+async def test_bulk_get_memories_preserves_input_order(sc):
+    tid = _t()
+    a = await _write_memory(sc, tid, "A")
+    b = await _write_memory(sc, tid, "B")
+    c = await _write_memory(sc, tid, "C")
+
+    rows = await sc.bulk_get_memories([c["id"], a["id"], b["id"]])
+    assert len(rows) == 3
+    assert [r["id"] for r in rows] == [c["id"], a["id"], b["id"]]
+    assert rows[0]["content"] == "C"
+
+
+async def test_bulk_get_memories_returns_none_for_missing(sc):
+    tid = _t()
+    a = await _write_memory(sc, tid, "exists")
+    ghost = str(uuid4())
+
+    rows = await sc.bulk_get_memories([a["id"], ghost])
+    assert len(rows) == 2
+    assert rows[0]["id"] == a["id"]
+    assert rows[1] is None
+
+
+async def test_bulk_get_memories_tenant_filter_yields_none(sc):
+    """If ``tenant_id`` is provided, cross-tenant ids return None (per-row
+    fail-closed) rather than leaking another tenant's memory dict."""
+    tid_a = _t()
+    tid_b = _t()
+    m_a = await _write_memory(sc, tid_a, "tenant A's")
+    m_b = await _write_memory(sc, tid_b, "tenant B's")
+
+    rows = await sc.bulk_get_memories([m_a["id"], m_b["id"]], tenant_id=tid_a)
+    assert rows[0] is not None and rows[0]["id"] == m_a["id"]
+    assert rows[1] is None  # cross-tenant → masked
+
+
+async def test_bulk_get_memories_empty_input(sc):
+    assert await sc.bulk_get_memories([]) == []
+
+
+# ============================================================================
+# /entities/bulk-resolve — Phase 1 exact, Phase 2 cosine, miss=None
+# ============================================================================
+
+
+async def _create_entity(sc, tenant_id: str, name: str, *, embedding=None) -> dict:
+    return await sc.create_entity(
+        {
+            "tenant_id": tenant_id,
+            "fleet_id": None,
+            "entity_type": "person",
+            "canonical_name": name,
+            "attributes": {},
+            "name_embedding": embedding,
+        }
+    )
+
+
+async def test_bulk_resolve_phase1_exact_matches(sc):
+    tid = _t()
+    e1 = await _create_entity(sc, tid, "alice")
+    e2 = await _create_entity(sc, tid, "bob")
+
+    results = await sc.bulk_resolve_entities(
+        tenant_id=tid,
+        items=[
+            {
+                "input_idx": 0,
+                "fleet_id": None,
+                "canonical_name": "alice",
+                "entity_type": "person",
+                "name_embedding": None,
+            },
+            {
+                "input_idx": 1,
+                "fleet_id": None,
+                "canonical_name": "bob",
+                "entity_type": "person",
+                "name_embedding": None,
+            },
+            {
+                "input_idx": 2,
+                "fleet_id": None,
+                "canonical_name": "carol",  # no match
+                "entity_type": "person",
+                "name_embedding": None,
+            },
+        ],
+        threshold=0.85,
+    )
+    assert len(results) == 3
+    assert results[0]["entity_id"] == e1["id"]
+    assert results[0]["matched_by"] == "exact"
+    assert results[1]["entity_id"] == e2["id"]
+    assert results[2] is None
+
+
+async def test_bulk_resolve_phase2_similarity_above_threshold(sc):
+    tid = _t()
+    # Stored entity with a known embedding.
+    stored_embedding = [0.1] * VECTOR_DIM
+    existing = await _create_entity(sc, tid, "helios-7", embedding=stored_embedding)
+
+    # Query with the same embedding → cosine similarity = 1.0 → match.
+    results = await sc.bulk_resolve_entities(
+        tenant_id=tid,
+        items=[
+            {
+                "input_idx": 0,
+                "fleet_id": None,
+                "canonical_name": "helios-seven",  # different surface form
+                "entity_type": "person",
+                "name_embedding": stored_embedding,
+            },
+        ],
+        threshold=0.85,
+    )
+    assert results[0] is not None
+    assert results[0]["entity_id"] == existing["id"]
+    assert results[0]["matched_by"] == "similarity"
+    assert results[0]["similarity"] >= 0.85
+
+
+async def test_bulk_resolve_phase2_skipped_when_no_embedding(sc):
+    """Item without ``name_embedding`` skips Phase 2 — mirrors entity_service
+    upsert_entity line 46. Combined with no exact match → returns None."""
+    tid = _t()
+    await _create_entity(sc, tid, "existing", embedding=[0.5] * VECTOR_DIM)
+
+    results = await sc.bulk_resolve_entities(
+        tenant_id=tid,
+        items=[
+            {
+                "input_idx": 0,
+                "fleet_id": None,
+                "canonical_name": "not-existing",
+                "entity_type": "person",
+                "name_embedding": None,  # explicitly no embedding
+            },
+        ],
+        threshold=0.85,
+    )
+    assert results[0] is None
+
+
+async def test_bulk_resolve_empty_input(sc):
+    assert (
+        await sc.bulk_resolve_entities(tenant_id=_t(), items=[], threshold=0.85) == []
+    )
+
+
+# ============================================================================
+# /entities/bulk-upsert — create + update + race-merge in one transaction
+# ============================================================================
+
+
+async def test_bulk_upsert_mixed_create_and_update(sc):
+    tid = _t()
+    existing = await _create_entity(sc, tid, "old-name")
+
+    results = await sc.bulk_upsert_entities(
+        items=[
+            {
+                "input_idx": 0,
+                "action": "create",
+                "tenant_id": tid,
+                "fleet_id": None,
+                "entity_type": "organization",
+                "canonical_name": "brand-new",
+                "attributes": {"foo": "bar"},
+            },
+            {
+                "input_idx": 1,
+                "action": "update",
+                "entity_id": existing["id"],
+                "tenant_id": tid,
+                "fleet_id": None,
+                "entity_type": "person",
+                "canonical_name": "old-name",
+                "attributes": {"merged": True, "_aliases": ["old-name"]},
+            },
+        ]
+    )
+
+    assert results[0]["action"] == "created"
+    assert results[1]["action"] == "updated"
+    assert results[1]["entity_id"] == existing["id"]
+
+    # Verify the create landed
+    new_entity = await sc.get_entity(results[0]["entity_id"])
+    assert new_entity["canonical_name"] == "brand-new"
+    assert new_entity["attributes"] == {"foo": "bar"}
+
+    # Verify the update wrote merged attrs
+    updated = await sc.get_entity(existing["id"])
+    assert updated["attributes"] == {"merged": True, "_aliases": ["old-name"]}
+
+
+async def test_bulk_upsert_create_race_merges(sc):
+    """When ``action=create`` but the natural-key row already exists
+    (someone created it between resolve and upsert), the endpoint must
+    fall back to update — mirroring ``entity_add``'s IntegrityError
+    recovery. Outcome: ``action="merged"``."""
+    tid = _t()
+    # Pre-create the row that would conflict
+    existing = await _create_entity(sc, tid, "concurrent")
+
+    results = await sc.bulk_upsert_entities(
+        items=[
+            {
+                "input_idx": 0,
+                "action": "create",
+                "tenant_id": tid,
+                "fleet_id": None,
+                "entity_type": "person",
+                "canonical_name": "concurrent",
+                "attributes": {"from": "racy-write"},
+            },
+        ]
+    )
+
+    assert results[0]["action"] == "merged"
+    assert results[0]["entity_id"] == existing["id"]
+
+    merged = await sc.get_entity(existing["id"])
+    assert merged["attributes"] == {"from": "racy-write"}
+
+
+async def test_bulk_upsert_update_missing_id_reports_missing(sc):
+    """Action=update on a deleted/nonexistent entity_id surfaces as
+    ``action="missing"`` so the caller can disambiguate."""
+    ghost = str(uuid4())
+    results = await sc.bulk_upsert_entities(
+        items=[
+            {
+                "input_idx": 0,
+                "action": "update",
+                "entity_id": ghost,
+                "tenant_id": _t(),
+                "fleet_id": None,
+                "entity_type": "person",
+                "canonical_name": "nope",
+                "attributes": {},
+            },
+        ]
+    )
+    assert results[0]["action"] == "missing"
+
+
+async def test_bulk_upsert_empty_input(sc):
+    assert await sc.bulk_upsert_entities(items=[]) == []
+
+
+# ============================================================================
+# /entities/links/bulk — idempotent (memory_id, entity_id) upsert
+# ============================================================================
+
+
+async def test_bulk_upsert_links_creates_all_new(sc):
+    tid = _t()
+    m = await _write_memory(sc, tid)
+    e1 = await _create_entity(sc, tid, "linked-one")
+    e2 = await _create_entity(sc, tid, "linked-two")
+
+    results = await sc.bulk_upsert_entity_links(
+        items=[
+            {
+                "input_idx": 0,
+                "memory_id": m["id"],
+                "entity_id": e1["id"],
+                "role": "subject",
+            },
+            {
+                "input_idx": 1,
+                "memory_id": m["id"],
+                "entity_id": e2["id"],
+                "role": "object",
+            },
+        ]
+    )
+
+    assert len(results) == 2
+    assert results[0]["created"] is True
+    assert results[1]["created"] is True
+    assert results[0]["role"] == "subject"
+    assert results[1]["role"] == "object"
+
+
+async def test_bulk_upsert_links_is_idempotent_on_pk_collision(sc):
+    """Two writes for the same (memory_id, entity_id) — second is no-op,
+    role from first call is preserved (mirrors find_entity_link → skip)."""
+    tid = _t()
+    m = await _write_memory(sc, tid)
+    e = await _create_entity(sc, tid, "the-entity")
+
+    first = await sc.bulk_upsert_entity_links(
+        items=[
+            {
+                "input_idx": 0,
+                "memory_id": m["id"],
+                "entity_id": e["id"],
+                "role": "subject",
+            },
+        ]
+    )
+    assert first[0]["created"] is True
+
+    second = await sc.bulk_upsert_entity_links(
+        items=[
+            {
+                "input_idx": 0,
+                "memory_id": m["id"],
+                "entity_id": e["id"],
+                "role": "object",
+            },
+        ]
+    )
+    assert second[0]["created"] is False
+    # Prior role wins.
+    assert second[0]["role"] == "subject"
+
+
+async def test_bulk_upsert_links_empty_input(sc):
+    assert await sc.bulk_upsert_entity_links(items=[]) == []
+
+
+# ============================================================================
+# Atomicity + correctness regressions
+# ============================================================================
+
+
+async def test_bulk_upsert_links_fk_violation_isolated_per_item(sc):
+    """An FK violation on one item must not roll back the others — each
+    insert gets its own session, and the failing item is reported with
+    ``created=False, error="fk_violation"`` so the caller can keep
+    processing."""
+    tid = _t()
+    m = await _write_memory(sc, tid)
+    e = await _create_entity(sc, tid, "real-entity")
+    ghost_entity = str(uuid4())  # No matching row → FK violation
+
+    results = await sc.bulk_upsert_entity_links(
+        items=[
+            {
+                "input_idx": 0,
+                "memory_id": m["id"],
+                "entity_id": e["id"],
+                "role": "subject",
+            },
+            {
+                "input_idx": 1,
+                "memory_id": m["id"],
+                "entity_id": ghost_entity,
+                "role": "object",
+            },
+            {"input_idx": 2, "memory_id": m["id"], "entity_id": e["id"], "role": "alt"},
+        ]
+    )
+    assert len(results) == 3
+    # Item 0 succeeded
+    assert results[0]["created"] is True
+    # Item 1 failed (FK violation), reported per-row
+    assert results[1]["created"] is False
+    assert results[1].get("error") == "fk_violation"
+    # Item 2 ran AFTER the failure and still landed (PK already
+    # exists from item 0, so created=False here is the role-preserve path,
+    # not the FK error path) — proves prior items weren't rolled back.
+    assert results[2]["created"] is False
+    assert "error" not in results[2]
+    assert results[2]["role"] == "subject"  # role preserved from item 0
+
+
+async def test_bulk_upsert_links_duplicate_input_pair_keeps_both_slots(sc):
+    """Two input items pointing at the same (memory_id, entity_id) pair
+    must each get their own slot in the response. Earlier the result map
+    was keyed by the PK tuple, so the second slot silently overwrote the
+    first; now keyed by ``input_idx``."""
+    tid = _t()
+    m = await _write_memory(sc, tid)
+    e = await _create_entity(sc, tid, "dup-target")
+
+    results = await sc.bulk_upsert_entity_links(
+        items=[
+            {
+                "input_idx": 0,
+                "memory_id": m["id"],
+                "entity_id": e["id"],
+                "role": "subject",
+            },
+            {
+                "input_idx": 1,
+                "memory_id": m["id"],
+                "entity_id": e["id"],
+                "role": "object",
+            },
+        ]
+    )
+    assert len(results) == 2
+    assert results[0]["input_idx"] == 0
+    assert results[1]["input_idx"] == 1
+    # First insert wins; both response slots reflect the persisted role.
+    assert results[0]["role"] == "subject"
+    assert results[1]["role"] == "subject"
+
+
+async def test_bulk_upsert_invalid_action_rejected_422(sc):
+    """An item with action not in {create, update} would otherwise be
+    silently dropped (response shorter than input). Router validates."""
+    import httpx
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entities(
+            items=[
+                {
+                    "input_idx": 0,
+                    "action": "delete",  # invalid
+                    "tenant_id": _t(),
+                    "fleet_id": None,
+                    "entity_type": "person",
+                    "canonical_name": "nope",
+                    "attributes": {},
+                },
+            ]
+        )
+    assert exc.value.response.status_code == 422
+
+
+async def test_patch_memory_status_returns_404_on_missing(sc):
+    """``PATCH /memories/{id}/status`` previously silently 200'd on a
+    nonexistent id (the bool return from ``memory_update_status`` was
+    ignored). Storage-side now returns 404; the client's ``_patch``
+    helper translates 404 → ``None`` (established convention shared
+    with ``update_entity`` et al.), so callers see ``None`` instead of
+    a silent ``{ok: True}`` they can't distinguish from a real update.
+    """
+    ghost = str(uuid4())
+    result = await sc.update_memory_status(ghost, "active")
+    assert result is None
+
+
+# ============================================================================
+# Input validation regressions (router-level)
+# ============================================================================
+
+
+async def test_bulk_upsert_input_idx_out_of_range_rejected_422(sc):
+    """``input_idx`` outside [0, len(items)) would crash with IndexError
+    inside the service (results list-indexing). Router 422s instead."""
+    import httpx
+
+    tid = _t()
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entities(
+            items=[
+                {
+                    "input_idx": 99,  # out of range for 1-item batch
+                    "action": "create",
+                    "tenant_id": tid,
+                    "fleet_id": None,
+                    "entity_type": "person",
+                    "canonical_name": "oob",
+                    "attributes": {},
+                },
+            ]
+        )
+    assert exc.value.response.status_code == 422
+    assert "input_idx" in exc.value.response.text
+
+
+async def test_bulk_upsert_input_idx_duplicate_rejected_422(sc):
+    """Two items with the same ``input_idx`` would overwrite each other
+    in the response list. Router rejects."""
+    import httpx
+
+    tid = _t()
+    base = {
+        "action": "create",
+        "tenant_id": tid,
+        "fleet_id": None,
+        "entity_type": "person",
+        "attributes": {},
+    }
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entities(
+            items=[
+                {**base, "input_idx": 0, "canonical_name": "a"},
+                {**base, "input_idx": 0, "canonical_name": "b"},  # duplicate
+            ]
+        )
+    assert exc.value.response.status_code == 422
+    assert "duplicate" in exc.value.response.text
+
+
+async def test_bulk_resolve_input_idx_out_of_range_rejected_422(sc):
+    """Same guard on the resolve endpoint."""
+    import httpx
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_resolve_entities(
+            tenant_id=_t(),
+            items=[
+                {
+                    "input_idx": 5,  # out of range
+                    "fleet_id": None,
+                    "canonical_name": "x",
+                    "entity_type": "person",
+                    "name_embedding": None,
+                },
+            ],
+            threshold=0.85,
+        )
+    assert exc.value.response.status_code == 422
+
+
+async def test_bulk_upsert_update_without_entity_id_rejected_422(sc):
+    """``action='update'`` without ``entity_id`` would crash inside the
+    service. Router rejects with 422 + the bad input_idx."""
+    import httpx
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entities(
+            items=[
+                {
+                    "input_idx": 0,
+                    "action": "update",
+                    # entity_id intentionally absent
+                    "tenant_id": _t(),
+                    "fleet_id": None,
+                    "entity_type": "person",
+                    "canonical_name": "needs-id",
+                    "attributes": {},
+                },
+            ]
+        )
+    assert exc.value.response.status_code == 422
+    assert "entity_id" in exc.value.response.text
+
+
+async def test_batch_update_status_malformed_uuid_returns_422(sc):
+    """``UUID('not-a-uuid')`` raised ValueError → uncaught 500 before
+    this fix; now reframed as a 422 naming the bad item."""
+    import httpx
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.batch_update_status(
+            {"updates": [{"memory_id": "not-a-uuid", "status": "active"}]}
+        )
+    assert exc.value.response.status_code == 422
+
+
+async def test_batch_update_status_missing_required_key_returns_422(sc):
+    """``KeyError`` on a missing ``status`` (or ``memory_id``) field
+    also surfaces as 422 instead of 500."""
+    import httpx
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.batch_update_status(
+            {"updates": [{"memory_id": str(uuid4())}]}  # missing "status"
+        )
+    assert exc.value.response.status_code == 422
+
+
+async def test_batch_update_status_partial_validation_failure_writes_nothing(sc):
+    """Validation runs as a pre-pass before any DB write — so a malformed
+    item at index K must NOT leave items 0..K-1 committed. Verify by
+    sending a valid row followed by a malformed one, then asserting the
+    valid row's status is unchanged."""
+    import httpx
+
+    tid = _t()
+    target = await _write_memory(sc, tid, "untouched")
+    original_status = target["status"]
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.batch_update_status(
+            {
+                "updates": [
+                    {"memory_id": target["id"], "status": "archived"},
+                    {"memory_id": "garbage", "status": "active"},  # crash pt
+                ]
+            }
+        )
+    assert exc.value.response.status_code == 422
+
+    # Critical: the valid row in position 0 must NOT have been committed.
+    post = await sc.get_memory(target["id"])
+    assert post["status"] == original_status, (
+        "validation pre-pass failed: status was committed before the "
+        f"batch was rejected (expected {original_status!r}, got {post['status']!r})"
+    )
+
+
+async def test_bulk_upsert_links_input_idx_out_of_range_rejected_422(sc):
+    """Same input_idx guard as the other bulk endpoints — without it,
+    out-of-range / missing input_idx would have crashed in the service."""
+    import httpx
+
+    tid = _t()
+    m = await _write_memory(sc, tid)
+    e = await _create_entity(sc, tid, "test-entity")
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entity_links(
+            items=[
+                {
+                    "input_idx": 7,  # out of range for 1-item batch
+                    "memory_id": m["id"],
+                    "entity_id": e["id"],
+                    "role": "subject",
+                },
+            ]
+        )
+    assert exc.value.response.status_code == 422
+    assert "input_idx" in exc.value.response.text
+
+
+async def test_bulk_upsert_links_input_idx_duplicate_rejected_422(sc):
+    """Two items sharing the same ``input_idx`` would overwrite each
+    other in ``idx_to_result`` → corrupted response shape."""
+    import httpx
+
+    tid = _t()
+    m = await _write_memory(sc, tid)
+    e = await _create_entity(sc, tid, "dup-target")
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entity_links(
+            items=[
+                {
+                    "input_idx": 0,
+                    "memory_id": m["id"],
+                    "entity_id": e["id"],
+                    "role": "subject",
+                },
+                {
+                    "input_idx": 0,
+                    "memory_id": m["id"],
+                    "entity_id": e["id"],
+                    "role": "object",
+                },
+            ]
+        )
+    assert exc.value.response.status_code == 422
+    assert "duplicate" in exc.value.response.text
+
+
+async def test_bulk_upsert_update_cross_tenant_returns_missing(sc):
+    """An ``action='update'`` whose ``entity_id`` belongs to a different
+    tenant must NOT silently update the foreign row. The service now
+    pins the UPDATE WHERE to ``tenant_id``; mismatched rows surface as
+    ``action='missing'`` rather than rewriting another tenant's entity."""
+    tid_a = _t()
+    tid_b = _t()
+    foreign = await _create_entity(sc, tid_b, "foreign-entity")
+    foreign_pre = await sc.get_entity(foreign["id"])
+
+    results = await sc.bulk_upsert_entities(
+        items=[
+            {
+                "input_idx": 0,
+                "action": "update",
+                "entity_id": foreign["id"],
+                "tenant_id": tid_a,  # different tenant
+                "fleet_id": None,
+                "entity_type": "person",
+                "canonical_name": "renamed",
+                "attributes": {"hijacked": True},
+            },
+        ]
+    )
+    assert results[0]["action"] == "missing"
+
+    # Foreign tenant's row stays put — attributes and canonical_name unchanged.
+    post = await sc.get_entity(foreign["id"])
+    assert post["attributes"] == foreign_pre["attributes"]
+    assert post["canonical_name"] == foreign_pre["canonical_name"]
+
+
+async def test_bulk_resolve_non_numeric_threshold_returns_422(sc):
+    """``float('abc')`` would raise ValueError → 500 before this fix;
+    router now reframes as 422 naming the bad field."""
+    resp = await sc._http.post(
+        f"{sc._prefix}/entities/bulk-resolve",
+        json={"tenant_id": _t(), "threshold": "abc", "items": []},
+        headers=await sc._auth_headers(read=False),
+    )
+    assert resp.status_code == 422
+    assert "threshold" in resp.text
+
+
+async def test_bulk_resolve_non_int_candidate_limit_returns_422(sc):
+    resp = await sc._http.post(
+        f"{sc._prefix}/entities/bulk-resolve",
+        json={
+            "tenant_id": _t(),
+            "threshold": 0.85,
+            "candidate_limit": "five",
+            "items": [],
+        },
+        headers=await sc._auth_headers(read=False),
+    )
+    assert resp.status_code == 422
+    assert "candidate_limit" in resp.text
+
+
+# ============================================================================
+# Required-field validation per bulk endpoint
+# ============================================================================
+
+
+async def test_bulk_upsert_entities_missing_required_field_returns_422(sc):
+    """Missing ``attributes`` would crash inside the service with a
+    KeyError → uncaught 500. Router validates required fields up-front."""
+    import httpx
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entities(
+            items=[
+                {
+                    "input_idx": 0,
+                    "action": "create",
+                    "tenant_id": _t(),
+                    "fleet_id": None,
+                    "entity_type": "person",
+                    "canonical_name": "no-attrs",
+                    # attributes intentionally absent
+                },
+            ]
+        )
+    assert exc.value.response.status_code == 422
+    assert "attributes" in exc.value.response.text
+
+
+async def test_bulk_resolve_missing_required_field_returns_422(sc):
+    """Missing ``entity_type`` would crash with KeyError inside Phase 1."""
+    resp = await sc._http.post(
+        f"{sc._prefix}/entities/bulk-resolve",
+        json={
+            "tenant_id": _t(),
+            "threshold": 0.85,
+            "items": [
+                {
+                    "input_idx": 0,
+                    "canonical_name": "no-type",
+                    # entity_type intentionally absent
+                },
+            ],
+        },
+        headers=await sc._auth_headers(read=False),
+    )
+    assert resp.status_code == 422
+    assert "entity_type" in resp.text
+
+
+async def test_bulk_upsert_links_missing_required_field_returns_422(sc):
+    """Missing ``role`` would crash inside the link upsert loop."""
+    import httpx
+
+    tid = _t()
+    m = await _write_memory(sc, tid)
+    e = await _create_entity(sc, tid, "rolesless")
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entity_links(
+            items=[
+                {
+                    "input_idx": 0,
+                    "memory_id": m["id"],
+                    "entity_id": e["id"],
+                    # role intentionally absent
+                },
+            ]
+        )
+    assert exc.value.response.status_code == 422
+    assert "role" in exc.value.response.text
+
+
+async def test_batch_update_status_error_detail_omits_raw_item_repr(sc):
+    """Sensitive item content (status values, supersedes ids) must not
+    leak into 422 error bodies. Detail names ``memory_id`` and exception
+    type only — not the full dict repr."""
+    resp = await sc._http.post(
+        f"{sc._prefix}/memories/batch-update-status",
+        json={
+            "updates": [
+                {
+                    "memory_id": str(uuid4()),
+                    # status intentionally absent → KeyError
+                    "supersedes_id": "secret-value-must-not-leak",
+                },
+            ]
+        },
+        headers=await sc._auth_headers(read=False),
+    )
+    assert resp.status_code == 422
+    body = resp.text
+    assert "secret-value-must-not-leak" not in body
+    # But the memory_id is still surfaced so the client knows which
+    # row was the offender.
+    assert "memory_id" in body
+
+
+async def test_batch_update_status_error_omits_malformed_uuid_value(sc):
+    """A ValueError from ``UUID("badly-formed")`` carries the raw input
+    in its message ("badly formed hexadecimal UUID string: <value>").
+    Detail must NOT echo the exception message back — only the
+    exception type + a generic field hint. ``memory_id`` itself is
+    echoed back by design (helps client identify the row), so the
+    leak case to guard is a bad value in a *different* UUID field."""
+    resp = await sc._http.post(
+        f"{sc._prefix}/memories/batch-update-status",
+        json={
+            "updates": [
+                {
+                    "memory_id": str(uuid4()),
+                    "status": "active",
+                    # Bad UUID in supersedes_id, NOT memory_id.
+                    "supersedes_id": "secret-uuid-must-not-leak-back",
+                },
+            ]
+        },
+        headers=await sc._auth_headers(read=False),
+    )
+    assert resp.status_code == 422
+    body = resp.text
+    assert "secret-uuid-must-not-leak-back" not in body
+    assert "ValueError" in body
+    assert "UUID field" in body
+
+
+# ============================================================================
+# UUID format validation at the router boundary
+# ============================================================================
+
+
+async def test_bulk_upsert_update_non_uuid_entity_id_returns_422(sc):
+    """``action='update'`` with a present-but-malformed ``entity_id``
+    would crash inside the service at ``UUID(eid)`` and bubble via the
+    generic 500 fallback. Router now validates UUID shape up-front."""
+    import httpx
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entities(
+            items=[
+                {
+                    "input_idx": 0,
+                    "action": "update",
+                    "entity_id": "not-a-uuid",  # malformed
+                    "tenant_id": _t(),
+                    "fleet_id": None,
+                    "entity_type": "person",
+                    "canonical_name": "x",
+                    "attributes": {},
+                },
+            ]
+        )
+    assert exc.value.response.status_code == 422
+    assert "entity_id" in exc.value.response.text
+
+
+async def test_bulk_upsert_links_non_uuid_memory_id_returns_422(sc):
+    """Malformed ``memory_id`` UUID must surface as 422 with the field
+    named, not as a generic 500."""
+    import httpx
+
+    tid = _t()
+    e = await _create_entity(sc, tid, "for-link")
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entity_links(
+            items=[
+                {
+                    "input_idx": 0,
+                    "memory_id": "not-a-uuid",  # malformed
+                    "entity_id": e["id"],
+                    "role": "subject",
+                },
+            ]
+        )
+    assert exc.value.response.status_code == 422
+    assert "memory_id" in exc.value.response.text
+
+
+async def test_bulk_upsert_links_non_uuid_entity_id_returns_422(sc):
+    import httpx
+
+    tid = _t()
+    m = await _write_memory(sc, tid)
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc.bulk_upsert_entity_links(
+            items=[
+                {
+                    "input_idx": 0,
+                    "memory_id": m["id"],
+                    "entity_id": "not-a-uuid",  # malformed
+                    "role": "subject",
+                },
+            ]
+        )
+    assert exc.value.response.status_code == 422
+    assert "entity_id" in exc.value.response.text


### PR DESCRIPTION
## Summary

Lays the storage-side foundation for the P1 / P2 / P5 performance overhaul (audit `report-codebase-audit-2026-05-19.md`, validated `codebase-audit-validation-2026-05-25.md`). Three follow-up consumer PRs land on top:

- **PR 2 (P2):** contradiction detector — collapses 9 sequential \`update_memory_status\` sites into one \`batch_update_status\` per detection path
- **PR 3 (P5):** crystallizer archive sweep — replaces two N+1 loops with \`bulk_get_memories\` + \`batch_update_status\`
- **PR 4 (P1):** entity-extraction worker — replaces 6N HTTPs/memory with ~3 HTTPs/memory via the new entity + entity-link bulk endpoints

## Endpoints

| Endpoint | Type | Used by |
|---|---|---|
| \`POST /memories/batch-update-status\` (widened, backward-compat) | Per-row \`supersedes_id\`/\`unset_supersedes\`/\`expected_supersedes_id\` honored. Response gains a \`skipped\` list for CAS misses. | P2, P5 |
| \`POST /memories/bulk-get\` (new) | Ordered list, \`null\` for missing/cross-tenant. 1000-id cap. | P5 |
| \`POST /entities/bulk-resolve\` (new) | Pure-read Phase 1 batched + per-item Phase 2 in one HTTP. Threshold required, no default. 500-item cap. | P1 |
| \`POST /entities/bulk-upsert\` (new) | Mixed create/update. Reports \`{created,updated,merged,missing}\` per row. TOCTOU-safe via fresh-session recovery. | P1 |
| \`POST /entities/links/bulk\` (new) | Idempotent (memory_id, entity_id) upsert. Pre-existing role preserved. | P1 |

Plus matching methods on \`storage_client.py\`: \`bulk_get_memories\`, \`bulk_resolve_entities\`, \`bulk_upsert_entities\`, \`bulk_upsert_entity_links\`. The existing \`batch_update_status\` is wire-compatible with the widened endpoint.

## Design notes

- **Functional unique index.** \`uq_entities_tenant_type_name_fleet\` is \`(tenant_id, entity_type, lower(canonical_name), COALESCE(fleet_id, ''))\` — SQLAlchemy's ON CONFLICT helpers can't target functional expressions via the column list, so bulk-upsert uses a read-then-write shape with TOCTOU recovery in fresh sessions. Single HTTP preserved; per-row sessions only for creates.
- **First-seen-wins canonical** (see comment at \`entity_service.py:83-91\`): the bulk_resolve response returns the existing \`canonical_name\` so the worker can replicate first-seen-wins client-side when building the bulk_upsert payload. Server side doesn't merge attributes — caller pre-computes.
- **Tenant scoping** on bulk-get is opt-in to mirror the single-row \`GET /memories/{id}\` contract (no behavior change for existing callers).

## Test plan

- [x] 19 integration tests in \`tests/test_storage_bulk_endpoints.py\`. All passing locally against the docker pgvector instance.
- [x] 50 pre-existing tests on adjacent surfaces (\`test_a4_status_retraction\`, \`test_storage_client_routing\`, \`test_storage_client_retry\`, \`test_bulk_atomicity\`) stay green.
- [x] Ruff lint + format clean.
- [x] mypy clean on core-storage-api (48 files). core-api mypy reports the pre-existing \`config.py\` croniter-stub issue (verified on \`main\` before this PR).

## Out of scope (filed as follow-ups)

- Internal "one Python loop, one session per row" inefficiency inside storage-side \`batch-update-status\` — the HTTP-roundtrip win is what P2/P5 actually need; SQL-level batching is a separate concern.
- \`entity_add\`'s latent \`session.rollback()\`-inside-context-manager bug surfaces under contention but isn't exercised by any existing test; the new bulk-upsert sidesteps it via fresh-session TOCTOU recovery rather than fixing \`entity_add\` in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)