### PR TITLE
fix(mcp): extend mcp-agent default refusal to all write tools (A14)

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -749,6 +749,10 @@ async def memclaw_manage(
     # no agent context (OSS/standalone) ⇒ tenant-scoped, no agent isolation.
     caller_agent_id = _get_agent_id()
     agent_id = caller_agent_id or agent_id
+    if op in {"update", "transition", "delete", "bulk_delete"} and (
+        refuse := _refuse_default_agent_on_gateway(agent_id)
+    ):
+        return _with_latency(refuse, t0)
 
     async with _mcp_session() as db:
         try:
@@ -1061,6 +1065,8 @@ async def memclaw_tune(
         return err
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
+    if refuse := _refuse_default_agent_on_gateway(agent_id):
+        return _with_latency(refuse, t0)
 
     from core_api.schemas import SearchProfileUpdate
 
@@ -1904,6 +1910,8 @@ async def memclaw_evolve(
         return err
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
+    if refuse := _refuse_default_agent_on_gateway(agent_id):
+        return _with_latency(refuse, t0)
 
     # Pre-validate inputs before consuming rate-limit budget.
     if outcome_type not in EVOLVE_OUTCOME_TYPES:
@@ -2171,6 +2179,8 @@ async def memclaw_keystones_set(
 
     tenant_id = _get_tenant()
     caller_agent_id = _get_agent_id() or "mcp-agent"
+    if refuse := _refuse_default_agent_on_gateway(caller_agent_id):
+        return _with_latency(refuse, t0)
 
     async with _mcp_session() as db:
         # The whole body sits inside the try so the catch-all also covers

--- a/tests/test_mcp_default_agent_guard_a14.py
+++ b/tests/test_mcp_default_agent_guard_a14.py
@@ -1,0 +1,52 @@
+"""A14: every MCP write tool must refuse the literal ``"mcp-agent"`` default
+on gateway-routed requests (tenant-key holder, no X-Agent-ID injection).
+
+The existing memclaw_write coverage lives in tests/test_mcp_write.py;
+this file extends the policy to the remaining write surfaces that
+were missed by PR #139 — memclaw_manage, memclaw_tune, memclaw_evolve,
+and the internal caller-identity fallback in memclaw_keystones_set.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from core_api import mcp_server
+from tests._mcp_test_helpers import parse_envelope
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest.mark.parametrize(
+    "tool_name,kwargs",
+    [
+        # memclaw_manage: write op (delete) with a valid UUID so we reach the guard.
+        ("memclaw_manage", {"op": "delete", "memory_id": str(uuid.uuid4())}),
+        # memclaw_tune: every param optional; guard is the first business logic step.
+        ("memclaw_tune", {}),
+        # memclaw_evolve: outcome + outcome_type required for arg validation.
+        ("memclaw_evolve", {"outcome": "any", "outcome_type": "success"}),
+        # memclaw_keystones_set: op + doc_id required to clear arg validation;
+        # the guard fires on the internal caller-identity fallback, not the
+        # schema param (which is the TARGET agent and defaults to None).
+        ("memclaw_keystones_set", {"op": "delete", "doc_id": "any-rule"}),
+    ],
+)
+async def test_write_tool_refuses_default_agent_on_gateway(mcp_env, tool_name, kwargs):
+    """Gateway-routed + tenant-key (no X-Agent-ID injected) + caller relies on
+    the default identity → MISSING_AGENT_ID, no downstream side-effect."""
+    tool = getattr(mcp_server, tool_name)
+
+    token = mcp_server._via_gateway_var.set(True)
+    try:
+        out = await tool(**kwargs)
+    finally:
+        mcp_server._via_gateway_var.reset(token)
+
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "MISSING_AGENT_ID", (
+        f"{tool_name} did not refuse the default identity on gateway path; "
+        f"got {payload!r}"
+    )


### PR DESCRIPTION
## Summary

PR #139 closed A14 for `memclaw_write` and `memclaw_doc op=write`. This PR
extends the same `_refuse_default_agent_on_gateway` guard to the remaining
four write surfaces that PR #139 didn't touch:

- `memclaw_manage` — guarded only on write ops (`update`/`transition`/`delete`/`bulk_delete`); reads keep current ergonomics.
- `memclaw_tune` — guarded (always a write).
- `memclaw_evolve` — guarded (always a write).
- `memclaw_keystones_set` — its schema `agent_id` is the TARGET agent (defaults to `None`), so the silent-attribution lived at the internal `caller_agent_id = _get_agent_id() or "mcp-agent"` line — guard runs against that fallback.

Same mechanism (`_refuse_default_agent_on_gateway`), same error code (`MISSING_AGENT_ID`), same message — just at four more call sites.

## What's intentionally out of scope

Read tools (`memclaw_recall`, `memclaw_list`, `memclaw_stats`, `memclaw_insights`, `memclaw_keystones`, `memclaw_doc op=read/search/list`) are NOT guarded by this PR. The A14 failure mode is destructive writes silently attributed to the reserved identity; reads against an unscoped agent return an empty result, which is a UX issue, not data loss. Worth tracking separately if it surfaces in usage — see the task list.

## Test plan

- [x] New parametrized unit test `tests/test_mcp_default_agent_guard_a14.py` asserts `MISSING_AGENT_ID` on all 4 tools when gateway-routed + literal default. (4 passed)
- [x] Wet-tested against a fresh `core-api` build on local-dev (gateway routing simulated via `_via_gateway_var = True`): each of the 4 returns `MISSING_AGENT_ID`; `memclaw_manage op=lineage` returns `NOT_FOUND` not `MISSING_AGENT_ID`, confirming writes-only scoping is correct.
- [x] Full non-benchmark test suite: 2563 passed / 3 skipped / 1 xfailed / 3 xpassed.
- [x] `ruff check` clean on changed files; `ruff format --check` clean.
- [x] `mypy` — 4 new `Incompatible return value type (got "str | CallToolResult")` errors of the same shape as 141 pre-existing ones in the file (including the existing PR #139 guard at line 589). Systemic `_with_latency` typing, out of scope.

## Notes

- Closes part of task A14 (the destructive class). Read-side A14 is being left open per the shared task list.
- Mirrors the call-site pattern from PR #139 for grep-ability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)