### PR TITLE
feat(storage): purge_org_data primitive for org hard-delete (CAURA-689)

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -55,6 +55,7 @@ from core_api.routes.keystones import router as keystones_router
 from core_api.routes.lifecycle import router as lifecycle_router
 from core_api.routes.memories import admin_memories_router
 from core_api.routes.memories import router as memories_router
+from core_api.routes.org_deletion import router as org_deletion_router
 from core_api.routes.plugin import plugin_bootstrap_router
 from core_api.routes.plugin import router as plugin_router
 from core_api.routes.settings import router as settings_router
@@ -595,6 +596,7 @@ app.include_router(stm_router, prefix="/api/v1")
 app.include_router(insights_router, prefix="/api/v1")
 app.include_router(evolve_router, prefix="/api/v1")
 app.include_router(lifecycle_router, prefix="/api/v1")
+app.include_router(org_deletion_router, prefix="/api/v1")
 
 # Test-only endpoints (time-warp, etc.) — only registered when TESTING=1
 if _os.getenv("TESTING") == "1":

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -646,6 +646,15 @@ class CoreStorageClient:
         result = await self._post("/memories/purge-soft-deleted", data)
         return result.get("deleted", 0)  # type: ignore[union-attr]
 
+    async def purge_tenant_data(self, tenant_id: str) -> dict[str, int]:
+        """Hard-delete ALL OSS data for ``tenant_id`` (CAURA-689 org delete).
+
+        Returns the per-table deleted counts. Idempotent at the storage
+        layer — a repeat call for an already-purged tenant returns zeros.
+        """
+        result = await self._post("/purge/tenant-data", {"tenant_id": tenant_id})
+        return result.get("deleted", {})  # type: ignore[union-attr,return-value]
+
     async def count_active(self, tenant_id: str, fleet_id: str | None = None) -> int:
         params: dict[str, Any] = {"tenant_id": tenant_id}
         if fleet_id is not None:

--- a/core-api/src/core_api/middleware/request_timeout.py
+++ b/core-api/src/core_api/middleware/request_timeout.py
@@ -33,7 +33,13 @@ logger = logging.getLogger(__name__)
 # silent-create regression in loadtest-1777301515 — the route now wraps
 # its own ``asyncio.wait_for`` and surfaces the 504 with the retry
 # contract intact.
-_TIMEOUT_OPT_OUT_PATHS: frozenset[str] = frozenset({"/api/v1/memories/bulk"})
+# ``/admin/org/purge-data`` (CAURA-689) hard-deletes every row of a
+# soft-deleted org across the OSS schema — a terminal admin batch op
+# driven by the daily sweep, not a user request. A large org can take
+# well past the hot-path budget; cancelling it mid-flight is pointless
+# (the purge is one transaction per tenant and idempotent on retry), so
+# it opts out and is bounded by the storage client's own timeout instead.
+_TIMEOUT_OPT_OUT_PATHS: frozenset[str] = frozenset({"/api/v1/memories/bulk", "/api/v1/admin/org/purge-data"})
 
 
 def _is_opted_out(path: str) -> bool:

--- a/core-api/src/core_api/routes/org_deletion.py
+++ b/core-api/src/core_api/routes/org_deletion.py
@@ -1,0 +1,125 @@
+"""Admin org-deletion endpoint (CAURA-689).
+
+``POST /admin/org/purge-data`` — permanently purge all OSS (``public.*``)
+data for a set of ``tenant_ids`` (every tenant of an enterprise org being
+hard-deleted). The enterprise ``enterprise.*`` rows are removed separately
+by platform-storage-api; the enterprise platform-admin-api orchestrates
+both during the hard-delete sweep / force-delete and calls this route with
+the configured ``CORE_API_ADMIN_API_KEY``.
+
+One ``lifecycle_audit`` row is written per tenant_id (action
+``hard-delete-org``): a ``pending`` row before the purge, flipped to
+``success`` (with per-table counts) or ``failure``. ``lifecycle_audit``
+itself is never purged, so this trail survives the deletion it records.
+
+Auth: admin-key only (``auth.enforce_admin``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from core_api.auth import AuthContext, get_auth_context
+from core_api.clients.storage_client import get_storage_client
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Admin", "Lifecycle"])
+
+_ACTION = "hard-delete-org"
+# Cap per call so a single request can't tie up a worker indefinitely — the
+# route is opted out of the global request timeout. The orchestrator splits
+# larger orgs across multiple calls.
+_MAX_TENANT_IDS = 100
+
+
+@router.post("/admin/org/purge-data")
+async def purge_org_data(
+    request: Request,
+    auth: AuthContext = Depends(get_auth_context),
+) -> JSONResponse:
+    """Purge OSS data for each ``tenant_id``. Body: ``{tenant_ids, triggered_by?}``.
+
+    Returns ``{"purged": {tenant_id: {table: count}}, "failed": {tenant_id: error}}``.
+    Per-tenant isolation: one tenant's failure neither aborts the others
+    nor rolls back tenants already purged (each purge is its own
+    transaction and is idempotent on retry). The caller inspects
+    ``failed`` before tearing down the enterprise rows.
+
+    Status code contract — uniform signalling: **200** when every tenant
+    purged successfully (``failed`` is empty); **207 Multi-Status** when
+    any tenant failed (partial or total). The orchestrator can detect
+    failure from the status code alone, without parsing the body.
+    """
+    auth.enforce_admin()
+    try:
+        body: dict = await request.json()
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=422, detail="request body must be valid JSON") from exc
+
+    tenant_ids = body.get("tenant_ids")
+    if (
+        not isinstance(tenant_ids, list)
+        or not tenant_ids
+        or not all(isinstance(t, str) and t for t in tenant_ids)
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_ids' must be a non-empty list of non-empty strings",
+        )
+    if len(tenant_ids) > _MAX_TENANT_IDS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"'tenant_ids' must contain at most {_MAX_TENANT_IDS} entries per call",
+        )
+    if len(tenant_ids) != len(set(tenant_ids)):
+        raise HTTPException(status_code=422, detail="'tenant_ids' must not contain duplicates")
+    triggered_by = body.get("triggered_by") or "admin-key"
+
+    storage = get_storage_client()
+    purged: dict[str, dict[str, int]] = {}
+    failed: dict[str, str] = {}
+
+    async def _finalize(audit_id: int | None, **kwargs: Any) -> None:
+        # The purge is the source of truth: a transient audit-write failure
+        # must never mask a completed purge or abort the rest of the batch.
+        if audit_id is None:
+            return
+        try:
+            await storage.update_lifecycle_audit_row(audit_id, **kwargs)
+        except Exception:
+            logger.warning("failed to update lifecycle_audit row %s", audit_id, exc_info=True)
+
+    for tenant_id in tenant_ids:
+        try:
+            audit_id: int | None = await storage.create_lifecycle_audit_row(
+                org_id=tenant_id, action=_ACTION, triggered_by=triggered_by
+            )
+        except Exception:
+            logger.exception("failed to create lifecycle_audit row for %s", tenant_id)
+            audit_id = None
+
+        try:
+            counts = await storage.purge_tenant_data(tenant_id)
+        except Exception as exc:
+            logger.exception("purge_tenant_data failed for tenant %s", tenant_id)
+            failed[tenant_id] = str(exc)
+            await _finalize(audit_id, status="failure", error_message=str(exc))
+            continue
+
+        purged[tenant_id] = counts
+        await _finalize(audit_id, status="success", stats={"deleted": counts})
+
+    logger.info(
+        "purge_org_data: %d purged, %d failed (triggered_by=%s)",
+        len(purged),
+        len(failed),
+        triggered_by,
+    )
+    status_code = 207 if failed else 200
+    return JSONResponse(status_code=status_code, content={"purged": purged, "failed": failed})

--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -37,6 +37,7 @@ from core_storage_api.routers import (
     keystones_router,
     lifecycle_audit_router,
     memories_router,
+    purge_router,
     reports_router,
     tasks_router,
 )
@@ -120,6 +121,7 @@ def create_app() -> FastAPI:
     app.include_router(tasks_router, prefix=prefix)
     app.include_router(idempotency_router, prefix=prefix)
     app.include_router(lifecycle_audit_router, prefix=prefix)
+    app.include_router(purge_router, prefix=prefix)
     # CAURA-686: ``GET /api/v1/storage/_debug/pg_locks`` for live
     # pg_locks / pg_stat_activity snapshots during contention triage.
     # Behind the same private-VPC posture as everything else here —

--- a/core-storage-api/src/core_storage_api/routers/__init__.py
+++ b/core-storage-api/src/core_storage_api/routers/__init__.py
@@ -9,6 +9,7 @@ from core_storage_api.routers.idempotency import router as idempotency_router
 from core_storage_api.routers.keystones import router as keystones_router
 from core_storage_api.routers.lifecycle_audit import router as lifecycle_audit_router
 from core_storage_api.routers.memories import router as memories_router
+from core_storage_api.routers.purge import router as purge_router
 from core_storage_api.routers.reports import router as reports_router
 from core_storage_api.routers.tasks import router as tasks_router
 
@@ -24,6 +25,7 @@ __all__ = [
     "keystones_router",
     "lifecycle_audit_router",
     "memories_router",
+    "purge_router",
     "reports_router",
     "tasks_router",
 ]

--- a/core-storage-api/src/core_storage_api/routers/purge.py
+++ b/core-storage-api/src/core_storage_api/routers/purge.py
@@ -1,0 +1,48 @@
+"""Org/tenant hard-purge endpoint (CAURA-689).
+
+Permanently deletes all OSS (``public.*``) data for a ``tenant_id``.
+Called by core-api's admin org-purge route during an organization
+hard-delete; core-api writes the ``lifecycle_audit`` trail around it.
+Kept here, not in core-api, to honor the "no DB outside
+core-storage-api" rule.
+
+Trust model (matches the rest of core-storage-api — see
+``routers/keystones.py`` for the same statement): no router-level
+authentication. Storage trusts that every caller has already passed
+the upstream auth check at core-api (``auth.enforce_admin`` on
+``POST /admin/org/purge-data``, gated by ``CORE_API_ADMIN_API_KEY``).
+The deployment-level control is that the storage service is reachable
+only from inside the VPC; do NOT expose it to the public internet.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, HTTPException, Request
+
+from core_storage_api.services.postgres_service import PostgresService
+
+router = APIRouter(prefix="/purge", tags=["Purge"])
+_svc = PostgresService()
+
+
+@router.post("/tenant-data")
+async def purge_tenant_data(request: Request) -> dict:
+    """Hard-delete every row scoped to ``tenant_id``. Body: ``{tenant_id}``.
+
+    Returns ``{tenant_id, deleted: {table: count}}``. Idempotent — a
+    second call for the same tenant deletes nothing.
+    """
+    try:
+        body: dict = await request.json()
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=422, detail="request body must be valid JSON") from exc
+    tenant_id = body.get("tenant_id")
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_id' is required and must be a non-empty string",
+        )
+    counts = await _svc.purge_tenant_data(tenant_id)
+    return {"tenant_id": tenant_id, "deleted": counts}

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -159,6 +159,40 @@ _MEMORY_VALID_FIELDS = frozenset(
 )
 
 
+# ── Org hard-delete purge (CAURA-689) ──
+#
+# Tables wiped when an organization is permanently deleted. Ordered
+# children-before-parents so the per-table DELETEs never trip a foreign
+# key. Tables WITHOUT their own ``tenant_id`` column (``memory_entity_links``)
+# are not listed — they're removed by the ON DELETE CASCADE from
+# ``memories`` / ``entities``. ``relations`` and ``fleet_commands`` are
+# listed explicitly (ahead of their parents) so their per-table counts are
+# reported rather than hidden inside a cascade.
+_PURGE_TENANT_TABLES: tuple[str, ...] = (
+    "relations",
+    "fleet_commands",
+    "memories",
+    "entities",
+    "agents",
+    "fleet_nodes",
+    "audit_log",
+    "documents",
+    "analysis_reports",
+    "dedup_reviews",
+    "background_task_log",
+    "idempotency_responses",
+)
+# OSS keys these by ``org_id``, which equals the tenant id in the
+# single-key-per-tenant OSS model (CAURA-654). ``lifecycle_audit`` is
+# deliberately NOT purged: it's the operational audit trail (including
+# the hard-delete-org row itself), so wiping it would erase the record
+# of the very deletion being performed.
+_PURGE_ORG_KEYED_TABLES: tuple[str, ...] = (
+    "organization_settings",
+    "organization_settings_audit",
+)
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # PostgresService
 # ═══════════════════════════════════════════════════════════════════════════
@@ -1621,6 +1655,46 @@ class PostgresService:
                 params,
             )
             return len(result.all())
+
+    async def purge_tenant_data(self, tenant_id: str) -> dict[str, int]:
+        """Permanently delete EVERY row scoped to ``tenant_id`` across the
+        OSS schema — the hard side of organization deletion (CAURA-689).
+
+        Runs in one transaction, children-before-parents, so a foreign key
+        never blocks a delete and a mid-purge failure rolls back cleanly.
+        Tables without their own ``tenant_id`` (``memory_entity_links``)
+        are removed by the CASCADE from ``memories`` / ``entities``;
+        ``organization_settings*`` are keyed by ``org_id`` (== tenant id in
+        OSS). ``lifecycle_audit`` is intentionally retained as the audit
+        trail. Returns per-table deleted counts.
+
+        Idempotent: re-running on an already-purged tenant deletes nothing
+        and returns zeros, so a retried org hard-delete is safe.
+
+        The enterprise ``enterprise.*`` rows (org, tenants, keys, …) are
+        purged separately by platform-storage-api; this owns the OSS
+        ``public.*`` schema only.
+        """
+        counts: dict[str, int] = {}
+        async with get_session() as session:
+            # One DELETE per table in the declared children-before-parents
+            # order (so a foreign key never blocks a delete) and one rowcount
+            # per table (the per-table breakdown is a reported feature). The
+            # two groups differ only in the scoping column: most tables carry
+            # ``tenant_id``; ``organization_settings*`` carry ``org_id``.
+            for tables, column in (
+                (_PURGE_TENANT_TABLES, "tenant_id"),
+                (_PURGE_ORG_KEYED_TABLES, "org_id"),
+            ):
+                for table_name in tables:
+                    # Schema-qualify (public.) so an irreversible hard-delete
+                    # can't be redirected by a non-default search_path.
+                    result = await session.execute(
+                        text(f"DELETE FROM public.{table_name} WHERE {column} = :tid"),
+                        {"tid": tenant_id},
+                    )
+                    counts[table_name] = result.rowcount  # type: ignore[attr-defined]
+        return counts
 
     async def memory_count_active(
         self,

--- a/core-storage-api/tests/test_purge.py
+++ b/core-storage-api/tests/test_purge.py
@@ -1,0 +1,90 @@
+"""Integration tests for the org/tenant hard-purge endpoint (CAURA-689).
+
+Uses a fresh, unique tenant_id per test (not the shared session fixture)
+so the purge can never wipe data other integration tests seeded under the
+shared tenant.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX, _memory_payload
+
+pytestmark = pytest.mark.asyncio
+
+
+def _fresh_ids() -> tuple[str, str]:
+    suffix = uuid.uuid4().hex[:8]
+    return f"purge-tenant-{suffix}", f"purge-fleet-{suffix}"
+
+
+class TestPurgeTenantData:
+    async def test_purge_deletes_data_and_reports_counts(self, client: AsyncClient) -> None:
+        tenant_id, fleet_id = _fresh_ids()
+        ids = []
+        for _ in range(3):
+            resp = await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+            assert resp.status_code == 200, resp.text
+            ids.append(resp.json()["id"])
+
+        resp = await client.post(f"{PREFIX}/purge/tenant-data", json={"tenant_id": tenant_id})
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["tenant_id"] == tenant_id
+        deleted = body["deleted"]
+        assert deleted["memories"] == 3
+        # Every configured table is reported, even when it deleted nothing —
+        # the orchestrator records the full per-table breakdown.
+        for table in (
+            "relations",
+            "agents",
+            "fleet_nodes",
+            "audit_log",
+            "documents",
+            "organization_settings",
+        ):
+            assert table in deleted, deleted
+
+        # The memories are physically gone (not just soft-deleted).
+        for memory_id in ids:
+            got = await client.get(f"{PREFIX}/memories/{memory_id}")
+            assert got.status_code == 404
+
+    async def test_purge_is_idempotent(self, client: AsyncClient) -> None:
+        tenant_id, fleet_id = _fresh_ids()
+        await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+        first = (await client.post(f"{PREFIX}/purge/tenant-data", json={"tenant_id": tenant_id})).json()
+        assert first["deleted"]["memories"] >= 1
+
+        second = (await client.post(f"{PREFIX}/purge/tenant-data", json={"tenant_id": tenant_id})).json()
+        assert second["deleted"]["memories"] == 0
+
+    async def test_purge_does_not_touch_other_tenants(self, client: AsyncClient) -> None:
+        keep_tenant, keep_fleet = _fresh_ids()
+        drop_tenant, drop_fleet = _fresh_ids()
+        keep = (await client.post(f"{PREFIX}/memories", json=_memory_payload(keep_tenant, keep_fleet))).json()
+        await client.post(f"{PREFIX}/memories", json=_memory_payload(drop_tenant, drop_fleet))
+
+        await client.post(f"{PREFIX}/purge/tenant-data", json={"tenant_id": drop_tenant})
+
+        # The other tenant's memory survives.
+        got = await client.get(f"{PREFIX}/memories/{keep['id']}")
+        assert got.status_code == 200
+
+    async def test_purge_requires_tenant_id(self, client: AsyncClient) -> None:
+        missing = await client.post(f"{PREFIX}/purge/tenant-data", json={})
+        assert missing.status_code == 422
+        empty = await client.post(f"{PREFIX}/purge/tenant-data", json={"tenant_id": ""})
+        assert empty.status_code == 422
+
+    async def test_purge_rejects_malformed_body(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            f"{PREFIX}/purge/tenant-data",
+            content="not json",
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

OSS side of the organization hard-delete (epic CAURA-513). Permanently removes all `public.*` data for a set of `tenant_ids` (every tenant of an enterprise org being deleted). Enterprise `platform-admin-api` calls this during the hard-delete sweep / force-delete; the `enterprise.*` rows are torn down separately by `platform-storage-api`.

- **core-storage-api** — `PostgresService.purge_tenant_data(tenant_id)` hard-deletes every row scoped to a tenant across the OSS schema in **one transaction, children-before-parents** (so a FK never blocks a delete), returning per-table counts. `memory_entity_links` cascades from `memories`/`entities`; `organization_settings*` are keyed by `org_id` (== tenant id in OSS). **`lifecycle_audit` is intentionally retained** — it's the audit trail. Exposed via `POST /purge/tenant-data`.
- **core-api** — admin route `POST /admin/org/purge-data` (admin-key) loops the `tenant_ids`, wrapping each storage purge in a `lifecycle_audit` row (`hard-delete-org`, `pending` → `success`/`failure`) and **isolating per-tenant failures**. The route opts out of the request-timeout middleware (terminal batch op, bounded by the storage client's own timeout).

Idempotent: re-purging an already-purged tenant deletes nothing and returns zeros, so a retried org hard-delete is safe.

## Test plan
- [x] `core-storage-api/tests/test_purge.py` — 4 integration tests (real PG): deletion + per-table counts, idempotency, tenant-isolation, validation. All pass.
- [x] `ruff check src/` + `ruff format --check src/` + `mypy src/` clean for both core-storage-api and core-api.
- [ ] Reviewer: confirm the purge table set stays in sync with the OSS schema (new tenant-scoped tables must be added to `_PURGE_TENANT_TABLES`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)