### PR TITLE
feat(core-api): add fleet-scoped hard-purge endpoint

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -655,6 +655,15 @@ class CoreStorageClient:
         result = await self._post("/purge/tenant-data", {"tenant_id": tenant_id})
         return result.get("deleted", {})  # type: ignore[union-attr,return-value]
 
+    async def purge_fleet_data(self, tenant_id: str, fleet_id: str) -> dict[str, int]:
+        """Hard-delete all OSS data scoped to ``(tenant_id, fleet_id)`` — the
+        per-fleet analogue of ``purge_tenant_data`` for run-scoped test-tenant
+        hygiene. Returns the per-table deleted counts. Idempotent at the
+        storage layer — a repeat call for an already-purged fleet returns zeros.
+        """
+        result = await self._post("/purge/fleet-data", {"tenant_id": tenant_id, "fleet_id": fleet_id})
+        return result.get("deleted", {})  # type: ignore[union-attr,return-value]
+
     async def count_tenant_data(self, tenant_id: str) -> dict[str, int]:
         """Per-table row count for ``tenant_id`` — drives the
         deletion-preview panel (CAURA-696). Same table set + scoping

--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -217,6 +217,46 @@ async def delete_fleet(
     await db.commit()
 
 
+@router.post("/fleet/{fleet_id}/purge")
+async def purge_fleet(
+    fleet_id: str,
+    tenant_id: str = Query(...),
+    auth: AuthContext = Depends(get_auth_context),
+    db: AsyncSession = Depends(get_db),
+):
+    """Permanently purge a fleet's entire footprint within a tenant.
+
+    Unlike ``DELETE /fleet/{fleet_id}`` (which removes only the fleet's nodes +
+    commands and intentionally keeps memories for history), this HARD-deletes
+    everything scoped to ``(tenant_id, fleet_id)``: memories, entities,
+    relations, agents, documents, analysis/dedup rows, nodes, and commands.
+    Irreversible. Returns the per-table deleted counts.
+
+    Intended for test-tenant hygiene: the OpenClaw fleet-tester purges its
+    run-scoped ``nightly-<run_id>-fleet-NN`` fleets at teardown so the shared
+    dev tenant doesn't accumulate run data that confounds isolation/trust tests.
+
+    Auth: a write-capable tenant-owner key. Agent-scoped credentials are
+    blocked (BFLA) — a hard fleet purge is an admin-plane operation, on par
+    with bulk memory delete and agent deletion. Idempotent.
+    """
+    auth.enforce_read_only()
+    auth.enforce_tenant(tenant_id)
+    auth.enforce_not_agent_credential("purge fleet data")
+
+    sc = get_storage_client()
+    counts = await sc.purge_fleet_data(tenant_id, fleet_id)
+    await log_action(
+        db,
+        tenant_id=tenant_id,
+        action="purge",
+        resource_type="fleet",
+        detail={"fleet_id": fleet_id, "deleted": counts},
+    )
+    await db.commit()
+    return {"ok": True, "tenant_id": tenant_id, "fleet_id": fleet_id, "deleted": counts}
+
+
 # ── Heartbeat ──
 
 

--- a/core-storage-api/src/core_storage_api/routers/purge.py
+++ b/core-storage-api/src/core_storage_api/routers/purge.py
@@ -46,3 +46,33 @@ async def purge_tenant_data(request: Request) -> dict:
         )
     counts = await _svc.purge_tenant_data(tenant_id)
     return {"tenant_id": tenant_id, "deleted": counts}
+
+
+@router.post("/fleet-data")
+async def purge_fleet_data(request: Request) -> dict:
+    """Hard-delete every row scoped to ``(tenant_id, fleet_id)``. Body:
+    ``{tenant_id, fleet_id}``.
+
+    Returns ``{tenant_id, fleet_id, deleted: {table: count}}``. Idempotent — a
+    second call for the same fleet deletes nothing. The per-fleet analogue of
+    ``/purge/tenant-data`` for run-scoped test-tenant hygiene; same VPC-only
+    trust model (no router auth — the upstream core-api route gates it).
+    """
+    try:
+        body: dict = await request.json()
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=422, detail="request body must be valid JSON") from exc
+    tenant_id = body.get("tenant_id")
+    fleet_id = body.get("fleet_id")
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_id' is required and must be a non-empty string",
+        )
+    if not isinstance(fleet_id, str) or not fleet_id:
+        raise HTTPException(
+            status_code=422,
+            detail="'fleet_id' is required and must be a non-empty string",
+        )
+    counts = await _svc.purge_fleet_data(tenant_id, fleet_id)
+    return {"tenant_id": tenant_id, "fleet_id": fleet_id, "deleted": counts}

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -192,6 +192,36 @@ _PURGE_ORG_KEYED_TABLES: tuple[str, ...] = (
     "organization_settings_audit",
 )
 
+# ── Fleet-scoped hard-purge (test-tenant hygiene) ──
+#
+# The subset of ``_PURGE_TENANT_TABLES`` that carries its own ``fleet_id``
+# column, so a single fleet's footprint can be permanently removed from a
+# SHARED tenant without touching the rest of the tenant. Used by the
+# OpenClaw fleet-tester to clean up its run-scoped ``nightly-<run_id>-fleet-NN``
+# fleets at teardown (the dev tenant otherwise accumulates run data that
+# confounds isolation/trust tests). Ordered children-before-parents so the
+# per-table DELETEs never trip a foreign key.
+#
+# ``fleet_commands`` is intentionally NOT in this tuple — it has no
+# ``fleet_id`` of its own (it's keyed by ``node_id``); ``purge_fleet_data``
+# deletes it explicitly by the fleet's node ids before the nodes go, so its
+# count is reported rather than hidden inside the ``fleet_nodes`` ON DELETE
+# CASCADE. ``memory_entity_links`` (no ``fleet_id``) rides the CASCADE from
+# ``memories`` / ``entities``. Tenant-wide tables (``audit_log``,
+# ``background_task_log``, ``idempotency_responses``, ``organization_settings*``)
+# are excluded — they're tenant config or the retained audit trail, not
+# fleet-scoped run data.
+_PURGE_FLEET_TABLES: tuple[str, ...] = (
+    "relations",
+    "memories",
+    "entities",
+    "agents",
+    "fleet_nodes",
+    "documents",
+    "analysis_reports",
+    "dedup_reviews",
+)
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # PostgresService
@@ -1727,6 +1757,60 @@ class PostgresService:
                         {"tid": tenant_id},
                     )
                     counts[table_name] = int(result.scalar() or 0)
+        return counts
+
+    async def purge_fleet_data(self, tenant_id: str, fleet_id: str) -> dict[str, int]:
+        """Permanently delete every row scoped to ``(tenant_id, fleet_id)``
+        across the fleet-scoped OSS tables — the per-fleet analogue of
+        ``purge_tenant_data`` for test-tenant hygiene (run-scoped fleet
+        cleanup). Returns per-table deleted counts.
+
+        Runs in one transaction, children-before-parents, so a foreign key
+        never blocks a delete and a mid-purge failure rolls back cleanly.
+        ``fleet_commands`` has no ``fleet_id`` of its own, so it's deleted by
+        the fleet's ``node_id``s first (and counted) before the nodes go;
+        ``memory_entity_links`` rides the ON DELETE CASCADE from ``memories`` /
+        ``entities``. ``audit_log`` and the tenant-wide settings tables are
+        intentionally untouched.
+
+        Idempotent: re-running on an already-purged fleet deletes nothing and
+        returns zeros, so a retried teardown is safe.
+        """
+        counts: dict[str, int] = {}
+        async with get_session() as session:
+            # ``fleet_commands`` is keyed by ``node_id`` (FK to fleet_nodes),
+            # not ``fleet_id`` — resolve the fleet's node ids and delete its
+            # commands first so the count is explicit rather than hidden in
+            # the fleet_nodes CASCADE below.
+            node_ids = list(
+                (
+                    await session.execute(
+                        select(FleetNode.id).where(
+                            FleetNode.tenant_id == tenant_id,
+                            FleetNode.fleet_id == fleet_id,
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            if node_ids:
+                cmd_result = await session.execute(
+                    FleetCommand.__table__.delete().where(FleetCommand.node_id.in_(node_ids))
+                )
+                counts["fleet_commands"] = cmd_result.rowcount  # type: ignore[attr-defined]
+            else:
+                counts["fleet_commands"] = 0
+
+            for table_name in _PURGE_FLEET_TABLES:
+                # Schema-qualify (``public.``) so an irreversible hard-delete
+                # can't be redirected by a non-default search_path — same
+                # defence as ``purge_tenant_data``.
+                result = await session.execute(
+                    text(f"DELETE FROM public.{table_name} WHERE tenant_id = :tid AND fleet_id = :fid"),
+                    {"tid": tenant_id, "fid": fleet_id},
+                )
+                counts[table_name] = result.rowcount  # type: ignore[attr-defined]
         return counts
 
     async def set_tenant_suppression(

--- a/core-storage-api/tests/test_purge.py
+++ b/core-storage-api/tests/test_purge.py
@@ -88,3 +88,119 @@ class TestPurgeTenantData:
             headers={"content-type": "application/json"},
         )
         assert resp.status_code == 422
+
+
+class TestPurgeFleetData:
+    """Fleet-scoped hard purge: removes one fleet's footprint from a tenant
+    while leaving the tenant's other fleets intact."""
+
+    async def _seed_node(self, client: AsyncClient, tenant_id: str, fleet_id: str) -> str:
+        resp = await client.post(
+            f"{PREFIX}/fleet/nodes",
+            json={"tenant_id": tenant_id, "fleet_id": fleet_id, "node_name": f"node-{uuid.uuid4().hex[:8]}"},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["id"]
+
+    async def test_purge_fleet_deletes_scoped_data_and_reports_counts(self, client: AsyncClient) -> None:
+        tenant_id, fleet_id = _fresh_ids()
+        _, other_fleet = _fresh_ids()  # different fleet, SAME tenant — must survive
+
+        drop_ids = []
+        for _ in range(3):
+            resp = await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+            assert resp.status_code == 200, resp.text
+            drop_ids.append(resp.json()["id"])
+        keep = (await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, other_fleet))).json()
+
+        node_id = await self._seed_node(client, tenant_id, fleet_id)
+        cmd = await client.post(
+            f"{PREFIX}/fleet/commands",
+            json={"tenant_id": tenant_id, "node_id": node_id, "command": "ping"},
+        )
+        assert cmd.status_code in (200, 201), cmd.text
+
+        resp = await client.post(
+            f"{PREFIX}/purge/fleet-data", json={"tenant_id": tenant_id, "fleet_id": fleet_id}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["tenant_id"] == tenant_id
+        assert body["fleet_id"] == fleet_id
+        deleted = body["deleted"]
+        assert deleted["memories"] == 3
+        assert deleted["fleet_nodes"] == 1
+        assert deleted["fleet_commands"] == 1
+        # Every configured fleet table is reported, even when it deleted nothing.
+        for table in (
+            "relations",
+            "memories",
+            "entities",
+            "agents",
+            "fleet_nodes",
+            "fleet_commands",
+            "documents",
+            "analysis_reports",
+            "dedup_reviews",
+        ):
+            assert table in deleted, deleted
+
+        # The purged fleet's memories are physically gone (not just soft-deleted).
+        for memory_id in drop_ids:
+            got = await client.get(f"{PREFIX}/memories/{memory_id}")
+            assert got.status_code == 404
+        # The same tenant's OTHER fleet is untouched.
+        survivor = await client.get(f"{PREFIX}/memories/{keep['id']}")
+        assert survivor.status_code == 200
+
+    async def test_purge_fleet_is_idempotent(self, client: AsyncClient) -> None:
+        tenant_id, fleet_id = _fresh_ids()
+        await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+        first = (
+            await client.post(
+                f"{PREFIX}/purge/fleet-data", json={"tenant_id": tenant_id, "fleet_id": fleet_id}
+            )
+        ).json()
+        assert first["deleted"]["memories"] >= 1
+
+        second = (
+            await client.post(
+                f"{PREFIX}/purge/fleet-data", json={"tenant_id": tenant_id, "fleet_id": fleet_id}
+            )
+        ).json()
+        assert second["deleted"]["memories"] == 0
+        assert second["deleted"]["fleet_commands"] == 0
+
+    async def test_purge_fleet_does_not_touch_other_tenant(self, client: AsyncClient) -> None:
+        keep_tenant, keep_fleet = _fresh_ids()
+        drop_tenant, drop_fleet = _fresh_ids()
+        keep = (await client.post(f"{PREFIX}/memories", json=_memory_payload(keep_tenant, keep_fleet))).json()
+        await client.post(f"{PREFIX}/memories", json=_memory_payload(drop_tenant, drop_fleet))
+
+        await client.post(
+            f"{PREFIX}/purge/fleet-data", json={"tenant_id": drop_tenant, "fleet_id": drop_fleet}
+        )
+
+        got = await client.get(f"{PREFIX}/memories/{keep['id']}")
+        assert got.status_code == 200
+
+    async def test_purge_fleet_requires_tenant_and_fleet(self, client: AsyncClient) -> None:
+        tenant_id, fleet_id = _fresh_ids()
+        assert (await client.post(f"{PREFIX}/purge/fleet-data", json={})).status_code == 422
+        assert (
+            await client.post(f"{PREFIX}/purge/fleet-data", json={"tenant_id": tenant_id})
+        ).status_code == 422
+        assert (
+            await client.post(f"{PREFIX}/purge/fleet-data", json={"fleet_id": fleet_id})
+        ).status_code == 422
+        assert (
+            await client.post(f"{PREFIX}/purge/fleet-data", json={"tenant_id": tenant_id, "fleet_id": ""})
+        ).status_code == 422
+
+    async def test_purge_fleet_rejects_malformed_body(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            f"{PREFIX}/purge/fleet-data",
+            content="not json",
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 422

--- a/tests/test_agent_admin_authz.py
+++ b/tests/test_agent_admin_authz.py
@@ -81,6 +81,9 @@ async def test_agent_cannot_change_fleet_or_delete_or_settings(client, as_agent)
     assert r.status_code == 403, r.text
     r = await client.put(f"/api/v1/settings?tenant_id={tenant_id}", json={"recall": {}})
     assert r.status_code == 403, r.text
+    # A hard fleet purge is admin-plane too — an agent key must not wipe a fleet.
+    r = await client.post(f"/api/v1/fleet/some-fleet/purge?tenant_id={tenant_id}")
+    assert r.status_code == 403, r.text
 
 
 @pytest.mark.integration

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -195,6 +195,47 @@ async def test_dispatch_command(client):
     assert any(c["command"] == "ping" and c["node_id"] == node_id for c in commands)
 
 
+async def test_purge_fleet_hard_deletes_nodes_and_memories(client):
+    """POST /fleet/{id}/purge removes the fleet's nodes AND memories (unlike
+    DELETE /fleet/{id}, which keeps memories)."""
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fid = f"fleet-purge-{tag}"
+
+    await _heartbeat(client, tenant_id, headers, f"node-purge-{tag}", fid)
+    mem = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "content": f"purge-me {tag}",
+            "agent_id": f"agent-{tag}",
+            "fleet_id": fid,
+            "memory_type": "fact",
+        },
+        headers=headers,
+    )
+    assert mem.status_code in (200, 201), mem.text
+    mem_id = mem.json()["id"]
+
+    resp = await client.post(
+        f"/api/v1/fleet/{fid}/purge?tenant_id={tenant_id}", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["fleet_id"] == fid
+    assert body["deleted"]["memories"] >= 1
+    assert body["deleted"]["fleet_nodes"] >= 1
+
+    # Node is gone from the fleet listing.
+    nodes = await _get_nodes(client, tenant_id, headers)
+    assert not any(n["node_name"] == f"node-purge-{tag}" for n in nodes)
+    # Memory is hard-deleted.
+    got = await client.get(
+        f"/api/v1/memories/{mem_id}?tenant_id={tenant_id}", headers=headers
+    )
+    assert got.status_code == 404, got.text
+
+
 async def test_node_agents_from_heartbeat(client):
     """Heartbeat with agents list → GET nodes returns node with those agents."""
     tenant_id, headers = get_test_auth()
@@ -202,7 +243,9 @@ async def test_node_agents_from_heartbeat(client):
     fid = f"fleet-{tag}"
 
     agents = [f"agent-x-{tag}", f"agent-y-{tag}", f"agent-z-{tag}"]
-    await _heartbeat(client, tenant_id, headers, f"node-agents-{tag}", fid, agents=agents)
+    await _heartbeat(
+        client, tenant_id, headers, f"node-agents-{tag}", fid, agents=agents
+    )
 
     nodes = await _get_nodes(client, tenant_id, headers)
     node = next(n for n in nodes if n["node_name"] == f"node-agents-{tag}")


### PR DESCRIPTION
## What

Adds `POST /api/v1/fleet/{fleet_id}/purge` — a **hard purge** of a single fleet's entire footprint within a tenant: memories, entities, relations, agents, documents, analysis/dedup rows, nodes, and commands. It's the per-fleet analogue of the org-delete tenant purge (`purge_tenant_data`).

Contrast with the existing `DELETE /api/v1/fleet/{fleet_id}`, which removes only the fleet's **nodes + commands** and intentionally keeps memories for history. This new route HARD-deletes the fleet's memories/agents too.

## Why

The OpenClaw fleet-tester (`caura-ai/openclaw-fleet-tester`) creates run-scoped fleets named `nightly-<run_id>-fleet-NN` on every nightly run, but teardown only deletes the GCP VMs — it never removes the fleet's data from the shared dev tenant. That tenant accumulates nodes/memories/entities across runs, which confounds the isolation/trust probes (org-wide recall returns every prior run's memories) and bloats the tenant.

A follow-up PR on the fleet-tester will call this endpoint at teardown (scoped strictly to its own `nightly-<run_id>-fleet-NN` ids), and a one-time backfill will clear the already-accumulated stale fleets.

## How

**core-storage-api**
- `PostgresService.purge_fleet_data(tenant_id, fleet_id)` — one transaction, children-before-parents. `fleet_commands` (no `fleet_id` column) is deleted by the fleet's node ids first so its count is explicit rather than hidden in the `fleet_nodes` `ON DELETE CASCADE`; `memory_entity_links` rides the CASCADE from `memories`/`entities`. Tables are schema-qualified (`public.`) with bound params, mirroring `purge_tenant_data`. `audit_log` + tenant-wide settings are untouched. Idempotent (zeros on a clean fleet).
- `POST /purge/fleet-data` (VPC-trusted, no router auth — same trust model as `/purge/tenant-data`).

**core-api**
- Public `POST /fleet/{fleet_id}/purge`, gated by a write-capable **tenant-owner key**. Agent-scoped credentials are blocked (`enforce_not_agent_credential`) — a hard fleet purge is an admin-plane operation, on par with bulk memory delete and agent deletion. Writes an audit row. Idempotent (no 404 on a missing fleet, so a retried teardown is safe).
- `storage_client.purge_fleet_data`.

## Tests
- `core-storage-api/tests/test_purge.py::TestPurgeFleetData` — scoped deletion + per-table counts, idempotency, fleet-isolation within a tenant, cross-tenant safety, required-field + malformed-body validation.
- `tests/test_api_fleet.py::test_purge_fleet_hard_deletes_nodes_and_memories` — node + memory hard-deleted through the public route.
- `tests/test_agent_admin_authz.py` — agent credential is 403'd on the purge route (BFLA).

Local gate green: `ruff check` + `ruff format --check` (src), `mypy core-api/src core-storage-api/src`, and the new tests pass against a pgvector Postgres.

## Notes
- Irreversible by design (hard delete). The blast radius is bounded to `(tenant_id, fleet_id)` and the caller's own tenant.
- First of a small cross-repo series (fleet-tester teardown integration + one-time backfill follow).
