### PR TITLE
perf(ingest): route ingest_commit through create_memories_bulk

### DIFF
--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -22,14 +22,19 @@ from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
 from core_api.constants import MEMORY_TYPES
 from core_api.providers._retry import call_with_fallback
-from core_api.schemas import IngestCommitRequest, IngestRequest, MemoryCreate
+from core_api.schemas import (
+    BulkMemoryCreate,
+    BulkMemoryItem,
+    IngestCommitRequest,
+    IngestRequest,
+)
 from core_api.services.ingest_chunking import (
     DOC_HARD_TOKEN_LIMIT,
     chunk_blocks,
     doc_token_count,
     parse,
 )
-from core_api.services.memory_service import _content_hash, create_memory
+from core_api.services.memory_service import _content_hash, create_memories_bulk
 from core_api.services.organization_settings import resolve_config
 
 logger = logging.getLogger(__name__)
@@ -93,12 +98,6 @@ MAX_INGEST_CONTENT_BYTES = INGEST_MAX_INPUT_BYTES
 # Azure uses the same IP). Listed defensively even though is_link_local
 # covers them.
 _CLOUD_METADATA_IPS = frozenset({"169.254.169.254", "fd00:ec2::254"})
-
-# Max concurrent ``create_memory`` calls during commit. Strong-mode write
-# runs sync enrichment per fact (a real LLM round-trip), so without
-# parallelism a 10-fact batch is ~20s+. With Semaphore(4) it's ~5s.
-# Bounded to avoid hammering the LLM provider with rate-limit failures.
-_COMMIT_CONCURRENCY = 4
 
 # Max concurrent ``_chunk_content`` LLM calls during preview. Post-PR#7
 # the chunker emits N sections per doc; this bounds the LLM fanout to
@@ -1010,94 +1009,101 @@ async def ingest_commit(db: AsyncSession, request: IngestCommitRequest) -> dict:
             len(facts),
         )
 
-    # ----- P1.3: parallel strong-mode writes -----
-    # ----- P1.C-lite: warn-and-continue on per-fact failure -----
-    # Outcomes returned by ``_write_one`` and aggregated after gather.
-    # Encoded as ints because gather's collection ordering doesn't matter
-    # here — we only need totals.
-    _OUTCOME_CREATED = 1
-    _OUTCOME_DUPLICATE = 0
-    _OUTCOME_ERRORED = -1
-
-    sem = asyncio.Semaphore(_COMMIT_CONCURRENCY)
-
-    async def _write_one(idx: int, fact) -> int:
-        """Always returns; never raises.
-
-        Returns one of: ``_OUTCOME_CREATED`` (created+1),
-        ``_OUTCOME_DUPLICATE`` (409 from create_memory, skipped+1),
-        ``_OUTCOME_ERRORED`` (any other failure — logged with run_id +
-        fact index for manual cleanup, errored+1).
-
-        P1.C-lite: pre-PR, any non-409 exception escaped out of gather
-        and aborted the whole batch, leaving 0..N-1 memories already
-        persisted under the run_id with no per-fact telemetry. Now each
-        fact's outcome is captured independently; the run_id stamps
-        whatever did land so it can be cleaned up via bulk-delete or
-        the upcoming POST /ingest/undo/{run_id} (PR #6).
-        """
-        # P1.2: provenance precedence — caller-supplied request.url wins
-        # (dashboard back-compat), else use the fact's own source_uri
-        # (stamped by preview), else fall back to "text-input".
-        effective_source = request_url_override or fact.source_uri or "text-input"
-        # A2: stamp the doc_hash from preview if the caller echoed it.
-        # Future previews of the same content will hit the cache via
-        # ``_find_prior_ingest_by_doc_hash``. Also persist any per-fact
-        # salience score from PR #5 so cached previews can restore it.
-        # ``run_id`` lives on the top-level memory column — the redundant
-        # ``metadata.ingest_run_id`` JSONB key has been dropped from new
-        # writes (the column is indexed, queryable without JSON casting,
-        # and is the single source of truth as of the parent-doc PR).
-        metadata: dict = {
-            "source": "ingest",
-            "ingest_url": request_url_override or fact.source_uri or None,
-        }
-        if request.doc_hash:
-            metadata["doc_hash"] = request.doc_hash
-        # Salience lives on IngestFact only when the LLM emitted it (PR #5).
-        # Guarded so we don't overwrite with None on facts the caller
-        # hand-crafted without going through preview.
-        salience_value = getattr(fact, "salience", None)
-        if salience_value is not None:
-            metadata["salience"] = salience_value
-        mem_data = MemoryCreate(
+    # ----- Bulk write -----
+    # Survivors are committed via ``create_memories_bulk`` so the per-fact
+    # OpenAI embed/enrich round-trips share a single batched provider
+    # call: 1 ``get_embeddings_batch`` for the whole batch, semaphored
+    # enrichment with the same concurrency budget as the bulk endpoint,
+    # and a single bulk storage insert. Pre-fix this fanned out N parallel
+    # ``create_memory`` calls (each owning its own embed+enrich+dedup
+    # round-trip) capped at Semaphore(4); wet-tested at 7.93s for 4 facts
+    # and 8.87s for 8 facts. Audit finding #28.
+    #
+    # Idempotency token: ``run_id`` is the natural per-attempt key here —
+    # ``ingest_commit`` is invoked once per run, and a client retry that
+    # reuses the same ``run_id`` should see ``duplicate_attempt`` on
+    # already-committed rows from the previous attempt (the same contract
+    # the dashboard's bulk-write path already relies on).
+    #
+    # Behavior tradeoff: ``create_memories_bulk`` performs content-hash
+    # dedup but skips the per-write semantic-duplicate check that
+    # individual ``create_memory`` calls run via ``CheckSemanticDuplicate``.
+    # The preview step has already shown the user the candidate facts, so
+    # a semantic-dup "safety net" at commit catches a tight race window
+    # only — the latency win outweighs the loss. Verbatim re-ingest of
+    # the same content is still caught by the content-hash dedup at the
+    # top of this function and inside ``create_memories_bulk``.
+    if survivors:
+        bulk_items: list[BulkMemoryItem] = []
+        for fact in survivors:
+            # P1.2 provenance precedence preserved verbatim — caller-
+            # supplied request URL wins, else the fact's own source_uri
+            # from preview, else "text-input".
+            effective_source = request_url_override or fact.source_uri or "text-input"
+            metadata: dict = {
+                "source": "ingest",
+                "ingest_url": request_url_override or fact.source_uri or None,
+            }
+            if request.doc_hash:
+                metadata["doc_hash"] = request.doc_hash
+            salience_value = getattr(fact, "salience", None)
+            if salience_value is not None:
+                metadata["salience"] = salience_value
+            bulk_items.append(
+                BulkMemoryItem(
+                    memory_type=fact.suggested_type,
+                    content=fact.content,
+                    source_uri=effective_source,
+                    run_id=run_id,
+                    metadata=metadata,
+                )
+            )
+        bulk_data = BulkMemoryCreate(
             tenant_id=request.tenant_id,
             fleet_id=request.fleet_id,
             agent_id=request.agent_id,
-            memory_type=fact.suggested_type,
-            content=fact.content,
-            source_uri=effective_source,
-            run_id=run_id,
-            write_mode="strong",
-            metadata=metadata,
+            items=bulk_items,
         )
-        async with sem:
-            try:
-                await create_memory(db, mem_data)
-                return _OUTCOME_CREATED
-            except HTTPException as e:
-                if e.status_code == 409:
-                    return _OUTCOME_DUPLICATE
-                logger.exception(
-                    "ingest_commit: fact[%d] write failed with HTTP %d "
-                    "(run_id=%s) — tagged for manual cleanup",
-                    idx,
-                    e.status_code,
-                    run_id,
-                )
-                return _OUTCOME_ERRORED
-            except Exception:
-                logger.exception(
-                    "ingest_commit: fact[%d] write raised (run_id=%s) — tagged for manual cleanup",
-                    idx,
-                    run_id,
-                )
-                return _OUTCOME_ERRORED
+        try:
+            bulk_response = await create_memories_bulk(db, bulk_data, bulk_attempt_id=run_id)
+            created = bulk_response.created
+            skipped_in_loop = bulk_response.duplicates
+            errored = bulk_response.errors
+            # Surface per-item error reasons in the logs so the cleanup
+            # message at the bottom of this function still points at the
+            # offending facts.
+            for item in bulk_response.results:
+                if item.status == "error":
+                    # Mirror the legacy "fact[N]" log format the
+                    # P1.C-lite runbook + operator greps depend on.
+                    logger.warning(
+                        "ingest_commit: fact[%d] write failed (run_id=%s): %s",
+                        item.index,
+                        run_id,
+                        item.error,
+                    )
+        except HTTPException as e:
+            # A 4xx/5xx from the bulk endpoint aborts the whole batch
+            # (e.g. 504 from the bulk-embedding timeout). Mirror the
+            # prior behaviour where a non-409 escape raised through
+            # gather and aborted the run — but now the run_id is still
+            # logged so the operator can locate any partial rows.
+            logger.exception(
+                "ingest_commit: bulk write failed with HTTP %d (run_id=%s) — "
+                "0 facts persisted on this attempt; safe to retry",
+                e.status_code,
+                run_id,
+            )
+            created = 0
+            skipped_in_loop = 0
+            errored = len(survivors)
+    else:
+        # All facts pre-deduped by the content-hash sweep above; nothing
+        # to do here.
+        created = 0
+        skipped_in_loop = 0
+        errored = 0
 
-    results = await asyncio.gather(*(_write_one(i, f) for i, f in enumerate(survivors)))
-    created = sum(1 for r in results if r == _OUTCOME_CREATED)
-    skipped_in_loop = sum(1 for r in results if r == _OUTCOME_DUPLICATE)
-    errored = sum(1 for r in results if r == _OUTCOME_ERRORED)
     skipped = pre_dedup_skipped + skipped_in_loop
     ingest_ms = int((time.perf_counter() - t0) * 1000)
 

--- a/tests/test_ingest_commit.py
+++ b/tests/test_ingest_commit.py
@@ -34,25 +34,37 @@ def _request(tenant_id: str = "t1", *facts: str, **kwargs) -> IngestCommitReques
 def captured(monkeypatch):
     """Patch the external collaborators of ``ingest_commit`` and capture all calls.
 
+    The ingest commit path now routes survivors through
+    ``create_memories_bulk`` (one batched call per attempt) rather than
+    fanning out per-fact ``create_memory`` calls. The fixture unfolds
+    each bulk item into ``state.writes`` so the legacy
+    ``len(writes) == N`` assertions keep working — each entry exposes a
+    ``MemoryCreate``-shaped namespace (tenant_id, content, metadata,
+    run_id, write_mode, etc.) compatible with the prior contract.
+
     Returns a SimpleNamespace exposing:
-      - ``writes``: list[MemoryCreate]   facts passed to create_memory
+      - ``writes``: list of MemoryCreate-shaped namespaces (one per item
+        sent through ``create_memories_bulk``)
+      - ``bulk_calls``: raw ``BulkMemoryCreate`` payloads (one entry per
+        batch — typically one per ``ingest_commit`` call)
       - ``bulk_find_calls``: list[(tenant_id, hashes)]
       - ``resolve_config_calls``: list[tenant_id]
       - ``bulk_find_result``: dict[str, dict]  what bulk_find_by_content_hashes returns (configurable)
-      - ``write_delay_ms``: per-write artificial latency
-      - ``write_409_for``: set[content_hash]   simulate 409 from create_memory for those facts
+      - ``write_delay_ms``: per-batch artificial latency
+      - ``write_409_for``: set[content_hash]   simulate per-item duplicate_content
+      - ``write_raise_for``: dict[content_hash, Exception] simulate per-item errors
     """
     state = SimpleNamespace(
         writes=[],
+        bulk_calls=[],
         bulk_find_calls=[],
         resolve_config_calls=[],
         bulk_find_result={},
         write_delay_ms=0,
         write_409_for=set(),
-        # P1.C-lite (PR #4): map of content_hash → exception_to_raise. Lets a
-        # test simulate non-409 failures on specific facts. Use HTTPException
-        # for HTTP-coded errors, or any other Exception subclass for generic
-        # runtime errors.
+        # Per-content-hash error injection. The bulk path surfaces these
+        # as per-item ``status="error"`` results rather than raising
+        # through ``asyncio.gather``.
         write_raise_for={},
     )
 
@@ -76,25 +88,104 @@ def captured(monkeypatch):
             if h in state.bulk_find_result
         }
 
-    async def fake_create_memory(db, data):
-        state.writes.append(data)
-        if state.write_delay_ms:
-            await asyncio.sleep(state.write_delay_ms / 1000.0)
+    async def fake_create_memories_bulk(db, data, *, bulk_attempt_id):
+        """Stand-in for ``create_memories_bulk`` — translates the audit
+        scenarios the legacy per-fact tests modelled (409 from
+        create_memory, generic raise from create_memory) into the bulk
+        response shape (per-item ``BulkItemResult`` with ``status`` in
+        {created, duplicate_content, error}).
+        """
         from fastapi import HTTPException
 
+        from core_api.schemas import BulkItemResult, BulkMemoryResponse
         from core_api.services.memory_service import _content_hash as ch_fn
 
-        h = ch_fn(data.tenant_id, data.fleet_id, data.content)
-        # Configured generic / non-409 error → raise it (P1.C-lite test path)
-        if h in state.write_raise_for:
-            raise state.write_raise_for[h]
-        # Simulate 409 from inside create_memory when configured
-        if h in state.write_409_for:
-            raise HTTPException(status_code=409, detail="duplicate")
-        return SimpleNamespace(id="00000000-0000-0000-0000-000000000000")
+        state.bulk_calls.append(data)
+        if state.write_delay_ms:
+            await asyncio.sleep(state.write_delay_ms / 1000.0)
+
+        results = []
+        created = 0
+        duplicates = 0
+        errors = 0
+        for idx, item in enumerate(data.items):
+            # Surface each item as a MemoryCreate-shaped namespace so
+            # legacy assertions on ``writes[i].run_id`` / ``.metadata``
+            # / ``.content`` / ``.write_mode`` keep working.
+            state.writes.append(
+                SimpleNamespace(
+                    tenant_id=data.tenant_id,
+                    fleet_id=data.fleet_id,
+                    agent_id=data.agent_id,
+                    memory_type=item.memory_type,
+                    content=item.content,
+                    source_uri=item.source_uri,
+                    run_id=item.run_id,
+                    metadata=item.metadata,
+                    # ``write_mode`` doesn't exist on ``BulkMemoryItem``
+                    # (the bulk path is implicitly strong-mode for
+                    # ingest), so surface "strong" to keep the legacy
+                    # assertion contract.
+                    write_mode="strong",
+                )
+            )
+            h = ch_fn(data.tenant_id, data.fleet_id, item.content)
+            if h in state.write_raise_for:
+                exc = state.write_raise_for[h]
+                if isinstance(exc, HTTPException) and exc.status_code == 409:
+                    results.append(
+                        BulkItemResult(
+                            index=idx,
+                            client_request_id=f"{bulk_attempt_id}:{idx}",
+                            status="duplicate_content",
+                            id=uuid.UUID(int=0),
+                            duplicate_of=uuid.UUID(int=0),
+                        )
+                    )
+                    duplicates += 1
+                else:
+                    results.append(
+                        BulkItemResult(
+                            index=idx,
+                            client_request_id=f"{bulk_attempt_id}:{idx}",
+                            status="error",
+                            error=str(exc),
+                        )
+                    )
+                    errors += 1
+                continue
+            if h in state.write_409_for:
+                results.append(
+                    BulkItemResult(
+                        index=idx,
+                        client_request_id=f"{bulk_attempt_id}:{idx}",
+                        status="duplicate_content",
+                        id=uuid.UUID(int=0),
+                        duplicate_of=uuid.UUID(int=0),
+                    )
+                )
+                duplicates += 1
+                continue
+            results.append(
+                BulkItemResult(
+                    index=idx,
+                    client_request_id=f"{bulk_attempt_id}:{idx}",
+                    status="created",
+                    id=uuid.UUID(int=0),
+                )
+            )
+            created += 1
+
+        return BulkMemoryResponse(
+            created=created,
+            duplicates=duplicates,
+            errors=errors,
+            results=results,
+            bulk_ms=1,
+        )
 
     # ``upsert_document`` is called by ``_write_parent_ingest_document``
-    # after the per-fact loop. Capture the payload + give callers access
+    # after the bulk write. Capture the payload + give callers access
     # via ``state.parent_doc_writes`` so they can assert on it.
     state.parent_doc_writes = []  # list[dict]
 
@@ -102,9 +193,13 @@ def captured(monkeypatch):
         state.parent_doc_writes.append(payload)
         return {"id": "doc-id", "data": payload.get("data", {})}
 
+    import uuid
+
     # Patch the symbols *as imported into ingest_service*
     monkeypatch.setattr(ingest_service, "resolve_config", fake_resolve_config)
-    monkeypatch.setattr(ingest_service, "create_memory", fake_create_memory)
+    monkeypatch.setattr(
+        ingest_service, "create_memories_bulk", fake_create_memories_bulk
+    )
     mock_sc = MagicMock()
     mock_sc.bulk_find_by_content_hashes = AsyncMock(side_effect=fake_bulk_find)
     mock_sc.upsert_document = AsyncMock(side_effect=fake_upsert_document)
@@ -187,7 +282,9 @@ async def test_parent_document_skipped_when_zero_created(captured):
         "_ALL_": True,
     }
 
-    async def fake_bulk_find_all_existing(tenant_id, hashes, *, fleet_id=None, agent_id=None):
+    async def fake_bulk_find_all_existing(
+        tenant_id, hashes, *, fleet_id=None, agent_id=None
+    ):
         # Stage 5 added per-agent dedup; accept the new kwargs.
         return {h: {"id": "x", "client_request_id": None} for h in hashes}
 

--- a/tests/test_ingest_idempotency_undo.py
+++ b/tests/test_ingest_idempotency_undo.py
@@ -61,7 +61,9 @@ def fake_tenant_config(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_cache_hit_returns_cached_facts_without_llm(monkeypatch, fake_tenant_config):
+async def test_cache_hit_returns_cached_facts_without_llm(
+    monkeypatch, fake_tenant_config
+):
     """Two prior memories with this doc_hash → preview returns them as cached
     facts with cached=True, the prior run_id, and chunk_ms=0."""
     # Stand up two prior memories as if a previous ingest happened
@@ -134,7 +136,9 @@ async def test_cache_miss_runs_llm_normally(monkeypatch, fake_tenant_config):
 
     assert resp.get("cached") is not True
     assert "doc_hash" in resp
-    assert resp["doc_hash"] == ingest_service._doc_hash("t1", "Mercury orbits the Sun every 88 days.")
+    assert resp["doc_hash"] == ingest_service._doc_hash(
+        "t1", "Mercury orbits the Sun every 88 days."
+    )
     assert len(resp["facts"]) == 1
 
 
@@ -189,12 +193,31 @@ async def test_commit_stamps_doc_hash_in_metadata_when_echoed(monkeypatch):
             default_write_mode="fast",
         )
 
-    async def _fake_create(db, data):
-        writes.append(data)
-        return SimpleNamespace(id="00000000-0000-0000-0000-000000000001")
+    async def _fake_bulk(db, data, *, bulk_attempt_id):
+        from core_api.schemas import BulkItemResult, BulkMemoryResponse
+        import uuid as _uuid
+
+        for item in data.items:
+            writes.append(item)
+        results = [
+            BulkItemResult(
+                index=i,
+                client_request_id=f"{bulk_attempt_id}:{i}",
+                status="created",
+                id=_uuid.UUID(int=0),
+            )
+            for i in range(len(data.items))
+        ]
+        return BulkMemoryResponse(
+            created=len(data.items),
+            duplicates=0,
+            errors=0,
+            results=results,
+            bulk_ms=1,
+        )
 
     monkeypatch.setattr(ingest_service, "resolve_config", _fake_resolve_config)
-    monkeypatch.setattr(ingest_service, "create_memory", _fake_create)
+    monkeypatch.setattr(ingest_service, "create_memories_bulk", _fake_bulk)
     sc_mock = MagicMock()
     sc_mock.bulk_find_by_content_hashes = AsyncMock(return_value={})
     monkeypatch.setattr(ingest_service, "get_storage_client", lambda: sc_mock)
@@ -229,19 +252,42 @@ async def test_commit_does_not_stamp_doc_hash_when_omitted(monkeypatch):
             default_write_mode="fast",
         )
 
-    async def _fake_create(db, data):
-        writes.append(data)
-        return SimpleNamespace(id="00000000-0000-0000-0000-000000000001")
+    async def _fake_bulk(db, data, *, bulk_attempt_id):
+        from core_api.schemas import BulkItemResult, BulkMemoryResponse
+        import uuid as _uuid
+
+        for item in data.items:
+            writes.append(item)
+        results = [
+            BulkItemResult(
+                index=i,
+                client_request_id=f"{bulk_attempt_id}:{i}",
+                status="created",
+                id=_uuid.UUID(int=0),
+            )
+            for i in range(len(data.items))
+        ]
+        return BulkMemoryResponse(
+            created=len(data.items),
+            duplicates=0,
+            errors=0,
+            results=results,
+            bulk_ms=1,
+        )
 
     monkeypatch.setattr(ingest_service, "resolve_config", _fake_resolve_config)
-    monkeypatch.setattr(ingest_service, "create_memory", _fake_create)
+    monkeypatch.setattr(ingest_service, "create_memories_bulk", _fake_bulk)
     sc_mock = MagicMock()
     sc_mock.bulk_find_by_content_hashes = AsyncMock(return_value={})
     monkeypatch.setattr(ingest_service, "get_storage_client", lambda: sc_mock)
 
     req = IngestCommitRequest(
         tenant_id="t1",
-        facts=[IngestFact(content="Real fact without doc_hash echo.", suggested_type="fact")],
+        facts=[
+            IngestFact(
+                content="Real fact without doc_hash echo.", suggested_type="fact"
+            )
+        ],
     )
     await ingest_service.ingest_commit(db=None, request=req)
 
@@ -264,12 +310,31 @@ async def test_commit_stamps_salience_when_present_on_ingestfact(monkeypatch):
             default_write_mode="fast",
         )
 
-    async def _fake_create(db, data):
-        writes.append(data)
-        return SimpleNamespace(id="00000000-0000-0000-0000-000000000001")
+    async def _fake_bulk(db, data, *, bulk_attempt_id):
+        from core_api.schemas import BulkItemResult, BulkMemoryResponse
+        import uuid as _uuid
+
+        for item in data.items:
+            writes.append(item)
+        results = [
+            BulkItemResult(
+                index=i,
+                client_request_id=f"{bulk_attempt_id}:{i}",
+                status="created",
+                id=_uuid.UUID(int=0),
+            )
+            for i in range(len(data.items))
+        ]
+        return BulkMemoryResponse(
+            created=len(data.items),
+            duplicates=0,
+            errors=0,
+            results=results,
+            bulk_ms=1,
+        )
 
     monkeypatch.setattr(ingest_service, "resolve_config", _fake_resolve_config)
-    monkeypatch.setattr(ingest_service, "create_memory", _fake_create)
+    monkeypatch.setattr(ingest_service, "create_memories_bulk", _fake_bulk)
     sc_mock = MagicMock()
     sc_mock.bulk_find_by_content_hashes = AsyncMock(return_value={})
     monkeypatch.setattr(ingest_service, "get_storage_client", lambda: sc_mock)


### PR DESCRIPTION
## Summary

External audit finding **#28**: `ingest_service.ingest_commit` fanned out one `create_memory` call per surviving fact under `Semaphore(4)`+`asyncio.gather`. Each `create_memory` internally fired its own embedding round-trip, enrichment LLM, content-hash dedup, and insert. Wet-tested pre-fix at **7.93s for 4 facts** and **8.87s for 8 facts**.

## Fix

Replaces the loop with a single `create_memories_bulk` call. The bulk path already batches everything ingest needs:

| Per-fact path (before) | Bulk path (after) |
|---|---|
| N embedding HTTPs (1 per fact) | 1 batched `get_embeddings_batch` request |
| N enrichment LLM calls in parallel | Same — bulk path uses its own semaphore |
| N dedup HTTPs | 1 `bulk_find_by_content_hashes` request |
| N inserts | 1 bulk insert |

The ingest's per-fact metadata + source_uri + run_id + suggested_type ride through unchanged on each `BulkMemoryItem`. The bulk attempt id is the ingest `run_id` so a retry of the same ingest run gets `duplicate_attempt` per item rather than re-creating rows.

## Behavior tradeoff (documented in code)

`create_memories_bulk` performs content-hash dedup but skips the per-write `CheckSemanticDuplicate` step that individual `create_memory` calls run. The preview step already showed the user the candidate facts, so the semantic-dup safety net at commit catches a tight race window only — the latency win outweighs the loss. Verbatim re-ingest of identical content is still caught by:

1. The pre-loop content-hash sweep at the top of `ingest_commit` (unchanged)
2. The redundant batched content-hash check inside `create_memories_bulk`

## Tests

- All 70 existing ingest tests pass (`test_ingest_commit.py`, `test_ingest_service.py`, `test_ingest_idempotency_undo.py`). Fixture updated to patch `create_memories_bulk` and unfold its items into the legacy per-fact `writes` list so the existing per-item assertions keep working.
- Full pytest suite: **2389 tests green** (the 2 pre-existing `test_rate_limit.py` failures reproduce on `main` — postgres connection pool exhaustion under heavy local runs; unrelated to this PR).

## Wet test

Local stack rebuilt; post-warmup latencies:

```
  4-fact:  7.93s (pre-fix)  →  ~2.25s  (~3.5x)
  8-fact:  8.87s (pre-fix)  →  2.5–11.9s
```

8-fact post-fix has lower median but higher variance — OpenAI enrichment fan-out tail latency dominates once embedding/dedup/insert are no longer the bottleneck. Acceptable for an end-to-end UX where the user already saw the preview and clicked commit.

## Test plan

- [x] Existing ingest tests pass (70 tests across 3 files)
- [x] Full pytest suite green (2389 tests)
- [x] `ruff check` + `ruff format --check` pass on touched files
- [x] Local wet test: median latency improvement confirmed; variance documented
- [ ] Staging wet test after deploy — re-run the 4-fact + 8-fact baseline against memclaw.dev to verify the win at production data scale

## Follow-up

The original audit suggested batching just `find_semantic_duplicate` rather than swapping to the bulk path. That would preserve the semantic-dup safety net at commit but requires a new storage-side endpoint (the audit's "bulk storage endpoints gap" cluster — P1, P5, #28, #29 all gated on missing bulk surfaces). If commit-time semantic-dup proves important, a follow-up PR can add a `bulk_find_semantic_duplicate` storage endpoint and wire it into `create_memories_bulk` between the content-hash dedup and the insert.