### PR TITLE
feat(evolve): surface weight-adjustment skip reason (A15)

### DIFF
--- a/core-api/src/core_api/services/evolve_service.py
+++ b/core-api/src/core_api/services/evolve_service.py
@@ -63,6 +63,38 @@ def _log_rule_skip(reason: str, tenant_id: str, outcome_type: str, **extra) -> N
     )
 
 
+# A15 — slugs identifying every silent-exit path on the weight-adjustment
+# flow. Mirrors RULE_SKIP_REASONS for the parallel observability story
+# on ``weight_adjustment_skipped_reason`` in the report_outcome response.
+# An evolve call that returns 200 OK with ``weight_adjustments=[]`` now
+# also carries the reason — callers can distinguish "no rows moved
+# because nothing was supplied" from "no rows moved because every ID was
+# out of scope" without parsing out_of_scope_count.
+WEIGHT_ADJUSTMENT_SKIP_REASONS: tuple[str, ...] = (
+    "no_related_ids",  # caller supplied no related_ids
+    "agent_id_mismatch",  # scope=agent, every related_id dropped by scope filter
+    "fleet_id_mismatch",  # scope=fleet, every related_id dropped by scope filter
+    "all_out_of_scope",  # scope=all, every related_id invalid UUID or missing row
+    "no_rows_updated",  # bulk UPDATE matched 0 rows (race: row deleted between filter and update)
+)
+
+
+def _log_weight_adjustment_skip(reason: str, tenant_id: str, scope: str, **extra) -> None:
+    """Always-fire log line for an evolve weight-adjustment skip.
+
+    Same grep-friendly shape as ``_log_rule_skip``: the slug lives in
+    the message itself so ``grep evolve_weight_adjustment_skipped <reason>``
+    works regardless of structlog ``extra={}`` handling."""
+    extras = " ".join(f"{k}={v}" for k, v in extra.items() if v is not None)
+    logger.info(
+        "evolve_weight_adjustment_skipped reason=%s tenant_id=%s scope=%s %s",
+        reason,
+        tenant_id,
+        scope,
+        extras,
+    )
+
+
 # -- Delta map ----------------------------------------------------------------
 
 _DELTA_MAP = {
@@ -259,7 +291,7 @@ async def _adjust_weights(
     related_ids: list[str],
     outcome_type: str,
     agent_id: str,
-) -> tuple[list[str], list[dict]]:
+) -> tuple[str | None, list[str], list[dict]]:
     """Adjust weights on related memories atomically.
 
     Executes a CTE-based UPDATE per memory so each row is read, clamped, and
@@ -276,7 +308,14 @@ async def _adjust_weights(
     Audit: update_memory's audit hook is bypassed; the outcome memory's
     metadata (`weight_adjustments`) records the change as a compensating trail.
 
-    Returns a tuple of (processed_ids, adjustments):
+    Returns a tuple of (skip_reason, processed_ids, adjustments):
+    - skip_reason: A15 — ``None`` when at least one row was updated;
+      ``"no_rows_updated"`` when every supplied id failed UUID parsing,
+      the bulk UPDATE returned no rows (row deleted between filter and
+      update), or the bulk UPDATE raised an exception. Callers feed this
+      into ``report_outcome``'s ``weight_adjustment_skipped_reason``
+      response field so a 200 OK with empty adjustments is no longer
+      indistinguishable from success.
     - processed_ids: IDs whose weights were actually updated in the DB.
       Excludes invalid UUIDs, missing rows, and rows whose UPDATE raised.
       Callers persist this in the outcome metadata so it reflects reality
@@ -312,7 +351,7 @@ async def _adjust_weights(
             logger.warning("evolve: skipping invalid UUID: %s", mid_str)
 
     if not parsed:
-        return [], []
+        return "no_rows_updated", [], []
 
     valid_uuids = [u for _, u in parsed]
 
@@ -338,7 +377,7 @@ async def _adjust_weights(
             rows = result.fetchall()
     except Exception:
         logger.warning("evolve: bulk weight update failed for %d memories", len(valid_uuids), exc_info=True)
-        return [], []
+        return "no_rows_updated", [], []
 
     # Map returned rows by id so we can preserve the caller's input
     # ordering when building the response. Rows missing from the
@@ -368,7 +407,12 @@ async def _adjust_weights(
             }
         )
 
-    return successfully_adjusted, adjustments
+    # Race / no-match path: parse + UPDATE succeeded but no rows came back
+    # (a row was deleted between _filter_by_scope and the UPDATE, or every
+    # id failed the tenant+deleted_at predicate). Surface as a slug so the
+    # caller can distinguish from a success.
+    skip_reason = "no_rows_updated" if not successfully_adjusted else None
+    return skip_reason, successfully_adjusted, adjustments
 
 
 # -- Rule generation ----------------------------------------------------------
@@ -669,7 +713,8 @@ async def report_outcome(
     Returns
     -------
     dict with outcome_id, outcome_type, scope, weight_adjustments,
-    rules_generated, out_of_scope_count, evolve_ms.
+    rules_generated, rule_skipped_reason, weight_adjustment_skipped_reason,
+    out_of_scope_count, evolve_ms.
     """
     t0 = time.perf_counter()
 
@@ -695,8 +740,18 @@ async def report_outcome(
     # LLM prompt never sees memory content the caller shouldn't access (e.g.,
     # a scope='agent' caller passing another agent's memory IDs). Dropped IDs
     # are tallied into out_of_scope_count for observability.
+    #
+    # A15: alongside the count, classify why no weights will move when the
+    # filter returns an empty set. The slug is the first thing populated;
+    # downstream paths (``_adjust_weights`` race / DB-failure) may override
+    # it. Mirrors the A10 rule_skipped_reason flow: pre-compute upstream,
+    # let the deeper stage override on a more-specific failure.
     out_of_scope_count = 0
-    if related_ids:
+    weight_adjustment_skipped_reason: str | None = None
+    if not related_ids:
+        weight_adjustment_skipped_reason = "no_related_ids"
+    else:
+        original_count = len(related_ids)
         related_ids, out_of_scope_count = await _filter_by_scope(
             db,
             tenant_id=tenant_id,
@@ -705,6 +760,21 @@ async def report_outcome(
             scope=scope,
             related_ids=related_ids,
         )
+        if not related_ids and out_of_scope_count >= original_count:
+            # Filter dropped everything. Map scope → slug.
+            weight_adjustment_skipped_reason = {
+                "agent": "agent_id_mismatch",
+                "fleet": "fleet_id_mismatch",
+                "all": "all_out_of_scope",
+            }.get(scope, "all_out_of_scope")
+            _log_weight_adjustment_skip(
+                weight_adjustment_skipped_reason,
+                tenant_id,
+                scope,
+                out_of_scope_count=out_of_scope_count,
+                caller_agent_id=agent_id,
+                fleet_id=fleet_id,
+            )
 
     # Resolve tenant config up front so ``_maybe_generate_rule`` can be
     # called without any DB dependency. Both REST (here) and MCP
@@ -738,6 +808,7 @@ async def report_outcome(
         rule_skipped_reason=rule_skipped_reason,
         scope=scope,
         out_of_scope_count=out_of_scope_count,
+        weight_adjustment_skipped_reason=weight_adjustment_skipped_reason,
         t0=t0,
     )
 
@@ -799,6 +870,7 @@ async def _apply_outcome_to_db(
     rule_skipped_reason: str | None,
     scope: str,
     out_of_scope_count: int,
+    weight_adjustment_skipped_reason: str | None,
     t0: float,
 ) -> dict:
     """Phases 2-5 + commit: the entire DB-bound write side of evolve.
@@ -816,9 +888,18 @@ async def _apply_outcome_to_db(
     processed_ids: list[str] = []
     weight_adjustments: list[dict] = []
     if related_ids:
-        processed_ids, weight_adjustments = await _adjust_weights(
+        adjust_skip_reason, processed_ids, weight_adjustments = await _adjust_weights(
             db, tenant_id, related_ids, outcome_type, agent_id
         )
+        # A15: the deeper stage's slug wins. The upstream slug from
+        # ``report_outcome`` only fires when the scope filter dropped
+        # every id; if we got here, the filter passed at least one
+        # but the bulk UPDATE didn't update any (race / parse error).
+        if adjust_skip_reason is not None:
+            weight_adjustment_skipped_reason = adjust_skip_reason
+            _log_weight_adjustment_skip(
+                adjust_skip_reason, tenant_id, scope, related_ids_count=len(related_ids)
+            )
 
     # Phase 3: Persist rule memory if confidence meets threshold. outcome_id
     # is not known yet; it is backfilled in Phase 5 after the outcome exists.
@@ -916,6 +997,11 @@ async def _apply_outcome_to_db(
         # path that fired. Mirrors the always-fire log line emitted
         # alongside.
         "rule_skipped_reason": rule_skipped_reason,
+        # A15 — see ``WEIGHT_ADJUSTMENT_SKIP_REASONS``. None when at
+        # least one weight moved; a slug otherwise. Distinguishes the
+        # silent-noop shape A15 reported (200 OK + ``weight_adjustments=[]``
+        # masquerading as success) into a contract callers can inspect.
+        "weight_adjustment_skipped_reason": weight_adjustment_skipped_reason,
         "out_of_scope_count": out_of_scope_count,
         "evolve_ms": int((time.perf_counter() - t0) * 1000),
     }

--- a/tests/test_a10_evolve_rule_skipped_reason.py
+++ b/tests/test_a10_evolve_rule_skipped_reason.py
@@ -75,7 +75,7 @@ async def test_response_includes_rule_skipped_reason_field():
     with (
         patch(
             "core_api.services.evolve_service._adjust_weights",
-            new=AsyncMock(return_value=([], [])),
+            new=AsyncMock(return_value=(None, [], [])),
         ),
         patch(
             "core_api.services.evolve_service._persist_outcome",
@@ -107,7 +107,7 @@ async def _run(outcome_type, related_ids=None, **patches):
     db = AsyncMock()
     base_patches = {
         "_filter_by_scope": AsyncMock(return_value=(related_ids or [], 0)),
-        "_adjust_weights": AsyncMock(return_value=([], [])),
+        "_adjust_weights": AsyncMock(return_value=(None, [], [])),
         "_persist_outcome": AsyncMock(
             return_value="00000000-0000-0000-0000-000000000001"
         ),

--- a/tests/test_a15_evolve_weight_adjustment_skipped_reason.py
+++ b/tests/test_a15_evolve_weight_adjustment_skipped_reason.py
@@ -1,0 +1,266 @@
+"""A15 — weight-adjustment silent-noop observability.
+
+Gap measured: ``memclaw_evolve`` returns 200 OK with ``weight_adjustments=[]``
+when scope-filter drops every related_id or the bulk UPDATE updates zero rows,
+making the caller's "RL feedback was applied" assumption silently wrong.
+
+A15 mirrors A10 (rule_skipped_reason): every silent-exit path on the
+weight-adjustment flow now sets a slug from ``WEIGHT_ADJUSTMENT_SKIP_REASONS``
+on a new ``weight_adjustment_skipped_reason`` field in the
+``report_outcome`` response, plus emits a structured log line in the
+``evolve_weight_adjustment_skipped reason=<slug> ...`` shape so a single
+``grep`` finds every such event regardless of structlog ``extra={}``
+rendering.
+
+The actual weight-adjustment logic is unchanged — this is pure
+observability.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_weight_adjustment_skip_reason_constants_defined():
+    """Central enum so callers can pattern-match on stable slugs."""
+    from core_api.services.evolve_service import WEIGHT_ADJUSTMENT_SKIP_REASONS
+
+    for slug in (
+        "no_related_ids",
+        "agent_id_mismatch",
+        "fleet_id_mismatch",
+        "all_out_of_scope",
+        "no_rows_updated",
+    ):
+        assert slug in WEIGHT_ADJUSTMENT_SKIP_REASONS
+
+
+# ---------------------------------------------------------------------------
+# Response shape — field is present on every call.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_response_includes_weight_adjustment_skipped_reason_field():
+    from core_api.services.evolve_service import report_outcome
+
+    db = AsyncMock()
+    with (
+        patch(
+            "core_api.services.evolve_service._adjust_weights",
+            new=AsyncMock(return_value=(None, [], [])),
+        ),
+        patch(
+            "core_api.services.evolve_service._persist_outcome",
+            new=AsyncMock(return_value="00000000-0000-0000-0000-000000000001"),
+        ),
+    ):
+        result = await report_outcome(
+            db,
+            tenant_id="t1",
+            outcome="passing test",
+            outcome_type="success",
+            related_ids=None,
+            agent_id="a1",
+        )
+
+    assert "weight_adjustment_skipped_reason" in result
+
+
+# ---------------------------------------------------------------------------
+# Per-path reason coverage.
+# ---------------------------------------------------------------------------
+
+
+async def _run(
+    outcome_type,
+    related_ids=None,
+    scope="agent",
+    fleet_id=None,
+    filter_return=None,
+    adjust_return=None,
+    **patches,
+):
+    """Invoke ``report_outcome`` with sensible-default mocks; allow per-test
+    override of the scope-filter and weight-adjust outputs."""
+    from core_api.services.evolve_service import report_outcome
+
+    db = AsyncMock()
+    base_patches = {
+        "_filter_by_scope": AsyncMock(
+            return_value=filter_return
+            if filter_return is not None
+            else (related_ids or [], 0)
+        ),
+        "_adjust_weights": AsyncMock(
+            return_value=adjust_return if adjust_return is not None else (None, [], [])
+        ),
+        "_persist_outcome": AsyncMock(
+            return_value="00000000-0000-0000-0000-000000000001"
+        ),
+    }
+    base_patches.update(patches)
+    with patch.multiple(
+        "core_api.services.evolve_service",
+        **{k: v for k, v in base_patches.items()},
+    ):
+        return await report_outcome(
+            db,
+            tenant_id="t1",
+            outcome="report",
+            outcome_type=outcome_type,
+            related_ids=related_ids,
+            scope=scope,
+            agent_id="a1",
+            fleet_id=fleet_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_related_ids_slug():
+    """Caller passed no IDs → slug = no_related_ids."""
+    result = await _run("failure", related_ids=None)
+    assert result["weight_adjustment_skipped_reason"] == "no_related_ids"
+    assert result["weight_adjustments"] == []
+
+
+@pytest.mark.asyncio
+async def test_no_related_ids_empty_list_slug():
+    """Caller passed an empty list → same slug."""
+    result = await _run("failure", related_ids=[])
+    assert result["weight_adjustment_skipped_reason"] == "no_related_ids"
+
+
+@pytest.mark.asyncio
+async def test_agent_id_mismatch_slug():
+    """scope=agent, filter drops every supplied id → agent_id_mismatch."""
+    result = await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000001"],
+        scope="agent",
+        # filter returns empty in_scope + the full count as out_of_scope
+        filter_return=([], 1),
+    )
+    assert result["weight_adjustment_skipped_reason"] == "agent_id_mismatch"
+    assert result["weight_adjustments"] == []
+    assert result["out_of_scope_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fleet_id_mismatch_slug():
+    """scope=fleet, filter drops every supplied id → fleet_id_mismatch."""
+    result = await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000002"],
+        scope="fleet",
+        fleet_id="f1",
+        filter_return=([], 1),
+    )
+    assert result["weight_adjustment_skipped_reason"] == "fleet_id_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_all_out_of_scope_slug():
+    """scope=all, filter drops every supplied id (invalid UUIDs / missing rows)
+    → all_out_of_scope."""
+    result = await _run(
+        "failure",
+        related_ids=["not-a-uuid", "also-bad"],
+        scope="all",
+        filter_return=([], 2),
+    )
+    assert result["weight_adjustment_skipped_reason"] == "all_out_of_scope"
+
+
+@pytest.mark.asyncio
+async def test_no_rows_updated_slug():
+    """Filter passed some IDs, but ``_adjust_weights`` returned empty —
+    e.g. row deleted between filter and UPDATE. Deeper-stage slug wins."""
+    result = await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000003"],
+        scope="agent",
+        # filter passed the id through
+        filter_return=(["00000000-0000-0000-0000-000000000003"], 0),
+        # _adjust_weights's race path
+        adjust_return=("no_rows_updated", [], []),
+    )
+    assert result["weight_adjustment_skipped_reason"] == "no_rows_updated"
+
+
+@pytest.mark.asyncio
+async def test_skip_reason_none_on_success():
+    """At least one weight moved → field is None."""
+    result = await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000004"],
+        scope="agent",
+        filter_return=(["00000000-0000-0000-0000-000000000004"], 0),
+        adjust_return=(
+            None,
+            ["00000000-0000-0000-0000-000000000004"],
+            [
+                {
+                    "memory_id": "00000000-0000-0000-0000-000000000004",
+                    "old_weight": 0.5,
+                    "new_weight": 0.55,
+                    "delta": 0.05,
+                }
+            ],
+        ),
+    )
+    assert result["weight_adjustment_skipped_reason"] is None
+    assert len(result["weight_adjustments"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Structured log emission.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_emitted_with_reason_in_message_on_scope_mismatch(caplog):
+    """Always-fire grep target: ``evolve_weight_adjustment_skipped reason=<slug>``."""
+    import logging
+
+    caplog.set_level(logging.INFO, logger="core_api.services.evolve_service")
+    await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000001"],
+        scope="agent",
+        filter_return=([], 1),
+    )
+    assert any(
+        "evolve_weight_adjustment_skipped" in rec.getMessage()
+        and "reason=agent_id_mismatch" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_log_emitted_with_reason_on_no_rows_updated(caplog):
+    import logging
+
+    caplog.set_level(logging.INFO, logger="core_api.services.evolve_service")
+    await _run(
+        "failure",
+        related_ids=["00000000-0000-0000-0000-000000000003"],
+        scope="agent",
+        filter_return=(["00000000-0000-0000-0000-000000000003"], 0),
+        adjust_return=("no_rows_updated", [], []),
+    )
+    assert any(
+        "evolve_weight_adjustment_skipped" in rec.getMessage()
+        and "reason=no_rows_updated" in rec.getMessage()
+        for rec in caplog.records
+    )

--- a/tests/test_evolve_service.py
+++ b/tests/test_evolve_service.py
@@ -209,7 +209,7 @@ async def test_evolve_success_increases_weight(db, sc):
 
     from core_api.services.evolve_service import _adjust_weights
 
-    _, adjustments = await _adjust_weights(
+    _, _, adjustments = await _adjust_weights(
         db, tenant_id, [mid], "success", "evolve-test-agent"
     )
 
@@ -232,7 +232,7 @@ async def test_evolve_failure_decreases_weight(db, sc):
 
     from core_api.services.evolve_service import _adjust_weights
 
-    _, adjustments = await _adjust_weights(
+    _, _, adjustments = await _adjust_weights(
         db, tenant_id, [mid], "failure", "evolve-test-agent"
     )
 
@@ -254,7 +254,7 @@ async def test_evolve_partial_slight_increase(db, sc):
 
     from core_api.services.evolve_service import _adjust_weights
 
-    _, adjustments = await _adjust_weights(
+    _, _, adjustments = await _adjust_weights(
         db, tenant_id, [mid], "partial", "evolve-test-agent"
     )
 
@@ -275,7 +275,7 @@ async def test_evolve_weight_floor(db, sc):
 
     from core_api.services.evolve_service import _adjust_weights
 
-    _, adjustments = await _adjust_weights(
+    _, _, adjustments = await _adjust_weights(
         db, tenant_id, [mid], "failure", "evolve-test-agent"
     )
 
@@ -294,7 +294,7 @@ async def test_evolve_weight_cap(db, sc):
 
     from core_api.services.evolve_service import _adjust_weights
 
-    _, adjustments = await _adjust_weights(
+    _, _, adjustments = await _adjust_weights(
         db, tenant_id, [mid], "success", "evolve-test-agent"
     )
 
@@ -311,7 +311,7 @@ async def test_evolve_nonexistent_memory_skipped(db):
 
     from core_api.services.evolve_service import _adjust_weights
 
-    _, adjustments = await _adjust_weights(
+    _, _, adjustments = await _adjust_weights(
         db, tenant_id, [fake_id], "success", "test-agent"
     )
     assert len(adjustments) == 0
@@ -325,7 +325,7 @@ async def test_evolve_invalid_uuid_skipped(db):
 
     from core_api.services.evolve_service import _adjust_weights
 
-    _, adjustments = await _adjust_weights(
+    _, _, adjustments = await _adjust_weights(
         db, tenant_id, ["not-a-uuid"], "success", "test-agent"
     )
     assert len(adjustments) == 0
@@ -345,7 +345,7 @@ async def test_evolve_truncates_related_ids_above_cap(db, caplog):
     oversized = [f"not-a-uuid-{i}" for i in range(EVOLVE_MAX_RELATED_IDS + 10)]
 
     with caplog.at_level(logging.WARNING, logger="core_api.services.evolve_service"):
-        _, adjustments = await _adjust_weights(
+        _, _, adjustments = await _adjust_weights(
             db, tenant_id, oversized, "success", "test-agent"
         )
 


### PR DESCRIPTION
## Summary

A15 mirrors [A10 / PR #199](https://github.com/caura-ai/caura-memclaw/pull/199) for the **weight-adjustment** side of `report_outcome`. An evolve call that returns 200 OK with `weight_adjustments=[]` had no contract for distinguishing:

- caller supplied no `related_ids`
- scope filter dropped every `related_id` (agent / fleet / all mismatch)
- bulk UPDATE found no matching rows (race / row deleted between filter and update)

…from genuine success. RL feedback was silently lost.

This PR adds a `weight_adjustment_skipped_reason` field to the response that names the silent-exit path. No change to persistence, scope-filter, or weight-adjustment logic.

## What changed

- **New module-level `WEIGHT_ADJUSTMENT_SKIP_REASONS`** tuple — 5 slugs (`no_related_ids`, `agent_id_mismatch`, `fleet_id_mismatch`, `all_out_of_scope`, `no_rows_updated`). Lives next to `RULE_SKIP_REASONS` for grep-ability.
- **New `_log_weight_adjustment_skip`** helper — emits `evolve_weight_adjustment_skipped reason=<slug> tenant_id=<tid> scope=<scope>` in the always-fire / grep-friendly shape (matches A10 / Gap-06).
- **`_adjust_weights` return type widened**: `(list[str], list[dict])` → `(str | None, list[str], list[dict])`. First element is the slug when no rows moved (no UUIDs parsed, bulk UPDATE 0-rows, or bulk UPDATE raised), None on success.
- **`report_outcome` computes the upstream slug** based on `_filter_by_scope` output; **`_apply_outcome_to_db` overrides** it if `_adjust_weights` returns a more-specific reason (deeper-stage wins, mirrors A10's `rule_skipped_reason` flow).
- **Response gains `weight_adjustment_skipped_reason`** — `None` on success, slug otherwise.

## What this doesn't do

- Doesn't change which IDs get dropped, how the scope filter works, or the bulk UPDATE atomicity contract.
- Doesn't raise on `_adjust_weights` DB exceptions — they still log + return empty, just now with the `no_rows_updated` slug. Behavior change is out of scope.
- Doesn't slug `db_update_failed` separately from `no_rows_updated` — keeping the slug count minimal per the early-stage / no-overcomplication philosophy. The exception detail is in the existing warning log.

## Test plan

- [x] New `tests/test_a15_evolve_weight_adjustment_skipped_reason.py`: 11 tests cover the slug constant set, response field presence, all 5 silent-exit paths, success path returns None, structured log lines emitted with reason in message.
- [x] Existing `tests/test_evolve_service.py` (9 callsites) and `tests/test_a10_evolve_rule_skipped_reason.py` (2 mock return_values) updated for the widened `_adjust_weights` return tuple.
- [x] Full non-benchmark suite: **2574 passed** (+11), 0 regressions.
- [x] `ruff check` clean; `ruff format --check` clean.
- [x] `mypy` — **0 new errors** (18 → 18 on `evolve_service.py`).
- [x] Wet-tested against a fresh `core-api` build on local-dev: each of the 5 silent-noop slugs returns the right value; success path returns `weight_adjustment_skipped_reason=None` with weight_adjustments populated.

## Notes

- Closes A15 in the canonical task list.
- Pairs naturally with A10's just-shipped `rule_skipped_reason` (PR #199 / `b16de2b`) — same observability pattern, parallel field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)