### PR TITLE
test(storage-api): default fake_embedding to VECTOR_DIM (1024)

### DIFF
--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -15,6 +15,8 @@ import uuid
 import pytest
 from httpx import AsyncClient
 
+from common.constants import VECTOR_DIM
+
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
 PREFIX = "/api/v1/storage"
@@ -30,7 +32,7 @@ def _uid() -> str:
     return uuid.uuid4().hex[:8]
 
 
-def fake_embedding(seed: str, dim: int = 768) -> list[float]:
+def fake_embedding(seed: str, dim: int = VECTOR_DIM) -> list[float]:
     """Deterministic unit-length embedding from a seed string."""
     h = hashlib.sha256(seed.encode()).digest()
     raw = h * (dim // len(h) + 1)


### PR DESCRIPTION
## Summary

The integration-test fixture `fake_embedding(seed, dim=768)` in `core-storage-api/tests/test_integration.py` has been silently stale since migration `012_vector_dim_1024.py` widened the `memories.embedding` pgvector column from 768 to 1024.

Every test in `TestMemories` was failing locally with:
```
sqlalchemy.exc.StatementError: (builtins.ValueError) expected 1024 dimensions, not 768
```

CI never caught this because it provisions a fresh DB on each run and the mismatch path was masked by other factors there. But anyone running `pytest` locally on `core-storage-api` was hitting it on the very first test that exercised the write path.

Fix: switch the default to `common.constants.VECTOR_DIM`, which is the canonical constant the rest of the embedding stack already uses (`common/embedding/providers/fake.py`, etc.). One import + one default change.

## Test plan

- [x] Re-ran `tests/test_integration.py::TestMemories` locally — the three tests that previously failed on Memory creation (`test_create_and_get_memory`, `test_update_status_via_patch`, `test_patch_entities_is_bulk_and_idempotent`) now all pass.
- [x] Confirmed `tests/test_qemb_cache_dim_versioning.py` is the only other 768 hardcode in tests — it's deliberate (tests the 768→1024 cache-key versioning), out of scope.
- [ ] CI

## Background

Discovered during CAURA-686 Phase 2 work (PR #220). My new test there couldn't be exercised locally because of this drift; CI was the only path. This unblocks local TDD on `core-storage-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)