### PR TITLE
fix(api): accept metadata_mode as a query param on PATCH /memories/{id} (C7)

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1334,6 +1334,18 @@ async def update_memory_endpoint(
     body: MemoryUpdate,
     tenant_id: str = Query(...),
     agent_id: str | None = Query(default=None),
+    metadata_mode: str | None = Query(
+        default=None,
+        pattern="^(merge|replace)$",
+        description=(
+            "C7: alias for the body field of the same name. Body wins on "
+            "conflict. When supplied as a query param without a matching "
+            "``metadata`` field in the body, returns 422 (same contract "
+            "as the body-side validator). Provided so SDK callers that "
+            "thread the toggle through a URL query don't silently get "
+            "the default merge behaviour."
+        ),
+    ),
     auth: AuthContext = Depends(get_auth_context),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1356,6 +1368,21 @@ async def update_memory_endpoint(
       defined behaviour, not a partial-merge anomaly.
     """
     auth.enforce_tenant(tenant_id)
+    # C7: propagate ``?metadata_mode=...`` query param into the body when
+    # body didn't supply its own. Body wins on conflict, so a caller who
+    # sends both ?metadata_mode=replace AND {"metadata_mode": "merge"} in
+    # the body gets merge — the body field is the canonical write
+    # payload, the query is a convenience shim. Mirror the body-side
+    # validator (``metadata_mode_requires_metadata``) by rejecting the
+    # query param when body has no ``metadata`` patch — sending only the
+    # mode flag is a real-value no-op the validator already rejects.
+    if metadata_mode is not None and body.metadata_mode is None:
+        if "metadata" not in body.model_fields_set:
+            raise HTTPException(
+                status_code=422,
+                detail="metadata_mode is only valid when metadata is also provided",
+            )
+        body.metadata_mode = metadata_mode
     if auth.tenant_id:  # skip usage metering for admin
         await check_and_increment(db, tenant_id, "write")
     # Authenticated agent identity (gateway X-Agent-ID) takes precedence over

--- a/tests/test_c7_metadata_mode_query_param.py
+++ b/tests/test_c7_metadata_mode_query_param.py
@@ -1,0 +1,256 @@
+"""C7 — ``metadata_mode`` accepted as query-string parameter on PATCH.
+
+Pre-C7: ``PATCH /api/v1/memories/{id}`` read ``metadata_mode`` only
+from the request body. A query-param of the same name was silently
+dropped by FastAPI as an unknown query arg and the PATCH fell back to
+the default ``merge`` behaviour — confusing for callers who can't
+easily wedge a body field in but can append to the URL (CLI tooling,
+audit-replay scripts, etc.).
+
+Post-C7: the endpoint accepts ``metadata_mode`` as a query parameter
+too. Body wins on conflict (the body is the canonical write payload).
+The query mode goes through the same regex validation as the body
+field (``merge|replace``); anything else 422s at FastAPI's parse
+layer.
+
+These tests pin the new query-param surface plus the corner cases
+where body-vs-query precedence matters and where the validator
+mirroring of the body-side "mode without metadata patch" rule applies.
+"""
+
+import pytest
+
+from tests.conftest import get_test_auth, uid as _uid
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+# ---------------------------------------------------------------------------
+# Local helper (mirrors test_api_memories._write_memory shape but kept
+# inline so this file is self-contained — the C7 contract is narrow and
+# we don't want to take a churn dep on the sibling test module).
+# ---------------------------------------------------------------------------
+
+
+async def _write_memory(client, tenant_id: str, headers: dict, content: str) -> dict:
+    tag = _uid()
+    resp = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "content": f"{content} [{tag}]",
+            "agent_id": f"c7-agent-{tag}",
+            "fleet_id": f"c7-fleet-{tag}",
+            "memory_type": "fact",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, f"seed write failed: {resp.text}"
+    return resp.json()
+
+
+async def _seed_metadata(
+    client, tenant_id: str, headers: dict, memory_id: str, md: dict
+) -> None:
+    """Seed initial metadata via an explicit replace PATCH so the
+    starting state is fully under test control regardless of any
+    enrichment-driven keys the write path might inject."""
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}",
+        json={"metadata": md, "metadata_mode": "replace"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, f"seed PATCH failed: {resp.text}"
+
+
+async def _read_metadata(client, tenant_id: str, headers: dict, memory_id: str) -> dict:
+    resp = await client.get(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json().get("metadata") or {}
+
+
+# ---------------------------------------------------------------------------
+# Truth-table tests
+# ---------------------------------------------------------------------------
+
+
+async def test_query_only_replace_applies(client):
+    """Body has ``metadata`` only; query has ``?metadata_mode=replace``
+    → REPLACE semantic applied (pre-C7 this would have merged)."""
+    tenant_id, headers = get_test_auth()
+    mem = await _write_memory(client, tenant_id, headers, "C7 query-only replace")
+    memory_id = mem["id"]
+
+    await _seed_metadata(client, tenant_id, headers, memory_id, {"a": 1, "b": 2})
+
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}&metadata_mode=replace",
+        json={"metadata": {"c": 3}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    md = await _read_metadata(client, tenant_id, headers, memory_id)
+    assert "a" not in md, "query-side replace must drop pre-existing keys"
+    assert "b" not in md
+    assert md.get("c") == 3
+
+
+async def test_body_only_replace_still_works(client):
+    """Regression: body-side ``metadata_mode=replace`` (the pre-C7
+    surface) keeps working unchanged."""
+    tenant_id, headers = get_test_auth()
+    mem = await _write_memory(client, tenant_id, headers, "C7 body-only replace")
+    memory_id = mem["id"]
+
+    await _seed_metadata(client, tenant_id, headers, memory_id, {"a": 1, "b": 2})
+
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}",
+        json={"metadata": {"c": 3}, "metadata_mode": "replace"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    md = await _read_metadata(client, tenant_id, headers, memory_id)
+    assert "a" not in md and "b" not in md
+    assert md.get("c") == 3
+
+
+async def test_no_mode_anywhere_defaults_to_merge(client):
+    """No ``metadata_mode`` in body or query → deep merge (the
+    pre-C7 default), sibling keys survive."""
+    tenant_id, headers = get_test_auth()
+    mem = await _write_memory(client, tenant_id, headers, "C7 default merge")
+    memory_id = mem["id"]
+
+    await _seed_metadata(client, tenant_id, headers, memory_id, {"a": 1, "b": 2})
+
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}",
+        json={"metadata": {"c": 3}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    md = await _read_metadata(client, tenant_id, headers, memory_id)
+    assert md.get("a") == 1, "merge must preserve sibling keys"
+    assert md.get("b") == 2
+    assert md.get("c") == 3
+
+
+async def test_body_wins_on_conflict(client):
+    """Body says ``merge``, query says ``replace`` → body wins, merge
+    semantic applies. The body is the canonical write payload; query
+    params are a convenience shim and must NOT override an explicit
+    body value (otherwise audit-log replay of the body alone would
+    produce a different outcome than the original call)."""
+    tenant_id, headers = get_test_auth()
+    mem = await _write_memory(client, tenant_id, headers, "C7 body wins")
+    memory_id = mem["id"]
+
+    await _seed_metadata(client, tenant_id, headers, memory_id, {"a": 1, "b": 2})
+
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}&metadata_mode=replace",
+        json={"metadata": {"c": 3}, "metadata_mode": "merge"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    md = await _read_metadata(client, tenant_id, headers, memory_id)
+    # body's "merge" beats query's "replace" — siblings survive.
+    assert md.get("a") == 1, "body's merge must win over query's replace"
+    assert md.get("b") == 2
+    assert md.get("c") == 3
+
+
+async def test_query_mode_without_metadata_patch_returns_422(client):
+    """Query-side ``metadata_mode`` without a corresponding
+    ``metadata`` field in the body is a no-op intent — the body-side
+    validator already rejects ``{"metadata_mode": "replace"}`` alone
+    with 422; the query-side surface must mirror that contract."""
+    tenant_id, headers = get_test_auth()
+    mem = await _write_memory(client, tenant_id, headers, "C7 query mode-only")
+    memory_id = mem["id"]
+
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}&metadata_mode=replace",
+        json={"title": "renamed but no metadata patch"},
+        headers=headers,
+    )
+    assert resp.status_code == 422, resp.text
+    detail_text = str(resp.json().get("detail", "")).lower()
+    # Error must namestamp both terms so the caller can grep their own
+    # client code without crawling the route source.
+    assert "metadata" in detail_text
+    assert "metadata_mode" in detail_text
+
+
+async def test_bogus_query_mode_returns_422_at_parse_layer(client):
+    """``?metadata_mode=BOGUS`` is rejected by FastAPI's regex
+    validation before the route body runs — no service call, no
+    storage hit. Mirrors the body-side field's ``Pattern`` constraint."""
+    tenant_id, headers = get_test_auth()
+    mem = await _write_memory(client, tenant_id, headers, "C7 bogus query mode")
+    memory_id = mem["id"]
+
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}&metadata_mode=BOGUS",
+        json={"metadata": {"c": 3}},
+        headers=headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_unrelated_patch_still_works(client):
+    """No metadata patch anywhere, no ``metadata_mode`` anywhere → an
+    unrelated field PATCH (title) is unaffected by the C7 plumbing
+    and still 200s."""
+    tenant_id, headers = get_test_auth()
+    mem = await _write_memory(client, tenant_id, headers, "C7 unrelated patch")
+    memory_id = mem["id"]
+
+    new_title = f"renamed-{_uid()}"
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}",
+        json={"title": new_title},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Verify the title actually landed (defends against a silent no-op
+    # in the same vein as the C7 422 we just pinned).
+    read = await client.get(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}",
+        headers=headers,
+    )
+    assert read.status_code == 200
+    assert read.json().get("title") == new_title
+
+
+async def test_body_and_query_both_replace_is_idempotent(client):
+    """Body has ``{"metadata": ..., "metadata_mode": "replace"}`` AND
+    URL has ``?metadata_mode=replace`` — the query is redundant but
+    must NOT double-apply, error, or alter the body's outcome. Net
+    effect = single replace."""
+    tenant_id, headers = get_test_auth()
+    mem = await _write_memory(client, tenant_id, headers, "C7 both replace")
+    memory_id = mem["id"]
+
+    await _seed_metadata(client, tenant_id, headers, memory_id, {"a": 1, "b": 2})
+
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}&metadata_mode=replace",
+        json={"metadata": {"c": 3}, "metadata_mode": "replace"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    md = await _read_metadata(client, tenant_id, headers, memory_id)
+    assert "a" not in md and "b" not in md
+    assert md.get("c") == 3


### PR DESCRIPTION
## Summary

\`PATCH /api/v1/memories/{memory_id}\` read \`metadata_mode\` only from the request body. A caller sending \`?metadata_mode=replace\` as a query string got the default merge behaviour silently — FastAPI drops unknown query params on the floor, and the body-side validator never sees the value.

C7 asked for either (a) accept it as a documented query param, OR (b) return 422 on unknown query params on PATCH. This PR picks (a) — targeted to the one endpoint, no behaviour change for callers who already use the body field.

## Changes

- \`update_memory_endpoint\` gains an optional \`metadata_mode\` query param with the same \`^(merge|replace)$\` pattern as the body field.
- **Body wins on conflict.** When body did NOT set \`metadata_mode\` and the query param IS set, the query value applies (and the body field is patched in place before the service call).
- Mirror the body-side \`metadata_mode_requires_metadata\` validator: if the caller supplies the query param without a matching \`metadata\` field in the body, return 422 with the same message. Sending only the mode flag is a no-op the existing validator already rejects on the body side; this PR makes the query-side symmetric.

## Truth table

| body \`metadata_mode\` | query \`metadata_mode\` | body \`metadata\` | outcome |
|---|---|---|---|
| no | no | yes | merge (default) — unchanged |
| no | yes (\`replace\`) | yes | **REPLACE via query** (new C7) |
| yes (\`replace\`) | no | yes | replace (existing) |
| yes (\`merge\`) | yes (\`replace\`) | yes | **merge — body wins** |
| no | yes (\`replace\`) | no | **422 — query-side mirror of body validator** |
| no | yes (\`bogus\`) | yes | 422 — FastAPI regex validation |

## Tests — black-box by a subagent

I implemented the fix, then briefed a subagent on the behavioural contract only (no access to \`routes/memories.py\`). It produced \`tests/test_c7_metadata_mode_query_param.py\` with 8 cases — one per row of the truth table plus an idempotency check.

## Test plan

- [x] \`tests/test_c7_metadata_mode_query_param.py\`: 8 tests, 1.14s, all pass.
- [x] Existing body-side tests (\`tests/test_api_memories.py\`) preserved.
- [x] Full non-benchmark suite: **2653 passed** (+8), 0 regressions.
- [x] \`ruff check\` + \`ruff format --check\` clean.
- [x] Wet-tested against a fresh core-api build on local-dev:
  - PATCH \`?metadata_mode=replace\` + body \`{metadata:{c:3}}\` → resulting metadata = \`{\"c\": 3}\` (replace applied via query).
  - PATCH \`?metadata_mode=replace\` + body \`{title:\"renamed\"}\` (no metadata) → 422 with expected message.

## Notes

- Closes C7 in the canonical task list.
- Doesn't broaden to 422-on-unknown-query-params (the alternative C7 option) — that would touch every PATCH and risk breaking clients that send tracking query params. Targeted accept is the minimal change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)