### PR TITLE
fix(version-compat): bump MIN_RECOMMENDED_PLUGIN_VERSION to 2.6.4

### DIFF
--- a/core-api/src/core_api/version_compat.py
+++ b/core-api/src/core_api/version_compat.py
@@ -6,7 +6,7 @@ We log a warning when a heartbeat reports a plugin older than the minimum
 recommended version; no hard rejection — operators decide when to upgrade.
 """
 
-MIN_RECOMMENDED_PLUGIN_VERSION = "2.6.3"
+MIN_RECOMMENDED_PLUGIN_VERSION = "2.6.4"
 
 # Server-side floor below which plugins must NOT auto-upgrade — the
 # heartbeat path in ``routes/fleet.py`` enforces this hard, and


### PR DESCRIPTION
Companion PR to #234 (urgent v2.6.3 group-chat compaction-wedge hotfix).

Without this bump, v2.6.3 nodes wouldn't auto-deploy to v2.6.4 — the heartbeat handler gates auto-deploy on `plugin_version < MIN_RECOMMENDED_PLUGIN_VERSION`. With the previous floor of 2.6.3, existing 2.6.3 nodes sit at the threshold and the deploy command never fires.

Same release-process gap PRs #204 (2.5.0 → 2.6.2) and #226 (2.6.2 → 2.6.3) closed.

## Merge order
Should be merged **after** PR #234 lands (so the new plugin code is on main when this bump tells the server to push it).

## Follow-up
Have release-please auto-sync this constant from plugin/package.json so we don't need a manual companion PR per plugin release. Tracked separately.