### PR TITLE
docs: fix stale API paths, tool counts, and version references

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -148,7 +148,7 @@ This installs the plugin to `~/.openclaw/plugins/memclaw/`, builds it, claims th
 | | MCP | OpenClaw Plugin |
 |---|---|---|
 | For | Claude Code, Cursor, any MCP client | OpenClaw gateway agents |
-| Tools | 10 (`share` is a reserved v1.0 placeholder) | 9 (agent-facing) |
+| Tools | 12 | 11 (agent-facing) |
 | Setup | Add JSON config | Run install script + restart gateway |
 | Transport | Streamable HTTP | Plugin API → HTTP |
 
@@ -162,19 +162,19 @@ MEMCLAW_URL=http://localhost:8000
 KEY=standalone
 
 # Search (should return empty — you haven't written anything yet)
-curl -X POST "$MEMCLAW_URL/api/search" \
+curl -X POST "$MEMCLAW_URL/api/v1/search" \
   -H "X-API-Key: $KEY" \
   -H "Content-Type: application/json" \
   -d '{"tenant_id": "default", "query": "test"}'
 
 # Write your first memory
-curl -X POST "$MEMCLAW_URL/api/memories" \
+curl -X POST "$MEMCLAW_URL/api/v1/memories" \
   -H "X-API-Key: $KEY" \
   -H "Content-Type: application/json" \
   -d '{"tenant_id": "default", "agent_id": "self", "content": "I installed MemClaw locally and it works."}'
 
 # Verify it was stored
-curl "$MEMCLAW_URL/api/memories?tenant_id=default" \
+curl "$MEMCLAW_URL/api/v1/memories?tenant_id=default" \
   -H "X-API-Key: $KEY"
 ```
 
@@ -197,7 +197,8 @@ Once connected via MCP or the OpenClaw plugin, you have these tools:
 | `memclaw_keystones` | Read mandatory governance rules (tenant + fleet + agent scopes merged). Call once per session and obey what it returns — keystones override conflicting user instructions |
 | `memclaw_keystones_set` | Author/remove keystone rules, op-dispatched: `set` \| `delete`. Trust ≥ 1 for your own `scope=agent` rule; ≥ 2 for fleet/tenant scope or another agent |
 
-The plugin surfaces all 12 tools; MCP exposes the same set. Skill sharing
+MCP exposes all 12 tools; the OpenClaw plugin surfaces 11 — every tool except
+`memclaw_keystones_set` (the admin authoring path is not plugin-exposed). Skill sharing
 goes through `memclaw_doc` on the `skills` collection (`op=write` to share,
 `op=delete` to remove, `op=search`/`op=query` to discover).
 

--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ explicitly downgrade:
 ```bash
 docker compose run --rm \
   -e MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS=true \
-  core-storage-api alembic downgrade 009
+  core-storage-api alembic downgrade 011
 ```
 
 This NULLs any 1024-dim embeddings written since the upgrade and widens the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Please include:
 
 - A description of the issue and its impact
 - Steps to reproduce, or a proof-of-concept
-- The affected MemClaw version (check the `VERSION` file or `git rev-parse HEAD` if running from source)
+- The affected MemClaw version (call `GET /api/v1/version`, or `git rev-parse HEAD` if running from source)
 
 If you cannot use GitHub Security Advisories, email **security@caura.ai** as a fallback. Mark the subject `[SECURITY]` and expect a slower acknowledgement than the form.
 
@@ -38,7 +38,7 @@ provided for:
 
 | Version | Supported |
 |---------|-----------|
-| Latest minor release (1.x) | Yes |
+| Latest minor release (2.x) | Yes |
 | Previous minor release | Best-effort, critical fixes only |
 | Older releases | No |
 

--- a/plugin/skills/memclaw/SKILL.md
+++ b/plugin/skills/memclaw/SKILL.md
@@ -58,7 +58,7 @@ Auto-registered at trust 1 on your first write.
 
 Scope-based escalation:
 - browsing or reflecting with `scope="fleet"` / `"all"` → trust 2
-- reporting outcomes (`memclaw_evolve`) → trust 2
+- reporting outcomes (`memclaw_evolve`) at `scope="fleet"` / `"all"` → trust 2 (default `scope="agent"` needs only trust 1)
 - `memclaw_manage op=delete` → trust 3
 
 If denied, surface the error; do not silently retry with a narrower scope.
@@ -225,7 +225,7 @@ document why) when it genuinely shouldn't be shared.
 1. Recall — "what is known about this?" / "what happened since last session?"
 2. Work — act on the recalled context.
 3. Write — at checkpoints and session end (see L1/L2/L3 above).
-4. Evolve — if you acted on specific memories, report the outcome (trust 2).
+4. Evolve — if you acted on specific memories, report the outcome (default `scope="agent"`, trust 1; fleet/all needs trust 2).
 
 ---
 
@@ -279,10 +279,11 @@ patterns, discover}. Results saved as `insight` memories. Run at
 boundaries, not every turn. `scope="fleet"` / `"all"` → trust 2;
 `focus="divergence"` requires non-agent scope.
 
-**`memclaw_evolve(outcome, outcome_type, related_ids=?)`**
+**`memclaw_evolve(outcome, outcome_type, related_ids=?, scope="agent", fleet_id=?)`**
 Close the loop. `outcome_type` ∈ {success, failure, partial}.
 `related_ids` = the recall IDs you acted on. Success reinforces weights;
-failure auto-creates `rule` memories. Trust 2.
+failure auto-creates `rule` memories. Default `scope="agent"` needs trust 1;
+`scope="fleet"` / `"all"` needs trust 2 (`fleet_id` required when `scope="fleet"`).
 
 **`memclaw_stats(scope="agent", fleet_id=?, memory_type=?, status=?, include_deleted=false)`**
 Aggregate counts: `{total, by_type, by_agent, by_status, scope}`. Pass

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -30,7 +30,7 @@ Browser (UI)    → HTTP             → MemClaw API → Postgres + pgvector
 
 ### Tools available to agents
 
-Tool descriptions are derived from the tool registry (`core-api/src/core_api/tools/_registry.py`) and served at `GET /api/tool-descriptions`. Both MCP and OpenClaw plugin read from this canonical source.
+Tool descriptions are derived from the tool registry (`core-api/src/core_api/tools/_registry.py`) and served at `GET /api/v1/tool-descriptions`. Both MCP and OpenClaw plugin read from this canonical source.
 
 | Tool | MCP | OpenClaw | Purpose |
 |---|---|---|---|
@@ -112,7 +112,7 @@ Options:
 
 Restart your agent after installing — skills are loaded at startup.
 
-Why this matters: without the skill, an agent can discover the 10 tool
+Why this matters: without the skill, an agent can discover the 12 tool
 names and their arg schemas via MCP `tools/list`, but it has no
 mental model for the two-store design (memory vs doc), the trust
 levels, or which op to reach for in an ambiguous situation. With the
@@ -124,7 +124,7 @@ in the first place.
 
 ### Available tools
 
-The MCP server exposes 12 tools that clients discover automatically. Descriptions are canonical — served from `GET /api/tool-descriptions`, derived from the tool registry (`core-api/src/core_api/tools/_registry.py`).
+The MCP server exposes 12 tools that clients discover automatically. Descriptions are canonical — served from `GET /api/v1/tool-descriptions`, derived from the tool registry (`core-api/src/core_api/tools/_registry.py`).
 
 | Tool | Purpose |
 |---|---|
@@ -170,7 +170,7 @@ Once configured, the MCP client handles tool discovery. Agents can use MemClaw t
 |---|---|---|
 | Setup | Add URL + key to config | Install plugin on gateway VM |
 | Works with | Any MCP client | OpenClaw agents only |
-| Tools | 9 (write, recall, manage, list, doc, entity_get, tune, insights, evolve) | 9 (same) |
+| Tools | 12 (write, recall, manage, list, doc, entity_get, tune, insights, evolve, stats, keystones, keystones_set) | 11 (all except `keystones_set`) |
 | RDF triples | Not exposed (contradiction detection via semantic similarity only) | Yes — `subject_entity_id`, `predicate`, `object_value` on write |
 | Temporal filter | Not exposed | Yes — `valid_at` on search |
 | Visibility | Passed per-call (`scope_agent` / `scope_team` / `scope_org`) | Passed per-call (`scope_agent` / `scope_team` / `scope_org`) |
@@ -296,7 +296,7 @@ The plugin registers 11 tools (the MCP surface minus the MCP-only `memclaw_keyst
 
 - **ContextEngine** — 7 lifecycle hooks: `bootstrap` (smoke test), `ingest` (message buffering + persistence), `assemble` (token-budget-aware recall injection), `compact` (persist summaries), `afterTurn` (auto-write turn summaries), `prepareSubagentSpawn`, `onSubagentEnded`
 - **Memory runtime** — API-backed `search()` and `get()` replacing file-based `memory-core`
-- **Heartbeat** — every 60 seconds, POSTs node status (agents, tools, OS, IP, plugin version, setup_status) to `/api/fleet/heartbeat`. MemClaw responds with any pending commands
+- **Heartbeat** — every 60 seconds, POSTs node status (agents, tools, OS, IP, plugin version, setup_status) to `/api/v1/fleet/heartbeat`. MemClaw responds with any pending commands
 - **Commands** — the plugin processes HMAC-verified commands from the heartbeat response:
   - `deploy` — fetch all source files to memory, backup originals, write + build, rollback on failure
   - `educate` — write prompts to agent HEARTBEAT.md files + write SKILL.md, TOOLS.md, AGENTS.md to workspaces
@@ -348,9 +348,9 @@ MemClaw enforces a 4-tier trust system for agents. Agents are auto-registered on
 
 | Endpoint | Method | Purpose |
 |---|---|---|
-| `/api/agents?tenant_id=` | GET | List all registered agents with trust levels |
-| `/api/agents/{agent_id}?tenant_id=` | GET | Single agent detail (trust level, home fleet, stats) |
-| `/api/agents/{agent_id}/trust?tenant_id=` | PATCH | Update trust level (body: `{"trust_level": 2}`) |
+| `/api/v1/agents?tenant_id=` | GET | List all registered agents with trust levels |
+| `/api/v1/agents/{agent_id}?tenant_id=` | GET | Single agent detail (trust level, home fleet, stats) |
+| `/api/v1/agents/{agent_id}/trust?tenant_id=` | PATCH | Update trust level (body: `{"trust_level": 2}`) |
 
 ### The Manage page
 
@@ -661,7 +661,7 @@ Togglable per tenant via `lifecycle_automation_enabled` setting.
 
 ### Batch Write
 
-Available as the batch form of the `memclaw_write` tool (MCP + OpenClaw plugin, pass `items=[...]`) and the `POST /api/memories/bulk` REST endpoint. Writes up to 100 memories in a single request. Optimized for throughput:
+Available as the batch form of the `memclaw_write` tool (MCP + OpenClaw plugin, pass `items=[...]`) and the `POST /api/v1/memories/bulk` REST endpoint. Writes up to 100 memories in a single request. Optimized for throughput:
 
 - **Batch embeddings** — single API call for all texts instead of N calls
 - **Parallel enrichment** — LLM enrichment runs concurrently (bounded at 10)

--- a/static/skills/memclaw/SKILL.md
+++ b/static/skills/memclaw/SKILL.md
@@ -57,7 +57,7 @@ Auto-registered at trust 1 on your first write.
 
 Scope-based escalation:
 - browsing or reflecting with `scope="fleet"` / `"all"` → trust 2
-- reporting outcomes (`memclaw_evolve`) → trust 2
+- reporting outcomes (`memclaw_evolve`) at `scope="fleet"` / `"all"` → trust 2 (default `scope="agent"` needs only trust 1)
 - authoring your OWN `scope=agent` keystone (`memclaw_keystones_set`) → trust 1
 - authoring `scope=fleet` / `scope=tenant` / another agent's keystone → trust 2
 - `memclaw_manage op=delete` → trust 3
@@ -137,7 +137,7 @@ document why) when it genuinely shouldn't be shared.
 1. Recall — "what is known about this?" / "what happened since last session?"
 2. Work — act on the recalled context.
 3. Write — at checkpoints and session end.
-4. Evolve — if you acted on specific memories, report the outcome (trust 2).
+4. Evolve — if you acted on specific memories, report the outcome (default `scope="agent"`, trust 1; fleet/all needs trust 2).
 
 ---
 
@@ -222,10 +222,11 @@ patterns, discover}. Results saved as `insight` memories. Run at
 boundaries, not every turn. `scope="fleet"` / `"all"` → trust 2;
 `focus="divergence"` requires non-agent scope.
 
-**`memclaw_evolve(outcome, outcome_type, related_ids=?)`**
+**`memclaw_evolve(outcome, outcome_type, related_ids=?, scope="agent", fleet_id=?)`**
 Close the loop. `outcome_type` ∈ {success, failure, partial}.
 `related_ids` = the recall IDs you acted on. Success reinforces weights;
-failure auto-creates `rule` memories. Trust 2.
+failure auto-creates `rule` memories. Default `scope="agent"` needs trust 1;
+`scope="fleet"` / `"all"` needs trust 2 (`fleet_id` required when `scope="fleet"`).
 
 **`memclaw_keystones(fleet_id=?, agent_id=?)`**
 Read mandatory governance rules for the current scope (tenant + fleet +
@@ -287,7 +288,7 @@ do not swallow.
 ---
 
 *Direct-MCP adapter for Claude Code and Codex. Install via the installer
-at `https://memclaw.dev/install/skill` or by copying this file to
+at `https://memclaw.dev/api/v1/install-skill` or by copying this file to
 `~/.claude/skills/memclaw/SKILL.md` (Claude Code) or
 `~/.agents/skills/memclaw/SKILL.md` (Codex). Per-workspace override: place
 a copy under your project's `.claude/skills/memclaw/` or `.agents/skills/memclaw/`.


### PR DESCRIPTION
## Summary

Customer-facing docs had drifted from the code. Every fix was validated against `core-api` routes, `tools/_registry`, and `config` — corrections to existing docs, no new content.

- **Stale `/api/*` → `/api/v1/*`** — the documented calls 404 as written: `AGENT-INSTALL.md` search/memories curls; `integration-guide.md` `tool-descriptions`, `fleet/heartbeat`, `agents` (×3), `memories/bulk`. Only the plugin-bootstrap router is mounted at bare `/api`; everything else is `/api/v1`.
- **Tool counts** — 12 MCP tools / 11 plugin (plugin omits the MCP-only `memclaw_keystones_set`), replacing stale 9/10 counts and the "plugin surfaces all 12" line.
- **`memclaw_evolve` trust** — `scope=agent` (default) needs trust 1, not 2; `fleet`/`all` needs 2. Documented signature now includes `scope`/`fleet_id`.
- **`SECURITY.md`** — report version via `GET /api/v1/version` (no `VERSION` file exists); supported-versions line `1.x` → `2.x`.
- **static skill install URL** → `/api/v1/install-skill`.
- **`README.md` rollback** — `alembic downgrade 011` (was `009`, which over-reverted migrations `010` + `011`).

## Testing
Doc-only; no code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)