### PR TITLE
fix(security): require admin-trust for bulk/whole-tenant memory deletes

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -433,6 +433,13 @@ async def delete_all_memories(
     """
     auth.enforce_read_only()
     auth.enforce_tenant(tenant_id)
+    # BFLA gate: a bulk/whole-tenant delete by an *agent* credential requires
+    # admin-trust (>= 3), matching single-delete (enforce_delete) and the trust
+    # ladder — a routine trust-1 write key must not be able to wipe a fleet or
+    # the tenant. Tenant/user credentials (no gateway X-Agent-ID → the tenant
+    # owner) keep full reach (dashboard reset, tagged cleanup) unchanged.
+    if auth.tenant_id and auth.agent_id:
+        await enforce_delete(db, tenant_id, auth.agent_id)
     from sqlalchemy import update
 
     stmt = update(Memory).where(Memory.tenant_id == tenant_id, Memory.deleted_at.is_(None))
@@ -511,6 +518,11 @@ async def bulk_delete_by_ids(
         raise HTTPException(status_code=400, detail="tenant_id required")
     auth.enforce_read_only()
     auth.enforce_tenant(tenant_id)
+    # BFLA gate (parity with delete_all_memories / single-delete): an agent
+    # credential must be admin-trust (>= 3) to bulk-delete by id; this also
+    # closes the cross-fleet/agent delete (the ids are otherwise unscoped).
+    if auth.tenant_id and auth.agent_id:
+        await enforce_delete(db, tenant_id, auth.agent_id)
     if not ids or len(ids) > 1000:
         raise HTTPException(status_code=400, detail="ids must be 1-1000 items")
 

--- a/tests/test_memory_byid_authz.py
+++ b/tests/test_memory_byid_authz.py
@@ -347,3 +347,53 @@ async def test_rest_search_scope_agent_uses_authenticated_identity(client, as_ag
 
     as_agent(tenant_id, "alice")
     assert priv in await _search(marker), "author cannot see own scope_agent row in search"
+
+
+# ---------------------------------------------------------------------------
+# F2 — bulk/whole-tenant delete requires admin-trust for agent credentials (BFLA)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_rest_delete_all_blocked_for_low_trust_agent(client, as_agent, patch_lookup):
+    """A trust-1 agent key must not be able to wipe the tenant via DELETE /memories."""
+    from tests.conftest import get_test_auth
+
+    tenant_id, _ = get_test_auth()
+    as_agent(tenant_id, "bob")
+    patch_lookup(fleet_id="fleet-beta", trust_level=1)
+    r = await client.delete(f"/api/v1/memories?tenant_id={tenant_id}")
+    assert r.status_code == 403, r.text
+
+    # Admin-trust (>=3) agent is allowed (scoped to a non-existent fleet → deletes 0).
+    patch_lookup(fleet_id="fleet-beta", trust_level=3)
+    r = await client.delete(f"/api/v1/memories?tenant_id={tenant_id}&fleet_id=nonexistent-{uuid.uuid4().hex[:6]}")
+    assert r.status_code == 204, r.text
+
+
+@pytest.mark.integration
+async def test_rest_bulk_delete_by_ids_blocked_for_low_trust_agent(client, as_agent, patch_lookup):
+    from tests.conftest import get_test_auth
+
+    tenant_id, _ = get_test_auth()
+    as_agent(tenant_id, "bob")
+    patch_lookup(fleet_id="fleet-beta", trust_level=1)
+    r = await client.post(
+        "/api/v1/memories/bulk-delete",
+        json={"tenant_id": tenant_id, "ids": [str(uuid.uuid4())]},
+    )
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.integration
+async def test_rest_delete_all_tenant_key_unchanged(client):
+    """Tenant/admin credential (no X-Agent-ID) keeps full delete reach — no regression
+    to dashboard reset / tagged cleanup. Scoped to a non-existent fleet to stay inert."""
+    from tests.conftest import get_test_auth
+
+    tenant_id, headers = get_test_auth()
+    r = await client.delete(
+        f"/api/v1/memories?tenant_id={tenant_id}&fleet_id=nonexistent-{uuid.uuid4().hex[:6]}",
+        headers=headers,
+    )
+    assert r.status_code == 204, r.text


### PR DESCRIPTION
## Summary

Destroy-side sibling of #250. The bulk-delete endpoints authorized on **write
capability + tenant match only** — no trust check — so a routine trust-1 agent
credential could soft-delete an entire fleet or the whole tenant in one call
(broken function-level authorization). Same root cause as #250: the tenant is
the only enforced boundary; the intra-tenant trust ladder wasn't applied here.

## What changed

- **`delete_all_memories`** (`DELETE /memories`) and **`bulk_delete_by_ids`**
  (`POST /memories/bulk-delete`): when the caller is an **agent credential**
  (gateway `X-Agent-ID` present), require **admin-trust (≥ 3)** via the existing
  `enforce_delete` — the same gate as single-delete (#250) and the trust ladder.
- **Tenant/user credentials** (no `X-Agent-ID` → the tenant owner) keep full
  reach, so dashboard reset and the load-test tagged cleanup are unchanged.
- Deny-only — can only reject more requests; no data-loss/corruption risk.

## Tests

`tests/test_memory_byid_authz.py` (+3): trust-1 agent blocked (403) on both
endpoints, trust-3 agent allowed, tenant-key control unchanged (204). Full
non-benchmark suite green (pre-existing unrelated `google-cloud-pubsub`
import failures aside).

## Note for reviewers

This closes the demonstrated path (a trust-1 *agent* key). An optional
defense-in-depth — requiring org-admin even for a *tenant* key's *unfiltered*
whole-tenant purge — is deliberately **not** included here because it needs
`org_role` plumbed on the `X-Tenant-ID` auth branch and would change dashboard
"reset tenant" behavior. Flagging as a follow-up decision rather than bundling
a UX/contract change into a security hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)