### PR TITLE
fix(plugin): don't create plugins.allow from nothing on autoFix (CAURA-000)

### DIFF
--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memclaw",
   "name": "MemClaw",
   "kind": "memory",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "Central persistent memory for OpenClaw agents — write, search, and entity lookup tools.",
   "entry": "dist/index.js",
   "skills": [

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caura/memclaw",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "OpenClaw plugin for MemClaw central memory",
   "license": "Apache-2.0",
   "private": true,

--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -1,9 +1,14 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
+import { writeFileSync, readFileSync, mkdtempSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import {
-  isMemorySlotClaimed,
+  autoFixAllowlist,
   isContextEngineSlotClaimed,
+  isMemclawAllowed,
   isMemclawFullyConfigured,
+  isMemorySlotClaimed,
   shouldRunAutoFix,
 } from "./config.js";
 import { getPluginDir } from "./paths.js";
@@ -48,9 +53,15 @@ describe("isMemclawFullyConfigured", () => {
     assert.equal(isMemclawFullyConfigured(happyConfig()), true);
   });
 
-  test("false when memclaw is not allowlisted", () => {
+  test("false when memclaw is not in a restrictive allowlist", () => {
+    // CAURA-000: pre-fix this test used `plugins.allow = []` to mean
+    // "not allowlisted", which assumed empty = restrictive. The
+    // OpenClaw runtime actually treats empty (and missing) as
+    // PERMISSIVE — "no restriction". Use an explicit non-empty
+    // allowlist that excludes memclaw to express the real
+    // "not allowlisted" case.
     const c = happyConfig();
-    (c as any).plugins.allow = [];
+    (c as any).plugins.allow = ["some-other-plugin"];
     assert.equal(isMemclawFullyConfigured(c), false);
   });
 
@@ -166,5 +177,187 @@ describe("shouldRunAutoFix — allowlist drift gate", () => {
 
   test("no-ops on a clean install with the flag present", () => {
     assert.equal(shouldRunAutoFix(clean), false);
+  });
+});
+
+
+// ---- isMemclawAllowed — permissive allowlist semantics (CAURA-000) ----
+//
+// OpenClaw 2026.6.x treats `plugins.allow` as a STRICT allowlist only when
+// it is BOTH present AND non-empty. A missing or empty array means "no
+// restriction" — every enabled plugin can load. Pre-fix our predicate
+// reported "not allowed" for the empty/missing case, which caused
+// `autoFixAllowlist` to *create* `["memclaw"]` — silently converting a
+// permissive config into a restrictive one and locking out built-ins
+// like the bundled `openai` provider plugin.
+
+describe("isMemclawAllowed — permissive when allow is missing or empty (CAURA-000)", () => {
+  test("true when plugins.allow is missing entirely (permissive default)", () => {
+    const c: any = { plugins: { entries: {}, load: {}, slots: {} } };
+    assert.equal(isMemclawAllowed(c), true);
+  });
+
+  test("true when plugins.allow is an empty array (permissive)", () => {
+    const c: any = { plugins: { allow: [], entries: {}, load: {}, slots: {} } };
+    assert.equal(isMemclawAllowed(c), true);
+  });
+
+  test("true when plugins.allow is non-empty AND includes memclaw", () => {
+    const c: any = {
+      plugins: { allow: ["memclaw", "browser"], entries: {}, load: {}, slots: {} },
+    };
+    assert.equal(isMemclawAllowed(c), true);
+  });
+
+  test("false when plugins.allow is non-empty AND excludes memclaw (the only real 'not allowed' case)", () => {
+    const c: any = {
+      plugins: { allow: ["browser"], entries: {}, load: {}, slots: {} },
+    };
+    assert.equal(isMemclawAllowed(c), false);
+  });
+
+  test("true when plugins object is completely missing (no allowlist to speak of)", () => {
+    const c: any = {};
+    assert.equal(isMemclawAllowed(c), true);
+  });
+});
+
+
+// ---- autoFixAllowlist.plugins.allow — non-creation invariant (CAURA-000) ----
+//
+// On a fresh install, autoFixAllowlist must NOT create `plugins.allow` from
+// nothing. Doing so would silently flip the user's permissive OpenClaw
+// config into a restrictive one — the exact mechanism behind the
+// customer-reported "openai disabled after 2.8.1 install" symptom.
+//
+// These tests drive the real `autoFixAllowlist` function against tiny
+// temp `openclaw.json` files and read back the resulting config.
+
+function _autoFixWithConfig(initial: Record<string, unknown>): {
+  written: Record<string, unknown> | null;
+  result: ReturnType<typeof autoFixAllowlist>;
+  cleanup: () => void;
+} {
+  const tmp = mkdtempSync(join(tmpdir(), "memclaw-autofix-test-"));
+  mkdirSync(join(tmp, ".openclaw"), { recursive: true });
+  const cfgPath = join(tmp, ".openclaw", "openclaw.json");
+  writeFileSync(cfgPath, JSON.stringify(initial), "utf-8");
+  const prevHome = process.env.HOME;
+  process.env.HOME = tmp;
+  const result = autoFixAllowlist({ forceSlotOverride: false });
+  process.env.HOME = prevHome;
+  let written: Record<string, unknown> | null = null;
+  try {
+    written = JSON.parse(readFileSync(cfgPath, "utf-8"));
+  } catch {
+    written = null;
+  }
+  return {
+    written,
+    result,
+    cleanup: () => {
+      try {
+        rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+describe("autoFixAllowlist — plugins.allow non-creation (CAURA-000)", () => {
+  test("does NOT create plugins.allow when it was missing (fresh-install regression)", () => {
+    // Mirrors a vanilla openclaw.json that the user / installer never
+    // touched — no `plugins.allow` field at all. Pre-fix autoFix would
+    // CREATE `plugins.allow = ["memclaw"]` here, the customer's
+    // observed crash mechanism.
+    const ctx = _autoFixWithConfig({
+      plugins: {
+        // NO `allow` field
+        entries: {},
+        load: { paths: [] },
+        slots: {},
+      },
+      tools: {},
+    });
+    try {
+      const written = ctx.written as any;
+      const allow = written?.plugins?.allow;
+      assert.ok(
+        allow === undefined || (Array.isArray(allow) && allow.length === 0),
+        `expected plugins.allow to stay missing/empty after autoFix; got: ${JSON.stringify(allow)}`,
+      );
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  test("does NOT push to plugins.allow when it was an explicit empty array", () => {
+    const ctx = _autoFixWithConfig({
+      plugins: {
+        allow: [], // user explicitly set empty = permissive
+        entries: {},
+        load: { paths: [] },
+        slots: {},
+      },
+      tools: {},
+    });
+    try {
+      const written = ctx.written as any;
+      assert.deepEqual(written?.plugins?.allow, [], "empty allow must stay empty");
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  test("DOES add memclaw to an existing non-empty allowlist that excludes it", () => {
+    // User has explicitly opted into a restrictive allowlist. We must
+    // add memclaw to it so memclaw itself can still load — otherwise
+    // we'd disable our own plugin while leaving the user's allowlist
+    // semantics intact.
+    const ctx = _autoFixWithConfig({
+      plugins: {
+        allow: ["browser", "filesystem"],
+        entries: {},
+        load: { paths: [] },
+        slots: {},
+      },
+      tools: {},
+    });
+    try {
+      const written = ctx.written as any;
+      const allow: string[] = written?.plugins?.allow ?? [];
+      assert.ok(
+        allow.includes("memclaw"),
+        `expected memclaw to be added; got: ${JSON.stringify(allow)}`,
+      );
+      assert.ok(allow.includes("browser"), "must preserve existing entries");
+      assert.ok(allow.includes("filesystem"), "must preserve existing entries");
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  test("does NOT add memclaw twice when already in a non-empty allowlist", () => {
+    const ctx = _autoFixWithConfig({
+      plugins: {
+        allow: ["browser", "memclaw", "filesystem"],
+        entries: {},
+        load: { paths: [] },
+        slots: {},
+      },
+      tools: {},
+    });
+    try {
+      const written = ctx.written as any;
+      const allow: string[] = written?.plugins?.allow ?? [];
+      assert.equal(
+        allow.filter((p) => p === "memclaw").length,
+        1,
+        `memclaw must appear exactly once; got: ${JSON.stringify(allow)}`,
+      );
+    } finally {
+      ctx.cleanup();
+    }
   });
 });

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -31,7 +31,27 @@ export function readOpenClawConfig(): Record<string, unknown> | null {
 
 export function isMemclawAllowed(config: Record<string, any>): boolean {
   const allow = config?.plugins?.allow;
-  return Array.isArray(allow) && allow.includes("memclaw");
+  // CAURA-000: `plugins.allow` in OpenClaw 2026.6.x is a STRICT
+  // allowlist only when it is BOTH present AND non-empty. The runtime
+  // gate is:
+  //
+  //     entry?.enabled === true
+  //       && (plugins.allow.length === 0 || plugins.allow.includes(pluginId))
+  //
+  // (from OpenClaw's selection layer — confirmed against
+  // `/usr/lib/node_modules/openclaw/dist/*.js` on the wet-test VM).
+  //
+  // So a missing OR empty `plugins.allow` means "no restriction —
+  // every enabled plugin can load". Memclaw doesn't need to appear
+  // in the array in those cases; it's allowed by default. Pre-fix this
+  // function returned `false` for missing/empty allow, which drove
+  // `autoFixAllowlist` step 1 to *create* an array containing only
+  // `"memclaw"` — flipping the user's permissive config into a
+  // restrictive one and silently locking out every other built-in
+  // plugin including `openai`. Customer-reported on a fresh 2.8.1
+  // install: "Unknown model: openai/gpt-5.5" 2 minutes after install.
+  if (!Array.isArray(allow) || allow.length === 0) return true;
+  return allow.includes("memclaw");
 }
 
 export function isMemclawEnabled(config: Record<string, any>): boolean {
@@ -98,10 +118,25 @@ export function autoFixAllowlist(options?: {
 
   const changes: string[] = [];
 
-  // 1. Ensure memclaw is in plugins.allow
-  if (!isMemclawAllowed(config)) {
-    if (!config.plugins) config.plugins = {};
-    if (!Array.isArray(config.plugins.allow)) config.plugins.allow = [];
+  // 1. Ensure memclaw is in `plugins.allow` IF — and only if — the
+  //    user has an explicit, non-empty allowlist. CAURA-000: pre-fix
+  //    this branch unconditionally created `["memclaw"]` from a
+  //    missing/empty array, converting a permissive OpenClaw config
+  //    into a restrictive one that locked out every other plugin
+  //    (the customer's "openai disabled after 2.8.1 install"
+  //    symptom). The runtime gate treats missing/empty allow as
+  //    "no restriction" — see `isMemclawAllowed` docstring for the
+  //    OpenClaw-side gate evidence.
+  //
+  //    So the fix is: leave a missing/empty allowlist alone; only
+  //    append to one that's already non-empty (i.e. the user has
+  //    explicitly opted into the allowlist mechanism and we need to
+  //    make sure memclaw is in their list).
+  if (
+    Array.isArray(config?.plugins?.allow) &&
+    config.plugins.allow.length > 0 &&
+    !config.plugins.allow.includes("memclaw")
+  ) {
     config.plugins.allow.push("memclaw");
     changes.push("plugins.allow");
   }

--- a/plugin/src/version.ts
+++ b/plugin/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated from plugin/package.json by scripts/gen-version.sh — do not edit
-export const PLUGIN_VERSION = "2.8.5";
+export const PLUGIN_VERSION = "2.8.6";


### PR DESCRIPTION
## Summary

Customer-reported: installing memclaw 2.8.1 on a fresh OpenClaw gateway caused the `openai/gpt-5.5` agent model to become unknown ~2 minutes after install (`FailoverError: Unknown model: openai/gpt-5.5`). The gateway log told the story directly: `http server listening (1 plugin: memclaw; 0.8s)` — OpenClaw loaded ONLY memclaw, blocking every other plugin including the bundled `openai` provider.

**The customer's suspicion was correct: our plugin was to blame.**

## Root cause

`autoFixAllowlist` step 1 in `config.ts`:
```typescript
if (!isMemclawAllowed(config)) {
  if (!Array.isArray(config.plugins.allow)) config.plugins.allow = [];
  config.plugins.allow.push("memclaw");
}
```

On a fresh `openclaw.json` with no `plugins.allow` field, this **created** `plugins.allow = ["memclaw"]`. Verified against OpenClaw 2026.6.1's plugin gate (read from `/usr/lib/node_modules/openclaw/dist/*.js`):

```js
entry?.enabled === true &&
  (plugins.allow.length === 0 || plugins.allow.includes(pluginId))
```

**A non-empty `plugins.allow` is a STRICT allowlist.** Empty or missing = no restriction. By materialising `["memclaw"]` from nothing, we flipped a permissive config into a restrictive one and locked out every other plugin.

Confirmation from the OpenClaw error strings in the same dist files:
- `"plugins.allow does not include browser. Add \"browser\" to plugins.allow or remove the restrictive plugin allowlist."`
- `"Add ${formatPluginList(ownerPluginIds)} to plugins.allow or remove plugins.allow."`

## Fix

Two minimal changes in `plugin/src/config.ts`:

1. **`isMemclawAllowed`**: missing or empty `plugins.allow` now returns `true` (matches OpenClaw's runtime semantics — memclaw can load anyway). Only returns `false` when allow is a non-empty array that excludes memclaw.

2. **`autoFixAllowlist` step 1**: only appends memclaw to an EXISTING, non-empty allowlist. Never materialises one from nothing.

The post-fix invariant:
- User had no `plugins.allow` → autoFix leaves it missing (permissive — memclaw + openai + others all load)
- User had `plugins.allow = []` → autoFix leaves it empty (permissive)
- User had `plugins.allow = ["browser", "filesystem"]` → autoFix adds memclaw → `["browser", "filesystem", "memclaw"]`
- User had `plugins.allow = ["browser", "memclaw"]` → no-op

## Validation

### Unit tests
- 310/310 pass plugin-side (was 301, +9 new):
  - 5 `isMemclawAllowed` tests pinning all 4 input shapes
  - 4 `autoFixAllowlist` tests driving the real function against temp `openclaw.json` files (verifies no-creation, empty-preserved, appended-to-restrictive, no-duplicate)
- 1 existing `isMemclawFullyConfigured` test updated: pre-fix it used `plugins.allow = []` to mean "not allowlisted", which assumed empty = restrictive; now uses an explicit non-empty allowlist that excludes memclaw (the only real "not allowed" case under corrected semantics).

### Wet test on `openclaw-test-ran` (GCE, OpenClaw 2026.6.1, plugin 2.8.6)

8/8 scenarios PASS:

```
✓ A. fresh install (no plugins.allow) — autoFix must NOT create restrictive allowlist
     plugins.allow after autoFix = undefined
✓ B. plugins.allow = [] (empty) — autoFix must leave it empty
✓ C. restrictive allow (without memclaw) — autoFix adds memclaw + preserves rest
     ["browser","filesystem","memclaw"]
✓ D. existing allow already with memclaw — no duplicate added
✓ E1. isMemclawAllowed: missing allow → true (permissive)
✓ E2. isMemclawAllowed: empty allow → true (permissive)
✓ E3. isMemclawAllowed: non-empty allow with memclaw → true
✓ E4. isMemclawAllowed: non-empty allow without memclaw → false
```

Scenario A is the **direct regression test for the customer bug**: pre-fix the same input produced `plugins.allow = ["memclaw"]` (the restrictive trap); post-fix it stays `undefined`.

## Customer recovery

Once 2.8.6 ships, the customer should:
1. Pull plugin 2.8.6 on the affected gateway (via the existing deploy machinery — note that PR #305 and #306 in this same batch fix the deploy-loop pathology, so the upgrade itself is no longer fragile)
2. Manually clear the bad `plugins.allow` in their `openclaw.json` (or remove the key entirely). Future installs/upgrades won't re-introduce the problem.

## Version

Plugin 2.8.5 → 2.8.6. No backend change.

## Test plan

- [x] 310/310 unit tests pass
- [x] Wet test on OpenClaw 2026.6.1 — 8/8 scenarios pass, including the direct customer-bug regression check
- [x] tsc clean (via `npm test` prefix)
- [x] DCO sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)