### PR TITLE
chore(ci): bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/claude_code_review.yml
+++ b/.github/workflows/claude_code_review.yml
@@ -192,7 +192,7 @@ jobs:
       # review script (lets a workflow/script change self-test on its own PR).
       # Secrets are withheld from fork-PR runs and pre-checks gate the rest.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -275,7 +275,7 @@ jobs:
 
       - name: Checkout PR branch
         if: steps.auth.outputs.authorized == 'true' && steps.pr.outputs.is_pr == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.head_ref }}
           fetch-depth: 1


### PR DESCRIPTION
GitHub forces Node 20 actions onto Node 24 on 2026-06-16. Bumps workflow action pins to Node-24 majors (checkout→v6) — version pins only, no logic change. Commit signed off for DCO. Replaces the inadvertently-closed #308 (whose branch had lost common history with main after a force-push).