### PR TITLE
ci: harden the shared review script

### DIFF
--- a/.github/scripts/claude_pr_review.sh
+++ b/.github/scripts/claude_pr_review.sh
@@ -46,13 +46,48 @@ RESULT=$(printf '%s' "$DIFF" | claude --print --model "$MODEL" --output-format j
   exit 1
 }
 
-REVIEW=$(printf '%s' "$RESULT" | jq -r '.result // empty')
-COST=$(printf '%s' "$RESULT" | jq -r '.total_cost_usd // empty')
-echo "::notice::Claude review cost: \$${COST:-unknown} (model ${MODEL}, PR #${PR_NUMBER})"
+# jq runs under `set -e`; a parse failure (claude returned non-JSON — a warning
+# banner, rate-limit HTML) must not silently kill the script before we post an
+# error. On failure, log the raw response so the workflow log actually has
+# something to check, then post a visible error.
+REVIEW=$(printf '%s' "$RESULT" | jq -r '.result // empty' 2>/dev/null) || {
+  echo "Claude returned non-JSON output. First 2000 chars of the raw response:" >&2
+  printf '%s\n' "${RESULT:0:2000}" >&2
+  post "⚠️ Claude Code review failed: response was not valid JSON (see workflow logs)."
+  exit 1
+}
 
+# Bail before logging any cost, so an empty .result can't leave a cost table in
+# the job summary next to a "review failed" comment.
 if [ -z "$REVIEW" ]; then
   post "⚠️ Claude Code review failed: empty result."
   exit 1
+fi
+
+COST=$(printf '%s' "$RESULT" | jq -r '.total_cost_usd // empty' 2>/dev/null || echo "unknown")
+echo "::notice::Claude review cost: \$${COST:-unknown} (model ${MODEL}, PR #${PR_NUMBER})"
+
+# Cost + token table in the Actions job summary (when running in a workflow).
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ -n "$COST" ] && [ "$COST" != "unknown" ]; then
+  TOKENS_IN=$(printf '%s' "$RESULT" | jq -r '.usage.input_tokens // empty' 2>/dev/null || true)
+  TOKENS_OUT=$(printf '%s' "$RESULT" | jq -r '.usage.output_tokens // empty' 2>/dev/null || true)
+  {
+    echo "### Claude Code Review Cost"
+    echo "| Metric | Value |"
+    echo "|--------|-------|"
+    echo "| Cost | \$${COST} |"
+    echo "| Input tokens | ${TOKENS_IN:-?} |"
+    echo "| Output tokens | ${TOKENS_OUT:-?} |"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# GitHub caps comment bodies at 65536 chars; truncate so a very large review
+# can't 422 and then silently fail under set -e.
+MAX_BODY=65000
+if [ "${#REVIEW}" -gt "$MAX_BODY" ]; then
+  REVIEW="${REVIEW:0:$MAX_BODY}
+
+_[Review truncated — exceeded GitHub's comment size limit.]_"
 fi
 
 # Footer surfaces per-review spend on the PR itself, not just the job log.


### PR DESCRIPTION
Hardens the shared review script (`.github/scripts/claude_pr_review.sh`) — follow-ups surfaced by the **enterprise repo's self-test review** of the identical script (the on-open review working as intended caught these):

- **Medium — jq silent-exit:** under `set -euo pipefail`, a non-JSON response from `claude` (warning banner, rate-limit HTML) made `jq` fail and killed the script *before* the empty-result guard, posting no error. Now guarded → posts a visible parse-error instead.
- **Low — 65 536-char comment limit:** a very large review would 422 on `gh api` then silently exit. Now truncated with a `_[truncated]_` marker.
- **Low — job-summary cost table:** restored the cost + input/output-token table to `$GITHUB_STEP_SUMMARY` (alongside the comment footer).

Declined (with reasoning, documented): the "PR-branch checkout runs the PR's script with secrets" finding — pinning to base would kill the self-test that *caught these very issues*; the real mitigation is the repo's "require approval for workflow runs" setting, not workflow code.

Keeps the script byte-identical across all three repos. This PR self-tests on open (it's a `.sh` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
