### PR TITLE
fix(plugin): suppress bootstrap agent-id warn + swallow afterTurn 409 (CAURA-000)

### DIFF
--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memclaw",
   "name": "MemClaw",
   "kind": "memory",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Central persistent memory for OpenClaw agents — write, search, and entity lookup tools.",
   "entry": "dist/index.js",
   "skills": [

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caura/memclaw",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "OpenClaw plugin for MemClaw central memory",
   "license": "Apache-2.0",
   "private": true,
@@ -16,7 +16,7 @@
     "pretest": "bash ../scripts/gen-version.sh",
     "build": "tsc",
     "dev": "bash ../scripts/gen-version.sh && tsc --watch",
-    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/keystones.test.js",
+    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/keystones.test.js dist/resolve-agent.test.js",
     "check:version": "bash -c 'V=$(node -p \"require(\\\"./package.json\\\").version\"); grep -qF \"PLUGIN_VERSION = \\\"$V\\\"\" src/version.ts || (echo \"version.ts out of sync with package.json ($V): run bash ../scripts/gen-version.sh\" >&2 && exit 1) && echo \"check:version ok: $V\"'"
   },
   "devDependencies": {

--- a/plugin/src/context-engine.test.ts
+++ b/plugin/src/context-engine.test.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 import {
   shouldRecall,
   getRecallMetrics,
+  isDuplicateMemoryError,
   type ShouldRecallInput,
 } from "./context-engine.js";
 
@@ -309,5 +310,51 @@ describe("getRecallMetrics", () => {
     assert.equal(typeof before.calls_total, "number");
     assert.equal(typeof before.skipped_total, "number");
     assert.equal(typeof before.skipped_by_reason, "object");
+  });
+});
+
+// ---- isDuplicateMemoryError — afterTurn 409 swallow gate (CAURA-000) ----
+//
+// Pins the regex that ``afterTurn`` uses to decide whether to silently
+// swallow a write rejection. Misclassifying a 5xx as a 409 would hide a
+// real outage from the operator log; misclassifying a 409 as a 5xx would
+// flood the log with ~5/hr noise (observed pre-fix on goodclaw). The
+// shape of the matched error message is pinned by ``transport.ts:82``
+// (``"MemClaw API " + status + ": " + body``) — if that ever changes,
+// this test fails loudly and forces the catch site to be updated too.
+
+describe("isDuplicateMemoryError — afterTurn 409 swallow gate", () => {
+  test("matches the dedup error shape thrown by transport.ts on HTTP 409", () => {
+    const e = new Error(
+      'MemClaw API 409: {"detail":"Duplicate memory exists: 9eea03d6-be61-456b-bf67-06ace594cf43","error":{"code":"CONFLICT","message":"Duplicate memory exists: 9eea03d6-be61-456b-bf67-06ace594cf43"}}',
+    );
+    assert.equal(isDuplicateMemoryError(e), true);
+  });
+
+  test("does NOT match a 500 / 502 / 4xx-other — non-409 errors must still surface", () => {
+    for (const status of [400, 401, 403, 404, 422, 500, 502, 503]) {
+      const e = new Error(`MemClaw API ${status}: {"detail":"x"}`);
+      assert.equal(
+        isDuplicateMemoryError(e),
+        false,
+        `status ${status} must not be classified as a 409 dedup`,
+      );
+    }
+  });
+
+  test("does NOT match arbitrary errors or non-Error inputs", () => {
+    assert.equal(isDuplicateMemoryError(new TypeError("fetch failed")), false);
+    assert.equal(isDuplicateMemoryError(new Error("something else 409")), false); // word-boundary guard: '409' alone is not enough
+    assert.equal(isDuplicateMemoryError("MemClaw API 409: string"), false); // must be an Error instance
+    assert.equal(isDuplicateMemoryError(null), false);
+    assert.equal(isDuplicateMemoryError(undefined), false);
+    assert.equal(isDuplicateMemoryError({ message: "MemClaw API 409: x" }), false);
+  });
+
+  test("matches even when the 409 message has additional context appended", () => {
+    // transport.ts truncates the body to 200 chars; the ``MemClaw API 409``
+    // prefix is always present at the start.
+    const e = new Error('MemClaw API 409: ...truncated...');
+    assert.equal(isDuplicateMemoryError(e), true);
   });
 });

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -31,7 +31,7 @@ import {
 } from "./env.js";
 import { memclawPromptSectionText } from "./prompt-section.js";
 import { MEMCLAW_TOOLS } from "./tools.js";
-import { resolveAgentId } from "./resolve-agent.js";
+import { resolveAgentId, resolveAgentIdQuiet } from "./resolve-agent.js";
 import { getTenantPrefix, getSessionKey } from "./context-engine.internal.js";
 import { logError, logErrorCritical } from "./logger.js";
 import { fetchKeystonesBlock } from "./keystones.js";
@@ -67,6 +67,28 @@ const MAX_SESSIONS = 100;
 const MAX_INGEST_WRITES_PER_SESSION = 10;
 const sessionBuffers = new Map<string, IngestMessage[]>();
 const sessionIngestCounts = new Map<string, number>();
+
+/**
+ * True iff the error is the content-hash dedup rejection from
+ * ``POST /memories`` (the backend's idempotency guard against re-writing
+ * identical content under the same ``(tenant_id, fleet_id, agent_id)``
+ * triple — see ``CheckExactDuplicate`` step in the write pipeline).
+ *
+ * Used by ``afterTurn`` to swallow this specific shape silently: the same
+ * agent emitting an identical short reply on consecutive turns ("Got it.",
+ * "ok", "thanks") is the common case, and the existing memory is what
+ * ``afterTurn`` would have written — so a 409 here is a soft no-op, not a
+ * failure. Pre-fix it produced ~5 warn/hr in the customer's goodclaw
+ * gateway, drowning real signal in the operator log. Anything that's NOT a
+ * 409 (5xx, network, auth) still routes to the normal error logger.
+ *
+ * Matches the error message format from ``transport.ts:82``:
+ *   ``new Error("MemClaw API " + status + ": " + body)``
+ */
+export function isDuplicateMemoryError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  return /\bMemClaw API 409\b/.test(e.message);
+}
 
 function pushToBuffer(sessionKey: string, message: IngestMessage): void {
   let buffer = sessionBuffers.get(sessionKey);
@@ -436,7 +458,14 @@ export class MemClawContextEngine {
   }
 
   private async _doBootstrap(): Promise<void> {
-    const bootAgentId = resolveAgentId(this.config);
+    // ``Quiet`` variant: the factoryCtx wrapper that OpenClaw passes at
+    // construction has no per-call session identity, so the install-default
+    // fallback IS the bootstrap design — the warn was pure noise. Per-turn
+    // call sites (assemble/ingest/afterTurn/prepareSubagentSpawn) still use
+    // the loud ``resolveAgentId`` so a real per-turn regression remains
+    // visible. (CAURA-000 — customer's 18h goodclaw 2.8.1 window shows
+    // 100% of residual warn noise comes from this exact bootstrap path.)
+    const bootAgentId = resolveAgentIdQuiet(this.config);
     console.log(
       `[memclaw] ContextEngine bootstrap: agent=${bootAgentId}, ` +
         `fleet=${MEMCLAW_FLEET_ID || "(unset)"}, ` +
@@ -1171,6 +1200,11 @@ export class MemClawContextEngine {
         tags: ["auto-turn-summary"],
       });
     } catch (e: unknown) {
+      // 409 dedup rejection is expected when the same agent emits identical
+      // content twice (very common for short replies). The existing memory
+      // already encodes what we'd have written → soft no-op. Swallow to
+      // keep operator-log signal-to-noise high; non-409 errors still log.
+      if (isDuplicateMemoryError(e)) return;
       logError("Failed to persist turn summary", e);
     }
   }

--- a/plugin/src/resolve-agent.test.ts
+++ b/plugin/src/resolve-agent.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for ``resolveAgentId`` / ``resolveAgentIdQuiet``.
+ *
+ * The quiet variant exists for ``ContextEngine`` bootstrap, where the
+ * factoryCtx wrapper that OpenClaw passes legitimately carries no per-call
+ * session identity — falling back to ``main-${installId}`` IS the design.
+ * The loud variant guards per-turn paths (assemble/ingest/afterTurn/
+ * prepareSubagentSpawn) where a fall-through is a real bug we want to see.
+ *
+ * Customer-side ground truth motivating this split: 18h goodclaw window
+ * post-2.8.1 shows exactly 1.00 ``Could not resolve agent ID`` warns per
+ * ``ContextEngine bootstrap`` event — i.e. 100% of residual warn noise
+ * comes from the bootstrap fallback. This test pins the contract so the
+ * fix doesn't accidentally also silence the per-turn diagnostic.
+ */
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+// Clear any inherited test pollution so the fallback path actually runs.
+delete process.env.MEMCLAW_AGENT_ID;
+
+const { resolveAgentId, resolveAgentIdQuiet } = await import(
+  "./resolve-agent.js"
+);
+
+let originalWarn: typeof console.warn;
+let warnLines: string[];
+
+function captureWarn(): void {
+  warnLines = [];
+  originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnLines.push(args.map((a) => String(a)).join(" "));
+  };
+}
+function restoreWarn(): void {
+  console.warn = originalWarn;
+}
+
+describe("resolveAgentId / resolveAgentIdQuiet — fallback warn semantics", () => {
+  beforeEach(() => captureWarn());
+  afterEach(() => restoreWarn());
+
+  test("loud variant emits warn when falling through to install-default", () => {
+    const id = resolveAgentId({}); // empty source → falls through
+    assert.match(id, /^main-[0-9a-f]+$/);
+    assert.equal(warnLines.length, 1, `expected 1 warn; got ${warnLines.length}: ${warnLines.join(" | ")}`);
+    assert.match(warnLines[0], /Could not resolve agent ID/);
+    assert.match(warnLines[0], /install-default/);
+  });
+
+  test("quiet variant returns same fallback but emits NO warn", () => {
+    const id = resolveAgentIdQuiet({});
+    assert.match(id, /^main-[0-9a-f]+$/);
+    assert.equal(warnLines.length, 0, `expected 0 warns from quiet path; got: ${warnLines.join(" | ")}`);
+  });
+
+  test("loud variant does NOT warn when the source resolves (no spurious noise)", () => {
+    const id = resolveAgentId({ sessionKey: "agent:goodclaw:whatsapp:direct:+972544576576" });
+    assert.equal(id, "goodclaw");
+    assert.equal(warnLines.length, 0, `expected 0 warns on successful resolve; got: ${warnLines.join(" | ")}`);
+  });
+
+  test("quiet variant ALSO resolves correctly when source is good (only the warn is silenced)", () => {
+    const id = resolveAgentIdQuiet({ sessionKey: "agent:dbaclaw:slack:#general" });
+    assert.equal(id, "dbaclaw");
+    assert.equal(warnLines.length, 0);
+  });
+
+  test("multiple sources: first match wins regardless of variant (pin precedence)", () => {
+    // Explicit agentId in perCall must win over sessionKey in config.
+    const id = resolveAgentId(
+      { agentId: "explicit-from-percall" },
+      { sessionKey: "agent:from-config:main" },
+    );
+    assert.equal(id, "explicit-from-percall");
+    assert.equal(warnLines.length, 0);
+  });
+});

--- a/plugin/src/resolve-agent.ts
+++ b/plugin/src/resolve-agent.ts
@@ -16,8 +16,9 @@
 import { MEMCLAW_AGENT_ID } from "./env.js";
 import { getInstallId } from "./install-id.js";
 
-export function resolveAgentId(
-  ...sources: Array<Record<string, unknown> | undefined | null>
+function resolveAgentIdInner(
+  sources: Array<Record<string, unknown> | undefined | null>,
+  quiet: boolean,
 ): string {
   for (const src of sources) {
     if (!src || typeof src !== "object") continue;
@@ -41,18 +42,49 @@ export function resolveAgentId(
   }
 
   if (MEMCLAW_AGENT_ID) {
-    console.warn(
-      "[memclaw] Agent ID resolved from MEMCLAW_AGENT_ID env var — consider passing agent_id explicitly",
-    );
+    if (!quiet) {
+      console.warn(
+        "[memclaw] Agent ID resolved from MEMCLAW_AGENT_ID env var — consider passing agent_id explicitly",
+      );
+    }
     return MEMCLAW_AGENT_ID;
   }
 
   // Per-install fallback. Was ``"unknown-agent"`` pre-Task6 — every
   // install collided on a single row.
   const fallback = `main-${getInstallId()}`;
-  console.warn(
-    `[memclaw] Could not resolve agent ID — using install-default '${fallback}'. ` +
-      `Pass agent_id explicitly (or set MEMCLAW_AGENT_ID) for clarity.`,
-  );
+  if (!quiet) {
+    console.warn(
+      `[memclaw] Could not resolve agent ID — using install-default '${fallback}'. ` +
+        `Pass agent_id explicitly (or set MEMCLAW_AGENT_ID) for clarity.`,
+    );
+  }
   return fallback;
+}
+
+export function resolveAgentId(
+  ...sources: Array<Record<string, unknown> | undefined | null>
+): string {
+  return resolveAgentIdInner(sources, false);
+}
+
+/**
+ * Same resolution as ``resolveAgentId`` but suppresses the install-default
+ * fallback warning. Use ONLY at call sites where the fallback is the design
+ * (e.g. ``ContextEngine`` bootstrap, where the ``factoryCtx`` wrapper
+ * legitimately carries no per-call session info — see CAURA-000 PR #286).
+ *
+ * Per-turn paths (``assemble`` / ``ingest`` / ``afterTurn`` /
+ * ``prepareSubagentSpawn``) MUST continue using the loud ``resolveAgentId``
+ * — a fall-through there is a real bug (it means OpenClaw's per-call
+ * context did not carry an agent identity), and silencing it would mask
+ * the next regression. The customer's 18h goodclaw window post-2.8.1
+ * shows exactly 1.00 warns per ``ContextEngine bootstrap`` event — i.e.
+ * 100% of the residual warn noise is from the bootstrap fallback, which
+ * is exactly the case this helper exists to silence.
+ */
+export function resolveAgentIdQuiet(
+  ...sources: Array<Record<string, unknown> | undefined | null>
+): string {
+  return resolveAgentIdInner(sources, true);
 }

--- a/plugin/src/version.ts
+++ b/plugin/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated from plugin/package.json by scripts/gen-version.sh — do not edit
-export const PLUGIN_VERSION = "2.8.2";
+export const PLUGIN_VERSION = "2.8.3";


### PR DESCRIPTION
## Summary

Two noise-reduction changes targeting the exact warn floor observed in the customer's goodclaw 2.8.1 window (2026-06-07T13:23 → 06-08T07:26, 18h):

| Pre-fix observed | Source | Fix |
|---|---|---|
| 227 \`Could not resolve agent ID\` warns | Bootstrap call site only (\`_doBootstrap\`) — 1.00 per bootstrap, 100% of residual noise | New \`resolveAgentIdQuiet\` variant; bootstrap is the only caller |
| 296 \`Failed to persist turn summary: MemClaw API 409\` warns (~5/hr) | \`afterTurn\` dedup rejection from identical replies ("ok", "Got it.") | New \`isDuplicateMemoryError\` gate; non-409 still logs |

Both are pure operator-log signal-to-noise improvements. No behavior change to the write/read paths themselves — the dedup is already working correctly server-side; the plugin just stops complaining about it.

### Why split the warn (loud/quiet) instead of just lowering severity

The per-turn paths (\`ingest\` / \`assemble\` / \`afterTurn\` / \`prepareSubagentSpawn\`) MUST keep warning loudly if agent_id falls through — that's the next-regression signal for PR #286. Silencing globally would mask real bugs. The bootstrap fallback is by design (no per-call context at construction); silencing **only that one call site** preserves the diagnostic for per-turn drift.

### Tests

New \`resolve-agent.test.ts\` (5 cases) pins:
- \`resolveAgentId({}) \` emits 1 warn, returns \`main-<id>\`
- \`resolveAgentIdQuiet({})\` emits 0 warns, returns \`main-<id>\`
- Successful resolves (sessionKey parsed) emit 0 warns from either variant
- Multi-source precedence is preserved

New describe block in \`context-engine.test.ts\` (4 cases) pins:
- 409 dedup error matches
- 400/401/403/404/422/500/502/503 do NOT match
- Non-Error inputs / null / undefined do NOT match
- Word-boundary regex rejects \`new Error("something else 409")\`

### Validation

- \`npm test\` in \`plugin/\`: **290/290 pass** (was 281, +9 new tests)
- \`pytest tests/test_plugin_source_manifest.py\`: 11/11 pass
- Wet test on \`openclaw-test-ran\` (GCE, OpenClaw 2026.6.1, plugin 2.8.3): **15/15 pass**, including PR #286 (sessionKey parsing) and PR #292 (AbortSignal threading) regression guards

### Version

Bumps \`2.8.2 → 2.8.3\` across \`package.json\`, \`openclaw.plugin.json\`, \`src/version.ts\` (auto-regenerated by \`gen-version.sh\` prebuild).

## Test plan

- [x] Unit tests pass
- [x] Wet-tested on GCE VM under OpenClaw 2026.6.1
- [ ] Customer push: \`memclaw.allowlist.fix\` to refresh plugin on each goodclaw/yoniclaw/antclaw VM; expect bootstrap warn count drop from 227/18h to 0 and \`Failed to persist turn summary\` count from 296/2d to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)