### PR TITLE
feat(embedding): let the platform singleton target a self-hosted endpoint

### DIFF
--- a/common/embedding/_platform.py
+++ b/common/embedding/_platform.py
@@ -29,6 +29,19 @@ _platform_embedding: EmbeddingProvider | None = None
 _platform_init_errors: list[str] = []
 
 
+def _reject_openai_config(msg: str, *args: object) -> None:
+    """Record a platform OpenAI-embedding misconfiguration and warn.
+
+    Single-sources the ``"openai-embedding-config"`` error tag shared by
+    every config-rejection arm. The caller must ``return`` after calling
+    this — the singleton is left ``None`` so the worker fails loud (drops
+    embed requests with a visible log) rather than silently embedding
+    against the wrong endpoint.
+    """
+    logger.warning(msg, *args)
+    _platform_init_errors.append("openai-embedding-config")
+
+
 def init_platform_embedding() -> None:
     """Build the singleton from ``PLATFORM_EMBEDDING_*`` env vars.
 
@@ -48,19 +61,90 @@ def init_platform_embedding() -> None:
     if provider == ProviderName.OPENAI:
         api_key = os.environ.get("PLATFORM_EMBEDDING_API_KEY", "")
         if not api_key:
-            logger.warning(
+            _reject_openai_config(
                 "PLATFORM_EMBEDDING_PROVIDER=openai but no PLATFORM_EMBEDDING_API_KEY"
             )
-            _platform_init_errors.append("openai-embedding-config")
             return
+
+        # Self-hosted OpenAI-compatible endpoint support (TEI, vLLM, ...).
+        # The core-worker embeds *documents* exclusively through THIS
+        # singleton (core_worker/consumer.py::handle_embed_request →
+        # get_platform_embedding), never the registry. Without threading a
+        # base_url through here, the worker's write path can only ever reach
+        # api.openai.com — so pointing core-api at a self-hosted endpoint via
+        # the registry's OPENAI_EMBEDDING_BASE_URL would silently leave the
+        # write path (and the stored corpus) on the old vendor. These knobs
+        # mirror the registry's in common/embedding/_registry.py so the
+        # platform tier can target the same self-hosted endpoint.
+        base_url = os.environ.get("PLATFORM_EMBEDDING_BASE_URL") or None
+        _send_dim_raw = os.environ.get(
+            "PLATFORM_EMBEDDING_SEND_DIMENSIONS", "true"
+        ).lower()
+        if _send_dim_raw not in ("true", "false"):
+            _reject_openai_config(
+                "PLATFORM_EMBEDDING_SEND_DIMENSIONS=%r must be 'true' or 'false'",
+                _send_dim_raw,
+            )
+            return
+        send_dimensions = _send_dim_raw == "true"
+
+        # The same two guaranteed-failure misconfigurations the registry
+        # rejects. Fail loud at init (None singleton → worker drops embed
+        # requests with a visible log) rather than 4xx'ing every embed call
+        # and silently persisting embedding=NULL.
+        if base_url and send_dimensions:
+            _reject_openai_config(
+                "PLATFORM_EMBEDDING_BASE_URL=%r is set but "
+                "PLATFORM_EMBEDDING_SEND_DIMENSIONS is true. Self-hosted "
+                "OpenAI-compatible endpoints (TEI, vLLM, ...) reject the "
+                "``dimensions=`` kwarg. Set PLATFORM_EMBEDDING_SEND_DIMENSIONS"
+                "=false for TEI/vLLM, or unset PLATFORM_EMBEDDING_BASE_URL to "
+                "use hosted OpenAI.",
+                base_url,
+            )
+            return
+        if not base_url and not send_dimensions:
+            _reject_openai_config(
+                "PLATFORM_EMBEDDING_SEND_DIMENSIONS=false but "
+                "PLATFORM_EMBEDDING_BASE_URL is unset (hosted OpenAI). Hosted "
+                "OpenAI returns the model's native dim without the "
+                "``dimensions=`` kwarg, which pgvector rejects at write time. "
+                "Set PLATFORM_EMBEDDING_SEND_DIMENSIONS=true (or unset it) for "
+                "the hosted OpenAI path, or set PLATFORM_EMBEDDING_BASE_URL to "
+                "a self-hosted endpoint producing VECTOR_DIM-sized vectors."
+            )
+            return
+
+        # Matryoshka truncation for models whose native dim > VECTOR_DIM
+        # (e.g. Qwen3-Embedding-4B). Constructor re-validates it equals
+        # VECTOR_DIM and renormalizes; surface the env-var name on parse error.
+        truncate_raw = os.environ.get("PLATFORM_EMBEDDING_TRUNCATE_TO_DIM")
+        try:
+            truncate_to_dim = int(truncate_raw) if truncate_raw else None
+        except ValueError:
+            _reject_openai_config(
+                "PLATFORM_EMBEDDING_TRUNCATE_TO_DIM=%r must be an integer",
+                truncate_raw,
+            )
+            return
+
         try:
             embed_model = (
                 os.environ.get("PLATFORM_EMBEDDING_MODEL") or OPENAI_EMBEDDING_MODEL
             )
             _platform_embedding = OpenAIEmbeddingProvider(
-                api_key=api_key, model=embed_model
+                api_key=api_key,
+                model=embed_model,
+                base_url=base_url,
+                send_dimensions=send_dimensions,
+                truncate_to_dim=truncate_to_dim,
             )
-            logger.info("Platform embedding: openai/%s", embed_model)
+            logger.info(
+                "Platform embedding: openai/%s (base_url=%s, send_dimensions=%s)",
+                embed_model,
+                base_url or "api.openai.com",
+                send_dimensions,
+            )
         except Exception:
             logger.exception("Failed to initialize platform OpenAI embedding provider")
             _platform_init_errors.append("openai-embedding")

--- a/tests/test_platform_providers.py
+++ b/tests/test_platform_providers.py
@@ -24,6 +24,15 @@ def _reset_platform_singletons():
 
     llm_mod._platform_llm = None
     embedding_mod._platform_embedding = None
+    # Also clear the init-error lists. They are module-global and feed the
+    # /health "degraded" signal (core_api/routes/health.py: a non-empty
+    # get_platform_init_errors() → status "degraded"). A leftover
+    # "openai-embedding-config" entry from a rejection test below otherwise
+    # leaks across files into later integration health assertions
+    # (e.g. test_security_tenant_isolation::test_health_no_tenant_stats).
+    embedding_mod._platform_init_errors.clear()
+    if hasattr(llm_mod, "_platform_init_errors"):
+        llm_mod._platform_init_errors.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -527,3 +536,121 @@ class _FakeTenantConfig:
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
+
+
+# ---------------------------------------------------------------------------
+# Group 6: Platform embedding against a self-hosted endpoint (TEI/vLLM)
+# ---------------------------------------------------------------------------
+
+
+def _init_and_assert_rejected():
+    """Run ``init_platform_embedding`` and assert it rejected the config.
+
+    A rejected config leaves the singleton ``None`` and records the
+    ``openai-embedding-config`` tag (which surfaces as health="degraded").
+    Deferred import is intentional — see the singleton-reset note in
+    ``_reset_platform_singletons``.
+    """
+    from common.embedding._platform import (
+        get_platform_embedding,
+        get_platform_init_errors,
+        init_platform_embedding,
+    )
+
+    init_platform_embedding()
+    assert get_platform_embedding() is None
+    assert "openai-embedding-config" in get_platform_init_errors()
+
+
+class TestPlatformEmbeddingSelfHosted:
+    """``init_platform_embedding`` honours ``PLATFORM_EMBEDDING_BASE_URL`` so the
+    core-worker write path (which only ever uses the platform singleton) can be
+    pointed at a self-hosted OpenAI-compatible endpoint such as TEI/bge-m3.
+
+    Calls ``common.embedding._platform.init_platform_embedding`` directly — the
+    exact entry point the worker lifespan uses — rather than the core-api
+    ``init_platform_providers`` wrapper.
+    """
+
+    def test_base_url_and_send_dimensions_false_builds_tei_provider(self, monkeypatch):
+        monkeypatch.setenv("PLATFORM_EMBEDDING_PROVIDER", "openai")
+        monkeypatch.setenv("PLATFORM_EMBEDDING_API_KEY", "sk-tei-noauth")
+        monkeypatch.setenv("PLATFORM_EMBEDDING_MODEL", "BAAI/bge-m3")
+        monkeypatch.setenv(
+            "PLATFORM_EMBEDDING_BASE_URL", "http://tei.staging.internal:80/v1"
+        )
+        monkeypatch.setenv("PLATFORM_EMBEDDING_SEND_DIMENSIONS", "false")
+
+        from common.embedding._platform import (
+            get_platform_embedding,
+            init_platform_embedding,
+        )
+        from common.embedding.providers.openai import OpenAIEmbeddingProvider
+
+        init_platform_embedding()
+        emb = get_platform_embedding()
+        assert isinstance(emb, OpenAIEmbeddingProvider)
+        assert emb._send_dimensions is False
+        assert emb.model == "BAAI/bge-m3"
+        assert "tei.staging.internal" in str(emb._client.base_url)
+
+    def test_hosted_openai_default_unchanged(self, monkeypatch):
+        """No base_url + default send_dimensions → identical to the old
+        behaviour: hosted api.openai.com with ``dimensions=`` enabled."""
+        monkeypatch.setenv("PLATFORM_EMBEDDING_PROVIDER", "openai")
+        monkeypatch.setenv("PLATFORM_EMBEDDING_API_KEY", "sk-hosted")
+        monkeypatch.setenv("PLATFORM_EMBEDDING_MODEL", "text-embedding-3-small")
+        monkeypatch.delenv("PLATFORM_EMBEDDING_BASE_URL", raising=False)
+        monkeypatch.delenv("PLATFORM_EMBEDDING_SEND_DIMENSIONS", raising=False)
+
+        from common.embedding._platform import (
+            get_platform_embedding,
+            init_platform_embedding,
+        )
+
+        init_platform_embedding()
+        emb = get_platform_embedding()
+        assert emb is not None
+        assert emb._send_dimensions is True
+        assert "api.openai.com" in str(emb._client.base_url)
+
+    def test_base_url_with_send_dimensions_true_is_rejected(self, monkeypatch, caplog):
+        monkeypatch.setenv("PLATFORM_EMBEDDING_PROVIDER", "openai")
+        monkeypatch.setenv("PLATFORM_EMBEDDING_API_KEY", "sk-tei")
+        monkeypatch.setenv(
+            "PLATFORM_EMBEDDING_BASE_URL", "http://tei.staging.internal:80/v1"
+        )
+        # send_dimensions defaults to "true" — guaranteed-failure combo.
+        monkeypatch.delenv("PLATFORM_EMBEDDING_SEND_DIMENSIONS", raising=False)
+
+        _init_and_assert_rejected()
+        assert "reject the" in caplog.text
+
+    def test_send_dimensions_false_without_base_url_is_rejected(self, monkeypatch):
+        monkeypatch.setenv("PLATFORM_EMBEDDING_PROVIDER", "openai")
+        monkeypatch.setenv("PLATFORM_EMBEDDING_API_KEY", "sk-hosted")
+        monkeypatch.delenv("PLATFORM_EMBEDDING_BASE_URL", raising=False)
+        monkeypatch.setenv("PLATFORM_EMBEDDING_SEND_DIMENSIONS", "false")
+
+        _init_and_assert_rejected()
+
+    def test_invalid_send_dimensions_is_rejected(self, monkeypatch):
+        monkeypatch.setenv("PLATFORM_EMBEDDING_PROVIDER", "openai")
+        monkeypatch.setenv("PLATFORM_EMBEDDING_API_KEY", "sk-tei")
+        monkeypatch.setenv(
+            "PLATFORM_EMBEDDING_BASE_URL", "http://tei.staging.internal:80/v1"
+        )
+        monkeypatch.setenv("PLATFORM_EMBEDDING_SEND_DIMENSIONS", "yes")
+
+        _init_and_assert_rejected()
+
+    def test_non_integer_truncate_to_dim_is_rejected(self, monkeypatch):
+        monkeypatch.setenv("PLATFORM_EMBEDDING_PROVIDER", "openai")
+        monkeypatch.setenv("PLATFORM_EMBEDDING_API_KEY", "sk-tei")
+        monkeypatch.setenv(
+            "PLATFORM_EMBEDDING_BASE_URL", "http://tei.staging.internal:80/v1"
+        )
+        monkeypatch.setenv("PLATFORM_EMBEDDING_SEND_DIMENSIONS", "false")
+        monkeypatch.setenv("PLATFORM_EMBEDDING_TRUNCATE_TO_DIM", "not-an-int")
+
+        _init_and_assert_rejected()


### PR DESCRIPTION
## Summary

The core-worker embeds documents **exclusively** through the platform embedding singleton (`core_worker/consumer.py::handle_embed_request` → `get_platform_embedding`), never the registry. `init_platform_embedding` built `OpenAIEmbeddingProvider(api_key, model)` with **no `base_url`**, so the worker write path could only ever reach `api.openai.com` — there was no env var to point it at a self-hosted OpenAI-compatible endpoint (TEI, vLLM).

This is the gap behind a subtle failure mode: pointing core-api at TEI via the registry's `OPENAI_EMBEDDING_BASE_URL` moves only the **query** path. The **write** path (and thus the stored corpus) silently stays on the old vendor — and cross-vendor cosine is ~random, so search recall collapses.

## Change

`init_platform_embedding` now also reads `PLATFORM_EMBEDDING_BASE_URL`, `PLATFORM_EMBEDDING_SEND_DIMENSIONS`, and `PLATFORM_EMBEDDING_TRUNCATE_TO_DIM` and threads them into the provider, with the same two fail-loud guards the registry uses (the `base_url` ⊕ `send_dimensions` misconfigurations). A small `_reject_openai_config` helper single-sources the `openai-embedding-config` error tag across the rejection arms.

**Backward compatible:** with `PLATFORM_EMBEDDING_BASE_URL` unset, behaviour is identical to today (hosted OpenAI, `dimensions=` enabled).

## Why

Unblocks pointing the platform/worker embedding tier at a self-hosted TEI/bge-m3 endpoint — the staging local-embedder rollout (Cloud Run GPU) needs this before a coherent query+write cutover. Same knobs the registry already exposes, so both tiers can target the same endpoint.

## Test plan

- New `TestPlatformEmbeddingSelfHosted` group in `tests/test_platform_providers.py`: TEI provider built with `base_url` + `send_dimensions=false`; hosted-OpenAI default unchanged; and the four reject paths (base_url+send_dimensions, send_dimensions-false-without-base_url, invalid bool, non-int truncate).
- `tests/test_platform_providers.py` — **32 passed**. Embedding test surface (platform + service + stampede + cache + qemb) — **54 passed**.
- `ruff check` + `ruff format --check` clean on changed files; `mypy` introduces 0 new errors in `_platform.py`.
- Note: full repo suite / CI not run locally — CI is the gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)