### PR TITLE
feat(lifecycle): align all lifecycle crons to a fixed UTC hour, not boot-relative intervals

### DIFF
--- a/core-operations/src/core_operations/app.py
+++ b/core-operations/src/core_operations/app.py
@@ -40,45 +40,54 @@ logger = logging.getLogger(__name__)
 
 
 def _register_scheduled_tasks() -> None:
-    # Each lifecycle op gets its own registration so an outage on one
-    # can't silently mask the others; their audit rows stay
-    # independent.
+    # Every lifecycle op is wall-clock aligned to a fixed UTC hour via
+    # delay_provider: it fires once a day at its configured hour, never at
+    # startup, and never drifts from the boot time. The ``24 * 3600`` arg
+    # is the nominal daily period (documentation only — the delay_provider
+    # drives the actual firing). Each op gets its own registration so an
+    # outage on one can't silently mask the others; their audit rows stay
+    # independent. Hours are independently configurable so operators can
+    # stagger the jobs; they all default to 02:00 UTC.
+    def _daily_at(hour_attr: str):
+        # Bind the setting lookup lazily so an operator override applied
+        # before start() is still picked up, and recompute each cycle.
+        return lambda: seconds_until_next_utc_hour(getattr(settings, hour_attr))
+
     scheduler.register(
         "lifecycle-archive-expired",
-        settings.lifecycle_archive_interval_seconds,
+        24 * 3600,
         run_archive_expired_tick,
+        delay_provider=_daily_at("lifecycle_archive_run_at_hour"),
     )
     scheduler.register(
         "lifecycle-archive-stale",
-        settings.lifecycle_archive_interval_seconds,
+        24 * 3600,
         run_archive_stale_tick,
+        delay_provider=_daily_at("lifecycle_archive_run_at_hour"),
     )
     scheduler.register(
         "lifecycle-purge-soft-deleted",
-        settings.lifecycle_purge_interval_seconds,
+        24 * 3600,
         run_purge_soft_deleted_tick,
+        delay_provider=_daily_at("lifecycle_purge_run_at_hour"),
     )
     scheduler.register(
         "lifecycle-crystallize",
-        settings.lifecycle_pipeline_interval_seconds,
+        24 * 3600,
         run_crystallize_tick,
+        delay_provider=_daily_at("lifecycle_pipeline_run_at_hour"),
     )
     scheduler.register(
         "lifecycle-entity-link",
-        settings.lifecycle_pipeline_interval_seconds,
+        24 * 3600,
         run_entity_link_tick,
+        delay_provider=_daily_at("lifecycle_pipeline_run_at_hour"),
     )
-    # Insights is the one lifecycle op pinned to a wall-clock hour rather
-    # than a boot-relative interval: it runs a fixed off-peak nightly slot
-    # (``lifecycle_insights_run_at_hour``, default 02:00 UTC) via
-    # delay_provider, so it never fires at startup and never drifts. The
-    # interval arg below is the nominal daily period (documentation only;
-    # the delay_provider drives the actual firing).
     scheduler.register(
         "lifecycle-insights",
         24 * 3600,
         run_insights_tick,
-        delay_provider=lambda: seconds_until_next_utc_hour(settings.lifecycle_insights_run_at_hour),
+        delay_provider=_daily_at("lifecycle_insights_run_at_hour"),
     )
 
 

--- a/core-operations/src/core_operations/config.py
+++ b/core-operations/src/core_operations/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import field_validator
+from pydantic import ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -37,38 +37,42 @@ class Settings(BaseSettings):
     core_api_url: str = "http://oss-core-api:8000"
     core_api_admin_api_key: str = ""
 
-    # Daily cadence for the SQL-only archive operations. Per-org
-    # scheduling isn't supported here (single global tick fans out to
-    # every active org); enterprise's per-org configurable cadences
-    # — e.g. ``security_audit.schedule_cron`` — still live on the
-    # enterprise scheduler.
-    lifecycle_archive_interval_seconds: float = 24 * 3600
-    # Separate cadence for purge — operationally a different concern
-    # (compliance-driven retention vs. staleness archival), so an
-    # operator can dial purge less frequently or to a different cycle
-    # without touching archive. Default matches archive (daily).
-    lifecycle_purge_interval_seconds: float = 24 * 3600
-    # Cadence for the pipeline ops (crystallize + entity-link).
-    # Independent because these are LLM-heavy and may want a longer
-    # cycle (cost) or different schedule (off-peak). Default daily;
-    # the consumer-side dedup gate filters double-fires within 23h.
-    lifecycle_pipeline_interval_seconds: float = 24 * 3600
-    # Insights discovery (focus='discover') schedule. Unlike the other
-    # lifecycle ops — which run on a fixed interval measured from service
-    # boot and so drift with each redeploy — insights is wall-clock
-    # aligned to a fixed UTC hour, so it lands in a predictable off-peak
-    # window regardless of when core-operations last started. Default
-    # 02:00 UTC. It's opt-in per-org (``auto_insights_enabled``, default
-    # off) and the consumer's activity gate further no-ops ticks where no
-    # non-insight memories landed since the last run, so a once-a-day
-    # fire is plenty.
+    # All lifecycle crons are wall-clock aligned to a fixed UTC hour
+    # rather than a boot-relative interval: each runs once a day at its
+    # configured hour, so it lands in a predictable off-peak window and
+    # never drifts with redeploys (and never fires an immediate tick at
+    # startup). Each knob is independently tunable so an operator can
+    # stagger the jobs across the night; they all default to 02:00 UTC.
+    # Per-org scheduling isn't supported here — a single global tick fans
+    # out to every active org; enterprise's per-org configurable cadences
+    # (e.g. ``security_audit.schedule_cron``) still live on its scheduler.
+
+    # SQL-only archive ops (expired + stale share this hour).
+    lifecycle_archive_run_at_hour: int = 2
+    # Purge is operationally a different concern (compliance-driven
+    # retention vs. staleness archival), so it gets its own hour and can
+    # be moved off the archive slot.
+    lifecycle_purge_run_at_hour: int = 2
+    # Pipeline ops (crystallize + entity-link) — LLM-heavy, so an operator
+    # may want these in their own off-peak slot away from the lighter SQL
+    # ops. The consumer-side dedup gate still filters double-fires.
+    lifecycle_pipeline_run_at_hour: int = 2
+    # Insights discovery (focus='discover'). Opt-in per-org
+    # (``auto_insights_enabled``, default off); the consumer's activity
+    # gate further no-ops ticks where no non-insight memories landed since
+    # the last run, so a once-a-day fire is plenty.
     lifecycle_insights_run_at_hour: int = 2
 
-    @field_validator("lifecycle_insights_run_at_hour")
+    @field_validator(
+        "lifecycle_archive_run_at_hour",
+        "lifecycle_purge_run_at_hour",
+        "lifecycle_pipeline_run_at_hour",
+        "lifecycle_insights_run_at_hour",
+    )
     @classmethod
-    def _validate_insights_hour(cls, v: int) -> int:
+    def _validate_run_at_hour(cls, v: int, info: ValidationInfo) -> int:
         if not 0 <= v <= 23:
-            raise ValueError("lifecycle_insights_run_at_hour must be in 0..23 (UTC hour)")
+            raise ValueError(f"{info.field_name} must be in 0..23 (UTC hour)")
         return v
 
 

--- a/core-operations/tests/test_app.py
+++ b/core-operations/tests/test_app.py
@@ -1,0 +1,74 @@
+"""Contract tests for the lifecycle cron registration in app.py.
+
+These pin two things that are easy to regress: (1) every lifecycle job
+is wall-clock aligned (has a ``delay_provider``) so none fire an
+immediate boot-time tick, and (2) per-job ``*_run_at_hour`` overrides
+are actually threaded through to the scheduler.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from core_operations import app
+from core_operations.config import Settings
+from core_operations.scheduler import Scheduler, seconds_until_next_utc_hour
+
+_EXPECTED_JOBS = {
+    "lifecycle-archive-expired",
+    "lifecycle-archive-stale",
+    "lifecycle-purge-soft-deleted",
+    "lifecycle-crystallize",
+    "lifecycle-entity-link",
+    "lifecycle-insights",
+}
+
+
+def test_all_lifecycle_jobs_registered_and_wall_clock_aligned(monkeypatch):
+    fresh = Scheduler()
+    monkeypatch.setattr(app, "scheduler", fresh)
+
+    app._register_scheduled_tasks()
+
+    assert fresh.task_count == len(_EXPECTED_JOBS)
+    assert {t.name for t in fresh._tasks} == _EXPECTED_JOBS
+    for t in fresh._tasks:
+        # Aligned => no immediate boot tick, no drift.
+        assert t.delay_provider is not None, f"{t.name} is not wall-clock aligned"
+        delay = t.delay_provider()
+        assert 0 < delay <= 24 * 3600, f"{t.name} delay out of range: {delay}"
+
+
+def test_run_at_hour_override_is_threaded_through(monkeypatch):
+    # An operator override on the pipeline hour should change when
+    # crystallize/entity-link fire.
+    monkeypatch.setattr(app.settings, "lifecycle_pipeline_run_at_hour", 5)
+    fresh = Scheduler()
+    monkeypatch.setattr(app, "scheduler", fresh)
+
+    app._register_scheduled_tasks()
+
+    for name in ("lifecycle-crystallize", "lifecycle-entity-link"):
+        task = next(t for t in fresh._tasks if t.name == name)
+        now = datetime.now(UTC)
+        # delay_provider uses its own now(); compare within a small window.
+        assert abs(task.delay_provider() - seconds_until_next_utc_hour(5, now=now)) < 5
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "lifecycle_archive_run_at_hour",
+        "lifecycle_purge_run_at_hour",
+        "lifecycle_pipeline_run_at_hour",
+        "lifecycle_insights_run_at_hour",
+    ],
+)
+def test_config_rejects_out_of_range_hour(field):
+    with pytest.raises(ValidationError, match=r"0\.\.23"):
+        Settings(**{field: 24})
+    with pytest.raises(ValidationError, match=r"0\.\.23"):
+        Settings(**{field: -1})


### PR DESCRIPTION
## What

Follow-up to #277. That PR moved the **insights** cron to a fixed UTC hour; this extends the same wall-clock alignment to **all** `core-operations` lifecycle crons:

`lifecycle-archive-expired`, `lifecycle-archive-stale`, `lifecycle-purge-soft-deleted`, `lifecycle-crystallize`, `lifecycle-entity-link` (insights already landed in #277).

Each now fires **once a day at a configurable UTC hour** (default **02:00 UTC**) via the scheduler's `delay_provider`, instead of a run-then-sleep interval that fired at startup and drifted by each tick's duration from the last deploy.

## How

- **config**: replace the three interval knobs (`lifecycle_{archive,purge,pipeline}_interval_seconds`) with per-job hour knobs (`lifecycle_{archive,purge,pipeline,insights}_run_at_hour`, int `0..23`, default `2`), validated by one shared `field_validator`. Hours are independent so operators can **stagger** the jobs across the night.
- **app**: every job registered with a `delay_provider`; archive-expired/stale share the archive hour, crystallize/entity-link share the pipeline hour.

The `delay_provider` mechanism and `seconds_until_next_utc_hour` helper already landed in #277 — this PR just wires the remaining five jobs to them.

No change to any consumer-side gate (`auto_*_enabled`, the insights activity gate, crystallize's >1000-active-memory threshold) — only **when** each daily tick fires.

## Behavior note

The boot-time tick is gone, so after a deploy a job won't run until the next occurrence of its hour (≤24h later) rather than immediately — the intended trade for predictable off-peak scheduling.

## Test

- `ruff check` ✓ · `ruff format --check` ✓ · `mypy src/` ✓ · `pytest` ✓ (34 passed)
- New `test_app.py`: all six jobs registered + wall-clock aligned (no boot tick), `*_run_at_hour` overrides thread through to the scheduler, config validator rejects out-of-range hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)