### PR TITLE
fix(plugin): delegate compaction to OpenClaw runtime SDK to unwedge over-budget groups (CAURA-000)

### DIFF
--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -47,6 +47,7 @@ _plugin_files = [
     "identity.ts",
     "reconcile-skills.ts",
     "keystones.ts",
+    "openclaw-sdk-bridge.ts",
 ]
 
 
@@ -403,7 +404,7 @@ fi
 
 if [ -z "$SRC_FILES" ] || [ -z "$ROOT_FILES" ]; then
   echo "WARNING: Could not fetch/parse /api/v1/plugin-manifest (python3 missing or endpoint unreachable). Falling back to hardcoded file list."
-  SRC_FILES="index.ts prompt-section.ts tools.ts tool-specs.ts version.ts env.ts transport.ts validation.ts config.ts paths.ts logger.ts resolve-agent.ts tool-definitions.ts deploy.ts heartbeat.ts educate.ts context-engine.ts agent-auth.ts health.ts install-id.ts identity.ts reconcile-skills.ts keystones.ts"
+  SRC_FILES="index.ts prompt-section.ts tools.ts tool-specs.ts version.ts env.ts transport.ts validation.ts config.ts paths.ts logger.ts resolve-agent.ts tool-definitions.ts deploy.ts heartbeat.ts educate.ts context-engine.ts agent-auth.ts health.ts install-id.ts identity.ts reconcile-skills.ts keystones.ts openclaw-sdk-bridge.ts"
   ROOT_FILES="openclaw.plugin.json tools.json skills/memclaw/SKILL.md"
 fi
 

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memclaw",
   "name": "MemClaw",
   "kind": "memory",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Central persistent memory for OpenClaw agents — write, search, and entity lookup tools.",
   "entry": "dist/index.js",
   "skills": [

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caura/memclaw",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "OpenClaw plugin for MemClaw central memory",
   "license": "Apache-2.0",
   "private": true,

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -1,9 +1,10 @@
 /**
  * MemClaw ContextEngine — lifecycle hooks for OpenClaw memory integration.
  *
- * Provides: bootstrap (smoke test), ingest (message buffering + persistence),
- * assemble (token-budget-aware recall injection), afterTurn (auto-write),
- * compact (persist compaction summaries).
+ * Provides: bootstrap (smoke test), ingest (message buffering +
+ * persistence), assemble (token-budget-aware recall injection),
+ * afterTurn (auto-write), compact (persist summary + delegate to
+ * OpenClaw runtime via ``openclaw-sdk-bridge``).
  *
  * Security:
  * - afterTurn enabled by default; opt out with MEMCLAW_AUTO_WRITE_TURNS=false
@@ -33,6 +34,7 @@ import { MEMCLAW_TOOLS } from "./tools.js";
 import { resolveAgentId } from "./resolve-agent.js";
 import { logError, logErrorCritical } from "./logger.js";
 import { fetchKeystonesBlock } from "./keystones.js";
+import { getOpenClawSdk } from "./openclaw-sdk-bridge.js";
 
 // --- Typed interfaces for ContextEngine hooks ---
 
@@ -396,7 +398,19 @@ export class MemClawContextEngine {
   private _bootstrapped = false;
   private _bootstrapPromise: Promise<void> | null = null;
 
-  /** Engine metadata — tells OpenClaw this engine owns compaction. */
+  /**
+   * Engine metadata — declares to OpenClaw that we own compaction.
+   *
+   * "Own" means we are the receiver of ``compact()`` calls and the
+   * caller has no fallback path if we don't compact. As of v2.6.4 we
+   * fulfill that contract by delegating to OpenClaw's runtime helper
+   * ``delegateCompactionToRuntime`` (same bridge the legacy engine
+   * uses internally — see ``compact()`` below). Setting this to
+   * ``false`` would NOT auto-fall-back to legacy behavior per the
+   * SDK docs (``docs/concepts/context-engine.md:241``); it would
+   * just disable compaction entirely. So we stay truthful and keep
+   * it ``true``.
+   */
   readonly info = {
     id: "memclaw",
     name: "MemClaw Context Engine",
@@ -847,7 +861,75 @@ export class MemClawContextEngine {
     // compaction is `compact()`'s job.
   }
 
-  async compact(context: CompactContext): Promise<undefined> {
+  /**
+   * Compact an over-budget session.
+   *
+   * Two responsibilities, in order:
+   *
+   *   1. **Persist** any pre-computed summary (passed in by OpenClaw
+   *      when its compaction pipeline ran the summarization step
+   *      before invoking us) as a MemClaw episode memory tagged
+   *      ``auto-compaction``. This is the long-standing
+   *      observability side-effect — surviving summaries get
+   *      recallable later via ``memclaw_recall``.
+   *
+   *   2. **Delegate** the actual transcript-reduction work to
+   *      ``delegateCompactionToRuntime`` from
+   *      ``openclaw/plugin-sdk``. This is the same bridge OpenClaw's
+   *      own legacy engine uses internally (see
+   *      ``delegate-DzhryVAO.js`` in the installed runtime). It
+   *      invokes ``compactEmbeddedPiSessionDirect`` which performs
+   *      summarization + transcript rotation + writes the result
+   *      to the session file. Returns a properly-shaped
+   *      ``CompactResult`` (``{ok, compacted, reason, result?}``) per
+   *      ``plugin-sdk/src/context-engine/types.d.ts``.
+   *
+   * # Why this shape (CAURA-000-hotfix, v2.6.4)
+   *
+   * Pre-v2.6.4, ``compact()`` returned ``undefined`` — not even a
+   * valid ``CompactResult``. With ``info.ownsCompaction: true`` (PR
+   * #212), this told OpenClaw "we own compaction" and the runtime
+   * delegated to us — but we returned nothing, so the over-budget
+   * session never shrank. The first deployments to hit this were
+   * WhatsApp group chats (transcript-per-participant pushes them
+   * past the 272k token budget); direct chats stayed under budget
+   * and never tripped the wedge. Agent looped on
+   * ``memclaw_keystones`` calls trying to make any progress, and
+   * eventual final replies were silently dropped (``Skipping
+   * auto-reply: final-only`` runtime warning).
+   *
+   * # Why we don't just return a "declined" CompactResult
+   *
+   * Inspection of OpenClaw 2026.5.4's pi-embedded overflow recovery
+   * loop (``pi-embedded-X0afS0ip.js:2466-2477``) shows that
+   * ``{compacted: false}`` does NOT trigger a safeguard fallback —
+   * it falls through to "normal handling" which leaves the session
+   * over-budget. The `compactionSafeguardExtension` listener on
+   * ``session_before_compact`` fires from a different code path
+   * (the LLM-driven summarization pipeline), not from a declined
+   * engine compact. The only reliable way for our engine to "let
+   * OpenClaw handle compaction" while still owning the slot is to
+   * call ``delegateCompactionToRuntime`` ourselves.
+   *
+   * # SDK resolution
+   *
+   * The ``openclaw/plugin-sdk`` package cannot be imported via
+   * bare-spec from our native-loaded ``.js`` plugin — see
+   * ``openclaw-sdk-bridge.ts`` for the runtime-discovery dance that
+   * works around this. If the bridge returns ``null`` (e.g.,
+   * exotic install layout, embedded test runner), we return a
+   * structured "declined" ``CompactResult`` so OpenClaw at least
+   * has a well-shaped response — same regression behavior as
+   * v2.6.3, no worse.
+   */
+  async compact(
+    context: CompactContext,
+  ): Promise<{ ok: boolean; compacted: boolean; reason?: string; result?: unknown }> {
+    // 1. Persist OpenClaw's summary into MemClaw as an episode
+    // memory. This runs regardless of whether the delegation
+    // succeeds below — even on a degraded environment the summary
+    // is worth keeping if we can. Failure here is logged and
+    // swallowed; never let it cascade into "compaction failed."
     const summary = context?.summary || context?.compactionSummary;
     if (summary && typeof summary === "string") {
       try {
@@ -868,7 +950,161 @@ export class MemClawContextEngine {
         logError("Failed to persist compaction summary", e);
       }
     }
-    return undefined;
+
+    // 2. Defensive pre-check: only delegate when we have the
+    // minimum params the runtime helper needs. The
+    // ``compactEmbeddedPiSessionDirect`` path inside
+    // ``delegateCompactionToRuntime`` requires a real session id
+    // and file to acquire locks and read transcript bytes —
+    // calling it with synthetic / empty input has been observed
+    // to crash the gateway process in ways our outer ``try``
+    // cannot catch (unhandled rejection inside the runtime
+    // helper's own async chain). OpenClaw's production
+    // compaction call site
+    // (``pi-embedded-X0afS0ip.js:2447`` and friends) ALWAYS
+    // passes both fields per ``ContextEngine.compact``'s
+    // type signature, so this guard is invisible in the
+    // happy path; it only blocks degenerate calls
+    // (gateway-RPC test probes, admin tools, future
+    // refactors).
+    const ctx = context as Record<string, unknown> | undefined;
+    const hasSessionId =
+      typeof ctx?.sessionId === "string" && (ctx.sessionId as string).length > 0;
+    const hasSessionFile =
+      typeof ctx?.sessionFile === "string" && (ctx.sessionFile as string).length > 0;
+    if (!hasSessionId || !hasSessionFile) {
+      return {
+        ok: false,
+        compacted: false,
+        reason:
+          "compact called without sessionId/sessionFile — runtime " +
+          "delegation skipped to avoid an unsafe call into " +
+          "delegateCompactionToRuntime. Production callers always supply both " +
+          "per the ContextEngine.compact contract.",
+      };
+    }
+
+    // 3. Delegate the actual compaction work to OpenClaw's runtime
+    // helper. ``getOpenClawSdk`` is cached, so this is a hot-path
+    // dictionary lookup after the first call.
+    //
+    // Two distinct try/catch scopes — one for the bridge resolution,
+    // one for the delegate call. Both ``getOpenClawSdk`` and the
+    // helper are documented as never-throw, but defensive code is
+    // wise here. Splitting the catches keeps the log label
+    // accurate: an operator seeing "delegateCompactionToRuntime
+    // threw" should know the throw came from inside the runtime
+    // helper, not from the resolver walk.
+    let sdk: Awaited<ReturnType<typeof getOpenClawSdk>>["sdk"];
+    let pkgRoot: Awaited<ReturnType<typeof getOpenClawSdk>>["pkgRoot"];
+    try {
+      ({ sdk, pkgRoot } = await getOpenClawSdk());
+    } catch (e: unknown) {
+      logError("openclaw-sdk-bridge resolution failed", e);
+      return {
+        ok: false,
+        compacted: false,
+        reason: e instanceof Error ? e.message : String(e),
+      };
+    }
+
+    if (sdk?.delegateCompactionToRuntime) {
+      try {
+        const raw = await sdk.delegateCompactionToRuntime(context as unknown);
+        // Defensive shape check against SDK contract drift / version
+        // skew. The two required ``CompactResult`` fields are
+        // ``ok: boolean`` and ``compacted: boolean`` per
+        // ``plugin-sdk/src/context-engine/types.d.ts``; if the helper
+        // returns anything else (null, undefined, primitive, an
+        // object with wrong-typed fields), downstream consumers
+        // (OpenClaw runtime accessing ``result.ok`` /
+        // ``result.compacted``) would NPE or branch on truthy strings
+        // — the same class of bug v2.6.3's ``undefined`` return
+        // caused. Surface contract violations with a named reason.
+        if (
+          !raw ||
+          typeof raw !== "object" ||
+          typeof (raw as Record<string, unknown>).ok !== "boolean" ||
+          typeof (raw as Record<string, unknown>).compacted !== "boolean"
+        ) {
+          return {
+            ok: false,
+            compacted: false,
+            reason:
+              "delegateCompactionToRuntime returned invalid CompactResult shape — SDK contract violation",
+          };
+        }
+        // Pass the runtime's verdict through verbatim. Touching
+        // its fields would risk drift from the SDK contract.
+        return raw as {
+          ok: boolean;
+          compacted: boolean;
+          reason?: string;
+          result?: unknown;
+        };
+      } catch (e: unknown) {
+        logError("delegateCompactionToRuntime threw", e);
+        return {
+          ok: false,
+          compacted: false,
+          reason: e instanceof Error ? e.message : String(e),
+        };
+      }
+    }
+
+    // Bridge found the openclaw package on disk but the plugin-sdk
+    // it exports did not include ``delegateCompactionToRuntime``.
+    // Most likely cause is OpenClaw older than 2026.5.x — the
+    // helper landed in CHANGELOG line 4940 ("expose
+    // ``delegateCompactionToRuntime(...)`` on the public plugin
+    // SDK"). Including the discovered ``pkgRoot`` in the log lets
+    // operators run ``ls -la $pkgRoot`` and verify the actual
+    // version on disk without guessing the install location.
+    if (pkgRoot !== null) {
+      // The discovered ``pkgRoot`` IS valuable to operators (they can
+      // ``ls -la $pkgRoot`` to verify the install), so keep it in
+      // the gateway-log line above via ``logError``. But the
+      // returned ``CompactResult.reason`` flows downstream through
+      // OpenClaw into runtime metrics, surface dashboards, and
+      // possibly cross-system error reports — places where leaking
+      // an absolute filesystem path is undesirable. Use a static
+      // remediation hint there; operators with log access already
+      // have the path.
+      logError(
+        "openclaw-sdk-bridge",
+        new Error(
+          `delegateCompactionToRuntime not exported by the openclaw plugin-sdk at "${pkgRoot}" — ` +
+            "OpenClaw may be too old (or the install is corrupted). Update openclaw to 2026.5.x or later.",
+        ),
+      );
+      return {
+        ok: false,
+        compacted: false,
+        reason:
+          "delegateCompactionToRuntime not available in openclaw plugin-sdk " +
+          "(version too old or corrupted? Run: openclaw --version)",
+      };
+    }
+
+    // Bridge did not discover openclaw at all — the launcher's
+    // parent path didn't contain a ``package.json`` with
+    // ``name: "openclaw"`` within MAX_WALK_DEPTH. Log once so
+    // operators can see this in the gateway log, then return a
+    // structured fallback.
+    logError(
+      "openclaw-sdk-bridge",
+      new Error(
+        "delegateCompactionToRuntime unavailable — openclaw could not be discovered from " +
+          "the plugin's runtime path. Check that openclaw is installed at a discoverable " +
+          "location (global npm, brew, nvm, asdf, or a source checkout) and that the gateway " +
+          "is launched via the openclaw script.",
+      ),
+    );
+    return {
+      ok: false,
+      compacted: false,
+      reason: "openclaw plugin-sdk not discoverable from plugin runtime",
+    };
   }
 
   /** afterTurn — auto-write turn summary. Enabled by default; opt out with MEMCLAW_AUTO_WRITE_TURNS=false. */

--- a/plugin/src/openclaw-sdk-bridge.ts
+++ b/plugin/src/openclaw-sdk-bridge.ts
@@ -1,0 +1,310 @@
+/**
+ * Runtime discovery bridge for ``openclaw/plugin-sdk`` exports.
+ *
+ * # Why this file exists
+ *
+ * Our plugin ships as compiled ``dist/index.js``. OpenClaw's plugin loader
+ * (``loader-CBUR8YGF.js`` → ``createPluginModuleLoader``) takes one of two
+ * paths per ``shouldPreferNativeModuleLoad``: jiti for ``.ts`` / ``.mts``
+ * / ``.cts`` sources, native Node import for ``.js`` / ``.mjs`` / ``.cjs``.
+ * The jiti path consults a ``PluginLoaderAliasMap`` that aliases the
+ * bare-spec ``openclaw/plugin-sdk`` to OpenClaw's bundled SDK location.
+ * Native-loaded ``.js`` plugins do NOT see that alias map — bare-spec
+ * resolution falls back to standard Node resolution, which from
+ * ``~/.openclaw/plugins/memclaw/dist/index.js`` walks the directory tree
+ * upward and never reaches OpenClaw's global install. Result:
+ *
+ *     import("openclaw/plugin-sdk")       // ERR_MODULE_NOT_FOUND
+ *     import("@openclaw/plugin-sdk")      // ERR_MODULE_NOT_FOUND
+ *     createRequire(argv[1]).resolve("openclaw/plugin-sdk")  // MODULE_NOT_FOUND
+ *
+ * (Wet-tested 2026-05-26 on openclaw-test-ran with OpenClaw 2026.5.4.)
+ *
+ * # What this bridge does
+ *
+ * Locate the OpenClaw install at runtime by realpath-resolving
+ * ``process.argv[1]`` (the launcher script, e.g. ``/usr/bin/openclaw``
+ * which is a symlink to ``/usr/lib/.../openclaw.mjs``), walking up until
+ * we find a ``package.json`` with ``name: "openclaw"``, then importing
+ * ``{pkgRoot}/dist/plugin-sdk/index.js`` via absolute path. The absolute
+ * path import bypasses the alias-map dependency entirely.
+ *
+ * Verified to work across global npm install. The same shape (launcher
+ * → symlink → real script inside the package) is used by brew, nvm,
+ * asdf, and source-checkout installs, so the discovery is portable.
+ *
+ * # What this bridge does NOT do
+ *
+ * - Does not throw. Every error becomes a ``null`` return so callers
+ *   can fall back gracefully (degraded behavior is better than a
+ *   crashed turn).
+ * - Does not attempt the bare-spec import first. That path is known
+ *   to fail in our deployment and would just add latency.
+ * - Does not assume a TypeScript dep on the ``openclaw`` package.
+ *   Returned values are typed structurally so we never need
+ *   ``import type`` from the SDK at compile time.
+ *
+ * # Why we keep ``ownsCompaction: true``
+ *
+ * With this bridge in place, our ``compact()`` delegates to
+ * ``delegateCompactionToRuntime`` from the SDK — which is exactly what
+ * OpenClaw's legacy engine does internally. Declaring
+ * ``ownsCompaction: true`` is therefore truthful: we own the contract
+ * with OpenClaw, and we fulfill it by handing the actual work to the
+ * shared runtime helper. Setting it to ``false`` would NOT auto-fall
+ * back to legacy behavior — per OpenClaw docs
+ * (``docs/concepts/context-engine.md:241``), ``false`` without a real
+ * implementation means no compaction at all.
+ */
+
+import { realpath, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/**
+ * Structural shape of the bits of ``openclaw/plugin-sdk`` we use.
+ * Kept minimal so we never grow a build-time dependency on the SDK
+ * package.
+ */
+export interface OpenClawSdkSurface {
+  /**
+   * Delegate a context-engine compaction request to OpenClaw's
+   * built-in runtime compaction path. Identical to the helper used by
+   * the legacy engine; returns a properly-shaped ``CompactResult``.
+   */
+  delegateCompactionToRuntime?: (params: unknown) => Promise<unknown>;
+  /**
+   * Build the memory-plugin prompt section as a single string suitable
+   * for ``systemPromptAddition``. Currently unused by our engine
+   * (assemble already composes its own section), but kept in the
+   * surface for future callers.
+   */
+  buildMemorySystemPromptAddition?: (params: {
+    availableTools: Set<string>;
+    citationsMode?: string;
+  }) => string | undefined;
+}
+
+/**
+ * Discovery outcome. Three distinct states matter for diagnostics:
+ *
+ *   * ``{sdk: object, pkgRoot: string}`` — happy path. SDK exports
+ *     at least one of the helpers we care about.
+ *   * ``{sdk: null,   pkgRoot: string}`` — discovered openclaw on
+ *     disk but its plugin-sdk did not export any of our target
+ *     functions, OR the import failed. Common cause: openclaw older
+ *     than 2026.5.x; possible cause: corrupted install. Operators
+ *     can ``ls -la $pkgRoot`` to verify.
+ *   * ``{sdk: null,   pkgRoot: null}``   — no openclaw discovered on
+ *     the launcher's parent path. Most likely cause: install layout
+ *     we don't recognize (custom symlink farm, vendored tree). The
+ *     operator's next step is to check where openclaw lives.
+ *
+ * Callers (currently just ``MemClawContextEngine.compact()``) branch
+ * on ``pkgRoot`` to emit a remediation-specific log message instead
+ * of a generic "not discoverable" hint that sends operators hunting
+ * for a missing install when the real cause is a present-but-broken
+ * one.
+ */
+export interface OpenClawSdkResolution {
+  sdk: OpenClawSdkSurface | null;
+  pkgRoot: string | null;
+}
+
+// Single in-flight promise per process lifetime. Storing the PROMISE
+// (rather than a pair of cachedSdk + triedAndFailed flags) means
+// concurrent callers all await the same resolution — no
+// stampede, no race window where caller B sees a half-set negative
+// flag while caller A's resolve is still in flight and would have
+// succeeded. The OpenClaw install location does not change during a
+// process lifetime, so a single promise is correct for both the
+// positive and negative outcomes.
+let sdkPromise: Promise<OpenClawSdkResolution> | null = null;
+
+/**
+ * Reset the resolver cache. Test-only — exported with a leading
+ * underscore so it never reads like a production API. The
+ * ``NODE_ENV !== "test"`` guard enforces test-only semantics
+ * explicitly: only when ``NODE_ENV`` is the literal string
+ * ``"test"`` will this function actually clear the cache. Any
+ * other value — ``"production"``, ``"development"``, ``"staging"``,
+ * or unset — turns this into a no-op. ``npm test`` sets
+ * ``NODE_ENV=test`` via ``package.json`` scripts, so the test
+ * suite is unaffected; everything else gets defense-in-depth
+ * against accidental cache invalidation.
+ */
+export function _resetSdkBridgeCache(): void {
+  if (process.env.NODE_ENV !== "test") return;
+  sdkPromise = null;
+}
+
+/**
+ * Resolve the OpenClaw SDK surface at runtime.
+ *
+ * Always resolves to an ``OpenClawSdkResolution`` — never throws.
+ * Callers branch on the combination of ``sdk`` and ``pkgRoot``:
+ *
+ *   * ``sdk`` truthy → use it.
+ *   * ``sdk`` null and ``pkgRoot`` truthy → openclaw is installed at
+ *     ``pkgRoot`` but its plugin-sdk did not expose any helper we
+ *     can use (likely too old, possibly corrupt). Including
+ *     ``pkgRoot`` in the operator-facing log message lets them
+ *     verify the file on disk without guessing the install path.
+ *   * Both null → openclaw was not discoverable from
+ *     ``process.argv[1]``.
+ *
+ * Note: this function is NOT marked ``async`` — it returns the
+ * cached promise directly so two concurrent callers receive the
+ * same in-flight resolution. Making it ``async`` would wrap each
+ * call in a NEW promise, defeating the cache.
+ */
+export function getOpenClawSdk(): Promise<OpenClawSdkResolution> {
+  if (!sdkPromise) sdkPromise = _resolveSdk();
+  return sdkPromise;
+}
+
+/**
+ * Resolve the SDK module subpath from a parsed ``openclaw``
+ * ``package.json``. Reads the standard Node ``exports`` field if
+ * present so we follow whatever output layout the installed
+ * openclaw version declares — robust to future moves of
+ * ``dist/plugin-sdk/index.js``.
+ *
+ * Returns ``null`` (so the caller falls back to the conventional
+ * layout) when ``exports`` is missing or doesn't declare
+ * ``./plugin-sdk``.
+ *
+ * Conditional-exports resolution preference, matching Node's own
+ * resolver as documented at
+ * https://nodejs.org/api/packages.html#conditional-exports:
+ * ``import`` → ``default`` → ``node``. ``default`` is the universal
+ * fallback. We don't honor ``require`` because our load uses
+ * ``import()`` which is ESM.
+ */
+function _resolveSdkSubpath(pkg: Record<string, unknown>): string | null {
+  const exports = pkg.exports;
+  if (!exports || typeof exports !== "object") return null;
+  const entry = (exports as Record<string, unknown>)["./plugin-sdk"];
+  if (typeof entry === "string") return entry;
+  if (entry && typeof entry === "object") {
+    const conditional = entry as Record<string, unknown>;
+    const candidate =
+      conditional.import ?? conditional.default ?? conditional.node;
+    if (typeof candidate === "string") return candidate;
+  }
+  return null;
+}
+
+async function _resolveSdk(): Promise<OpenClawSdkResolution> {
+  // Stop walking after this many parent directories. Eight is plenty
+  // for ``/usr/lib/node_modules/openclaw`` (5 levels above ``dist/``)
+  // and short enough that a misconfigured environment fails quickly.
+  const MAX_WALK_DEPTH = 8;
+
+  // Phase 1 — find the openclaw package root by walking up from the
+  // launcher script. Anything that goes wrong in here means we
+  // never even located openclaw on disk, so both fields stay null.
+  // We retain the PARSED ``package.json`` (not just the path) so
+  // Phase 2 can consult the ``exports`` field for SDK resolution
+  // without re-reading the file.
+  let pkgRoot: string | null = null;
+  let pkg: Record<string, unknown> | null = null;
+  try {
+    const launcher = process.argv?.[1];
+    if (!launcher || typeof launcher !== "string") {
+      return { sdk: null, pkgRoot: null };
+    }
+
+    let realLauncher: string;
+    try {
+      realLauncher = await realpath(launcher);
+    } catch {
+      return { sdk: null, pkgRoot: null };
+    }
+
+    let dir = dirname(realLauncher);
+    for (let depth = 0; depth < MAX_WALK_DEPTH; depth++) {
+      const pj = join(dir, "package.json");
+      // ``readFile`` throws ENOENT for missing files and EACCES for
+      // unreadable ones — both mean "no package.json here, walk up."
+      // A pre-check via ``access`` would only add a TOCTOU window and
+      // an extra await without changing the signal.
+      let pkgText: string;
+      try {
+        pkgText = await readFile(pj, "utf8");
+      } catch {
+        const parent = dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(pkgText) as Record<string, unknown>;
+        // Strict name match. ``openclaw`` is the canonical npm name
+        // for the runtime; any other name (``@openclaw/sdk``, a
+        // fork, etc.) is intentionally NOT accepted — the SDK
+        // surface contract is tied to ``openclaw`` versioning.
+        if (parsed.name === "openclaw") {
+          pkgRoot = dir;
+          pkg = parsed;
+          break;
+        }
+      } catch {
+        // Malformed package.json — keep walking.
+      }
+      const parent = dirname(dir);
+      // Hit filesystem root or symlink loop — stop walking.
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    return { sdk: null, pkgRoot: null };
+  }
+
+  if (!pkgRoot || !pkg) return { sdk: null, pkgRoot: null };
+
+  // Phase 2 — load the SDK module from the discovered package. Any
+  // failure here KEEPS ``pkgRoot`` set in the return: we know
+  // openclaw is on disk, just can't use it. Caller's diagnostic
+  // distinguishes this from the "never found" case.
+  //
+  // Prefer the path openclaw declares via package.json ``exports``;
+  // only fall back to the conventional ``dist/plugin-sdk/index.js``
+  // when the package doesn't tell us where to look. This makes the
+  // bridge robust to future openclaw releases that move the build
+  // output (e.g., to a different top-level dir).
+  const subpath = _resolveSdkSubpath(pkg) ?? "dist/plugin-sdk/index.js";
+  const sdkPath = join(pkgRoot, subpath);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mod: Record<string, any>;
+  try {
+    // No pre-check on sdkPath — ``import()`` already rejects with a
+    // clear error if the file is missing or unreadable. A separate
+    // ``access`` would add a TOCTOU window and another await for no
+    // signal beyond what the import already provides.
+    mod = (await import(sdkPath)) as Record<string, any>;
+  } catch {
+    return { sdk: null, pkgRoot };
+  }
+
+  // Structural extraction. Anything missing is fine — callers
+  // guard on the specific field they need.
+  //
+  // Surface is returned unconditionally when Phase 2 loads cleanly,
+  // even if the extracted object is empty. We deliberately do NOT
+  // collapse "no recognized exports" to ``sdk: null`` here because
+  // the SDK resolution is shared across all callers via a single
+  // process-lifetime promise cache: gating on one caller's required
+  // field would make any other field permanently unreachable for
+  // the rest of the process. Each caller is responsible for
+  // checking ``sdk?.<field>`` and falling back via the ``pkgRoot``
+  // diagnostic when their specific field is absent.
+  const surface: OpenClawSdkSurface = {};
+  if (typeof mod.delegateCompactionToRuntime === "function") {
+    surface.delegateCompactionToRuntime = mod.delegateCompactionToRuntime;
+  }
+  if (typeof mod.buildMemorySystemPromptAddition === "function") {
+    surface.buildMemorySystemPromptAddition =
+      mod.buildMemorySystemPromptAddition;
+  }
+  return { sdk: surface, pkgRoot };
+}

--- a/plugin/src/runtime-contract.test.ts
+++ b/plugin/src/runtime-contract.test.ts
@@ -572,3 +572,191 @@ describe("ContextEngine.assemble contract (OpenClaw AssembleResult)", () => {
     );
   });
 });
+
+// --- ContextEngine.compact + openclaw-sdk-bridge contract (v2.6.4 hotfix) ---
+//
+// Customer escalation 2026-05-26: WhatsApp group sessions stuck
+// running on plugin v2.6.3. ``openclaw status`` showed group
+// contexts over budget (312k/272k, 292k/272k tokens). Agent looped
+// on ``memclaw_keystones`` tool calls 3-5 times per turn, never
+// finalizing; final replies were silently dropped.
+//
+// Root cause: ``info.ownsCompaction: true`` (set in PR #212 with
+// the contextEngine slot auto-claim) told OpenClaw we owned
+// compaction, but our ``compact()`` returned ``undefined`` — not
+// a valid ``CompactResult`` per OpenClaw 2026.5.4
+// ``plugin-sdk/src/context-engine/types.d.ts``. Over-budget
+// sessions delegated to us, got nothing back, never shrank.
+//
+// The v2.6.4 fix: discover the ``openclaw/plugin-sdk`` runtime
+// helper ``delegateCompactionToRuntime`` via filesystem walk from
+// ``process.argv[1]`` (see ``openclaw-sdk-bridge.ts`` for the
+// rationale — bare-spec import fails for native-loaded plugins),
+// call it from ``compact()``, return the proper
+// ``{ok, compacted, reason, result}`` shape it produces.
+//
+// These tests pin:
+//   1. ``info.ownsCompaction === true`` (regression guard — flipping
+//      to ``false`` without implementing a real ``CompactResult``
+//      return would break compaction silently again).
+//   2. ``compact()`` returns a structured ``CompactResult`` shape
+//      regardless of whether the SDK is discoverable.
+//   3. ``compact()`` still persists the summary into MemClaw as a
+//      side effect (existing behavior preserved).
+//   4. The bridge's resolver cache works — second call doesn't
+//      repeat the filesystem walk.
+//   5. The bridge returns ``null`` gracefully when no openclaw
+//      install can be discovered (e.g., running under
+//      ``node --test`` where ``argv[1]`` is the test runner, not
+//      ``openclaw``).
+//
+// Note on test environment: under ``node --test``, ``process.argv[1]``
+// is the path to our compiled ``*.test.js`` file, NOT the openclaw
+// launcher. So the bridge's walk from that path will not find an
+// openclaw package.json, and ``getOpenClawSdk()`` returns ``null``.
+// That's the "graceful fallback" path we want to exercise here —
+// the wet test on the GCE VM exercises the success path against a
+// real openclaw install.
+
+// MemClawContextEngine already imported above for the assemble-contract
+// block. Import only what's new for the compaction-bridge contract.
+import { _resetSdkBridgeCache, getOpenClawSdk } from "./openclaw-sdk-bridge.js";
+
+describe("ContextEngine.info compaction-ownership (v2.6.4)", () => {
+  test("info.ownsCompaction === true (we own compaction by delegating to SDK)", () => {
+    const engine = new MemClawContextEngine({});
+    assert.equal(
+      engine.info.ownsCompaction,
+      true,
+      "ownsCompaction must stay true — compact() now delegates via " +
+        "delegateCompactionToRuntime, fulfilling the contract. Setting " +
+        "false does NOT auto-fall-back to legacy compaction per OpenClaw docs.",
+    );
+  });
+
+  test("info.id === 'memclaw' (slot resolver depends on this)", () => {
+    const engine = new MemClawContextEngine({});
+    assert.equal(engine.info.id, "memclaw");
+  });
+});
+
+describe("openclaw-sdk-bridge resolver", () => {
+  test("returns {sdk: null, pkgRoot: null} in test runtime (argv[1] is the test runner, not openclaw)", async () => {
+    _resetSdkBridgeCache();
+    const res = await getOpenClawSdk();
+    // We're running under `node --test path/to/dist/runtime-contract.test.js`,
+    // so the launcher walk won't find an openclaw package.json. Both fields
+    // null is the documented graceful-degradation return value for this
+    // failure mode (not "discovered but broken").
+    assert.equal(
+      res.sdk,
+      null,
+      "bridge must return sdk=null in non-openclaw runtimes",
+    );
+    assert.equal(
+      res.pkgRoot,
+      null,
+      "pkgRoot must be null when openclaw cannot be discovered — caller " +
+        "uses pkgRoot to distinguish 'never found' from 'found but broken'",
+    );
+  });
+
+  test("caches the negative result — second call does not re-walk filesystem", async () => {
+    // We can't directly observe filesystem calls without a spy, but we can
+    // observe that two successive calls return the same value with no
+    // throw — the function is idempotent and cheap on repeat invocation.
+    // The promise-cache pattern means both awaits resolve to the SAME
+    // object reference, which we check with strictEqual.
+    _resetSdkBridgeCache();
+    const first = await getOpenClawSdk();
+    const second = await getOpenClawSdk();
+    assert.strictEqual(first, second);
+  });
+});
+
+describe("ContextEngine.compact contract (delegation + persistence)", () => {
+  test("returns a CompactResult-shaped object (not undefined)", async () => {
+    _resetSdkBridgeCache();
+    const engine = new MemClawContextEngine({});
+    // In the test runtime, the bridge returns null, so compact() takes
+    // the structured-fallback path. We must still get the v2.6.4 shape
+    // — not a regression to v2.6.3's `undefined`.
+    const result = await engine.compact({});
+    assert.ok(result, "compact() must return an object (not undefined)");
+    assert.equal(typeof result.ok, "boolean", "result.ok is boolean");
+    assert.equal(
+      typeof result.compacted,
+      "boolean",
+      "result.compacted is boolean",
+    );
+    assert.equal(
+      result.ok,
+      false,
+      "ok=false in test env (SDK not discoverable)",
+    );
+    assert.equal(
+      result.compacted,
+      false,
+      "compacted=false in test env (delegation didn't run)",
+    );
+    assert.ok(
+      typeof result.reason === "string" && result.reason.length > 0,
+      "result.reason names why compaction did not occur",
+    );
+  });
+
+  test("compact() with no summary returns the fallback without throwing", async () => {
+    _resetSdkBridgeCache();
+    const engine = new MemClawContextEngine({});
+    const result = await engine.compact({ sessionId: "test-session" });
+    assert.equal(result.ok, false);
+    assert.equal(result.compacted, false);
+  });
+
+  test("compact() with missing sessionId skips SDK delegation entirely (defensive guard)", async () => {
+    // The defensive pre-check in compact() short-circuits to a
+    // structured fallback when sessionId/sessionFile aren't both
+    // present. This protects against gateway-RPC test probes and
+    // future degenerate callers that could otherwise trigger
+    // ``compactEmbeddedPiSessionDirect`` to crash the host
+    // process. OpenClaw production compaction (per
+    // ``pi-embedded-X0afS0ip.js:2447``) ALWAYS provides both
+    // fields, so this guard never fires on the happy path.
+    _resetSdkBridgeCache();
+    const engine = new MemClawContextEngine({});
+    const result = await engine.compact({ sessionFile: "/tmp/test.jsonl" }); // no sessionId
+    assert.equal(result.ok, false);
+    assert.equal(result.compacted, false);
+    assert.match(
+      String(result.reason || ""),
+      /sessionId\/sessionFile/,
+      "fallback reason must name the missing field for operator diagnosis",
+    );
+  });
+
+  test("compact() with missing sessionFile skips SDK delegation entirely (defensive guard)", async () => {
+    _resetSdkBridgeCache();
+    const engine = new MemClawContextEngine({});
+    const result = await engine.compact({ sessionId: "test-id" }); // no sessionFile
+    assert.equal(result.ok, false);
+    assert.equal(result.compacted, false);
+    assert.match(String(result.reason || ""), /sessionId\/sessionFile/);
+  });
+
+  test("compact() with a summary attempts MemClaw persist but does not throw on failure", async () => {
+    // Persistence target is unconfigured (no MEMCLAW_API_KEY in test env),
+    // so the POST /memories call fails. compact() must catch that and still
+    // return a CompactResult. This is the production-safety contract:
+    // compaction must NEVER break a turn just because the memory write
+    // failed.
+    _resetSdkBridgeCache();
+    const engine = new MemClawContextEngine({});
+    const result = await engine.compact({
+      summary: "synthetic compaction summary for the contract test",
+      sessionId: "test-session",
+    });
+    assert.ok(result);
+    assert.equal(typeof result.ok, "boolean");
+    assert.equal(typeof result.compacted, "boolean");
+  });
+});

--- a/plugin/src/version.ts
+++ b/plugin/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated from plugin/package.json — do not edit
-export const PLUGIN_VERSION = "2.6.3";
+export const PLUGIN_VERSION = "2.6.4";


### PR DESCRIPTION
## Summary

**Urgent hotfix for v2.6.3 regression.** Customer escalation 2026-05-26: WhatsApp group sessions stuck running, looping on `memclaw_keystones` tool calls without finalizing, emitting `Skipping auto-reply: ... final-only` warnings. Group contexts reported over budget at 312k/272k and 292k/272k tokens via `openclaw status`. Direct chats with the same agent worked normally.

**Root cause:** `MemClawContextEngine.info.ownsCompaction = true` told OpenClaw we owned compaction, but `compact()` returned `undefined` — not a valid `CompactResult` per OpenClaw 2026.5.4 `plugin-sdk/src/context-engine/types.d.ts`. Over-budget sessions delegated to us, got nothing back, never shrank. Direct chats stayed under budget so the latent bug never surfaced; group chats accumulate transcript across participants and hit the wedge first.

**Fix:** stay `ownsCompaction: true` (truthful) and have `compact()` actually do its job by delegating to `delegateCompactionToRuntime` from `openclaw/plugin-sdk` — the same helper the legacy engine uses internally. Required a runtime SDK-discovery bridge (`openclaw-sdk-bridge.ts`) because OpenClaw's plugin loader routes `.js` files through native Node import, which bypasses the alias-map that would normally resolve the bare-spec import. Plus a defensive pre-check that returns a structured `CompactResult` fallback when `sessionId`/`sessionFile` are missing, blocking degenerate calls from reaching `compactEmbeddedPiSessionDirect` (which we observed can crash the gateway with synthetic params).

Note: I considered the simpler `ownsCompaction: false` change first. Per OpenClaw docs (`docs/concepts/context-engine.md:241`), `false` does NOT auto-fall-back to legacy compaction — it just disables compaction entirely. So we have to delegate explicitly to fulfill the contract.

## Files changed

- **`plugin/src/openclaw-sdk-bridge.ts`** (new, 203 lines): runtime SDK discovery via `process.argv[1]` walk → first `package.json` with `name: "openclaw"` → absolute-path dynamic import of `dist/plugin-sdk/index.js`. Structurally-typed surface, no build-time dep on `openclaw`. Cached resolver state for the process lifetime. `_resetSdkBridgeCache()` exposed for tests.
- **`plugin/src/context-engine.ts`**:
  - `info.ownsCompaction` stays `true`; comment block expanded to document why and warn against flipping (per the OpenClaw docs).
  - `compact()` rewritten with three responsibilities: persist OpenClaw's pre-computed summary as a MemClaw `auto-compaction` episode (preserved); defensive guard for missing `sessionId`/`sessionFile`; delegate to the SDK helper via the bridge. Pass the runtime's `CompactResult` through verbatim. Structured fallback on any internal failure.
  - File-level docstring updated.
- **`plugin/src/runtime-contract.test.ts`** (179 new lines): 9 new tests covering `ownsCompaction === true` invariant, bridge null-safety in test envs, bridge cache idempotency, `compact()` always returns CompactResult shape (regression guard from v2.6.3's `undefined`), the defensive guards for missing `sessionId`/`sessionFile`.
- `plugin/package.json` + `plugin/openclaw.plugin.json` + `plugin/src/version.ts` (auto-regen): 2.6.3 → 2.6.4.

## Test plan

- [x] `npm test` in `plugin/` — **259/259 pass** (250 prior + 9 new compaction-bridge tests).
- [x] `npx tsc --noEmit` clean.
- [x] **Wet-test on GCE VM** (`openclaw-test-ran`) with **OpenClaw 2026.5.4** + v2.6.4 build (probe-E):
  - Boot: `[memclaw] BOOT: plugin v2.6.4, 11 tools registered, node 22.22.1`; `ContextEngine 'memclaw' registered`; zero `assemble failed` lines; zero warnings.
  - Bridge resolves SDK from real plugin loader context: `sdk=object, delegate=function`.
  - `info.ownsCompaction=true, id=memclaw`.
  - `compact({})`, `compact({sessionId, sessionFile: ""})`, `compact({summary})` all return structured `CompactResult` via the defensive guard — no hang, no crash, no thrown error.
  - `assemble({...})` returns `messages: array, estimatedTokens: 152, systemPromptAddition.length: 605` — unchanged from v2.6.3.
- [ ] **Pending customer verification post-2.6.4 publish**: WhatsApp group session no longer wedges on over-budget; `<keystone_rules>` block still appears in system prompt; assemble + compaction both function end-to-end.

## Customer mitigation (immediate, no code push needed)

For customers stuck on v2.6.3, regress the slot until v2.6.4 is published:

```bash
sudo cp ~/.openclaw/openclaw.json ~/.openclaw/openclaw.json.v263-broken
python3 -c "import json;p='/home/'+__import__('os').getenv('USER')+'/.openclaw/openclaw.json';c=json.load(open(p));c['plugins']['slots'].pop('contextEngine',None);json.dump(c,open(p,'w'),indent=2)"
echo "MEMCLAW_AUTO_FIX_CONFIG=false" >> ~/.openclaw/plugins/memclaw/.env
sudo systemctl restart openclaw
```

This regresses in-prompt keystone injection (the `memclaw_keystones` tool call surface stays functional) but unwedges over-budget sessions immediately. After 2.6.4 lands, customers remove the `.env` line + delete the slot removal, restart — the upgrade re-claims the slot and keystone injection resumes with proper compaction delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)