### PR TITLE
fix(events): env-scoped topic prefix for PubSubEventBus (no-op default)

### DIFF
--- a/common/events/factory.py
+++ b/common/events/factory.py
@@ -54,7 +54,9 @@ def get_event_bus() -> EventBus:
             # behaviour) — a strict no-op. Set EVENT_BUS_TOPIC_PREFIX per-env (e.g.
             # "prod"/"staging") to isolate Pub/Sub topics across environments that
             # share one GCP project, eliminating cross-env message fan-out.
-            topic_prefix = os.getenv("EVENT_BUS_TOPIC_PREFIX")
+            # Strip so a fat-fingered secret (e.g. "prod ") can't produce an
+            # invalid GCP topic name like "prod --memclaw.memory.embedded".
+            topic_prefix = (os.getenv("EVENT_BUS_TOPIC_PREFIX") or "").strip()
             if topic_prefix:
                 kwargs["topic_prefix"] = topic_prefix
             # Environment identity for the cross-env fan-out guard. Two

--- a/common/events/factory.py
+++ b/common/events/factory.py
@@ -49,6 +49,14 @@ def get_event_bus() -> EventBus:
                     "EVENT_BUS_BACKEND=pubsub requires GCP_PROJECT_ID (or "
                     "EVENT_BUS_PROJECT_ID) and EVENT_BUS_SUBSCRIPTION_PREFIX"
                 )
+            kwargs: dict[str, Any] = {}
+            # Env-scoped topic prefix. Unset/empty ⇒ raw topic names (today's
+            # behaviour) — a strict no-op. Set EVENT_BUS_TOPIC_PREFIX per-env (e.g.
+            # "prod"/"staging") to isolate Pub/Sub topics across environments that
+            # share one GCP project, eliminating cross-env message fan-out.
+            topic_prefix = os.getenv("EVENT_BUS_TOPIC_PREFIX")
+            if topic_prefix:
+                kwargs["topic_prefix"] = topic_prefix
             # Environment identity for the cross-env fan-out guard. Two
             # environments sharing one GCP project also share its topic
             # namespace, so Pub/Sub delivers every published message to
@@ -75,7 +83,7 @@ def get_event_bus() -> EventBus:
                     "is DISABLED; messages from sibling environments sharing "
                     "this project's topics will not be dropped."
                 )
-            kwargs: dict[str, Any] = {"env": env}
+            kwargs["env"] = env
             raw_max = os.getenv("EVENT_BUS_PUBSUB_MAX_MESSAGES")
             if raw_max:
                 try:

--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -100,6 +100,7 @@ class PubSubEventBus(EventBus):
         pull_timeout: float = 20.0,
         error_backoff: float = 5.0,
         publish_concurrency: int = 32,
+        topic_prefix: str = "",
     ) -> None:
         # No SDK import at construction: the factory can return this
         # instance even in environments where google-cloud-pubsub isn't
@@ -111,6 +112,11 @@ class PubSubEventBus(EventBus):
         # publisher's stamp mismatch a subscriber's comparison. Empty
         # string collapses to None so it behaves identically to "unset".
         self._env = env.strip() if env and env.strip() else None
+        # Env-scoped TOPIC prefix, mirroring subscription_prefix. Empty ("") ⇒ raw
+        # topic names — byte-identical to today. Set EVENT_BUS_TOPIC_PREFIX per-env
+        # (via the factory) to isolate topics across environments that share one GCP
+        # project, eliminating cross-env message fan-out. See _topic_name().
+        self._topic_prefix = topic_prefix
         self._max_messages = max_messages
         self._pull_timeout = pull_timeout
         self._error_backoff = error_backoff
@@ -340,6 +346,13 @@ class PubSubEventBus(EventBus):
             return False
         return not self._failed_subscriptions
 
+    def _topic_name(self, topic: str) -> str:
+        """Apply the env-scoped topic prefix, if configured. Empty prefix returns
+        the raw topic name (today's behaviour) — so this is a strict no-op until
+        EVENT_BUS_TOPIC_PREFIX is set. Used at BOTH the publish and subscribe sites
+        so an env's publishers and subscribers always agree on the topic id."""
+        return f"{self._topic_prefix}--{topic}" if self._topic_prefix else topic
+
     def _get_publish_executor(self) -> concurrent.futures.ThreadPoolExecutor:
         # Refuse to spin up a fresh executor during stop()'s teardown
         # window — otherwise a concurrent publish() could create a pool
@@ -373,7 +386,7 @@ class PubSubEventBus(EventBus):
                 "events. Call `await bus.start()` at service startup."
             )
         publisher = await self._ensure_publisher()
-        topic_path = publisher.topic_path(self._project_id, topic)
+        topic_path = publisher.topic_path(self._project_id, self._topic_name(topic))
         payload = event.model_dump_json().encode("utf-8")
         # Fire the publish into the client's internal batch queue and
         # return — do NOT block on the returned Future. .result(timeout=30)
@@ -515,7 +528,7 @@ class PubSubEventBus(EventBus):
                 thread_name_prefix="pubsub-pull",
             )
             for topic, handlers in self._handlers.items():
-                sub_name = f"{self._subscription_prefix}--{topic}"
+                sub_name = f"{self._subscription_prefix}--{self._topic_name(topic)}"
                 task = asyncio.create_task(self._pull_loop(sub_name, handlers))
                 self._pull_tasks.append(task)
         self._started = True

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -47,6 +47,31 @@ async def test_publish_encodes_envelope_as_json(bus: PubSubEventBus) -> None:
     assert parsed["payload"] == {"memory_id": "abc"}
 
 
+async def test_topic_prefix_scopes_publish(bus: PubSubEventBus) -> None:
+    # With an env-scoped topic prefix set, publish targets the prefixed topic id —
+    # so an env's publishers/subscribers stay isolated from another env sharing the
+    # GCP project (cross-env fan-out fix).
+    bus._topic_prefix = "prod"
+    event = Event(
+        event_type=Topics.Memory.EMBEDDED, tenant_id="t1", payload={"memory_id": "abc"}
+    )
+    await bus.publish(Topics.Memory.EMBEDDED, event)
+    topic_path, _ = bus._publisher.publish.call_args[0]
+    assert topic_path == "projects/proj/topics/prod--memclaw.memory.embedded"
+
+
+def test_topic_name_prefix_and_no_op() -> None:
+    scoped = PubSubEventBus(
+        project_id="proj", subscription_prefix="prod-core-api", topic_prefix="prod"
+    )
+    assert (
+        scoped._topic_name("memclaw.memory.embedded") == "prod--memclaw.memory.embedded"
+    )
+    # Empty/unset prefix ⇒ the raw topic name (byte-identical to today's behaviour).
+    noop = PubSubEventBus(project_id="proj", subscription_prefix="test")
+    assert noop._topic_name("memclaw.memory.embedded") == "memclaw.memory.embedded"
+
+
 async def test_decode_accepts_well_formed_envelope() -> None:
     src = Event(event_type=Topics.Memory.CREATED, tenant_id="t1", payload={"k": "v"})
     bytes_ = src.model_dump_json().encode("utf-8")


### PR DESCRIPTION
## What
Cross-env Pub/Sub **fan-out**: prod + staging share one GCP project (`alpine-theory-469016-c8`) and publish/subscribe against the **same non-env-scoped topics** (`memclaw.memory.*`, `lifecycle.*`, `audit.*`, …), so every event is delivered to **both** envs' workers — the foreign env logs `target row missing; ack-dropping`. The EventBus already env-scopes **subscriptions** (`EVENT_BUS_SUBSCRIPTION_PREFIX`) but **not topics** — that asymmetry is the root cause. (Filed as the P0 cross-env-leakage report; verified real but ~P2 — no data loss, since each env has its own subscription and processes its own copy; the foreign env just wastes work + logs noise + is a latent cross-env-write risk.)

## This PR — the safe enabling primitive only (strict no-op)
A `_topic_name()` helper that prefixes the topic id with an env-scoped `EVENT_BUS_TOPIC_PREFIX`, applied at **both** the publish (`topic_path`) and subscribe (`sub_name`) call sites so an env's publishers and subscribers always agree. **Default (unset/empty) returns the raw topic name — byte-identical to today.** `topics.py`, terraform, and the events manifest are untouched, so **this changes nothing in prod on its own** (the cross-repo `pubsub-provisioning` validator is unaffected).

- `common/events/pubsub.py` — `topic_prefix` ctor kwarg + `_topic_name()` + both call sites.
- `common/events/factory.py` — read `EVENT_BUS_TOPIC_PREFIX` (empty default ⇒ no-op).
- `tests/test_events/test_pubsub_bus.py` — prefixed + no-op coverage (`40 passed`; ruff clean).

## Deferred — the actual cutover (NOT in this PR)
Activating cross-env isolation is a **staged terraform cutover**: create per-env topics (`{prefix}--<topic>` + DLQs) in each env's terraform, dual-publish, drain, set `EVENT_BUS_TOPIC_PREFIX` per env, flip all consumers (core-api, core-worker, platform-audit-api, platform-admin-api), then delete the old shared topics. Renaming terraform topics is destroy-recreate, so it must be phased (big-bang would crash consumers + lose in-flight messages). The terraform topic name **must** equal this helper's `{prefix}--{topic}` format.

@erni-a — over to you. This PR is intentionally a no-op until the cutover wires `EVENT_BUS_TOPIC_PREFIX`; it just lands the primitive so the cutover is a config/terraform change, not a code change under time pressure.
