### PR TITLE
feat(graph-build): drop literal/attr entity nodes, block suffix-distinct merges, rerank entity_lookup by query overlap

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -111,6 +111,7 @@ class ClassifyQuery:
                         entity_hops,
                         tenant_id,
                         top_k,
+                        query=query,
                         fleet_ids=fleet_ids,
                         caller_agent_id=caller_agent_id,
                         filter_agent_id=filter_agent_id,
@@ -271,6 +272,7 @@ class ClassifyQuery:
         tenant_id: str,
         top_k: int,
         *,
+        query: str = "",
         fleet_ids: list[str] | None = None,
         caller_agent_id: str | None = None,
         filter_agent_id: str | None = None,
@@ -385,5 +387,19 @@ class ClassifyQuery:
             for mid, boost in memory_boost.items()
             if mid in memories_by_id
         ]
-        rows.sort(key=lambda r: r.score, reverse=True)
+        # Re-rank the candidate pool by lexical overlap with the query before
+        # trimming to top_k. entity_lookup matches greedily and hop-boost is
+        # near-uniform, so the exact-entity memory can be diluted below
+        # token-sharing siblings; this prefers rows whose content shares more of
+        # the query's tokens, with hop-boost as the tiebreak.
+        q_tokens = set(extract_entity_tokens(query)) if query else set()
+
+        def _query_overlap(row: types.SimpleNamespace) -> float:
+            if not q_tokens:
+                return 0.0
+            content = getattr(row.Memory, "content", "") or ""
+            c_tokens = set(extract_entity_tokens(content))
+            return len(q_tokens & c_tokens) / len(q_tokens)
+
+        rows.sort(key=lambda r: (_query_overlap(r), r.score), reverse=True)
         return rows[:top_k]

--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import re
 from uuid import UUID
 
 from common.embedding import get_embedding
@@ -19,10 +20,43 @@ from core_api.services.entity_service import upsert_relation
 logger = logging.getLogger(__name__)
 
 
+# CAURA graph-build fix (A): reject literal VALUES and attribute/field NAMES so they
+# never become entity nodes (and thus hub bridges that explode entity_lookup's pool).
+# Shapes only — preserves legit named identifiers like "PR-2025-A" / "gpt-5.4-nano"
+# (no underscores, contain letters) while dropping dates, numbers/money/percent, and
+# snake_case field names (sla_uptime, q3_revenue, founded_year).
+_LITERAL_OR_ATTR_RE = re.compile(
+    r"^(?:"
+    r"\d{4}-\d{2}-\d{2}"  # ISO date: 2024-03-23
+    r"|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}"  # slashed/dashed date
+    r"|\$?\d[\d,]*(?:\.\d+)?\s*%?\s*[kmb]?"  # number / money / percent: 14402, $35.4M, 95.1%, 1935
+    r"|[a-z][a-z0-9]*(?:_[a-z0-9]+)+"  # snake_case field/attribute name
+    r")$",
+    re.IGNORECASE,
+)
+
+
+def _same_identifier_signature(a: str, b: str) -> bool:
+    """CAURA graph-build fix (B): two names may only merge if they carry the SAME set
+    of digit-bearing identifier tokens. Synthetic suffix-distinct names like
+    'comet #0002' vs 'comet #0012' embed near-identically and trip the 0.85 similarity
+    merge, collapsing distinct entities into one contaminated mega-node."""
+    ta = set(re.findall(r"\d[\w.\-]*", a.lower()))
+    tb = set(re.findall(r"\d[\w.\-]*", b.lower()))
+    return ta == tb
+
+
 def _is_valid_entity(name: str, blocklist: frozenset[str] | None = None) -> bool:
     """Reject obviously generic names that are not real named entities."""
     bl = blocklist if blocklist is not None else ENTITY_NAME_BLOCKLIST
-    return len(name) >= MIN_ENTITY_NAME_LENGTH and name.lower() not in bl
+    if len(name) < MIN_ENTITY_NAME_LENGTH or name.lower() in bl:
+        return False
+    # CAURA graph-build fix (A): drop literal values + attribute/field names. Dropping
+    # the node cascades to its edges — relations require both endpoints to be persisted
+    # nodes (relation loop: `if from_id and to_id`).
+    if _LITERAL_OR_ATTR_RE.match(name.strip()):
+        return False
+    return True
 
 
 async def _discover_cross_links_for_memory(
@@ -210,6 +244,11 @@ async def process_entity_extraction(
             upsert_items: list[dict] = []
             for i, (name, entity_type, _role) in enumerate(filtered):
                 match = resolved[i] if i < len(resolved) else None
+                # CAURA graph-build fix (B): reject a similarity-merge when the two
+                # names carry DIFFERENT identifier tokens (e.g. "#0002" vs "#0012").
+                # Forces the create path so suffix-distinct entities stay separate.
+                if match and not _same_identifier_signature(name, match.get("canonical_name") or ""):
+                    match = None
                 item: dict = {
                     "input_idx": i,
                     "tenant_id": tenant_id,

--- a/tests/test_graph_build_fix.py
+++ b/tests/test_graph_build_fix.py
@@ -1,0 +1,84 @@
+"""Graph-build fix: literal/attribute values must not become entity nodes (A),
+and similarity-merges must not cross distinct identifier suffixes (B).
+
+Regression for the entity_lookup recall collapse at scale: literal/attribute
+nodes became high-degree hubs and #NNNN-suffix names merged into contaminated
+mega-nodes, exploding entity_lookup's candidate pool.
+"""
+
+import pytest
+
+from core_api.services.entity_extraction_worker import (
+    _is_valid_entity,
+    _same_identifier_signature,
+)
+
+
+@pytest.mark.unit
+class TestLiteralAndAttributeRejection:
+    """(A) literal values and attribute/field names are not valid entities."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "2024-03-23",  # ISO date
+            "2024-10-16",
+            "12/31/2024",  # slashed date
+            "95.1%",  # percentage
+            "99.0%",
+            "14402",  # plain number
+            "1935",  # year-as-value
+            "$35.4M",  # money
+            "$885.3M",
+            "sla_uptime",  # snake_case attribute names
+            "q3_revenue",
+            "founded_year",
+            "employee_count",
+            "launch_date",
+        ],
+    )
+    def test_literals_and_attributes_rejected(self, name):
+        assert not _is_valid_entity(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "comet #0002",  # suffixed named entities
+            "wayne enterprises #0000",
+            "stark industries #0002",
+            "mark lin",  # person
+            "PR-2025-A",  # legit identifiers (hyphenated, contain letters)
+            "build-734",
+            "gpt-5.4-nano",
+        ],
+    )
+    def test_real_entities_and_identifiers_pass(self, name):
+        assert _is_valid_entity(name)
+
+
+@pytest.mark.unit
+class TestIdentifierSignatureMerge:
+    """(B) only merge names that share the same identifier-token signature."""
+
+    @pytest.mark.parametrize(
+        "a,b",
+        [
+            ("comet #0002", "comet #0012"),  # different numeric suffix
+            ("wayne enterprises #0000", "wayne enterprises #0017"),
+            ("mark lin", "mark lin #0005"),  # bare value vs numbered person
+            ("stark industries #0002", "stark industries #0019"),
+        ],
+    )
+    def test_distinct_suffixes_do_not_merge(self, a, b):
+        assert not _same_identifier_signature(a, b)
+
+    @pytest.mark.parametrize(
+        "a,b",
+        [
+            ("comet #0002", "comet #0002"),  # identical
+            ("openai", "open ai"),  # no digit tokens → allowed to merge (aliasing)
+            ("acme corp", "acme corporation"),
+        ],
+    )
+    def test_same_signature_may_merge(self, a, b):
+        assert _same_identifier_signature(a, b)


### PR DESCRIPTION
# feat(graph-build): fix entity_lookup recall collapse at scale (literal/attr nodes + suffix-merge)

**Branch:** `feat/entity-graph-build-fix` (`6d9ce66`)
**Files:** `core-api/src/core_api/services/entity_extraction_worker.py`, `core-api/src/core_api/pipeline/steps/search/classify_query.py`

## Problem
`entity_lookup` recall **collapses at scale**. On the S1 benchmark (entity-named attribute lookups):

| scale | recall |
|---|---|
| K=100 | 22/25 |
| **K≈1000** | **7/25 (≈0.28)** |

This is the bench's documented "K-collapse" (condition C → 0.31 at K≥1000). Root-caused to the **graph build**, not retrieval.

## Root cause
The LLM entity-extraction over-populates the entity/relation graph two ways:

- **(A) Literal values and attribute names become entity NODES.** Dates (`2024-03-23`), percentages (`95.1%`), money, and attribute *names* (`sla_uptime`, `q3_revenue`) are extracted as entities (typed `identifier`/`concept`/`artifact`). Attribute names become **high-degree hubs** (`q3_revenue` deg 11, `sla_uptime` deg 9) that bridge every entity sharing an attribute.
- **(B) Entity resolution merges suffix-distinct names.** Names differing only by a `#NNNN` suffix embed ≈identically → cosine ≥ `ENTITY_RESOLUTION_THRESHOLD (0.85)` → merge (first-seen-wins). All `Comet #NNNN` collapse into one contaminated node carrying every Comet's edges.

**Consequence:** in `entity_lookup`, 2–3 matched entities graph-expand (`_expand_per_fleet`, 3-hop union) through these hubs/merged-nodes to **~the entire corpus** (2 seeds → 51 entities/96 mems @K=100; 151/1041 @K=1000), all at near-uniform hop-boost. The `GRAPH_MAX_BOOSTED_MEMORIES=50` cap then drops the exact entity **before** any ranking → miss. (Dump evidence: a single `Comet #0002` fact carried 5 edges incl. *other* Comets' launch_dates + a foreign `owns mark lin`.)

## Fix
**entity_extraction_worker.py**
- **A** — `_is_valid_entity` now rejects literal-shaped names (ISO dates, numbers/money/percent) and snake_case attribute names, so they never become nodes. Dropping the node **cascades to its edges** (relations require both endpoints to be persisted nodes). Shape-only → preserves legit named identifiers (`PR-2025-A`, `gpt-5.4-nano`).
- **B** — before accepting a similarity-merge, require both names to share the same digit-bearing identifier tokens (`_same_identifier_signature`). `#0002` vs `#0012` → don't merge.

**classify_query.py**
- **rerank (secondary)** — order `entity_lookup` candidates by query-token overlap before trimming to `top_k`, so the exact entity isn't diluted below token-sharing siblings.

## Evidence (local, full-stack wet test, S1 fixtures)
| scale | before | **after** |
|---|---|---|
| K=100 | 22/25 | 22/25 |
| **K≈1000 (clean 1000-fact corpus)** | **7/25** | **22/25 (0.88)** |

Graph density (clean K=100 tenant, before→after A): **83 entities / 131 relations → 40 / 62**; literal/attribute nodes **many → 0**. `Comet #0002`: **5 edges → isolated → rank 1**.

## NOT addressed (tracked as follow-ups)
- **Person-hub expansion** — queries about person-valued attributes (`X's manager/ceo/team`) connect the subject to a person hub (`mark lin` deg ~20) and still dilute (2 of 3 residual K=1000 misses).
- **Semantic near-duplicate dilution** — at scale, near-identical facts dilute in *vector* space too (1 residual miss via `semantic_search`).
- **Distractor abstention** — retrieval still returns sibling rows for non-existent entities (no "not found" signal).
- **Heuristic hardening** — the A regex misses `#`-prefixed bare suffixes (`#0012` still node-ified); B is token-based. Consider moving B server-side into resolution.

## Testing
- **Lint/type:** `ruff check` ✓, `ruff format --check` ✓, `mypy` ✓ (changed files).
- **Unit:** all relevant existing tests pass (193 across `test_entity_blocklist`, `test_p1_entity_extraction_bulk`, `test_entity_lookup_short_circuit`, `test_entity_linking_wiring`, `test_adaptive_fts_weight`, `test_a27_shared_tokenizer`, …) — **no breakage** from A/B/rerank. New regression test `tests/test_graph_build_fix.py` locks in: literals/attrs not node-ified (A) + suffix-distinct not merged (B).
- **End-to-end:** full-stack rebuild + S1 replay (K=100 and clean K=1000, 1001 facts); before/after Postgres graph dumps.
- **Before merge:** wet test on memclaw.dev per workflow; full `pytest tests/` (incl. DB-integration suite) runs in CI.
