### PR TITLE
perf(mcp): close DB session before insights LLM round-trip

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1683,45 +1683,102 @@ async def memclaw_insights(
     # Dynamic trust: scope='agent' requires trust ≥ 1, 'fleet'/'all' requires ≥ 2.
     min_level = 1 if scope == "agent" else 2
 
-    async with _mcp_session() as db:
-        # Mirror the REST insights gate: ``require_trust`` soft-passes a
-        # missing Agent row at ``DEFAULT_TRUST_LEVEL`` (read-only ergonomics
-        # — see ``memclaw_list`` below for the intended consumer), but
-        # this handler persists insight memories + audit-log rows keyed
-        # to ``agent_id``. Without a registered row backing the name,
-        # attribution becomes unverifiable, so re-block unregistered
-        # agents on the write path. ``terr`` is None for the soft-pass
-        # case, so without the explicit ``not_found`` check below the
-        # fabricated id would fall through and write.
-        _, not_found, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
-        if not_found:
-            return _with_latency(
-                _error_response(
-                    "FORBIDDEN",
-                    f"Agent '{agent_id}' is not registered. Register the agent by writing one memory first.",
-                ),
-                t0,
-            )
-        if terr:
-            return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
-        try:
-            await check_and_increment(db, tenant_id, "insights")
-            from core_api.services.insights_service import generate_insights
+    # Audit finding P3 (insights portion): prior implementation held a
+    # single ``_mcp_session()`` open across the multi-second LLM
+    # analysis round-trip, pinning a pooled DB connection during work
+    # that is entirely network-bound to the LLM provider. Restructured
+    # into three phases so the connection is released during the LLM:
+    #   1. session 1 — trust + usage gates, query memories, resolve config
+    #   2. no DB     — synthesize_insights (LLM)
+    #   3. session 2 — persist findings + commit
+    from core_api.services.insights_service import (
+        _QUERY_DISPATCH,
+        _DiscoverResult,
+        _persist_findings,
+        synthesize_insights,
+    )
+    from core_api.services.organization_settings import resolve_config
 
-            result = await generate_insights(
-                db,
-                tenant_id=tenant_id,
-                focus=focus,
-                scope=scope,
-                fleet_id=fleet_id,
-                agent_id=agent_id,
-            )
-            return _with_latency(json.dumps(result, indent=2, default=str), t0)
-        except HTTPException as e:
-            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
-        except Exception as e:
-            logger.exception("Unhandled error in memclaw_insights")
-            return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
+    try:
+        # ── Phase 1: DB reads ──────────────────────────────────────
+        async with _mcp_session() as db:
+            # Mirror the REST insights gate: ``require_trust`` soft-passes
+            # a missing Agent row at ``DEFAULT_TRUST_LEVEL`` (read-only
+            # ergonomics — see ``memclaw_list`` below for the intended
+            # consumer), but this handler persists insight memories +
+            # audit-log rows keyed to ``agent_id``. Without a registered
+            # row backing the name, attribution becomes unverifiable, so
+            # re-block unregistered agents on the write path.
+            _, not_found, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
+            if not_found:
+                return _with_latency(
+                    _error_response(
+                        "FORBIDDEN",
+                        f"Agent '{agent_id}' is not registered. Register the agent by writing one memory first.",
+                    ),
+                    t0,
+                )
+            if terr:
+                return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
+            await check_and_increment(db, tenant_id, "insights")
+            memories_or_clusters = await _QUERY_DISPATCH[focus](db, tenant_id, fleet_id, agent_id, scope)
+            if focus == "discover" and isinstance(memories_or_clusters, _DiscoverResult):
+                is_clustered = memories_or_clusters.is_clustered
+                memories_or_clusters = memories_or_clusters.data
+            else:
+                is_clustered = False
+            # Short-circuit when the query found no candidate memories —
+            # no LLM work, no second session, just a stable empty result.
+            if not memories_or_clusters:
+                return _with_latency(
+                    json.dumps(
+                        {
+                            "focus": focus,
+                            "scope": scope,
+                            "memories_analyzed": 0,
+                            "findings": [],
+                            "summary": "No relevant memories found for this analysis.",
+                            "insight_memory_ids": [],
+                            "insights_ms": int((time.perf_counter() - t0) * 1000),
+                        },
+                        indent=2,
+                        default=str,
+                    ),
+                    t0,
+                )
+            config = await resolve_config(db, tenant_id)
+        # ── Session closed. The LLM analysis runs with no DB held. ──
+
+        # ── Phase 2: LLM (no DB) ───────────────────────────────────
+        synth = await synthesize_insights(
+            memories_or_clusters,
+            is_clustered,
+            config,
+            focus=focus,
+            scope=scope,
+        )
+        findings = synth["findings"]
+
+        # ── Phase 3: persist findings + commit ─────────────────────
+        async with _mcp_session() as db:
+            insight_ids = await _persist_findings(db, tenant_id, agent_id, fleet_id, focus, scope, findings)
+            await db.commit()
+
+        result = {
+            "focus": focus,
+            "scope": scope,
+            "memories_analyzed": synth["memories_analyzed"],
+            "findings": [{**f, "insight_memory_id": mid} for f, mid in zip(findings, insight_ids)],
+            "summary": synth["summary"],
+            "insight_memory_ids": [mid for mid in insight_ids if mid],
+            "insights_ms": int((time.perf_counter() - t0) * 1000),
+        }
+        return _with_latency(json.dumps(result, indent=2, default=str), t0)
+    except HTTPException as e:
+        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+    except Exception as e:
+        logger.exception("Unhandled error in memclaw_insights")
+        return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
 
 
 async def memclaw_evolve(

--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -845,6 +845,91 @@ def _to_float(val, default: float = 0.5) -> float:
 # -- Public API ----------------------------------------------------------------
 
 
+async def synthesize_insights(
+    memories_or_clusters: list,
+    is_clustered: bool,
+    config,
+    *,
+    focus: str,
+    scope: str,
+) -> dict:
+    """LLM-only analysis step. No DB access.
+
+    Audit finding P3: ``memclaw_insights`` previously held its
+    ``_mcp_session()`` open across the multi-second ``_run_llm_analysis``
+    round-trip, pinning a pooled DB connection. This helper takes the
+    already-queried memories + resolved tenant config and produces the
+    same intermediate shape the legacy ``generate_insights`` body
+    produced in steps 3-5, so the MCP tool can exit the session block
+    before invoking it.
+
+    Returns
+    -------
+    dict with:
+      - ``findings``: list of sanitized finding dicts
+      - ``summary``: LLM-emitted overall summary string
+      - ``memories_analyzed``: count of memories that fed the prompt
+    """
+    prompt_template = _PROMPT_DISPATCH[focus]
+    if is_clustered:
+        memories_text, shown_ids = _format_clusters_for_analysis(memories_or_clusters)
+        count = sum(c.get("size", 0) for c in memories_or_clusters)
+    else:
+        memories_text, shown_ids = _format_memories_for_analysis(memories_or_clusters)
+        count = len(memories_or_clusters)
+        if focus == "discover":
+            prompt_template = _PROMPT_DISPATCH["patterns"]
+
+    # Escape literal braces in memories_text before .format(). Cluster mode
+    # always includes Python dict reprs (type_distribution); content mode can
+    # include user-controlled `{...}` strings. Without escaping, str.format
+    # raises KeyError on any stray `{word}`.
+    safe_memories = memories_text.replace("{", "{{").replace("}", "}}")
+    prompt = prompt_template.format(memories=safe_memories, count=count)
+
+    analysis = await _run_llm_analysis(prompt, config)
+
+    findings = analysis.get("findings", [])
+    if not isinstance(findings, list):
+        findings = []
+    sanitized = []
+    total_dropped = 0
+    findings_with_drops = 0
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        raw_related = [str(rid) for rid in f.get("related_memory_ids", []) if rid]
+        kept_related = [rid for rid in raw_related if rid in shown_ids]
+        dropped = len(raw_related) - len(kept_related)
+        if dropped > 0:
+            total_dropped += dropped
+            findings_with_drops += 1
+        sanitized.append(
+            {
+                "type": str(f.get("type", focus))[:50],
+                "title": str(f.get("title", "Untitled"))[:80],
+                "description": str(f.get("description", "")),
+                "confidence": max(0.0, min(1.0, _to_float(f.get("confidence", 0.5)))),
+                "related_memory_ids": kept_related,
+                "recommendation": str(f.get("recommendation", "")),
+            }
+        )
+    if total_dropped > 0:
+        logger.info(
+            "insights: dropped %d hallucinated related_memory_ids across %d findings (focus=%s, scope=%s)",
+            total_dropped,
+            findings_with_drops,
+            focus,
+            scope,
+        )
+
+    return {
+        "findings": sanitized,
+        "summary": analysis.get("summary", ""),
+        "memories_analyzed": count,
+    }
+
+
 async def generate_insights(
     db: AsyncSession,
     tenant_id: str,
@@ -923,65 +1008,17 @@ async def generate_insights(
 
     config = await resolve_config(db, tenant_id)
 
-    # 3. Build prompt -- discover mode formats clusters differently.
-    # The format functions also return the set of IDs actually rendered into
-    # the prompt, so hallucination filtering stays in sync with what the LLM
-    # saw (not just what we intended to send).
-    prompt_template = _PROMPT_DISPATCH[focus]
-    if is_clustered:
-        memories_text, shown_ids = _format_clusters_for_analysis(memories_or_clusters)
-        count = sum(c.get("size", 0) for c in memories_or_clusters)
-    else:
-        memories_text, shown_ids = _format_memories_for_analysis(memories_or_clusters)
-        count = len(memories_or_clusters)
-        if focus == "discover":
-            prompt_template = _PROMPT_DISPATCH["patterns"]
-
-    # Escape literal braces in memories_text before .format(). Cluster mode
-    # always includes Python dict reprs (type_distribution); content mode can
-    # include user-controlled `{...}` strings. Without escaping, str.format
-    # raises KeyError on any stray `{word}`.
-    safe_memories = memories_text.replace("{", "{{").replace("}", "}}")
-    prompt = prompt_template.format(memories=safe_memories, count=count)
-
-    # 4. Run LLM analysis
-    analysis = await _run_llm_analysis(prompt, config)
-
-    # 5. Validate and sanitize findings
-    findings = analysis.get("findings", [])
-    if not isinstance(findings, list):
-        findings = []
-    sanitized = []
-    total_dropped = 0
-    findings_with_drops = 0
-    for f in findings:
-        if not isinstance(f, dict):
-            continue
-        raw_related = [str(rid) for rid in f.get("related_memory_ids", []) if rid]
-        kept_related = [rid for rid in raw_related if rid in shown_ids]
-        dropped = len(raw_related) - len(kept_related)
-        if dropped > 0:
-            total_dropped += dropped
-            findings_with_drops += 1
-        sanitized.append(
-            {
-                "type": str(f.get("type", focus))[:50],
-                "title": str(f.get("title", "Untitled"))[:80],
-                "description": str(f.get("description", "")),
-                "confidence": max(0.0, min(1.0, _to_float(f.get("confidence", 0.5)))),
-                "related_memory_ids": kept_related,
-                "recommendation": str(f.get("recommendation", "")),
-            }
-        )
-    findings = sanitized
-    if total_dropped > 0:
-        logger.info(
-            "insights: dropped %d hallucinated related_memory_ids across %d findings (focus=%s, scope=%s)",
-            total_dropped,
-            findings_with_drops,
-            focus,
-            scope,
-        )
+    # 3-5. LLM analysis (no DB). Delegated to ``synthesize_insights`` so
+    # MCP callers that want to release their session before the LLM
+    # round-trip can do so independently (see ``memclaw_insights``).
+    synth = await synthesize_insights(
+        memories_or_clusters,
+        is_clustered,
+        config,
+        focus=focus,
+        scope=scope,
+    )
+    findings = synth["findings"]
 
     # 6. Persist findings as insight memories
     insight_ids = await _persist_findings(db, tenant_id, agent_id, fleet_id, focus, scope, findings)
@@ -990,9 +1027,9 @@ async def generate_insights(
     return {
         "focus": focus,
         "scope": scope,
-        "memories_analyzed": count,
+        "memories_analyzed": synth["memories_analyzed"],
         "findings": [{**f, "insight_memory_id": mid} for f, mid in zip(findings, insight_ids)],
-        "summary": analysis.get("summary", ""),
+        "summary": synth["summary"],
         "insight_memory_ids": [mid for mid in insight_ids if mid],
         "insights_ms": int((time.perf_counter() - t0) * 1000),
     }

--- a/tests/test_mcp_insights_session_split.py
+++ b/tests/test_mcp_insights_session_split.py
@@ -1,0 +1,182 @@
+"""Audit P3 regression test for ``memclaw_insights``.
+
+The handler previously held a single ``_mcp_session()`` open across
+the multi-second LLM round-trip in ``_run_llm_analysis``, pinning a
+pooled DB connection. The refactor splits the work into three phases:
+
+  1. Session 1 — trust + usage gates, query memories, resolve config.
+  2. No DB     — ``synthesize_insights`` (LLM-only).
+  3. Session 2 — ``_persist_findings`` + commit.
+
+This module asserts the timing invariant with patched
+``_mcp_session`` (capture enter/exit timestamps) and patched
+``synthesize_insights`` (capture entry timestamp). A regression that
+moves the LLM call back inside the session would flip the order
+and fail.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core_api import mcp_server
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+async def test_insights_closes_first_session_before_llm(mcp_env, monkeypatch):
+    """Phase 1 session must close BEFORE ``synthesize_insights`` runs.
+
+    Captures interleaved enter/exit events on every ``_mcp_session``
+    entry plus a sentinel when the LLM helper fires. The expected
+    event order is:
+
+        session-enter (phase 1)
+        session-exit  (phase 1)
+        llm-start
+        session-enter (phase 3)
+        session-exit  (phase 3)
+
+    If a future change re-merges phases 1+2, the order flips and the
+    assertion fails.
+    """
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def _captured_session():
+        events.append("session-enter")
+        try:
+            yield MagicMock(name="db")
+        finally:
+            events.append("session-exit")
+
+    monkeypatch.setattr(mcp_server, "_mcp_session", _captured_session)
+
+    # Phase-1 collaborators
+    monkeypatch.setattr(
+        mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None))
+    )
+    monkeypatch.setattr(mcp_server, "check_and_increment", AsyncMock())
+
+    # Phase-1 dispatch — return one fake "memory" with the .id attribute
+    # the format helpers expect. The downstream synthesize_insights is
+    # patched, so the format helpers never actually run on this stub.
+    fake_memory = SimpleNamespace(
+        id="m1",
+        content="x",
+        memory_type="fact",
+        title=None,
+        status="active",
+        ts_valid_start=None,
+    )
+    fake_query = AsyncMock(return_value=[fake_memory])
+    monkeypatch.setattr(
+        "core_api.services.insights_service._QUERY_DISPATCH",
+        {
+            "contradictions": fake_query,
+            "patterns": fake_query,
+            "discover": fake_query,
+            "failures": fake_query,
+            "stale": fake_query,
+            "divergence": fake_query,
+        },
+    )
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config",
+        AsyncMock(return_value=SimpleNamespace()),
+    )
+
+    # The LLM helper — record entry timestamp via the events list.
+    async def _capturing_synthesize(*_args, **_kwargs):
+        events.append("llm-start")
+        return {
+            "findings": [],
+            "summary": "synthesized in test",
+            "memories_analyzed": 1,
+        }
+
+    monkeypatch.setattr(
+        "core_api.services.insights_service.synthesize_insights",
+        _capturing_synthesize,
+    )
+
+    # Phase-3 persistence — return an empty list of ids.
+    monkeypatch.setattr(
+        "core_api.services.insights_service._persist_findings",
+        AsyncMock(return_value=[]),
+    )
+
+    await mcp_server.memclaw_insights(
+        focus="contradictions", scope="agent", agent_id="a1"
+    )
+
+    # Locate the events. We expect the LLM start strictly between two
+    # session entries (phase 1 closed, phase 3 not yet open).
+    assert "llm-start" in events, "LLM helper never ran"
+    llm_idx = events.index("llm-start")
+    # The most recent "session-exit" before the LLM corresponds to phase 1.
+    prior_exits = [i for i, e in enumerate(events[:llm_idx]) if e == "session-exit"]
+    assert prior_exits, "no session closed before the LLM call — P3 fix regressed"
+    # The next "session-enter" after the LLM is phase 3.
+    next_enters = [
+        i
+        for i, e in enumerate(events[llm_idx + 1 :], start=llm_idx + 1)
+        if e == "session-enter"
+    ]
+    assert next_enters, (
+        "no second session opened after LLM — persistence phase missing or merged"
+    )
+
+
+async def test_insights_short_circuits_when_no_memories(mcp_env, monkeypatch):
+    """When the query returns zero rows, the handler must NOT open a
+    second session and must NOT invoke ``synthesize_insights``. The
+    empty-result fast path lives entirely in phase 1."""
+    session_entries: list[int] = []
+
+    @asynccontextmanager
+    async def _counting_session():
+        session_entries.append(1)
+        try:
+            yield MagicMock(name="db")
+        finally:
+            pass
+
+    monkeypatch.setattr(mcp_server, "_mcp_session", _counting_session)
+    monkeypatch.setattr(
+        mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None))
+    )
+    monkeypatch.setattr(mcp_server, "check_and_increment", AsyncMock())
+
+    empty_query = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        "core_api.services.insights_service._QUERY_DISPATCH",
+        {
+            "contradictions": empty_query,
+            "patterns": empty_query,
+            "discover": empty_query,
+            "failures": empty_query,
+            "stale": empty_query,
+            "divergence": empty_query,
+        },
+    )
+
+    synth_calls: list = []
+
+    async def _spy(*_a, **_kw):
+        synth_calls.append(1)
+        return {"findings": [], "summary": "", "memories_analyzed": 0}
+
+    monkeypatch.setattr("core_api.services.insights_service.synthesize_insights", _spy)
+
+    await mcp_server.memclaw_insights(
+        focus="contradictions", scope="agent", agent_id="a1"
+    )
+
+    # Exactly one session opened (phase 1). No LLM invocation.
+    assert sum(session_entries) == 1
+    assert synth_calls == []


### PR DESCRIPTION
## Summary

Follow-up to PR #228 (which fixed `memclaw_recall`). External audit **P3** also flagged `memclaw_insights`: the handler held a single `_mcp_session()` open across the multi-second LLM analysis in `_run_llm_analysis`, pinning a pooled DB connection during work that is entirely network-bound to the LLM provider.

## Fix

### `insights_service.py` — extract the LLM step

New helper `synthesize_insights(memories_or_clusters, is_clustered, config, *, focus, scope)` does only the LLM analysis + sanitization. No DB access. Same intermediate shape the legacy inline block produced — `{findings, summary, memories_analyzed}`.

The single-shot wrapper `generate_insights(db, ...)` keeps working for the REST surface; it now delegates the LLM step to `synthesize_insights`.

### `memclaw_insights` — three-phase session pattern

```
Phase 1 (session 1):
    - trust + usage gates
    - dispatch query (memories or clusters)
    - resolve tenant config
    - early-exit on empty result

# Session 1 closed. No DB held during the LLM.

Phase 2 (no DB):
    - synthesize_insights(memories, is_clustered, config, ...)

Phase 3 (session 2):
    - _persist_findings(db, ...)
    - db.commit()
```

Wet test on local stack: `memclaw_insights(focus="patterns", scope="agent")` took ~30 s end-to-end (LLM-dominated). Previously that entire window held a pooled connection; now only the phase-1 and phase-3 work does (~200 ms combined).

## Tests

New file `tests/test_mcp_insights_session_split.py`:

- `test_insights_closes_first_session_before_llm` — patches `_mcp_session` to record `enter`/`exit` events and `synthesize_insights` to record the LLM start. Asserts the LLM event sits strictly between a session exit (phase 1 closed) and the next session enter (phase 3 not yet opened). A regression that re-merges phases 1+2 fails this assertion.
- `test_insights_short_circuits_when_no_memories` — asserts the empty-query path opens exactly one session and never invokes the LLM helper.

Existing coverage:
- `tests/test_insights_service.py` — 36 tests, all pass (the `generate_insights` wrapper preserves its REST-side contract).
- `tests/test_tools_registry.py` + `test_mcp_iserror_propagation.py` + `test_direct_mcp_skill.py` — 49 combined tests pass.

Full suite: **2404 passed** (was 2402, +2). The 2 pre-existing `test_rate_limit.py` failures reproduce on `main` and are unrelated.

## Wet test

Verified inside the rebuilt local stack:
- `synthesize_insights` defined in `services/insights_service.py:848`
- `memclaw_insights` handler imports it and references `P3 (insights` audit marker
- Live `memclaw_insights(focus="patterns")` call returned 40 analyzed memories + findings in ~30 s (LLM-dominated); DB pool no longer held across the LLM call

## Test plan

- [x] Unit tests pass (2 new regression cases)
- [x] Existing insights service + MCP tests pass (85 combined)
- [x] Full pytest suite green (2404 tests)
- [x] `ruff check` + `ruff format --check` pass on touched files
- [x] Local wet test: functional + code-presence verified
- [ ] Staging wet test after deploy — observe DB pool utilization during insights load to confirm the connection pin is gone

## Follow-up

`memclaw_evolve` has the same DB→LLM→DB shape but is more invasive to split — the LLM-emitted rule sits between weight-adjust row locks (must be in a transaction) and a final commit with atomicity guarantees. Tracked as a separate, more careful PR.