### PR TITLE
fix(plugin): memoize bootstrap at process level (CAURA-000)

### DIFF
--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memclaw",
   "name": "MemClaw",
   "kind": "memory",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Central persistent memory for OpenClaw agents — write, search, and entity lookup tools.",
   "entry": "dist/index.js",
   "skills": [

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caura/memclaw",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "OpenClaw plugin for MemClaw central memory",
   "license": "Apache-2.0",
   "private": true,
@@ -16,7 +16,7 @@
     "pretest": "bash ../scripts/gen-version.sh",
     "build": "tsc",
     "dev": "bash ../scripts/gen-version.sh && tsc --watch",
-    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/keystones.test.js dist/resolve-agent.test.js",
+    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js",
     "check:version": "bash -c 'V=$(node -p \"require(\\\"./package.json\\\").version\"); grep -qF \"PLUGIN_VERSION = \\\"$V\\\"\" src/version.ts || (echo \"version.ts out of sync with package.json ($V): run bash ../scripts/gen-version.sh\" >&2 && exit 1) && echo \"check:version ok: $V\"'"
   },
   "devDependencies": {

--- a/plugin/src/bootstrap-memoization.test.ts
+++ b/plugin/src/bootstrap-memoization.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the process-level bootstrap memoization (CAURA-000).
+ *
+ * Pins the contract that ``MemClawContextEngine.bootstrap()`` runs the
+ * smoke test (write → search → delete) AT MOST ONCE per Node process,
+ * regardless of how many engine instances OpenClaw constructs. The
+ * customer's goodclaw window logged 390 ``ContextEngine bootstrap``
+ * events in 31.4h pre-fix (12/hr); post-fix expectation is 1 per process
+ * lifetime (with retry-on-failure preserved).
+ *
+ * The tests mock ``globalThis.fetch`` and count "smoke-shaped" requests
+ * (``POST /memories`` with ``__smoke_test__`` tag in the body) — this
+ * isolates the memoization contract from the rest of the smoke test's
+ * internal mechanics (parseSearchItems, similarity threshold, etc.).
+ */
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+// Set required env before importing the module so resolveTenantId
+// short-circuits without hitting the network.
+process.env.MEMCLAW_API_KEY = "mc_test_key_for_bootstrap_memo";
+process.env.MEMCLAW_API_URL = "http://localhost:8000";
+process.env.MEMCLAW_TENANT_ID = "t_test";
+
+const { MemClawContextEngine, _resetBootstrapForTests } = await import(
+  "./context-engine.js"
+);
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  body?: unknown;
+}
+
+let originalFetch: typeof fetch;
+let calls: CapturedCall[];
+let originalLog: typeof console.log;
+let originalWarn: typeof console.warn;
+let originalError: typeof console.error;
+
+/**
+ * Mock fetch that returns a memory ID for the smoke-test write, returns
+ * a high-similarity hit for the smoke-test search, and 204s on the
+ * cleanup DELETE. Counts requests in ``calls`` so tests can pin the
+ * exact request shape.
+ */
+function installSmokeMockFetch(): void {
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const bodyStr = typeof init?.body === "string" ? init.body : undefined;
+    let body: unknown;
+    try {
+      body = bodyStr ? JSON.parse(bodyStr) : undefined;
+    } catch {
+      body = bodyStr;
+    }
+    calls.push({ url, method, body });
+
+    // Mock responses per endpoint shape:
+    if (url.includes("/memories") && method === "POST") {
+      // Smoke-test write → return a memory ID
+      return new Response(
+        JSON.stringify({ id: "00000000-0000-0000-0000-000000000001" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.includes("/search") && method === "POST") {
+      // Smoke-test search → return a high-similarity hit so the smoke
+      // test passes on attempt 0 (no 500ms-retry stalls).
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "00000000-0000-0000-0000-000000000001",
+              score: 0.95,
+              content: (body as { query?: string })?.query ?? "",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.includes("/memories/") && method === "DELETE") {
+      return new Response(null, { status: 204 });
+    }
+    return new Response("{}", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+function silenceConsole(): void {
+  originalLog = console.log;
+  originalWarn = console.warn;
+  originalError = console.error;
+  console.log = () => {};
+  console.warn = () => {};
+  console.error = () => {};
+}
+function restoreConsole(): void {
+  console.log = originalLog;
+  console.warn = originalWarn;
+  console.error = originalError;
+}
+
+function countSmokeWrites(): number {
+  return calls.filter(
+    (c) =>
+      c.method === "POST" &&
+      c.url.includes("/memories") &&
+      !c.url.includes("/memories/") && // exclude DELETE /memories/{id}
+      (c.body as { tags?: string[] })?.tags?.includes("__smoke_test__") === true,
+  ).length;
+}
+
+describe("MemClawContextEngine — process-level bootstrap memoization (CAURA-000)", () => {
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    calls = [];
+    installSmokeMockFetch();
+    silenceConsole();
+    _resetBootstrapForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    restoreConsole();
+    _resetBootstrapForTests();
+  });
+
+  test("two engine instances share one smoke test (the headline fix)", async () => {
+    const engine1 = new MemClawContextEngine({ sessionId: "session-a" });
+    const engine2 = new MemClawContextEngine({ sessionId: "session-b" });
+
+    await engine1.bootstrap();
+    await engine2.bootstrap();
+
+    assert.equal(
+      countSmokeWrites(),
+      1,
+      "expected exactly 1 smoke-test write across both engine instances " +
+        "(was: 2 pre-fix — every fresh engine ran its own smoke). " +
+        `Saw ${countSmokeWrites()} smoke writes in ${calls.length} total fetch calls.`,
+    );
+  });
+
+  test("ten concurrent engine instances share one smoke test (race-safe)", async () => {
+    // The ``if (!_x) _x = ...`` pattern is safe in Node's single-threaded
+    // event loop because the first synchronous assignment wins and every
+    // other concurrent caller sees the already-set promise. This test
+    // pins that guarantee — a regression to per-instance state would
+    // race-trigger N smoke writes here.
+    const engines = Array.from(
+      { length: 10 },
+      (_, i) => new MemClawContextEngine({ sessionId: `session-${i}` }),
+    );
+    await Promise.all(engines.map((e) => e.bootstrap()));
+
+    assert.equal(
+      countSmokeWrites(),
+      1,
+      `expected 1 smoke write across 10 concurrent engines; saw ${countSmokeWrites()}`,
+    );
+  });
+
+  test("after success, subsequent bootstrap() calls are instant no-ops", async () => {
+    const engine = new MemClawContextEngine({ sessionId: "session-a" });
+    await engine.bootstrap();
+    const callsAfterFirst = calls.length;
+
+    // Bootstrap again on the same engine + on fresh engines — none should
+    // trigger new fetches.
+    await engine.bootstrap();
+    await new MemClawContextEngine({ sessionId: "session-b" }).bootstrap();
+    await new MemClawContextEngine({ sessionId: "session-c" }).bootstrap();
+
+    assert.equal(
+      calls.length,
+      callsAfterFirst,
+      `subsequent bootstrap() calls must NOT fetch; saw ${calls.length - callsAfterFirst} extra calls`,
+    );
+  });
+
+  test("backend 500 on smoke write does NOT reject bootstrap (existing contract preserved)", async () => {
+    // ``_doBootstrap`` has an inner try/catch that swallows smoke-write
+    // failures via ``logErrorCritical("SMOKE TEST ERROR", ...)``. This
+    // was the pre-memoization behavior and we PRESERVE it: a sick
+    // backend should not crash plugin lifecycle hooks. Pin this here so
+    // a future "make bootstrap fail loud" refactor has to also update
+    // every caller (``ingest`` / ``assemble`` / ``afterTurn`` all
+    // ``await this.bootstrap()`` and would start throwing).
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      calls.push({ url, method });
+      // EVERY smoke-related request returns 500 — write, search, delete
+      if (url.includes("/memories") || url.includes("/search")) {
+        return new Response("backend unavailable", { status: 500 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const engine = new MemClawContextEngine({ sessionId: "sick-backend" });
+    // MUST NOT throw — the smoke is internal-best-effort, lifecycle hooks
+    // continue regardless. (Customer ground truth: their 2 SMOKE TEST
+    // ERROR log lines on 06-07 13:14/13:22 did NOT prevent subsequent
+    // ingest/assemble calls from succeeding once the backend came back.)
+    await engine.bootstrap();
+    // And the memoization holds — second engine doesn't re-fail and
+    // re-log; one error per process, not per engine.
+    const callsAfterFirst = calls.length;
+    await new MemClawContextEngine({ sessionId: "subsequent" }).bootstrap();
+    assert.equal(
+      calls.length,
+      callsAfterFirst,
+      "subsequent bootstrap on sick backend must use memoized result " +
+        `(saw ${calls.length - callsAfterFirst} extra calls)`,
+    );
+  });
+});

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -68,6 +68,37 @@ const MAX_INGEST_WRITES_PER_SESSION = 10;
 const sessionBuffers = new Map<string, IngestMessage[]>();
 const sessionIngestCounts = new Map<string, number>();
 
+// --- Process-level bootstrap memoization (CAURA-000) ---
+//
+// OpenClaw's ``resolveContextEngine`` calls our factory every time any
+// of ~7 subsystems (embedded-agent, cli-compaction, init, openclaw-tools,
+// prepare.runtime, subagent-registry, context-engine-host-compat) needs
+// a ContextEngine — there's NO caching at the OpenClaw side
+// (``registry-CMq-i5MO.js: engine = await entry.factory(factoryCtx)``).
+// Customer log on goodclaw shows 390 ``ContextEngine bootstrap`` events
+// in 31.4 hours (~12/hour) → 388 smoke tests passed, 0 actionable
+// warnings. Each smoke = 1 write + 1-3 searches + 1 delete = 3-5 backend
+// ops + 2 embedding computations + ~500-1500ms wall-clock.
+//
+// The bootstrap state was previously instance-level (``private
+// _bootstrapped`` + ``_bootstrapPromise``), so each freshly-constructed
+// engine ran its own smoke test. Hoisting to module-level memoizes
+// across instances within the same Node process: smoke runs ONCE per
+// process lifetime, all subsequent engines share the resolved promise
+// and short-circuit instantly.
+//
+// On failure, the catch resets the promise to ``null`` so the next
+// engine retries — the "first-deploy validation" property is preserved.
+let _processBootstrapPromise: Promise<void> | null = null;
+
+/**
+ * Test-only: reset the process-level bootstrap memo so each test
+ * exercises the smoke path fresh. NOT for production use.
+ */
+export function _resetBootstrapForTests(): void {
+  _processBootstrapPromise = null;
+}
+
 /**
  * True iff the error is the content-hash dedup rejection from
  * ``POST /memories`` (the backend's idempotency guard against re-writing
@@ -404,8 +435,6 @@ const recallCache = new Map<string, { text: string; ts: number }>();
 
 export class MemClawContextEngine {
   private config: Record<string, unknown>;
-  private _bootstrapped = false;
-  private _bootstrapPromise: Promise<void> | null = null;
 
   /**
    * Engine metadata — declares to OpenClaw that we own compaction.
@@ -447,14 +476,21 @@ export class MemClawContextEngine {
   }
 
   async bootstrap(): Promise<void> {
-    if (this._bootstrapped) return;
-    if (!this._bootstrapPromise) {
-      this._bootstrapPromise = this._doBootstrap().catch((e) => {
-        this._bootstrapPromise = null;
+    // Process-level memoization: smoke test runs once per Node process,
+    // shared across every engine instance OpenClaw constructs. See
+    // ``_processBootstrapPromise`` docstring at top of file for the why.
+    // Concurrent callers all await the same in-flight promise (Node is
+    // single-threaded so the ``if (!_x) _x = ...`` assignment is safe).
+    if (!_processBootstrapPromise) {
+      _processBootstrapPromise = this._doBootstrap().catch((e) => {
+        // Reset on failure so the next engine instance can retry —
+        // matches the pre-change behavior of clearing the cache on a
+        // failed bootstrap, just at process scope instead of instance.
+        _processBootstrapPromise = null;
         throw e;
       });
     }
-    return this._bootstrapPromise;
+    return _processBootstrapPromise;
   }
 
   private async _doBootstrap(): Promise<void> {
@@ -538,7 +574,8 @@ export class MemClawContextEngine {
         ).catch(() => {});
       }
     }
-    this._bootstrapped = true;
+    // No need to set a flag here — the resolved ``_processBootstrapPromise``
+    // serves as the "done" signal; subsequent ``await``s are instant.
   }
 
   /**

--- a/plugin/src/version.ts
+++ b/plugin/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated from plugin/package.json by scripts/gen-version.sh — do not edit
-export const PLUGIN_VERSION = "2.8.3";
+export const PLUGIN_VERSION = "2.8.4";


### PR DESCRIPTION
## Summary

Hoist the ContextEngine bootstrap (smoke-test) state from instance-level to module-level so it runs **once per Node process** instead of once per engine instance. OpenClaw's `resolveContextEngine` constructs a fresh engine every time any of ~7 subsystems needs one (no caching at OpenClaw's side), and each fresh instance was running its own write→search→delete smoke test.

## Customer ground truth

Goodclaw gateway, 31.4h window (2026-06-07 → 06-08):

| | Count |
|---|---:|
| `ContextEngine bootstrap` log lines | 390 (12.4/hr) |
| `Smoke test passed` | 388 |
| `SMOKE TEST WARNING` (score < 0.7) | 0 |
| `SMOKE TEST ERROR` (backend 5xx) | 2 (echoes of the 13:14-13:22 outage; not new signal) |

Net actionable signal from running the smoke test 388 times: **zero**. Cost: ~37-62 backend ops/hour, ~25 embedding computations/hour, ~500-1500ms latency tax on each fresh engine's first lifecycle hook, ~25 log lines/hour, and a fragility risk (the cleanup DELETE is fire-and-forget — if it ever 422s again as it did pre-PR-#274, smoke memories leak into the tenant on every restart).

## Mechanism (OpenClaw side)

`/usr/lib/node_modules/openclaw/dist/registry-CMq-i5MO.js`:

```js
engine = await entry.factory(factoryCtx);   // ← calls (config) => new MemClawContextEngine(config)
```

No caching. Called from 7 OpenClaw subsystems: `embedded-agent-*.js`, `cli-compaction-*.js`, `init-*.js`, `openclaw-tools-*.js`, `prepare.runtime-*.js`, `subagent-registry-*.js`, `context-engine-host-compat-*.js`. Goodclaw observed ratio: ~1.93 bootstraps per logical turn.

## Fix

Replace the per-instance state:

```typescript
private _bootstrapped = false;
private _bootstrapPromise: Promise<void> | null = null;
```

with a module-level promise:

```typescript
let _processBootstrapPromise: Promise<void> | null = null;
```

The `bootstrap()` method now reads/writes this single promise. Concurrent callers in the same engine OR across different engines all `await` the same in-flight promise. Retry-on-failure semantics preserved: the `.catch` resets the memo to `null` on rejection so the next engine can retry.

A test-only `_resetBootstrapForTests()` is exported so each test exercises the smoke path fresh.

## Customer impact (post-deploy expectation)

| Metric | Pre-fix (observed) | Post-fix (expected) |
|---|---:|---:|
| `ContextEngine bootstrap` lines | 390 / 31.4h | 1 per gateway restart |
| Smoke write RPS | 12.4/hr | ~0 |
| Smoke search RPS | ~25/hr | ~0 |
| Smoke delete RPS | 12.4/hr | ~0 |
| Embedding compute (smoke) | ~25/hr | ~0 |
| Latency on first-call after engine construction | +500-1500ms | unchanged for first engine of process; **eliminated for subsequent engines** |

## Tests

New `plugin/src/bootstrap-memoization.test.ts` (4 cases):

1. **Two engines share one smoke test** — the headline assertion
2. **Ten concurrent engines share one smoke test** — race-safety pin (Node's single-threaded event loop guarantees the `if (!_x) _x = ...` pattern is safe)
3. **Subsequent bootstrap() calls are instant no-ops** — pins the cache hit path
4. **Backend 500 doesn't reject bootstrap, AND memo holds on sick backend** — pins the pre-existing "swallow smoke errors internally" contract AND the new "one error log per process, not per engine" behavior

Full suite: 294/294 pass (was 290, +4 new). Manifest drift test: 11/11 pass.

## Wet test

`openclaw-test-ran` (GCE, OpenClaw 2026.6.1, plugin 2.8.4):

```
--- Wet test: 20 engines, sequential bootstrap() ---
  smoke writes  : 1  (pre-fix would be 20)
  smoke searches: 1  (pre-fix would be 20-60)
  smoke deletes : 1  (pre-fix would be 20)
  Verdict: PASS

--- Race test: 10 concurrent bootstrap() on fresh engines ---
  new HTTP requests: 0 (memoized → expect 0)
  Verdict: PASS
```

The probe spun up a real HTTP server on `127.0.0.1:<random>`, pointed `MEMCLAW_API_URL` at it, constructed 20 sequential + 10 concurrent engine instances, and counted requests by shape. Single `[memclaw] ContextEngine bootstrap` log line across all 30 engines.

## Plugin version

Bump `2.8.3 → 2.8.4`.

## Test plan

- [x] Unit tests: 294/294 pass
- [x] Manifest drift: 11/11 pass
- [x] Wet test under OpenClaw 2026.6.1: PASS both scenarios
- [ ] Customer push: refresh plugin on each gateway VM; expect `[memclaw] ContextEngine bootstrap` log count to drop from ~12/hr to ~0 (once per gateway restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)