### PR TITLE
feat(lifecycle): add insights daily cron

### DIFF
--- a/common/events/__init__.py
+++ b/common/events/__init__.py
@@ -24,6 +24,7 @@ from common.events.lifecycle_publishers import (
     publish_archive_stale_request,
     publish_crystallize_request,
     publish_entity_link_request,
+    publish_insights_request,
     publish_purge_soft_deleted_request,
 )
 from common.events.memory_embed_publisher import publish_memory_embed_request
@@ -49,6 +50,7 @@ __all__ = [
     "publish_archive_stale_request",
     "publish_crystallize_request",
     "publish_entity_link_request",
+    "publish_insights_request",
     "publish_purge_soft_deleted_request",
     "publish_memory_embed_request",
     "publish_memory_enrich_request",

--- a/common/events/lifecycle_handlers.py
+++ b/common/events/lifecycle_handlers.py
@@ -74,6 +74,8 @@ class PipelineStorageAdapter(Protocol):
 
     async def entity_link(self, *, org_id: str, fleet_id: str | None) -> int: ...
 
+    async def insights(self, *, org_id: str, fleet_id: str | None) -> int: ...
+
     async def has_recent_lifecycle_success(
         self, *, org_id: str, action: str, since_hours: int
     ) -> bool: ...
@@ -326,6 +328,9 @@ def register_pipeline_consumers(adapter: PipelineStorageAdapter) -> None:
     async def entity_link_op(req: LifecycleArchiveRequest) -> int:
         return await adapter.entity_link(org_id=req.org_id, fleet_id=req.fleet_id)
 
+    async def insights_op(req: LifecycleArchiveRequest) -> int:
+        return await adapter.insights(org_id=req.org_id, fleet_id=req.fleet_id)
+
     bus = get_event_bus()
     bus.subscribe(
         Topics.Lifecycle.CRYSTALLIZE_REQUESTED,
@@ -348,6 +353,18 @@ def register_pipeline_consumers(adapter: PipelineStorageAdapter) -> None:
             run_op=entity_link_op,
             stats_key="links_created",
             action="entity-link",
+            dedup_window_hours=_PIPELINE_DEDUP_WINDOW_HOURS,
+        ),
+    )
+    bus.subscribe(
+        Topics.Lifecycle.INSIGHTS_REQUESTED,
+        partial(
+            _run_action,
+            adapter=adapter,
+            payload_cls=LifecycleArchiveRequest,
+            run_op=insights_op,
+            stats_key="insights_created",
+            action="insights",
             dedup_window_hours=_PIPELINE_DEDUP_WINDOW_HOURS,
         ),
     )

--- a/common/events/lifecycle_publishers.py
+++ b/common/events/lifecycle_publishers.py
@@ -128,3 +128,27 @@ async def publish_entity_link_request(
             fleet_id=fleet_id,
         ),
     )
+
+
+async def publish_insights_request(
+    *,
+    audit_id: int,
+    org_id: str,
+    triggered_by: str,
+    fleet_id: str | None = None,
+) -> None:
+    """Trigger insights discovery (focus='discover') for one org.
+    Same payload shape as the other pipeline ops. ``auto_insights_enabled``
+    is consulted by the consumer (opt-in, default off); fanout fires
+    blanket and the consumer no-ops orgs that have it disabled or whose
+    corpus hasn't grown since the last insights run.
+    """
+    await _publish(
+        Topics.Lifecycle.INSIGHTS_REQUESTED,
+        LifecycleArchiveRequest(
+            audit_id=audit_id,
+            org_id=org_id,
+            triggered_by=triggered_by,
+            fleet_id=fleet_id,
+        ),
+    )

--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -48,6 +48,7 @@ class Lifecycle(enum.StrEnum):
     # both live there and have transitive deps the worker doesn't carry.
     CRYSTALLIZE_REQUESTED = "memclaw.lifecycle.crystallize-requested"
     ENTITY_LINK_REQUESTED = "memclaw.lifecycle.entity-link-requested"
+    INSIGHTS_REQUESTED = "memclaw.lifecycle.insights-requested"
 
 
 class Topics:

--- a/core-api/src/core_api/routes/lifecycle.py
+++ b/core-api/src/core_api/routes/lifecycle.py
@@ -29,6 +29,7 @@ from common.events import (
     publish_archive_stale_request,
     publish_crystallize_request,
     publish_entity_link_request,
+    publish_insights_request,
     publish_purge_soft_deleted_request,
 )
 from common.events.lifecycle_purge_request import (
@@ -56,6 +57,9 @@ _ACTION_PUBLISHERS: dict[str, _PublisherFn] = {
     # CAURA-657: pipeline ops — consumer is core-api itself.
     "crystallize": publish_crystallize_request,
     "entity-link": publish_entity_link_request,
+    # Periodic discovery insights. Consumer also lives in core-api and
+    # short-circuits via the activity gate + opt-in org flag.
+    "insights": publish_insights_request,
 }
 
 # Cap on concurrent per-org ``audit_begin + publish`` pairs in the

--- a/core-api/src/core_api/services/lifecycle_audit.py
+++ b/core-api/src/core_api/services/lifecycle_audit.py
@@ -94,6 +94,72 @@ class _CoreApiLifecycleAdapter:
         report_id = await run_crystallization(None, org_id, fleet_id, trigger="lifecycle")
         return 1 if report_id is not None else 0
 
+    async def insights(self, *, org_id: str, fleet_id: str | None) -> int:
+        """Lifecycle-driven insights discovery (focus='discover') for one org.
+
+        Two gates:
+
+        1. ``config.auto_insights_enabled`` — opt-in flag (default
+           **False**, unlike crystallize / entity-link which default
+           True). Each tenant must flip this explicitly because the
+           reflection LLM call is expensive and not all corpuses
+           benefit from periodic discovery.
+        2. Activity gate — skip if no non-insight memories have been
+           created since the most-recent insight memory in the same
+           scope. Cheap two-query check; saves an LLM round-trip when
+           the corpus hasn't grown.
+
+        Scope: ``fleet`` when a ``fleet_id`` is supplied, else ``all``.
+        Returns the number of insight memories produced (audit row's
+        ``stats.insights_created``).
+        """
+        config = await resolve_config(None, org_id)
+        if not config.auto_insights_enabled:
+            return 0
+
+        # Lazy imports — insights_service has heavy transitive deps
+        # (LLM clients, embedding providers) we don't want loading at
+        # core-api startup just for the lifecycle adapter wiring.
+        from sqlalchemy import func, select
+
+        from common.models.memory import Memory
+        from core_api.db.session import async_session
+        from core_api.services.insights_service import generate_insights
+
+        # Single session covers both the cheap activity gate and the
+        # heavier ``generate_insights`` pass — mirrors entity_link's
+        # pattern of one session per adapter call, explicit commit.
+        async with async_session() as db:
+            scope_filter = [
+                Memory.tenant_id == org_id,
+                Memory.deleted_at.is_(None),
+            ]
+            if fleet_id:
+                scope_filter.append(Memory.fleet_id == fleet_id)
+
+            latest_non_insight = await db.scalar(
+                select(func.max(Memory.created_at)).where(*scope_filter, Memory.memory_type != "insight")
+            )
+            if latest_non_insight is None:
+                return 0
+
+            latest_insight = await db.scalar(
+                select(func.max(Memory.created_at)).where(*scope_filter, Memory.memory_type == "insight")
+            )
+            if latest_insight is not None and latest_non_insight <= latest_insight:
+                return 0
+
+            result = await generate_insights(
+                db,
+                org_id,
+                focus="discover",
+                scope="fleet" if fleet_id else "all",
+                fleet_id=fleet_id,
+            )
+            await db.commit()
+
+        return len(result.get("insight_memory_ids", []))
+
     async def entity_link(self, *, org_id: str, fleet_id: str | None) -> int:
         """CAURA-657: run the entity-linking pipeline for one org.
 

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -90,6 +90,18 @@ DEFAULT_SETTINGS: dict = {
     "entity_linking": {
         "auto_entity_linking_enabled": None,
     },
+    # Periodic discovery insights (lifecycle-insights cron). Opt-in:
+    # default is False because each tick runs an LLM reasoning pass
+    # per fleet (or per tenant when fleet-less) and that cost is not
+    # justified for every corpus. An org flips this to True when it
+    # wants the daily ``generate_insights(focus='discover')`` pass.
+    # The activity gate inside the consumer additionally skips ticks
+    # where no non-insight memories have been written since the last
+    # insights run, so even an enabled tenant pays only when the
+    # corpus has grown.
+    "insights": {
+        "auto_insights_enabled": None,
+    },
     "chunking": {
         "auto_chunk_enabled": None,
     },
@@ -309,6 +321,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "lifecycle.lifecycle_automation_enabled": bool,
     "lifecycle.memory_retention_days": int,
     "entity_linking.auto_entity_linking_enabled": bool,
+    "insights.auto_insights_enabled": bool,
     "chunking.auto_chunk_enabled": bool,
     "agents.require_agent_approval": bool,
     "entity_blocklist": list,
@@ -529,6 +542,14 @@ class ResolvedConfig:
     def auto_entity_linking_enabled(self) -> bool:
         val = self._ts.get("entity_linking", {}).get("auto_entity_linking_enabled")
         return val if val is not None else True
+
+    # Insights — opt-in (default False). Sibling of auto_crystallize /
+    # auto_entity_linking but with the inverse default because the
+    # discovery LLM pass is expensive and not universally useful.
+    @property
+    def auto_insights_enabled(self) -> bool:
+        val = self._ts.get("insights", {}).get("auto_insights_enabled")
+        return val if val is not None else False
 
     # Chunking
     @property

--- a/core-operations/src/core_operations/app.py
+++ b/core-operations/src/core_operations/app.py
@@ -32,6 +32,7 @@ from core_operations.tasks import (
     run_archive_stale_tick,
     run_crystallize_tick,
     run_entity_link_tick,
+    run_insights_tick,
     run_purge_soft_deleted_tick,
 )
 
@@ -66,6 +67,11 @@ def _register_scheduled_tasks() -> None:
         "lifecycle-entity-link",
         settings.lifecycle_pipeline_interval_seconds,
         run_entity_link_tick,
+    )
+    scheduler.register(
+        "lifecycle-insights",
+        settings.lifecycle_insights_interval_seconds,
+        run_insights_tick,
     )
 
 

--- a/core-operations/src/core_operations/config.py
+++ b/core-operations/src/core_operations/config.py
@@ -52,6 +52,14 @@ class Settings(BaseSettings):
     # cycle (cost) or different schedule (off-peak). Default daily;
     # the consumer-side dedup gate filters double-fires within 23h.
     lifecycle_pipeline_interval_seconds: float = 24 * 3600
+    # Insights discovery (focus='discover') cadence. Separate knob
+    # because it's opt-in per-org (``auto_insights_enabled``, default
+    # off) and individual operators may want a longer cycle than the
+    # crystallize/entity-link pair. The consumer's activity gate also
+    # short-circuits to a no-op when no non-insight memories landed
+    # since the last run, so re-firing more aggressively is mostly
+    # harmless. Daily default.
+    lifecycle_insights_interval_seconds: float = 24 * 3600
 
 
 settings = Settings()  # type: ignore[call-arg]

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -99,3 +99,15 @@ async def run_entity_link_tick() -> None:
     consumer-side dedup window as crystallize.
     """
     await _fire_fanout("entity-link")
+
+
+async def run_insights_tick() -> None:
+    """Trigger insights discovery per active org. Same shape as the
+    crystallize / entity-link ticks — POST the fanout endpoint and
+    let core-api enumerate orgs + publish per-org events. The
+    consumer is opt-in (``auto_insights_enabled`` default off) and
+    short-circuits via an activity gate when the corpus hasn't grown
+    since the last insights run, so firing daily is safe even for
+    quiet tenants.
+    """
+    await _fire_fanout("insights")

--- a/core-operations/tests/test_tasks.py
+++ b/core-operations/tests/test_tasks.py
@@ -155,3 +155,15 @@ async def test_entity_link_tick_hits_correct_path(monkeypatch: pytest.MonkeyPatc
         await tasks.run_entity_link_tick()
 
     assert stub.calls[0][0].endswith("/admin/lifecycle/fanout/entity-link")
+
+
+@pytest.mark.asyncio
+async def test_insights_tick_hits_correct_path(monkeypatch: pytest.MonkeyPatch):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    response = _StubResponse(200, {"action": "insights", "published": 1, "failed": 0})
+    async with _patch_client(monkeypatch, response=response) as stub:
+        await tasks.run_insights_tick()
+
+    assert stub.calls[0][0].endswith("/admin/lifecycle/fanout/insights")

--- a/tests/test_lifecycle_automation.py
+++ b/tests/test_lifecycle_automation.py
@@ -87,6 +87,10 @@ class TestLifecycleTopics:
             Topics.Lifecycle.ENTITY_LINK_REQUESTED
             == "memclaw.lifecycle.entity-link-requested"
         )
+        assert (
+            Topics.Lifecycle.INSIGHTS_REQUESTED
+            == "memclaw.lifecycle.insights-requested"
+        )
 
     def test_topic_strenum_format(self):
         from common.events.topics import Topics

--- a/tests/test_lifecycle_handlers.py
+++ b/tests/test_lifecycle_handlers.py
@@ -30,6 +30,7 @@ class _FakeAdapter:
         purged_count: int = 5,
         crystallized_count: int = 1,
         entity_linked_count: int = 12,
+        insights_count: int = 3,
         raise_on_op: Exception | None = None,
         has_recent_success: bool = False,
         raise_on_dedup_check: Exception | None = None,
@@ -39,6 +40,7 @@ class _FakeAdapter:
         self.purged_count = purged_count
         self.crystallized_count = crystallized_count
         self.entity_linked_count = entity_linked_count
+        self.insights_count = insights_count
         self.raise_on_op = raise_on_op
         self.has_recent_success_value = has_recent_success
         self.raise_on_dedup_check = raise_on_dedup_check
@@ -77,6 +79,12 @@ class _FakeAdapter:
         if self.raise_on_op is not None:
             raise self.raise_on_op
         return self.entity_linked_count
+
+    async def insights(self, *, org_id: str, fleet_id: str | None) -> int:
+        self.archive_calls.append(("insights", org_id, fleet_id, None))
+        if self.raise_on_op is not None:
+            raise self.raise_on_op
+        return self.insights_count
 
     async def has_recent_lifecycle_success(
         self, *, org_id: str, action: str, since_hours: int
@@ -180,6 +188,13 @@ def _bind(adapter: _FakeAdapter, *, action: str, dedup_window_hours: int | None 
 
         payload_cls = LifecycleArchiveRequest
         stats_key = "links_created"
+    elif action == "insights":
+
+        async def _op(req: LifecycleArchiveRequest) -> int:
+            return await adapter.insights(org_id=req.org_id, fleet_id=req.fleet_id)
+
+        payload_cls = LifecycleArchiveRequest
+        stats_key = "insights_created"
     else:
         raise ValueError(f"unknown action {action!r}")
 
@@ -346,6 +361,38 @@ async def test_entity_link_runs_when_no_recent_success():
     await handler(_archive_event(Topics.Lifecycle.ENTITY_LINK_REQUESTED))
     assert adapter.archive_calls == [("entity-link", "tenant-x", None, None)]
     assert adapter.audit_calls[-1][2] == {"links_created": 42}
+
+
+@pytest.mark.asyncio
+async def test_insights_runs_when_no_recent_success():
+    adapter = _FakeAdapter(insights_count=7, has_recent_success=False)
+    handler = _bind(adapter, action="insights", dedup_window_hours=23)
+    await handler(_archive_event(Topics.Lifecycle.INSIGHTS_REQUESTED))
+    # Dedup gate consulted with the same 23h window the pipeline ops use.
+    assert adapter.dedup_calls == [("tenant-x", "insights", 23)]
+    # Primitive invoked with the published payload.
+    assert adapter.archive_calls == [("insights", "tenant-x", None, None)]
+    # Audit transitions: in_progress → success carrying the new stats key.
+    statuses = [c[1] for c in adapter.audit_calls]
+    assert statuses == ["in_progress", "success"]
+    assert adapter.audit_calls[-1][2] == {"insights_created": 7}
+
+
+@pytest.mark.asyncio
+async def test_insights_dedup_gate_skips_when_recent_success_exists():
+    """Insights inherits the 23h pipeline dedup gate: a successful
+    run in the window short-circuits to a no-op success record with
+    ``stats={skipped: True}`` and the adapter primitive is never invoked.
+    """
+    adapter = _FakeAdapter(has_recent_success=True)
+    handler = _bind(adapter, action="insights", dedup_window_hours=23)
+    await handler(_archive_event(Topics.Lifecycle.INSIGHTS_REQUESTED))
+    assert adapter.archive_calls == []
+    assert len(adapter.audit_calls) == 1
+    _, status, stats, error = adapter.audit_calls[0]
+    assert status == "success"
+    assert stats == {"skipped": True, "reason": "recent_success"}
+    assert error is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a sixth lifecycle cron — `lifecycle-insights` — that fans out a daily `generate_insights(focus='discover')` pass per active org. Mirrors the crystallize / entity-link pattern exactly: dedicated topic, publisher, subscriber, adapter method, cron tick, fanout case, and org-settings flag.

Closes the gap surfaced when a tenant connected to memclaw.net accrued memories for two days without producing a single `memory_type=insight` row: `core-operations` registered only five lifecycle jobs and the insights service was reachable only via the on-demand MCP/REST surface — no scheduler called it.

## Behavior

- **Opt-in** — new org setting `insights.auto_insights_enabled` defaults to **False** (sibling of `auto_crystallize_enabled` / `auto_entity_linking_enabled` but with the inverse default). The reflection LLM call is expensive and not universally useful, so operators flip the flag explicitly per tenant.
- **Activity gate** — even on enabled tenants the consumer short-circuits when no non-insight memories have been written since the most-recent insight memory in scope. Two cheap `select max(created_at)` queries; saves the LLM round-trip when the corpus hasn't grown.
- **Dedup window** — inherits the same `_PIPELINE_DEDUP_WINDOW_HOURS=23` gate as crystallize / entity-link.
- **Scope** — `fleet` when a `fleet_id` is supplied, otherwise `all`. Stats key is `insights_created` on the `lifecycle_audit` row.

## Changes

13 files, +224/-0:

- `common/events/topics.py` — new `Lifecycle.INSIGHTS_REQUESTED` topic.
- `common/events/lifecycle_publishers.py` + `__init__.py` — `publish_insights_request` reusing `LifecycleArchiveRequest`.
- `common/events/lifecycle_handlers.py` — `insights` method on `PipelineStorageAdapter` Protocol + `insights_op` + third `bus.subscribe` in `register_pipeline_consumers`.
- `core-api/src/core_api/services/lifecycle_audit.py` — `insights()` adapter on `_CoreApiLifecycleAdapter` with the two gates; single session covers gate + `generate_insights` + explicit commit (mirrors `entity_link`).
- `core-api/src/core_api/services/organization_settings.py` — `"insights"` defaults section, `auto_insights_enabled` property (default False), validator entry.
- `core-api/src/core_api/routes/lifecycle.py` — `"insights"` added to `_ACTION_PUBLISHERS`.
- `core-operations/{config,tasks,app}.py` — `lifecycle_insights_interval_seconds` (24h default), `run_insights_tick`, `scheduler.register("lifecycle-insights", ...)`.

## Test plan

- [x] Unit: `tests/test_lifecycle_handlers.py` — subscriber happy path + dedup-gate skip (2 new tests + Fake adapter extended).
- [x] Unit: `tests/test_lifecycle_automation.py` — `INSIGHTS_REQUESTED` topic-string + StrEnum format assertions.
- [x] Unit: `core-operations/tests/test_tasks.py` — cron tick hits `/admin/lifecycle/fanout/insights`.
- [x] Full test suite — 2435 passed, 3 skipped, 1 xfailed, 3 xpassed locally. No regressions.
- [x] ruff check + format clean on all touched files.
- [x] mypy clean on core-api/src (161 source files).
- [x] **Wet test on local stack (dev-71cebd tenant, 1025 active memories)**:
  - Phase 1 — flag OFF (default): fanout fired, audit row `success`, `stats={"insights_created":0}`, no insight memories created. Gate 1 confirmed.
  - Phase 2 — flag ON: fanout fired, **7 insight memories persisted** in 5s, audit `success`, `stats={"insights_created":7}`. Adapter end-to-end confirmed.
  - Phase 3 — re-fire with no new non-insight writes: audit `success` in 52ms, `stats={"insights_created":0}`, insight count unchanged at 7. Activity gate confirmed.

## Deploy notes

- No schema migration — org settings live in the existing `organization_settings.settings` JSONB column under a new top-level `"insights"` key.
- Deploy `core-api` before `core-operations` so the new `/admin/lifecycle/fanout/insights` action exists before any cron tick reaches it; otherwise the cron would 404 and retry next interval (no data loss, just noise).
- To enable on an existing tenant: `UPDATE organization_settings SET settings = jsonb_set(settings, '{insights,auto_insights_enabled}', 'true'::jsonb, true) WHERE org_id = '<tenant>';` (or via whatever settings admin UI is in use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)