### PR TITLE
perf(contradiction): collapse N+1 status updates into batch_update_status per path (P2)

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -111,6 +111,39 @@ def _pick_older(a: dict, b: dict) -> dict:
     return a
 
 
+def _merge_status_update(acc: dict[str, dict], row: dict) -> None:
+    """Merge a per-row update into the accumulator keyed by ``memory_id``.
+
+    The contradiction-detection loops can append two writes for the same
+    ``memory_id`` in a mixed canonical/flipped run — one bare
+    ``{status: ...}`` from the top-of-loop "older → outdated" branch and
+    one ``{status: ..., supersedes_id: ...}`` from the inner attribution
+    branch. The old serial code relied on those two writes landing in
+    iteration order and the second one's ``supersedes_id`` taking
+    effect; the new batched code passes both rows in one
+    ``batch_update_status`` payload, where last-write-wins semantics
+    inside the endpoint are an implementation detail, not part of the
+    contract (a future ``UPDATE FROM VALUES`` optimisation would make
+    order undefined). Dedupe per ``memory_id`` here so the wire payload
+    carries one merged row per memory and the storage endpoint can be
+    optimised freely without changing the resulting DB state.
+
+    Later writes override earlier writes on a per-field basis (plain
+    ``dict.update``) — preserving today's last-write-wins semantics
+    on the fields the inner branch sets (``status``, ``supersedes_id``)
+    while keeping any earlier fields that the later write doesn't touch.
+    This matches the existing ``TestMixedDirectionStateGuard`` invariant
+    in ``test_contradiction_direction_invariance.py``: both the
+    canonical iteration's ``supersedes_id`` chain link AND the flipped
+    iteration's status update must land for the same ``memory_id``.
+    """
+    mid = row["memory_id"]
+    if mid in acc:
+        acc[mid].update(row)
+    else:
+        acc[mid] = dict(row)
+
+
 # ---------------------------------------------------------------------------
 # Public API: async post-commit entry point (P1-1)
 # ---------------------------------------------------------------------------
@@ -284,6 +317,13 @@ async def _detect(
         # ``new_memory`` back to its previous status ("active") while
         # setting ``supersedes_id``.
         new_memory_is_outdated = False
+        # Collapsed-write accumulator — folded in per audit P2 even
+        # though the RDF loop isn't gather-prefaced; same N+1 shape and
+        # keeps the file consistent with semantic / Path C. Keyed by
+        # ``memory_id`` so a mixed canonical/flipped run that touches
+        # ``new_memory`` twice collapses into one merged row (see
+        # ``_merge_status_update`` for the ordering rationale).
+        rdf_updates: dict[str, dict] = {}
         for old in rdf_conflicts:
             # CAURA-125 — decide attribution direction AFTER confirming
             # the conflict, not before. ``_pick_older`` chooses which
@@ -297,7 +337,7 @@ async def _detect(
             older_id = older.get("id")
             newer_id = newer.get("id")
 
-            await sc.update_memory_status(str(older_id), "outdated")
+            _merge_status_update(rdf_updates, {"memory_id": str(older_id), "status": "outdated"})
             if newer is new_memory:
                 # Canonical case (candidate is older). Track via local
                 # ``supersedes_id`` so multiple conflict candidates in
@@ -319,10 +359,13 @@ async def _detect(
                     target_status = (
                         "outdated" if new_memory_is_outdated else new_memory.get("status", "active")
                     )
-                    await sc.update_memory_status(
-                        str(memory_id),
-                        target_status,
-                        supersedes_id=str(older_id),
+                    _merge_status_update(
+                        rdf_updates,
+                        {
+                            "memory_id": str(memory_id),
+                            "status": target_status,
+                            "supersedes_id": str(older_id),
+                        },
                     )
             else:
                 # Flipped case (candidate is newer). The just-written
@@ -344,10 +387,13 @@ async def _detect(
                         newer.get("supersedes_id"),
                     )
                 else:
-                    await sc.update_memory_status(
-                        str(newer_id),
-                        newer.get("status", "active"),
-                        supersedes_id=str(older_id),
+                    _merge_status_update(
+                        rdf_updates,
+                        {
+                            "memory_id": str(newer_id),
+                            "status": newer.get("status", "active"),
+                            "supersedes_id": str(older_id),
+                        },
                     )
 
             # ``ContradictionInfo.old_memory_id`` is documented as the
@@ -380,6 +426,26 @@ async def _detect(
                 direction,
             )
 
+        if rdf_updates:
+            rdf_result = await sc.batch_update_status({"updates": list(rdf_updates.values())})
+            if rdf_result.get("skipped"):
+                # ``skipped`` carries rows the storage-side dropped — CAS
+                # gate fail (caller-supplied ``expected_supersedes_id``
+                # mismatch) or row already deleted. Pre-batch, the single-
+                # row PATCH route surfaced 404 as a hard error; the batch
+                # route returns the list instead so we don't abort the
+                # whole detection cycle. Log so the dropped writes are
+                # visible in tracing — the contradiction detector itself
+                # doesn't use ``expected_supersedes_id`` today, so a
+                # non-empty list usually means the target row was
+                # soft-deleted between detect-and-flush.
+                logger.warning(
+                    "batch_update_status (RDF path) skipped %d row(s) (trigger memory %s): %s",
+                    len(rdf_result["skipped"]),
+                    memory_id,
+                    rdf_result["skipped"],
+                )
+
     # --- Path 2: Semantic contradiction (vector similarity + batch LLM check) ---
     if not contradictions:
         candidates = await sc.find_similar_candidates(
@@ -408,6 +474,15 @@ async def _detect(
             # CAURA-125 — state-corruption guard, same rationale as the
             # RDF path above.
             new_memory_is_outdated = False
+            # Collect per-row status updates and flush them with one
+            # ``batch_update_status`` HTTP after the loop. The prior shape
+            # (one ``update_memory_status`` per row) issued up to 3K
+            # writes per detection cycle — same wire effect, ~Kx the
+            # round-trips (audit P2). All branches that set status here
+            # share one batch; the post-loop call is a no-op when
+            # ``updates`` is empty. Keyed by ``memory_id`` — see
+            # ``_merge_status_update`` for the dedupe rationale.
+            updates: dict[str, dict] = {}
             for candidate, result in zip(candidates, results):
                 if isinstance(result, Exception):
                     logger.warning(
@@ -430,7 +505,7 @@ async def _detect(
                     older_id = older.get("id")
                     newer_id = newer.get("id")
 
-                    await sc.update_memory_status(str(older_id), "conflicted")
+                    _merge_status_update(updates, {"memory_id": str(older_id), "status": "conflicted"})
                     if newer is new_memory:
                         if not supersedes_id:
                             supersedes_id = older_id
@@ -443,10 +518,13 @@ async def _detect(
                             target_status = (
                                 "conflicted" if new_memory_is_outdated else new_memory.get("status", "active")
                             )
-                            await sc.update_memory_status(
-                                str(memory_id),
-                                target_status,
-                                supersedes_id=str(older_id),
+                            _merge_status_update(
+                                updates,
+                                {
+                                    "memory_id": str(memory_id),
+                                    "status": target_status,
+                                    "supersedes_id": str(older_id),
+                                },
                             )
                     else:
                         new_memory_is_outdated = True
@@ -460,10 +538,13 @@ async def _detect(
                                 newer.get("supersedes_id"),
                             )
                         else:
-                            await sc.update_memory_status(
-                                str(newer_id),
-                                newer.get("status", "active"),
-                                supersedes_id=str(older_id),
+                            _merge_status_update(
+                                updates,
+                                {
+                                    "memory_id": str(newer_id),
+                                    "status": newer.get("status", "active"),
+                                    "supersedes_id": str(older_id),
+                                },
                             )
 
                     direction = "canonical" if newer is new_memory else "flipped"
@@ -483,6 +564,17 @@ async def _detect(
                         older_id,
                         newer_id,
                         direction,
+                    )
+
+            if updates:
+                sem_result = await sc.batch_update_status({"updates": list(updates.values())})
+                if sem_result.get("skipped"):
+                    # See RDF path above for the ``skipped`` semantics.
+                    logger.warning(
+                        "batch_update_status (semantic path) skipped %d row(s) (trigger memory %s): %s",
+                        len(sem_result["skipped"]),
+                        memory_id,
+                        sem_result["skipped"],
                     )
 
     return contradictions
@@ -1037,6 +1129,11 @@ async def detect_contradictions_by_entities_async(
         # CAURA-125 — state-corruption guard; mirrors the RDF and
         # semantic paths in ``_detect()``.
         new_memory_is_outdated = False
+        # Collapsed-write accumulator — same rationale as the semantic
+        # path's ``updates`` dict (audit P2 Path C). Keyed by
+        # ``memory_id`` so a mixed canonical/flipped run produces one
+        # merged row per memory; see ``_merge_status_update``.
+        updates: dict[str, dict] = {}
         for candidate, result in zip(candidates, results):
             if isinstance(result, Exception):
                 logger.warning(
@@ -1061,7 +1158,7 @@ async def detect_contradictions_by_entities_async(
                 older_id = older.get("id")
                 newer_id = newer.get("id")
 
-                await sc.update_memory_status(str(older_id), "conflicted")
+                _merge_status_update(updates, {"memory_id": str(older_id), "status": "conflicted"})
                 if not found:
                     if newer is new_memory:
                         # See RDF path above for the rationale of
@@ -1072,10 +1169,13 @@ async def detect_contradictions_by_entities_async(
                         target_status = (
                             "conflicted" if new_memory_is_outdated else new_memory.get("status", "active")
                         )
-                        await sc.update_memory_status(
-                            str(memory_id),
-                            target_status,
-                            supersedes_id=str(older_id),
+                        _merge_status_update(
+                            updates,
+                            {
+                                "memory_id": str(memory_id),
+                                "status": target_status,
+                                "supersedes_id": str(older_id),
+                            },
                         )
                     else:
                         new_memory_is_outdated = True
@@ -1089,10 +1189,13 @@ async def detect_contradictions_by_entities_async(
                                 newer.get("supersedes_id"),
                             )
                         else:
-                            await sc.update_memory_status(
-                                str(newer_id),
-                                newer.get("status", "active"),
-                                supersedes_id=str(older_id),
+                            _merge_status_update(
+                                updates,
+                                {
+                                    "memory_id": str(newer_id),
+                                    "status": newer.get("status", "active"),
+                                    "supersedes_id": str(older_id),
+                                },
                             )
                 found = True
                 n_conflicts += 1
@@ -1101,6 +1204,17 @@ async def detect_contradictions_by_entities_async(
                     older_id,
                     newer_id,
                     "canonical" if newer is new_memory else "flipped",
+                )
+
+        if updates:
+            path_c_result = await sc.batch_update_status({"updates": list(updates.values())})
+            if path_c_result.get("skipped"):
+                # See RDF path in ``_detect`` for the ``skipped`` semantics.
+                logger.warning(
+                    "batch_update_status (Path C entity-overlap) skipped %d row(s) (trigger memory %s): %s",
+                    len(path_c_result["skipped"]),
+                    memory_id,
+                    path_c_result["skipped"],
                 )
     except Exception:
         logger.exception("Entity-based contradiction detection failed for %s", memory_id)

--- a/tests/_contradiction_batch_compat.py
+++ b/tests/_contradiction_batch_compat.py
@@ -1,0 +1,59 @@
+"""Test-side compatibility shim for the P2 batch-status migration.
+
+The contradiction detector used to issue one ``sc.update_memory_status``
+HTTP per affected row inside its detection loops. After audit P2, all
+three paths (semantic / Path C / RDF) accumulate updates and flush one
+``sc.batch_update_status`` call after the loop instead.
+
+Existing tests assert on ``mock_sc.update_memory_status.call_args_list``
+to check direction, supersedes_id wiring, status values, etc. — pure
+behavior checks expressed through the legacy call shape. Migrating
+every assertion to ``batch_update_status.call_args_list`` would be
+mostly mechanical noise (~80 sites across 7 files); instead this
+helper installs a ``batch_update_status`` side-effect that replays
+each row of the payload as if it were an individual
+``update_memory_status`` call. The legacy assertions continue to fire
+unchanged.
+
+New tests that want to assert on the batched shape directly should not
+install the shim — they can read ``mock_sc.batch_update_status.call_args``
+directly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from typing import Any
+
+
+def install_batch_status_replay_shim(mock_sc: Any) -> None:
+    """Make ``mock_sc.batch_update_status({"updates": [...]})`` replay each
+    row as a per-row ``mock_sc.update_memory_status(memory_id, status,
+    **kwargs)`` call on the same mock, so existing tests' call-arg
+    assertions stay valid post-P2.
+
+    Idempotent: safe to call after ``mock_sc.update_memory_status`` has
+    already been replaced with an ``AsyncMock`` (the common pattern).
+    Does NOT overwrite an existing ``update_memory_status`` mock — it
+    only routes the batch-side replay into it.
+    """
+    if not isinstance(getattr(mock_sc, "update_memory_status", None), AsyncMock):
+        mock_sc.update_memory_status = AsyncMock()
+
+    update_mock = mock_sc.update_memory_status
+
+    async def _replay(payload: dict) -> dict:
+        for row in payload.get("updates", []):
+            mid = row["memory_id"]
+            status = row["status"]
+            kwargs: dict[str, Any] = {}
+            if "supersedes_id" in row:
+                kwargs["supersedes_id"] = row["supersedes_id"]
+            if "unset_supersedes" in row:
+                kwargs["unset_supersedes"] = row["unset_supersedes"]
+            if "expected_supersedes_id" in row:
+                kwargs["expected_supersedes_id"] = row["expected_supersedes_id"]
+            await update_mock(mid, status, **kwargs)
+        return {"ok": True, "skipped": []}
+
+    mock_sc.batch_update_status = AsyncMock(side_effect=_replay)

--- a/tests/test_a1_17_subject_entity_preflight.py
+++ b/tests/test_a1_17_subject_entity_preflight.py
@@ -32,6 +32,7 @@ judge runs as before.
 from __future__ import annotations
 
 import pytest
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
 
 pytestmark = pytest.mark.unit
@@ -331,6 +332,7 @@ async def test_path_c_filters_candidates_with_distinct_subject():
         return_value=[distinct_subject_candidate]
     )
     sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
 
     judge = AsyncMock()
     with (
@@ -403,6 +405,7 @@ async def test_path_c_calls_judge_when_subjects_match():
         return_value=[matching_subject_candidate]
     )
     sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
 
     judge = AsyncMock(return_value=(False, 0.90))
     with (
@@ -468,6 +471,7 @@ async def test_path_c_falls_through_when_new_memory_has_no_subject():
     sc.get_memory = AsyncMock(return_value=new_memory)
     sc.find_entity_overlap_candidates = AsyncMock(return_value=[candidate])
     sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
 
     judge = AsyncMock(return_value=(False, 0.90))
     with (

--- a/tests/test_a4_13_path_c_retraction.py
+++ b/tests/test_a4_13_path_c_retraction.py
@@ -55,6 +55,7 @@ from unittest.mock import AsyncMock, patch
 from uuid import UUID, uuid4
 
 import pytest
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
 
 # ---------------------------------------------------------------------------
@@ -108,6 +109,7 @@ def _mock_sc_with_retraction_setup(
     sc.get_memory = AsyncMock(side_effect=get_memory)
     sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
     sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
     return sc
 
 
@@ -355,6 +357,7 @@ async def test_no_retraction_when_new_memory_has_no_supersedes_id():
     )
     sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
     sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
 
     judge = AsyncMock()
     with (

--- a/tests/test_a4_14_back_channel_idempotency.py
+++ b/tests/test_a4_14_back_channel_idempotency.py
@@ -46,6 +46,7 @@ from unittest.mock import AsyncMock, patch
 from uuid import UUID, uuid4
 
 import pytest
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
 
 pytestmark = pytest.mark.unit
@@ -150,6 +151,7 @@ async def test_path_c_second_call_skips_when_lock_already_held():
     sc.get_memory = AsyncMock(return_value=_make_memory(mid))
     sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
     sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
 
     with (
         patch(
@@ -181,6 +183,7 @@ async def test_path_c_first_call_runs_when_lock_acquired():
     sc.get_memory = AsyncMock(return_value=_make_memory(mid))
     sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
     sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
 
     with (
         patch(

--- a/tests/test_contradiction_direction_invariance.py
+++ b/tests/test_contradiction_direction_invariance.py
@@ -25,6 +25,7 @@ import pytest
 
 from core_api.constants import VECTOR_DIM
 from core_api.services.contradiction_detector import _detect, _pick_older
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +142,7 @@ class TestRdfAttributionDirection:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -180,6 +182,7 @@ class TestRdfAttributionDirection:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -221,6 +224,7 @@ class TestRdfAttributionDirection:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -265,6 +269,7 @@ class TestRdfAttributionDirection:
             mock_sc = AsyncMock()
             mock_sc.find_rdf_conflicts = AsyncMock(return_value=[cand])
             mock_sc.update_memory_status = AsyncMock()
+            install_batch_status_replay_shim(mock_sc)
 
             with patch(
                 "core_api.services.contradiction_detector.get_storage_client",
@@ -312,6 +317,7 @@ class TestSemanticAttributionDirection:
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
         mock_sc.find_similar_candidates = AsyncMock(return_value=[cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with (
             patch(
@@ -352,6 +358,7 @@ class TestSemanticAttributionDirection:
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
         mock_sc.find_similar_candidates = AsyncMock(return_value=[cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with (
             patch(
@@ -392,6 +399,7 @@ class TestNoConflictNoSupersession:
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
         mock_sc.find_similar_candidates = AsyncMock(return_value=[])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -414,6 +422,7 @@ class TestNoConflictNoSupersession:
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
         mock_sc.find_similar_candidates = AsyncMock(return_value=[cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with (
             patch(
@@ -465,6 +474,7 @@ class TestMixedDirectionStateGuard:
         # the just-set "outdated" status.
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[newer_cand, older_cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -532,6 +542,7 @@ class TestMixedDirectionStateGuard:
         # Order matters: flipped iteration fires FIRST.
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[newer_cand, older_cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -600,6 +611,7 @@ class TestMixedDirectionStateGuard:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[older_cand, newer_cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -646,6 +658,7 @@ class TestFlippedSkipsExistingSupersedesId:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -694,6 +707,7 @@ class TestFlippedSkipsExistingSupersedesId:
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])  # force semantic path
         mock_sc.find_similar_candidates = AsyncMock(return_value=[cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with (
             patch(
@@ -738,6 +752,7 @@ class TestContradictionInfoSemantics:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -763,6 +778,7 @@ class TestContradictionInfoSemantics:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[cand])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",

--- a/tests/test_embed_stability.py
+++ b/tests/test_embed_stability.py
@@ -35,6 +35,7 @@ from core_api.constants import VECTOR_DIM
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.steps.write.parallel_embed_enrich import ParallelEmbedEnrich
 from core_api.schemas import MemoryCreate
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
 pytestmark = pytest.mark.asyncio
 
@@ -181,6 +182,7 @@ async def test_atomic_fact_children_embed_raw_fact_content() -> None:
     sc.get_memory = AsyncMock(return_value=mem_row)
     sc.update_embedding = AsyncMock()
     sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
     sc.create_memory = AsyncMock()
     sc._patch = AsyncMock()
 

--- a/tests/test_p1_contradiction.py
+++ b/tests/test_p1_contradiction.py
@@ -23,6 +23,7 @@ from core_api.constants import (
     CONTRADICTION_CANDIDATE_MAX,
     CONTRADICTION_SIMILARITY_THRESHOLD,
 )
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
 
 # ---------------------------------------------------------------------------
@@ -138,6 +139,7 @@ class TestSupersessionSemantics:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[old_memory])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -193,6 +195,7 @@ class TestSupersessionSemantics:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[old_mem_1, old_mem_2])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -207,7 +210,8 @@ class TestSupersessionSemantics:
         # First contradicted memory wins for supersession
         # Verify supersedes_id was set to old_id_1 (first conflict)
         supersession_calls = [
-            c for c in mock_sc.update_memory_status.call_args_list
+            c
+            for c in mock_sc.update_memory_status.call_args_list
             if c.kwargs.get("supersedes_id")
         ]
         assert len(supersession_calls) == 1
@@ -243,15 +247,19 @@ class TestSupersessionSemantics:
         mock_sc = AsyncMock()
         mock_sc.find_similar_candidates = AsyncMock(return_value=[old_memory])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
-        with patch(
-            "core_api.services.contradiction_detector.get_storage_client",
-            return_value=mock_sc,
-        ), patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
-            new_callable=AsyncMock,
-            # A4 #12 — judge returns (verdict, confidence) tuple.
-            return_value=(True, 0.90),
+        with (
+            patch(
+                "core_api.services.contradiction_detector.get_storage_client",
+                return_value=mock_sc,
+            ),
+            patch(
+                "core_api.services.contradiction_detector._llm_contradiction_check",
+                new_callable=AsyncMock,
+                # A4 #12 — judge returns (verdict, confidence) tuple.
+                return_value=(True, 0.90),
+            ),
         ):
             contradictions = await _detect(new_memory, [0.1] * 10)
 
@@ -299,6 +307,7 @@ class TestSupersessionSemantics:
         mock_sc = AsyncMock()
         mock_sc.find_similar_candidates = AsyncMock(return_value=[old_mem_1, old_mem_2])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with (
             patch(
@@ -320,7 +329,8 @@ class TestSupersessionSemantics:
         mock_sc.update_memory_status.assert_any_call(old_id_2, "conflicted")
         # First contradicted memory wins for supersession
         supersession_calls = [
-            c for c in mock_sc.update_memory_status.call_args_list
+            c
+            for c in mock_sc.update_memory_status.call_args_list
             if c.kwargs.get("supersedes_id")
         ]
         assert len(supersession_calls) == 1
@@ -484,11 +494,13 @@ class TestContradictionIntegration:
         from core_api.services.contradiction_detector import detect_contradictions
 
         sc = get_storage_client()
-        entity = await sc.create_entity({
-            "tenant_id": tenant_id,
-            "entity_type": "person",
-            "canonical_name": "Alice",
-        })
+        entity = await sc.create_entity(
+            {
+                "tenant_id": tenant_id,
+                "entity_type": "person",
+                "canonical_name": "Alice",
+            }
+        )
         entity_id = entity["id"]
 
         old = await self._insert_memory(
@@ -538,7 +550,9 @@ class TestContradictionIntegration:
         )
         emb = fake_embedding(new["content"])
 
-        with patch("core_api.services.contradiction_detector.settings") as mock_settings:
+        with patch(
+            "core_api.services.contradiction_detector.settings"
+        ) as mock_settings:
             mock_settings.entity_extraction_provider = "fake"
             contradictions = await detect_contradictions(db, new, emb)
 
@@ -555,7 +569,9 @@ class TestContradictionIntegration:
         new = await self._insert_memory(db, tenant_id, "The weather is sunny today")
         emb = fake_embedding(new["content"])
 
-        with patch("core_api.services.contradiction_detector.settings") as mock_settings:
+        with patch(
+            "core_api.services.contradiction_detector.settings"
+        ) as mock_settings:
             mock_settings.entity_extraction_provider = "fake"
             contradictions = await detect_contradictions(db, new, emb)
 
@@ -572,33 +588,37 @@ class TestContradictionIntegration:
             content = f"{base_content} for endpoint {i}"
             emb_i = fake_embedding(content)
             ch = hashlib.sha256(f"{tenant_id}:None:{content}".encode()).hexdigest()
-            await sc.create_memory({
-                "tenant_id": tenant_id,
-                "agent_id": "test-agent",
-                "memory_type": "fact",
-                "content": content,
-                "embedding": emb_i,
-                "content_hash": ch,
-                "weight": 0.5,
-                "status": "active",
-                "visibility": "scope_team",
-            })
+            await sc.create_memory(
+                {
+                    "tenant_id": tenant_id,
+                    "agent_id": "test-agent",
+                    "memory_type": "fact",
+                    "content": content,
+                    "embedding": emb_i,
+                    "content_hash": ch,
+                    "weight": 0.5,
+                    "status": "active",
+                    "visibility": "scope_team",
+                }
+            )
 
         # Create the "new" memory via storage client too
         new_content = base_content
         emb = fake_embedding(new_content)
         ch_new = hashlib.sha256(f"{tenant_id}:None:{new_content}".encode()).hexdigest()
-        new_mem = await sc.create_memory({
-            "tenant_id": tenant_id,
-            "agent_id": "test-agent",
-            "memory_type": "fact",
-            "content": new_content,
-            "embedding": emb,
-            "content_hash": ch_new,
-            "weight": 0.5,
-            "status": "active",
-            "visibility": "scope_team",
-        })
+        new_mem = await sc.create_memory(
+            {
+                "tenant_id": tenant_id,
+                "agent_id": "test-agent",
+                "memory_type": "fact",
+                "content": new_content,
+                "embedding": emb,
+                "content_hash": ch_new,
+                "weight": 0.5,
+                "status": "active",
+                "visibility": "scope_team",
+            }
+        )
 
         # Build a lightweight stand-in with the attributes find_similar_candidates needs
         new_proxy = MagicMock()

--- a/tests/test_p2_contradiction_batch_status.py
+++ b/tests/test_p2_contradiction_batch_status.py
@@ -1,0 +1,264 @@
+"""Audit P2 — collapse sequential ``update_memory_status`` calls in the
+contradiction detector into one ``batch_update_status`` per detection path.
+
+These shape-explicit tests assert the post-P2 wire effect directly:
+- Exactly one ``sc.batch_update_status({"updates": [...]})`` call per path
+- Zero per-row ``sc.update_memory_status`` calls (the legacy shape)
+- All affected memory_ids present in the batch payload, with the same
+  status / supersedes_id values the serial path produced
+
+Companion to the legacy-shape assertions in
+``test_contradiction_direction_invariance.py`` and ``test_p1_contradiction.py``,
+which now route through ``install_batch_status_replay_shim`` and stay
+backward-compatible.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from core_api.constants import VECTOR_DIM
+from core_api.services.contradiction_detector import _detect
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+def _make_new(
+    *, mid: str, ts: str = "2026-04-29T12:00:00+00:00", object_value: str = "B"
+) -> dict:
+    return {
+        "id": mid,
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "content": f"X lives in {object_value}",
+        "subject_entity_id": "00000000-0000-0000-0000-0000000000aa",
+        "predicate": "lives_in",
+        "object_value": object_value,
+        "deleted_at": None,
+        "status": "active",
+        "visibility": "scope_team",
+        "supersedes_id": None,
+        "created_at": ts,
+    }
+
+
+def _make_cand(
+    *, cid: str, ts: str = "2026-04-29T10:00:00+00:00", object_value: str = "A"
+) -> dict:
+    return {
+        "id": cid,
+        "content": f"X lives in {object_value}",
+        "status": "active",
+        "object_value": object_value,
+        "created_at": ts,
+    }
+
+
+# ----------------------------------------------------------------------------
+# RDF path — one batch call covering all rdf_conflicts
+# ----------------------------------------------------------------------------
+
+
+async def test_rdf_path_collapses_to_one_batch_call():
+    """Three RDF conflicts → one ``batch_update_status`` HTTP, not three
+    (audit P2 RDF path: lines 300/322/347 pre-fix)."""
+    new_id = str(uuid4())
+    new = _make_new(mid=new_id)
+
+    # Three older candidates — canonical direction for each.
+    cands = [_make_cand(cid=str(uuid4()), object_value=f"v{i}") for i in range(3)]
+
+    mock_sc = AsyncMock()
+    mock_sc.find_rdf_conflicts = AsyncMock(return_value=cands)
+    mock_sc.batch_update_status = AsyncMock(return_value={"ok": True, "skipped": []})
+    mock_sc.update_memory_status = AsyncMock()
+    mock_sc.find_similar_candidates = AsyncMock(return_value=[])
+
+    with patch(
+        "core_api.services.contradiction_detector.get_storage_client",
+        return_value=mock_sc,
+    ):
+        await _detect(new, [0.1] * VECTOR_DIM)
+
+    assert mock_sc.update_memory_status.call_count == 0, (
+        f"per-row update_memory_status must be 0 after P2; got "
+        f"{mock_sc.update_memory_status.call_count} call(s)"
+    )
+    assert mock_sc.batch_update_status.call_count == 1, (
+        f"expected exactly 1 batch_update_status; got "
+        f"{mock_sc.batch_update_status.call_count}"
+    )
+    payload = mock_sc.batch_update_status.call_args.args[0]
+    # Per candidate the canonical path writes 1 row (older → outdated) plus,
+    # for the FIRST canonical candidate only, 1 more row (new_memory →
+    # supersedes_id wired). With 3 same-direction candidates that's 3 + 1 = 4.
+    assert len(payload["updates"]) == 4
+
+    older_rows = [u for u in payload["updates"] if u["status"] == "outdated"]
+    new_rows = [u for u in payload["updates"] if u["memory_id"] == new_id]
+    assert len(older_rows) == 3
+    assert len(new_rows) == 1
+    assert "supersedes_id" in new_rows[0]
+
+
+# ----------------------------------------------------------------------------
+# Semantic path — one batch call covering all gather'd verdicts
+# ----------------------------------------------------------------------------
+
+
+async def test_semantic_path_collapses_to_one_batch_call():
+    """Two semantic-conflict verdicts → one batch call (lines 433/446/463
+    pre-fix)."""
+    new_id = str(uuid4())
+    # Use a non-RDF-eligible predicate so we go straight to the semantic
+    # path. Easiest: drop subject_entity_id/predicate/object_value.
+    new = _make_new(mid=new_id)
+    new["subject_entity_id"] = None
+    new["predicate"] = None
+    new["object_value"] = None
+
+    cands = [_make_cand(cid=str(uuid4()), object_value=f"v{i}") for i in range(2)]
+
+    mock_sc = AsyncMock()
+    mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])  # not reached
+    mock_sc.find_similar_candidates = AsyncMock(return_value=cands)
+    mock_sc.batch_update_status = AsyncMock(return_value={"ok": True, "skipped": []})
+    mock_sc.update_memory_status = AsyncMock()
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=mock_sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            AsyncMock(return_value=(True, 0.9)),  # both verdicts: contradict
+        ),
+    ):
+        await _detect(new, [0.1] * VECTOR_DIM)
+
+    assert mock_sc.update_memory_status.call_count == 0
+    assert mock_sc.batch_update_status.call_count == 1
+    payload = mock_sc.batch_update_status.call_args.args[0]
+    # Two canonical candidates ⇒ 2 older-conflicted rows + 1 new_memory
+    # row (only the FIRST canonical candidate wires supersedes_id; the
+    # ``if not supersedes_id`` gate skips the rest). Total 3.
+    assert len(payload["updates"]) == 3
+
+    conflicted = [
+        u
+        for u in payload["updates"]
+        if u["status"] == "conflicted" and u["memory_id"] != new_id
+    ]
+    new_row = [u for u in payload["updates"] if u["memory_id"] == new_id]
+    assert len(conflicted) == 2
+    assert len(new_row) == 1
+    assert new_row[0].get("supersedes_id") is not None
+
+
+# ----------------------------------------------------------------------------
+# Empty paths — no batch call when there are no conflicts
+# ----------------------------------------------------------------------------
+
+
+async def test_rdf_path_empty_conflicts_skips_batch_call():
+    """No RDF conflicts → no batch_update_status HTTP (avoid empty round-trip)."""
+    new = _make_new(mid=str(uuid4()))
+
+    mock_sc = AsyncMock()
+    mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
+    mock_sc.find_similar_candidates = AsyncMock(return_value=[])
+    mock_sc.batch_update_status = AsyncMock()
+    mock_sc.update_memory_status = AsyncMock()
+
+    with patch(
+        "core_api.services.contradiction_detector.get_storage_client",
+        return_value=mock_sc,
+    ):
+        await _detect(new, [0.1] * VECTOR_DIM)
+
+    assert mock_sc.batch_update_status.call_count == 0
+    assert mock_sc.update_memory_status.call_count == 0
+
+
+async def test_semantic_path_no_verdicts_skips_batch_call():
+    """All candidates non-contradictory → no batch call."""
+    new = _make_new(mid=str(uuid4()))
+    new["subject_entity_id"] = None
+    new["predicate"] = None
+    new["object_value"] = None
+
+    cands = [_make_cand(cid=str(uuid4()))]
+
+    mock_sc = AsyncMock()
+    mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
+    mock_sc.find_similar_candidates = AsyncMock(return_value=cands)
+    mock_sc.batch_update_status = AsyncMock()
+    mock_sc.update_memory_status = AsyncMock()
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=mock_sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            AsyncMock(return_value=(False, 0.1)),  # no verdict
+        ),
+    ):
+        await _detect(new, [0.1] * VECTOR_DIM)
+
+    assert mock_sc.batch_update_status.call_count == 0
+    assert mock_sc.update_memory_status.call_count == 0
+
+
+# ----------------------------------------------------------------------------
+# Mixed gather results — exception in one candidate doesn't break the batch
+# ----------------------------------------------------------------------------
+
+
+async def test_semantic_path_skips_exception_candidate_still_batches():
+    """One LLM call raises, one returns verdict=True. The exception
+    candidate is skipped; the successful one still ends up in the batch."""
+    new_id = str(uuid4())
+    new = _make_new(mid=new_id)
+    new["subject_entity_id"] = None
+    new["predicate"] = None
+    new["object_value"] = None
+
+    cands = [
+        _make_cand(cid=str(uuid4()), object_value="explode"),
+        _make_cand(cid=str(uuid4()), object_value="ok"),
+    ]
+
+    async def _judge(new_content, old_content, _cfg):
+        if "explode" in old_content:
+            raise TimeoutError("simulated llm timeout")
+        return (True, 0.9)
+
+    mock_sc = AsyncMock()
+    mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
+    mock_sc.find_similar_candidates = AsyncMock(return_value=cands)
+    mock_sc.batch_update_status = AsyncMock(return_value={"ok": True, "skipped": []})
+    mock_sc.update_memory_status = AsyncMock()
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=mock_sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            side_effect=_judge,
+        ),
+    ):
+        await _detect(new, [0.1] * VECTOR_DIM)
+
+    assert mock_sc.update_memory_status.call_count == 0
+    assert mock_sc.batch_update_status.call_count == 1
+    payload = mock_sc.batch_update_status.call_args.args[0]
+    # One verdict ⇒ 1 candidate-conflicted row + 1 new_memory row.
+    assert len(payload["updates"]) == 2

--- a/tests/test_single_value_predicates.py
+++ b/tests/test_single_value_predicates.py
@@ -16,6 +16,7 @@ from core_api.constants import (
     SINGLE_VALUE_PREDICATES,
     VECTOR_DIM,
 )
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +199,7 @@ class TestRdfPathGating:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[old_mem])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -227,6 +229,7 @@ class TestRdfPathGating:
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
         mock_sc.find_similar_candidates = AsyncMock(return_value=[])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -258,6 +261,7 @@ class TestRdfPathGating:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[old_mem])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -284,6 +288,7 @@ class TestRdfPathGating:
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
         mock_sc.find_similar_candidates = AsyncMock(return_value=[])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -315,6 +320,7 @@ class TestRdfPathGating:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[old_mem])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",

--- a/tests/test_visibility_contradiction.py
+++ b/tests/test_visibility_contradiction.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 import pytest
 
 from core_api.constants import VECTOR_DIM
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +217,7 @@ class TestContradictionVisibilityScoping:
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
         mock_sc.find_similar_candidates = AsyncMock(return_value=[])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -228,9 +230,7 @@ class TestContradictionVisibilityScoping:
         mock_sc.find_rdf_conflicts.assert_called_once()
         # Verify tenant_id was passed (fleet scoping is handled by storage client)
         call_args = mock_sc.find_rdf_conflicts.call_args
-        assert call_args[0][0] == "t1", (
-            "RDF query must include tenant_id"
-        )
+        assert call_args[0][0] == "t1", "RDF query must include tenant_id"
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +289,7 @@ class TestSupersessionFirstMatchOnly:
         mock_sc = AsyncMock()
         mock_sc.find_rdf_conflicts = AsyncMock(return_value=[old_mem_1, old_mem_2])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
         with patch(
             "core_api.services.contradiction_detector.get_storage_client",
@@ -306,7 +307,8 @@ class TestSupersessionFirstMatchOnly:
 
         # supersedes_id should point to the first contradicted memory
         supersession_calls = [
-            c for c in mock_sc.update_memory_status.call_args_list
+            c
+            for c in mock_sc.update_memory_status.call_args_list
             if c.kwargs.get("supersedes_id")
         ]
         assert len(supersession_calls) == 1, (
@@ -358,15 +360,19 @@ class TestSupersessionFirstMatchOnly:
         mock_sc = AsyncMock()
         mock_sc.find_similar_candidates = AsyncMock(return_value=[old_mem_1, old_mem_2])
         mock_sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(mock_sc)
 
-        with patch(
-            "core_api.services.contradiction_detector.get_storage_client",
-            return_value=mock_sc,
-        ), patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
-            new_callable=AsyncMock,
-            # A4 #12 — judge returns (verdict, confidence) tuple.
-            return_value=(True, 0.90),
+        with (
+            patch(
+                "core_api.services.contradiction_detector.get_storage_client",
+                return_value=mock_sc,
+            ),
+            patch(
+                "core_api.services.contradiction_detector._llm_contradiction_check",
+                new_callable=AsyncMock,
+                # A4 #12 — judge returns (verdict, confidence) tuple.
+                return_value=(True, 0.90),
+            ),
         ):
             embedding = [0.1] * VECTOR_DIM
             contradictions = await _detect(new_memory, embedding)
@@ -376,8 +382,10 @@ class TestSupersessionFirstMatchOnly:
         # supersedes_id should point to the first contradicted memory.
         # Verify via the update_memory_status calls that set supersedes_id
         supersession_calls = [
-            c for c in mock_sc.update_memory_status.call_args_list
-            if c.kwargs.get("supersedes_id") or (len(c.args) > 1 and "supersedes_id" in str(c))
+            c
+            for c in mock_sc.update_memory_status.call_args_list
+            if c.kwargs.get("supersedes_id")
+            or (len(c.args) > 1 and "supersedes_id" in str(c))
         ]
         # The first status update with supersedes_id should reference old_id_1
         assert any(
@@ -386,7 +394,10 @@ class TestSupersessionFirstMatchOnly:
 
         # Verify both old memories were marked conflicted
         conflicted_calls = [
-            c for c in mock_sc.update_memory_status.call_args_list
+            c
+            for c in mock_sc.update_memory_status.call_args_list
             if "conflicted" in str(c)
         ]
-        assert len(conflicted_calls) >= 2, "Both old memories should be marked conflicted"
+        assert len(conflicted_calls) >= 2, (
+            "Both old memories should be marked conflicted"
+        )


### PR DESCRIPTION
## Summary

Audit P2 — the contradiction detector issued up to **3K** `update_memory_status` HTTPs per detection cycle (K conflicts × 3 call shapes per match), all serial, after the parallel LLM `asyncio.gather`. The `batch_update_status` storage endpoint (widened in #222) was sitting with zero callers. This PR is its first consumer.

## Sites collapsed (9 → 3 batch flushes)

| Path | Before | After |
|---|---|---|
| Semantic (`_detect`, post-gather loop) | 3 call shapes at lines 433/446/463 | 1 `batch_update_status` |
| Path C (`detect_contradictions_by_entities_async`) | 3 call shapes at lines 1064/1075/1092 | 1 `batch_update_status` |
| RDF (`_detect`, `for old in rdf_conflicts`) | 3 call shapes at lines 300/322/347 | 1 `batch_update_status` |

`_attempt_path_c_retraction`'s two sequential `update_memory_status` calls stay — they're not in a loop, only 2 calls; collapsing costs more clarity than it saves.

## Test plan

- [x] New `tests/test_p2_contradiction_batch_status.py` (5 tests) — asserts shape directly: exactly one `batch_update_status` per cycle, zero per-row `update_memory_status`, correct payload contents per path, empty paths skip the HTTP, gather-exception isolation
- [x] Legacy `mock_sc.update_memory_status.call_args_list` assertions in 7 test files stay green via `tests/_contradiction_batch_compat.install_batch_status_replay_shim` — a one-line addition per test setup that routes the batch call back to per-row mock invocations, sparing ~80 mechanical assertion migrations
- [x] Full contradiction-related sweep: **144/144** unit tests pass (`test_contradiction_*`, `test_a4_*`, `test_p1_contradiction`, `test_p2_contradiction_batch_status`, `test_visibility_contradiction`, `test_a1_17_subject_entity_preflight`, `test_embed_stability`)
- [x] Integration tests still pass: `test_a4_11_overlap_includes_conflicted_supersedes`, `test_a4_status_retraction`, `test_api_contradictions`, `test_storage_bulk_endpoints` (53/53)
- [x] Ruff lint + format clean on the touched files
- [x] mypy clean on `core-api` (single pre-existing `config.py` croniter stub error confirmed on `main` before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)