### PR TITLE
CAURA-699 fix(enrichment): stop the auto-classifier minting reserved …

### DIFF
--- a/common/enrichment/_prompts.py
+++ b/common/enrichment/_prompts.py
@@ -12,11 +12,23 @@ import time, so adding a type there propagates here automatically.
 
 from __future__ import annotations
 
-from common.enrichment.constants import MEMORY_TYPE_DESCRIPTIONS, MEMORY_TYPES
+from common.enrichment.constants import (
+    MEMORY_TYPE_DESCRIPTIONS,
+    MEMORY_TYPES,
+    SERVER_RESERVED_MEMORY_TYPES,
+)
 
-_TYPES_INLINE = ", ".join(f'"{name}"' for name in MEMORY_TYPES)
+# The auto-classifier is only ever offered the agent-writable types. The
+# server-reserved types (insight/outcome/rule) are authored exclusively by
+# internal flows (insights_service / evolve_service) with the type set
+# explicitly, so they never travel through this prompt. Offering them here
+# is what let agent writes leak into the insight space (CAURA-699).
+_CLASSIFIABLE_TYPES = tuple(
+    t for t in MEMORY_TYPES if t not in SERVER_RESERVED_MEMORY_TYPES
+)
+_TYPES_INLINE = ", ".join(f'"{name}"' for name in _CLASSIFIABLE_TYPES)
 _TYPE_BULLETS = "\n".join(
-    f"   - {name}: {desc}" for name, desc in MEMORY_TYPE_DESCRIPTIONS.items()
+    f"   - {name}: {MEMORY_TYPE_DESCRIPTIONS[name]}" for name in _CLASSIFIABLE_TYPES
 )
 
 ENRICHMENT_PROMPT = (

--- a/common/enrichment/constants.py
+++ b/common/enrichment/constants.py
@@ -99,10 +99,14 @@ MEMORY_TYPES = tuple(t.value for t in MemoryType)
 # ``rule`` come out of evolve_service; ``insight`` comes out of
 # insights_service. Each is still a valid value at the storage layer
 # (the schema enum is unchanged) — only the route + MCP boundaries
-# reject explicit agent-supplied values. The LLM auto-classifier can
-# still emit these types when content genuinely looks insight-/rule-
-# /outcome-shaped; that path goes through the same internal write
-# helpers and is intentionally allowed.
+# reject explicit agent-supplied values.
+#
+# CAURA-699 — the LLM auto-classifier must NOT mint these from agent
+# content either: the enrichment prompt omits them from the offered
+# vocabulary (see ``common.enrichment._prompts``) and ``_validate_enrichment``
+# demotes any reserved type that slips through to ``DEFAULT_MEMORY_TYPE``.
+# The reserved types only ever reach storage via the internal flows above,
+# which set ``memory_type`` explicitly and bypass the classifier path.
 SERVER_RESERVED_MEMORY_TYPES: frozenset[str] = frozenset({"outcome", "rule", "insight"})
 
 # Import-time guard: enum and description dict must agree, otherwise

--- a/common/enrichment/service.py
+++ b/common/enrichment/service.py
@@ -24,7 +24,13 @@ from dateutil import parser as dateutil_parser
 from dateutil.parser import ParserError
 
 from common.enrichment._prompts import ENRICHMENT_PROMPT
-from common.enrichment.constants import MEMORY_STATUSES, MEMORY_TYPES
+from common.enrichment.constants import (
+    DEFAULT_MEMORY_TYPE,
+    MEMORY_STATUSES,
+    MEMORY_TYPES,
+    SERVER_RESERVED_MEMORY_TYPES,
+    MemoryType,
+)
 from common.enrichment.schema import EnrichmentResult
 from common.llm.protocols import LLMProvider
 from common.llm.retry import call_with_fallback
@@ -67,8 +73,15 @@ def _validate_enrichment(raw: dict, llm_ms: int) -> EnrichmentResult:
         raise ValueError(
             f"enrichment LLM returned a JSON {type(raw).__name__} where a dict was expected"
         )
-    if raw.get("memory_type") not in MEMORY_TYPES:
-        raw["memory_type"] = "fact"
+    # Backstop for CAURA-699: the prompt no longer offers the server-reserved
+    # types (insight/outcome/rule), so a reserved value here means a
+    # hallucinated/out-of-vocab classification — treat it like any other
+    # invalid type and fall to the default. Reserved types are authored only
+    # by internal flows that set ``memory_type`` explicitly and bypass this
+    # classifier path entirely.
+    mt = raw.get("memory_type")
+    if mt not in MEMORY_TYPES or mt in SERVER_RESERVED_MEMORY_TYPES:
+        raw["memory_type"] = DEFAULT_MEMORY_TYPE
     if raw.get("status") not in MEMORY_STATUSES:
         raw["status"] = "active"
     # Guard against the LLM emitting either a JSON null
@@ -131,8 +144,12 @@ def _validate_enrichment(raw: dict, llm_ms: int) -> EnrichmentResult:
             if not isinstance(fc, str) or not fc.strip():
                 continue
             st = f.get("suggested_type")
-            if not isinstance(st, str) or st not in MEMORY_TYPES:
-                st = "fact"
+            if (
+                not isinstance(st, str)
+                or st not in MEMORY_TYPES
+                or st in SERVER_RESERVED_MEMORY_TYPES
+            ):
+                st = DEFAULT_MEMORY_TYPE
             fh = f.get("retrieval_hint")
             if not isinstance(fh, str):
                 fh = ""
@@ -234,6 +251,24 @@ def fake_enrich(content: str) -> EnrichmentResult:
     )
 
 
+def _demote_reserved_enrichment(result: EnrichmentResult) -> EnrichmentResult:
+    """CAURA-699 — the auto-classifier must never mint a server-reserved type.
+
+    ``insight`` / ``outcome`` / ``rule`` reach storage only via internal flows
+    (insights_service / evolve_service) that set ``memory_type`` explicitly.
+    The LLM path is already guarded in ``_validate_enrichment`` (the prompt
+    omits these types and any hallucinated value is demoted); this is the
+    matching guard for the keyword-heuristic fallback (:func:`fake_enrich`),
+    whose primitive vocabulary still recognises rule/outcome shapes. Demoting
+    here, rather than in the primitive, keeps ``fake_enrich`` reusable.
+    """
+    if result.memory_type in SERVER_RESERVED_MEMORY_TYPES:
+        return result.model_copy(
+            update={"memory_type": MemoryType(DEFAULT_MEMORY_TYPE)}
+        )
+    return result
+
+
 async def enrich_memory(
     content: str,
     tenant_config: object | None = None,
@@ -261,7 +296,7 @@ async def enrich_memory(
         )
 
     if provider_name == ProviderName.FAKE:
-        return fake_enrich(content)
+        return _demote_reserved_enrichment(fake_enrich(content))
     if provider_name == ProviderName.NONE:
         return EnrichmentResult()
 
@@ -292,7 +327,7 @@ async def enrich_memory(
     return await call_with_fallback(
         primary_provider_name=provider_name,
         call_fn=_do_enrich,
-        fake_fn=lambda: fake_enrich(content),
+        fake_fn=lambda: _demote_reserved_enrichment(fake_enrich(content)),
         tenant_config=tenant_config,
         service_label="enrichment",
         model_override=enrichment_model,

--- a/plugin/skills/memclaw/SKILL.md
+++ b/plugin/skills/memclaw/SKILL.md
@@ -249,7 +249,10 @@ an LLM-summarized paragraph. Superseded memories (`status` ∈
 Provide exactly one of `content` / `items`. Server auto-classifies.
 `items` batches up to 100. `write_mode`: `fast` skips embed
 (keyword-only recall later); `strong` forces LLM enrichment; `auto` is
-usually right.
+usually right. `insight` / `outcome` / `rule` are server-generated only
+(via `memclaw_insights` / `memclaw_evolve`) — you cannot write them, and
+auto-classify will never assign them; record reflections as `semantic` or
+`fact` (or omit `memory_type`).
 
 **`memclaw_manage(op, memory_id, ...)`** — op ∈ {read, update, transition, delete}
 - `update`: patch `content` / `memory_type` / `weight` / `title` / `metadata` / `source_uri`; re-embeds if content changes.

--- a/static/skills/memclaw/SKILL.md
+++ b/static/skills/memclaw/SKILL.md
@@ -158,7 +158,10 @@ an LLM-summarized paragraph.
 Provide exactly one of `content` / `items`. Server auto-classifies.
 `items` batches up to 100. `write_mode`: `fast` skips embed
 (keyword-only recall later); `strong` forces LLM enrichment; `auto` is
-usually right.
+usually right. `insight` / `outcome` / `rule` are server-generated only
+(via `memclaw_insights` / `memclaw_evolve`) — you cannot write them, and
+auto-classify will never assign them; record reflections as `semantic` or
+`fact` (or omit `memory_type`).
 
 **`fleet_id` MUST be passed explicitly when the write should land in a
 fleet.** The MCP connection URL's `?fleet_id=…` query param is used for

--- a/tests/test_enrichment_prompt.py
+++ b/tests/test_enrichment_prompt.py
@@ -34,11 +34,13 @@ class TestEnrichmentPromptSignalPhrases:
         assert "committed to" in prompt
         assert "pledged" in prompt
 
-    def test_rule_has_signal_phrases(self):
-        prompt = self._get_prompt()
-        # Rule line should mention key directive words
-        assert "always" in prompt.lower()
-        assert "never" in prompt.lower()
+    def test_rule_signal_phrases_absent(self):
+        """CAURA-699: ``rule`` is server-reserved and no longer offered to the
+        classifier, so its directive cues ("always"/"never") — which only ever
+        lived in the rule bullet — must be gone from the prompt."""
+        prompt = self._get_prompt().lower()
+        assert "always" not in prompt
+        assert "never" not in prompt
 
     def test_prompt_token_count_reasonable(self):
         """Prompt ceiling — keeps cost bounded while leaving room for small additions.
@@ -64,14 +66,19 @@ class TestEnrichmentPromptSignalPhrases:
 
 @pytest.mark.unit
 class TestEnrichmentPromptVocabularySync:
-    """Prompt vocabulary must stay in lock-step with ``MEMORY_TYPES``.
+    """Prompt vocabulary must stay in lock-step with the *classifiable* types.
 
     Lives here because the prompt was the original drift site: ``insight``
     was added to the tuple but missed in the prompt's hardcoded list,
     causing the LLM to never emit that type. The renderer in
     ``common/enrichment/_prompts.py`` now derives both the inline list
-    and the bullet descriptions from ``MEMORY_TYPE_DESCRIPTIONS``, and
-    these tests guard that contract.
+    and the bullet descriptions from ``MEMORY_TYPE_DESCRIPTIONS``.
+
+    CAURA-699: the server-reserved types (insight/outcome/rule) are
+    deliberately EXCLUDED from the classifier vocabulary — they are authored
+    only by internal flows (insights_service / evolve_service). The renderer
+    filters them out, and these tests guard both halves of that contract:
+    every agent-writable type is present, and no reserved type leaks in.
     """
 
     def _get_prompt(self) -> str:
@@ -79,21 +86,44 @@ class TestEnrichmentPromptVocabularySync:
 
         return ENRICHMENT_PROMPT
 
-    def test_every_memory_type_appears_quoted_in_inline_list(self):
-        from common.enrichment.constants import MEMORY_TYPES
+    def test_every_classifiable_type_appears_quoted_in_inline_list(self):
+        from common.enrichment.constants import (
+            MEMORY_TYPES,
+            SERVER_RESERVED_MEMORY_TYPES,
+        )
 
         prompt = self._get_prompt()
         for t in MEMORY_TYPES:
+            if t in SERVER_RESERVED_MEMORY_TYPES:
+                continue
             assert f'"{t}"' in prompt, (
                 f"memory_type {t!r} missing from inline list — prompt vocabulary "
-                "drifted from MEMORY_TYPES"
+                "drifted from the classifiable types"
             )
 
-    def test_every_memory_type_has_a_bullet(self):
-        from common.enrichment.constants import MEMORY_TYPE_DESCRIPTIONS
+    def test_reserved_types_excluded_from_vocabulary(self):
+        """The classifier must never be OFFERED a server-reserved type."""
+        from common.enrichment.constants import SERVER_RESERVED_MEMORY_TYPES
+
+        prompt = self._get_prompt()
+        for t in sorted(SERVER_RESERVED_MEMORY_TYPES):
+            assert f'"{t}"' not in prompt, (
+                f"reserved memory_type {t!r} must not appear in the inline list"
+            )
+            assert f"   - {t}: " not in prompt, (
+                f"reserved memory_type {t!r} must not have a prompt bullet"
+            )
+
+    def test_every_classifiable_type_has_a_bullet(self):
+        from common.enrichment.constants import (
+            MEMORY_TYPE_DESCRIPTIONS,
+            SERVER_RESERVED_MEMORY_TYPES,
+        )
 
         prompt = self._get_prompt()
         for name, desc in MEMORY_TYPE_DESCRIPTIONS.items():
+            if name in SERVER_RESERVED_MEMORY_TYPES:
+                continue
             assert f"   - {name}: " in prompt, f"{name!r} bullet missing from prompt"
             # First clause of the description should also land verbatim
             first_clause = desc.split(".")[0].split(",")[0].strip()

--- a/tests/test_reserved_type_classifier_guard.py
+++ b/tests/test_reserved_type_classifier_guard.py
@@ -1,0 +1,118 @@
+"""CAURA-699: the auto-classifier must never mint a server-reserved type.
+
+``insight`` / ``outcome`` / ``rule`` are authored only by internal flows
+(``insights_service`` for insight, ``evolve_service`` for outcome/rule) that
+set ``memory_type`` explicitly. External agent writes flow through the
+enrichment auto-classifier, which previously could classify content as one of
+these — polluting, in particular, the insight space that the reports flow
+assumes is server-owned.
+
+Two guards enforce the policy:
+  1. The enrichment prompt omits the reserved types from the offered
+     vocabulary (see ``tests/test_enrichment_prompt.py``).
+  2. Any reserved type that still surfaces is demoted to ``DEFAULT_MEMORY_TYPE``
+     — in ``_validate_enrichment`` for the LLM path (top-level type AND each
+     atomic-fact ``suggested_type``), and at the ``enrich_memory`` boundary for
+     the keyword-heuristic fallback.
+
+These tests exercise the demotion directly; the boundary-rejection of
+*explicit* agent-supplied reserved types is covered by
+``tests/test_c3_c8_reserved_memory_types.py``.
+"""
+
+import pytest
+
+from common.enrichment.constants import (
+    DEFAULT_MEMORY_TYPE,
+    SERVER_RESERVED_MEMORY_TYPES,
+)
+from common.enrichment.service import (
+    _validate_enrichment,
+    enrich_memory,
+    fake_enrich,
+)
+
+
+class _FakeProviderConfig:
+    """Minimal tenant_config routing enrich_memory to the keyword heuristic."""
+
+    enrichment_provider = "fake"
+    enrichment_enabled = True
+    enrichment_model = None
+
+
+@pytest.mark.unit
+class TestLLMPathDemotion:
+    @pytest.mark.parametrize("reserved", sorted(SERVER_RESERVED_MEMORY_TYPES))
+    def test_reserved_top_level_type_demoted(self, reserved):
+        """A reserved type hallucinated by the LLM is demoted to the default."""
+        result = _validate_enrichment(
+            {"memory_type": reserved, "weight": 0.9, "title": "t"}, llm_ms=5
+        )
+        assert result.memory_type == DEFAULT_MEMORY_TYPE
+
+    @pytest.mark.parametrize("reserved", sorted(SERVER_RESERVED_MEMORY_TYPES))
+    def test_reserved_atomic_fact_suggested_type_demoted(self, reserved):
+        """A reserved ``suggested_type`` on an atomic fact is demoted too."""
+        result = _validate_enrichment(
+            {
+                "memory_type": "fact",
+                "title": "t",
+                "atomic_facts": [
+                    {"content": "a distinct claim", "suggested_type": reserved},
+                    {"content": "another distinct claim", "suggested_type": "decision"},
+                ],
+            },
+            llm_ms=5,
+        )
+        types = [f.suggested_type for f in result.atomic_facts]
+        assert types[0] == DEFAULT_MEMORY_TYPE
+        assert types[1] == "decision"  # non-reserved type preserved
+
+    def test_non_reserved_type_preserved(self):
+        result = _validate_enrichment(
+            {"memory_type": "decision", "weight": 0.8, "title": "t"}, llm_ms=5
+        )
+        assert result.memory_type == "decision"
+
+    def test_unknown_type_still_falls_to_default(self):
+        result = _validate_enrichment(
+            {"memory_type": "not-a-real-type", "title": "t"}, llm_ms=5
+        )
+        assert result.memory_type == DEFAULT_MEMORY_TYPE
+
+
+@pytest.mark.unit
+class TestHeuristicBoundaryDemotion:
+    def test_primitive_still_recognises_reserved_shapes(self):
+        """The reusable primitive is intentionally unchanged — it still
+        classifies rule/outcome shapes. The policy is enforced one level up,
+        at the ``enrich_memory`` boundary."""
+        assert (
+            fake_enrich("Always notify security before deploying").memory_type == "rule"
+        )
+        assert (
+            fake_enrich("The migration achieved a great result").memory_type
+            == "outcome"
+        )
+
+    @pytest.mark.asyncio
+    async def test_enrich_memory_demotes_rule_shaped_heuristic(self):
+        result = await enrich_memory(
+            "Always notify security before deploying", _FakeProviderConfig()
+        )
+        assert result.memory_type == DEFAULT_MEMORY_TYPE
+
+    @pytest.mark.asyncio
+    async def test_enrich_memory_demotes_outcome_shaped_heuristic(self):
+        result = await enrich_memory(
+            "The migration achieved a great result", _FakeProviderConfig()
+        )
+        assert result.memory_type == DEFAULT_MEMORY_TYPE
+
+    @pytest.mark.asyncio
+    async def test_enrich_memory_preserves_non_reserved_heuristic(self):
+        result = await enrich_memory(
+            "We decided to use PostgreSQL", _FakeProviderConfig()
+        )
+        assert result.memory_type == "decision"


### PR DESCRIPTION
…types

The internal insights flow is the only intended author of insight-type memories — reports, supersession, and the lifecycle activity gate all assume every insight row is server-generated. External agents were polluting that space: the enrichment prompt offered the LLM the full type vocabulary (insight/outcome/rule included) and _validate_enrichment accepted those values, so an agent write that merely *looked* insight-/ rule-/outcome-shaped got auto-classified into a server-reserved type. Explicit agent-supplied reserved types were already rejected at the MCP/REST boundary (C3/C8); the auto-classification path was the open door.

Fix, in two layers:
- Don't offer them. The classifier prompt vocabulary is now rendered from MEMORY_TYPES minus SERVER_RESERVED_MEMORY_TYPES, so the LLM never sees insight/outcome/rule as choices.
- Demote any that slip through. _validate_enrichment maps a reserved top-level type (and any reserved atomic-fact suggested_type) to DEFAULT_MEMORY_TYPE, and enrich_memory applies the same guard to the keyword-heuristic fallback. The fake_enrich primitive is left unchanged (still reusable); the policy is enforced at the enrich_memory boundary.

Internal flows are unaffected: insights_service / evolve_service set memory_type explicitly and bypass the classifier path entirely.

Docs: the SKILL.md write sections now state insight/outcome/rule are server-generated only and never auto-assigned; the misleading "intentionally allowed" note on SERVER_RESERVED_MEMORY_TYPES is corrected.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
