### PR TITLE
docs(contributing): warn about commit subjects that break release-please

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,9 +123,25 @@ as minor (`bump-minor-pre-major: true` in `release-please-config.json`).
 - Include context in the body when the change is non-obvious.
 - One logical change per commit.
 
+**Common parser breakers — avoid in subject lines:**
+
+- **Leading ticket identifier** (e.g. `CAURA-129 feat(contradiction): …`).
+  The conventional-commit parser expects the subject to *start* with a
+  type token; anything before `feat`/`fix`/etc. fails with
+  `unexpected token ' '`. Put the ticket id in the **body**
+  (`Closes CAURA-129.`) instead.
+- **Unicode ellipsis `…` (U+2026)** anywhere in the subject. The
+  parser rejects it with the same error class. If GitHub's squash-merge
+  UI truncates a long title with `…`, rewrite the title before merging.
+- **Non-ASCII punctuation generally** (em-dashes `—`, smart quotes
+  `“ ”`). `ruff` will also flag these in code comments; the parser
+  is even less forgiving in commit titles. Use plain `-` and `"`.
+
 **Squash-merge note:** PR titles must themselves be Conventional Commits,
 because the squash-merge commit on `main` is what release-please reads.
-Reviewers will rename PR titles before merging if needed.
+Reviewers will rename PR titles before merging if needed. A single
+un-parseable subject line in the post-tag window can block the entire
+next release from being opened — when in doubt, lean strict.
 
 ## Sign-off (DCO)
 


### PR DESCRIPTION
## Summary

Adds a 'Common parser breakers' subsection to `CONTRIBUTING.md`'s commit-messages guidance. Documents three real failure modes that have caused release-please to skip commits — including one that **currently blocks the next release PR from being opened**.

## Context

After `backend-v2.12.0` (May 28), three commits landed on `main`:

| SHA | Title | Why release-please skipped it |
|---|---|---|
| 094b9594 | `CAURA-699 fix(enrichment): … …` | Leading ticket id + Unicode ellipsis |
| 7e1bcde1 | `CAURA-132 chore(contradiction): …` | Leading ticket id; `chore:` also doesn't trigger |
| ea039109 | `Reword fleet-scope 403s …` | No conventional prefix |

Result: `release-please` ran on every push and reported `Considering: 0 commits` → no release PR opened → CAURA-132 diagnostic logs sit unreleased → wet-test verification of CAURA-128/129/130/131 stays blocked.

This PR is the unblocker: a clean `docs:` commit that release-please WILL parse, sweeping the post-v2.12.0 SHA range into the next release PR. The actual content (warning about the three parser breakers) means the failure class is documented for everyone going forward.

## What the new subsection covers

1. **Leading ticket identifier** (`CAURA-NNN feat(scope): …`) — the dominant pattern in recent PRs and the proximate cause of the current release-please block.
2. **Unicode ellipsis (`…`, U+2026)** — GitHub's squash-merge UI can introduce this on long titles. Bit us on CAURA-699.
3. **Non-ASCII punctuation generally** (em-dashes, smart quotes) — adjacent failure class, already flagged by `ruff` in code comments. Adds consistency.

Plus a small strengthening of the existing squash-merge note: a single un-parseable subject in the post-tag window can block the whole next release.

## Validation

- [x] `CONTRIBUTING.md` renders cleanly in GitHub's markdown preview.
- [x] No code touched.
- [x] DCO sign-off.

## Rollback

Single `git revert`. Pure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)