### PR TITLE
fix(events): drop cross-environment Pub/Sub fan-out messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@
 
 # -- Mode -------------------------------------------------------------------
 IS_STANDALONE=true
+# Also the default environment identity for the Pub/Sub event bus: when
+# EVENT_BUS_BACKEND=pubsub, the bus stamps each message with this value and
+# drops messages published by a sibling environment that shares the same GCP
+# project's topics. Override independently with EVENT_BUS_ENV if the bus
+# identity must differ from ENVIRONMENT. Irrelevant for the default
+# in-process bus (single environment per process).
 ENVIRONMENT=development
 
 # -- Image version (docker-compose only) ------------------------------------

--- a/common/events/factory.py
+++ b/common/events/factory.py
@@ -59,8 +59,12 @@ def get_event_bus() -> EventBus:
             # the broader ``ENVIRONMENT`` if needed; falling back to
             # ``ENVIRONMENT`` means existing deployments (already set to a
             # per-environment value) get the guard with no infra change.
-            env = os.getenv("EVENT_BUS_ENV") or os.getenv("ENVIRONMENT")
-            if not env or not env.strip():
+            # Strip before the fallback so a whitespace-only EVENT_BUS_ENV
+            # (truthy) doesn't short-circuit the ``or`` and block the
+            # ENVIRONMENT fallback; empty collapses to None (guard disabled).
+            event_bus_env = os.getenv("EVENT_BUS_ENV", "").strip()
+            env = event_bus_env or os.getenv("ENVIRONMENT", "").strip() or None
+            if not env:
                 # Fail-soft: the guard stays disabled (every message is
                 # treated as same-env, i.e. today's behaviour). Warn so a
                 # misconfigured multi-env deploy is visible rather than

--- a/common/events/factory.py
+++ b/common/events/factory.py
@@ -7,6 +7,7 @@ subscribers in the same process share the same bus instance.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 from typing import Any
@@ -14,6 +15,8 @@ from typing import Any
 from common.events.base import EventBus
 from common.events.inprocess import InProcessEventBus
 from common.events.pubsub import PubSubEventBus
+
+logger = logging.getLogger(__name__)
 
 _bus: EventBus | None = None
 _lock = threading.Lock()
@@ -46,7 +49,29 @@ def get_event_bus() -> EventBus:
                     "EVENT_BUS_BACKEND=pubsub requires GCP_PROJECT_ID (or "
                     "EVENT_BUS_PROJECT_ID) and EVENT_BUS_SUBSCRIPTION_PREFIX"
                 )
-            kwargs: dict[str, Any] = {}
+            # Environment identity for the cross-env fan-out guard. Two
+            # environments sharing one GCP project also share its topic
+            # namespace, so Pub/Sub delivers every published message to
+            # *both* envs' subscriptions; the bus uses this to stamp
+            # outgoing messages and drop foreign copies (see
+            # ``PubSubEventBus`` docstring). Dedicated ``EVENT_BUS_ENV``
+            # takes precedence so the bus identity can be decoupled from
+            # the broader ``ENVIRONMENT`` if needed; falling back to
+            # ``ENVIRONMENT`` means existing deployments (already set to a
+            # per-environment value) get the guard with no infra change.
+            env = os.getenv("EVENT_BUS_ENV") or os.getenv("ENVIRONMENT")
+            if not env or not env.strip():
+                # Fail-soft: the guard stays disabled (every message is
+                # treated as same-env, i.e. today's behaviour). Warn so a
+                # misconfigured multi-env deploy is visible rather than
+                # silently leaking across environments.
+                logger.warning(
+                    "EVENT_BUS_BACKEND=pubsub but neither EVENT_BUS_ENV nor "
+                    "ENVIRONMENT is set — the cross-environment fan-out guard "
+                    "is DISABLED; messages from sibling environments sharing "
+                    "this project's topics will not be dropped."
+                )
+            kwargs: dict[str, Any] = {"env": env}
             raw_max = os.getenv("EVENT_BUS_PUBSUB_MAX_MESSAGES")
             if raw_max:
                 try:

--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -11,6 +11,22 @@ with infra. This class assumes the topics/subscriptions already exist.
 
 Import is lazy so `common.events` can be imported in OSS standalone
 installs that don't have `google-cloud-pubsub` installed.
+
+**Cross-environment isolation.** When two environments (e.g. production
+and a sandbox/staging) share one GCP project, they also share the topic
+namespace — topic names are not env-scoped. Each env gets its *own*
+subscription per topic, so Pub/Sub fans every published message out to
+*both* environments' subscribers. The foreign-env subscriber then does
+real work (a worker re-runs the embed/enrich provider call on the payload
+content) before its tenant-scoped DB write no-ops, wasting spend and
+emitting `target row missing` noise. To prevent this, the bus stamps each
+message with a `source_env` attribute (see ``SOURCE_ENV_ATTRIBUTE``) and
+``_pull_loop`` ack-drops any message whose `source_env` differs from this
+process's ``env`` *before* decode/dispatch. The guard is a no-op when
+``env`` is unset or the attribute is absent (backward-compatible with
+publishers that predate the attribute), so it is safe to roll out in any
+order. A follow-up moves the same drop server-side via a subscription
+`filter` on the attribute.
 """
 
 from __future__ import annotations
@@ -28,6 +44,15 @@ from pydantic import ValidationError
 from common.events.base import Event, EventBus, EventHandler
 
 logger = logging.getLogger(__name__)
+
+# Pub/Sub message attribute carrying the publishing environment's identity
+# (e.g. "production" / "sandbox"). Stamped on every publish when the bus is
+# constructed with an ``env`` and used by ``_pull_loop`` to drop foreign-env
+# messages. It is a Pub/Sub *attribute* (not a field in the JSON envelope) so
+# a future subscription ``filter`` can drop foreign messages server-side —
+# filters can only match attributes, never the message body. See the
+# cross-environment leakage note in the module docstring.
+SOURCE_ENV_ATTRIBUTE = "source_env"
 
 
 class PubSubEventBus(EventBus):
@@ -57,6 +82,15 @@ class PubSubEventBus(EventBus):
         project_id: str,
         subscription_prefix: str,
         *,
+        # Identity of the publishing environment ("production" /
+        # "sandbox" / ...). Stamped onto every published message as the
+        # ``SOURCE_ENV_ATTRIBUTE`` Pub/Sub attribute and used by
+        # ``_pull_loop`` to drop foreign-env messages that fanned out
+        # from a sibling environment sharing this project's topics. When
+        # None the cross-env guard is disabled (no stamping, no
+        # filtering) — preserves the pre-guard behaviour for single-env
+        # deployments and in-process tests.
+        env: str | None = None,
         # Batch size per pull. Caps ``workers × max_messages``
         # concurrent embed calls across the deployed pool, so 25
         # balances drain throughput against the OpenAI per-org
@@ -73,6 +107,10 @@ class PubSubEventBus(EventBus):
         # `start` — see `_ensure_pubsub_sdk` below.
         self._project_id = project_id
         self._subscription_prefix = subscription_prefix
+        # Normalise so a stray trailing space in the env var can't make a
+        # publisher's stamp mismatch a subscriber's comparison. Empty
+        # string collapses to None so it behaves identically to "unset".
+        self._env = env.strip() if env and env.strip() else None
         self._max_messages = max_messages
         self._pull_timeout = pull_timeout
         self._error_backoff = error_backoff
@@ -351,10 +389,18 @@ class PubSubEventBus(EventBus):
         # per-message publish errors to the caller — publisher-side
         # failures land in the SDK's background-thread log instead.
         # For a fire-and-forget audit path that is the right shape.
+        # Stamp the publishing environment so sibling environments that
+        # share this project's topics can drop our fan-out copies (see
+        # ``_pull_loop`` and the module docstring). Passed as a Pub/Sub
+        # *attribute* (kwarg to ``publish``) rather than folded into the
+        # JSON body so a subscription ``filter`` can later match it
+        # server-side. Omitted entirely when ``env`` is unset so the wire
+        # format is unchanged for single-env deployments.
+        attributes = {SOURCE_ENV_ATTRIBUTE: self._env} if self._env else {}
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(
             self._get_publish_executor(),
-            functools.partial(publisher.publish, topic_path, payload),
+            functools.partial(publisher.publish, topic_path, payload, **attributes),
         )
 
     # ── subscriber ─────────────────────────────────────────────────
@@ -474,6 +520,33 @@ class PubSubEventBus(EventBus):
                 self._pull_tasks.append(task)
         self._started = True
 
+    def _foreign_source_env(self, message: Any) -> str | None:
+        """Return the message's ``source_env`` when it was published by a
+        *different* environment than this bus — i.e. the message should be
+        dropped — otherwise ``None`` (process it normally).
+
+        Returns ``None`` (= process) in every backward-compatible case:
+
+        - this bus has no ``env`` configured, so the guard is disabled;
+        - the message carries no ``source_env`` attribute (the publisher
+          predates the attribute, or it came from outside this bus —
+          e.g. a Google-originated push), so we can't prove it's foreign;
+        - the attribute equals this bus's ``env``.
+
+        Only a *present* attribute that *differs* from ``self._env`` is
+        treated as foreign. This keeps the guard safe to deploy in any
+        order: until every publisher stamps the attribute, unstamped
+        messages keep their pre-guard fan-out behaviour rather than being
+        silently dropped.
+        """
+        if self._env is None:
+            return None
+        attributes = getattr(message, "attributes", None) or {}
+        source_env = attributes.get(SOURCE_ENV_ATTRIBUTE)
+        if not source_env or source_env == self._env:
+            return None
+        return source_env
+
     async def _pull_loop(
         self, subscription_name: str, handlers: list[EventHandler]
     ) -> None:
@@ -526,6 +599,27 @@ class PubSubEventBus(EventBus):
                 ack_ids: list[str] = []
                 nack_ids: list[str] = []
                 for received in response.received_messages:
+                    foreign_env = self._foreign_source_env(received.message)
+                    if foreign_env is not None:
+                        # Fan-out copy from a sibling environment sharing
+                        # this project's topics. Ack-drop *before* decode
+                        # and dispatch — running the handler would re-run a
+                        # provider (embed/enrich) call on the payload and
+                        # then no-op against a tenant row that doesn't exist
+                        # in this env's DB, wasting spend and emitting
+                        # `target row missing` noise. Ack (not nack) so it
+                        # isn't redelivered; the owning env has its own
+                        # subscription and processes its own copy.
+                        ack_ids.append(received.ack_id)
+                        logger.info(
+                            "event-bus: dropping foreign-env message",
+                            extra={
+                                "subscription": subscription_name,
+                                "source_env": foreign_env,
+                                "env": self._env,
+                            },
+                        )
+                        continue
                     event = self._decode(received.message.data)
                     if event is None:
                         # Malformed message — ack so we don't redeliver

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -932,3 +932,184 @@ async def test_decode_handles_pydantic_validation_error() -> None:
         {"event_type": "memclaw.memory.created", "occurred_at": "not-a-date"}
     ).encode()
     assert PubSubEventBus._decode(bad_ts) is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-environment fan-out guard
+#
+# Two environments sharing one GCP project share its topic namespace, so
+# Pub/Sub fans every message out to *both* envs' subscriptions. The bus
+# stamps a ``source_env`` attribute on publish and drops foreign-env copies
+# in ``_pull_loop`` before they reach a handler.
+# ---------------------------------------------------------------------------
+
+
+def _make_received(data: bytes, ack_id: str, attributes: dict[str, str]) -> Any:
+    """Build a fake Pub/Sub ReceivedMessage with real-dict attributes.
+
+    A bare ``MagicMock`` would make ``message.attributes.get(...)`` return a
+    truthy mock, defeating the guard's "attribute absent" branch — so the
+    attributes must be a real mapping.
+    """
+    received = MagicMock()
+    received.ack_id = ack_id
+    received.message.data = data
+    received.message.attributes = attributes
+    return received
+
+
+async def _drive_one_batch(bus: PubSubEventBus, received: list[Any]) -> dict[str, Any]:
+    """Run ``_pull_loop`` for exactly one batch and return what happened.
+
+    Returns ``{"dispatched": [...events], "acked": [...ack_ids],
+    "nacked": [...ack_ids]}``. The first pull yields *received*; the second
+    flips ``_stopping`` and returns nothing so the loop exits cleanly.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    dispatched: list[Event] = []
+
+    async def recording_dispatch(_handlers: Any, event: Event) -> bool:
+        dispatched.append(event)
+        return True
+
+    acked: list[str] = []
+    nacked: list[str] = []
+
+    fake_subscriber = MagicMock()
+    fake_subscriber.subscription_path = lambda proj, sub: (
+        f"projects/{proj}/subscriptions/{sub}"
+    )
+
+    calls = {"n": 0}
+
+    def fake_pull(request: Any = None, timeout: Any = None) -> Any:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return MagicMock(received_messages=received)
+        bus._stopping = True
+        return MagicMock(received_messages=[])
+
+    fake_subscriber.pull = MagicMock(side_effect=fake_pull)
+    fake_subscriber.acknowledge = MagicMock(
+        side_effect=lambda request: acked.extend(request["ack_ids"])
+    )
+    fake_subscriber.modify_ack_deadline = MagicMock(
+        side_effect=lambda request: nacked.extend(request["ack_ids"])
+    )
+
+    bus._subscriber = fake_subscriber
+    bus._pull_executor = MagicMock()
+
+    loop = asyncio.get_running_loop()
+
+    async def _direct_run(_executor: Any, fn: Any, *args: Any) -> Any:
+        return fn(*args)
+
+    with (
+        patch.object(bus, "_dispatch_all", new=recording_dispatch),
+        patch.object(loop, "run_in_executor", new=AsyncMock(side_effect=_direct_run)),
+    ):
+        await bus._pull_loop("test-sub", [lambda _e: None])
+
+    return {"dispatched": dispatched, "acked": acked, "nacked": nacked}
+
+
+async def test_publish_stamps_source_env_attribute() -> None:
+    bus = PubSubEventBus(project_id="proj", subscription_prefix="test", env="production")
+    fake_publisher = MagicMock()
+    fake_publisher.topic_path = lambda proj, topic: f"projects/{proj}/topics/{topic}"
+    fake_publisher.publish = MagicMock(return_value=MagicMock())
+    bus._publisher = fake_publisher
+
+    await bus.publish(
+        Topics.Memory.EMBED_REQUESTED,
+        Event(event_type=Topics.Memory.EMBED_REQUESTED, payload={"memory_id": "abc"}),
+    )
+
+    # Attribute rides as a kwarg, leaving the positional (topic, data)
+    # wire format intact.
+    assert fake_publisher.publish.call_args.kwargs == {"source_env": "production"}
+
+
+async def test_publish_omits_source_env_when_env_unset(bus: PubSubEventBus) -> None:
+    # The shared fixture constructs the bus without an env.
+    await bus.publish(
+        Topics.Memory.EMBED_REQUESTED,
+        Event(event_type=Topics.Memory.EMBED_REQUESTED),
+    )
+    assert "source_env" not in bus._publisher.publish.call_args.kwargs
+
+
+async def test_env_is_normalised_and_empty_collapses_to_none() -> None:
+    assert (
+        PubSubEventBus(project_id="p", subscription_prefix="s", env=" production ")._env
+        == "production"
+    )
+    assert PubSubEventBus(project_id="p", subscription_prefix="s", env="   ")._env is None
+    assert PubSubEventBus(project_id="p", subscription_prefix="s", env="")._env is None
+    assert PubSubEventBus(project_id="p", subscription_prefix="s")._env is None
+
+
+async def test_foreign_source_env_decision_matrix() -> None:
+    prod = PubSubEventBus(project_id="p", subscription_prefix="s", env="production")
+    # Guard disabled when this bus has no env.
+    no_env = PubSubEventBus(project_id="p", subscription_prefix="s")
+
+    def msg(attrs: dict[str, str]) -> Any:
+        m = MagicMock()
+        m.attributes = attrs
+        return m
+
+    # Foreign → returns the offending env (drop).
+    assert prod._foreign_source_env(msg({"source_env": "sandbox"})) == "sandbox"
+    # Same env → None (process).
+    assert prod._foreign_source_env(msg({"source_env": "production"})) is None
+    # Attribute absent → None (backward-compatible, process).
+    assert prod._foreign_source_env(msg({})) is None
+    # Bus has no env → None regardless of the attribute.
+    assert no_env._foreign_source_env(msg({"source_env": "sandbox"})) is None
+
+
+async def test_pull_loop_drops_foreign_env_message_before_dispatch() -> None:
+    bus = PubSubEventBus(project_id="proj", subscription_prefix="test", env="production")
+    foreign = _make_received(
+        b'{"event_type": "memclaw.memory.embedded"}',
+        "ack-foreign",
+        {"source_env": "sandbox"},
+    )
+
+    result = await _drive_one_batch(bus, [foreign])
+
+    # Never handled (no wasted provider call), acked so it isn't redelivered.
+    assert result["dispatched"] == []
+    assert result["acked"] == ["ack-foreign"]
+    assert result["nacked"] == []
+
+
+async def test_pull_loop_processes_same_env_message() -> None:
+    bus = PubSubEventBus(project_id="proj", subscription_prefix="test", env="production")
+    local = _make_received(
+        b'{"event_type": "memclaw.memory.embedded"}',
+        "ack-local",
+        {"source_env": "production"},
+    )
+
+    result = await _drive_one_batch(bus, [local])
+
+    assert len(result["dispatched"]) == 1
+    assert result["acked"] == ["ack-local"]
+
+
+async def test_pull_loop_processes_message_without_source_env_attribute() -> None:
+    # A publisher that predates the attribute (or an external producer) must
+    # still be processed — the guard only drops *provably* foreign messages.
+    bus = PubSubEventBus(project_id="proj", subscription_prefix="test", env="production")
+    legacy = _make_received(
+        b'{"event_type": "memclaw.memory.embedded"}', "ack-legacy", {}
+    )
+
+    result = await _drive_one_batch(bus, [legacy])
+
+    assert len(result["dispatched"]) == 1
+    assert result["acked"] == ["ack-legacy"]


### PR DESCRIPTION
## Problem

When two environments share one GCP project, they also share its Pub/Sub topic namespace — topic names are not env-scoped (`topic_path(project_id, topic)` uses bare names). Each topic has a separate subscription per environment, so Pub/Sub **fans every published message out to both environments**.

The foreign-env subscriber then does real work: the core-worker's `handle_embed_request` / `handle_enrich_request` call `provider.embed(...)` / `enrich_memory(...)` on the **payload content** *before* the DB write, then the tenant-scoped `UPDATE … WHERE tenant_id/id` no-ops against a row that doesn't exist in that env's database. The result is wasted embedding/LLM spend, doubled compute, and a flood of `target row missing; ack-dropping` logs across the memory, lifecycle, audit and suppression topics.

**No data is lost** — each environment has its own subscription and successfully processes its own copy; the foreign copy is a duplicate that gets dropped.

## Fix

Make the event bus environment-aware:

- `publish()` stamps every message with a `source_env` Pub/Sub **attribute** (an attribute, not a body field, so a later subscription `filter` can match it server-side).
- `_pull_loop` ack-drops any message whose `source_env` differs from this process's env **before decode/dispatch**, so the foreign-env handler — and its provider call — never runs.
- Env identity resolves from `EVENT_BUS_ENV`, falling back to `ENVIRONMENT` (already set per service) → **activates with no infra change**.

The guard lives in the bus, so it covers **every** topic, not just the memory ones.

### Backward-compatible / safe rollout in any order
A message with **no** `source_env` attribute is processed exactly as today. Until every publisher stamps the attribute, unstamped messages keep their current fan-out behaviour rather than being dropped — so there is no data-loss window regardless of deploy order. If neither env var is set the guard is disabled (fail-soft) with a startup warning.

## Verification
- New tests in `tests/test_events/test_pubsub_bus.py`: attribute stamping (+ omission when env unset), env normalization, the foreign-env decision matrix, and `_pull_loop` behaviour (foreign dropped+acked+not-dispatched / same-env processed / no-attribute backward-compat).
- `tests/test_events/` — 78 passed; `mypy` clean on both changed files.

## Follow-up (separate, infra-only)
Once `source_env` is confirmed flowing on both envs, recreate each subscription with a server-side `filter` on `attributes.source_env`. That moves the drop server-side (eliminates even the wasted pull) and makes this code guard defense-in-depth. **Must land after this is fully deployed** — adding the filter before publishers stamp the attribute would drop everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)