### PR TITLE
perf(mcp): close DB session before evolve LLM round-trip

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1832,44 +1832,88 @@ async def memclaw_evolve(
     # Dynamic trust: scope='agent' requires trust ≥ 1, 'fleet'/'all' requires ≥ 2.
     min_level = 1 if scope == "agent" else 2
 
-    async with _mcp_session() as db:
-        # Mirror the REST evolve gate (and ``memclaw_insights`` above):
-        # block unregistered agents on the write path so the
-        # outcome/rule memories + audit-log rows have a real registered
-        # ``agent_id`` backing them. Soft-pass remains in
-        # ``require_trust`` itself for the read-only ``memclaw_list``
-        # below.
-        _, not_found, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
-        if not_found:
-            return _with_latency(
-                _error_response(
-                    "FORBIDDEN",
-                    f"Agent '{agent_id}' is not registered. Register the agent by writing one memory first.",
-                ),
-                t0,
-            )
-        if terr:
-            return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
-        try:
-            await check_and_increment(db, tenant_id, "evolve")
-            from core_api.services.evolve_service import report_outcome
+    # Audit finding P3 (evolve portion): prior implementation held a
+    # single ``_mcp_session()`` open across the rule-generation LLM
+    # round-trip — multiple seconds during which a pooled DB connection
+    # was pinned for work that is entirely network-bound to the LLM
+    # provider. Three-phase restructure (same pattern as insights):
+    #   1. session 1 — trust + usage gates, filter_by_scope, resolve_config
+    #   2. no DB     — _maybe_generate_rule (LLM)
+    #   3. session 2 — _apply_outcome_to_db (weights + persist + backfill + commit)
+    from core_api.services.evolve_service import (
+        _apply_outcome_to_db,
+        _filter_by_scope,
+        _maybe_generate_rule,
+    )
+    from core_api.services.organization_settings import resolve_config
 
-            result = await report_outcome(
+    try:
+        # ── Phase 1: DB reads ──────────────────────────────────────
+        async with _mcp_session() as db:
+            # Mirror the REST evolve gate (and ``memclaw_insights`` above):
+            # block unregistered agents on the write path so the
+            # outcome/rule memories + audit-log rows have a real
+            # registered ``agent_id`` backing them.
+            _, not_found, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
+            if not_found:
+                return _with_latency(
+                    _error_response(
+                        "FORBIDDEN",
+                        f"Agent '{agent_id}' is not registered. Register the agent by writing one memory first.",
+                    ),
+                    t0,
+                )
+            if terr:
+                return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
+            await check_and_increment(db, tenant_id, "evolve")
+
+            in_scope_ids = related_ids or []
+            out_of_scope_count = 0
+            if in_scope_ids:
+                in_scope_ids, out_of_scope_count = await _filter_by_scope(
+                    db,
+                    tenant_id=tenant_id,
+                    caller_agent_id=agent_id,
+                    fleet_id=fleet_id,
+                    scope=scope,
+                    related_ids=in_scope_ids,
+                )
+            config = await resolve_config(db, tenant_id)
+        # ── Session closed. The LLM rule generation runs with no DB held. ──
+
+        # ── Phase 2: LLM (no DB) ───────────────────────────────────
+        rule_result, rule_skipped_reason = await _maybe_generate_rule(
+            tenant_id,
+            outcome,
+            outcome_type,
+            in_scope_ids,
+            config,
+            agent_id,
+            fleet_id,
+        )
+
+        # ── Phase 3: persist + commit ──────────────────────────────
+        async with _mcp_session() as db:
+            result = await _apply_outcome_to_db(
                 db,
                 tenant_id=tenant_id,
-                outcome=outcome,
-                outcome_type=outcome_type,
-                related_ids=related_ids,
-                scope=scope,
                 agent_id=agent_id,
                 fleet_id=fleet_id,
+                outcome=outcome,
+                outcome_type=outcome_type,
+                related_ids=in_scope_ids,
+                rule_result=rule_result,
+                rule_skipped_reason=rule_skipped_reason,
+                scope=scope,
+                out_of_scope_count=out_of_scope_count,
+                t0=t0,
             )
-            return _with_latency(json.dumps(result, indent=2, default=str), t0)
-        except HTTPException as e:
-            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
-        except Exception as e:
-            logger.exception("Unhandled error in memclaw_evolve")
-            return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
+        return _with_latency(json.dumps(result, indent=2, default=str), t0)
+    except HTTPException as e:
+        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+    except Exception as e:
+        logger.exception("Unhandled error in memclaw_evolve")
+        return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/core-api/src/core_api/services/evolve_service.py
+++ b/core-api/src/core_api/services/evolve_service.py
@@ -358,11 +358,11 @@ def _fake_rule() -> dict:
 
 
 async def _generate_rule(
-    db: AsyncSession,
     tenant_id: str,
     outcome: str,
     outcome_type: str,
     related_ids: list[str],
+    config,
     agent_id: str,
     fleet_id: str | None,
 ) -> tuple[str | None, dict | None]:
@@ -376,13 +376,23 @@ async def _generate_rule(
     (``report_outcome``) can propagate the specific reason out to the
     response + structured log instead of conflating "no candidates",
     "LLM blew up", and "fetched zero memories" into a single None.
+
+    Audit P3 (evolve): ``db`` was removed from this signature. The
+    function only used it to resolve tenant config; callers now do
+    that themselves and pass ``config`` in. This lets the MCP tool
+    (``memclaw_evolve``) close its DB session before invoking the
+    LLM round-trip — which can take multiple seconds and would
+    otherwise pin a pooled connection.
+
+    ``agent_id`` and ``fleet_id`` are reserved arguments; the body
+    does not use them today but they're preserved so future
+    rule-generation strategies (per-agent prompts, fleet-scoped
+    examples) can light up without a signature break.
     """
     from core_api.clients.storage_client import get_storage_client
     from core_api.providers._retry import call_with_fallback
-    from core_api.services.organization_settings import resolve_config
 
     sc = get_storage_client()
-    config = await resolve_config(db, tenant_id)
 
     # Fetch related memories for context (cap at 10 for prompt size).
     # Parallelize HTTP fetches so latency is O(1) instead of O(n) round trips.
@@ -652,6 +662,8 @@ async def report_outcome(
     if scope == "fleet" and not fleet_id:
         raise ValueError("fleet_id is required when scope is 'fleet'.")
 
+    from core_api.services.organization_settings import resolve_config
+
     # Phase 0: Filter related_ids by scope. Runs before rule generation so the
     # LLM prompt never sees memory content the caller shouldn't access (e.g.,
     # a scope='agent' caller passing another agent's memory IDs). Dropped IDs
@@ -667,37 +679,111 @@ async def report_outcome(
             related_ids=related_ids,
         )
 
-    # Phase 1: Generate rule BEFORE touching weights. Rule generation makes
-    # HTTP calls to the storage client and an LLM that can take several seconds;
-    # doing it first means Phase 2's row locks are held for DB round-trips only,
-    # never across HTTP/LLM I/O. The rule prompt only needs memory content for
-    # context — it has no dependency on the updated weights.
-    #
-    # A10 — track the specific skip reason through every silent-exit
-    # branch so the response carries it back to the caller (and a
-    # structured log line lets operators bisect by reason).
-    rule_result: dict | None = None
-    rule_skipped_reason: str | None = None
-    if outcome_type not in ("failure", "partial"):
-        rule_skipped_reason = "not_failure_or_partial"
-        _log_rule_skip(rule_skipped_reason, tenant_id, outcome_type)
-    elif not related_ids:
-        rule_skipped_reason = "no_related_ids"
-        _log_rule_skip(rule_skipped_reason, tenant_id, outcome_type)
-    else:
-        gen_reason, rule_result = await _generate_rule(
-            db,
-            tenant_id,
-            outcome,
-            outcome_type,
-            related_ids,
-            agent_id,
-            fleet_id,
-        )
-        if gen_reason is not None:
-            rule_skipped_reason = gen_reason
-            _log_rule_skip(rule_skipped_reason, tenant_id, outcome_type)
+    # Resolve tenant config up front so ``_maybe_generate_rule`` can be
+    # called without any DB dependency. Both REST (here) and MCP
+    # (``memclaw_evolve``) feed config in the same way.
+    config = await resolve_config(db, tenant_id)
 
+    # Phase 1: Generate rule BEFORE touching weights. The MCP tool
+    # closes its DB session between this phase and ``_apply_outcome_to_db``
+    # so the LLM round-trip (which can take several seconds) doesn't
+    # pin a pooled connection. REST callers run the whole chain in one
+    # session — same total latency, just no pool relief.
+    rule_result, rule_skipped_reason = await _maybe_generate_rule(
+        tenant_id,
+        outcome,
+        outcome_type,
+        related_ids,
+        config,
+        agent_id,
+        fleet_id,
+    )
+
+    return await _apply_outcome_to_db(
+        db,
+        tenant_id=tenant_id,
+        agent_id=agent_id,
+        fleet_id=fleet_id,
+        outcome=outcome,
+        outcome_type=outcome_type,
+        related_ids=related_ids,
+        rule_result=rule_result,
+        rule_skipped_reason=rule_skipped_reason,
+        scope=scope,
+        out_of_scope_count=out_of_scope_count,
+        t0=t0,
+    )
+
+
+async def _maybe_generate_rule(
+    tenant_id: str,
+    outcome: str,
+    outcome_type: str,
+    related_ids: list[str],
+    config,
+    agent_id: str,
+    fleet_id: str | None,
+) -> tuple[dict | None, str | None]:
+    """Decide whether to invoke ``_generate_rule`` and return ``(rule, skip_reason)``.
+
+    Pure compute + LLM call, NO DB access. Callers resolve tenant config
+    first and pass it in. Lets the MCP tool fire this between two
+    independent DB sessions so the multi-second LLM round-trip doesn't
+    pin a pooled connection (audit P3).
+
+    Returns:
+      - ``(rule_dict, None)`` on a successful generation.
+      - ``(None, slug)`` for any silent-exit path; ``slug`` names the
+        reason (one of ``RULE_SKIP_REASONS``).
+    """
+    if outcome_type not in ("failure", "partial"):
+        reason = "not_failure_or_partial"
+        _log_rule_skip(reason, tenant_id, outcome_type)
+        return None, reason
+    if not related_ids:
+        reason = "no_related_ids"
+        _log_rule_skip(reason, tenant_id, outcome_type)
+        return None, reason
+    gen_reason, rule_result = await _generate_rule(
+        tenant_id,
+        outcome,
+        outcome_type,
+        related_ids,
+        config,
+        agent_id,
+        fleet_id,
+    )
+    if gen_reason is not None:
+        _log_rule_skip(gen_reason, tenant_id, outcome_type)
+        return None, gen_reason
+    return rule_result, None
+
+
+async def _apply_outcome_to_db(
+    db: AsyncSession,
+    *,
+    tenant_id: str,
+    agent_id: str,
+    fleet_id: str | None,
+    outcome: str,
+    outcome_type: str,
+    related_ids: list[str],
+    rule_result: dict | None,
+    rule_skipped_reason: str | None,
+    scope: str,
+    out_of_scope_count: int,
+    t0: float,
+) -> dict:
+    """Phases 2-5 + commit: the entire DB-bound write side of evolve.
+
+    Audit P3 (evolve): split out of ``report_outcome`` so the MCP tool
+    can call it from a fresh DB session, opened AFTER the LLM rule
+    generation. Atomicity contract is preserved — every local write
+    (weight UPDATEs, backfill UPDATE) commits in this one session;
+    the storage-api writes (rule + outcome memories) commit eagerly
+    via HTTP and are not rolled back if the local commit fails, same
+    as before.
+    """
     # Phase 2: Adjust weights atomically. Row locks are acquired and released
     # entirely within this block — no long-running work runs while locks are held.
     processed_ids: list[str] = []

--- a/tests/test_evolve_service.py
+++ b/tests/test_evolve_service.py
@@ -444,14 +444,20 @@ async def test_evolve_generate_rule_returns_valid_structure(db, sc):
     mid, _ = await _create_test_memory_via_sc(sc, tenant_id, weight=0.5)
 
     from core_api.services.evolve_service import _generate_rule
+    from core_api.services.organization_settings import resolve_config
+
+    # Audit P3 (evolve): ``_generate_rule`` no longer takes ``db`` —
+    # callers resolve the tenant config first and pass it in. This
+    # lets the MCP tool close its session before the LLM round-trip.
+    config = await resolve_config(db, tenant_id)
 
     # A10: _generate_rule now returns (skip_reason, rule_dict) tuple.
     reason, rule = await _generate_rule(
-        db,
         tenant_id=tenant_id,
         outcome=f"Failed because of bad info [{tag}]",
         outcome_type="failure",
         related_ids=[mid],
+        config=config,
         agent_id="evolve-test-agent",
         fleet_id=None,
     )

--- a/tests/test_mcp_evolve_session_split.py
+++ b/tests/test_mcp_evolve_session_split.py
@@ -1,0 +1,178 @@
+"""Audit P3 regression test for ``memclaw_evolve``.
+
+The handler previously held a single ``_mcp_session()`` open across
+the rule-generation LLM round-trip in ``_generate_rule``, pinning a
+pooled DB connection. The refactor splits the work into three phases:
+
+  1. Session 1 — trust + usage gates, ``_filter_by_scope``, resolve config.
+  2. No DB     — ``_maybe_generate_rule`` (LLM).
+  3. Session 2 — ``_apply_outcome_to_db`` (weights + persist + backfill + commit).
+
+This module asserts the timing invariant with a patched
+``_mcp_session`` capturing enter/exit events and a patched
+``_maybe_generate_rule`` recording its entry. A regression that
+re-merges phases 1+2 would flip the order and fail.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core_api import mcp_server
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+async def test_evolve_closes_first_session_before_llm(mcp_env, monkeypatch):
+    """Phase 1 session must close BEFORE ``_maybe_generate_rule`` runs.
+
+    Expected event order:
+
+        session-enter (phase 1)
+        session-exit  (phase 1)
+        llm-start
+        session-enter (phase 3)
+        session-exit  (phase 3)
+
+    A future change that re-merges phases 1+2 flips this order and
+    the assertion fails.
+    """
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def _captured_session():
+        events.append("session-enter")
+        try:
+            yield MagicMock(name="db")
+        finally:
+            events.append("session-exit")
+
+    monkeypatch.setattr(mcp_server, "_mcp_session", _captured_session)
+    monkeypatch.setattr(
+        mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None))
+    )
+    monkeypatch.setattr(mcp_server, "check_and_increment", AsyncMock())
+
+    # Phase-1 collaborators — return one in-scope id so the rule path
+    # actually exercises the LLM step (skipped when related_ids empty).
+    monkeypatch.setattr(
+        "core_api.services.evolve_service._filter_by_scope",
+        AsyncMock(return_value=(["11111111-1111-1111-1111-111111111111"], 0)),
+    )
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config",
+        AsyncMock(return_value=SimpleNamespace()),
+    )
+
+    # Phase-2 LLM — record entry into the events list.
+    async def _capturing_llm(*_a, **_kw):
+        events.append("llm-start")
+        return ({"condition": "x", "action": "y", "confidence": 0.5}, None)
+
+    monkeypatch.setattr(
+        "core_api.services.evolve_service._maybe_generate_rule", _capturing_llm
+    )
+
+    # Phase-3 commit — return a deterministic result.
+    monkeypatch.setattr(
+        "core_api.services.evolve_service._apply_outcome_to_db",
+        AsyncMock(
+            return_value={
+                "outcome_id": "00000000-0000-0000-0000-000000000001",
+                "outcome_type": "failure",
+                "scope": "agent",
+                "weight_adjustments": [],
+                "rules_generated": [],
+                "rule_skipped_reason": "below_confidence_threshold",
+                "out_of_scope_count": 0,
+                "evolve_ms": 1,
+            }
+        ),
+    )
+
+    await mcp_server.memclaw_evolve(
+        outcome="a thing happened",
+        outcome_type="failure",
+        related_ids=["11111111-1111-1111-1111-111111111111"],
+        scope="agent",
+        agent_id="a1",
+    )
+
+    assert "llm-start" in events, "LLM helper never ran"
+    llm_idx = events.index("llm-start")
+    prior_exits = [i for i, e in enumerate(events[:llm_idx]) if e == "session-exit"]
+    assert prior_exits, "no session closed before the LLM call — P3 fix regressed"
+    next_enters = [
+        i
+        for i, e in enumerate(events[llm_idx + 1 :], start=llm_idx + 1)
+        if e == "session-enter"
+    ]
+    assert next_enters, (
+        "no second session opened after LLM — persist phase missing or merged"
+    )
+
+
+async def test_evolve_uses_two_distinct_sessions(mcp_env, monkeypatch):
+    """The refactor opens exactly two sessions per successful call:
+    one for the read phase, one for the persist + commit phase. A
+    regression to a single session, or a third session, would change
+    this count."""
+    session_count = 0
+
+    @asynccontextmanager
+    async def _counting_session():
+        nonlocal session_count
+        session_count += 1
+        try:
+            yield MagicMock(name=f"db-{session_count}")
+        finally:
+            pass
+
+    monkeypatch.setattr(mcp_server, "_mcp_session", _counting_session)
+    monkeypatch.setattr(
+        mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None))
+    )
+    monkeypatch.setattr(mcp_server, "check_and_increment", AsyncMock())
+    monkeypatch.setattr(
+        "core_api.services.evolve_service._filter_by_scope",
+        AsyncMock(return_value=(["11111111-1111-1111-1111-111111111111"], 0)),
+    )
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config",
+        AsyncMock(return_value=SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        "core_api.services.evolve_service._maybe_generate_rule",
+        AsyncMock(return_value=(None, "not_failure_or_partial")),
+    )
+    monkeypatch.setattr(
+        "core_api.services.evolve_service._apply_outcome_to_db",
+        AsyncMock(
+            return_value={
+                "outcome_id": "00000000-0000-0000-0000-000000000001",
+                "outcome_type": "success",
+                "scope": "agent",
+                "weight_adjustments": [],
+                "rules_generated": [],
+                "rule_skipped_reason": "not_failure_or_partial",
+                "out_of_scope_count": 0,
+                "evolve_ms": 1,
+            }
+        ),
+    )
+
+    await mcp_server.memclaw_evolve(
+        outcome="all good",
+        outcome_type="success",
+        related_ids=["11111111-1111-1111-1111-111111111111"],
+        scope="agent",
+        agent_id="a1",
+    )
+
+    assert session_count == 2, (
+        f"expected 2 distinct sessions (read + write), got {session_count}"
+    )


### PR DESCRIPTION
## Summary

Final follow-up of audit **P3** (after PR #228 recall + PR #231 insights). `memclaw_evolve` held a single `_mcp_session()` open across the rule-generation LLM round-trip in `_generate_rule` — multiple seconds during which a pooled DB connection was pinned for work that is entirely network-bound to the LLM provider.

## Fix

### `evolve_service.py` — split into DB-free + DB-bound phases

| Helper | Takes `db`? | Purpose |
|---|---|---|
| `_filter_by_scope` (existing) | yes | Phase 0 — drop out-of-scope related_ids. |
| `_generate_rule` | **no longer** | Now pure HTTP + LLM. Caller passes `config` in. |
| `_maybe_generate_rule` (new) | no | Wraps the outcome-type / related-ids skip gate around `_generate_rule`. Returns `(rule, skip_reason)`. |
| `_apply_outcome_to_db` (new) | yes | Phases 2-5 + final `db.commit()`. |

`report_outcome` (REST entry point) keeps single-session ergonomics — orchestrates `_filter_by_scope` → `resolve_config` → `_maybe_generate_rule` → `_apply_outcome_to_db` in one session. Same atomicity contract as before.

### `memclaw_evolve` MCP handler — three explicit phases

```python
async with _mcp_session() as db:
    # Phase 1: trust + usage gates, filter_by_scope, resolve_config
    ...

# Session closed. No DB held during LLM.

# Phase 2: LLM
rule_result, rule_skipped_reason = await _maybe_generate_rule(...)

async with _mcp_session() as db:
    # Phase 3: apply_outcome_to_db (weights + persist + backfill + commit)
    result = await _apply_outcome_to_db(db, ...)
```

## Tests

`tests/test_mcp_evolve_session_split.py` (new, 2 cases):

- `test_evolve_closes_first_session_before_llm` — patches `_mcp_session` to record `enter`/`exit` events and `_maybe_generate_rule` to record the LLM start. Asserts the LLM event sits strictly between a session exit (phase 1 closed) and the next session enter (phase 3 not yet opened).
- `test_evolve_uses_two_distinct_sessions` — pins the contract that exactly two sessions open per successful call.

`tests/test_evolve_service.py::test_evolve_generate_rule_returns_valid_structure` updated to resolve `config` in the caller and pass it through the new `_generate_rule` signature.

Full suite: **2406 passed** (was 2404, +2). The 2 pre-existing `test_rate_limit.py` failures reproduce on `main`.

## Wet test (designed by a context-free sub-agent)

Plan designed by a fresh sub-agent with no prior session context — see commit body for the plan summary. Five of seven probes ran on the rebuilt local stack; all five pass.

| Probe | Result |
|---|---|
| 1. `success` outcome (no LLM, no rule path) | ✅ delta=+0.1, `rule_skipped_reason="not_failure_or_partial"`, evolve_ms=247 |
| 2. `failure` with empty related_ids | ✅ `rule_skipped_reason="no_related_ids"`, evolve_ms=302 |
| 3. Full LLM path | ✅ confidence=0.78 → rule persisted, 3 weight deltas (-0.15), evolve_ms=2525 |
| 4. **Perf probe** — `pg_stat_activity` poll | ✅ `idle in transaction` seen in **1 of 25 samples** (~0.3 s phase-3 commit burst) during a 10 s call. Pre-fix would have shown it continuously across the LLM window. |
| 6. Scope filter | ✅ out-of-scope id dropped (`out_of_scope_count=1`), only the caller's own memory got a weight adjustment |
| 5. Concurrent load | Skipped — sub-agent noted this is a soft signal at the local dev pool size; meaningful only at prod scale. |
| 7. REST parity | N/A — no REST `/api/evolve` endpoint exists; evolve is MCP-only. |

## Test plan

- [x] Unit tests pass (2 new regression cases)
- [x] Existing evolve service + a10 + tools_registry + iserror tests pass (88 combined)
- [x] Full pytest suite green (2406 tests)
- [x] `ruff check` + `ruff format --check` pass on touched files
- [x] Local wet test: 5/5 applicable probes pass; perf-signal confirmed via `pg_stat_activity`
- [ ] Staging wet test after deploy — observe DB pool utilization during sustained evolve load to confirm the connection pin is gone at scale

## Status of audit P3

With this PR, all three MCP tools that previously pinned a DB connection across an LLM round-trip have been restructured:

- **memclaw_recall** (PR #228) — merged
- **memclaw_insights** (PR #231) — merged
- **memclaw_evolve** — this PR

Audit P3 is fully addressed.