### PR TITLE
fix(security): gateway-shared-secret gate on the X-Tenant-ID auth path (CRITICAL-1, app side)

### DIFF
--- a/core-api/src/core_api/auth.py
+++ b/core-api/src/core_api/auth.py
@@ -385,6 +385,19 @@ async def get_auth_context(
     # ── Path 4: X-Tenant-ID header (set by enterprise nginx / ingress) ──
     tenant_id = request.headers.get("x-tenant-id")
     if tenant_id:
+        # Perimeter check: this path TRUSTS the X-Tenant-ID / X-Agent-ID /
+        # X-Readable-Tenant-IDs headers with no credential of its own — safe
+        # only when the request came through the gateway. When a shared secret
+        # is configured, require the gateway-injected ``X-Gateway-Secret`` so a
+        # caller hitting core-api directly (e.g. its public run.app URL) cannot
+        # impersonate a tenant by setting the identity headers itself. No-op
+        # when unset (OSS / standalone / dev).
+        gw_secret = settings.gateway_shared_secret
+        if gw_secret and not hmac.compare_digest(request.headers.get("x-gateway-secret") or "", gw_secret):
+            raise HTTPException(
+                status_code=401,
+                detail="Direct access to this service is not permitted.",
+            )
         await _block_if_suppressed(tenant_id)
         # Cross-tenant credentials carry a list of readable tenants via
         # ``X-Readable-Tenant-IDs``. The home tenant was just checked

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -45,6 +45,12 @@ class Settings(BaseSettings):
     api_key: str | None = None  # legacy, deprecated
     admin_api_key: str | None = None
     memclaw_api_key: str | None = None  # Optional: when set, all non-admin requests must present this key
+    # Perimeter secret shared with the enterprise gateway. When set, the
+    # header-trust auth path (X-Tenant-ID) additionally requires a matching
+    # ``X-Gateway-Secret`` header — so a caller who reaches core-api directly
+    # (bypassing the gateway via its public run.app URL) cannot impersonate a
+    # tenant by setting identity headers itself. Unset (OSS/standalone/dev) = no-op.
+    gateway_shared_secret: str | None = None
     embedding_provider: str = "openai"  # fake | openai | local
     # Per-deploy control for where embedding + LLM enrichment run.
     #

--- a/tests/test_gateway_secret_gate.py
+++ b/tests/test_gateway_secret_gate.py
@@ -1,0 +1,64 @@
+"""Perimeter gate: the header-trust auth path requires X-Gateway-Secret.
+
+CRITICAL-1 mitigation — core-api is publicly reachable on its run.app URL and
+Path 4 trusts X-Tenant-ID with no credential. When GATEWAY_SHARED_SECRET is
+configured, a request must carry the gateway-injected X-Gateway-Secret, so a
+direct (gateway-bypassing) caller can't impersonate a tenant by setting the
+identity header itself. Unset = no-op (OSS/standalone/dev).
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from core_api import auth as auth_mod
+
+
+class _Req:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+async def _ctx(monkeypatch, headers, *, secret):
+    monkeypatch.setattr(auth_mod.settings, "gateway_shared_secret", secret)
+    monkeypatch.setattr(auth_mod.settings, "is_standalone", False)
+    monkeypatch.setattr(auth_mod.settings, "memclaw_api_key", None)
+    monkeypatch.setattr(auth_mod, "get_admin_key", lambda: None)
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(auth_mod, "_block_if_suppressed", _noop)
+    monkeypatch.setattr(auth_mod, "_block_if_any_readable_suppressed", _noop)
+    return await auth_mod.get_auth_context(_Req(headers), key=None)
+
+
+@pytest.mark.unit
+async def test_path4_requires_gateway_secret_when_configured(monkeypatch):
+    # missing header → 401
+    with pytest.raises(HTTPException) as e:
+        await _ctx(monkeypatch, {"x-tenant-id": "t"}, secret="topsecret")
+    assert e.value.status_code == 401
+
+    # wrong secret → 401
+    with pytest.raises(HTTPException) as e:
+        await _ctx(
+            monkeypatch,
+            {"x-tenant-id": "t", "x-gateway-secret": "nope"},
+            secret="topsecret",
+        )
+    assert e.value.status_code == 401
+
+    # correct secret → resolves the tenant
+    ctx = await _ctx(
+        monkeypatch,
+        {"x-tenant-id": "t", "x-gateway-secret": "topsecret"},
+        secret="topsecret",
+    )
+    assert ctx.tenant_id == "t"
+
+
+@pytest.mark.unit
+async def test_path4_noop_when_secret_unset(monkeypatch):
+    # No shared secret configured (OSS/dev) → X-Tenant-ID alone still works.
+    ctx = await _ctx(monkeypatch, {"x-tenant-id": "t"}, secret=None)
+    assert ctx.tenant_id == "t"


### PR DESCRIPTION
## Summary

Application-layer mitigation for the **gateway-bypass** finding (CRITICAL-1):
core-api is reachable on its public `*.run.app` URL and **Path 4 trusts
`X-Tenant-ID` / `X-Agent-ID` / `X-Readable-Tenant-IDs` with no credential of its
own** — safe only behind the gateway. A direct caller could set those headers
and impersonate any tenant (confirmed live: a keyless `GET` with `X-Tenant-ID`
returned data).

## What changed

- New setting **`GATEWAY_SHARED_SECRET`**. When set, **Path 4** additionally
  requires a matching **`X-Gateway-Secret`** header (injected by the gateway on
  every core-api location), checked with `hmac.compare_digest`, before honoring
  the identity headers. A direct/gateway-bypassing request lacks it → **401**.
- **Surgical**: only the unauthenticated header-trust path is gated. Admin-key,
  `MEMCLAW_API_KEY`, and standalone paths are untouched. Unset secret
  (OSS / standalone / dev) is a **no-op** — fully backward compatible.
- Reversible (unset the env var).

## Tests

`tests/test_gateway_secret_gate.py` — missing/wrong secret → 401; correct →
resolves the tenant; unset → no-op. Full non-benchmark suite green.

## Rollout (coordinated — this is one of three pieces)

1. **This PR** (core-api): deploy with `GATEWAY_SHARED_SECRET` set (Secret
   Manager) — but only **after** the gateway is sending the header, or set it
   empty first.
2. **Gateway** (enterprise, separate PR): `proxy_set_header X-Gateway-Secret
   <secret>` on every core-api/auth/audit location, same secret value.
3. Deploy order: gateway first (sending the header is harmless if core-api
   ignores it while the secret is unset), then set the secret on core-api.
   Verify the live PoC (`curl https://<core-api>.run.app/api/v1/memories
   -H 'X-Tenant-ID: t'`) now returns **401**, and the gateway path still 200s.

Defense-in-depth follow-up (Option B): lock core-api ingress to internal +
give the gateway a VPC connector, so it isn't publicly reachable at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)