### PR TITLE
fix(version-compat): bump MIN_RECOMMENDED_PLUGIN_VERSION to 2.7.0

### DIFF
--- a/core-api/src/core_api/version_compat.py
+++ b/core-api/src/core_api/version_compat.py
@@ -6,7 +6,7 @@ We log a warning when a heartbeat reports a plugin older than the minimum
 recommended version; no hard rejection — operators decide when to upgrade.
 """
 
-MIN_RECOMMENDED_PLUGIN_VERSION = "2.6.4"
+MIN_RECOMMENDED_PLUGIN_VERSION = "2.7.0"
 
 # Server-side floor below which plugins must NOT auto-upgrade — the
 # heartbeat path in ``routes/fleet.py`` enforces this hard, and


### PR DESCRIPTION
Companion to the plugin **2.7.0** release (#243). Bumps the auto-upgrade floor so manifest-aware nodes (plugin >= 2.6.0) auto-upgrade to 2.7.0 once the server runs the `onprem-v2.9.0` image set. Nodes below 2.6.0 (`MIN_AUTO_DEPLOY_PLUGIN_VERSION`) still require manual re-install.

Merge alongside #243, then `onprem-v2.9.0` is cut from the result.