### PR TITLE
fix(search): per-task timeout for parallel_embed_entity_boost (D7)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
+++ b/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -24,6 +25,14 @@ from core_api.services.entity_tokens import extract_entity_tokens
 from core_api.services.memory_service import _get_or_cache_embedding
 
 logger = logging.getLogger(__name__)
+
+# Overall wall-clock budget for the embedding + entity-boost step. Embedding
+# uses the full budget; entity boost runs in parallel and gets whatever
+# remains after the embedding resolves (clamped below by
+# ``_MIN_ENTITY_BUDGET_S`` so a near-instant embedding still gives the
+# in-flight entity task a moment to finish).
+_OVERALL_TIMEOUT_S = 15.0
+_MIN_ENTITY_BUDGET_S = 0.1
 
 
 async def _entity_boost_via_storage(
@@ -156,23 +165,48 @@ class ParallelEmbedAndEntityBoost:
                 precomputed_hops=data.pop("_classified_entity_hops", None),
             )
         )
+        # D7 — split the prior shared ``gather`` timeout into per-task budgets.
+        # Embedding is the critical path: a missing vector means the search
+        # can't run, so a timeout there still raises 504. Entity boost is a
+        # supplementary signal — a slow lookup should NOT cancel a completed
+        # embedding; degrade to vector-only search and log instead. Total
+        # budget stays at ``_OVERALL_TIMEOUT_S`` so a slow entity task can't
+        # double the step's wall-clock budget.
+        t0 = time.perf_counter()
         try:
-            embedding, (boosted_memory_ids, memory_boost_factor) = await asyncio.wait_for(
-                asyncio.gather(emb_task, ent_task),
-                timeout=15.0,
-            )
+            embedding = await asyncio.wait_for(emb_task, timeout=_OVERALL_TIMEOUT_S)
         except TimeoutError:
-            emb_task.cancel()
             ent_task.cancel()
             raise HTTPException(status_code=504, detail="Search embedding timed out")
         except ValueError as exc:
-            emb_task.cancel()
             ent_task.cancel()
             raise HTTPException(status_code=503, detail=str(exc))
-        except Exception:
-            emb_task.cancel()
+        except BaseException:
             ent_task.cancel()
             raise
+
+        # ent_task has been running in parallel with emb_task since the
+        # ``ensure_future`` calls above, so the remaining-budget wait_for
+        # below is usually trivial — the task is already done. The guard
+        # only fires when entity_boost outlasts the embedding.
+        remaining = max(_MIN_ENTITY_BUDGET_S, _OVERALL_TIMEOUT_S - (time.perf_counter() - t0))
+        try:
+            boosted_memory_ids, memory_boost_factor = await asyncio.wait_for(ent_task, timeout=remaining)
+        except TimeoutError:
+            logger.warning(
+                "entity_boost timed out after %.2fs remaining budget; continuing with vector-only search",
+                remaining,
+            )
+            boosted_memory_ids, memory_boost_factor = set(), {}
+        except BaseException as exc:
+            # ``_entity_boost_via_storage`` swallows most exceptions internally
+            # and returns ``(set(), {})``; anything that escapes is unexpected
+            # but still non-fatal for the search — fall back to vector-only.
+            logger.warning(
+                "entity_boost raised after embedding ready; continuing with vector-only search: %r",
+                exc,
+            )
+            boosted_memory_ids, memory_boost_factor = set(), {}
 
         data["embedding"] = embedding
         data["boosted_memory_ids"] = boosted_memory_ids

--- a/tests/test_d7_parallel_embed_per_task_timeout.py
+++ b/tests/test_d7_parallel_embed_per_task_timeout.py
@@ -1,0 +1,344 @@
+"""D7 — Per-task timeout for ParallelEmbedAndEntityBoost.
+
+The step runs two coroutines concurrently under one wall-clock budget:
+
+1. ``_get_or_cache_embedding`` — critical path. Without an embedding the
+   search cannot run. A failure here MUST escalate to an ``HTTPException``
+   (504 on timeout, 503 on ``ValueError``).
+2. ``_entity_boost_via_storage`` — supplementary ranking signal. A failure
+   (timeout OR any other exception) MUST degrade gracefully to an empty
+   set/dict and emit a single WARNING log line; no exception escapes.
+
+D7 (will-be PR #260) splits the previously-shared ``asyncio.gather`` budget
+into a critical-path timeout for the embedding and a separate, smaller
+remaining-budget timeout for the entity boost. The headline regression
+the fix addresses: a slow entity task used to cancel a fast embedding
+because both shared the same ``wait_for`` scope, surfacing as a spurious
+504 even though the embedding had completed in <10 ms.
+
+These tests pin every branch of the new contract. They are pure unit tests
+(no DB) and finish in well under a second each by monkeypatching the two
+module-level budget constants down to small values.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search import parallel_embed_entity_boost as mod
+from core_api.pipeline.steps.search.parallel_embed_entity_boost import (
+    ParallelEmbedAndEntityBoost,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EMBED_PATH = (
+    "core_api.pipeline.steps.search.parallel_embed_entity_boost"
+    "._get_or_cache_embedding"
+)
+_BOOST_PATH = (
+    "core_api.pipeline.steps.search.parallel_embed_entity_boost"
+    "._entity_boost_via_storage"
+)
+
+_LOGGER_NAME = "core_api.pipeline.steps.search.parallel_embed_entity_boost"
+
+
+def _make_ctx() -> PipelineContext:
+    """Minimal PipelineContext shaped like ParallelEmbedAndEntityBoost expects.
+
+    Mirrors the construction used in ``tests/pipeline/test_search_pipeline.py``
+    (the D step's existing test) — same keys, same default ``graph_max_hops``.
+    """
+    return PipelineContext(
+        db=AsyncMock(),
+        data={
+            "query": "test",
+            "tenant_id": "t1",
+            "tenant_config": None,
+            "search_params": {"graph_max_hops": 2},
+            "graph_expand": True,
+            "fleet_ids": ["fleet-1"],
+        },
+    )
+
+
+def _shrink_budgets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the two budget knobs down so timeout-cases finish quickly.
+
+    Without this every 504-path test would burn 15 s of wall-clock.
+    """
+    monkeypatch.setattr(mod, "_OVERALL_TIMEOUT_S", 0.3)
+    monkeypatch.setattr(mod, "_MIN_ENTITY_BUDGET_S", 0.05)
+
+
+_DUMMY_EMBED = [0.1] * 1536
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_path_writes_embedding_and_boost(monkeypatch):
+    """Both helpers return quickly → all three ctx.data fields populated."""
+    _shrink_budgets(monkeypatch)
+
+    boosted = {"00000000-0000-0000-0000-000000000001"}
+    factors = {"00000000-0000-0000-0000-000000000001": 1.5}
+
+    async def fast_embed(*args, **kwargs):
+        return _DUMMY_EMBED
+
+    async def fast_boost(*args, **kwargs):
+        return (boosted, factors)
+
+    ctx = _make_ctx()
+    with (
+        patch(_EMBED_PATH, side_effect=fast_embed),
+        patch(_BOOST_PATH, side_effect=fast_boost),
+    ):
+        step = ParallelEmbedAndEntityBoost()
+        await step.execute(ctx)
+
+    assert ctx.data["embedding"] == _DUMMY_EMBED
+    assert ctx.data["boosted_memory_ids"] == boosted
+    assert ctx.data["memory_boost_factor"] == factors
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — embedding times out → HTTPException(504)
+# ---------------------------------------------------------------------------
+
+
+async def test_embedding_timeout_raises_504(monkeypatch):
+    """Critical-path timeout escalates to 504; no partial writes."""
+    _shrink_budgets(monkeypatch)
+
+    async def slow_embed(*args, **kwargs):
+        # Exceeds _OVERALL_TIMEOUT_S (0.3 s) — must trip the 504 path.
+        await asyncio.sleep(5.0)
+        return _DUMMY_EMBED
+
+    async def fast_boost(*args, **kwargs):
+        return (set(), {})
+
+    ctx = _make_ctx()
+    with (
+        patch(_EMBED_PATH, side_effect=slow_embed),
+        patch(_BOOST_PATH, side_effect=fast_boost),
+    ):
+        step = ParallelEmbedAndEntityBoost()
+        with pytest.raises(HTTPException) as exc_info:
+            await step.execute(ctx)
+
+    assert exc_info.value.status_code == 504
+    # No partial state written.
+    assert "embedding" not in ctx.data
+    assert "boosted_memory_ids" not in ctx.data
+    assert "memory_boost_factor" not in ctx.data
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — embedding raises ValueError → HTTPException(503)
+# ---------------------------------------------------------------------------
+
+
+async def test_embedding_value_error_raises_503(monkeypatch):
+    """ValueError from embed → 503 with original message preserved."""
+    _shrink_budgets(monkeypatch)
+
+    async def bad_embed(*args, **kwargs):
+        raise ValueError("embedding provider down: bork-bork-bork")
+
+    async def fast_boost(*args, **kwargs):
+        return (set(), {})
+
+    ctx = _make_ctx()
+    with (
+        patch(_EMBED_PATH, side_effect=bad_embed),
+        patch(_BOOST_PATH, side_effect=fast_boost),
+    ):
+        step = ParallelEmbedAndEntityBoost()
+        with pytest.raises(HTTPException) as exc_info:
+            await step.execute(ctx)
+
+    assert exc_info.value.status_code == 503
+    assert "bork-bork-bork" in str(exc_info.value.detail)
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — entity boost times out, embedding succeeds → graceful fallback
+# ---------------------------------------------------------------------------
+
+
+async def test_entity_boost_timeout_falls_back_quietly(monkeypatch, caplog):
+    """Slow entity task → empty boost + warning log; no exception."""
+    _shrink_budgets(monkeypatch)
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+
+    async def fast_embed(*args, **kwargs):
+        await asyncio.sleep(0.01)
+        return _DUMMY_EMBED
+
+    async def slow_boost(*args, **kwargs):
+        # Exceeds the patched _MIN_ENTITY_BUDGET_S (0.05 s) but well
+        # under _OVERALL_TIMEOUT_S so the embedding completes first.
+        await asyncio.sleep(5.0)
+        return (set(), {})
+
+    ctx = _make_ctx()
+    with (
+        patch(_EMBED_PATH, side_effect=fast_embed),
+        patch(_BOOST_PATH, side_effect=slow_boost),
+    ):
+        step = ParallelEmbedAndEntityBoost()
+        # No exception escapes.
+        await step.execute(ctx)
+
+    assert ctx.data["embedding"] == _DUMMY_EMBED
+    assert ctx.data["boosted_memory_ids"] == set()
+    assert ctx.data["memory_boost_factor"] == {}
+    # A warning is logged for the dropped entity-boost signal.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a WARNING log line on entity-boost fallback"
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — entity boost raises (non-timeout) → graceful fallback
+# ---------------------------------------------------------------------------
+
+
+async def test_entity_boost_exception_falls_back_quietly(monkeypatch, caplog):
+    """Any boost exception → empty boost + warning log; embedding kept."""
+    _shrink_budgets(monkeypatch)
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+
+    async def fast_embed(*args, **kwargs):
+        return _DUMMY_EMBED
+
+    async def kaboom_boost(*args, **kwargs):
+        raise RuntimeError("storage-api unreachable")
+
+    ctx = _make_ctx()
+    with (
+        patch(_EMBED_PATH, side_effect=fast_embed),
+        patch(_BOOST_PATH, side_effect=kaboom_boost),
+    ):
+        step = ParallelEmbedAndEntityBoost()
+        await step.execute(ctx)  # must not raise
+
+    assert ctx.data["embedding"] == _DUMMY_EMBED
+    assert ctx.data["boosted_memory_ids"] == set()
+    assert ctx.data["memory_boost_factor"] == {}
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a WARNING log line on entity-boost exception"
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — D7 regression: slow entity must NOT cancel a fast embedding
+# ---------------------------------------------------------------------------
+
+
+async def test_d7_slow_entity_does_not_cancel_fast_embedding(monkeypatch, caplog):
+    """D7 / PR #260 regression guard.
+
+    The headline behaviour the D7 split-budget fix delivers: a slow entity
+    task no longer cancels a fast embedding that already completed.
+
+    Before the fix, both legs shared one ``asyncio.gather(..., wait_for=...)``
+    scope, so a 5 s entity-task cancelled the 10 ms embedding and the
+    step raised a spurious 504 — even though the embedding succeeded in
+    plenty of time.
+
+    After the fix, the embedding has its own ``_OVERALL_TIMEOUT_S`` budget
+    and the entity-boost gets its own (smaller) ``_MIN_ENTITY_BUDGET_S``
+    budget on the remainder. So this test:
+
+    - mocks embed to finish in ~10 ms
+    - mocks boost to sleep 5 s (way over ``_MIN_ENTITY_BUDGET_S``)
+    - asserts that the step completes without raising
+    - asserts ``ctx.data["embedding"]`` is populated
+
+    If this test ever starts raising HTTPException(504), the D7 split
+    has regressed — the two budgets are sharing a single cancellation
+    scope again.
+    """
+    _shrink_budgets(monkeypatch)
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+
+    async def fast_embed(*args, **kwargs):
+        await asyncio.sleep(0.01)
+        return _DUMMY_EMBED
+
+    async def slow_boost(*args, **kwargs):
+        await asyncio.sleep(5.0)
+        return (set(), {})
+
+    ctx = _make_ctx()
+    with (
+        patch(_EMBED_PATH, side_effect=fast_embed),
+        patch(_BOOST_PATH, side_effect=slow_boost),
+    ):
+        step = ParallelEmbedAndEntityBoost()
+        # The pre-D7 code would have raised HTTPException(504) here.
+        await step.execute(ctx)
+
+    assert ctx.data["embedding"] == _DUMMY_EMBED, (
+        "D7 regression: a slow entity task cancelled the fast embedding "
+        "(shared timeout scope). See PR #260."
+    )
+    # Boost legitimately timed out → empty fallback + warning.
+    assert ctx.data["boosted_memory_ids"] == set()
+    assert ctx.data["memory_boost_factor"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — wall-clock ceiling: slow entity cannot blow past total budget
+# ---------------------------------------------------------------------------
+
+
+async def test_wall_clock_bounded_by_overall_timeout(monkeypatch):
+    """A slow entity task must not push the step past ``_OVERALL_TIMEOUT_S``."""
+    _shrink_budgets(monkeypatch)
+
+    async def fast_embed(*args, **kwargs):
+        return _DUMMY_EMBED
+
+    async def slow_boost(*args, **kwargs):
+        await asyncio.sleep(5.0)
+        return (set(), {})
+
+    ctx = _make_ctx()
+    loop = asyncio.get_event_loop()
+    with (
+        patch(_EMBED_PATH, side_effect=fast_embed),
+        patch(_BOOST_PATH, side_effect=slow_boost),
+    ):
+        step = ParallelEmbedAndEntityBoost()
+        t0 = loop.time()
+        await step.execute(ctx)
+        elapsed = loop.time() - t0
+
+    # Generous slack for asyncio scheduling / pytest overhead, but well
+    # under the 5 s slow-boost sleep — proves the entity leg was
+    # capped, not awaited to completion.
+    slack = 0.5
+    ceiling = mod._OVERALL_TIMEOUT_S + slack
+    assert elapsed < ceiling, (
+        f"step took {elapsed:.3f}s, expected < {ceiling:.3f}s "
+        f"(overall budget {mod._OVERALL_TIMEOUT_S}s + slack {slack}s)"
+    )
+    # Sanity: embedding still made it through.
+    assert ctx.data["embedding"] == _DUMMY_EMBED


### PR DESCRIPTION
## Summary

`ParallelEmbedAndEntityBoost.execute` wrapped `asyncio.gather(emb_task, ent_task)` in a single `asyncio.wait_for(..., timeout=15.0)`. The two tasks shared one cancellation scope, so a slow entity-boost lookup cancelled a completed embedding alongside itself — the request surfaced as a spurious HTTP 504 even though the vector for a vector-only search was already in hand.

D7's prescription: split the budget so the embedding (critical path) and the entity-boost (supplementary signal) get independent timeouts. On entity-boost failure (timeout or otherwise) the step degrades to vector-only search with a warning log, not 504.

## Changes

- Two module-level constants: `_OVERALL_TIMEOUT_S = 15.0` (preserved from the prior shared timeout) and `_MIN_ENTITY_BUDGET_S = 0.1` (floor on the entity leg so a near-instant embedding still gives the in-flight entity task a moment to finish).
- Embedding is awaited first with `_OVERALL_TIMEOUT_S`. Timeout → still HTTP 504. ValueError → still HTTP 503. Either path cancels the in-flight entity task.
- After the embedding resolves, the remaining budget (clamped below by `_MIN_ENTITY_BUDGET_S`) is used for the entity-boost. On any failure (timeout or other) the step logs a warning and proceeds with `(set(), {})`. Total wall-clock stays bounded by `_OVERALL_TIMEOUT_S`.

## Tests — black-box by a subagent

I implemented the production fix, then briefed a subagent on the behavioural contract only (no access to the implementation file). The subagent produced `tests/test_d7_parallel_embed_per_task_timeout.py` covering 7 contract cases:

1. happy path — both helpers return; ctx.data populated.
2. embedding timeout → HTTPException(504); no partial writes.
3. embedding ValueError → HTTPException(503); message preserved.
4. entity-boost timeout → empty boost + WARNING log; no exception.
5. entity-boost exception → empty boost + WARNING log; no exception.
6. **D7 headline regression** — slow entity does NOT cancel fast embed.
7. wall-clock ceiling — slow entity cannot push step past budget.

All seven pass; the budget knobs are monkey-patched down (~0.3s / 0.05s) so the suite runs in <2s.

## Test plan

- [x] New `tests/test_d7_parallel_embed_per_task_timeout.py`: 7 cases, 1.74s.
- [x] Existing `tests/pipeline/test_search_pipeline.py::test_parallel_embed_gather_has_timeout` still passes (504 path under the 15s default).
- [x] Full non-benchmark suite: **2598 passed** (+7), 0 regressions.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy`: 0 new errors (18 → 18).
- [x] Wet-tested against a fresh core-api build on local-dev: D7 headline case (10ms embed + 5s boost under shrunken 0.3s budget) completes in 0.302s with embedding populated and the warning log fired — vs the prior code path which would have raised 504.

## Notes

- Closes D7 in the canonical task list.
- The two constants are kept module-private (`_`-prefixed). Tests monkey-patch them to keep wall-clock fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)