### PR TITLE
fix(fleet): bound deploy-queue runaway when a previous deploy is acked (CAURA-000)

### DIFF
--- a/core-api/src/core_api/repositories/fleet_repository.py
+++ b/core-api/src/core_api/repositories/fleet_repository.py
@@ -139,6 +139,49 @@ class FleetRepository:
         )
         return result.scalars().all()
 
+    async def has_recent_in_flight_deploy(
+        self,
+        db: AsyncSession,
+        *,
+        node_id: UUID,
+        since: datetime,
+    ) -> bool:
+        """True if a ``deploy`` command for this node is still in flight.
+
+        "In flight" means status in (``pending``, ``acked``) and
+        ``created_at >= since``. Used by the auto-upgrade gate to suppress
+        queueing duplicate deploys when a previous one has been sent to
+        the plugin but never reported back as completed/failed.
+
+        Why this matters (CAURA-000): the existing pending-only gate
+        (``_has_recent_deploy_command_from_list``) is blind to ``acked``
+        commands. After the heartbeat handler transitions a command
+        ``pending`` → ``acked`` and ships it to the plugin, the gate
+        sees an empty pending list on the next heartbeat and happily
+        queues another deploy — even if the plugin's last deploy is
+        still in flight or got killed mid-result-POST by its own
+        ``systemctl restart``. Customer prod-data observation
+        (2026-06-08): 1,381 deploy commands stuck at ``acked``, one new
+        per heartbeat, on a single node — exactly the customer-reported
+        "SIGTERM every 60s" cycle.
+
+        The ``since`` window bounds the gate: an acked command older
+        than ~10 min is assumed abandoned, and a retry is allowed. This
+        recovers nodes whose plugin crashed mid-deploy (lost result-POST)
+        without needing operator intervention to clear stale rows.
+        """
+        result = await db.execute(
+            select(FleetCommand.id)
+            .where(
+                FleetCommand.node_id == node_id,
+                FleetCommand.command == "deploy",
+                FleetCommand.status.in_(("pending", "acked")),
+                FleetCommand.created_at >= since,
+            )
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+
     async def ack_commands(self, db: AsyncSession, *, command_ids: list[UUID], now: datetime) -> None:
         if not command_ids:
             return

--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -15,6 +15,7 @@ from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
 from core_api.constants import NODE_OFFLINE_SECONDS, NODE_STALE_SECONDS
 from core_api.db.session import get_db
+from core_api.repositories import fleet_repo
 from core_api.services.audit_service import log_action
 from core_api.services.organization_settings import get_raw_settings
 from core_api.version_compat import (
@@ -22,6 +23,15 @@ from core_api.version_compat import (
     MIN_RECOMMENDED_PLUGIN_VERSION,
     is_plugin_outdated,
 )
+
+# How long an ``acked`` deploy command counts as "in flight" before the
+# auto-upgrade gate allows queueing another. CAURA-000: customer prod
+# accumulated 1,381 stuck-acked deploys at a 60s/queue cadence because
+# the pending-only gate was blind to in-flight commands. A typical deploy
+# completes in <2 min (build ~30s + restart ~10s + plugin re-init ~5s);
+# 10 min is generous slack that still recovers genuinely-abandoned
+# commands without needing operator intervention.
+DEPLOY_IN_FLIGHT_WINDOW = timedelta(minutes=10)
 
 router = APIRouter(tags=["Fleet"])
 
@@ -423,6 +433,41 @@ async def _maybe_queue_auto_upgrade(
     if not await _auto_upgrade_enabled_for_tenant(db, body.tenant_id):
         return False
     if _has_recent_deploy_command_from_list(pending_commands):
+        return False
+    # CAURA-000: defence against ``acked``-then-stuck queue runaway.
+    # The pending-only list above is blind to commands the heartbeat
+    # handler has already shipped to the plugin (status: ``acked``).
+    # If a previous deploy is still in flight — OR was killed mid-
+    # result-POST by its own systemctl restart — queueing another
+    # one creates the 60s SIGTERM cycle observed on customer prod.
+    # The repo lookup is gated behind the cheaper checks above so we
+    # only pay for the DB roundtrip when an auto-upgrade is actually
+    # eligible. Falls back to ALLOW on error so a transient DB hiccup
+    # doesn't break the upgrade path entirely (the pending check above
+    # is already a safety net).
+    try:
+        in_flight = await fleet_repo.has_recent_in_flight_deploy(
+            db,
+            node_id=UUID(node_id),
+            since=datetime.now(UTC) - DEPLOY_IN_FLIGHT_WINDOW,
+        )
+    except Exception:
+        logger.warning(
+            "fleet.heartbeat: has_recent_in_flight_deploy lookup failed "
+            "node=%s tenant=%s — falling back to allow (pending check "
+            "above still gates)",
+            body.node_name,
+            body.tenant_id,
+            exc_info=True,
+        )
+        in_flight = False
+    if in_flight:
+        logger.info(
+            "fleet.heartbeat: skipping auto-upgrade for node=%s — a "
+            "deploy is already in flight within the last %s",
+            body.node_name,
+            DEPLOY_IN_FLIGHT_WINDOW,
+        )
         return False
 
     try:

--- a/tests/test_fleet_heartbeat_auto_upgrade.py
+++ b/tests/test_fleet_heartbeat_auto_upgrade.py
@@ -23,7 +23,7 @@ from core_api.routes import fleet as fleet_mod
         ("2.3.0", "2.4.0", True),
         ("2.4.0", "2.3.0", False),
         ("2.4.0", "2.4.0", False),
-        ("2.4", "2.4.1", True),    # zero-pad
+        ("2.4", "2.4.1", True),  # zero-pad
         ("2.4.1", "2.4", False),
         ("1.10.0", "1.9.0", False),  # int compare, not lex
         ("1.9.0", "1.10.0", True),
@@ -76,46 +76,34 @@ def test_known_broken_set_is_frozen():
 @pytest.mark.asyncio
 async def test_auto_upgrade_enabled_default_true(monkeypatch):
     """No tenant override → enabled (the global default)."""
+
     async def _fake(_db, _tid):
         return {}  # no override
 
-    monkeypatch.setattr(
-        "core_api.routes.fleet.get_raw_settings", _fake
-    )
-    assert (
-        await fleet_mod._auto_upgrade_enabled_for_tenant(None, "tenant-1")
-        is True
-    )
+    monkeypatch.setattr("core_api.routes.fleet.get_raw_settings", _fake)
+    assert await fleet_mod._auto_upgrade_enabled_for_tenant(None, "tenant-1") is True
 
 
 @pytest.mark.asyncio
 async def test_auto_upgrade_enabled_override_false(monkeypatch):
     """Tenant override `memclaw.auto_upgrade_enabled = false` → disabled."""
+
     async def _fake(_db, _tid):
         return {"memclaw": {"auto_upgrade_enabled": False}}
 
-    monkeypatch.setattr(
-        "core_api.routes.fleet.get_raw_settings", _fake
-    )
-    assert (
-        await fleet_mod._auto_upgrade_enabled_for_tenant(None, "tenant-1")
-        is False
-    )
+    monkeypatch.setattr("core_api.routes.fleet.get_raw_settings", _fake)
+    assert await fleet_mod._auto_upgrade_enabled_for_tenant(None, "tenant-1") is False
 
 
 @pytest.mark.asyncio
 async def test_auto_upgrade_enabled_override_true(monkeypatch):
     """Tenant override `memclaw.auto_upgrade_enabled = true` → enabled."""
+
     async def _fake(_db, _tid):
         return {"memclaw": {"auto_upgrade_enabled": True}}
 
-    monkeypatch.setattr(
-        "core_api.routes.fleet.get_raw_settings", _fake
-    )
-    assert (
-        await fleet_mod._auto_upgrade_enabled_for_tenant(None, "tenant-1")
-        is True
-    )
+    monkeypatch.setattr("core_api.routes.fleet.get_raw_settings", _fake)
+    assert await fleet_mod._auto_upgrade_enabled_for_tenant(None, "tenant-1") is True
 
 
 @pytest.mark.asyncio
@@ -123,16 +111,12 @@ async def test_auto_upgrade_fail_open_on_settings_error(monkeypatch):
     """If settings resolve raises, default to enabled (cooldown machinery
     on the plugin side prevents loops in the worst case).
     """
+
     async def _fake(_db, _tid):
         raise RuntimeError("settings backend down")
 
-    monkeypatch.setattr(
-        "core_api.routes.fleet.get_raw_settings", _fake
-    )
-    assert (
-        await fleet_mod._auto_upgrade_enabled_for_tenant(None, "tenant-1")
-        is True
-    )
+    monkeypatch.setattr("core_api.routes.fleet.get_raw_settings", _fake)
+    assert await fleet_mod._auto_upgrade_enabled_for_tenant(None, "tenant-1") is True
 
 
 # ---------------------------------------------------------------------------
@@ -175,7 +159,13 @@ async def test_maybe_queue_auto_upgrade_skips_for_known_broken(monkeypatch):
 
     monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
     sc = _FakeStorage()
-    await fleet_mod._maybe_queue_auto_upgrade(db=None, sc=sc, body=_body("2.3.0"), pending_commands=sc.pending_commands, node_id="node-uuid-1")
+    await fleet_mod._maybe_queue_auto_upgrade(
+        db=None,
+        sc=sc,
+        body=_body("2.3.0"),
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
+    )
     assert sc.created_commands == []
 
 
@@ -189,7 +179,13 @@ async def test_maybe_queue_auto_upgrade_skips_when_current(monkeypatch):
 
     monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
     sc = _FakeStorage()
-    await fleet_mod._maybe_queue_auto_upgrade(db=None, sc=sc, body=_body("2.4.0"), pending_commands=sc.pending_commands, node_id="node-uuid-1")
+    await fleet_mod._maybe_queue_auto_upgrade(
+        db=None,
+        sc=sc,
+        body=_body("2.4.0"),
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
+    )
     assert sc.created_commands == []
 
 
@@ -203,7 +199,13 @@ async def test_maybe_queue_auto_upgrade_skips_when_newer(monkeypatch):
 
     monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
     sc = _FakeStorage()
-    await fleet_mod._maybe_queue_auto_upgrade(db=None, sc=sc, body=_body("2.5.0-dev"), pending_commands=sc.pending_commands, node_id="node-uuid-1")
+    await fleet_mod._maybe_queue_auto_upgrade(
+        db=None,
+        sc=sc,
+        body=_body("2.5.0-dev"),
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
+    )
     assert sc.created_commands == []
 
 
@@ -219,12 +221,14 @@ async def test_maybe_queue_auto_upgrade_skips_when_blocked(monkeypatch):
     sc = _FakeStorage()
     # 1 hour in the future — well within the 7-day MAX_BLOCK_MS cap.
     from datetime import UTC, datetime
+
     near_future_ms = int(datetime.now(UTC).timestamp() * 1000) + 3600_000
     await fleet_mod._maybe_queue_auto_upgrade(
         db=None,
         sc=sc,
         body=_body("2.3.5", deploy_blocked_until=near_future_ms),
-        pending_commands=sc.pending_commands, node_id="node-uuid-1",
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
     )
     assert sc.created_commands == []
 
@@ -254,7 +258,8 @@ async def test_maybe_queue_auto_upgrade_ignores_absurd_block_cap(monkeypatch):
         db=None,
         sc=sc,
         body=_body("2.3.5", deploy_blocked_until=absurd_future_ms),
-        pending_commands=sc.pending_commands, node_id="node-uuid-1",
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
     )
     # Absurd value ignored → deploy IS queued (normal path).
     assert len(sc.created_commands) == 1
@@ -271,7 +276,13 @@ async def test_maybe_queue_auto_upgrade_skips_when_disabled(monkeypatch):
 
     monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _disabled)
     sc = _FakeStorage()
-    await fleet_mod._maybe_queue_auto_upgrade(db=None, sc=sc, body=_body("2.3.5"), pending_commands=sc.pending_commands, node_id="node-uuid-1")
+    await fleet_mod._maybe_queue_auto_upgrade(
+        db=None,
+        sc=sc,
+        body=_body("2.3.5"),
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
+    )
     assert sc.created_commands == []
 
 
@@ -285,7 +296,13 @@ async def test_maybe_queue_auto_upgrade_skips_when_already_pending(monkeypatch):
 
     monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
     sc = _FakeStorage(pending=[{"command": "deploy", "payload": {}}])
-    await fleet_mod._maybe_queue_auto_upgrade(db=None, sc=sc, body=_body("2.3.5"), pending_commands=sc.pending_commands, node_id="node-uuid-1")
+    await fleet_mod._maybe_queue_auto_upgrade(
+        db=None,
+        sc=sc,
+        body=_body("2.3.5"),
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
+    )
     assert sc.created_commands == []
 
 
@@ -295,8 +312,12 @@ async def test_maybe_queue_auto_upgrade_skips_when_already_pending(monkeypatch):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("stale_version", ["0.98.4", "2.0.0", "2.3.0", "2.4.0", "2.5.0"])
-async def test_maybe_queue_auto_upgrade_skips_pre_manifest_aware(monkeypatch, stale_version):
+@pytest.mark.parametrize(
+    "stale_version", ["0.98.4", "2.0.0", "2.3.0", "2.4.0", "2.5.0"]
+)
+async def test_maybe_queue_auto_upgrade_skips_pre_manifest_aware(
+    monkeypatch, stale_version
+):
     """Pre-manifest-aware floor blocks every released plugin tag.
 
     The hardcoded fallback file list in those releases doesn't include
@@ -313,8 +334,11 @@ async def test_maybe_queue_auto_upgrade_skips_pre_manifest_aware(monkeypatch, st
     monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
     sc = _FakeStorage()
     await fleet_mod._maybe_queue_auto_upgrade(
-        db=None, sc=sc, body=_body(stale_version),
-        pending_commands=sc.pending_commands, node_id="node-uuid-1",
+        db=None,
+        sc=sc,
+        body=_body(stale_version),
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
     )
     assert sc.created_commands == [], (
         f"Expected no deploy queued for pre-manifest-aware {stale_version!r}; "
@@ -337,8 +361,11 @@ async def test_maybe_queue_auto_upgrade_allowed_at_or_above_floor(monkeypatch):
     monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
     sc = _FakeStorage()
     await fleet_mod._maybe_queue_auto_upgrade(
-        db=None, sc=sc, body=_body("2.6.0"),
-        pending_commands=sc.pending_commands, node_id="node-uuid-1",
+        db=None,
+        sc=sc,
+        body=_body("2.6.0"),
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
     )
     assert len(sc.created_commands) == 1, (
         f"Expected deploy queued for floor version 2.6.0; got {sc.created_commands!r}"
@@ -394,7 +421,13 @@ async def test_maybe_queue_auto_upgrade_queues_deploy_for_old_version(monkeypatc
 
     monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
     sc = _FakeStorage()
-    await fleet_mod._maybe_queue_auto_upgrade(db=None, sc=sc, body=_body("2.3.5"), pending_commands=sc.pending_commands, node_id="node-uuid-1")
+    await fleet_mod._maybe_queue_auto_upgrade(
+        db=None,
+        sc=sc,
+        body=_body("2.3.5"),
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
+    )
     assert len(sc.created_commands) == 1
     cmd = sc.created_commands[0]
     assert cmd["command"] == "deploy"
@@ -421,7 +454,8 @@ async def test_maybe_queue_auto_upgrade_skips_when_plugin_version_missing(monkey
         db=None,
         sc=sc,
         body=fleet_mod.HeartbeatIn(tenant_id="tenant-1", node_name="node-a"),
-        pending_commands=sc.pending_commands, node_id="node-uuid-1",
+        pending_commands=sc.pending_commands,
+        node_id="node-uuid-1",
     )
     assert sc.created_commands == []
 
@@ -458,7 +492,10 @@ def test_recall_metrics_over_cap_rejected():
     import pytest as _pt
     from pydantic import ValidationError
 
-    huge = {"calls_total": 1, "skipped_by_reason": {f"reason-{i}": i for i in range(500)}}
+    huge = {
+        "calls_total": 1,
+        "skipped_by_reason": {f"reason-{i}": i for i in range(500)},
+    }
     # 500 keys × ~20 bytes ≈ 10 KB → well over the 4 KB cap.
     with _pt.raises(ValidationError, match="exceeds 4 KB limit"):
         fleet_mod.HeartbeatIn(
@@ -521,3 +558,179 @@ def test_deploy_blocked_until_negative_rejected():
             node_name="node-a",
             deploy_blocked_until=-1,
         )
+
+
+# ---------------------------------------------------------------------------
+# CAURA-000: in-flight deploy gate (acked-but-not-completed protection)
+# ---------------------------------------------------------------------------
+#
+# The pending-only gate (``_has_recent_deploy_command_from_list``) above
+# is blind to ``acked`` deploy commands — once the heartbeat handler
+# ships a deploy to the plugin (transitioning ``pending`` → ``acked``),
+# the next heartbeat sees an empty pending list and queues another
+# deploy, even if the previous one is still building or got killed
+# mid-result-POST by its own systemctl restart. Customer prod data
+# (2026-06-08): 1,381 acked-stuck deploys on a single node, one new
+# per 60s heartbeat — the "SIGTERM every 60 seconds" cycle.
+#
+# The fix adds a second gate that consults the repository for any
+# ``deploy`` row with status IN (pending, acked) inside a 10-minute
+# window. These tests pin both the skip-when-in-flight and the
+# fail-open-on-DB-error behaviors.
+
+
+@pytest.mark.asyncio
+async def test_maybe_queue_auto_upgrade_skips_when_acked_deploy_in_flight(monkeypatch):
+    """CAURA-000: an acked-but-not-completed deploy within the window
+    blocks queueing another one (the customer's 60s-SIGTERM-loop fix)."""
+    monkeypatch.setattr(fleet_mod, "MIN_RECOMMENDED_PLUGIN_VERSION", "2.4.0")
+    monkeypatch.setattr(fleet_mod, "MIN_AUTO_DEPLOY_PLUGIN_VERSION", "0.0.0")
+
+    async def _enabled(_db, _tid):
+        return True
+
+    monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
+
+    # The repo reports "yes, a deploy is in flight" — gate must skip.
+    async def _has_in_flight(_db, *, node_id, since):
+        return True
+
+    monkeypatch.setattr(
+        fleet_mod.fleet_repo, "has_recent_in_flight_deploy", _has_in_flight
+    )
+
+    sc = _FakeStorage()
+    queued = await fleet_mod._maybe_queue_auto_upgrade(
+        db=None,
+        sc=sc,
+        body=_body("2.3.5"),
+        pending_commands=sc.pending_commands,
+        node_id="00000000-0000-0000-0000-000000000001",
+    )
+    assert queued is False
+    assert sc.created_commands == [], (
+        f"in-flight acked deploy must block queueing another; got {sc.created_commands}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_maybe_queue_auto_upgrade_queues_when_no_in_flight(monkeypatch):
+    """Happy path: no in-flight deploy → queue as before. Pins that the
+    new gate doesn't break the regular auto-upgrade flow when the repo
+    reports no recent in-flight commands."""
+    monkeypatch.setattr(fleet_mod, "MIN_RECOMMENDED_PLUGIN_VERSION", "2.4.0")
+    monkeypatch.setattr(fleet_mod, "MIN_AUTO_DEPLOY_PLUGIN_VERSION", "0.0.0")
+
+    async def _enabled(_db, _tid):
+        return True
+
+    monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
+
+    async def _no_in_flight(_db, *, node_id, since):
+        return False
+
+    monkeypatch.setattr(
+        fleet_mod.fleet_repo, "has_recent_in_flight_deploy", _no_in_flight
+    )
+
+    sc = _FakeStorage()
+    queued = await fleet_mod._maybe_queue_auto_upgrade(
+        db=None,
+        sc=sc,
+        body=_body("2.3.5"),
+        pending_commands=sc.pending_commands,
+        node_id="00000000-0000-0000-0000-000000000001",
+    )
+    assert queued is True
+    assert len(sc.created_commands) == 1
+    assert sc.created_commands[0]["command"] == "deploy"
+
+
+@pytest.mark.asyncio
+async def test_maybe_queue_auto_upgrade_fails_open_on_repo_error(monkeypatch):
+    """DB hiccup on the new gate must NOT break auto-upgrade. The
+    existing pending-only gate above is still a safety net, and an
+    operator clearing the queue manually shouldn't require the new
+    gate to be available. Logs a warning so the issue is observable."""
+    monkeypatch.setattr(fleet_mod, "MIN_RECOMMENDED_PLUGIN_VERSION", "2.4.0")
+    monkeypatch.setattr(fleet_mod, "MIN_AUTO_DEPLOY_PLUGIN_VERSION", "0.0.0")
+
+    async def _enabled(_db, _tid):
+        return True
+
+    monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
+
+    async def _throws(_db, *, node_id, since):
+        raise RuntimeError("DB connection lost")
+
+    monkeypatch.setattr(fleet_mod.fleet_repo, "has_recent_in_flight_deploy", _throws)
+
+    sc = _FakeStorage()
+    queued = await fleet_mod._maybe_queue_auto_upgrade(
+        db=None,
+        sc=sc,
+        body=_body("2.3.5"),
+        pending_commands=sc.pending_commands,
+        node_id="00000000-0000-0000-0000-000000000001",
+    )
+    # Fail-open: queue still happens. (Pre-fix this path had no DB
+    # call at all, so we preserve that behavior on DB error.)
+    assert queued is True
+    assert len(sc.created_commands) == 1
+
+
+@pytest.mark.asyncio
+async def test_maybe_queue_auto_upgrade_skips_pending_before_querying_repo(monkeypatch):
+    """The cheaper pending-list check must run BEFORE the DB query.
+    Pins the gate ordering: a deploy already in the pending list short-
+    circuits without paying for a DB roundtrip. Avoids unnecessary
+    storage load on every heartbeat under normal operation."""
+    monkeypatch.setattr(fleet_mod, "MIN_RECOMMENDED_PLUGIN_VERSION", "2.4.0")
+    monkeypatch.setattr(fleet_mod, "MIN_AUTO_DEPLOY_PLUGIN_VERSION", "0.0.0")
+
+    async def _enabled(_db, _tid):
+        return True
+
+    monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
+
+    # If the gate calls the repo, this records it — we assert it was NOT
+    # called because the pending check fires first.
+    call_count = {"n": 0}
+
+    async def _has_in_flight(_db, *, node_id, since):
+        call_count["n"] += 1
+        return False
+
+    monkeypatch.setattr(
+        fleet_mod.fleet_repo, "has_recent_in_flight_deploy", _has_in_flight
+    )
+
+    sc = _FakeStorage(pending=[{"id": "x", "command": "deploy"}])
+    queued = await fleet_mod._maybe_queue_auto_upgrade(
+        db=None,
+        sc=sc,
+        body=_body("2.3.5"),
+        pending_commands=sc.pending_commands,
+        node_id="00000000-0000-0000-0000-000000000001",
+    )
+    assert queued is False
+    assert sc.created_commands == []
+    assert call_count["n"] == 0, (
+        "pending check must short-circuit before the repo call; "
+        f"repo was called {call_count['n']} time(s)"
+    )
+
+
+def test_deploy_in_flight_window_is_sensible():
+    """Lock the chosen window (10 min). Too short → races a slow build.
+    Too long → manual recovery needed for genuinely-abandoned acks."""
+    from datetime import timedelta
+
+    assert fleet_mod.DEPLOY_IN_FLIGHT_WINDOW >= timedelta(minutes=2), (
+        "window must exceed typical deploy wall-clock (build ~30s + "
+        "restart ~10s + re-init ~5s + safety margin)"
+    )
+    assert fleet_mod.DEPLOY_IN_FLIGHT_WINDOW <= timedelta(minutes=30), (
+        "window must be short enough that genuinely-abandoned acks "
+        "auto-recover without operator intervention"
+    )


### PR DESCRIPTION
## Summary

The auto-upgrade gate in `_maybe_queue_auto_upgrade` was blind to `acked`-but-not-completed deploy commands. Every heartbeat queued another duplicate, the plugin processed it, restarted via `systemctl` (sending SIGTERM to itself), and the cycle repeated every 60 seconds — exactly matching the customer-reported "SIGTERM every 60 seconds" on the affected gateway.

This PR adds a second gate that consults the repository for any in-flight deploy (`status IN (pending, acked)`, `created_at` within a 10-minute window) and short-circuits if one is found.

## Customer ground truth (read-only ssh)

Postgres on `134.98.155.239`, `2026-06-08`:

| Metric | Value |
|---|---:|
| Deploy commands stuck at `status='acked'` | **1,381** |
| Stuck-acked on a single node (`cb457f2c-…`) | **1,223** |
| Timestamps between consecutive stuck commands | 60s |
| All target_version | `"2.8.1"` |

"Removing memclaw plugin solved it" because the plugin's `setInterval(sendHeartbeat, 60_000)` is what pulled the perpetually-fresh deploy command and triggered the restart cycle. No plugin → no heartbeat → no pull → no restart.

## Mechanism (full trace in commit message)

1. Heartbeat handler fetches `pending` commands → empty (previous deploy was `acked`)
2. Gate `_has_recent_deploy_command_from_list` sees no deploy in pending → allows queue
3. New deploy queued (`status=pending`) → re-fetched → `ack_commands` transitions to `acked` → sent to plugin
4. Plugin's `processCommand("deploy")` schedules `systemctl restart` in 2s
5. The plugin POSTs the result, but if the POST takes >2s the restart's SIGTERM kills it mid-flight
6. Command stays at `acked` forever
7. 60s later, repeat from step 1

## Fix (smallest blast radius — backend only)

| | File | Change |
|---|---|---|
| 1 | `core-api/.../repositories/fleet_repository.py` | New `has_recent_in_flight_deploy` method — direct SQLAlchemy query |
| 2 | `core-api/.../routes/fleet.py` | Import `fleet_repo`, define `DEPLOY_IN_FLIGHT_WINDOW = 10 min`, add a second gate check inside `_maybe_queue_auto_upgrade` AFTER the cheaper pending-list check, falls open on repo exception |

The cheaper pending-list check still fires first (no DB roundtrip on the happy path with a fresh pending deploy already in the list). The new DB check only runs when the auto-upgrade is otherwise eligible. The 10-minute window means a genuinely-abandoned deploy auto-recovers without operator intervention.

## What this PR explicitly does NOT do

- **No plugin change.** The plugin's `setTimeout(systemctl restart, 2000)` race with the result POST is a real bug that should be fixed in a follow-up PR. But the backend gate makes the customer's loop bounded regardless of plugin version.
- **No DB cleanup.** The 1,381 existing stuck-acked rows on the customer's prod will be naturally bypassed by the new gate (they're outside any future 10-min window). Optional follow-up: `UPDATE fleet_commands SET status='failed' WHERE status='acked' AND created_at < now() - interval '1 hour'` if the customer wants the queue trimmed.
- **No constant changes.** `MIN_RECOMMENDED_PLUGIN_VERSION`, retry semantics, ack timing — all unchanged.

## Wet test (against real customer prod data)

Read-only SQL simulation on `memclaw-postgres-1` (no writes; queries only):

```
total_queued_deploys | would_have_been_blocked_by_new_gate | pct_blocked
---------------------+-------------------------------------+-------------
                1223 |                                1218 |       99.6
```

The 5 unblocked are the **first** commands in the cycle (gate has nothing to see yet — first attempt must pass). After that the gate would have suppressed every follow-up for 10 minutes. Result: 60s → 10min cap on the SIGTERM cadence, AND zero runaway once a deploy completes successfully.

## Tests

5 new in `tests/test_fleet_heartbeat_auto_upgrade.py`:
- `test_maybe_queue_auto_upgrade_skips_when_acked_deploy_in_flight` — headline behavior
- `test_maybe_queue_auto_upgrade_queues_when_no_in_flight` — happy path unchanged
- `test_maybe_queue_auto_upgrade_fails_open_on_repo_error` — DB hiccup safety
- `test_maybe_queue_auto_upgrade_skips_pending_before_querying_repo` — gate ordering (cheaper check first)
- `test_deploy_in_flight_window_is_sensible` — pins the constant value range

| Test scope | Result |
|---|---|
| `test_fleet_heartbeat_auto_upgrade.py` (full file) | **51/51 pass** (was 46, +5) |
| Broader `pytest -k "fleet or heartbeat" -m unit` | 24/24 pass, 0 regressions |
| `ruff check` + `ruff format --check` | clean |

## Test plan

- [x] Unit tests: 51/51 pass in the auto-upgrade file
- [x] Broader fleet/heartbeat sweep: 24/24 pass
- [x] Wet test against customer prod data (read-only SQL): 1,218/1,223 (99.6%) of past stuck commands would have been blocked
- [ ] Customer redeploy: expect `[memclaw] command deploy reported` log lines to drop to ≤1 per 10 min on previously-stuck nodes; `[fleet.heartbeat] skipping auto-upgrade for node=...` INFO lines start appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)