### PR TITLE
test(cross-tenant): lock in widening + audit emission contracts (T1+T2+T3)

### DIFF
--- a/tests/test_cross_tenant_audit_surfaces.py
+++ b/tests/test_cross_tenant_audit_surfaces.py
@@ -1,0 +1,359 @@
+"""Per-surface assertions that ``log_cross_tenant_read`` fires from
+every cross-tenant read site (audit T2).
+
+Existing coverage (already shipped):
+  - REST entity routes (PR-A2): ``rest_entities_list``, ``rest_graph``,
+    ``rest_entity_get`` — see ``tests/test_entity_routes_cross_tenant.py``.
+
+This module covers the remaining surfaces:
+  - ``memclaw_recall``      (MCP)
+  - ``memclaw_doc`` search   (MCP)
+  - ``memclaw_list``         (MCP)
+  - ``memclaw_stats``        (MCP)
+  - ``rest_memories_list``   (REST)
+  - ``rest_documents_search``(REST)
+
+Each test sets up a cross-tenant credential, runs the handler against
+mocks that return rows from at least one sibling tenant, spies on
+``log_cross_tenant_read``, and asserts the spy was called with the
+correct ``surface`` tag and ``source_tenants`` set. A regression that
+silently drops the audit emission on any of these paths would fail the
+corresponding test.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _spy_log(monkeypatch, module_or_path) -> AsyncMock:
+    """Patch ``log_cross_tenant_read`` on the given module or dotted
+    path with an AsyncMock; return the spy.
+
+    The audit helper is imported into many modules; patching at the
+    call site (rather than at ``core_api.services.audit_service``) is
+    what guarantees the spy actually intercepts the handler's call.
+    """
+    spy = AsyncMock(name="log_cross_tenant_read")
+    if isinstance(module_or_path, str):
+        monkeypatch.setattr(module_or_path, spy)
+    else:
+        monkeypatch.setattr(module_or_path, "log_cross_tenant_read", spy)
+    return spy
+
+
+class _MemoryRow:
+    """Minimal stand-in for a memory row — exposes the ``tenant_id``
+    attribute the audit code reads to compute ``result_count_by_tenant``,
+    plus enough other attributes that handlers' serializers don't
+    explode while we focus on the audit emission contract."""
+
+    def __init__(self, tenant_id: str):
+        self.id = UUID("00000000-0000-0000-0000-000000000001")
+        self.tenant_id = tenant_id
+        self.fleet_id = None
+        self.agent_id = "test-agent"
+        self.memory_type = "fact"
+        self.title = None
+        self.content = "x"
+        self.weight = 0.5
+        self.source_uri = None
+        self.run_id = None
+        self.metadata_ = {}
+        # MemoryOut validates ``created_at`` as a real datetime; the
+        # handler serializes via _memory_to_out which reads this attr.
+        self.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+        self.expires_at = None
+        self.subject_entity_id = None
+        self.predicate = None
+        self.object_value = None
+        self.ts_valid_start = None
+        self.ts_valid_end = None
+        self.status = "active"
+        self.visibility = "scope_team"
+        self.recall_count = 0
+        self.last_recalled_at = None
+        self.supersedes_id = None
+        self.deleted_at = None
+        self.embedding = None
+
+    def model_dump(self, mode: str = "python"):  # noqa: ARG002
+        return {"id": self.id, "tenant_id": self.tenant_id}
+
+
+# ===========================================================================
+# MCP surfaces (cross-tenant ContextVars + spy on mcp_server.log_cross_tenant_read)
+# ===========================================================================
+
+
+@pytest.fixture
+def cross_tenant_mcp_env(mcp_env, monkeypatch):
+    """Extends the standard ``mcp_env`` fixture with cross-tenant ContextVars
+    (home tenant + one sibling readable). Returns the spy installed on
+    ``mcp_server.log_cross_tenant_read``."""
+    from core_api import mcp_server
+
+    # Pin the context vars to model a cross-tenant credential.
+    monkeypatch.setattr(mcp_server, "_get_tenant", lambda: "tenant-home")
+    monkeypatch.setattr(
+        mcp_server, "_get_readable_tenants", lambda: ["tenant-home", "tenant-sibling"]
+    )
+    spy = _spy_log(monkeypatch, mcp_server)
+    return spy
+
+
+# --- memclaw_recall ---------------------------------------------------------
+
+
+async def test_memclaw_recall_emits_cross_tenant_audit(
+    cross_tenant_mcp_env, mcp_env, monkeypatch
+):
+    from core_api import mcp_server
+
+    # Search returns one row from each tenant — the sibling row drives
+    # the audit emission.
+    mcp_env["service"]("search_memories").return_value = [
+        _MemoryRow("tenant-home"),
+        _MemoryRow("tenant-sibling"),
+    ]
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config",
+        AsyncMock(return_value=SimpleNamespace(recall_boost=False, graph_expand=False)),
+    )
+    monkeypatch.setattr(
+        "core_api.repositories.agent_repo.get_by_id", AsyncMock(return_value=None)
+    )
+
+    await mcp_server.memclaw_recall(query="cross-tenant probe", agent_id="a1")
+
+    cross_tenant_mcp_env.assert_awaited_once()
+    kwargs = cross_tenant_mcp_env.await_args.kwargs
+    assert kwargs["surface"] == "memclaw_recall"
+    assert kwargs["source_tenants"] == ["tenant-sibling"]
+    assert kwargs["home_tenant_id"] == "tenant-home"
+
+
+# --- memclaw_list -----------------------------------------------------------
+
+
+async def test_memclaw_list_emits_cross_tenant_audit(
+    cross_tenant_mcp_env, mcp_env, monkeypatch
+):
+    """``memclaw_list`` widens via the same context-var path and
+    audits with ``surface=memclaw_list``."""
+    from core_api import mcp_server
+
+    monkeypatch.setattr(
+        "core_api.repositories.memory_repo.list_by_filters",
+        AsyncMock(
+            return_value=[_MemoryRow("tenant-home"), _MemoryRow("tenant-sibling")]
+        ),
+    )
+    # Trust gate stubbed so the handler doesn't 403 before reaching list_by_filters.
+    monkeypatch.setattr(
+        mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None))
+    )
+
+    await mcp_server.memclaw_list(scope="fleet", agent_id="a1")
+
+    cross_tenant_mcp_env.assert_awaited()
+    kwargs = cross_tenant_mcp_env.await_args.kwargs
+    assert kwargs["surface"] == "memclaw_list"
+    assert "tenant-sibling" in kwargs["source_tenants"]
+    counts = kwargs.get("result_count_by_tenant") or {}
+    assert counts.get("tenant-sibling", 0) >= 1
+
+
+# --- memclaw_stats ---------------------------------------------------------
+
+
+async def test_memclaw_stats_emits_cross_tenant_audit(
+    cross_tenant_mcp_env, mcp_env, monkeypatch
+):
+    """``memclaw_stats`` with ``scope=fleet`` widens to readable_tenant_ids."""
+    from core_api import mcp_server
+
+    monkeypatch.setattr(
+        mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None))
+    )
+    # ``compute_memory_stats`` is imported INSIDE the handler — patch
+    # at the source so the late import resolves to our mock.
+    monkeypatch.setattr(
+        "core_api.services.memory_stats.compute_memory_stats",
+        AsyncMock(
+            return_value={
+                "total": 5,
+                "by_type": {"fact": 5},
+                "by_agent": {},
+                "by_status": {"active": 5},
+                "by_tenant": {"tenant-home": 3, "tenant-sibling": 2},
+            }
+        ),
+    )
+
+    await mcp_server.memclaw_stats(scope="fleet", agent_id="a1")
+
+    cross_tenant_mcp_env.assert_awaited()
+    kwargs = cross_tenant_mcp_env.await_args.kwargs
+    assert kwargs["surface"] == "memclaw_stats"
+    assert "tenant-sibling" in kwargs["source_tenants"]
+
+
+# --- memclaw_doc (search) ---------------------------------------------------
+
+
+async def test_memclaw_doc_search_emits_cross_tenant_audit(
+    cross_tenant_mcp_env, mcp_env, monkeypatch
+):
+    """``op=search`` on ``memclaw_doc`` widens via ``readable_tenant_ids``
+    and audits with ``surface=memclaw_doc_search``. The handler embeds
+    the query, calls ``document_repo.search``, then emits."""
+    from core_api import mcp_server
+
+    fake_doc = SimpleNamespace(tenant_id="tenant-sibling", id="d1", collection="things")
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.search",
+        AsyncMock(return_value=[(fake_doc, 0.91)]),
+    )
+    # The embed step is gated by an embed-provider call we'd rather not
+    # touch in a unit test — patch the helper that wraps it.
+    monkeypatch.setattr(
+        "core_api.services.memory_service.get_query_embedding",
+        AsyncMock(return_value=[0.1] * 8),
+    )
+    # ``tenant_config`` resolution short-circuits to a fake.
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config",
+        AsyncMock(return_value=SimpleNamespace(embedding_model=None)),
+    )
+
+    await mcp_server.memclaw_doc(op="search", query="hello world", agent_id="a1")
+
+    cross_tenant_mcp_env.assert_awaited()
+    kwargs = cross_tenant_mcp_env.await_args.kwargs
+    assert kwargs["surface"] == "memclaw_doc_search"
+    assert "tenant-sibling" in kwargs["source_tenants"]
+
+
+# ===========================================================================
+# REST surfaces (build AuthContext explicitly + spy on the route's import)
+# ===========================================================================
+
+
+def _cross_tenant_auth():
+    """Return an AuthContext modeling a cross-tenant credential —
+    home=``home``, readable=[home, sibling]."""
+    from core_api.auth import AuthContext
+
+    return AuthContext(
+        tenant_id="home",
+        agent_id="a1",
+        readable_tenant_ids=["home", "sibling"],
+    )
+
+
+# --- rest_memories_list ----------------------------------------------------
+
+
+async def test_rest_memories_list_emits_cross_tenant_audit(monkeypatch):
+    """``GET /api/v1/memories`` widens when ``tenant_id`` is omitted on
+    a cross-tenant credential; the broad fan-out path emits one event
+    per source tenant with ``surface=rest_memories_list``."""
+    from core_api.routes import memories as memories_routes
+
+    spy = _spy_log(monkeypatch, memories_routes)
+    # The route does a late import of ``memory_repo`` so we patch it
+    # at the source.
+    monkeypatch.setattr(
+        "core_api.repositories.memory_repo.list_by_filters",
+        AsyncMock(return_value=[_MemoryRow("home"), _MemoryRow("sibling")]),
+    )
+
+    auth = _cross_tenant_auth()
+    db = MagicMock()
+
+    await memories_routes.list_memories(
+        tenant_id=None,  # broad — triggers widening
+        fleet_id=None,
+        agent_id=None,
+        memory_type=None,
+        status=None,
+        visibility=None,
+        run_id=None,
+        cursor=None,
+        sort="created_at",
+        order="desc",
+        offset=0,
+        limit=25,
+        include_deleted=False,
+        auth=auth,
+        db=db,
+    )
+
+    spy.assert_awaited_once()
+    kwargs = spy.await_args.kwargs
+    assert kwargs["surface"] == "rest_memories_list"
+    assert "sibling" in kwargs["source_tenants"]
+
+
+# --- rest_documents_search -------------------------------------------------
+
+
+async def test_rest_documents_search_emits_cross_tenant_audit(monkeypatch):
+    """The REST documents search endpoint mirrors ``memclaw_doc`` op=search
+    on the cross-tenant audit emission, but with ``surface=rest_documents_search``."""
+    from core_api.routes import documents as documents_routes
+
+    spy = _spy_log(monkeypatch, documents_routes)
+    fake_doc = SimpleNamespace(
+        tenant_id="sibling",
+        id="d1",
+        collection="things",
+        doc_id="docX",
+        data={},
+    )
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.search",
+        AsyncMock(return_value=[(fake_doc, 0.91)]),
+    )
+    monkeypatch.setattr(
+        "core_api.services.memory_service.get_query_embedding",
+        AsyncMock(return_value=[0.1] * 8),
+    )
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config",
+        AsyncMock(return_value=SimpleNamespace(embedding_model=None)),
+    )
+    monkeypatch.setattr(documents_routes, "check_and_increment", AsyncMock())
+    # The route uses ``common.embedding.get_embedding`` (a separate
+    # provider entry from ``get_query_embedding``); patch it too.
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", AsyncMock(return_value=[0.1] * 8)
+    )
+
+    body = documents_routes.DocSearchRequest(
+        tenant_id="home",
+        query="hello",
+        top_k=5,
+    )
+    auth = _cross_tenant_auth()
+    db = MagicMock()
+
+    await documents_routes.search_documents(body=body, auth=auth, db=db)
+
+    spy.assert_awaited()
+    kwargs = spy.await_args.kwargs
+    assert kwargs["surface"] == "rest_documents_search"
+    assert "sibling" in kwargs["source_tenants"]

--- a/tests/test_cross_tenant_auth.py
+++ b/tests/test_cross_tenant_auth.py
@@ -215,33 +215,84 @@ def test_source_tenants_for_audit_empty_for_admin_tenant_none():
 # guard the wider sweep (list, stats, doc surfaces) from regressing.
 
 
-@pytest.mark.unit
-def test_list_by_filters_widens_when_readable_set():
-    """Inspect the SQL produced by ``list_by_filters`` to confirm it
-    uses ``IN (...)`` instead of ``= $1`` once ``readable_tenant_ids``
-    is populated. The test reads the compiled SQL string rather than
-    executing it — keeps the test DB-independent while still asserting
-    the predicate shape."""
-    # Don't actually invoke list_by_filters (needs an AsyncSession);
-    # mirror the predicate logic so a refactor of the repo that
-    # changes the column path still has to update this test. The
-    # repo uses ``Memory.tenant_id.in_(...)`` when readable_tenant_ids
-    # is a non-empty list, falls back to equality otherwise.
-    from sqlalchemy import select
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_by_filters_widens_to_readable_set(db):
+    """Invoke the real ``MemoryRepository.list_by_filters`` and verify
+    that passing ``readable_tenant_ids`` returns rows from EVERY tenant
+    in the set, not just ``tenant_id``.
+
+    Audit T3: the prior version of this test mirrored the predicate
+    logic with a hand-rolled ``select(Memory)`` — it asserted on what
+    a literal ``Memory.tenant_id.in_(...)`` would compile to, never
+    invoking the repo function. A refactor that changed the visibility
+    predicate or the column path would silently break the cross-tenant
+    contract while this test stayed green. This rewrite exercises the
+    real call path: seed rows in two tenants, call ``list_by_filters``,
+    and assert the result set crosses tenants only when widened.
+    """
+    import hashlib
+    import uuid as _uuid
 
     from common.models.memory import Memory
+    from core_api.repositories.memory_repository import MemoryRepository
 
-    # Single-tenant path → equality predicate.
-    stmt_single = select(Memory).where(Memory.tenant_id == "home")
-    compiled_single = str(stmt_single.compile(compile_kwargs={"literal_binds": True}))
-    assert "tenant_id = 'home'" in compiled_single
+    suffix = _uuid.uuid4().hex[:8]
+    home = f"home-{suffix}"
+    sibling = f"sibling-{suffix}"
 
-    # Cross-tenant path → IN predicate.
-    stmt_wide = select(Memory).where(Memory.tenant_id.in_(["home", "src-a", "src-b"]))
-    compiled_wide = str(stmt_wide.compile(compile_kwargs={"literal_binds": True}))
-    assert "tenant_id IN" in compiled_wide
-    assert "'src-a'" in compiled_wide
-    assert "'src-b'" in compiled_wide
+    def _seed(tenant_id: str, content: str) -> Memory:
+        m = Memory(
+            tenant_id=tenant_id,
+            fleet_id=None,
+            agent_id=f"agent-{suffix}",
+            memory_type="fact",
+            content=content,
+            content_hash=hashlib.sha256(content.encode()).hexdigest(),
+            weight=0.5,
+            visibility="scope_team",
+            status="active",
+        )
+        db.add(m)
+        return m
+
+    home_mem = _seed(home, f"home-fact-{suffix}")
+    sibling_mem = _seed(sibling, f"sibling-fact-{suffix}")
+    await db.flush()
+
+    repo = MemoryRepository()
+
+    # Single-tenant path: readable_tenant_ids omitted → only home rows.
+    rows = await repo.list_by_filters(db, tenant_id=home, limit=50)
+    row_ids = {r.id for r in rows}
+    assert home_mem.id in row_ids
+    assert sibling_mem.id not in row_ids, (
+        "single-tenant query leaked a sibling-tenant row"
+    )
+
+    # Single-tenant path with explicit single-element readable list →
+    # same as above (still only home). This is the safety net for
+    # auth-context plumbing that always sends ``readable_tenant_ids``
+    # even on single-tenant credentials.
+    rows_single_list = await repo.list_by_filters(
+        db, tenant_id=home, readable_tenant_ids=[home], limit=50
+    )
+    row_ids_single = {r.id for r in rows_single_list}
+    assert sibling_mem.id not in row_ids_single
+
+    # Cross-tenant path: readable_tenant_ids includes the sibling →
+    # both rows surface.
+    rows_wide = await repo.list_by_filters(
+        db,
+        tenant_id=home,
+        readable_tenant_ids=[home, sibling],
+        limit=50,
+    )
+    row_ids_wide = {r.id for r in rows_wide}
+    assert home_mem.id in row_ids_wide
+    assert sibling_mem.id in row_ids_wide, (
+        "cross-tenant widening did not return sibling-tenant rows"
+    )
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -480,6 +480,100 @@ async def test_doc_search_embedding_provider_failure_aborts(mcp_env, monkeypatch
 
 
 # ---------------------------------------------------------------------------
+# Read-op widening: ``_readable_tenant_ids_var`` reaches the repo call
+# (audit T1)
+# ---------------------------------------------------------------------------
+#
+# Cross-tenant credentials surface as a non-empty
+# ``_readable_tenant_ids_var``; the tool reads it via
+# ``_get_readable_tenants()`` and passes the list as ``readable_tenant_ids``
+# to whichever ``document_repo`` function backs the requested op:
+#
+#   list_collections → document_repo.list_collections
+#   read             → document_repo.get_by_doc_id
+#   query            → document_repo.query
+#   search           → document_repo.search
+#
+# T1 locks in the wiring: a regression that silently drops the list on
+# any of those four paths would fail the corresponding test below.
+
+
+async def _capture_readable_tenant_ids(monkeypatch, repo_attr: str, return_value):
+    """Patch the named ``document_repo`` function with a capture stub
+    that records the ``readable_tenant_ids`` kwarg and returns the
+    given value."""
+    captured: dict = {}
+
+    async def fake(*args, **kwargs):  # noqa: ARG001
+        captured["readable_tenant_ids"] = kwargs.get("readable_tenant_ids")
+        return return_value
+
+    monkeypatch.setattr(f"core_api.repositories.document_repo.{repo_attr}", fake)
+    return captured
+
+
+async def test_doc_list_collections_passes_readable_tenants(mcp_env, monkeypatch):
+    """``op=list_collections`` widens to the readable set when the
+    caller's credential is cross-tenant."""
+    monkeypatch.setattr(
+        mcp_server, "_get_readable_tenants", lambda: ["home", "sibling"]
+    )
+    captured = await _capture_readable_tenant_ids(monkeypatch, "list_collections", [])
+    await mcp_server.memclaw_doc(op="list_collections")
+    assert captured["readable_tenant_ids"] == ["home", "sibling"]
+
+
+async def test_doc_list_collections_single_tenant_passes_none(mcp_env, monkeypatch):
+    """Single-tenant credential: ``_get_readable_tenants()`` returns
+    ``[]`` → the tool collapses it to ``None`` before calling the repo
+    (so the repo's single-tenant fast path runs)."""
+    monkeypatch.setattr(mcp_server, "_get_readable_tenants", lambda: [])
+    captured = await _capture_readable_tenant_ids(monkeypatch, "list_collections", [])
+    await mcp_server.memclaw_doc(op="list_collections")
+    assert captured["readable_tenant_ids"] is None
+
+
+async def test_doc_read_passes_readable_tenants(mcp_env, monkeypatch):
+    """``op=read`` widens via ``readable_tenant_ids``. The repo can
+    then resolve a doc that lives in a sibling tenant when the caller
+    is authorized to read from it."""
+    monkeypatch.setattr(
+        mcp_server, "_get_readable_tenants", lambda: ["home", "sibling"]
+    )
+    captured = await _capture_readable_tenant_ids(
+        monkeypatch, "get_by_doc_id", _DocRow()
+    )
+    await mcp_server.memclaw_doc(op="read", collection="customers", doc_id="acme")
+    assert captured["readable_tenant_ids"] == ["home", "sibling"]
+
+
+async def test_doc_query_passes_readable_tenants(mcp_env, monkeypatch):
+    """``op=query`` (filter-by-data) widens the same way."""
+    monkeypatch.setattr(
+        mcp_server, "_get_readable_tenants", lambda: ["home", "sibling"]
+    )
+    captured = await _capture_readable_tenant_ids(monkeypatch, "query", [])
+    await mcp_server.memclaw_doc(op="query", collection="customers", where={"k": 1})
+    assert captured["readable_tenant_ids"] == ["home", "sibling"]
+
+
+async def test_doc_search_passes_readable_tenants(mcp_env, monkeypatch):
+    """``op=search`` (vector recall) widens the same way. The audit
+    emission has its own assertion in
+    ``tests/test_cross_tenant_audit_surfaces.py``; this test only
+    confirms the wiring from the context var to the repo arg."""
+    monkeypatch.setattr(
+        mcp_server, "_get_readable_tenants", lambda: ["home", "sibling"]
+    )
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    captured = await _capture_readable_tenant_ids(monkeypatch, "search", [])
+    await mcp_server.memclaw_doc(op="search", query="hello")
+    assert captured["readable_tenant_ids"] == ["home", "sibling"]
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

External audit findings **T1, T2, and T3** — three gaps in cross-tenant test coverage. All three are **tests-only** — no production code changes.

### T3 — Rewrite `list_by_filters` widening test

The previous test (`test_list_by_filters_widens_when_readable_set`) mirrored the predicate logic with a hand-rolled `select(Memory).where(Memory.tenant_id.in_(...))` and asserted on the compiled SQL string. It never invoked the repo function. A refactor that changed the visibility predicate or the column path would silently break the cross-tenant contract while the test stayed green.

Rewritten as an integration test that:
- Seeds rows in two tenants (home + sibling) via the test `db` fixture
- Calls `MemoryRepository.list_by_filters` with three different `readable_tenant_ids` shapes (omitted, single-tenant list, widened list)
- Asserts the result set crosses tenants **only** when widened

### T2 — Per-surface `log_cross_tenant_read` assertions

New file `tests/test_cross_tenant_audit_surfaces.py` covers the 6 surfaces not exercised by prior tests:

| Surface | Type | Audit tag |
|---|---|---|
| `memclaw_recall` | MCP | `memclaw_recall` |
| `memclaw_doc` (search) | MCP | `memclaw_doc_search` |
| `memclaw_list` | MCP | `memclaw_list` |
| `memclaw_stats` | MCP | `memclaw_stats` |
| REST list | REST | `rest_memories_list` |
| REST doc search | REST | `rest_documents_search` |

(PR-A2 already covered `rest_entities_list`, `rest_graph`, `rest_entity_get` in `test_entity_routes_cross_tenant.py`.)

Each test sets up a cross-tenant credential, returns rows from a sibling tenant, spies on the audit emission, and asserts both the `surface` tag and the `source_tenants` set. A regression that silently drops the audit on any of these paths fails the corresponding test.

### T1 — `memclaw_doc` read-op widening tests

5 new cases in `tests/test_mcp_doc.py` patch `_get_readable_tenants` to model a cross-tenant credential and assert the `readable_tenant_ids` list reaches the underlying `document_repo` call for each read op:

- `list_collections` → `document_repo.list_collections(..., readable_tenant_ids=[...])`
- `read` → `document_repo.get_by_doc_id(..., readable_tenant_ids=[...])`
- `query` → `document_repo.query(..., readable_tenant_ids=[...])`
- `search` → `document_repo.search(..., readable_tenant_ids=[...])`

A negative case confirms the single-tenant path collapses the empty list to `None` before calling the repo (the repo's fast path).

## Tests

- New file `test_cross_tenant_audit_surfaces.py` — 6 tests
- `test_mcp_doc.py` extended with 5 new T1 tests (38 total, was 33)
- `test_cross_tenant_auth.py` rewrites the predicate-mirror test (still 14 tests total)

Full suite: **2402 passed** (was 2391 — net +11 tests). The 2 pre-existing `test_rate_limit.py` failures reproduce on `main` and are unrelated to this PR.

## Test plan

- [x] Each new test passes individually
- [x] All 58 cross-tenant / doc tests pass together
- [x] Full pytest suite green (2402 tests)
- [x] `ruff check` + `ruff format --check` pass on touched files
- [x] T3's new integration test exercises the real `list_by_filters` against a seeded DB — verified the cross-tenant row only surfaces with widened `readable_tenant_ids`