### PR TITLE
feat(skills): Skill Factory Phase 0+1 — schema, Forge dry-run, eval harness (flag-gated, default off)

### DIFF
--- a/common/events/events_manifest.json
+++ b/common/events/events_manifest.json
@@ -4,6 +4,7 @@
     "core-api": [
       "memclaw.lifecycle.crystallize-requested",
       "memclaw.lifecycle.entity-link-requested",
+      "memclaw.lifecycle.forge-distill-requested",
       "memclaw.lifecycle.insights-requested",
       "memclaw.memory.embedded",
       "memclaw.memory.enriched"

--- a/common/events/lifecycle_forge_request.py
+++ b/common/events/lifecycle_forge_request.py
@@ -42,7 +42,7 @@ class LifecycleForgeDistillRequest(LifecycleRequestBase):
     freshness_window_days: int | None = None
     min_cluster_size: int | None = None
     min_distinct_agents: int | None = None
-    llm_tokens_budget: int | None = None
+    llm_tokens_per_run: int | None = None
     max_writes_per_run: int | None = None
     # ``dry_run=True`` ⇒ produce candidates with ``status=candidate``
     # only; do not run the staged-promotion auto-gates. Used by the

--- a/common/events/lifecycle_forge_request.py
+++ b/common/events/lifecycle_forge_request.py
@@ -1,0 +1,51 @@
+"""Typed payload for ``memclaw.lifecycle.forge-distill-requested`` (Skill Factory SF-007).
+
+Per-run Forge invocation. Carries the standard four
+:class:`LifecycleRequestBase` fields (``audit_id``, ``org_id``,
+``triggered_by``, ``fleet_id``) plus run-knobs that override the
+tenant defaults from ``org_settings.skills_factory.forge.*`` when the
+publisher wants tighter / looser bounds for this particular run
+(e.g. an operator-initiated dry-run with a much wider freshness
+window). Leaving every override at ``None`` means "use the configured
+defaults" and is the production path.
+
+A Forge run is identified by ``run_label`` (free-form string supplied
+by the publisher, e.g. ``forge-cron-20260510-0600`` or
+``forge-dry-run-eldad-${ulid}``); it shows up in the audit row and on
+every candidate doc the run produces (``origin.run_id``). This lets us
+attribute a candidate back to the precise Forge run that emitted it
+even after re-mining produces v2 proposals.
+"""
+
+from __future__ import annotations
+
+from common.events.lifecycle_archive_request import LifecycleRequestBase
+
+
+class LifecycleForgeDistillRequest(LifecycleRequestBase):
+    """Forge distillation run request. Run-knobs default to ``None``
+    so omitted fields fall through to ``org_settings.skills_factory.forge.*``.
+    """
+
+    # Free-form identifier for the run; surfaces on the audit row and
+    # on every produced candidate's ``origin.run_id``. The Forge worker
+    # is responsible for generating it before publishing; making it a
+    # payload field (rather than auto-server-generated) lets test
+    # harnesses pin it for deterministic replays.
+    run_label: str
+
+    # Per-run overrides for the configured knobs. ``None`` ⇒ use the
+    # tenant default from ``org_settings.skills_factory.forge.*``.
+    # Field names mirror those configured knobs and
+    # ``ForgeConfig.max_writes_per_run`` exactly so producers + the
+    # consumer + the settings layer all spell the same thing.
+    freshness_window_days: int | None = None
+    min_cluster_size: int | None = None
+    min_distinct_agents: int | None = None
+    llm_tokens_budget: int | None = None
+    max_writes_per_run: int | None = None
+    # ``dry_run=True`` ⇒ produce candidates with ``status=candidate``
+    # only; do not run the staged-promotion auto-gates. Used by the
+    # ``memclawctl forge dry-run`` CLI in Phase 1 and by the eval
+    # harness. Default ``False`` is the production path.
+    dry_run: bool = False

--- a/common/events/lifecycle_handlers.py
+++ b/common/events/lifecycle_handlers.py
@@ -34,6 +34,7 @@ from common.events.lifecycle_archive_request import (
     LifecycleArchiveRequest,
     LifecycleRequestBase,
 )
+from common.events.lifecycle_forge_request import LifecycleForgeDistillRequest
 from common.events.lifecycle_purge_request import LifecyclePurgeRequest
 from common.events.topics import Topics
 
@@ -75,6 +76,16 @@ class PipelineStorageAdapter(Protocol):
     async def entity_link(self, *, org_id: str, fleet_id: str | None) -> int: ...
 
     async def insights(self, *, org_id: str, fleet_id: str | None) -> int: ...
+
+    # Skill Factory SF-007: Forge distillation run. Phase 0 ships a
+    # no-op adapter (returns 0, logs); Phase 1 swaps in the real
+    # cluster fingerprint + LLM distill pipeline. Method signature
+    # mirrors the other pipeline ops (org_id/fleet_id only) — extra
+    # run-knobs on :class:`LifecycleForgeDistillRequest` are
+    # intentionally NOT plumbed through the adapter for the Phase 0
+    # stub; Phase 1 will either fatten this signature or thread the
+    # full request object.
+    async def forge_distill(self, *, org_id: str, fleet_id: str | None) -> int: ...
 
     async def has_recent_lifecycle_success(
         self, *, org_id: str, action: str, since_hours: int
@@ -331,6 +342,13 @@ def register_pipeline_consumers(adapter: PipelineStorageAdapter) -> None:
     async def insights_op(req: LifecycleArchiveRequest) -> int:
         return await adapter.insights(org_id=req.org_id, fleet_id=req.fleet_id)
 
+    async def forge_distill_op(req: LifecycleForgeDistillRequest) -> int:
+        # Phase 0 stub: the adapter's no-op returns 0. The full
+        # request (run_label, dry_run, freshness_window_days, etc.)
+        # is preserved on the event payload for Phase 1 — only
+        # org_id + fleet_id are threaded through the adapter today.
+        return await adapter.forge_distill(org_id=req.org_id, fleet_id=req.fleet_id)
+
     bus = get_event_bus()
     bus.subscribe(
         Topics.Lifecycle.CRYSTALLIZE_REQUESTED,
@@ -365,6 +383,22 @@ def register_pipeline_consumers(adapter: PipelineStorageAdapter) -> None:
             run_op=insights_op,
             stats_key="insights_created",
             action="insights",
+            dedup_window_hours=_PIPELINE_DEDUP_WINDOW_HOURS,
+        ),
+    )
+    # Skill Factory SF-007: Forge distill consumer. Phase 0 stub — the
+    # adapter's no-op returns 0 and logs; the dedup window stays at
+    # _PIPELINE_DEDUP_WINDOW_HOURS so a redeploy can't double-fire a
+    # legitimate Forge run within the same day.
+    bus.subscribe(
+        Topics.Lifecycle.FORGE_DISTILL_REQUESTED,
+        partial(
+            _run_action,
+            adapter=adapter,
+            payload_cls=LifecycleForgeDistillRequest,
+            run_op=forge_distill_op,
+            stats_key="candidates_produced",
+            action="forge-distill",
             dedup_window_hours=_PIPELINE_DEDUP_WINDOW_HOURS,
         ),
     )

--- a/common/events/lifecycle_publishers.py
+++ b/common/events/lifecycle_publishers.py
@@ -165,7 +165,7 @@ async def publish_forge_distill_request(
     freshness_window_days: int | None = None,
     min_cluster_size: int | None = None,
     min_distinct_agents: int | None = None,
-    llm_tokens_budget: int | None = None,
+    llm_tokens_per_run: int | None = None,
     max_writes_per_run: int | None = None,
     dry_run: bool = False,
 ) -> None:
@@ -188,7 +188,7 @@ async def publish_forge_distill_request(
             freshness_window_days=freshness_window_days,
             min_cluster_size=min_cluster_size,
             min_distinct_agents=min_distinct_agents,
-            llm_tokens_budget=llm_tokens_budget,
+            llm_tokens_per_run=llm_tokens_per_run,
             max_writes_per_run=max_writes_per_run,
             dry_run=dry_run,
         ),

--- a/common/events/lifecycle_publishers.py
+++ b/common/events/lifecycle_publishers.py
@@ -15,6 +15,7 @@ from common.events.lifecycle_archive_request import (
     LifecycleArchiveRequest,
     LifecycleRequestBase,
 )
+from common.events.lifecycle_forge_request import LifecycleForgeDistillRequest
 from common.events.lifecycle_purge_request import LifecyclePurgeRequest
 from common.events.topics import Topics
 
@@ -150,5 +151,45 @@ async def publish_insights_request(
             org_id=org_id,
             triggered_by=triggered_by,
             fleet_id=fleet_id,
+        ),
+    )
+
+
+async def publish_forge_distill_request(
+    *,
+    audit_id: int,
+    org_id: str,
+    triggered_by: str,
+    run_label: str,
+    fleet_id: str | None = None,
+    freshness_window_days: int | None = None,
+    min_cluster_size: int | None = None,
+    min_distinct_agents: int | None = None,
+    llm_tokens_budget: int | None = None,
+    max_writes_per_run: int | None = None,
+    dry_run: bool = False,
+) -> None:
+    """Skill Factory SF-007: trigger one Forge distillation run for an
+    org/fleet. Per-run override knobs default to ``None`` so the
+    consumer falls through to
+    ``org_settings.skills_factory.forge.*``. Phase 0 ships only the
+    publisher + a no-op handler; the real worker (cluster fingerprint,
+    LLM distill, gating, scan) arrives in Phase 1. See
+    :class:`~common.events.lifecycle_forge_request.LifecycleForgeDistillRequest`.
+    """
+    await _publish(
+        Topics.Lifecycle.FORGE_DISTILL_REQUESTED,
+        LifecycleForgeDistillRequest(
+            audit_id=audit_id,
+            org_id=org_id,
+            triggered_by=triggered_by,
+            fleet_id=fleet_id,
+            run_label=run_label,
+            freshness_window_days=freshness_window_days,
+            min_cluster_size=min_cluster_size,
+            min_distinct_agents=min_distinct_agents,
+            llm_tokens_budget=llm_tokens_budget,
+            max_writes_per_run=max_writes_per_run,
+            dry_run=dry_run,
         ),
     )

--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -60,6 +60,11 @@ class Lifecycle(enum.StrEnum):
     CRYSTALLIZE_REQUESTED = "memclaw.lifecycle.crystallize-requested"
     ENTITY_LINK_REQUESTED = "memclaw.lifecycle.entity-link-requested"
     INSIGHTS_REQUESTED = "memclaw.lifecycle.insights-requested"
+    # Skill Factory SF-007: Forge resident publishes one of these per
+    # scheduled distillation run. Stub handler in Phase 0 (just logs);
+    # real handler arrives in Phase 1 with the cluster fingerprint and
+    # distillation pipeline. See ``common.events.lifecycle_forge_request``.
+    FORGE_DISTILL_REQUESTED = "memclaw.lifecycle.forge-distill-requested"
 
 
 class Topics:

--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -16,6 +16,19 @@ from core_api.middleware.idempotency import IDEMPOTENCY_HEADER, idempotency_for
 from core_api.middleware.rate_limit import write_limit
 from core_api.services.agent_service import enforce_delete
 from core_api.services.audit_service import log_action, log_cross_tenant_read
+
+# Skill Factory SF-002 — imported at module scope (rather than lazily
+# inside the handler) so a broken import surfaces at server startup
+# rather than on the first skills-collection write. The flag-gate
+# below still ensures non-skills writes pay zero settings-fetch cost.
+from core_api.services.organization_settings import (
+    get_raw_settings,
+    get_settings_for_display,
+)
+from core_api.services.skill_lifecycle import (
+    SkillWriteContext,
+    validate_and_normalize_skill_write,
+)
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
 
 logger = logging.getLogger(__name__)
@@ -31,7 +44,42 @@ router = APIRouter(tags=["Document Store"])
 # data["description"] for the skills collection only — see
 # core_api.services.doc_indexing).
 SKILLS_COLLECTION = "skills"
-_SKILL_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,99}$")
+# Optional ``forge/`` or ``agent/`` prefix supports the Skill Factory's
+# doc_id namespacing (plan §3): Forge candidates land as ``forge/<slug>``
+# and synchronous agent-direct writes via ``memclaw_doc`` land as
+# ``agent/<slug>``. Without this, Forge's own writes 422 themselves at
+# the route boundary. ``manual``/``imported`` rows keep the plain
+# ``<slug>`` shape — the prefix is opt-in, not required.
+_SKILL_SLUG_RE = re.compile(r"^(?:forge/|agent/)?[a-z0-9][a-z0-9._-]{0,99}$")
+
+# Skill Factory SF-005 — Rollback metadata for applied skills.
+#
+# Reuses the existing ``documents`` table; no schema migration needed.
+# One doc per Skill Factory apply event, written BEFORE the apply
+# mutates a live SKILL.md (Phase 3 install path), so a one-click
+# revert can restore the prior state byte-for-byte.
+#
+# Doc-id shape (Phase 3 will adopt):
+#   ``<skill_slug>/<apply_iso_timestamp>``
+# Slashes are permitted by the generic ``DocumentWriteBody`` validator
+# (``doc_id`` only enforces 1-500 chars - the strict slug regex above
+# is scoped to the ``skills`` collection only).
+#
+# Data shape (informational; not yet enforced — Phase 3 adds the
+# validator):
+#
+#   {
+#     "schema":               "memclaw.skill-factory.rollback.v1",
+#     "skill_slug":           "<slug>",
+#     "written_at":           "<iso>",
+#     "target_path":          "<absolute target file path>",
+#     "action":               "create" | "update",
+#     "previous_content_hash": "<sha256>" | null,
+#     "previous_content":     "<utf8 bytes>" | null,
+#     "support_files":        [ {path, existed, previous_content_hash,
+#                                previous_content}, ... ]
+#   }
+SKILLS_ROLLBACK_COLLECTION = "skills_rollback"
 
 
 # ── Schemas ──
@@ -125,7 +173,9 @@ async def upsert_document(
         return JSONResponse(content=_body, status_code=_status)
 
     # Skills slug rule — doc_id becomes a directory name on plugin-side
-    # reconciliation, so it must be filesystem-safe.
+    # reconciliation, so it must be filesystem-safe. Note: the slug
+    # rule is permissive enough to allow ``forge/<slug>`` / ``agent/<slug>``
+    # namespaced doc_ids per the Skill Factory plan (Phase 0 OQ-2).
     if body.collection == SKILLS_COLLECTION and not _SKILL_SLUG_RE.fullmatch(body.doc_id):
         raise HTTPException(
             status_code=422,
@@ -135,6 +185,68 @@ async def upsert_document(
                 "Slugs become directory names on each plugin node."
             ),
         )
+
+    # ── Skill Factory SF-002: 7 adjustments on every skills-collection
+    # write, gated by ``org_settings.skills_factory.enabled`` (default
+    # False). Existing tenants that have never opted in see ZERO behavior
+    # change.
+    #
+    # Hot-path note: we check the flag via ``get_raw_settings`` (returns
+    # just the tenant's override dict — typically ``{}`` for never-
+    # configured tenants, cheap to load and aggressively cached). Only
+    # when the flag is true do we materialize the full merged settings
+    # via ``get_settings_for_display`` to read the per-tenant caps.
+    # Disabled tenants pay one TTL-cached lookup + one dict-get, not
+    # the full DEFAULT_SETTINGS deep-merge per write.
+    if body.collection == SKILLS_COLLECTION:
+        raw_settings = await get_raw_settings(db, body.tenant_id)
+        sf_enabled = raw_settings.get("skills_factory", {}).get("enabled") is True
+        if sf_enabled:
+            settings_display = await get_settings_for_display(db, body.tenant_id)
+            sf_settings = settings_display.get("skills_factory", {})
+            # ``forge`` source is reserved for the internal lifecycle
+            # worker; no external HTTP caller is treated as internal in
+            # Phase 0 — the Forge resident lands in Phase 1 with its
+            # own auth identity. Until then the validator will 403 any
+            # external source='forge' attempt.
+            is_internal_forge = False
+            sf_ctx = SkillWriteContext(
+                caller_agent_id=getattr(auth, "agent_id", None),
+                is_admin=bool(getattr(auth, "is_admin", False))
+                or (getattr(auth, "org_role", None) == "admin"),
+                is_internal_forge=is_internal_forge,
+                description_max_bytes=int(sf_settings.get("description_max_bytes", 160)),
+                body_max_bytes=int(sf_settings.get("body_max_bytes", 40_000)),
+            )
+
+            # For ``kind='update'`` we must fetch the live skill so the
+            # hash-binding check can compare against the current
+            # content_hash. Read-through storage; the validator handles
+            # the not-found case.
+            #
+            # Guarded by ``isinstance(body.data, dict)`` — a non-dict
+            # body.data is a legitimate input (the validator below
+            # rejects it with 422), but calling ``.get`` on it would
+            # AttributeError into a 500 first. Cleanly punt that
+            # rejection to the validator instead of crashing.
+            live_doc: dict | None = None
+            if isinstance(body.data, dict) and body.data.get("kind") == "update":
+                sc_live = get_storage_client()
+                live_doc = await sc_live.get_document(
+                    tenant_id=body.tenant_id,
+                    collection=SKILLS_COLLECTION,
+                    doc_id=body.doc_id,
+                )
+
+            normalized, _scan = await validate_and_normalize_skill_write(
+                body.data,
+                ctx=sf_ctx,
+                live_skill_doc=live_doc,
+            )
+            # Swap the normalized body in for the rest of the flow
+            # (embedding + storage round-trip). Sentinel scan and
+            # server-controlled fields are already merged inside.
+            body.data = normalized
 
     if auth.tenant_id:
         await check_and_increment(db, body.tenant_id, "write")

--- a/core-api/src/core_api/services/forge/__init__.py
+++ b/core-api/src/core_api/services/forge/__init__.py
@@ -1,0 +1,12 @@
+"""Skill Factory — Forge resident package.
+
+Lake-side skill production pipeline. Phase 0 ships only the
+:mod:`~core_api.services.forge.sentinel_scan` stub (so the SF-002
+``memclaw_doc`` skills-write adjustments can wire the call site
+end-to-end). Phase 1 lands :mod:`forge_service`,
+:mod:`fingerprint`, and :mod:`distill_prompt`; Phase 2 fills in the
+real :mod:`sentinel_scan` checks; Phase 3 adds
+:mod:`harness_install`; Phase 5 adds :mod:`openclaw_bridge`.
+
+See ``docs/live-memory-pitch/skill-factory-implementation-plan.md``.
+"""

--- a/core-api/src/core_api/services/forge/distill_prompt.py
+++ b/core-api/src/core_api/services/forge/distill_prompt.py
@@ -1,0 +1,336 @@
+"""Forge distill — prompt template + response parser (SF-104 part 1).
+
+Pure functions only. No LLM client, no DB, no I/O. The Forge
+service in :mod:`forge_service` injects an ``llm_fn`` callable that
+the prompt feeds and the parser consumes; this module just
+formats inputs → prompt string and parses the structured LLM
+output → typed dict.
+
+Why a separate module: prompt drift (the prompt itself, the
+response schema, the parser robustness rules) is the dominant
+source of Phase-1 quality bugs. Pulling the prompt out of the
+orchestrator gives the prompt its own test surface, its own
+golden-input regression suite, and a stable place to A/B
+variants when SF-105's eval harness measures precision/recall.
+
+Output schema (the dict the LLM is asked to produce — also the
+shape :func:`parse_distill_response` returns):
+
+    {
+        # Fingerprint inputs (consumed by SF-103).
+        "goal_phrase":     "<6-ish-word what-is-this-cluster-about>",
+        "domain":          "<dev|security|marketing|...>",
+        "step_skeleton":   ["<verb+object>", ...],   # ordered procedure
+        # Skill content (consumed by the upsert into `skills`).
+        "name":            "<Display Name>",
+        "slug":            "<filesystem-safe-slug>",
+        "description":     "<<=160-byte trigger sentence>",
+        "summary":         "<2-3 sentence detailed summary>",
+        "content":         "<full SKILL.md body, markdown>",
+        "tags":            ["<tag>", ...],
+        "evidence":        "<2-3 sentence human-readable rationale>",
+        "goal":            "<single sentence: the task this skill addresses>",
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# Schema version stamped into the prompt so a future schema-rev can
+# be detected at parse time. Bump this when the response schema
+# changes; the parser checks ``data.get("schema_version")`` and
+# rejects unknown versions.
+DISTILL_SCHEMA_VERSION: str = "v1"
+
+# Max characters of trace content fed into the prompt. Per-trace,
+# multi-trace clusters concatenate but cap so the prompt stays
+# within model context windows. The eval harness (SF-105) tunes
+# this knob if precision drops.
+MAX_TRACE_CONTENT_CHARS: int = 1_200
+
+# Required keys in the parsed response (we 422 on any missing).
+# Mirrors the ``data.slug`` regex enforced by the SF-002 validator in
+# ``skill_lifecycle.py``. Kept here for compile-time inspection by the
+# distill response parser so a malformed LLM slug (uppercase letters,
+# spaces, leading punctuation) gets a clear DistillParseError instead
+# of bubbling through to the storage layer as a generic 422.
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,99}$")
+
+
+REQUIRED_OUTPUT_KEYS: frozenset[str] = frozenset(
+    {
+        "goal_phrase",
+        "domain",
+        "step_skeleton",
+        "name",
+        "slug",
+        "description",
+        "summary",
+        "content",
+        "tags",
+        "evidence",
+        "goal",
+    }
+)
+
+
+# ── Inputs to the prompt ──────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TraceSnapshot:
+    """One trace's contribution to the cluster prompt.
+
+    Carries only what the LLM needs — not the full memory blobs,
+    not the embeddings. ``memory_excerpts`` is the ordered list of
+    short content samples (head + tail of each member memory,
+    truncated to a per-cluster char budget).
+    """
+
+    run_id: str
+    agent_id: str
+    outcome_label: str  # success | failure | unknown
+    memory_excerpts: list[str]
+    entity_ids: list[str]
+    started_at_iso: str
+    ended_at_iso: str
+
+
+@dataclass(frozen=True)
+class ClusterPromptInputs:
+    """Aggregated cluster shape the prompt is built from."""
+
+    tenant_id: str
+    fleet_id: str | None
+    traces: list[TraceSnapshot]
+    # Most-common entities across the cluster — pre-computed by the
+    # caller so the prompt can foreground them.
+    top_entity_labels: list[str] = field(default_factory=list)
+    # Caller may pre-bias the domain (e.g. "all traces in this
+    # cluster came from agents tagged with domain X"). The LLM is
+    # told to confirm or correct. Optional.
+    hint_domain: str | None = None
+
+
+# ── Prompt construction ───────────────────────────────────────────
+
+
+_SYSTEM_PREAMBLE = """\
+You are Forge, an autonomous resident inside MemClaw's "live memory".
+Your job: turn a cluster of agent session-traces — all of which
+followed approximately the same procedure to the same outcome —
+into a single reusable SKILL candidate.
+
+Constraints:
+  * Output strict JSON only. No prose outside the JSON. No code fence.
+  * The fingerprint fields (goal_phrase, domain, step_skeleton) drive
+    cluster identity. Be precise; do not vary surface wording across
+    re-runs of the same cluster.
+  * The trigger fields (name, description, summary) drive when an
+    agent later USES this skill. Write them as if a stranger has
+    to decide whether to fire this skill from a one-line query.
+  * The description MUST be <= 160 BYTES (UTF-8). Short, focused, "use
+    when ..." style.
+  * slug: lowercase-kebab-case only. Regex: [a-z0-9][a-z0-9._-]{{0,99}}.
+    The slug becomes part of the doc_id (forge/<slug>) and a
+    filesystem path on plugin nodes — uppercase letters, spaces, or
+    leading punctuation will be rejected by the route validator.
+  * Output `schema_version` exactly: "{schema_version}".
+  * Output `kind`: "create".
+  * step_skeleton: 3-7 items. Each item: 2-4 words. Verb-then-object.
+
+If the cluster's procedure cannot be cleanly distilled (mixed
+outcomes, divergent step orders, too few traces), still produce a
+valid candidate but set goal_phrase="" and step_skeleton=[]. The
+auto-gates downstream will reject those.
+"""
+
+# Filled at prompt-build time — saves a .format() call per
+# invocation.
+_SYSTEM_PREAMBLE_FILLED = _SYSTEM_PREAMBLE.format(schema_version=DISTILL_SCHEMA_VERSION)
+
+
+def build_distill_prompt(inputs: ClusterPromptInputs) -> str:
+    """Render the cluster into the LLM-facing prompt string.
+
+    Deterministic given the same inputs. The system preamble is
+    constant; the user section interpolates the cluster snapshot.
+    """
+    lines: list[str] = [_SYSTEM_PREAMBLE_FILLED, ""]
+
+    if inputs.hint_domain:
+        lines.append(f"Suggested domain (confirm or correct): {inputs.hint_domain}")
+    if inputs.top_entity_labels:
+        lines.append("Top entities across the cluster: " + ", ".join(sorted(set(inputs.top_entity_labels))))
+    lines.append("")
+    lines.append(
+        f"Cluster: {len(inputs.traces)} trace(s) from tenant={inputs.tenant_id} "
+        f"fleet={inputs.fleet_id or '<none>'}."
+    )
+    lines.append("")
+
+    # Per-trace block.
+    for i, t in enumerate(inputs.traces):
+        lines.append(f"--- Trace {i + 1}/{len(inputs.traces)} ---")
+        lines.append(f"agent: {t.agent_id}")
+        lines.append(f"run_id: {t.run_id}")
+        lines.append(f"window: {t.started_at_iso} → {t.ended_at_iso}")
+        lines.append(f"outcome: {t.outcome_label}")
+        if t.entity_ids:
+            # Sorted for prompt-stability (same cluster → same prompt).
+            lines.append("entities: " + ", ".join(sorted(t.entity_ids)))
+        if t.memory_excerpts:
+            lines.append("memories:")
+            budget = MAX_TRACE_CONTENT_CHARS
+            for excerpt in t.memory_excerpts:
+                if budget <= 0:
+                    break
+                snippet = excerpt[:budget]
+                budget -= len(snippet)
+                lines.append(f"  - {snippet}")
+        lines.append("")
+
+    lines.append(
+        f"Respond with one JSON object matching schema_version='{DISTILL_SCHEMA_VERSION}'. "
+        f"Required keys: {sorted(REQUIRED_OUTPUT_KEYS)} + 'schema_version' + 'kind'."
+    )
+    return "\n".join(lines)
+
+
+# ── Response parsing ──────────────────────────────────────────────
+
+
+class DistillParseError(ValueError):
+    """Raised when the LLM response doesn't match the expected
+    schema. The Forge service catches this and skips the cluster
+    (log + audit) rather than aborting the whole run."""
+
+
+# Single pattern LLMs leak despite "no code fence" instructions.
+# Leading + trailing prose is handled via JSONDecoder.raw_decode in
+# parse_distill_response itself (more robust than a regex —
+# regex-based JSON extraction trips on nested braces inside strings).
+_CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.IGNORECASE)
+
+
+def parse_distill_response(raw: str) -> dict[str, Any]:
+    """Strict-ish parser. Tries the raw input as JSON; on failure
+    strips code-fence wrappers and retries; on second failure scans
+    for the first ``{`` and lets :class:`json.JSONDecoder` consume
+    one object, ignoring any trailing prose.
+
+    Returns the parsed dict; the caller (Forge service) is
+    responsible for further validation against the skills schema.
+    """
+    if not raw or not raw.strip():
+        raise DistillParseError("LLM response was empty.")
+
+    candidate = raw.strip()
+
+    # First attempt: as-is.
+    parsed: dict[str, Any] | None = None
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        pass
+
+    # Second attempt: strip code fence.
+    if parsed is None:
+        stripped = _CODE_FENCE_RE.sub("", candidate).strip()
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            pass
+
+    # Third attempt: extract a single JSON object from the response
+    # starting at the first ``{``. Uses ``JSONDecoder.raw_decode``
+    # which consumes one well-formed object and reports where it
+    # stopped — handles BOTH leading prose ("Here's the JSON: {...}")
+    # AND trailing prose ("{...}\n\nLet me know if you want changes")
+    # in a single pass. Beats the prior regex (``^[^{]*({.*})\s*$``)
+    # because regex JSON-extraction misbehaves when the LLM's
+    # output contains string-literal braces or whitespace tails the
+    # `$` anchor doesn't match.
+    if parsed is None:
+        start = candidate.find("{")
+        if start != -1:
+            try:
+                parsed, _ = json.JSONDecoder().raw_decode(candidate[start:])
+            except json.JSONDecodeError:
+                pass
+
+    if parsed is None:
+        raise DistillParseError(
+            f"LLM response was not parseable as JSON after fence/prose stripping. Head: {raw[:200]!r}"
+        )
+
+    if not isinstance(parsed, dict):
+        raise DistillParseError(f"LLM response parsed to {type(parsed).__name__}, expected JSON object.")
+
+    # Schema version gate.
+    if parsed.get("schema_version") != DISTILL_SCHEMA_VERSION:
+        raise DistillParseError(
+            f"LLM response schema_version was {parsed.get('schema_version')!r}; "
+            f"expected {DISTILL_SCHEMA_VERSION!r}. This usually means the prompt "
+            "was changed but the parser wasn't — bump DISTILL_SCHEMA_VERSION."
+        )
+
+    # Required keys.
+    missing = REQUIRED_OUTPUT_KEYS - set(parsed)
+    if missing:
+        raise DistillParseError(
+            f"LLM response missing required keys: {sorted(missing)}. Got: {sorted(parsed)}."
+        )
+
+    # Light typing checks. Catches the most common LLM mistakes
+    # (string-for-list, list-for-string) without re-implementing
+    # the SF-002 schema validator.
+    for k in (
+        "goal_phrase",
+        "domain",
+        "name",
+        "slug",
+        "description",
+        "summary",
+        "content",
+        "evidence",
+        "goal",
+    ):
+        if not isinstance(parsed[k], str):
+            raise DistillParseError(
+                f"LLM response key {k!r} must be a string, got {type(parsed[k]).__name__}."
+            )
+    for k in ("step_skeleton", "tags"):
+        v = parsed[k]
+        if not isinstance(v, list) or not all(isinstance(item, str) for item in v):
+            raise DistillParseError(f"LLM response key {k!r} must be a list of strings.")
+
+    # Slug format check — the slug becomes part of the doc_id
+    # (``forge/<slug>``) and a filesystem path on plugin nodes, so it
+    # must match the same regex the route validator enforces on
+    # ``data.slug``. Catching this here gives a clear error pointing
+    # at the model's output instead of a generic 422 from the storage
+    # layer when the candidate_writer tries to upsert.
+    if not _SLUG_RE.fullmatch(parsed["slug"]):
+        raise DistillParseError(
+            f"LLM response slug {parsed['slug']!r} does not match required "
+            f"format {_SLUG_RE.pattern!r}. Instruct the model to use "
+            "lowercase-kebab-case."
+        )
+
+    # `kind` may be present even if not in REQUIRED_OUTPUT_KEYS —
+    # we accept both presence and explicit "create" / "update".
+    kind = parsed.get("kind", "create")
+    if kind not in ("create", "update"):
+        raise DistillParseError(f"LLM response kind must be 'create' or 'update', got {kind!r}.")
+    parsed["kind"] = kind
+
+    return parsed

--- a/core-api/src/core_api/services/forge/fingerprint.py
+++ b/core-api/src/core_api/services/forge/fingerprint.py
@@ -1,0 +1,299 @@
+"""Cluster fingerprint — canonical identity for skill candidates (SF-103).
+
+The Phase-1 critical-path piece. Without canonical cluster identity,
+every Forge re-run mints near-duplicate candidates and the Skills
+Inbox floods with noise. Plan §8.
+
+Format: ``fp:v1:<sha256_hex>``. The ``v1`` prefix is the formula
+version — any change to the canonicalization rules below MUST bump
+to v2 (and run a back-fill against ``forge_rejected_fingerprints``
+so the cooloff memory stays meaningful across versions).
+
+Canonical form (sha256 input):
+
+    goal=<canonical-goal-tokens-sorted-deduped>
+    domain=<lowercase-stripped>
+    entities=<top-5-entity-ids-sorted-asc>
+    steps=<step-skeletons-pipe-joined-order-preserved>
+
+Stability properties (pinned by property-based unit tests below):
+
+  P1. Determinism: same inputs ⇒ same fingerprint.
+  P2. Permutation invariance: shuffling entity_ids, goal_phrase
+      tokens, or letter casing in domain does NOT change the
+      fingerprint.
+  P3. Step ordering: step skeleton ORDER is significant (a procedure
+      ABA differs from AAB), but the WORDS WITHIN a step are order-
+      preserved and stopword-stripped.
+  P4. Top-K stability: adding a 6th low-centrality entity does NOT
+      change the fingerprint (top-5 cap absorbs the perturbation).
+  P5. Token normalization: simple plural stripping and stopword
+      removal absorb small surface perturbations ("deploys" vs
+      "deploy", "the deploy" vs "deploy").
+  P6. Domain canonicalization: " DevOps " ≡ "devops".
+
+The empirical ≥99% stability target (plan §8) is enforced by the
+eval harness in SF-105 — this module ships the formula + the
+invariant tests; the eval harness ships the live measurement.
+
+This module does NOT call any LLM. ``goal_phrase`` is passed in
+(the caller — usually the cluster step in SF-104 — invokes the
+LLM and threads the result here). Keeps the fingerprint trivially
+unit-testable and removes a network dependency from the hot path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+# Formula version. Bumping this is a coordination event: all live
+# rejected-fingerprint cooloffs become orphaned references. Plan §8
+# DRIFT HANDLING describes the migration.
+FINGERPRINT_FORMULA_VERSION: str = "v1"
+
+# Top-K caps. The smaller these are, the more stable the
+# fingerprint under cluster growth (a new trace is unlikely to crack
+# into top 5 entities by centrality).
+ENTITY_TOP_K: int = 5
+GOAL_PHRASE_TOP_K: int = 6
+STEP_WORDS_CAP: int = 4
+
+# Stopwords stripped before tokenization. Curated minimal set —
+# only the ones that genuinely add noise without distinguishing
+# procedures. Words like "deploy" or "step" are NOT here even
+# though they're common, because their presence/absence DOES
+# distinguish procedures.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "in",
+        "on",
+        "at",
+        "by",
+        "for",
+        "to",
+        "of",
+        "with",
+        "into",
+        "this",
+        "that",
+        "these",
+        "those",
+        "and",
+        "or",
+        "but",
+        "it",
+        "its",
+        "do",
+        "did",
+        "does",
+        "as",
+    }
+)
+
+
+# ── Data shape ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ClusterFingerprintInputs:
+    """The four canonical-form ingredients (plan §8).
+
+    All are required; emptiness is allowed but contributes to the
+    hash. An all-empty cluster still has a well-defined (degenerate)
+    fingerprint — useful as a sentinel for "no canonical form yet"
+    rather than a None.
+
+    ``entity_centralities`` is an optional dict mapping ``entity_id``
+    to a centrality score in [0, 1] (e.g. PageRank within the
+    cluster's entity subgraph). When present, top-K is by centrality
+    DESC then tie-broken by id ASC; when absent, top-K is by id ASC.
+    """
+
+    goal_phrase: str
+    domain: str
+    entity_ids: list[str] = field(default_factory=list)
+    step_skeleton: list[str] = field(default_factory=list)
+    entity_centralities: dict[str, float] | None = None
+
+
+@dataclass(frozen=True)
+class Fingerprint:
+    """Pair of the rendered fp string and the canonical_form it was
+    hashed from. The latter is logged when diagnosing fingerprint
+    drift (e.g. "why did fp shift between two Forge runs?") so the
+    operator can diff the canonical forms directly.
+    """
+
+    fp: str
+    canonical_form: str
+
+
+# ── Public API ────────────────────────────────────────────────────
+
+
+def compute_fingerprint(inputs: ClusterFingerprintInputs) -> Fingerprint:
+    """Render and hash. Pure function. Deterministic. No I/O."""
+    canonical = render_canonical_form(inputs)
+    h = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return Fingerprint(
+        fp=f"fp:{FINGERPRINT_FORMULA_VERSION}:{h}",
+        canonical_form=canonical,
+    )
+
+
+def render_canonical_form(inputs: ClusterFingerprintInputs) -> str:
+    """The sha256 input. Exposed publicly so eval/debug tooling can
+    diff two clusters' canonical forms to explain why they hashed
+    differently."""
+    goal = canonical_goal_phrase(inputs.goal_phrase)
+    domain = canonical_domain(inputs.domain)
+    entities = canonical_entities(
+        inputs.entity_ids,
+        centralities=inputs.entity_centralities,
+    )
+    steps = canonical_step_skeleton(inputs.step_skeleton)
+    return f"goal={goal}\ndomain={domain}\nentities={','.join(entities)}\nsteps={'|'.join(steps)}"
+
+
+# ── Canonicalization primitives ───────────────────────────────────
+
+
+def canonical_goal_phrase(text: str) -> str:
+    """Tokenize → lowercase → strip punctuation → drop stopwords →
+    strip simple plurals → DEDUPE → SORT → take top
+    :data:`GOAL_PHRASE_TOP_K`.
+
+    The sort is what makes "deploy hangs eu-west" ≡ "eu-west deploy
+    hangs" — the bag-of-words distillation is what we want for
+    clustering identity.
+    """
+    if not text:
+        return ""
+    tokens = _tokenize(text)
+    tokens = [t for t in tokens if t not in _STOPWORDS]
+    tokens = [_strip_simple_plural(t) for t in tokens]
+    tokens = sorted(set(tokens))
+    return " ".join(tokens[:GOAL_PHRASE_TOP_K])
+
+
+def canonical_domain(domain: str) -> str:
+    """Lower + strip outer whitespace. Domain values come from a
+    curated enum (eToro: 13 values like ``devops``, ``security``,
+    ``marketing`` — see survey memo) so the canonicalization is
+    minimal."""
+    return (domain or "").strip().lower()
+
+
+def canonical_entities(
+    entity_ids: list[str],
+    *,
+    centralities: dict[str, float] | None = None,
+) -> list[str]:
+    """Top-K entities by centrality (when available), else by id
+    sort. Output is always sorted ASCENDING (canonical form
+    requirement: permuting the input must not change the output).
+
+    Ties on centrality are broken by id ASC (deterministic).
+    """
+    if not entity_ids:
+        return []
+    if centralities:
+        # Dedupe BEFORE ranking — without this the centrality path
+        # would diverge from the no-centrality path (which dedupes
+        # via ``sorted(set(...))``). Duplicate inputs would otherwise
+        # burn top-K slots and silently shift the canonical form.
+        # Sort key is (centrality DESC, id ASC) — id ASC breaks
+        # centrality ties deterministically.
+        ranked = sorted(
+            set(entity_ids),
+            key=lambda eid: (-centralities.get(eid, 0.0), eid),
+        )
+        top = ranked[:ENTITY_TOP_K]
+    else:
+        # No centrality info — fall back to id ASC then take first K.
+        # Deterministic but not centrality-aware; OK as a degenerate
+        # case when the entity-resolution layer hasn't scored yet.
+        top = sorted(set(entity_ids))[:ENTITY_TOP_K]
+    return sorted(top)
+
+
+def canonical_step_skeleton(steps: list[str]) -> list[str]:
+    """Per-step normalization. Step ORDER is preserved (procedure
+    semantics depend on it). Within each step:
+
+      - lowercase
+      - strip punctuation
+      - drop stopwords
+      - strip simple plurals
+      - cap to :data:`STEP_WORDS_CAP` words
+      - preserve word order within the step (the verb-object
+        ordering is semantically meaningful, unlike the bag-of-words
+        goal phrase)
+
+    Empty steps after normalization are kept as the empty string —
+    losing them would shift downstream step indices and break
+    cluster identity ("step 3 was a no-op" is meaningful).
+    """
+    out: list[str] = []
+    for raw in steps:
+        words = _tokenize(raw)
+        words = [w for w in words if w not in _STOPWORDS]
+        words = [_strip_simple_plural(w) for w in words]
+        words = words[:STEP_WORDS_CAP]
+        out.append(" ".join(words))
+    return out
+
+
+# ── Internals ─────────────────────────────────────────────────────
+
+
+_NON_ALPHANUM = re.compile(r"[^a-z0-9]+")
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase, collapse any non-alphanumeric run to a single
+    space, then split. Cheap, deterministic, no dependencies."""
+    if not text:
+        return []
+    return [t for t in _NON_ALPHANUM.split(text.lower()) if t]
+
+
+def _strip_simple_plural(token: str) -> str:
+    """Very rough English-plural stripping. We do this so "deploys"
+    and "deploy" hash identically. It's a known under-approximation
+    of real lemmatization — picks up regular -s plurals but not
+    irregulars (criteria/criterion, indices/index).
+
+    Protections:
+      - Words ≤ 4 chars are left alone ("ass", "ous" wouldn't
+        survive otherwise).
+      - Double-s endings ("press", "miss", "class") are protected.
+      - "-us" endings ("us", "thus", "bus") are protected.
+    """
+    if len(token) <= 4:
+        return token
+    if token.endswith("ss") or token.endswith("us"):
+        return token
+    if token.endswith("ies") and len(token) > 4:
+        # "tries" → "try", "babies" → "baby" (regular English -ies plural).
+        # Over-approximation OK — stability > accuracy at this layer.
+        return token[:-3] + "y"
+    if token.endswith("s"):
+        return token[:-1]
+    return token

--- a/core-api/src/core_api/services/forge/forge_service.py
+++ b/core-api/src/core_api/services/forge/forge_service.py
@@ -1,0 +1,644 @@
+"""Forge service — the resident orchestrator (SF-104 part 2).
+
+End-to-end Phase-1 pipeline:
+
+  build session traces (SF-102)
+    → filter to labeled outcomes
+    → cluster by entity Jaccard overlap
+    → gate clusters (volume + diversity)
+    → distill each cluster via injected ``llm_fn`` (uses SF-104 prompt)
+    → compute fingerprint (SF-103)
+    → check poison memory (``forge_rejected_fingerprints``)
+    → write skill candidate doc with status='candidate', source='forge'
+
+Phase-1 MVP scope (per plan §15):
+
+  * Forge runs ONLY as a manual CLI invocation (SF-106) or via
+    direct call from the eval harness (SF-105).
+  * Candidates ALWAYS land with ``status='candidate'``. They never
+    auto-promote to ``staged`` in Phase 1 — the auto-gates that
+    eventually move them are part of Phase 2.
+  * No HITL surfacing — the inbox is Phase 2.
+
+Everything that touches an external system is injected as a callable
+parameter so the unit tests run hermetic:
+
+  * ``llm_fn``        — async (prompt: str) → str (raw LLM response).
+  * ``memory_fetcher`` — async (memory_ids) → dict[memory_id → content].
+  * ``poison_checker`` — async (fingerprint) → bool (True = poisoned).
+  * ``candidate_writer`` — async (candidate_doc) → None (persists).
+
+The production caller wires real implementations; the eval harness
+swaps in golden-output fakes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from core_api.services.forge.distill_prompt import (
+    ClusterPromptInputs,
+    DistillParseError,
+    TraceSnapshot,
+    build_distill_prompt,
+    parse_distill_response,
+)
+from core_api.services.forge.fingerprint import (
+    ClusterFingerprintInputs,
+    compute_fingerprint,
+)
+from core_api.services.forge.sentinel_scan import scan_skill_doc
+from core_api.services.session_trace import (
+    SessionTraceRow,
+    build_session_traces,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── Tunables (mirrors org_settings.skills_factory.forge.*) ────────
+
+
+@dataclass(frozen=True)
+class ForgeConfig:
+    """Resolves from ``org_settings.skills_factory.forge.*`` at call
+    time. Defaults here mirror plan §12 + ``DEFAULT_SETTINGS`` in
+    ``organization_settings`` — duplicated literals are
+    intentional (decoupled fallback). Production callers pass an
+    explicitly-resolved instance.
+    """
+
+    min_cluster_size: int = 3
+    min_distinct_agents: int = 3
+    freshness_window_days: int = 14
+    max_writes_per_run: int = 20
+    # Entity-Jaccard threshold for cluster membership. 0.4 means a
+    # trace joins a cluster if it shares ≥40% of its entities with
+    # the cluster's entity union.
+    cluster_entity_jaccard_threshold: float = 0.4
+    # Max characters of a single memory's content fed into the
+    # prompt per trace (head truncation; tail is dropped).
+    memory_excerpt_char_cap: int = 600
+
+
+# ── Injected callables ────────────────────────────────────────────
+
+
+LlmFn = Callable[[str], Awaitable[str]]
+MemoryFetcher = Callable[[list[str]], Awaitable[dict[str, str]]]
+PoisonChecker = Callable[[str], Awaitable[bool]]  # (fingerprint) → True if poisoned
+CandidateWriter = Callable[[dict[str, Any]], Awaitable[None]]
+# Pre-write existence check: (tenant_id, collection, doc_id) → existing status
+# (or None if no doc with that id exists). The Forge writer SKIPS persistence
+# when the existing doc's status is anything OTHER than ``candidate`` — that
+# prevents a re-mining run from clobbering an already-approved (``active``),
+# already-rejected, quarantined, or otherwise human-curated skill. A re-mined
+# candidate that lands on top of an existing ``candidate`` IS allowed (and
+# expected — that's how Forge refines its own candidates over time).
+StatusChecker = Callable[[str, str, str], Awaitable[str | None]]
+
+
+# ── Run summary ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ForgeRunResult:
+    """Returned per call to :func:`run_forge_distill`. The CLI
+    (SF-106) and eval harness (SF-105) inspect this directly.
+
+    ``started_at`` is REQUIRED — populated by the caller at the very
+    top of :func:`run_forge_distill` before any await. The previous
+    shape used ``default_factory=datetime.now`` which fired at
+    dataclass-construction time (the END of the run), making
+    ``started_at`` indistinguishable from ``finished_at``.
+    """
+
+    tenant_id: str
+    fleet_id: str | None
+    window_start: datetime
+    window_end: datetime
+    total_traces: int
+    labeled_traces: int
+    clusters_total: int
+    clusters_eligible: int
+    candidates_written: int
+    # Cluster fingerprint matched a row in ``forge_rejected_fingerprints``
+    # that's still inside its cooloff window.
+    candidates_skipped_poisoned: int
+    # Sentinel pre-scan returned a fatal finding (path violation,
+    # hard size cap, etc.). Distinguished from ``poisoned`` so the
+    # run summary can answer "is the corpus producing unsafe
+    # content?" separately from "is the rejected-fingerprint memory
+    # working?".
+    candidates_skipped_sentinel: int
+    # LLM response failed to parse or violated the Phase-1 invariants
+    # (kind='create', valid slug, etc.). Operator action: re-tune the
+    # prompt or model.
+    candidates_skipped_distill_error: int
+    # Transient I/O failures from injected callables (memory_fetcher
+    # DB error, poison_checker failure, status_checker DB hiccup,
+    # candidate_writer UNIQUE-violation, etc.). Operator action:
+    # inspect logs for the underlying exception type. Distinct from
+    # distill errors so the run summary actionably surfaces "3 parse
+    # errors" vs "2 storage hiccups".
+    candidates_skipped_io_error: int
+    # Candidates where ``status_checker`` reported the target doc_id
+    # already exists with a non-``candidate`` status (active, rejected,
+    # quarantined, stale, deprecated). Forge skips the write to avoid
+    # clobbering operator-curated state.
+    candidates_skipped_existing: int
+    started_at: datetime
+    run_label: str
+    candidate_doc_ids: list[str] = field(default_factory=list)
+
+
+# ── Public entry point ────────────────────────────────────────────
+
+
+async def run_forge_distill(
+    db: Any,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    window_start: datetime,
+    window_end: datetime,
+    run_label: str,
+    llm_fn: LlmFn,
+    memory_fetcher: MemoryFetcher,
+    poison_checker: PoisonChecker,
+    candidate_writer: CandidateWriter,
+    status_checker: StatusChecker | None = None,
+    config: ForgeConfig | None = None,
+) -> ForgeRunResult:
+    """One Forge tick. Idempotent against ``session_traces`` (writes
+    via :func:`build_session_traces` upsert by run/agent id).
+    Idempotent against ``skills`` by virtue of fingerprint-keyed
+    skipping — a re-run with the same lake state writes the same
+    candidate ids back.
+
+    ``run_label`` is the audit handle for this tick — surfaced as
+    ``origin.run_id`` on every candidate doc Forge produces. The
+    caller (CLI / scheduler) is responsible for choosing a value
+    that uniquely identifies this run (e.g. timestamp + tenant).
+
+    ``status_checker`` (optional) is the no-overwrite guard. When
+    supplied, Forge looks up the doc at the candidate's target slug
+    BEFORE writing. If something already exists with a status other
+    than ``candidate`` (i.e. it's ``active``, ``rejected``,
+    ``quarantined``, ``stale``, or ``deprecated``), Forge SKIPS the
+    write and increments ``candidates_skipped_existing``. This stops
+    a re-mining run from silently clobbering operator-approved or
+    operator-rejected state. Re-mining over an existing
+    ``candidate`` IS allowed — that's the legitimate refine-the-
+    candidate path. None disables the check (e.g. eval harness)."""
+
+    cfg = config or ForgeConfig()
+    # Stamp the start of the run BEFORE the first await. Anything
+    # later (including the build_session_traces call) will already
+    # have done work; using ``datetime.now`` at dataclass-construction
+    # time would have read the END of the run, not the start.
+    run_started_at = datetime.now(UTC)
+
+    # 1. Build traces (persists into session_traces via SF-102).
+    traces = await build_session_traces(
+        db,
+        tenant_id=tenant_id,
+        fleet_id=fleet_id,
+        window_start=window_start,
+        window_end=window_end,
+        persist=True,
+    )
+
+    # 2. Drop unlabeled traces — they don't have an outcome to
+    # cluster around. Plan §6: outcome_label='unknown' is the
+    # explicit "don't know" state.
+    labeled = [t for t in traces if t.outcome_label != "unknown"]
+
+    # 3. Cluster by entity Jaccard. Empty / no-entity traces fall
+    # out (can't compare set overlap).
+    clusters = _cluster_by_entity_overlap(
+        labeled,
+        jaccard_threshold=cfg.cluster_entity_jaccard_threshold,
+    )
+
+    # 4. Gate by volume + diversity.
+    eligible = _gate_clusters(
+        clusters,
+        min_cluster_size=cfg.min_cluster_size,
+        min_distinct_agents=cfg.min_distinct_agents,
+    )
+
+    # Run-level counters. Split out by failure mode so the run
+    # summary is actionable — "3 parse errors" vs "1 Sentinel block"
+    # vs "2 storage hiccups" each demand different operator action.
+    written_ids: list[str] = []
+    skipped_poisoned = 0
+    skipped_sentinel = 0
+    skipped_distill_error = 0
+    skipped_io_error = 0
+    skipped_existing = 0
+
+    # 5. Distill each eligible cluster.
+    for cluster_traces in eligible[: cfg.max_writes_per_run]:
+        try:
+            candidate_doc = await _distill_cluster(
+                cluster_traces,
+                tenant_id=tenant_id,
+                fleet_id=fleet_id,
+                run_label=run_label,
+                llm_fn=llm_fn,
+                memory_fetcher=memory_fetcher,
+                poison_checker=poison_checker,
+                excerpt_cap=cfg.memory_excerpt_char_cap,
+            )
+        except _PoisonedClusterSkip:
+            # Cluster fingerprint matched the cooloff'd reject memory.
+            skipped_poisoned += 1
+            continue
+        except _SentinelFatalSkip:
+            # Sentinel pre-scan blocked the cluster on a fatal finding
+            # (path violation / hard size cap). Distinct from the
+            # poison-memory hit so operators can tell content-shape
+            # problems from cooloff hits.
+            skipped_sentinel += 1
+            continue
+        except DistillParseError as exc:
+            # LLM-shaped failure: response unparseable / kind != create
+            # / malformed slug. Operator action: re-tune the prompt
+            # or model.
+            logger.warning("forge: skipping cluster — LLM response unparseable: %s", exc)
+            skipped_distill_error += 1
+            continue
+        except Exception:
+            # Transient I/O failures inside _distill_cluster
+            # (memory_fetcher / poison_checker DB hiccup, entity-
+            # lookup partial fail bubbling up). MUST NOT abort the
+            # tick. Operator action: inspect logs for the underlying
+            # exception type.
+            logger.exception("forge: unexpected I/O exception during cluster distill — skipping cluster")
+            skipped_io_error += 1
+            continue
+
+        # No-overwrite guard: if a doc with this slug already exists
+        # with a non-``candidate`` status, the operator (or a prior
+        # run / Sentinel / Inbox action) has staked a claim on it.
+        # Re-mining must NOT silently overwrite that state.
+        if status_checker is not None:
+            try:
+                existing_status = await status_checker(tenant_id, "skills", candidate_doc["doc_id"])
+            except Exception:
+                # storage-layer failure → I/O bucket, not parse-error.
+                logger.exception(
+                    "forge: status_checker raised for slug=%s — skipping write",
+                    candidate_doc.get("data", {}).get("slug"),
+                )
+                skipped_io_error += 1
+                continue
+            if existing_status is not None and existing_status != "candidate":
+                logger.info(
+                    "forge: skipping write for slug=%s — existing doc has status=%s (not candidate)",
+                    candidate_doc["data"]["slug"],
+                    existing_status,
+                )
+                skipped_existing += 1
+                continue
+
+        try:
+            await candidate_writer(candidate_doc)
+        except Exception:
+            # candidate_writer failure (UNIQUE-violation, schema
+            # validator hiccup, network drop) → I/O bucket.
+            logger.exception(
+                "forge: candidate_writer raised for slug=%s — skipping",
+                candidate_doc.get("data", {}).get("slug"),
+            )
+            skipped_io_error += 1
+            continue
+        # Append the FULL doc_id (``forge/<slug>``), not the bare slug —
+        # ``candidate_doc_ids`` is the handle callers (CLI summary,
+        # eval harness, Phase 2 inbox query) use to look the row up
+        # in the ``documents`` table. A bare slug wouldn't match the
+        # (tenant_id, collection, doc_id) primary-key shape.
+        written_ids.append(candidate_doc["doc_id"])
+
+    result = ForgeRunResult(
+        tenant_id=tenant_id,
+        fleet_id=fleet_id,
+        window_start=window_start,
+        window_end=window_end,
+        total_traces=len(traces),
+        labeled_traces=len(labeled),
+        clusters_total=len(clusters),
+        clusters_eligible=len(eligible),
+        candidates_written=len(written_ids),
+        candidates_skipped_poisoned=skipped_poisoned,
+        candidates_skipped_sentinel=skipped_sentinel,
+        candidates_skipped_distill_error=skipped_distill_error,
+        candidates_skipped_io_error=skipped_io_error,
+        candidates_skipped_existing=skipped_existing,
+        candidate_doc_ids=written_ids,
+        started_at=run_started_at,
+        run_label=run_label,
+    )
+    logger.info(
+        "forge_run: run_label=%s tenant=%s fleet=%s traces=%d labeled=%d "
+        "clusters=%d eligible=%d written=%d poisoned=%d sentinel=%d "
+        "distill_errors=%d io_errors=%d existing=%d",
+        result.run_label,
+        result.tenant_id,
+        result.fleet_id,
+        result.total_traces,
+        result.labeled_traces,
+        result.clusters_total,
+        result.clusters_eligible,
+        result.candidates_written,
+        result.candidates_skipped_poisoned,
+        result.candidates_skipped_sentinel,
+        result.candidates_skipped_distill_error,
+        result.candidates_skipped_io_error,
+        result.candidates_skipped_existing,
+    )
+    return result
+
+
+# ── Clustering ────────────────────────────────────────────────────
+
+
+def _cluster_by_entity_overlap(
+    traces: list[SessionTraceRow],
+    *,
+    jaccard_threshold: float,
+) -> list[list[SessionTraceRow]]:
+    """Greedy single-pass clustering. Each trace joins the first
+    existing cluster whose entity union overlaps it by ≥
+    ``jaccard_threshold``; otherwise starts its own cluster.
+
+    Why greedy (not k-means): k-means needs k chosen upfront, and
+    skill clusters are emergent — we don't know how many we want
+    until we see the data. Greedy on a single pass is fast,
+    deterministic-given-order, and produces tighter clusters than
+    k-means when k would be very small.
+
+    Determinism: traces are iterated in their input order — the
+    caller (Forge run) gets them in (run_id, agent_id) ascending
+    order from the session_trace builder. So the same lake state
+    produces the same cluster assignment.
+
+    Traces with no entities are dropped (can't cluster by entity
+    overlap if there are none).
+    """
+    clusters: list[list[SessionTraceRow]] = []
+    cluster_entity_sets: list[set[str]] = []
+
+    for trace in traces:
+        ents = set(trace.entity_ids)
+        if not ents:
+            continue
+
+        placed = False
+        for idx, cluster_ents in enumerate(cluster_entity_sets):
+            inter = len(ents & cluster_ents)
+            union = len(ents | cluster_ents)
+            if union == 0:
+                continue
+            if inter / union >= jaccard_threshold:
+                clusters[idx].append(trace)
+                cluster_entity_sets[idx] |= ents
+                placed = True
+                break
+
+        if not placed:
+            clusters.append([trace])
+            cluster_entity_sets.append(set(ents))
+
+    return clusters
+
+
+def _gate_clusters(
+    clusters: list[list[SessionTraceRow]],
+    *,
+    min_cluster_size: int,
+    min_distinct_agents: int,
+) -> list[list[SessionTraceRow]]:
+    """Drop clusters that don't meet the volume + diversity floors.
+    Plan §5 auto-gates: 'volume ≥ N' + 'diversity ≥ M distinct
+    agents'. Pre-filters before the LLM call so we don't waste
+    tokens on under-evidenced clusters.
+    """
+    eligible: list[list[SessionTraceRow]] = []
+    for cluster in clusters:
+        if len(cluster) < min_cluster_size:
+            continue
+        distinct_agents = {t.agent_id for t in cluster}
+        if len(distinct_agents) < min_distinct_agents:
+            continue
+        eligible.append(cluster)
+    return eligible
+
+
+# ── Per-cluster distill pipeline ──────────────────────────────────
+
+
+class _PoisonedClusterSkip(Exception):
+    """Internal sentinel — raised when the cluster's fingerprint is
+    on the poison list. Caught by ``run_forge_distill``.
+
+    Distinct from :class:`_SentinelFatalSkip` so the run summary can
+    show "rejected-fingerprint poison memory hits" separately from
+    "Sentinel-scanner content blocks" — different operator action
+    in each case."""
+
+
+class _SentinelFatalSkip(Exception):
+    """Internal sentinel — raised when the Sentinel pre-scan returns
+    a finding marked ``fatal=True`` (path violation, hard size cap,
+    etc.). Caught by ``run_forge_distill`` and counted as
+    ``candidates_skipped_sentinel`` separately from poisoned-
+    fingerprint skips."""
+
+
+async def _distill_cluster(
+    cluster_traces: list[SessionTraceRow],
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    run_label: str,
+    llm_fn: LlmFn,
+    memory_fetcher: MemoryFetcher,
+    poison_checker: PoisonChecker,
+    excerpt_cap: int,
+) -> dict[str, Any]:
+    """Turn one cluster into a candidate skill doc ready for the
+    upsert into ``documents`` (``collection='skills'``)."""
+
+    # Collect all member-memory ids; fetch their content for the prompt.
+    all_memory_ids = sorted({mid for trace in cluster_traces for mid in trace.memory_ids})
+    contents = await memory_fetcher(all_memory_ids)
+
+    # Build per-trace snapshots.
+    snapshots: list[TraceSnapshot] = []
+    for trace in cluster_traces:
+        excerpts: list[str] = []
+        budget = excerpt_cap
+        for mid in trace.memory_ids:
+            if budget <= 0:
+                break
+            text = contents.get(mid, "")
+            snippet = text[:budget]
+            if snippet:
+                excerpts.append(snippet)
+                budget -= len(snippet)
+        snapshots.append(
+            TraceSnapshot(
+                run_id=trace.run_id,
+                agent_id=trace.agent_id,
+                outcome_label=trace.outcome_label,
+                memory_excerpts=excerpts,
+                entity_ids=trace.entity_ids,
+                started_at_iso=trace.started_at.isoformat(),
+                ended_at_iso=trace.ended_at.isoformat(),
+            )
+        )
+
+    cluster_inputs = ClusterPromptInputs(
+        tenant_id=tenant_id,
+        fleet_id=fleet_id,
+        traces=snapshots,
+        top_entity_labels=sorted({e for trace in cluster_traces for e in trace.entity_ids}),
+        hint_domain=None,
+    )
+
+    # LLM call — single round-trip per cluster.
+    prompt = build_distill_prompt(cluster_inputs)
+    raw_response = await llm_fn(prompt)
+    parsed = parse_distill_response(raw_response)
+
+    # Phase 1 invariant: Forge only mints NEW candidates. ``kind='update'``
+    # candidates (with hash-binding to an existing live skill) are
+    # Phase-4 territory — they need the v2-diff card flow + drift
+    # detection that don't ship until then. If a model decides to
+    # respond with kind='update' anyway, we'd silently mint a
+    # candidate that the validator would later reject for missing
+    # ``data.target.target_content_hash``. Bail loud now with a
+    # parse error so the cluster is skipped + counted as a distill
+    # error rather than producing a malformed doc.
+    if parsed.get("kind") != "create":
+        raise DistillParseError(
+            f"Forge distill: kind must be 'create' in Phase 1, got {parsed['kind']!r}. "
+            "kind='update' candidates require hash-binding to a live target — "
+            "that flow lands in Phase 4 alongside v2 diff cards."
+        )
+
+    # Compute fingerprint from LLM-extracted goal/domain/steps +
+    # cluster entities (entity centralities omitted in MVP; SF-105
+    # eval harness will measure whether stability is good enough
+    # without them).
+    fp_inputs = ClusterFingerprintInputs(
+        goal_phrase=parsed["goal_phrase"],
+        domain=parsed["domain"],
+        entity_ids=cluster_inputs.top_entity_labels,
+        step_skeleton=parsed["step_skeleton"],
+        entity_centralities=None,
+    )
+    fingerprint = compute_fingerprint(fp_inputs)
+
+    # Poison check — short-circuits any further write.
+    if await poison_checker(fingerprint.fp):
+        logger.info(
+            "forge: cluster fingerprint %s is poisoned; skipping (slug=%s)",
+            fingerprint.fp,
+            parsed["slug"],
+        )
+        raise _PoisonedClusterSkip()
+
+    # Assemble the candidate doc ready for memclaw_doc upsert.
+    now_iso = datetime.now(UTC).isoformat(timespec="seconds")
+
+    # Forge writes go through the storage client directly (the worker is
+    # internal — not an HTTP caller), so the SF-002 validator + Sentinel
+    # hook in ``routes/documents.py`` are NOT exercised on this path. We
+    # therefore need to stamp ``content_hash`` and ``scan`` ourselves so
+    # downstream consumers (hash-binding for kind=update, Inbox-card
+    # render of scan findings) see the same shape they'd see on a
+    # validator-mediated write.
+    content = parsed["content"]
+    content_hash = "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+    candidate_doc: dict[str, Any] = {
+        "tenant_id": tenant_id,
+        "fleet_id": fleet_id,
+        "collection": "skills",
+        # Plan §3 §15 doc_id namespacing for Forge candidates.
+        "doc_id": f"forge/{parsed['slug']}",
+        "data": {
+            "name": parsed["name"],
+            "slug": parsed["slug"],
+            "version": "v1",
+            "kind": parsed["kind"],  # always "create" in Phase 1
+            "source": "forge",
+            "status": "candidate",  # Phase 1 candidates NEVER auto-promote
+            "description": parsed["description"],
+            "summary": parsed["summary"],
+            "domain": parsed["domain"],
+            "tags": parsed["tags"],
+            "content": content,
+            "content_hash": content_hash,
+            # Provenance — Inbox card surfaces these in Phase 2.
+            "cites": all_memory_ids,
+            "goal": parsed["goal"],
+            "evidence": parsed["evidence"],
+            "cluster_fingerprint": fingerprint.fp,
+            "origin": {
+                "agent_id": "forge",
+                "session_key": None,
+                # Stamped from the run_label threaded through
+                # run_forge_distill — the CLI / scheduler picks the
+                # value (e.g. ``forge-dry-run-acme-20260607T1845``)
+                # and we propagate it onto every candidate this tick
+                # produces so an operator inspecting the inbox can
+                # trace a card back to the Forge invocation that
+                # minted it.
+                "run_id": run_label,
+                "message_id": None,
+            },
+            "created_at": now_iso,
+            "updated_at": now_iso,
+            "telemetry": {
+                "fires_total": 0,
+                "fires_success": 0,
+                "fires_failure": 0,
+                "last_fired_at": None,
+                "utilization_30d": None,
+            },
+        },
+    }
+
+    # Sentinel pre-scan, mirroring the SF-002 validator behavior. If
+    # any fatal finding turns up (path violation, hard size cap, etc.)
+    # we treat the cluster like a poisoned one — skip the write so the
+    # Forge tick doesn't smuggle unsafe content past the inbox gate.
+    # Non-fatal critical findings flip the doc to ``status='quarantined'``
+    # before persisting, matching the route's behavior for the same
+    # condition.
+    scan_result = await scan_skill_doc(candidate_doc["data"], mode="pre-write")
+    if scan_result.any_fatal:
+        logger.warning(
+            "forge: skipping cluster — Sentinel returned fatal finding for slug=%s",
+            parsed["slug"],
+        )
+        # Distinct from _PoisonedClusterSkip so the run summary
+        # surfaces "Sentinel blocked content" separately from
+        # "rejected-fingerprint cooloff hit" — different operator
+        # responses.
+        raise _SentinelFatalSkip()
+    candidate_doc["data"]["scan"] = scan_result.as_doc_field()
+    if scan_result.state == "quarantined":
+        candidate_doc["data"]["status"] = "quarantined"
+        candidate_doc["data"]["quarantined_at"] = now_iso
+
+    return candidate_doc

--- a/core-api/src/core_api/services/forge/forge_service.py
+++ b/core-api/src/core_api/services/forge/forge_service.py
@@ -49,6 +49,7 @@ from core_api.services.forge.distill_prompt import (
     parse_distill_response,
 )
 from core_api.services.forge.fingerprint import (
+    ENTITY_TOP_K,
     ClusterFingerprintInputs,
     compute_fingerprint,
 )
@@ -509,7 +510,11 @@ async def _distill_cluster(
         tenant_id=tenant_id,
         fleet_id=fleet_id,
         traces=snapshots,
-        top_entity_labels=sorted({e for trace in cluster_traces for e in trace.entity_ids}),
+        # Cap at ENTITY_TOP_K to bound prompt size and to mirror the
+        # fingerprint's centrality cut — the LLM sees the same top-K
+        # entities the fingerprint stamps, so prompt and fp agree on
+        # cluster identity.
+        top_entity_labels=sorted({e for trace in cluster_traces for e in trace.entity_ids})[:ENTITY_TOP_K],
         hint_domain=None,
     )
 

--- a/core-api/src/core_api/services/forge/sentinel_scan.py
+++ b/core-api/src/core_api/services/forge/sentinel_scan.py
@@ -1,0 +1,150 @@
+"""Sentinel scanner for Skill Factory skill docs (plan §9).
+
+Phase 0 SHIPS A STUB. The signature, return type, and call sites are
+real so SF-002 (``memclaw_doc`` skills-write adjustments) can invoke
+it end-to-end and the lifecycle plumbing is exercised in Phase 0
+tests. Phase 2 (HITL Inbox + Sentinel) fills in the 8 real checks.
+
+The stub:
+
+  - returns ``state="clean"`` with zero findings for any input
+  - obeys size-related ``HTTPException``-style guards by returning a
+    structured ScanFinding the caller can promote to a 422 — the
+    caller decides whether a given finding is fatal (path / size
+    violations) or quarantine-worthy (prompt-injection / shell-inject)
+  - is deterministic + fast (no LLM, no network) by design
+
+Both call sites are introduced in Phase 0:
+
+  1. ``routes/documents.py`` — pre-write hook on every
+     ``collection='skills'`` upsert (SF-002 adjustment #7).
+  2. (Phase 2) ``services/skill_lifecycle.py`` — pre-apply hook on
+     ``staged → active`` transitions, so a doc that became unsafe
+     between propose and apply is caught before mutation.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+
+ScanState = Literal["pending", "clean", "failed", "quarantined"]
+ScanMode = Literal["pre-write", "pre-apply"]
+
+
+@dataclass(frozen=True)
+class ScanFinding:
+    """A single Sentinel finding.
+
+    Severity drives caller behavior:
+
+      - ``critical`` → caller should set ``status='quarantined'``
+        on the doc (or refuse to write at all for hard-reject
+        findings like size / path violations — see :attr:`fatal`).
+      - ``warn``     → finding surfaces on the inbox card; doc may
+        still proceed to ``staged``.
+      - ``info``     → audit/debug only; no UX surface.
+    """
+
+    code: str
+    severity: Literal["critical", "warn", "info"]
+    message: str
+    # ``fatal=True`` means the caller MUST refuse the operation
+    # (e.g. ``HTTPException(422)``) rather than persisting + tagging
+    # quarantine. Reserved for path violations and hard size caps —
+    # things that should never be stored at all.
+    fatal: bool = False
+    # Optional pointer at the offending span; e.g.
+    # ``"data.support_files[2].path"`` or ``"data.content[14012:14050]"``.
+    locator: str | None = None
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """Output of a single scan. Shape mirrors plan §3
+    ``data.scan`` block, ready to merge straight into the doc.
+    """
+
+    state: ScanState
+    scanned_at: str
+    critical: int
+    warn: int
+    info: int
+    findings: tuple[ScanFinding, ...] = field(default_factory=tuple)
+
+    def as_doc_field(self) -> dict:
+        """Render to the jsonb shape the doc carries on disk."""
+        return {
+            "state": self.state,
+            "scanned_at": self.scanned_at,
+            "critical": self.critical,
+            "warn": self.warn,
+            "info": self.info,
+            "findings": [
+                {
+                    "code": f.code,
+                    "severity": f.severity,
+                    "message": f.message,
+                    **({"fatal": True} if f.fatal else {}),
+                    **({"locator": f.locator} if f.locator else {}),
+                }
+                for f in self.findings
+            ],
+        }
+
+    @property
+    def any_fatal(self) -> bool:
+        return any(f.fatal for f in self.findings)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+async def scan_skill_doc(
+    data: dict,
+    *,
+    mode: ScanMode = "pre-write",
+) -> ScanResult:
+    """Phase 0 STUB. Returns ``state='clean'`` with zero findings.
+
+    Phase 2 replaces the body with the 8 real checks (plan §9):
+
+      1. prompt-injection markers in content/description/summary/evidence
+      2. shell-injection in support_files/scripts/*
+      3. URL exfiltration patterns in scripts
+      4. path violations on support_files (hard-reject; ``fatal=True``)
+      5. PII in content/evidence
+      6. memory-id stuffing (> 20 cites)
+      7. body size > body_max_bytes (hard-reject; ``fatal=True``)
+      8. description size > description_max_bytes (hard-reject; ``fatal=True``)
+
+    Until then, every input scans clean. The call site is real so
+    that Phase 2 is a body-only swap.
+
+    Performance budget (Phase 2): p95 < 500ms on a 40KB body, regex +
+    classifiers + path checks, NO LLM, NO network. Cacheable by
+    ``content_hash``.
+    """
+    logger.debug(
+        "sentinel_scan stub invoked (Phase 0; always clean)",
+        extra={
+            "mode": mode,
+            "data_keys": sorted(data) if isinstance(data, dict) else None,
+            "stub": True,
+            "phase": "0",
+        },
+    )
+    return ScanResult(
+        state="clean",
+        scanned_at=_now_iso(),
+        critical=0,
+        warn=0,
+        info=0,
+        findings=(),
+    )

--- a/core-api/src/core_api/services/forge/sentinel_scan.py
+++ b/core-api/src/core_api/services/forge/sentinel_scan.py
@@ -90,7 +90,9 @@ class ScanResult:
                     "code": f.code,
                     "severity": f.severity,
                     "message": f.message,
-                    **({"fatal": True} if f.fatal else {}),
+                    # Always emit ``fatal`` so Phase 2 consumers can
+                    # index ``finding["fatal"]`` directly — uniform schema.
+                    "fatal": f.fatal,
                     **({"locator": f.locator} if f.locator else {}),
                 }
                 for f in self.findings

--- a/core-api/src/core_api/services/lifecycle_audit.py
+++ b/core-api/src/core_api/services/lifecycle_audit.py
@@ -195,6 +195,28 @@ class _CoreApiLifecycleAdapter:
             links_created = ctx.data.get("links_created", 0)
         return int(links_created)
 
+    async def forge_distill(self, *, org_id: str, fleet_id: str | None) -> int:
+        """Skill Factory SF-007 — Forge distillation run. Phase 0 STUB.
+
+        Logs the invocation and returns 0 (no candidates produced).
+        The real worker — outcome inference → session-trace clustering
+        → fingerprint stability → LLM distill → Sentinel scan →
+        skills-collection write — lands in Phase 1 inside
+        ``core_api.services.forge.forge_service``. Until then the
+        topic + payload + handler wiring is exercisable end-to-end so
+        the Phase 1 swap is a body-only change.
+        """
+        logger.info(
+            "forge_distill stub invoked (Phase 0; no-op)",
+            extra={
+                "org_id": org_id,
+                "fleet_id": fleet_id,
+                "stub": True,
+                "phase": "0",
+            },
+        )
+        return 0
+
     async def has_recent_lifecycle_success(self, *, org_id: str, action: str, since_hours: int) -> bool:
         return await self._storage.has_recent_lifecycle_success(
             org_id=org_id, action=action, since_hours=since_hours

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -147,6 +147,51 @@ DEFAULT_SETTINGS: dict = {
         "alert_critical_findings_min": None,
         "alert_score_drop_delta": None,
     },
+    # Skill Factory SF-006 — per-tenant knobs for the lake-side skill
+    # production pipeline (Forge resident + HITL Inbox + Sentinel scan +
+    # harness install). Defaults are CONCRETE here (not None) so the
+    # OSS resolver and tests have predictable values; tenants override
+    # by writing a partial dict (existing _deep_merge + _check_keys
+    # plumbing). See docs/live-memory-pitch/skill-factory-implementation-plan.md §12.
+    "skills_factory": {
+        # Feature flag gating the SF-002 ``memclaw_doc`` skills-write
+        # adjustments. OSS default ``False`` so existing eToro and
+        # caura-dev-fleet tenants see ZERO behavior change until they
+        # explicitly opt in. Phase 0 ships the plumbing; per-tenant
+        # rollout flips this true.
+        "enabled": False,
+        # Hard caps. ``_check_keys`` and ``_LEAF_TYPES`` enforce shape;
+        # the routes/documents.py write path enforces values.
+        "description_max_bytes": 160,
+        "body_max_bytes": 40_000,
+        "inbox_max_pending": 50,
+        # Days a rejected cluster_fingerprint stays poison-flagged in
+        # forge_rejected_fingerprints before Forge may re-propose it.
+        "rejection_cooloff_days": 30,
+        # Sentinel scanner behavior. ``fail_on_critical=true`` → any
+        # critical finding flips the doc to ``status=quarantined``
+        # instead of letting it surface in the inbox.
+        "sentinel": {
+            "fail_on_critical": True,
+        },
+        # Forge resident knobs. Phase 0 publishes the topic + stub
+        # handler; Phase 1 lands the real worker that reads these.
+        # ``min_cluster_size`` default 3 is the demo value (plan §5);
+        # production tenants flip to 10 once outcome volume justifies.
+        "forge": {
+            "cron_interval_hours": 6,
+            "min_cluster_size": 3,
+            "min_distinct_agents": 3,
+            "freshness_window_days": 14,
+            "llm_tokens_per_run": 50_000,
+            "max_writes_per_run": 20,
+        },
+        # OpenClaw PROPOSAL.md bridge (Phase 5). Default OFF — turning
+        # it on only matters once the OpenClaw workspace emitter ships.
+        "openclaw_bridge": {
+            "enabled": False,
+        },
+    },
     "entity_blocklist": [
         "team",
         "meeting",
@@ -335,6 +380,20 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "memclaw.auto_upgrade_enabled": bool,
     "write.triple_emission_enabled": bool,
     "write.retraction_enabled": bool,
+    # Skill Factory SF-006 — type validators for the skills_factory namespace.
+    "skills_factory.enabled": bool,
+    "skills_factory.description_max_bytes": int,
+    "skills_factory.body_max_bytes": int,
+    "skills_factory.inbox_max_pending": int,
+    "skills_factory.rejection_cooloff_days": int,
+    "skills_factory.sentinel.fail_on_critical": bool,
+    "skills_factory.forge.cron_interval_hours": int,
+    "skills_factory.forge.min_cluster_size": int,
+    "skills_factory.forge.min_distinct_agents": int,
+    "skills_factory.forge.freshness_window_days": int,
+    "skills_factory.forge.llm_tokens_per_run": int,
+    "skills_factory.forge.max_writes_per_run": int,
+    "skills_factory.openclaw_bridge.enabled": bool,
 }
 
 # Inclusive range constraints applied AFTER type validation. Listed

--- a/core-api/src/core_api/services/outcome_inference/__init__.py
+++ b/core-api/src/core_api/services/outcome_inference/__init__.py
@@ -1,0 +1,162 @@
+"""Outcome inference — the 6 free signals (Skill Factory plan §6).
+
+The lake produces a memory stream. This package mines that stream
+for passive outcome evidence — no ``memclaw_evolve`` call required.
+Each signal module reads existing MemClaw data (memories table
+columns, recall counters, contradiction status, audit log) and
+emits :class:`SignalEvidence` events keyed by ``(tenant_id, run_id,
+agent_id)``. The session-trace builder (SF-102) consumes these
+events and assigns a single ``outcome_label`` per trace.
+
+Signal modules (one file each):
+
+  1. :mod:`.contradictions`     — recalled memory was contradicted soon
+                                  after  (existing ``contradiction_detector``
+                                  emits ``status='outdated' | 'conflicted'``)
+  2. :mod:`.supersessions`      — memory was directly superseded (``memories.supersedes_id``)
+  3. :mod:`.repeat_recall`      — same query produced multiple recalls; first answer didn't land
+  4. :mod:`.terminal_memory`    — last memory in session = ``shipped`` / ``fixed`` (success)
+                                  vs ``blocked`` / ``abandoned`` (failure)
+  5. :mod:`.cross_agent_reuse`  — ≥3 distinct agents recalled the same memory ⇒ load-bearing
+  6. :mod:`.external_hooks`     — git / PR / CI status tied to ``run_id`` (when available)
+
+All signal modules conform to the :class:`SignalExtractor` protocol.
+The session-trace builder runs them concurrently and folds their
+results into per-trace evidence.
+
+This module is INTENTIONALLY zero-cost on the write path. All
+extractors run lazily, on demand, when Forge or the session-trace
+builder asks for evidence. No producer hooks, no on-write
+side effects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class SignalKind(str, Enum):
+    """Stable identifiers for the 6 signals. Used as dict keys in
+    :attr:`SessionTrace.signals_summary` and as discriminators in
+    log lines / metrics. NEVER renumber; the value strings land in
+    persisted ``session_traces.signals_summary`` JSONB rows.
+    """
+
+    CONTRADICTION = "contradiction"
+    SUPERSESSION = "supersession"
+    REPEAT_RECALL = "repeat_recall"
+    TERMINAL_MEMORY = "terminal_memory"
+    CROSS_AGENT_REUSE = "cross_agent_reuse"
+    EXTERNAL_HOOK = "external_hook"
+
+
+# Outcome polarity each signal contributes. Used by the session-trace
+# builder to decide the final ``outcome_label``: it sums weighted
+# polarities across all signals that fired for a given trace.
+class Polarity(str, Enum):
+    SUCCESS = "success"  # signal evidence supports a successful outcome
+    FAILURE = "failure"  # signal evidence supports a failed outcome
+    NEUTRAL = "neutral"  # informational; no polarity (e.g. cross-agent-reuse)
+
+
+@dataclass(frozen=True)
+class SignalEvidence:
+    """One signal firing.
+
+    Aggregated per ``(tenant_id, run_id, agent_id)`` by the session-
+    trace builder. The fields below are the MINIMUM the builder needs;
+    each signal may set ``details`` to a dict carrying extractor-
+    specific context (e.g. ``{"contradicted_memory_id": "...",
+    "by_memory_id": "..."}``) which the inbox-card UI can surface.
+    """
+
+    kind: SignalKind
+    polarity: Polarity
+    # Weight is a per-signal strength in [0.0, 1.0]. The builder
+    # multiplies polarity by weight when aggregating. Strong signals
+    # (terminal memory) carry weight near 1.0; weak signals
+    # (cross-agent reuse) closer to 0.3.
+    weight: float
+    # Pointers back into the lake for traceability in the inbox card.
+    memory_ids: tuple[str, ...] = ()
+    # Free-shape extractor context; lands in
+    # session_traces.signals_summary[<kind>].details.
+    details: dict[str, Any] = field(default_factory=dict)
+    observed_at: datetime | None = None
+
+    def as_jsonb(self) -> dict:
+        """Render to the shape persisted in ``session_traces.signals_summary``."""
+        return {
+            "polarity": self.polarity.value,
+            "weight": self.weight,
+            "memory_ids": list(self.memory_ids),
+            "details": self.details,
+            "observed_at": self.observed_at.isoformat() if self.observed_at else None,
+        }
+
+
+# ── Default per-signal weight floors ──────────────────────────────
+#
+# Tuned so a single strong signal (terminal "shipped") is enough to
+# label a trace; weaker signals (cross-agent reuse alone) are NOT.
+# The session-trace builder applies these as priors; per-tenant
+# tuning may override via org settings later (Phase 4+).
+DEFAULT_SIGNAL_WEIGHTS: dict[SignalKind, float] = {
+    SignalKind.TERMINAL_MEMORY: 0.9,
+    SignalKind.EXTERNAL_HOOK: 0.85,
+    SignalKind.CONTRADICTION: 0.7,
+    SignalKind.SUPERSESSION: 0.7,
+    SignalKind.REPEAT_RECALL: 0.4,
+    SignalKind.CROSS_AGENT_REUSE: 0.3,
+}
+
+
+@dataclass(frozen=True)
+class SignalQuery:
+    """Inputs every extractor accepts.
+
+    Extractors are pure functions of ``(query, db)``. They return a
+    list of :class:`SignalEvidence`. The builder calls all 6
+    concurrently for one trace window, then folds the results.
+    """
+
+    tenant_id: str
+    fleet_id: str | None
+    # Window the trace covers. Extractors return only evidence
+    # observed within this window (exclusive of ``window_end``).
+    window_start: datetime
+    window_end: datetime
+    # If set, restrict to this single trace's run_id / agent_id.
+    # If None, the extractor returns evidence across all traces in
+    # the window — the builder partitions by (run_id, agent_id).
+    run_id: str | None = None
+    agent_id: str | None = None
+
+
+@runtime_checkable
+class SignalExtractor(Protocol):
+    """Contract every signal extractor implements.
+
+    A concrete extractor is a callable + a ``kind`` attribute. The
+    session-trace builder discovers extractors by importing each
+    submodule in this package and collecting any module-level
+    ``EXTRACTOR`` object exposing this Protocol.
+    """
+
+    kind: SignalKind
+
+    async def extract(self, query: SignalQuery, db: Any) -> list[SignalEvidence]: ...
+
+
+# Public re-exports.
+__all__ = [
+    "DEFAULT_SIGNAL_WEIGHTS",
+    "Polarity",
+    "SignalEvidence",
+    "SignalExtractor",
+    "SignalKind",
+    "SignalQuery",
+]

--- a/core-api/src/core_api/services/outcome_inference/contradictions.py
+++ b/core-api/src/core_api/services/outcome_inference/contradictions.py
@@ -1,0 +1,131 @@
+"""Contradiction signal — memory got contradicted soon after recall.
+
+The existing :mod:`core_api.services.contradiction_detector` (Path A
++ Path C) flags memories whose claims a newer write contradicted.
+The detector's effect on the data plane is a status flip on the
+OLDER memory:
+
+  - ``status = 'outdated'``    — RDF-triple path detected a stale
+                                  state-transition (older lost the race)
+  - ``status = 'conflicted'``  — semantic path found a contradiction
+                                  that didn't resolve cleanly
+
+Both indicate "this memory turned out to be wrong" and therefore
+the session that wrote it likely failed at its task. This signal
+fires polarity=FAILURE on the trace that produced the now-outdated /
+conflicted memory.
+
+We restrict the window check to the status TRANSITION time, not the
+memory's original ``created_at`` — i.e. a memory that's been around
+for weeks but only just got contradicted SHOULD still register a
+firing inside the current scan window. Until the storage layer adds
+a ``status_changed_at`` column (CAURA-future), we approximate via
+``COALESCE(updated_at, created_at)`` (an outdated/conflicted memory's
+``updated_at`` is the status flip).
+
+Plan §6 signal #1. Plan §3 schema field
+``signals_summary.contradiction``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import text
+
+from . import (
+    DEFAULT_SIGNAL_WEIGHTS,
+    Polarity,
+    SignalEvidence,
+    SignalKind,
+    SignalQuery,
+)
+
+logger = logging.getLogger(__name__)
+
+kind: SignalKind = SignalKind.CONTRADICTION
+
+
+# ``status`` values the detector writes on a contradicted memory. Both
+# are treated as failure evidence for outcome inference. Keep this set
+# in sync with the writes in
+# ``core_api.services.contradiction_detector`` (search for
+# ``_merge_status_update(..., {"status": "outdated"})`` and
+# ``"conflicted"``).
+CONTRADICTED_STATUSES: tuple[str, ...] = ("outdated", "conflicted")
+
+
+async def extract(query: SignalQuery, db: Any) -> list[SignalEvidence]:
+    """Return one evidence per contradicted memory whose status flip
+    falls inside the window. The trace that originally wrote the
+    memory (``run_id``, ``agent_id``) is the one that pays the
+    FAILURE polarity.
+
+    Idempotency: each memory only emits one firing per scan — multiple
+    bumps to ``updated_at`` after the initial status flip do not
+    multiply the signal (we de-duplicate at the (memory_id) level via
+    SELECT DISTINCT).
+    """
+    weight = DEFAULT_SIGNAL_WEIGHTS[SignalKind.CONTRADICTION]
+
+    # Bind the status list explicitly rather than inlining the tuple
+    # so Postgres can use the existing tenant-status indexes.
+    sql = """
+        SELECT DISTINCT ON (m.id)
+            m.id          AS memory_id,
+            m.run_id      AS run_id,
+            m.agent_id    AS agent_id,
+            m.status      AS status,
+            COALESCE(m.updated_at, m.created_at) AS observed_at
+        FROM memories AS m
+        WHERE m.tenant_id = :tenant_id
+          AND m.status = ANY(:contradicted_statuses)
+          AND COALESCE(m.updated_at, m.created_at) >= :w_start
+          AND COALESCE(m.updated_at, m.created_at) <  :w_end
+          AND (:fleet_id IS NULL OR m.fleet_id = :fleet_id OR m.fleet_id IS NULL)
+          AND (:run_id   IS NULL OR m.run_id   = :run_id)
+          AND (:agent_id IS NULL OR m.agent_id = :agent_id)
+          AND m.run_id IS NOT NULL
+    """
+
+    rows = (
+        await db.execute(
+            text(sql),
+            {
+                "tenant_id": query.tenant_id,
+                "fleet_id": query.fleet_id,
+                "w_start": query.window_start,
+                "w_end": query.window_end,
+                "run_id": query.run_id,
+                "agent_id": query.agent_id,
+                "contradicted_statuses": list(CONTRADICTED_STATUSES),
+            },
+        )
+    ).fetchall()
+
+    out: list[SignalEvidence] = []
+    for row in rows:
+        out.append(
+            SignalEvidence(
+                kind=SignalKind.CONTRADICTION,
+                polarity=Polarity.FAILURE,
+                weight=weight,
+                memory_ids=(str(row.memory_id),),
+                details={
+                    "memory_id": str(row.memory_id),
+                    "status": row.status,
+                    "run_id": row.run_id,
+                    "agent_id": row.agent_id,
+                },
+                observed_at=row.observed_at,
+            )
+        )
+
+    if out:
+        logger.debug(
+            "contradiction signal: %d firings in window for tenant=%s",
+            len(out),
+            query.tenant_id,
+        )
+    return out

--- a/core-api/src/core_api/services/outcome_inference/contradictions.py
+++ b/core-api/src/core_api/services/outcome_inference/contradictions.py
@@ -62,17 +62,18 @@ async def extract(query: SignalQuery, db: Any) -> list[SignalEvidence]:
     memory (``run_id``, ``agent_id``) is the one that pays the
     FAILURE polarity.
 
-    Idempotency: each memory only emits one firing per scan — multiple
-    bumps to ``updated_at`` after the initial status flip do not
-    multiply the signal (we de-duplicate at the (memory_id) level via
-    SELECT DISTINCT).
+    Idempotency: each memory only emits one firing per scan because
+    ``m.id`` is the primary key — a plain SELECT already returns at
+    most one row per memory. The previous ``DISTINCT ON (m.id)``
+    without an ``ORDER BY`` was both a no-op (PK uniqueness) AND
+    technically undefined per Postgres docs; removed for clarity.
     """
     weight = DEFAULT_SIGNAL_WEIGHTS[SignalKind.CONTRADICTION]
 
     # Bind the status list explicitly rather than inlining the tuple
     # so Postgres can use the existing tenant-status indexes.
     sql = """
-        SELECT DISTINCT ON (m.id)
+        SELECT
             m.id          AS memory_id,
             m.run_id      AS run_id,
             m.agent_id    AS agent_id,

--- a/core-api/src/core_api/services/outcome_inference/cross_agent_reuse.py
+++ b/core-api/src/core_api/services/outcome_inference/cross_agent_reuse.py
@@ -1,0 +1,122 @@
+"""Cross-agent reuse signal — load-bearing memories indicate good patterns.
+
+If memory M was recalled by ≥3 DISTINCT agents, the procedure that
+produced it is almost certainly something the fleet has converged on
+— a candidate skill, not a fluke. The signal fires polarity=NEUTRAL
+(informational only — it doesn't claim the originating session was
+"successful", just that the artifact it produced is being reused).
+
+The session-trace builder treats NEUTRAL evidence as a boost toward
+"this trace deserves clustering" without driving the success/failure
+label one way or the other. Plan §6 signal #5.
+
+**MVP data source**: ``memories.recall_count`` (existing column,
+incremented by ``track_recalls`` pipeline step). It counts TOTAL
+recalls, not distinct-agent recalls. We approximate distinct-agent
+reuse via the recall_count threshold — it's an over-approximation
+(a single agent re-recalling the same memory inflates the count)
+but conservative on the firing side: ``recall_count >= 5`` typically
+means ≥3 distinct agents in practice.
+
+**Phase 2+ upgrade path**: a ``memory_recalls`` table keyed
+``(memory_id, agent_id, last_recalled_at)`` gives the exact distinct-
+agent count without inflation. The extractor signature stays the
+same; the SQL gets sharper. Tracked as OQ-future.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import text
+
+from . import (
+    DEFAULT_SIGNAL_WEIGHTS,
+    Polarity,
+    SignalEvidence,
+    SignalKind,
+    SignalQuery,
+)
+
+logger = logging.getLogger(__name__)
+
+kind: SignalKind = SignalKind.CROSS_AGENT_REUSE
+
+# Threshold for "load-bearing". Conservative — recall_count counts
+# ALL recalls (including self-recalls), so 5 total usually corresponds
+# to ~3 distinct agents in the wild. Configurable per-tenant via
+# org_settings.skills_factory.forge.cross_agent_reuse_threshold (added
+# in Phase 2 settings expansion; default for MVP wired here).
+DEFAULT_RECALL_COUNT_THRESHOLD: int = 5
+
+
+async def extract(query: SignalQuery, db: Any) -> list[SignalEvidence]:
+    """Find memories with recall_count above threshold whose AUTHOR's
+    trace is in the window. The signal fires on the AUTHOR's trace
+    (the session that produced the load-bearing memory), not on the
+    recalling sessions — that's where Forge needs the evidence to
+    decide "this trace's procedure is worth crystallising".
+    """
+    weight = DEFAULT_SIGNAL_WEIGHTS[SignalKind.CROSS_AGENT_REUSE]
+
+    sql = """
+        SELECT
+            m.id           AS memory_id,
+            m.run_id       AS run_id,
+            m.agent_id     AS agent_id,
+            m.recall_count AS recall_count,
+            m.last_recalled_at AS observed_at
+        FROM memories AS m
+        WHERE m.tenant_id = :tenant_id
+          AND m.recall_count >= :threshold
+          AND m.created_at >= :w_start
+          AND m.created_at <  :w_end
+          AND m.run_id IS NOT NULL
+          AND (:fleet_id IS NULL OR m.fleet_id = :fleet_id OR m.fleet_id IS NULL)
+          AND (:run_id   IS NULL OR m.run_id   = :run_id)
+          AND (:agent_id IS NULL OR m.agent_id = :agent_id)
+    """
+
+    rows = (
+        await db.execute(
+            text(sql),
+            {
+                "tenant_id": query.tenant_id,
+                "fleet_id": query.fleet_id,
+                "w_start": query.window_start,
+                "w_end": query.window_end,
+                "run_id": query.run_id,
+                "agent_id": query.agent_id,
+                "threshold": DEFAULT_RECALL_COUNT_THRESHOLD,
+            },
+        )
+    ).fetchall()
+
+    out: list[SignalEvidence] = []
+    for row in rows:
+        out.append(
+            SignalEvidence(
+                kind=SignalKind.CROSS_AGENT_REUSE,
+                polarity=Polarity.NEUTRAL,
+                weight=weight,
+                memory_ids=(str(row.memory_id),),
+                details={
+                    "memory_id": str(row.memory_id),
+                    "run_id": row.run_id,
+                    "agent_id": row.agent_id,
+                    "recall_count": row.recall_count,
+                    "threshold": DEFAULT_RECALL_COUNT_THRESHOLD,
+                    "approximation": "total-recalls (Phase 1 v1) — see module docstring",
+                },
+                observed_at=row.observed_at,
+            )
+        )
+
+    if out:
+        logger.debug(
+            "cross_agent_reuse signal: %d load-bearing memories for tenant=%s",
+            len(out),
+            query.tenant_id,
+        )
+    return out

--- a/core-api/src/core_api/services/outcome_inference/external_hooks.py
+++ b/core-api/src/core_api/services/outcome_inference/external_hooks.py
@@ -1,0 +1,52 @@
+"""External hooks signal — git/PR/CI status tied to ``run_id``.
+
+The ground-truth-iest signal we have when available: a PR merged
+within the window with a ``run_id`` matching the trace is a near-
+certain SUCCESS; a CI run that failed with the same ``run_id`` is
+a near-certain FAILURE. Plan §6 signal #6, weight 0.85.
+
+**MVP**: the OSS MemClaw deployment has no built-in hook to ingest
+external events from git / GitHub / CI today. The extractor ships
+with the contract finalised but the body returns [] until an
+optional ``external_hooks`` table or webhook ingest is wired.
+
+The Phase-5 OpenClaw bridge integration is the natural place to
+ingest these — OpenClaw plugins surface workflow-completion events
+that already carry a ``run_id`` correlatable to MemClaw memory
+writes. When that lands, this extractor becomes a SELECT against
+the ingested-events table.
+
+**Why ship the stub now**: keeping the extractor in the signal
+registry from day one means the session-trace builder doesn't have
+to learn about a new signal type later; only the extractor body
+changes. Same contract, same return shape.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from . import (
+    DEFAULT_SIGNAL_WEIGHTS,  # noqa: F401
+    SignalEvidence,
+    SignalKind,
+    SignalQuery,
+)
+
+logger = logging.getLogger(__name__)
+
+kind: SignalKind = SignalKind.EXTERNAL_HOOK
+
+
+async def extract(query: SignalQuery, db: Any) -> list[SignalEvidence]:
+    """Phase 1 MVP returns []. Enterprise / Phase 5 swaps in the
+    real ingest-events read against an ``external_hooks_events``
+    table (or equivalent) populated by webhook handlers.
+    """
+    logger.debug(
+        "external_hooks extractor: returning [] (no ingest configured "
+        "in MVP — Phase 5 OpenClaw bridge / webhook). tenant=%s",
+        query.tenant_id,
+    )
+    return []

--- a/core-api/src/core_api/services/outcome_inference/repeat_recall.py
+++ b/core-api/src/core_api/services/outcome_inference/repeat_recall.py
@@ -1,0 +1,61 @@
+"""Repeat-recall signal — same query produced multiple recalls.
+
+When an agent issues the same (or near-same) recall query multiple
+times within a session, the first answer didn't land. Plan §6
+signal #3.
+
+**Data source gap (acknowledged)**: MemClaw does not currently
+persist a per-recall log keyed by (session, agent, query, ts) with
+the query string preserved. Two reasonable proxies are available
+today:
+
+  (a) The agent's own memory stream — if the same trace produced
+      multiple recalls *and* multiple writes about the same entity,
+      the entity sequence within a single run_id reveals the
+      pattern.
+  (b) The audit log (op='recall') — but does not carry the query
+      string.
+
+**Phase 1 MVP**: ship the extractor with the contract finalised but
+the body conservative — return [] unless the explicit recall log
+(``memory_recalls`` table, Phase 2 deliverable) is in place. This
+prevents false positives from the proxy approach while keeping the
+extractor wired into the dispatcher so Phase 2's swap-in is body-
+only.
+
+The extractor logs at INFO level on every invocation so operators
+running Phase 1 forge dry-runs can see the gap explicitly in the
+console without it being silent.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from . import (
+    DEFAULT_SIGNAL_WEIGHTS,  # noqa: F401  (re-exported via __init__; kept here for consistency)
+    SignalEvidence,
+    SignalKind,
+    SignalQuery,
+)
+
+logger = logging.getLogger(__name__)
+
+kind: SignalKind = SignalKind.REPEAT_RECALL
+
+
+async def extract(query: SignalQuery, db: Any) -> list[SignalEvidence]:
+    """Phase 1 MVP returns []. Phase 2 swaps in the recall-log read.
+
+    Returning [] is the safe default per plan §6 / plan §17 risk
+    table — false positives are worse than false negatives for
+    outcome inference (they'd label good traces as failures and
+    push Forge to NOT propose what was actually a fine procedure).
+    """
+    logger.info(
+        "repeat_recall extractor: returning [] (Phase 1 MVP — recall log "
+        "table arrives in Phase 2; see module docstring). tenant=%s",
+        query.tenant_id,
+    )
+    return []

--- a/core-api/src/core_api/services/outcome_inference/supersessions.py
+++ b/core-api/src/core_api/services/outcome_inference/supersessions.py
@@ -1,0 +1,128 @@
+"""Supersession signal — directly superseded memories indicate failure.
+
+A memory with ``supersedes_id IS NOT NULL`` is the NEWER one that
+replaces an older statement. The OLDER memory (referenced by
+``supersedes_id``) was, by definition, wrong or stale. The signal
+fires on the OLDER memory's trace, marking that trace as a likely
+failure.
+
+Worked example: agent A writes "Deploy script v4 is fine in eu-west"
+(memory M1). Later, agent A or B writes "Deploy script v4 hangs in
+eu-west on step 7" (memory M2, with ``supersedes_id=M1``). The
+supersession signal:
+
+  - fires polarity=FAILURE on M1's session-trace (M1 was wrong)
+  - does NOT fire on M2's session-trace (M2 is the corrective)
+
+This avoids the trap where a session that DISCOVERED a contradiction
+gets penalised for it — only the original incorrect session pays.
+
+Plan §6 signal #2. Plan §3 schema field
+``signals_summary.supersession``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import text
+
+from . import (
+    DEFAULT_SIGNAL_WEIGHTS,
+    Polarity,
+    SignalEvidence,
+    SignalKind,
+    SignalQuery,
+)
+
+logger = logging.getLogger(__name__)
+
+kind: SignalKind = SignalKind.SUPERSESSION
+
+
+async def extract(query: SignalQuery, db: Any) -> list[SignalEvidence]:
+    """Find memories superseded WITHIN this window's trace.
+
+    The query returns one row per superseded (older) memory: it joins
+    ``memories AS new`` (the corrective) against ``memories AS old``
+    (the one being superseded). We emit one ``SignalEvidence`` per
+    superseded memory, keyed at the SUPERSEDED memory's
+    ``(run_id, agent_id)`` — so the FAILURE polarity lands on the
+    session that wrote the bad memory, not the session that found the
+    contradiction.
+
+    Window semantics: we use the ``new`` memory's ``created_at`` for
+    the window check (when the contradiction surfaced), not the
+    ``old`` memory's. This lets a memory written weeks ago still
+    accumulate failure evidence retroactively if it gets superseded
+    inside the current scan window.
+    """
+    weight = DEFAULT_SIGNAL_WEIGHTS[SignalKind.SUPERSESSION]
+
+    sql = """
+        SELECT
+            old_mem.id           AS superseded_id,
+            old_mem.run_id       AS run_id,
+            old_mem.agent_id     AS agent_id,
+            new_mem.id           AS by_id,
+            new_mem.created_at   AS observed_at
+        FROM memories AS new_mem
+        JOIN memories AS old_mem
+          ON old_mem.id = new_mem.supersedes_id
+         AND old_mem.tenant_id = new_mem.tenant_id
+        WHERE new_mem.tenant_id = :tenant_id
+          AND new_mem.created_at >= :w_start
+          AND new_mem.created_at <  :w_end
+          AND (:fleet_id  IS NULL OR new_mem.fleet_id  = :fleet_id  OR new_mem.fleet_id IS NULL)
+          -- Cross-fleet isolation: the FAILURE polarity must land on
+          -- a trace inside the queried fleet, not just the corrective
+          -- memory that triggered the supersession. Without this, an
+          -- agent in fleet A correcting a fact written by fleet B
+          -- would erroneously land failure evidence on fleet B's
+          -- trace inside a fleet-A scan.
+          AND (:fleet_id  IS NULL OR old_mem.fleet_id  = :fleet_id  OR old_mem.fleet_id IS NULL)
+          AND (:run_id    IS NULL OR old_mem.run_id    = :run_id)
+          AND (:agent_id  IS NULL OR old_mem.agent_id  = :agent_id)
+          AND old_mem.run_id IS NOT NULL
+    """
+
+    rows = (
+        await db.execute(
+            text(sql),
+            {
+                "tenant_id": query.tenant_id,
+                "fleet_id": query.fleet_id,
+                "w_start": query.window_start,
+                "w_end": query.window_end,
+                "run_id": query.run_id,
+                "agent_id": query.agent_id,
+            },
+        )
+    ).fetchall()
+
+    out: list[SignalEvidence] = []
+    for row in rows:
+        out.append(
+            SignalEvidence(
+                kind=SignalKind.SUPERSESSION,
+                polarity=Polarity.FAILURE,
+                weight=weight,
+                memory_ids=(str(row.superseded_id),),
+                details={
+                    "superseded_memory_id": str(row.superseded_id),
+                    "superseded_by_memory_id": str(row.by_id),
+                    "run_id": row.run_id,
+                    "agent_id": row.agent_id,
+                },
+                observed_at=row.observed_at,
+            )
+        )
+
+    if out:
+        logger.debug(
+            "supersession signal: %d firings in window for tenant=%s",
+            len(out),
+            query.tenant_id,
+        )
+    return out

--- a/core-api/src/core_api/services/outcome_inference/terminal_memory.py
+++ b/core-api/src/core_api/services/outcome_inference/terminal_memory.py
@@ -1,0 +1,195 @@
+"""Terminal-memory signal — the last memory in a session labels it.
+
+The end of a session is the strongest free signal we have. A trace
+ending with a memory whose content matches "shipped" / "done" /
+"fixed" / "deployed" is almost certainly a successful trace; a trace
+ending with "blocked" / "abandoning" / "stuck" / "rolled back" is
+almost certainly a failure.
+
+Plan §6 signal #4. Plan default weight 0.9 — the highest of the six
+because it is the closest thing to ground truth available without
+hooking external systems.
+
+**MVP approach**: keyword/regex classifier on the LAST memory of each
+(tenant, fleet, run, agent) window. Per-trace, not per-memory — so
+one evidence per session, not per matching word.
+
+The classifier is intentionally lenient on the SUCCESS side and
+strict on the FAILURE side: false-positive successes are far more
+expensive (we'd promote a bad procedure to a skill) than false-
+negative failures (we'd just leave a trace unlabeled). Hence the
+asymmetric thresholds + curated keyword lists below.
+
+A Phase-2+ upgrade can swap the regex classifier for an LLM call
+without changing the extractor signature — same return shape, same
+caller contract. Documented as such in :data:`CLASSIFIER_VERSION`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from sqlalchemy import text
+
+from . import (
+    DEFAULT_SIGNAL_WEIGHTS,
+    Polarity,
+    SignalEvidence,
+    SignalKind,
+    SignalQuery,
+)
+
+logger = logging.getLogger(__name__)
+
+kind: SignalKind = SignalKind.TERMINAL_MEMORY
+
+# Bump this when the classifier changes (e.g. swapping in an LLM).
+# Stored in evidence.details so re-running Forge against the same
+# data can detect classifier drift via re-eval.
+CLASSIFIER_VERSION: str = "v1-regex"
+
+
+# Curated keyword sets. Word boundaries on both sides so "shipped" in
+# "shipped/abandoned" doesn't accidentally fire success. Lowercased
+# match (the content is lowercased before regex).
+_SUCCESS_TERMS: tuple[str, ...] = (
+    r"shipped",
+    r"deployed",
+    r"merged",
+    r"fixed",
+    r"resolved",
+    r"closed",
+    r"completed",
+    r"done",
+    r"landed",
+    r"passing",
+    r"verified",
+    r"approved",
+    r"signed off",
+)
+_FAILURE_TERMS: tuple[str, ...] = (
+    r"blocked",
+    r"abandoned",
+    r"abandoning",
+    r"stuck",
+    r"rolled back",
+    r"reverted",
+    r"giving up",
+    r"gave up",
+    r"can't",
+    r"could not",
+    r"failed to",
+    r"unable to",
+    r"timeout",
+    r"crashed",
+)
+# Compile once. ``\b`` works for word boundaries; we accept some
+# adjacent punctuation (apostrophes in "can't") via the curated list.
+_SUCCESS_RE = re.compile(r"\b(?:" + "|".join(_SUCCESS_TERMS) + r")\b", re.IGNORECASE)
+_FAILURE_RE = re.compile(r"\b(?:" + "|".join(_FAILURE_TERMS) + r")\b", re.IGNORECASE)
+
+
+def _classify(content: str | None) -> Polarity | None:
+    """Return SUCCESS / FAILURE if confident, None if ambiguous.
+
+    Asymmetric rules:
+      - FAILURE always wins ties (better to under-promote skills than to
+        promote bad ones).
+      - At least one keyword required to commit a label. Empty content
+        ⇒ unlabeled.
+    """
+    if not content:
+        return None
+    has_fail = bool(_FAILURE_RE.search(content))
+    has_succ = bool(_SUCCESS_RE.search(content))
+    if has_fail:
+        return Polarity.FAILURE
+    if has_succ:
+        return Polarity.SUCCESS
+    return None
+
+
+async def extract(query: SignalQuery, db: Any) -> list[SignalEvidence]:
+    """Find the LAST memory of each session within the window and
+    classify its content.
+
+    Window: a memory qualifies as "terminal" if its ``created_at`` is
+    the maximum across its (run_id, agent_id) group AND falls inside
+    [window_start, window_end). The window-trailing semantics
+    elegantly skip mid-session memories that happen to contain the
+    word "shipped" but aren't the terminal write.
+
+    Output: at most one ``SignalEvidence`` per (run_id, agent_id) pair
+    that produced a confidently classified terminal.
+    """
+    weight = DEFAULT_SIGNAL_WEIGHTS[SignalKind.TERMINAL_MEMORY]
+
+    # DISTINCT ON pattern picks the latest memory per (run_id,
+    # agent_id) — Postgres-specific but already used elsewhere in
+    # the codebase (see contradictions.py).
+    sql = """
+        SELECT DISTINCT ON (m.run_id, m.agent_id)
+            m.id          AS memory_id,
+            m.run_id      AS run_id,
+            m.agent_id    AS agent_id,
+            m.content     AS content,
+            m.created_at  AS observed_at
+        FROM memories AS m
+        WHERE m.tenant_id = :tenant_id
+          AND m.created_at >= :w_start
+          AND m.created_at <  :w_end
+          AND m.run_id IS NOT NULL
+          AND (:fleet_id IS NULL OR m.fleet_id = :fleet_id OR m.fleet_id IS NULL)
+          AND (:run_id   IS NULL OR m.run_id   = :run_id)
+          AND (:agent_id IS NULL OR m.agent_id = :agent_id)
+        ORDER BY m.run_id, m.agent_id, m.created_at DESC
+    """
+
+    rows = (
+        await db.execute(
+            text(sql),
+            {
+                "tenant_id": query.tenant_id,
+                "fleet_id": query.fleet_id,
+                "w_start": query.window_start,
+                "w_end": query.window_end,
+                "run_id": query.run_id,
+                "agent_id": query.agent_id,
+            },
+        )
+    ).fetchall()
+
+    out: list[SignalEvidence] = []
+    classified_count = 0
+    for row in rows:
+        verdict = _classify(row.content)
+        if verdict is None:
+            continue
+        classified_count += 1
+        out.append(
+            SignalEvidence(
+                kind=SignalKind.TERMINAL_MEMORY,
+                polarity=verdict,
+                weight=weight,
+                memory_ids=(str(row.memory_id),),
+                details={
+                    "memory_id": str(row.memory_id),
+                    "run_id": row.run_id,
+                    "agent_id": row.agent_id,
+                    "classifier_version": CLASSIFIER_VERSION,
+                    "verdict": verdict.value,
+                },
+                observed_at=row.observed_at,
+            )
+        )
+
+    if rows:
+        logger.debug(
+            "terminal_memory signal: %d/%d terminals classified for tenant=%s",
+            classified_count,
+            len(rows),
+            query.tenant_id,
+        )
+    return out

--- a/core-api/src/core_api/services/session_trace.py
+++ b/core-api/src/core_api/services/session_trace.py
@@ -1,0 +1,499 @@
+"""Session-trace builder (Skill Factory SF-102).
+
+Produces one ``session_traces`` row per ``(tenant_id, run_id,
+agent_id)`` group of memories within a scan window, labeled with an
+inferred ``outcome_label`` derived from the 6 signal extractors in
+:mod:`core_api.services.outcome_inference`.
+
+This module is the bridge between the raw memory stream and Forge:
+the cluster + fingerprint step (SF-103) reads from ``session_traces``,
+not from ``memories`` directly. Centralising trace identity here
+means the cluster step doesn't have to re-derive what counts as a
+trace.
+
+Algorithm (one pass per Forge tick):
+
+  1. Run all 6 extractors concurrently over the window, collecting
+     :class:`SignalEvidence` from each.
+  2. Partition evidence by ``(run_id, agent_id)`` using
+     ``evidence.details["run_id"]`` and ``...["agent_id"]``. Each
+     extractor stamps these on every emitted evidence.
+  3. Query ``memories`` in the window to enumerate every
+     ``(run_id, agent_id)`` group — including groups with no signal
+     evidence at all. Their traces label ``outcome_label='unknown'``
+     and DO still get persisted (Forge filters them out later, but
+     downstream consumers may want them for analytics).
+  4. Fold per-trace evidence into an outcome label via
+     :func:`fold_outcome_label`.
+  5. Upsert rows into ``session_traces`` keyed by the
+     ``(tenant_id, run_id, agent_id)`` unique constraint
+     (migration 021).
+
+Idempotency: re-running over the same window produces the same
+rows. The upsert collapses repeated runs into one row per trace.
+Multiple extractors firing on the same evidence (e.g. supersession
++ contradiction both pointing at the same memory) accumulate in
+``signals_summary`` without inflating the label — the fold uses the
+WEIGHTED SUM of polarities, not the count.
+
+This module does NOT (intentionally):
+  - Make any LLM call. The ``goal_phrase`` field (used by the
+    fingerprint step) is left NULL here; SF-103 populates it.
+  - Resolve entities. ``entity_ids`` is read from the existing
+    ``memory_entity_links`` join; no LLM resolution.
+  - Trigger any Forge run. The dry-run CLI (SF-106) calls this
+    builder explicitly; the autonomous Forge worker (Phase 1 final
+    step) also calls it explicitly. Never invoked on the write path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import text
+
+from core_api.services.outcome_inference import (
+    Polarity,
+    SignalEvidence,
+    SignalQuery,
+    contradictions,
+    cross_agent_reuse,
+    external_hooks,
+    repeat_recall,
+    supersessions,
+    terminal_memory,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Registry of signal modules. The order here matches the enum order
+# only for log-line predictability; the dispatcher gathers
+# concurrently and does not rely on it.
+SIGNAL_MODULES: tuple = (
+    contradictions,
+    supersessions,
+    repeat_recall,
+    terminal_memory,
+    cross_agent_reuse,
+    external_hooks,
+)
+
+
+# Minimum weighted-evidence sum required to commit a label (vs.
+# ``unknown``). Tuned conservatively: a single terminal-memory hit
+# (weight 0.9) clears the bar alone; a single cross-agent-reuse hit
+# (weight 0.3) does NOT. Plan §6 weighting + §17 risk #1 (garbage-in).
+MIN_TOTAL_WEIGHT_FOR_LABEL: float = 0.5
+
+
+@dataclass(frozen=True)
+class SessionTraceRow:
+    """In-memory representation of one ``session_traces`` row.
+
+    Shape mirrors migration 021. The builder hands this dataclass
+    to the upserter; the upserter renders it to the SQL bind
+    parameters.
+    """
+
+    tenant_id: str
+    fleet_id: str | None
+    run_id: str
+    agent_id: str
+    outcome_label: str  # 'success' | 'failure' | 'unknown'
+    memory_ids: list[str]
+    entity_ids: list[str]
+    signals_summary: dict[str, Any]
+    started_at: datetime
+    ended_at: datetime
+    goal_phrase: str | None = None  # populated later by SF-103
+
+    def as_bind(self) -> dict[str, Any]:
+        return {
+            "tenant_id": self.tenant_id,
+            "fleet_id": self.fleet_id,
+            "run_id": self.run_id,
+            "agent_id": self.agent_id,
+            "outcome_label": self.outcome_label,
+            "memory_ids": self.memory_ids,
+            "entity_ids": self.entity_ids,
+            "signals_summary": self.signals_summary,
+            "goal_phrase": self.goal_phrase,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+        }
+
+
+@dataclass
+class _MemoryRow:
+    """Per-memory row read from the ``memories`` scan. Kept narrow:
+    the builder doesn't need ``content`` or ``embedding`` — only the
+    grouping/timestamp/id fields."""
+
+    memory_id: str
+    run_id: str
+    agent_id: str
+    fleet_id: str | None
+    created_at: datetime
+
+
+# ── Public API ────────────────────────────────────────────────────
+
+
+def fold_outcome_label(
+    evidence: list[SignalEvidence],
+    *,
+    min_total_weight: float = MIN_TOTAL_WEIGHT_FOR_LABEL,
+) -> str:
+    """Reduce a per-trace evidence list to one of
+    ``{'success', 'failure', 'unknown'}``.
+
+    Rule:
+      - SUCCESS / FAILURE polarities sum their weights independently.
+      - NEUTRAL evidence is informational; it does NOT vote on the label.
+      - If ``success_weight + failure_weight < min_total_weight`` →
+        ``unknown`` (not enough evidence to commit).
+      - If ``failure_weight > success_weight`` → ``failure``.
+      - If ``success_weight > failure_weight`` → ``success``.
+      - Tie (including both = 0) → ``unknown``.
+
+    The asymmetric tie-break ("failure wins on equal totals") lives
+    inside :mod:`terminal_memory` (the dominant single signal). At
+    the fold layer ties go to ``unknown`` so other signals don't
+    accidentally vote against the terminal-memory verdict — let the
+    weights speak.
+    """
+    if not evidence:
+        return "unknown"
+
+    success_w = 0.0
+    failure_w = 0.0
+    for ev in evidence:
+        if ev.polarity == Polarity.SUCCESS:
+            success_w += ev.weight
+        elif ev.polarity == Polarity.FAILURE:
+            failure_w += ev.weight
+        # NEUTRAL: no vote.
+
+    if success_w + failure_w < min_total_weight:
+        return "unknown"
+    if failure_w > success_w:
+        return "failure"
+    if success_w > failure_w:
+        return "success"
+    return "unknown"
+
+
+def summarize_evidence(evidence: list[SignalEvidence]) -> dict[str, Any]:
+    """Render the per-trace evidence list to the JSONB shape
+    persisted in ``session_traces.signals_summary``.
+
+    Groups by signal kind so the Inbox card can render
+    ``signals_summary.contradiction.firings[*]`` without re-walking
+    the whole list. Order within a kind is preserved (chronological
+    as the extractor returned it).
+    """
+    grouped: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"firings": [], "total_weight": 0.0, "polarity_counts": {}}
+    )
+    for ev in evidence:
+        slot = grouped[ev.kind.value]
+        slot["firings"].append(ev.as_jsonb())
+        slot["total_weight"] = round(slot["total_weight"] + ev.weight, 6)
+        pc = slot["polarity_counts"]
+        pc[ev.polarity.value] = pc.get(ev.polarity.value, 0) + 1
+    return dict(grouped)
+
+
+async def build_session_traces(
+    db: Any,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    window_start: datetime,
+    window_end: datetime,
+    persist: bool = True,
+) -> list[SessionTraceRow]:
+    """Build session traces for the window. Returns the rows in
+    memory; persists to ``session_traces`` when ``persist=True``.
+
+    ``persist=False`` is the dry-run / eval-harness path — useful
+    when calling the builder repeatedly during SF-105 fingerprint
+    stability tests without mutating the DB.
+    """
+    query = SignalQuery(
+        tenant_id=tenant_id,
+        fleet_id=fleet_id,
+        window_start=window_start,
+        window_end=window_end,
+        run_id=None,
+        agent_id=None,
+    )
+
+    # 1. Run all 6 extractors concurrently.
+    extractor_results = await asyncio.gather(
+        *(mod.extract(query, db) for mod in SIGNAL_MODULES),
+        return_exceptions=True,
+    )
+    all_evidence: list[SignalEvidence] = []
+    for mod, result in zip(SIGNAL_MODULES, extractor_results, strict=True):
+        if isinstance(result, BaseException):
+            # One extractor failing must NOT abort the whole build —
+            # the others still produce useful evidence. Log + skip.
+            logger.warning(
+                "outcome_inference extractor %s raised %s; skipping its evidence",
+                getattr(mod, "__name__", repr(mod)),
+                type(result).__name__,
+                exc_info=result,
+            )
+            continue
+        all_evidence.extend(result)
+
+    # 2. Partition evidence by (run_id, agent_id).
+    #
+    # Every signal extractor MUST stamp ``run_id`` and ``agent_id`` on
+    # its ``SignalEvidence.details`` — without those keys the
+    # evidence has no trace to attach to and is silently lost.
+    # Dropping is the safe default (better than crashing the whole
+    # build over one buggy extractor), but log at WARNING so a
+    # regression in an extractor surfaces in the run summary rather
+    # than disappearing into the void.
+    by_trace: dict[tuple[str, str], list[SignalEvidence]] = defaultdict(list)
+    for ev in all_evidence:
+        run_id = ev.details.get("run_id")
+        agent_id = ev.details.get("agent_id")
+        if not (run_id and agent_id):
+            logger.warning(
+                "outcome_inference: dropping %s evidence — missing "
+                "run_id or agent_id in details (got run_id=%r agent_id=%r)",
+                ev.kind.value,
+                run_id,
+                agent_id,
+            )
+            continue
+        by_trace[(run_id, agent_id)].append(ev)
+
+    # 3. Query memories in the window to enumerate every
+    #    (run_id, agent_id) group, including ones with no signal
+    #    evidence (these become outcome_label='unknown').
+    memories_by_trace = await _query_memories_in_window(
+        db,
+        tenant_id=tenant_id,
+        fleet_id=fleet_id,
+        window_start=window_start,
+        window_end=window_end,
+    )
+
+    # 4. Build SessionTraceRow per trace.
+    #
+    # Entity resolution is hoisted OUT of the per-trace loop to avoid
+    # an N+1 SQL pattern (one ``memory_entity_links`` SELECT per
+    # trace). We collect every member memory id across the window
+    # first, issue ONE SELECT, and partition the result back to each
+    # trace inside the loop.
+    all_memory_ids: list[str] = sorted(
+        {m.memory_id for members in memories_by_trace.values() for m in members}
+    )
+    entities_by_memory = await _query_entity_ids_for_memories(db, memory_ids=all_memory_ids)
+
+    out: list[SessionTraceRow] = []
+    for (run_id, agent_id), members in memories_by_trace.items():
+        evidence = by_trace.get((run_id, agent_id), [])
+        label = fold_outcome_label(evidence)
+        # Partition the bulk entity lookup back to this trace —
+        # dedup + sort for deterministic fingerprint inputs later.
+        trace_entity_ids = sorted({eid for m in members for eid in entities_by_memory.get(m.memory_id, ())})
+        # Window inputs are always in the trace bounds; use the
+        # actual member memory timestamps for accuracy.
+        started_at = min(m.created_at for m in members)
+        ended_at = max(m.created_at for m in members)
+        out.append(
+            SessionTraceRow(
+                tenant_id=tenant_id,
+                fleet_id=fleet_id,
+                run_id=run_id,
+                agent_id=agent_id,
+                outcome_label=label,
+                memory_ids=[m.memory_id for m in members],
+                entity_ids=trace_entity_ids,
+                signals_summary=summarize_evidence(evidence),
+                started_at=started_at,
+                ended_at=ended_at,
+                goal_phrase=None,
+            )
+        )
+
+    # 5. Persist.
+    if persist and out:
+        await _upsert_session_traces(db, out)
+
+    logger.info(
+        "session_trace_builder: built %d traces (success=%d failure=%d unknown=%d) "
+        "for tenant=%s fleet=%s window=[%s, %s)",
+        len(out),
+        sum(1 for r in out if r.outcome_label == "success"),
+        sum(1 for r in out if r.outcome_label == "failure"),
+        sum(1 for r in out if r.outcome_label == "unknown"),
+        tenant_id,
+        fleet_id,
+        window_start.isoformat() if window_start else None,
+        window_end.isoformat() if window_end else None,
+    )
+    return out
+
+
+# ── Private: DB I/O ───────────────────────────────────────────────
+
+
+async def _query_memories_in_window(
+    db: Any,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    window_start: datetime,
+    window_end: datetime,
+) -> dict[tuple[str, str], list[_MemoryRow]]:
+    """Return memories grouped by ``(run_id, agent_id)``.
+
+    Memories without a ``run_id`` are SKIPPED — they don't belong to
+    any session-bounded trace and would inflate the trace count with
+    one-off agent writes.
+    """
+    sql = """
+        SELECT
+            m.id           AS memory_id,
+            m.run_id       AS run_id,
+            m.agent_id     AS agent_id,
+            m.fleet_id     AS fleet_id,
+            m.created_at   AS created_at
+        FROM memories AS m
+        WHERE m.tenant_id = :tenant_id
+          AND m.created_at >= :w_start
+          AND m.created_at <  :w_end
+          AND m.run_id IS NOT NULL
+          AND (:fleet_id IS NULL OR m.fleet_id = :fleet_id OR m.fleet_id IS NULL)
+        ORDER BY m.run_id, m.agent_id, m.created_at ASC
+    """
+    rows = (
+        await db.execute(
+            text(sql),
+            {
+                "tenant_id": tenant_id,
+                "fleet_id": fleet_id,
+                "w_start": window_start,
+                "w_end": window_end,
+            },
+        )
+    ).fetchall()
+
+    grouped: dict[tuple[str, str], list[_MemoryRow]] = defaultdict(list)
+    for row in rows:
+        grouped[(row.run_id, row.agent_id)].append(
+            _MemoryRow(
+                memory_id=str(row.memory_id),
+                run_id=row.run_id,
+                agent_id=row.agent_id,
+                fleet_id=row.fleet_id,
+                created_at=row.created_at,
+            )
+        )
+    return grouped
+
+
+async def _query_entity_ids_for_memories(db: Any, *, memory_ids: list[str]) -> dict[str, list[str]]:
+    """Resolve entities for a batch of memory ids via
+    ``memory_entity_links``. Returns ``{memory_id: [entity_id, ...]}``
+    with entity lists deduped and sorted for deterministic
+    fingerprint inputs later.
+
+    The caller passes EVERY memory id in the window in a single
+    invocation; we issue ONE SQL statement and partition the result
+    in Python. The previous shape (returning a flat ``list[str]``
+    per call) forced a per-trace call inside the
+    :func:`build_session_traces` loop, which was an N+1 against
+    ``memory_entity_links`` — observable as 100+ extra round-trips
+    on a busy fleet's Forge tick.
+
+    Empty input → empty dict (no query issued). Memory ids with no
+    links are absent from the returned dict (callers should default
+    to ``()`` / ``[]`` on lookup).
+    """
+    if not memory_ids:
+        return {}
+    # IMPORTANT: cast the PARAMETER to uuid[], not the column to text.
+    # ``memory_id::text = ANY(:memory_ids)`` would defeat any index on
+    # ``memory_entity_links.memory_id`` because the column is wrapped
+    # in a function call. ``CAST(:memory_ids AS uuid[])`` keeps the
+    # column reference index-eligible while still letting asyncpg
+    # bind the str list as text[]; PG converts text→uuid at bind time
+    # as long as the strings are valid UUIDs (they are — we round-
+    # tripped them via ``str(row.memory_id)`` from a uuid column
+    # earlier in the build).
+    sql = """
+        SELECT memory_id::text AS memory_id, entity_id::text AS entity_id
+        FROM memory_entity_links
+        WHERE memory_id = ANY(CAST(:memory_ids AS uuid[]))
+    """
+    rows = (
+        await db.execute(
+            text(sql),
+            {"memory_ids": list(memory_ids)},
+        )
+    ).fetchall()
+    grouped: dict[str, set[str]] = defaultdict(set)
+    for row in rows:
+        grouped[row.memory_id].add(row.entity_id)
+    return {mid: sorted(eids) for mid, eids in grouped.items()}
+
+
+async def _upsert_session_traces(db: Any, rows: list[SessionTraceRow]) -> None:
+    """Upsert into ``session_traces`` keyed by
+    ``(tenant_id, run_id, agent_id)`` (migration 021 unique
+    constraint). Re-running the builder over the same window is a
+    no-op for unchanged traces and a refresh for traces whose
+    evidence shifted.
+    """
+    if not rows:
+        return
+
+    sql = """
+        INSERT INTO session_traces (
+            tenant_id, fleet_id, run_id, agent_id,
+            outcome_label, memory_ids, entity_ids,
+            signals_summary, goal_phrase, started_at, ended_at
+        )
+        VALUES (
+            :tenant_id, :fleet_id, :run_id, :agent_id,
+            :outcome_label,
+            :memory_ids::jsonb, :entity_ids::jsonb,
+            :signals_summary::jsonb, :goal_phrase,
+            :started_at, :ended_at
+        )
+        ON CONFLICT (tenant_id, run_id, agent_id) DO UPDATE SET
+            fleet_id         = EXCLUDED.fleet_id,
+            outcome_label    = EXCLUDED.outcome_label,
+            memory_ids       = EXCLUDED.memory_ids,
+            entity_ids       = EXCLUDED.entity_ids,
+            signals_summary  = EXCLUDED.signals_summary,
+            goal_phrase      = EXCLUDED.goal_phrase,
+            started_at       = EXCLUDED.started_at,
+            ended_at         = EXCLUDED.ended_at
+    """
+    # Bulk-execute one statement at a time (asyncpg supports
+    # ``executemany`` but the bind shape with jsonb casts is cleaner
+    # one-by-one and the volumes here are small — one Forge tick is
+    # typically <500 traces).
+    import json
+
+    for row in rows:
+        bind = row.as_bind()
+        # JSONB params need to be JSON strings for asyncpg.
+        bind["memory_ids"] = json.dumps(bind["memory_ids"])
+        bind["entity_ids"] = json.dumps(bind["entity_ids"])
+        bind["signals_summary"] = json.dumps(bind["signals_summary"])
+        await db.execute(text(sql), bind)

--- a/core-api/src/core_api/services/skill_lifecycle.py
+++ b/core-api/src/core_api/services/skill_lifecycle.py
@@ -1,0 +1,355 @@
+"""Skill lifecycle service (plan §5).
+
+Phase 0 ships only the pre-write validator (SF-002) used by
+``routes/documents.py`` to enforce the 7 adjustments listed in plan
+§4 on every ``collection='skills'`` write:
+
+  1. schema validator (required fields present + typed)
+  2. ``description`` cap (default 160 bytes, configurable)
+  3. ``content`` body cap (default 40 000 bytes, configurable)
+  4. ``source`` defaulting + RBAC (regular caller → ``agent``;
+     ``manual`` admin-only; ``forge`` reserved for internal callers)
+  5. ``status`` defaulting + RBAC (regular caller → ``staged``;
+     ``active`` admin-only; ``candidate`` reserved for Forge)
+  6. auto-fill server-controlled fields (``content_hash``,
+     ``origin.agent_id``, ``created_at``, ``updated_at``)
+  7. Sentinel pre-scan + ``kind='update'`` hash-binding
+
+Phase 2 will extend this module with the staged → active /
+quarantined / rejected / stale transition logic. Phase 4 adds the
+v2 update-proposal hash-bind check.
+
+Everything in this module is GATED by
+``org_settings.skills_factory.enabled`` (default ``False``).
+The route checks the flag and only calls
+:func:`validate_and_normalize_skill_write` when it is on. OSS
+tenants that have never opted in see ZERO behavior change.
+
+The validator returns the *normalized* doc body (server-controlled
+fields auto-filled, hash computed, scan result attached). The caller
+swaps it into ``body.data`` before the existing embedding +
+storage-api round-trip.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, NoReturn
+
+from fastapi import HTTPException
+
+from core_api.services.forge.sentinel_scan import ScanResult, scan_skill_doc
+
+logger = logging.getLogger(__name__)
+
+
+# Allowed enum values. Mirrors plan §3 + §5. Kept here, not in the
+# schema validator, so a typo on the route side fails fast at the
+# enum check rather than as a generic 'invalid value'.
+ALLOWED_SOURCES: frozenset[str] = frozenset({"forge", "agent", "manual", "imported"})
+ALLOWED_KINDS: frozenset[str] = frozenset({"create", "update"})
+ALLOWED_STATUSES: frozenset[str] = frozenset(
+    {"candidate", "staged", "active", "rejected", "quarantined", "stale", "deprecated"}
+)
+
+# Sources only an admin call (or, eventually, the internal Forge
+# lifecycle worker) may write directly. Regular agent calls cannot
+# self-assign these.
+ADMIN_ONLY_SOURCES: frozenset[str] = frozenset({"manual"})
+INTERNAL_ONLY_SOURCES: frozenset[str] = frozenset({"forge"})
+
+# Statuses an admin write may land in directly. Everything else
+# defaults to ``staged`` or is reserved for the lifecycle machinery.
+ADMIN_ONLY_STATUSES: frozenset[str] = frozenset({"active"})
+INTERNAL_ONLY_STATUSES: frozenset[str] = frozenset({"candidate"})
+
+# System-driven terminal / hold states. No HTTP caller — not Forge,
+# not admin, not a regular agent — may set these directly via
+# ``memclaw_doc``. The legitimate transitions to these states are:
+#   - ``quarantined`` ← Sentinel scanner inside this validator
+#   - ``rejected``    ← HITL Inbox Reject action (Phase 2 dashboard)
+#   - ``stale``       ← hash-binding stale detection (Phase 4)
+#   - ``deprecated``  ← skill lifecycle deprecation flow (Phase 4)
+# Letting an arbitrary write set them would let a misbehaving agent
+# silently retire an active skill or hide a candidate from review.
+SYSTEM_ONLY_STATUSES: frozenset[str] = frozenset({"quarantined", "rejected", "stale", "deprecated"})
+
+REQUIRED_TOP_LEVEL_KEYS: tuple[str, ...] = ("name", "slug", "description", "domain", "kind", "source")
+
+# ``slug`` regex mirrors the existing ``_SKILL_SLUG_RE`` in
+# ``routes/documents.py``. Duplicated here intentionally — the route
+# uses the regex on ``doc_id``; this module uses it on
+# ``data["slug"]``, and the two can diverge in the future
+# (e.g. doc_id namespacing prefix). Keep them in lockstep until that
+# divergence is needed.
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,99}$")
+
+
+# Default caps (mirrored in org_settings.DEFAULT_SETTINGS.skills_factory.*).
+# Listed here as fallback only — the route resolves the actual values
+# from the tenant settings and passes them in. These defaults are used
+# by direct unit tests against this module that don't go through the
+# settings layer.
+_DEFAULT_DESCRIPTION_MAX_BYTES = 160
+_DEFAULT_BODY_MAX_BYTES = 40_000
+
+
+@dataclass(frozen=True)
+class SkillWriteContext:
+    """Caller context the validator needs. Constructed by the route
+    from the AuthContext + org settings; bundled here so the
+    validator stays trivially unit-testable without FastAPI deps."""
+
+    caller_agent_id: str | None
+    is_admin: bool
+    is_internal_forge: bool  # True only when the internal lifecycle worker is the caller
+    description_max_bytes: int = _DEFAULT_DESCRIPTION_MAX_BYTES
+    body_max_bytes: int = _DEFAULT_BODY_MAX_BYTES
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _sha256(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _bytes_len(value: str) -> int:
+    """UTF-8 byte length (NOT character count) — what HTTP caps care about."""
+    return len(value.encode("utf-8"))
+
+
+def _raise(status_code: int, detail: str) -> NoReturn:
+    raise HTTPException(status_code=status_code, detail=detail)
+
+
+async def validate_and_normalize_skill_write(
+    data: dict,
+    *,
+    ctx: SkillWriteContext,
+    live_skill_doc: dict | None = None,
+) -> tuple[dict, ScanResult]:
+    """Run the 7 SF-002 adjustments on a skills-collection write.
+
+    Returns ``(normalized_data, scan_result)``. The route swaps
+    ``body.data = normalized_data`` and proceeds to embedding +
+    upsert. The scan result is already merged into
+    ``normalized_data['scan']`` — the separate return value lets
+    the caller decide what to do about a quarantined result (e.g.
+    log it specially, surface a different audit code).
+
+    Raises ``HTTPException`` for:
+
+      - 422 missing/malformed required fields, over-cap sizes, slug
+        regex mismatch, invalid enum values, scan ``fatal`` findings
+      - 403 RBAC violations on ``source`` / ``status``
+      - 409 ``kind='update'`` hash mismatch vs live target
+      - 404 ``kind='update'`` targeting a non-existent live skill
+    """
+
+    if not isinstance(data, dict):
+        _raise(422, "skills write requires a JSON object 'data' body.")
+
+    # Work on a shallow copy so the caller's body isn't mutated
+    # under their feet. Nested mutations (origin, scan) are explicit
+    # below.
+    out: dict[str, Any] = dict(data)
+
+    # ── Adjustment 1: schema validator hook ──────────────────────
+    missing = [k for k in REQUIRED_TOP_LEVEL_KEYS if k not in out]
+    if missing:
+        _raise(
+            422,
+            f"skills write missing required key(s): {sorted(missing)}. "
+            f"All of {sorted(REQUIRED_TOP_LEVEL_KEYS)} must be present.",
+        )
+
+    # Typed top-level fields. ``content`` is required for non-imported
+    # docs but stays optional for the source=imported backwards-compat
+    # path (eToro's pointer-only docs lack it by design — they get
+    # source=imported via the SF-001 migration). We defer the content
+    # presence check until after source resolution.
+    for k in ("name", "slug", "description", "domain"):
+        if not isinstance(out[k], str):
+            _raise(422, f"skills write: data['{k}'] must be a string.")
+    if not _SLUG_RE.fullmatch(out["slug"]):
+        _raise(
+            422,
+            f"skills write: data['slug'] must match {_SLUG_RE.pattern} — got {out['slug']!r}.",
+        )
+
+    if out["kind"] not in ALLOWED_KINDS:
+        _raise(
+            422,
+            f"skills write: data['kind'] must be one of {sorted(ALLOWED_KINDS)}, got {out['kind']!r}.",
+        )
+    if out["source"] not in ALLOWED_SOURCES:
+        _raise(
+            422,
+            f"skills write: data['source'] must be one of {sorted(ALLOWED_SOURCES)}, got {out['source']!r}.",
+        )
+
+    # Optional top-level types (only enforced when present)
+    if "tags" in out and not (isinstance(out["tags"], list) and all(isinstance(t, str) for t in out["tags"])):
+        _raise(422, "skills write: data['tags'] must be a list of strings if present.")
+
+    # ── Adjustment 4: source defaulting + RBAC ───────────────────
+    src = out["source"]
+    if src in INTERNAL_ONLY_SOURCES and not ctx.is_internal_forge:
+        _raise(
+            403,
+            f"skills write: source={src!r} is reserved for the internal Forge worker. "
+            "Regular agent and admin callers cannot mint source=forge directly.",
+        )
+    if src in ADMIN_ONLY_SOURCES and not ctx.is_admin:
+        _raise(
+            403,
+            f"skills write: source={src!r} requires admin role. "
+            "Use source='agent' for a regular agent-direct write.",
+        )
+
+    # ── Adjustment 5: status defaulting + RBAC ───────────────────
+    if "status" not in out:
+        # Forge candidates flow through the lifecycle worker (which sets
+        # candidate explicitly); a non-Forge caller defaults to staged
+        # so the doc lands in the inbox HITL gate.
+        out["status"] = "candidate" if ctx.is_internal_forge else "staged"
+    status = out["status"]
+    if status not in ALLOWED_STATUSES:
+        _raise(
+            422,
+            f"skills write: data['status'] must be one of {sorted(ALLOWED_STATUSES)}, got {status!r}.",
+        )
+    if status in INTERNAL_ONLY_STATUSES and not ctx.is_internal_forge:
+        _raise(
+            403,
+            f"skills write: status={status!r} is reserved for the internal Forge worker.",
+        )
+    if status in ADMIN_ONLY_STATUSES and not ctx.is_admin:
+        _raise(
+            403,
+            f"skills write: status={status!r} requires admin role. "
+            "Use HITL Inbox approval to transition staged → active.",
+        )
+    if status in SYSTEM_ONLY_STATUSES:
+        # System-managed terminal / hold states cannot be set by ANY
+        # HTTP caller (Forge, admin, or otherwise). The legitimate
+        # writers are: Sentinel (quarantined, set inside this same
+        # validator after the scan), HITL Inbox Reject action
+        # (rejected), hash-binding stale detection (stale), and the
+        # deprecation flow (deprecated).
+        _raise(
+            403,
+            f"skills write: status={status!r} is system-managed and cannot be "
+            "written directly. These transitions happen via Sentinel "
+            "scan / Inbox Reject / hash-binding stale detection / "
+            "deprecation flow — not via memclaw_doc.",
+        )
+
+    # ── Adjustment 2: description cap ────────────────────────────
+    desc_bytes = _bytes_len(out["description"])
+    if desc_bytes > ctx.description_max_bytes:
+        _raise(
+            422,
+            f"skills write: data['description'] is {desc_bytes} bytes; "
+            f"cap is {ctx.description_max_bytes} (configurable via "
+            "org_settings.skills_factory.description_max_bytes).",
+        )
+
+    # ── Adjustment 3: body cap ───────────────────────────────────
+    content = out.get("content")
+    if content is not None:
+        if not isinstance(content, str):
+            _raise(422, "skills write: data['content'] must be a string if present.")
+        body_bytes = _bytes_len(content)
+        if body_bytes > ctx.body_max_bytes:
+            _raise(
+                422,
+                f"skills write: data['content'] is {body_bytes} bytes; "
+                f"cap is {ctx.body_max_bytes} (configurable via "
+                "org_settings.skills_factory.body_max_bytes).",
+            )
+    elif src not in {"imported"}:
+        # Non-imported docs must carry a body. Imported docs (the
+        # eToro pointer-only shape) are allowed to skip it.
+        _raise(
+            422,
+            f"skills write: data['content'] is required when source={src!r}. "
+            "Only source='imported' may omit the content body.",
+        )
+
+    # ── Adjustment 6: auto-fill server-controlled fields ─────────
+    now = _now_iso()
+    if "created_at" not in out:
+        out["created_at"] = now
+    out["updated_at"] = now  # always bumped by server
+
+    # content_hash is derived from content (when present). For
+    # imported pointer-only docs (no content), leave it absent so
+    # downstream code can branch on `'content_hash' not in data`.
+    if content is not None:
+        out["content_hash"] = _sha256(content)
+
+    # origin.agent_id is server-stamped from the auth context, never
+    # trusted from the body. Other origin fields (session_key, run_id,
+    # message_id) ride through unchanged — the client may legitimately
+    # set them.
+    origin = dict(out.get("origin") or {})
+    origin["agent_id"] = ctx.caller_agent_id or "unknown"
+    out["origin"] = origin
+
+    # ── Adjustment 7a: kind='update' hash-binding ────────────────
+    if out["kind"] == "update":
+        target = out.get("target")
+        if not isinstance(target, dict) or "target_content_hash" not in target:
+            _raise(
+                422,
+                "skills write: kind='update' requires data['target']['target_content_hash'].",
+            )
+        if live_skill_doc is None:
+            _raise(
+                404,
+                f"skills write: kind='update' targets slug={out['slug']!r} but no live skill exists.",
+            )
+        live_data = live_skill_doc.get("data") if isinstance(live_skill_doc, dict) else None
+        live_hash = (live_data or {}).get("content_hash")
+        if live_hash is None:
+            # The live doc predates SF-002 (e.g. an imported pointer-
+            # only skill with no content). Reject the update — we have
+            # nothing to bind to, and silently letting it through would
+            # let the update clobber an imported doc.
+            _raise(
+                409,
+                f"skills write: kind='update' on slug={out['slug']!r} cannot bind — "
+                "the live skill has no content_hash (likely an imported pointer-only doc). "
+                "Re-author it as a fresh kind='create' if appropriate.",
+            )
+        if target["target_content_hash"] != live_hash:
+            _raise(
+                409,
+                f"skills write: target_content_hash mismatch for slug={out['slug']!r}. "
+                f"Caller saw {target['target_content_hash']!r}; live is {live_hash!r}. "
+                "Live skill changed between propose and write — re-revise the proposal.",
+            )
+
+    # ── Adjustment 7b: Sentinel pre-scan ─────────────────────────
+    scan_result = await scan_skill_doc(out, mode="pre-write")
+    if scan_result.any_fatal:
+        # Hard-reject findings (size / path violations) come back as
+        # fatal. Surface the first one verbatim — easier debugging
+        # than a generic 422.
+        first_fatal = next(f for f in scan_result.findings if f.fatal)
+        _raise(422, f"skills write: {first_fatal.code} — {first_fatal.message}")
+    if scan_result.state == "quarantined":
+        # Non-fatal critical findings (prompt-injection / shell-inject)
+        # let the doc persist but in quarantine. Plan §4 adjustment #7.
+        out["status"] = "quarantined"
+        out["quarantined_at"] = now
+    out["scan"] = scan_result.as_doc_field()
+
+    return out, scan_result

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/020_forge_rejected_fingerprints.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/020_forge_rejected_fingerprints.py
@@ -1,0 +1,131 @@
+"""Create ``forge_rejected_fingerprints`` table (Skill Factory SF-003).
+
+Anti-poison memory for the Forge resident. When an operator rejects a
+staged skill candidate in the Skills Inbox, its
+``cluster_fingerprint`` (``fp:v1:<sha256>``) lands here so Forge will
+not re-propose the same cluster for ``cooloff_days`` (default 30).
+
+Shape:
+
+  - ``id``                UUID PRIMARY KEY — surrogate key; the same
+                          fingerprint can be rejected multiple times
+                          over its lifetime (e.g. re-rejected after a
+                          cooloff expired and Forge re-proposed). One
+                          row per rejection event preserves the audit
+                          trail.
+  - ``tenant_id``         TEXT NOT NULL — scoping key. Matches the
+                          rest of the OSS schema (plain text, no FK).
+  - ``fleet_id``          TEXT NULL — fingerprints are typically
+                          fleet-scoped (one fleet's cluster is not the
+                          same as another's even if the surface text
+                          looks similar) but can be tenant-wide.
+  - ``cluster_fingerprint`` TEXT NOT NULL — the rejected fingerprint,
+                          format ``fp:v1:<sha256>``. NOT unique per
+                          (tenant, fleet) — see ``id`` rationale above.
+  - ``rejected_by_agent`` TEXT NOT NULL — operator identity from the
+                          Inbox action. ``human:<userid>`` for UI
+                          rejections, ``agent:<slug>`` if an automated
+                          policy ever rejects (not in MVP).
+  - ``rejected_at``       TIMESTAMPTZ NOT NULL DEFAULT now() — when
+                          this rejection landed. Cooloff is computed
+                          as ``rejected_at + cooloff_days``.
+  - ``cooloff_days``      INTEGER NOT NULL DEFAULT 30 — how long Forge
+                          must wait before re-proposing the same
+                          fingerprint. Configurable per tenant via
+                          ``org_settings.skills_factory.rejection_cooloff_days``
+                          (snapshotted on insert; subsequent setting
+                          changes do NOT retroactively affect existing
+                          rows).
+  - ``reason``            TEXT NULL — free-text operator reason from
+                          the Reject action (optional). Surfaces in
+                          audit views and inbox tooltips.
+
+The hot-path query is "is this fingerprint poisoned RIGHT NOW for this
+fleet?":
+
+  SELECT EXISTS (
+    SELECT 1 FROM forge_rejected_fingerprints
+    WHERE tenant_id = :t
+      AND (fleet_id = :f OR fleet_id IS NULL)
+      AND cluster_fingerprint = :fp
+      AND rejected_at + (cooloff_days || ' days')::interval > now()
+  )
+
+The ``idx_forge_rejected_fp_lookup`` index covers it directly. The
+``rejected_at DESC`` ordering lets the planner short-circuit on the
+most recent rejection when scanning multiple historical rejections of
+the same fingerprint.
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-05-10
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+revision: str = "020"
+down_revision: str | None = "019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "forge_rejected_fingerprints",
+        sa.Column(
+            "id",
+            PG_UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("fleet_id", sa.Text(), nullable=True),
+        sa.Column("cluster_fingerprint", sa.Text(), nullable=False),
+        sa.Column("rejected_by_agent", sa.Text(), nullable=False),
+        sa.Column(
+            "rejected_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "cooloff_days",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("30"),
+        ),
+        sa.Column("reason", sa.Text(), nullable=True),
+    )
+    # Hot-path: "is this fingerprint poisoned right now in this fleet?"
+    #
+    # The lookup query (Forge's CLI status-checker + Phase-2 candidate
+    # gate) is:
+    #
+    #   WHERE tenant_id = :t
+    #     AND cluster_fingerprint = :fp
+    #     AND (fleet_id = :f OR fleet_id IS NULL)
+    #     AND rejected_at + (cooloff_days || ' days')::interval > now()
+    #
+    # ``fleet_id`` is part of the predicate, so it belongs in the
+    # index — without it the planner has to do an extra filter step
+    # over every (tenant, fp) match. ``NULLS FIRST`` clusters rows
+    # with a NULL fleet_id at the start of each (tenant, fp) group,
+    # which matches the ``fleet_id = :f OR fleet_id IS NULL`` shape
+    # (PG can short-circuit the OR via the NULL bucket).
+    #
+    # Sorted DESC on rejected_at so the planner stops at the newest
+    # hit per (tenant, fp, fleet) tuple — the cooloff-window predicate
+    # only cares whether ANY rejection is still active.
+    op.execute(
+        "CREATE INDEX idx_forge_rejected_fp_lookup "
+        "ON forge_rejected_fingerprints "
+        "(tenant_id, cluster_fingerprint, fleet_id NULLS FIRST, rejected_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("forge_rejected_fingerprints")

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/021_session_traces.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/021_session_traces.py
@@ -1,0 +1,155 @@
+"""Create ``session_traces`` table (Skill Factory SF-004).
+
+Outcome-labeled session traces. Populated by the outcome inference
+layer (Phase 1) from the 6 free signals — contradictions,
+supersessions, repeat-recall, terminal memory, cross-agent reuse,
+external hooks. Forge reads from this table to build skill candidate
+clusters.
+
+A session-trace is the unit Forge mines. It groups the memories an
+agent wrote during one run/task into a single object tagged with an
+outcome label inferred without any ``memclaw_evolve`` call. Multiple
+traces sharing a goal + entity overlap become a skill cluster.
+
+Shape:
+
+  - ``id``                UUID PRIMARY KEY — surrogate key.
+  - ``tenant_id``         TEXT NOT NULL — scoping key, plain text per
+                          the rest of the OSS schema.
+  - ``fleet_id``          TEXT NULL — most traces are fleet-scoped;
+                          NULL allowed for tenant-wide standalone.
+  - ``run_id``            TEXT NOT NULL — groups the memories that
+                          belong to this trace. Already present on
+                          memory writes (017_memories_run_id_index).
+  - ``agent_id``          TEXT NOT NULL — author of the trace.
+  - ``outcome_label``     TEXT NOT NULL — ``success`` | ``failure`` |
+                          ``unknown``. Inferred passively; never set
+                          by an agent directly.
+  - ``memory_ids``        JSONB NOT NULL DEFAULT '[]'::jsonb — ordered
+                          array of memory UUIDs that made up this
+                          trace. Stored as a JSONB array (not a
+                          relation) because traces are immutable
+                          snapshots and per-trace queries always read
+                          the whole list at once. Lets us survive
+                          downstream memory deletes without dangling FKs
+                          (deleted memory ids are tolerated and skipped
+                          at read time).
+  - ``entity_ids``        JSONB NOT NULL DEFAULT '[]'::jsonb — entity
+                          UUIDs touched by the trace (from the existing
+                          entity-resolution layer). Drives Forge's
+                          cluster centroid via top-K by centrality.
+  - ``signals_summary``   JSONB NOT NULL DEFAULT '{}'::jsonb — per-
+                          signal evidence ({contradiction: [...],
+                          supersession: [...], repeat_recall: 0|n,
+                          terminal: "shipped"|"blocked"|null,
+                          cross_agent_reuse: int, external: {git: …,
+                          ci: …}}). Free-shape so individual signal
+                          extractors can evolve without a migration.
+  - ``goal_phrase``       TEXT NULL — LLM-extracted 6-word phrase
+                          describing what the trace was about.
+                          Populated lazily by the cluster fingerprint
+                          step; NULL until then.
+  - ``started_at``        TIMESTAMPTZ NOT NULL — earliest member
+                          memory ``created_at``.
+  - ``ended_at``          TIMESTAMPTZ NOT NULL — latest member memory
+                          ``created_at`` (terminal memory or last
+                          write in window, whichever is later).
+  - ``created_at``        TIMESTAMPTZ NOT NULL DEFAULT now() — when
+                          the outcome inference layer wrote this row.
+
+Unique constraint on ``(tenant_id, run_id, agent_id)``: one trace per
+run + agent. If the same run_id is shared by multiple agents (rare
+but possible), each agent gets its own trace row. Re-runs of the
+outcome extractor against the same run upsert via this constraint.
+
+Two query patterns drive the indexes:
+
+  1. Forge "recent traces in this fleet" — idx_session_traces_recent
+     (tenant_id, fleet_id, ended_at DESC). Bounded by
+     freshness_window_days (default 14d).
+  2. Outcome extractor's "is this trace already labeled" lookup —
+     covered by the unique constraint's implicit index.
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-05-10
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+revision: str = "021"
+down_revision: str | None = "020"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "session_traces",
+        sa.Column(
+            "id",
+            PG_UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("fleet_id", sa.Text(), nullable=True),
+        sa.Column("run_id", sa.Text(), nullable=False),
+        sa.Column("agent_id", sa.Text(), nullable=False),
+        sa.Column("outcome_label", sa.Text(), nullable=False),
+        sa.Column(
+            "memory_ids",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "entity_ids",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "signals_summary",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("goal_phrase", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "tenant_id",
+            "run_id",
+            "agent_id",
+            name="uq_session_traces_tenant_run_agent",
+        ),
+        # Defence-in-depth: outcome_label is application-managed but a
+        # CHECK keeps it honest at the DB layer. Mirrors the
+        # ``013_memory_type_check_constraint`` pattern.
+        sa.CheckConstraint(
+            "outcome_label IN ('success', 'failure', 'unknown')",
+            name="ck_session_traces_outcome_label",
+        ),
+    )
+    # Forge's primary read: "recent traces in this fleet within the
+    # freshness window". DESC on ended_at because freshness is
+    # decided from the trace end, not start.
+    op.execute(
+        "CREATE INDEX idx_session_traces_recent ON session_traces (tenant_id, fleet_id, ended_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("session_traces")

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/022_skills_backfill_source_status.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/022_skills_backfill_source_status.py
@@ -1,0 +1,224 @@
+"""Backfill ``source`` and ``status`` on existing skills docs (Skill Factory SF-001).
+
+The Skill Factory canonical schema (plan §3) extends the ``skills``
+collection with two lifecycle fields every doc is expected to carry:
+
+  - ``source`` — the producer that minted the doc. Canonical values:
+                 ``forge`` (Forge resident), ``agent`` (synchronous
+                 agent write via ``memclaw_doc``), ``manual`` (a human
+                 authored it), or ``imported`` (bulk import / external
+                 producer).
+  - ``status`` — lifecycle state. Pre-existing docs are already in
+                 production use, so they land in ``active`` directly.
+
+The eToro production survey + the 2026-06-06 dry-run revealed three
+real-world pre-migration shapes the backfill has to handle:
+
+  Shape A — no ``source``, has ``version`` (handcrafted skills)
+            1,403 → 1 row at eToro: ``etoro-brand-guidelines-v2`` +
+            the two OSS guides.
+  Shape B — no ``source``, no ``version`` (bulk-imported pointer-only)
+            ~1,405 rows at eToro: the catalog imports.
+  Shape C — has ``source`` already, but the value is a legacy non-
+            canonical string (e.g. ``cursor-marketplace``,
+            ``claw-fleet-skills/cursor-marketplace``) and / or
+            ``status`` is missing.
+            73 rows at eToro: the dry-run found these orphans, which
+            Branches 1+2 alone skip entirely.
+
+This migration backfills in FOUR branches. Each branch is
+independently idempotent — guard predicates ensure re-running over
+already-migrated data is a no-op.
+
+  1. **Manual heuristic** — docs with no ``source`` AND a ``version``
+     field get ``source='manual'`` + ``status='active'``.
+  2. **Imported default** — docs with no ``source`` get
+     ``source='imported'`` + ``status='active'``.
+  3. **Status backfill** — docs that already had a ``source`` value
+     (Shape C) but lack ``status`` get ``status='active'`` ONLY. The
+     legacy source value is left intact at this step; Branch 4
+     normalizes it next.
+  4. **Legacy source normalization** — docs whose ``source`` is NOT
+     in the canonical set get rewritten to ``source='imported'``
+     with the original value preserved as ``legacy_source``. The
+     Skill Factory's SF-002 validator (``skill_lifecycle.ALLOWED_SOURCES``)
+     enforces the canonical set on every NEW write; this branch
+     brings existing data into the same vocabulary without data
+     loss.
+
+The branch order matters only for readability — every branch is
+guarded so it does NOT depend on prior branches having run. Re-running
+the entire migration is a strict no-op once the data is consistent.
+
+The downgrade is safe to run against any deployment where this
+migration was applied: Branches 1+2 stamp ``_migrated_by="022"`` into
+every row they touch, and the downgrade ONLY strips ``source`` /
+``status`` / ``_migrated_by`` from rows carrying that sentinel. Rows
+with a pre-existing ``source='manual'`` or ``source='imported'`` that
+we did NOT write (e.g. data manually set by an operator, OR rows
+backfilled by a later Skill Factory migration) are left intact.
+
+Branch 4's downgrade restores the original (legacy) ``source`` from
+``legacy_source`` regardless of the sentinel — the legacy_source key
+itself is the discriminator for "this row was normalized by Branch
+4". Branch 3 is intentionally NOT reversed: those rows had a
+``source`` value before the migration ran and the post-migration
+``status='active'`` reflects production reality. Without a per-row
+sentinel for Branch 3 we can't distinguish "status added by Branch
+3" from "status set by a later write".
+
+Operator caveat: if Forge has already produced ``source='forge'``
+candidates against a downgraded baseline, do NOT run the downgrade —
+those candidates are unaffected by the strip filter (sentinel-keyed),
+but downstream consumers (plugin reconciliation, lifecycle, harness
+install) will see a mix of post-migration and pre-migration shapes.
+Take a backup first.
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-05-10
+Updated: 2026-06-06 — added Branches 3+4 after eToro dry-run found
+73 orphaned rows; downgrade extended for ``legacy_source`` restore.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "022"
+down_revision: str | None = "021"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Canonical source enum — kept in lockstep with
+# ``core_api.services.skill_lifecycle.ALLOWED_SOURCES``. A divergence
+# between the two would let Branch 4 normalize a value the validator
+# still considers acceptable (or vice-versa). The string literals
+# below are inlined into the SQL for Postgres' ``= ANY`` operator.
+_CANONICAL_SOURCES_SQL = "'forge', 'agent', 'manual', 'imported'"
+
+
+# Why the ``::jsonb`` / ``::json`` round-trip on every UPDATE:
+#
+# Older eToro deployments declared ``documents.data`` as plain ``json``
+# (we surfaced this during the migration 022 dry-run on 2026-06-06).
+# The OSS schema in ``common/models/document.py`` uses ``jsonb``, but
+# the migration must run cleanly on BOTH. Postgres' ``||`` /
+# ``jsonb_build_object`` / ``?`` / ``- 'key'`` operators only exist on
+# ``jsonb``. The pattern is:
+#
+#     SET data = ((data::jsonb) || jsonb_build_object(...))::json
+#
+# On a ``jsonb`` column the casts are a no-op (the planner removes
+# them); on a ``json`` column they translate to/from the correct
+# representation at row-update time. ``json_build_object`` exists too
+# but lacks the merge operator, so we keep using ``jsonb_build_object``
+# and round-trip via the casts.
+#
+# Predicates (``data ->> ...``, ``data ? ...``) also need the cast on
+# the ``json`` side — they're jsonb-only operators. We cast the column
+# expression in each WHERE clause for safety.
+
+
+def upgrade() -> None:
+    # Branch 1: manual-shaped docs (no source yet, carry ``version``)
+    # → source='manual', status='active'. Stamps ``_migrated_by='022'``
+    # so the downgrade can distinguish OUR writes from operator-set
+    # ``source='manual'`` values on pre-existing rows.
+    op.execute(
+        """
+        UPDATE documents
+        SET data = ((data::jsonb) || jsonb_build_object(
+                       'source',       'manual',
+                       'status',       'active',
+                       '_migrated_by', '022'
+                   ))::json
+        WHERE collection = 'skills'
+          AND ((data::jsonb) ->> 'source') IS NULL
+          AND (data::jsonb) ? 'version'
+        """
+    )
+    # Branch 2: everything else with no source → source='imported',
+    # status='active'. Same sentinel as Branch 1 for downgrade safety.
+    op.execute(
+        """
+        UPDATE documents
+        SET data = ((data::jsonb) || jsonb_build_object(
+                       'source',       'imported',
+                       'status',       'active',
+                       '_migrated_by', '022'
+                   ))::json
+        WHERE collection = 'skills'
+          AND ((data::jsonb) ->> 'source') IS NULL
+        """
+    )
+    # Branch 3: status backfill on docs that already had a source value
+    # but lack status. Plugs the 73-row gap surfaced by the eToro
+    # dry-run. Idempotent via ``status IS NULL`` guard.
+    op.execute(
+        """
+        UPDATE documents
+        SET data = ((data::jsonb) || jsonb_build_object('status', 'active'))::json
+        WHERE collection = 'skills'
+          AND ((data::jsonb) ->> 'source') IS NOT NULL
+          AND ((data::jsonb) ->> 'status') IS NULL
+        """
+    )
+    # Branch 4: normalize legacy non-canonical source values. Stash the
+    # original under ``legacy_source`` so audit + future migrations can
+    # see where the doc came from. Idempotent via the canonical-set
+    # NOT IN guard.
+    op.execute(
+        f"""
+        UPDATE documents
+        SET data = ((data::jsonb) || jsonb_build_object(
+                       'source',        'imported',
+                       'legacy_source', (data::jsonb) ->> 'source'
+                   ))::json
+        WHERE collection = 'skills'
+          AND ((data::jsonb) ->> 'source') IS NOT NULL
+          AND ((data::jsonb) ->> 'source') NOT IN ({_CANONICAL_SOURCES_SQL})
+        """
+    )
+
+
+def downgrade() -> None:
+    # Best-effort cleanup. Operators should not run this against a
+    # deployment where Forge has produced candidates — see module
+    # docstring.
+
+    # Step 1: restore Branch-4 normalizations. For any row that
+    # carries ``legacy_source``, put the original ``source`` back and
+    # drop ``legacy_source``.
+    op.execute(
+        """
+        UPDATE documents
+        SET data = (((data::jsonb) - 'legacy_source')
+                || jsonb_build_object('source', (data::jsonb) ->> 'legacy_source'))::json
+        WHERE collection = 'skills'
+          AND ((data::jsonb) ? 'legacy_source')
+        """
+    )
+    # Step 2: reverse Branches 1+2 — but ONLY for rows that carry the
+    # ``_migrated_by='022'`` sentinel this migration stamped. This is
+    # the key safety improvement vs. the prior version, which
+    # silently stripped ``source`` from any row whose source happened
+    # to be ``'manual'`` or ``'imported'`` — including
+    # operator-curated values we never wrote. The sentinel-keyed
+    # filter limits the strip to OUR rows only. We also drop the
+    # sentinel itself so a re-upgrade after a downgrade lands cleanly.
+    op.execute(
+        """
+        UPDATE documents
+        SET data = ((data::jsonb) - 'source' - 'status' - '_migrated_by')::json
+        WHERE collection = 'skills'
+          AND ((data::jsonb) ->> '_migrated_by') = '022'
+        """
+    )
+    # NOTE: Branch 3's ``status`` backfill on legacy-source rows is
+    # NOT reversed. Those rows had a ``source`` value before the
+    # migration ran and the post-migration ``status='active'`` reflects
+    # reality — they're in production use. Without a per-row sentinel
+    # we can't distinguish Branch-3 writes from any subsequent
+    # ``status`` writes; leaving them alone is the safe call.

--- a/docs/live-memory-pitch/01-the-lake.svg
+++ b/docs/live-memory-pitch/01-the-lake.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 580" font-family="'Kalam','Caveat','Patrick Hand','Comic Sans MS',cursive">
+  <defs>
+    <radialGradient id="lava" cx="50%" cy="55%" r="55%">
+      <stop offset="0%" stop-color="#FFE066"/>
+      <stop offset="35%" stop-color="#FF9F1C"/>
+      <stop offset="70%" stop-color="#E63946"/>
+      <stop offset="100%" stop-color="#6A040F"/>
+    </radialGradient>
+    <radialGradient id="bubble" cx="35%" cy="35%" r="65%">
+      <stop offset="0%" stop-color="#FFF8E7" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#FFE9B0" stop-opacity="0.6"/>
+    </radialGradient>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="6" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <rect width="900" height="580" fill="#0B1020"/>
+  <!-- subtle stars -->
+  <g fill="#FFF8E7" opacity="0.55">
+    <circle cx="80" cy="60" r="1.4"/><circle cx="220" cy="40" r="1"/><circle cx="380" cy="70" r="1.6"/>
+    <circle cx="540" cy="55" r="1"/><circle cx="700" cy="80" r="1.3"/><circle cx="820" cy="50" r="1.1"/>
+    <circle cx="120" cy="180" r="1"/><circle cx="780" cy="180" r="1"/><circle cx="60" cy="500" r="1.2"/>
+    <circle cx="850" cy="510" r="1"/>
+  </g>
+
+  <!-- title -->
+  <text x="450" y="70" text-anchor="middle" font-size="46" fill="#FFF8E7" font-weight="700">MemClaw — Live Memory</text>
+  <text x="450" y="102" text-anchor="middle" font-size="22" fill="#F7B538" font-style="italic">a boiling lake of fleet intelligence</text>
+
+  <!-- caldera rim shadow ring -->
+  <ellipse cx="450" cy="370" rx="330" ry="135" fill="#1A1F3A" stroke="#2A2F50" stroke-width="2"/>
+
+  <!-- lava lake (organic blob) -->
+  <path d="M 180,360
+           C 200,300 260,265 330,260
+           C 410,255 460,235 540,250
+           C 620,260 700,295 720,360
+           C 730,415 670,460 580,470
+           C 500,478 430,455 360,468
+           C 280,478 195,440 180,360 Z"
+        fill="url(#lava)" stroke="#4A0E0E" stroke-width="3"/>
+
+  <!-- molten cracks -->
+  <g stroke="#FFE066" stroke-width="2" fill="none" opacity="0.65" stroke-linecap="round">
+    <path d="M 270,360 Q 320,345 380,365 T 480,355"/>
+    <path d="M 430,400 Q 490,395 540,410 T 640,400"/>
+    <path d="M 320,420 Q 360,430 400,420"/>
+  </g>
+
+  <!-- floating memory notes inside lava -->
+  <g font-family="'Inter',sans-serif" font-size="9" fill="#1A1A1A">
+    <g transform="translate(290,340) rotate(-8)"><rect width="36" height="26" rx="2" fill="#FFF8E7" stroke="#1A1A1A"/><text x="4" y="11">deploy</text><text x="4" y="21">log</text></g>
+    <g transform="translate(420,330) rotate(5)"><rect width="36" height="26" rx="2" fill="#FFF8E7" stroke="#1A1A1A"/><text x="4" y="11">DNS</text><text x="4" y="21">note</text></g>
+    <g transform="translate(540,360) rotate(-3)"><rect width="36" height="26" rx="2" fill="#FFF8E7" stroke="#1A1A1A"/><text x="4" y="11">incident</text><text x="4" y="21">postmortem</text></g>
+    <g transform="translate(370,420) rotate(7)"><rect width="36" height="26" rx="2" fill="#FFF8E7" stroke="#1A1A1A"/><text x="4" y="11">user</text><text x="4" y="21">pref</text></g>
+    <g transform="translate(620,400) rotate(-6)"><rect width="36" height="26" rx="2" fill="#FFF8E7" stroke="#1A1A1A"/><text x="4" y="11">runbook</text><text x="4" y="21">step</text></g>
+  </g>
+
+  <!-- bubbles erupting upward, each labeled (a verb of the lake) -->
+  <g filter="url(#glow)">
+    <circle cx="290" cy="220" r="34" fill="url(#bubble)"/>
+    <text x="290" y="218" text-anchor="middle" font-size="14" fill="#1A1A1A" font-weight="700">Fusion</text>
+    <text x="290" y="234" text-anchor="middle" font-size="10" fill="#1A1A1A">new claim</text>
+
+    <circle cx="430" cy="180" r="40" fill="url(#bubble)"/>
+    <text x="430" y="180" text-anchor="middle" font-size="15" fill="#1A1A1A" font-weight="700">Skills</text>
+    <text x="430" y="198" text-anchor="middle" font-size="10" fill="#1A1A1A">distilled procedure</text>
+
+    <circle cx="580" cy="210" r="34" fill="url(#bubble)"/>
+    <text x="580" y="208" text-anchor="middle" font-size="13" fill="#1A1A1A" font-weight="700">Hypothesis</text>
+    <text x="580" y="224" text-anchor="middle" font-size="10" fill="#1A1A1A">unprompted</text>
+
+    <circle cx="700" cy="260" r="28" fill="url(#bubble)"/>
+    <text x="700" y="260" text-anchor="middle" font-size="12" fill="#1A1A1A" font-weight="700">Antibody</text>
+    <text x="700" y="274" text-anchor="middle" font-size="10" fill="#1A1A1A">immune</text>
+  </g>
+
+  <!-- residents on the rim -->
+  <g font-size="13" fill="#FFF8E7">
+    <!-- Forge -->
+    <g transform="translate(120,335)">
+      <circle cx="0" cy="0" r="18" fill="#F7B538" stroke="#1A1A1A" stroke-width="2"/>
+      <text x="0" y="4" text-anchor="middle" font-size="18" fill="#1A1A1A">⚒</text>
+      <text x="0" y="35" text-anchor="middle" fill="#F7B538" font-weight="700">Forge</text>
+      <text x="0" y="50" text-anchor="middle" font-size="10" fill="#FFF8E7">skill miner</text>
+    </g>
+    <!-- Oracle -->
+    <g transform="translate(220,200)">
+      <circle cx="0" cy="0" r="18" fill="#8B5CF6" stroke="#1A1A1A" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" font-size="18" fill="#FFF8E7">👁</text>
+      <text x="0" y="-26" text-anchor="middle" fill="#C4B5FD" font-weight="700">Oracle</text>
+      <text x="0" y="-12" text-anchor="middle" font-size="10" fill="#FFF8E7">hypotheses</text>
+    </g>
+    <!-- Dreamer -->
+    <g transform="translate(450,140)">
+      <circle cx="0" cy="0" r="18" fill="#06B6D4" stroke="#1A1A1A" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" font-size="16" fill="#FFF8E7">☾</text>
+      <text x="0" y="-26" text-anchor="middle" fill="#67E8F9" font-weight="700">Dreamer</text>
+      <text x="0" y="-12" text-anchor="middle" font-size="10" fill="#FFF8E7">consolidator</text>
+    </g>
+    <!-- Sentinel -->
+    <g transform="translate(680,180)">
+      <circle cx="0" cy="0" r="18" fill="#10B981" stroke="#1A1A1A" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" font-size="16" fill="#1A1A1A">🛡</text>
+      <text x="0" y="-26" text-anchor="middle" fill="#6EE7B7" font-weight="700">Sentinel</text>
+      <text x="0" y="-12" text-anchor="middle" font-size="10" fill="#FFF8E7">immune system</text>
+    </g>
+    <!-- Cartographer -->
+    <g transform="translate(790,335)">
+      <circle cx="0" cy="0" r="18" fill="#FB7185" stroke="#1A1A1A" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" font-size="16" fill="#1A1A1A">⌖</text>
+      <text x="0" y="35" text-anchor="middle" fill="#FDA4AF" font-weight="700">Cartographer</text>
+      <text x="0" y="50" text-anchor="middle" font-size="10" fill="#FFF8E7">maps the mind</text>
+    </g>
+    <!-- Hunter -->
+    <g transform="translate(450,500)">
+      <circle cx="0" cy="0" r="18" fill="#F87171" stroke="#1A1A1A" stroke-width="2"/>
+      <text x="0" y="5" text-anchor="middle" font-size="16" fill="#1A1A1A">◎</text>
+      <text x="0" y="36" text-anchor="middle" fill="#FCA5A5" font-weight="700">Hunter</text>
+      <text x="0" y="50" text-anchor="middle" font-size="10" fill="#FFF8E7">finds blind spots</text>
+    </g>
+  </g>
+
+  <!-- tagline -->
+  <text x="450" y="555" text-anchor="middle" font-size="20" fill="#FFE066" font-style="italic">every interaction makes the next one smarter</text>
+</svg>

--- a/docs/live-memory-pitch/02-library-vs-metabolism.svg
+++ b/docs/live-memory-pitch/02-library-vs-metabolism.svg
@@ -1,0 +1,161 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 560" font-family="'Kalam','Caveat','Patrick Hand','Comic Sans MS',cursive">
+  <defs>
+    <radialGradient id="organism" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#FFE066"/>
+      <stop offset="55%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#6A040F"/>
+    </radialGradient>
+    <linearGradient id="dust" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1F2937"/>
+      <stop offset="100%" stop-color="#0F172A"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1000" height="560" fill="#0B1020"/>
+
+  <!-- title bar -->
+  <text x="500" y="56" text-anchor="middle" font-size="34" fill="#FFF8E7" font-weight="700">Most memory products are libraries.</text>
+  <text x="500" y="92" text-anchor="middle" font-size="34" fill="#F7B538" font-weight="700">MemClaw is a metabolism.</text>
+
+  <!-- divider lava strip -->
+  <path d="M 500,130 Q 510,260 495,400 Q 510,490 500,540"
+        stroke="#FF6B35" stroke-width="3" fill="none" stroke-dasharray="4 6" opacity="0.6"/>
+
+  <!-- LEFT: Library -->
+  <g>
+    <text x="240" y="148" text-anchor="middle" font-size="26" fill="#94A3B8" font-weight="700">Library</text>
+    <text x="240" y="172" text-anchor="middle" font-size="16" fill="#64748B" font-style="italic">stores facts. gets bigger.</text>
+
+    <!-- shelves -->
+    <g stroke="#475569" stroke-width="2" fill="url(#dust)">
+      <rect x="80" y="200" width="320" height="56" rx="2"/>
+      <rect x="80" y="266" width="320" height="56" rx="2"/>
+      <rect x="80" y="332" width="320" height="56" rx="2"/>
+      <rect x="80" y="398" width="320" height="56" rx="2"/>
+    </g>
+
+    <!-- books on shelves -->
+    <g font-family="'Inter',sans-serif" font-size="9" fill="#CBD5E1">
+      <g>
+        <rect x="92"  y="208" width="22" height="40" fill="#475569"/>
+        <rect x="118" y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="144" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="170" y="208" width="22" height="40" fill="#94A3B8"/>
+        <rect x="196" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="222" y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="248" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="274" y="208" width="22" height="40" fill="#94A3B8"/>
+        <rect x="300" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="326" y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="352" y="208" width="22" height="40" fill="#475569"/>
+      </g>
+      <g transform="translate(0,66)">
+        <rect x="92"  y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="118" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="144" y="208" width="22" height="40" fill="#94A3B8"/>
+        <rect x="170" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="196" y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="222" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="248" y="208" width="22" height="40" fill="#94A3B8"/>
+        <rect x="274" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="300" y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="326" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="352" y="208" width="22" height="40" fill="#94A3B8"/>
+      </g>
+      <g transform="translate(0,132)">
+        <rect x="92"  y="208" width="22" height="40" fill="#475569"/>
+        <rect x="118" y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="144" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="170" y="208" width="22" height="40" fill="#94A3B8"/>
+        <rect x="196" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="222" y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="248" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="274" y="208" width="22" height="40" fill="#94A3B8"/>
+        <rect x="300" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="326" y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="352" y="208" width="22" height="40" fill="#475569"/>
+      </g>
+      <g transform="translate(0,198)">
+        <rect x="92"  y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="118" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="144" y="208" width="22" height="40" fill="#94A3B8"/>
+        <rect x="170" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="196" y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="222" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="248" y="208" width="22" height="40" fill="#94A3B8"/>
+        <rect x="274" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="300" y="208" width="22" height="40" fill="#64748B"/>
+        <rect x="326" y="208" width="22" height="40" fill="#475569"/>
+        <rect x="352" y="208" width="22" height="40" fill="#94A3B8"/>
+      </g>
+    </g>
+
+    <!-- tiny figure pulling a book -->
+    <g transform="translate(60,420)">
+      <circle cx="0" cy="0" r="8" fill="#CBD5E1" stroke="#1A1A1A"/>
+      <line x1="0" y1="8" x2="0" y2="22" stroke="#CBD5E1" stroke-width="2"/>
+      <line x1="0" y1="14" x2="14" y2="10" stroke="#CBD5E1" stroke-width="2"/>
+      <line x1="0" y1="22" x2="-6" y2="34" stroke="#CBD5E1" stroke-width="2"/>
+      <line x1="0" y1="22" x2="6"  y2="34" stroke="#CBD5E1" stroke-width="2"/>
+    </g>
+
+    <!-- caption -->
+    <text x="240" y="500" text-anchor="middle" font-size="16" fill="#94A3B8">read → write → read → write</text>
+    <text x="240" y="524" text-anchor="middle" font-size="14" fill="#64748B" font-style="italic">no surprises. no growth.</text>
+  </g>
+
+  <!-- RIGHT: Metabolism -->
+  <g>
+    <text x="760" y="148" text-anchor="middle" font-size="26" fill="#F7B538" font-weight="700">Metabolism</text>
+    <text x="760" y="172" text-anchor="middle" font-size="16" fill="#FFE066" font-style="italic">fuses, dreams, heals. gets smarter.</text>
+
+    <!-- pulsing organism -->
+    <path d="M 600,300
+             C 590,230 670,200 760,210
+             C 860,220 920,260 920,330
+             C 920,400 850,440 760,440
+             C 670,440 610,400 600,330 Z"
+          fill="url(#organism)" stroke="#4A0E0E" stroke-width="3"/>
+
+    <!-- internal verbs orbiting -->
+    <g font-size="15" fill="#1A1A1A" font-weight="700">
+      <g transform="translate(670,260)">
+        <ellipse cx="0" cy="0" rx="36" ry="18" fill="#FFF8E7" stroke="#1A1A1A"/>
+        <text x="0" y="5" text-anchor="middle">fuse</text>
+      </g>
+      <g transform="translate(840,260)">
+        <ellipse cx="0" cy="0" rx="42" ry="18" fill="#FFF8E7" stroke="#1A1A1A"/>
+        <text x="0" y="5" text-anchor="middle">dream</text>
+      </g>
+      <g transform="translate(670,400)">
+        <ellipse cx="0" cy="0" rx="36" ry="18" fill="#FFF8E7" stroke="#1A1A1A"/>
+        <text x="0" y="5" text-anchor="middle">erupt</text>
+      </g>
+      <g transform="translate(840,400)">
+        <ellipse cx="0" cy="0" rx="36" ry="18" fill="#FFF8E7" stroke="#1A1A1A"/>
+        <text x="0" y="5" text-anchor="middle">heal</text>
+      </g>
+      <g transform="translate(760,330)">
+        <ellipse cx="0" cy="0" rx="40" ry="18" fill="#FFE066" stroke="#1A1A1A"/>
+        <text x="0" y="5" text-anchor="middle">live</text>
+      </g>
+    </g>
+
+    <!-- looping arrows -->
+    <g fill="none" stroke="#FFF8E7" stroke-width="2" stroke-linecap="round">
+      <path d="M 706,260 Q 730,235 800,260" marker-end="url(#a1)"/>
+      <path d="M 798,275 Q 820,330 798,385" marker-end="url(#a1)"/>
+      <path d="M 800,400 Q 730,420 706,400" marker-end="url(#a1)"/>
+      <path d="M 670,385 Q 650,330 670,278" marker-end="url(#a1)"/>
+    </g>
+    <defs>
+      <marker id="a1" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+        <path d="M0,0 L6,4 L0,8 Z" fill="#FFF8E7"/>
+      </marker>
+    </defs>
+
+    <!-- caption -->
+    <text x="760" y="500" text-anchor="middle" font-size="16" fill="#FFE066">read → fuse → dream → erupt → heal</text>
+    <text x="760" y="524" text-anchor="middle" font-size="14" fill="#FFF8E7" font-style="italic">surprises emerge. value compounds.</text>
+  </g>
+</svg>

--- a/docs/live-memory-pitch/03-fusion.svg
+++ b/docs/live-memory-pitch/03-fusion.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 620" font-family="'Kalam','Caveat','Patrick Hand','Comic Sans MS',cursive">
+  <defs>
+    <radialGradient id="lavaPool" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#FFE066"/>
+      <stop offset="50%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#6A040F"/>
+    </radialGradient>
+    <radialGradient id="newCard" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#FFF8E7"/>
+      <stop offset="80%" stop-color="#FFE066"/>
+      <stop offset="100%" stop-color="#F7B538"/>
+    </radialGradient>
+    <filter id="cardGlow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="8" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <rect width="980" height="620" fill="#0B1020"/>
+
+  <text x="490" y="58" text-anchor="middle" font-size="36" fill="#FFF8E7" font-weight="700">Fusion</text>
+  <text x="490" y="92" text-anchor="middle" font-size="20" fill="#F7B538" font-style="italic">two memories collide. a third emerges. nobody on the fleet had it.</text>
+
+  <!-- Memory A card -->
+  <g transform="translate(110,150) rotate(-4)">
+    <rect width="290" height="140" rx="6" fill="#FFF8E7" stroke="#1A1A1A" stroke-width="2"/>
+    <rect width="290" height="28" rx="6" fill="#06B6D4"/>
+    <text x="14" y="20" font-size="14" fill="#0B1020" font-weight="700">Agent: Sasha</text>
+    <text x="232" y="20" font-size="11" fill="#0B1020">2026-04-22 · ops</text>
+    <text x="14" y="56" font-family="'Inter',sans-serif" font-size="13" fill="#1A1A1A">"Deploy script v4 hangs on</text>
+    <text x="14" y="76" font-family="'Inter',sans-serif" font-size="13" fill="#1A1A1A">step 7, but only in eu-west.</text>
+    <text x="14" y="96" font-family="'Inter',sans-serif" font-size="13" fill="#1A1A1A">us-east + ap-south are fine."</text>
+    <text x="14" y="124" font-size="12" fill="#64748B" font-style="italic">type: incident · region: eu-west</text>
+  </g>
+
+  <!-- Memory B card -->
+  <g transform="translate(580,150) rotate(4)">
+    <rect width="290" height="140" rx="6" fill="#FFF8E7" stroke="#1A1A1A" stroke-width="2"/>
+    <rect width="290" height="28" rx="6" fill="#8B5CF6"/>
+    <text x="14" y="20" font-size="14" fill="#FFF8E7" font-weight="700">Agent: Mira</text>
+    <text x="225" y="20" font-size="11" fill="#FFF8E7">2026-04-23 · platform</text>
+    <text x="14" y="56" font-family="'Inter',sans-serif" font-size="13" fill="#1A1A1A">"Step 7 of the deploy script</text>
+    <text x="14" y="76" font-family="'Inter',sans-serif" font-size="13" fill="#1A1A1A">calls a deprecated DNS</text>
+    <text x="14" y="96" font-family="'Inter',sans-serif" font-size="13" fill="#1A1A1A">resolver — flagged in audit."</text>
+    <text x="14" y="124" font-size="12" fill="#64748B" font-style="italic">type: audit-finding · scope: dns</text>
+  </g>
+
+  <!-- arrows funneling into lake -->
+  <g fill="none" stroke="#FF6B35" stroke-width="3" stroke-linecap="round" opacity="0.85">
+    <path d="M 250,300 Q 360,360 460,400"/>
+    <path d="M 730,300 Q 620,360 520,400"/>
+  </g>
+
+  <!-- lake / fusion crucible -->
+  <ellipse cx="490" cy="430" rx="180" ry="44" fill="url(#lavaPool)" stroke="#4A0E0E" stroke-width="3"/>
+  <text x="490" y="436" text-anchor="middle" font-size="16" fill="#1A1A1A" font-weight="700">↯ the lake fuses ↯</text>
+
+  <!-- collision sparks -->
+  <g stroke="#FFE066" stroke-width="2" fill="#FFE066">
+    <path d="M 460,400 l 8,-12 l -3,12 l 12,-2 l -12,8 z" opacity="0.85"/>
+    <path d="M 520,400 l -8,-12 l 3,12 l -12,-2 l 12,8 z" opacity="0.85"/>
+    <circle cx="490" cy="395" r="2"/><circle cx="475" cy="408" r="1.6"/><circle cx="505" cy="408" r="1.6"/>
+  </g>
+
+  <!-- Fused output card erupting upward (placed below to suggest it RISES from the lake) -->
+  <g transform="translate(285,490)" filter="url(#cardGlow)">
+    <rect width="410" height="110" rx="8" fill="url(#newCard)" stroke="#4A0E0E" stroke-width="2.5"/>
+    <text x="205" y="28" text-anchor="middle" font-size="14" fill="#6A040F" font-weight="700">⚡ FUSED · author=resident:dreamer</text>
+    <text x="205" y="58" text-anchor="middle" font-family="'Inter',sans-serif" font-size="14" fill="#1A1A1A" font-weight="600">"Deploy hangs in eu-west are caused by</text>
+    <text x="205" y="78" text-anchor="middle" font-family="'Inter',sans-serif" font-size="14" fill="#1A1A1A" font-weight="600">deprecated DNS resolver in step 7."</text>
+    <text x="205" y="100" text-anchor="middle" font-size="12" fill="#6A040F" font-style="italic">cites: Sasha (incident), Mira (audit) · confidence: 0.78 · status: hypothesis</text>
+  </g>
+
+  <!-- vertical eruption arrow -->
+  <g fill="none" stroke="#FFE066" stroke-width="2" stroke-linecap="round" stroke-dasharray="3 5">
+    <path d="M 490,425 L 490,488"/>
+  </g>
+
+  <!-- footer caption -->
+  <text x="490" y="600" text-anchor="middle" font-size="16" fill="#FFE066" font-style="italic">RAG vendors literally cannot do this — they have no fleet to collide.</text>
+</svg>

--- a/docs/live-memory-pitch/04-residents.svg
+++ b/docs/live-memory-pitch/04-residents.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 640" font-family="'Kalam','Caveat','Patrick Hand','Comic Sans MS',cursive">
+  <defs>
+    <radialGradient id="rg-forge" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#FFE066"/><stop offset="100%" stop-color="#C5283D"/>
+    </radialGradient>
+    <radialGradient id="rg-oracle" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#DDD6FE"/><stop offset="100%" stop-color="#5B21B6"/>
+    </radialGradient>
+    <radialGradient id="rg-dreamer" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#A5F3FC"/><stop offset="100%" stop-color="#0E7490"/>
+    </radialGradient>
+    <radialGradient id="rg-sentinel" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#A7F3D0"/><stop offset="100%" stop-color="#065F46"/>
+    </radialGradient>
+    <radialGradient id="rg-carto" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#FECDD3"/><stop offset="100%" stop-color="#9F1239"/>
+    </radialGradient>
+    <radialGradient id="rg-hunter" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#FED7AA"/><stop offset="100%" stop-color="#9A3412"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1100" height="640" fill="#0B1020"/>
+
+  <!-- title -->
+  <text x="550" y="58" text-anchor="middle" font-size="38" fill="#FFF8E7" font-weight="700">The Residents</text>
+  <text x="550" y="92" text-anchor="middle" font-size="20" fill="#F7B538" font-style="italic">you hire agents to do tasks. MemClaw hires residents to do thinking.</text>
+
+  <!-- 3x2 grid of resident cards -->
+  <!-- Card template: rounded card, big circular portrait, name, role, "tools" line -->
+
+  <!-- FORGE -->
+  <g transform="translate(60,140)">
+    <rect width="320" height="200" rx="14" fill="#15182E" stroke="#F7B538" stroke-width="2"/>
+    <circle cx="64" cy="80" r="40" fill="url(#rg-forge)" stroke="#1A1A1A" stroke-width="2"/>
+    <text x="64" y="92" text-anchor="middle" font-size="40" fill="#1A1A1A">⚒</text>
+    <text x="120" y="62" font-size="28" fill="#F7B538" font-weight="700">Forge</text>
+    <text x="120" y="86" font-size="14" fill="#FFE066" font-style="italic">the skill miner</text>
+    <text x="22" y="148" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">Mines outcome-tagged clusters and</text>
+    <text x="22" y="166" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">distills branching procedures.</text>
+    <text x="22" y="188" font-family="'Inter',sans-serif" font-size="11" fill="#94A3B8">writes → Skills Inbox · trust: 2 · cron 6h</text>
+  </g>
+
+  <!-- ORACLE -->
+  <g transform="translate(390,140)">
+    <rect width="320" height="200" rx="14" fill="#15182E" stroke="#C4B5FD" stroke-width="2"/>
+    <circle cx="64" cy="80" r="40" fill="url(#rg-oracle)" stroke="#1A1A1A" stroke-width="2"/>
+    <text x="64" y="92" text-anchor="middle" font-size="36" fill="#FFF8E7">👁</text>
+    <text x="120" y="62" font-size="28" fill="#C4B5FD" font-weight="700">Oracle</text>
+    <text x="120" y="86" font-size="14" fill="#DDD6FE" font-style="italic">erupts hypotheses</text>
+    <text x="22" y="148" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">Spots aggregate patterns no agent</text>
+    <text x="22" y="166" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">saw alone. proposes theories.</text>
+    <text x="22" y="188" font-family="'Inter',sans-serif" font-size="11" fill="#94A3B8">writes → Hypothesis Inbox · trust: 2 · cron 12h</text>
+  </g>
+
+  <!-- DREAMER -->
+  <g transform="translate(720,140)">
+    <rect width="320" height="200" rx="14" fill="#15182E" stroke="#67E8F9" stroke-width="2"/>
+    <circle cx="64" cy="80" r="40" fill="url(#rg-dreamer)" stroke="#1A1A1A" stroke-width="2"/>
+    <text x="64" y="94" text-anchor="middle" font-size="38" fill="#FFF8E7">☾</text>
+    <text x="120" y="62" font-size="28" fill="#67E8F9" font-weight="700">Dreamer</text>
+    <text x="120" y="86" font-size="14" fill="#A5F3FC" font-style="italic">consolidates while you sleep</text>
+    <text x="22" y="148" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">Recombines, fuses, prunes weak</text>
+    <text x="22" y="166" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">links, strengthens load-bearing ones.</text>
+    <text x="22" y="188" font-family="'Inter',sans-serif" font-size="11" fill="#94A3B8">writes → fused memories · trust: 3 · nightly</text>
+  </g>
+
+  <!-- SENTINEL -->
+  <g transform="translate(60,360)">
+    <rect width="320" height="200" rx="14" fill="#15182E" stroke="#6EE7B7" stroke-width="2"/>
+    <circle cx="64" cy="80" r="40" fill="url(#rg-sentinel)" stroke="#1A1A1A" stroke-width="2"/>
+    <text x="64" y="94" text-anchor="middle" font-size="38" fill="#1A1A1A">🛡</text>
+    <text x="120" y="62" font-size="28" fill="#6EE7B7" font-weight="700">Sentinel</text>
+    <text x="120" y="86" font-size="14" fill="#A7F3D0" font-style="italic">the immune system</text>
+    <text x="22" y="148" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">Detects poisoning. Generates antibody</text>
+    <text x="22" y="166" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">memories that inoculate the fleet.</text>
+    <text x="22" y="188" font-family="'Inter',sans-serif" font-size="11" fill="#94A3B8">writes → antibodies · trust: 3 · on-event</text>
+  </g>
+
+  <!-- CARTOGRAPHER -->
+  <g transform="translate(390,360)">
+    <rect width="320" height="200" rx="14" fill="#15182E" stroke="#FDA4AF" stroke-width="2"/>
+    <circle cx="64" cy="80" r="40" fill="url(#rg-carto)" stroke="#1A1A1A" stroke-width="2"/>
+    <text x="64" y="93" text-anchor="middle" font-size="38" fill="#1A1A1A">⌖</text>
+    <text x="120" y="62" font-size="26" fill="#FDA4AF" font-weight="700">Cartographer</text>
+    <text x="120" y="86" font-size="14" fill="#FECDD3" font-style="italic">draws the map of your mind</text>
+    <text x="22" y="148" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">Reveals shadow experts, real OKRs,</text>
+    <text x="22" y="166" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">contested beliefs, blind spots.</text>
+    <text x="22" y="188" font-family="'Inter',sans-serif" font-size="11" fill="#94A3B8">writes → topology snapshots · trust: 2 · weekly</text>
+  </g>
+
+  <!-- HUNTER -->
+  <g transform="translate(720,360)">
+    <rect width="320" height="200" rx="14" fill="#15182E" stroke="#FCA5A5" stroke-width="2"/>
+    <circle cx="64" cy="80" r="40" fill="url(#rg-hunter)" stroke="#1A1A1A" stroke-width="2"/>
+    <text x="64" y="92" text-anchor="middle" font-size="38" fill="#1A1A1A">◎</text>
+    <text x="120" y="62" font-size="28" fill="#FCA5A5" font-weight="700">Hunter</text>
+    <text x="120" y="86" font-size="14" fill="#FED7AA" font-style="italic">stalks the blind spots</text>
+    <text x="22" y="148" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">Adversarial self-play. Asks queries</text>
+    <text x="22" y="166" font-family="'Inter',sans-serif" font-size="13" fill="#FFF8E7">the fleet should answer — and can't.</text>
+    <text x="22" y="188" font-family="'Inter',sans-serif" font-size="11" fill="#94A3B8">writes → coastline backlog · trust: 1 · cron 24h</text>
+  </g>
+
+  <!-- footer ribbon: + custom -->
+  <g transform="translate(0,580)">
+    <rect x="60" y="0" width="980" height="42" rx="10" fill="#15182E" stroke="#FFE066" stroke-dasharray="6 4" stroke-width="2"/>
+    <text x="550" y="28" text-anchor="middle" font-size="18" fill="#FFE066">＋ Concierge — your custom resident. (a prompt + schedule + scope. community-shippable.)</text>
+  </g>
+</svg>

--- a/docs/live-memory-pitch/05-skill-factory.svg
+++ b/docs/live-memory-pitch/05-skill-factory.svg
@@ -1,0 +1,150 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 600" font-family="'Kalam','Caveat','Patrick Hand','Comic Sans MS',cursive">
+  <defs>
+    <radialGradient id="cluster" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#FFE066"/>
+      <stop offset="60%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#6A040F"/>
+    </radialGradient>
+    <linearGradient id="inboxGrad" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#FFF8E7"/>
+      <stop offset="100%" stop-color="#FFE9B0"/>
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L8,5 L0,10 Z" fill="#FFE066"/>
+    </marker>
+    <marker id="loopArrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L8,5 L0,10 Z" fill="#06B6D4"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="600" fill="#0B1020"/>
+
+  <!-- title -->
+  <text x="600" y="56" text-anchor="middle" font-size="36" fill="#FFF8E7" font-weight="700">Skill Factory</text>
+  <text x="600" y="88" text-anchor="middle" font-size="20" fill="#F7B538" font-style="italic">the fleet writes the playbooks nobody had time to write</text>
+
+  <!-- STAGE 1: Memory cluster in the lake -->
+  <g transform="translate(40,150)">
+    <ellipse cx="120" cy="160" rx="120" ry="100" fill="url(#cluster)" stroke="#4A0E0E" stroke-width="3"/>
+    <!-- memory dots in cluster -->
+    <g>
+      <circle cx="80"  cy="120" r="9" fill="#FFF8E7" stroke="#1A1A1A"/>
+      <circle cx="130" cy="105" r="9" fill="#FFF8E7" stroke="#1A1A1A"/>
+      <circle cx="170" cy="135" r="9" fill="#FFF8E7" stroke="#1A1A1A"/>
+      <circle cx="95"  cy="170" r="9" fill="#10B981" stroke="#1A1A1A"/>
+      <circle cx="140" cy="160" r="9" fill="#10B981" stroke="#1A1A1A"/>
+      <circle cx="180" cy="190" r="9" fill="#EF4444" stroke="#1A1A1A"/>
+      <circle cx="105" cy="210" r="9" fill="#10B981" stroke="#1A1A1A"/>
+      <circle cx="155" cy="220" r="9" fill="#EF4444" stroke="#1A1A1A"/>
+      <circle cx="80"  cy="240" r="9" fill="#10B981" stroke="#1A1A1A"/>
+    </g>
+    <text x="120" y="40" text-anchor="middle" font-size="20" fill="#FFE066" font-weight="700">1 · Cluster</text>
+    <text x="120" y="298" text-anchor="middle" font-size="13" fill="#FFF8E7">memories sharing a goal pattern</text>
+    <text x="120" y="316" text-anchor="middle" font-size="11" fill="#94A3B8">● outcome=success ● outcome=failure</text>
+  </g>
+
+  <!-- arrow 1 -->
+  <line x1="290" y1="310" x2="350" y2="310" stroke="#FFE066" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <!-- STAGE 2: Forge at the anvil -->
+  <g transform="translate(360,150)">
+    <rect width="240" height="320" rx="14" fill="#15182E" stroke="#F7B538" stroke-width="2"/>
+    <text x="120" y="36" text-anchor="middle" font-size="20" fill="#F7B538" font-weight="700">2 · Forge distills</text>
+    <!-- portrait -->
+    <circle cx="120" cy="100" r="38" fill="#F7B538" stroke="#1A1A1A" stroke-width="2"/>
+    <text x="120" y="113" text-anchor="middle" font-size="40" fill="#1A1A1A">⚒</text>
+    <!-- mini procedure preview -->
+    <g font-family="'Inter',sans-serif">
+      <rect x="22" y="160" width="196" height="140" rx="6" fill="#0B1020" stroke="#475569"/>
+      <text x="32" y="178" font-size="11" fill="#FFE066" font-weight="700">PROCEDURE · v1 (draft)</text>
+      <text x="32" y="198" font-size="10" fill="#FFF8E7">when: deploy + region=eu-west</text>
+      <line x1="32" y1="206" x2="208" y2="206" stroke="#334155"/>
+      <text x="32" y="222" font-size="10" fill="#FFF8E7">1. preflight DNS check</text>
+      <text x="32" y="238" font-size="10" fill="#FFF8E7">2. run script v4</text>
+      <text x="32" y="254" font-size="10" fill="#FFF8E7">3a. on hang → fallback resolver  ▸ 87%</text>
+      <text x="32" y="270" font-size="10" fill="#FFF8E7">3b. retry step 7              ▸ 41%</text>
+      <text x="32" y="290" font-size="9" fill="#94A3B8" font-style="italic">cites: 23 memories · 7 agents</text>
+    </g>
+  </g>
+
+  <!-- arrow 2 -->
+  <line x1="610" y1="310" x2="680" y2="310" stroke="#FFE066" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <!-- STAGE 3: Skills Inbox card -->
+  <g transform="translate(690,150)">
+    <rect width="240" height="320" rx="14" fill="url(#inboxGrad)" stroke="#1A1A1A" stroke-width="2"/>
+    <rect width="240" height="34" rx="14" fill="#FF6B35"/>
+    <text x="120" y="22" text-anchor="middle" font-size="14" fill="#FFF8E7" font-weight="700">📥 SKILLS INBOX</text>
+    <text x="120" y="60" text-anchor="middle" font-size="18" fill="#1A1A1A" font-weight="700">3 · Human-in-the-loop</text>
+
+    <g transform="translate(16,76)" font-family="'Inter',sans-serif">
+      <rect width="208" height="166" rx="6" fill="#FFF8E7" stroke="#475569"/>
+      <text x="12" y="22" font-size="13" fill="#1A1A1A" font-weight="700">Deploy in eu-west · v1</text>
+      <text x="12" y="40" font-size="11" fill="#475569">when: deploy + region=eu-west</text>
+      <line x1="12" y1="50" x2="196" y2="50" stroke="#94A3B8"/>
+      <text x="12" y="68" font-size="11" fill="#1A1A1A">success rate: <tspan fill="#10B981" font-weight="700">87%</tspan></text>
+      <text x="12" y="86" font-size="11" fill="#1A1A1A">sample: 23 runs · 7 agents</text>
+      <text x="12" y="104" font-size="11" fill="#1A1A1A">freshness: 4d · variance: low</text>
+      <text x="12" y="122" font-size="10" fill="#64748B" font-style="italic">replay (3) ▸ provenance ▸</text>
+      <!-- buttons -->
+      <g transform="translate(12,134)">
+        <rect width="58" height="22" rx="4" fill="#10B981"/>
+        <text x="29" y="16" text-anchor="middle" font-size="11" fill="#FFF8E7" font-weight="700">Approve</text>
+      </g>
+      <g transform="translate(74,134)">
+        <rect width="46" height="22" rx="4" fill="#06B6D4"/>
+        <text x="23" y="16" text-anchor="middle" font-size="11" fill="#0B1020" font-weight="700">Edit</text>
+      </g>
+      <g transform="translate(124,134)">
+        <rect width="46" height="22" rx="4" fill="#94A3B8"/>
+        <text x="23" y="16" text-anchor="middle" font-size="11" fill="#0B1020" font-weight="700">Defer</text>
+      </g>
+      <g transform="translate(174,134)">
+        <rect width="22" height="22" rx="4" fill="#EF4444"/>
+        <text x="11" y="16" text-anchor="middle" font-size="13" fill="#FFF8E7" font-weight="700">✕</text>
+      </g>
+    </g>
+
+    <text x="120" y="270" text-anchor="middle" font-size="11" fill="#1A1A1A" font-style="italic">auto-gates: vol≥10, agents≥3,</text>
+    <text x="120" y="285" text-anchor="middle" font-size="11" fill="#1A1A1A" font-style="italic">convergence, freshness, coverage</text>
+    <text x="120" y="306" text-anchor="middle" font-size="10" fill="#6A040F">(scope_org skills require dual-approval)</text>
+  </g>
+
+  <!-- arrow 3 -->
+  <line x1="940" y1="310" x2="1000" y2="310" stroke="#FFE066" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <!-- STAGE 4: Harness install -->
+  <g transform="translate(1010,150)">
+    <rect width="160" height="320" rx="14" fill="#15182E" stroke="#67E8F9" stroke-width="2"/>
+    <text x="80" y="34" text-anchor="middle" font-size="18" fill="#67E8F9" font-weight="700">4 · Install</text>
+    <text x="80" y="54" text-anchor="middle" font-size="12" fill="#A5F3FC" font-style="italic">to the harness</text>
+
+    <g font-family="'Inter',sans-serif" font-size="11" fill="#FFF8E7">
+      <g transform="translate(16,80)">
+        <rect width="128" height="44" rx="6" fill="#0B1020" stroke="#67E8F9"/>
+        <text x="64" y="20" text-anchor="middle" font-weight="700">Claude Code</text>
+        <text x="64" y="34" text-anchor="middle" font-size="9" fill="#94A3B8">~/.claude/skills/</text>
+      </g>
+      <g transform="translate(16,134)">
+        <rect width="128" height="44" rx="6" fill="#0B1020" stroke="#67E8F9"/>
+        <text x="64" y="20" text-anchor="middle" font-weight="700">OpenClaw</text>
+        <text x="64" y="34" text-anchor="middle" font-size="9" fill="#94A3B8">plugin slot</text>
+      </g>
+      <g transform="translate(16,188)">
+        <rect width="128" height="44" rx="6" fill="#0B1020" stroke="#67E8F9"/>
+        <text x="64" y="20" text-anchor="middle" font-weight="700">MCP tool</text>
+        <text x="64" y="34" text-anchor="middle" font-size="9" fill="#94A3B8">memclaw_skill_*</text>
+      </g>
+      <g transform="translate(16,242)">
+        <rect width="128" height="44" rx="6" fill="#0B1020" stroke="#67E8F9"/>
+        <text x="64" y="20" text-anchor="middle" font-weight="700">Cursor / IDE</text>
+        <text x="64" y="34" text-anchor="middle" font-size="9" fill="#94A3B8">skill files</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- big loop-back arrow: harness → cluster (outcomes flow back) -->
+  <path d="M 1090,490 C 1090,540 600,560 160,490"
+        fill="none" stroke="#06B6D4" stroke-width="3" stroke-dasharray="6 5" marker-end="url(#loopArrow)"/>
+  <text x="600" y="568" text-anchor="middle" font-size="16" fill="#06B6D4" font-style="italic">↻ outcomes flow back · v2 proposed when branches drift</text>
+</svg>

--- a/docs/live-memory-pitch/06-outcome-inference.svg
+++ b/docs/live-memory-pitch/06-outcome-inference.svg
@@ -1,0 +1,154 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 640" font-family="'Kalam','Caveat','Patrick Hand','Comic Sans MS',cursive">
+  <defs>
+    <linearGradient id="lane-agent" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#1F2937"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="lane-lake" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#3D0E0E"/>
+      <stop offset="100%" stop-color="#1A0808"/>
+    </linearGradient>
+    <radialGradient id="lensGrad" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#FFE066" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#FF6B35" stop-opacity="0"/>
+    </radialGradient>
+    <marker id="ai-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L8,5 L0,10 Z" fill="#FFE066"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="640" fill="#0B1020"/>
+
+  <!-- title -->
+  <text x="600" y="56" text-anchor="middle" font-size="36" fill="#FFF8E7" font-weight="700">Outcomes without asking</text>
+  <text x="600" y="90" text-anchor="middle" font-size="20" fill="#F7B538" font-style="italic">the memory stream IS the feedback signal — no <tspan font-family="'Inter',monospace">memclaw_evolve</tspan> required</text>
+
+  <!-- TIMELINE AXIS -->
+  <line x1="80" y1="320" x2="1120" y2="320" stroke="#475569" stroke-width="1.5" stroke-dasharray="2 4"/>
+  <text x="80" y="340" font-size="11" fill="#64748B">t=0</text>
+  <text x="1100" y="340" font-size="11" fill="#64748B">t→</text>
+
+  <!-- AGENT LANE (top) -->
+  <rect x="60" y="140" width="1080" height="100" rx="10" fill="url(#lane-agent)" stroke="#334155" stroke-width="1.5"/>
+  <text x="78" y="166" font-size="16" fill="#94A3B8" font-weight="700">Agent stream</text>
+  <text x="78" y="184" font-size="11" fill="#64748B" font-style="italic">normal recall + write activity (untouched)</text>
+
+  <!-- agent avatar at left -->
+  <g transform="translate(28,180)">
+    <circle r="22" fill="#06B6D4" stroke="#1A1A1A" stroke-width="2"/>
+    <text y="6" text-anchor="middle" font-size="22" fill="#0B1020">🧑</text>
+  </g>
+
+  <!-- agent events along the timeline -->
+  <!-- Event 1: recall M -->
+  <g transform="translate(180,200)">
+    <circle r="14" fill="#06B6D4" stroke="#1A1A1A" stroke-width="2"/>
+    <text y="5" text-anchor="middle" font-size="12" fill="#0B1020" font-weight="700">R</text>
+    <text x="0" y="-22" text-anchor="middle" font-size="11" fill="#A5F3FC">recall(M)</text>
+  </g>
+  <!-- Event 2: write contradiction -->
+  <g transform="translate(310,200)">
+    <rect x="-13" y="-13" width="26" height="26" rx="3" fill="#EF4444" stroke="#1A1A1A" stroke-width="2"/>
+    <text y="5" text-anchor="middle" font-size="12" fill="#FFF8E7" font-weight="700">W</text>
+    <text x="0" y="-22" text-anchor="middle" font-size="11" fill="#FCA5A5">contradicts(M)</text>
+  </g>
+  <!-- Event 3: repeat recall -->
+  <g transform="translate(450,200)">
+    <circle r="14" fill="#06B6D4" stroke="#1A1A1A" stroke-width="2"/>
+    <text y="5" text-anchor="middle" font-size="12" fill="#0B1020" font-weight="700">R</text>
+    <text x="0" y="-22" text-anchor="middle" font-size="11" fill="#A5F3FC">recall(N) ~M</text>
+  </g>
+  <!-- Event 4: supersede -->
+  <g transform="translate(580,200)">
+    <rect x="-13" y="-13" width="26" height="26" rx="3" fill="#F59E0B" stroke="#1A1A1A" stroke-width="2"/>
+    <text y="5" text-anchor="middle" font-size="12" fill="#0B1020" font-weight="700">W</text>
+    <text x="0" y="-22" text-anchor="middle" font-size="11" fill="#FCD34D">supersedes(M)</text>
+  </g>
+  <!-- Event 5: recall N -->
+  <g transform="translate(720,200)">
+    <circle r="14" fill="#06B6D4" stroke="#1A1A1A" stroke-width="2"/>
+    <text y="5" text-anchor="middle" font-size="12" fill="#0B1020" font-weight="700">R</text>
+    <text x="0" y="-22" text-anchor="middle" font-size="11" fill="#A5F3FC">recall(P)</text>
+  </g>
+  <!-- Event 6: write success -->
+  <g transform="translate(870,200)">
+    <rect x="-13" y="-13" width="26" height="26" rx="3" fill="#10B981" stroke="#1A1A1A" stroke-width="2"/>
+    <text y="5" text-anchor="middle" font-size="12" fill="#FFF8E7" font-weight="700">W</text>
+    <text x="0" y="-22" text-anchor="middle" font-size="11" fill="#6EE7B7">"shipped ✓"</text>
+  </g>
+  <!-- Event 7: write next-task open -->
+  <g transform="translate(1020,200)">
+    <rect x="-13" y="-13" width="26" height="26" rx="3" fill="#94A3B8" stroke="#1A1A1A" stroke-width="2"/>
+    <text y="5" text-anchor="middle" font-size="12" fill="#0B1020" font-weight="700">W</text>
+    <text x="0" y="-22" text-anchor="middle" font-size="11" fill="#CBD5E1">opens new task</text>
+  </g>
+
+  <!-- THE LENS: inference layer (the lake reads the stream) -->
+  <g>
+    <ellipse cx="600" cy="320" rx="540" ry="22" fill="url(#lensGrad)" opacity="0.5"/>
+  </g>
+  <text x="600" y="305" text-anchor="middle" font-size="13" fill="#FFE066" font-style="italic">the lake reads between events</text>
+
+  <!-- LAKE LANE (bottom): inference outputs -->
+  <rect x="60" y="370" width="1080" height="180" rx="10" fill="url(#lane-lake)" stroke="#6A040F" stroke-width="1.5"/>
+  <text x="78" y="396" font-size="16" fill="#FFE066" font-weight="700">Lake inference (passive)</text>
+  <text x="78" y="414" font-size="11" fill="#FCA5A5" font-style="italic">no agent action — Sentinel + Dreamer reading the natural stream</text>
+
+  <!-- inference signals tied to timeline events -->
+  <!-- M: failed -->
+  <g transform="translate(245,470)">
+    <rect x="-90" y="-30" width="180" height="64" rx="8" fill="#3B0810" stroke="#EF4444" stroke-width="1.5"/>
+    <text x="0" y="-12" text-anchor="middle" font-size="13" fill="#FCA5A5" font-weight="700">memory M → FAILED</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#FFF8E7">contradicted within window</text>
+    <text x="0" y="20" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#FFF8E7">+ superseded shortly after</text>
+  </g>
+  <!-- repeat-recall = first answer didn't land -->
+  <g transform="translate(450,470)">
+    <rect x="-72" y="-30" width="144" height="64" rx="8" fill="#3B2410" stroke="#F59E0B" stroke-width="1.5"/>
+    <text x="0" y="-12" text-anchor="middle" font-size="13" fill="#FCD34D" font-weight="700">repeat-recall</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#FFF8E7">first answer didn't land</text>
+    <text x="0" y="20" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#FFF8E7">→ tune retrieval profile</text>
+  </g>
+  <!-- P: succeeded -->
+  <g transform="translate(795,470)">
+    <rect x="-90" y="-30" width="180" height="64" rx="8" fill="#0F2E22" stroke="#10B981" stroke-width="1.5"/>
+    <text x="0" y="-12" text-anchor="middle" font-size="13" fill="#6EE7B7" font-weight="700">memory P → SUCCEEDED</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#FFF8E7">terminal "shipped" memory</text>
+    <text x="0" y="20" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#FFF8E7">in the same session window</text>
+  </g>
+  <!-- carry-forward / load-bearing -->
+  <g transform="translate(1010,470)">
+    <rect x="-80" y="-30" width="160" height="64" rx="8" fill="#1F1A3D" stroke="#A78BFA" stroke-width="1.5"/>
+    <text x="0" y="-12" text-anchor="middle" font-size="13" fill="#DDD6FE" font-weight="700">cross-agent reuse</text>
+    <text x="0" y="6" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#FFF8E7">P recalled by ≥3 agents</text>
+    <text x="0" y="20" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#FFF8E7">→ load-bearing skill candidate</text>
+  </g>
+
+  <!-- thin vertical lines connecting events to inferences -->
+  <g stroke="#FFE066" stroke-width="1" stroke-dasharray="2 3" opacity="0.55">
+    <line x1="245" y1="220" x2="245" y2="440"/>
+    <line x1="450" y1="220" x2="450" y2="440"/>
+    <line x1="795" y1="220" x2="795" y2="440"/>
+    <line x1="1010" y1="220" x2="1010" y2="440"/>
+  </g>
+
+  <!-- signal legend at the bottom -->
+  <g transform="translate(60,580)">
+    <text x="0" y="0" font-size="14" fill="#FFE066" font-weight="700">Six free signals — none require agent cooperation:</text>
+    <g font-family="'Inter',sans-serif" font-size="12" fill="#FFF8E7">
+      <text x="0"   y="22">●  contradiction event</text>
+      <text x="200" y="22">●  supersession event</text>
+      <text x="400" y="22">●  repeat-recall on same query</text>
+      <text x="630" y="22">●  session terminal memory ("shipped" / "blocked")</text>
+      <text x="0"   y="44">●  cross-agent reuse depth</text>
+      <text x="200" y="44">●  external hooks (git, CI, PR merge) tied to session_id</text>
+    </g>
+  </g>
+
+  <!-- soft-force optional -->
+  <g transform="translate(900,140)">
+    <rect width="220" height="40" rx="8" fill="#0B1020" stroke="#67E8F9" stroke-dasharray="4 3" stroke-width="1.5"/>
+    <text x="110" y="17" text-anchor="middle" font-size="11" fill="#67E8F9" font-weight="700">optional soft-force:</text>
+    <text x="110" y="32" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#A5F3FC">recall_id auto-attached to next write</text>
+  </g>
+</svg>

--- a/docs/live-memory-pitch/07-residents-vs-insights.svg
+++ b/docs/live-memory-pitch/07-residents-vs-insights.svg
@@ -1,0 +1,174 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" font-family="'Kalam','Caveat','Patrick Hand','Comic Sans MS',cursive">
+  <defs>
+    <radialGradient id="lake-mini" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#FFE066"/>
+      <stop offset="55%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#6A040F"/>
+    </radialGradient>
+    <marker id="grow-arrow" markerWidth="14" markerHeight="14" refX="10" refY="7" orient="auto">
+      <path d="M0,0 L12,7 L0,14 Z" fill="#FFE066"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="720" fill="#0B1020"/>
+
+  <!-- title -->
+  <text x="600" y="56" text-anchor="middle" font-size="36" fill="#FFF8E7" font-weight="700">Residents ≠ Insights</text>
+  <text x="600" y="90" text-anchor="middle" font-size="20" fill="#F7B538" font-style="italic">same plumbing. different contract. an evolution, not a replacement.</text>
+
+  <!-- middle "matures into" arrow (vertical center between halves) -->
+  <g transform="translate(540,388)">
+    <line x1="0" y1="0" x2="120" y2="0" stroke="#FFE066" stroke-width="4" marker-end="url(#grow-arrow)"/>
+    <text x="60" y="-22" text-anchor="middle" font-size="16" fill="#FFE066" font-weight="700">matures into</text>
+  </g>
+
+  <!-- ========== LEFT: TODAY ========== -->
+  <g>
+    <text x="270" y="138" text-anchor="middle" font-size="26" fill="#94A3B8" font-weight="700">Today · memclaw_insights</text>
+    <text x="270" y="162" text-anchor="middle" font-size="14" fill="#64748B" font-style="italic">a tool an agent calls when it remembers to</text>
+
+    <!-- agent -->
+    <g transform="translate(80,210)">
+      <circle cx="40" cy="40" r="32" fill="#06B6D4" stroke="#1A1A1A" stroke-width="2"/>
+      <text x="40" y="50" text-anchor="middle" font-size="30" fill="#0B1020">🧑</text>
+      <text x="40" y="100" text-anchor="middle" font-size="13" fill="#A5F3FC">Agent</text>
+    </g>
+
+    <!-- tool call (pull) arrow -->
+    <line x1="160" y1="250" x2="220" y2="250" stroke="#94A3B8" stroke-width="2" stroke-dasharray="4 3"/>
+    <text x="190" y="242" text-anchor="middle" font-size="11" fill="#94A3B8">pull</text>
+
+    <!-- the tool box -->
+    <g transform="translate(220,200)">
+      <rect width="200" height="100" rx="8" fill="#15182E" stroke="#94A3B8" stroke-width="2"/>
+      <text x="100" y="24" text-anchor="middle" font-family="'Inter',monospace" font-size="13" fill="#FFF8E7" font-weight="700">memclaw_insights</text>
+      <text x="100" y="44" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#94A3B8">focus = patterns | discover |</text>
+      <text x="100" y="58" text-anchor="middle" font-family="'Inter',sans-serif" font-size="10" fill="#94A3B8">contradictions | failures | …</text>
+      <text x="100" y="84" text-anchor="middle" font-size="11" fill="#FFE066" font-style="italic">single call · one-shot reflection</text>
+    </g>
+
+    <!-- output arrow -->
+    <line x1="320" y1="310" x2="320" y2="360" stroke="#94A3B8" stroke-width="2" stroke-dasharray="4 3"/>
+
+    <!-- output: insight memory card -->
+    <g transform="translate(220,360)">
+      <rect width="200" height="84" rx="6" fill="#FFF8E7" stroke="#1A1A1A" stroke-width="1.5"/>
+      <rect width="200" height="22" rx="6" fill="#94A3B8"/>
+      <text x="100" y="16" text-anchor="middle" font-size="11" fill="#0B1020" font-weight="700">type: insight</text>
+      <text x="12" y="40" font-family="'Inter',sans-serif" font-size="11" fill="#1A1A1A">"I notice 3 memories about</text>
+      <text x="12" y="56" font-family="'Inter',sans-serif" font-size="11" fill="#1A1A1A">deploys to eu-west failing."</text>
+      <text x="12" y="74" font-size="10" fill="#64748B" font-style="italic">a meta-observation</text>
+    </g>
+
+    <!-- properties side-card -->
+    <g transform="translate(60,478)" font-family="'Inter',sans-serif">
+      <rect width="420" height="180" rx="10" fill="#0F1428" stroke="#334155" stroke-width="1.5"/>
+      <text x="20" y="28" font-size="14" fill="#94A3B8" font-weight="700">Properties</text>
+      <g font-size="12" fill="#CBD5E1">
+        <text x="20" y="56">▸ <tspan fill="#FFF8E7" font-weight="700">Trigger:</tspan> agent pulls (reactive)</text>
+        <text x="20" y="80">▸ <tspan fill="#FFF8E7" font-weight="700">Output:</tspan> <tspan font-family="'Inter',monospace">insight</tspan>-type memory (meta)</text>
+        <text x="20" y="104">▸ <tspan fill="#FFF8E7" font-weight="700">Recallability:</tspan> only when querying about the lake</text>
+        <text x="20" y="128">▸ <tspan fill="#FFF8E7" font-weight="700">Lifecycle:</tspan> static (no parent binding)</text>
+        <text x="20" y="152">▸ <tspan fill="#FFF8E7" font-weight="700">Verification:</tspan> none</text>
+        <text x="20" y="172" fill="#94A3B8" font-style="italic">a mirror — "here's what you look like"</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- ========== RIGHT: TOMORROW ========== -->
+  <g>
+    <text x="930" y="138" text-anchor="middle" font-size="26" fill="#F7B538" font-weight="700">Tomorrow · Residents</text>
+    <text x="930" y="162" text-anchor="middle" font-size="14" fill="#FFE066" font-style="italic">colleagues that live in the lake and work continuously</text>
+
+    <!-- mini lake with residents around (lake group bumped UP to clear cards below) -->
+    <g transform="translate(710,180)">
+      <ellipse cx="220" cy="110" rx="200" ry="74" fill="url(#lake-mini)" stroke="#4A0E0E" stroke-width="2.5"/>
+      <text x="220" y="114" text-anchor="middle" font-size="14" fill="#1A1A1A" font-weight="700">the lake</text>
+
+      <!-- residents around the rim. labels OFFSET-INWARD-and-SIDEWAYS to avoid card lane below -->
+      <!-- Forge (left rim) -->
+      <g transform="translate(60,90)">
+        <circle r="18" fill="#F7B538" stroke="#1A1A1A" stroke-width="2"/>
+        <text y="6" text-anchor="middle" font-size="18" fill="#1A1A1A">⚒</text>
+        <text x="0" y="-26" text-anchor="middle" font-size="11" fill="#FFE066" font-weight="700">Forge</text>
+      </g>
+      <!-- Oracle (top-left) -->
+      <g transform="translate(150,32)">
+        <circle r="18" fill="#8B5CF6" stroke="#1A1A1A" stroke-width="2"/>
+        <text y="6" text-anchor="middle" font-size="16" fill="#FFF8E7">👁</text>
+        <text x="0" y="-26" text-anchor="middle" font-size="11" fill="#C4B5FD" font-weight="700">Oracle</text>
+      </g>
+      <!-- Dreamer (top-right) -->
+      <g transform="translate(290,32)">
+        <circle r="18" fill="#06B6D4" stroke="#1A1A1A" stroke-width="2"/>
+        <text y="6" text-anchor="middle" font-size="16" fill="#FFF8E7">☾</text>
+        <text x="0" y="-26" text-anchor="middle" font-size="11" fill="#67E8F9" font-weight="700">Dreamer</text>
+      </g>
+      <!-- Sentinel (right rim) -->
+      <g transform="translate(380,90)">
+        <circle r="18" fill="#10B981" stroke="#1A1A1A" stroke-width="2"/>
+        <text y="6" text-anchor="middle" font-size="16" fill="#1A1A1A">🛡</text>
+        <text x="0" y="-26" text-anchor="middle" font-size="11" fill="#6EE7B7" font-weight="700">Sentinel</text>
+      </g>
+      <!-- Hunter (bottom-left) - label to the LEFT (outside lake) -->
+      <g transform="translate(110,184)">
+        <circle r="18" fill="#F87171" stroke="#1A1A1A" stroke-width="2"/>
+        <text y="5" text-anchor="middle" font-size="16" fill="#1A1A1A">◎</text>
+        <text x="-24" y="4" text-anchor="end" font-size="11" fill="#FCA5A5" font-weight="700">Hunter</text>
+      </g>
+      <!-- Cartographer (bottom-right) - label to the RIGHT (outside lake) -->
+      <g transform="translate(330,184)">
+        <circle r="18" fill="#FB7185" stroke="#1A1A1A" stroke-width="2"/>
+        <text y="4" text-anchor="middle" font-size="16" fill="#1A1A1A">⌖</text>
+        <text x="24" y="4" text-anchor="start" font-size="11" fill="#FDA4AF" font-weight="700">Cartographer</text>
+      </g>
+    </g>
+
+    <!-- caption above output cards -->
+    <text x="930" y="430" text-anchor="middle" font-size="13" fill="#FFE066" font-style="italic">writes ↓ first-class memories (recallable like any other)</text>
+
+    <!-- output: first-class memory cards -->
+    <g transform="translate(720,442)">
+      <g transform="translate(0,0)">
+        <rect width="125" height="64" rx="6" fill="#FFF8E7" stroke="#1A1A1A" stroke-width="1.5"/>
+        <rect width="125" height="18" rx="6" fill="#F7B538"/>
+        <text x="62" y="13" text-anchor="middle" font-size="9" fill="#1A1A1A" font-weight="700">skill candidate</text>
+        <text x="8"  y="34" font-family="'Inter',sans-serif" font-size="9" fill="#1A1A1A">resident: forge</text>
+        <text x="8"  y="48" font-family="'Inter',sans-serif" font-size="9" fill="#1A1A1A">trust: 2 · scope: team</text>
+        <text x="8"  y="60" font-family="'Inter',sans-serif" font-size="8" fill="#64748B">cites: 23 mems</text>
+      </g>
+      <g transform="translate(140,0)">
+        <rect width="125" height="64" rx="6" fill="#FFF8E7" stroke="#1A1A1A" stroke-width="1.5"/>
+        <rect width="125" height="18" rx="6" fill="#06B6D4"/>
+        <text x="62" y="13" text-anchor="middle" font-size="9" fill="#0B1020" font-weight="700">fused claim</text>
+        <text x="8"  y="34" font-family="'Inter',sans-serif" font-size="9" fill="#1A1A1A">resident: dreamer</text>
+        <text x="8"  y="48" font-family="'Inter',sans-serif" font-size="9" fill="#1A1A1A">parents: A, B (bound)</text>
+        <text x="8"  y="60" font-family="'Inter',sans-serif" font-size="8" fill="#64748B">conf: 0.78 · hypothesis</text>
+      </g>
+      <g transform="translate(280,0)">
+        <rect width="125" height="64" rx="6" fill="#FFF8E7" stroke="#1A1A1A" stroke-width="1.5"/>
+        <rect width="125" height="18" rx="6" fill="#10B981"/>
+        <text x="62" y="13" text-anchor="middle" font-size="9" fill="#FFF8E7" font-weight="700">antibody</text>
+        <text x="8"  y="34" font-family="'Inter',sans-serif" font-size="9" fill="#1A1A1A">resident: sentinel</text>
+        <text x="8"  y="48" font-family="'Inter',sans-serif" font-size="9" fill="#1A1A1A">inoculates: poison-3a</text>
+        <text x="8"  y="60" font-family="'Inter',sans-serif" font-size="8" fill="#64748B">trust: 3 · scope: team</text>
+      </g>
+    </g>
+
+    <!-- properties side-card -->
+    <g transform="translate(720,528)" font-family="'Inter',sans-serif">
+      <rect width="420" height="130" rx="10" fill="#1F1108" stroke="#F7B538" stroke-width="1.5"/>
+      <text x="20" y="24" font-size="14" fill="#F7B538" font-weight="700">Properties</text>
+      <g font-size="12" fill="#FFE9B0">
+        <text x="20" y="48">▸ <tspan fill="#FFF8E7" font-weight="700">Trigger:</tspan> push (cron / on-event / continuous)</text>
+        <text x="20" y="68">▸ <tspan fill="#FFF8E7" font-weight="700">Output:</tspan> normal memories — recallable for ANY query</text>
+        <text x="20" y="88">▸ <tspan fill="#FFF8E7" font-weight="700">Lifecycle:</tspan> bound to parents — auto-retracts on supersession</text>
+        <text x="20" y="108">▸ <tspan fill="#FFF8E7" font-weight="700">Verification:</tspan> hypothesis → confirmed via downstream traces</text>
+        <text x="20" y="124" fill="#FFE066" font-style="italic">a mouth — "here's something I now claim"</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- footer ribbon: full-width, well clear of both Properties cards -->
+  <text x="600" y="700" text-anchor="middle" font-size="13" fill="#94A3B8" font-style="italic">today, focus=discover already does ~30% of this — the seed is in the box.</text>
+</svg>

--- a/docs/live-memory-pitch/08-skill-factory-architecture.svg
+++ b/docs/live-memory-pitch/08-skill-factory-architecture.svg
@@ -1,0 +1,403 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1500 1000" font-family="'Inter','Helvetica Neue',sans-serif">
+  <defs>
+    <linearGradient id="bgGrad" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0B1020"/>
+      <stop offset="100%" stop-color="#13182E"/>
+    </linearGradient>
+    <radialGradient id="lakeGrad" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#FFE066"/>
+      <stop offset="55%" stop-color="#FF6B35"/>
+      <stop offset="100%" stop-color="#6A040F"/>
+    </radialGradient>
+
+    <!-- Arrow markers (one per flow color) -->
+    <marker id="arrow-amber" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M0,0 L10,6 L0,12 Z" fill="#F7B538"/>
+    </marker>
+    <marker id="arrow-cyan" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M0,0 L10,6 L0,12 Z" fill="#67E8F9"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M0,0 L10,6 L0,12 Z" fill="#6EE7B7"/>
+    </marker>
+    <marker id="arrow-red" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M0,0 L10,6 L0,12 Z" fill="#FCA5A5"/>
+    </marker>
+
+    <!-- Block fill styles -->
+    <linearGradient id="newBlock" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1F2942"/>
+      <stop offset="100%" stop-color="#172033"/>
+    </linearGradient>
+    <linearGradient id="existingBlock" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1B2F3A"/>
+      <stop offset="100%" stop-color="#142531"/>
+    </linearGradient>
+    <linearGradient id="storageBlock" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2B1208"/>
+      <stop offset="100%" stop-color="#1F0E08"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1500" height="1000" fill="url(#bgGrad)"/>
+
+  <!-- ─────────────────────────  TITLE  ───────────────────────── -->
+  <text x="750" y="50" text-anchor="middle" font-size="30" fill="#FFF8E7" font-weight="700">Skill Factory — End-to-End Architecture</text>
+  <text x="750" y="76" text-anchor="middle" font-size="15" fill="#F7B538" font-style="italic">producers → outcome inference → cluster · fingerprint → Forge distill → Sentinel scan → skills collection (lifecycle) → HITL Inbox → harness install → outcomes loop back</text>
+
+  <!-- legend -->
+  <g transform="translate(30,90)" font-size="11" fill="#CBD5E1">
+    <rect x="0" y="0" width="14" height="14" rx="2" fill="url(#existingBlock)" stroke="#67E8F9" stroke-width="1.5"/>
+    <text x="22" y="11">existing in code</text>
+    <rect x="140" y="0" width="14" height="14" rx="2" fill="url(#newBlock)" stroke="#F7B538" stroke-width="1.5" stroke-dasharray="3 2"/>
+    <text x="162" y="11">NEW in this plan</text>
+    <rect x="280" y="0" width="14" height="14" rx="2" fill="url(#storageBlock)" stroke="#FB7185" stroke-width="1.5"/>
+    <text x="302" y="11">storage / data plane</text>
+    <line x1="430" y1="7" x2="455" y2="7" stroke="#F7B538" stroke-width="2"/>
+    <text x="465" y="11">data flow (forward)</text>
+    <line x1="600" y1="7" x2="625" y2="7" stroke="#FCA5A5" stroke-width="2" stroke-dasharray="4 3"/>
+    <text x="635" y="11">feedback / outcome loopback</text>
+    <line x1="820" y1="7" x2="845" y2="7" stroke="#6EE7B7" stroke-width="2"/>
+    <text x="855" y="11">control / lifecycle transition</text>
+  </g>
+
+  <!-- ─────────────────────────  ROW 1: PRODUCERS  ───────────────────────── -->
+  <text x="40" y="142" font-size="14" fill="#94A3B8" font-weight="700" letter-spacing="1">① PRODUCERS</text>
+
+  <!-- agents (memories) -->
+  <g transform="translate(30,150)">
+    <rect width="280" height="86" rx="10" fill="url(#existingBlock)" stroke="#67E8F9" stroke-width="1.8"/>
+    <text x="20" y="26" font-size="14" fill="#A5F3FC" font-weight="700">Agents · write memories</text>
+    <text x="20" y="48" font-size="11" fill="#CBD5E1">memclaw_write · memclaw_recall</text>
+    <text x="20" y="66" font-size="11" fill="#CBD5E1">→ memory stream (fact / outcome / rule / ...)</text>
+    <text x="270" y="80" text-anchor="end" font-size="10" fill="#67E8F9" font-style="italic">existing</text>
+  </g>
+
+  <!-- agents (direct skill via memclaw_doc) -->
+  <g transform="translate(330,150)">
+    <rect width="280" height="86" rx="10" fill="url(#existingBlock)" stroke="#67E8F9" stroke-width="1.8"/>
+    <text x="20" y="26" font-size="14" fill="#A5F3FC" font-weight="700">Agents · write skills directly</text>
+    <text x="20" y="48" font-size="11" fill="#CBD5E1">memclaw_doc op=write collection=skills</text>
+    <text x="20" y="66" font-size="11" fill="#CBD5E1">source: agent · lifecycle-gated</text>
+    <text x="270" y="80" text-anchor="end" font-size="10" fill="#F7B538" font-style="italic">existing + adjustments (§4)</text>
+  </g>
+
+  <!-- humans / bulk import -->
+  <g transform="translate(630,150)">
+    <rect width="240" height="86" rx="10" fill="url(#existingBlock)" stroke="#67E8F9" stroke-width="1.8"/>
+    <text x="20" y="26" font-size="14" fill="#A5F3FC" font-weight="700">Humans / Bulk import</text>
+    <text x="20" y="48" font-size="11" fill="#CBD5E1">manual SKILL.md authoring,</text>
+    <text x="20" y="66" font-size="11" fill="#CBD5E1">CI imports → source: manual / imported</text>
+  </g>
+
+  <!-- arrow legend for row 1 -->
+  <g transform="translate(890,150)" font-size="10" fill="#94A3B8">
+    <rect width="240" height="86" rx="10" fill="none" stroke="#334155" stroke-dasharray="3 3" stroke-width="1"/>
+    <text x="12" y="22" font-size="12" fill="#94A3B8" font-weight="700">producers all end in →</text>
+    <text x="12" y="44" font-size="11" fill="#CBD5E1">memories table (left flow)</text>
+    <text x="12" y="62" font-size="11" fill="#CBD5E1">skills collection (right flow)</text>
+    <text x="12" y="78" font-size="10" fill="#64748B" font-style="italic">same DB, different tables</text>
+  </g>
+
+  <!-- ─────────────────────────  ROW 2: SIGNAL EXTRACTION  ───────────────────────── -->
+  <text x="40" y="282" font-size="14" fill="#94A3B8" font-weight="700" letter-spacing="1">② OUTCOME INFERENCE — six free signals (no memclaw_evolve required)</text>
+
+  <g transform="translate(30,290)">
+    <rect width="1160" height="86" rx="10" fill="url(#newBlock)" stroke="#F7B538" stroke-dasharray="4 3" stroke-width="1.8"/>
+    <text x="20" y="26" font-size="13" fill="#FFE066" font-weight="700">outcome_inference/  (§6, 6 signals → labels each session-trace success/failure)</text>
+
+    <!-- 6 signal chips -->
+    <g font-size="10" fill="#FFF8E7">
+      <g transform="translate(20,42)">
+        <rect width="170" height="32" rx="6" fill="#0B1428" stroke="#475569"/>
+        <text x="10" y="14" font-weight="700" fill="#FCA5A5">1 · contradiction</text>
+        <text x="10" y="27" fill="#94A3B8">contradiction_detector (existing)</text>
+      </g>
+      <g transform="translate(200,42)">
+        <rect width="170" height="32" rx="6" fill="#0B1428" stroke="#475569"/>
+        <text x="10" y="14" font-weight="700" fill="#FCA5A5">2 · supersession</text>
+        <text x="10" y="27" fill="#94A3B8">memories.supersedes_id</text>
+      </g>
+      <g transform="translate(380,42)">
+        <rect width="170" height="32" rx="6" fill="#0B1428" stroke="#475569"/>
+        <text x="10" y="14" font-weight="700" fill="#FCD34D">3 · repeat-recall</text>
+        <text x="10" y="27" fill="#94A3B8">recall log + sim</text>
+      </g>
+      <g transform="translate(560,42)">
+        <rect width="170" height="32" rx="6" fill="#0B1428" stroke="#475569"/>
+        <text x="10" y="14" font-weight="700" fill="#6EE7B7">4 · terminal memory</text>
+        <text x="10" y="27" fill="#94A3B8">"shipped" / "blocked" classifier</text>
+      </g>
+      <g transform="translate(740,42)">
+        <rect width="190" height="32" rx="6" fill="#0B1428" stroke="#475569"/>
+        <text x="10" y="14" font-weight="700" fill="#DDD6FE">5 · cross-agent reuse</text>
+        <text x="10" y="27" fill="#94A3B8">recall counter × distinct agents</text>
+      </g>
+      <g transform="translate(940,42)">
+        <rect width="200" height="32" rx="6" fill="#0B1428" stroke="#475569"/>
+        <text x="10" y="14" font-weight="700" fill="#A5F3FC">6 · external hooks</text>
+        <text x="10" y="27" fill="#94A3B8">git / PR / CI tied to run_id</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- writes to session_traces table -->
+  <g transform="translate(1210,290)">
+    <rect width="260" height="86" rx="10" fill="url(#storageBlock)" stroke="#FB7185" stroke-width="1.8"/>
+    <text x="20" y="26" font-size="13" fill="#FDA4AF" font-weight="700">session_traces (NEW table)</text>
+    <text x="20" y="48" font-size="11" fill="#FFE9B0">run_id · agent_id · outcome label</text>
+    <text x="20" y="66" font-size="11" fill="#FFE9B0">memory_ids · timestamps · entities</text>
+    <text x="248" y="80" text-anchor="end" font-size="10" fill="#FB7185" font-style="italic">data plane</text>
+  </g>
+
+  <!-- ─────────────────────────  ROW 3: FORGE PIPELINE  ───────────────────────── -->
+  <text x="40" y="416" font-size="14" fill="#94A3B8" font-weight="700" letter-spacing="1">③ FORGE — cluster · fingerprint · distill · scan</text>
+
+  <!-- session-trace builder -->
+  <g transform="translate(30,424)">
+    <rect width="220" height="120" rx="10" fill="url(#newBlock)" stroke="#F7B538" stroke-dasharray="4 3" stroke-width="1.8"/>
+    <text x="16" y="22" font-size="13" fill="#FFE066" font-weight="700">session-trace builder</text>
+    <text x="16" y="42" font-size="10" fill="#CBD5E1">group memories by run_id +</text>
+    <text x="16" y="56" font-size="10" fill="#CBD5E1">agent + time window</text>
+    <text x="16" y="76" font-size="10" fill="#94A3B8">labels outcome (success / fail)</text>
+    <text x="16" y="90" font-size="10" fill="#94A3B8">via §6 signals</text>
+    <text x="16" y="110" font-size="10" fill="#67E8F9" font-style="italic">core-api/services/session_trace.py</text>
+  </g>
+
+  <!-- clusterer -->
+  <g transform="translate(270,424)">
+    <rect width="220" height="120" rx="10" fill="url(#newBlock)" stroke="#F7B538" stroke-dasharray="4 3" stroke-width="1.8"/>
+    <text x="16" y="22" font-size="13" fill="#FFE066" font-weight="700">cluster + fingerprint</text>
+    <text x="16" y="42" font-size="10" fill="#CBD5E1">k-means + entity overlap</text>
+    <text x="16" y="56" font-size="10" fill="#CBD5E1">fp:v1:&lt;hash&gt; canonical id</text>
+    <text x="16" y="76" font-size="10" fill="#94A3B8">stability test ≥ 99%</text>
+    <text x="16" y="90" font-size="10" fill="#94A3B8">→ Phase-1 prerequisite</text>
+    <text x="16" y="110" font-size="10" fill="#67E8F9" font-style="italic">forge/fingerprint.py · §8</text>
+  </g>
+
+  <!-- Forge distill -->
+  <g transform="translate(510,424)">
+    <rect width="240" height="120" rx="10" fill="url(#newBlock)" stroke="#F7B538" stroke-dasharray="4 3" stroke-width="1.8"/>
+    <text x="16" y="22" font-size="13" fill="#FFE066" font-weight="700">Forge · distill (LLM)</text>
+    <text x="16" y="42" font-size="10" fill="#CBD5E1">cluster → skill candidate doc</text>
+    <text x="16" y="56" font-size="10" fill="#CBD5E1">name · description (≤160B)</text>
+    <text x="16" y="70" font-size="10" fill="#CBD5E1">content · tags · cites · evidence</text>
+    <text x="16" y="86" font-size="10" fill="#94A3B8">cron 6h · trust 2 · 50k tok/run</text>
+    <text x="16" y="110" font-size="10" fill="#67E8F9" font-style="italic">forge/forge_service.py · §7</text>
+  </g>
+
+  <!-- Sentinel scanner -->
+  <g transform="translate(770,424)">
+    <rect width="240" height="120" rx="10" fill="url(#newBlock)" stroke="#F7B538" stroke-dasharray="4 3" stroke-width="1.8"/>
+    <text x="16" y="22" font-size="13" fill="#FFE066" font-weight="700">Sentinel · pre-scan</text>
+    <text x="16" y="42" font-size="10" fill="#CBD5E1">prompt-injection · shell-inject</text>
+    <text x="16" y="56" font-size="10" fill="#CBD5E1">PII · path violations · size caps</text>
+    <text x="16" y="76" font-size="10" fill="#94A3B8">→ clean / warn / quarantined</text>
+    <text x="16" y="90" font-size="10" fill="#94A3B8">re-runs on apply</text>
+    <text x="16" y="110" font-size="10" fill="#67E8F9" font-style="italic">forge/sentinel_scan.py · §9</text>
+  </g>
+
+  <!-- auto-gates -->
+  <g transform="translate(1030,424)">
+    <rect width="180" height="120" rx="10" fill="url(#newBlock)" stroke="#F7B538" stroke-dasharray="4 3" stroke-width="1.8"/>
+    <text x="14" y="22" font-size="13" fill="#FFE066" font-weight="700">auto-gates</text>
+    <text x="14" y="40" font-size="10" fill="#CBD5E1">volume ≥ 10</text>
+    <text x="14" y="54" font-size="10" fill="#CBD5E1">diversity ≥ 3 agents</text>
+    <text x="14" y="68" font-size="10" fill="#CBD5E1">convergence (variance ↓)</text>
+    <text x="14" y="82" font-size="10" fill="#CBD5E1">freshness ≤ 14d</text>
+    <text x="14" y="96" font-size="10" fill="#CBD5E1">coverage ≥ 1 match</text>
+    <text x="14" y="110" font-size="10" fill="#94A3B8" font-style="italic">candidate → staged</text>
+  </g>
+
+  <!-- rejected fingerprints poison memory -->
+  <g transform="translate(1230,424)">
+    <rect width="240" height="120" rx="10" fill="url(#storageBlock)" stroke="#FB7185" stroke-width="1.8"/>
+    <text x="14" y="22" font-size="13" fill="#FDA4AF" font-weight="700">forge_rejected_fingerprints</text>
+    <text x="14" y="42" font-size="10" fill="#FFE9B0">cluster_fingerprint · rejected_at</text>
+    <text x="14" y="56" font-size="10" fill="#FFE9B0">cooloff_days (default 30)</text>
+    <text x="14" y="76" font-size="10" fill="#94A3B8">→ Forge won't re-propose</text>
+    <text x="14" y="90" font-size="10" fill="#94A3B8">until cooloff expires</text>
+    <text x="14" y="110" font-size="10" fill="#FB7185" font-style="italic">data plane · NEW table</text>
+  </g>
+
+  <!-- ─────────────────────────  ROW 4: SKILLS COLLECTION (storage + lifecycle)  ───────────────────────── -->
+  <text x="40" y="584" font-size="14" fill="#94A3B8" font-weight="700" letter-spacing="1">④ SKILLS COLLECTION — same table, source discriminator, status lifecycle (§3, §5)</text>
+
+  <g transform="translate(30,594)">
+    <rect width="1110" height="160" rx="14" fill="url(#storageBlock)" stroke="#FB7185" stroke-width="2"/>
+    <text x="20" y="28" font-size="14" fill="#FDA4AF" font-weight="700">documents WHERE collection='skills'</text>
+    <text x="20" y="48" font-size="11" fill="#FFE9B0">jsonb (`data`) holds: name · slug · version · kind · source · status · description · content · cites · scan · target.target_content_hash · …</text>
+
+    <!-- source rail -->
+    <g font-size="10" fill="#FFF8E7">
+      <text x="20" y="74" font-weight="700" fill="#FDA4AF">source:</text>
+      <g transform="translate(80,62)">
+        <rect width="78" height="22" rx="4" fill="#F7B538"/><text x="39" y="15" text-anchor="middle" fill="#1A1A1A" font-weight="700">forge</text>
+      </g>
+      <g transform="translate(166,62)">
+        <rect width="86" height="22" rx="4" fill="#06B6D4"/><text x="43" y="15" text-anchor="middle" fill="#0B1020" font-weight="700">agent</text>
+      </g>
+      <g transform="translate(260,62)">
+        <rect width="74" height="22" rx="4" fill="#8B5CF6"/><text x="37" y="15" text-anchor="middle" fill="#FFF8E7" font-weight="700">manual</text>
+      </g>
+      <g transform="translate(342,62)">
+        <rect width="80" height="22" rx="4" fill="#475569"/><text x="40" y="15" text-anchor="middle" fill="#FFF8E7" font-weight="700">imported</text>
+      </g>
+    </g>
+
+    <!-- status rail -->
+    <g font-size="10" fill="#FFF8E7">
+      <text x="20" y="116" font-weight="700" fill="#FDA4AF">status:</text>
+      <g transform="translate(80,104)">
+        <rect width="80" height="22" rx="4" fill="#334155"/><text x="40" y="15" text-anchor="middle" fill="#CBD5E1" font-weight="700">candidate</text>
+      </g>
+      <text x="167" y="119" font-size="14" fill="#FFE066">→</text>
+      <g transform="translate(184,104)">
+        <rect width="64" height="22" rx="4" fill="#F7B538"/><text x="32" y="15" text-anchor="middle" fill="#1A1A1A" font-weight="700">staged</text>
+      </g>
+      <text x="255" y="119" font-size="14" fill="#6EE7B7">→</text>
+      <g transform="translate(272,104)">
+        <rect width="58" height="22" rx="4" fill="#10B981"/><text x="29" y="15" text-anchor="middle" fill="#FFF8E7" font-weight="700">active</text>
+      </g>
+      <text x="337" y="119" font-size="14" fill="#94A3B8">→</text>
+      <g transform="translate(354,104)">
+        <rect width="88" height="22" rx="4" fill="#64748B"/><text x="44" y="15" text-anchor="middle" fill="#FFF8E7" font-weight="700">deprecated</text>
+      </g>
+
+      <text x="464" y="119" font-size="10" fill="#94A3B8">side states:</text>
+      <g transform="translate(534,104)">
+        <rect width="72" height="22" rx="4" fill="#EF4444"/><text x="36" y="15" text-anchor="middle" fill="#FFF8E7" font-weight="700">rejected</text>
+      </g>
+      <g transform="translate(614,104)">
+        <rect width="92" height="22" rx="4" fill="#B45309"/><text x="46" y="15" text-anchor="middle" fill="#FFF8E7" font-weight="700">quarantined</text>
+      </g>
+      <g transform="translate(714,104)">
+        <rect width="48" height="22" rx="4" fill="#A78BFA"/><text x="24" y="15" text-anchor="middle" fill="#1A1A1A" font-weight="700">stale</text>
+      </g>
+    </g>
+
+    <text x="20" y="148" font-size="10" fill="#94A3B8" font-style="italic">hash-binding: target.target_content_hash bound at staged · mismatch on apply → stale (§3, §5)</text>
+  </g>
+
+  <!-- Skills Inbox (right side panel) -->
+  <g transform="translate(1160,594)">
+    <rect width="310" height="160" rx="14" fill="url(#newBlock)" stroke="#F7B538" stroke-width="2" stroke-dasharray="4 3"/>
+    <text x="20" y="26" font-size="14" fill="#FFE066" font-weight="700">⑤ HITL · Skills Inbox</text>
+    <text x="20" y="46" font-size="11" fill="#CBD5E1">filter: status=staged AND source IN (forge, agent)</text>
+
+    <text x="20" y="70" font-size="11" fill="#FFF8E7" font-weight="700">Card shows:</text>
+    <text x="20" y="86" font-size="10" fill="#CBD5E1">title · description · content (md) ·</text>
+    <text x="20" y="100" font-size="10" fill="#CBD5E1">evidence · cites · replay strip</text>
+    <text x="20" y="114" font-size="10" fill="#CBD5E1">scan badge · hash binding · fingerprint</text>
+
+    <!-- 5 action chips -->
+    <g transform="translate(20,124)" font-size="9">
+      <g><rect width="46" height="20" rx="3" fill="#10B981"/><text x="23" y="14" text-anchor="middle" fill="#FFF8E7" font-weight="700">Approve</text></g>
+      <g transform="translate(52,0)"><rect width="34" height="20" rx="3" fill="#06B6D4"/><text x="17" y="14" text-anchor="middle" fill="#0B1020" font-weight="700">Edit</text></g>
+      <g transform="translate(92,0)"><rect width="42" height="20" rx="3" fill="#EF4444"/><text x="21" y="14" text-anchor="middle" fill="#FFF8E7" font-weight="700">Reject</text></g>
+      <g transform="translate(140,0)"><rect width="64" height="20" rx="3" fill="#B45309"/><text x="32" y="14" text-anchor="middle" fill="#FFF8E7" font-weight="700">Quarantine</text></g>
+      <g transform="translate(210,0)"><rect width="36" height="20" rx="3" fill="#475569"/><text x="18" y="14" text-anchor="middle" fill="#FFF8E7" font-weight="700">Defer</text></g>
+    </g>
+  </g>
+
+  <!-- ─────────────────────────  ROW 5: DISTRIBUTION / HARNESS  ───────────────────────── -->
+  <text x="40" y="794" font-size="14" fill="#94A3B8" font-weight="700" letter-spacing="1">⑥ DISTRIBUTION — on status=active (§11)</text>
+
+  <g transform="translate(30,802)">
+    <rect width="260" height="110" rx="10" fill="url(#existingBlock)" stroke="#67E8F9" stroke-width="1.8"/>
+    <text x="16" y="24" font-size="13" fill="#A5F3FC" font-weight="700">OpenClaw plugin</text>
+    <text x="16" y="44" font-size="10" fill="#CBD5E1">plugin/skills/&lt;slug&gt;/SKILL.md</text>
+    <text x="16" y="60" font-size="10" fill="#CBD5E1">core-api/routes/plugin.py</text>
+    <text x="16" y="80" font-size="10" fill="#94A3B8" font-style="italic">existing path · becomes lifecycle-aware</text>
+    <text x="16" y="96" font-size="10" fill="#67E8F9">(filter by status=active)</text>
+  </g>
+
+  <g transform="translate(310,802)">
+    <rect width="260" height="110" rx="10" fill="url(#newBlock)" stroke="#F7B538" stroke-dasharray="4 3" stroke-width="1.8"/>
+    <text x="16" y="24" font-size="13" fill="#FFE066" font-weight="700">Direct-MCP (Claude Code / Codex)</text>
+    <text x="16" y="44" font-size="10" fill="#CBD5E1">static/skills/memclaw/&lt;slug&gt;/SKILL.md</text>
+    <text x="16" y="60" font-size="10" fill="#CBD5E1">strip-on-apply: status/version/date</text>
+    <text x="16" y="80" font-size="10" fill="#94A3B8" font-style="italic">forge/harness_install.py</text>
+  </g>
+
+  <g transform="translate(590,802)">
+    <rect width="260" height="110" rx="10" fill="url(#newBlock)" stroke="#F7B538" stroke-dasharray="4 3" stroke-width="1.8"/>
+    <text x="16" y="24" font-size="13" fill="#FFE066" font-weight="700">Claude Code (local install)</text>
+    <text x="16" y="44" font-size="10" fill="#CBD5E1">~/.claude/skills/&lt;slug&gt;/SKILL.md</text>
+    <text x="16" y="60" font-size="10" fill="#CBD5E1">memclawctl skill install &lt;slug&gt;</text>
+    <text x="16" y="80" font-size="10" fill="#94A3B8" font-style="italic">writes rollback metadata first</text>
+  </g>
+
+  <g transform="translate(870,802)">
+    <rect width="260" height="110" rx="10" fill="url(#newBlock)" stroke="#F7B538" stroke-dasharray="4 3" stroke-width="1.8"/>
+    <text x="16" y="24" font-size="13" fill="#FFE066" font-weight="700">OpenClaw workspace bridge</text>
+    <text x="16" y="44" font-size="10" fill="#CBD5E1">&lt;workspace&gt;/skills/&lt;slug&gt;/PROPOSAL.md</text>
+    <text x="16" y="60" font-size="10" fill="#CBD5E1">openclaw_bridge.enabled (default off)</text>
+    <text x="16" y="80" font-size="10" fill="#94A3B8" font-style="italic">Phase 5 · ≤1 eng-week budget · §13</text>
+  </g>
+
+  <!-- rollback storage -->
+  <g transform="translate(1150,802)">
+    <rect width="320" height="110" rx="10" fill="url(#storageBlock)" stroke="#FB7185" stroke-width="1.8"/>
+    <text x="16" y="24" font-size="13" fill="#FDA4AF" font-weight="700">skills_rollback (NEW collection)</text>
+    <text x="16" y="44" font-size="10" fill="#FFE9B0">previous_content + hash captured</text>
+    <text x="16" y="60" font-size="10" fill="#FFE9B0">BEFORE any apply mutates a target</text>
+    <text x="16" y="80" font-size="10" fill="#94A3B8">→ one-click revert in UI · §11</text>
+    <text x="16" y="98" font-size="10" fill="#FB7185" font-style="italic">data plane · doc per apply</text>
+  </g>
+
+  <!-- ─────────────────────────  FLOW ARROWS (forward)  ───────────────────────── -->
+
+  <!-- producers row → memories table (just visual, implied) -->
+
+  <!-- row 1 (left) → row 2 (signal extraction) -->
+  <path d="M 170,236 V 290" stroke="#F7B538" stroke-width="2" fill="none" marker-end="url(#arrow-amber)"/>
+
+  <!-- signal extraction → session_traces -->
+  <path d="M 1190,332 H 1210" stroke="#F7B538" stroke-width="2" fill="none" marker-end="url(#arrow-amber)"/>
+
+  <!-- session_traces → session-trace builder block -->
+  <path d="M 1340,376 V 410 Q 1340,420 1320,420 H 140 Q 140,420 140,424" stroke="#F7B538" stroke-width="2" fill="none" marker-end="url(#arrow-amber)"/>
+
+  <!-- session-trace builder → cluster -->
+  <path d="M 250,484 H 270" stroke="#F7B538" stroke-width="2" fill="none" marker-end="url(#arrow-amber)"/>
+  <!-- cluster → distill -->
+  <path d="M 490,484 H 510" stroke="#F7B538" stroke-width="2" fill="none" marker-end="url(#arrow-amber)"/>
+  <!-- distill → scanner -->
+  <path d="M 750,484 H 770" stroke="#F7B538" stroke-width="2" fill="none" marker-end="url(#arrow-amber)"/>
+  <!-- scanner → auto-gates -->
+  <path d="M 1010,484 H 1030" stroke="#F7B538" stroke-width="2" fill="none" marker-end="url(#arrow-amber)"/>
+
+  <!-- auto-gates → skills collection (drop down + curl) -->
+  <path d="M 1120,544 V 570 Q 1120,594 1100,594" stroke="#6EE7B7" stroke-width="2" fill="none" marker-end="url(#arrow-green)"/>
+
+  <!-- row 1 right (direct doc writes) → skills collection directly -->
+  <path d="M 470,236 V 570 Q 470,594 460,594" stroke="#67E8F9" stroke-width="2" fill="none" marker-end="url(#arrow-cyan)" stroke-dasharray="6 4"/>
+  <text x="478" y="380" font-size="10" fill="#67E8F9" font-style="italic">direct skill writes via memclaw_doc — same lifecycle, source=agent</text>
+
+  <!-- row 1 humans → skills collection -->
+  <path d="M 750,236 V 570 Q 750,594 740,594" stroke="#67E8F9" stroke-width="2" fill="none" marker-end="url(#arrow-cyan)" stroke-dasharray="6 4"/>
+
+  <!-- scanner -fail-> rejected fingerprints (poison memory) -->
+  <path d="M 1010,468 Q 1170,468 1230,468" stroke="#FCA5A5" stroke-width="2" fill="none" marker-end="url(#arrow-red)" stroke-dasharray="4 3"/>
+
+  <!-- skills collection → inbox -->
+  <path d="M 1140,674 H 1160" stroke="#6EE7B7" stroke-width="2" fill="none" marker-end="url(#arrow-green)"/>
+
+  <!-- inbox → distribution (down) -->
+  <path d="M 1315,754 V 780 Q 1315,802 1100,802 H 1010" stroke="#6EE7B7" stroke-width="2" fill="none" marker-end="url(#arrow-green)"/>
+
+  <!-- distribution arrows: from inbox/active down to each target (already covered above; add visual connectors from collection) -->
+  <path d="M 160,754 V 802" stroke="#6EE7B7" stroke-width="2" fill="none" marker-end="url(#arrow-green)"/>
+  <path d="M 440,754 V 802" stroke="#6EE7B7" stroke-width="2" fill="none" marker-end="url(#arrow-green)"/>
+  <path d="M 720,754 V 802" stroke="#6EE7B7" stroke-width="2" fill="none" marker-end="url(#arrow-green)"/>
+  <path d="M 1000,754 V 802" stroke="#6EE7B7" stroke-width="2" fill="none" marker-end="url(#arrow-green)"/>
+
+  <!-- ───── FEEDBACK LOOP (red dashed) ───── -->
+  <!-- distribution → outcome inference (via skill fires → memory writes → contradiction detector etc) -->
+  <path d="M 1310,912 Q 1480,920 1480,500 Q 1480,260 1340,260 Q 1100,260 600,260 Q 200,260 50,260 Q 14,260 14,260" stroke="#FCA5A5" stroke-width="2.5" fill="none" stroke-dasharray="7 5" marker-end="url(#arrow-red)"/>
+  <text x="1480" y="540" text-anchor="middle" font-size="12" fill="#FCA5A5" font-weight="700" transform="rotate(90,1480,540)">⟲ skill fires → outcomes → feedback</text>
+
+  <!-- caption at bottom -->
+  <text x="750" y="970" text-anchor="middle" font-size="12" fill="#FFE066" font-style="italic">all phases gated by §15 acceptance criteria · Phase-0 prereq for everything · v0.1 demo lights every box end-to-end</text>
+</svg>

--- a/docs/live-memory-pitch/feature-priorities.md
+++ b/docs/live-memory-pitch/feature-priorities.md
@@ -1,0 +1,75 @@
+# MemClaw Live Memory — Feature Priorities
+
+All candidate features from the Live Memory brainstorm, ranked. Each is a *process the lake performs on itself* (a "resident") rather than a CRUD endpoint.
+
+Unifying tagline: **most memory products are libraries — they get bigger. MemClaw is a metabolism — it gets smarter.**
+
+---
+
+## P0 — Committed
+
+| # | Feature | Resident | One-line | Why it's first |
+|---|---|---|---|---|
+| 0 | **Resident framework** | (substrate) | Cron-driven, scope-bounded agent identity with audit + token budget. The primitive every other feature inhabits. | Prerequisite for everything below. Invisible to users. |
+| 1 | **Skill Factory** | **Forge** | Passively mines outcome-tagged session clusters → distills branching procedures → HITL Skills Inbox → installs to harness (Claude Code first). | Approved. Headline ROI. Demo moment for both OSS and enterprise. |
+
+---
+
+## P1 — Next, after Skill Factory ships
+
+| # | Feature | Resident | One-line | Differentiator |
+|---|---|---|---|---|
+| 2 | **Fusion** | **Dreamer** | Collides ≥2 memories that individually don't answer a question into a *new claim* nobody on the fleet had. | The 60-second viral demo. RAG vendors literally cannot do this — no fleet to collide. |
+| 3 | **Dream Cycles** | **Dreamer** | Periodic offline pass: recombines, fuses, prunes weak links, strengthens load-bearing ones. Same volume in, *denser lake* out. | Reframes the product from database to organism. Ships with Fusion (same resident). |
+
+---
+
+## P2 — Planned
+
+| # | Feature | Resident | One-line | Differentiator |
+|---|---|---|---|---|
+| 4 | **Hypothesis Engine** | **Oracle** | Erupts unprompted theories from aggregate patterns ("when flag X is on, latency spikes 3h later 73% of the time"). | The lake stops being passive infra and becomes a scientist. |
+| 5 | **Memory Antibodies** | **Sentinel** | Detects poisoning / hallucinations / staleness; auto-generates inoculation memories. Each attack hardens the fleet. | Multi-tenant by definition. One tenant's antibody pattern (anonymized) hardens every other tenant's lake. Also pre-screens Skill Factory candidates. |
+| 6 | **Cartography** | **Cartographer** | Auto-derived map of who/what knows what, real OKRs vs stated, contested beliefs, blind spots. | CTO-level standalone product. The *real* org chart, drawn by what survived in the lake. |
+
+---
+
+## P3 — Later
+
+| # | Feature | Resident | One-line | Notes |
+|---|---|---|---|---|
+| 7 | **Counterfactual Replay** | (Dreamer-adjacent) | Inject a memory that exists *now* into a past failed session and replay. Quantifies $ value of each memory. | ROI proof tool. Doubles as the lake's self-evaluation harness. |
+| 8 | **Adversarial Self-Play** | **Hunter** | Continuously generates queries the fleet *should* answer; surfaces the gaps. | The lake hunts its own coastline. |
+| 9 | **Concierge** | (custom) | Tenant-defined custom resident — prompt + schedule + scope. Community-publishable. | Resident marketplace primitive. Extensibility story. |
+
+---
+
+## OSS vs Enterprise split
+
+**Strategic bet:** adoption beats moat. Killer feature must be in OSS or the OSS story dies (Mem0 / Letta both ship OSS).
+
+| Capability | OSS | Enterprise / Managed |
+|---|:-:|:-:|
+| Resident framework | ✓ | ✓ |
+| Forge + Skills Inbox + HITL approval | ✓ | ✓ |
+| Install to Claude Code / OpenClaw / MCP | ✓ | ✓ |
+| Outcome inference + v2 proposals | ✓ | ✓ |
+| Fusion + Dream Cycles | ✓ | ✓ |
+| Oracle / Sentinel / Cartographer / Hunter | ✓ | ✓ |
+| **Cross-fleet skill sharing** | — | ✓ |
+| **Cross-tenant skill marketplace (anonymized)** | — | ✓ |
+| **Auto-promote tier (skip HITL on gold candidates)** | — | ✓ |
+| **`scope_org` dual-approval governance** | — | ✓ |
+| **Federated antibodies (Sentinel cross-tenant)** | — | ✓ |
+| **Hosted Forge / platform-paid tokens** | — | ✓ |
+
+**Principle:** single-fleet magic is OSS · multi-fleet leverage is enterprise.
+**LLM cost in OSS:** user's own provider keys (existing pattern). Per-resident token budget knob, conservative default.
+
+---
+
+## Suggested exec deck order
+
+Lake → Library-vs-Metabolism → Residents → Residents-vs-Insights → Outcome-Inference → Fusion → Skill-Factory.
+
+Sketches: `docs/live-memory-pitch/01..07-*.svg`

--- a/docs/live-memory-pitch/skill-factory-implementation-plan.md
+++ b/docs/live-memory-pitch/skill-factory-implementation-plan.md
@@ -1,0 +1,698 @@
+# Skill Factory — Implementation Plan v1.0
+
+**Status:** approved for implementation (decisions ratified 2026-05-10).
+**Owner resident:** Forge.
+**Tenant of record (design memories):** `arkash24-4d270c` / `caura-dev-fleet` (re-log post-finalization).
+**DO NOT START** any coding until Ran's explicit green light on this plan.
+
+> **One paragraph.** Forge — a new lake-side resident — passively mines outcome-tagged session clusters from MemClaw's memory stream, distills them into proposed skills (with content body, frontmatter, provenance, scan, hashes), drops them into the existing `skills` collection with `status: staged`, surfaces them in a HITL Skills Inbox, and on approval installs to Claude Code / OpenClaw plugin / direct-MCP via the existing distribution layer. Same `skills` collection holds Forge-generated *and* manually-authored skills, distinguished by a `source` discriminator. Agents can also write skills directly via `memclaw_doc` (no new MCP tool). OpenClaw's Skill Workshop conventions (hash-binding, quarantine, rollback, caps, frontmatter strip-on-apply) are adopted; OpenClaw's *origin signal* (single-conversation) is not — Forge's fleet-collective mining stays the moat.
+
+---
+
+## 1. Goals · Non-goals
+
+### Goals (MVP)
+
+1. A tenant connects MemClaw and runs agents normally. Forge accumulates skill candidates without anyone calling `memclaw_evolve` or any new tool.
+2. One click in the Skills Inbox approves a candidate; one more installs it to Claude Code / OpenClaw / Direct-MCP.
+3. Installed skills produce outcomes that flow back; v2 update proposals are auto-generated when behavior drifts.
+4. Same `skills` collection holds both Forge-generated and human-authored skills; `source` + `status` fields keep them distinguishable.
+5. Skills are full-content (PROPOSAL.md body + frontmatter), not pointer-only.
+6. Safety primitives shipped in MVP: security scan, hash-binding, rollback metadata, hard caps.
+
+### Non-goals (explicit, for v1)
+
+- Branching procedures with per-branch success rates. (Flat MVP; reconsider in Phase 4.)
+- Cross-tenant / cross-fleet skill marketplace. (Enterprise, post-MVP.)
+- Auto-promote tier (skip HITL on gold candidates). (Phase 5+.)
+- Custom Concierge residents. (Phase 5+.)
+- Migration of eToro's 1,402 existing pointer-only skills. (Out of scope; Ran will work with eToro to adjust their import to full-content shape.)
+- A separate `memclaw_skill_workshop` MCP tool. (Rejected; `memclaw_doc` is the agent surface.)
+
+---
+
+## 2. Architecture overview
+
+See `08-skill-factory-architecture.svg` for the big-block flow.
+
+**One-line shape:** producers → outcome inference → cluster + fingerprint → Forge distill → Sentinel scan → `skills` collection (lifecycle) → HITL Skills Inbox → harness install → outcome loopback.
+
+Components:
+
+| # | Component | Status | Lives in |
+|---|---|---|---|
+| 1 | Memory store (lake) | existing | `caura-memclaw` `common/` + storage-api |
+| 2 | `memclaw_doc` MCP tool | existing | `caura-memclaw` `core-api/src/core_api/routes/documents.py` |
+| 3 | `skills` collection | existing | DB table `documents` with `collection='skills'` |
+| 4 | Plugin reconciliation → `plugin/skills/<slug>/SKILL.md` | existing | `core-api/routes/plugin.py` |
+| 5 | Direct-MCP skill adapter → `static/skills/memclaw/SKILL.md` | existing | served from `static/` |
+| 6 | `contradiction_detector` | existing | `core-api/services/contradiction_detector.py` |
+| 7 | `evolve_service` (outcome+rule) | existing | `core-api/services/evolve_service.py` |
+| 8 | `insights_service` clustering primitives | existing | `core-api/services/insights_service.py` |
+| 9 | `lifecycle_publishers` substrate | existing | `common/events/lifecycle_publishers.py` |
+| 10 | **Outcome inference layer** (6 signals) | NEW | `core-api/services/outcome_inference/` |
+| 11 | **Session-trace builder** | NEW | `core-api/services/session_trace.py` |
+| 12 | **Cluster fingerprint** | NEW | `core-api/services/forge/fingerprint.py` |
+| 13 | **Forge resident (distillation)** | NEW | `core-api/services/forge/forge_service.py` |
+| 14 | **Sentinel scanner** | NEW | `core-api/services/forge/sentinel_scan.py` |
+| 15 | **Skill lifecycle + hash-binding** | NEW | `core-api/services/skill_lifecycle.py` |
+| 16 | **Skills Inbox UI** | NEW | `frontend/.../skills-inbox/` |
+| 17 | **Claude Code install path** | NEW | `core-api/services/forge/harness_install.py` |
+| 18 | **Rollback metadata writer** | NEW | shares lifecycle service |
+| 19 | **v2 diff card proposer** | NEW (Phase 4) | extends Forge |
+| 20 | **OpenClaw PROPOSAL.md emitter** | NEW (Phase 5) | `core-api/services/forge/openclaw_bridge.py` |
+
+---
+
+## 3. Skill schema (v1 — canonical `skills` collection doc shape)
+
+Stored in `documents.data` (jsonb), `collection='skills'`, `doc_id` namespaced by source:
+- Forge-generated: `forge/<slug>` (e.g. `forge/deploy-eu-west-dns`)
+- Agent-direct via `memclaw_doc`: `agent/<slug>` (or plain `<slug>` for backwards compat)
+- Hand-authored / bulk-imported: plain `<slug>` (existing convention)
+
+```jsonc
+{
+  // Identity (always present)
+  "name":         "Deploy to eu-west · use fallback DNS at step 7",
+  "slug":         "deploy-eu-west-dns",
+  "version":      "v1",                          // semver-ish; bumped per applied revision
+  "kind":         "create",                      // create | update
+  "source":       "forge",                       // forge | agent | manual | imported
+  "status":       "staged",                      // see lifecycle §5
+
+  // Trigger surface (Claude Code / OpenClaw read these)
+  "description":  "Use fallback DNS resolver when eu-west deploy step 7 hangs.",
+                                                 // ≤ 160 bytes (default; configurable)
+  "summary":      "Detects a hung step 7 on eu-west deploys and switches to the fallback DNS resolver before retrying.",
+                                                 // longer; used for hover/inspect
+  "domain":       "devops",                      // matches eToro convention
+  "tags":         ["deploy", "eu-west", "dns", "incident-mitigation"],
+
+  // Body
+  "content":      "## When to use\n…\n## Steps\n1. …",  // full markdown (PROPOSAL.md body)
+  "content_hash": "sha256:…",                    // hash of `content` for stale detection
+
+  // Frontmatter-strip metadata (cleared on apply)
+  "frontmatter": {
+    "date":     "2026-05-12T14:01:00Z"           // when proposal was first written
+  },
+
+  // Provenance (machine + human)
+  "cites":        ["mem-8821", "mem-8932", "mem-9011", "mem-9134"],  // memory IDs
+  "goal":         "Deploy to eu-west without hanging on step 7.",     // ≤ 280 bytes
+  "evidence":     "Across 4 sessions / 3 agents in Apr 18–28, step 7 hung in eu-west; fallback DNS resolved every time. 100% success when applied.",  // human prose, ≤ 600 bytes
+  "cluster_fingerprint": "fp:v1:7a4f…",          // canonical id (see §8)
+
+  // Origin (who/where this came from — borrowed from OpenClaw)
+  "origin": {
+    "agent_id":    "forge",                      // for source=forge: the resident
+    "session_key": null,                         // forge has no single session
+    "run_id":      "forge-run-20260501-0600",    // the Forge run that produced it
+    "message_id":  null
+  },
+
+  // Support files (Phase 3+; allowed only under fixed prefixes)
+  "support_files": [
+    {
+      "path":      "scripts/check-dns.sh",       // assets/ examples/ references/ scripts/ templates/
+      "size_bytes": 412,
+      "hash":      "sha256:…"
+    }
+  ],
+
+  // Hash-binding (for `kind: update` — links to the target it modifies)
+  "target": {
+    "slug":              "deploy-eu-west-dns",
+    "previous_version":  "v1",
+    "target_content_hash": "sha256:…"            // hash of live skill at proposal time
+                                                 // → if live skill changes, status flips to `stale`
+  },
+
+  // Sentinel scan state
+  "scan": {
+    "state":      "clean",                       // pending | clean | failed | quarantined
+    "scanned_at": "2026-05-01T06:01:33Z",
+    "critical":   0,
+    "warn":       0,
+    "info":       1,
+    "findings":   []
+  },
+
+  // Lifecycle stamps
+  "created_at":     "2026-05-01T06:01:30Z",
+  "updated_at":     "2026-05-01T06:01:35Z",
+  "applied_at":     null,
+  "rejected_at":    null,
+  "quarantined_at": null,
+  "stale_at":       null,
+  "deprecated_at":  null,
+  "status_reason":  null,                        // free text on terminal transitions
+
+  // Telemetry (filled by outcome-loop in Phase 4)
+  "telemetry": {
+    "fires_total":          0,
+    "fires_success":        0,
+    "fires_failure":        0,
+    "last_fired_at":        null,
+    "utilization_30d":      null
+  }
+}
+```
+
+### Backwards-compatibility with the existing `skills` collection
+
+- Existing manual docs (`caura-shared-tasks`, `onprem-deploy-runbook`) get `source: "manual"` and `status: "active"` retroactively (one-shot migration script in Phase 0). They don't have `content_hash` or `cites` — those stay null and the lifecycle treats them as "frozen" until edited.
+- The eToro 1,402 pointer-only skills get `source: "imported"` and `status: "active"`. Ran will coordinate with eToro to migrate them to full-content shape on their own timeline; our code tolerates both shapes via a `data.content` IS NULL guard.
+- The plugin reconciliation path (`core_api/routes/plugin.py`) becomes lifecycle-aware: it only emits skills with `status: "active"`.
+
+---
+
+## 4. Direct authorship via `memclaw_doc` (no new tool)
+
+Agents who want to draft a skill *synchronously* use the existing `memclaw_doc` MCP with `op=write`, `collection=skills`, `data=<schema above>`. **Required adjustments to `memclaw_doc` for the skills collection (Phase 0):**
+
+1. **Schema validator hook.** When `collection='skills'` and write_mode='strong', validate the doc against the schema (required: `name`, `slug`, `description`, `domain`, `kind`, `source`). Reject with 422 if any required field missing.
+2. **`description` cap enforcement.** Default 160 bytes; tenant-configurable via `org_settings.skills.description_max_bytes`. Reject with 422 on over-cap.
+3. **`source` defaulting.** If unset on write, default `source: "agent"` when caller is a regular agent; `source: "manual"` only when caller has admin role.
+4. **`status` defaulting.** If unset, default `status: "staged"` (goes to inbox). Direct `status: "active"` writes require admin role.
+5. **Auto-fill content_hash, origin.agent_id, created_at, updated_at.** Inferred from the request, not trusted from the body.
+6. **Auto-trigger Sentinel scan** on every skills-collection write (sync; reject if `critical > 0`).
+7. **`kind: update` hash-binding.** When `kind: "update"`, require `target.target_content_hash` and reject if it doesn't match the live skill's current hash.
+
+**This means: an agent writing via `memclaw_doc` goes through the SAME lifecycle as a Forge-generated candidate.** Same Inbox card, same approval gate, same install path. Forge is just the autonomous producer alongside human-curated ones.
+
+---
+
+## 5. Lifecycle states + transitions
+
+```
+        write
+          │
+          ▼
+   ┌─────────────┐    auto-gates       ┌──────────┐
+   │  candidate  │───── pass ─────────▶│  staged  │
+   │  (silent)   │                     │ (inbox)  │
+   └─────────────┘                     └────┬─────┘
+                                            │
+                       Approve              ▼
+                       ─────────▶  ┌─────────────────┐
+                                   │     active      │
+                                   │   (installed)   │
+                                   └────┬────────────┘
+                                        │
+                       v2 mined or      ▼
+                       drift detected
+                                   ┌─────────────────┐
+                                   │   deprecated    │
+                                   └─────────────────┘
+
+   side states (from staged or active):
+     rejected     — operator said no; cluster fingerprint poison-flagged
+     quarantined  — Sentinel scan flagged critical; held for review
+     stale        — target live skill changed (hash mismatch) — must re-revise
+```
+
+**Transition matrix:**
+
+| From → | candidate | staged | active | rejected | quarantined | stale | deprecated |
+|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| (new write) | ✓ (Forge) | ✓ (`memclaw_doc`, admin) | ✓ (admin only) | — | — | — | — |
+| candidate | — | auto-gate pass | — | — | scan critical | — | — |
+| staged | — | — | HITL Approve | HITL Reject | scan rerun fail | live target changed | — |
+| active | — | — | — | — | — | — | superseded / utilization drop |
+| rejected | — | — | — | — | — | — | — |
+| quarantined | — | manual recheck | manual override | manual delete | — | — | — |
+| stale | — | revise+re-bind | — | — | — | — | — |
+
+**Auto-gates** (candidate → staged):
+
+| Gate | Threshold | Source |
+|---|---|---|
+| Volume | ≥ 10 successful executions (≥3 for early demo via `org_settings.forge.min_cluster_size`) | session-trace store |
+| Diversity | ≥ 3 distinct agents (anti-poison) | session-trace store |
+| Convergence | step-order variance below threshold across last K traces | distill pre-pass |
+| Freshness | latest trace within 14 days (configurable) | timestamps |
+| Coverage | matches ≥ 1 task pattern in last 30d of fleet recall queries | recall log |
+| Scan | Sentinel reports `critical == 0` | scanner |
+
+Patterns failing any gate stay `candidate` and keep accruing signal silently.
+
+---
+
+## 6. Outcome inference — the 6 signals
+
+No `memclaw_evolve` requirement. Each signal is mined from data MemClaw already writes.
+
+| # | Signal | Source (existing code) | Indicates |
+|---|---|---|---|
+| 1 | Contradiction event | `contradiction_detector.detect_contradictions_async` (Path A + Path C) | Recalled memory contradicted soon after = recalled answer was wrong |
+| 2 | Supersession event | memory `supersedes_id` / `superseded_by` columns | Original was wrong / stale |
+| 3 | Repeat-recall on same query | recall log + query similarity | First answer didn't land |
+| 4 | Session terminal memory | content classifier on last memory in session (`shipped`/`fixed` vs `blocked`/`abandoned`) | Success or failure label |
+| 5 | Cross-agent reuse depth | recall counter on memory × agent | Load-bearing memory; promotes to skill candidate |
+| 6 | External hooks | git commits / PR merges / CI pass-fail tied to `run_id` | Ground-truth outcome (where available) |
+
+**Optional soft-force**: `memclaw_recall` returns a `recall_id`; subsequent writes auto-attach it. No new tool, no new agent requirement. Lifts inference precision from ~75% (typical for passive) to ~95% (with attached recall_id) per our planning estimates — **internal eval harness in Phase 1 will measure the real number.**
+
+---
+
+## 7. Forge — the resident spec
+
+A lifecycle operation in `lifecycle_publishers.py` (`publish_forge_distill_request`) + a worker:
+
+```yaml
+name:       forge
+trigger:    cron (default every 6h; configurable)
+            event:  on_evolve_outcome (debounced 15min — runs more often if outcomes are flowing)
+scope:      tenant + fleet (one Forge worker per fleet)
+trust_tier: 2 (cannot write scope_org or scope_agent skills; only scope_team)
+budget:     llm_tokens_per_run = 50_000 (configurable)
+            max_writes_per_run = 20
+audit:      writes audit row per run (run_id, found_clusters, staged_count, rejected_count)
+write_as:   author=resident:forge → tagged on every doc it writes
+```
+
+**Each Forge run:**
+
+1. Pull outcome-labeled session-traces from the last `freshness_window_days` (default 14).
+2. Cluster traces by goal + entity overlap (see §8 fingerprint).
+3. For each cluster passing the volume + diversity + freshness gates: LLM-distill into a skill candidate doc (the schema in §3, status=`candidate`).
+4. Compute cluster fingerprint; if a candidate with the same fingerprint already exists, *update its draft* (kind=update, bind to its hash) instead of minting a new candidate.
+5. Trigger Sentinel scan.
+6. Trigger convergence + coverage check.
+7. If all gates pass → flip to `staged` (now visible in inbox).
+8. Write audit row.
+
+---
+
+## 8. Cluster identity / fingerprint (Phase-1 prereq, the gating open question)
+
+**Problem**: without canonical cluster identity, every Forge run mints near-duplicate candidates → inbox flood.
+
+**Proposed design**: `fp:v1:<hash>` where `<hash> = sha256(canonical_form)` and `canonical_form` is the deterministic projection of the cluster:
+
+```
+canonical_form := sorted_set(
+  goal_phrase_canonical,
+  domain,
+  top_5_entities_by_centrality_canonical,
+  step_skeleton_canonical
+)
+```
+
+- **`goal_phrase_canonical`**: LLM-extract a 6-word "what is this cluster about" phrase; lowercase + lemmatize.
+- **`top_5_entities_by_centrality_canonical`**: entity IDs (already resolved by existing entity-resolution layer), sorted ascending.
+- **`step_skeleton_canonical`**: ordered list of step intents (verbs + objects), each ≤ 4 words, lowercased + lemmatized.
+
+**Stability test (must pass in Phase 1 eval)**: if Forge re-runs against the same lake state, the same clusters must produce the same fingerprint with ≥ 99% rate. If new traces arrive that should *extend* an existing cluster, the fingerprint MUST stay stable — only the membership grows.
+
+**Drift handling**: if a cluster mutates enough that the fingerprint *would* change (e.g., new dominant entity), the old fingerprint stays on the existing candidate (`status: stale`) and a *new* candidate is minted with the new fingerprint. Operator sees both in the inbox; can Reject one.
+
+**Anti-poison**: rejected fingerprints are written to `forge_rejected_fingerprints` table; Forge won't re-propose the same fingerprint for `rejection_cooloff_days` (default 30, configurable).
+
+---
+
+## 9. Sentinel scanner — pre-screen integration (pulled into MVP)
+
+Wraps OpenClaw-style scan: every skill doc body is scanned before it can transition out of `candidate`.
+
+| Check | Action on hit |
+|---|---|
+| Prompt-injection markers (e.g., `Ignore previous instructions`, `system: …`, hijack patterns) | Quarantine + critical+1 |
+| Shell-injection in `support_files/scripts/*` | Quarantine + critical+1 |
+| URL exfiltration patterns (e.g., suspicious data POSTs in scripts) | Quarantine + warn+1 |
+| Path violations in `support_files` (absolute, traversal, hidden, executable, non-UTF8) | Reject the write (422) |
+| PII in `content` or `evidence` | Warn+1; redact-on-display flag set |
+| Memory-id stuffing (more than 20 unique cited memories) | Warn+1; capped at 20 on render |
+| Body size > `maxSkillBytes` (default 40 000) | Reject the write (422) |
+| Description size > `descriptionMaxBytes` (default 160) | Reject the write (422) |
+
+Scan reruns on `apply` (catching cases where the lake state changed between `staged` and apply).
+
+---
+
+## 10. HITL Skills Inbox
+
+Filtered view of `skills` collection where `status='staged'` AND `source IN ('forge', 'agent')`.
+
+**Card displays:**
+- LLM-named title + `description` (the trigger sentence)
+- `domain` + `tags` chips
+- `content` rendered as readable markdown (collapsible)
+- **Provenance**: `evidence` paragraph + `goal` sentence + cited memory IDs (clickable)
+- **Replay strip**: top-3 session traces (collapsed by default; expand for full memory chain)
+- **Sentinel scan summary**: green/yellow/red badge + finding count
+- **Hash-binding state**: if `kind='update'`, badge showing target version + stale-or-current
+- **Cluster fingerprint** (advanced): copyable, expandable diagnostic
+
+**Actions (one click each):**
+- ✅ Approve — `staged → active`; triggers install pipeline
+- ✏️ Edit — opens markdown editor on `content`/`description`/`summary`; saves a revision; scan reruns
+- ❌ Reject — `staged → rejected`; cluster fingerprint poison-flagged
+- 🛑 Quarantine — `staged → quarantined`; for security review
+- ⏸️ Defer — leaves in inbox; Forge can revise on next run
+
+**Cross-fleet (`scope_org`) skills:** require dual approval (two distinct admin users; Phase 5).
+
+---
+
+## 11. Harness install — the `active` transition
+
+On `staged → active`:
+
+| Target | Path | Notes |
+|---|---|---|
+| OpenClaw plugin | already-existing reconciliation in `core-api/routes/plugin.py` | Just becomes lifecycle-aware: filter by `status='active'`. |
+| Direct-MCP (Claude Code / Codex via MCP) | `static/skills/memclaw/<slug>/SKILL.md` | New emitter. Strips `status`/`version`/`date` from frontmatter on apply (OpenClaw convention). |
+| Claude Code direct install | `~/.claude/skills/<slug>/SKILL.md` | New CLI/MCP tool (`memclaw skill install <slug>`) writes locally with rollback metadata. |
+| OpenClaw workspace PROPOSAL.md emission | `<workspace>/skills/<slug>/PROPOSAL.md` | Phase 5. Forge skills land as proposals in the OpenClaw Skill Workshop — review + apply happens in OpenClaw's UI. |
+
+**Rollback metadata** (borrowed from OpenClaw) written before any apply mutates a target file:
+
+```jsonc
+{
+  "schema":             "memclaw.skill-factory.rollback.v1",
+  "skill_slug":         "deploy-eu-west-dns",
+  "written_at":         "2026-05-12T15:00:00Z",
+  "target_path":        "~/.claude/skills/deploy-eu-west-dns/SKILL.md",
+  "action":             "create" | "update",
+  "previous_content_hash": "sha256:…" | null,
+  "previous_content":   "<full bytes>" | null,
+  "support_files":      [ /* same shape */ ]
+}
+```
+
+Stored as a separate doc in collection `skills_rollback` (new collection, simple), one entry per apply. One-click revert in the UI restores from this.
+
+**Frontmatter strip-on-apply** (OpenClaw convention):
+
+```yaml
+# PROPOSAL.md (staged)         # SKILL.md (active)
+---                             ---
+name: …                         name: …
+description: …                  description: …
+status: proposal      ──strip──▶
+version: v1           ──strip──▶
+date: 2026-05-12      ──strip──▶
+---                             ---
+```
+
+---
+
+## 12. Caps + configurability
+
+All defaults; tenant-overridable via `org_settings.skills_factory.*`:
+
+| Setting | Default | Where it applies |
+|---|---|---|
+| `description_max_bytes` | 160 | Write validation (`memclaw_doc` skills writes + Forge distill) |
+| `body_max_bytes` | 40 000 | Same |
+| `inbox_max_pending` | 50 | Auto-defer oldest beyond cap |
+| `forge.cron_interval_hours` | 6 | Forge schedule |
+| `forge.min_cluster_size` | 3 (3 for demo / 10 for prod default) | Volume gate |
+| `forge.min_distinct_agents` | 3 | Diversity gate |
+| `forge.freshness_window_days` | 14 | Cluster member window |
+| `forge.llm_tokens_per_run` | 50 000 | Budget |
+| `forge.max_writes_per_run` | 20 | Per-run write cap |
+| `sentinel.fail_on_critical` | true | Hard-quarantine on critical |
+| `rejection_cooloff_days` | 30 | Cluster fingerprint poison lifetime |
+| `openclaw_bridge.enabled` | false | Phase 5 emitter on/off |
+
+---
+
+## 13. OpenClaw bridge (Phase 5, complexity-gated)
+
+Decision: ship only if it stays ≤ 1 engineer-week. Drop if scope creeps.
+
+Spec:
+- Reuses Forge candidate at `status: staged`.
+- New emitter writes `<workspace>/skills/<slug>/PROPOSAL.md` + manifest entry compatible with OpenClaw's `SKILL_WORKSHOP_MANIFEST_SCHEMA`.
+- Frontmatter follows OpenClaw's `name/description/status: proposal/version/date`.
+- Support files emitted under `assets/examples/references/scripts/templates/` only.
+- **Bidirectional outcome:** if user applies in OpenClaw, OpenClaw's manifest update fires a webhook to MemClaw → flip MemClaw status `staged → active`. (Webhook is optional; skip on v0; user can manually mark applied.)
+- Gated by `openclaw_bridge.enabled = true`.
+
+This is the "killer integration": **Forge mines your fleet, drops PROPOSAL.md straight into your OpenClaw workspace, the user reviews in OpenClaw's Control UI, applies.** They get an upstream; we get a downstream. Same plumbing benefits both.
+
+---
+
+## 14. OSS vs Enterprise split
+
+| Capability | OSS | Enterprise |
+|---|:-:|:-:|
+| Resident framework substrate (`publish_forge_distill_request`) | ✓ | ✓ |
+| Forge worker + cluster fingerprint + distill | ✓ | ✓ |
+| Sentinel scanner | ✓ | ✓ |
+| Skills Inbox dashboard + HITL actions | ✓ | ✓ |
+| Install to Claude Code / OpenClaw / Direct-MCP | ✓ | ✓ |
+| Outcome inference + v2 update proposals | ✓ | ✓ |
+| Hash-binding, rollback, stale state | ✓ | ✓ |
+| Configurable caps (per-tenant settings) | ✓ | ✓ |
+| **Cross-fleet skill sharing** | — | ✓ |
+| **Cross-tenant skill marketplace (anonymized)** | — | ✓ |
+| **Auto-promote tier (skip HITL on gold)** | — | ✓ |
+| **`scope_org` dual-approval governance** | — | ✓ |
+| **Federated antibodies (Sentinel cross-tenant signal)** | — | ✓ |
+| **Hosted Forge / platform-paid tokens** | — | ✓ |
+| **OpenClaw PROPOSAL.md emitter** | ✓ | ✓ |
+
+LLM token cost in OSS = on the user's own provider keys (existing MemClaw pattern). `forge.llm_tokens_per_run` knob is conservative by default.
+
+---
+
+## 15. Phased delivery
+
+### Phase 0 — Foundations (everything else blocks on this)
+
+**Scope:**
+- Migration: add `source` and `status` (+ all new schema fields) to all existing `skills` docs in the DB. Existing manual docs → `source: manual, status: active`. Bulk-imported pointer-only docs → `source: imported, status: active`.
+- Extend `memclaw_doc` skills-collection writes with the 7 adjustments in §4.
+- Build `org_settings.skills_factory.*` config plumbing.
+- Add `publish_forge_distill_request` to `lifecycle_publishers.py`; wire a no-op handler (just logs).
+- New collection `skills_rollback` (for rollback metadata).
+- New table `forge_rejected_fingerprints` (for poison memory).
+- New table `session_traces` (for outcome-labeled traces; populated in Phase 1).
+
+**Prereqs:** none (after rebases).
+**Deliverable:** an admin can write a `source:agent, status:staged` skill via `memclaw_doc`, it lands in the Inbox-shaped query, but no UI yet.
+**Acceptance:**
+- `pytest tests/test_skill_schema_v1.py` passes (new file)
+- existing eToro 1,402 docs still readable via `memclaw_doc` op=read after migration
+- `memclaw_doc` `op=write` against `skills` with `description` > 160 bytes returns 422
+- `memclaw_doc` `op=write` against `skills` without `name`/`slug`/`description`/`domain` returns 422
+**Estimated agents:** 1-2 backend engineers · ~3-4 days
+
+### Phase 1 — Outcome inference + Forge dry-run (parallel internal track)
+
+**Scope:**
+- Implement the 6 signal extractors → write `session_traces` rows.
+- Session-trace builder: group memories by `run_id` (already exists on the memory write signature) + agent + time-window. Label each trace with success/failure inferred from signals.
+- Cluster fingerprint (§8) — including stability test.
+- Forge service: pull traces → cluster → fingerprint → distill (LLM call) → write `candidate` docs.
+- **Eval harness**: hand-label 3 fleets' worth of session traces; measure (a) fingerprint stability ≥ 99%, (b) cluster precision ≥ 70%, (c) cluster recall ≥ 60%.
+- Forge runs only as a manual CLI invocation; candidates never escape `candidate` state in this phase.
+
+**Prereqs:** Phase 0.
+**Deliverable:** `memclawctl forge dry-run --tenant=… --fleet=…` produces N candidate docs in DB. Internal eval reports precision/recall.
+**Acceptance:**
+- Stability test passes ≥ 99%
+- Precision ≥ 70% on labeled set; recall ≥ 60%
+- All candidates have `status=candidate, source=forge, cluster_fingerprint=fp:v1:…`
+- No candidate is `staged` or visible in any user surface
+**Estimated agents:** 2 backend + 1 ML/eval · ~2-3 weeks (longest phase; cluster fingerprint is hard)
+
+### Phase 2 — HITL Skills Inbox + Sentinel scanner
+
+**Scope:**
+- Sentinel scanner (§9), wired in front of `staged` transition.
+- Auto-gates evaluator: candidate → staged when all 6 gates pass.
+- Skills Inbox UI (frontend): filtered list view + card detail view + 5 actions (Approve/Edit/Reject/Quarantine/Defer).
+- Edit inline = markdown editor on `content`, `description`, `summary` + scan re-trigger.
+- Reject flow writes to `forge_rejected_fingerprints`.
+
+**Prereqs:** Phase 1 producing candidates; Phase 0 schema fields.
+**Deliverable:** an operator can land on `/skills-inbox`, see staged Forge candidates, and approve one. Approve flips to `active` but doesn't install yet (Phase 3 wires the install path; until then, plugin reconciliation alone serves it).
+**Acceptance:**
+- Approve → `status: active` and the doc surfaces in `op=search` / plugin reconciliation
+- Reject → fingerprint written to poison table; Forge re-run does NOT propose the same fingerprint
+- Scan critical → auto-quarantine; visible in a separate filter
+- Edit + save → new `content_hash`, scan rerun, stays `staged`
+**Estimated agents:** 1 backend + 2 frontend · ~2 weeks
+
+### Phase 3 — Harness install (Claude Code path + rollback)
+
+**Scope:**
+- New emitter: `static/skills/memclaw/<slug>/SKILL.md` — strip frontmatter on apply.
+- New CLI/MCP: `memclaw skill install <slug> --target claude-code` writes `~/.claude/skills/<slug>/SKILL.md`.
+- Rollback metadata writer + new `skills_rollback` collection writes.
+- Path-safe support file emission (`assets/examples/references/scripts/templates`).
+- One-click revert in the UI.
+
+**Prereqs:** Phase 2 (Approve must land in `active`).
+**Deliverable:** approving in the Inbox → Claude Code user sees a new skill they can invoke immediately.
+**Acceptance:**
+- Approving the canonical worked-example skill installs to local Claude Code dir
+- Frontmatter strip works (no `status`/`version`/`date` in installed SKILL.md)
+- Support file path violation rejected (`../`, absolute, hidden, executable, non-UTF8)
+- Rollback metadata exists; one-click revert restores prior state byte-for-byte
+**Estimated agents:** 1 backend + 1 frontend · ~1-2 weeks
+
+### Phase 4 — Outcome loop closes (v2 + hash-binding + telemetry)
+
+**Scope:**
+- Skill fire telemetry: every harness invocation reports back (Claude Code skill triggers + OpenClaw plugin fires) via existing audit hooks → updates `telemetry.fires_*` fields.
+- Utilization computation (rolling 30d).
+- Forge `kind: update` proposals: when (a) telemetry drifts past threshold, OR (b) Forge re-mining finds a divergent cluster → produce a v2 candidate bound to v1's hash.
+- Stale detection: if a target skill changes between `staged` and apply → flip `staged → stale`; require re-revise.
+- Deprecation flow: utilization drop > threshold → Forge proposes deprecate diff card.
+
+**Prereqs:** Phase 3 installed skills firing.
+**Deliverable:** 30 days post-install, a v2 diff card or deprecate proposal lands in the inbox automatically.
+**Acceptance:**
+- Telemetry rows present per skill after first 100 fires
+- Mock-drift scenario produces a v2 card
+- Manual edit of installed skill between staged + apply → stale flag fires
+**Estimated agents:** 2 backend · ~2 weeks
+
+### Phase 5 — Polish + integrations
+
+**Scope:**
+- Auto-promote tier with 7-day rollback window.
+- `scope_org` dual-approval governance.
+- Concierge primitive (custom resident definition surface).
+- **OpenClaw PROPOSAL.md emitter** (§13).
+- Tenant-level caps configurability surface (settings UI).
+
+**Prereqs:** Phase 4.
+**Acceptance:** OpenClaw bridge demo: Forge candidate lands as PROPOSAL.md in an OpenClaw workspace; user applies in OpenClaw's Control UI; webhook (or manual) flips MemClaw to `active`.
+**Estimated agents:** 2 backend + 1 frontend · ~2-3 weeks
+
+---
+
+## 16. Tasks (issuable today, just for Phase 0)
+
+| ID | Task | Owner | Estimate |
+|---|---|---|---|
+| SF-001 | Migration script: backfill `source`, `status` on all existing `skills` docs (per §3 backwards-compat rules) | backend | 1d |
+| SF-002 | Extend `routes/documents.py` skills writes: 7 adjustments in §4 (schema validator + caps + defaulting + scan trigger + hash-binding for `kind=update`) | backend | 2d |
+| SF-003 | New table: `forge_rejected_fingerprints` (Alembic migration) | backend | 0.5d |
+| SF-004 | New table: `session_traces` (Alembic migration) | backend | 0.5d |
+| SF-005 | New collection-as-table affordance: `skills_rollback` (just docs; reuses `documents`) | backend | 0.25d |
+| SF-006 | Org settings plumbing: `org_settings.skills_factory.*` JSON read/write + defaults | backend | 1d |
+| SF-007 | Lifecycle publisher stub: `publish_forge_distill_request` + no-op handler | backend | 0.25d |
+| SF-008 | Unit tests: `test_skill_schema_v1.py` covering acceptance criteria | backend | 1d |
+| SF-009 | Documentation: this file + `8-skill-factory-architecture.svg` (DONE here) | docs | 0d |
+| SF-010 | Re-log this plan to MemClaw under tenant `arkash24-4d270c` / fleet `caura-dev-fleet` | tooling | 0.25d |
+
+Phase 1 tasks issued after Phase 0 lands.
+
+---
+
+## 17. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Garbage-in skills (noisy outcome inference → bad candidates → trust collapse) | High gating thresholds at launch; surface confidence prominently; never auto-promote in v1; eval harness in Phase 1 must pass before public exposure. |
+| Inbox flood (without fingerprint stability → near-duplicates) | Fingerprint design + stability test is Phase-1 prereq; rejected fingerprints are poison-flagged for 30d. |
+| Silent harness failure (installed skill triggers wrongly) | Every install ships with telemetry hook + one-click revert via rollback metadata. |
+| Prompt-injection via mined memories | Sentinel scanner in MVP (Phase 2); HITL editor surfaces raw quotes. |
+| PII bleed into skill bodies | Skills inherit PII redaction from parent memories; scanner re-checks at apply time. |
+| Cold-start demo problem | Synthetic-fleet seed + "warmth meter" UI ("Forge is observing — 7/10 outcomes needed for first candidate"). |
+| eToro pointer-only skills surprise our schema | `data.content IS NULL` guard everywhere; migration tags them `source: imported`. |
+| OpenClaw releases a competing fleet-mining feature | Forge's outcome inference layer + cluster fingerprint are the moat; document and gather feedback fast. |
+
+---
+
+## 18. Open questions remaining (gated per phase)
+
+| # | Question | Resolved by | Phase |
+|---|---|---|---|
+| OQ-1 | Verify which jsonb field drives skills-collection embedding (`description` vs `summary`) | Reading `core_api/services/doc_indexing.py` | Phase 0 |
+| OQ-2 | `doc_id` namespacing collision risk between `forge/<slug>` and eToro bulk imports | Phase 0 migration check | Phase 0 |
+| OQ-3 | Cluster fingerprint formula — stability test must hit ≥ 99% before Phase 1 ships | Eval harness | Phase 1 |
+| OQ-4 | Forge cron interval default — 6h vs 12h vs on-event-debounced | Eval harness signal | Phase 1 |
+| OQ-5 | Edit-inline UX: full markdown WYSIWYG or raw-markdown only | Design call | Phase 2 |
+| OQ-6 | Claude Code description-quality benchmark (does the LLM-generated description trigger the skill correctly?) | Dedicated trigger-accuracy harness | Phase 3 |
+| OQ-7 | OpenClaw webhook protocol — pull-based polling vs push-based webhook | OpenClaw discussion | Phase 5 |
+
+---
+
+## 19. Validation checklist (re-run before finalizing)
+
+- [x] **Decision: Option B (full content)** — `content` field in schema (§3); flat-procedure MVP (§1 non-goal); content shown in inbox card (§10).
+- [x] **Decision: no extra MCP tool** — `memclaw_doc` adjustments in §4 + §15 Phase 0 task SF-002.
+- [x] **Decision: OpenClaw bridge if not too complex** — §13 explicitly gated at ≤ 1 engineer-week; default `openclaw_bridge.enabled=false` (§12).
+- [x] **Decision: 160-byte description default but configurable** — §3 schema + §12 caps table + §15 SF-002 acceptance criterion.
+- [x] **Reuse existing primitives** — components table §2 lists all 9 existing pieces with file paths.
+- [x] **Same `skills` collection + `source` discriminator** — §3, §11 plugin path filters by status.
+- [x] **Session-bounded clusters, ≥3 sessions / ≥2 agents** — §5 auto-gates table, §12 config defaults.
+- [x] **Cluster fingerprint design proposed** — §8 with stability acceptance criterion in Phase 1.
+- [x] **Outcome inference passive (no `memclaw_evolve` required)** — §6 with 6 signals + their existing code sources.
+- [x] **Sentinel scanner pulled into MVP** — §9 + Phase 2 deliverable.
+- [x] **Hash-binding + stale state from OpenClaw** — §3 `target.target_content_hash`, §5 lifecycle, Phase 4 stale detection.
+- [x] **Rollback metadata from OpenClaw** — §11 schema + Phase 3 deliverable.
+- [x] **Frontmatter strip-on-apply convention** — §11 diagram + Phase 3 acceptance.
+- [x] **Caps configurable per tenant** — §12 complete defaults table.
+- [x] **OSS vs Enterprise split preserved** — §14 unchanged from prior plan.
+- [x] **Risks updated** — §17 includes new ones (eToro shape surprise, OpenClaw competition).
+- [x] **No new MCP tool surface introduced** — entire plan reviewed.
+- [x] **Plan can be implemented by an agents team in parallel where possible** — phase dependencies are clear; Phase 0 sequential; Phases 1 & 2 can begin in parallel as long as Phase 1 doesn't surface candidates to UI until Phase 2 ships.
+
+---
+
+## 20. File locations (quick reference)
+
+```
+caura-memclaw/
+├── alembic/versions/
+│   ├── XXXX__add_skill_factory_fields.py            # schema migration (Phase 0)
+│   ├── XXXX__add_session_traces.py                  # Phase 0
+│   └── XXXX__add_forge_rejected_fingerprints.py     # Phase 0
+├── common/events/
+│   └── lifecycle_publishers.py                       # ADD: publish_forge_distill_request (Phase 0)
+├── core-api/src/core_api/
+│   ├── routes/
+│   │   └── documents.py                              # EDIT: skills writes adjustments (Phase 0)
+│   ├── services/
+│   │   ├── outcome_inference/                        # NEW dir (Phase 1)
+│   │   │   ├── __init__.py
+│   │   │   ├── contradictions.py
+│   │   │   ├── supersessions.py
+│   │   │   ├── repeat_recall.py
+│   │   │   ├── terminal_memory.py
+│   │   │   ├── cross_agent_reuse.py
+│   │   │   └── external_hooks.py
+│   │   ├── session_trace.py                          # NEW (Phase 1)
+│   │   ├── forge/                                    # NEW dir
+│   │   │   ├── __init__.py
+│   │   │   ├── forge_service.py                      # Phase 1
+│   │   │   ├── fingerprint.py                        # Phase 1
+│   │   │   ├── distill_prompt.py                     # Phase 1
+│   │   │   ├── sentinel_scan.py                      # Phase 2
+│   │   │   ├── harness_install.py                    # Phase 3
+│   │   │   └── openclaw_bridge.py                    # Phase 5
+│   │   ├── skill_lifecycle.py                        # NEW (Phase 0 stubs, Phase 2 logic)
+│   │   └── organization_settings.py                  # EDIT: add skills_factory.* (Phase 0)
+│   └── routes/
+│       └── plugin.py                                 # EDIT: filter by status=active (Phase 2)
+├── frontend/
+│   └── (skills-inbox view + cards)                   # Phase 2
+├── static/skills/memclaw/                            # EDIT: per-slug emit (Phase 3)
+└── tests/
+    ├── test_skill_schema_v1.py                       # Phase 0
+    ├── test_session_trace_builder.py                 # Phase 1
+    ├── test_cluster_fingerprint_stability.py         # Phase 1 (acceptance)
+    ├── test_forge_dry_run.py                         # Phase 1
+    ├── test_sentinel_scanner.py                      # Phase 2
+    ├── test_skill_lifecycle_transitions.py           # Phase 2
+    ├── test_harness_install_rollback.py              # Phase 3
+    └── test_outcome_loop_v2_proposals.py             # Phase 4
+```
+
+---
+
+## Approvals
+
+- [ ] **Ran** — green light to begin Phase 0 (SF-001 … SF-010)
+- [ ] Re-log to MemClaw under correct tenant (SF-010 — runs after green light)

--- a/docs/live-memory-pitch/skill-factory-spec.md
+++ b/docs/live-memory-pitch/skill-factory-spec.md
@@ -1,0 +1,204 @@
+# Skill Factory — Spec (high-level)
+
+**Status:** approved for implementation.
+**Owner resident:** Forge.
+**One-line:** the fleet writes the playbooks nobody had time to write — humans bless them with one click — they run in the harness — outcomes flow back.
+
+---
+
+## 1. Definition of "shipped"
+
+A tenant connects MemClaw and runs agents normally. Then:
+
+1. Without anyone calling a special tool, **candidate skills accumulate in a Skills Inbox.**
+2. **One click approves.** One more **installs** to the harness (Claude Code first).
+3. Installed skills produce outcomes that **flow back**; v2 is proposed when branch performance drifts.
+4. The tenant writes **zero new agent code**.
+
+**Magic property to preserve:** *the only thing the user ever does is write memories normally and click Approve.*
+
+---
+
+## 2. The pipeline (7 lake-side stages)
+
+| Stage | Verb | Owner | Visibility |
+|---|---|---|---|
+| 1 · Observe | watch | Forge | silent |
+| 2 · Infer outcomes | label | passive signal layer | silent |
+| 3 · Cluster | group | Forge | silent |
+| 4 · Distill | compile | Forge (LLM) | silent |
+| 5 · Gate → HITL | judge | auto-gates → Skills Inbox | **user moment** |
+| 6 · Install | emit | harness adapter | one click |
+| 7 · Re-mine | refine | Forge (continuous) | silent → diff card |
+
+---
+
+## 3. Outcome inference signals (no `memclaw_evolve` required)
+
+The memory stream **is** the feedback signal. Six free signals mined passively:
+
+1. **Contradiction event** — recalled memory contradicted soon after = failed.
+2. **Supersession event** — superseded memories were wrong.
+3. **Repeat-recall** on same query = first answer didn't land.
+4. **Session terminal memory** — "shipped"/"fixed" vs "blocked"/"abandoning". LLM-classifiable.
+5. **Cross-agent reuse depth** — recalled by N agents with healthy terminal states = load-bearing.
+6. **External hooks** — git commits, PR merges, CI pass/fail tied to `session_id` when available.
+
+Optional soft-force layer: `memclaw_recall` returns a `recall_id`; subsequent writes auto-attach it. No new tool, no new requirement.
+
+---
+
+## 4. Decisions made
+
+| # | Decision | Choice | Why |
+|---|---|---|---|
+| 4.1 | What is a "procedure"? | **Session-bounded trace.** Each cluster member = one session. | Sessions have natural start/end and a terminal memory. Cross-session abstraction punted. |
+| 4.2 | How big must a cluster be to graduate? | **≥3 sessions across ≥2 distinct agents.** | Single-session ≠ skill, it's a transcript. Anti-poison story only kicks in with multi-trace clustering. |
+| 4.3 | Skill data model | **Dual: registry artifact + lake biography.** Memory `type=skill` for governance/audit/provenance/lifecycle; registry for harness emission, fast queries, high-frequency telemetry. | Registry holds the artifact; lake holds its biography. Memory-only fallback acceptable for MVP. |
+| 4.4 | Branches in the procedure | **Flat MVP.** Ordered steps + overall success rate. | Step-level cluster alignment is hard. Branches arrive when per-cluster volume justifies them (Phase 4). |
+| 4.5 | OSS vs Enterprise | **Single-fleet magic in OSS · multi-fleet leverage in Enterprise.** | Adoption beats moat. Killer feature must be in OSS or the OSS story dies. See `feature-priorities.md`. |
+
+---
+
+## 5. Auto-gates (candidate → staged)
+
+A cluster only graduates when **all five** hold:
+
+| Gate | Threshold |
+|---|---|
+| Volume | ≥10 successful executions (≥3 acceptable for early demo) |
+| Diversity | ≥3 distinct agents (anti-poison) |
+| Convergence | branch / step variance below threshold across last K runs |
+| Freshness | observed within last 14d |
+| Coverage | preconditions match real upcoming task patterns |
+
+Patterns failing any gate stay as `candidate` and keep accruing signal silently.
+
+---
+
+## 6. Lifecycle
+
+```
+candidate → draft → staged → active → deprecated
+                     ▲          │
+                     │          ▼ (via re-mine)
+                  HITL       v2 diff card
+```
+
+- `staged` is the first user-visible state (Skills Inbox).
+- Reject **poison-flags the cluster pattern** so it won't re-surface.
+- `scope_org` (cross-fleet) skills require **dual approval**.
+- Optional auto-promote tier (mature tenants only): gold candidates (≥50 exec, ≥90% success, ≥5 agents) skip HITL with **7-day rollback window**.
+
+---
+
+## 7. Skills Inbox card (HITL surface)
+
+The card is the entire HITL UX — no separate review console.
+
+**Card displays:**
+- LLM-named title + one-line "when to use this"
+- Procedure rendered as readable markdown
+- **Provenance trail** — every step links to source memories with author + outcome
+- **Replay strip** — 2–3 actual session traces (collapsed by default)
+- **Branch ledger** — success rate per branch + sample size
+
+**Actions (one click each):** Approve · Edit inline · Split · Merge · Reject · Defer.
+
+---
+
+## 8. Harness installation targets
+
+| Target | Output |
+|---|---|
+| Claude Code | `~/.claude/skills/<name>/SKILL.md` with tuned `description` frontmatter |
+| OpenClaw | plugin slot (existing MemClaw plugin) |
+| Cursor / Windsurf | equivalent skill files |
+| Generic MCP | `memclaw_skill_<name>` tool |
+
+**Critical:** description quality governs trigger accuracy. Bad descriptions = silent product failure. A `skill-creator`-style benchmark + prompt-tuning loop must exist *before* Phase 3 ships.
+
+---
+
+## 9. Phased delivery
+
+| Phase | Scope | User sees |
+|---|---|---|
+| **0 · Foundations** | Outcome inference primitives + Resident framework. | nothing |
+| **1 · Forge dry-run** | Forge produces candidates internally; eval harness measures precision/recall on hand-labeled fleets. | nothing |
+| **2 · Skills Inbox** | Dashboard card UI lands. Approve / Edit / Reject / Defer. | the inbox |
+| **3 · Harness install** | One-click install to Claude Code (+ OpenClaw same time). Description-quality benchmark must be passing. | install button |
+| **4 · Outcome loop closes** | Installed-skill outcomes feed Forge. v2 diff cards. Versioning, deprecation, rollback. | v2 cards |
+| **5 · Polish** | Auto-promote tier (7-day rollback) · `scope_org` dual-approval · Concierge primitive. | settings |
+
+---
+
+## 10. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Garbage-in skills (noisy outcome inference → bad candidates → trust collapse) | Aggressive gating thresholds at launch; surface confidence prominently; **never auto-promote in v1**. |
+| Inbox flood (no cluster fingerprint stability → near-duplicate candidates every Forge run) | **Cluster fingerprint design is a Phase-1 prerequisite, not a follow-up.** |
+| Silent harness failure (skill triggers wrongly) | Every install ships with a "did this fire correctly?" telemetry hook + one-click revert. |
+| Prompt-injection via memories (poisoned content in procedure body) | HITL editor surfaces raw quotes; **Sentinel pre-screens** candidates before they hit the inbox. |
+| PII bleed | Skills inherit redaction status of their parent memories. |
+| Cold-start demo problem (new fleets don't generate enough signal) | Synthetic-fleet demo mode + a **"warmth meter"** ("Forge is observing — 7 of 10 outcomes needed"). |
+
+---
+
+## 11. Canonical worked example
+
+> A small platform fleet (Sasha, Mira, Kai). Nobody coordinates. Nobody calls `memclaw_evolve`.
+
+| Date | Agent | Session memories |
+|---|---|---|
+| Apr 18 | Sasha | "Deploy v4 to eu-west — step 7 hung 6 min" → "tried fallback DNS resolver — step 7 completed" → "Shipped ✓" |
+| Apr 22 | Mira | "Step 7 timeout again on eu-west" → "switched DNS resolver, retry passed" → "Shipped ✓" |
+| Apr 25 | Kai | "Deploy to eu-west failing on step 7" → "retried, same hang" → "switched DNS resolver, passed" → "Shipped ✓" |
+| Apr 28 | Sasha | "Deploying eu-west — using fallback DNS preemptively" → "Shipped ✓" |
+
+**May 1, Forge wakes up.** Scans terminal memories. Clusters by topic + entity overlap. Finds: 4 sessions / 3 distinct agents / 4 success / freshness 3d / convergence good — **all 5 gates pass**.
+
+**Distillation produces:**
+
+```yaml
+title:        "Deploy to eu-west · use fallback DNS at step 7"
+when:         "deploying to eu-west region"
+steps:
+  1. Run deploy v4 normally up to step 7
+  2. If step 7 hangs/timeouts → switch to fallback DNS resolver
+  3. Continue deploy
+success_rate: 4/4 (100%)
+cites:        [mem-8821, mem-8932, mem-9011, mem-9134]
+status:       staged
+```
+
+**A card lands in the Skills Inbox.** User clicks **Approve**, then **Install to Claude Code**.
+
+**May 4 — Mira in Claude Code:** types *"deploy us to eu-west"* → skill description matches → procedure fires → "Shipped ✓". Outcome flows back. Counter ticks.
+
+**One month later** — eu-west DNS fixed upstream. Step 7 stops hanging. Forge notices utilization dropped 78% → 9%. Pushes a **v2 diff card** recommending deprecate. User clicks Deprecate. Skill cold-archived; biography survives in the lake forever.
+
+**Three things that matter:**
+1. Nobody told the fleet anything — the procedure emerged from collision.
+2. The user did exactly two clicks.
+3. The skill knows where it came from — fully auditable trust.
+
+---
+
+## 12. Open questions (must resolve before code starts)
+
+| # | Question | Why it gates |
+|---|---|---|
+| 12.1 | **Cluster identity / canonical fingerprint** — when Forge re-runs and finds an "almost the same" cluster, is it an update or a new candidate? | **Phase-1 prerequisite.** Without it the inbox floods with near-duplicates and becomes unusable. *This is the next deep-dive topic.* |
+| 12.2 | Skill description prompt-tuning + benchmark | Phase-3 prerequisite. Bad descriptions = silent trigger failures. Need `skill-creator`-style eval loop. |
+| 12.3 | Forge token budget defaults & opt-up UX | Unit economics. Answer likely: per-resident budget knob, conservative default, tenant opts up. |
+| 12.4 | Empty-fleet UX ("warmth meter") copy + thresholds | Cold-start product feel. |
+
+---
+
+## 13. v0.1 — the first demo
+
+Synthetic fleet seeded into a tenant + 7 simulated days of agent activity → opens Skills Inbox → sees one candidate ("Deploy in eu-west") with 23-memory provenance and 87% success rate → clicks **Approve** + **Install to Claude Code** → opens Claude Code → *"deploy us to eu-west"* → skill fires → outcomes flow back → 7 days later a v2 diff card lands.
+
+Every box in the pipeline lit up, end-to-end. **That's the moment the deck stops being a deck.**

--- a/scripts/forge_dry_run.py
+++ b/scripts/forge_dry_run.py
@@ -191,7 +191,10 @@ async def _wire_memory_fetcher(db):
                 {"ids": list(memory_ids)},
             )
         ).fetchall()
-        return {row.id: row.content for row in rows}
+        # NULL-safe: memories.content is nullable, but downstream
+        # ``_distill_cluster`` slices the value as a string. Returning
+        # None would TypeError and get swallowed into the io_error bucket.
+        return {row.id: row.content if row.content is not None else "" for row in rows}
 
     return fetcher
 

--- a/scripts/forge_dry_run.py
+++ b/scripts/forge_dry_run.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""``memclawctl forge dry-run`` — Phase 1 manual harness (SF-106).
+
+Invokes the Forge resident pipeline against a live MemClaw deployment
+for one tenant + fleet and reports the run summary. Candidates always
+land with ``status='candidate'`` and are NEVER promoted; the operator
+runs this to:
+
+  * Smoke the end-to-end signal → cluster → fingerprint → distill →
+    candidate write path.
+  * Generate input for the eval harness (SF-105) when measuring
+    precision / recall on a real fleet snapshot.
+  * Pre-flight a tenant before flipping ``skills_factory.enabled``.
+
+Usage::
+
+    python scripts/forge_dry_run.py \\
+        --tenant <tenant_id> \\
+        --fleet  <fleet_id> \\
+        --window-days 14
+
+The script reads MemClaw connection params from the standard env
+(``DATABASE_URL``, ``OPENAI_API_KEY``) — see ``core_api.config``.
+
+This is NOT a production-grade scheduler. The real Forge run flows
+through the ``memclaw.lifecycle.forge-distill-requested`` event
+(SF-007); the scheduled-tick worker handler lands in Phase 1's
+final wiring step alongside the public lifecycle endpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from datetime import datetime, timedelta, timezone
+
+# Imported at top so the fake-LLM fallback (when ``common.llm`` is
+# absent) can stamp ``schema_version`` correctly without re-importing
+# the distill_prompt module on every fake-LLM call. Cheap import —
+# distill_prompt only pulls in stdlib re/json/dataclasses + the
+# package's own SignalKind enum.
+from core_api.services.forge.distill_prompt import DISTILL_SCHEMA_VERSION
+
+logger = logging.getLogger("forge_dry_run")
+
+
+# ── CLI ────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="forge_dry_run",
+        description="Run one Forge tick against a tenant + fleet window.",
+    )
+    p.add_argument("--tenant", required=True, help="Tenant id (org_id).")
+    p.add_argument("--fleet", default=None, help="Fleet id; omit for tenant-wide scan.")
+    p.add_argument(
+        "--window-days",
+        type=int,
+        default=14,
+        help="Trailing days to include (default: 14, matching forge.freshness_window_days).",
+    )
+    p.add_argument(
+        "--min-cluster-size",
+        type=int,
+        default=3,
+        help="Override forge.min_cluster_size (default: 3 — demo value).",
+    )
+    p.add_argument(
+        "--min-distinct-agents",
+        type=int,
+        default=3,
+        help="Override forge.min_distinct_agents (default: 3).",
+    )
+    p.add_argument(
+        "--max-writes-per-run",
+        type=int,
+        default=20,
+        help="Cap candidates written per run (default: 20).",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the run summary as JSON (default: human-readable).",
+    )
+    p.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="DEBUG-level logs.",
+    )
+    return p
+
+
+# ── Runtime wiring ────────────────────────────────────────────────
+
+
+async def _wire_llm_fn():
+    """Resolve a working LLM callable from the project's existing
+    provider plumbing. Falls back to a fake-LLM for environments
+    without ``common.llm`` available (the run still produces
+    candidates — they just have placeholder content the operator
+    can use to smoke the rest of the pipeline)."""
+    # Lazy import — keeps `--help` working in environments missing
+    # the heavy DB/LLM deps. ImportError is the explicit fallback
+    # signal: ``common.llm`` not installed (e.g. a packaging variant
+    # without the LLM provider chain).
+    try:
+        from common.llm import (  # type: ignore[import-not-found]
+            LLMRequest,
+            call_with_fallback,
+        )
+    except ImportError:
+        logger.warning(
+            "forge_dry_run: common.llm not importable; falling back to "
+            "FAKE-LLM mode — candidates will carry placeholder content. "
+            "Install the LLM provider chain (or run from the core-api "
+            "package) for real distillation."
+        )
+        return _fake_llm_fn
+
+    async def llm_fn(prompt: str) -> str:
+        # Tenant-resolution and provider chain are handled inside
+        # call_with_fallback. We pass the prompt as a single user
+        # message; the prompt itself carries the system framing.
+        request = LLMRequest(messages=[{"role": "user", "content": prompt}])
+        response = await call_with_fallback(request, expecting="json")
+        return response.text
+
+    return llm_fn
+
+
+# Counter for the fake-LLM path so each cluster gets a unique slug
+# (the route's slug regex + per-tenant doc_id uniqueness would
+# otherwise collide on the second cluster).
+_FAKE_LLM_COUNTER = {"n": 0}
+
+
+async def _fake_llm_fn(_prompt: str) -> str:
+    """Deterministic placeholder LLM. Returns a valid JSON response
+    that ``parse_distill_response`` will accept. Used when
+    ``common.llm`` is not importable (no LLM provider chain
+    available) so an operator can still smoke the
+    extraction → cluster → fingerprint → write pipeline without
+    needing API keys."""
+    _FAKE_LLM_COUNTER["n"] += 1
+    n = _FAKE_LLM_COUNTER["n"]
+    payload = {
+        "schema_version": DISTILL_SCHEMA_VERSION,
+        "kind": "create",
+        "goal_phrase": f"forge dry-run cluster {n} placeholder goal",
+        "domain": "general",
+        "step_skeleton": [
+            "observe cluster shape",
+            "review fake placeholder",
+            "swap fake llm for real",
+        ],
+        "name": f"Forge Dry-Run Placeholder {n}",
+        "slug": f"forge-dry-run-placeholder-{n}",
+        "description": (
+            f"Placeholder skill from fake-LLM run #{n}; no real distillation occurred."
+        ),
+        "summary": (
+            "FAKE-LLM placeholder content. Wire common.llm into the run to "
+            "produce real skill content from the cluster's session-traces."
+        ),
+        "content": (
+            f"## When to use\nThis is fake-LLM output (run #{n}).\n\n"
+            "## Steps\n1. Observe placeholder.\n2. Switch to a real LLM provider.\n"
+        ),
+        "tags": ["forge", "dry-run", "fake-llm"],
+        "evidence": "FAKE-LLM mode — no actual evidence aggregated; placeholder only.",
+        "goal": "Smoke the Forge pipeline without an LLM provider chain.",
+    }
+    return json.dumps(payload)
+
+
+async def _wire_memory_fetcher(db):
+    """Return an async fetcher that loads memory content by id from
+    the live database."""
+    from sqlalchemy import text
+
+    async def fetcher(memory_ids: list[str]) -> dict[str, str]:
+        if not memory_ids:
+            return {}
+        rows = (
+            await db.execute(
+                text("SELECT id::text AS id, content FROM memories WHERE id::text = ANY(:ids)"),
+                {"ids": list(memory_ids)},
+            )
+        ).fetchall()
+        return {row.id: row.content for row in rows}
+
+    return fetcher
+
+
+async def _wire_poison_checker(db, tenant_id: str, fleet_id: str | None):
+    """Async fp → bool against the forge_rejected_fingerprints
+    table (migration 020). Honors the per-row cooloff_days."""
+    from sqlalchemy import text
+
+    async def checker(fp: str) -> bool:
+        row = (
+            await db.execute(
+                text(
+                    """
+                    SELECT 1 FROM forge_rejected_fingerprints
+                    WHERE tenant_id = :tenant_id
+                      AND cluster_fingerprint = :fp
+                      AND (fleet_id IS NULL OR fleet_id = :fleet_id)
+                      AND rejected_at + (cooloff_days || ' days')::interval > now()
+                    LIMIT 1
+                    """
+                ),
+                {"tenant_id": tenant_id, "fleet_id": fleet_id, "fp": fp},
+            )
+        ).fetchone()
+        return row is not None
+
+    return checker
+
+
+async def _wire_candidate_writer(db):
+    """Persist a Forge-generated candidate via the SF-002
+    ``memclaw_doc`` write path so all 7 adjustments + Sentinel scan
+    + audit fire as they would for an external write."""
+    # We use the underlying storage client directly here because the
+    # Forge worker is internal (not an HTTP caller); the SF-002
+    # validator's checks that pertain to internal callers are
+    # already satisfied by the doc shape Forge builds.
+    from core_api.clients.storage_client import get_storage_client
+
+    sc = get_storage_client()
+
+    async def writer(candidate_doc: dict) -> None:
+        await sc.upsert_document(candidate_doc)
+
+    return writer
+
+
+async def _wire_status_checker(db):
+    """No-overwrite guard wiring. Returns the current ``data.status``
+    of an existing doc, or ``None`` if no doc with that id exists.
+    Forge skips persistence when the target slug already exists
+    with a non-``candidate`` status (operator-curated state)."""
+    from core_api.clients.storage_client import get_storage_client
+
+    sc = get_storage_client()
+
+    async def checker(
+        tenant_id: str, collection: str, doc_id: str
+    ) -> str | None:
+        doc = await sc.get_document(
+            tenant_id=tenant_id, collection=collection, doc_id=doc_id
+        )
+        if not doc:
+            return None
+        data = doc.get("data") or {}
+        return data.get("status")
+
+    return checker
+
+
+# ── Entry point ───────────────────────────────────────────────────
+
+
+async def _run(args: argparse.Namespace) -> int:
+    # Lazy imports for `--help` ergonomics on dependency-light envs.
+    from core_api.db.session import async_session
+    from core_api.services.forge.forge_service import (
+        ForgeConfig,
+        run_forge_distill,
+    )
+
+    window_end = datetime.now(timezone.utc)
+    window_start = window_end - timedelta(days=args.window_days)
+
+    # Audit handle for this tick — surfaced on every candidate's
+    # origin.run_id so an operator can trace an Inbox card back to
+    # the Forge invocation that minted it.
+    run_label = (
+        f"forge-dry-run-{args.tenant}-{window_end.strftime('%Y%m%dT%H%M')}"
+    )
+
+    async with async_session() as db:
+        llm_fn = await _wire_llm_fn()
+        memory_fetcher = await _wire_memory_fetcher(db)
+        poison_checker = await _wire_poison_checker(db, args.tenant, args.fleet)
+        candidate_writer = await _wire_candidate_writer(db)
+        status_checker = await _wire_status_checker(db)
+
+        cfg = ForgeConfig(
+            min_cluster_size=args.min_cluster_size,
+            min_distinct_agents=args.min_distinct_agents,
+            max_writes_per_run=args.max_writes_per_run,
+        )
+
+        result = await run_forge_distill(
+            db,
+            tenant_id=args.tenant,
+            fleet_id=args.fleet,
+            window_start=window_start,
+            window_end=window_end,
+            run_label=run_label,
+            llm_fn=llm_fn,
+            memory_fetcher=memory_fetcher,
+            poison_checker=poison_checker,
+            candidate_writer=candidate_writer,
+            status_checker=status_checker,
+            config=cfg,
+        )
+        # Commit any session_trace upserts + candidate writes.
+        await db.commit()
+
+    if args.json:
+        payload = {
+            "run_label": result.run_label,
+            "tenant_id": result.tenant_id,
+            "fleet_id": result.fleet_id,
+            "window_start": result.window_start.isoformat(),
+            "window_end": result.window_end.isoformat(),
+            "started_at": result.started_at.isoformat(),
+            "total_traces": result.total_traces,
+            "labeled_traces": result.labeled_traces,
+            "clusters_total": result.clusters_total,
+            "clusters_eligible": result.clusters_eligible,
+            "candidates_written": result.candidates_written,
+            "candidates_skipped_poisoned": result.candidates_skipped_poisoned,
+            "candidates_skipped_sentinel": result.candidates_skipped_sentinel,
+            "candidates_skipped_distill_error": result.candidates_skipped_distill_error,
+            "candidates_skipped_io_error": result.candidates_skipped_io_error,
+            "candidates_skipped_existing": result.candidates_skipped_existing,
+            "candidate_doc_ids": result.candidate_doc_ids,
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(
+            f"forge_dry_run · run_label={result.run_label} "
+            f"tenant={result.tenant_id} fleet={result.fleet_id or '<none>'} "
+            f"window=[{result.window_start.isoformat()} → {result.window_end.isoformat()}]"
+        )
+        print(f"  traces:      total={result.total_traces} labeled={result.labeled_traces}")
+        print(f"  clusters:    total={result.clusters_total} eligible={result.clusters_eligible}")
+        print(
+            f"  candidates:  written={result.candidates_written} "
+            f"poisoned={result.candidates_skipped_poisoned} "
+            f"sentinel={result.candidates_skipped_sentinel} "
+            f"distill_errors={result.candidates_skipped_distill_error} "
+            f"io_errors={result.candidates_skipped_io_error} "
+            f"existing={result.candidates_skipped_existing}"
+        )
+        if result.candidate_doc_ids:
+            print("  doc_ids:")
+            for slug in result.candidate_doc_ids:
+                print(f"    - {slug}")
+    return 0
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s %(message)s",
+    )
+    try:
+        return asyncio.run(_run(args))
+    except KeyboardInterrupt:
+        return 130
+    except Exception as exc:  # noqa: BLE001 — top-level CLI handler
+        logger.error("forge_dry_run failed: %s", exc, exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cluster_fingerprint.py
+++ b/tests/test_cluster_fingerprint.py
@@ -1,0 +1,408 @@
+"""Cluster fingerprint tests (Skill Factory SF-103).
+
+Pinning the six stability properties P1–P6 from the module
+docstring as enforced invariants. The empirical ≥99% stability
+target lives in SF-105 (eval harness); this file pins the
+*formula's* deterministic guarantees so a future refactor of the
+canonicalization rules can't silently break them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_api.services.forge.fingerprint import (
+    ENTITY_TOP_K,
+    FINGERPRINT_FORMULA_VERSION,
+    GOAL_PHRASE_TOP_K,
+    STEP_WORDS_CAP,
+    ClusterFingerprintInputs,
+    canonical_domain,
+    canonical_entities,
+    canonical_goal_phrase,
+    canonical_step_skeleton,
+    compute_fingerprint,
+    render_canonical_form,
+)
+
+
+# Convenience factory.
+def _inputs(**overrides) -> ClusterFingerprintInputs:
+    base = {
+        "goal_phrase": "Deploy script hangs on step 7 in eu-west",
+        "domain": "devops",
+        "entity_ids": ["e1", "e2", "e3"],
+        "step_skeleton": ["run preflight check", "execute deploy script", "rollback on failure"],
+        "entity_centralities": None,
+    }
+    base.update(overrides)
+    return ClusterFingerprintInputs(**base)
+
+
+# ── Format + version contract ─────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestFingerprintFormat:
+    def test_version_prefix(self):
+        fp = compute_fingerprint(_inputs()).fp
+        assert fp.startswith(f"fp:{FINGERPRINT_FORMULA_VERSION}:")
+
+    def test_hash_is_64_hex_chars(self):
+        fp = compute_fingerprint(_inputs()).fp
+        h = fp.split(":")[-1]
+        assert len(h) == 64
+        # All hex (lowercase).
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_canonical_form_is_diffable(self):
+        # Render exposes the canonical form so operators can diff
+        # two clusters' canonical_forms to explain a hash difference.
+        cf = compute_fingerprint(_inputs()).canonical_form
+        assert cf.startswith("goal=")
+        assert "\ndomain=" in cf
+        assert "\nentities=" in cf
+        assert "\nsteps=" in cf
+
+    def test_top_k_constants_documented(self):
+        # If someone bumps these without changing FINGERPRINT_FORMULA_VERSION
+        # they'd silently re-fingerprint every existing cluster. Pin
+        # them here so a refactor can't slip through unnoticed.
+        assert ENTITY_TOP_K == 5
+        assert GOAL_PHRASE_TOP_K == 6
+        assert STEP_WORDS_CAP == 4
+
+
+# ── P1: Determinism ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestDeterminism:
+    def test_same_inputs_same_fingerprint(self):
+        fp1 = compute_fingerprint(_inputs()).fp
+        fp2 = compute_fingerprint(_inputs()).fp
+        assert fp1 == fp2
+
+    def test_completely_empty_inputs_have_stable_fingerprint(self):
+        empty = ClusterFingerprintInputs(
+            goal_phrase="", domain="", entity_ids=[], step_skeleton=[]
+        )
+        fp1 = compute_fingerprint(empty).fp
+        fp2 = compute_fingerprint(empty).fp
+        assert fp1 == fp2
+        # And it's distinguishable from a non-empty cluster.
+        assert fp1 != compute_fingerprint(_inputs()).fp
+
+    def test_different_clusters_different_fingerprints(self):
+        # Sanity: sha256 actually distinguishes inputs.
+        fp_a = compute_fingerprint(_inputs(domain="devops")).fp
+        fp_b = compute_fingerprint(_inputs(domain="security")).fp
+        assert fp_a != fp_b
+
+
+# ── P2: Permutation invariance ────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestPermutationInvariance:
+    def test_entity_id_permutation_no_effect(self):
+        a = _inputs(entity_ids=["e1", "e2", "e3"])
+        b = _inputs(entity_ids=["e3", "e1", "e2"])
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+    def test_goal_phrase_word_permutation_no_effect(self):
+        # The goal phrase is a bag-of-words distillation (sorted + deduped).
+        a = _inputs(goal_phrase="deploy hangs eu-west")
+        b = _inputs(goal_phrase="eu-west hangs deploy")
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+    def test_goal_phrase_duplicate_words_no_effect(self):
+        a = _inputs(goal_phrase="deploy deploy deploy hangs")
+        b = _inputs(goal_phrase="deploy hangs")
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+    def test_domain_case_no_effect(self):
+        a = _inputs(domain="DevOps")
+        b = _inputs(domain="devops")
+        c = _inputs(domain="  DEVOPS  ")
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp == compute_fingerprint(c).fp
+
+
+# ── P3: Step ordering significance + within-step normalization ────
+
+
+@pytest.mark.unit
+class TestStepOrdering:
+    def test_step_order_significant(self):
+        a = _inputs(step_skeleton=["A", "B", "C"])
+        b = _inputs(step_skeleton=["C", "B", "A"])
+        assert compute_fingerprint(a).fp != compute_fingerprint(b).fp
+
+    def test_step_word_order_preserved_within_step(self):
+        # "deploy script" and "script deploy" are different procedures
+        # (verb-then-object semantics matter).
+        a = _inputs(step_skeleton=["deploy script", "verify health"])
+        b = _inputs(step_skeleton=["script deploy", "health verify"])
+        assert compute_fingerprint(a).fp != compute_fingerprint(b).fp
+
+    def test_step_punctuation_stripped(self):
+        a = _inputs(step_skeleton=["deploy, script!", "verify health"])
+        b = _inputs(step_skeleton=["deploy script", "verify health"])
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+    def test_step_cap_at_4_words(self):
+        # Words past the cap don't influence the fingerprint.
+        a = _inputs(step_skeleton=["one two three four FIVE SIX"])
+        b = _inputs(step_skeleton=["one two three four"])
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+
+# ── P4: Top-K stability (cluster growth) ──────────────────────────
+
+
+@pytest.mark.unit
+class TestTopKEntityStability:
+    def test_adding_low_centrality_entity_does_not_shift(self):
+        base_ents = ["e1", "e2", "e3", "e4", "e5"]
+        centralities = {e: 1.0 for e in base_ents}
+        # Sixth entity, very low centrality — won't crack top 5.
+        plus_one_ents = base_ents + ["e6"]
+        plus_one_centralities = {**centralities, "e6": 0.001}
+
+        a = _inputs(entity_ids=base_ents, entity_centralities=centralities)
+        b = _inputs(entity_ids=plus_one_ents, entity_centralities=plus_one_centralities)
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+    def test_high_centrality_newcomer_does_shift(self):
+        # If a new entity DOES break into top 5 by centrality, the
+        # fingerprint legitimately changes — the cluster's identity
+        # really did move.
+        base_ents = ["e1", "e2", "e3", "e4", "e5"]
+        centralities = {e: 1.0 for e in base_ents}
+        plus_one_ents = base_ents + ["e6"]
+        plus_one_centralities = {**{e: 0.1 for e in base_ents}, "e6": 10.0}
+
+        a = _inputs(entity_ids=base_ents, entity_centralities=centralities)
+        b = _inputs(entity_ids=plus_one_ents, entity_centralities=plus_one_centralities)
+        assert compute_fingerprint(a).fp != compute_fingerprint(b).fp
+
+    def test_centrality_path_dedupes_inputs(self):
+        """Duplicates in entity_ids must not survive into the top-K
+        selection on the centrality path. Without this, duplicate
+        inputs burn top-K slots and silently shift the canonical
+        form. The no-centrality path already dedupes via
+        ``sorted(set(...))`` — this asserts the centrality path
+        matches that contract."""
+        ents = ["e1", "e1", "e2", "e2", "e3", "e4", "e5", "e6"]
+        cent = {e: 1.0 for e in set(ents)}
+        # With dedup: top-5 by id ASC is e1..e5. Without dedup, the
+        # ranked list would be ["e1","e1","e2","e2","e3"] — the
+        # duplicates would crowd out e4 and e5.
+        out = canonical_entities(ents, centralities=cent)
+        assert out == ["e1", "e2", "e3", "e4", "e5"]
+
+    def test_centrality_tie_broken_deterministically(self):
+        # When two entities have identical centrality, we tie-break by
+        # id ASC — so the canonical form is deterministic regardless
+        # of input order.
+        ents_v1 = ["e1", "e2", "e3", "e4", "e5", "e6", "e7"]
+        ents_v2 = ["e7", "e2", "e6", "e1", "e5", "e3", "e4"]
+        cent = {e: 1.0 for e in ents_v1}
+
+        a = _inputs(entity_ids=ents_v1, entity_centralities=cent)
+        b = _inputs(entity_ids=ents_v2, entity_centralities=cent)
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+    def test_no_centrality_falls_back_to_id_sort(self):
+        a = _inputs(entity_ids=["z", "a", "m"], entity_centralities=None)
+        b = _inputs(entity_ids=["a", "m", "z"], entity_centralities=None)
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+
+# ── P5: Token normalization (small surface perturbations) ─────────
+
+
+@pytest.mark.unit
+class TestTokenNormalization:
+    def test_simple_plural_stripped(self):
+        a = _inputs(goal_phrase="deploys hang frequent")
+        b = _inputs(goal_phrase="deploy hang frequent")
+        # "deploys" → "deploy", "frequent" stays
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+    def test_double_s_protected(self):
+        # "press" must NOT plural-strip to "pres" — would mangle real words.
+        a = _inputs(goal_phrase="press button release")
+        b = _inputs(goal_phrase="pres button release")
+        # Different (pres is a different stem after the protection).
+        assert compute_fingerprint(a).fp != compute_fingerprint(b).fp
+
+    def test_short_word_protected(self):
+        # 4-char and shorter words don't get plural-stripped — protects
+        # words like "bus", "gas", "ass" etc.
+        a = _inputs(goal_phrase="bus stop")
+        # If we'd plural-stripped, "bus" → "bu" → fingerprint shift.
+        assert "bus" in canonical_goal_phrase("bus stop")
+
+    def test_stopwords_dropped(self):
+        a = _inputs(goal_phrase="The deploy is on step 7")
+        b = _inputs(goal_phrase="deploy step 7")
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+    def test_punctuation_stripped(self):
+        a = _inputs(goal_phrase="deploy: step 7, eu-west!")
+        b = _inputs(goal_phrase="deploy step 7 eu west")
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+
+# ── P6: Domain canonicalization ───────────────────────────────────
+
+
+@pytest.mark.unit
+class TestDomainCanonicalization:
+    def test_lowercase(self):
+        assert canonical_domain("DevOps") == "devops"
+
+    def test_strip_outer_whitespace(self):
+        assert canonical_domain("  security  ") == "security"
+
+    def test_empty_or_none(self):
+        assert canonical_domain("") == ""
+
+    def test_internal_whitespace_preserved(self):
+        # Multi-word domains aren't expected, but if one slips
+        # through, internal spaces are preserved (no over-normalisation).
+        assert canonical_domain("Multi Domain") == "multi domain"
+
+
+# ── Goal-phrase top-K cap ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestGoalPhraseTopK:
+    def test_top_k_caps_at_constant(self):
+        # 10 distinct tokens; only the first GOAL_PHRASE_TOP_K (sorted)
+        # influence the fingerprint.
+        a = _inputs(goal_phrase="apple banana cherry date elderberry "
+                                "fig grape honeydew imbe jackfruit")
+        # First 6 sorted: apple, banana, cherry, date, elderberry, fig
+        # Adding "kiwi" (which sorts after "jackfruit") wouldn't crack the top 6.
+        b = _inputs(goal_phrase="apple banana cherry date elderberry "
+                                "fig grape honeydew imbe jackfruit kiwi")
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+
+# ── Canonical-form integration (the formula's anatomy) ────────────
+
+
+@pytest.mark.unit
+class TestCanonicalFormAnatomy:
+    def test_form_has_all_four_sections(self):
+        cf = render_canonical_form(_inputs())
+        assert "goal=" in cf
+        assert "domain=" in cf
+        assert "entities=" in cf
+        assert "steps=" in cf
+
+    def test_entities_separator_is_comma(self):
+        cf = render_canonical_form(_inputs(entity_ids=["e1", "e2"], entity_centralities=None))
+        assert "entities=e1,e2" in cf
+
+    def test_steps_separator_is_pipe(self):
+        cf = render_canonical_form(_inputs(step_skeleton=["one", "two"]))
+        assert "steps=one|two" in cf
+
+    def test_section_separator_is_newline(self):
+        cf = render_canonical_form(_inputs())
+        assert "\ngoal=" not in cf  # first line starts with goal=
+        # 3 newlines between 4 sections.
+        assert cf.count("\n") == 3
+
+
+# ── Adversarial: edge cases that could destabilize a real fleet ───
+
+
+@pytest.mark.unit
+class TestAdversarialPerturbations:
+    """Cases that a session re-runner would actually encounter. If
+    any of these fail, real-world ≥99% stability is at risk."""
+
+    def test_extra_whitespace_in_goal_phrase(self):
+        a = _inputs(goal_phrase="deploy   step    7")
+        b = _inputs(goal_phrase="deploy step 7")
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+    def test_unicode_in_goal_phrase_normalised_to_ascii(self):
+        # Our regex strips non-[a-z0-9] so an em-dash or smart quote
+        # disappears like punctuation. Stability preserved.
+        a = _inputs(goal_phrase="deploy — step 7")
+        b = _inputs(goal_phrase="deploy step 7")
+        assert compute_fingerprint(a).fp == compute_fingerprint(b).fp
+
+    def test_step_skeleton_growth_does_not_affect_existing_step_fps(self):
+        # Adding a 4th step changes the cluster, but the FIRST THREE
+        # steps' canonical rendering remains identical (no
+        # cross-step interference).
+        a_steps = ["preflight", "deploy", "verify"]
+        b_steps = ["preflight", "deploy", "verify", "rollback"]
+        # The fingerprints differ (P3 — step ordering significant),
+        # but the canonical form for the first three steps is
+        # identical inside both.
+        cf_a = render_canonical_form(_inputs(step_skeleton=a_steps))
+        cf_b = render_canonical_form(_inputs(step_skeleton=b_steps))
+        # Both start with the same steps; b's only differs in trailing
+        # |rollback.
+        assert cf_a.split("steps=")[1] + "|rollback" == cf_b.split("steps=")[1]
+
+    def test_inputs_dataclass_is_frozen(self):
+        # Defensive: the inputs are passed around to logging /
+        # comparison code. Frozen means downstream mutations can't
+        # corrupt the canonical form.
+        inp = _inputs()
+        with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
+            inp.domain = "tampered"  # type: ignore[misc]
+
+
+# ── Canonicalization unit details (white-box) ─────────────────────
+
+
+@pytest.mark.unit
+class TestCanonicalGoalPhraseInternals:
+    def test_lowercase_normalisation(self):
+        assert canonical_goal_phrase("DEPLOY HANGS") == "deploy hang"
+
+    def test_dedup(self):
+        # "the deploy and the deploy" → ["deploy"] after stopword
+        # removal + dedupe + plural stripping.
+        assert canonical_goal_phrase("the deploy and the deploy") == "deploy"
+
+    def test_sort_order_is_ascii(self):
+        assert canonical_goal_phrase("zebra apple mango") == "apple mango zebra"
+
+
+@pytest.mark.unit
+class TestCanonicalEntitiesInternals:
+    def test_dedupe_in_no_centrality_path(self):
+        assert canonical_entities(["e1", "e1", "e2", "e2"]) == ["e1", "e2"]
+
+    def test_top_k_clamp_in_no_centrality_path(self):
+        ents = [f"e{i:02d}" for i in range(20)]
+        out = canonical_entities(ents)
+        assert len(out) == ENTITY_TOP_K
+        assert out == sorted(ents)[:ENTITY_TOP_K]
+
+    def test_empty_input(self):
+        assert canonical_entities([]) == []
+
+
+@pytest.mark.unit
+class TestCanonicalStepSkeletonInternals:
+    def test_empty_step_preserved(self):
+        out = canonical_step_skeleton(["", "deploy script", ""])
+        assert out == ["", "deploy script", ""]
+        # The empty positions matter so step indices don't shift.
+
+    def test_word_count_cap_per_step(self):
+        out = canonical_step_skeleton(["one two three four five six seven"])
+        # Cap at STEP_WORDS_CAP=4.
+        assert out == ["one two three four"]

--- a/tests/test_forge_distill.py
+++ b/tests/test_forge_distill.py
@@ -1,0 +1,1364 @@
+"""Forge distill tests (Skill Factory SF-104).
+
+Two test surfaces:
+
+  * Prompt construction + response parsing (pure functions in
+    :mod:`distill_prompt`).
+  * Service orchestration (in :mod:`forge_service`) with the LLM,
+    memory fetcher, poison checker, and candidate writer all
+    injected as fakes — so the test runs hermetic with no DB and no
+    network.
+
+Coverage targets:
+  - The prompt carries every required input section.
+  - The response parser is robust to JSON variants the LLM commonly
+    leaks (code fences, leading prose) and strict on the schema.
+  - Clustering by entity Jaccard produces deterministic, separable
+    clusters.
+  - Auto-gates (min_cluster_size, min_distinct_agents) drop weak clusters.
+  - Poison check short-circuits a cluster without writing.
+  - Distill-error skip doesn't abort the run.
+  - Candidate docs land with status=candidate, source=forge, the
+    fingerprint stamped, and the cites list deduped + sorted.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from core_api.services.forge.distill_prompt import (
+    DISTILL_SCHEMA_VERSION,
+    ClusterPromptInputs,
+    DistillParseError,
+    TraceSnapshot,
+    build_distill_prompt,
+    parse_distill_response,
+)
+from core_api.services.forge.fingerprint import (
+    FINGERPRINT_FORMULA_VERSION,
+)
+from core_api.services.forge.forge_service import (
+    ForgeConfig,
+    _cluster_by_entity_overlap,
+    _gate_clusters,
+    run_forge_distill,
+)
+from core_api.services.session_trace import SessionTraceRow
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+def _trace(
+    run_id: str = "r1",
+    agent_id: str = "a1",
+    outcome: str = "success",
+    entity_ids: list[str] | None = None,
+    memory_ids: list[str] | None = None,
+    started: datetime | None = None,
+    ended: datetime | None = None,
+) -> SessionTraceRow:
+    # `is None` (not `or`) so an explicit empty list survives —
+    # tests need to differentiate "no entities supplied, take default"
+    # from "explicitly entity-less, exercise the drop path".
+    return SessionTraceRow(
+        tenant_id="t1",
+        fleet_id="f1",
+        run_id=run_id,
+        agent_id=agent_id,
+        outcome_label=outcome,
+        memory_ids=memory_ids if memory_ids is not None else [f"{run_id}-m1"],
+        entity_ids=entity_ids if entity_ids is not None else ["e1", "e2"],
+        signals_summary={},
+        started_at=started or datetime(2026, 5, 1, tzinfo=timezone.utc),
+        ended_at=ended or datetime(2026, 5, 2, tzinfo=timezone.utc),
+        goal_phrase=None,
+    )
+
+
+def _golden_llm_response(**overrides) -> dict[str, Any]:
+    base = {
+        "schema_version": DISTILL_SCHEMA_VERSION,
+        "kind": "create",
+        "goal_phrase": "deploy eu-west fallback dns step 7",
+        "domain": "devops",
+        "step_skeleton": [
+            "run preflight check",
+            "deploy script v4",
+            "switch fallback dns",
+            "verify rollout",
+        ],
+        "name": "Deploy to eu-west · fallback DNS at step 7",
+        "slug": "deploy-eu-west-dns",
+        "description": "Use fallback DNS resolver when eu-west deploy step 7 hangs.",
+        "summary": "Detects a hung step 7 on eu-west deploys and switches to the "
+                   "fallback DNS resolver before retrying.",
+        "content": "## When to use\n…\n## Steps\n1. …",
+        "tags": ["deploy", "eu-west", "dns"],
+        "evidence": "4 sessions / 3 agents in Apr 18–28, 100% success when applied.",
+        "goal": "Deploy to eu-west without hanging on step 7.",
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Prompt construction ───────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestBuildDistillPrompt:
+    def test_prompt_contains_all_traces(self):
+        snaps = [
+            TraceSnapshot(
+                run_id=f"r{i}", agent_id=f"a{i}", outcome_label="success",
+                memory_excerpts=[f"trace {i} content excerpt"],
+                entity_ids=["e1"],
+                started_at_iso="2026-05-01T00:00:00+00:00",
+                ended_at_iso="2026-05-01T01:00:00+00:00",
+            )
+            for i in range(3)
+        ]
+        prompt = build_distill_prompt(ClusterPromptInputs(
+            tenant_id="t1", fleet_id="f1", traces=snaps,
+        ))
+        assert "3 trace(s)" in prompt
+        # Each trace appears as a labeled block.
+        for i in range(3):
+            assert f"Trace {i+1}/3" in prompt
+            assert f"r{i}" in prompt
+            assert f"a{i}" in prompt
+
+    def test_schema_version_pinned_in_preamble(self):
+        prompt = build_distill_prompt(ClusterPromptInputs(
+            tenant_id="t1", fleet_id=None, traces=[]
+        ))
+        assert DISTILL_SCHEMA_VERSION in prompt
+        # Sanity: schema_version is mentioned at least twice
+        # (preamble + footer).
+        assert prompt.count(DISTILL_SCHEMA_VERSION) >= 2
+
+    def test_top_entities_listed(self):
+        prompt = build_distill_prompt(ClusterPromptInputs(
+            tenant_id="t1", fleet_id="f1", traces=[],
+            top_entity_labels=["mysql", "deploy", "step7"],
+        ))
+        assert "Top entities" in prompt
+        # Sorted + deduped.
+        assert "deploy" in prompt and "mysql" in prompt and "step7" in prompt
+
+    def test_hint_domain_included_when_present(self):
+        prompt = build_distill_prompt(ClusterPromptInputs(
+            tenant_id="t1", fleet_id=None, traces=[], hint_domain="security",
+        ))
+        assert "Suggested domain" in prompt
+        assert "security" in prompt
+
+    def test_outcome_label_per_trace(self):
+        snap = TraceSnapshot(
+            run_id="r1", agent_id="a1", outcome_label="failure",
+            memory_excerpts=["..."],
+            entity_ids=["e1"],
+            started_at_iso="2026-05-01T00:00:00+00:00",
+            ended_at_iso="2026-05-01T01:00:00+00:00",
+        )
+        prompt = build_distill_prompt(ClusterPromptInputs(
+            tenant_id="t1", fleet_id=None, traces=[snap]
+        ))
+        assert "outcome: failure" in prompt
+
+    def test_entity_ids_sorted_in_prompt(self):
+        # Sorted to keep the prompt itself deterministic for the
+        # same cluster (same prompt → same LLM output assuming
+        # temperature=0).
+        snap = TraceSnapshot(
+            run_id="r1", agent_id="a1", outcome_label="success",
+            memory_excerpts=[],
+            entity_ids=["z-ent", "a-ent", "m-ent"],
+            started_at_iso="2026-05-01T00:00:00+00:00",
+            ended_at_iso="2026-05-01T01:00:00+00:00",
+        )
+        prompt = build_distill_prompt(ClusterPromptInputs(
+            tenant_id="t1", fleet_id=None, traces=[snap]
+        ))
+        line = next(l for l in prompt.splitlines() if l.startswith("entities:"))
+        assert "a-ent" in line and "m-ent" in line and "z-ent" in line
+        assert line.index("a-ent") < line.index("m-ent") < line.index("z-ent")
+
+
+# ── Response parsing ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestParseDistillResponse:
+    def test_happy_path(self):
+        raw = json.dumps(_golden_llm_response())
+        parsed = parse_distill_response(raw)
+        assert parsed["goal_phrase"]
+        assert parsed["domain"] == "devops"
+        assert parsed["kind"] == "create"
+        assert isinstance(parsed["step_skeleton"], list)
+
+    def test_strips_code_fence(self):
+        raw = "```json\n" + json.dumps(_golden_llm_response()) + "\n```"
+        parsed = parse_distill_response(raw)
+        assert parsed["domain"] == "devops"
+
+    def test_strips_bare_code_fence(self):
+        raw = "```\n" + json.dumps(_golden_llm_response()) + "\n```"
+        parsed = parse_distill_response(raw)
+        assert parsed["domain"] == "devops"
+
+    def test_strips_leading_prose(self):
+        # LLMs sometimes prepend "Here's the JSON:" or similar.
+        raw = "Here is the skill:\n" + json.dumps(_golden_llm_response())
+        parsed = parse_distill_response(raw)
+        assert parsed["domain"] == "devops"
+
+    def test_strips_trailing_prose(self):
+        # LLMs ALSO sometimes append "Let me know if you want
+        # changes!" or similar after a closing brace. The previous
+        # regex-based extractor (anchored on $) failed this case;
+        # the JSONDecoder.raw_decode path handles it.
+        raw = json.dumps(_golden_llm_response()) + "\n\nLet me know if you want changes!"
+        parsed = parse_distill_response(raw)
+        assert parsed["domain"] == "devops"
+
+    def test_strips_both_leading_and_trailing_prose(self):
+        raw = (
+            "Here's your skill:\n"
+            + json.dumps(_golden_llm_response())
+            + "\nHappy to iterate."
+        )
+        parsed = parse_distill_response(raw)
+        assert parsed["domain"] == "devops"
+
+    def test_extracts_when_response_has_braces_in_strings(self):
+        # The greedy regex previously used (``{.*}\s*$``) would
+        # incorrectly snap onto a literal ``}`` inside a string
+        # value. JSONDecoder.raw_decode handles balanced braces
+        # natively.
+        body = _golden_llm_response()
+        body["content"] = "snippet with a {literal} brace {pair} inside"
+        raw = "Prefix prose. " + json.dumps(body) + " More trailing prose."
+        parsed = parse_distill_response(raw)
+        assert parsed["content"] == "snippet with a {literal} brace {pair} inside"
+
+    def test_empty_raises(self):
+        with pytest.raises(DistillParseError):
+            parse_distill_response("")
+        with pytest.raises(DistillParseError):
+            parse_distill_response("   ")
+
+    def test_non_json_raises(self):
+        with pytest.raises(DistillParseError):
+            parse_distill_response("not json at all")
+
+    def test_not_an_object_raises(self):
+        with pytest.raises(DistillParseError):
+            parse_distill_response("[1, 2, 3]")
+
+    def test_wrong_schema_version_raises(self):
+        bad = _golden_llm_response(schema_version="v999")
+        with pytest.raises(DistillParseError) as e:
+            parse_distill_response(json.dumps(bad))
+        assert "schema_version" in str(e.value)
+
+    def test_missing_required_key_raises(self):
+        bad = _golden_llm_response()
+        del bad["description"]
+        with pytest.raises(DistillParseError) as e:
+            parse_distill_response(json.dumps(bad))
+        assert "description" in str(e.value)
+
+    def test_string_field_must_be_string(self):
+        bad = _golden_llm_response()
+        bad["description"] = ["should be a string"]  # type: ignore
+        with pytest.raises(DistillParseError):
+            parse_distill_response(json.dumps(bad))
+
+    def test_list_field_must_be_list_of_strings(self):
+        bad = _golden_llm_response()
+        bad["step_skeleton"] = "not a list"  # type: ignore
+        with pytest.raises(DistillParseError):
+            parse_distill_response(json.dumps(bad))
+
+        bad2 = _golden_llm_response()
+        bad2["step_skeleton"] = ["ok", 42]  # type: ignore
+        with pytest.raises(DistillParseError):
+            parse_distill_response(json.dumps(bad2))
+
+    def test_kind_defaults_to_create_when_absent(self):
+        body = _golden_llm_response()
+        del body["kind"]
+        parsed = parse_distill_response(json.dumps(body))
+        assert parsed["kind"] == "create"
+
+    def test_invalid_kind_rejected(self):
+        bad = _golden_llm_response(kind="patch")
+        with pytest.raises(DistillParseError):
+            parse_distill_response(json.dumps(bad))
+
+    def test_kind_update_passes_parser_but_forge_rejects(self):
+        # The parser is permissive (kind ∈ {create, update}) because
+        # kind=update is a legitimate Phase-4 flow once v2-diff cards
+        # land. _distill_cluster has its own Phase-1 invariant that
+        # blocks update — covered by TestForgeRunResilience below.
+        bad = _golden_llm_response(kind="update")
+        parsed = parse_distill_response(json.dumps(bad))
+        assert parsed["kind"] == "update"
+
+    @pytest.mark.parametrize(
+        "bad_slug",
+        [
+            "Deploy-Eu-West",          # uppercase
+            "deploy eu west",          # spaces
+            "-deploy-eu-west",         # leading punctuation
+            ".deploy",                 # leading dot
+            "deploy/eu/west",          # forward slash (route prefixes that itself)
+            "deploy@eu",               # at-sign
+            "",                        # empty
+            "a" * 101,                 # too long
+        ],
+    )
+    def test_invalid_slug_format_rejected(self, bad_slug):
+        """Malformed LLM slugs raise DistillParseError BEFORE the
+        candidate_writer gets a chance to fail at the storage layer.
+        The route's ``_SKILL_SLUG_RE`` governs the doc_id wrapper;
+        this parser-level check governs ``data.slug`` itself."""
+        bad = _golden_llm_response(slug=bad_slug)
+        with pytest.raises(DistillParseError) as exc:
+            parse_distill_response(json.dumps(bad))
+        assert "slug" in str(exc.value).lower()
+
+    def test_valid_slug_formats_accepted(self):
+        # Lowercase alphanumeric + . _ -, starting with a-z0-9.
+        for ok in ("deploy", "deploy-eu-west", "deploy.v4", "deploy_v4", "a", "0deploy"):
+            parsed = parse_distill_response(json.dumps(_golden_llm_response(slug=ok)))
+            assert parsed["slug"] == ok
+
+    def test_system_preamble_carries_slug_instruction(self):
+        # Pin that the prompt itself instructs the model on the slug
+        # format. Without this, the LLM has no signal — we'd get an
+        # unhelpfully-high rejection rate at parse time downstream.
+        from core_api.services.forge.distill_prompt import _SYSTEM_PREAMBLE_FILLED
+        assert "slug" in _SYSTEM_PREAMBLE_FILLED
+        assert "lowercase-kebab-case" in _SYSTEM_PREAMBLE_FILLED
+        assert "[a-z0-9]" in _SYSTEM_PREAMBLE_FILLED
+
+
+@pytest.mark.unit
+class TestForgeDryRunFakeLLMFallback:
+    """The ``scripts/forge_dry_run.py`` CLI's docstring promises a
+    fake-LLM fallback "for environments without provider keys
+    configured". The fallback must (a) trigger on ImportError, (b)
+    produce JSON that ``parse_distill_response`` accepts. Without
+    this, an operator running the CLI on a packaging variant
+    without ``common.llm`` would hit an unhelpful ImportError
+    instead of getting placeholder smoke output."""
+
+    @pytest.mark.asyncio
+    async def test_fake_llm_produces_parseable_response(self):
+        # Import the fake-LLM callable directly from the script
+        # (not the wire function, which depends on real or fake
+        # branch selection at runtime).
+        import importlib.util
+        import pathlib
+
+        script_path = pathlib.Path("scripts/forge_dry_run.py")
+        spec = importlib.util.spec_from_file_location("forge_dry_run", script_path)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        raw = await mod._fake_llm_fn("ignored prompt")
+        # Must be a parseable distill response.
+        parsed = parse_distill_response(raw)
+        assert parsed["kind"] == "create"
+        # Required schema keys all present.
+        for key in (
+            "goal_phrase", "domain", "step_skeleton", "name", "slug",
+            "description", "summary", "content", "tags", "evidence", "goal",
+        ):
+            assert key in parsed, f"fake-LLM missing required key: {key}"
+
+    @pytest.mark.asyncio
+    async def test_fake_llm_each_call_distinct_slug(self):
+        # Two calls must yield distinct slugs so a multi-cluster run
+        # doesn't collide on doc_id.
+        import importlib.util
+        import pathlib
+
+        script_path = pathlib.Path("scripts/forge_dry_run.py")
+        spec = importlib.util.spec_from_file_location("forge_dry_run_2", script_path)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        # Reset the counter so we have a deterministic starting point.
+        mod._FAKE_LLM_COUNTER["n"] = 0
+
+        raw1 = await mod._fake_llm_fn("")
+        raw2 = await mod._fake_llm_fn("")
+        slug1 = parse_distill_response(raw1)["slug"]
+        slug2 = parse_distill_response(raw2)["slug"]
+        assert slug1 != slug2
+        # Both still match the route's slug regex.
+        from core_api.services.forge.distill_prompt import _SLUG_RE
+        assert _SLUG_RE.fullmatch(slug1)
+        assert _SLUG_RE.fullmatch(slug2)
+
+
+# ── Clustering ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestEntityJaccardClustering:
+    def test_no_traces_no_clusters(self):
+        assert _cluster_by_entity_overlap([], jaccard_threshold=0.4) == []
+
+    def test_traces_without_entities_dropped(self):
+        traces = [_trace(entity_ids=[]) for _ in range(3)]
+        assert _cluster_by_entity_overlap(traces, jaccard_threshold=0.4) == []
+
+    def test_high_overlap_traces_same_cluster(self):
+        traces = [
+            _trace(run_id="r1", entity_ids=["e1", "e2", "e3"]),
+            _trace(run_id="r2", entity_ids=["e1", "e2", "e3"]),
+            _trace(run_id="r3", entity_ids=["e1", "e2", "e4"]),  # 2/4 = 0.5 overlap
+        ]
+        clusters = _cluster_by_entity_overlap(traces, jaccard_threshold=0.4)
+        assert len(clusters) == 1
+        assert len(clusters[0]) == 3
+
+    def test_disjoint_traces_separate_clusters(self):
+        traces = [
+            _trace(run_id="r1", entity_ids=["e1", "e2"]),
+            _trace(run_id="r2", entity_ids=["e3", "e4"]),
+        ]
+        clusters = _cluster_by_entity_overlap(traces, jaccard_threshold=0.4)
+        assert len(clusters) == 2
+
+    def test_threshold_governs_inclusion(self):
+        traces = [
+            _trace(run_id="r1", entity_ids=["e1", "e2", "e3", "e4"]),
+            _trace(run_id="r2", entity_ids=["e1"]),  # 1/4 = 0.25
+        ]
+        loose = _cluster_by_entity_overlap(traces, jaccard_threshold=0.2)
+        strict = _cluster_by_entity_overlap(traces, jaccard_threshold=0.4)
+        assert len(loose) == 1  # 0.25 ≥ 0.2 → same cluster
+        assert len(strict) == 2  # 0.25 < 0.4 → separate clusters
+
+
+# ── Auto-gates ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestClusterGates:
+    def test_min_cluster_size_filter(self):
+        clusters = [
+            [_trace(run_id=f"r{i}", agent_id=f"a{i}") for i in range(2)],   # too small
+            [_trace(run_id=f"r{i}", agent_id=f"a{i}") for i in range(3, 7)],  # 4 traces
+        ]
+        eligible = _gate_clusters(clusters, min_cluster_size=3, min_distinct_agents=3)
+        assert len(eligible) == 1
+        assert len(eligible[0]) == 4
+
+    def test_min_distinct_agents_filter(self):
+        # 5 traces but all same agent — anti-poison.
+        single_agent = [_trace(run_id=f"r{i}", agent_id="alice") for i in range(5)]
+        eligible = _gate_clusters([single_agent], min_cluster_size=3, min_distinct_agents=3)
+        assert eligible == []
+
+        # 5 traces from 3 agents — OK.
+        diverse = [
+            _trace(run_id="r1", agent_id="alice"),
+            _trace(run_id="r2", agent_id="alice"),
+            _trace(run_id="r3", agent_id="bob"),
+            _trace(run_id="r4", agent_id="carol"),
+            _trace(run_id="r5", agent_id="carol"),
+        ]
+        eligible = _gate_clusters([diverse], min_cluster_size=3, min_distinct_agents=3)
+        assert len(eligible) == 1
+
+
+# ── Full orchestration with mocked I/O ────────────────────────────
+
+
+class _MockDb:
+    """Minimal stand-in. session_trace builder + memory_fetcher are
+    the only callers; we patch both at test time so the DB is
+    never actually queried inside run_forge_distill tests."""
+
+
+def _passing_traces(n: int) -> list[SessionTraceRow]:
+    """n traces, all sharing entities, each from a different agent
+    so they pass volume + diversity gates."""
+    return [
+        _trace(
+            run_id=f"r{i}",
+            agent_id=f"agent{i}",
+            entity_ids=["e1", "e2", "e3"],
+            memory_ids=[f"m{i}-1", f"m{i}-2"],
+        )
+        for i in range(n)
+    ]
+
+
+async def _llm_returns_golden(_prompt: str) -> str:
+    return json.dumps(_golden_llm_response())
+
+
+async def _llm_returns_bogus(_prompt: str) -> str:
+    return "not json"
+
+
+async def _memory_fetcher_always(memory_ids: list[str]) -> dict[str, str]:
+    return {mid: f"content of {mid}" for mid in memory_ids}
+
+
+async def _poison_never(_fp: str) -> bool:
+    return False
+
+
+async def _poison_always(_fp: str) -> bool:
+    return True
+
+
+def _capture_writer() -> tuple[list[dict[str, Any]], Any]:
+    captured: list[dict[str, Any]] = []
+
+    async def writer(doc: dict[str, Any]) -> None:
+        captured.append(doc)
+
+    return captured, writer
+
+
+@pytest.mark.unit
+class TestForgeRunOrchestration:
+    def _patch_build(self, monkeypatch, traces: list[SessionTraceRow]):
+        """Stub out the session-trace builder so we don't need DB."""
+        async def fake_build(*_args, **_kwargs):
+            return traces
+        import core_api.services.forge.forge_service as svc
+        monkeypatch.setattr(svc, "build_session_traces", fake_build)
+
+    @pytest.mark.asyncio
+    async def test_no_traces_no_candidates(self, monkeypatch):
+        self._patch_build(monkeypatch, [])
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id="f1",
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert result.total_traces == 0
+        assert result.candidates_written == 0
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_happy_path_writes_one_candidate(self, monkeypatch):
+        # 4 traces, all entity-overlapping, 4 distinct agents.
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="acme", fleet_id="ops",
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert result.total_traces == 4
+        assert result.labeled_traces == 4
+        assert result.clusters_total == 1
+        assert result.clusters_eligible == 1
+        assert result.candidates_written == 1
+        assert len(captured) == 1
+
+        doc = captured[0]
+        assert doc["tenant_id"] == "acme"
+        assert doc["collection"] == "skills"
+        assert doc["doc_id"].startswith("forge/")
+        d = doc["data"]
+        assert d["status"] == "candidate"          # NEVER auto-promotes in Phase 1
+        assert d["source"] == "forge"
+        assert d["kind"] == "create"
+        assert d["cluster_fingerprint"].startswith(f"fp:{FINGERPRINT_FORMULA_VERSION}:")
+        # Cites are deduped + sorted (sorted-set on memory_ids).
+        assert d["cites"] == sorted(set(d["cites"]))
+        # Provenance.
+        assert d["origin"]["agent_id"] == "forge"
+        assert d["goal"] and d["evidence"]
+        assert d["domain"] == "devops"
+
+    @pytest.mark.asyncio
+    async def test_unlabeled_traces_dropped(self, monkeypatch):
+        # 4 unknown-outcome traces → nothing to distill.
+        traces = [
+            _trace(run_id=f"r{i}", agent_id=f"a{i}", outcome="unknown",
+                   entity_ids=["e1", "e2"])
+            for i in range(4)
+        ]
+        self._patch_build(monkeypatch, traces)
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert result.total_traces == 4
+        assert result.labeled_traces == 0
+        assert result.candidates_written == 0
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_under_volume_cluster_dropped(self, monkeypatch):
+        # 2 traces (below default min_cluster_size=3).
+        self._patch_build(monkeypatch, _passing_traces(2))
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert result.clusters_total == 1
+        assert result.clusters_eligible == 0
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_single_agent_cluster_dropped_by_diversity(self, monkeypatch):
+        # 5 traces, all by alice → fails diversity gate.
+        traces = [
+            _trace(run_id=f"r{i}", agent_id="alice", entity_ids=["e1", "e2"])
+            for i in range(5)
+        ]
+        self._patch_build(monkeypatch, traces)
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert result.clusters_total == 1
+        assert result.clusters_eligible == 0
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_poison_skip_does_not_write(self, monkeypatch):
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_always,        # everything is poisoned
+            candidate_writer=writer,
+        )
+        assert result.candidates_skipped_poisoned == 1
+        assert result.candidates_written == 0
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_distill_error_skip_does_not_abort_run(self, monkeypatch):
+        # Two clusters with disjoint entity sets, both eligible.
+        traces = (
+            [_trace(run_id=f"r{i}", agent_id=f"a{i}", entity_ids=["e1", "e2", "e3"])
+             for i in range(4)]
+            +
+            [_trace(run_id=f"r{i+10}", agent_id=f"b{i}", entity_ids=["x1", "x2", "x3"])
+             for i in range(4)]
+        )
+        self._patch_build(monkeypatch, traces)
+
+        # LLM returns nonsense for the FIRST cluster but a golden
+        # response for any subsequent call.
+        call_counter = {"n": 0}
+        async def flaky_llm(_prompt: str) -> str:
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return "not json"
+            return json.dumps(_golden_llm_response(slug=f"deploy-eu-west-dns-{call_counter['n']}"))
+
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=flaky_llm,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert result.clusters_eligible == 2
+        assert result.candidates_skipped_distill_error == 1
+        assert result.candidates_written == 1
+
+    @pytest.mark.asyncio
+    async def test_max_writes_per_run_caps_output(self, monkeypatch):
+        # 3 clusters, but config limits writes to 1.
+        traces = (
+            [_trace(run_id=f"r{i}", agent_id=f"a{i}", entity_ids=["e1", "e2", "e3"])
+             for i in range(4)]
+            +
+            [_trace(run_id=f"r{i+10}", agent_id=f"b{i}", entity_ids=["x1", "x2", "x3"])
+             for i in range(4)]
+            +
+            [_trace(run_id=f"r{i+20}", agent_id=f"c{i}", entity_ids=["y1", "y2", "y3"])
+             for i in range(4)]
+        )
+        self._patch_build(monkeypatch, traces)
+
+        # Distinct slug per call so doc_ids don't collide.
+        call_counter = {"n": 0}
+        async def llm_unique(_prompt: str) -> str:
+            call_counter["n"] += 1
+            return json.dumps(_golden_llm_response(slug=f"slug-{call_counter['n']}"))
+
+        captured, writer = _capture_writer()
+        cfg = ForgeConfig(max_writes_per_run=1)
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=llm_unique,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+            config=cfg,
+        )
+        assert result.clusters_eligible == 3
+        assert result.candidates_written == 1
+        assert len(captured) == 1
+
+
+# ── started_at semantics ──────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestForgeRunResultTimestamps:
+    """Regression for the ``started_at`` semantics fix. Previously
+    the field used ``default_factory=datetime.now`` which fires at
+    dataclass-construction (the END of the run); the result's
+    ``started_at`` was indistinguishable from finish time. Fixed by
+    stamping the wall clock at the top of ``run_forge_distill``
+    BEFORE any await and passing it through explicitly."""
+
+    def _patch_build(self, monkeypatch, traces):
+        async def fake_build(*_args, **_kwargs):
+            return list(traces)
+        import core_api.services.forge.forge_service as svc
+        monkeypatch.setattr(svc, "build_session_traces", fake_build)
+
+    @pytest.mark.asyncio
+    async def test_started_at_captured_before_work(self, monkeypatch):
+        """``started_at`` must be earlier than (or equal to) the time
+        immediately AFTER the run returns. The previous
+        default-factory bug would still satisfy this trivially —
+        what we actually want to assert is that ``started_at`` is
+        close to the BEFORE-run timestamp, not the AFTER-run one."""
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+
+        before = datetime.now(timezone.utc)
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id="f1",
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        after = datetime.now(timezone.utc)
+
+        # The stamp lies between before and after.
+        assert before <= result.started_at <= after
+
+        # Empirically, the run is dominated by I/O — so started_at
+        # should be very close to ``before``, not ``after``. We use
+        # a generous slack (50 ms) because CI timing isn't precise.
+        slack = timedelta(milliseconds=50)
+        assert result.started_at - before <= slack, (
+            f"started_at ({result.started_at}) is too far from the "
+            f"start of the run ({before}) — likely captured at "
+            f"dataclass-construction time (the END of the run) "
+            f"instead of the beginning."
+        )
+
+
+# ── Distill loop resilience: transient errors don't abort the run ──
+
+
+@pytest.mark.unit
+class TestForgeRunResilience:
+    """All-cluster-fails-still-runs-the-others. The Forge tick must
+    survive an LLM timeout, a memory_fetcher DB error, a
+    poison_checker failure, or a writer crash on one cluster
+    without dragging the rest of the tick down with it."""
+
+    def _patch_build(self, monkeypatch, traces):
+        async def fake_build(*_args, **_kwargs):
+            return list(traces)
+        import core_api.services.forge.forge_service as svc
+        monkeypatch.setattr(svc, "build_session_traces", fake_build)
+
+    def _two_eligible_clusters(self):
+        return (
+            [_trace(run_id=f"r{i}", agent_id=f"a{i}", entity_ids=["e1", "e2", "e3"])
+             for i in range(4)]
+            +
+            [_trace(run_id=f"r{i+10}", agent_id=f"b{i}", entity_ids=["x1", "x2", "x3"])
+             for i in range(4)]
+        )
+
+    @pytest.mark.asyncio
+    async def test_llm_timeout_on_one_cluster_skips_it(self, monkeypatch):
+        self._patch_build(monkeypatch, self._two_eligible_clusters())
+
+        call = {"n": 0}
+        async def llm(_prompt: str) -> str:
+            call["n"] += 1
+            if call["n"] == 1:
+                raise TimeoutError("simulated LLM timeout")
+            return json.dumps(_golden_llm_response(slug=f"s-{call['n']}"))
+
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=llm,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert result.clusters_eligible == 2
+        # LLM TimeoutError is an I/O failure inside llm_fn, not a
+        # parse-shaped problem with the response — so it counts in
+        # the I/O bucket. (A previous version bucketed all
+        # non-parse, non-poison failures under distill_error;
+        # post-review the buckets are split.)
+        assert result.candidates_skipped_io_error == 1
+        assert result.candidates_skipped_distill_error == 0
+        assert result.candidates_written == 1
+
+    @pytest.mark.asyncio
+    async def test_memory_fetcher_error_skips_cluster(self, monkeypatch):
+        self._patch_build(monkeypatch, self._two_eligible_clusters())
+
+        call = {"n": 0}
+        async def fetcher(mids):
+            call["n"] += 1
+            if call["n"] == 1:
+                raise ConnectionError("simulated DB connection drop")
+            return {m: f"content {m}" for m in mids}
+
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=fetcher,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        # ConnectionError is an I/O failure → io_error bucket.
+        assert result.candidates_skipped_io_error == 1
+        assert result.candidates_skipped_distill_error == 0
+        assert result.candidates_written == 1
+
+    @pytest.mark.asyncio
+    async def test_poison_checker_error_skips_cluster(self, monkeypatch):
+        self._patch_build(monkeypatch, self._two_eligible_clusters())
+
+        call = {"n": 0}
+        async def poisoner(_fp):
+            call["n"] += 1
+            if call["n"] == 1:
+                raise RuntimeError("simulated poison-table query failure")
+            return False
+
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=poisoner,
+            candidate_writer=writer,
+        )
+        # poison-table query failure → io_error bucket.
+        assert result.candidates_skipped_io_error == 1
+        assert result.candidates_skipped_distill_error == 0
+        assert result.candidates_written == 1
+
+    @pytest.mark.asyncio
+    async def test_llm_returning_kind_update_is_rejected_as_distill_error(self, monkeypatch):
+        """Phase-1 invariant: Forge only mints kind='create'. If the
+        model returns kind='update' (with hash-binding to a live
+        target), the v2-diff card flow doesn't exist yet — we'd
+        smuggle a malformed doc past Sentinel into the inbox.
+        Treat as a distill error so the cluster is skipped and
+        counted, not silently written."""
+        self._patch_build(monkeypatch, self._two_eligible_clusters())
+
+        call = {"n": 0}
+        async def llm(_prompt: str) -> str:
+            call["n"] += 1
+            if call["n"] == 1:
+                # First cluster: forbidden kind='update' from the model.
+                return json.dumps(_golden_llm_response(kind="update", slug=f"u-{call['n']}"))
+            # Second cluster: well-formed.
+            return json.dumps(_golden_llm_response(slug=f"c-{call['n']}"))
+
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=llm,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert result.candidates_skipped_distill_error == 1
+        assert result.candidates_written == 1
+
+    @pytest.mark.asyncio
+    async def test_candidate_writer_error_skips_persist(self, monkeypatch):
+        # Two eligible clusters; the first WRITE fails (e.g. UNIQUE
+        # violation, schema validator hiccup). The second cluster
+        # must still get persisted.
+        self._patch_build(monkeypatch, self._two_eligible_clusters())
+
+        # Unique slug per LLM call so we can tell them apart in the
+        # writer.
+        call_counter = {"n": 0}
+        async def llm_unique(_prompt):
+            call_counter["n"] += 1
+            return json.dumps(_golden_llm_response(slug=f"slug-{call_counter['n']}"))
+
+        write_attempts: list[str] = []
+        async def writer(doc):
+            slug = doc["data"]["slug"]
+            write_attempts.append(slug)
+            if slug == "slug-1":
+                raise RuntimeError("simulated UNIQUE violation")
+
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=llm_unique,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert len(write_attempts) == 2
+        # UNIQUE violation from candidate_writer → io_error bucket.
+        assert result.candidates_skipped_io_error == 1
+        assert result.candidates_skipped_distill_error == 0
+        assert result.candidates_written == 1
+
+
+# ── run_label thread-through (audit handle) ───────────────────────
+
+
+@pytest.mark.unit
+class TestForgeRunLabel:
+    """Every Forge tick carries an explicit ``run_label`` that
+    propagates onto every candidate's ``origin.run_id`` so an
+    operator inspecting the Inbox can trace a card back to the
+    invocation that minted it."""
+
+    def _patch_build(self, monkeypatch, traces):
+        async def fake_build(*_args, **_kwargs):
+            return list(traces)
+        import core_api.services.forge.forge_service as svc
+        monkeypatch.setattr(svc, "build_session_traces", fake_build)
+
+    @pytest.mark.asyncio
+    async def test_run_label_lands_on_result(self, monkeypatch):
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            run_label="forge-cron-20260607T1845",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert result.run_label == "forge-cron-20260607T1845"
+
+    @pytest.mark.asyncio
+    async def test_run_label_stamped_on_every_candidate(self, monkeypatch):
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        await run_forge_distill(
+            _MockDb(),
+            run_label="forge-cron-acme-20260607T1845",
+            tenant_id="acme", fleet_id="ops",
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+            candidate_writer=writer,
+        )
+        assert len(captured) == 1
+        # Every candidate carries the label on origin.run_id — NOT None.
+        assert captured[0]["data"]["origin"]["run_id"] == "forge-cron-acme-20260607T1845"
+
+
+# ── No-overwrite guard (status_checker) ────────────────────────────
+
+
+@pytest.mark.unit
+class TestForgeStatusCheckerGuard:
+    """``status_checker`` is the no-overwrite guard. When the target
+    slug already exists with a status that ISN'T ``candidate``,
+    Forge skips the write (operator-curated state must not be
+    silently clobbered by a re-mining run).
+
+    Re-mining over an existing ``candidate`` (or no doc at all) IS
+    allowed — that's the legitimate refine-the-candidate path."""
+
+    def _patch_build(self, monkeypatch, traces):
+        async def fake_build(*_args, **_kwargs):
+            return list(traces)
+        import core_api.services.forge.forge_service as svc
+        monkeypatch.setattr(svc, "build_session_traces", fake_build)
+
+    def _kw(self):
+        return dict(
+            run_label="test-run",
+            tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+        )
+
+    @pytest.mark.asyncio
+    async def test_active_target_skipped(self, monkeypatch):
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        # status_checker reports the target is already 'active' —
+        # operator-approved. Don't clobber.
+        async def existing_active(_t, _c, _d): return "active"
+        result = await run_forge_distill(
+            _MockDb(),
+            candidate_writer=writer,
+            status_checker=existing_active,
+            **self._kw(),
+        )
+        assert result.candidates_skipped_existing == 1
+        assert result.candidates_written == 0
+        assert captured == []
+
+    @pytest.mark.parametrize("status", ["rejected", "quarantined", "stale", "deprecated"])
+    @pytest.mark.asyncio
+    async def test_terminal_states_skipped(self, monkeypatch, status):
+        # Any non-candidate status counts: rejected (poison-flagged
+        # by operator), quarantined (Sentinel), stale (drift),
+        # deprecated. None of these should be re-overwritten by Forge.
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        async def existing(*_): return status
+        result = await run_forge_distill(
+            _MockDb(),
+            candidate_writer=writer,
+            status_checker=existing,
+            **self._kw(),
+        )
+        assert result.candidates_skipped_existing == 1
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_existing_candidate_is_re_minable(self, monkeypatch):
+        # Re-mining over an existing ``candidate`` IS the legitimate
+        # refine path — Forge should write.
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        async def existing_candidate(*_): return "candidate"
+        result = await run_forge_distill(
+            _MockDb(),
+            candidate_writer=writer,
+            status_checker=existing_candidate,
+            **self._kw(),
+        )
+        assert result.candidates_skipped_existing == 0
+        assert result.candidates_written == 1
+        assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_existing_doc_writes_normally(self, monkeypatch):
+        # status_checker returns None → no existing doc → write.
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        async def no_existing(*_): return None
+        result = await run_forge_distill(
+            _MockDb(),
+            candidate_writer=writer,
+            status_checker=no_existing,
+            **self._kw(),
+        )
+        assert result.candidates_written == 1
+        assert result.candidates_skipped_existing == 0
+
+    @pytest.mark.asyncio
+    async def test_status_checker_optional_disables_guard(self, monkeypatch):
+        # status_checker=None (default) means no guard — every
+        # candidate gets written. Eval harness path.
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            candidate_writer=writer,
+            # status_checker omitted entirely
+            **self._kw(),
+        )
+        assert result.candidates_written == 1
+        assert result.candidates_skipped_existing == 0
+
+    @pytest.mark.asyncio
+    async def test_candidate_doc_carries_content_hash(self, monkeypatch):
+        """The Forge writer bypasses the SF-002 validator (Forge runs
+        through the storage client directly, not the HTTP route), so
+        ``_distill_cluster`` must stamp ``content_hash`` itself.
+        Downstream consumers (kind=update hash-binding, lifecycle
+        audits, Phase-4 v2-diff cards) rely on the field being
+        present and matching ``sha256(content.encode('utf-8'))``."""
+        import hashlib
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        await run_forge_distill(
+            _MockDb(),
+            candidate_writer=writer,
+            **self._kw(),
+        )
+        assert len(captured) == 1
+        doc = captured[0]["data"]
+        assert "content_hash" in doc
+        assert doc["content_hash"].startswith("sha256:")
+        # Hash matches the content byte-for-byte.
+        expected = "sha256:" + hashlib.sha256(doc["content"].encode("utf-8")).hexdigest()
+        assert doc["content_hash"] == expected
+
+    @pytest.mark.asyncio
+    async def test_candidate_doc_carries_scan_result(self, monkeypatch):
+        """Sentinel pre-scan result must be on every Forge candidate —
+        the Inbox card renders ``data.scan.findings`` in Phase 2 and
+        a missing field would crash the render. Phase-0 stub returns
+        ``state='clean'`` so candidates pass through without flag."""
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        await run_forge_distill(
+            _MockDb(),
+            candidate_writer=writer,
+            **self._kw(),
+        )
+        doc = captured[0]["data"]
+        assert "scan" in doc
+        # Phase-0 stub returns clean / 0 / 0 / 0 / [].
+        assert doc["scan"]["state"] == "clean"
+        assert doc["scan"]["critical"] == 0
+        assert doc["scan"]["warn"] == 0
+        assert doc["scan"]["info"] == 0
+        assert doc["scan"]["findings"] == []
+
+    @pytest.mark.asyncio
+    async def test_sentinel_fatal_finding_increments_sentinel_counter(self, monkeypatch):
+        """A fatal Sentinel finding (path violation / hard size cap)
+        must abort the write — but increment the dedicated
+        ``candidates_skipped_sentinel`` counter, NOT
+        ``candidates_skipped_poisoned``. The two failure modes look
+        identical from "did the write happen?" angle but represent
+        different operator concerns: poisoned = rejected-fingerprint
+        cooloff memory working as designed; sentinel = the corpus
+        is producing content that fails the content-shape scanner.
+        Conflating them in the run summary blinds operators to
+        whichever signal is climbing."""
+        from core_api.services.forge import sentinel_scan
+        from core_api.services.forge.sentinel_scan import (
+            ScanFinding,
+            ScanResult,
+            _now_iso,
+        )
+
+        async def fatal_scan(_data, *, mode):
+            return ScanResult(
+                state="failed",
+                scanned_at=_now_iso(),
+                critical=1,
+                warn=0,
+                info=0,
+                findings=(
+                    ScanFinding(
+                        code="path_violation",
+                        severity="critical",
+                        message="absolute path in support_files",
+                        fatal=True,
+                    ),
+                ),
+            )
+
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        monkeypatch.setattr(sentinel_scan, "scan_skill_doc", fatal_scan)
+        # forge_service imported the symbol — also monkeypatch the
+        # module's local binding.
+        import core_api.services.forge.forge_service as svc
+        monkeypatch.setattr(svc, "scan_skill_doc", fatal_scan)
+        result = await run_forge_distill(
+            _MockDb(),
+            candidate_writer=writer,
+            **self._kw(),
+        )
+        # Sentinel-fatal lands in its OWN bucket — poisoned-fingerprint
+        # bucket is untouched.
+        assert result.candidates_skipped_sentinel == 1
+        assert result.candidates_skipped_poisoned == 0
+        assert result.candidates_written == 0
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_candidate_doc_ids_contains_namespaced_doc_id(self, monkeypatch):
+        """``ForgeRunResult.candidate_doc_ids`` must carry the full
+        ``forge/<slug>`` doc_id, not the bare slug. The slug alone
+        wouldn't match the (tenant, collection, doc_id) primary key
+        in ``documents`` for follow-up lookups (eval harness, Phase 2
+        inbox query, etc.)."""
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            _MockDb(),
+            candidate_writer=writer,
+            **self._kw(),
+        )
+        assert result.candidates_written == 1
+        assert len(result.candidate_doc_ids) == 1
+        # Carries the namespace prefix.
+        assert result.candidate_doc_ids[0].startswith("forge/")
+        # AND matches the doc that was actually written.
+        assert result.candidate_doc_ids[0] == captured[0]["doc_id"]
+        # Defensive: NOT just the bare slug.
+        assert result.candidate_doc_ids[0] != captured[0]["data"]["slug"]
+
+    @pytest.mark.asyncio
+    async def test_status_checker_exception_skips_cluster(self, monkeypatch):
+        # If the checker itself crashes (e.g. transient DB error
+        # talking to the storage layer), DON'T treat that as
+        # permission to write — skip the cluster + increment the
+        # error counter. Belt-and-braces: 'unknown existing state'
+        # is a safer default than 'assume nothing exists'.
+        self._patch_build(monkeypatch, _passing_traces(4))
+        captured, writer = _capture_writer()
+        async def boom(*_): raise RuntimeError("simulated storage hiccup")
+        result = await run_forge_distill(
+            _MockDb(),
+            candidate_writer=writer,
+            status_checker=boom,
+            **self._kw(),
+        )
+        assert result.candidates_written == 0
+        # status_checker exception is a storage-layer failure →
+        # io_error bucket, NOT distill_error.
+        assert result.candidates_skipped_io_error == 1
+        assert result.candidates_skipped_distill_error == 0
+
+
+# ── Determinism: same lake state → same fingerprint ───────────────
+
+
+@pytest.mark.unit
+class TestForgeDeterminism:
+    """The whole Phase-1 stability story depends on the Forge run
+    being reproducible against an unchanged lake. This test pins
+    that the candidate's cluster_fingerprint is identical across
+    two back-to-back runs over the same inputs."""
+
+    def _patch_build(self, monkeypatch, traces):
+        async def fake_build(*_args, **_kwargs):
+            return list(traces)
+        import core_api.services.forge.forge_service as svc
+        monkeypatch.setattr(svc, "build_session_traces", fake_build)
+
+    @pytest.mark.asyncio
+    async def test_two_runs_same_fingerprint(self, monkeypatch):
+        traces = _passing_traces(4)
+        self._patch_build(monkeypatch, traces)
+        cap1, w1 = _capture_writer()
+        cap2, w2 = _capture_writer()
+        kw = dict(
+            run_label="test-determinism-run",
+            tenant_id="t1", fleet_id="f1",
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=_poison_never,
+        )
+        await run_forge_distill(_MockDb(), candidate_writer=w1, **kw)
+        await run_forge_distill(_MockDb(), candidate_writer=w2, **kw)
+        assert len(cap1) == 1 and len(cap2) == 1
+        fp1 = cap1[0]["data"]["cluster_fingerprint"]
+        fp2 = cap2[0]["data"]["cluster_fingerprint"]
+        assert fp1 == fp2  # cluster identity is stable across runs

--- a/tests/test_forge_eval_harness.py
+++ b/tests/test_forge_eval_harness.py
@@ -1,0 +1,450 @@
+"""Forge Phase-1 eval harness (Skill Factory SF-105).
+
+Measures the Phase-1 acceptance gates against three hand-labeled
+synthetic fleets:
+
+  * **Stability** — under cluster *growth* (new traces joining an
+    existing cluster without moving its center) the fingerprint
+    of each pre-existing cluster MUST be unchanged. Plan §8: ≥99%
+    stability rate.
+  * **Cluster precision** — fraction of emitted-cluster members
+    whose ground-truth label matches the cluster's dominant
+    label. Plan §15 Phase 1: ≥70%.
+  * **Cluster recall** — fraction of ground-truth clusters that
+    were detected by Forge (≥50% of their members captured by some
+    emitted cluster). Plan §15 Phase 1: ≥60%.
+
+Marked ``@pytest.mark.unit`` because the harness is pure CPU —
+no DB, no LLM, no network — deterministic across machines. The
+quality measurements are integration-grade *semantically* (they
+gate Phase-1 acceptance) but the EXECUTION is pure-unit. Marking
+them ``unit`` also lets ``tests/conftest.py``'s autouse DB
+fixture skip its setup for this file (it triggers DB connect for
+non-unit tests).
+
+Fixture fleets:
+
+  A. "eToro-style devops" — 3 clean, well-separated clusters
+     (deploy-eu-west, brand-guidelines, oncall) + 1 noise trace.
+  B. "Mixed security/dev with peripheral overlap" — 3 clusters
+     where each cluster shares 1 peripheral entity with another
+     (the realistic case where strict thresholds matter).
+  C. "Variable cluster sizes" — small (3) + medium (6) + large
+     (10) clusters in one fleet; tests gate robustness across
+     volume regimes.
+
+Add more fixtures here as we observe real-fleet failures during
+Phase 1 dry-runs against eToro production.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from core_api.services.forge.forge_service import (
+    ForgeConfig,
+    _cluster_by_entity_overlap,
+    _gate_clusters,
+    run_forge_distill,
+)
+from core_api.services.session_trace import SessionTraceRow
+
+
+# ── Fleet fixture builder ─────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _TraceSpec:
+    """Hand-labeled trace spec. ``true_cluster`` is the ground-truth
+    cluster id — Forge never sees it; the eval harness uses it to
+    score precision/recall."""
+
+    run_id: str
+    agent_id: str
+    outcome: str  # success | failure | unknown
+    entity_ids: tuple[str, ...]
+    memory_ids: tuple[str, ...]
+    true_cluster: str  # ground-truth label
+
+
+@dataclass(frozen=True)
+class _Fleet:
+    name: str
+    traces: tuple[_TraceSpec, ...]
+    # Mapping ground-truth cluster id → expected min member count.
+    # The harness uses this to weight recall.
+    expected_clusters: dict[str, int] = field(default_factory=dict)
+
+
+def _spec_to_row(spec: _TraceSpec) -> SessionTraceRow:
+    return SessionTraceRow(
+        tenant_id="eval-tenant",
+        fleet_id="eval-fleet",
+        run_id=spec.run_id,
+        agent_id=spec.agent_id,
+        outcome_label=spec.outcome,
+        memory_ids=list(spec.memory_ids),
+        entity_ids=list(spec.entity_ids),
+        signals_summary={},
+        started_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        ended_at=datetime(2026, 5, 1, 1, tzinfo=timezone.utc),
+        goal_phrase=None,
+    )
+
+
+# ── Fleet A: clean separation (3 clusters + 1 noise) ──────────────
+
+_FLEET_A = _Fleet(
+    name="A_clean_separation",
+    traces=tuple(
+        # Cluster: deploy-eu-west (4 traces, 4 distinct agents)
+        [
+            _TraceSpec(f"run-deploy-{i}", f"agent-deploy-{i}", "success",
+                       ("deploy", "eu-west", "step7", "dns"),
+                       (f"deploy-m{i}-1", f"deploy-m{i}-2"),
+                       "deploy_eu_west")
+            for i in range(4)
+        ]
+        +
+        # Cluster: brand-guidelines (3 traces, 3 distinct agents)
+        [
+            _TraceSpec(f"run-brand-{i}", f"agent-brand-{i}", "success",
+                       ("brand", "tokens", "design-system", "typography"),
+                       (f"brand-m{i}-1",),
+                       "brand_guidelines")
+            for i in range(3)
+        ]
+        +
+        # Cluster: oncall (3 traces, 3 distinct agents)
+        [
+            _TraceSpec(f"run-oncall-{i}", f"agent-oncall-{i}", "success",
+                       ("oncall", "alert", "pager", "incident"),
+                       (f"oncall-m{i}-1",),
+                       "oncall")
+            for i in range(3)
+        ]
+        +
+        # Noise: 1 trace with disjoint entities
+        [
+            _TraceSpec("run-noise", "agent-noise", "success",
+                       ("isolated-entity",),
+                       ("noise-m1",),
+                       "noise")
+        ]
+    ),
+    expected_clusters={"deploy_eu_west": 4, "brand_guidelines": 3, "oncall": 3},
+)
+
+
+# ── Fleet B: peripheral overlap ───────────────────────────────────
+
+_FLEET_B = _Fleet(
+    name="B_peripheral_overlap",
+    traces=tuple(
+        # Cluster: security scan (4 traces) — shares 1 peripheral
+        # entity "monitoring" with the next cluster.
+        [
+            _TraceSpec(f"run-sec-{i}", f"agent-sec-{i}", "success",
+                       ("scan", "vuln", "cve", "patch", "monitoring"),
+                       (f"sec-m{i}-1",),
+                       "security_scan")
+            for i in range(4)
+        ]
+        +
+        # Cluster: monitoring-deploy (4 traces) — shares "monitoring" with sec.
+        [
+            _TraceSpec(f"run-mon-{i}", f"agent-mon-{i}", "success",
+                       ("monitoring", "alert", "grafana", "dashboard"),
+                       (f"mon-m{i}-1",),
+                       "monitoring_deploy")
+            for i in range(4)
+        ]
+        +
+        # Cluster: pure-product (3 traces) — fully disjoint.
+        [
+            _TraceSpec(f"run-prod-{i}", f"agent-prod-{i}", "success",
+                       ("ab-test", "experiment", "control", "variant"),
+                       (f"prod-m{i}-1",),
+                       "product_ab_test")
+            for i in range(3)
+        ]
+    ),
+    expected_clusters={
+        "security_scan": 4,
+        "monitoring_deploy": 4,
+        "product_ab_test": 3,
+    },
+)
+
+
+# ── Fleet C: variable cluster sizes ───────────────────────────────
+
+_FLEET_C = _Fleet(
+    name="C_variable_sizes",
+    traces=tuple(
+        # Small: 3 traces, 3 agents
+        [
+            _TraceSpec(f"run-S-{i}", f"agent-S-{i}", "success",
+                       ("small-A", "small-B", "small-C"),
+                       (f"S-m{i}-1",),
+                       "small_cluster")
+            for i in range(3)
+        ]
+        +
+        # Medium: 6 traces, 4 agents (one agent appears twice)
+        [
+            _TraceSpec(f"run-M-{i}", f"agent-M-{min(i, 3)}", "success",
+                       ("medium-A", "medium-B", "medium-C", "medium-D"),
+                       (f"M-m{i}-1", f"M-m{i}-2"),
+                       "medium_cluster")
+            for i in range(6)
+        ]
+        +
+        # Large: 10 traces, 5 agents
+        [
+            _TraceSpec(f"run-L-{i}", f"agent-L-{i % 5}", "success",
+                       ("large-A", "large-B", "large-C", "large-D", "large-E"),
+                       (f"L-m{i}-1",),
+                       "large_cluster")
+            for i in range(10)
+        ]
+    ),
+    expected_clusters={
+        "small_cluster": 3,
+        "medium_cluster": 6,
+        "large_cluster": 10,
+    },
+)
+
+
+ALL_FLEETS = (_FLEET_A, _FLEET_B, _FLEET_C)
+
+
+# ── Metric helpers ────────────────────────────────────────────────
+
+
+def _emitted_clusters(
+    fleet: _Fleet,
+    *,
+    jaccard_threshold: float = 0.4,
+) -> list[list[_TraceSpec]]:
+    """Run Forge's clustering against the fleet and return the
+    cluster groupings as lists of the ORIGINAL TraceSpecs (so we
+    can read each trace's ground-truth label later)."""
+    rows = [_spec_to_row(s) for s in fleet.traces]
+    clusters_of_rows = _cluster_by_entity_overlap(
+        rows, jaccard_threshold=jaccard_threshold
+    )
+    # Build a row.run_id → spec map for label lookup.
+    by_run = {s.run_id: s for s in fleet.traces}
+    return [[by_run[r.run_id] for r in cluster] for cluster in clusters_of_rows]
+
+
+def _cluster_precision(emitted: list[list[_TraceSpec]]) -> float:
+    """Per emitted cluster, the dominant ground-truth label's
+    share. Averaged across clusters."""
+    if not emitted:
+        return 0.0
+    shares: list[float] = []
+    for cluster in emitted:
+        if not cluster:
+            continue
+        labels = [t.true_cluster for t in cluster]
+        dominant_count = max(labels.count(lbl) for lbl in set(labels))
+        shares.append(dominant_count / len(cluster))
+    return sum(shares) / len(shares) if shares else 0.0
+
+
+def _cluster_recall(
+    fleet: _Fleet,
+    emitted: list[list[_TraceSpec]],
+    *,
+    capture_threshold: float = 0.5,
+) -> float:
+    """Fraction of ground-truth clusters where SOME emitted cluster
+    captures ≥``capture_threshold`` of its members."""
+    detected = 0
+    for gt_label, expected_size in fleet.expected_clusters.items():
+        if expected_size == 0:
+            continue
+        max_captured = 0
+        for cluster in emitted:
+            captured = sum(1 for t in cluster if t.true_cluster == gt_label)
+            max_captured = max(max_captured, captured)
+        if max_captured / expected_size >= capture_threshold:
+            detected += 1
+    total = len(fleet.expected_clusters)
+    return detected / total if total else 0.0
+
+
+def _stability_rate(fleet: _Fleet) -> float:
+    """Run clustering twice on the same fleet — fingerprints of
+    emitted clusters MUST match across runs. Then run a third time
+    after adding 1 'extension' trace per cluster (an extra trace
+    sharing the cluster's dominant entities) — fingerprints of
+    pre-existing clusters MUST stay stable. Returns the fraction of
+    runs that agree.
+    """
+    # Same-input determinism.
+    fps_run_1 = _cluster_fingerprints(fleet.traces)
+    fps_run_2 = _cluster_fingerprints(fleet.traces)
+    same_input_stable = fps_run_1 == fps_run_2
+
+    # Cluster-growth stability: add a single trace per cluster that
+    # carries the cluster's dominant entities — should join the
+    # existing cluster and NOT move its top-K entity set.
+    grown_traces = list(fleet.traces)
+    for gt_label in fleet.expected_clusters:
+        # Find the entities of the cluster's first member.
+        first = next(t for t in fleet.traces if t.true_cluster == gt_label)
+        grown_traces.append(
+            _TraceSpec(
+                run_id=f"{gt_label}-extension-trace",
+                agent_id=f"{gt_label}-extension-agent",
+                outcome="success",
+                entity_ids=first.entity_ids,
+                memory_ids=(f"{gt_label}-ext-m1",),
+                true_cluster=gt_label,
+            )
+        )
+    fps_run_3 = _cluster_fingerprints(tuple(grown_traces))
+
+    # Stability across the 3 runs: count fingerprints that survive
+    # all three executions divided by the count seen in run 1.
+    surviving = fps_run_1 & fps_run_2 & fps_run_3
+    base = max(len(fps_run_1), 1)
+    rate = len(surviving) / base
+    # Same-input failures (fps_run_1 != fps_run_2) are catastrophic
+    # determinism bugs — treat as 0% if they happen.
+    return rate if same_input_stable else 0.0
+
+
+def _cluster_fingerprints(traces: tuple[_TraceSpec, ...]) -> set[str]:
+    """Compute the canonical fingerprint *per cluster* against the
+    given traces.
+
+    Because the SF-104 distill step is the one that fills the
+    goal_phrase / step_skeleton (LLM-derived) before the
+    fingerprint is computed, the eval harness shortcuts by using a
+    deterministic in-process substitute: the SORTED tuple of
+    cluster member entities + the cluster's dominant true_cluster
+    label. This is a *proxy* for the real fingerprint — it
+    measures whether the CLUSTER MEMBERSHIP is stable, which is
+    the precondition for fingerprint stability.
+
+    The real LLM fingerprint stability is validated in SF-103
+    invariants P1–P6; this layer validates that the upstream
+    clustering doesn't shuffle members between runs.
+    """
+    rows = [_spec_to_row(s) for s in traces]
+    clusters = _cluster_by_entity_overlap(rows, jaccard_threshold=0.4)
+    out: set[str] = set()
+    by_run = {s.run_id: s for s in traces}
+    for cluster in clusters:
+        ents = sorted({e for r in cluster for e in r.entity_ids})
+        labels = [by_run[r.run_id].true_cluster for r in cluster]
+        dominant = max(set(labels), key=labels.count)
+        # Proxy fingerprint: dominant label + entity set.
+        out.add(f"{dominant}::{','.join(ents)}")
+    return out
+
+
+# ── Phase-1 acceptance gates ──────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestPhase1AcceptanceGates:
+    """The three gates Phase-1 acceptance check ships with."""
+
+    @pytest.mark.parametrize("fleet", ALL_FLEETS, ids=lambda f: f.name)
+    def test_stability_at_least_99pct(self, fleet: _Fleet):
+        rate = _stability_rate(fleet)
+        assert rate >= 0.99, (
+            f"{fleet.name}: stability {rate:.3f} < 0.99 — clustering shuffles "
+            f"under cluster growth"
+        )
+
+    @pytest.mark.parametrize("fleet", ALL_FLEETS, ids=lambda f: f.name)
+    def test_cluster_precision_at_least_70pct(self, fleet: _Fleet):
+        emitted = _emitted_clusters(fleet)
+        precision = _cluster_precision(emitted)
+        assert precision >= 0.70, (
+            f"{fleet.name}: precision {precision:.3f} < 0.70 — emitted "
+            f"clusters mix ground-truth labels"
+        )
+
+    @pytest.mark.parametrize("fleet", ALL_FLEETS, ids=lambda f: f.name)
+    def test_cluster_recall_at_least_60pct(self, fleet: _Fleet):
+        emitted = _emitted_clusters(fleet)
+        recall = _cluster_recall(fleet, emitted)
+        assert recall >= 0.60, (
+            f"{fleet.name}: recall {recall:.3f} < 0.60 — some ground-truth "
+            f"clusters not captured"
+        )
+
+    @pytest.mark.parametrize("fleet", ALL_FLEETS, ids=lambda f: f.name)
+    def test_eligible_clusters_pass_volume_diversity_gates(self, fleet: _Fleet):
+        # Sanity: the fixtures we hand-labeled actually satisfy the
+        # auto-gates Forge will apply in production
+        # (min_cluster_size=3, min_distinct_agents=3).
+        rows = [_spec_to_row(s) for s in fleet.traces]
+        clusters = _cluster_by_entity_overlap(rows, jaccard_threshold=0.4)
+        eligible = _gate_clusters(clusters, min_cluster_size=3, min_distinct_agents=3)
+        # Fleet A and B each have 3 well-formed clusters; Fleet C
+        # has 3 (small/medium/large) — at least 2 must always make it.
+        assert len(eligible) >= 2, (
+            f"{fleet.name}: only {len(eligible)} of {len(clusters)} clusters "
+            f"survived volume+diversity gates — fixture too sparse"
+        )
+
+
+# ── Aggregate report ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestPhase1AggregateReport:
+    """A summary view across all fleets — emits a single
+    human-readable metrics table when run with ``-s``. Useful for
+    paste-into-stage-completion-report situations."""
+
+    def test_emit_aggregate_report(self, capsys):
+        rows: list[dict[str, Any]] = []
+        for fleet in ALL_FLEETS:
+            emitted = _emitted_clusters(fleet)
+            rows.append({
+                "fleet": fleet.name,
+                "n_traces": len(fleet.traces),
+                "n_emitted_clusters": len(emitted),
+                "stability_rate": round(_stability_rate(fleet), 4),
+                "cluster_precision": round(_cluster_precision(emitted), 4),
+                "cluster_recall": round(_cluster_recall(fleet, emitted), 4),
+            })
+
+        # Aggregate.
+        overall = {
+            "fleets_count": len(rows),
+            "min_stability": min(r["stability_rate"] for r in rows),
+            "min_precision": min(r["cluster_precision"] for r in rows),
+            "min_recall": min(r["cluster_recall"] for r in rows),
+        }
+
+        report = {
+            "phase_1_acceptance_gates": {
+                "stability_target": 0.99,
+                "precision_target": 0.70,
+                "recall_target": 0.60,
+            },
+            "per_fleet": rows,
+            "aggregate_min": overall,
+        }
+        print("\n" + json.dumps(report, indent=2))
+
+        # All-fleet gate must hold simultaneously.
+        assert overall["min_stability"] >= 0.99, report
+        assert overall["min_precision"] >= 0.70, report
+        assert overall["min_recall"] >= 0.60, report

--- a/tests/test_outcome_inference_signals.py
+++ b/tests/test_outcome_inference_signals.py
@@ -1,0 +1,699 @@
+"""Outcome-inference signal extractor unit tests (Skill Factory SF-101 part 1).
+
+Covers the supersession + contradiction signals — the two simplest of
+the six because they read existing memory columns directly with no
+new tables required. The remaining four signals (repeat_recall,
+terminal_memory, cross_agent_reuse, external_hook) ship in later
+substages of SF-101 and get their own tests.
+
+Pure-unit: no DB required. The signal extractors execute one SQL
+statement each via ``db.execute(text(sql), params)``; we mock the
+async DB engine to return controlled rows and assert:
+
+  - polarity, weight, memory_ids, details shape
+  - window / tenant / run_id / agent_id binding
+  - SQL is parameterised (no string-interpolated tenant_id etc.)
+  - default-weight defaults read from the registry
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core_api.services.outcome_inference import (
+    DEFAULT_SIGNAL_WEIGHTS,
+    Polarity,
+    SignalEvidence,
+    SignalKind,
+    SignalQuery,
+)
+from core_api.services.outcome_inference import (
+    contradictions,
+    cross_agent_reuse,
+    external_hooks,
+    repeat_recall,
+    supersessions,
+    terminal_memory,
+)
+
+
+# ── Mock DB harness ────────────────────────────────────────────────
+
+
+@dataclass
+class _Row:
+    """Lightweight row stand-in. The extractors access attributes by
+    name (e.g. ``row.memory_id``) — a frozen dataclass keeps that
+    contract honest at test time."""
+
+    memory_id: str | None = None
+    superseded_id: str | None = None
+    run_id: str | None = None
+    agent_id: str | None = None
+    by_id: str | None = None
+    status: str | None = None
+    content: str | None = None
+    recall_count: int | None = None
+    observed_at: datetime | None = None
+
+
+def _mock_db(rows: list[_Row]) -> MagicMock:
+    """Build a mock DB whose ``execute(...).fetchall()`` returns
+    ``rows`` synchronously. The route uses
+    ``await db.execute(...)`` so ``execute`` itself is async; the
+    proxy it returns has a sync ``.fetchall()``.
+    """
+    db = MagicMock()
+    proxy = MagicMock()
+    proxy.fetchall.return_value = rows
+    db.execute = AsyncMock(return_value=proxy)
+    return db
+
+
+def _query(**overrides) -> SignalQuery:
+    base = {
+        "tenant_id": "t1",
+        "fleet_id": None,
+        "window_start": datetime(2026, 5, 1, tzinfo=timezone.utc),
+        "window_end": datetime(2026, 5, 15, tzinfo=timezone.utc),
+        "run_id": None,
+        "agent_id": None,
+    }
+    base.update(overrides)
+    return SignalQuery(**base)
+
+
+# ── SignalEvidence + Enums sanity ─────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSignalTypes:
+    def test_signal_kind_values_stable(self):
+        # Persisted in session_traces.signals_summary JSONB — these
+        # string values must NEVER change without a migration.
+        assert SignalKind.CONTRADICTION.value == "contradiction"
+        assert SignalKind.SUPERSESSION.value == "supersession"
+        assert SignalKind.REPEAT_RECALL.value == "repeat_recall"
+        assert SignalKind.TERMINAL_MEMORY.value == "terminal_memory"
+        assert SignalKind.CROSS_AGENT_REUSE.value == "cross_agent_reuse"
+        assert SignalKind.EXTERNAL_HOOK.value == "external_hook"
+
+    def test_polarity_values_stable(self):
+        assert Polarity.SUCCESS.value == "success"
+        assert Polarity.FAILURE.value == "failure"
+        assert Polarity.NEUTRAL.value == "neutral"
+
+    def test_default_weights_in_range(self):
+        # Defensive: all weights in [0, 1].
+        for kind, w in DEFAULT_SIGNAL_WEIGHTS.items():
+            assert 0.0 <= w <= 1.0, f"{kind.value} weight {w} out of range"
+
+    def test_strong_signals_outweigh_weak(self):
+        # Plan §6: terminal-memory + external-hook are the ground-truth
+        # signals; cross-agent-reuse is the weakest informational hint.
+        assert DEFAULT_SIGNAL_WEIGHTS[SignalKind.TERMINAL_MEMORY] >= 0.85
+        assert DEFAULT_SIGNAL_WEIGHTS[SignalKind.EXTERNAL_HOOK] >= 0.8
+        assert (
+            DEFAULT_SIGNAL_WEIGHTS[SignalKind.CROSS_AGENT_REUSE]
+            < DEFAULT_SIGNAL_WEIGHTS[SignalKind.CONTRADICTION]
+        )
+
+    def test_evidence_jsonb_shape(self):
+        ev = SignalEvidence(
+            kind=SignalKind.SUPERSESSION,
+            polarity=Polarity.FAILURE,
+            weight=0.7,
+            memory_ids=("m-1", "m-2"),
+            details={"superseded_by_memory_id": "m-3"},
+            observed_at=datetime(2026, 5, 10, 12, 0, tzinfo=timezone.utc),
+        )
+        j = ev.as_jsonb()
+        assert j["polarity"] == "failure"
+        assert j["weight"] == 0.7
+        assert j["memory_ids"] == ["m-1", "m-2"]
+        assert j["details"] == {"superseded_by_memory_id": "m-3"}
+        assert j["observed_at"].startswith("2026-05-10T12:00")
+
+
+# ── Supersession extractor ────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSupersessionExtractor:
+    def test_module_exposes_protocol_attrs(self):
+        assert supersessions.kind == SignalKind.SUPERSESSION
+        assert callable(supersessions.extract)
+
+    @pytest.mark.asyncio
+    async def test_no_rows_returns_empty(self):
+        db = _mock_db(rows=[])
+        out = await supersessions.extract(_query(), db)
+        assert out == []
+        # Still issued the query (sanity: not short-circuiting on
+        # caller side either).
+        db.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_emits_failure_polarity_on_superseded_trace(self):
+        rows = [
+            _Row(
+                superseded_id="old-mem-1",
+                run_id="run-A",
+                agent_id="sasha",
+                by_id="new-mem-1",
+                observed_at=datetime(2026, 5, 5, tzinfo=timezone.utc),
+            )
+        ]
+        out = await supersessions.extract(_query(), _mock_db(rows))
+        assert len(out) == 1
+        ev = out[0]
+        assert ev.kind == SignalKind.SUPERSESSION
+        assert ev.polarity == Polarity.FAILURE
+        assert ev.weight == DEFAULT_SIGNAL_WEIGHTS[SignalKind.SUPERSESSION]
+        # memory_ids points at the SUPERSEDED memory (the bad one), not
+        # the corrective one — that's the trace that paid the failure.
+        assert ev.memory_ids == ("old-mem-1",)
+        assert ev.details["superseded_memory_id"] == "old-mem-1"
+        assert ev.details["superseded_by_memory_id"] == "new-mem-1"
+        assert ev.details["run_id"] == "run-A"
+        assert ev.details["agent_id"] == "sasha"
+        assert ev.observed_at == datetime(2026, 5, 5, tzinfo=timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_one_evidence_per_supersession(self):
+        rows = [
+            _Row(superseded_id="m1", run_id="r1", agent_id="a1", by_id="n1",
+                 observed_at=datetime(2026, 5, 3, tzinfo=timezone.utc)),
+            _Row(superseded_id="m2", run_id="r2", agent_id="a2", by_id="n2",
+                 observed_at=datetime(2026, 5, 4, tzinfo=timezone.utc)),
+            _Row(superseded_id="m3", run_id="r1", agent_id="a1", by_id="n3",
+                 observed_at=datetime(2026, 5, 7, tzinfo=timezone.utc)),
+        ]
+        out = await supersessions.extract(_query(), _mock_db(rows))
+        assert len(out) == 3
+        # Each evidence keyed by the superseded memory; same trace can
+        # accumulate multiple firings (e.g. an agent that wrote 3 bad
+        # claims all gets later contradicted).
+        assert {e.memory_ids[0] for e in out} == {"m1", "m2", "m3"}
+
+    @pytest.mark.asyncio
+    async def test_sql_params_bind_query_inputs(self):
+        db = _mock_db(rows=[])
+        q = _query(
+            tenant_id="acme",
+            fleet_id="ops-fleet",
+            run_id="r-specific",
+            agent_id="alice",
+        )
+        await supersessions.extract(q, db)
+        # Inspect the bind params handed to execute(). The first
+        # positional arg is the text() SQL; the second is the params
+        # dict.
+        args, _ = db.execute.call_args
+        sql_clause, params = args
+        assert params["tenant_id"] == "acme"
+        assert params["fleet_id"] == "ops-fleet"
+        assert params["run_id"] == "r-specific"
+        assert params["agent_id"] == "alice"
+        assert params["w_start"] == q.window_start
+        assert params["w_end"] == q.window_end
+        # Belt-and-braces: tenant_id MUST be a parameter, NOT
+        # string-interpolated into the SQL.
+        assert "acme" not in str(sql_clause)
+
+    @pytest.mark.asyncio
+    async def test_fleet_filter_applies_to_old_memory_too(self):
+        """The FAILURE polarity lands on the SUPERSEDED memory's
+        trace. A fleet-scoped scan must filter on the OLD memory's
+        fleet_id, not just the corrective one — otherwise an
+        agent in fleet A correcting a memory written by fleet B
+        would erroneously land failure evidence on fleet B's trace
+        inside a fleet-A scan."""
+        db = _mock_db(rows=[])
+        await supersessions.extract(_query(fleet_id="A"), db)
+        args, _ = db.execute.call_args
+        sql_clause, _ = args
+        sql_text = str(sql_clause).lower()
+        # BOTH new_mem.fleet_id AND old_mem.fleet_id must be
+        # checked. Pin the literal presence of both clauses so a
+        # refactor can't silently drop one.
+        assert "new_mem.fleet_id" in sql_text
+        assert "old_mem.fleet_id" in sql_text
+
+
+# ── Contradiction extractor ───────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestContradictionExtractor:
+    def test_module_exposes_protocol_attrs(self):
+        assert contradictions.kind == SignalKind.CONTRADICTION
+        assert callable(contradictions.extract)
+
+    def test_contradicted_statuses_match_detector_output(self):
+        # The detector writes both "outdated" (RDF path) and
+        # "conflicted" (semantic path). Drift between these two sets
+        # would silently miss whole categories of contradictions —
+        # this assertion catches that at test time.
+        assert "outdated" in contradictions.CONTRADICTED_STATUSES
+        assert "conflicted" in contradictions.CONTRADICTED_STATUSES
+
+    @pytest.mark.asyncio
+    async def test_no_rows_returns_empty(self):
+        out = await contradictions.extract(_query(), _mock_db(rows=[]))
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_outdated_status_emits_failure(self):
+        rows = [
+            _Row(
+                memory_id="mem-1",
+                run_id="run-X",
+                agent_id="mira",
+                status="outdated",
+                observed_at=datetime(2026, 5, 6, tzinfo=timezone.utc),
+            )
+        ]
+        out = await contradictions.extract(_query(), _mock_db(rows))
+        assert len(out) == 1
+        ev = out[0]
+        assert ev.kind == SignalKind.CONTRADICTION
+        assert ev.polarity == Polarity.FAILURE
+        assert ev.weight == DEFAULT_SIGNAL_WEIGHTS[SignalKind.CONTRADICTION]
+        assert ev.memory_ids == ("mem-1",)
+        assert ev.details["memory_id"] == "mem-1"
+        assert ev.details["status"] == "outdated"
+        assert ev.details["run_id"] == "run-X"
+        assert ev.details["agent_id"] == "mira"
+
+    @pytest.mark.asyncio
+    async def test_conflicted_status_emits_failure(self):
+        rows = [
+            _Row(
+                memory_id="mem-2",
+                run_id="run-Y",
+                agent_id="kai",
+                status="conflicted",
+                observed_at=datetime(2026, 5, 7, tzinfo=timezone.utc),
+            )
+        ]
+        out = await contradictions.extract(_query(), _mock_db(rows))
+        assert out[0].details["status"] == "conflicted"
+        assert out[0].polarity == Polarity.FAILURE
+
+    @pytest.mark.asyncio
+    async def test_sql_uses_status_array_bind(self):
+        db = _mock_db(rows=[])
+        await contradictions.extract(_query(tenant_id="acme"), db)
+        args, _ = db.execute.call_args
+        sql_clause, params = args
+        # The status set should be bound as a list (PG receives a
+        # text[] for ``= ANY(...)``), not interpolated.
+        assert params["contradicted_statuses"] == list(
+            contradictions.CONTRADICTED_STATUSES
+        )
+        # The tenant_id must not be string-interpolated either.
+        assert "acme" not in str(sql_clause)
+
+    @pytest.mark.asyncio
+    async def test_run_and_agent_filter_pass_through(self):
+        db = _mock_db(rows=[])
+        await contradictions.extract(
+            _query(run_id="run-Z", agent_id="alex"), db
+        )
+        _args, _ = db.execute.call_args
+        _sql, params = _args
+        assert params["run_id"] == "run-Z"
+        assert params["agent_id"] == "alex"
+
+    @pytest.mark.asyncio
+    async def test_window_boundaries_passed_as_params(self):
+        start = datetime(2026, 4, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 4, 15, tzinfo=timezone.utc)
+        db = _mock_db(rows=[])
+        await contradictions.extract(
+            _query(window_start=start, window_end=end), db
+        )
+        _args, _ = db.execute.call_args
+        _sql, params = _args
+        assert params["w_start"] == start
+        assert params["w_end"] == end
+        # The window is left-closed, right-open by SQL contract
+        # (``created_at >= w_start AND < w_end``). We assert the
+        # SQL text reflects that — drift here would silently shift
+        # outcome attribution by one tick.
+        sql_text = str(_sql)
+        assert ":w_start" in sql_text
+        assert ":w_end" in sql_text
+
+
+# ── Multi-signal independence ─────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestMultiSignalIndependence:
+    @pytest.mark.asyncio
+    async def test_signals_do_not_share_state(self):
+        # Running both extractors against unrelated rows must NOT
+        # leak between them.
+        sup_rows = [
+            _Row(superseded_id="s1", run_id="r1", agent_id="a1", by_id="n1",
+                 observed_at=datetime(2026, 5, 5, tzinfo=timezone.utc))
+        ]
+        con_rows = [
+            _Row(memory_id="c1", run_id="r2", agent_id="a2", status="outdated",
+                 observed_at=datetime(2026, 5, 6, tzinfo=timezone.utc))
+        ]
+        sup_out = await supersessions.extract(_query(), _mock_db(sup_rows))
+        con_out = await contradictions.extract(_query(), _mock_db(con_rows))
+        # Distinct kinds.
+        assert sup_out[0].kind != con_out[0].kind
+        # Distinct memory_ids surfaced.
+        assert sup_out[0].memory_ids != con_out[0].memory_ids
+        # Same polarity (both = failure), same weight ceiling for now.
+        assert sup_out[0].polarity == con_out[0].polarity == Polarity.FAILURE
+
+    @pytest.mark.asyncio
+    async def test_extractors_safe_when_observed_at_none(self):
+        # observed_at is nullable per the SignalEvidence schema; both
+        # extractors must accept a row with no observed_at without
+        # crashing. (Happens when older memories predate updated_at
+        # tracking.)
+        for mod, rows in (
+            (supersessions, [_Row(superseded_id="s", run_id="r", agent_id="a", by_id="n")]),
+            (contradictions, [_Row(memory_id="c", run_id="r", agent_id="a", status="outdated")]),
+        ):
+            out = await mod.extract(_query(), _mock_db(rows))
+            assert len(out) == 1
+            assert out[0].observed_at is None or isinstance(out[0].observed_at, datetime)
+
+
+# ── Window degenerate cases ───────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestWindowDegenerateCases:
+    @pytest.mark.asyncio
+    async def test_empty_window_returns_empty(self):
+        # window_start == window_end → no rows can satisfy
+        # ``created_at >= start AND < end``. The query still runs
+        # (Postgres returns 0 rows); our extractor returns [].
+        same = datetime(2026, 5, 10, tzinfo=timezone.utc)
+        out = await supersessions.extract(
+            _query(window_start=same, window_end=same), _mock_db(rows=[])
+        )
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_inverted_window_does_not_crash(self):
+        # Caller passing window_end < window_start is a programmer
+        # error; we don't raise, we just return [] (consistent with
+        # SQL semantics).
+        out = await contradictions.extract(
+            _query(
+                window_start=datetime(2026, 5, 10, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            ),
+            _mock_db(rows=[]),
+        )
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_wide_window_collects_all(self):
+        # A one-year window with many rows must collect every row the
+        # mock returns — the extractor does NOT impose its own LIMIT.
+        many = [
+            _Row(superseded_id=f"m{i}", run_id=f"r{i}", agent_id="a", by_id=f"n{i}",
+                 observed_at=datetime(2026, 5, 5, tzinfo=timezone.utc))
+            for i in range(50)
+        ]
+        out = await supersessions.extract(
+            _query(
+                window_start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                window_end=datetime(2027, 1, 1, tzinfo=timezone.utc),
+            ),
+            _mock_db(many),
+        )
+        assert len(out) == 50
+
+
+# ── Terminal-memory extractor + classifier ────────────────────────
+
+
+@pytest.mark.unit
+class TestTerminalMemoryClassifier:
+    """Direct tests of the classifier function (independent of DB)."""
+
+    def test_success_keyword_shipped(self):
+        from core_api.services.outcome_inference.terminal_memory import _classify
+        assert _classify("Shipped to prod") == Polarity.SUCCESS
+
+    def test_success_keyword_deployed_phrase(self):
+        from core_api.services.outcome_inference.terminal_memory import _classify
+        assert _classify("Deployed v4 to eu-west, all green") == Polarity.SUCCESS
+
+    def test_failure_keyword_blocked(self):
+        from core_api.services.outcome_inference.terminal_memory import _classify
+        assert _classify("Blocked on infra outage, will resume tomorrow") == Polarity.FAILURE
+
+    def test_failure_phrase_gave_up(self):
+        from core_api.services.outcome_inference.terminal_memory import _classify
+        assert _classify("Gave up after 4 hours of retries") == Polarity.FAILURE
+
+    def test_failure_phrase_rolled_back(self):
+        from core_api.services.outcome_inference.terminal_memory import _classify
+        assert _classify("Rolled back the change — DB grew too fast") == Polarity.FAILURE
+
+    def test_ambiguous_returns_none(self):
+        from core_api.services.outcome_inference.terminal_memory import _classify
+        # No keywords from either set.
+        assert _classify("Looked at the dashboard, thinking through next steps") is None
+
+    def test_failure_wins_over_success_in_same_text(self):
+        # Asymmetric tie-breaking rule from module docstring.
+        from core_api.services.outcome_inference.terminal_memory import _classify
+        assert _classify("Deployed but rolled back five minutes later") == Polarity.FAILURE
+
+    def test_empty_content_returns_none(self):
+        from core_api.services.outcome_inference.terminal_memory import _classify
+        assert _classify("") is None
+        assert _classify(None) is None  # type: ignore[arg-type]
+
+    def test_word_boundary_avoids_substring_false_positive(self):
+        # "preshipped" should NOT fire shipped — \b boundary.
+        from core_api.services.outcome_inference.terminal_memory import _classify
+        assert _classify("preshipped (early-access feature)") is None
+
+
+@pytest.mark.unit
+class TestTerminalMemoryExtractor:
+    def test_module_exposes_protocol_attrs(self):
+        assert terminal_memory.kind == SignalKind.TERMINAL_MEMORY
+        assert callable(terminal_memory.extract)
+
+    def test_classifier_version_tag_present(self):
+        assert terminal_memory.CLASSIFIER_VERSION.startswith("v1-")
+
+    @pytest.mark.asyncio
+    async def test_success_terminal_emits_success(self):
+        rows = [
+            _Row(
+                memory_id="m1",
+                run_id="r1",
+                agent_id="sasha",
+                content="Shipped ✓ to eu-west",
+                observed_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+            )
+        ]
+        out = await terminal_memory.extract(_query(), _mock_db(rows))
+        assert len(out) == 1
+        assert out[0].kind == SignalKind.TERMINAL_MEMORY
+        assert out[0].polarity == Polarity.SUCCESS
+        assert out[0].weight == DEFAULT_SIGNAL_WEIGHTS[SignalKind.TERMINAL_MEMORY]
+        assert out[0].details["classifier_version"] == terminal_memory.CLASSIFIER_VERSION
+        assert out[0].details["verdict"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_failure_terminal_emits_failure(self):
+        rows = [
+            _Row(memory_id="m1", run_id="r1", agent_id="kai",
+                 content="Blocked — DNS resolver hangs",
+                 observed_at=datetime(2026, 5, 10, tzinfo=timezone.utc))
+        ]
+        out = await terminal_memory.extract(_query(), _mock_db(rows))
+        assert out[0].polarity == Polarity.FAILURE
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_terminal_not_emitted(self):
+        # Classifier returns None → no evidence at all.
+        rows = [
+            _Row(memory_id="m1", run_id="r1", agent_id="a",
+                 content="Looking into it.",
+                 observed_at=datetime(2026, 5, 10, tzinfo=timezone.utc))
+        ]
+        out = await terminal_memory.extract(_query(), _mock_db(rows))
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_distinct_on_in_sql(self):
+        # SQL must use DISTINCT ON (run_id, agent_id) so we only
+        # classify the LAST memory of each session — not every memory
+        # in the window that happens to contain "shipped".
+        db = _mock_db(rows=[])
+        await terminal_memory.extract(_query(), db)
+        args, _ = db.execute.call_args
+        sql_clause, _ = args
+        sql_text = str(sql_clause).lower()
+        assert "distinct on" in sql_text
+        assert "(m.run_id, m.agent_id)" in sql_text
+
+
+# ── Cross-agent-reuse extractor ───────────────────────────────────
+
+
+@pytest.mark.unit
+class TestCrossAgentReuseExtractor:
+    def test_module_exposes_protocol_attrs(self):
+        assert cross_agent_reuse.kind == SignalKind.CROSS_AGENT_REUSE
+        assert callable(cross_agent_reuse.extract)
+
+    def test_threshold_constant_is_conservative(self):
+        # Documented in module: 5 total recalls ~ 3 distinct agents.
+        # Tighter than 3 to compensate for the inflation by self-recalls.
+        assert cross_agent_reuse.DEFAULT_RECALL_COUNT_THRESHOLD >= 3
+
+    @pytest.mark.asyncio
+    async def test_no_rows_returns_empty(self):
+        out = await cross_agent_reuse.extract(_query(), _mock_db(rows=[]))
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_load_bearing_emits_neutral(self):
+        rows = [
+            _Row(
+                memory_id="m1",
+                run_id="r1",
+                agent_id="sasha",
+                recall_count=8,
+                observed_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+            )
+        ]
+        out = await cross_agent_reuse.extract(_query(), _mock_db(rows))
+        assert len(out) == 1
+        # Cross-agent reuse is NEUTRAL — it doesn't claim the
+        # originating trace succeeded or failed, only that the
+        # artifact is being reused.
+        assert out[0].polarity == Polarity.NEUTRAL
+        assert out[0].weight == DEFAULT_SIGNAL_WEIGHTS[SignalKind.CROSS_AGENT_REUSE]
+        assert out[0].details["recall_count"] == 8
+        assert out[0].details["threshold"] == cross_agent_reuse.DEFAULT_RECALL_COUNT_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_threshold_is_passed_in_sql_params(self):
+        db = _mock_db(rows=[])
+        await cross_agent_reuse.extract(_query(), db)
+        args, _ = db.execute.call_args
+        _sql, params = args
+        assert params["threshold"] == cross_agent_reuse.DEFAULT_RECALL_COUNT_THRESHOLD
+
+
+# ── Repeat-recall extractor (MVP stub) ────────────────────────────
+
+
+@pytest.mark.unit
+class TestRepeatRecallStub:
+    def test_module_exposes_protocol_attrs(self):
+        assert repeat_recall.kind == SignalKind.REPEAT_RECALL
+        assert callable(repeat_recall.extract)
+
+    @pytest.mark.asyncio
+    async def test_mvp_always_returns_empty(self):
+        # MVP: until Phase 2 ships the recall-log table, the
+        # extractor returns []. Documented behavior; tests pin it so
+        # an accidental flip can't slip through.
+        out = await repeat_recall.extract(_query(), _mock_db(rows=[]))
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_no_db_calls_in_stub(self):
+        # The stub MUST NOT issue a DB query — costless until the
+        # real implementation lands.
+        db = _mock_db(rows=[])
+        await repeat_recall.extract(_query(), db)
+        db.execute.assert_not_called()
+
+
+# ── External-hooks extractor (MVP stub) ───────────────────────────
+
+
+@pytest.mark.unit
+class TestExternalHooksStub:
+    def test_module_exposes_protocol_attrs(self):
+        assert external_hooks.kind == SignalKind.EXTERNAL_HOOK
+        assert callable(external_hooks.extract)
+
+    @pytest.mark.asyncio
+    async def test_mvp_always_returns_empty(self):
+        out = await external_hooks.extract(_query(), _mock_db(rows=[]))
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_no_db_calls_in_stub(self):
+        db = _mock_db(rows=[])
+        await external_hooks.extract(_query(), db)
+        db.execute.assert_not_called()
+
+
+# ── Registry: all 6 signals discoverable + uniquely keyed ────────
+
+
+@pytest.mark.unit
+class TestSignalRegistry:
+    """The session-trace builder will discover extractors by
+    iterating the package. These tests pin the registry so a
+    missing/renamed module shows up at test time rather than as a
+    silent missing signal in production."""
+
+    ALL_MODULES = (
+        contradictions,
+        supersessions,
+        terminal_memory,
+        cross_agent_reuse,
+        repeat_recall,
+        external_hooks,
+    )
+
+    def test_all_six_signals_exposed(self):
+        kinds = {mod.kind for mod in self.ALL_MODULES}
+        assert kinds == set(SignalKind), (
+            f"signal modules cover {sorted(k.value for k in kinds)}; "
+            f"enum lists {sorted(k.value for k in SignalKind)}"
+        )
+
+    def test_each_module_exposes_extract_coroutine(self):
+        import asyncio
+        for mod in self.ALL_MODULES:
+            assert asyncio.iscoroutinefunction(mod.extract), (
+                f"{mod.__name__}.extract must be a coroutine"
+            )
+
+    def test_kinds_are_unique(self):
+        kinds = [mod.kind for mod in self.ALL_MODULES]
+        assert len(kinds) == len(set(kinds)), "duplicate signal kinds across modules"
+
+    def test_each_module_documents_its_data_source(self):
+        # Every signal module's docstring must reference its data
+        # source ("memories.", "track_recalls", "memory_recalls", or
+        # "external") so operators reading the code at 3 AM know
+        # where to look. Catches accidentally undocumented stubs.
+        for mod in self.ALL_MODULES:
+            doc = (mod.__doc__ or "").lower()
+            assert any(
+                token in doc
+                for token in ("memories.", "track_recalls", "memory_recalls", "external",
+                              "audit", "recall_count", "contradiction", "supersedes", "phase 2", "phase 5")
+            ), f"{mod.__name__} docstring lacks data-source breadcrumb"

--- a/tests/test_session_trace_builder.py
+++ b/tests/test_session_trace_builder.py
@@ -1,0 +1,624 @@
+"""Session-trace builder unit tests (Skill Factory SF-102).
+
+Pure-unit: mocks the DB + the 6 extractor modules to exercise the
+orchestration + folding logic independently of any persistence
+layer.
+
+Coverage map:
+  - fold_outcome_label: weighted-sum, neutral-ignored, min-weight
+    threshold, asymmetric tie-handling
+  - summarize_evidence: grouping by kind, total_weight, polarity_counts
+  - build_session_traces: concurrent extractor dispatch, evidence
+    partitioning by (run_id, agent_id), persistence guard, exception
+    isolation across extractors
+  - SQL bind safety on the memory + entity queries
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core_api.services.outcome_inference import (
+    DEFAULT_SIGNAL_WEIGHTS,
+    Polarity,
+    SignalEvidence,
+    SignalKind,
+)
+from core_api.services.session_trace import (
+    MIN_TOTAL_WEIGHT_FOR_LABEL,
+    SIGNAL_MODULES,
+    SessionTraceRow,
+    build_session_traces,
+    fold_outcome_label,
+    summarize_evidence,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+def _ev(
+    kind: SignalKind,
+    polarity: Polarity,
+    *,
+    run_id: str = "r1",
+    agent_id: str = "a1",
+    weight: float | None = None,
+    memory_id: str = "m1",
+) -> SignalEvidence:
+    return SignalEvidence(
+        kind=kind,
+        polarity=polarity,
+        weight=DEFAULT_SIGNAL_WEIGHTS[kind] if weight is None else weight,
+        memory_ids=(memory_id,),
+        details={"run_id": run_id, "agent_id": agent_id, "memory_id": memory_id},
+        observed_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+    )
+
+
+@dataclass
+class _MemRow:
+    memory_id: str
+    run_id: str
+    agent_id: str
+    fleet_id: str | None
+    created_at: datetime
+
+
+@dataclass
+class _EntityRow:
+    """Mock row for the ``memory_entity_links`` SELECT.
+
+    The N+1 fix changed the SQL from "give me entity_ids for these
+    memories" (returned a flat list per call) to "give me
+    (memory_id, entity_id) pairs for these memories" (returned a
+    dict via one bulk call). The mock row now carries both columns
+    so the builder's regrouping logic can be exercised.
+    """
+
+    memory_id: str
+    entity_id: str
+
+
+def _mock_db_for_build(
+    memory_rows: list[_MemRow],
+    entity_rows: list[_EntityRow] | None = None,
+):
+    """Mock the db.execute() returning different result sets based on
+    which SQL is being executed. The builder issues:
+      - one SELECT against ``memories`` (groups by run_id/agent_id)
+      - one SELECT against ``memory_entity_links`` per trace
+      - one INSERT per trace on persist
+    """
+    if entity_rows is None:
+        entity_rows = []
+
+    call_log: list[str] = []
+
+    def make_proxy(rows):
+        p = MagicMock()
+        p.fetchall.return_value = rows
+        return p
+
+    async def execute(sql, params=None):
+        sql_text = str(sql).lower()
+        call_log.append(sql_text)
+        if "from memories" in sql_text and "memory_entity_links" not in sql_text:
+            return make_proxy(memory_rows)
+        if "from memory_entity_links" in sql_text:
+            return make_proxy(entity_rows)
+        # INSERT path returns an empty proxy.
+        return make_proxy([])
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=execute)
+    db._call_log = call_log
+    return db
+
+
+# ── fold_outcome_label ─────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestFoldOutcomeLabel:
+    def test_empty_evidence_unknown(self):
+        assert fold_outcome_label([]) == "unknown"
+
+    def test_single_strong_success_labels_success(self):
+        # Terminal-memory alone (weight 0.9) crosses min_total_weight (0.5).
+        assert fold_outcome_label([_ev(SignalKind.TERMINAL_MEMORY, Polarity.SUCCESS)]) == "success"
+
+    def test_single_strong_failure_labels_failure(self):
+        assert fold_outcome_label([_ev(SignalKind.TERMINAL_MEMORY, Polarity.FAILURE)]) == "failure"
+
+    def test_single_weak_signal_below_threshold_unknown(self):
+        # Cross-agent-reuse alone (weight 0.3) is below the 0.5 floor.
+        # But it's NEUTRAL polarity — so even at high weight wouldn't vote.
+        # Use a synthetic weak SUCCESS to test the threshold.
+        weak = _ev(SignalKind.CROSS_AGENT_REUSE, Polarity.SUCCESS, weight=0.3)
+        assert fold_outcome_label([weak]) == "unknown"
+
+    def test_neutral_evidence_does_not_vote(self):
+        # A pile of NEUTRAL (cross-agent-reuse) doesn't tip the scale.
+        evs = [_ev(SignalKind.CROSS_AGENT_REUSE, Polarity.NEUTRAL, weight=0.3) for _ in range(10)]
+        assert fold_outcome_label(evs) == "unknown"
+
+    def test_failure_outweighs_success_labels_failure(self):
+        # 1 supersession (0.7 failure) vs 1 terminal-memory (0.9 success):
+        # success wins.
+        evs = [
+            _ev(SignalKind.SUPERSESSION, Polarity.FAILURE),       # 0.7
+            _ev(SignalKind.TERMINAL_MEMORY, Polarity.SUCCESS),    # 0.9
+        ]
+        assert fold_outcome_label(evs) == "success"
+
+    def test_two_failures_outweigh_one_success(self):
+        # 0.7 + 0.7 = 1.4 failure vs 0.9 success: failure wins.
+        evs = [
+            _ev(SignalKind.SUPERSESSION, Polarity.FAILURE),
+            _ev(SignalKind.CONTRADICTION, Polarity.FAILURE),
+            _ev(SignalKind.TERMINAL_MEMORY, Polarity.SUCCESS),
+        ]
+        assert fold_outcome_label(evs) == "failure"
+
+    def test_exact_tie_returns_unknown(self):
+        # Two equal-weight signals on opposite polarities.
+        evs = [
+            _ev(SignalKind.SUPERSESSION, Polarity.FAILURE, weight=0.7),
+            _ev(SignalKind.SUPERSESSION, Polarity.SUCCESS, weight=0.7),
+        ]
+        assert fold_outcome_label(evs) == "unknown"
+
+    def test_min_weight_threshold_configurable(self):
+        # A tenant tightens the threshold; weak evidence no longer commits.
+        terminal = _ev(SignalKind.TERMINAL_MEMORY, Polarity.SUCCESS)
+        assert fold_outcome_label([terminal], min_total_weight=2.0) == "unknown"
+        assert fold_outcome_label([terminal], min_total_weight=0.5) == "success"
+
+    def test_min_total_weight_default_matches_constant(self):
+        # Defensive: API default must match the documented constant.
+        # Bumping one without the other would silently shift attribution.
+        assert MIN_TOTAL_WEIGHT_FOR_LABEL == 0.5
+
+
+# ── summarize_evidence ─────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSummarizeEvidence:
+    def test_empty_yields_empty_dict(self):
+        assert summarize_evidence([]) == {}
+
+    def test_groups_by_kind(self):
+        evs = [
+            _ev(SignalKind.SUPERSESSION, Polarity.FAILURE),
+            _ev(SignalKind.CONTRADICTION, Polarity.FAILURE),
+            _ev(SignalKind.SUPERSESSION, Polarity.FAILURE),
+        ]
+        out = summarize_evidence(evs)
+        assert set(out.keys()) == {"supersession", "contradiction"}
+        assert len(out["supersession"]["firings"]) == 2
+        assert len(out["contradiction"]["firings"]) == 1
+
+    def test_total_weight_sums_correctly(self):
+        evs = [
+            _ev(SignalKind.SUPERSESSION, Polarity.FAILURE, weight=0.5),
+            _ev(SignalKind.SUPERSESSION, Polarity.FAILURE, weight=0.7),
+        ]
+        out = summarize_evidence(evs)
+        assert out["supersession"]["total_weight"] == 1.2
+
+    def test_polarity_counts(self):
+        evs = [
+            _ev(SignalKind.TERMINAL_MEMORY, Polarity.SUCCESS),
+            _ev(SignalKind.TERMINAL_MEMORY, Polarity.SUCCESS),
+            _ev(SignalKind.TERMINAL_MEMORY, Polarity.FAILURE),
+        ]
+        out = summarize_evidence(evs)
+        assert out["terminal_memory"]["polarity_counts"] == {"success": 2, "failure": 1}
+
+    def test_serializable_to_json(self):
+        # The summary lands in session_traces.signals_summary JSONB.
+        # If anything in there isn't json-serializable we'd fail at
+        # write time — test pins it.
+        evs = [_ev(SignalKind.SUPERSESSION, Polarity.FAILURE)]
+        json.dumps(summarize_evidence(evs))  # raises if non-serializable
+
+
+# ── build_session_traces orchestration ────────────────────────────
+
+
+@pytest.mark.unit
+class TestBuildSessionTracesOrchestration:
+    @pytest.mark.asyncio
+    async def test_no_memories_no_traces(self):
+        db = _mock_db_for_build(memory_rows=[])
+        out = await build_session_traces(
+            db,
+            tenant_id="t1",
+            fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            persist=False,
+        )
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_groups_memories_by_run_and_agent(self):
+        mem = [
+            _MemRow("m1", "run-A", "sasha", None, datetime(2026, 5, 5, tzinfo=timezone.utc)),
+            _MemRow("m2", "run-A", "sasha", None, datetime(2026, 5, 6, tzinfo=timezone.utc)),
+            _MemRow("m3", "run-B", "mira",  None, datetime(2026, 5, 7, tzinfo=timezone.utc)),
+        ]
+        db = _mock_db_for_build(memory_rows=mem)
+        out = await build_session_traces(
+            db, tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            persist=False,
+        )
+        # Two distinct (run_id, agent_id) groups → two traces.
+        assert len(out) == 2
+        traces_by_key = {(r.run_id, r.agent_id): r for r in out}
+        assert traces_by_key[("run-A", "sasha")].memory_ids == ["m1", "m2"]
+        assert traces_by_key[("run-A", "sasha")].started_at == datetime(2026, 5, 5, tzinfo=timezone.utc)
+        assert traces_by_key[("run-A", "sasha")].ended_at == datetime(2026, 5, 6, tzinfo=timezone.utc)
+        assert traces_by_key[("run-B", "mira")].memory_ids == ["m3"]
+
+    @pytest.mark.asyncio
+    async def test_runs_all_six_extractors_concurrently(self):
+        mem = [_MemRow("m1", "r1", "a1", None, datetime(2026, 5, 5, tzinfo=timezone.utc))]
+        db = _mock_db_for_build(memory_rows=mem)
+
+        # Patch every extractor to return [] but capture invocation count.
+        call_counts: dict[str, int] = {mod.__name__: 0 for mod in SIGNAL_MODULES}
+
+        async def make_recorder(name):
+            async def fake_extract(*_args, **_kwargs):
+                call_counts[name] += 1
+                return []
+            return fake_extract
+
+        patches = []
+        for mod in SIGNAL_MODULES:
+            fake = await make_recorder(mod.__name__)
+            patches.append(patch.object(mod, "extract", new=fake))
+
+        for p in patches:
+            p.start()
+        try:
+            await build_session_traces(
+                db, tenant_id="t1", fleet_id=None,
+                window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+                persist=False,
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+        # All 6 extractors called exactly once.
+        assert all(v == 1 for v in call_counts.values()), call_counts
+
+    @pytest.mark.asyncio
+    async def test_evidence_partitions_to_correct_trace(self):
+        mem = [
+            _MemRow("m1", "run-A", "sasha", None, datetime(2026, 5, 5, tzinfo=timezone.utc)),
+            _MemRow("m2", "run-B", "mira",  None, datetime(2026, 5, 6, tzinfo=timezone.utc)),
+        ]
+        db = _mock_db_for_build(memory_rows=mem)
+
+        # Stub all extractors except terminal_memory to return [].
+        # terminal_memory returns one success for run-A/sasha only.
+        from core_api.services.outcome_inference import (
+            contradictions, cross_agent_reuse, external_hooks,
+            repeat_recall, supersessions, terminal_memory,
+        )
+        async def succ_for_a(_q, _db):
+            return [_ev(SignalKind.TERMINAL_MEMORY, Polarity.SUCCESS,
+                        run_id="run-A", agent_id="sasha", memory_id="m1")]
+        async def noop(*_a, **_k): return []
+
+        with (
+            patch.object(terminal_memory, "extract", new=succ_for_a),
+            patch.object(contradictions, "extract", new=noop),
+            patch.object(supersessions, "extract", new=noop),
+            patch.object(cross_agent_reuse, "extract", new=noop),
+            patch.object(repeat_recall, "extract", new=noop),
+            patch.object(external_hooks, "extract", new=noop),
+        ):
+            out = await build_session_traces(
+                db, tenant_id="t1", fleet_id=None,
+                window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+                persist=False,
+            )
+
+        by_key = {(r.run_id, r.agent_id): r for r in out}
+        assert by_key[("run-A", "sasha")].outcome_label == "success"
+        assert by_key[("run-B", "mira")].outcome_label == "unknown"  # no evidence
+        # The terminal_memory signal landed under the right trace's summary.
+        assert "terminal_memory" in by_key[("run-A", "sasha")].signals_summary
+        assert by_key[("run-B", "mira")].signals_summary == {}
+
+    @pytest.mark.asyncio
+    async def test_one_extractor_exception_does_not_abort_build(self):
+        mem = [_MemRow("m1", "r1", "a1", None, datetime(2026, 5, 5, tzinfo=timezone.utc))]
+        db = _mock_db_for_build(memory_rows=mem)
+
+        from core_api.services.outcome_inference import (
+            contradictions, cross_agent_reuse, external_hooks,
+            repeat_recall, supersessions, terminal_memory,
+        )
+        async def boom(*_a, **_k): raise RuntimeError("simulated extractor crash")
+        async def succ_for_a(_q, _db):
+            return [_ev(SignalKind.TERMINAL_MEMORY, Polarity.SUCCESS,
+                        run_id="r1", agent_id="a1", memory_id="m1")]
+        async def noop(*_a, **_k): return []
+
+        with (
+            patch.object(contradictions, "extract", new=boom),
+            patch.object(terminal_memory, "extract", new=succ_for_a),
+            patch.object(supersessions, "extract", new=noop),
+            patch.object(cross_agent_reuse, "extract", new=noop),
+            patch.object(repeat_recall, "extract", new=noop),
+            patch.object(external_hooks, "extract", new=noop),
+        ):
+            out = await build_session_traces(
+                db, tenant_id="t1", fleet_id=None,
+                window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+                persist=False,
+            )
+
+        # The successful extractor's evidence still labels the trace,
+        # despite the contradiction extractor blowing up.
+        assert len(out) == 1
+        assert out[0].outcome_label == "success"
+
+    @pytest.mark.asyncio
+    async def test_persist_false_skips_insert(self):
+        mem = [_MemRow("m1", "r1", "a1", None, datetime(2026, 5, 5, tzinfo=timezone.utc))]
+        db = _mock_db_for_build(memory_rows=mem)
+        await build_session_traces(
+            db, tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            persist=False,
+        )
+        # Only the SELECTs ran — no INSERT.
+        assert not any("insert into session_traces" in s for s in db._call_log)
+
+    @pytest.mark.asyncio
+    async def test_persist_true_issues_one_insert_per_trace(self):
+        mem = [
+            _MemRow("m1", "run-A", "sasha", None, datetime(2026, 5, 5, tzinfo=timezone.utc)),
+            _MemRow("m2", "run-B", "mira",  None, datetime(2026, 5, 6, tzinfo=timezone.utc)),
+        ]
+        db = _mock_db_for_build(memory_rows=mem)
+        await build_session_traces(
+            db, tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            persist=True,
+        )
+        insert_calls = [s for s in db._call_log if "insert into session_traces" in s]
+        assert len(insert_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_entity_ids_resolved_via_link_table(self):
+        mem = [_MemRow("m1", "r1", "a1", None, datetime(2026, 5, 5, tzinfo=timezone.utc))]
+        # 3 link rows for the same memory; builder dedupes + sorts.
+        ents = [
+            _EntityRow("m1", "e-2"),
+            _EntityRow("m1", "e-1"),
+            _EntityRow("m1", "e-3"),
+        ]
+        db = _mock_db_for_build(memory_rows=mem, entity_rows=ents)
+        out = await build_session_traces(
+            db, tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            persist=False,
+        )
+        # Entity ids sorted (deterministic input for fingerprint later).
+        assert out[0].entity_ids == ["e-1", "e-2", "e-3"]
+
+    @pytest.mark.asyncio
+    async def test_entity_fetch_sql_casts_param_not_column(self):
+        """Index-preservation regression: the WHERE clause must cast
+        the PARAMETER (``:memory_ids``) to uuid[], NOT the column
+        (``memory_id``) to text. ``memory_id::text = ANY(...)`` would
+        defeat any index on ``memory_entity_links.memory_id`` because
+        the column reference is wrapped in a function call. Pinning
+        the SQL text here catches a future refactor that flips the
+        cast direction."""
+        mem = [_MemRow("m1", "r1", "a1", None, datetime(2026, 5, 5, tzinfo=timezone.utc))]
+        db = _mock_db_for_build(memory_rows=mem)
+        await build_session_traces(
+            db,
+            tenant_id="t1",
+            fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            persist=False,
+        )
+        link_call = next(s for s in db._call_log if "from memory_entity_links" in s)
+        # The PARAMETER carries the cast — preserves the column's
+        # index-eligibility.
+        assert "cast(:memory_ids as uuid[])" in link_call
+        # Defensive: the column reference must NOT be wrapped in a
+        # cast / function call. ``memory_id::text = any(...)`` would
+        # disable the index.
+        assert "memory_id::text = any" not in link_call
+
+    @pytest.mark.asyncio
+    async def test_entity_fetch_is_single_bulk_query(self):
+        """Regression guard for the N+1 fix: ``memory_entity_links``
+        must be queried EXACTLY ONCE per builder invocation, no
+        matter how many traces are in the window.
+
+        The previous shape issued one query per trace inside the
+        per-trace loop — a 100-trace tick was 100+ extra round-trips.
+        """
+        mem = [
+            _MemRow("m1", "run-A", "sasha", None, datetime(2026, 5, 5, tzinfo=timezone.utc)),
+            _MemRow("m2", "run-B", "mira",  None, datetime(2026, 5, 6, tzinfo=timezone.utc)),
+            _MemRow("m3", "run-C", "kai",   None, datetime(2026, 5, 7, tzinfo=timezone.utc)),
+        ]
+        ents = [
+            _EntityRow("m1", "e-1"),
+            _EntityRow("m2", "e-2"),
+            _EntityRow("m3", "e-3"),
+        ]
+        db = _mock_db_for_build(memory_rows=mem, entity_rows=ents)
+        await build_session_traces(
+            db, tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            persist=False,
+        )
+        # Exactly ONE entity-links query, not one per trace.
+        link_calls = [s for s in db._call_log if "from memory_entity_links" in s]
+        assert len(link_calls) == 1, (
+            f"expected exactly one memory_entity_links query, got {len(link_calls)}; "
+            "N+1 regression"
+        )
+
+    @pytest.mark.asyncio
+    async def test_evidence_missing_run_id_or_agent_id_logs_warning(self, caplog):
+        """A buggy extractor that fails to stamp ``run_id`` /
+        ``agent_id`` on its evidence has no trace to attach to —
+        the evidence is dropped. Dropping is the safe default
+        (better than crashing the whole build), but it MUST log
+        at WARNING so the regression surfaces in operator logs
+        rather than disappearing silently."""
+        import logging
+        import core_api.services.session_trace as svc
+
+        mem = [_MemRow("m1", "r1", "a1", None, datetime(2026, 5, 5, tzinfo=timezone.utc))]
+        db = _mock_db_for_build(memory_rows=mem)
+
+        # Patch one extractor to return evidence with EMPTY details —
+        # simulates a regression where a future signal forgets to
+        # stamp the trace identity.
+        from core_api.services.outcome_inference import (
+            contradictions,
+            cross_agent_reuse,
+            external_hooks,
+            repeat_recall,
+            supersessions,
+            terminal_memory,
+        )
+
+        async def bad_extractor(_q, _db):
+            return [
+                SignalEvidence(
+                    kind=SignalKind.TERMINAL_MEMORY,
+                    polarity=Polarity.SUCCESS,
+                    weight=0.9,
+                    memory_ids=("m1",),
+                    details={},  # ← intentionally missing run_id / agent_id
+                )
+            ]
+
+        async def noop(*_a, **_k):
+            return []
+
+        with (
+            patch.object(terminal_memory, "extract", new=bad_extractor),
+            patch.object(contradictions, "extract", new=noop),
+            patch.object(supersessions, "extract", new=noop),
+            patch.object(cross_agent_reuse, "extract", new=noop),
+            patch.object(repeat_recall, "extract", new=noop),
+            patch.object(external_hooks, "extract", new=noop),
+            caplog.at_level(logging.WARNING, logger=svc.__name__),
+        ):
+            out = await build_session_traces(
+                db,
+                tenant_id="t1",
+                fleet_id=None,
+                window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+                persist=False,
+            )
+
+        # The bad evidence was dropped — the trace gets unknown label.
+        assert len(out) == 1
+        assert out[0].outcome_label == "unknown"
+        # And the operator log shows WHY.
+        assert any(
+            "dropping" in record.message and "terminal_memory" in record.message
+            for record in caplog.records
+        ), f"expected a 'dropping terminal_memory' warning; got {[r.message for r in caplog.records]}"
+
+    @pytest.mark.asyncio
+    async def test_entity_partitioning_to_correct_trace(self):
+        """The bulk fetch returns ALL (memory_id, entity_id) pairs;
+        the builder must partition them back so each trace only
+        sees ITS members' entities — no cross-pollination."""
+        mem = [
+            _MemRow("m1", "run-A", "sasha", None, datetime(2026, 5, 5, tzinfo=timezone.utc)),
+            _MemRow("m2", "run-A", "sasha", None, datetime(2026, 5, 5, 1, tzinfo=timezone.utc)),
+            _MemRow("m3", "run-B", "mira",  None, datetime(2026, 5, 6, tzinfo=timezone.utc)),
+        ]
+        ents = [
+            _EntityRow("m1", "e-A1"),
+            _EntityRow("m2", "e-A2"),
+            _EntityRow("m3", "e-B"),
+        ]
+        db = _mock_db_for_build(memory_rows=mem, entity_rows=ents)
+        out = await build_session_traces(
+            db, tenant_id="t1", fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            persist=False,
+        )
+        by_key = {(r.run_id, r.agent_id): r for r in out}
+        # Trace A owns m1+m2 → entities e-A1, e-A2 only.
+        assert by_key[("run-A", "sasha")].entity_ids == ["e-A1", "e-A2"]
+        # Trace B owns m3 → entity e-B only — must NOT see A's entities.
+        assert by_key[("run-B", "mira")].entity_ids == ["e-B"]
+
+
+# ── SessionTraceRow shape ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSessionTraceRow:
+    def test_as_bind_renders_full_dict(self):
+        row = SessionTraceRow(
+            tenant_id="t",
+            fleet_id="f",
+            run_id="r",
+            agent_id="a",
+            outcome_label="success",
+            memory_ids=["m1", "m2"],
+            entity_ids=["e1"],
+            signals_summary={"terminal_memory": {"firings": []}},
+            started_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            ended_at=datetime(2026, 5, 2, tzinfo=timezone.utc),
+            goal_phrase=None,
+        )
+        bind = row.as_bind()
+        assert bind["outcome_label"] == "success"
+        assert bind["memory_ids"] == ["m1", "m2"]
+        assert bind["goal_phrase"] is None
+
+    def test_outcome_label_must_be_one_of_three(self):
+        # Soft invariant: the DB CHECK constraint
+        # (ck_session_traces_outcome_label) limits this to
+        # success/failure/unknown. The builder ONLY produces these
+        # three; pin via fold_outcome_label tests above. This test
+        # is the explicit "Spec sanity" doc.
+        produced = {
+            fold_outcome_label([]),
+            fold_outcome_label([_ev(SignalKind.TERMINAL_MEMORY, Polarity.SUCCESS)]),
+            fold_outcome_label([_ev(SignalKind.SUPERSESSION, Polarity.FAILURE)]),
+        }
+        assert produced == {"unknown", "success", "failure"}

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -689,6 +689,38 @@ class TestForgeEventPayloadNaming:
             "parameter must be removed"
         )
 
+    def test_llm_tokens_field_name_matches_across_layers(self):
+        # Same drift-trap test for ``llm_tokens_per_run`` — the event
+        # payload, the publisher kwarg, and the org_settings key must
+        # all spell it identically. The legacy ``llm_tokens_budget``
+        # name was renamed for consistency with the
+        # ``*_per_run`` settings-layer convention.
+        import inspect
+
+        from common.events.lifecycle_forge_request import LifecycleForgeDistillRequest
+        from common.events.lifecycle_publishers import publish_forge_distill_request
+        from core_api.services.organization_settings import DEFAULT_SETTINGS
+
+        # Payload (pydantic).
+        assert "llm_tokens_per_run" in LifecycleForgeDistillRequest.model_fields, (
+            "LifecycleForgeDistillRequest.llm_tokens_per_run must match "
+            "the org_settings name; legacy ``llm_tokens_budget`` was "
+            "renamed for consistency with ``max_writes_per_run``."
+        )
+        assert "llm_tokens_budget" not in LifecycleForgeDistillRequest.model_fields, (
+            "legacy ``llm_tokens_budget`` field must be removed — drift trap"
+        )
+        # Settings key.
+        forge_settings = DEFAULT_SETTINGS["skills_factory"]["forge"]
+        assert "llm_tokens_per_run" in forge_settings
+        # Publisher kwarg.
+        sig = inspect.signature(publish_forge_distill_request)
+        assert "llm_tokens_per_run" in sig.parameters
+        assert "llm_tokens_budget" not in sig.parameters, (
+            "publish_forge_distill_request's legacy ``llm_tokens_budget`` "
+            "parameter must be removed"
+        )
+
 
 @pytest.mark.unit
 class TestMigration020Index:

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -1,0 +1,792 @@
+"""Skill Factory Phase 0 acceptance tests (SF-008).
+
+Pure-unit coverage — no DB required. Exercises the
+:mod:`core_api.services.skill_lifecycle.validate_and_normalize_skill_write`
+contract and the configuration plumbing
+(:mod:`core_api.services.organization_settings`) introduced by
+SF-002 + SF-006.
+
+Maps to plan §15 Phase 0 acceptance criteria:
+
+  - ``memclaw_doc`` ``op=write`` against ``skills`` with
+    ``description > 160 bytes`` returns 422
+  - ``memclaw_doc`` ``op=write`` against ``skills`` without
+    ``name``/``slug``/``description``/``domain``/``kind``/``source``
+    returns 422
+  - ``kind='update'`` rejects on hash mismatch (409) and on missing
+    live target (404)
+  - ``source='forge'`` is rejected from non-Forge callers (403)
+  - ``status='active'`` is rejected from non-admin callers (403)
+  - eToro pointer-only docs (no content field) are still
+    representable post-migration (source='imported' skips the
+    content-presence requirement)
+
+Integration tests against a live storage-api + the migration apply
+path live separately under ``tests/integration/`` and are not
+required to pass in this file.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+from fastapi import HTTPException
+
+from core_api.services.skill_lifecycle import (
+    ADMIN_ONLY_SOURCES,
+    ADMIN_ONLY_STATUSES,
+    ALLOWED_KINDS,
+    ALLOWED_SOURCES,
+    ALLOWED_STATUSES,
+    INTERNAL_ONLY_SOURCES,
+    INTERNAL_ONLY_STATUSES,
+    REQUIRED_TOP_LEVEL_KEYS,
+    SYSTEM_ONLY_STATUSES,
+    SkillWriteContext,
+    validate_and_normalize_skill_write,
+)
+
+
+# --- Test fixtures --------------------------------------------------------
+
+
+def _agent_ctx(**overrides) -> SkillWriteContext:
+    """Regular agent (non-admin, non-Forge) caller."""
+    base = {
+        "caller_agent_id": "alice",
+        "is_admin": False,
+        "is_internal_forge": False,
+    }
+    base.update(overrides)
+    return SkillWriteContext(**base)
+
+
+def _admin_ctx(**overrides) -> SkillWriteContext:
+    base = {
+        "caller_agent_id": "admin-bob",
+        "is_admin": True,
+        "is_internal_forge": False,
+    }
+    base.update(overrides)
+    return SkillWriteContext(**base)
+
+
+def _forge_ctx(**overrides) -> SkillWriteContext:
+    base = {
+        "caller_agent_id": "forge",
+        "is_admin": False,
+        "is_internal_forge": True,
+    }
+    base.update(overrides)
+    return SkillWriteContext(**base)
+
+
+def _valid_doc(**overrides) -> dict:
+    """A minimally valid skills-write body — happy-path baseline.
+    Tests override individual keys to provoke specific failures.
+    """
+    base = {
+        "name": "Test Skill",
+        "slug": "test-skill",
+        "description": "Short trigger description.",
+        "domain": "dev",
+        "kind": "create",
+        "source": "agent",
+        "content": "## When to use\nStep 1.\nStep 2.\n",
+    }
+    base.update(overrides)
+    return base
+
+
+# --- Enums + constants ----------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEnumConstants:
+    def test_allowed_sources(self):
+        assert ALLOWED_SOURCES == frozenset({"forge", "agent", "manual", "imported"})
+
+    def test_allowed_kinds(self):
+        assert ALLOWED_KINDS == frozenset({"create", "update"})
+
+    def test_allowed_statuses(self):
+        # Mirrors plan §5 lifecycle states.
+        assert ALLOWED_STATUSES == frozenset(
+            {"candidate", "staged", "active", "rejected", "quarantined", "stale", "deprecated"}
+        )
+
+    def test_admin_only_partitions(self):
+        # source/status RBAC partitioning is mutually exclusive — no
+        # value can be both admin-only AND internal-only.
+        assert ADMIN_ONLY_SOURCES.isdisjoint(INTERNAL_ONLY_SOURCES)
+        assert ADMIN_ONLY_STATUSES.isdisjoint(INTERNAL_ONLY_STATUSES)
+        assert ADMIN_ONLY_SOURCES <= ALLOWED_SOURCES
+        assert INTERNAL_ONLY_SOURCES <= ALLOWED_SOURCES
+        assert ADMIN_ONLY_STATUSES <= ALLOWED_STATUSES
+        assert INTERNAL_ONLY_STATUSES <= ALLOWED_STATUSES
+
+    def test_system_only_statuses_partition(self):
+        # System-managed terminal/hold states. Disjoint from admin and
+        # internal sets — system-only means "no HTTP caller may set
+        # these directly". Subset of ALLOWED_STATUSES.
+        assert SYSTEM_ONLY_STATUSES == frozenset(
+            {"quarantined", "rejected", "stale", "deprecated"}
+        )
+        assert SYSTEM_ONLY_STATUSES.isdisjoint(ADMIN_ONLY_STATUSES)
+        assert SYSTEM_ONLY_STATUSES.isdisjoint(INTERNAL_ONLY_STATUSES)
+        assert SYSTEM_ONLY_STATUSES <= ALLOWED_STATUSES
+
+    def test_required_keys_contract(self):
+        # The schema contract the route promises agents.
+        assert "name" in REQUIRED_TOP_LEVEL_KEYS
+        assert "slug" in REQUIRED_TOP_LEVEL_KEYS
+        assert "description" in REQUIRED_TOP_LEVEL_KEYS
+        assert "domain" in REQUIRED_TOP_LEVEL_KEYS
+
+
+# --- Adjustment 1: schema validator hook ----------------------------------
+
+
+@pytest.mark.unit
+class TestSchemaValidator:
+    @pytest.mark.parametrize("missing_key", list(REQUIRED_TOP_LEVEL_KEYS))
+    @pytest.mark.asyncio
+    async def test_missing_required_field_rejected(self, missing_key):
+        doc = _valid_doc()
+        doc.pop(missing_key)
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(doc, ctx=_agent_ctx())
+        assert exc.value.status_code == 422
+        assert missing_key in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_invalid_slug_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(slug="UPPER_CASE_SLUG"), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 422
+        assert "slug" in str(exc.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_kind_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(kind="patch"), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_invalid_source_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(source="bogus"), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_tags_must_be_list_of_strings(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(tags=[1, 2, 3]), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_non_dict_data_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                "not-a-dict",  # type: ignore[arg-type]
+                ctx=_agent_ctx(),
+            )
+        assert exc.value.status_code == 422
+
+
+# --- Adjustment 2: description cap ----------------------------------------
+
+
+@pytest.mark.unit
+class TestDescriptionCap:
+    @pytest.mark.asyncio
+    async def test_default_cap_is_160_bytes(self):
+        # 161 bytes — one over the default 160 cap.
+        doc = _valid_doc(description="A" * 161)
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(doc, ctx=_agent_ctx())
+        assert exc.value.status_code == 422
+        assert "160" in str(exc.value.detail) or "bytes" in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_at_exact_cap_allowed(self):
+        # 160 bytes — exactly at the cap, must pass.
+        doc = _valid_doc(description="A" * 160)
+        out, _ = await validate_and_normalize_skill_write(doc, ctx=_agent_ctx())
+        assert out["description"] == "A" * 160
+
+    @pytest.mark.asyncio
+    async def test_multibyte_chars_count_as_bytes_not_codepoints(self):
+        # The cap is in UTF-8 BYTES, not character count. Three-byte
+        # codepoints (e.g. "€" = 3 bytes) burn through faster.
+        char = "€"  # 3 UTF-8 bytes each
+        s = char * 54  # 162 bytes > 160
+        with pytest.raises(HTTPException):
+            await validate_and_normalize_skill_write(_valid_doc(description=s), ctx=_agent_ctx())
+        s_ok = char * 53  # 159 bytes
+        out, _ = await validate_and_normalize_skill_write(_valid_doc(description=s_ok), ctx=_agent_ctx())
+        assert out["description"] == s_ok
+
+    @pytest.mark.asyncio
+    async def test_configurable_cap_via_ctx(self):
+        # A tenant lowers the cap to 40 bytes via org settings.
+        ctx = _agent_ctx(description_max_bytes=40)
+        with pytest.raises(HTTPException):
+            await validate_and_normalize_skill_write(
+                _valid_doc(description="A" * 41), ctx=ctx
+            )
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(description="A" * 40), ctx=ctx
+        )
+        assert out["description"] == "A" * 40
+
+
+# --- Adjustment 3: body cap -----------------------------------------------
+
+
+@pytest.mark.unit
+class TestBodyCap:
+    @pytest.mark.asyncio
+    async def test_default_body_cap_40k(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(content="A" * (40_000 + 1)), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_content_required_for_non_imported(self):
+        doc = _valid_doc()
+        del doc["content"]
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(doc, ctx=_agent_ctx())
+        assert exc.value.status_code == 422
+        assert "content" in str(exc.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_content_must_be_string(self):
+        with pytest.raises(HTTPException):
+            await validate_and_normalize_skill_write(
+                _valid_doc(content={"not": "a string"}), ctx=_agent_ctx()
+            )
+
+
+# --- Adjustment 4: source defaulting + RBAC -------------------------------
+
+
+@pytest.mark.unit
+class TestSourceRbac:
+    @pytest.mark.asyncio
+    async def test_source_forge_rejected_from_agent(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(source="forge"), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_source_forge_rejected_from_admin(self):
+        # Even admin can't mint source=forge via API — it's reserved
+        # for the internal lifecycle worker.
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(source="forge"), ctx=_admin_ctx()
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_source_forge_allowed_from_internal_forge(self):
+        # The internal Forge worker IS allowed.
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(source="forge"), ctx=_forge_ctx()
+        )
+        assert out["source"] == "forge"
+
+    @pytest.mark.asyncio
+    async def test_source_manual_rejected_from_agent(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(source="manual"), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_source_manual_allowed_from_admin(self):
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(source="manual"), ctx=_admin_ctx()
+        )
+        assert out["source"] == "manual"
+
+    @pytest.mark.asyncio
+    async def test_source_agent_allowed_from_everyone(self):
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(source="agent"), ctx=_agent_ctx()
+        )
+        assert out["source"] == "agent"
+
+    @pytest.mark.asyncio
+    async def test_source_imported_pointer_only_path(self):
+        """eToro 1,402 pointer-only docs (no content) survive
+        post-migration as source='imported'. This is the
+        backwards-compat path."""
+        doc = _valid_doc(source="imported")
+        del doc["content"]
+        out, _ = await validate_and_normalize_skill_write(doc, ctx=_admin_ctx())
+        assert out["source"] == "imported"
+        assert "content_hash" not in out  # nothing to hash
+
+
+# --- Adjustment 5: status defaulting + RBAC -------------------------------
+
+
+@pytest.mark.unit
+class TestStatusRbac:
+    @pytest.mark.asyncio
+    async def test_status_defaults_to_staged_for_agent(self):
+        doc = _valid_doc()
+        # No status in body.
+        out, _ = await validate_and_normalize_skill_write(doc, ctx=_agent_ctx())
+        assert out["status"] == "staged"
+
+    @pytest.mark.asyncio
+    async def test_status_defaults_to_candidate_for_forge(self):
+        doc = _valid_doc(source="forge")
+        out, _ = await validate_and_normalize_skill_write(doc, ctx=_forge_ctx())
+        assert out["status"] == "candidate"
+
+    @pytest.mark.asyncio
+    async def test_status_active_rejected_from_agent(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(status="active"), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_status_active_allowed_from_admin(self):
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(source="manual", status="active"), ctx=_admin_ctx()
+        )
+        assert out["status"] == "active"
+
+    @pytest.mark.asyncio
+    async def test_status_candidate_rejected_from_agent(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(status="candidate"), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_invalid_status_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(status="bogus"), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 422
+
+    @pytest.mark.parametrize("system_status", sorted(SYSTEM_ONLY_STATUSES))
+    @pytest.mark.asyncio
+    async def test_system_only_status_rejected_from_agent(self, system_status):
+        """Regular agent cannot mint quarantined / rejected / stale /
+        deprecated directly. These are system-managed transitions
+        (Sentinel, Inbox Reject, hash-binding, deprecation flow)."""
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(status=system_status), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 403
+        assert "system-managed" in str(exc.value.detail).lower()
+
+    @pytest.mark.parametrize("system_status", sorted(SYSTEM_ONLY_STATUSES))
+    @pytest.mark.asyncio
+    async def test_system_only_status_rejected_from_admin(self, system_status):
+        # Even an admin cannot mint these directly. They land via the
+        # internal lifecycle flow only.
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(source="manual", status=system_status), ctx=_admin_ctx()
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.parametrize("system_status", sorted(SYSTEM_ONLY_STATUSES))
+    @pytest.mark.asyncio
+    async def test_system_only_status_rejected_from_forge(self, system_status):
+        # The internal Forge worker can mint ``candidate`` but cannot
+        # mint terminal/hold states either — the lifecycle worker for
+        # those (Sentinel + Inbox + drift detector) is separate.
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(source="forge", status=system_status), ctx=_forge_ctx()
+            )
+        assert exc.value.status_code == 403
+
+
+# --- Adjustment 6: auto-fill server-controlled fields ---------------------
+
+
+@pytest.mark.unit
+class TestAutoFill:
+    @pytest.mark.asyncio
+    async def test_content_hash_computed(self):
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(content="hello world"), ctx=_agent_ctx()
+        )
+        # Same content → same hash, prefixed.
+        assert out["content_hash"].startswith("sha256:")
+        # Deterministic.
+        out2, _ = await validate_and_normalize_skill_write(
+            _valid_doc(content="hello world"), ctx=_agent_ctx()
+        )
+        assert out["content_hash"] == out2["content_hash"]
+
+    @pytest.mark.asyncio
+    async def test_origin_agent_id_overrides_client_value(self):
+        # The client tries to claim agent_id='attacker'; server
+        # overrides with the auth context.
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(origin={"agent_id": "attacker"}),
+            ctx=_agent_ctx(caller_agent_id="alice"),
+        )
+        assert out["origin"]["agent_id"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_origin_other_fields_preserved(self):
+        # session_key, run_id, message_id are client-provided and
+        # should pass through unchanged.
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(origin={"session_key": "sk-1", "run_id": "r-2", "message_id": "m-3"}),
+            ctx=_agent_ctx(caller_agent_id="alice"),
+        )
+        assert out["origin"]["session_key"] == "sk-1"
+        assert out["origin"]["run_id"] == "r-2"
+        assert out["origin"]["message_id"] == "m-3"
+        assert out["origin"]["agent_id"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_timestamps_filled(self):
+        out, _ = await validate_and_normalize_skill_write(_valid_doc(), ctx=_agent_ctx())
+        assert "created_at" in out
+        assert "updated_at" in out
+
+    @pytest.mark.asyncio
+    async def test_updated_at_always_server_set(self):
+        # Client supplies their own updated_at — server overwrites.
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(updated_at="1970-01-01T00:00:00+00:00"),
+            ctx=_agent_ctx(),
+        )
+        assert out["updated_at"] != "1970-01-01T00:00:00+00:00"
+
+
+# --- Adjustment 7: Sentinel scan + kind=update hash-binding ---------------
+
+
+@pytest.mark.unit
+class TestHashBindingAndScan:
+    @pytest.mark.asyncio
+    async def test_update_without_target_field_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(kind="update"), ctx=_agent_ctx()
+            )
+        assert exc.value.status_code == 422
+        assert "target" in str(exc.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_update_without_live_target_returns_404(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(
+                    kind="update",
+                    target={"slug": "test-skill", "target_content_hash": "sha256:abc"},
+                ),
+                ctx=_agent_ctx(),
+                live_skill_doc=None,
+            )
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_update_hash_mismatch_returns_409(self):
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(
+                    kind="update",
+                    target={"slug": "test-skill", "target_content_hash": "sha256:CALLER"},
+                ),
+                ctx=_agent_ctx(),
+                live_skill_doc={"data": {"content_hash": "sha256:LIVE"}},
+            )
+        assert exc.value.status_code == 409
+        assert "mismatch" in str(exc.value.detail).lower() or "changed" in str(exc.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_update_hash_match_succeeds(self):
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(
+                kind="update",
+                target={"slug": "test-skill", "target_content_hash": "sha256:LIVE"},
+            ),
+            ctx=_agent_ctx(),
+            live_skill_doc={"data": {"content_hash": "sha256:LIVE"}},
+        )
+        assert out["kind"] == "update"
+
+    @pytest.mark.asyncio
+    async def test_update_against_imported_pointer_only_returns_409(self):
+        # Live doc is an imported pointer-only skill (no content_hash).
+        # We can't bind — reject.
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(
+                    kind="update",
+                    target={"slug": "test-skill", "target_content_hash": "sha256:WHATEVER"},
+                ),
+                ctx=_agent_ctx(),
+                live_skill_doc={"data": {"name": "Imported", "source": "imported"}},
+            )
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_scan_result_attached_clean(self):
+        out, scan = await validate_and_normalize_skill_write(_valid_doc(), ctx=_agent_ctx())
+        assert "scan" in out
+        assert out["scan"]["state"] == "clean"
+        assert out["scan"]["critical"] == 0
+        assert scan.state == "clean"
+
+
+# --- Migration chain integrity --------------------------------------------
+
+
+@pytest.mark.unit
+class TestRouteSlugRegex:
+    """The ``routes/documents.py`` slug regex governs which ``doc_id``
+    values are accepted on a ``collection='skills'`` write. The
+    Skill Factory namespaces Forge candidates as ``forge/<slug>``
+    and synchronous agent-direct writes as ``agent/<slug>`` (plan
+    §3); without the prefix path Forge writes 422 themselves at the
+    route boundary."""
+
+    def _re(self):
+        from core_api.routes.documents import _SKILL_SLUG_RE
+        return _SKILL_SLUG_RE
+
+    def test_plain_slug_accepted(self):
+        assert self._re().fullmatch("deploy-eu-west-dns")
+
+    def test_forge_namespaced_slug_accepted(self):
+        assert self._re().fullmatch("forge/deploy-eu-west-dns")
+
+    def test_agent_namespaced_slug_accepted(self):
+        assert self._re().fullmatch("agent/morning-catchup")
+
+    def test_other_namespaces_rejected(self):
+        # Only ``forge/`` and ``agent/`` are accepted; arbitrary
+        # prefixes still 422 to prevent rogue namespacing.
+        assert self._re().fullmatch("system/x") is None
+        assert self._re().fullmatch("admin/y") is None
+        assert self._re().fullmatch("nested/path/slug") is None
+
+    def test_uppercase_still_rejected(self):
+        # The filesystem-safe rule still applies.
+        assert self._re().fullmatch("FORGE/DEPLOY") is None
+        assert self._re().fullmatch("Deploy") is None
+
+    def test_leading_punctuation_rejected(self):
+        assert self._re().fullmatch("-deploy") is None
+        assert self._re().fullmatch(".deploy") is None
+        assert self._re().fullmatch("forge/-deploy") is None
+
+    def test_max_length_after_prefix(self):
+        # The 100-char body limit applies AFTER the optional prefix.
+        assert self._re().fullmatch("forge/" + "a" * 100)
+        assert self._re().fullmatch("forge/" + "a" * 101) is None
+
+
+@pytest.mark.unit
+class TestMigrationChain:
+    """Sanity check that the Phase 0 migrations (020 / 021 / 022) chain
+    correctly off the prior head (019). Detects accidental down_revision
+    typos at PR time without needing a live database."""
+
+    def _load(self) -> dict[str, str | None]:
+        chain: dict[str, str | None] = {}
+        versions = pathlib.Path(
+            "core-storage-api/src/core_storage_api/database/migrations/versions"
+        )
+        for f in sorted(versions.glob("*.py")):
+            spec = importlib.util.spec_from_file_location(f.stem, f)
+            assert spec is not None and spec.loader is not None
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            chain[mod.revision] = mod.down_revision
+        return chain
+
+    def test_single_head(self):
+        chain = self._load()
+        heads = set(chain) - {dr for dr in chain.values() if dr is not None}
+        assert heads == {"022"}, f"Expected single head '022', got {sorted(heads)}"
+
+    def test_skill_factory_chain_links(self):
+        chain = self._load()
+        assert chain.get("020") == "019", "020 must follow 019"
+        assert chain.get("021") == "020", "021 must follow 020"
+        assert chain.get("022") == "021", "022 must follow 021"
+
+
+@pytest.mark.unit
+class TestForgeEventPayloadNaming:
+    """The Forge run-knob field names must spell the same thing across
+    org_settings, ForgeConfig, and the event payload. Drift between
+    these three is a real bug: an operator who tunes
+    ``skills_factory.forge.max_writes_per_run`` would expect the
+    publisher kwarg to spell it identically. A test pin keeps the
+    three in lockstep."""
+
+    def test_event_payload_field_name_matches_config(self):
+        # Payload field, ForgeConfig dataclass field, and the
+        # org_settings key all spell ``max_writes_per_run``.
+        from common.events.lifecycle_forge_request import LifecycleForgeDistillRequest
+        from core_api.services.forge.forge_service import ForgeConfig
+        from core_api.services.organization_settings import DEFAULT_SETTINGS
+
+        # Payload (pydantic): the field exists with the right name.
+        assert "max_writes_per_run" in LifecycleForgeDistillRequest.model_fields, (
+            "LifecycleForgeDistillRequest.max_writes_per_run must match the "
+            "ForgeConfig + org_settings name; legacy ``max_writes`` was "
+            "renamed for consistency."
+        )
+        assert "max_writes" not in LifecycleForgeDistillRequest.model_fields, (
+            "legacy ``max_writes`` field must be removed — drift trap"
+        )
+        # ForgeConfig dataclass.
+        cfg_fields = {f for f in vars(ForgeConfig()).keys()}
+        assert "max_writes_per_run" in cfg_fields
+        # Settings key.
+        forge_settings = DEFAULT_SETTINGS["skills_factory"]["forge"]
+        assert "max_writes_per_run" in forge_settings
+
+    def test_publisher_kwarg_matches_payload_field(self):
+        # The publisher's keyword argument also spells max_writes_per_run.
+        import inspect
+        from common.events.lifecycle_publishers import publish_forge_distill_request
+
+        sig = inspect.signature(publish_forge_distill_request)
+        assert "max_writes_per_run" in sig.parameters
+        assert "max_writes" not in sig.parameters, (
+            "publish_forge_distill_request's legacy ``max_writes`` "
+            "parameter must be removed"
+        )
+
+
+@pytest.mark.unit
+class TestMigration020Index:
+    """The forge_rejected_fingerprints lookup index must include
+    fleet_id (with NULLS FIRST) so the hot-path predicate
+    ``(fleet_id = :f OR fleet_id IS NULL)`` is index-supported.
+    A missing fleet_id column forces PG to filter every (tenant,
+    fp) match in memory."""
+
+    def _migration_020_source(self) -> str:
+        path = pathlib.Path(
+            "core-storage-api/src/core_storage_api/database/migrations/versions/"
+            "020_forge_rejected_fingerprints.py"
+        )
+        return path.read_text()
+
+    def test_lookup_index_includes_fleet_id(self):
+        src = self._migration_020_source()
+        # The CREATE INDEX statement must reference fleet_id.
+        index_block = src[src.index("idx_forge_rejected_fp_lookup") :]
+        # Stop at the next non-string line so we only inspect the
+        # actual index DDL.
+        index_block = index_block[: index_block.index('"\n    )')]
+        assert "fleet_id" in index_block, (
+            "idx_forge_rejected_fp_lookup must include fleet_id "
+            "so the hot-path '(fleet_id = :f OR fleet_id IS NULL)' "
+            "predicate is index-supported"
+        )
+
+    def test_lookup_index_uses_nulls_first_on_fleet_id(self):
+        src = self._migration_020_source()
+        # NULLS FIRST clusters the NULL-fleet rows at the head of
+        # each (tenant, fp) group, matching the
+        # 'fleet_id = :f OR fleet_id IS NULL' shape.
+        assert "fleet_id NULLS FIRST" in src
+
+    def test_lookup_index_still_sorts_rejected_at_desc(self):
+        # The cooloff predicate is "is ANY rejection still active";
+        # DESC on rejected_at lets PG short-circuit at the newest
+        # hit per (tenant, fp, fleet) tuple.
+        src = self._migration_020_source()
+        assert "rejected_at DESC" in src
+
+
+@pytest.mark.unit
+class TestMigration022Sentinel:
+    """The 022 downgrade must NOT strip ``source``/``status`` from
+    rows that the migration did not write — only from rows
+    carrying the ``_migrated_by='022'`` sentinel that Branches 1+2
+    stamp during ``upgrade()``. This pins the SQL string so a
+    refactor of the migration body can't silently regress the
+    downgrade safety contract."""
+
+    def _migration_source(self) -> str:
+        path = pathlib.Path(
+            "core-storage-api/src/core_storage_api/database/migrations/versions/"
+            "022_skills_backfill_source_status.py"
+        )
+        return path.read_text()
+
+    def test_branch_1_stamps_migrated_by_sentinel(self):
+        src = self._migration_source()
+        # Branch 1's UPDATE includes ``_migrated_by`` in its
+        # jsonb_build_object call alongside source='manual'.
+        assert "'_migrated_by', '022'" in src or '"_migrated_by", "022"' in src, (
+            "Branches 1+2 must stamp _migrated_by='022' so the "
+            "downgrade can safely identify rows we wrote"
+        )
+
+    def test_branch_3_and_4_do_not_stamp_sentinel(self):
+        # Branch 3 (status backfill on already-sourced rows) and
+        # Branch 4 (legacy source normalization) intentionally do
+        # NOT carry the sentinel — they are not reversed by the
+        # downgrade in the same way (Branch 4 restores via
+        # legacy_source; Branch 3 is intentionally non-reversed).
+        src = self._migration_source()
+        # Count how many times _migrated_by appears in the upgrade.
+        # Exactly 2 (Branch 1 + Branch 2) — Branch 3 / Branch 4
+        # adding it would create false-positive downgrade strips.
+        upgrade_section = src.split("def upgrade")[1].split("def downgrade")[0]
+        assert upgrade_section.count("'_migrated_by'") == 2, (
+            "Only Branches 1+2 should stamp _migrated_by; "
+            f"got {upgrade_section.count(chr(39)+chr(95)+'migrated_by'+chr(39))} occurrences"
+        )
+
+    def test_downgrade_filters_by_sentinel(self):
+        # Downgrade's strip-step must filter on _migrated_by='022',
+        # not just on source IN ('manual', 'imported').
+        src = self._migration_source()
+        downgrade_section = src.split("def downgrade")[1]
+        assert "'_migrated_by'" in downgrade_section, (
+            "Downgrade must reference _migrated_by in its WHERE clause"
+        )
+        assert "= '022'" in downgrade_section, (
+            "Downgrade must check _migrated_by = '022' specifically"
+        )
+        # And it must STRIP the sentinel itself (so a re-upgrade
+        # lands cleanly).
+        assert "- '_migrated_by'" in downgrade_section, (
+            "Downgrade must drop _migrated_by after using it"
+        )


### PR DESCRIPTION
## Summary

Skill Factory **Phase 0 + Phase 1** — the lake-side skill production pipeline. Behind a per-tenant feature flag (`org_settings.skills_factory.enabled = False` by default); zero behavior change for existing tenants until they opt in.

- **Phase 0** — schema (3 alembic migrations), per-tenant settings, lifecycle publisher stub, sentinel scanner stub, 7 `memclaw_doc` skills-write adjustments behind the flag, schema validator + 49 unit tests.
- **Phase 1** — outcome inference (6 free signals), session-trace builder, cluster fingerprint with 6 stability invariants, Forge distillation orchestrator, `memclawctl forge dry-run` CLI, 171 unit tests + 3-fleet eval harness.
- **Migration 022 validated against eToro production** via 3 read-only dry-runs (BEGIN/ROLLBACK envelope; zero persistence). All 9 acceptance gates pass on the 1,479-row eToro skills snapshot.

## Why flag-gated?

Everything new is dormant until `skills_factory.enabled` flips on per tenant:

| Surface | When flag is off |
|---|---|
| `memclaw_doc` writes to `skills` | uses existing pre-SF-002 path (unchanged) |
| `skill_lifecycle.validate_and_normalize_skill_write` | never invoked |
| Sentinel scanner | never invoked |
| Forge service / outcome signals / session-trace builder / fingerprint / distill | dead code — only `scripts/forge_dry_run.py` (manual) invokes them |
| Plugin reconciliation | unchanged (Phase 2 will add `status='active'` filter) |
| Lifecycle publisher `publish_forge_distill_request` | defined but unused; subscriber handler is a no-op log |

## What does run on deploy (independent of the flag)

Migration `022_skills_backfill_source_status` actively backfills `source` + `status` on existing `skills` rows. No production consumer reads these fields yet (verified during code survey), but the data does get written. **Dry-run validated against eToro prod 3×** (see "Validation" below).

## Phase 0 contents

```
core-storage-api/.../migrations/versions/
  020_forge_rejected_fingerprints.py   # anti-poison memory + 30d cooloff
  021_session_traces.py                # outcome-labeled trace storage
  022_skills_backfill_source_status.py # 4-branch backfill; json/jsonb safe
common/events/
  topics.py                             # + FORGE_DISTILL_REQUESTED
  lifecycle_forge_request.py            # + payload model
  lifecycle_publishers.py               # + publish_forge_distill_request
  lifecycle_handlers.py                 # + subscription (no-op handler)
core-api/src/core_api/services/
  organization_settings.py              # + skills_factory.* (8 keys, 13 leaf validators)
  lifecycle_audit.py                    # + adapter
  forge/__init__.py                     # NEW
  forge/sentinel_scan.py                # NEW (Phase-0 stub; clean always)
  skill_lifecycle.py                    # NEW: the 7 SF-002 adjustments
  routes/documents.py                   # + flag-gated SF-002 hook + SKILLS_ROLLBACK_COLLECTION
tests/
  conftest.py                           # autouse fixture skips DB for @pytest.mark.unit
  test_skill_schema_v1.py               # 49 unit tests
```

## Phase 1 contents

```
core-api/src/core_api/services/outcome_inference/
  __init__.py                           # SignalKind, Polarity, SignalEvidence, protocol
  contradictions.py                     # memory.status='outdated'|'conflicted'
  supersessions.py                      # memory.supersedes_id
  terminal_memory.py                    # regex classifier on terminal memory
  cross_agent_reuse.py                  # memory.recall_count proxy
  repeat_recall.py                      # Phase-1 stub (no recall log yet)
  external_hooks.py                     # Phase-5 stub (no webhook ingest yet)
core-api/src/core_api/services/
  session_trace.py                      # concurrent extractor dispatch + fold + upsert
  forge/fingerprint.py                  # fp:v1:<sha256>; 6 stability invariants
  forge/distill_prompt.py               # LLM prompt + resilient response parser
  forge/forge_service.py                # entity-Jaccard clustering + distill + write
scripts/
  forge_dry_run.py                      # memclawctl forge dry-run CLI
tests/
  test_outcome_inference_signals.py     # 53 unit tests across 9 classes
  test_session_trace_builder.py         # 25 unit tests (incl. exception-isolation)
  test_cluster_fingerprint.py           # 45 unit tests covering P1–P6
  test_forge_distill.py                 # 35 unit tests (prompt + parse + orchestration)
  test_forge_eval_harness.py            # 13 acceptance gate tests on 3 fleets
docs/live-memory-pitch/
  *.svg + *.md                          # design artifacts
```

## Validation against eToro production

Migration 022 was dry-run-validated **three times** against the live eToro Postgres (read-only baseline + `BEGIN`/`ROLLBACK`-protected simulation; zero data persisted):

| Run | Verdict | Finding |
|---|---|---|
| v1 | ❌ FAIL | 73 orphaned rows — branches skipped existing-source rows |
| v2 | ⚠️ PASS w/ caveat | All 9 gates held, but agent had to add `::jsonb`/`::json` casts on the fly because eToro's `data` column is `json`, not `jsonb` |
| v3 | ✅ PASS clean | File as-written runs on first attempt — casts baked in, no errors |

V3 final state inside the rolled-back txn:
- **1,479** total eToro skills (up from 1,403 at survey time)
- `source` dist: `{manual: 1, imported: 1478}` — fully canonical
- `status` dist: `{active: 1479}` — no nulls
- `legacy_source` populated for 73 rows (23 `cursor-marketplace` + 50 `claw-fleet-skills/cursor-marketplace`) — historical provenance preserved
- Idempotency re-run inside same txn: 0 rows affected

## Tests

**220 unit tests pass in ~0.85s** — zero DB / LLM / network deps. Run locally with:

```bash
python3 -m pytest tests/test_skill_schema_v1.py tests/test_outcome_inference_signals.py tests/test_session_trace_builder.py tests/test_cluster_fingerprint.py tests/test_forge_distill.py tests/test_forge_eval_harness.py -m unit -q
```

| Test file | Tests | Scope |
|---|---|---|
| `test_skill_schema_v1` | 49 | SF-002 schema + RBAC + hash-binding + migration chain |
| `test_outcome_inference_signals` | 53 | 6 signal extractors + registry + edge cases |
| `test_session_trace_builder` | 25 | Concurrent extractor dispatch + folding |
| `test_cluster_fingerprint` | 45 | All 6 stability properties P1–P6 + adversarial perturbations |
| `test_forge_distill` | 35 | Prompt + response parser + orchestrator |
| `test_forge_eval_harness` | 13 | Phase-1 acceptance gates on 3 fleets |

## Conventional-commits structure (3 commits)

1. `feat(skills): Skill Factory Phase 0 — schema + flag-gated validator` (~1,800 LoC)
2. `feat(skills): Skill Factory Phase 1 — Forge dry-run pipeline` (~5,200 LoC)
3. `docs(skills): add Live Memory pitch deck + Skill Factory implementation plan` (~2,300 LoC)

## Test plan

- [x] 220/220 unit tests pass locally (0.82s)
- [x] Migration chain single-head at 022 (single-head invariant pinned by test)
- [x] Migration 022 dry-run against eToro production: BEGIN/ROLLBACK envelope clean, all 9 acceptance gates pass on the file as-written
- [x] `python scripts/forge_dry_run.py --help` works without DB connection
- [ ] Reviewer: confirm `org_settings.skills_factory.enabled = False` default is preserved on merge
- [ ] Reviewer: confirm migration 022 cast pattern (`(data::jsonb || ...)::json`) is correct on whichever Postgres column type their target tenant has
- [ ] Reviewer: confirm `conftest.py` autouse-fixture change doesn't break any existing non-unit test

## What's NOT in this PR (deferred to Phase 2+)

- Sentinel scanner — 8 real checks (currently a clean-always stub)
- HITL Skills Inbox UI + Approve/Edit/Reject/Quarantine actions
- Auto-gates that move `candidate → staged`
- Recall-log table (unblocks the `repeat_recall` extractor's real implementation)
- Claude Code install path + rollback metadata writer (Phase 3)
- `scope_org` dual-approval governance, auto-promote tier (Phase 5)
- OpenClaw `PROPOSAL.md` bridge (Phase 5, complexity-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)