### PR TITLE
perf(entity-extraction): collapse worker N+1 storage HTTPs (P1)

### DIFF
--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -1,15 +1,20 @@
 """Background worker: extract entities from a memory and upsert them."""
 
+import asyncio
 import logging
 from uuid import UUID
 
 from common.embedding import get_embedding
 from core_api.clients.storage_client import get_storage_client
-from core_api.constants import ENTITY_NAME_BLOCKLIST, MIN_ENTITY_NAME_LENGTH
-from core_api.schemas import EntityUpsert, RelationUpsert
+from core_api.constants import (
+    ENTITY_NAME_BLOCKLIST,
+    ENTITY_RESOLUTION_THRESHOLD,
+    MIN_ENTITY_NAME_LENGTH,
+)
+from core_api.schemas import RelationUpsert
 from core_api.services.audit_service import log_action
 from core_api.services.entity_extraction import extract_entities_from_content
-from core_api.services.entity_service import upsert_entity, upsert_relation
+from core_api.services.entity_service import upsert_relation
 
 logger = logging.getLogger(__name__)
 
@@ -85,56 +90,268 @@ async def process_entity_extraction(
 
         blocklist = tenant_cfg.entity_blocklist
 
-        # Embed entity names for fuzzy resolution
-        name_embeddings: dict[str, list[float]] = {}
-        for ent in graph.entities:
-            try:
-                name_embeddings[ent.canonical_name] = await get_embedding(ent.canonical_name)
-            except Exception:
-                logger.debug(
-                    "Failed to embed entity name '%s', skipping fuzzy resolution",
-                    ent.canonical_name,
-                )
-
-        # Upsert entities and build name -> UUID map
-        name_to_id: dict[str, UUID] = {}
-        entity_roles: dict[str, str] = {}
-
+        # ---- Filter + dedupe entities up-front ----
+        #
+        # The old serial path interleaved blocklist filtering with
+        # per-entity HTTPs. Collapsing into the bulk path means filtering
+        # first so the resolve / upsert / link batches don't carry
+        # already-rejected names. Duplicate ``canonical_name`` values in
+        # ``graph.entities`` (the LLM occasionally repeats them across
+        # mentions) collapse to the FIRST occurrence here — preserves
+        # today's role binding (``entity_roles[ent.canonical_name] =
+        # ent.role`` in the old serial path also picked first-wins).
+        filtered: list[tuple[str, str, str]] = []  # (canonical_name, entity_type, role)
+        seen_names: set[str] = set()
         for ent in graph.entities:
             if not _is_valid_entity(ent.canonical_name, blocklist):
-                logger.debug(
-                    "Skipping invalid entity name '%s'",
-                    ent.canonical_name,
-                )
+                logger.debug("Skipping invalid entity name '%s'", ent.canonical_name)
                 continue
-            # ``data`` is positional, ``name_embedding`` keyword-only
-            # under the CAURA-127 signature cleanup.
-            result = await upsert_entity(
-                EntityUpsert(
-                    tenant_id=tenant_id,
-                    fleet_id=fleet_id,
-                    entity_type=ent.entity_type,
-                    canonical_name=ent.canonical_name,
-                ),
-                name_embedding=name_embeddings.get(ent.canonical_name),
-            )
-            name_to_id[ent.canonical_name] = result.id
-            entity_roles[ent.canonical_name] = ent.role
+            if ent.canonical_name in seen_names:
+                continue
+            seen_names.add(ent.canonical_name)
+            filtered.append((ent.canonical_name, ent.entity_type, ent.role))
 
-        # Create memory-entity links
-        for name, entity_id in name_to_id.items():
-            existing = await sc.find_entity_link(
-                str(memory_id),
-                str(entity_id),
+        if not filtered:
+            # Nothing to persist; skip the bulk flow but keep the
+            # downstream audit-log + contradiction-trigger paths so a
+            # zero-entity memory still records the run.
+            name_to_id: dict[str, UUID] = {}
+        else:
+            # ---- Step 1: parallel embeddings (audit P1) ----
+            #
+            # Replaces the per-entity ``await get_embedding(...)`` loop
+            # with one ``asyncio.gather`` round. ``return_exceptions=True``
+            # carries the prior skip-on-failure semantics — a single
+            # entity that fails to embed becomes ``None`` in its slot
+            # rather than aborting the whole batch.
+            embed_results = await asyncio.gather(
+                *(get_embedding(name) for name, _et, _role in filtered),
+                return_exceptions=True,
             )
-            if not existing:
-                await sc.create_entity_link(
+            name_embeddings: dict[str, list[float] | None] = {}
+            for (name, _et, _role), emb in zip(filtered, embed_results):
+                # ``BaseException`` — ``asyncio.gather(return_exceptions=
+                # True)`` captures ALL ``BaseException`` subclasses as
+                # result values, not just ``Exception``. The narrower
+                # ``isinstance(emb, Exception)`` check would silently
+                # store ``CancelledError`` (and other ``BaseException``
+                # subclasses) as if it were a valid embedding, since
+                # ``CancelledError`` inherits directly from
+                # ``BaseException`` in Python 3.8+. Trade-off vs the
+                # pre-P1 per-entity ``try/except Exception`` shape: we
+                # now drop cancellations to ``None`` and continue
+                # instead of letting them propagate; preferable to
+                # corrupting the embedding payload with an exception
+                # instance.
+                if isinstance(emb, BaseException):
+                    logger.debug(
+                        "Failed to embed entity name '%s', skipping fuzzy resolution",
+                        name,
+                    )
+                    name_embeddings[name] = None
+                else:
+                    name_embeddings[name] = emb
+
+            # ---- Step 2a: bulk resolve ----
+            #
+            # One HTTP replaces N x (find_exact + optional similarity).
+            # Storage-side ``/entities/bulk-resolve`` mirrors the
+            # ``upsert_entity`` precedence: exact match first, then
+            # cosine similarity (Phase 2) only when ``name_embedding``
+            # is non-null and no exact match was found.
+            resolve_items = [
+                {
+                    "input_idx": i,
+                    "fleet_id": fleet_id,
+                    "canonical_name": name,
+                    "entity_type": entity_type,
+                    "name_embedding": name_embeddings.get(name),
+                }
+                for i, (name, entity_type, _role) in enumerate(filtered)
+            ]
+            resolved = await sc.bulk_resolve_entities(
+                tenant_id=tenant_id,
+                items=resolve_items,
+                threshold=ENTITY_RESOLUTION_THRESHOLD,
+            )
+
+            # Storage-side contract: ``bulk_resolve_entities`` returns
+            # one slot per input item (``None`` for no-match,
+            # match-dict otherwise). A shorter response indicates a
+            # storage-layer partial failure — surface it explicitly so
+            # the implicit "items beyond ``len(resolved)`` fall through
+            # to the create branch" behaviour below isn't a silent
+            # data-divergence path. The ``resolved[i] if i <
+            # len(resolved) else None`` guard a few lines down still
+            # carries the safe default.
+            if len(resolved) != len(filtered):
+                logger.warning(
+                    "bulk_resolve_entities returned %d result(s) for %d input(s); "
+                    "items beyond index %d treated as no-match (create path) — "
+                    "check for storage-layer partial failures",
+                    len(resolved),
+                    len(filtered),
+                    # ``max(0, ...)`` avoids a confusing "beyond index -1"
+                    # when storage returns an empty list (all items
+                    # treated as no-match starting from index 0).
+                    max(0, len(resolved) - 1),
+                )
+
+            # ---- Step 2b: client-side merge — first-seen-wins canonical ----
+            #
+            # CRITICAL correctness gate. Mirrors ``entity_service.upsert_entity``
+            # lines 74-100 exactly: when an existing entity is found
+            # (exact or similarity), the EXISTING ``canonical_name`` wins
+            # ("first-seen-wins"), and the new surface form is added to
+            # ``_aliases``. Comment at entity_service.py:91-100 warns
+            # about the prior "longest-wins" regression that turned LLM
+            # hallucinations into canonical rows — this preservation is
+            # the audit P1 fix's correctness gate.
+            upsert_items: list[dict] = []
+            for i, (name, entity_type, _role) in enumerate(filtered):
+                match = resolved[i] if i < len(resolved) else None
+                item: dict = {
+                    "input_idx": i,
+                    "tenant_id": tenant_id,
+                    "fleet_id": fleet_id,
+                    "entity_type": entity_type,
+                }
+                emb = name_embeddings.get(name)
+                if emb is not None:
+                    item["name_embedding"] = emb
+
+                if match:
+                    # Existing row found — merge into it.
+                    existing_attrs = match.get("attributes") or {}
+                    merged_attrs = dict(existing_attrs)
+                    # NOTE: ``ExtractedEntity`` currently emits no extra
+                    # attributes (only ``canonical_name`` / ``entity_type``
+                    # / ``role`` come back from the LLM). If the
+                    # extraction schema later grows attribute fields,
+                    # add ``merged_attrs.update(<new fields>)`` here to
+                    # match ``entity_service.upsert_entity`` (line 79:
+                    # ``if data.attributes: merged_attrs.update(data.attributes)``)
+                    # and keep the bulk path's merge semantics
+                    # equivalent to the single-row serial path.
+                    aliases = list(merged_attrs.get("_aliases") or [])
+                    # Defensive fallback: storage-side ``bulk_resolve_entities``
+                    # SHOULD always carry a non-empty ``canonical_name`` on a
+                    # match (the row had to exist for a match to fire). An
+                    # empty / missing value here would degenerately become
+                    # the new canonical under first-seen-wins, which is
+                    # worse than just using the incoming name. Log + fall
+                    # back so a malformed resolve response gets surfaced
+                    # rather than silently corrupting the entity row.
+                    existing_name = match.get("canonical_name") or ""
+                    if not existing_name:
+                        logger.warning(
+                            "bulk_resolve_entities match for '%s' has no canonical_name; "
+                            "falling back to incoming name",
+                            name,
+                        )
+                        existing_name = name
+                    if existing_name and existing_name not in aliases:
+                        aliases.append(existing_name)
+                    if name not in aliases:
+                        aliases.append(name)
+                    merged_attrs["_aliases"] = aliases
+                    # Defensive guard mirroring the ``canonical_name``
+                    # fallback above: a malformed resolve match without
+                    # ``entity_id`` would otherwise crash with KeyError
+                    # inside the upsert payload. Fall through to the
+                    # create path so the row still lands; log so the
+                    # storage-side data hygiene issue is surfaced.
+                    match_entity_id = match.get("entity_id")
+                    if not match_entity_id:
+                        logger.warning(
+                            "bulk_resolve_entities match for '%s' has no entity_id; "
+                            "falling back to create path",
+                            name,
+                        )
+                        item["action"] = "create"
+                        item["canonical_name"] = name
+                        item["attributes"] = {}
+                    else:
+                        item["action"] = "update"
+                        item["entity_id"] = match_entity_id
+                        item["canonical_name"] = existing_name  # first-seen wins
+                        item["attributes"] = merged_attrs
+                else:
+                    # No match — create.
+                    item["action"] = "create"
+                    item["canonical_name"] = name
+                    item["attributes"] = {}
+                upsert_items.append(item)
+
+            # ---- Step 2c: bulk upsert ----
+            #
+            # Returns ``{input_idx, entity_id, action}`` per row, where
+            # ``action`` may be ``"created" | "updated" | "merged" |
+            # "missing"`` (see /entities/bulk-upsert). ``merged`` covers
+            # the TOCTOU race where another writer created the natural-
+            # key match between our resolve and our upsert — semantically
+            # equivalent to ``updated`` for the worker.
+            upserted = await sc.bulk_upsert_entities(items=upsert_items)
+            # Explicit loop (not a comprehension) so an out-of-range
+            # ``input_idx`` from a misbehaving storage response surfaces
+            # as a WARN log instead of an IndexError → 500. Mirrors the
+            # length-mismatch warning above on ``bulk_resolve_entities``
+            # — same "treat malformed responses defensively" pattern.
+            name_to_id: dict[str, UUID] = {}
+            for r in upserted:
+                if not r.get("entity_id"):
+                    continue
+                idx = r["input_idx"]
+                if idx >= len(filtered):
+                    logger.warning(
+                        "bulk_upsert_entities returned out-of-range input_idx %d (filtered len=%d); skipping",
+                        idx,
+                        len(filtered),
+                    )
+                    continue
+                name_to_id[filtered[idx][0]] = UUID(r["entity_id"])
+
+            # ---- Step 3: bulk entity-link upsert ----
+            #
+            # Idempotent (memory_id, entity_id) writes — pre-existing
+            # rows have their role preserved, matching today's
+            # ``find_entity_link → skip-if-exists`` flow.
+            # ``input_idx`` must be contiguous in ``[0, len(link_items))``
+            # for the storage-side ``_validate_input_idxs`` check —
+            # otherwise gaps in the source ``filtered`` list (entries
+            # filtered out because their upsert came back as ``missing``
+            # / no entity_id) would produce non-contiguous indexes and
+            # trip the 422. Use a dedicated ``link_idx`` counter so the
+            # response idxs always tile the payload contiguously.
+            link_items = []
+            link_idx = 0
+            for name, _et, role in filtered:
+                if name not in name_to_id:
+                    continue
+                link_items.append(
                     {
+                        "input_idx": link_idx,
                         "memory_id": str(memory_id),
-                        "entity_id": str(entity_id),
-                        "role": entity_roles.get(name, "mentioned"),
+                        "entity_id": str(name_to_id[name]),
+                        "role": role,
                     }
                 )
+                link_idx += 1
+            if link_items:
+                link_result = await sc.bulk_upsert_entity_links(items=link_items)
+                # Surface any FK violations from the per-item path
+                # (storage-side reports ``error="fk_violation"`` for rows
+                # whose memory_id or entity_id no longer exists). Same
+                # observability shape we added on the contradiction
+                # detector's batch path.
+                fk_errors = [r for r in link_result if r.get("error")]
+                if fk_errors:
+                    logger.warning(
+                        "Entity link upsert: %d/%d row(s) failed with FK violation for memory %s",
+                        len(fk_errors),
+                        len(link_items),
+                        memory_id,
+                    )
 
         # Upsert relations
         rel_count = 0

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -562,7 +562,12 @@ class ResolvedConfig:
     def entity_blocklist(self) -> frozenset[str]:
         custom = self._ts.get("entity_blocklist")
         if custom is not None:
-            return frozenset(custom)
+            # Lower-case normalisation so this is symmetric with the
+            # ``name.lower() not in bl`` check in
+            # ``entity_extraction_worker._is_valid_entity``. Tenant-
+            # supplied entries with mixed case (``"Team"``,
+            # ``"SYSTEM"``) would otherwise silently miss the filter.
+            return frozenset(entry.lower() for entry in custom)
         return frozenset(DEFAULT_SETTINGS["entity_blocklist"])
 
     # Write mode

--- a/tests/test_entity_linking_wiring.py
+++ b/tests/test_entity_linking_wiring.py
@@ -44,9 +44,6 @@ def _fake_config(**overrides):
     "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
 )
 @patch(
-    "core_api.services.entity_extraction_worker.upsert_entity", new_callable=AsyncMock
-)
-@patch(
     "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
 )
 @patch("core_api.services.entity_extraction_worker.get_storage_client")
@@ -60,7 +57,6 @@ async def test_extraction_triggers_cross_links_when_enabled(
     mock_extract,
     mock_sc_factory,
     mock_embed,
-    mock_upsert_entity,
     mock_upsert_relation,
     mock_log,
     mock_discover,
@@ -85,9 +81,19 @@ async def test_extraction_triggers_cross_links_when_enabled(
 
     mock_embed.return_value = [0.1] * 10
 
-    upsert_result = MagicMock()
-    upsert_result.id = uuid.uuid4()
-    mock_upsert_entity.return_value = upsert_result
+    # Plumb the post-P1 bulk flow: resolve returns ``None`` (no
+    # existing match), so the worker takes the create path. The
+    # resulting entity_id is what populates ``name_to_id`` and
+    # gates the downstream cross-link discovery trigger.
+    sc.bulk_resolve_entities = AsyncMock(return_value=[None])
+    sc.bulk_upsert_entities = AsyncMock(
+        return_value=[
+            {"input_idx": 0, "entity_id": str(uuid.uuid4()), "action": "created"}
+        ]
+    )
+    sc.bulk_upsert_entity_links = AsyncMock(
+        return_value=[{"input_idx": 0, "created": True}]
+    )
 
     memory_id = uuid.uuid4()
 
@@ -114,9 +120,6 @@ async def test_extraction_triggers_cross_links_when_enabled(
     "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
 )
 @patch(
-    "core_api.services.entity_extraction_worker.upsert_entity", new_callable=AsyncMock
-)
-@patch(
     "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
 )
 @patch("core_api.services.entity_extraction_worker.get_storage_client")
@@ -130,7 +133,6 @@ async def test_extraction_skips_cross_links_when_disabled(
     mock_extract,
     mock_sc_factory,
     mock_embed,
-    mock_upsert_entity,
     mock_upsert_relation,
     mock_log,
     mock_discover,
@@ -154,9 +156,19 @@ async def test_extraction_skips_cross_links_when_disabled(
 
     mock_embed.return_value = [0.1] * 10
 
-    upsert_result = MagicMock()
-    upsert_result.id = uuid.uuid4()
-    mock_upsert_entity.return_value = upsert_result
+    # Plumb the post-P1 bulk flow: resolve returns ``None`` (no
+    # existing match), so the worker takes the create path. The
+    # resulting entity_id is what populates ``name_to_id`` and
+    # gates the downstream cross-link discovery trigger.
+    sc.bulk_resolve_entities = AsyncMock(return_value=[None])
+    sc.bulk_upsert_entities = AsyncMock(
+        return_value=[
+            {"input_idx": 0, "entity_id": str(uuid.uuid4()), "action": "created"}
+        ]
+    )
+    sc.bulk_upsert_entity_links = AsyncMock(
+        return_value=[{"input_idx": 0, "created": True}]
+    )
 
     memory_id = uuid.uuid4()
 
@@ -183,9 +195,6 @@ async def test_extraction_skips_cross_links_when_disabled(
     "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
 )
 @patch(
-    "core_api.services.entity_extraction_worker.upsert_entity", new_callable=AsyncMock
-)
-@patch(
     "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
 )
 @patch("core_api.services.entity_extraction_worker.get_storage_client")
@@ -199,7 +208,6 @@ async def test_extraction_cross_link_failure_is_nonfatal(
     mock_extract,
     mock_sc_factory,
     mock_embed,
-    mock_upsert_entity,
     mock_upsert_relation,
     mock_log,
     mock_discover,
@@ -223,9 +231,19 @@ async def test_extraction_cross_link_failure_is_nonfatal(
 
     mock_embed.return_value = [0.1] * 10
 
-    upsert_result = MagicMock()
-    upsert_result.id = uuid.uuid4()
-    mock_upsert_entity.return_value = upsert_result
+    # Plumb the post-P1 bulk flow: resolve returns ``None`` (no
+    # existing match), so the worker takes the create path. The
+    # resulting entity_id is what populates ``name_to_id`` and
+    # gates the downstream cross-link discovery trigger.
+    sc.bulk_resolve_entities = AsyncMock(return_value=[None])
+    sc.bulk_upsert_entities = AsyncMock(
+        return_value=[
+            {"input_idx": 0, "entity_id": str(uuid.uuid4()), "action": "created"}
+        ]
+    )
+    sc.bulk_upsert_entity_links = AsyncMock(
+        return_value=[{"input_idx": 0, "created": True}]
+    )
 
     mock_discover.side_effect = RuntimeError("boom")
 

--- a/tests/test_p1_entity_extraction_bulk.py
+++ b/tests/test_p1_entity_extraction_bulk.py
@@ -1,0 +1,684 @@
+"""Audit P1 — collapse N+1 storage HTTPs in the entity-extraction worker.
+
+The pre-fix path issued up to ~6 HTTPs per entity (1 embed + up to 2 in
+``upsert_entity`` find/create + up to 2 in find/create-link).
+
+After P1:
+  - one ``asyncio.gather`` round of ``get_embedding`` calls
+  - one ``sc.bulk_resolve_entities`` HTTP
+  - one ``sc.bulk_upsert_entities`` HTTP
+  - one ``sc.bulk_upsert_entity_links`` HTTP
+
+Two test families:
+
+1. **Shape**: assert the wire effect directly — exactly one of each
+   bulk call per memory, zero per-row HTTPs.
+
+2. **State-equivalence**: replicate the ``entity_service.upsert_entity``
+   merge contract end-to-end:
+     - first-seen-wins canonical_name (the audit's correctness gate,
+       see entity_service.py:91-100 for the prior longest-wins
+       regression that this rule guards against)
+     - alias accumulation in ``attributes["_aliases"]``
+     - exact match overrides similarity match
+     - Phase 2 skipped when no embedding
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from core_api.services.entity_extraction_worker import process_entity_extraction
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+# ---------------------------------------------------------------------------
+# Shared builders
+# ---------------------------------------------------------------------------
+
+
+def _config(**overrides):
+    cfg = MagicMock()
+    cfg.auto_entity_linking_enabled = False
+    cfg.entity_blocklist = frozenset()
+    cfg.entity_extraction_provider = "openai"
+    cfg.entity_extraction_model = "gpt-4o-mini"
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _entity(name: str, entity_type: str = "person", role: str = "subject") -> MagicMock:
+    e = MagicMock()
+    e.canonical_name = name
+    e.entity_type = entity_type
+    e.role = role
+    return e
+
+
+def _graph(entities: list[MagicMock], relations: list = None) -> MagicMock:
+    g = MagicMock()
+    g.entities = entities
+    g.relations = relations or []
+    return g
+
+
+def _build_sc_mock(
+    *,
+    resolve_returns: list[dict | None],
+    upsert_returns: list[dict],
+    links_returns: list[dict] | None = None,
+) -> MagicMock:
+    sc = MagicMock()
+    sc.bulk_resolve_entities = AsyncMock(return_value=resolve_returns)
+    sc.bulk_upsert_entities = AsyncMock(return_value=upsert_returns)
+    sc.bulk_upsert_entity_links = AsyncMock(
+        return_value=links_returns
+        or [{"input_idx": i, "created": True} for i in range(len(upsert_returns))]
+    )
+    # Spies for the legacy per-row paths — must stay at zero call_count.
+    sc.find_entity_link = AsyncMock()
+    sc.create_entity_link = AsyncMock()
+    sc.find_exact_entity = AsyncMock()
+    sc.find_by_embedding_similarity = AsyncMock()
+    sc.update_entity = AsyncMock()
+    sc.create_entity = AsyncMock()
+    return sc
+
+
+# ---------------------------------------------------------------------------
+# Shape tests — one HTTP per stage
+# ---------------------------------------------------------------------------
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_bulk_path_collapses_to_3_storage_https_for_n_entities(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """Three new entities → exactly one bulk_resolve + one bulk_upsert +
+    one bulk_upsert_entity_links. Zero per-row find/create calls."""
+    mock_resolve.return_value = _config()
+    mock_extract.return_value = _graph(
+        [_entity("alice"), _entity("bob"), _entity("carol")]
+    )
+    mock_embed.return_value = [0.1] * 10
+
+    sc = _build_sc_mock(
+        resolve_returns=[None, None, None],  # all new (no match)
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": str(uuid4()), "action": "created"},
+            {"input_idx": 1, "entity_id": str(uuid4()), "action": "created"},
+            {"input_idx": 2, "entity_id": str(uuid4()), "action": "created"},
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="alice met bob and carol",
+            memory_type="episodic",
+        )
+
+    assert sc.bulk_resolve_entities.call_count == 1
+    assert sc.bulk_upsert_entities.call_count == 1
+    assert sc.bulk_upsert_entity_links.call_count == 1
+    # Legacy per-row paths must be untouched.
+    assert sc.find_entity_link.call_count == 0
+    assert sc.create_entity_link.call_count == 0
+    assert sc.find_exact_entity.call_count == 0
+    assert sc.create_entity.call_count == 0
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_embeddings_fire_concurrently_via_gather(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """The N embed calls land on the storage layer / provider in
+    parallel — assert all N are awaited within the same gather tick by
+    checking that ``get_embedding`` saw all N inputs (without
+    requiring per-call sequencing)."""
+    mock_resolve.return_value = _config()
+    names = ["alice", "bob", "carol", "dave"]
+    mock_extract.return_value = _graph([_entity(n) for n in names])
+    mock_embed.return_value = [0.1] * 10
+    sc = _build_sc_mock(
+        resolve_returns=[None] * 4,
+        upsert_returns=[
+            {"input_idx": i, "entity_id": str(uuid4()), "action": "created"}
+            for i in range(4)
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content=" ".join(names),
+            memory_type="episodic",
+        )
+
+    # All four names were embedded (one call each).
+    embed_args = [c.args[0] for c in mock_embed.await_args_list]
+    assert sorted(embed_args) == sorted(names)
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_zero_entities_skips_bulk_https_entirely(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """Empty extracted graph → no bulk HTTPs (early return)."""
+    mock_resolve.return_value = _config()
+    mock_extract.return_value = _graph([])  # no entities
+
+    sc = _build_sc_mock(resolve_returns=[], upsert_returns=[])
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="empty content",
+            memory_type="episodic",
+        )
+
+    assert sc.bulk_resolve_entities.call_count == 0
+    assert sc.bulk_upsert_entities.call_count == 0
+    assert sc.bulk_upsert_entity_links.call_count == 0
+    assert mock_embed.call_count == 0  # gather skipped too
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_blocklisted_entities_filtered_before_bulk_path(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """Blocklisted names dropped from the resolve / upsert / link
+    batches — payloads carry only the survivors."""
+    mock_resolve.return_value = _config(entity_blocklist=frozenset({"team", "system"}))
+    mock_extract.return_value = _graph(
+        [_entity("alice"), _entity("team"), _entity("bob"), _entity("system")]
+    )
+    mock_embed.return_value = [0.1] * 10
+
+    sc = _build_sc_mock(
+        resolve_returns=[None, None],
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": str(uuid4()), "action": "created"},
+            {"input_idx": 1, "entity_id": str(uuid4()), "action": "created"},
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="alice and bob from system team",
+            memory_type="episodic",
+        )
+
+    payload = sc.bulk_resolve_entities.call_args.kwargs
+    names = [it["canonical_name"] for it in payload["items"]]
+    assert names == ["alice", "bob"]  # blocklisted survivors removed, order preserved
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_duplicate_canonical_names_collapse_to_first(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """LLM occasionally returns the same canonical_name twice (across
+    mentions). Old serial path collapsed via the ``name_to_id`` dict;
+    bulk path collapses up-front in the filter step so the resolve /
+    upsert / link batches don't carry duplicates.
+
+    First-occurrence role wins (matches the old code's
+    ``entity_roles[ent.canonical_name] = ent.role`` which was
+    first-write-wins via dict semantics)."""
+    mock_resolve.return_value = _config()
+    mock_extract.return_value = _graph(
+        [
+            _entity("alice", role="subject"),
+            _entity("alice", role="object"),  # duplicate
+            _entity("bob"),
+        ]
+    )
+    mock_embed.return_value = [0.1] * 10
+
+    sc = _build_sc_mock(
+        resolve_returns=[None, None],
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": str(uuid4()), "action": "created"},
+            {"input_idx": 1, "entity_id": str(uuid4()), "action": "created"},
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="alice met bob",
+            memory_type="episodic",
+        )
+
+    resolve_payload = sc.bulk_resolve_entities.call_args.kwargs
+    names = [it["canonical_name"] for it in resolve_payload["items"]]
+    assert names == ["alice", "bob"]
+
+    link_payload = sc.bulk_upsert_entity_links.call_args.kwargs["items"]
+    alice_links = [li for li in link_payload if li["input_idx"] == 0]
+    assert len(alice_links) == 1
+    assert alice_links[0]["role"] == "subject"  # first-occurrence role
+
+
+# ---------------------------------------------------------------------------
+# State-equivalence tests — replicate entity_service.upsert_entity contract
+# ---------------------------------------------------------------------------
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_first_seen_wins_canonical_when_longer_name_arrives(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """Regression guard for the prior longest-wins bug (see
+    ``entity_service.py:91-100``). Existing row has ``canonical_name=
+    "globex"``; the new memory mentions ``"globex industries"``;
+    similarity merges the two. The upsert payload MUST set
+    ``canonical_name="globex"`` (first-seen wins), with
+    ``"globex industries"`` accumulated in ``_aliases``."""
+    existing_entity_id = str(uuid4())
+    mock_resolve.return_value = _config()
+    mock_extract.return_value = _graph([_entity("globex industries", "organization")])
+    mock_embed.return_value = [0.1] * 10
+
+    sc = _build_sc_mock(
+        # bulk_resolve returns the existing ``globex`` row matched by similarity.
+        resolve_returns=[
+            {
+                "entity_id": existing_entity_id,
+                "canonical_name": "globex",
+                "attributes": {},
+                "matched_by": "similarity",
+                "similarity": 0.92,
+            }
+        ],
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": existing_entity_id, "action": "updated"}
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="globex industries shipped a new product",
+            memory_type="episodic",
+        )
+
+    upsert_payload = sc.bulk_upsert_entities.call_args.kwargs["items"][0]
+    assert upsert_payload["action"] == "update"
+    assert upsert_payload["entity_id"] == existing_entity_id
+    # First-seen-wins — existing ``globex`` stays canonical.
+    assert upsert_payload["canonical_name"] == "globex"
+    # The longer surface form lands in ``_aliases``, not as canonical.
+    aliases = upsert_payload["attributes"]["_aliases"]
+    assert "globex" in aliases
+    assert "globex industries" in aliases
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_existing_aliases_preserved_and_extended(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """The existing entity's ``_aliases`` list is preserved verbatim,
+    with the existing ``canonical_name`` and the new surface form
+    appended if not already present. Idempotent under repeated runs."""
+    existing_entity_id = str(uuid4())
+    mock_resolve.return_value = _config()
+    mock_extract.return_value = _graph([_entity("acme co", "organization")])
+    mock_embed.return_value = [0.1] * 10
+
+    sc = _build_sc_mock(
+        resolve_returns=[
+            {
+                "entity_id": existing_entity_id,
+                "canonical_name": "acme",
+                "attributes": {"_aliases": ["acme", "acme corp"]},
+                "matched_by": "similarity",
+                "similarity": 0.91,
+            }
+        ],
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": existing_entity_id, "action": "updated"}
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="acme co",
+            memory_type="episodic",
+        )
+
+    aliases = sc.bulk_upsert_entities.call_args.kwargs["items"][0]["attributes"][
+        "_aliases"
+    ]
+    # Prior aliases preserved; "acme co" is new and gets appended.
+    assert aliases == ["acme", "acme corp", "acme co"]
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_no_match_takes_create_path(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """``bulk_resolve_entities`` returns ``None`` for a name with no
+    existing match — the upsert payload uses ``action="create"`` with
+    the new canonical_name and an empty attributes dict (consistent
+    with ``entity_service.create_data["attributes"] = data.attributes
+    or {}``)."""
+    mock_resolve.return_value = _config()
+    mock_extract.return_value = _graph([_entity("brand-new-entity", "person")])
+    mock_embed.return_value = [0.1] * 10
+
+    sc = _build_sc_mock(
+        resolve_returns=[None],
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": str(uuid4()), "action": "created"}
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="brand-new-entity appeared",
+            memory_type="episodic",
+        )
+
+    item = sc.bulk_upsert_entities.call_args.kwargs["items"][0]
+    assert item["action"] == "create"
+    assert item["canonical_name"] == "brand-new-entity"
+    assert item["attributes"] == {}
+    assert "entity_id" not in item
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_embedding_failure_yields_null_in_resolve_payload(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """``return_exceptions=True`` on the gather means a per-entity
+    embed failure surfaces as ``None`` in the resolve payload, NOT a
+    raised exception. Storage's Phase 2 (similarity) then skips that
+    item; exact-match still runs. Same skip semantic as the old
+    serial path's per-entity try/except."""
+    mock_resolve.return_value = _config()
+    mock_extract.return_value = _graph([_entity("alice"), _entity("bob")])
+
+    # Make the second embed call raise.
+    mock_embed.side_effect = [
+        [0.1] * 10,
+        RuntimeError("simulated embed failure"),
+    ]
+
+    sc = _build_sc_mock(
+        resolve_returns=[None, None],
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": str(uuid4()), "action": "created"},
+            {"input_idx": 1, "entity_id": str(uuid4()), "action": "created"},
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="alice met bob",
+            memory_type="episodic",
+        )
+
+    items = sc.bulk_resolve_entities.call_args.kwargs["items"]
+    by_name = {it["canonical_name"]: it for it in items}
+    assert by_name["alice"]["name_embedding"] is not None
+    assert by_name["bob"]["name_embedding"] is None  # embed failed → null
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_link_role_binding_preserved_per_entity(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """The role attached to each entity (subject/object/mentioned)
+    must follow that entity into the link upsert — the prior bug
+    surface was the old ``name_to_id.items()`` loop which lost the
+    explicit role binding by dict iteration order."""
+    mock_resolve.return_value = _config()
+    mock_extract.return_value = _graph(
+        [
+            _entity("alice", role="subject"),
+            _entity("bob", role="object"),
+            _entity("carol", role="mentioned"),
+        ]
+    )
+    mock_embed.return_value = [0.1] * 10
+
+    eids = [str(uuid4()) for _ in range(3)]
+    sc = _build_sc_mock(
+        resolve_returns=[None, None, None],
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": eids[0], "action": "created"},
+            {"input_idx": 1, "entity_id": eids[1], "action": "created"},
+            {"input_idx": 2, "entity_id": eids[2], "action": "created"},
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="alice met bob, mentioning carol",
+            memory_type="episodic",
+        )
+
+    link_items = sc.bulk_upsert_entity_links.call_args.kwargs["items"]
+    by_eid = {li["entity_id"]: li for li in link_items}
+    assert by_eid[eids[0]]["role"] == "subject"
+    assert by_eid[eids[1]]["role"] == "object"
+    assert by_eid[eids[2]]["role"] == "mentioned"
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_threshold_constant_passed_to_resolve(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """The worker hands ``ENTITY_RESOLUTION_THRESHOLD`` to the storage
+    endpoint — the resolution rule lives in the core-api layer, not
+    the storage executor (see ``/entities/bulk-resolve`` docstring)."""
+    from core_api.constants import ENTITY_RESOLUTION_THRESHOLD
+
+    mock_resolve.return_value = _config()
+    mock_extract.return_value = _graph([_entity("alice")])
+    mock_embed.return_value = [0.1] * 10
+
+    sc = _build_sc_mock(
+        resolve_returns=[None],
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": str(uuid4()), "action": "created"}
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="alice",
+            memory_type="episodic",
+        )
+
+    kwargs = sc.bulk_resolve_entities.call_args.kwargs
+    assert kwargs["threshold"] == ENTITY_RESOLUTION_THRESHOLD


### PR DESCRIPTION
## Summary

Audit P1 — `process_entity_extraction` previously issued up to **6 HTTPs per entity**: 1 embed, 2-3 inside `upsert_entity` (find_exact / find_similarity / update_or_create), 2 for the entity link (find / create). For a 10-entity memory that's ~60 HTTPs; the audit-validation flagged ceilings around 240.

After P1: **one ``asyncio.gather`` round + 3 bulk HTTPs per memory**, regardless of entity count.

## Sites collapsed

| Stage | Before | After |
|---|---|---|
| Embeddings | Serial `await get_embedding(name)` per entity | One `asyncio.gather` with `return_exceptions=True` |
| Entity upsert | Per-entity `upsert_entity` (2-3 HTTPs internally) | One `sc.bulk_resolve_entities` + client-side merge + one `sc.bulk_upsert_entities` |
| Entity links | Per-entity `find_entity_link` + `create_entity_link` (2 HTTPs) | One `sc.bulk_upsert_entity_links` |

## Correctness gate: first-seen-wins canonical_name

The audit's most important correctness rule — see [`entity_service.py:91-100`](../blob/main/core-api/src/core_api/services/entity_service.py#L91-L100). When an existing entity matches (exact or similarity), the **existing** `canonical_name` wins and the new surface form accumulates in `attributes["_aliases"]`. This guards a real prior regression where "longest-wins" promoted LLM hallucinations to canonical rows.

The worker ports ``entity_service.upsert_entity``'s merge logic (lines 74-100) verbatim into a client-side step between resolve and upsert.

## Behavior preserved

- Blocklist + min-length filter applied **before** the bulk batch (was previously interleaved with per-entity HTTPs)
- Duplicate `canonical_name` in `graph.entities` collapses to first occurrence (matches old `name_to_id`-dict semantics)
- Per-entity embed failure → `None` in resolve payload → Phase 2 skipped server-side; exact-match still runs (same skip semantic as old per-entity try/except)
- Audit log, contradiction trigger, cross-link discovery wiring unchanged

## Test plan

- [x] **New** `tests/test_p1_entity_extraction_bulk.py` (11 tests):
  - **Shape** (5): one of each bulk call per memory; zero per-row HTTPs; empty graph skips bulk; blocklist filter; duplicate-name collapse with role binding
  - **State-equivalence** (6): first-seen-wins canonical regression guard, alias preservation/extension, no-match→create, embed-failure→null, role-per-entity link binding, `ENTITY_RESOLUTION_THRESHOLD` constant threaded through
- [x] Existing `tests/test_entity_linking_wiring.py` (3 tests) migrated to bulk mocks; same cross-link wiring assertions
- [x] **140** entity-adjacent tests pass (P1, wiring, blocklist, p0_1_matching, p3_1_resolution, a5c_tenant_config, storage_bulk_endpoints)
- [x] Full unit sweep: **1338 passing**
- [x] Ruff lint + format clean
- [x] mypy clean on core-api (pre-existing `config.py` croniter stub error unrelated)

## Audit queue status after this PR

| Audit ID | PR | Status |
|---|---|---|
| B4 (MCP error envelopes) | #217 | merged |
| P1/P2/P5 storage foundation | #222 | merged |
| T5 + #22/#25/#29/#31 | #235 | merged |
| P2 (contradiction batch) | #236 | merged |
| P5 (crystallizer archive) | #239 | open |
| **P1 (this PR)** | — | open |

After this PR + #239 merge, **all of Ran's assigned audit findings ship.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)