### PR TITLE
feat(plugin): bump MEMCLAW_KEYSTONES_TOKEN_CAP default 500 → 1500 (CAURA-000)

### DIFF
--- a/plugin/src/env.test.ts
+++ b/plugin/src/env.test.ts
@@ -117,3 +117,44 @@ describe("resolveTenantId — network failure handling", () => {
     }
   });
 });
+
+// --- Default-value source-pin tests ---
+//
+// We don't pin defaults via runtime import because other test files in
+// this suite override env vars at their module-load time (e.g.
+// ``keystones.test.ts:26`` sets ``MEMCLAW_KEYSTONES_TOKEN_CAP=120``),
+// and ``node --test`` shares process env across files — so any
+// runtime read could see a polluted value. Reading the source TS
+// file's literal value is robust to that, and also documents the
+// chosen default in a way that fails CI loudly if someone bumps it
+// without intent.
+
+describe("env.ts default-value source pins", () => {
+  test("MEMCLAW_KEYSTONES_TOKEN_CAP default literal is 1500 (CAURA-000)", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join } = await import("node:path");
+    // The dist/env.test.js sits next to dist/env.js but we need the
+    // SOURCE env.ts. Resolve via project structure: dist/env.test.js
+    // → plugin/dist/ → plugin/src/env.ts.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const envSrc = await readFile(join(here, "..", "src", "env.ts"), "utf8");
+    // Match the exact ``_readIntEnv`` call site to avoid colliding with
+    // doc-comment occurrences of the number 1500.
+    const re = /_readIntEnv\(\s*"MEMCLAW_KEYSTONES_TOKEN_CAP"\s*,\s*(\d+)\s*,/;
+    const match = envSrc.match(re);
+    assert.ok(
+      match,
+      "could not locate MEMCLAW_KEYSTONES_TOKEN_CAP _readIntEnv call in env.ts",
+    );
+    assert.equal(
+      match![1],
+      "1500",
+      "MEMCLAW_KEYSTONES_TOKEN_CAP default must be 1500 — bumped from 500 " +
+        "after CAURA-000 customer with 16 rules saw 4 dropped at every turn. " +
+        "If you intend to change it, also update the doc comment in env.ts " +
+        "and review the keystones formatter's truncation behavior in " +
+        "keystones.test.ts.",
+    );
+  });
+});

--- a/plugin/src/env.ts
+++ b/plugin/src/env.ts
@@ -223,10 +223,15 @@ export const MAX_RECALL_CONTENT_LENGTH = 300;
 // - ``MEMCLAW_KEYSTONES_ENABLED`` (default ``"true"``) — kill switch so
 //   ops can disable the auto-inject without redeploying if something
 //   misfires. Set to ``"false"`` to turn it off.
-// - ``MEMCLAW_KEYSTONES_TOKEN_CAP`` (default 500 tokens, ~2000 chars)
+// - ``MEMCLAW_KEYSTONES_TOKEN_CAP`` (default 1500 tokens, ~6000 chars)
 //   — hard ceiling on the injected block. Lowest-weight rules are
 //   dropped first when the cap is hit so a runaway rule set can't crowd
-//   out recall or the operator prompt.
+//   out recall or the operator prompt. The default of 1500 comfortably
+//   fits ~20-30 medium-length rules (~120 chars each) with header /
+//   footer / truncation-reserve overhead; operators with very large
+//   rule sets can raise it further, and operators on small-context
+//   models can lower it. Previously 500 — bumped after a customer
+//   with 16 rules saw 4 dropped at every turn (CAURA-000).
 // - ``MEMCLAW_KEYSTONES_CACHE_TTL_MS`` (default 5 minutes) — per-identity
 //   cache TTL. ``memclaw_keystones_set`` invocations bust the cache for
 //   the current session so a freshly authored rule takes effect on the
@@ -266,7 +271,7 @@ export const MEMCLAW_KEYSTONES_ENABLED: boolean = _readBoolEnv(
 );
 export const MEMCLAW_KEYSTONES_TOKEN_CAP: number = _readIntEnv(
   "MEMCLAW_KEYSTONES_TOKEN_CAP",
-  500,
+  1500,
   1,
 );
 export const MEMCLAW_KEYSTONES_CACHE_TTL_MS: number = _readIntEnv(


### PR DESCRIPTION
## Summary

Customer escalation 2026-05-28: BankingClaw agent reports the `<keystone_rules>` block in its system prompt is being truncated every turn. Of 16 keystone rules in their tenant, only 12 are injected — the prompt ends with `... (4 more rules omitted)`.

Root cause: `MEMCLAW_KEYSTONES_TOKEN_CAP` defaults to **500 tokens** (~2000 chars). With ~120 chars/rule + header/footer overhead, only 12 rules fit. The 500-token default predates the contextEngine-slot work (PR #212/234/247) — it was set when in-prompt keystone injection was experimental. Now that keystones are a stable per-turn feature, and modern context windows start at 200k+ tokens, 500 is overcautious.

## Change

Single literal: `plugin/src/env.ts:269` `500` → `1500`. Doc comment updated to explain the new headroom (~20-30 rules at ~120 chars each) and reference CAURA-000 for the precedent.

## Tests

`plugin/src/env.test.ts` — new `env.ts default-value source pins` describe block. Reads the source file and asserts the `_readIntEnv("MEMCLAW_KEYSTONES_TOKEN_CAP", N, ...)` call has `N === 1500`. **Source-file** (not runtime) pin because `keystones.test.ts:26` overrides the env var at module-load time and `node --test` shares process env across files — a runtime read could see the polluted value. Error message in the assertion points future maintainers at the customer-impact reasoning so accidental refactor reverts fail loudly.

## Test plan

- [x] `npm test` — **262/262 pass** (261 prior + 1 new source-pin).
- [x] `npx tsc --noEmit` clean.
- [x] Existing `keystones.test.ts:26` override still exercises truncation logic at cap=120 explicitly — no regression of the truncation algorithm itself, only the default ceiling.
- [ ] Customer post-upgrade: ask the agent `Search your system prompt for "<keystone_rules>" — paste the count of bullets and any "N more rules omitted" line` — should report 16 bullets, no truncation line.

## Customer mitigation pending publish

`MEMCLAW_KEYSTONES_TOKEN_CAP=1500` in `~/.openclaw/plugins/memclaw/.env` + restart gives them the same result today without waiting for a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)