### PR TITLE
fix(version-compat): bump MIN_RECOMMENDED_PLUGIN_VERSION to 2.6.3

### DIFF
--- a/core-api/src/core_api/version_compat.py
+++ b/core-api/src/core_api/version_compat.py
@@ -6,7 +6,7 @@ We log a warning when a heartbeat reports a plugin older than the minimum
 recommended version; no hard rejection — operators decide when to upgrade.
 """
 
-MIN_RECOMMENDED_PLUGIN_VERSION = "2.6.2"
+MIN_RECOMMENDED_PLUGIN_VERSION = "2.6.3"
 
 # Server-side floor below which plugins must NOT auto-upgrade — the
 # heartbeat path in ``routes/fleet.py`` enforces this hard, and


### PR DESCRIPTION
Without this bump, v2.6.2 nodes never auto-upgrade to v2.6.3 — the heartbeat handler gates auto-deploy on `plugin_version < MIN_RECOMMENDED_PLUGIN_VERSION` and the previous floor of 2.6.2 leaves existing 2.6.2 nodes above the threshold. PR #212 (keystones in WhatsApp system prompt) would sit on the server unused.

Same release-process gap PR #204 closed for the 2.5.0 → 2.6.2 bump.

## Follow-up
Have release-please auto-sync this constant from plugin/package.json so we don't need a manual companion PR per plugin release. Tracked separately.