### PR TITLE
CAURA-128 fix(contradiction): tighten Path C retraction threshold 0.60 → 0.90

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -904,15 +904,40 @@ def _fake_contradiction_check(new_content: str, old_content: str) -> bool:
 
 # Minimum confidence the judge must report for a ``verdict=False`` to
 # trigger retraction. Above this we trust the "not a contradiction"
-# call; below this we leave Path A's verdict in place (the model's
-# response was malformed / unparseable — see ``_CONF_FALLBACK``).
+# call; below this we leave Path A's verdict in place.
 #
-# Gate 1 (0.60) is the canonical retraction signal: model said
-# ``contradicts=True`` with ``same_subject=False``, parser overrode
-# to False. Path A flagged on surface similarity; the entity-aware
-# judge confirmed they're different subjects. Acting on 0.60 is
-# exactly the bug A4 #13 fixes.
-RETRACTION_CONFIDENCE_THRESHOLD = 0.60
+# CAURA-128 — tightened from 0.60 → 0.90.
+#
+# The retraction code was originally written as "re-judge with full
+# entity context"; the comment block at A4 #13's introduction promised
+# the judge would see the resolved entity_links and answer a different,
+# entity-aware question than Path A's semantic similarity check. In
+# practice ``_attempt_path_c_retraction`` calls ``_llm_contradiction_check
+# (new_content, old_content, ...)`` with the SAME prompt and SAME inputs
+# as Path A's semantic judge. There is no entity context in the request
+# — it is the same LLM call rolled twice.
+#
+# Wet-tested on memclaw.net 2026-05-26 (S2 race probe, scripts/
+# repro_contradictions_race.py). Two memories with directly conflicting
+# release dates about a synthetic proper-noun subject. Path A correctly
+# flagged the conflict; Path C's independent roll returned
+# ``(verdict=False, confidence=0.60)`` on a non-trivial fraction of runs
+# and silently retracted the correct flag. Confidence rubric:
+#   0.90 — clean LLM agreement (both gates aligned on "not contradict")
+#   0.85 — gate 2 fired (model named a non_conflict_reason)
+#   0.60 — gate 1 fired (model said contradicts=True same_subject=False;
+#          parser overrode). THIS IS THE STOCHASTIC FLIP CASE.
+#   0.50 — malformed / heuristic fallback
+#
+# Raising the floor to 0.90 means retraction only fires on clean
+# agreement — both gates of the parser say "not a contradiction" with
+# no parser-override. Gate-1 (the stochastic-flip case) and gate-2
+# (single-gate non_conflict_reason) both now leave Path A's verdict in
+# place. This is the "quick fix" tier; the deeper fix (an entity-aware
+# prompt that actually receives entity_links + canonical names) is
+# tracked separately and will revisit this threshold once the judge has
+# a different question to answer.
+RETRACTION_CONFIDENCE_THRESHOLD = _CONF_CLEAN
 
 
 async def _attempt_path_c_retraction(
@@ -976,7 +1001,15 @@ async def _attempt_path_c_retraction(
         # Judge agrees with Path A — real contradiction, leave it.
         return False
     if confidence < RETRACTION_CONFIDENCE_THRESHOLD:
-        # Heuristic fallback / malformed — don't trust ``verdict=False``.
+        # Below the CAURA-128 floor (0.90). Covers gate-1 (0.60, the
+        # stochastic-flip case where parser overrode ``contradicts=True
+        # same_subject=False`` to False), gate-2 (0.85, single-gate
+        # ``non_conflict_reason``), and the heuristic / malformed
+        # fallback (0.50). None are trustworthy enough on their own —
+        # the judge call is the same prompt + same inputs as Path A's
+        # semantic judge, so a single-gate disagreement is just an
+        # independent LLM roll flipping. Leave Path A's verdict in
+        # place until the deeper entity-aware-prompt fix lands.
         logger.info(
             "Path C retraction skipped low-confidence verdict for memory %s "
             "candidate %s (confidence=%.2f < threshold=%.2f)",

--- a/tests/test_a4_13_path_c_retraction.py
+++ b/tests/test_a4_13_path_c_retraction.py
@@ -31,10 +31,17 @@ Confidence rubric (A4 #12):
   0.60 — gate 1 fired (model said contradicts=True with same_subject=False)
   0.50 — malformed / heuristic fallback
 
-Retraction acts on every ``verdict=False`` case EXCEPT malformed
-(threshold ``RETRACTION_CONFIDENCE_THRESHOLD = 0.60``). Gate 1 is the
-canonical retraction signal — the model said "different subjects" but
-its own ``contradicts=True`` was wrong; the safety gate corrected it.
+CAURA-128 — threshold tightened from 0.60 to 0.90. The retraction
+judge calls ``_llm_contradiction_check`` with the SAME inputs as Path
+A's semantic judge; there is no extra entity context. Independent rolls
+of the same LLM call disagree non-deterministically on synthetic /
+unusual subjects, and at threshold 0.60 the parser-override gate (gate
+1) silently retracted genuine Path A verdicts. Wet-tested on net 2026-
+05-26 via ``scripts/repro_contradictions_race.py``. Retraction now
+fires only on clean LLM agreement (confidence ≥ 0.90); gate-1 (0.60)
+and gate-2 (0.85) leave Path A's verdict in place until the deeper fix
+lands (a separate entity-aware prompt that actually receives the
+resolved entity_links).
 
 Why direct lookup (not via A4 #11):
 A4 #11's ``include_supersedes=True`` filter was structurally inverted
@@ -174,9 +181,16 @@ async def test_retracts_when_judge_says_not_contradiction_clean_confidence():
 
 
 @pytest.mark.asyncio
-async def test_retracts_when_judge_says_not_contradiction_gate2_confidence():
-    """Gate 2 fired (e.g. ``refinement`` / ``temporal_supersession`` / etc.):
-    verdict=False at confidence 0.85. Retraction MUST fire."""
+async def test_no_retraction_at_gate2_below_threshold():
+    """CAURA-128 — Gate 2 fired (verdict=False, confidence 0.85) USED to
+    retract under the original threshold 0.60. The judge call is the
+    same LLM prompt + same inputs as Path A's semantic judge — no extra
+    entity context is passed — so a 0.85 disagreement is just a single
+    independent roll flipping. We tightened the floor to 0.90; gate-2
+    alone is no longer sufficient to silently revert Path A.
+
+    Wet-test evidence: scripts/repro_contradictions_race.py on net
+    2026-05-26 — see CAURA-128 PR body."""
     from core_api.services.contradiction_detector import (
         detect_contradictions_by_entities_async,
     )
@@ -203,19 +217,25 @@ async def test_retracts_when_judge_says_not_contradiction_gate2_confidence():
     ):
         await detect_contradictions_by_entities_async(new_id, "t1", "f1")
 
-    assert any(
-        c.args == (str(cand_id), "active")
+    revert_calls = [
+        c
         for c in sc.update_memory_status.call_args_list
+        if c.args == (str(cand_id), "active")
+    ]
+    assert revert_calls == [], (
+        f"verdict=False at 0.85 must NOT retract under the tightened "
+        f"CAURA-128 threshold (0.90); got {revert_calls}"
     )
 
 
 @pytest.mark.asyncio
-async def test_retracts_on_gate1_confidence_canonical_case():
-    """Gate 1 fired — model said ``contradicts=True`` with
-    ``same_subject=False``; parser overrode to False at confidence 0.60.
-    This is the **canonical retraction case**: Path A wrongly flagged
-    on similarity; the entity-aware re-judge says "different subjects"
-    via the safety gate. Retraction MUST fire."""
+async def test_no_retraction_on_gate1_stochastic_signal():
+    """CAURA-128 regression test — Gate 1 (verdict=False, confidence
+    0.60) is the **stochastic flip case**: model said
+    ``contradicts=True`` with ``same_subject=False`` and the parser
+    overrode to False. Under the original threshold 0.60 this silently
+    retracted genuine Path A flags on memclaw.net. Now it must NOT
+    retract."""
     from core_api.services.contradiction_detector import (
         detect_contradictions_by_entities_async,
     )
@@ -242,9 +262,14 @@ async def test_retracts_on_gate1_confidence_canonical_case():
     ):
         await detect_contradictions_by_entities_async(new_id, "t1", "f1")
 
-    assert any(
-        c.args == (str(cand_id), "active")
+    revert_calls = [
+        c
         for c in sc.update_memory_status.call_args_list
+        if c.args == (str(cand_id), "active")
+    ]
+    assert revert_calls == [], (
+        f"verdict=False at 0.60 (gate-1 stochastic flip) must NOT retract "
+        f"under the tightened CAURA-128 threshold (0.90); got {revert_calls}"
     )
 
 


### PR DESCRIPTION
## Summary

The A4 #13 retraction was designed to *re-judge a Path A verdict with full entity context*. In practice `_attempt_path_c_retraction` calls `_llm_contradiction_check(new_content, old_content, tenant_config)` with the **same prompt and same inputs** as Path A's semantic judge. No entity context is passed in — it's the same LLM call rolled twice.

LLMs are non-deterministic. Independent rolls disagree some fraction of the time. Under the original 0.60 floor, gate-1 (`verdict=False` after a `contradicts=True same_subject=False` parser override — confidence 0.60) was sufficient to silently retract a genuine Path A flag.

This PR raises `RETRACTION_CONFIDENCE_THRESHOLD` from `0.60` → `0.90`. Retraction now fires only on clean LLM agreement (both gates aligned with no parser override).

## Wet-test evidence (memclaw.net, 2026-05-26)

Probe: `scripts/repro_contradictions_race.py` — two memories with directly conflicting release dates about a synthetic proper-noun subject.

| gap_ms | detected | status A / B          | entity_links A / B | interpretation                                            |
|-------:|:--------:|:----------------------|:-------------------|:----------------------------------------------------------|
| 0      | **No**   | confirmed / active    | 2 / 0              | Path A flagged → Path C retracted on stochastic 0.60 roll |
| 100    | Yes      | conflicted / confirmed| 0 / 0              | polled before Path C ran                                  |
| 500    | Yes      | conflicted / confirmed| 0 / 0              | same — caught the window                                  |
| 2000   | **No**   | confirmed / confirmed | 2 / 0              | Path C ran and retracted                                  |

The "race" is not between inter-write gaps — it is between the client's read and Path C's wall-clock. Production clients reading `/contradictions` after Path C completes see the retraction.

Full architecture map and prioritised gap list: `docs/contradiction-detection-status-2026-05-26.html`.

## Why this is the *quick* fix tier

Three options were laid out in the status report. This PR is option 1:

1. **Quick** (this PR): raise the floor so single-gate signals can't retract; only clean agreement (0.90) is strong enough.
2. **Real** (follow-up): pass `entity_links` + canonical names into a distinct entity-aware prompt that asks a *different* question than Path A. The comment block at line 899 promises this; the code never implemented it.
3. **Belt-and-suspenders** (future): replace silent revert with a `disputed` status + tiebreaker pass.

## Test changes

| Test                                                               | Before                | After                                          |
|--------------------------------------------------------------------|-----------------------|------------------------------------------------|
| `…_clean_confidence` (0.90)                                        | retracts ✓            | retracts ✓ (unchanged — clean agreement)       |
| `…_gate2_confidence` (0.85)                                        | retracts              | renamed → `test_no_retraction_at_gate2_below_threshold` — asserts NO retract |
| `test_retracts_on_gate1_confidence_canonical_case` (0.60)          | retracts (THE BUG)    | renamed → `test_no_retraction_on_gate1_stochastic_signal` — asserts NO retract |
| `…_malformed_fallback` (0.50)                                      | no retract ✓          | no retract ✓ (unchanged)                       |
| `…_judge_confirms_contradiction` (True, 0.90)                      | no retract ✓          | no retract ✓ (unchanged)                       |
| 2× precondition tests (no `supersedes_id`, already active)         | no retract ✓          | no retract ✓ (unchanged)                       |

## Test plan

- [x] Syntax + AST + pytest collection clean in local worktree.
- [ ] CI runs the unit tests (Postgres-backed conftest needed; local pg :5432 unavailable here).
- [ ] After merge → deploy to `dev` → re-run `scripts/repro_contradictions_race.py` against `memclaw.dev` to confirm trials are no longer retracted.
- [ ] After dev confirms → soak on `net` via next nightly loadtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)