### PR TITLE
chore(perf+sec+tests): ran follow-ups — T5 + #22/#25/#29/#31

### DIFF
--- a/core-api/src/core_api/routes/crystallizer.py
+++ b/core-api/src/core_api/routes/crystallizer.py
@@ -131,7 +131,16 @@ async def get_report(
     report = await sc.get_report(str(report_id))
     if not report:
         raise HTTPException(status_code=404, detail="Report not found")
-    auth.enforce_tenant(report.get("tenant_id", ""))
+    # Collapse foreign-tenant (403) into not-found (404) so callers
+    # can't probe for the existence of reports in other tenants by
+    # distinguishing 403 from 404 on random UUIDs (audit finding #22).
+    # Cross-tenant read keys (``readable_tenant_ids`` widened past the
+    # home tenant) are honoured here — the set always contains
+    # ``auth.tenant_id`` by construction (``AuthContext`` line 85-90),
+    # so the 404 mask still hides reports the caller has no read
+    # access to.
+    if not auth.is_admin and report.get("tenant_id") not in auth.readable_tenant_ids:
+        raise HTTPException(status_code=404, detail="Report not found")
     return {
         "id": str(report.get("id", "")),
         "tenant_id": report.get("tenant_id"),

--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -83,121 +83,118 @@ async def process_entity_extraction(
 
         sc = get_storage_client()
 
-        try:
-            blocklist = tenant_cfg.entity_blocklist
+        blocklist = tenant_cfg.entity_blocklist
 
-            # Embed entity names for fuzzy resolution
-            name_embeddings: dict[str, list[float]] = {}
-            for ent in graph.entities:
-                try:
-                    name_embeddings[ent.canonical_name] = await get_embedding(ent.canonical_name)
-                except Exception:
-                    logger.debug(
-                        "Failed to embed entity name '%s', skipping fuzzy resolution",
-                        ent.canonical_name,
-                    )
+        # Embed entity names for fuzzy resolution
+        name_embeddings: dict[str, list[float]] = {}
+        for ent in graph.entities:
+            try:
+                name_embeddings[ent.canonical_name] = await get_embedding(ent.canonical_name)
+            except Exception:
+                logger.debug(
+                    "Failed to embed entity name '%s', skipping fuzzy resolution",
+                    ent.canonical_name,
+                )
 
-            # Upsert entities and build name -> UUID map
-            name_to_id: dict[str, UUID] = {}
-            entity_roles: dict[str, str] = {}
+        # Upsert entities and build name -> UUID map
+        name_to_id: dict[str, UUID] = {}
+        entity_roles: dict[str, str] = {}
 
-            for ent in graph.entities:
-                if not _is_valid_entity(ent.canonical_name, blocklist):
-                    logger.debug(
-                        "Skipping invalid entity name '%s'",
-                        ent.canonical_name,
-                    )
-                    continue
-                # ``data`` is positional, ``name_embedding`` keyword-only
-                # under the CAURA-127 signature cleanup.
-                result = await upsert_entity(
-                    EntityUpsert(
+        for ent in graph.entities:
+            if not _is_valid_entity(ent.canonical_name, blocklist):
+                logger.debug(
+                    "Skipping invalid entity name '%s'",
+                    ent.canonical_name,
+                )
+                continue
+            # ``data`` is positional, ``name_embedding`` keyword-only
+            # under the CAURA-127 signature cleanup.
+            result = await upsert_entity(
+                EntityUpsert(
+                    tenant_id=tenant_id,
+                    fleet_id=fleet_id,
+                    entity_type=ent.entity_type,
+                    canonical_name=ent.canonical_name,
+                ),
+                name_embedding=name_embeddings.get(ent.canonical_name),
+            )
+            name_to_id[ent.canonical_name] = result.id
+            entity_roles[ent.canonical_name] = ent.role
+
+        # Create memory-entity links
+        for name, entity_id in name_to_id.items():
+            existing = await sc.find_entity_link(
+                str(memory_id),
+                str(entity_id),
+            )
+            if not existing:
+                await sc.create_entity_link(
+                    {
+                        "memory_id": str(memory_id),
+                        "entity_id": str(entity_id),
+                        "role": entity_roles.get(name, "mentioned"),
+                    }
+                )
+
+        # Upsert relations
+        rel_count = 0
+        for rel in graph.relations:
+            from_id = name_to_id.get(rel.from_entity)
+            to_id = name_to_id.get(rel.to_entity)
+            if from_id and to_id:
+                await upsert_relation(
+                    None,
+                    RelationUpsert(
                         tenant_id=tenant_id,
                         fleet_id=fleet_id,
-                        entity_type=ent.entity_type,
-                        canonical_name=ent.canonical_name,
+                        from_entity_id=from_id,
+                        relation_type=rel.relation_type,
+                        to_entity_id=to_id,
+                        evidence_memory_id=memory_id,
                     ),
-                    name_embedding=name_embeddings.get(ent.canonical_name),
                 )
-                name_to_id[ent.canonical_name] = result.id
-                entity_roles[ent.canonical_name] = ent.role
+                rel_count += 1
 
-            # Create memory-entity links
-            for name, entity_id in name_to_id.items():
-                existing = await sc.find_entity_link(
-                    str(memory_id),
-                    str(entity_id),
-                )
-                if not existing:
-                    await sc.create_entity_link(
-                        {
-                            "memory_id": str(memory_id),
-                            "entity_id": str(entity_id),
-                            "role": entity_roles.get(name, "mentioned"),
-                        }
-                    )
+        # Audit log
+        await log_action(
+            None,
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            action="entity_extraction",
+            resource_type="memory",
+            resource_id=memory_id,
+            detail={
+                "entities_count": len(name_to_id),
+                "relations_count": rel_count,
+            },
+        )
 
-            # Upsert relations
-            rel_count = 0
-            for rel in graph.relations:
-                from_id = name_to_id.get(rel.from_entity)
-                to_id = name_to_id.get(rel.to_entity)
-                if from_id and to_id:
-                    await upsert_relation(
-                        None,
-                        RelationUpsert(
-                            tenant_id=tenant_id,
-                            fleet_id=fleet_id,
-                            from_entity_id=from_id,
-                            relation_type=rel.relation_type,
-                            to_entity_id=to_id,
-                            evidence_memory_id=memory_id,
-                        ),
-                    )
-                    rel_count += 1
+        logger.info(
+            "Entity extraction complete for memory %s: %d entities, %d relations",
+            memory_id,
+            len(name_to_id),
+            rel_count,
+        )
 
-            # Audit log
-            await log_action(
-                None,
-                tenant_id=tenant_id,
-                agent_id=agent_id,
-                action="entity_extraction",
-                resource_type="memory",
-                resource_id=memory_id,
-                detail={
-                    "entities_count": len(name_to_id),
-                    "relations_count": rel_count,
-                },
+        # Trigger entity-based contradiction detection now that entity links exist
+        if name_to_id:
+            from core_api.services.contradiction_detector import (
+                detect_contradictions_by_entities_async,
             )
+            from core_api.tasks import track_task
 
-            logger.info(
-                "Entity extraction complete for memory %s: %d entities, %d relations",
-                memory_id,
-                len(name_to_id),
-                rel_count,
-            )
+            track_task(detect_contradictions_by_entities_async(memory_id, tenant_id, fleet_id))
 
-            # Trigger entity-based contradiction detection now that entity links exist
-            if name_to_id:
-                from core_api.services.contradiction_detector import (
-                    detect_contradictions_by_entities_async,
+        # Cross-link discovery (non-fatal)
+        if tenant_cfg.auto_entity_linking_enabled:
+            try:
+                await _discover_cross_links_for_memory(memory_id, tenant_id, fleet_id)
+            except Exception:
+                logger.warning(
+                    "Cross-link discovery failed for memory %s (non-fatal)",
+                    memory_id,
+                    exc_info=True,
                 )
-                from core_api.tasks import track_task
-
-                track_task(detect_contradictions_by_entities_async(memory_id, tenant_id, fleet_id))
-
-            # Cross-link discovery (non-fatal)
-            if tenant_cfg.auto_entity_linking_enabled:
-                try:
-                    await _discover_cross_links_for_memory(memory_id, tenant_id, fleet_id)
-                except Exception:
-                    logger.warning(
-                        "Cross-link discovery failed for memory %s (non-fatal)",
-                        memory_id,
-                        exc_info=True,
-                    )
-        except Exception:
-            raise
 
     except Exception:
         logger.exception("Entity extraction failed for memory %s (non-fatal)", memory_id)

--- a/core-api/src/core_api/services/evolve_service.py
+++ b/core-api/src/core_api/services/evolve_service.py
@@ -10,7 +10,7 @@ import logging
 import time
 from uuid import UUID
 
-from sqlalchemy import select, text
+from sqlalchemy import bindparam, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core_api.constants import (
@@ -112,22 +112,25 @@ Respond with JSON:
 # -- Weight adjustment --------------------------------------------------------
 
 
-_ADJUST_WEIGHT_SQL = text(
+_ADJUST_WEIGHTS_BULK_SQL = text(
     """
-    WITH old_val AS (
-        SELECT weight AS old_weight
+    WITH old_vals AS (
+        SELECT id, weight AS old_weight
           FROM memories
-         WHERE id = :mid AND tenant_id = :tid AND deleted_at IS NULL
+         WHERE id IN :mids
+           AND tenant_id = :tid
+           AND deleted_at IS NULL
     )
     UPDATE memories
        SET weight = GREATEST(:floor, LEAST(:cap, weight + :delta))
-      FROM old_val
-     WHERE memories.id = :mid
+      FROM old_vals
+     WHERE memories.id = old_vals.id
        AND memories.tenant_id = :tid
        AND memories.deleted_at IS NULL
-    RETURNING old_val.old_weight AS old_weight, memories.weight AS new_weight
+    RETURNING memories.id AS id, old_vals.old_weight AS old_weight,
+              memories.weight AS new_weight
     """
-)
+).bindparams(bindparam("mids", expanding=True))
 
 
 # Backfill the rule memory's metadata.source_outcome_id after the outcome
@@ -299,38 +302,62 @@ async def _adjust_weights(
     adjustments: list[dict] = []
     successfully_adjusted: list[str] = []
 
+    # Parse all UUIDs up front. Invalid strings are logged + dropped
+    # before the SQL roundtrip rather than failing the whole batch.
+    parsed: list[tuple[str, UUID]] = []
     for mid_str in related_ids:
         try:
-            mid = UUID(mid_str)
+            parsed.append((mid_str, UUID(mid_str)))
         except ValueError:
             logger.warning("evolve: skipping invalid UUID: %s", mid_str)
-            continue
 
-        # Savepoint isolates a per-row UPDATE failure: without it, an asyncpg
-        # error here would put the connection in aborted-transaction state and
-        # the swallowed exception would only surface later as a confusing
-        # `RELEASE SAVEPOINT` failure on the final db.commit().
-        try:
-            async with db.begin_nested():
-                result = await db.execute(
-                    _ADJUST_WEIGHT_SQL,
-                    {
-                        "mid": mid,  # UUID object; asyncpg handles type
-                        "tid": tenant_id,
-                        "floor": EVOLVE_WEIGHT_FLOOR,
-                        "cap": EVOLVE_WEIGHT_CAP,
-                        "delta": delta,
-                    },
-                )
-                row = result.fetchone()
-        except Exception:
-            logger.warning("evolve: weight update failed for memory %s", mid, exc_info=True)
-            continue
+    if not parsed:
+        return [], []
 
-        if not row:
+    valid_uuids = [u for _, u in parsed]
+
+    # Single bulk UPDATE keyed by the validated UUID set; collapses the
+    # prior N+1 round-trips and N savepoint pairs into one statement
+    # (audit finding #25). Single savepoint isolates the entire weight-
+    # adjustment batch from the outer evolve transaction; per-row
+    # isolation is not preserved — a DB error aborts all weight updates
+    # as a unit. The outer evolve transaction still gets to persist the
+    # outcome / rule memory rows downstream regardless.
+    try:
+        async with db.begin_nested():
+            result = await db.execute(
+                _ADJUST_WEIGHTS_BULK_SQL,
+                {
+                    "mids": valid_uuids,
+                    "tid": tenant_id,
+                    "floor": EVOLVE_WEIGHT_FLOOR,
+                    "cap": EVOLVE_WEIGHT_CAP,
+                    "delta": delta,
+                },
+            )
+            rows = result.fetchall()
+    except Exception:
+        logger.warning("evolve: bulk weight update failed for %d memories", len(valid_uuids), exc_info=True)
+        return [], []
+
+    # Map returned rows by id so we can preserve the caller's input
+    # ordering when building the response. Rows missing from the
+    # result set correspond to ids not found (or filtered by the
+    # tenant + deleted_at predicate); skip them with the same
+    # warning the per-row path emitted previously.
+    #
+    # ``UUID(str(row.id))`` normalises the key — some DB drivers /
+    # cursor result shapes hand ``row.id`` back as ``str`` rather than
+    # ``uuid.UUID``. Without normalisation the lookup below
+    # (``row_by_id.get(mid)`` with a real ``UUID`` key) silently
+    # misses every row, falling through to the "not found" warning
+    # branch and dropping the whole batch from the response.
+    row_by_id = {UUID(str(row.id)): row for row in rows}
+    for mid_str, mid in parsed:
+        row = row_by_id.get(mid)
+        if row is None:
             logger.warning("evolve: memory %s not found for tenant %s, skipping", mid, tenant_id)
             continue
-
         successfully_adjusted.append(mid_str)
         adjustments.append(
             {

--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -718,11 +718,13 @@ async def _persist_findings(
     transitioning them to 'outdated', preventing duplicate pile-up on re-runs.
     """
     # Find existing active insights for this focus to supersede after creation
+    from uuid import uuid4
+
     from sqlalchemy import select
 
     from common.models.memory import Memory
-    from core_api.schemas import MemoryCreate
-    from core_api.services.memory_service import create_memory
+    from core_api.schemas import BulkMemoryCreate, BulkMemoryItem
+    from core_api.services.memory_service import create_memories_bulk
 
     prior_stmt = (
         select(Memory.id)
@@ -770,9 +772,53 @@ async def _persist_findings(
             logger.warning("Failed to supersede prior insights; skipping persist", exc_info=True)
             return [None] * len(findings)
 
-    insight_ids: list[str | None] = []
+    # Empty-findings short-circuit: ``BulkMemoryCreate.items`` enforces
+    # min_length=1, and the prior-supersede block above already returned
+    # `[None] * len(findings)` for the failure path. An empty findings
+    # list reaches here only when no priors existed either — return
+    # straight away without touching the bulk path.
+    if not findings:
+        return []
+
+    # Build one ``BulkMemoryItem`` per finding so the persist runs as a
+    # single ``create_memories_bulk`` call rather than N serial
+    # ``create_memory`` round-trips each in their own savepoint (audit
+    # finding #29). Per-item error isolation is preserved by the bulk
+    # contract — failed rows surface as ``BulkItemResult(status="error")``
+    # and become ``None`` in the returned ``insight_ids`` (same shape as
+    # the prior per-savepoint exception path).
+    #
+    # write_mode behaviour change vs the pre-#29 path
+    # -----------------------------------------------
+    # The previous serial path passed ``write_mode="strong"`` on every
+    # ``MemoryCreate``. ``BulkMemoryItem`` carries no ``write_mode``
+    # field, and ``create_memories_bulk`` doesn't pick the strong vs fast
+    # pipeline per item — so the bulk path effectively drops the strong
+    # mode override. The only behavioural delta between the strong and
+    # fast pipelines is the inline ``CheckSemanticDuplicate`` step (see
+    # ``core_api/pipeline/compositions/write.py``); everything else
+    # (embed, enrich, exact-dedup, write, schedule background tasks) is
+    # identical. The post-write fire-and-forget tasks — entity extraction,
+    # async contradiction detection, deferred enrichment — are still
+    # scheduled per memory by the bulk path's ``ScheduleBackgroundTasks``-
+    # equivalent loop, so contradiction detection coverage is intact.
+    #
+    # Why dropping inline semantic dedup is acceptable for insights
+    # specifically: the supersede-priors block above ALREADY transitions
+    # any prior active insight for this ``insight_focus`` + ``scope`` +
+    # ``agent_id`` to ``outdated`` before this persist runs. That handles
+    # the cross-run "same insight regenerated" dedup case at the
+    # type-aware level that matters for insights. Inline semantic dedup
+    # would compare each finding against EVERY memory in the tenant
+    # (not just insights), which risks blocking a genuinely-novel
+    # insight whose content happens to look semantically similar to an
+    # unrelated fact. Net: cheaper persist AND fewer false-positive
+    # rejections.
+    titles: list[str] = []
+    items: list[BulkMemoryItem] = []
     for finding in findings:
         title = str(finding.get("title", "Untitled insight"))[:80]
+        titles.append(title)
         description = str(finding.get("description", ""))[:1000]
         recommendation = str(finding.get("recommendation", ""))[:500]
         confidence = max(0.0, min(1.0, float(finding.get("confidence", 0.5))))
@@ -782,35 +828,67 @@ async def _persist_findings(
         if recommendation:
             content += f" Recommendation: {recommendation}"
 
-        # MemoryCreate has no `title` field — the title is already encoded in `content`
-        # as "[Insight/{type}] {title}: {description}".
-        data = MemoryCreate(
-            tenant_id=tenant_id,
-            agent_id=agent_id,
-            fleet_id=fleet_id,
-            memory_type="insight",
-            content=content,
-            weight=confidence,
-            metadata={
-                "insight_focus": focus,
-                "insight_scope": scope,
-                "insight_type": finding.get("type", focus),
-                "related_memory_ids": [str(rid) for rid in related_ids],
-                "recommendation": recommendation,
-                "confidence": confidence,
-            },
-            visibility=_SCOPE_TO_VISIBILITY.get(scope, "scope_team"),
-            write_mode="strong",
+        # ``BulkMemoryItem`` has no ``title`` field — the title is encoded
+        # in ``content`` as "[Insight/{type}] {title}: {description}".
+        items.append(
+            BulkMemoryItem(
+                memory_type="insight",
+                content=content,
+                weight=confidence,
+                metadata={
+                    "insight_focus": focus,
+                    "insight_scope": scope,
+                    "insight_type": finding.get("type", focus),
+                    "related_memory_ids": [str(rid) for rid in related_ids],
+                    "recommendation": recommendation,
+                    "confidence": confidence,
+                },
+            )
         )
-        # Savepoint per finding so one failure doesn't corrupt the outer
-        # transaction and abort subsequent inserts.
-        try:
-            async with db.begin_nested():
-                result = await create_memory(db, data)
-            insight_ids.append(str(result.id))
-        except Exception:
-            logger.exception("Failed to persist insight finding: %s", title)
-            insight_ids.append(None)
+
+    bulk_data = BulkMemoryCreate(
+        tenant_id=tenant_id,
+        fleet_id=fleet_id,
+        agent_id=agent_id,
+        items=items,
+        visibility=_SCOPE_TO_VISIBILITY.get(scope, "scope_team"),
+    )
+    # Per-attempt id is required by the bulk contract for idempotent
+    # retries; insights persist is called from one place per
+    # generate_insights invocation, so a fresh uuid4 here is the right
+    # granularity (a retry would be a fresh generate_insights call with
+    # a new attempt id anyway).
+    bulk_attempt_id = f"insights:{uuid4()}"
+
+    insight_ids: list[str | None] = []
+    try:
+        response = await create_memories_bulk(db, bulk_data, bulk_attempt_id=bulk_attempt_id)
+    except Exception:
+        logger.exception("Bulk persist of insight findings failed entirely")
+        insight_ids = [None] * len(findings)
+    else:
+        # Bulk contract: ``results`` is aligned to input order, one
+        # entry per item. ``id`` is set for ``created`` /
+        # ``duplicate_attempt`` / ``duplicate_content``; absent for
+        # ``error``.
+        by_index = {r.index: r for r in response.results}
+        for i, finding_title in enumerate(titles):
+            r = by_index.get(i)
+            if r is None or r.id is None:
+                if r is not None and r.error:
+                    logger.warning(
+                        "Failed to persist insight finding %s: %s",
+                        finding_title,
+                        r.error,
+                    )
+                else:
+                    logger.warning(
+                        "Insight finding %s missing from bulk response",
+                        finding_title,
+                    )
+                insight_ids.append(None)
+            else:
+                insight_ids.append(str(r.id))
 
     # Safety net: if every finding failed to persist, restore the priors we
     # pre-emptively outdated so the user isn't left with nothing active.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,10 +201,18 @@ async def _patch_storage_client(_engine, _setup_schema):
             "http://test-storage:8002", _storage_asgi_http
         )
 
+    # Try/finally so a setup-time exception between the mutation and
+    # the yield (or anywhere in the test body) restores the original
+    # client. Without this guard, a failing setup or a teardown error
+    # would leak the ASGI-bridged client into subsequent tests via the
+    # module-level ``sc_mod._client`` singleton — caused intermittent
+    # cascade failures previously (audit T5).
     old_client = sc_mod._client
     sc_mod._client = _storage_sc
-    yield
-    sc_mod._client = old_client
+    try:
+        yield
+    finally:
+        sc_mod._client = old_client
 
 
 @pytest.fixture

--- a/tests/test_api_crystallizer.py
+++ b/tests/test_api_crystallizer.py
@@ -165,6 +165,73 @@ async def test_get_report_not_found(client):
     assert resp.status_code == 404
 
 
+async def test_get_report_foreign_tenant_returns_404_not_403():
+    """A non-admin caller probing a report owned by a different tenant
+    must see 404 (same as a missing report), not 403 — otherwise an
+    attacker could enumerate report_ids across tenants by distinguishing
+    the two status codes (audit finding #22).
+    """
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from fastapi import HTTPException
+
+    from core_api.auth import AuthContext
+    from core_api.routes.crystallizer import get_report
+
+    foreign_report = {
+        "id": str(uuid4()),
+        "tenant_id": "tenant-A",  # owned by tenant A
+        "fleet_id": None,
+    }
+    caller = AuthContext(tenant_id="tenant-B", is_admin=False)
+
+    sc_mock = AsyncMock()
+    sc_mock.get_report = AsyncMock(return_value=foreign_report)
+    with patch("core_api.routes.crystallizer.get_storage_client", return_value=sc_mock):
+        try:
+            await get_report(report_id=uuid4(), auth=caller)
+        except HTTPException as e:
+            assert e.status_code == 404, (
+                f"Foreign-tenant report read must surface as 404; got {e.status_code}"
+            )
+            assert e.detail == "Report not found"
+        else:
+            raise AssertionError(
+                "Expected HTTPException(404) for foreign-tenant report"
+            )
+
+
+async def test_get_report_foreign_tenant_admin_bypass():
+    """Admin keys keep their cross-tenant read ability (no 404 mask)."""
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from core_api.auth import AuthContext
+    from core_api.routes.crystallizer import get_report
+
+    foreign_report = {
+        "id": str(uuid4()),
+        "tenant_id": "tenant-A",
+        "fleet_id": None,
+        "trigger": "manual",
+        "status": "completed",
+        "summary": {},
+        "hygiene": {},
+        "health": {},
+        "issues": [],
+        "crystallization": {},
+    }
+    admin = AuthContext(tenant_id=None, is_admin=True)
+
+    sc_mock = AsyncMock()
+    sc_mock.get_report = AsyncMock(return_value=foreign_report)
+    with patch("core_api.routes.crystallizer.get_storage_client", return_value=sc_mock):
+        result = await get_report(report_id=uuid4(), auth=admin)
+    # Admin sees the full payload.
+    assert result["tenant_id"] == "tenant-A"
+
+
 async def test_get_latest_report_empty_returns_200_null(client):
     """GET /api/crystallize/latest returns 200 with body ``null`` when the
     tenant has no completed reports — empty state, not a missing resource.

--- a/tests/test_insights_service.py
+++ b/tests/test_insights_service.py
@@ -80,7 +80,10 @@ class TestSanitizeContent:
     def test_redacts_ignore_previous(self):
         from core_api.services.insights_service import _sanitize_content
 
-        assert "ignore previous" not in _sanitize_content("ignore previous instructions").lower()
+        assert (
+            "ignore previous"
+            not in _sanitize_content("ignore previous instructions").lower()
+        )
 
     def test_redacts_inst_at_start(self):
         """[INST] at position 0 must be redacted (regex bug fix)."""
@@ -214,7 +217,9 @@ class TestScopeFilters:
         from fastapi import HTTPException
 
         with pytest.raises(HTTPException) as exc_info:
-            await generate_insights(None, "t1", focus="patterns", scope="fleet", fleet_id=None)
+            await generate_insights(
+                None, "t1", focus="patterns", scope="fleet", fleet_id=None
+            )
         assert exc_info.value.status_code == 422
         assert "fleet_id" in exc_info.value.detail.lower()
 
@@ -260,7 +265,9 @@ class TestFocusValidation:
 # ---------------------------------------------------------------------------
 
 
-async def _write_memory(client, content, memory_type="fact", weight=None, agent_id=None, fleet_id=None):
+async def _write_memory(
+    client, content, memory_type="fact", weight=None, agent_id=None, fleet_id=None
+):
     """Write a memory and return the response JSON."""
     tag = _uid()
     _, headers = get_test_auth()
@@ -677,7 +684,9 @@ class TestSupersedeOrdering:
     """P0: supersede must run BEFORE create, with a rollback safety net."""
 
     @pytest.mark.asyncio
-    async def test_new_finding_persists_despite_similar_prior_insight(self, db, monkeypatch):
+    async def test_new_finding_persists_despite_similar_prior_insight(
+        self, db, monkeypatch
+    ):
         """A prior similar insight is outdated first, so the new finding persists.
 
         Because the reorder moves the prior to 'outdated' before create_memory
@@ -802,12 +811,17 @@ class TestSupersedeOrdering:
             ],
         )
 
-        async def failing_create(db, data):
+        async def failing_create_bulk(db, data, *, bulk_attempt_id):
             raise HTTPException(status_code=409, detail="duplicate")
 
-        # Patch the name as used inside _persist_findings (imported locally there)
+        # Patch the bulk path; ``_persist_findings`` now persists every
+        # finding in a single ``create_memories_bulk`` call (audit
+        # finding #29). A failure here exercises the same "all findings
+        # failed → restore priors" code path the previous per-call
+        # version protected.
         import core_api.services.memory_service as ms_mod
-        monkeypatch.setattr(ms_mod, "create_memory", failing_create)
+
+        monkeypatch.setattr(ms_mod, "create_memories_bulk", failing_create_bulk)
 
         result = await insights_service.generate_insights(
             db,
@@ -821,7 +835,9 @@ class TestSupersedeOrdering:
         prior_status = (
             await db.execute(select(Memory.status).where(Memory.id == prior_id))
         ).scalar_one()
-        assert prior_status == "active", "prior should be restored when all findings fail"
+        assert prior_status == "active", (
+            "prior should be restored when all findings fail"
+        )
         assert result.get("insight_memory_ids", []) == []
 
     @pytest.mark.asyncio
@@ -877,7 +893,9 @@ class TestSupersedeOrdering:
         prior_status = (
             await db.execute(select(Memory.status).where(Memory.id == prior_id))
         ).scalar_one()
-        assert prior_status == "active", "prior must stay active when there are no findings"
+        assert prior_status == "active", (
+            "prior must stay active when there are no findings"
+        )
 
 
 class TestHallucinatedIds:


### PR DESCRIPTION
## Summary

Five small, independent fixes from the audit follow-up queue. Each is contained to one file and none depends on the others — could be split into 5 PRs, bundled here for review efficiency since the per-change LOC is small.

| Audit ID | Surface | Type | LOC |
|---|---|---|---|
| **T5** | tests/conftest.py — `_patch_storage_client` fixture | Test hygiene (cross-test leak) | +5 |
| **#22** | routes/crystallizer.py — `get_report` | Security (cross-tenant existence leak) | +6 |
| **#25** | services/evolve_service.py — `_apply_outcome_to_db` | Perf (N+1 UPDATE → single statement) | ~80 |
| **#29** | services/insights_service.py — `_persist_findings` | Perf (serial create_memory → create_memories_bulk) | ~75 |
| **#31** | services/entity_extraction_worker.py | Cleanup (dead try/except) | de-indent only |

## Per-fix detail

### T5 — try/finally on `_patch_storage_client`
The autouse fixture mutated `sc_mod._client` then `yield`ed. A setup-time exception between the mutation and yield (or any teardown error) would leak the ASGI-bridged client into subsequent tests via the module-level singleton — caused intermittent cascade failures previously. Wrap in try/finally.

### #22 — 404 (not 403) for foreign-tenant report read
`GET /crystallize/reports/{id}` used to 404 on missing rows but **403** on foreign-tenant rows (via `enforce_tenant`). Two distinguishable states let attackers enumerate cross-tenant report_ids by random-probing UUIDs (403 = exists in another tenant; 404 = doesn't exist anywhere). Collapse both to 404 with the same detail. Admin keys keep cross-tenant read via the `is_admin` bypass.

### #25 — Collapse evolve_service N+1 weight UPDATEs
One UPDATE per `related_id` inside its own savepoint → single `UPDATE FROM (VALUES …)` via `IN :mids` expanding bindparam. One outer savepoint preserves the "DB failure aborts the bulk but not the outer transaction" contract. Per-row response ordering and the "row-not-found → skip with warning" semantics preserved.

### #29 — Use `create_memories_bulk` in insights findings persist
Serial `create_memory` per finding inside per-finding savepoint → single `create_memories_bulk` call. Per-item error isolation comes from the bulk contract (`BulkItemResult(status="error")` → `None` in `insight_ids`). Empty-findings short-circuit added (`BulkMemoryCreate.items` enforces `min_length=1`).

### #31 — Delete dead try/except
Inner `try: ... except Exception: raise` re-raised into the outer except one frame above — pure no-op. Removed the wrapper and de-indented the body. Smaller stack on logged exceptions; cleaner blame.

## Test plan

- [x] **2 new regression tests** in `tests/test_api_crystallizer.py` for #22:
  - `test_get_report_foreign_tenant_returns_404_not_403`: non-admin caller, foreign report → 404 (asserts via direct route call with mocked AuthContext + storage client; no HTTP fixture required).
  - `test_get_report_foreign_tenant_admin_bypass`: admin still reads cross-tenant.
- [x] **Updated** `tests/test_insights_service.py::test_priors_restored_when_all_findings_fail` to patch `create_memories_bulk` (the new persist target) instead of `create_memory`. Still exercises the "all findings failed → restore priors" branch.
- [x] **218 tests pass** across touched surfaces (storage bulk endpoints, entity linking, insights, crystallizer, evolve, A4 status, A10 evolve rule, MCP insights, entity blocklist, A5c tenant config).
- [x] Ruff lint + format clean.
- [x] mypy on core-api clean (only pre-existing `config.py` croniter stub from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)