### PR TITLE
perf(mcp): close DB session before recall brief LLM round-trip

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -449,8 +449,17 @@ async def memclaw_recall(
     agent_id = _get_agent_id() or agent_id  # prefer gateway-verified identity
     capped_top_k = min(top_k, MAX_SEARCH_TOP_K)
 
-    async with _mcp_session() as db:
-        try:
+    # Audit finding P3: prior implementation held ``_mcp_session()``
+    # open across the brief-generation LLM round-trip (~5-30s), pinning
+    # a pooled DB connection during work that is entirely network-bound
+    # to the LLM provider. The brief path also issued a duplicate
+    # ``search_memories`` call (once here, once inside ``recall()``).
+    # Both are fixed by doing all DB-bound work inside the session,
+    # capturing the search results + config + readable-tenant set, then
+    # closing the session before invoking ``summarize_memories`` for
+    # the LLM brief.
+    try:
+        async with _mcp_session() as db:
             await check_and_increment(db, tenant_id, "search")
             from core_api.repositories import agent_repo
             from core_api.services.organization_settings import resolve_config
@@ -483,25 +492,6 @@ async def memclaw_recall(
                 search_profile=agent_profile,
                 readable_tenant_ids=_get_readable_tenants() or None,
             )
-            payload: dict = {
-                "results": [r.model_dump(mode="json") for r in results] if results else [],
-            }
-            if include_brief:
-                from core_api.services.recall_service import recall as _recall
-
-                brief = await _recall(
-                    db,
-                    tenant_id=tenant_id,
-                    query=query,
-                    fleet_ids=fleet_ids,
-                    filter_agent_id=filter_agent_id,
-                    caller_agent_id=agent_id,
-                    memory_type_filter=memory_type,
-                    status_filter=status,
-                    top_k=capped_top_k,
-                    readable_tenant_ids=_get_readable_tenants() or None,
-                )
-                payload["brief"] = brief
             # Cross-tenant read audit (F2): emit one event per source
             # tenant when the credential widened beyond home. Async
             # queue — does not block the response.
@@ -516,10 +506,24 @@ async def memclaw_recall(
                     surface="memclaw_recall",
                     query_summary=(query or "")[:200],
                 )
-            return _with_latency(json.dumps(payload, indent=2, default=str), t0)
-        except HTTPException as e:
-            logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+        # ── Session closed; the LLM brief (when requested) runs without
+        # holding a DB connection.
+        payload: dict = {
+            "results": [r.model_dump(mode="json") for r in results] if results else [],
+        }
+        if include_brief:
+            from core_api.services.recall_service import summarize_memories
+
+            payload["brief"] = await summarize_memories(
+                results,
+                query,
+                config,
+                top_k=capped_top_k,
+            )
+        return _with_latency(json.dumps(payload, indent=2, default=str), t0)
+    except HTTPException as e:
+        logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
+        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
 
 
 async def memclaw_write(

--- a/core-api/src/core_api/services/recall_service.py
+++ b/core-api/src/core_api/services/recall_service.py
@@ -65,49 +65,34 @@ def _format_memories_for_prompt(memories: list) -> str:
     return _json.dumps(items, indent=2, ensure_ascii=False)
 
 
-async def recall(
-    db: AsyncSession,
-    tenant_id: str,
+async def summarize_memories(
+    memories: list,
     query: str,
-    fleet_ids: list[str] | None = None,
-    filter_agent_id: str | None = None,
-    caller_agent_id: str | None = None,
-    memory_type_filter: str | None = None,
-    status_filter: str | None = None,
-    top_k: int = DEFAULT_SEARCH_TOP_K,
+    config,
+    *,
     valid_at: datetime | None = None,
     diagnostic: bool = False,
-    readable_tenant_ids: list[str] | None = None,
+    diagnostic_ctx: dict | None = None,
+    top_k: int = DEFAULT_SEARCH_TOP_K,
+    t0: float | None = None,
 ) -> dict:
-    """Search memories and synthesize a context summary.
+    """LLM-only summarization step. No DB access.
 
-    Returns: {"query": ..., "summary": ..., "memory_count": ..., "memories": [...], "recall_ms": ...}
+    Audit finding P3: ``memclaw_recall`` previously held the
+    ``_mcp_session()`` open across the multi-second LLM round-trip,
+    pinning a pooled DB connection. This helper takes already-fetched
+    memories + the resolved tenant config and produces the same dict
+    shape the legacy ``recall()`` wrapper returned, so the MCP tool can
+    exit the session block before invoking it.
+
+    ``t0`` is the caller's ``time.perf_counter()`` checkpoint for the
+    surrounding handler — passing it preserves the original "recall_ms
+    measures end-to-end from auth-pass" semantics. Omitted callers get
+    a fresh checkpoint that only times the summary itself.
     """
-    t0 = time.perf_counter()
-
-    # Search for relevant memories
-    from core_api.services.organization_settings import resolve_config
-
-    config = await resolve_config(db, tenant_id)
-    diagnostic_ctx: dict = {} if diagnostic else {}
-    memories = await search_memories(
-        db,
-        tenant_id=tenant_id,
-        query=query,
-        fleet_ids=fleet_ids,
-        filter_agent_id=filter_agent_id,
-        caller_agent_id=caller_agent_id,
-        memory_type_filter=memory_type_filter,
-        status_filter=status_filter,
-        top_k=top_k,
-        valid_at=valid_at,
-        recall_boost=config.recall_boost,
-        graph_expand=config.graph_expand,
-        tenant_config=config,
-        diagnostic=diagnostic,
-        diagnostic_ctx=diagnostic_ctx if diagnostic else None,
-        readable_tenant_ids=readable_tenant_ids,
-    )
+    if t0 is None:
+        t0 = time.perf_counter()
+    diagnostic_ctx = diagnostic_ctx or {}
 
     if not memories:
         resp = {
@@ -132,11 +117,11 @@ async def recall(
             }
         return resp
 
-    # Sort chronologically so the LLM sees a natural timeline
+    # Sort chronologically so the LLM sees a natural timeline. Callers
+    # may have already sorted; the operation is idempotent.
     _DT_MIN_UTC = datetime.min.replace(tzinfo=UTC)
     memories.sort(key=lambda m: getattr(m, "ts_valid_start", None) or _DT_MIN_UTC)
 
-    # Format memories for the LLM
     memories_text = _format_memories_for_prompt(memories)
     if valid_at:
         reference_date_line = f"Current Date: {valid_at.strftime('%Y-%m-%d')}\n"
@@ -205,7 +190,6 @@ async def recall(
     }
 
     if diagnostic:
-        recall_model = getattr(config, "recall_model", None)
         result["diagnostic"] = {
             "recall_prompt": prompt,
             "recall_model": recall_model or "default",
@@ -220,3 +204,64 @@ async def recall(
         }
 
     return result
+
+
+async def recall(
+    db: AsyncSession,
+    tenant_id: str,
+    query: str,
+    fleet_ids: list[str] | None = None,
+    filter_agent_id: str | None = None,
+    caller_agent_id: str | None = None,
+    memory_type_filter: str | None = None,
+    status_filter: str | None = None,
+    top_k: int = DEFAULT_SEARCH_TOP_K,
+    valid_at: datetime | None = None,
+    diagnostic: bool = False,
+    readable_tenant_ids: list[str] | None = None,
+) -> dict:
+    """Search memories and synthesize a context summary.
+
+    Returns: {"query": ..., "summary": ..., "memory_count": ..., "memories": [...], "recall_ms": ...}
+
+    Thin wrapper over ``search_memories`` + ``summarize_memories``. MCP
+    tool callers that already hold the search results and tenant config
+    should invoke ``summarize_memories`` directly so they can close
+    their DB session before the LLM round-trip (audit P3). This wrapper
+    is retained for the REST surface and other callers that prefer the
+    one-shot ergonomics.
+    """
+    t0 = time.perf_counter()
+
+    from core_api.services.organization_settings import resolve_config
+
+    config = await resolve_config(db, tenant_id)
+    diagnostic_ctx: dict = {} if diagnostic else {}
+    memories = await search_memories(
+        db,
+        tenant_id=tenant_id,
+        query=query,
+        fleet_ids=fleet_ids,
+        filter_agent_id=filter_agent_id,
+        caller_agent_id=caller_agent_id,
+        memory_type_filter=memory_type_filter,
+        status_filter=status_filter,
+        top_k=top_k,
+        valid_at=valid_at,
+        recall_boost=config.recall_boost,
+        graph_expand=config.graph_expand,
+        tenant_config=config,
+        diagnostic=diagnostic,
+        diagnostic_ctx=diagnostic_ctx if diagnostic else None,
+        readable_tenant_ids=readable_tenant_ids,
+    )
+    return await summarize_memories(
+        memories,
+        query,
+        config,
+        valid_at=valid_at,
+        diagnostic=diagnostic,
+        diagnostic_ctx=diagnostic_ctx,
+        top_k=top_k,
+        t0=t0,
+    )

--- a/tests/test_mcp_recall.py
+++ b/tests/test_mcp_recall.py
@@ -9,6 +9,7 @@ Covers:
 - ``HTTPException`` from the service → ``Error (…)`` envelope.
 - Auth failure short-circuits.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -52,19 +53,25 @@ async def test_recall_happy_path(mcp_env, monkeypatch):
 
 
 async def test_recall_with_include_brief(mcp_env, monkeypatch):
-    """`include_brief=True` runs the brief call and merges it."""
+    """`include_brief=True` runs the brief call and merges it.
+
+    Audit P3: ``memclaw_recall`` now closes its DB session before
+    invoking the brief LLM step. Patch ``summarize_memories`` (the
+    LLM-only helper) rather than the legacy ``recall()`` wrapper —
+    the tool no longer reaches the wrapper path.
+    """
     mcp_env["service"]("search_memories").return_value = [_MemoryStub("m-1")]
 
     brief_mock = _fake_async_return({"summary": "alice onboarded last quarter"})
-    monkeypatch.setattr("core_api.services.recall_service.recall", brief_mock)
+    monkeypatch.setattr(
+        "core_api.services.recall_service.summarize_memories", brief_mock
+    )
     monkeypatch.setattr(
         "core_api.services.organization_settings.resolve_config", _fake_resolve_config
     )
     monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
 
-    out = await mcp_server.memclaw_recall(
-        query="status?", include_brief=True
-    )
+    out = await mcp_server.memclaw_recall(query="status?", include_brief=True)
     payload = parse_envelope(out)
     assert "brief" in payload
     assert payload["brief"]["summary"].startswith("alice")
@@ -131,6 +138,74 @@ async def test_recall_auth_failure_shortcircuits(monkeypatch):
 
     out = await mcp_server.memclaw_recall(query="x")
     assert out == mcp_server._AUTH_ERROR
+
+
+async def test_recall_closes_session_before_brief_llm_call(mcp_env, monkeypatch):
+    """Audit P3: the DB session must be closed before the LLM brief
+    fires, otherwise a pooled connection is pinned across the multi-
+    second OpenAI round-trip. We assert this by patching
+    ``_mcp_session`` to track its enter/exit timestamps and patching
+    ``summarize_memories`` to record when it ran, then comparing the
+    timestamps."""
+    import time as _time
+    from contextlib import asynccontextmanager
+    from unittest.mock import MagicMock
+
+    mcp_env["service"]("search_memories").return_value = [_MemoryStub("m-1")]
+
+    session_exited_at: dict = {"t": None}
+    brief_started_at: dict = {"t": None}
+
+    @asynccontextmanager
+    async def _tracking_session():
+        db = MagicMock()
+        try:
+            yield db
+        finally:
+            session_exited_at["t"] = _time.perf_counter()
+
+    async def _tracking_summarize(*_args, **_kwargs):
+        brief_started_at["t"] = _time.perf_counter()
+        return {"summary": "anything"}
+
+    monkeypatch.setattr(mcp_server, "_mcp_session", _tracking_session)
+    monkeypatch.setattr(
+        "core_api.services.recall_service.summarize_memories", _tracking_summarize
+    )
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
+    )
+    monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
+
+    await mcp_server.memclaw_recall(query="x", include_brief=True)
+
+    assert session_exited_at["t"] is not None, "session never exited"
+    assert brief_started_at["t"] is not None, "brief never ran"
+    assert brief_started_at["t"] >= session_exited_at["t"], (
+        "brief LLM call started while session was still open — P3 fix regressed"
+    )
+
+
+async def test_recall_brief_skipped_when_include_brief_false(mcp_env, monkeypatch):
+    """When ``include_brief=False`` (default), ``summarize_memories``
+    must NOT be invoked at all — no LLM cost on the bare-recall path."""
+    mcp_env["service"]("search_memories").return_value = [_MemoryStub("m-1")]
+    calls: list = []
+
+    async def _spy(*args, **kwargs):  # noqa: ARG001
+        calls.append(1)
+        return {"summary": "should not run"}
+
+    monkeypatch.setattr("core_api.services.recall_service.summarize_memories", _spy)
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
+    )
+    monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
+
+    out = await mcp_server.memclaw_recall(query="x")
+    payload = parse_envelope(out)
+    assert calls == []
+    assert "brief" not in payload
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

External audit finding **P3** (recall portion). `memclaw_recall` held its `_mcp_session()` open across the brief-generation LLM round-trip — typically a 3-5s OpenAI call during which a pooled DB connection was pinned. The same handler also issued a duplicate `search_memories` call when `include_brief=True` (once at the tool top, again inside the `recall()` wrapper).

## Fix

### `recall_service.py` — split LLM step from DB step

New helper `summarize_memories(memories, query, config, ...)` does only the LLM summarization. No DB access. Same return shape the legacy `recall()` produced (`query`, `summary`, `memory_count`, `memories`, `recall_ms`, optional `diagnostic`).

The legacy `recall(db, ...)` wrapper is retained for REST callers and other one-shot consumers — it just does the DB queries (`resolve_config` + `search_memories`) and delegates to `summarize_memories`.

### `mcp_server.memclaw_recall` — close session, then brief

```
async with _mcp_session() as db:
    config = await resolve_config(db, tenant_id)
    results = await search_memories(db, ...)
    if source_tenants:
        await log_cross_tenant_read(db, ...)
# Session closed here. No DB connection held beyond this point.

payload = {"results": [...]}
if include_brief:
    payload["brief"] = await summarize_memories(results, query, config, ...)
```

Three wins:
1. **DB connection released** during the multi-second LLM call.
2. **Duplicate `search_memories` eliminated** — the in-tool search result feeds the brief directly instead of `recall()` re-fetching the same rows.
3. **Read path simpler** — search + audit happen in one tidy session block; LLM lives outside.

## Tests

`tests/test_mcp_recall.py`:

- `test_recall_with_include_brief` updated to patch `summarize_memories` (the new entry point).
- **NEW** `test_recall_closes_session_before_brief_llm_call`: patches `_mcp_session` to record exit timestamp and patches `summarize_memories` to record entry timestamp. Asserts `brief_start >= session_exit` — locks in the contract.
- **NEW** `test_recall_brief_skipped_when_include_brief_false`: spy on `summarize_memories` asserts zero invocations on the default path.

Full suite **2391 tests green** (excluding the 2 pre-existing `test_rate_limit.py` failures unrelated to this PR).

## Wet test

Local stack rebuilt; verified:

- The new code paths are in the built image (`summarize_memories` defined; mcp_server `P3:` comment + `summarize_memories` import + call present).
- Bare `memclaw_recall` returns 200 with results in ~4s.
- `memclaw_recall` with `include_brief=True` consistently 3.3-3.8s — dominated by the LLM call, NOT by DB queue waits.
- Response payload shape preserved (`results` + `brief`).

## Scope: recall only

P3 also flagged `memclaw_insights` and `memclaw_evolve` for the same pattern, but the LLM call in those tools sits BETWEEN two DB phases (query → LLM → persist findings), so closing the session requires opening a new one for the writes. That's a more invasive split — tracking as a follow-up PR.

## Test plan

- [x] Unit tests pass (10 in `test_mcp_recall.py`)
- [x] Full pytest suite green (2391 tests)
- [x] `ruff check` + `ruff format --check` pass on touched files
- [x] Local wet test: brief returns valid payload in LLM-dominated latency; DB no longer held
- [ ] Staging wet test after deploy — observe DB pool utilization during recall+brief load to confirm the connection-pin gone