### PR TITLE
fix(evolve): pass weight_adjustment_skipped_reason from MCP evolve path

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -2003,6 +2003,7 @@ async def memclaw_evolve(
     from core_api.services.evolve_service import (
         _apply_outcome_to_db,
         _filter_by_scope,
+        _log_weight_adjustment_skip,
         _maybe_generate_rule,
     )
     from core_api.services.organization_settings import resolve_config
@@ -2027,9 +2028,18 @@ async def memclaw_evolve(
                 return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
             await check_and_increment(db, tenant_id, "evolve")
 
+            # A15: classify why no weights will move, mirroring the REST
+            # report_outcome path. _apply_outcome_to_db requires this slug;
+            # the MCP path previously omitted it, raising a TypeError on the
+            # write path (prod incident). A deeper stage (_adjust_weights
+            # race / DB failure) may still override it.
             in_scope_ids = related_ids or []
             out_of_scope_count = 0
-            if in_scope_ids:
+            weight_adjustment_skipped_reason: str | None = None
+            if not in_scope_ids:
+                weight_adjustment_skipped_reason = "no_related_ids"
+            else:
+                original_count = len(in_scope_ids)
                 in_scope_ids, out_of_scope_count = await _filter_by_scope(
                     db,
                     tenant_id=tenant_id,
@@ -2038,6 +2048,21 @@ async def memclaw_evolve(
                     scope=scope,
                     related_ids=in_scope_ids,
                 )
+                if not in_scope_ids and out_of_scope_count >= original_count:
+                    # Filter dropped everything. Map scope → slug.
+                    weight_adjustment_skipped_reason = {
+                        "agent": "agent_id_mismatch",
+                        "fleet": "fleet_id_mismatch",
+                        "all": "all_out_of_scope",
+                    }.get(scope, "all_out_of_scope")
+                    _log_weight_adjustment_skip(
+                        weight_adjustment_skipped_reason,
+                        tenant_id,
+                        scope,
+                        out_of_scope_count=out_of_scope_count,
+                        caller_agent_id=agent_id,
+                        fleet_id=fleet_id,
+                    )
             config = await resolve_config(db, tenant_id)
         # ── Session closed. The LLM rule generation runs with no DB held. ──
 
@@ -2066,6 +2091,7 @@ async def memclaw_evolve(
                 rule_skipped_reason=rule_skipped_reason,
                 scope=scope,
                 out_of_scope_count=out_of_scope_count,
+                weight_adjustment_skipped_reason=weight_adjustment_skipped_reason,
                 t0=t0,
             )
         return _with_latency(json.dumps(result, indent=2, default=str), t0)

--- a/tests/test_mcp_evolve_session_split.py
+++ b/tests/test_mcp_evolve_session_split.py
@@ -16,6 +16,7 @@ re-merges phases 1+2 would flip the order and fail.
 
 from __future__ import annotations
 
+import inspect
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -25,6 +26,104 @@ import pytest
 from core_api import mcp_server
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+_APPLY_OUTCOME_RESULT = {
+    "outcome_id": "00000000-0000-0000-0000-000000000001",
+    "outcome_type": "failure",
+    "scope": "agent",
+    "weight_adjustments": [],
+    "rules_generated": [],
+    "rule_skipped_reason": "below_confidence_threshold",
+    "out_of_scope_count": 0,
+    "weight_adjustment_skipped_reason": None,
+    "evolve_ms": 1,
+}
+
+
+async def _run_evolve_capturing_apply_kwargs(monkeypatch, *, related_ids, filter_result):
+    """Drive memclaw_evolve with mocked collaborators, returning the kwargs
+    the handler passed to ``_apply_outcome_to_db``."""
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def _session():
+        yield MagicMock(name="db")
+
+    async def _spy_apply(_db, **kwargs):
+        captured.update(kwargs)
+        return _APPLY_OUTCOME_RESULT
+
+    monkeypatch.setattr(mcp_server, "_mcp_session", _session)
+    monkeypatch.setattr(mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None)))
+    monkeypatch.setattr(mcp_server, "check_and_increment", AsyncMock())
+    monkeypatch.setattr(
+        "core_api.services.evolve_service._filter_by_scope",
+        AsyncMock(return_value=filter_result),
+    )
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config",
+        AsyncMock(return_value=SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        "core_api.services.evolve_service._maybe_generate_rule",
+        AsyncMock(return_value=(None, "not_failure_or_partial")),
+    )
+    monkeypatch.setattr("core_api.services.evolve_service._apply_outcome_to_db", _spy_apply)
+
+    await mcp_server.memclaw_evolve(
+        outcome="a thing happened",
+        outcome_type="failure",
+        related_ids=related_ids,
+        scope="agent",
+        agent_id="a1",
+    )
+    return captured
+
+
+async def test_evolve_passes_all_required_apply_outcome_kwargs(mcp_env, monkeypatch):
+    """memclaw_evolve must pass every required kwarg of _apply_outcome_to_db.
+
+    The handler patches _apply_outcome_to_db with a mock that swallows any
+    signature, so a missing required kwarg (e.g. weight_adjustment_skipped_reason)
+    only surfaces in prod as a TypeError. Bind the captured kwargs against the
+    REAL signature so that class of bug fails here instead.
+    """
+    captured = await _run_evolve_capturing_apply_kwargs(
+        monkeypatch,
+        related_ids=["11111111-1111-1111-1111-111111111111"],
+        filter_result=(["11111111-1111-1111-1111-111111111111"], 0),
+    )
+
+    real_sig = inspect.signature(
+        __import__(
+            "core_api.services.evolve_service", fromlist=["_apply_outcome_to_db"]
+        )._apply_outcome_to_db
+    )
+    # Raises TypeError "missing a required argument" if any required kwarg
+    # (incl. weight_adjustment_skipped_reason) is absent from the call.
+    real_sig.bind(MagicMock(name="db"), **captured)
+    assert "weight_adjustment_skipped_reason" in captured
+
+
+async def test_evolve_weight_skip_reason_no_related_ids(mcp_env, monkeypatch):
+    """Empty related_ids → 'no_related_ids' slug passed through (A15)."""
+    captured = await _run_evolve_capturing_apply_kwargs(
+        monkeypatch,
+        related_ids=[],
+        filter_result=([], 0),
+    )
+    assert captured["weight_adjustment_skipped_reason"] == "no_related_ids"
+
+
+async def test_evolve_weight_skip_reason_all_out_of_scope(mcp_env, monkeypatch):
+    """Scope filter drops every id → scope-mapped slug passed through (A15)."""
+    captured = await _run_evolve_capturing_apply_kwargs(
+        monkeypatch,
+        related_ids=["11111111-1111-1111-1111-111111111111"],
+        filter_result=([], 1),  # all dropped
+    )
+    assert captured["weight_adjustment_skipped_reason"] == "agent_id_mismatch"
 
 
 async def test_evolve_closes_first_session_before_llm(mcp_env, monkeypatch):


### PR DESCRIPTION
## The error (prod)

```
Unhandled error in memclaw_evolve
TypeError: _apply_outcome_to_db() missing 1 required keyword-only argument:
'weight_adjustment_skipped_reason'
```

## Root cause

The A15 work added `weight_adjustment_skipped_reason` as a **required** keyword-only arg of `_apply_outcome_to_db` and updated the REST `report_outcome` caller (`evolve_service.py:744-811`) — but the **MCP `memclaw_evolve` caller** (`mcp_server.py`) was never updated. It ran its scope filter but neither computed the slug nor passed it, so every write-path evolve through MCP raised the `TypeError`.

Same class as the recent cross-link fix: a required arg added, one call site missed.

## Fix

Replicate the REST A15 slug logic in the MCP scope block and pass it through:
- `no_related_ids` when there are no related ids
- `agent_id_mismatch` / `fleet_id_mismatch` / `all_out_of_scope` when the scope filter drops everything
- pass `weight_adjustment_skipped_reason=` into `_apply_outcome_to_db`

## Why CI didn't catch it

The existing `test_mcp_evolve_session_split.py` tests patch `_apply_outcome_to_db` with an `AsyncMock`, which **accepts any signature** — so the missing required kwarg never surfaced. This PR adds a regression test that captures the kwargs the handler actually passes and **binds them against the real `_apply_outcome_to_db` signature**, so a missing required kwarg fails the test. Plus slug-value tests for the `no_related_ids` and all-out-of-scope cases.

## Verification

- `ruff check` clean ✅
- `pytest tests/test_mcp_evolve_session_split.py` → 5 passed ✅
- **Red/green proven:** the new bind guard *fails* when the pass-through is removed (reproduces the prod `TypeError`) and *passes* with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)