### PR TITLE
fix(search): share entity tokenizer between FTS-weight + entity-FTS gates (A27)

### DIFF
--- a/core-api/src/core_api/services/entity_tokens.py
+++ b/core-api/src/core_api/services/entity_tokens.py
@@ -58,18 +58,29 @@ def _strip_possessive(s: str) -> str:
     return s
 
 
-def extract_entity_tokens(query: str) -> list[str]:
+def extract_entity_tokens(query: str, *, preserve_case: bool = False) -> list[str]:
     """Return entity-FTS-ready tokens from ``query``.
 
     Splits on whitespace and internal punctuation; drops short tokens,
     stopwords, and hex-only IDs; strips possessive ``'s``; lowercases
     each surviving token so callers don't have to.
+
+    ``preserve_case=True`` keeps the original casing of each surviving
+    token instead of lowercasing. Stopword / length / hex-id checks
+    still run on the lowercased form (so the filter set stays the
+    same), but the returned tokens preserve case. Callers that need
+    case for downstream signals (e.g. ``_adaptive_fts_weight``'s
+    proper-noun heuristic in ``memory_service``, A27) use this; the
+    default keeps the entity-FTS contract unchanged.
     """
-    return [
-        lower
-        for t in _TOKEN_SEP_RE.split(query)
-        if (stripped := _strip_possessive(t.strip(string.punctuation)))
-        and len(stripped) >= ENTITY_TOKEN_MIN_LENGTH
-        and (lower := stripped.lower()) not in ENTITY_STOPWORDS
-        and not _is_hex_id(stripped)
-    ]
+    out: list[str] = []
+    for t in _TOKEN_SEP_RE.split(query):
+        stripped = _strip_possessive(t.strip(string.punctuation))
+        if not stripped or len(stripped) < ENTITY_TOKEN_MIN_LENGTH:
+            continue
+        if stripped.lower() in ENTITY_STOPWORDS:
+            continue
+        if _is_hex_id(stripped):
+            continue
+        out.append(stripped if preserve_case else stripped.lower())
+    return out

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -46,8 +46,6 @@ from core_api.constants import (
     DEFAULT_MEMORY_WEIGHT,
     DEFAULT_SEARCH_TOP_K,
     EMBEDDING_CACHE_TTL,
-    ENTITY_STOPWORDS,
-    ENTITY_TOKEN_MIN_LENGTH,
     FRESHNESS_DECAY_DAYS,
     FRESHNESS_FLOOR,
     FTS_BOOST_MAX_TOKENS,
@@ -2555,18 +2553,39 @@ def _is_specific_token(token: str) -> bool:
 
 
 def _adaptive_fts_weight(query: str) -> float:
-    """Return a boosted FTS weight for short, specific queries."""
-    tokens = query.split()
-    if len(tokens) > FTS_BOOST_MAX_TOKENS:
-        return FTS_WEIGHT
-    meaningful = [
-        t for t in tokens if len(t) >= ENTITY_TOKEN_MIN_LENGTH and t.lower() not in ENTITY_STOPWORDS
-    ]
-    if not meaningful:
+    """Return a boosted FTS weight for short, specific queries.
+
+    A27 — shares the canonical tokenizer with the entity-FTS gate so a
+    hyphenated query like ``claude-opus-4-7`` no longer produces a
+    1-token view here but a 4-token view at ``extract_entity_tokens``.
+    Two behavioural details are preserved across the share:
+
+    1. ``MAX_TOKENS`` gates on RAW whitespace count, not on the
+       post-filter token count. A 4+ word natural-language sentence
+       should stay default-weight even when the shared filter would
+       collapse it to a single meaningful token (``"tell me about
+       NEXAI"`` → semantic-heavy, don't boost).
+    2. Sigil tokens (``$BTC`` / ``@karpathy`` / ``#trending``) are
+       detected on the RAW query before ``extract_entity_tokens``
+       strips leading punctuation, so the handle / ticker / hashtag
+       signal that ``_is_specific_token`` keys on still fires after
+       the share.
+    """
+    from core_api.services.entity_tokens import extract_entity_tokens
+
+    raw = query.split()
+    if len(raw) > FTS_BOOST_MAX_TOKENS:
         return FTS_WEIGHT
 
-    specific_count = sum(1 for t in meaningful if _is_specific_token(t))
-    if specific_count / len(meaningful) > FTS_BOOST_SPECIFICITY_RATIO:
+    tokens = extract_entity_tokens(query, preserve_case=True)
+    sigil_count = sum(1 for t in raw if t and t[0] in ("$", "@", "#") and len(t) > 1)
+
+    if not tokens and sigil_count == 0:
+        return FTS_WEIGHT
+
+    specific_count = sum(1 for t in tokens if _is_specific_token(t)) + sigil_count
+    denom = len(tokens) or 1
+    if specific_count / denom > FTS_BOOST_SPECIFICITY_RATIO:
         return FTS_WEIGHT_BOOSTED
 
     return FTS_WEIGHT

--- a/tests/test_a27_shared_tokenizer.py
+++ b/tests/test_a27_shared_tokenizer.py
@@ -1,0 +1,122 @@
+"""A27 — FTS-weight gate and entity-FTS gate share the same tokenizer.
+
+Before A27, ``_adaptive_fts_weight`` used naive ``query.split()`` while
+``extract_entity_tokens`` (the entity-FTS gate) split on hyphens too.
+A hyphenated identifier like ``claude-opus-4-7`` produced disagreeing
+views — 1 token to the FTS-weight gate, 4 tokens to entity-FTS — so
+the two gates routed inconsistently across the same query.
+
+These tests prove the share is in place and the existing behaviour
+the FTS-weight gate cared about (sigil handle / ticker boosts; raw
+sentence-length detection) survives the migration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_api.constants import FTS_WEIGHT, FTS_WEIGHT_BOOSTED
+from core_api.services.entity_tokens import extract_entity_tokens
+from core_api.services.memory_service import _adaptive_fts_weight
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# extract_entity_tokens — preserve_case kwarg.
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEntityTokensPreserveCase:
+    def test_default_lowercases(self):
+        assert extract_entity_tokens("CertiK OpenAI") == ["certik", "openai"]
+
+    def test_preserve_case_keeps_original(self):
+        assert extract_entity_tokens("CertiK OpenAI", preserve_case=True) == [
+            "CertiK",
+            "OpenAI",
+        ]
+
+    def test_preserve_case_still_filters_stopwords(self):
+        assert extract_entity_tokens("the OpenAI Foundation", preserve_case=True) == [
+            "OpenAI",
+            "Foundation",
+        ]
+
+    def test_preserve_case_still_drops_hex_ids(self):
+        # 8+ hex chars are dropped regardless of case-preservation.
+        out = extract_entity_tokens("abc123-deadbeef notable", preserve_case=True)
+        assert "deadbeef" not in out
+        assert "notable" in out
+
+
+# ---------------------------------------------------------------------------
+# Token agreement between gates.
+# ---------------------------------------------------------------------------
+
+
+class TestTokenizerAgreement:
+    """Both gates should classify hyphenated identifiers the same way."""
+
+    def test_hyphenated_identifier_does_not_overboost(self):
+        # A27 root-cause case: claude-opus-4-7 was 1 specific token to
+        # _adaptive_fts_weight (lone token with digits → BOOSTED) and 4
+        # tokens to the entity-FTS gate. After A27, the FTS-weight gate
+        # sees the same split — claude/opus/4/7 — and neither "claude"
+        # nor "opus" are specific (no digits, no upper, no sigil), so
+        # the query no longer auto-boosts.
+        assert _adaptive_fts_weight("claude-opus-4-7") == FTS_WEIGHT
+
+    def test_hyphenated_identifier_yields_multiple_entity_tokens(self):
+        # Sanity check that the entity-FTS gate continues to see the
+        # multiple-token view it always did. Both gates now agree on
+        # boundary detection — that's the A27 contract.
+        assert extract_entity_tokens("claude-opus-4-7") == ["claude", "opus"]
+
+
+# ---------------------------------------------------------------------------
+# Sigil preservation across the share.
+# ---------------------------------------------------------------------------
+
+
+class TestSigilPreservation:
+    """Handle / ticker / hashtag tokens still boost FTS weight even though
+    ``extract_entity_tokens`` strips the leading sigil before returning."""
+
+    def test_handle_boosts(self):
+        assert _adaptive_fts_weight("@karpathy") == FTS_WEIGHT_BOOSTED
+
+    def test_ticker_boosts(self):
+        assert _adaptive_fts_weight("$BTC") == FTS_WEIGHT_BOOSTED
+
+    def test_hashtag_boosts(self):
+        assert _adaptive_fts_weight("#trending") == FTS_WEIGHT_BOOSTED
+
+    def test_sigil_with_other_content_still_boosts(self):
+        # 'find $BTC price' — 'find' is a stopword, leaves $BTC + price.
+        # The sigil + BTC's all-caps both count as specific.
+        assert _adaptive_fts_weight("find $BTC price") == FTS_WEIGHT_BOOSTED
+
+
+# ---------------------------------------------------------------------------
+# Raw-count MAX_TOKENS gate (preserves natural-language detection).
+# ---------------------------------------------------------------------------
+
+
+class TestRawMaxTokensGate:
+    """4+ raw words → semantic intent, default weight, even when the
+    shared filter would collapse the query to a single meaningful token."""
+
+    def test_long_sentence_with_one_specific_stays_default(self):
+        # Pre-A27 would have stayed default because raw count > MAX. The
+        # naive 'meaningful = [...]' filter inside _adaptive_fts_weight
+        # left the same 1 specific over a small denominator and the raw
+        # MAX gate is what kept the boost from firing. A27 preserves
+        # the raw MAX gate explicitly.
+        assert _adaptive_fts_weight("tell me about NEXAI") == FTS_WEIGHT
+
+    def test_long_sentence_with_camelcase_stays_default(self):
+        assert _adaptive_fts_weight("what is the address of OpenAI") == FTS_WEIGHT
+
+    def test_long_sentence_with_ticker_stays_default(self):
+        assert _adaptive_fts_weight("how much is $BTC worth now") == FTS_WEIGHT


### PR DESCRIPTION
## Summary

`_adaptive_fts_weight` (the FTS-vs-semantic blend gate) used naive `query.split()`, while `extract_entity_tokens` (the entity-FTS short-circuit gate) split on hyphens and stripped possessives. A hyphenated identifier like `claude-opus-4-7` gave **1 token to the FTS-weight gate but 4 tokens to entity-FTS** — the two gates routed the same query inconsistently.

A27's stated fix: share the tokenizer. The share required preserving two existing behaviours of the FTS-weight gate:

1. **Raw `MAX_TOKENS` gate** — a 4+ word natural-language sentence (`"tell me about NEXAI"`) should stay semantic-weight, even when the shared filter would collapse it to a single meaningful token.
2. **Sigil signal** — `extract_entity_tokens` strips leading `$@#` punctuation, so handle / ticker / hashtag boost signals would otherwise vanish post-share.

## Changes

- `extract_entity_tokens` gains `preserve_case=False` kwarg. Default behaviour (entity-FTS gate) is unchanged. The FTS-weight gate passes `preserve_case=True` so its proper-noun heuristic (CamelCase / ALL-CAPS detection) keeps working.
- `_adaptive_fts_weight` rewritten to: (a) gate `MAX_TOKENS` on raw whitespace count, (b) call `extract_entity_tokens` for specificity computation, (c) sigil-detect on the raw query before tokenization strips leading punctuation.
- Dropped now-unused `ENTITY_STOPWORDS` / `ENTITY_TOKEN_MIN_LENGTH` imports from `memory_service.py` (filter logic lives in the shared helper now).

## Behavioural impact

- **Hyphenated identifiers no longer auto-boost.** `claude-opus-4-7`, `gpt-5-turbo` etc. used to boost FTS via the "lone-token-with-digits" specificity heuristic. After the share, the tokenizer splits them on hyphens, neither half is specific on its own, and the ratio falls below threshold. This matches what the entity-FTS gate already saw — and that's the A27 contract.
- **Everything else preserved**: `NEXAI`, `CertiK OpenAI`, `$BTC`, `@karpathy`, `#trending`, `find $BTC price`, `GPT-5 release` all still boost. Long sentences with one rare term still stay default.

## Test plan

- [x] New `tests/test_a27_shared_tokenizer.py`: 13 tests cover the `preserve_case` kwarg, tokenizer agreement on hyphenated identifiers, sigil preservation, and the raw `MAX_TOKENS` gate.
- [x] Existing `tests/test_adaptive_fts_weight.py` (24 tests) and `tests/test_entity_tokens.py` (40 tests) pass unchanged — no regressions on the prior contracts.
- [x] Full non-benchmark suite: **2587 passed** (+13), 0 regressions.
- [x] `ruff check` clean; `ruff format --check` clean.
- [x] `mypy`: 0 new errors (78 → 78).
- [x] Wet-tested against a fresh `core-api` build on local-dev: 8 probe queries verified against expected weights and entity-token outputs.

```
claude-opus-4-7                  0.3  ['claude', 'opus']
@karpathy                        0.6  ['karpathy']
$BTC                             0.6  ['BTC']
NEXAI                            0.6  ['NEXAI']
CertiK OpenAI                    0.6  ['CertiK', 'OpenAI']
tell me about NEXAI              0.3  ['NEXAI']
what is the address of OpenAI    0.3  ['address', 'OpenAI']
good crypto                      0.3  ['crypto']
```

## Notes

- Closes A27 in the canonical task list.
- Related: A7 (Query classifier mis-routes entity-token queries) is still open. If A7's fix changes `extract_entity_tokens`, the FTS-weight gate now inherits those changes for free — they were the point of sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)