### PR TITLE
feat(core): deletion-preview counts (CAURA-696 PR A — OSS half)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -655,6 +655,15 @@ class CoreStorageClient:
         result = await self._post("/purge/tenant-data", {"tenant_id": tenant_id})
         return result.get("deleted", {})  # type: ignore[union-attr,return-value]
 
+    async def count_tenant_data(self, tenant_id: str) -> dict[str, int]:
+        """Per-table row count for ``tenant_id`` — drives the
+        deletion-preview panel (CAURA-696). Same table set + scoping
+        as ``purge_tenant_data`` so the preview is a faithful forecast.
+        Read-only.
+        """
+        result = await self._post("/preview/tenant-counts", {"tenant_id": tenant_id})
+        return result.get("counts", {})  # type: ignore[union-attr,return-value]
+
     async def count_active(self, tenant_id: str, fleet_id: str | None = None) -> int:
         params: dict[str, Any] = {"tenant_id": tenant_id}
         if fleet_id is not None:

--- a/core-api/src/core_api/routes/org_deletion.py
+++ b/core-api/src/core_api/routes/org_deletion.py
@@ -1,4 +1,4 @@
-"""Admin org-deletion endpoint (CAURA-689).
+"""Admin org-deletion endpoints (CAURA-689 + CAURA-696).
 
 ``POST /admin/org/purge-data`` — permanently purge all OSS (``public.*``)
 data for a set of ``tenant_ids`` (every tenant of an enterprise org being
@@ -11,6 +11,12 @@ One ``lifecycle_audit`` row is written per tenant_id (action
 ``hard-delete-org``): a ``pending`` row before the purge, flipped to
 ``success`` (with per-table counts) or ``failure``. ``lifecycle_audit``
 itself is never purged, so this trail survives the deletion it records.
+
+``POST /admin/org/preview-data`` — read-only per-tenant row counts that
+mirror exactly what a subsequent purge would delete. Powers the
+"what will be deleted?" panel the OPS UI (and the customer self-delete
+flow, CAURA-697) shows before the destructive action. No audit row;
+this is a forecast, not an event.
 
 Auth: admin-key only (``auth.enforce_admin``).
 """
@@ -123,3 +129,71 @@ async def purge_org_data(
     )
     status_code = 207 if failed else 200
     return JSONResponse(status_code=status_code, content={"purged": purged, "failed": failed})
+
+
+@router.post("/admin/org/preview-data")
+async def preview_org_data(
+    request: Request,
+    auth: AuthContext = Depends(get_auth_context),
+) -> JSONResponse:
+    """Per-tenant row-count forecast for a set of ``tenant_ids`` (CAURA-696).
+
+    Body: ``{tenant_ids}``. Returns
+    ``{"counts": {tenant_id: {table: row_count}}, "failed": {tenant_id: error}}``.
+
+    Status code contract mirrors ``purge_org_data``: **200** on a fully
+    clean preview (``failed`` empty), **207 Multi-Status** when any
+    tenant's count round-trip failed — so the orchestrator's display
+    layer can decide whether to render partial data with an "incomplete"
+    badge or surface the failure outright.
+
+    Read-only. Per-tenant isolation: one storage hiccup on tenant A
+    does not abort the read for tenant B. No ``lifecycle_audit`` row
+    written — a preview is a query, not a lifecycle event.
+    """
+    auth.enforce_admin()
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        # Match the hardened tenant-suppression / preview routers — a
+        # malformed UTF-8 body would otherwise surface as 500.
+        raise HTTPException(status_code=422, detail="request body must be valid JSON") from exc
+    # Reject non-object JSON bodies — ``request.json()`` succeeds for
+    # arrays / strings / numbers, and ``.get`` on those raises
+    # ``AttributeError`` → 500. The storage-layer preview router has
+    # the same defence; mirror it here so the public surface stays
+    # consistent. Bot review round 1 on PR #246.
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="request body must be a JSON object")
+
+    tenant_ids = body.get("tenant_ids")
+    if (
+        not isinstance(tenant_ids, list)
+        or not tenant_ids
+        or not all(isinstance(t, str) and t for t in tenant_ids)
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_ids' must be a non-empty list of non-empty strings",
+        )
+    if len(tenant_ids) > _MAX_TENANT_IDS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"'tenant_ids' must contain at most {_MAX_TENANT_IDS} entries per call",
+        )
+    if len(tenant_ids) != len(set(tenant_ids)):
+        raise HTTPException(status_code=422, detail="'tenant_ids' must not contain duplicates")
+
+    storage = get_storage_client()
+    counts: dict[str, dict[str, int]] = {}
+    failed: dict[str, str] = {}
+
+    for tenant_id in tenant_ids:
+        try:
+            counts[tenant_id] = await storage.count_tenant_data(tenant_id)
+        except Exception as exc:
+            logger.exception("count_tenant_data failed for tenant %s", tenant_id)
+            failed[tenant_id] = str(exc)
+
+    status_code = 207 if failed else 200
+    return JSONResponse(status_code=status_code, content={"counts": counts, "failed": failed})

--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -37,6 +37,7 @@ from core_storage_api.routers import (
     keystones_router,
     lifecycle_audit_router,
     memories_router,
+    preview_router,
     purge_router,
     reports_router,
     tasks_router,
@@ -123,6 +124,11 @@ def create_app() -> FastAPI:
     app.include_router(idempotency_router, prefix=prefix)
     app.include_router(lifecycle_audit_router, prefix=prefix)
     app.include_router(purge_router, prefix=prefix)
+    # CAURA-696: per-tenant row counts for the deletion-preview panel.
+    # Mirrors ``purge``'s VPC-only trust model: no router-level auth,
+    # trusted callers only reach storage via core-api which applies
+    # the admin check.
+    app.include_router(preview_router, prefix=prefix)
     # CAURA-694: tenant-suppression mirror. POST upsert for the OSS
     # suppression consumer (core-worker); GET is the boundary-guard
     # read used by core-api on every authenticated request.

--- a/core-storage-api/src/core_storage_api/routers/__init__.py
+++ b/core-storage-api/src/core_storage_api/routers/__init__.py
@@ -9,6 +9,7 @@ from core_storage_api.routers.idempotency import router as idempotency_router
 from core_storage_api.routers.keystones import router as keystones_router
 from core_storage_api.routers.lifecycle_audit import router as lifecycle_audit_router
 from core_storage_api.routers.memories import router as memories_router
+from core_storage_api.routers.preview import router as preview_router
 from core_storage_api.routers.purge import router as purge_router
 from core_storage_api.routers.reports import router as reports_router
 from core_storage_api.routers.tasks import router as tasks_router
@@ -26,6 +27,7 @@ __all__ = [
     "keystones_router",
     "lifecycle_audit_router",
     "memories_router",
+    "preview_router",
     "purge_router",
     "reports_router",
     "tasks_router",

--- a/core-storage-api/src/core_storage_api/routers/preview.py
+++ b/core-storage-api/src/core_storage_api/routers/preview.py
@@ -1,0 +1,57 @@
+"""Org/tenant deletion-preview endpoint (CAURA-696).
+
+Read-only per-table row counts for a ``tenant_id`` across the OSS
+schema. Drives the "what will be deleted?" panel that operators see
+before triggering a hard-delete (and that customers see before
+self-delete, CAURA-697). The counts mirror exactly what
+``purge_tenant_data`` (CAURA-689) would remove — same table set,
+same scoping column — so the preview is a faithful forecast.
+
+Trust model (same as ``routers/purge.py``): no router-level
+authentication; storage trusts the upstream auth at core-api
+(``auth.enforce_admin`` on the preview admin route). The deployment
+control is that the storage service is VPC-internal — do NOT expose
+this surface to the public internet.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, HTTPException, Request
+
+from core_storage_api.services.postgres_service import PostgresService
+
+router = APIRouter(prefix="/preview", tags=["Preview"])
+_svc = PostgresService()
+
+
+@router.post("/tenant-counts")
+async def preview_tenant_counts(request: Request) -> dict:
+    """Per-table row count for a tenant. Body: ``{tenant_id}``.
+
+    Returns ``{tenant_id, counts: {table: row_count}}``. Tables with
+    no rows are reported as ``0`` so the caller gets the full
+    breakdown without round-tripping for each missing entry.
+    """
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        # ``UnicodeDecodeError`` is NOT a subclass of
+        # ``JSONDecodeError``; catching both matches the
+        # ``tenant_suppression`` router's hardened shape (PR #244
+        # round 1).
+        raise HTTPException(status_code=422, detail="request body must be valid JSON") from exc
+    # Reject non-object JSON bodies — ``body.get`` on a list / string
+    # would raise ``AttributeError`` and surface as 500. Same defence
+    # PR #244 round 1 added to ``tenant_suppression``.
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="request body must be a JSON object")
+    tenant_id = body.get("tenant_id")
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_id' is required and must be a non-empty string",
+        )
+    counts = await _svc.count_tenant_data(tenant_id)
+    return {"tenant_id": tenant_id, "counts": counts}

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1696,6 +1696,39 @@ class PostgresService:
                     counts[table_name] = result.rowcount  # type: ignore[attr-defined]
         return counts
 
+    async def count_tenant_data(self, tenant_id: str) -> dict[str, int]:
+        """Per-table row count for a ``tenant_id`` across the OSS schema
+        (CAURA-696). Mirrors ``purge_tenant_data``'s table set + column
+        layout so the preview is an accurate forecast of what the
+        purge would delete — adding a new table to the purge list
+        means adding it here too (one source of truth would be nice
+        but the two ops have different read/write modes, so we
+        accept the parallel constants and call out the invariant in
+        comments on both).
+
+        Cheap, read-only: one ``SELECT count(*)`` per table, all
+        keyed off the same indexed ``tenant_id`` / ``org_id``
+        columns. Reports zeros for tables with no rows so the caller
+        gets the full breakdown without a follow-up round-trip.
+        """
+        counts: dict[str, int] = {}
+        async with get_read_session() as session:
+            for tables, column in (
+                (_PURGE_TENANT_TABLES, "tenant_id"),
+                (_PURGE_ORG_KEYED_TABLES, "org_id"),
+            ):
+                for table_name in tables:
+                    # Schema-qualify (``public.``) for the same reason
+                    # ``purge_tenant_data`` does — a non-default
+                    # ``search_path`` could otherwise target the wrong
+                    # rows / mask drift between preview and purge.
+                    result = await session.execute(
+                        text(f"SELECT count(*) FROM public.{table_name} WHERE {column} = :tid"),
+                        {"tid": tenant_id},
+                    )
+                    counts[table_name] = int(result.scalar() or 0)
+        return counts
+
     async def set_tenant_suppression(
         self,
         tenant_id: str,

--- a/core-storage-api/tests/test_preview.py
+++ b/core-storage-api/tests/test_preview.py
@@ -1,0 +1,104 @@
+"""Integration tests for the per-tenant deletion-preview endpoint (CAURA-696).
+
+Uses a fresh, unique tenant_id per test so the count isn't polluted by
+data other integration tests seeded under the shared tenant. The
+preview is read-only and must mirror exactly what ``purge_tenant_data``
+would delete — the assertions here lean on the same memory-payload
+fixture as ``test_purge.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX, _memory_payload
+
+pytestmark = pytest.mark.asyncio
+
+
+def _fresh_ids() -> tuple[str, str]:
+    suffix = uuid.uuid4().hex[:8]
+    return f"preview-tenant-{suffix}", f"preview-fleet-{suffix}"
+
+
+class TestPreviewTenantCounts:
+    async def test_counts_match_seeded_memory_rows(self, client: AsyncClient) -> None:
+        """Seed three memories under a fresh tenant; preview should
+        return ``memories=3`` plus zeros for every other table. The
+        full-breakdown shape (zeros included) is part of the
+        contract — callers shouldn't have to handle missing keys."""
+        tenant_id, fleet_id = _fresh_ids()
+        for _ in range(3):
+            resp = await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+            assert resp.status_code == 200, resp.text
+
+        resp = await client.post(f"{PREFIX}/preview/tenant-counts", json={"tenant_id": tenant_id})
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["tenant_id"] == tenant_id
+        counts = body["counts"]
+        assert counts["memories"] == 3
+        # Every other table in the purge set reports zero, not absent.
+        for table in (
+            "relations",
+            "agents",
+            "fleet_nodes",
+            "audit_log",
+            "documents",
+            "organization_settings",
+        ):
+            assert counts.get(table) == 0, f"expected 0 for {table}, got {counts!r}"
+
+    async def test_unknown_tenant_returns_all_zeros(self, client: AsyncClient) -> None:
+        """A tenant with no data anywhere yields zeros across the
+        full table set — the preview never 404s on an unknown
+        tenant. (Matches the standalone-OSS shape where every fresh
+        tenant starts empty.)"""
+        tid = f"never-seen-{uuid.uuid4().hex[:8]}"
+        resp = await client.post(f"{PREFIX}/preview/tenant-counts", json={"tenant_id": tid})
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["tenant_id"] == tid
+        assert all(v == 0 for v in body["counts"].values())
+
+    async def test_preview_is_read_only(self, client: AsyncClient) -> None:
+        """Two consecutive previews must return the same counts —
+        the read MUST NOT mutate state."""
+        tenant_id, fleet_id = _fresh_ids()
+        await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+        first = (await client.post(f"{PREFIX}/preview/tenant-counts", json={"tenant_id": tenant_id})).json()[
+            "counts"
+        ]
+        second = (await client.post(f"{PREFIX}/preview/tenant-counts", json={"tenant_id": tenant_id})).json()[
+            "counts"
+        ]
+        assert first == second
+
+    async def test_rejects_missing_tenant_id(self, client: AsyncClient) -> None:
+        missing = await client.post(f"{PREFIX}/preview/tenant-counts", json={})
+        assert missing.status_code == 422
+        empty = await client.post(f"{PREFIX}/preview/tenant-counts", json={"tenant_id": ""})
+        assert empty.status_code == 422
+
+    async def test_rejects_malformed_body(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            f"{PREFIX}/preview/tenant-counts",
+            content="not json",
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 422
+
+    async def test_rejects_non_object_json_body(self, client: AsyncClient) -> None:
+        """Same defence the suppression router added on PR #244 round 1
+        — a top-level array / number / string is valid JSON but blows
+        up on ``.get`` if we don't guard."""
+        for shape in ("[1,2,3]", '"a string"', "42"):
+            resp = await client.post(
+                f"{PREFIX}/preview/tenant-counts",
+                content=shape,
+                headers={"content-type": "application/json"},
+            )
+            assert resp.status_code == 422, f"body={shape!r}: {resp.text}"


### PR DESCRIPTION
## Summary

Adds the **read-only forecast** of what a subsequent hard-delete would remove. Mirrors `purge_tenant_data` (CAURA-689) one-for-one — same table set, same scoping columns — so the preview is a faithful "what will be deleted" view for the OPS UI (CAURA-693) and the customer self-delete flow (CAURA-697).

## Layers (OSS)

| Layer | Change |
|---|---|
| `core-storage-api` | New `PostgresService.count_tenant_data(tenant_id)` — `SELECT count(*)` per table over the same `_PURGE_TENANT_TABLES` + `_PURGE_ORG_KEYED_TABLES` constants. Returns the full per-table breakdown including zeros. New `POST /api/v1/storage/preview/tenant-counts` router — same VPC-internal trust model as the existing `purge` route. Hardened JSON-decode (`JSONDecodeError` + `UnicodeDecodeError`) and non-object-body guard — same defences PR #244 round 1 added to the suppression router. |
| `core-api` | New `CoreStorageClient.count_tenant_data` HTTP wrapper. New `POST /admin/org/preview-data` admin route. Body `{tenant_ids}`. Returns `{counts: {tenant_id: {table: row_count}}, failed: {tenant_id: error}}`. Per-tenant isolation; 200 clean / 207 Multi-Status partial. **No `lifecycle_audit` row** — a preview is a query, not a lifecycle event. Same validation + 100-tenant cap as `purge_org_data`. |

## Why a separate route from purge

- Read-only — should be cheap to call from the preview UI on every confirm-dialog open.
- No state side-effects → no audit row → no on-call noise.
- Same per-tenant isolation + 207 contract → admin-api can use one code path for both.

## What's not in this PR (PR B follow-up)

- Per-org count endpoint on `platform-storage-api` (enterprise rows: org, tenants, members, api_keys, etc.).
- Aggregator at `platform-admin-api`: `GET /api/v1/org-lifecycle/{org_id}/deletion-preview` that combines platform-storage (enterprise) + core-api (OSS, all tenants in the org) into a single unified payload for the OPS UI / self-delete UI.
- OPS UI panel itself — that's CAURA-693.

## Test plan

- [x] `core-storage-api/tests/test_preview.py` — happy path (3 seeded memories → `memories=3` + zeros), unknown-tenant returns all zeros, read-only, 422 on missing/empty/malformed/non-object body.
- [x] `uv run mypy src/` on core-api + core-storage-api → clean
- [x] `uv run ruff check` + `format --check` → clean
- [ ] CI integration suite against ephemeral postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)