### PR TITLE
fix(search): include EMBEDDING_QUERY_INSTRUCTION in embedding cache key (C9)

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2620,25 +2620,45 @@ async def _get_or_cache_embedding(query: str, tenant_id: str, tenant_config):
     old entries with a mismatched dim become unreachable under the new
     key and expire naturally via ``EMBEDDING_CACHE_TTL``.
 
+    The cache key also includes ``EMBEDDING_QUERY_INSTRUCTION`` (C9):
+    instruction-aware models (Qwen3-Embedding, e5-instruct, KaLM) prepend
+    the resolved instruction to the query before encoding, so the SAME
+    raw query under TWO different instructions produces TWO different
+    embeddings. Omitting the instruction from the key meant an env-var
+    change (or set / unset) served stale embeddings until the TTL
+    expired. The registry-level provider cache already keys on this —
+    we mirror it at the search-cache layer.
+
     Concurrent cold-cache callers for the same key share a single
     ``get_query_embedding`` round-trip via ``_inflight_embeddings`` —
     measured 3-second tail spread on 5 parallel novel-query recalls
     pre-fix; post-fix all callers join the leader's future.
     """
+    import os
+
     from core_api.cache import cache_get, cache_set
 
     _model = (
         getattr(tenant_config, "embedding_model", None) if tenant_config is not None else None
     ) or OPENAI_EMBEDDING_MODEL
     _normalized = _normalize_query_for_cache(query)
-    _qhash = hashlib.sha256(f"{_model}:{VECTOR_DIM}:{tenant_id}:{_normalized}".encode()).hexdigest()
-    # Prefix bumped from ``qemb2:`` → ``qemb3:`` because the hash input
-    # changed (added ``VECTOR_DIM``). The bump makes the
+    # Resolved instruction — same env var the OpenAI provider reads at
+    # registry-construction time (common/embedding/_registry.py:218). When
+    # unset, we hash the empty string so the key stays stable across
+    # never-set vs explicitly-empty (both behave identically downstream:
+    # the provider's ``embed_query`` short-circuits the instruction
+    # prefix).
+    _instruction = os.environ.get("EMBEDDING_QUERY_INSTRUCTION") or ""
+    _qhash = hashlib.sha256(
+        f"{_model}:{VECTOR_DIM}:{_instruction}:{tenant_id}:{_normalized}".encode()
+    ).hexdigest()
+    # Prefix bumped from ``qemb3:`` → ``qemb4:`` because the hash input
+    # changed (added ``EMBEDDING_QUERY_INSTRUCTION``). The bump makes the
     # cache-generation boundary explicit in Redis key stats so an
     # operator can see the cold-start at deploy time and confirm the
     # embedding provider can absorb the working-set re-fetch. Old
-    # ``qemb2:*`` entries expire naturally via ``EMBEDDING_CACHE_TTL``.
-    _cache_key = f"qemb3:{_qhash}"
+    # ``qemb3:*`` entries expire naturally via ``EMBEDDING_CACHE_TTL``.
+    _cache_key = f"qemb4:{_qhash}"
     _cached_raw = await cache_get(_cache_key)
     if _cached_raw is not None:
         try:

--- a/tests/test_c9_embedding_cache_instruction_key.py
+++ b/tests/test_c9_embedding_cache_instruction_key.py
@@ -1,0 +1,165 @@
+"""C9 — embedding cache key includes ``EMBEDDING_QUERY_INSTRUCTION``.
+
+For instruction-aware models (Qwen3-Embedding, e5-instruct, KaLM), the
+same raw query is encoded differently depending on the resolved
+task-description prefix the provider prepends. Before C9, the search
+cache key was ``{model}:{VECTOR_DIM}:{tenant_id}:{normalized_query}`` —
+no instruction. Switching ``EMBEDDING_QUERY_INSTRUCTION`` (set / unset /
+edit) would serve embeddings from the prior instruction until the TTL
+expired, looking like a model regression but actually a cache-key
+omission.
+
+This test file proves the new key shape is honored:
+- Same query + different instruction → different cache key (no stale
+  hit).
+- Same query + same instruction → cache hit (steady-state unchanged).
+- The cache prefix is bumped (``qemb4:``) so post-deploy Redis stats
+  show a clean cold-start boundary.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from core_api.services import memory_service
+
+pytestmark = [pytest.mark.unit]
+
+
+_FAKE_EMBED_A = [0.1] * 8
+_FAKE_EMBED_B = [0.2] * 8
+
+
+@pytest.fixture(autouse=True)
+def _clear_inflight():
+    """Mirror the stampede-guard test setup so a leftover future from a
+    prior test doesn't deadlock the next."""
+    memory_service._inflight_embeddings.clear()
+    yield
+    memory_service._inflight_embeddings.clear()
+
+
+async def test_cache_key_uses_qemb4_prefix(monkeypatch):
+    """Sanity check on the prefix bump — proves the migration boundary
+    so operators can grep ``qemb4:*`` in Redis stats post-deploy."""
+    seen_keys: list[str] = []
+
+    async def _capture_get(key):
+        seen_keys.append(key)
+        return None
+
+    async def _noop_set(key, value, ttl=0):
+        return None
+
+    async def _embed(query, tenant_config):
+        return _FAKE_EMBED_A
+
+    monkeypatch.delenv("EMBEDDING_QUERY_INSTRUCTION", raising=False)
+    with (
+        patch("core_api.cache.cache_get", new=_capture_get),
+        patch("core_api.cache.cache_set", new=_noop_set),
+        patch.object(memory_service, "get_query_embedding", new=_embed),
+    ):
+        await memory_service._get_or_cache_embedding("q", "tenant-A", None)
+
+    assert seen_keys, "cache_get was never called"
+    assert seen_keys[0].startswith("qemb4:"), (
+        f"expected qemb4: prefix, got {seen_keys[0]!r}"
+    )
+
+
+async def test_different_instruction_produces_different_cache_key(monkeypatch):
+    """The point of C9: env-var change MUST flip the cache key so old
+    embeddings (computed under the prior instruction) don't get served."""
+    seen_keys: set[str] = set()
+
+    async def _capture_get(key):
+        seen_keys.add(key)
+        return None
+
+    async def _noop_set(key, value, ttl=0):
+        return None
+
+    async def _embed(query, tenant_config):
+        return _FAKE_EMBED_A
+
+    with (
+        patch("core_api.cache.cache_get", new=_capture_get),
+        patch("core_api.cache.cache_set", new=_noop_set),
+        patch.object(memory_service, "get_query_embedding", new=_embed),
+    ):
+        monkeypatch.setenv("EMBEDDING_QUERY_INSTRUCTION", "Retrieve relevant docs")
+        await memory_service._get_or_cache_embedding("q", "tenant-A", None)
+        memory_service._inflight_embeddings.clear()
+
+        monkeypatch.setenv(
+            "EMBEDDING_QUERY_INSTRUCTION", "Find passages that answer the question"
+        )
+        await memory_service._get_or_cache_embedding("q", "tenant-A", None)
+
+    assert len(seen_keys) == 2, f"expected two distinct keys, got {seen_keys}"
+
+
+async def test_same_instruction_hits_cache(monkeypatch):
+    """Steady-state: same query + same instruction → one embed call."""
+    embed_calls = 0
+    stored_value: dict[str, str] = {}
+
+    async def _embed(query, tenant_config):
+        nonlocal embed_calls
+        embed_calls += 1
+        return _FAKE_EMBED_A
+
+    async def _cache_get(key):
+        return stored_value.get(key)
+
+    async def _cache_set(key, value, ttl=0):
+        stored_value[key] = value
+
+    monkeypatch.setenv("EMBEDDING_QUERY_INSTRUCTION", "Retrieve relevant docs")
+    with (
+        patch.object(memory_service, "get_query_embedding", new=_embed),
+        patch("core_api.cache.cache_get", new=_cache_get),
+        patch("core_api.cache.cache_set", new=_cache_set),
+    ):
+        # First call — cold cache, embeds once + writes.
+        await memory_service._get_or_cache_embedding("q", "tenant-A", None)
+        memory_service._inflight_embeddings.clear()
+        # Second call — warm cache hit, no new embed.
+        await memory_service._get_or_cache_embedding("q", "tenant-A", None)
+
+    assert embed_calls == 1, f"expected 1 embed call, got {embed_calls}"
+
+
+async def test_unset_vs_empty_instruction_equivalent(monkeypatch):
+    """Unset and explicit-empty resolve to the same key — both fall
+    through to the provider's no-prefix branch."""
+    seen_keys: set[str] = set()
+
+    async def _capture_get(key):
+        seen_keys.add(key)
+        return None
+
+    async def _noop_set(key, value, ttl=0):
+        return None
+
+    async def _embed(query, tenant_config):
+        return _FAKE_EMBED_A
+
+    with (
+        patch("core_api.cache.cache_get", new=_capture_get),
+        patch("core_api.cache.cache_set", new=_noop_set),
+        patch.object(memory_service, "get_query_embedding", new=_embed),
+    ):
+        monkeypatch.delenv("EMBEDDING_QUERY_INSTRUCTION", raising=False)
+        await memory_service._get_or_cache_embedding("q", "tenant-A", None)
+        memory_service._inflight_embeddings.clear()
+
+        monkeypatch.setenv("EMBEDDING_QUERY_INSTRUCTION", "")
+        await memory_service._get_or_cache_embedding("q", "tenant-A", None)
+
+    assert len(seen_keys) == 1, (
+        f"unset and empty should hash to the same key, got {seen_keys}"
+    )


### PR DESCRIPTION
## Summary

The search-side embedding cache (``_get_or_cache_embedding`` in ``memory_service.py``) keyed on ``{model}:{VECTOR_DIM}:{tenant_id}:{normalized_query}``. For instruction-aware models (Qwen3-Embedding, e5-instruct, KaLM), the provider prepends ``EMBEDDING_QUERY_INSTRUCTION`` to each query at encode time — so the SAME raw query under TWO different instructions produces TWO different embeddings. Omitting the instruction from the key meant an env-var change served embeddings encoded under the prior instruction until the TTL expired. Looks like a model regression; root cause is a cache-key omission.

The registry-level provider cache (``common/embedding/_registry.py:254-261``) already keys on ``query_instruction``. This PR mirrors that contract at the search-cache layer.

## Changes

- ``_get_or_cache_embedding`` reads ``EMBEDDING_QUERY_INSTRUCTION`` from the env (same source the registry uses) and hashes it into the cache key.
- Cache prefix bumped ``qemb3:`` → ``qemb4:``. Old ``qemb3:*`` entries expire naturally via ``EMBEDDING_CACHE_TTL`` — mirrors the prior ``qemb2:`` → ``qemb3:`` migration when ``VECTOR_DIM`` was added.
- Unset and explicit-empty resolve to the same key (both fall through to the provider's no-prefix branch — equivalent downstream).

Pure correctness — no behavior change for symmetric-model deployments (OpenAI text-embedding-3-small, bge-m3, etc.), no change to the encode path itself.

## Test plan

- [x] New ``tests/test_c9_embedding_cache_instruction_key.py``: 4 tests cover the new ``qemb4:`` prefix, distinct keys under different instructions, cache hit under same instruction, unset / empty equivalence.
- [x] Existing ``tests/test_query_embedding_stampede_guard.py`` (6 tests) pass unchanged.
- [x] Full non-benchmark suite: **2591 passed**, 0 regressions.
- [x] ``ruff check`` clean; ``ruff format --check`` clean.
- [x] ``mypy``: 0 new errors (78 → 78).
- [x] Wet-tested against a fresh core-api build on local-dev: three distinct ``qemb4:*`` keys for the same query under unset / instruction-A / instruction-B.

```
unset instruction:  qemb4:8ae02b9687b775c56c21cc3bd61d93f05f7cf6ea3347260fea3bcb6a5909ea97
instruction A:      qemb4:768fdfe0eed12d5af3a9b1948b1881bff0a277d6e124d726196c7cf6c58bf1d7
instruction B:      qemb4:919a12fbc306bd8626824a53702cb5ab789a77eb6bfc723c55a29ac5543ac1d1
```

## Notes

- Closes C9 in the canonical task list.
- The fix only addresses the cache-key omission. If a future feature exposes per-call instruction overrides (the optional ``instruction`` arg on ``get_query_embedding`` that this codebase doesn't use today), that'll need its own threading into ``_get_or_cache_embedding``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)