### PR TITLE
fix: return real columns from cross-link insert instead of nonexistent id

### DIFF
--- a/core-api/src/core_api/pipeline/steps/entity_linking/discover_cross_links.py
+++ b/core-api/src/core_api/pipeline/steps/entity_linking/discover_cross_links.py
@@ -136,11 +136,15 @@ class DiscoverCrossLinks:
         links_created = 0
         if to_insert:
             try:
+                # memory_entity_links has a composite PK (memory_id, entity_id)
+                # and no surrogate `id` column, so RETURNING must reference real
+                # columns. With ON CONFLICT DO NOTHING, only actually-inserted
+                # rows are returned, so the count below stays accurate.
                 insert_link_returning = text("""
                     INSERT INTO memory_entity_links (memory_id, entity_id, role)
                     VALUES (:memory_id, :entity_id, 'mentioned')
                     ON CONFLICT (memory_id, entity_id) DO NOTHING
-                    RETURNING id
+                    RETURNING memory_id, entity_id
                 """)
                 result = await ctx.require_db.execute(insert_link_returning, to_insert)
                 links_created = len(result.all())

--- a/tests/pipeline/test_entity_linking.py
+++ b/tests/pipeline/test_entity_linking.py
@@ -77,6 +77,45 @@ async def test_discover_creates_links():
 
 
 @pytest.mark.asyncio
+async def test_discover_insert_returns_real_columns_not_id():
+    """The INSERT must RETURN real columns.
+
+    ``memory_entity_links`` has a composite PK (memory_id, entity_id) and no
+    surrogate ``id`` column, so ``RETURNING id`` raises UndefinedColumnError
+    against Postgres (prod incident). Guard against its reintroduction — the
+    mock-based tests above never execute real SQL, so this asserts the SQL
+    shape directly.
+    """
+    mem_id = uuid.uuid4()
+    ent_id = uuid.uuid4()
+    embedding = [0.1] * 10
+
+    candidates = [(mem_id, "Alice loves coffee", embedding)]
+    lateral = [(mem_id, ent_id, "Alice", None, 0.95)]
+    inserted = [(mem_id, ent_id)]
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_result(candidates),
+        _mock_result(lateral),
+        _mock_result(inserted),
+    ]
+    db.flush = AsyncMock()
+
+    ctx = _make_ctx(db, cross_link_text_verify=False)
+    step = DiscoverCrossLinks()
+    result = await step.execute(ctx)
+
+    assert result.outcome == StepOutcome.SUCCESS
+    assert ctx.data["links_created"] == 1
+
+    insert_sql = str(db.execute.call_args_list[2][0][0].text)
+    assert "INSERT INTO memory_entity_links" in insert_sql
+    assert "RETURNING memory_id, entity_id" in insert_sql
+    assert "RETURNING id" not in insert_sql
+
+
+@pytest.mark.asyncio
 async def test_discover_text_verify_filters():
     """Text-verify rejects entities whose name doesn't appear in memory content."""
     mem_id = uuid.uuid4()


### PR DESCRIPTION
## The error (prod)

```
Error bulk-inserting 1 cross-links for tenant olivier-obuchowski-3d53f3
asyncpg.exceptions.UndefinedColumnError: column "id" does not exist
```

## Root cause

`DiscoverCrossLinks` inserts into `memory_entity_links` with `RETURNING id`, but that table is a **pure junction table** — composite PK `(memory_id, entity_id)`, no surrogate `id` column (`common/models/entity.py:53-62`). So `RETURNING id` references a column that doesn't exist and Postgres rejects the statement.

**Latent since v1.0.0** (`7456e23`), not a regression. It only surfaced now because (1) the insert branch only fires when a memory has <3 entity links *and* a similar entity clears the 0.75 threshold *and* text-verify passes, and (2) the existing tests mock the DB, so the invalid SQL was never validated against a real schema. Tenant `olivier-obuchowski-3d53f3` is the first prod write to reach the branch.

**Blast radius:** non-fatal. The step catches the exception and returns `FAILED`; the parent memory write still succeeds. Effect = degraded cross-link discovery, no data loss.

## Fix

```diff
-                    RETURNING id
+                    RETURNING memory_id, entity_id
```

Behaviour-preserving for the count: with `ON CONFLICT … DO NOTHING`, `RETURNING` only emits actually-inserted rows, so `links_created` stays accurate — it just selects columns that exist.

## Test

Mock-based tests can't catch a bad column name, so this adds a SQL-shape regression test (`test_discover_insert_returns_real_columns_not_id`) asserting the INSERT returns `memory_id, entity_id` and never `RETURNING id` again — mirroring the existing CAURA-675 guard in the same file.

## Verification

- `ruff check` clean ✅
- `pytest tests/pipeline/test_entity_linking.py tests/test_entity_linking_wiring.py` → 10 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)