### PR TITLE
chore: add glama.json for Glama MCP registry claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "yanki-m"
+  ]
+}


### PR DESCRIPTION
## What

Adds `glama.json` at the repo root to register/claim the MemClaw MCP server on [glama.ai](https://glama.ai/mcp).

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": [
    "yanki-m"
  ]
}
```

## Why

Glama's MCP registry requires a `glama.json` with a `maintainers` array to verify repository ownership before the server can be claimed. Lists `yanki-m` as the maintainer.

## Next step

After merge, claim the server via "Login with GitHub to claim" on Glama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)