### PR TITLE
fix(security): block agent credentials from agent-management & settings (trust self-escalation)

### DIFF
--- a/core-api/src/core_api/auth.py
+++ b/core-api/src/core_api/auth.py
@@ -195,6 +195,26 @@ class AuthContext:
         if self.org_role != "admin":
             raise HTTPException(status_code=403, detail="Org admin access required")
 
+    def enforce_not_agent_credential(self, action: str = "perform this action") -> None:
+        """Raise 403 if the caller is an agent-scoped credential.
+
+        Agent management (trust level, fleet, deletion) and org settings are
+        admin-plane operations. An agent-scoped credential (the enterprise
+        gateway injects ``X-Agent-ID`` only for ``kind=agent_key``) must not be
+        able to escalate its own trust_level, relocate its fleet, delete peer
+        agents, or rewrite tenant settings — otherwise the trust ladder is
+        self-defeating. Tenant/user/admin credentials (no ``X-Agent-ID``) are
+        unaffected, so the dashboard and admin tooling keep working without
+        depending on ``org_role`` being plumbed on the gateway auth branch.
+        """
+        if self.is_admin:
+            return
+        if self.agent_id:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Agent-scoped credentials cannot {action}; use an admin credential.",
+            )
+
     def enforce_tenant(self, requested_tenant: str) -> None:
         """Raise 403 if the request tenant doesn't match the key's tenant."""
         if self.is_admin:

--- a/core-api/src/core_api/routes/agents.py
+++ b/core-api/src/core_api/routes/agents.py
@@ -50,6 +50,9 @@ async def patch_agent_trust(
 ):
     """Update an agent's trust level (and optionally fleet)."""
     auth.enforce_tenant(tenant_id)
+    # Trust changes are the master key to the whole ladder — an agent must not
+    # be able to PATCH its own (or a peer's) trust_level to self-promote.
+    auth.enforce_not_agent_credential("change agent trust levels")
     agent = await update_trust_level(
         db,
         tenant_id,
@@ -72,6 +75,9 @@ async def update_agent_fleet(
     auth.enforce_read_only()
     auth.enforce_usage_limits()
     auth.enforce_tenant(tenant_id)
+    # Fleet reassignment grants home-fleet access to the target fleet — an agent
+    # must not be able to relocate itself/a peer to reach another fleet's data.
+    auth.enforce_not_agent_credential("reassign agent fleets")
     fleet_id = body.get("fleet_id")
     if not fleet_id:
         raise HTTPException(status_code=400, detail="fleet_id is required")
@@ -111,6 +117,10 @@ async def patch_agent_tune(
 ):
     """Update an agent's search profile (per-agent retrieval tuning). Pass ?reset=true to clear."""
     auth.enforce_tenant(tenant_id)
+    # An agent may tune ITS OWN profile (also exposed via MCP memclaw_tune), but
+    # not a peer's — block cross-agent tamper while leaving self-tune + admin keys.
+    if auth.agent_id and auth.agent_id != agent_id:
+        raise HTTPException(status_code=403, detail="Agents can only tune their own search profile.")
     sc = get_storage_client()
     agent = await sc.get_agent(agent_id, tenant_id)
     if not agent:
@@ -146,6 +156,10 @@ async def delete_agent(
     """Delete an agent. Memories written by this agent are NOT deleted."""
     auth.enforce_read_only()
     auth.enforce_tenant(tenant_id)
+    # Deleting an agent wipes its trust/profile/identity (and re-registration
+    # resets to DEFAULT_TRUST_LEVEL) — an agent must not delete itself/peers to
+    # evade controls.
+    auth.enforce_not_agent_credential("delete agents")
     sc = get_storage_client()
     agent = await sc.get_agent(agent_id, tenant_id)
     if not agent:

--- a/core-api/src/core_api/routes/settings.py
+++ b/core-api/src/core_api/routes/settings.py
@@ -52,6 +52,10 @@ async def update_tenant_settings(
     tid = _resolve_tenant(auth, tenant_id)
     if auth.is_demo:
         raise HTTPException(status_code=403, detail="Demo sandbox is read-only")
+    # Tenant settings include security-relevant toggles (e.g. require_agent_approval,
+    # which governs whether new agents start quarantined). An agent-scoped
+    # credential must not be able to flip them.
+    auth.enforce_not_agent_credential("change tenant settings")
     # Only trust X-Changed-By from admin-key callers (the enterprise proxy).
     # Regular users could forge this header otherwise.
     changed_by: str | None

--- a/tests/test_agent_admin_authz.py
+++ b/tests/test_agent_admin_authz.py
@@ -1,0 +1,112 @@
+"""Agent-management & settings are admin-plane: agent credentials are blocked.
+
+Regression for the trust self-escalation gap — PATCH /agents/{id}/trust (and the
+fleet/delete/settings mutators) authorized on tenant only, so any agent key could
+PATCH its own trust_level to 3 and unlock the entire trust ladder. Fixed with
+AuthContext.enforce_not_agent_credential (agent-scoped creds blocked; tenant/user/
+admin creds — no gateway X-Agent-ID — unaffected).
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from core_api.auth import AuthContext
+
+
+# ---------------------------------------------------------------------------
+# Unit: the helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_enforce_not_agent_credential_blocks_agent():
+    ctx = AuthContext(tenant_id="t", agent_id="bob")
+    with pytest.raises(HTTPException) as exc:
+        ctx.enforce_not_agent_credential("change agent trust levels")
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.unit
+def test_enforce_not_agent_credential_allows_user_and_admin():
+    AuthContext(tenant_id="t", agent_id=None).enforce_not_agent_credential()  # tenant/user key
+    AuthContext(tenant_id=None, is_admin=True, agent_id="x").enforce_not_agent_credential()  # admin bypass
+
+
+# ---------------------------------------------------------------------------
+# API: agent credentials are 403'd on the admin-plane endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def as_agent():
+    from core_api.app import app
+    from core_api.auth import AuthContext as _AC, get_auth_context
+    from core_api.db.session import set_current_tenant
+
+    def _install(tenant_id, agent_id):
+        async def _dep():
+            set_current_tenant(tenant_id)
+            return _AC(tenant_id=tenant_id, agent_id=agent_id, readable_tenant_ids=[tenant_id])
+
+        app.dependency_overrides[get_auth_context] = _dep
+
+    yield _install
+    from core_api.app import app as _app
+    from core_api.auth import get_auth_context as _gac
+
+    _app.dependency_overrides.pop(_gac, None)
+
+
+@pytest.mark.integration
+async def test_agent_cannot_escalate_own_trust(client, as_agent):
+    from tests.conftest import get_test_auth
+
+    tenant_id, _ = get_test_auth()
+    as_agent(tenant_id, "bob")
+    r = await client.patch(f"/api/v1/agents/bob/trust?tenant_id={tenant_id}", json={"trust_level": 3})
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.integration
+async def test_agent_cannot_change_fleet_or_delete_or_settings(client, as_agent):
+    from tests.conftest import get_test_auth
+
+    tenant_id, _ = get_test_auth()
+    as_agent(tenant_id, "bob")
+    r = await client.patch(f"/api/v1/agents/bob/fleet?tenant_id={tenant_id}", json={"fleet_id": "f2"})
+    assert r.status_code == 403, r.text
+    r = await client.delete(f"/api/v1/agents/victim?tenant_id={tenant_id}")
+    assert r.status_code == 403, r.text
+    r = await client.put(f"/api/v1/settings?tenant_id={tenant_id}", json={"recall": {}})
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.integration
+async def test_agent_tune_self_allowed_peer_blocked(client, as_agent):
+    from tests.conftest import get_test_auth
+
+    tenant_id, _ = get_test_auth()
+    as_agent(tenant_id, "bob")
+    # peer → 403
+    r = await client.patch(f"/api/v1/agents/alice/tune?tenant_id={tenant_id}", json={"top_k": 5})
+    assert r.status_code == 403, r.text
+    # self → passes the gate (404 because 'bob' isn't registered in test storage, NOT 403)
+    r = await client.patch(f"/api/v1/agents/bob/tune?tenant_id={tenant_id}", json={"top_k": 5})
+    assert r.status_code != 403, r.text
+
+
+@pytest.mark.integration
+async def test_admin_key_can_still_manage_agents(client):
+    """Control: a non-agent (admin/tenant) credential is NOT blocked by the gate."""
+    from tests.conftest import get_test_auth
+
+    tenant_id, headers = get_test_auth()  # admin key → is_admin, agent_id=None
+    # gate passes; reaches update_trust_level → not a 403 (404/200/422 depending on storage)
+    r = await client.patch(
+        f"/api/v1/agents/nonexistent-{uuid.uuid4().hex[:6]}/trust?tenant_id={tenant_id}",
+        json={"trust_level": 2},
+        headers=headers,
+    )
+    assert r.status_code != 403, r.text


### PR DESCRIPTION
## Summary

`PATCH /agents/{id}/trust` authorized on **tenant match only** — no admin/trust
gate (the router's `tags=["Admin"]` is cosmetic; it's mounted at plain
`/api/v1`). So an **agent-scoped credential could `PATCH /agents/{self}/trust
{"trust_level": 3}` and self-promote to admin trust**, which unlocks every
cross-fleet read/write/delete and keystone-authoring gate the trust ladder is
built on — defeating #250 and #251. The fleet-reassignment, peer-agent-delete,
and tenant-settings (`PUT /settings`, e.g. `require_agent_approval`) endpoints
had the same tenant-only gate.

## What changed

- **`AuthContext.enforce_not_agent_credential(action)`** — blocks agent-scoped
  credentials (gateway `X-Agent-ID` present) from admin-plane operations.
  Tenant/user/admin credentials (no `X-Agent-ID`) are unaffected, so the
  dashboard/admin tooling keep working **without** depending on `org_role`
  being plumbed on the gateway auth branch.
- Applied to: `PATCH /agents/{id}/trust`, `PATCH /agents/{id}/fleet`,
  `DELETE /agents/{id}`, `PUT /settings`.
- `PATCH /agents/{id}/tune` (search profile) allows **self** (`agent_id ==
  caller`) but blocks tampering with a peer's profile.

## Tests

`tests/test_agent_admin_authz.py` — helper unit tests + API: an agent credential
gets 403 on trust/fleet/delete/settings; self-tune passes the gate while
peer-tune is 403; admin-key control is unaffected. Full non-benchmark suite green.

## Context

Found in a second-pass audit after #250/#251. This is the *master key* to the
trust ladder — arguably more severe than the by-id BOLA/BFLA, since it lets a
low-trust agent grant itself everything those fixes gate. A separate, even more
severe **infra** finding (core-api reachable directly on its public run.app URL,
bypassing the gateway) is being handled out-of-band — that one is not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)