### PR TITLE
CAURA-129 feat(contradiction): entity-aware Path C retraction judge

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -683,6 +683,101 @@ Reply with ONLY a JSON object, no prose, no markdown fences:
 """
 
 
+# CAURA-129 — entity-aware retraction prompt. Path C's retraction judge
+# runs AFTER entity extraction has resolved the canonical entities for
+# both memories. This prompt is the "real fix" tier — it asks a
+# structurally different question than ``CONTRADICTION_PROMPT`` (which
+# Path A's semantic judge already used) by surfacing the resolved
+# entity rows authoritatively. Disagreement with Path A now carries
+# meaningful signal (the model is reasoning over RESOLVED entities,
+# not over the raw text NER it ran once already).
+#
+# JSON output schema is intentionally identical to ``CONTRADICTION_PROMPT``
+# so ``_judge_contradiction`` parses both unchanged. The new placeholders
+# are ``{new_entities}`` and ``{old_entities}`` — rendered by
+# ``_format_entity_context``.
+ENTITY_AWARE_CONTRADICTION_PROMPT = """\
+You are a contradiction detector for a business memory system, running
+the second-pass judgement after entity resolution has already linked
+both statements to their canonical entities.
+
+Two statements contradict ONLY IF they make incompatible claims about
+the SAME real-world subject. Different subjects -> NOT a contradiction,
+even if the predicates look opposite or the statements look semantically
+similar.
+
+CRITICAL: Resolved entities below are AUTHORITATIVE. If the subjects in
+the two RESOLVED-ENTITIES blocks are different entity rows (different
+canonical names or different entity IDs), same_subject MUST be false
+regardless of how similar the raw statement text looks. If the subjects
+are the SAME canonical entity row, treat same_subject as true even if
+the statement text refers to it by alias / role / pronoun.
+
+Statement A (NEW): {new_content}
+RESOLVED ENTITIES for Statement A:
+{new_entities}
+
+Statement B (EXISTING): {old_content}
+RESOLVED ENTITIES for Statement B:
+{old_entities}
+
+Follow these steps in order:
+
+1. Identify subject_a: from Statement A's resolved entities, the entity
+   with role="subject" (or the canonical subject if no role is marked).
+   Use its canonical name.
+2. Identify subject_b: same from Statement B's resolved entities.
+3. Decide same_subject. Set true ONLY when subject_a and subject_b are
+   the same resolved entity (same canonical name AND same entity_type).
+   Set false when:
+     - the resolved subjects are different entity rows
+     - either side has no resolved subject (degenerate input — this
+       prompt should not have been invoked, but if it is, prefer false)
+     - the canonical names match but entity_types differ (two
+       different real-world things that happen to share a name)
+4. Decide non_conflict_reason. Even when same_subject is true, certain
+   shapes describe two claims that BOTH hold and so are NOT a
+   contradiction. Pick at most one value; pick "none" when the two
+   statements really do assert mutually exclusive states.
+     - "temporal_supersession": sequential states of the same subject's
+       lifecycle (planned -> shipped, open -> closed, draft ->
+       published, beta -> GA, hired -> promoted). The newer state
+       supersedes the older one; both held in sequence.
+     - "list_valued_predicate": attributes that do not compete for a
+       single slot — multi-value predicates (supports English /
+       supports French) or two entirely different attributes of the
+       same subject (Alice's title vs Alice's team).
+     - "refinement": one statement is a more specific version of the
+       other (Europe vs Munich; Q3 vs September 15). Both hold.
+     - "scope_mismatch": same subject, different implicit qualifiers
+       (whole vs part, different time windows, different contexts).
+     - "same_name_distinct_subject": surface names match but the
+       resolved entities differ — choose this when you also set
+       same_subject=false because the entity blocks disambiguate.
+     - "conditional_unrealized": one statement is hypothetical /
+       irrealis; conditionals do not contradict realised states.
+     - "event_restatement": the two statements describe the SAME event
+       with different tense / aspect / synonyms.
+     - "none": none of the above; the two statements assert mutually
+       exclusive states about the same subject at the same time frame.
+5. Decide contradicts:
+   - If same_subject is false, contradicts MUST be false.
+   - If non_conflict_reason is not "none", contradicts MUST be false.
+   - Otherwise contradicts is true only when the two statements assert
+     mutually exclusive states about that subject in the same time
+     frame. Corrections / updates about the same subject ARE
+     contradictions.
+
+Reply with ONLY a JSON object, no prose, no markdown fences:
+{{"subject_a": "<canonical name from RESOLVED ENTITIES for A>",
+  "subject_b": "<canonical name from RESOLVED ENTITIES for B>",
+  "same_subject": true/false,
+  "non_conflict_reason": "none|temporal_supersession|list_valued_predicate|refinement|scope_mismatch|same_name_distinct_subject|conditional_unrealized|event_restatement",
+  "contradicts": true/false,
+  "reason": "one short phrase referencing the resolved subjects and the conflict (or its absence)"}}
+"""
+
+
 # CAURA-124 — within-subject false-positive shapes that hard-gate
 # ``contradicts=true`` to ``false``. ``none`` (or absent / unknown
 # value) is the only enum value that allows a contradiction to stand.
@@ -896,6 +991,162 @@ def _fake_contradiction_check(new_content: str, old_content: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# CAURA-129 — Entity-aware retraction judge.
+# ---------------------------------------------------------------------------
+#
+# Path C runs AFTER ``process_entity_extraction`` has resolved the
+# canonical entities and written ``MemoryEntityLink`` rows. The
+# retraction judge below leverages that — it fetches resolved entity
+# names for both memories and asks ``ENTITY_AWARE_CONTRADICTION_PROMPT``
+# which authoritatively grounds same_subject on entity identity rather
+# than on raw-text NER (Path A's semantic judge already did that, so
+# re-asking the same question gave us LLM-stochastic flips —
+# CAURA-128). Shape mirrors ``_llm_contradiction_check`` so the
+# retraction call site is a one-line swap.
+
+
+_ENTITY_CONTEXT_MAX_ENTITIES = 10
+_ENTITY_CONTEXT_NAME_MAX_CHARS = 100
+
+
+def _format_entity_context(entities: list[dict]) -> str:
+    """Render resolved entity rows into a readable block for the prompt.
+
+    ``entities`` is a list of dicts shaped ``{name, entity_type, role}``
+    (also accepts ``canonical_name`` as a primary alias for ``name``).
+    Returns one bullet per entity, e.g.
+
+        - "Project Helios" (type: project, role: subject)
+        - "2027-05-01" (type: date, role: object)
+
+    Bounds (mirror the ``[:500]`` content truncation in
+    ``_llm_entity_aware_contradiction_check`` — keep prompt token
+    cost bounded against runaway / adversarial inputs):
+
+      * At most ``_ENTITY_CONTEXT_MAX_ENTITIES`` (10) bullets rendered;
+        excess entities are dropped silently. The judge's signal
+        saturates well before 10 entities per memory; in practice we
+        see 1-5.
+      * Each ``name`` is truncated to
+        ``_ENTITY_CONTEXT_NAME_MAX_CHARS`` (100) characters. Canonical
+        names are short by construction (the entity extractor produces
+        ≤30-char names typically); 100 chars covers the long tail
+        without giving an attacker a runaway lever.
+
+    Returns the literal string ``"(none resolved)"`` when ``entities``
+    is empty — defensive; callers SHOULD have guarded earlier, but if
+    they didn't the prompt still reads as well-formed.
+    """
+    if not entities:
+        return "(none resolved)"
+    capped = entities[:_ENTITY_CONTEXT_MAX_ENTITIES]
+    lines: list[str] = []
+    for e in capped:
+        name = (e.get("canonical_name") or e.get("name") or "<unknown>")[:_ENTITY_CONTEXT_NAME_MAX_CHARS]
+        etype = e.get("entity_type") or "<unknown>"
+        role = e.get("role") or "<unspecified>"
+        lines.append(f'- "{name}" (type: {etype}, role: {role})')
+    return "\n".join(lines)
+
+
+async def _fetch_entity_context(sc, memory_id: str) -> list[dict]:
+    """Fetch and denormalise ``MemoryEntityLink`` rows for a single memory.
+
+    Two storage round-trips at worst:
+      1. ``get_entity_links_for_memories([memory_id])`` — batch endpoint;
+         returns ``{memory_id: [{entity_id, role}, ...]}``.
+      2. ``get_entity(entity_id)`` per link, fan-out via ``asyncio.gather``
+         — Path C is post-commit async so the round-trip parallelism is
+         latency-invisible to the write path.
+
+    Returns ``[]`` (not ``None``) when the memory has no resolved links;
+    the caller treats empty as the skip-retraction signal so this
+    function never raises on missing data.
+    """
+    try:
+        links_by_mem = await sc.get_entity_links_for_memories([memory_id])
+    except Exception as e:
+        logger.warning(
+            "Path C entity-context fetch failed (links) for memory %s: %s",
+            memory_id,
+            e,
+        )
+        return []
+    links = (links_by_mem or {}).get(memory_id, []) if isinstance(links_by_mem, dict) else []
+    if not links:
+        return []
+
+    async def _hydrate(link: dict) -> dict | None:
+        entity_id = link.get("entity_id")
+        if not entity_id:
+            return None
+        try:
+            entity = await sc.get_entity(str(entity_id))
+        except Exception as e:
+            logger.warning(
+                "Path C entity-context fetch failed (entity %s) for memory %s: %s",
+                entity_id,
+                memory_id,
+                e,
+            )
+            return None
+        if not entity:
+            return None
+        # ``canonical_name`` is the column on Entity; fall back to
+        # ``name`` for any future schema change / mocked-test data.
+        return {
+            "name": entity.get("canonical_name") or entity.get("name"),
+            "entity_type": entity.get("entity_type"),
+            "role": link.get("role"),
+        }
+
+    hydrated = await asyncio.gather(*(_hydrate(link) for link in links))
+    return [h for h in hydrated if h is not None]
+
+
+async def _llm_entity_aware_contradiction_check(
+    new_content: str,
+    old_content: str,
+    new_entities: list[dict],
+    old_entities: list[dict],
+    tenant_config=None,
+) -> tuple[bool, float]:
+    """Entity-aware variant of ``_llm_contradiction_check``.
+
+    Same return shape, same fallback chain, same ``_judge_contradiction``
+    parser; differs only in the prompt template (which receives resolved
+    entity context as ``{new_entities}`` / ``{old_entities}``). Callers
+    MUST have verified both ``new_entities`` and ``old_entities`` are
+    non-empty before invoking — see ``_attempt_path_c_retraction`` for
+    the guard.
+    """
+    provider_name = (
+        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
+    )
+
+    prompt = ENTITY_AWARE_CONTRADICTION_PROMPT.format(
+        new_content=new_content[:500],
+        old_content=old_content[:500],
+        new_entities=_format_entity_context(new_entities),
+        old_entities=_format_entity_context(old_entities),
+    )
+
+    async def _do_check(llm) -> tuple[bool, float]:
+        raw = await llm.complete_json(prompt)
+        return _judge_contradiction(raw)
+
+    return await call_with_fallback(
+        primary_provider_name=provider_name,
+        call_fn=_do_check,
+        fake_fn=lambda: (_fake_contradiction_check(new_content, old_content), _CONF_FALLBACK),
+        tenant_config=tenant_config,
+        service_label="contradiction-entity-aware",
+        model_attr="entity_extraction_model",
+        timeout=10.0,
+    )
+
+
+# ---------------------------------------------------------------------------
 # A4 #13 — Retraction phase: re-judge a Path A verdict with full entity
 # context and undo it via the A4 #10 storage primitive when the re-judge
 # disagrees with sufficient confidence.
@@ -983,9 +1234,53 @@ async def _attempt_path_c_retraction(
     new_content = new_memory.get("content", "") or ""
     old_content = candidate.get("content", "") or ""
 
+    # CAURA-129 — fetch resolved entity context for BOTH memories. If
+    # either side has no resolved entities, the entity-aware judge has
+    # nothing to ground same_subject on, and we'd degenerate to the
+    # CAURA-128 pre-fix state (same prompt + same inputs as Path A,
+    # stochastically flipping). Empty on either side → skip retraction;
+    # Path A's verdict stands. This is correct for the common case (the
+    # entity-extraction worker that *enqueued* Path C populates the
+    # links by definition), and conservative for the edge case
+    # (degenerate inputs / extractor failure).
+    # Wrap the fetch in ``asyncio.wait_for`` so a hung storage
+    # round-trip cannot block Path C indefinitely (mirrors the LLM
+    # call's cancellation boundary below). 5s budget is ample for two
+    # parallel storage calls (~50-200ms p95 in practice); on failure
+    # (timeout, network, storage error), treat as "no context, leave
+    # Path A alone" rather than retrying.
+    try:
+        new_entities, old_entities = await asyncio.wait_for(
+            asyncio.gather(
+                _fetch_entity_context(sc, str(new_memory.get("id"))),
+                _fetch_entity_context(sc, str(candidate.get("id"))),
+            ),
+            timeout=5.0,
+        )
+    except Exception as e:
+        logger.warning(
+            "Path C entity-context fetch failed for memory %s candidate %s: %s. Path A's verdict stands.",
+            new_memory.get("id"),
+            candidate.get("id"),
+            e,
+        )
+        return False
+
+    if not new_entities or not old_entities:
+        logger.info(
+            "Path C retraction skipped — empty entity context for "
+            "memory %s (new_n=%d cand_n=%d). Path A's verdict stands.",
+            new_memory.get("id"),
+            len(new_entities),
+            len(old_entities),
+        )
+        return False
+
     try:
         verdict, confidence = await asyncio.wait_for(
-            _llm_contradiction_check(new_content, old_content, tenant_config),
+            _llm_entity_aware_contradiction_check(
+                new_content, old_content, new_entities, old_entities, tenant_config
+            ),
             timeout=10.0,
         )
     except (TimeoutError, Exception) as e:

--- a/tests/test_a4_13_path_c_retraction.py
+++ b/tests/test_a4_13_path_c_retraction.py
@@ -31,17 +31,24 @@ Confidence rubric (A4 #12):
   0.60 — gate 1 fired (model said contradicts=True with same_subject=False)
   0.50 — malformed / heuristic fallback
 
-CAURA-128 — threshold tightened from 0.60 to 0.90. The retraction
-judge calls ``_llm_contradiction_check`` with the SAME inputs as Path
-A's semantic judge; there is no extra entity context. Independent rolls
-of the same LLM call disagree non-deterministically on synthetic /
-unusual subjects, and at threshold 0.60 the parser-override gate (gate
-1) silently retracted genuine Path A verdicts. Wet-tested on net 2026-
-05-26 via ``scripts/repro_contradictions_race.py``. Retraction now
-fires only on clean LLM agreement (confidence ≥ 0.90); gate-1 (0.60)
-and gate-2 (0.85) leave Path A's verdict in place until the deeper fix
-lands (a separate entity-aware prompt that actually receives the
-resolved entity_links).
+CAURA-128 — threshold tightened from 0.60 to 0.90. The original
+retraction judge called ``_llm_contradiction_check`` with the SAME
+inputs as Path A's semantic judge; there was no extra entity context.
+Independent rolls of the same LLM call disagreed non-deterministically
+on synthetic / unusual subjects, and at threshold 0.60 the
+parser-override gate (gate 1) silently retracted genuine Path A
+verdicts. Wet-tested on net 2026-05-26 via
+``scripts/repro_contradictions_race.py``.
+
+CAURA-129 — the retraction judge now calls
+``_llm_entity_aware_contradiction_check``, which renders the resolved
+``MemoryEntityLink`` rows for both memories into the prompt (canonical
+names + entity_type + role). The judge answers a structurally different
+question than Path A — grounded on entity identity rather than raw-text
+NER. Retraction is also skipped when either memory has no resolved
+entity_links (degenerate input → Path A's verdict stands; see the
+empty-context tests below). Threshold remains at ``_CONF_CLEAN`` (0.90)
+for the initial PR; revisit after production signal.
 
 Why direct lookup (not via A4 #11):
 A4 #11's ``include_supersedes=True`` filter was structurally inverted
@@ -116,6 +123,27 @@ def _mock_sc_with_retraction_setup(
     sc.get_memory = AsyncMock(side_effect=get_memory)
     sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
     sc.update_memory_status = AsyncMock()
+    # CAURA-129 — Path C retraction now fetches entity context for both
+    # memories before the judge fires. Default mock returns one resolved
+    # link per memory so existing tests stay on the same code path; the
+    # empty-links guard is exercised by dedicated tests below.
+    _ent_new = str(uuid4())
+    _ent_cand = str(uuid4())
+    sc.get_entity_links_for_memories = AsyncMock(
+        return_value={
+            str(new_id): [{"entity_id": _ent_new, "role": "subject"}],
+            str(cand_id): [{"entity_id": _ent_cand, "role": "subject"}],
+        }
+    )
+
+    async def get_entity(eid: str) -> dict | None:
+        if eid == _ent_new:
+            return {"id": eid, "canonical_name": "Project X", "entity_type": "project"}
+        if eid == _ent_cand:
+            return {"id": eid, "canonical_name": "Project Y", "entity_type": "project"}
+        return None
+
+    sc.get_entity = AsyncMock(side_effect=get_entity)
     install_batch_status_replay_shim(sc)
     return sc
 
@@ -147,7 +175,7 @@ async def test_retracts_when_judge_says_not_contradiction_clean_confidence():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
             new_callable=AsyncMock,
             return_value=(False, 0.90),
         ),
@@ -204,7 +232,7 @@ async def test_no_retraction_at_gate2_below_threshold():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
             new_callable=AsyncMock,
             return_value=(False, 0.85),
         ),
@@ -249,7 +277,7 @@ async def test_no_retraction_on_gate1_stochastic_signal():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
             new_callable=AsyncMock,
             return_value=(False, 0.60),
         ),
@@ -297,7 +325,7 @@ async def test_no_retraction_on_malformed_fallback_confidence():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
             new_callable=AsyncMock,
             return_value=(False, 0.50),
         ),
@@ -338,7 +366,7 @@ async def test_no_retraction_when_judge_confirms_contradiction():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
             new_callable=AsyncMock,
             return_value=(True, 0.90),
         ),
@@ -391,7 +419,7 @@ async def test_no_retraction_when_new_memory_has_no_supersedes_id():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
             judge,
         ),
         patch(
@@ -428,7 +456,7 @@ async def test_no_retraction_when_candidate_already_active():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
             judge,
         ),
         patch(
@@ -447,3 +475,107 @@ async def test_no_retraction_when_candidate_already_active():
         if c.args == (str(cand_id), "active")
     ]
     assert revert_calls == []
+
+
+# ---------------------------------------------------------------------------
+# CAURA-129 — empty-entity-context guards. The new entity-aware judge
+# has nothing to ground same_subject on if either memory has no resolved
+# entity_links; degenerating to raw-content judgement would reintroduce
+# the CAURA-128 stochastic-flip class. Empty on either side → skip
+# retraction and leave Path A's verdict in place.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_retraction_when_new_memory_has_no_entity_links():
+    """CAURA-129 — entity-extraction has not (yet?) populated links on
+    the new memory side. Skip retraction; do NOT fall back to raw-content
+    judging (that's what CAURA-128 raised the threshold against)."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    sc = _mock_sc_with_retraction_setup(new_id, cand_id)
+    # Override: new side has no links; candidate side keeps its default.
+    cand_links = sc.get_entity_links_for_memories.return_value[str(cand_id)]
+    sc.get_entity_links_for_memories = AsyncMock(
+        return_value={str(new_id): [], str(cand_id): cand_links}
+    )
+    judge = AsyncMock(return_value=(False, 0.95))
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
+            judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    judge.assert_not_called()
+    revert_calls = [
+        c
+        for c in sc.update_memory_status.call_args_list
+        if c.args == (str(cand_id), "active")
+    ]
+    assert revert_calls == [], (
+        "empty entity_links on new memory must skip retraction without "
+        "invoking the judge"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_retraction_when_candidate_has_no_entity_links():
+    """CAURA-129 — symmetric guard: candidate side has no resolved
+    entity_links. The empty-context guard fires regardless of which
+    side is degenerate."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    sc = _mock_sc_with_retraction_setup(new_id, cand_id)
+    new_links = sc.get_entity_links_for_memories.return_value[str(new_id)]
+    sc.get_entity_links_for_memories = AsyncMock(
+        return_value={str(new_id): new_links, str(cand_id): []}
+    )
+    judge = AsyncMock(return_value=(False, 0.95))
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
+            judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    judge.assert_not_called()
+    revert_calls = [
+        c
+        for c in sc.update_memory_status.call_args_list
+        if c.args == (str(cand_id), "active")
+    ]
+    assert revert_calls == [], (
+        "empty entity_links on candidate must skip retraction without "
+        "invoking the judge"
+    )

--- a/tests/test_caura_129_entity_aware_retraction_prompt.py
+++ b/tests/test_caura_129_entity_aware_retraction_prompt.py
@@ -1,0 +1,477 @@
+"""CAURA-129 — Direct unit tests for the entity-aware retraction prompt
+and judge.
+
+The retraction flow itself is covered by
+``tests/test_a4_13_path_c_retraction.py``. This file exercises the new
+plumbing in isolation:
+
+  * ``ENTITY_AWARE_CONTRADICTION_PROMPT`` template invariants —
+    required placeholders, required JSON keys, authoritative-entity
+    framing.
+  * ``_format_entity_context`` — readable rendering, empty-list path.
+  * ``_fetch_entity_context`` — storage round-trip composition,
+    canonical_name fallback, error swallowing.
+  * ``_llm_entity_aware_contradiction_check`` — wiring to
+    ``call_with_fallback`` with the right service label, timeout, and
+    ``_judge_contradiction`` parser reuse.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# ENTITY_AWARE_CONTRADICTION_PROMPT template invariants
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_has_required_placeholders():
+    """The prompt must format with the four expected fields and only
+    those four. Missing placeholders fail at .format() time in
+    production — this test catches drift early."""
+    from core_api.services.contradiction_detector import (
+        ENTITY_AWARE_CONTRADICTION_PROMPT,
+    )
+
+    for placeholder in (
+        "{new_content}",
+        "{old_content}",
+        "{new_entities}",
+        "{old_entities}",
+    ):
+        assert placeholder in ENTITY_AWARE_CONTRADICTION_PROMPT, (
+            f"prompt missing placeholder {placeholder!r}"
+        )
+
+
+def test_prompt_renders_with_realistic_inputs():
+    """End-to-end .format() with realistic values — catches format-spec
+    bugs (e.g. an accidentally-unescaped JSON brace would raise here)."""
+    from core_api.services.contradiction_detector import (
+        ENTITY_AWARE_CONTRADICTION_PROMPT,
+    )
+
+    rendered = ENTITY_AWARE_CONTRADICTION_PROMPT.format(
+        new_content="Project Helios has release date 2027-05-01.",
+        old_content="Project Helios has release date 2028-10-15.",
+        new_entities='- "Project Helios" (type: project, role: subject)',
+        old_entities='- "Project Helios" (type: project, role: subject)',
+    )
+    assert "Project Helios" in rendered
+    assert "2027-05-01" in rendered
+    assert "2028-10-15" in rendered
+    # JSON braces should survive the format() call as literal braces.
+    assert '"contradicts": true/false' in rendered
+
+
+def test_prompt_keeps_contradiction_json_schema_for_parser_reuse():
+    """``_judge_contradiction`` parses the same five keys for both
+    prompts. If the entity-aware prompt drifts on the schema, the
+    parser silently mis-classifies. Lock the schema here."""
+    from core_api.services.contradiction_detector import (
+        ENTITY_AWARE_CONTRADICTION_PROMPT,
+    )
+
+    for key in (
+        "subject_a",
+        "subject_b",
+        "same_subject",
+        "non_conflict_reason",
+        "contradicts",
+    ):
+        assert key in ENTITY_AWARE_CONTRADICTION_PROMPT, (
+            f"prompt missing JSON key {key!r} expected by _judge_contradiction"
+        )
+
+
+def test_prompt_frames_resolved_entities_as_authoritative():
+    """The whole point of the new prompt is that resolved entities
+    override raw-text NER. If this framing weakens, we're back to
+    CAURA-128's stochastic flips."""
+    from core_api.services.contradiction_detector import (
+        ENTITY_AWARE_CONTRADICTION_PROMPT,
+    )
+
+    text = ENTITY_AWARE_CONTRADICTION_PROMPT.lower()
+    assert "authoritative" in text, (
+        "prompt must explicitly mark the resolved entities as authoritative"
+    )
+    assert "resolved entities" in text
+
+
+# ---------------------------------------------------------------------------
+# _format_entity_context — rendering shape
+# ---------------------------------------------------------------------------
+
+
+def test_format_entity_context_renders_bullets():
+    from core_api.services.contradiction_detector import _format_entity_context
+
+    out = _format_entity_context(
+        [
+            {"name": "Project Helios", "entity_type": "project", "role": "subject"},
+            {"name": "2027-05-01", "entity_type": "date", "role": "object"},
+        ]
+    )
+    assert '- "Project Helios" (type: project, role: subject)' in out
+    assert '- "2027-05-01" (type: date, role: object)' in out
+
+
+def test_format_entity_context_empty_returns_sentinel():
+    """Empty list renders as a placeholder so the prompt stays
+    well-formed even if a buggy caller skips the guard."""
+    from core_api.services.contradiction_detector import _format_entity_context
+
+    assert _format_entity_context([]) == "(none resolved)"
+
+
+def test_format_entity_context_tolerates_missing_fields():
+    """Defensive — production data may have null role / type. Render
+    them as ``<unknown>`` / ``<unspecified>`` instead of raising."""
+    from core_api.services.contradiction_detector import _format_entity_context
+
+    out = _format_entity_context([{"name": None, "entity_type": None, "role": None}])
+    assert "<unknown>" in out
+    assert "<unspecified>" in out
+
+
+def test_format_entity_context_caps_list_at_ten_entities():
+    """Bound the prompt blast radius — only the first
+    ``_ENTITY_CONTEXT_MAX_ENTITIES`` (10) bullets are rendered. Mirrors
+    the ``[:500]`` content truncation in the judge."""
+    from core_api.services.contradiction_detector import (
+        _ENTITY_CONTEXT_MAX_ENTITIES,
+        _format_entity_context,
+    )
+
+    many = [
+        {"name": f"entity-{i}", "entity_type": "project", "role": "subject"}
+        for i in range(25)
+    ]
+    out = _format_entity_context(many)
+    bullet_count = out.count("\n- ") + (1 if out.startswith("- ") else 0)
+    assert bullet_count == _ENTITY_CONTEXT_MAX_ENTITIES == 10
+    # The 11th entity onwards must be dropped.
+    assert "entity-10" not in out
+    # Sanity: the rendered ones ARE present.
+    assert "entity-0" in out
+    assert "entity-9" in out
+
+
+def test_format_entity_context_truncates_long_names():
+    """Each rendered name is truncated to
+    ``_ENTITY_CONTEXT_NAME_MAX_CHARS`` (100). Adversarial / runaway
+    canonical names can't blow up the prompt token cost."""
+    from core_api.services.contradiction_detector import (
+        _ENTITY_CONTEXT_NAME_MAX_CHARS,
+        _format_entity_context,
+    )
+
+    out = _format_entity_context(
+        [{"name": "A" * 500, "entity_type": "project", "role": "subject"}]
+    )
+    # The rendered bullet must contain at most _ENTITY_CONTEXT_NAME_MAX_CHARS A's.
+    a_run = out.count("A")
+    assert a_run <= _ENTITY_CONTEXT_NAME_MAX_CHARS == 100, (
+        f"expected name truncated to ≤100 chars; got {a_run} A's"
+    )
+
+
+def test_format_entity_context_prefers_canonical_name_over_name():
+    """When the input dict carries both ``canonical_name`` and ``name``
+    (e.g. a raw entity row rather than the normalised shape from
+    ``_fetch_entity_context``), prefer the canonical."""
+    from core_api.services.contradiction_detector import _format_entity_context
+
+    out = _format_entity_context(
+        [
+            {
+                "canonical_name": "Project Helios",
+                "name": "Helios",
+                "entity_type": "project",
+                "role": "subject",
+            }
+        ]
+    )
+    assert '"Project Helios"' in out
+    assert '"Helios"' not in out
+
+
+# ---------------------------------------------------------------------------
+# _fetch_entity_context — storage composition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_entity_context_composes_two_round_trips():
+    """One call to ``get_entity_links_for_memories`` (batch endpoint,
+    one round-trip) + one ``get_entity`` per link, gathered in
+    parallel. Caller gets a clean list of ``{name, entity_type,
+    role}`` dicts."""
+    from core_api.services.contradiction_detector import _fetch_entity_context
+
+    mem_id = str(uuid4())
+    ent_a, ent_b = str(uuid4()), str(uuid4())
+
+    sc = AsyncMock()
+    sc.get_entity_links_for_memories = AsyncMock(
+        return_value={
+            mem_id: [
+                {"entity_id": ent_a, "role": "subject"},
+                {"entity_id": ent_b, "role": "object"},
+            ]
+        }
+    )
+
+    async def get_entity(eid: str) -> dict | None:
+        return {
+            ent_a: {"canonical_name": "Project Helios", "entity_type": "project"},
+            ent_b: {"canonical_name": "2027-05-01", "entity_type": "date"},
+        }.get(eid)
+
+    sc.get_entity = AsyncMock(side_effect=get_entity)
+
+    out = await _fetch_entity_context(sc, mem_id)
+    by_name = {e["name"]: e for e in out}
+    assert by_name["Project Helios"]["entity_type"] == "project"
+    assert by_name["Project Helios"]["role"] == "subject"
+    assert by_name["2027-05-01"]["entity_type"] == "date"
+    assert by_name["2027-05-01"]["role"] == "object"
+
+
+@pytest.mark.asyncio
+async def test_fetch_entity_context_empty_when_no_links():
+    from core_api.services.contradiction_detector import _fetch_entity_context
+
+    mem_id = str(uuid4())
+    sc = AsyncMock()
+    sc.get_entity_links_for_memories = AsyncMock(return_value={mem_id: []})
+    sc.get_entity = AsyncMock()
+
+    out = await _fetch_entity_context(sc, mem_id)
+    assert out == []
+    sc.get_entity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_entity_context_falls_back_to_name_if_no_canonical_name():
+    """Some test/legacy fixtures use ``name`` instead of
+    ``canonical_name``. Tolerate both."""
+    from core_api.services.contradiction_detector import _fetch_entity_context
+
+    mem_id = str(uuid4())
+    ent = str(uuid4())
+    sc = AsyncMock()
+    sc.get_entity_links_for_memories = AsyncMock(
+        return_value={mem_id: [{"entity_id": ent, "role": "subject"}]}
+    )
+    sc.get_entity = AsyncMock(
+        return_value={"name": "Legacy Entity", "entity_type": "project"}
+    )
+    out = await _fetch_entity_context(sc, mem_id)
+    assert out[0]["name"] == "Legacy Entity"
+
+
+@pytest.mark.asyncio
+async def test_fetch_entity_context_swallows_links_lookup_error():
+    """Storage layer error must NOT propagate — Path C is post-commit
+    and best-effort. Return empty so the empty-context guard fires."""
+    from core_api.services.contradiction_detector import _fetch_entity_context
+
+    sc = AsyncMock()
+    sc.get_entity_links_for_memories = AsyncMock(
+        side_effect=RuntimeError("storage down")
+    )
+    out = await _fetch_entity_context(sc, str(uuid4()))
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_entity_context_swallows_per_entity_error():
+    """Per-entity lookup failure drops that one link but doesn't kill
+    the rest."""
+    from core_api.services.contradiction_detector import _fetch_entity_context
+
+    mem_id = str(uuid4())
+    ent_ok, ent_bad = str(uuid4()), str(uuid4())
+    sc = AsyncMock()
+    sc.get_entity_links_for_memories = AsyncMock(
+        return_value={
+            mem_id: [
+                {"entity_id": ent_ok, "role": "subject"},
+                {"entity_id": ent_bad, "role": "object"},
+            ]
+        }
+    )
+
+    async def get_entity(eid: str) -> dict | None:
+        if eid == ent_bad:
+            raise RuntimeError("entity-row gone")
+        return {"canonical_name": "Fine Entity", "entity_type": "project"}
+
+    sc.get_entity = AsyncMock(side_effect=get_entity)
+    out = await _fetch_entity_context(sc, mem_id)
+    assert len(out) == 1
+    assert out[0]["name"] == "Fine Entity"
+
+
+# ---------------------------------------------------------------------------
+# _llm_entity_aware_contradiction_check — wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_judge_calls_call_with_fallback_with_correct_args():
+    """The judge must route through ``call_with_fallback`` with the
+    entity-aware service label and the same 10s timeout as Path A's
+    judge."""
+    from core_api.services.contradiction_detector import (
+        _llm_entity_aware_contradiction_check,
+    )
+
+    captured: dict = {}
+
+    async def fake_call_with_fallback(**kwargs):
+        captured.update(kwargs)
+        return (False, 0.90)
+
+    with patch(
+        "core_api.services.contradiction_detector.call_with_fallback",
+        side_effect=fake_call_with_fallback,
+    ):
+        result = await _llm_entity_aware_contradiction_check(
+            "new content",
+            "old content",
+            [{"name": "X", "entity_type": "project", "role": "subject"}],
+            [{"name": "Y", "entity_type": "project", "role": "subject"}],
+            tenant_config=None,
+        )
+
+    assert result == (False, 0.90)
+    assert captured["service_label"] == "contradiction-entity-aware"
+    assert captured["timeout"] == 10.0
+    assert captured["model_attr"] == "entity_extraction_model"
+    # fake_fn shape: zero-arg callable returning (bool, float).
+    fake_val = captured["fake_fn"]()
+    assert isinstance(fake_val, tuple) and len(fake_val) == 2
+    assert isinstance(fake_val[0], bool) and isinstance(fake_val[1], float)
+
+
+@pytest.mark.asyncio
+async def test_judge_renders_entities_into_prompt_payload():
+    """The rendered prompt that reaches ``llm.complete_json`` must
+    contain both formatted entity blocks. This is the contract the
+    LLM relies on to ground same_subject."""
+    from core_api.services.contradiction_detector import (
+        _llm_entity_aware_contradiction_check,
+    )
+
+    seen_prompt: dict = {}
+
+    class _Recorder:
+        async def complete_json(self, prompt: str):
+            seen_prompt["text"] = prompt
+            return {
+                "subject_a": "Helios",
+                "subject_b": "Helios",
+                "same_subject": True,
+                "non_conflict_reason": "none",
+                "contradicts": True,
+                "reason": "different dates",
+            }
+
+    async def fake_call_with_fallback(**kwargs):
+        return await kwargs["call_fn"](_Recorder())
+
+    with patch(
+        "core_api.services.contradiction_detector.call_with_fallback",
+        side_effect=fake_call_with_fallback,
+    ):
+        verdict, _conf = await _llm_entity_aware_contradiction_check(
+            "Project Helios has release date 2027-05-01.",
+            "Project Helios has release date 2028-10-15.",
+            [{"name": "Project Helios", "entity_type": "project", "role": "subject"}],
+            [{"name": "Project Helios", "entity_type": "project", "role": "subject"}],
+        )
+
+    assert verdict is True
+    prompt = seen_prompt["text"]
+    assert "Project Helios" in prompt
+    # Both entity blocks must be present and labelled.
+    assert "RESOLVED ENTITIES for Statement A" in prompt
+    assert "RESOLVED ENTITIES for Statement B" in prompt
+    # The bulleted format from _format_entity_context.
+    assert "(type: project, role: subject)" in prompt
+
+
+@pytest.mark.asyncio
+async def test_judge_truncates_long_content_to_500_chars():
+    """Mirror ``_llm_contradiction_check``'s 500-char truncation —
+    keeps token cost bounded for runaway content.
+
+    The prompt template itself contains literal uppercase characters
+    (``Statement A``, ``AUTHORITATIVE``, ``SAME``, ``CRITICAL``,
+    etc.), so counting characters in the rendered prompt mixes
+    template + content. We compare against a baseline render with
+    EMPTY content but identical entities, so the byte-diff equals
+    exactly ``len(truncated_new) + len(truncated_old)``."""
+    from core_api.services.contradiction_detector import (
+        ENTITY_AWARE_CONTRADICTION_PROMPT,
+        _format_entity_context,
+        _llm_entity_aware_contradiction_check,
+    )
+
+    seen_prompt: dict = {}
+
+    class _Recorder:
+        async def complete_json(self, prompt: str):
+            seen_prompt["text"] = prompt
+            return {
+                "subject_a": "x",
+                "subject_b": "x",
+                "same_subject": True,
+                "non_conflict_reason": "none",
+                "contradicts": False,
+                "reason": "ok",
+            }
+
+    async def fake_call_with_fallback(**kwargs):
+        return await kwargs["call_fn"](_Recorder())
+
+    long = "A" * 5000
+    entities = [{"name": "X", "entity_type": "project", "role": "subject"}]
+    with patch(
+        "core_api.services.contradiction_detector.call_with_fallback",
+        side_effect=fake_call_with_fallback,
+    ):
+        await _llm_entity_aware_contradiction_check(
+            long,
+            long,
+            entities,
+            entities,
+        )
+
+    entities_block = _format_entity_context(entities)
+    baseline = ENTITY_AWARE_CONTRADICTION_PROMPT.format(
+        new_content="",
+        old_content="",
+        new_entities=entities_block,
+        old_entities=entities_block,
+    )
+    content_bytes = len(seen_prompt["text"]) - len(baseline)
+    assert content_bytes <= 1000, (
+        f"expected ≤500-char truncation per side (≤1000 total); "
+        f"got {content_bytes} content bytes"
+    )
+    # Sanity: truncation actually fired. Without this guard a future
+    # template that silently drops the truncation would still pass.
+    assert content_bytes < len(long) * 2, (
+        f"expected truncation on 5000-char input; got {content_bytes} bytes "
+        f"(both inputs passed through untrimmed)"
+    )


### PR DESCRIPTION
## Summary

Tier-2 fix for the Path C retraction non-determinism class. CAURA-128 (PR #267) raised the confidence floor 0.60 → 0.90 to mitigate the stochastic-flip case. This PR delivers the deeper fix the original docstring at `contradiction_detector.py:898-901` promised but never implemented: **Path C now asks a structurally different question than Path A**, grounded on resolved entities rather than raw-text NER.

Status report L3.1: `docs/contradiction-detection-status-2026-05-26.html`.

## Architecture diff

**Before (CAURA-128):**
```
_attempt_path_c_retraction
  └─ _llm_contradiction_check(new_content, old_content, ...)   ← same prompt as Path A
                                                                  same inputs as Path A
                                                                  → stochastic flip
```

**After (CAURA-129):**
```
_attempt_path_c_retraction
  ├─ _fetch_entity_context(new_memory)   ── get_entity_links_for_memories + get_entity ×N
  ├─ _fetch_entity_context(candidate)    ── (gather'd in parallel)
  ├─ if either empty → log + skip       ── guard against degenerate inputs
  └─ _llm_entity_aware_contradiction_check(
        new_content, old_content,
        new_entities, old_entities,      ← AUTHORITATIVE entity context
        tenant_config
     )                                    → ENTITY_AWARE_CONTRADICTION_PROMPT
                                           same JSON schema → _judge_contradiction reused
```

## What ships

| Component | Purpose |
|---|---|
| `ENTITY_AWARE_CONTRADICTION_PROMPT` | New template; identical JSON schema to `CONTRADICTION_PROMPT` so the parser is reused. Explicitly frames resolved entities as authoritative. |
| `_format_entity_context(entities)` | Render `{name, entity_type, role}` dicts as a bulleted block for the prompt. |
| `_fetch_entity_context(sc, memory_id)` | Compose `get_entity_links_for_memories` (1 RT, batch) + per-entity `get_entity` (gather'd). Errors swallowed → returns `[]`. |
| `_llm_entity_aware_contradiction_check(...)` | Same fallback chain, same 10s timeout, same parser. Service label `contradiction-entity-aware`. |
| Rewired `_attempt_path_c_retraction` | Fetch both contexts in parallel; skip retraction (log INFO) when either side empty; otherwise call new judge. |

Threshold stays at `_CONF_CLEAN = 0.90` for this PR — we want production signal that the new judge is genuinely more deterministic before lowering it. A follow-up can drop to `_CONF_GATE2` after data.

## Tests (25 collected across both files)

**`tests/test_a4_13_path_c_retraction.py`** — 9 tests, all 7 originals preserve their semantics; patch target updated to the new judge. Default mock now returns one resolved subject per memory. 2 new guard tests:
- `test_no_retraction_when_new_memory_has_no_entity_links`
- `test_no_retraction_when_candidate_has_no_entity_links`

**`tests/test_caura_129_entity_aware_retraction_prompt.py`** *(new)* — 16 direct tests:
- Prompt: required placeholders, JSON schema for parser reuse, authoritative-entity framing, end-to-end `.format()` with realistic inputs.
- `_format_entity_context`: bullets, empty sentinel, missing-field defaults.
- `_fetch_entity_context`: two-round-trip composition, canonical_name/name fallback, links-lookup error swallow, per-entity error tolerance.
- `_llm_entity_aware_contradiction_check`: `call_with_fallback` wiring (service label, timeout, model_attr), prompt payload carries both entity blocks, 500-char truncation per side.

## Validation

- [x] `python -m py_compile` clean on production + both test files.
- [x] `pytest --collect-only` collects 25 tests with no errors.
- [ ] CI runs pytest with Postgres (local environment unavailable).
- [ ] Post-merge wet test: `scripts/repro_contradictions_race.py` on dev. Expect detection rate ≥ 95% across all gaps.

## Cost analysis

Path C is post-commit async (no user is waiting). The new fetch adds **3-4 storage round-trips per retraction attempt**:

- 1 round-trip: batch `get_entity_links_for_memories([new_id, cand_id])` — wait, currently we pass one memory_id at a time per `_fetch_entity_context` call. *Could* be optimised in a follow-up to one batch call covering both memories; not done here to keep diff surgical.
- N round-trips: per-entity `get_entity` calls, parallelised via `asyncio.gather`. Typical N = 2–5 per memory.

Total latency: roughly the slowest `get_entity` call ≈ 50–150ms p95. Invisible to the write path.

## Rollback

Single `git revert` of the merged squash fully restores the post-CAURA-128 state. No DB migration, no schema change, no flag flip.

## Follow-ups (not in this PR)

1. Tier-3 belt-and-suspenders: replace silent retract with `disputed` status + tiebreaker (separate ticket).
2. Per-tenant retraction kill-switch (L3.8).
3. Optional storage micro-opt: one round-trip per retraction via a `get_memory_with_entity_details(memory_id)` endpoint (file as P3 if profiling warrants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)