### PR TITLE
ci(plugin): wire check:version script into CI (CAURA-000 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,19 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Node.js (for plugin version-sync check)
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Check plugin version-sync (gen-version.sh → src/version.ts)
+        # Fails fast if plugin/src/version.ts has drifted from
+        # plugin/package.json's "version" field — i.e., someone bumped
+        # package.json but didn't run scripts/gen-version.sh, or hand-
+        # edited version.ts. The drift-prevention guarantee documented
+        # in scripts/gen-version.sh is enforced here.
+        run: cd plugin && npm run check:version
+
       - name: Install uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5.4.2
         with:

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -16,7 +16,8 @@
     "pretest": "bash ../scripts/gen-version.sh",
     "build": "tsc",
     "dev": "bash ../scripts/gen-version.sh && tsc --watch",
-    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/keystones.test.js"
+    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/keystones.test.js",
+    "check:version": "bash -c 'V=$(node -p \"require(\\\"./package.json\\\").version\"); grep -qF \"PLUGIN_VERSION = \\\"$V\\\"\" src/version.ts || (echo \"version.ts out of sync with package.json ($V): run bash ../scripts/gen-version.sh\" >&2 && exit 1) && echo \"check:version ok: $V\"'"
   },
   "devDependencies": {
     "@types/node": "^25.4.0",


### PR DESCRIPTION
## Summary

Follow-up to PR #247. The `scripts/gen-version.sh` header documents that "CI also runs `npm run check:version` to fail fast if version.ts ever drifts from package.json" — but the script itself was not an npm entry and there was no CI step to invoke it. This PR closes both gaps.

## Changes

- **`plugin/package.json`**: new `check:version` script (one line, no new deps). Uses `grep -qF` for an exact-literal match on `PLUGIN_VERSION = "<version>"` in `src/version.ts`. Stricter than a substring check — passes only when the literal assignment is present.
- **`.github/workflows/ci.yml`**: two new steps right after `actions/checkout`:
  1. `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0, SHA-pinned matching the existing workflow's style).
  2. `cd plugin && npm run check:version`.
  
  Placed before `Install uv` so a version drift fails fast without paying the Python-deps install cost.

## Test plan

- [x] `npm run check:version` (in-sync) → `check:version ok: 2.6.5`, exit 0.
- [x] Synthetic drift (`sed s/2.6.5/2.6.4/ src/version.ts`) → `version.ts out of sync with package.json (2.6.5): run bash ../scripts/gen-version.sh`, exit 1.
- [x] YAML validity confirmed (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`); 18 steps total, new Node steps at positions 2-3.
- [ ] CI run on this PR exercises the new step against a known-in-sync state (should pass).

No code changes. Pure tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)