### PR TITLE
fix(plugin): context-engine auto-recall, smoke cleanup & post-upgrade allowlist drift

### DIFF
--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -4,6 +4,7 @@ import {
   isMemorySlotClaimed,
   isContextEngineSlotClaimed,
   isMemclawFullyConfigured,
+  shouldRunAutoFix,
 } from "./config.js";
 import { getPluginDir } from "./paths.js";
 
@@ -118,5 +119,52 @@ describe("isMemclawFullyConfigured — contextEngine slot is now required", () =
     const c = happyConfig();
     (c as any).plugins.slots.contextEngine = "legacy";
     assert.equal(isMemclawFullyConfigured(c), false);
+  });
+});
+
+describe("shouldRunAutoFix — allowlist drift gate", () => {
+  // The original gate ran auto-fix once (guarded by .allowlist-applied),
+  // so a plugin upgrade that ADDED a tool (memclaw_keystones) never landed
+  // it in tools.alsoAllow on existing installs — and a later OpenClaw
+  // tools.profile then stripped it. The gate now also re-runs on drift.
+  const clean = {
+    flagExists: true,
+    missingToolCount: 0,
+    contextEngineSlotClaimed: true,
+  };
+
+  test("MEMCLAW_AUTO_FIX_CONFIG=true always runs (explicit force)", () => {
+    assert.equal(shouldRunAutoFix({ ...clean, autoFixEnv: "true" }), true);
+  });
+
+  test("MEMCLAW_AUTO_FIX_CONFIG=false never runs, even with drift", () => {
+    assert.equal(
+      shouldRunAutoFix({
+        autoFixEnv: "false",
+        flagExists: false,
+        missingToolCount: 5,
+        contextEngineSlotClaimed: false,
+      }),
+      false,
+    );
+  });
+
+  test("first run (no flag) runs", () => {
+    assert.equal(shouldRunAutoFix({ ...clean, flagExists: false }), true);
+  });
+
+  test("re-runs when a tool is missing despite the flag (the keystones upgrade case)", () => {
+    assert.equal(shouldRunAutoFix({ ...clean, missingToolCount: 1 }), true);
+  });
+
+  test("re-runs when the contextEngine slot is unclaimed despite the flag", () => {
+    assert.equal(
+      shouldRunAutoFix({ ...clean, contextEngineSlotClaimed: false }),
+      true,
+    );
+  });
+
+  test("no-ops on a clean install with the flag present", () => {
+    assert.equal(shouldRunAutoFix(clean), false);
   });
 });

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -230,3 +230,35 @@ export function getMissingTools(config: Record<string, any>): string[] {
   if (!Array.isArray(alsoAllow)) return [...MEMCLAW_TOOLS];
   return MEMCLAW_TOOLS.filter((t) => !alsoAllow.includes(t));
 }
+
+/**
+ * Decide whether ``autoFixAllowlist`` should run on this registration.
+ *
+ * Pure so it can be unit-tested. The original gate ran auto-fix exactly
+ * once (guarded by the ``.allowlist-applied`` flag file), which meant a
+ * plugin upgrade that ADDED a tool to ``MEMCLAW_TOOLS`` (e.g.
+ * ``memclaw_keystones``) never got that tool into ``tools.alsoAllow`` on
+ * an existing install — so a later OpenClaw ``tools.profile`` (which only
+ * grants core tools + ``alsoAllow``) silently stripped it. We now also
+ * re-run when there is drift: a missing tool or an unclaimed contextEngine
+ * slot. ``autoFixAllowlist`` is idempotent (writes only on change) so a
+ * clean install with the flag present still no-ops.
+ *
+ *   - ``MEMCLAW_AUTO_FIX_CONFIG=true``  → always run (explicit force).
+ *   - ``MEMCLAW_AUTO_FIX_CONFIG=false`` → never run (explicit opt-out).
+ *   - unset → run on first registration (no flag) OR when drift exists.
+ */
+export function shouldRunAutoFix(params: {
+  autoFixEnv?: string;
+  flagExists: boolean;
+  missingToolCount: number;
+  contextEngineSlotClaimed: boolean;
+}): boolean {
+  if (params.autoFixEnv === "true") return true;
+  if (params.autoFixEnv === "false") return false;
+  return (
+    !params.flagExists ||
+    params.missingToolCount > 0 ||
+    !params.contextEngineSlotClaimed
+  );
+}

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -12,7 +12,7 @@
  */
 
 import { createHash } from "crypto";
-import { apiCall } from "./transport.js";
+import { apiCall, parseSearchItems } from "./transport.js";
 import {
   MEMCLAW_FLEET_ID,
   MEMCLAW_TENANT_ID,
@@ -463,8 +463,11 @@ export class MemClawContextEngine {
 
     const testContent = `memclaw-smoke-${Date.now()}`;
     let writtenId: string | null = null;
+    // Hoisted out of the try so the finally-block cleanup DELETE can pass
+    // the tenant_id the backend requires (see below).
+    let tid: string | null = null;
     try {
-      const tid = await ensureTenantId();
+      tid = await ensureTenantId();
       const wr = (await apiCall("POST", "/memories", {
         tenant_id: tid,
         agent_id: "__health_check__",
@@ -490,9 +493,7 @@ export class MemClawContextEngine {
           query: testContent,
           top_k: 1,
         })) as Record<string, unknown> | Record<string, unknown>[];
-        const firstResult = Array.isArray(sr)
-          ? sr[0]
-          : ((sr?.results as Record<string, unknown>[]) || [])[0];
+        const firstResult = parseSearchItems(sr)[0];
         top = firstResult as Record<string, unknown> | undefined;
         score = (top?.score as number) ?? (top?.similarity as number) ?? 0;
         if (top && score >= 0.7) break;
@@ -514,10 +515,15 @@ export class MemClawContextEngine {
     } catch (e: unknown) {
       logErrorCritical("SMOKE TEST ERROR", e);
     } finally {
-      if (writtenId) {
+      // DELETE /memories/{id} requires tenant_id as a query param
+      // (core-api ``tenant_id: str = Query(...)``); omitting it returns 422
+      // and the smoke-test memory leaks into the tenant on every restart.
+      if (writtenId && tid) {
         apiCall(
           "DELETE",
           `/memories/${encodeURIComponent(writtenId)}`,
+          undefined,
+          { tenant_id: tid },
         ).catch(() => {});
       }
     }
@@ -811,11 +817,7 @@ export class MemClawContextEngine {
           undefined,
           controller.signal,
         )) as Record<string, unknown> | Record<string, unknown>[];
-        const results = Array.isArray(sr)
-          ? sr
-          : ((sr as Record<string, unknown>)?.results as
-              | Record<string, unknown>[]
-              | undefined) || [];
+        const results = parseSearchItems(sr);
         if (results.length > 0) {
           const lines = results.map(
             (m: Record<string, unknown>) =>

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -36,7 +36,7 @@ import {
   HEARTBEAT_INITIAL_DELAY_MS,
   MAX_SOURCE_SIZE,
 } from "./env.js";
-import { apiCall } from "./transport.js";
+import { apiCall, parseSearchItems } from "./transport.js";
 import { PLUGIN_VERSION } from "./version.js";
 import {
   memclawPromptSectionBuilder,
@@ -55,6 +55,7 @@ import {
   isMemclawPathLoaded,
   isMemclawFullyConfigured,
   isContextEngineSlotClaimed,
+  shouldRunAutoFix,
 } from "./config.js";
 import { createToolFromSpec } from "./tool-definitions.js";
 import { deployPlugin } from "./deploy.js";
@@ -101,9 +102,7 @@ async function searchMemories(
       "/search",
       { tenant_id: tid, query, top_k: limit },
     )) as Record<string, unknown> | Record<string, unknown>[];
-    const arr = Array.isArray(results)
-      ? results
-      : ((results as Record<string, unknown>)?.results as Record<string, unknown>[]) ?? [];
+    const arr = parseSearchItems(results);
     return arr.map((m: Record<string, unknown>) => ({
       content: (m.content as string) || "",
       path: `memclaw://${m.id}`,
@@ -401,9 +400,24 @@ const memclawPlugin = {
     const allowlistFlagPath = join(getPluginDir(), ".allowlist-applied");
     const autoFixEnv = process.env.MEMCLAW_AUTO_FIX_CONFIG;
     const flagExists = existsSync(allowlistFlagPath);
-    const shouldAutoFix =
-      autoFixEnv === "true" ||                    // explicit force
-      (!flagExists && autoFixEnv !== "false");     // first run, not opted out
+    // Read config once to detect drift so auto-fix re-runs even when the
+    // one-time flag is already present: a plugin upgrade that ADDS a tool
+    // to MEMCLAW_TOOLS (e.g. memclaw_keystones) would otherwise never land
+    // in tools.alsoAllow on an existing install, and a later OpenClaw
+    // tools.profile (core tools + alsoAllow only) silently strips it.
+    // autoFixAllowlist is idempotent (writes only on change), so a clean
+    // install with the flag present still no-ops.
+    const preFixConfig = readOpenClawConfig() as Record<string, any> | null;
+    const shouldAutoFix = shouldRunAutoFix({
+      autoFixEnv,
+      flagExists,
+      missingToolCount: preFixConfig
+        ? getMissingTools(preFixConfig).length
+        : MEMCLAW_TOOLS.length,
+      contextEngineSlotClaimed: preFixConfig
+        ? isContextEngineSlotClaimed(preFixConfig)
+        : false,
+    });
 
     if (shouldAutoFix) {
       try {

--- a/plugin/src/transport.test.ts
+++ b/plugin/src/transport.test.ts
@@ -12,7 +12,7 @@ process.env.MEMCLAW_API_KEY = "mc_test_key_for_transport_tests";
 process.env.MEMCLAW_API_URL = "http://localhost:8000";
 process.env.MEMCLAW_TENANT_ID = "t_test";
 
-const { apiCall } = await import("./transport.js");
+const { apiCall, parseSearchItems } = await import("./transport.js");
 
 interface MockCall {
   url: string;
@@ -78,5 +78,51 @@ describe("apiCall — MEMCLAW_API_PREFIX handling", () => {
       calls[0].url,
       "http://localhost:8000/api/v1/memories?tenant_id=t1",
     );
+  });
+});
+
+describe("parseSearchItems — search-response shape handling", () => {
+  // Regression guard: the REST /search endpoint returns { items: [...] }
+  // (core-api SearchResponse), but the plugin historically read .results
+  // and silently got [] — breaking context-engine auto-recall and the
+  // bootstrap smoke test. items must win, with results + bare-array
+  // fallbacks for the MCP-shaped and legacy responses.
+  const m = (id: string) => ({ id, content: `c-${id}` });
+
+  test("reads the REST `items` array", () => {
+    const out = parseSearchItems({ items: [m("a"), m("b")] });
+    assert.deepEqual(out.map((r) => r.id), ["a", "b"]);
+  });
+
+  test("falls back to `results` (MCP-shaped response)", () => {
+    const out = parseSearchItems({ results: [m("a")] });
+    assert.deepEqual(out.map((r) => r.id), ["a"]);
+  });
+
+  test("prefers `items` over `results` when both present", () => {
+    const out = parseSearchItems({ items: [m("i")], results: [m("r")] });
+    assert.deepEqual(out.map((r) => r.id), ["i"]);
+  });
+
+  test("accepts a bare array", () => {
+    const out = parseSearchItems([m("a"), m("b")]);
+    assert.equal(out.length, 2);
+  });
+
+  test("returns [] for empty / null / primitive / missing keys", () => {
+    assert.deepEqual(parseSearchItems({}), []);
+    assert.deepEqual(parseSearchItems(null), []);
+    assert.deepEqual(parseSearchItems(undefined), []);
+    assert.deepEqual(parseSearchItems("nope"), []);
+    assert.deepEqual(parseSearchItems({ items: undefined }), []);
+  });
+
+  test("returns [] when items/results is present but NOT an array (never throws)", () => {
+    // Malformed server responses must not slip through the cast and make
+    // callers' .map/.length throw.
+    assert.deepEqual(parseSearchItems({ items: {} }), []);
+    assert.deepEqual(parseSearchItems({ items: "oops" }), []);
+    assert.deepEqual(parseSearchItems({ items: 42 }), []);
+    assert.deepEqual(parseSearchItems({ results: { nested: true } }), []);
   });
 });

--- a/plugin/src/transport.ts
+++ b/plugin/src/transport.ts
@@ -101,6 +101,28 @@ export async function apiCall(
   }
 }
 
+/**
+ * Extract the memory array from a ``POST /search`` response.
+ *
+ * The REST search endpoint returns ``{ items: [...] }`` (core-api
+ * ``SearchResponse(items=...)``), while the MCP ``memclaw_recall`` path
+ * returns ``{ results: [...] }`` and some legacy/test shims return a bare
+ * array. Reading only ``.results`` (as we did pre-fix) silently yielded
+ * ``[]`` against the REST backend — breaking context-engine auto-recall
+ * and the bootstrap smoke test. Prefer ``items`` (the live REST contract),
+ * fall back to ``results``, and accept a bare array. Never throws.
+ */
+export function parseSearchItems(sr: unknown): Record<string, unknown>[] {
+  if (Array.isArray(sr)) return sr as Record<string, unknown>[];
+  const o = sr as Record<string, unknown> | null | undefined;
+  // Guard with Array.isArray: a malformed response like ``{ items: {} }``
+  // or ``{ items: "..." }`` would otherwise slip through the cast and make
+  // callers' ``.map`` / ``.length`` throw — breaking the "never throws"
+  // contract above. Non-array → ``[]``.
+  const arr = o?.items ?? o?.results;
+  return Array.isArray(arr) ? (arr as Record<string, unknown>[]) : [];
+}
+
 export function textResult(text: string): {
   content: Array<{ type: string; text: string }>;
   details: Record<string, unknown>;

--- a/scripts/wet-test-install.sh
+++ b/scripts/wet-test-install.sh
@@ -162,13 +162,17 @@ if [[ -f "$OPENCLAW_CONFIG" ]]; then
     const pluginDir = '$PLUGIN_DIR';
     if (!config.plugins.load.paths.includes(pluginDir)) config.plugins.load.paths.push(pluginDir);
 
-    // Ensure tools are allowed
+    // Ensure tools are allowed.
+    // Keep in sync with MEMCLAW_TOOLS (plugin/src/tools.ts) — a missing
+    // entry here means that tool is absent from tools.alsoAllow, so any
+    // OpenClaw tools.profile (which grants core tools + alsoAllow only)
+    // strips it. memclaw_keystones was the casualty of this drift.
     if (!config.tools) config.tools = {};
     if (!Array.isArray(config.tools.alsoAllow)) config.tools.alsoAllow = [];
     const tools = [
       'memclaw_recall','memclaw_write','memclaw_manage','memclaw_doc',
       'memclaw_list','memclaw_entity_get','memclaw_tune','memclaw_insights',
-      'memclaw_evolve','memclaw_stats'
+      'memclaw_evolve','memclaw_stats','memclaw_keystones'
     ];
     for (const t of tools) {
       if (!config.tools.alsoAllow.includes(t)) config.tools.alsoAllow.push(t);


### PR DESCRIPTION
## Summary

Three independent plugin defects surfaced while validating the MemClaw plugin against **OpenClaw 2026.5.28** on a wet-test VM (`openclaw-test-ran`). All three are verified — #1 and #2 live against `memclaw.net`, #3 via unit tests.

### 1. Auto-recall injected nothing (high impact)
The REST `POST /api/v1/search` endpoint returns `{ items: [...] }` (core-api `SearchResponse(items=...)`), but `assemble()` and `searchMemories` parsed **`.results`** → always `[]`. Context-engine auto-recall has therefore been silently empty (masked because the explicit `memclaw_recall` *tool* uses the MCP path, which does return `results`). The bootstrap smoke test parsed `.results` too, so it also misfired (`SMOKE TEST FAILED: … check EMBEDDING_PROVIDER`).
- New `parseSearchItems()` helper: `items` → `results` → bare-array fallback, never throws.
- Applied at all three `/search` consumers: recall, smoke test, memory-runtime search.
- **Verified live:** recall block now injects the matching memory (`RECALL block present: true`).

### 2. Smoke-test memory leaked on every restart
Bootstrap cleanup `DELETE /memories/{id}` omitted the required `tenant_id` query param → 422 (swallowed by `.catch(()=>{})`) → a `__health_check__` memory accumulated on each start. Hoist `tid` out of the `try` and pass `{ tenant_id }`.
- **Verified live:** 0 leaked memories after bootstrap (was: one per restart).

### 3. Tools dropped from `tools.alsoAllow` after a plugin upgrade
`autoFixAllowlist` already adds all `MEMCLAW_TOOLS`, but the gate ran it **once** (`.allowlist-applied` flag). So a tool added in a later plugin version (`memclaw_keystones`) never landed in `alsoAllow` on existing installs — and OpenClaw 2026.5.28's new `tools.profile` (grants core tools + `alsoAllow` only) then **stripped it**. Extracted pure `shouldRunAutoFix()` that also re-runs on drift (a missing tool, or an unclaimed contextEngine slot); `autoFixAllowlist` is idempotent so clean installs still no-op. Also added `memclaw_keystones` to the wet-test installer's tool list.

## Tests
- `parseSearchItems` — 5 cases (items / results / both / bare array / empty·null·primitive).
- `shouldRunAutoFix` — truth table (force / opt-out / first-run / missing-tool / unclaimed-slot / clean).
- Full plugin suite green: **273 passing**.

## Scope / non-goals
- The **compaction SDK-bridge** and **`assemble` contract** were verified *unaffected* by 2026.5.28 (runtime still calls `assemble()` and injects `systemPromptAddition`) — not touched here.
- **Skills-discovery truncation** (new 300/200 caps) is intentionally **out of scope**.
- `plugin/dist` is gitignored; build artifacts not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)