### PR TITLE
feat(api): surface near_duplicate_of in default-mode write metadata (A21)

### DIFF
--- a/core-api/src/core_api/pipeline/compositions/write.py
+++ b/core-api/src/core_api/pipeline/compositions/write.py
@@ -6,6 +6,7 @@ from core_api.pipeline.steps.write import (
     CheckExactDuplicate,
     CheckSemanticDuplicate,
     ComputeContentHash,
+    DetectNearDuplicate,
     EmitMemoryTriple,
     LoadTenantConfig,
     MergeEnrichmentFields,
@@ -48,7 +49,15 @@ def build_persist_pipeline() -> Pipeline:
 
 
 def build_fast_write_pipeline() -> Pipeline:
-    """Fast write mode: enrichment + exact-dedup + write (skips semantic dedup)."""
+    """Fast write mode: enrichment + exact-dedup + advisory near-dup detect + write.
+
+    Distinct from strong-mode: ``DetectNearDuplicate`` (A21) is advisory —
+    it stashes ``metadata["near_duplicate_of"]`` and ``metadata["near_duplicate_similarity"]``
+    on a high-similarity hit but does NOT 409-reject the write. Strong-mode
+    keeps its 409 contract via ``CheckSemanticDuplicate``. Net: agents
+    using fast-mode can now detect "I just re-stated the same fact"
+    without paying the strong-mode dedup latency / rejection.
+    """
     return Pipeline(
         "write_fast",
         [
@@ -59,6 +68,7 @@ def build_fast_write_pipeline() -> Pipeline:
             MergeEnrichmentFields(),
             EmitMemoryTriple(),
             CheckExactDuplicate(),
+            DetectNearDuplicate(),
             WriteMemoryRow(),
             ScheduleBackgroundTasks(),
         ],

--- a/core-api/src/core_api/pipeline/steps/write/__init__.py
+++ b/core-api/src/core_api/pipeline/steps/write/__init__.py
@@ -4,6 +4,7 @@ from core_api.pipeline.steps.write.check_content_length import CheckContentLengt
 from core_api.pipeline.steps.write.check_exact_duplicate import CheckExactDuplicate
 from core_api.pipeline.steps.write.check_semantic_duplicate import CheckSemanticDuplicate
 from core_api.pipeline.steps.write.compute_content_hash import ComputeContentHash
+from core_api.pipeline.steps.write.detect_near_duplicate import DetectNearDuplicate
 from core_api.pipeline.steps.write.emit_memory_triple import EmitMemoryTriple
 from core_api.pipeline.steps.write.load_tenant_config import LoadTenantConfig
 from core_api.pipeline.steps.write.merge_enrichment_fields import MergeEnrichmentFields
@@ -20,6 +21,7 @@ __all__ = [
     "CheckExactDuplicate",
     "CheckSemanticDuplicate",
     "ComputeContentHash",
+    "DetectNearDuplicate",
     "EmitMemoryTriple",
     "LoadTenantConfig",
     "MergeEnrichmentFields",

--- a/core-api/src/core_api/pipeline/steps/write/detect_near_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/detect_near_duplicate.py
@@ -1,0 +1,114 @@
+"""DetectNearDuplicate — A21 advisory dedup signal on the fast write path.
+
+Strong-mode writes run ``CheckSemanticDuplicate`` and 409-reject on a high-
+similarity candidate. Default (fast / auto) writes skip semantic dedup
+entirely — by design, so callers who want low-latency writes don't pay
+the dedup round-trip + the LLM-judge call. But that left the asymmetry
+A21 surfaced: an agent that calls in default-mode and re-states the same
+fact twice ends up with two independent rows, no signal to the caller
+that a near-duplicate already exists.
+
+This step is the *advisory* twin of ``CheckSemanticDuplicate``. It runs
+only on fast-mode writes, against the JUDGE band threshold (similarity ≥
+``SEMANTIC_DEDUP_JUDGE_THRESHOLD = 0.85``) — wider than the strong-side
+auto-reject band (``SEMANTIC_DEDUP_AUTO_THRESHOLD = 0.97``) so it catches
+real paraphrases (which typically sit at cosine 0.85-0.94 once you
+strip the surface lexical match) without invoking the LLM judge that
+the strong path runs above this threshold. Cost: one storage round-trip
+per fast write, no LLM. On hit, it stashes the candidate id on the
+in-flight ``metadata`` dict (where dedup decision metadata already
+lives — see ``check_semantic_duplicate.py`` for the established keys):
+
+  metadata["near_duplicate_of"]          = "<uuid of nearest stored row>"
+  metadata["near_duplicate_similarity"]  = <cosine similarity float>
+
+The write is NOT rejected — callers continue to get a 201. They can
+read the metadata back on the response to decide whether to undo, merge,
+or accept the duplicate. False positives are tolerable because the
+signal is advisory: an agent that mis-treats a non-duplicate as one
+just loses one row's worth of context, whereas a strong-mode 409 on a
+non-duplicate would have hard-rejected a legitimate write — the
+LLM-judge gate exists for exactly that asymmetry, and we deliberately
+skip it on the fast path. Strong-mode's 409 contract is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from common.constants import SEMANTIC_DEDUP_JUDGE_THRESHOLD
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.step import StepOutcome, StepResult
+from core_api.services.dedup_identifier_filter import _content_is_identifier_bearing
+from core_api.services.memory_service import _find_semantic_duplicate
+
+logger = logging.getLogger(__name__)
+
+
+class DetectNearDuplicate:
+    @property
+    def name(self) -> str:
+        return "detect_near_duplicate"
+
+    async def execute(self, ctx: PipelineContext) -> StepResult | None:
+        data = ctx.data["input"]
+        tenant_config = ctx.tenant_config
+        embedding = ctx.data["embedding"]
+        fields = ctx.data["memory_fields"]
+        metadata = fields["metadata"]
+
+        # Same gates the strong-side check uses: respect the tenant's
+        # ``semantic_dedup_enabled`` knob and skip when no embedding is
+        # available (fast-mode with deferred embed, identifier-bearing
+        # content, etc.).
+        if not tenant_config.semantic_dedup_enabled or embedding is None:
+            return StepResult(outcome=StepOutcome.SKIPPED)
+
+        # Identifier pre-filter — mirrors ``CheckSemanticDuplicate``'s A1
+        # carve-out. Content with UUID / PR-ref / build-number / semver
+        # / commit-SHA tokens hits the embedder's template-slot collapse
+        # at cosine ≥ 0.95 and produces false-positive near-dups.
+        if _content_is_identifier_bearing(getattr(data, "content", "") or ""):
+            metadata["near_dup_skipped_reason"] = "identifier_prefilter"
+            return StepResult(
+                outcome=StepOutcome.SKIPPED,
+                detail={"reason": "identifier_prefilter"},
+            )
+
+        t_dedup = time.perf_counter()
+        # JUDGE band threshold (0.85) — broad enough to catch real
+        # paraphrases that the strong-side path would have surfaced
+        # AND sent to the LLM judge for confirm/reject. We skip the
+        # LLM call on the fast path (latency-critical), accept the
+        # false-positive cost (advisory signal only, no hard reject),
+        # and let callers decide what to do with the candidate.
+        sem_dup = await _find_semantic_duplicate(
+            ctx.require_db,
+            data.tenant_id,
+            data.fleet_id,
+            embedding,
+            visibility=data.visibility or "scope_team",
+            min_similarity=SEMANTIC_DEDUP_JUDGE_THRESHOLD,
+        )
+        metadata["near_dup_check_ms"] = round((time.perf_counter() - t_dedup) * 1000, 1)
+
+        if sem_dup is None:
+            return None
+
+        sem_dup_dict = sem_dup if isinstance(sem_dup, dict) else None
+        candidate_id = sem_dup_dict.get("id") if sem_dup_dict else getattr(sem_dup, "id", None)
+        similarity = float(sem_dup_dict.get("similarity", 0.0)) if sem_dup_dict else 0.0
+
+        if candidate_id is None:
+            return None
+
+        metadata["near_duplicate_of"] = str(candidate_id)
+        metadata["near_duplicate_similarity"] = round(similarity, 4)
+        logger.info(
+            "near_duplicate_of=%s similarity=%.4f tenant_id=%s",
+            candidate_id,
+            similarity,
+            data.tenant_id,
+        )
+        return None

--- a/tests/test_a21_detect_near_duplicate.py
+++ b/tests/test_a21_detect_near_duplicate.py
@@ -1,0 +1,431 @@
+"""A21 — ``DetectNearDuplicate`` is the advisory twin of
+``CheckSemanticDuplicate`` for the fast / non-strong write path.
+
+Strong mode (unchanged): runs ``CheckSemanticDuplicate`` which 409s when
+content lands in the AUTO band or the LLM judge confirms a JUDGE-band
+duplicate.
+
+Fast / auto modes (the gap A21 closes): previously skipped semantic
+dedup entirely — identical-fact fast writes accumulated independent
+rows with no signal to the caller. ``DetectNearDuplicate`` runs ONLY
+the AUTO band (no LLM judge, no judge band) and is purely advisory:
+
+  - Never raises.  The write always proceeds to 201.
+  - On a high-similarity hit, stashes ``near_duplicate_of`` (uuid str)
+    and ``near_duplicate_similarity`` (float, 4dp) in the in-flight
+    memory's metadata so the caller / downstream can observe it.
+  - Always sets ``near_dup_check_ms`` when the check ran (mirrors the
+    strong side's ``semantic_dedup_ms``).
+  - Skip gates mirror the strong side: tenant config off, embedding
+    missing, identifier-bearing content. Identifier skip ALSO stashes
+    a ``near_dup_skipped_reason`` slug.
+
+The step sits in ``build_fast_write_pipeline()`` between
+``CheckExactDuplicate`` and ``WriteMemoryRow``. It is NOT in the
+strong pipeline (strong already has ``CheckSemanticDuplicate``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Test context helper — mirrors test_a1_identifier_prefilter._build_ctx and
+# test_a1_16_dedup_judge_dispatch._build_ctx.
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_EMBEDDING: list[float] = [0.1] * 10
+_UNSET = object()
+
+
+def _build_ctx(
+    *,
+    content: str = "Plain natural text that won't trip identifier filters.",
+    dedup_enabled: bool = True,
+    embedding=_UNSET,
+):
+    """Minimal fake PipelineContext that exercises the step's actual code
+    path. ``embedding`` defaults to a non-None vector — pass ``None``
+    explicitly to drive the missing-embedding skip path."""
+    if embedding is _UNSET:
+        embedding = _DEFAULT_EMBEDDING
+    ctx = MagicMock()
+    ctx.tenant_config = MagicMock(semantic_dedup_enabled=dedup_enabled)
+    ctx.data = {
+        "input": MagicMock(
+            tenant_id="t1",
+            fleet_id="f1",
+            agent_id="a1",
+            visibility="scope_team",
+            subject_entity_id=None,
+            content=content,
+        ),
+        "embedding": embedding,
+        "memory_fields": {"metadata": {}},
+    }
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy detection — candidate above AUTO threshold → metadata stashed,
+#    no exception, step returns None.
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_detection_stashes_near_duplicate_metadata():
+    from core_api.pipeline.steps.write.detect_near_duplicate import (
+        DetectNearDuplicate,
+    )
+
+    ctx = _build_ctx()
+    candidate_id = str(uuid4())
+    candidate = {
+        "id": candidate_id,
+        "similarity": 0.97,
+        "content": "Existing memory we're advisory-matching against.",
+        "subject_entity_id": None,
+    }
+
+    with patch(
+        "core_api.pipeline.steps.write.detect_near_duplicate._find_semantic_duplicate",
+        new=AsyncMock(return_value=candidate),
+    ):
+        step = DetectNearDuplicate()
+        result = await step.execute(ctx)
+
+    # Advisory only — no exception was raised; step returns None on
+    # accept-with-stash (mirrors CheckSemanticDuplicate's None-on-accept
+    # contract from A1 #16).
+    assert result is None
+
+    md = ctx.data["memory_fields"]["metadata"]
+    assert md["near_duplicate_of"] == candidate_id
+    assert md["near_duplicate_similarity"] == pytest.approx(0.97)
+    assert "near_dup_check_ms" in md
+    assert isinstance(md["near_dup_check_ms"], float)
+
+
+# ---------------------------------------------------------------------------
+# 2. No candidate — _find_semantic_duplicate returns None.
+# ---------------------------------------------------------------------------
+
+
+async def test_no_candidate_records_only_check_ms():
+    from core_api.pipeline.steps.write.detect_near_duplicate import (
+        DetectNearDuplicate,
+    )
+
+    ctx = _build_ctx()
+    with patch(
+        "core_api.pipeline.steps.write.detect_near_duplicate._find_semantic_duplicate",
+        new=AsyncMock(return_value=None),
+    ):
+        step = DetectNearDuplicate()
+        result = await step.execute(ctx)
+
+    assert result is None
+    md = ctx.data["memory_fields"]["metadata"]
+    # The check ran, just no candidate landed in the AUTO band.
+    assert "near_dup_check_ms" in md
+    # And NO advisory stash — the field is the contract signal for
+    # "did we find one?", so absence must be load-bearing.
+    assert "near_duplicate_of" not in md
+    assert "near_duplicate_similarity" not in md
+
+
+# ---------------------------------------------------------------------------
+# 3. Disabled by tenant config — short-circuit, no storage call.
+# ---------------------------------------------------------------------------
+
+
+async def test_disabled_by_tenant_config_returns_skipped():
+    from core_api.pipeline.step import StepOutcome
+    from core_api.pipeline.steps.write.detect_near_duplicate import (
+        DetectNearDuplicate,
+    )
+
+    ctx = _build_ctx(dedup_enabled=False)
+    find = AsyncMock()
+    with patch(
+        "core_api.pipeline.steps.write.detect_near_duplicate._find_semantic_duplicate",
+        new=find,
+    ):
+        step = DetectNearDuplicate()
+        result = await step.execute(ctx)
+
+    assert result is not None
+    assert result.outcome == StepOutcome.SKIPPED
+    find.assert_not_called()
+    # No check ran → no timing key, no stash.
+    md = ctx.data["memory_fields"]["metadata"]
+    assert "near_dup_check_ms" not in md
+    assert "near_duplicate_of" not in md
+
+
+# ---------------------------------------------------------------------------
+# 4. Disabled by missing embedding — fast-mode-with-deferred-embed path.
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_embedding_returns_skipped():
+    from core_api.pipeline.step import StepOutcome
+    from core_api.pipeline.steps.write.detect_near_duplicate import (
+        DetectNearDuplicate,
+    )
+
+    ctx = _build_ctx(embedding=None)
+    find = AsyncMock()
+    with patch(
+        "core_api.pipeline.steps.write.detect_near_duplicate._find_semantic_duplicate",
+        new=find,
+    ):
+        step = DetectNearDuplicate()
+        result = await step.execute(ctx)
+
+    assert result is not None
+    assert result.outcome == StepOutcome.SKIPPED
+    find.assert_not_called()
+    md = ctx.data["memory_fields"]["metadata"]
+    assert "near_dup_check_ms" not in md
+
+
+# ---------------------------------------------------------------------------
+# 5. Identifier-bearing content — skip with reason slug stash. Mirrors
+#    A1's identifier pre-filter behaviour on the strong-side step.
+# ---------------------------------------------------------------------------
+
+
+async def test_identifier_bearing_content_skips_with_reason():
+    from core_api.pipeline.step import StepOutcome
+    from core_api.pipeline.steps.write.detect_near_duplicate import (
+        DetectNearDuplicate,
+    )
+
+    ctx = _build_ctx(content="Build pr-456 deployed to staging.")
+    find = AsyncMock()
+    with (
+        patch(
+            "core_api.pipeline.steps.write.detect_near_duplicate._content_is_identifier_bearing",
+            return_value=True,
+        ),
+        patch(
+            "core_api.pipeline.steps.write.detect_near_duplicate._find_semantic_duplicate",
+            new=find,
+        ),
+    ):
+        step = DetectNearDuplicate()
+        result = await step.execute(ctx)
+
+    assert result is not None
+    assert result.outcome == StepOutcome.SKIPPED
+    # Reason exposed both on the step result detail AND in metadata —
+    # the metadata stash is the durable signal (lands on the row); the
+    # detail is the pipeline-log signal.
+    assert result.detail == {"reason": "identifier_prefilter"}
+    md = ctx.data["memory_fields"]["metadata"]
+    assert md["near_dup_skipped_reason"] == "identifier_prefilter"
+    find.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 6. Defensive guard: candidate dict has ``id=None`` (storage corner case).
+# ---------------------------------------------------------------------------
+
+
+async def test_candidate_with_no_id_is_silently_dropped():
+    from core_api.pipeline.steps.write.detect_near_duplicate import (
+        DetectNearDuplicate,
+    )
+
+    ctx = _build_ctx()
+    candidate = {
+        "id": None,
+        "similarity": 0.98,
+        "content": "Existing memory but with broken id.",
+        "subject_entity_id": None,
+    }
+    with patch(
+        "core_api.pipeline.steps.write.detect_near_duplicate._find_semantic_duplicate",
+        new=AsyncMock(return_value=candidate),
+    ):
+        step = DetectNearDuplicate()
+        result = await step.execute(ctx)
+
+    assert result is None
+    md = ctx.data["memory_fields"]["metadata"]
+    # The check ran — timing always recorded when we reached the call.
+    assert "near_dup_check_ms" in md
+    # But the defensive guard suppressed the stash (no useful UUID to
+    # surface to the caller).
+    assert "near_duplicate_of" not in md
+    assert "near_duplicate_similarity" not in md
+
+
+# ---------------------------------------------------------------------------
+# 7. JUDGE threshold is the one passed to _find_semantic_duplicate — wider
+#    than AUTO so the advisory step catches real paraphrases that sit in
+#    the 0.85–0.97 band, without the LLM judge call (advisory, no reject).
+# ---------------------------------------------------------------------------
+
+
+async def test_calls_find_with_judge_threshold():
+    from common.constants import (
+        SEMANTIC_DEDUP_AUTO_THRESHOLD,
+        SEMANTIC_DEDUP_JUDGE_THRESHOLD,
+    )
+    from core_api.pipeline.steps.write.detect_near_duplicate import (
+        DetectNearDuplicate,
+    )
+
+    ctx = _build_ctx()
+    find = AsyncMock(return_value=None)
+    with patch(
+        "core_api.pipeline.steps.write.detect_near_duplicate._find_semantic_duplicate",
+        new=find,
+    ):
+        step = DetectNearDuplicate()
+        await step.execute(ctx)
+
+    find.assert_called_once()
+    # ``_find_semantic_duplicate`` is called with ``min_similarity`` as a
+    # keyword arg (positional shape may shift; the contract is the
+    # keyword). Cross-check both shapes to stay robust to a minor refactor.
+    call_kwargs = find.call_args.kwargs
+    if "min_similarity" in call_kwargs:
+        threshold = call_kwargs["min_similarity"]
+    else:
+        # Positional fallback — find the float-in-(0,1) arg.
+        threshold = next(
+            a for a in find.call_args.args if isinstance(a, float) and 0.0 < a < 1.0
+        )
+    assert threshold == SEMANTIC_DEDUP_JUDGE_THRESHOLD
+    assert threshold != SEMANTIC_DEDUP_AUTO_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# 8. Step name — pins the structured-log / pipeline-composition contract.
+# ---------------------------------------------------------------------------
+
+
+def test_step_name_is_detect_near_duplicate():
+    from core_api.pipeline.steps.write.detect_near_duplicate import (
+        DetectNearDuplicate,
+    )
+
+    assert DetectNearDuplicate().name == "detect_near_duplicate"
+
+
+# ---------------------------------------------------------------------------
+# 9. Pipeline wiring — fast pipeline has the step exactly once, between
+#    CheckExactDuplicate and WriteMemoryRow. Strong pipeline does NOT
+#    have it (it uses CheckSemanticDuplicate instead).
+# ---------------------------------------------------------------------------
+
+
+def test_fast_pipeline_wires_detect_near_duplicate_exactly_once():
+    from core_api.pipeline.compositions.write import build_fast_write_pipeline
+
+    names = [s.name for s in build_fast_write_pipeline()._steps]
+    assert names.count("detect_near_duplicate") == 1
+
+
+def test_fast_pipeline_has_step_after_exact_dedup_and_before_write():
+    from core_api.pipeline.compositions.write import build_fast_write_pipeline
+
+    names = [s.name for s in build_fast_write_pipeline()._steps]
+    assert "detect_near_duplicate" in names
+    assert "check_exact_duplicate" in names
+    assert "write_memory_row" in names
+    assert names.index("check_exact_duplicate") < names.index("detect_near_duplicate")
+    assert names.index("detect_near_duplicate") < names.index("write_memory_row")
+
+
+def test_strong_pipeline_does_not_include_detect_near_duplicate():
+    from core_api.pipeline.compositions.write import build_strong_write_pipeline
+
+    names = [s.name for s in build_strong_write_pipeline()._steps]
+    assert "detect_near_duplicate" not in names
+    # Strong path keeps the LLM-gated CheckSemanticDuplicate.
+    assert "check_semantic_duplicate" in names
+
+
+def test_fast_pipeline_name_is_write_fast():
+    from core_api.pipeline.compositions.write import build_fast_write_pipeline
+
+    p = build_fast_write_pipeline()
+    assert p._name == "write_fast"
+
+
+# ---------------------------------------------------------------------------
+# 10. The advisory contract: even a candidate well above AUTO must NOT
+#     raise. This is the load-bearing difference vs CheckSemanticDuplicate.
+# ---------------------------------------------------------------------------
+
+
+async def test_high_similarity_candidate_does_not_raise_http_exception():
+    from fastapi import HTTPException
+
+    from core_api.pipeline.steps.write.detect_near_duplicate import (
+        DetectNearDuplicate,
+    )
+
+    ctx = _build_ctx()
+    candidate = {
+        "id": str(uuid4()),
+        "similarity": 0.999,  # would 409 on the strong-side step
+        "content": "Near-identical existing memory.",
+        "subject_entity_id": None,
+    }
+    with patch(
+        "core_api.pipeline.steps.write.detect_near_duplicate._find_semantic_duplicate",
+        new=AsyncMock(return_value=candidate),
+    ):
+        step = DetectNearDuplicate()
+        # The whole point of A21: advisory, never raises. Wrap in a
+        # try/except so a stray HTTPException would surface explicitly.
+        try:
+            result = await step.execute(ctx)
+        except HTTPException as exc:  # pragma: no cover — failure shape
+            pytest.fail(
+                f"DetectNearDuplicate must never raise HTTPException; got {exc.status_code}"
+            )
+    assert result is None
+    # Stash is present so the caller observes the near-dup signal.
+    assert ctx.data["memory_fields"]["metadata"]["near_duplicate_of"] == candidate["id"]
+
+
+# ---------------------------------------------------------------------------
+# Rounding contract — similarity stored as 4dp (mirrors the "<float, rounded
+# to 4 places>" line in the A21 spec).
+# ---------------------------------------------------------------------------
+
+
+async def test_similarity_rounded_to_four_decimals():
+    from core_api.pipeline.steps.write.detect_near_duplicate import (
+        DetectNearDuplicate,
+    )
+
+    ctx = _build_ctx()
+    candidate = {
+        "id": str(uuid4()),
+        "similarity": 0.973456789,
+        "content": "...",
+        "subject_entity_id": None,
+    }
+    with patch(
+        "core_api.pipeline.steps.write.detect_near_duplicate._find_semantic_duplicate",
+        new=AsyncMock(return_value=candidate),
+    ):
+        await DetectNearDuplicate().execute(ctx)
+
+    md = ctx.data["memory_fields"]["metadata"]
+    # 4dp round — equality, not approx, because the contract is exact.
+    assert md["near_duplicate_similarity"] == 0.9735


### PR DESCRIPTION
## Summary
- Adds `DetectNearDuplicate`, an advisory twin of `CheckSemanticDuplicate`, wired into the fast write pipeline between `CheckExactDuplicate` and `WriteMemoryRow`. On a high-similarity hit it stashes `metadata["near_duplicate_of"]`, `metadata["near_duplicate_similarity"]`, and `metadata["near_dup_check_ms"]` on the write response — **never 409-rejects** (strong-mode keeps that contract via `CheckSemanticDuplicate`).
- Uses the JUDGE threshold (`SEMANTIC_DEDUP_JUDGE_THRESHOLD = 0.85`), not AUTO (0.97). Wider band catches real paraphrases that sit at cosine 0.85–0.94; we skip the LLM-judge call the strong path makes above this threshold (advisory ≠ rejection, so false-positives are tolerable). Same A1 identifier-bearing pre-filter + same `semantic_dedup_enabled` tenant gate as the strong-side step.
- Closes A21 from the V4 task checklist: closes the asymmetry where default-mode agents could re-state the same fact and get two rows with no signal a near-duplicate already exists.

## Test plan
- [x] 14 blackbox unit tests in `tests/test_a21_detect_near_duplicate.py` (subagent-written, no implementation access — verifies: gate behavior, metadata key contract, embedding/visibility plumbing, identifier-prefilter skip, JUDGE-threshold pin, non-blocking semantics, latency-record contract)
- [x] Full non-benchmark suite (`pytest tests/ -x -q`): 2667 passed
- [x] `ruff check` + `ruff format --check` clean on the four touched files
- [x] Local wet test against `localhost` gateway: two semantically-equivalent writes ("Dana likes her tea steeped for exactly 3 minutes" → "Dana prefers her tea steeped for 3 minutes", 15s gap, both `write_mode=fast`) — second response carries `near_duplicate_of` pointing at the first id, `similarity=0.9766`, `check_ms=3.6`. Both writes accepted (201, as designed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)