### PR TITLE
fix(core-api): bump storage_client httpx pool limits 100/50 -> 200/150 (CAURA-682)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -184,7 +184,7 @@ class CoreStorageClient:
         else:
             # Share one pool when the split isn't configured — or when an
             # operator accidentally points both URLs at the same upstream.
-            # Otherwise we'd double the connection budget (200 vs 100 max)
+            # Otherwise we'd double the connection budget (400 vs 200 max)
             # against a single service for no benefit.
             self._read_http = self._http
 
@@ -210,7 +210,15 @@ class CoreStorageClient:
         """
         return httpx.AsyncClient(
             timeout=httpx.Timeout(connect=5.0, read=120.0, write=120.0, pool=5.0),
-            limits=httpx.Limits(max_connections=100, max_keepalive_connections=50),
+            # CAURA-682: pre-fix values 100/50 caused TCP ConnectTimeout
+            # retries (3x 5s ~= 13s tail per affected request) during
+            # noisy-neighbor write storms — concurrent core-api → storage
+            # demand exceeded keepalive ceiling, forcing new TCP
+            # handshakes that piled up at the Cloud Run frontend.
+            # Sized for 20 concurrent storm writes x ~5 storage calls
+            # each = 100 in-flight at peak, plus tenant-B probe headroom
+            # and a 33% burst margin.
+            limits=httpx.Limits(max_connections=200, max_keepalive_connections=150),
             follow_redirects=True,
         )
 


### PR DESCRIPTION
## Summary

Phase 3 follow-up to [CAURA-686](https://caura-ai.atlassian.net/browse/CAURA-686) / [CAURA-682](https://caura-ai.atlassian.net/browse/CAURA-682). PR caura-memclaw#220 eliminated the DB-side `Lock/transactionid` contention; this PR addresses the next bottleneck exposed by that fix — TCP-level `httpx.ConnectTimeout` retries between core-api and storage-api during noisy-neighbor write storms.

## Evidence

Storm-window analysis of post-CAURA-686 loadtests showed:

- 24 `httpx.ConnectTimeout` retries in 30s on the reader pool (`GET /memories/{id}`)
- After bumping `staging-memclaw-core-storage-{writer,reader} minScale=3->6`: 16 retries (-33%)
- Remaining retries persisted *despite* 6 warm reader instances × cc=20 = 120 capacity headroom

→ The limiter isn't Cloud Run instance count. It's httpx's `max_keepalive_connections=50` ceiling forcing new TCP handshakes during the storm burst that pile up at the Cloud Run frontend accept queue.

The 13s outlier shape of affected requests matches `3 attempts × 5s connect timeout + 0.2s/0.4s backoff` exactly.

## Change

In [storage_client.py:_make_pool()](core-api/src/core_api/clients/storage_client.py):

```python
limits=httpx.Limits(max_connections=100, max_keepalive_connections=50)
# →
limits=httpx.Limits(max_connections=200, max_keepalive_connections=150)
```

Sized for the storm in-flight peak: 20 concurrent writes × ~5 storage calls each = ~100 in-flight. Keepalive=150 covers that + tenant-B probe headroom + 33% burst margin. Max=200 leaves additional headroom for bursts above keepalive.

## Test plan

- [x] mypy + ruff clean
- [ ] CI
- [ ] After merge + staging auto-deploy: re-run staging loadtest (multi-shot) and confirm:
  - storm-window `ConnectTimeout` retries trend toward 0
  - tenant B write storm/baseline ratio stabilises (less run-to-run variance)
  - tenant B search storm/baseline ratio drops toward target ≤ 2.0×
- [ ] Prod promotion stays gated per `loadtest-autonomy` keystone + [CAURA-676](https://caura-ai.atlassian.net/browse/CAURA-676)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAURA-686]: https://caura-ai.atlassian.net/browse/CAURA-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAURA-682]: https://caura-ai.atlassian.net/browse/CAURA-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAURA-676]: https://caura-ai.atlassian.net/browse/CAURA-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ