### PR TITLE
fix(security): enforce fleet/agent scope on entity reads + document deletes

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1037,7 +1037,7 @@ async def memclaw_entity_get(
         )
 
     async with _mcp_session() as db:
-        result = await get_entity(db, uid, _get_tenant())
+        result = await get_entity(db, uid, _get_tenant(), caller_agent_id=_get_agent_id())
         text = "Entity not found." if not result else _serialize(result)
         return _with_latency(text, t0)
 
@@ -1168,7 +1168,10 @@ async def memclaw_doc(
     if op in {"write", "delete"} and (err := _check_write_scope()):
         return err
     tenant_id = _get_tenant()
-    agent_id = _get_agent_id() or agent_id
+    # Raw authenticated identity for the delete trust gate (None ⇒ no agent
+    # context). Must not fall back to the ``mcp-agent`` default.
+    caller_agent_id = _get_agent_id()
+    agent_id = caller_agent_id or agent_id
     # Refuse the default identity for write ops on the gateway path; read-only
     # ops don't carry the same attribution risk.
     if op == "write" and (refuse := _refuse_default_agent_on_gateway(agent_id)):
@@ -1402,6 +1405,10 @@ async def memclaw_doc(
             # op == "delete"
             if not doc_id:
                 return _with_latency(_error_response("INVALID_ARGUMENTS", "op=delete requires 'doc_id'."), t0)
+            # Admin-trust (>= 3) gate for agent credentials, parity with memory
+            # deletes — a routine trust-1 agent must not destroy tenant documents.
+            if caller_agent_id:
+                await enforce_delete(db, tenant_id, caller_agent_id)
             from sqlalchemy import delete as sa_delete
 
             from common.models.document import Document

--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -14,6 +14,7 @@ from core_api.clients.storage_client import get_storage_client
 from core_api.db.session import get_db
 from core_api.middleware.idempotency import IDEMPOTENCY_HEADER, idempotency_for
 from core_api.middleware.rate_limit import write_limit
+from core_api.services.agent_service import enforce_delete
 from core_api.services.audit_service import log_action, log_cross_tenant_read
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
 
@@ -345,6 +346,11 @@ async def delete_document(
     """Delete a document by collection + doc_id."""
     auth.enforce_tenant(tenant_id)
     auth.enforce_read_only()
+    # Bulk/destructive parity with memory deletes: an agent credential needs
+    # admin-trust (>= 3) to delete documents (which carry customer records /
+    # configs). Tenant/user credentials (no X-Agent-ID) are unaffected.
+    if auth.tenant_id and auth.agent_id:
+        await enforce_delete(db, tenant_id, auth.agent_id)
     sc = get_storage_client()
     deleted = await sc.delete_document(tenant_id=tenant_id, collection=collection, doc_id=doc_id)
     if not deleted:

--- a/core-api/src/core_api/routes/entities.py
+++ b/core-api/src/core_api/routes/entities.py
@@ -171,7 +171,7 @@ async def get_entity_route(
     reads widen via ``readable_tenant_ids``; foreign-tenant reads are
     audited to the source tenant."""
     auth.enforce_readable_tenant(tenant_id)
-    entity = await get_entity(db, entity_id, tenant_id)
+    entity = await get_entity(db, entity_id, tenant_id, caller_agent_id=auth.agent_id)
     if not entity:
         raise HTTPException(status_code=404, detail="Entity not found")
     if auth.is_cross_tenant_read and tenant_id != auth.tenant_id:

--- a/core-api/src/core_api/services/entity_service.py
+++ b/core-api/src/core_api/services/entity_service.py
@@ -136,7 +136,9 @@ async def upsert_entity(
     )
 
 
-async def get_entity(db: AsyncSession, entity_id: UUID, tenant_id: str) -> EntityOut | None:
+async def get_entity(
+    db: AsyncSession, entity_id: UUID, tenant_id: str, caller_agent_id: str | None = None
+) -> EntityOut | None:
     sc = get_storage_client()
     result = await sc.get_entity_with_linked_memories(str(entity_id))
     if not result:
@@ -149,6 +151,27 @@ async def get_entity(db: AsyncSession, entity_id: UUID, tenant_id: str) -> Entit
     # Build linked memories from dict data
     raw_entries = result.get("linked_memories", [])
     linked_memories_raw = [entry.get("memory", entry) for entry in raw_entries]
+
+    # Fleet/agent-scope filter: an agent credential must only see the linked
+    # memories it may read (same scope_agent + cross-fleet trust contract as
+    # GET /memories/{id} and search). Without this the entity is a side-door
+    # that returns a peer agent's scope_agent secret / cross-fleet content by
+    # entity id. No-op for tenant/user/admin credentials (caller_agent_id None).
+    if caller_agent_id:
+        from core_api.services.agent_service import authorize_memory_access
+
+        scoped: list[dict] = []
+        for mem in linked_memories_raw:
+            if await authorize_memory_access(
+                db,
+                tenant_id,
+                caller_agent_id,
+                visibility=mem.get("visibility"),
+                owner_agent_id=mem.get("agent_id"),
+                fleet_id=mem.get("fleet_id"),
+            ):
+                scoped.append(mem)
+        linked_memories_raw = scoped
     linked_memories = []
     for mem in linked_memories_raw:
         entity_links_raw = mem.get("entity_links", [])

--- a/tests/test_entity_doc_authz.py
+++ b/tests/test_entity_doc_authz.py
@@ -1,0 +1,185 @@
+"""Entity & document intra-tenant scope (parity with the memory by-id fixes).
+
+- Entity side-door: get_entity returned ALL linked memories with full content,
+  only checking the entity's tenant — leaking a peer agent's scope_agent secret
+  / cross-fleet content by entity id. Now filtered via authorize_memory_access.
+- Document delete: DELETE /documents/{id} (+ MCP op=delete) gated on write-cap
+  only — a trust-1 agent could destroy tenant documents. Now enforce_delete.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _mem(agent_id, visibility, fleet_id, content):
+    return {
+        "memory": {
+            "id": str(uuid.uuid4()),
+            "tenant_id": "t",
+            "fleet_id": fleet_id,
+            "agent_id": agent_id,
+            "visibility": visibility,
+            "memory_type": "fact",
+            "content": content,
+            "weight": 0.5,
+            "source_uri": None,
+            "run_id": None,
+            "metadata": None,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "expires_at": None,
+            "entity_links": [],
+            "recall_count": 0,
+            "last_recalled_at": None,
+        }
+    }
+
+
+def _entity_result(linked):
+    return {
+        "entity": {
+            "id": str(uuid.uuid4()),
+            "tenant_id": "t",
+            "fleet_id": "fleet-alpha",
+            "entity_type": "person",
+            "canonical_name": "X",
+            "attributes": {},
+            "relations": [],
+        },
+        "linked_memories": linked,
+    }
+
+
+@pytest.fixture
+def fake_storage(monkeypatch):
+    def _set(linked):
+        sc = MagicMock()
+        sc.get_entity_with_linked_memories = AsyncMock(
+            return_value=_entity_result(linked)
+        )
+        from core_api.services import entity_service
+
+        monkeypatch.setattr(entity_service, "get_storage_client", lambda: sc)
+
+    return _set
+
+
+@pytest.fixture
+def patch_lookup(monkeypatch):
+    def _set(*, fleet_id=None, trust_level=0, exists=True):
+        from core_api.services import agent_service
+
+        async def fake(db, tenant_id, agent_id):
+            return (
+                None
+                if not exists
+                else {
+                    "agent_id": agent_id,
+                    "fleet_id": fleet_id,
+                    "trust_level": trust_level,
+                }
+            )
+
+        monkeypatch.setattr(agent_service, "lookup_agent", fake)
+
+    return _set
+
+
+@pytest.mark.unit
+async def test_entity_filters_scope_agent_and_cross_fleet(fake_storage, patch_lookup):
+    from core_api.services.entity_service import get_entity
+
+    fake_storage(
+        [
+            _mem(
+                "alice", "scope_agent", "fleet-alpha", "alice private"
+            ),  # peer's private → hide
+            _mem(
+                "alice", "scope_org", "fleet-beta", "org wide"
+            ),  # tenant-global → keep
+            _mem(
+                "alice", "scope_team", "fleet-beta", "other fleet team"
+            ),  # cross-fleet, trust<2 → hide
+            _mem(
+                "bob", "scope_agent", "fleet-alpha", "bob own private"
+            ),  # caller's own → keep
+        ]
+    )
+    patch_lookup(fleet_id="fleet-alpha", trust_level=1)  # bob: fleet-alpha, trust 1
+
+    out = await get_entity(MagicMock(), uuid.uuid4(), "t", caller_agent_id="bob")
+    contents = {m.content for m in out.linked_memories}
+    assert "alice private" not in contents
+    assert "other fleet team" not in contents
+    assert "org wide" in contents
+    assert "bob own private" in contents
+
+
+@pytest.mark.unit
+async def test_entity_unfiltered_for_tenant_credential(fake_storage):
+    """No agent identity (dashboard/admin) → full linked-memory reach, unchanged."""
+    from core_api.services.entity_service import get_entity
+
+    fake_storage([_mem("alice", "scope_agent", "fleet-beta", "alice private")])
+    out = await get_entity(MagicMock(), uuid.uuid4(), "t", caller_agent_id=None)
+    assert "alice private" in {m.content for m in out.linked_memories}
+
+
+# ── Document delete trust gate (API) ──
+
+
+@pytest.fixture
+def as_agent():
+    from core_api.app import app
+    from core_api.auth import AuthContext, get_auth_context
+    from core_api.db.session import set_current_tenant
+
+    def _install(tenant_id, agent_id):
+        async def _dep():
+            set_current_tenant(tenant_id)
+            return AuthContext(
+                tenant_id=tenant_id, agent_id=agent_id, readable_tenant_ids=[tenant_id]
+            )
+
+        app.dependency_overrides[get_auth_context] = _dep
+
+    yield _install
+    from core_api.app import app as _app
+    from core_api.auth import get_auth_context as _gac
+
+    _app.dependency_overrides.pop(_gac, None)
+
+
+@pytest.mark.integration
+async def test_document_delete_blocked_for_low_trust_agent(
+    client, as_agent, patch_lookup
+):
+    from tests.conftest import get_test_auth
+
+    tenant_id, _ = get_test_auth()
+    as_agent(tenant_id, "bob")
+    patch_lookup(fleet_id="fleet-beta", trust_level=1)
+    r = await client.delete(
+        f"/api/v1/documents/some-doc?tenant_id={tenant_id}&collection=c"
+    )
+    assert r.status_code == 403, r.text
+
+    # trust-3 passes the gate (404 because the doc doesn't exist, NOT 403)
+    patch_lookup(fleet_id="fleet-beta", trust_level=3)
+    r = await client.delete(
+        f"/api/v1/documents/some-doc?tenant_id={tenant_id}&collection=c"
+    )
+    assert r.status_code != 403, r.text
+
+
+@pytest.mark.integration
+async def test_document_delete_tenant_key_unchanged(client):
+    from tests.conftest import get_test_auth
+
+    tenant_id, headers = get_test_auth()
+    r = await client.delete(
+        f"/api/v1/documents/nope-{uuid.uuid4().hex[:6]}?tenant_id={tenant_id}&collection=c",
+        headers=headers,
+    )
+    assert r.status_code != 403, r.text


### PR DESCRIPTION
## Summary

Two more instances of the intra-tenant-scope class (siblings of #250/#251), on
non-memory resources, found in the second-pass audit:

- **Entity side-door (BOLA):** `get_entity` returned **every linked memory's
  full content**, checking only the entity's tenant — so a peer agent's
  `scope_agent` secret or a cross-fleet row leaked **by entity id**, routing
  around the `GET /memories/{id}` fix (#250). Now each linked memory is filtered
  through `authorize_memory_access`; `GET /entities/{id}` and MCP
  `memclaw_entity_get` pass the caller identity.
- **Document delete (BFLA):** `DELETE /documents/{id}` and MCP `memclaw_doc
  op=delete` gated on write-capability only — a trust-1 agent could destroy
  tenant documents (customer records/configs). Now `enforce_delete` (trust ≥ 3)
  for agent credentials.

Tenant/user/admin credentials (no gateway `X-Agent-ID`) are unaffected.

## Tests

`tests/test_entity_doc_authz.py` — entity filters `scope_agent`/cross-fleet
linked memories for an agent and stays unfiltered for tenant creds; doc delete
is 403 for a trust-1 agent, allowed for trust-3, tenant-key unaffected. Full
non-benchmark suite green.

## Remaining backlog (flagged, not in this PR)

Document **read** fleet-scoping (`get`/`query`/`search`/`list_collections` —
cross-fleet doc reads for trust<2 agents) is the next increment. Plus the
non-memory items from the audit: STM notes cross-agent (`/stm/notes`),
`/fleet/commands` missing `enforce_tenant`, SSRF DNS-rebinding in ingest,
prompt-injection in recall briefs, and the gateway `/api/` catch-all header
strip. The **CRITICAL** infra finding (core-api publicly reachable, bypassing
the gateway) is handled out-of-band — it is not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)