### PR TITLE
chore(plugin): bump MIN_RECOMMENDED_PLUGIN_VERSION 2.8.1 → 2.9.0 (floor companion for #290)

### DIFF
--- a/core-api/src/core_api/version_compat.py
+++ b/core-api/src/core_api/version_compat.py
@@ -6,7 +6,7 @@ We log a warning when a heartbeat reports a plugin older than the minimum
 recommended version; no hard rejection — operators decide when to upgrade.
 """
 
-MIN_RECOMMENDED_PLUGIN_VERSION = "2.8.1"
+MIN_RECOMMENDED_PLUGIN_VERSION = "2.9.0"
 
 # Server-side floor below which plugins must NOT auto-upgrade — the
 # heartbeat path in ``routes/fleet.py`` enforces this hard, and


### PR DESCRIPTION
## Floor companion for plugin-v2.9.0 (release-please #290)

Bumps the server-side auto-upgrade floor `MIN_RECOMMENDED_PLUGIN_VERSION` `2.8.1 → 2.9.0` so it matches the **served** plugin version that #290 will publish.

### Why
release-please (#290) bumps the plugin version files + manifest to 2.9.0 but does **not** touch `version_compat.py`. Without this companion, main would have served=2.9.0 while floor=2.8.1 → manifest-aware nodes wouldn't be driven to 2.9.0 and we'd reintroduce the served≠floor drift we fixed in #289.

### Merge order
1. Merge **#290** first (served plugin → 2.9.0, tags `plugin-v2.9.0`).
2. Then merge **this** — so main never sits at floor 2.9.0 while served is still 2.8.1.

Both must be on main before the next on-prem tag (`onprem-v2.10.0`) is cut for eToro.

### Risk
One-line constant change. No tests pin the literal (the fleet-heartbeat tests `monkeypatch` their own values). DCO signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)