### PR TITLE
CAURA-687 fix(search): wire ENTITY_LOOKUP short-circuit to dedicated …

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -606,6 +606,15 @@ class CoreStorageClient:
     async def scored_search(self, data: dict) -> list[dict]:
         return await self._post("/memories/scored-search", data, read=True)  # type: ignore[return-value]
 
+    async def load_memories_by_ids(self, data: dict) -> list[dict]:
+        """ENTITY_LOOKUP short-circuit endpoint (CAURA-687).
+
+        Skips vector/FTS/freshness scoring — caller supplies memory IDs,
+        server applies visibility/fleet/agent filters and returns raw
+        memory rows. Pairs with PostgresService.memory_load_by_ids.
+        """
+        return await self._post("/memories/load-by-ids", data, read=True)  # type: ignore[return-value]
+
     async def archive_expired(self, tenant_id: str, fleet_id: str | None = None) -> int:
         data: dict[str, Any] = {"tenant_id": tenant_id}
         if fleet_id is not None:

--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 import re
 import types
+from datetime import datetime
 from uuid import UUID
 
 from core_api.clients.storage_client import get_storage_client
@@ -65,6 +66,8 @@ class ClassifyQuery:
         filter_agent_id: str | None = ctx.data.get("filter_agent_id")
         memory_type_filter: str | None = ctx.data.get("memory_type_filter")
         status_filter: str | None = ctx.data.get("status_filter")
+        valid_at = ctx.data.get("valid_at")
+        readable_tenant_ids: list[str] | None = ctx.data.get("readable_tenant_ids")
         graph_max_hops: int = sp["graph_max_hops"]
         top_k: int = sp["top_k"]
 
@@ -95,6 +98,8 @@ class ClassifyQuery:
                         filter_agent_id=filter_agent_id,
                         memory_type_filter=memory_type_filter,
                         status_filter=status_filter,
+                        valid_at=valid_at,
+                        readable_tenant_ids=readable_tenant_ids,
                     )
 
                     if filtered_rows:
@@ -252,6 +257,8 @@ class ClassifyQuery:
         filter_agent_id: str | None = None,
         memory_type_filter: str | None = None,
         status_filter: str | None = None,
+        valid_at: datetime | None = None,
+        readable_tenant_ids: list[str] | None = None,
     ) -> list[types.SimpleNamespace]:
         """Load memories linked to graph-expanded entities, scored by hop distance."""
         all_entity_ids = list(entity_hops.keys())
@@ -299,10 +306,21 @@ class ClassifyQuery:
             ]
             memory_boost = {mid: memory_boost[mid] for mid in memory_ids_sorted}
 
-        # Use scored_search with entity-lookup mode to load and filter memories.
-        # We pass memory_ids as a filter to get only the linked memories,
-        # with visibility/fleet/agent filters applied server-side.
-        search_data = {
+        # CAURA-687: load memories by ID via the dedicated short-circuit
+        # endpoint. Pre-CAURA-687 this POSTed to /memories/scored-search
+        # with a ``memory_ids`` key + ``entity_lookup: True`` flag that
+        # route never read; storage hard-indexed body["embedding"], 500'd,
+        # and the broad except below swallowed it. The path silently fell
+        # through to keyword/semantic on every entity-token query.
+        # ``valid_at`` / ``readable_tenant_ids`` are forwarded so this
+        # short-circuit's visibility behaviour matches the scored-search
+        # fallthrough exactly — drift is a cross-tenant leak risk.
+        # top_k is intentionally NOT forwarded: storage returns ALL matching
+        # IDs (capped client-side at GRAPH_MAX_BOOSTED_MEMORIES = 50), and
+        # the user-facing top_k is applied below AFTER sorting by hop boost.
+        # A server-side LIMIT here would discard high-boost rows non-
+        # deterministically because the storage query has no ORDER BY.
+        search_data: dict = {
             "tenant_id": tenant_id,
             "memory_ids": list(memory_boost.keys()),
             "fleet_ids": fleet_ids,
@@ -310,9 +328,16 @@ class ClassifyQuery:
             "filter_agent_id": filter_agent_id,
             "memory_type_filter": memory_type_filter,
             "status_filter": status_filter,
-            "top_k": top_k,
-            "entity_lookup": True,
         }
+        if valid_at is not None:
+            search_data["valid_at"] = str(valid_at)
+        # Forward readable_tenant_ids whenever the caller's authorised set
+        # differs from home-tenant-only. The explicit comparison (rather
+        # than `len > 1`) handles the edge case where a single-element
+        # list names a tenant other than ``tenant_id``: silently dropping
+        # it would degrade to home-tenant reads with no error or log.
+        if readable_tenant_ids and readable_tenant_ids != [tenant_id]:
+            search_data["readable_tenant_ids"] = readable_tenant_ids
         # Per-tenant storage bulkhead (CAURA-602 follow-up). Same key as
         # the main scored-search step in execute_scored_search.py — a
         # single classify-then-execute pipeline acquires the slot twice
@@ -320,7 +345,7 @@ class ClassifyQuery:
         # to its own storage roundtrip, so there's no deadlock or
         # cumulative latency beyond the time storage actually spends.
         async with per_tenant_storage_slot("storage_search", tenant_id):
-            memories = await sc.scored_search(search_data)
+            memories = await sc.load_memories_by_ids(search_data)
 
         # Build result rows with boost scores.
         memories_by_id = {m["id"]: m for m in memories}

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -189,6 +189,79 @@ async def scored_search(request: Request) -> list[dict]:
     return out
 
 
+@router.post("/load-by-ids")
+async def load_by_ids(request: Request) -> list[dict]:
+    """Load memories by ID with visibility/fleet/agent filters applied.
+
+    CAURA-687: dedicated endpoint for the ENTITY_LOOKUP short-circuit.
+    Bypasses vector cosine + FTS + freshness scoring — the caller (
+    ClassifyQuery._collect_memories in core-api) already picked the
+    memory IDs via entity graph expansion and just needs them loaded
+    with the standard visibility filters applied server-side.
+
+    Previously this caller POSTed to ``/scored-search`` with a
+    ``memory_ids`` key that route never read; the route hard-indexed
+    ``body["embedding"]`` and 500'd, the broad except in classify_query
+    swallowed it, and the short-circuit silently fell through to
+    keyword/semantic search on every entity-token query.
+    """
+    body: dict = await request.json()
+
+    t_start = time.perf_counter()
+    db_timer = None
+    out: list[dict] = []
+    success = True
+    # Parsed inside try so malformed-input failures (bad UUID, non-ISO
+    # date) get captured by log_request in the finally rather than
+    # bubbling up unlogged. Pre-declared so the finally can read them
+    # safely even if the parse raised.
+    memory_ids: list[UUID] = []
+    try:
+        memory_ids = [UUID(mid) for mid in body.get("memory_ids", [])]
+        if not memory_ids:
+            return []
+
+        # Explicit 422 on missing tenant_id rather than letting body["tenant_id"]
+        # raise a bare KeyError that the broad except below turns into an opaque
+        # 500. Callers should know the difference between "I sent a bad payload"
+        # and "the server blew up".
+        tenant_id: str | None = body.get("tenant_id")
+        if not tenant_id:
+            raise HTTPException(status_code=422, detail="tenant_id is required")
+
+        valid_at = body.get("valid_at")
+        if isinstance(valid_at, str):
+            valid_at = datetime.fromisoformat(valid_at)
+
+        with bind_timer() as db_timer:
+            memories = await _svc.memory_load_by_ids(
+                memory_ids=memory_ids,
+                tenant_id=tenant_id,
+                fleet_ids=body.get("fleet_ids"),
+                caller_agent_id=body.get("caller_agent_id"),
+                filter_agent_id=body.get("filter_agent_id"),
+                memory_type_filter=body.get("memory_type_filter"),
+                status_filter=body.get("status_filter"),
+                valid_at=valid_at,
+                readable_tenant_ids=body.get("readable_tenant_ids") or None,
+            )
+        out = [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
+    except Exception:
+        success = False
+        raise
+    finally:
+        log_request(
+            "load-by-ids",
+            tenant_id=body.get("tenant_id"),
+            total_ms=(time.perf_counter() - t_start) * 1000,
+            db_ms=db_timer.total_ms if db_timer is not None else 0.0,
+            row_count=len(out),
+            id_count=len(memory_ids),
+            error=not success,
+        )
+    return out
+
+
 # ------------------------------------------------------------------
 # Dedup / content hash
 # ------------------------------------------------------------------

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1169,6 +1169,112 @@ class PostgresService:
         return list(grouped.values())
 
     # ------------------------------------------------------------------
+    # C-2) Load specific memories by ID (ENTITY_LOOKUP short-circuit)
+    # ------------------------------------------------------------------
+
+    async def memory_load_by_ids(
+        self,
+        memory_ids: list[UUID],
+        tenant_id: str,
+        *,
+        fleet_ids: list[str] | None = None,
+        caller_agent_id: str | None = None,
+        filter_agent_id: str | None = None,
+        memory_type_filter: str | None = None,
+        status_filter: str | None = None,
+        valid_at: datetime | None = None,
+        readable_tenant_ids: list[str] | None = None,
+    ) -> list[Memory]:
+        """Load memories by ID with visibility/fleet/agent filters applied.
+
+        Used by the ENTITY_LOOKUP short-circuit in ``ClassifyQuery._collect_memories``,
+        which already chose the specific memory IDs based on entity graph
+        expansion and just needs them loaded — no vector cosine, no FTS,
+        no freshness scoring.
+
+        No server-side ``top_k`` LIMIT: the caller has already capped the
+        ID set at ``GRAPH_MAX_BOOSTED_MEMORIES`` (=50) and will apply the
+        user-facing ``top_k`` AFTER sorting by hop-distance boost. A SQL
+        LIMIT here would return an arbitrary subset (no ORDER BY in this
+        query) and silently discard high-boost rows before the sort.
+
+        CAURA-687: the short-circuit previously POSTed to ``/memories/
+        scored-search`` with a ``memory_ids`` key + ``entity_lookup: True``
+        flag the route never read, so storage hard-indexed ``body["embedding"]``
+        and 500'd. The broad except at classify_query.py:123 swallowed it,
+        and the path silently fell through to keyword/semantic.
+
+        Filter semantics MUST match ``memory_scored_search`` exactly so the
+        short-circuit and the scored-search fallthrough surface identical
+        rows when given the same filter args. Any drift is a cross-tenant
+        leak risk — keep these two WHERE-clause blocks in sync.
+        """
+        if not memory_ids:
+            return []
+        async with get_read_session() as session:
+            stmt = select(Memory).where(
+                Memory.id.in_(memory_ids),
+                Memory.tenant_id.in_(readable_tenant_ids)
+                if readable_tenant_ids
+                else Memory.tenant_id == tenant_id,
+                Memory.deleted_at.is_(None),
+            )
+            if fleet_ids:
+                stmt = stmt.where(
+                    or_(
+                        Memory.fleet_id.in_(fleet_ids),
+                        Memory.fleet_id.is_(None),
+                        Memory.visibility == "scope_org",
+                    )
+                )
+            if caller_agent_id:
+                stmt = stmt.where(
+                    or_(
+                        Memory.visibility == "scope_org",
+                        Memory.visibility == "scope_team",
+                        and_(
+                            Memory.visibility == "scope_agent",
+                            Memory.agent_id == caller_agent_id,
+                        ),
+                    )
+                )
+            else:
+                stmt = stmt.where(Memory.visibility != "scope_agent")
+            if filter_agent_id:
+                stmt = stmt.where(Memory.agent_id == filter_agent_id)
+            if memory_type_filter:
+                stmt = stmt.where(Memory.memory_type == memory_type_filter)
+            if status_filter:
+                stmt = stmt.where(Memory.status == status_filter)
+            else:
+                # Mirrors scored_search: exclude superseded memories from
+                # default results. Callers wanting them pass status_filter.
+                stmt = stmt.where(Memory.status.notin_(("outdated", "conflicted")))
+            if valid_at:
+                from datetime import date as _date_type
+
+                from sqlalchemy import Date as _Date
+                from sqlalchemy import cast as _cast
+                from sqlalchemy import literal as _literal
+
+                # DATE-cast comparison matches scored_search semantics
+                # (same-day-later memories pass). End side is intentionally
+                # NOT a hard filter — see scored_search currency_factor.
+                _valid_at_date = (
+                    valid_at.date()
+                    if hasattr(valid_at, "date")
+                    else _date_type.fromisoformat(str(valid_at)[:10])
+                )
+                stmt = stmt.where(
+                    or_(
+                        Memory.ts_valid_start.is_(None),
+                        _cast(Memory.ts_valid_start, _Date) <= _cast(_literal(_valid_at_date), _Date),
+                    ),
+                )
+            result = await session.execute(stmt)
+            return list(result.scalars().all())
+
+    # ------------------------------------------------------------------
     # D-0) Supersedes chain: find successor memories
     # ------------------------------------------------------------------
 

--- a/tests/pipeline/test_classify_query.py
+++ b/tests/pipeline/test_classify_query.py
@@ -50,6 +50,10 @@ def _mock_sc(**overrides) -> AsyncMock:
     sc.fts_search_entities = AsyncMock(return_value=[])
     sc.expand_graph = AsyncMock(return_value={})
     sc.get_memory_ids_by_entity_ids = AsyncMock(return_value=[])
+    # CAURA-687: ENTITY_LOOKUP short-circuit now calls load_memories_by_ids
+    # (dedicated endpoint) instead of scored_search. scored_search default
+    # kept for legacy test paths that may still reference it.
+    sc.load_memories_by_ids = AsyncMock(return_value=[])
     sc.scored_search = AsyncMock(return_value=[])
     for k, v in overrides.items():
         setattr(sc, k, v)
@@ -110,7 +114,8 @@ async def test_entity_lookup_with_match(mock_get_sc):
     sc.get_memory_ids_by_entity_ids = AsyncMock(
         return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
     )
-    sc.scored_search = AsyncMock(
+    # CAURA-687: ENTITY_LOOKUP path now calls load_memories_by_ids.
+    sc.load_memories_by_ids = AsyncMock(
         return_value=[
             {
                 "id": mid_str,
@@ -295,7 +300,7 @@ async def test_entity_lookup_takes_priority_over_temporal(mock_get_sc):
     sc.get_memory_ids_by_entity_ids = AsyncMock(
         return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
     )
-    sc.scored_search = AsyncMock(
+    sc.load_memories_by_ids = AsyncMock(
         return_value=[
             {
                 "id": mid_str,
@@ -399,7 +404,7 @@ async def test_entity_lookup_takes_priority_over_recent(mock_get_sc):
     sc.get_memory_ids_by_entity_ids = AsyncMock(
         return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
     )
-    sc.scored_search = AsyncMock(
+    sc.load_memories_by_ids = AsyncMock(
         return_value=[
             {
                 "id": mid_str,
@@ -512,7 +517,7 @@ async def test_collect_memories_caps_entity_ids():
 
     sc = AsyncMock()
     sc.get_memory_ids_by_entity_ids = AsyncMock(return_value=[])
-    sc.scored_search = AsyncMock(return_value=[])
+    sc.load_memories_by_ids = AsyncMock(return_value=[])
 
     result = await ClassifyQuery._collect_memories(
         sc=sc,

--- a/tests/test_entity_lookup_short_circuit.py
+++ b/tests/test_entity_lookup_short_circuit.py
@@ -62,11 +62,9 @@ async def test_entity_lookup_short_circuit_fires_with_dict_shaped_expand_graph()
             }
         ]
     )
-    # _collect_memories' scored_search call is mocked to return rows
-    # directly. The deeper bug — payload missing embedding/query/
-    # search_params — is tracked separately; isolating this test from
-    # that contract gap lets the line-214 fix be asserted alone.
-    fake_storage.scored_search = AsyncMock(
+    # CAURA-687: _collect_memories now calls the dedicated
+    # load_memories_by_ids endpoint instead of scored_search.
+    fake_storage.load_memories_by_ids = AsyncMock(
         return_value=[
             {
                 "id": matched_memory_id,
@@ -144,4 +142,208 @@ async def test_expand_per_fleet_parses_dict_shape_directly():
 
     assert merged == {eid1: (0, 1.0), eid2: (1, 0.8)}, (
         f"Expected merged hop/weight tuples; got {merged}"
+    )
+
+
+async def test_collect_memories_forwards_valid_at_and_readable_tenant_ids():
+    """CAURA-687: _collect_memories must forward valid_at and
+    readable_tenant_ids to the load-by-ids endpoint. Pre-687 these were
+    dropped — the short-circuit's visibility behaviour silently diverged
+    from the scored-search fallthrough's (cross-tenant read widening and
+    historical-question filtering both broken).
+    """
+    from datetime import datetime, timezone
+
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.search.classify_query import ClassifyQuery
+    from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
+
+    matched_entity_id = uuid4()
+    matched_memory_id = str(uuid4())
+    valid_at_dt = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+
+    fake_storage = AsyncMock()
+    fake_storage.fts_search_entities = AsyncMock(return_value=[str(matched_entity_id)])
+    fake_storage.expand_graph = AsyncMock(
+        return_value={str(matched_entity_id): {"hop": 0, "weight": 1.0}}
+    )
+    fake_storage.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[
+            {"memory_id": matched_memory_id, "entity_id": str(matched_entity_id), "role": "subject"}
+        ]
+    )
+    fake_storage.load_memories_by_ids = AsyncMock(
+        return_value=[
+            {
+                "id": matched_memory_id,
+                "tenant_id": "home-tenant",
+                "content": "x",
+                "memory_type": "task",
+                "weight": 0.5,
+                "status": "active",
+                "ts_valid_start": None,
+                "ts_valid_end": None,
+                "metadata_": {},
+                "fleet_id": None,
+            }
+        ]
+    )
+
+    ctx = PipelineContext()
+    ctx.data = {
+        "query": "central control",
+        "tenant_id": "home-tenant",
+        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 5},
+        "temporal_window": None,
+        "valid_at": valid_at_dt,
+        "readable_tenant_ids": ["home-tenant", "source-tenant-a"],
+    }
+
+    with patch(
+        "core_api.pipeline.steps.search.classify_query.get_storage_client",
+        return_value=fake_storage,
+    ):
+        await ClassifyQuery().execute(ctx)
+
+    assert ctx.data["retrieval_plan"].strategy == RetrievalStrategy.ENTITY_LOOKUP
+    fake_storage.load_memories_by_ids.assert_awaited_once()
+    sent = fake_storage.load_memories_by_ids.await_args.args[0]
+    assert sent["valid_at"] == str(valid_at_dt), (
+        f"valid_at must be forwarded as string; got {sent.get('valid_at')!r}"
+    )
+    assert sent["readable_tenant_ids"] == ["home-tenant", "source-tenant-a"], (
+        f"readable_tenant_ids must be forwarded for cross-tenant reads; "
+        f"got {sent.get('readable_tenant_ids')!r}"
+    )
+    # Sanity: the old stale keys (embedding/query/search_params/entity_lookup)
+    # MUST NOT be present — they were the original payload-contract bug.
+    assert "embedding" not in sent
+    assert "query" not in sent
+    assert "search_params" not in sent
+    assert "entity_lookup" not in sent
+
+
+async def test_collect_memories_omits_readable_tenant_ids_when_single_tenant():
+    """Single-tenant callers (the common case) leave readable_tenant_ids
+    absent from the payload so storage uses the cheap single-tenant
+    WHERE predicate. Mirrors execute_scored_search.py:79-81.
+    """
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.search.classify_query import ClassifyQuery
+
+    matched_entity_id = uuid4()
+    matched_memory_id = str(uuid4())
+
+    fake_storage = AsyncMock()
+    fake_storage.fts_search_entities = AsyncMock(return_value=[str(matched_entity_id)])
+    fake_storage.expand_graph = AsyncMock(
+        return_value={str(matched_entity_id): {"hop": 0, "weight": 1.0}}
+    )
+    fake_storage.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[
+            {"memory_id": matched_memory_id, "entity_id": str(matched_entity_id), "role": "subject"}
+        ]
+    )
+    fake_storage.load_memories_by_ids = AsyncMock(
+        return_value=[
+            {
+                "id": matched_memory_id,
+                "tenant_id": "home-tenant",
+                "content": "x",
+                "memory_type": "task",
+                "weight": 0.5,
+                "status": "active",
+                "ts_valid_start": None,
+                "ts_valid_end": None,
+                "metadata_": {},
+                "fleet_id": None,
+            }
+        ]
+    )
+
+    ctx = PipelineContext()
+    ctx.data = {
+        "query": "central control",
+        "tenant_id": "home-tenant",
+        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 5},
+        "temporal_window": None,
+        # Single-tenant: readable_tenant_ids unset OR equals [tenant_id]
+        "readable_tenant_ids": ["home-tenant"],
+    }
+
+    with patch(
+        "core_api.pipeline.steps.search.classify_query.get_storage_client",
+        return_value=fake_storage,
+    ):
+        await ClassifyQuery().execute(ctx)
+
+    sent = fake_storage.load_memories_by_ids.await_args.args[0]
+    assert "readable_tenant_ids" not in sent, (
+        "Single-tenant calls should not send readable_tenant_ids — "
+        "storage falls back to the cheaper tenant_id == X predicate."
+    )
+
+
+async def test_collect_memories_forwards_single_element_when_different_from_home():
+    """Edge case (PR 237 review): a single-element ``readable_tenant_ids``
+    that names a tenant OTHER than ``tenant_id`` must still be forwarded.
+
+    Previous guard ``len(readable_tenant_ids) > 1`` silently dropped this
+    case, degrading to home-tenant-only reads with no error or log if the
+    upstream middleware ever broke its "single element always == home"
+    invariant. The replacement guard ``!= [tenant_id]`` handles it.
+    """
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.search.classify_query import ClassifyQuery
+
+    matched_entity_id = uuid4()
+    matched_memory_id = str(uuid4())
+
+    fake_storage = AsyncMock()
+    fake_storage.fts_search_entities = AsyncMock(return_value=[str(matched_entity_id)])
+    fake_storage.expand_graph = AsyncMock(
+        return_value={str(matched_entity_id): {"hop": 0, "weight": 1.0}}
+    )
+    fake_storage.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[
+            {"memory_id": matched_memory_id, "entity_id": str(matched_entity_id), "role": "subject"}
+        ]
+    )
+    fake_storage.load_memories_by_ids = AsyncMock(
+        return_value=[
+            {
+                "id": matched_memory_id,
+                "tenant_id": "source-tenant",
+                "content": "x",
+                "memory_type": "task",
+                "weight": 0.5,
+                "status": "active",
+                "ts_valid_start": None,
+                "ts_valid_end": None,
+                "metadata_": {},
+                "fleet_id": None,
+            }
+        ]
+    )
+
+    ctx = PipelineContext()
+    ctx.data = {
+        "query": "central control",
+        "tenant_id": "home-tenant",
+        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 5},
+        "temporal_window": None,
+        # Single element, but NOT the home tenant — must still be forwarded.
+        "readable_tenant_ids": ["source-tenant"],
+    }
+
+    with patch(
+        "core_api.pipeline.steps.search.classify_query.get_storage_client",
+        return_value=fake_storage,
+    ):
+        await ClassifyQuery().execute(ctx)
+
+    sent = fake_storage.load_memories_by_ids.await_args.args[0]
+    assert sent.get("readable_tenant_ids") == ["source-tenant"], (
+        f"single-element readable_tenant_ids that differs from tenant_id "
+        f"must be forwarded; got {sent.get('readable_tenant_ids')!r}"
     )


### PR DESCRIPTION
…storage endpoint

The ENTITY_LOOKUP short-circuit in ClassifyQuery._collect_memories posted a payload with ``memory_ids`` + ``entity_lookup: True`` to ``/memories/ scored-search``, but that route never read those keys — it hard-indexed ``body["embedding"]`` and 500'd. The broad ``except Exception:`` at classify_query.py:123 swallowed the failure and the pipeline silently fell through to keyword/semantic search on every entity-token query.

This was the second bug in the same code path. CAURA-684 fixed the dict- vs-tuple shape mismatch at _expand_per_fleet line 214; once that landed the next gate (_collect_memories → scored_search) became reachable and its contract bug surfaced as a storage 500 (confirmed live in staging 2026-05-27: same query, same fallthrough warning, but trace now ends at KeyError 'embedding' on the storage side instead of KeyError 0 on the client side).

Adopts Approach A from the design discussion:

- New storage method ``PostgresService.memory_load_by_ids`` that selects memories by ID with visibility/fleet/agent/memory_type/status/valid_at filters lifted verbatim from ``memory_scored_search``. No vector cosine, no FTS, no freshness scoring — sub-millisecond ``SELECT WHERE id IN (...)``. Filter clauses MUST stay in sync with ``memory_scored_search`` (any drift is a cross-tenant leak risk — comment notes this for future maintainers).

- New route ``POST /memories/load-by-ids`` (dedicated endpoint rather than a conditional branch inside ``/memories/scored-search`` — clearer contract, smaller blast radius, easier to test).

- New storage client method ``load_memories_by_ids``.

- ``_collect_memories`` switches the call from ``scored_search`` to ``load_memories_by_ids``. Also now forwards ``valid_at`` and ``readable_tenant_ids`` which were silently dropped before — the short-circuit's visibility behaviour now matches the scored-search fallthrough exactly. Drops the unused ``entity_lookup: True`` flag.

Tests:

- tests/test_entity_lookup_short_circuit.py: switched the storage mock to ``load_memories_by_ids``. Added two assertions: (1) ``valid_at`` + ``readable_tenant_ids`` are forwarded in the cross-tenant case. (2) ``readable_tenant_ids`` is OMITTED in the single-tenant case so storage uses the cheap ``tenant_id == X`` predicate. Both also assert the old stale keys (``embedding``/``query``/ ``search_params``/``entity_lookup``) are absent from the payload.

- tests/pipeline/test_classify_query.py: switched the four ENTITY_LOOKUP test paths' mocks from ``scored_search`` to ``load_memories_by_ids``, plus the ``_mock_sc`` default. The remaining scored_search default stays for non-ENTITY_LOOKUP test paths.

Follow-up worth a separate ticket: tighten the broad ``except Exception:`` at classify_query.py:123 to catch only expected exception types so the next regression doesn't take months to surface.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
