### PR TITLE
CAURA-130 feat(contradiction): Path C kill-switch + entity-links preflight

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1008,6 +1008,17 @@ def _fake_contradiction_check(new_content: str, old_content: str) -> bool:
 _ENTITY_CONTEXT_MAX_ENTITIES = 10
 _ENTITY_CONTEXT_NAME_MAX_CHARS = 100
 
+# CAURA-130 (L3.4) — upper bound on the fall-through set size before
+# the entity-links subject preflight starts fetching. Each candidate
+# costs one parallel storage round-trip; ``find_entity_overlap_candidates``
+# can theoretically return many rows for a high-fanout subject (popular
+# entity referenced by hundreds of memories), so cap the fan-out before
+# it becomes a thundering-herd risk on the storage API. Above the cap
+# we fail open (skip the L3.4 stage, let the LLM judge decide) rather
+# than drop everything — the legacy A1 #17 gate has already done what
+# it can.
+_ENTITY_LINKS_PREFLIGHT_MAX_CANDIDATES = 20
+
 
 def _format_entity_context(entities: list[dict]) -> str:
     """Render resolved entity rows into a readable block for the prompt.
@@ -1047,6 +1058,41 @@ def _format_entity_context(entities: list[dict]) -> str:
         role = e.get("role") or "<unspecified>"
         lines.append(f'- "{name}" (type: {etype}, role: {role})')
     return "\n".join(lines)
+
+
+def _extract_subject_canonical_identity(
+    entities: list[dict],
+) -> tuple[str, str, str] | None:
+    """CAURA-130 (L3.4) — extract the canonical subject identity from a
+    list of resolved entity rows.
+
+    Returns ``(canonical_name, entity_type, entity_id)`` of the FIRST
+    entity with ``role == "subject"``, or ``None`` if no subject-role
+    entity is present (degenerate / object-only link sets, empty
+    lists, malformed data). Used by the forward-Path-C preflight to
+    catch first-name collisions when ``subject_entity_id`` is NULL on
+    either memory (the A1 #17 legacy gate can't decide those cases —
+    see the inline TODO at the preflight site for the original
+    ``priya``-collision write-up).
+
+    Identity is keyed on ``entity_id`` ONLY — two ``priya`` rows with
+    the same canonical name but different entity rows ARE distinct
+    subjects (that's the whole point). The canonical name + type are
+    returned for logging / debugging, not for equality.
+    """
+    if not entities:
+        return None
+    for e in entities:
+        if (e.get("role") or "").lower() == "subject":
+            name = e.get("canonical_name") or e.get("name") or "<unknown>"
+            etype = e.get("entity_type") or "<unknown>"
+            entity_id = e.get("entity_id") or e.get("id")
+            if not entity_id:
+                # No identity to key on — caller should treat as
+                # "unknown subject" rather than asserting mismatch.
+                continue
+            return (str(name), str(etype), str(entity_id))
+    return None
 
 
 async def _fetch_entity_context(sc, memory_id: str) -> list[dict]:
@@ -1094,10 +1140,14 @@ async def _fetch_entity_context(sc, memory_id: str) -> list[dict]:
             return None
         # ``canonical_name`` is the column on Entity; fall back to
         # ``name`` for any future schema change / mocked-test data.
+        # ``entity_id`` is preserved on the normalised shape (CAURA-
+        # 130 L3.4 — the forward-Path-C preflight uses it as the
+        # canonical-subject identity key).
         return {
             "name": entity.get("canonical_name") or entity.get("name"),
             "entity_type": entity.get("entity_type"),
             "role": link.get("role"),
+            "entity_id": str(entity_id),
         }
 
     hydrated = await asyncio.gather(*(_hydrate(link) for link in links))
@@ -1217,6 +1267,20 @@ async def _attempt_path_c_retraction(
          our read and our write; we treat that as "the retraction is
          no longer ours to do" and swallow it.
     """
+    # CAURA-130 (L3.8) — per-tenant retraction kill-switch. Ops escape
+    # valve: flip ``retraction_enabled`` to False on a misbehaving
+    # tenant to leave Path A's verdict in place unconditionally,
+    # without a deploy. Default ON (no behavior change for existing
+    # tenants — the resolver returns True when the JSONB key is
+    # absent / None). Check before any other work so the early exit
+    # is also cheap.
+    if tenant_config is not None and not getattr(tenant_config, "retraction_enabled", True):
+        logger.info(
+            "Path C retraction skipped — disabled by tenant config for memory %s",
+            new_memory.get("id"),
+        )
+        return False
+
     retraction_target_id = new_memory.get("supersedes_id")
     if not retraction_target_id:
         return False
@@ -1427,7 +1491,8 @@ async def detect_contradictions_by_entities_async(
         # "priya" but resolve to distinct entity rows (see
         # ``followup-path-c-judge-first-name-collisions``) and (2)
         # wasteful API spend regardless. Candidates with NULL
-        # ``subject_entity_id`` on either side fall through unchanged.
+        # ``subject_entity_id`` on either side fall through to the
+        # entity-links preflight below.
         new_subject = new_memory.get("subject_entity_id")
         filtered_candidates = [
             c
@@ -1440,6 +1505,93 @@ async def detect_contradictions_by_entities_async(
             logger.info(
                 "Path C preflight skipped all %d candidates for memory %s (distinct subject_entity_id)",
                 n_preflight_skipped,
+                memory_id,
+            )
+            return
+
+        # CAURA-130 (L3.4) — entity-links subject preflight. The A1 #17
+        # gate above only fires when BOTH sides have non-NULL
+        # ``subject_entity_id``. When one side is NULL (heuristic
+        # missed but entity-extraction worker populated entity_links
+        # with a subject-role entity), same-canonical-name distinct-
+        # entity pairs (the ``priya``-collision case in the original
+        # followup TODO) silently fell through to the LLM judge — which
+        # then mis-classified as a contradiction. Here we resolve the
+        # canonical subject identity from ``entity_links`` for the
+        # affected candidates and drop on identity mismatch.
+        #
+        # Cost: only fetch entity context for candidates whose legacy
+        # ``subject_entity_id`` gate fell through (at least one side
+        # NULL). When BOTH sides have non-NULL ids the A1 #17 gate
+        # already handled them — those candidates skip this stage.
+        # New memory's context fetched once (1 storage round-trip);
+        # remaining work scales with the size of the fall-through set.
+        # The whole stage is wrapped in ``asyncio.wait_for(timeout=
+        # 5.0)`` — on failure we fail-open (keep candidates) rather
+        # than dropping potentially-real contradictions.
+        # Track drops from THIS stage separately from the A1 #17
+        # legacy gate above — the final log message attributes the
+        # count to the entity-links stage, so mixing in the legacy
+        # drops would be misleading.
+        n_entity_links_skipped = 0
+        fallthrough = [c for c in candidates if new_subject is None or c.get("subject_entity_id") is None]
+        if len(fallthrough) > _ENTITY_LINKS_PREFLIGHT_MAX_CANDIDATES:
+            # Bound the storage fan-out. A popular entity can produce
+            # a large fall-through set; gathering N parallel fetches
+            # against the storage API risks a thundering herd. Above
+            # the cap we fail open: skip the L3.4 stage entirely and
+            # let the LLM judge handle the candidates. The legacy A1
+            # #17 gate has already done what it can; we don't drop
+            # candidates we couldn't verify.
+            logger.warning(
+                "Path C entity-links preflight skipped for memory %s — "
+                "fall-through set size %d > cap %d. Falling through to LLM judge.",
+                memory_id,
+                len(fallthrough),
+                _ENTITY_LINKS_PREFLIGHT_MAX_CANDIDATES,
+            )
+        elif fallthrough:
+            try:
+                new_ctx, *cand_ctxs = await asyncio.wait_for(
+                    asyncio.gather(
+                        _fetch_entity_context(sc, str(memory_id)),
+                        *(_fetch_entity_context(sc, str(c.get("id"))) for c in fallthrough),
+                    ),
+                    timeout=5.0,
+                )
+                new_identity = _extract_subject_canonical_identity(new_ctx)
+                if new_identity is not None:
+                    new_eid = new_identity[2]
+                    drop_ids: set[str] = set()
+                    for c, ctx in zip(fallthrough, cand_ctxs, strict=False):
+                        cand_identity = _extract_subject_canonical_identity(ctx)
+                        if cand_identity is None:
+                            continue  # No subject resolved — fail open.
+                        if cand_identity[2] != new_eid:
+                            drop_ids.add(str(c.get("id")))
+                    if drop_ids:
+                        before = len(candidates)
+                        candidates = [c for c in candidates if str(c.get("id")) not in drop_ids]
+                        n_entity_links_skipped = before - len(candidates)
+                        logger.info(
+                            "Path C entity-links preflight dropped %d candidate(s) "
+                            "for memory %s (canonical subjects differ by entity_id)",
+                            n_entity_links_skipped,
+                            memory_id,
+                        )
+            except Exception as e:
+                # Fail open — keep candidates and let the LLM judge
+                # decide. Conservative against losing real
+                # contradictions on a transient storage hiccup.
+                logger.warning(
+                    "Path C entity-links preflight failed for memory %s: %s. Falling through to LLM judge.",
+                    memory_id,
+                    e,
+                )
+        if not candidates:
+            logger.info(
+                "Path C preflight skipped all %d candidates for memory %s (entity-links subject mismatch)",
+                n_entity_links_skipped,
                 memory_id,
             )
             return

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -114,6 +114,13 @@ DEFAULT_SETTINGS: dict = {
         # instead of falling through to the LLM. ``None`` resolves to
         # the global default (true).
         "triple_emission_enabled": None,
+        # CAURA-130 (L3.8) — Path C retraction kill-switch. When true
+        # (the default), Path C's ``_attempt_path_c_retraction`` runs
+        # the entity-aware judge and may revert a Path A verdict. When
+        # false, Path C skips retraction entirely and Path A's verdict
+        # stands. Ops escape valve for tenants whose retraction
+        # misbehaves; flip per-tenant without a deploy.
+        "retraction_enabled": None,
     },
     "agents": {
         "require_agent_approval": None,
@@ -327,6 +334,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "entity_blocklist": list,
     "memclaw.auto_upgrade_enabled": bool,
     "write.triple_emission_enabled": bool,
+    "write.retraction_enabled": bool,
 }
 
 # Inclusive range constraints applied AFTER type validation. Listed
@@ -583,6 +591,15 @@ class ResolvedConfig:
         # CAURA-123 — default ON. Tenants can opt out per-org without
         # a deploy (instant rollback path).
         val = self._ts.get("write", {}).get("triple_emission_enabled")
+        return bool(val) if val is not None else True
+
+    @property
+    def retraction_enabled(self) -> bool:
+        # CAURA-130 (L3.8) — default ON. Per-tenant kill-switch for
+        # Path C's retraction phase. Flip to False to leave Path A's
+        # verdict in place unconditionally for this tenant; useful as
+        # an ops escape valve if a tenant's retraction misbehaves.
+        val = self._ts.get("write", {}).get("retraction_enabled")
         return bool(val) if val is not None else True
 
     # Agents

--- a/tests/test_a4_13_path_c_retraction.py
+++ b/tests/test_a4_13_path_c_retraction.py
@@ -579,3 +579,95 @@ async def test_no_retraction_when_candidate_has_no_entity_links():
         "empty entity_links on candidate must skip retraction without "
         "invoking the judge"
     )
+
+
+# ---------------------------------------------------------------------------
+# CAURA-130 (L3.8) — Per-tenant retraction kill-switch.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_disabled_skips_retraction():
+    """CAURA-130 — when ``tenant_config.retraction_enabled`` is False
+    the judge MUST NOT be invoked and Path A's verdict stands. Ops
+    escape valve for misbehaving tenants."""
+    from types import SimpleNamespace
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    sc = _mock_sc_with_retraction_setup(new_id, cand_id)
+    judge = AsyncMock(return_value=(False, 0.95))
+    disabled_cfg = SimpleNamespace(retraction_enabled=False)
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
+            judge,
+        ),
+        # Patch at the SOURCE module — ``resolve_config`` is imported
+        # function-local in ``detect_contradictions_by_entities_async``
+        # (line ~1422), so patching the consuming module is a no-op.
+        # Patching at the source intercepts the function-local
+        # ``from ... import resolve_config`` rebind on every call.
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new_callable=AsyncMock,
+            return_value=disabled_cfg,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    judge.assert_not_called()
+    revert_calls = [
+        c
+        for c in sc.update_memory_status.call_args_list
+        if c.args == (str(cand_id), "active")
+    ]
+    assert revert_calls == [], (
+        "retraction_enabled=False must skip retraction entirely without "
+        "invoking the judge"
+    )
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_enabled_default_allows_retraction():
+    """CAURA-130 — when ``tenant_config.retraction_enabled`` is True
+    (the default), retraction proceeds as normal. Sanity test that the
+    kill-switch only gates when explicitly off."""
+    from types import SimpleNamespace
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    sc = _mock_sc_with_retraction_setup(new_id, cand_id)
+    enabled_cfg = SimpleNamespace(retraction_enabled=True)
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
+            new_callable=AsyncMock,
+            return_value=(False, 0.95),  # clean disagreement → retract
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new_callable=AsyncMock,
+            return_value=enabled_cfg,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    assert any(
+        c.args == (str(cand_id), "active")
+        for c in sc.update_memory_status.call_args_list
+    ), "retraction_enabled=True must still allow the canonical retract path"

--- a/tests/test_caura_130_path_c_safety.py
+++ b/tests/test_caura_130_path_c_safety.py
@@ -1,0 +1,488 @@
+"""CAURA-130 — Direct unit tests for the Path C safety controls:
+
+  * ``_extract_subject_canonical_identity`` — pure helper, no I/O.
+  * Forward-path entity-links preflight in
+    ``detect_contradictions_by_entities_async`` (L3.4): when the
+    legacy ``subject_entity_id`` gate falls through (NULL on at
+    least one side), the entity-links subject identity gate fires
+    and drops candidates whose canonical subjects are distinct
+    entity rows (the original ``priya``-collision case from the
+    inline TODO).
+  * ``ResolvedConfig.retraction_enabled`` resolver (L3.8): JSONB
+    absence → True; explicit False → False; explicit True → True.
+
+The kill-switch behaviour in ``_attempt_path_c_retraction`` itself
+is locked in by tests in ``tests/test_a4_13_path_c_retraction.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# _extract_subject_canonical_identity — pure helper
+# ---------------------------------------------------------------------------
+
+
+def test_subject_identity_extracts_first_subject_role():
+    from core_api.services.contradiction_detector import (
+        _extract_subject_canonical_identity,
+    )
+
+    out = _extract_subject_canonical_identity(
+        [
+            {
+                "name": "Project Helios",
+                "entity_type": "project",
+                "role": "subject",
+                "entity_id": "ent-1",
+            },
+            {
+                "name": "2027-05-01",
+                "entity_type": "date",
+                "role": "object",
+                "entity_id": "ent-2",
+            },
+        ]
+    )
+    assert out == ("Project Helios", "project", "ent-1")
+
+
+def test_subject_identity_empty_list_returns_none():
+    from core_api.services.contradiction_detector import (
+        _extract_subject_canonical_identity,
+    )
+
+    assert _extract_subject_canonical_identity([]) is None
+
+
+def test_subject_identity_no_subject_role_returns_none():
+    """Only ``object``-role entities → no subject identity to key on."""
+    from core_api.services.contradiction_detector import (
+        _extract_subject_canonical_identity,
+    )
+
+    out = _extract_subject_canonical_identity(
+        [
+            {
+                "name": "2027-05-01",
+                "entity_type": "date",
+                "role": "object",
+                "entity_id": "ent-1",
+            },
+        ]
+    )
+    assert out is None
+
+
+def test_subject_identity_falls_back_to_name_when_no_canonical_name():
+    """Raw entity rows (rather than the normalised shape from
+    ``_fetch_entity_context``) may carry ``name`` directly. The helper
+    must still extract a subject."""
+    from core_api.services.contradiction_detector import (
+        _extract_subject_canonical_identity,
+    )
+
+    out = _extract_subject_canonical_identity(
+        [
+            {
+                "name": "Priya Patel",
+                "entity_type": "person",
+                "role": "subject",
+                "entity_id": "ent-priya-1",
+            }
+        ]
+    )
+    assert out == ("Priya Patel", "person", "ent-priya-1")
+
+
+def test_subject_identity_skips_subject_with_no_entity_id():
+    """A subject-role entry with no ``entity_id`` carries no identity
+    to compare against; skip it (and continue searching for another
+    subject)."""
+    from core_api.services.contradiction_detector import (
+        _extract_subject_canonical_identity,
+    )
+
+    out = _extract_subject_canonical_identity(
+        [
+            {"name": "phantom", "entity_type": "person", "role": "subject"},
+            {
+                "name": "Real Subject",
+                "entity_type": "person",
+                "role": "subject",
+                "entity_id": "ent-real",
+            },
+        ]
+    )
+    assert out == ("Real Subject", "person", "ent-real")
+
+
+def test_subject_identity_role_match_is_case_insensitive():
+    """Some storage paths may produce ``Subject`` rather than
+    ``subject``. Be lenient on case for the role match."""
+    from core_api.services.contradiction_detector import (
+        _extract_subject_canonical_identity,
+    )
+
+    out = _extract_subject_canonical_identity(
+        [
+            {
+                "name": "X",
+                "entity_type": "project",
+                "role": "Subject",
+                "entity_id": "ent-x",
+            }
+        ]
+    )
+    assert out is not None
+    assert out[2] == "ent-x"
+
+
+# ---------------------------------------------------------------------------
+# ResolvedConfig.retraction_enabled — JSONB resolver
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_config_retraction_enabled_defaults_true_on_empty_settings():
+    from core_api.services.organization_settings import ResolvedConfig
+
+    cfg = ResolvedConfig({})
+    assert cfg.retraction_enabled is True
+
+
+def test_resolved_config_retraction_enabled_defaults_true_when_unset_in_write_block():
+    """The JSONB key may be present at the ``write`` block level but
+    explicitly ``None`` — that still means "use the global default"
+    which is True."""
+    from core_api.services.organization_settings import ResolvedConfig
+
+    cfg = ResolvedConfig({"write": {"retraction_enabled": None}})
+    assert cfg.retraction_enabled is True
+
+
+def test_resolved_config_retraction_enabled_explicit_false_disables():
+    from core_api.services.organization_settings import ResolvedConfig
+
+    cfg = ResolvedConfig({"write": {"retraction_enabled": False}})
+    assert cfg.retraction_enabled is False
+
+
+def test_resolved_config_retraction_enabled_explicit_true_enables():
+    from core_api.services.organization_settings import ResolvedConfig
+
+    cfg = ResolvedConfig({"write": {"retraction_enabled": True}})
+    assert cfg.retraction_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Forward-path L3.4 entity-links preflight
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(
+    mid, *, subject_entity_id=None, content: str = "candidate content"
+) -> dict:
+    return {
+        "id": str(mid),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "content": content,
+        "subject_entity_id": subject_entity_id,
+        "visibility": "scope_team",
+        "deleted_at": None,
+        "created_at": "2026-05-24T10:00:00+00:00",
+    }
+
+
+def _make_new_memory(mid, *, subject_entity_id=None) -> dict:
+    return {
+        "id": str(mid),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "content": "new memory content",
+        "subject_entity_id": subject_entity_id,
+        "visibility": "scope_team",
+        "supersedes_id": None,
+        "deleted_at": None,
+        "created_at": "2026-05-24T11:00:00+00:00",
+    }
+
+
+def _sc_for_forward_path(
+    new_mem: dict, candidates: list[dict], links_by_mem: dict[str, list[dict]]
+) -> AsyncMock:
+    """Build a mock storage client for the forward Path C path."""
+    sc = AsyncMock()
+
+    async def get_memory(mid: str):
+        if mid == new_mem["id"]:
+            return new_mem
+        for c in candidates:
+            if c["id"] == mid:
+                return c
+        return None
+
+    sc.get_memory = AsyncMock(side_effect=get_memory)
+    sc.find_entity_overlap_candidates = AsyncMock(return_value=candidates)
+    sc.update_memory_status = AsyncMock()
+    sc.get_entity_links_for_memories = AsyncMock(return_value=links_by_mem)
+
+    async def get_entity(eid: str):
+        # Synthesize a minimal entity row keyed by id; tests pass the
+        # canonical_name they want here via the links_by_mem structure
+        # (we encode it in the link by using entity_id == "ent:<name>").
+        return {
+            "id": eid,
+            "canonical_name": eid.split(":", 1)[-1] if ":" in eid else eid,
+            "entity_type": "person" if "priya" in eid else "project",
+        }
+
+    sc.get_entity = AsyncMock(side_effect=get_entity)
+    install_batch_status_replay_shim(sc)
+    return sc
+
+
+@pytest.mark.asyncio
+async def test_forward_preflight_drops_collision_when_subject_entity_id_null():
+    """The legacy A1 #17 gate can't decide cases where ``subject_entity_id``
+    is NULL on at least one side. CAURA-130 L3.4 — resolve the canonical
+    subject via entity_links; drop the candidate when subjects are
+    distinct entity rows even though canonical names match."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    new_mem = _make_new_memory(new_id, subject_entity_id=None)
+    cand = _make_candidate(cand_id, subject_entity_id=None)
+    # Same canonical name ("Priya"), different entity_ids → distinct
+    # real-world subjects → preflight must drop.
+    links = {
+        str(new_id): [{"entity_id": "ent:priya-A", "role": "subject"}],
+        str(cand_id): [{"entity_id": "ent:priya-B", "role": "subject"}],
+    }
+    sc = _sc_for_forward_path(new_mem, [cand], links)
+    judge = AsyncMock(return_value=(True, 0.95))
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    judge.assert_not_called()
+    assert sc.update_memory_status.call_args_list == [], (
+        "candidate with distinct entity_id under same canonical name "
+        "must be dropped by the L3.4 preflight"
+    )
+
+
+@pytest.mark.asyncio
+async def test_forward_preflight_keeps_candidate_when_subjects_truly_match():
+    """Same canonical name AND same entity_id → same subject → preflight
+    must NOT drop; let the LLM judge handle it."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    new_mem = _make_new_memory(new_id, subject_entity_id=None)
+    cand = _make_candidate(cand_id, subject_entity_id=None)
+    links = {
+        str(new_id): [{"entity_id": "ent:project-helios", "role": "subject"}],
+        str(cand_id): [{"entity_id": "ent:project-helios", "role": "subject"}],
+    }
+    sc = _sc_for_forward_path(new_mem, [cand], links)
+    judge = AsyncMock(return_value=(False, 0.95))  # judge says not a contradiction
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    judge.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_forward_preflight_skipped_when_both_subject_ids_nonnull():
+    """Cost guard — when BOTH sides have non-NULL ``subject_entity_id``,
+    the legacy A1 #17 gate already covered it; the L3.4 entity-links
+    stage must NOT issue a fetch (saves the round-trips)."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    # Same subject_entity_id on both sides — legacy gate passes them
+    # both through, and L3.4 stage must skip the fetch.
+    same_sid = "sid-shared"
+    new_mem = _make_new_memory(new_id, subject_entity_id=same_sid)
+    cand = _make_candidate(cand_id, subject_entity_id=same_sid)
+    sc = _sc_for_forward_path(new_mem, [cand], {})
+    judge = AsyncMock(return_value=(False, 0.95))
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    # The fetch path must not run when both sides have non-NULL ids.
+    sc.get_entity_links_for_memories.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_forward_preflight_fails_open_on_storage_error():
+    """Storage failure during the entity-links fetch must NOT drop
+    candidates — fail open and let the LLM judge decide. Conservative
+    against losing real contradictions on a transient hiccup."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    new_mem = _make_new_memory(new_id, subject_entity_id=None)
+    cand = _make_candidate(cand_id, subject_entity_id=None)
+    sc = _sc_for_forward_path(new_mem, [cand], {})
+    sc.get_entity_links_for_memories = AsyncMock(
+        side_effect=RuntimeError("storage down")
+    )
+    judge = AsyncMock(return_value=(False, 0.95))
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    # Storage failure must not prevent the judge from running.
+    judge.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_forward_preflight_caps_fallthrough_set_at_max():
+    """CAURA-130 (L3.4) — when the fall-through set exceeds the
+    ``_ENTITY_LINKS_PREFLIGHT_MAX_CANDIDATES`` cap, the L3.4 stage
+    must skip the fan-out fetch entirely and fail-open (let the LLM
+    judge decide). Bounds the storage round-trip blast radius for
+    popular entities with high candidate-count."""
+    from core_api.services.contradiction_detector import (
+        _ENTITY_LINKS_PREFLIGHT_MAX_CANDIDATES,
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id = uuid4()
+    new_mem = _make_new_memory(new_id, subject_entity_id=None)
+    # Build cap + 5 candidates, all with NULL subject_entity_id so
+    # they all fall through.
+    cand_ids = [uuid4() for _ in range(_ENTITY_LINKS_PREFLIGHT_MAX_CANDIDATES + 5)]
+    cands = [_make_candidate(cid, subject_entity_id=None) for cid in cand_ids]
+    sc = _sc_for_forward_path(new_mem, cands, {})
+    judge = AsyncMock(return_value=(False, 0.95))
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    # The fan-out fetch must NOT run when the set exceeds the cap.
+    sc.get_entity_links_for_memories.assert_not_called()
+    # Fail-open: judge still runs on each candidate.
+    assert judge.call_count == len(cands), (
+        f"expected {len(cands)} judge calls (fail-open), got {judge.call_count}"
+    )


### PR DESCRIPTION
## Summary

Two safety controls on Path C contradiction detection, bundled because they touch the same code path and share testing infrastructure.

### L3.8 — Per-tenant retraction kill-switch

CAURA-128/129 tightened the retraction judge but left no operational escape valve. This PR adds `ResolvedConfig.retraction_enabled` (default `True`) backed by `organization_settings.settings["write"]["retraction_enabled"]`. Ops can flip per-tenant in the JSONB blob without a deploy.

Mirrors the existing `triple_emission_enabled` pattern (CAURA-123):
- `DEFAULT_SETTINGS["write"]["retraction_enabled"]` — `None` placeholder; resolver returns `True` when None/absent.
- `_LEAF_TYPES["write.retraction_enabled"] = bool` — type validation on PATCH.
- `ResolvedConfig.retraction_enabled` — property reading the blob with True default.
- Early-return at the top of `_attempt_path_c_retraction` with INFO log.

### L3.4 — Entity-links subject preflight (forward Path C)

The A1 #17 subject preflight only fires when **both** memories have non-NULL `subject_entity_id`. When one side is NULL (heuristic missed but entity-extraction populated `entity_links` with a subject-role entity), same-canonical-name distinct-entity pairs — the **`priya`-collision case** from the inline TODO at `contradiction_detector.py:1100` — silently fell through to the LLM judge, which mis-classified them as contradictions.

New plumbing:
- `_extract_subject_canonical_identity(entities)` — pure helper returning `(canonical_name, entity_type, entity_id)` of the first subject-role entity, or `None`. Identity keyed on `entity_id`.
- `_fetch_entity_context`'s hydrated row now includes `entity_id` (additive; doesn't break CAURA-129 consumers).
- Forward Path C preflight (post A1 #17 filter): fetches entity context for the fall-through set (candidates where `subject_entity_id` is NULL on at least one side), compares canonical identity by `entity_id`, drops on mismatch.

### Cost guards (per D3 in the plan)

| Case | Behaviour |
|---|---|
| Both `subject_entity_id` non-NULL | L3.4 stage **skips entirely** — legacy A1 #17 already covered it. Zero new round-trips. |
| At least one side NULL | Fetch via parallel `gather` wrapped in `asyncio.wait_for(timeout=5.0)`. 1 RT for new_memory + N RTs for fall-through candidates. |
| Storage error / timeout / missing subject identity | **Fail-open** — keep candidates, let the LLM judge decide. Conservative against losing real contradictions on a transient hiccup. |

## Tests (25 collected across both files)

**`tests/test_a4_13_path_c_retraction.py`** — 2 new kill-switch tests:
- `test_kill_switch_disabled_skips_retraction`
- `test_kill_switch_enabled_default_allows_retraction`

**`tests/test_caura_130_path_c_safety.py`** *(new — 14 tests)*:
- **6** `_extract_subject_canonical_identity` helper tests (first-subject-role, empty, no-subject, name fallback, skip missing entity_id, role match case-insensitive).
- **4** `ResolvedConfig.retraction_enabled` resolver tests (defaults, explicit True/False).
- **4** forward-path preflight tests:
  - Drops collision when `subject_entity_id` NULL on either side.
  - Keeps candidate when subjects truly match (same entity_id).
  - Skipped entirely when both subject_entity_id non-NULL (zero RT cost).
  - Fails open on storage error.

All CAURA-128/129 tests preserved unchanged.

## Validation

- [x] `python -m py_compile` clean.
- [x] `uv run ruff check core-api/src/` clean.
- [x] `uv run ruff format --check` clean.
- [x] `pytest --collect-only` collects 25 tests.
- [ ] CI runs full pytest (Postgres required for autouse fixture).
- [ ] Post-merge wet test:
  - Re-run `scripts/repro_contradictions_race.py` on dev → expect ≥95% detection across all gaps.
  - Optional: build a synthetic ``priya``-collision repro to confirm L3.4 drops the false-positive.

## Rollback

Single `git revert` of the merged squash. No DB migration, no schema change. Per-tenant kill-switch state lives in JSONB; clearing the key restores default-ON behaviour.

## Follow-ups (not in this PR)

- L3.4 in retraction path — already handled by CAURA-129's entity-aware judge; no change needed.
- Per-fleet kill-switch granularity — defer until tenant-level proves insufficient.
- Tier-3 `disputed` status + tiebreaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)