### PR TITLE
feat(skills): auto-approve clean Forge candidates (skip HITL inbox)

### DIFF
--- a/core-api/src/core_api/services/forge/cron_handler.py
+++ b/core-api/src/core_api/services/forge/cron_handler.py
@@ -90,6 +90,20 @@ async def _resolve_forge_config(db: AsyncSession, org_id: str) -> ForgeConfig:
     )
 
 
+async def _resolve_auto_promote_clean(db: AsyncSession, org_id: str) -> bool:
+    """Read ``skills_factory.sentinel.auto_promote_clean`` for a tenant.
+
+    Default False (HITL preserved). ``get_settings_for_display`` is
+    cached (5-min TTL), so the second fetch within a tick — alongside
+    ``_resolve_forge_config`` — is a cache hit, not a second DB
+    round-trip.
+    """
+    settings = await get_settings_for_display(db, org_id)
+    sf = (settings or {}).get("skills_factory") or {}
+    sentinel = sf.get("sentinel") or {}
+    return bool(sentinel.get("auto_promote_clean", False))
+
+
 # ── Injectable factories ──────────────────────────────────────────
 
 
@@ -221,6 +235,7 @@ async def run_forge_cron_tick(
     retries on its normal schedule.
     """
     cfg = await _resolve_forge_config(db, tenant_id)
+    auto_promote_clean = await _resolve_auto_promote_clean(db, tenant_id)
     now = datetime.now(UTC)
     window_end = now
     window_start = now - timedelta(days=cfg.freshness_window_days)
@@ -261,11 +276,17 @@ async def run_forge_cron_tick(
         min_distinct_agents=cfg.min_distinct_agents,
         freshness_window_days=cfg.freshness_window_days,
         now=now,
+        auto_promote_clean=auto_promote_clean,
     )
 
     stats = {
         "candidates_written": forge_result.candidates_written,
         "promoted": promote_result.promoted,
+        # Subset of ``promoted`` that skipped the Inbox and went
+        # straight to ``active`` (opt-in ``auto_promote_clean`` +
+        # clean Sentinel scan). ``promoted - auto_approved`` is the
+        # count that landed in ``staged`` for human review.
+        "auto_approved": promote_result.auto_approved,
         "scanned": promote_result.scanned,
         "held": promote_result.held,
         # Surface the 5 Forge skip buckets so audit rows are

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -173,6 +173,16 @@ DEFAULT_SETTINGS: dict = {
         # instead of letting it surface in the inbox.
         "sentinel": {
             "fail_on_critical": True,
+            # When True, a Forge candidate that passes ALL six
+            # auto-gates AND carries a clean Sentinel scan
+            # (``scan.state='clean'``, ``critical=0``) is promoted
+            # straight to ``status='active'`` — skipping the HITL
+            # Inbox approve step. Default False keeps the human in
+            # the loop. Flipping this true means the tenant TRUSTS
+            # the Sentinel scanner as the sole gate before a skill
+            # goes live; dirty / quarantined / warn-only candidates
+            # still route to ``staged`` and require human review.
+            "auto_promote_clean": False,
         },
         # Forge resident knobs. Phase 0 publishes the topic + stub
         # handler; Phase 1 lands the real worker that reads these.
@@ -387,6 +397,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "skills_factory.inbox_max_pending": int,
     "skills_factory.rejection_cooloff_days": int,
     "skills_factory.sentinel.fail_on_critical": bool,
+    "skills_factory.sentinel.auto_promote_clean": bool,
     "skills_factory.forge.cron_interval_hours": int,
     "skills_factory.forge.min_cluster_size": int,
     "skills_factory.forge.min_distinct_agents": int,

--- a/core-api/src/core_api/services/skill_promoter.py
+++ b/core-api/src/core_api/services/skill_promoter.py
@@ -84,11 +84,19 @@ class AlreadyTransitionedError(RuntimeError):
 class PromotionAttempt:
     """One candidate's verdict — included in :class:`PromoterRunResult`
     so the operator UI / audit log can show "promoted: N, held: M
-    (with breakdown)" without a second query."""
+    (with breakdown)" without a second query.
+
+    ``target_status`` records WHERE a promoted candidate landed:
+    ``'staged'`` (the normal HITL path — surfaces in the Inbox) or
+    ``'active'`` (auto-approved — skipped the human gate because the
+    tenant opted into ``auto_promote_clean`` and the Sentinel scan
+    was clean). ``None`` for held candidates.
+    """
 
     doc_id: str
     promoted: bool
     gates: AutoGateResult
+    target_status: str | None = None
 
 
 @dataclass(frozen=True)
@@ -98,6 +106,12 @@ class PromoterRunResult:
     scanned: int
     promoted: int
     held: int
+    # Subset of ``promoted`` that went straight to ``active`` via
+    # ``auto_promote_clean`` (skipping the Inbox). ``promoted`` is the
+    # total; ``auto_approved`` is the auto-activated slice, so
+    # ``promoted - auto_approved`` is the count that landed in
+    # ``staged`` for human review.
+    auto_approved: int = 0
     attempts: tuple[PromotionAttempt, ...] = field(default_factory=tuple)
 
 
@@ -225,6 +239,36 @@ def make_db_status_updater(db: Any, *, expected_status: str) -> StatusUpdaterCal
 # ── Tick entry point ───────────────────────────────────────────────
 
 
+def _scan_is_clean(doc: dict) -> bool:
+    """True iff the candidate's stamped Sentinel scan is fully clean
+    (``state='clean'`` AND no critical findings).
+
+    The candidate's ``data.scan`` is written at Forge-distill time
+    (``forge_service._distill_cluster`` runs ``scan_skill_doc`` and
+    stamps the result). A ``status='candidate'`` doc's scan therefore
+    always reflects its current content: the only path that mutates a
+    candidate's content is the Inbox ``edit`` endpoint, which re-runs
+    the scan AND leaves the doc in ``staged`` (so it's no longer in
+    the promoter's ``status='candidate'`` query). Trusting the
+    stamped scan here is safe — no fresh rescan needed.
+
+    NOTE: auto-gate G5 already requires ``scan.state == 'clean'`` for
+    ``gates.promote`` to be True, so this check is partially redundant
+    with the gate. We re-assert it locally anyway so the
+    security-critical "only a clean scan auto-activates" invariant is
+    self-contained at the decision site and not load-bearing on an
+    unrelated gate that could be relaxed in a future refactor.
+    """
+    scan = doc.get("scan") or {}
+    if not isinstance(scan, dict):
+        return False
+    try:
+        critical = int(scan.get("critical", 0))
+    except (TypeError, ValueError):
+        return False
+    return scan.get("state") == "clean" and critical == 0
+
+
 async def promote_pending_candidates(
     db: Any,
     *,
@@ -238,6 +282,7 @@ async def promote_pending_candidates(
     freshness_window_days: int,
     now: datetime | None = None,
     limit: int = 50,
+    auto_promote_clean: bool = False,
 ) -> PromoterRunResult:
     """One promoter tick. Reads up to ``limit`` candidates; evaluates
     each; promotes those that pass all gates.
@@ -245,6 +290,17 @@ async def promote_pending_candidates(
     ``limit`` caps wall-time per tick (and matches
     ``org_settings.skills_factory.inbox_max_pending`` — beyond that,
     the Inbox is the relief valve).
+
+    ``auto_promote_clean`` (opt-in, from
+    ``org_settings.skills_factory.sentinel.auto_promote_clean``) routes
+    a candidate that passed ALL six auto-gates AND carries a clean
+    Sentinel scan straight to ``status='active'`` instead of
+    ``'staged'`` — skipping the HITL Inbox. It NEVER bypasses the
+    gates: a candidate that fails any gate is held exactly as before;
+    the flag only changes the DESTINATION of an already-passing
+    candidate. Candidates with a non-clean scan never reach the
+    promote branch (gate G5 holds them), so they can't be
+    auto-activated regardless of the flag.
     """
     now = now or datetime.now(UTC)
     rows = (
@@ -276,6 +332,7 @@ async def promote_pending_candidates(
 
     attempts: list[PromotionAttempt] = []
     promoted = 0
+    auto_approved = 0
     for row in rows:
         doc = row.data if isinstance(row.data, dict) else {}
         # Use the candidate's OWN fleet for gate evaluation — the tick
@@ -298,8 +355,16 @@ async def promote_pending_candidates(
             freshness_window_days=freshness_window_days,
         )
         if gates.promote:
+            # Destination: ``active`` when the tenant opted into
+            # auto-promotion AND the stamped Sentinel scan is clean;
+            # otherwise the normal HITL ``staged`` path. The candidate
+            # has already cleared all six gates by this point —
+            # ``auto_promote_clean`` only chooses where it lands, never
+            # whether it lands.
+            is_auto = auto_promote_clean and _scan_is_clean(doc)
+            target_status = "active" if is_auto else "staged"
             try:
-                await status_updater(tenant_id, "skills", row.doc_id, "staged")
+                await status_updater(tenant_id, "skills", row.doc_id, target_status)
             except AlreadyTransitionedError:
                 # Concurrent writer (another promoter tick or an
                 # operator action) moved the row. Don't count it as a
@@ -321,7 +386,16 @@ async def promote_pending_candidates(
                 attempts.append(PromotionAttempt(doc_id=row.doc_id, promoted=False, gates=gates))
                 continue
             promoted += 1
-            attempts.append(PromotionAttempt(doc_id=row.doc_id, promoted=True, gates=gates))
+            if is_auto:
+                auto_approved += 1
+            attempts.append(
+                PromotionAttempt(
+                    doc_id=row.doc_id,
+                    promoted=True,
+                    gates=gates,
+                    target_status=target_status,
+                )
+            )
         else:
             attempts.append(PromotionAttempt(doc_id=row.doc_id, promoted=False, gates=gates))
 
@@ -332,11 +406,14 @@ async def promote_pending_candidates(
     # promotions silently rolls back when the session exits.
     await db.commit()
     logger.info(
-        "skill_promoter tick: tenant=%s fleet=%s scanned=%d promoted=%d held=%d",
+        "skill_promoter tick: tenant=%s fleet=%s scanned=%d promoted=%d "
+        "(auto_approved=%d → active, %d → staged) held=%d",
         tenant_id,
         fleet_id,
         len(attempts),
         promoted,
+        auto_approved,
+        promoted - auto_approved,
         held,
     )
     return PromoterRunResult(
@@ -345,6 +422,7 @@ async def promote_pending_candidates(
         scanned=len(attempts),
         promoted=promoted,
         held=held,
+        auto_approved=auto_approved,
         attempts=tuple(attempts),
     )
 

--- a/docs/operator-forge-cron.md
+++ b/docs/operator-forge-cron.md
@@ -95,6 +95,50 @@ passes all 6 auto-gates (volume, diversity, freshness, poison, scan,
 hash-binding) lands in `staged` within the same tick — operators
 don't have to wait a second cron firing.
 
+## Auto-approve clean candidates (skip the HITL inbox)
+
+Setting `org_settings.skills_factory.sentinel.auto_promote_clean=true`
+(default **false**) makes a candidate that passes **all 6 auto-gates
+AND carries a clean Sentinel scan** (`scan.state='clean'`,
+`scan.critical=0`) promote straight to `status='active'` —
+**skipping the human Inbox approval step entirely**.
+
+**This is a trust decision.** Flipping it true means the tenant treats
+the Sentinel scanner + the 6 auto-gates as a sufficient gate before a
+skill goes live to agents. Use it only for fleets where:
+
+- the Sentinel rule-set is tuned for the tenant's content, and
+- the cost of a bad skill reaching agents is low / quickly reversible
+  (a human can still Reject an active skill, which poisons its
+  fingerprint and stops re-derivation).
+
+What it does **not** bypass:
+
+- **The 6 auto-gates.** A candidate that fails volume / diversity /
+  freshness / poison / scan / hash-binding is held exactly as before —
+  the flag only changes the destination of an *already-passing*
+  candidate, never whether it passes.
+- **The Sentinel scan.** A candidate with a dirty scan
+  (quarantined, or any critical finding) never reaches the promotion
+  branch — gate G5 holds it in `candidate`, and even if a future gate
+  refactor let it through, the promoter re-asserts scan cleanliness at
+  the auto-approve decision site. Scans in a non-clean state
+  (`quarantined`, `warn`, `dirty`) or with any critical finding are
+  not auto-promoted; they always route to `staged` for human review.
+  A clean scan may carry `warn`-count > 0 and still auto-promote —
+  warns are surfaced on the operator card but do not block activation
+  (matching the inbox approve semantics; see
+  `test_flag_on_but_warn_scan_still_auto_activates`).
+
+Audit visibility: the lifecycle-audit row's `stats.auto_approved`
+counts how many of that tick's promotions skipped the inbox; `promoted
+- auto_approved` is the count that landed in `staged`. The structured
+promoter log line breaks both out per tick.
+
+**To pause:** flip back to `false`. The next tick's clean candidates
+route to `staged` again — already-active skills are unaffected (no
+rollback), and the inbox resumes as the gate.
+
 ## Dedup safety
 
 The shared lifecycle handler uses

--- a/tests/test_forge_cron_tick.py
+++ b/tests/test_forge_cron_tick.py
@@ -96,7 +96,9 @@ class TestResolvePublisherKwargs:
         # Deterministic format: ``forge-cron-<org>-<UTC YYYYMMDDtHHMM>``
         # so an operator inspecting an inbox card's ``origin.run_id``
         # can trace it back to the cron tick that minted it.
-        assert re.match(r"^forge-cron-wet-test-tenant-\d{8}T\d{4}$", kwargs["run_label"])
+        assert re.match(
+            r"^forge-cron-wet-test-tenant-\d{8}T\d{4}$", kwargs["run_label"]
+        )
 
     @pytest.mark.asyncio
     async def test_archive_expired_returns_empty(self):
@@ -193,6 +195,7 @@ class TestRunForgeCronTick:
             scanned=3,
             promoted=2,
             held=1,
+            auto_approved=0,
         )
 
         with (
@@ -252,6 +255,100 @@ class TestRunForgeCronTick:
         # Skip counters surface from the Forge result.
         assert stats["skipped_poisoned"] == 1
         assert stats["skipped_sentinel"] == 0
+        # auto_approved surfaces from the promoter result (0 here — the
+        # flag defaults off because the patched settings omit it).
+        assert stats["auto_approved"] == 0
+        # Flag-off: promoter invoked with auto_promote_clean=False.
+        assert run_promote.await_args.kwargs["auto_promote_clean"] is False
+
+    @pytest.mark.asyncio
+    async def test_auto_promote_clean_flag_threaded_when_enabled(self):
+        from core_api.services.forge.cron_handler import run_forge_cron_tick
+
+        fake_forge_result = ForgeRunResult(
+            tenant_id="t1",
+            fleet_id=None,
+            window_start=None,
+            window_end=None,
+            total_traces=0,
+            labeled_traces=0,
+            clusters_total=0,
+            clusters_eligible=0,
+            candidates_written=1,
+            candidates_skipped_poisoned=0,
+            candidates_skipped_sentinel=0,
+            candidates_skipped_distill_error=0,
+            candidates_skipped_io_error=0,
+            candidates_skipped_existing=0,
+            started_at=None,
+            run_label="forge-cron-t1-20260610T0000",
+            candidate_doc_ids=["forge/x"],
+        )
+        fake_promote_result = PromoterRunResult(
+            tenant_id="t1",
+            fleet_id=None,
+            scanned=1,
+            promoted=1,
+            held=0,
+            auto_approved=1,  # the one candidate auto-activated
+        )
+
+        with (
+            patch(
+                "core_api.services.forge.cron_handler.get_settings_for_display",
+                new=AsyncMock(
+                    return_value={
+                        "skills_factory": {
+                            "forge": {},
+                            "sentinel": {"auto_promote_clean": True},
+                        }
+                    }
+                ),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler._wire_llm_fn",
+                new=AsyncMock(return_value=AsyncMock()),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler._make_candidate_writer",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler._make_status_checker",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler.run_forge_distill",
+                new=AsyncMock(return_value=fake_forge_result),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler.promote_pending_candidates",
+                new=AsyncMock(return_value=fake_promote_result),
+            ) as run_promote,
+            patch(
+                "core_api.services.forge.cron_handler.make_db_poison_checker",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler.make_db_live_data_fetcher",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler.make_db_status_updater",
+                return_value=AsyncMock(),
+            ),
+        ):
+            stats = await run_forge_cron_tick(
+                db=AsyncMock(),
+                tenant_id="t1",
+                fleet_id=None,
+                run_label="forge-cron-t1-20260610T0000",
+            )
+
+        # The flag from org_settings.sentinel.auto_promote_clean is
+        # threaded into the promoter.
+        assert run_promote.await_args.kwargs["auto_promote_clean"] is True
+        assert stats["auto_approved"] == 1
 
     @pytest.mark.asyncio
     async def test_missing_llm_provider_raises_runtime_error(self):

--- a/tests/test_skill_lifecycle_transitions.py
+++ b/tests/test_skill_lifecycle_transitions.py
@@ -16,6 +16,7 @@ status_updater) are async fakes that the test pins.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -186,7 +187,9 @@ class TestGate3Freshness:
     @pytest.mark.asyncio
     async def test_unparseable_window_end_fails(self):
         r = await evaluate_auto_gates(
-            _candidate_doc(origin={**_candidate_doc()["origin"], "window_end": "not-iso"}),
+            _candidate_doc(
+                origin={**_candidate_doc()["origin"], "window_end": "not-iso"}
+            ),
             tenant_id="t1",
             fleet_id=None,
             now=datetime.now(UTC),
@@ -284,7 +287,9 @@ class TestGate5Scan:
     @pytest.mark.asyncio
     async def test_quarantined_scan_fails(self):
         r = await evaluate_auto_gates(
-            _candidate_doc(scan={"state": "quarantined", "critical": 1, "findings": []}),
+            _candidate_doc(
+                scan={"state": "quarantined", "critical": 1, "findings": []}
+            ),
             tenant_id="t1",
             fleet_id=None,
             now=datetime.now(UTC),
@@ -313,7 +318,9 @@ class TestGate6HashBinding:
         live_data = {"content_hash": "sha256:LIVE"}
         fetcher = await _fake_live_data_returns(live_data)
         r = await evaluate_auto_gates(
-            _candidate_doc(kind="update", target={"target_content_hash": "sha256:LIVE"}),
+            _candidate_doc(
+                kind="update", target={"target_content_hash": "sha256:LIVE"}
+            ),
             tenant_id="t1",
             fleet_id=None,
             now=datetime.now(UTC),
@@ -327,7 +334,9 @@ class TestGate6HashBinding:
         live_data = {"content_hash": "sha256:DIFFERENT"}
         fetcher = await _fake_live_data_returns(live_data)
         r = await evaluate_auto_gates(
-            _candidate_doc(kind="update", target={"target_content_hash": "sha256:STALE"}),
+            _candidate_doc(
+                kind="update", target={"target_content_hash": "sha256:STALE"}
+            ),
             tenant_id="t1",
             fleet_id=None,
             now=datetime.now(UTC),
@@ -581,6 +590,140 @@ class TestPromoter:
         assert result.held == 1
         # both updater calls were attempted (no early exit).
         assert seen == ["forge/a", "forge/b"]
+
+
+# ── auto_promote_clean (skip the HITL inbox) ───────────────────────
+
+
+@pytest.mark.unit
+class TestAutoPromoteClean:
+    @pytest.mark.asyncio
+    async def test_flag_off_routes_clean_candidate_to_staged(self):
+        # Default behavior (flag off): even a clean candidate lands in
+        # ``staged`` for human review.
+        db = _FakeDb([_FakeRow("forge/clean", _candidate_doc())])
+        updates: list[tuple] = []
+
+        async def updater(t, c, d, s):
+            updates.append((t, c, d, s))
+
+        result = await promote_pending_candidates(
+            db,
+            tenant_id="t1",
+            fleet_id=None,
+            poison_checker=_fake_poison_never,
+            live_data_fetcher=await _fake_live_data_returns(None),
+            status_updater=updater,
+            min_cluster_size=3,
+            min_distinct_agents=3,
+            freshness_window_days=14,
+            auto_promote_clean=False,
+        )
+        assert updates == [("t1", "skills", "forge/clean", "staged")]
+        assert result.promoted == 1
+        assert result.auto_approved == 0
+        assert result.attempts[0].target_status == "staged"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_clean_candidate_goes_straight_to_active(self):
+        db = _FakeDb([_FakeRow("forge/clean", _candidate_doc())])
+        updates: list[tuple] = []
+
+        async def updater(t, c, d, s):
+            updates.append((t, c, d, s))
+
+        result = await promote_pending_candidates(
+            db,
+            tenant_id="t1",
+            fleet_id=None,
+            poison_checker=_fake_poison_never,
+            live_data_fetcher=await _fake_live_data_returns(None),
+            status_updater=updater,
+            min_cluster_size=3,
+            min_distinct_agents=3,
+            freshness_window_days=14,
+            auto_promote_clean=True,
+        )
+        # Clean scan + flag on → active, skipping the inbox entirely.
+        assert updates == [("t1", "skills", "forge/clean", "active")]
+        assert result.promoted == 1
+        assert result.auto_approved == 1
+        assert result.attempts[0].target_status == "active"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_but_warn_scan_still_auto_activates(self):
+        # A scan with warn>0 but state='clean' + critical=0 is still a
+        # clean PASS for auto-approve — warns surface on the card but
+        # don't block (matching the inbox approve semantics). The
+        # decisive fields are ``state`` + ``critical``.
+        doc = _candidate_doc(
+            scan={"state": "clean", "critical": 0, "warn": 2, "findings": []}
+        )
+        db = _FakeDb([_FakeRow("forge/warned", doc)])
+        updates: list[tuple] = []
+
+        async def updater(t, c, d, s):
+            updates.append((t, c, d, s))
+
+        result = await promote_pending_candidates(
+            db,
+            tenant_id="t1",
+            fleet_id=None,
+            poison_checker=_fake_poison_never,
+            live_data_fetcher=await _fake_live_data_returns(None),
+            status_updater=updater,
+            min_cluster_size=3,
+            min_distinct_agents=3,
+            freshness_window_days=14,
+            auto_promote_clean=True,
+        )
+        assert updates == [("t1", "skills", "forge/warned", "active")]
+        assert result.auto_approved == 1
+
+    @pytest.mark.asyncio
+    async def test_flag_on_missing_scan_block_falls_back_to_staged(self):
+        # Defensive: a candidate that somehow reaches the promote
+        # branch without a clean ``scan`` block (shouldn't happen —
+        # gate G5 would hold it — but the auto-approve site re-asserts
+        # cleanliness rather than trusting the gate transitively) must
+        # NOT be auto-activated. It falls back to staged.
+        #
+        # We bypass G5 by injecting a doc whose scan is clean enough
+        # for the gate but whose ``critical`` is non-zero — proving the
+        # local re-assertion catches it even if a gate refactor let it
+        # through.
+        doc = _candidate_doc(
+            scan={"state": "clean", "critical": 3, "warn": 0, "findings": []}
+        )
+        db = _FakeDb([_FakeRow("forge/sketchy", doc)])
+        updates: list[tuple] = []
+
+        async def updater(t, c, d, s):
+            updates.append((t, c, d, s))
+
+        # Force the gate to pass so we exercise the auto-approve
+        # re-assertion in isolation (real G5 would hold this; we patch
+        # it to prove the promoter's own check is the safety net).
+        with patch(
+            "core_api.services.skill_promoter.evaluate_auto_gates",
+            new=AsyncMock(return_value=AutoGateResult(promote=True, gates=())),
+        ):
+            result = await promote_pending_candidates(
+                db,
+                tenant_id="t1",
+                fleet_id=None,
+                poison_checker=_fake_poison_never,
+                live_data_fetcher=await _fake_live_data_returns(None),
+                status_updater=updater,
+                min_cluster_size=3,
+                min_distinct_agents=3,
+                freshness_window_days=14,
+                auto_promote_clean=True,
+            )
+        # critical>0 → NOT clean → staged, not active.
+        assert updates == [("t1", "skills", "forge/sketchy", "staged")]
+        assert result.auto_approved == 0
+        assert result.attempts[0].target_status == "staged"
 
 
 # ── rescan_before_apply ────────────────────────────────────────────


### PR DESCRIPTION
Adds an **opt-in** flag that promotes a Forge candidate which passes **all 6 auto-gates AND carries a clean Sentinel scan** straight to `status='active'` — skipping the human Inbox approval step. **Default off**; HITL stays the default posture.

## What's new

| File | Change |
|---|---|
| `organization_settings.py` | New `skills_factory.sentinel.auto_promote_clean` (bool, default `False`) + `_LEAF_TYPES` validator |
| `skill_promoter.py` | `promote_pending_candidates` takes `auto_promote_clean`. Per passing candidate, destination = `active` if (flag on AND scan clean: `state='clean'`, `critical=0`) else `staged`. New `_scan_is_clean` helper; `PromotionAttempt.target_status`; `PromoterRunResult.auto_approved` |
| `cron_handler.py` | Reads the flag (`_resolve_auto_promote_clean`), threads it into the promoter, surfaces `auto_approved` in audit `stats` |
| `docs/operator-forge-cron.md` | New "Auto-approve clean candidates" section — trust trade-off, what it does/doesn't bypass, audit visibility, pause path |

## Safety invariants (the important part)

- **Never bypasses the 6 auto-gates.** The flag only changes the *destination* of an already-passing candidate — never whether it passes.
- **A dirty/quarantined scan never auto-activates.** Gate G5 holds it in `candidate`; and the promoter **re-asserts** scan cleanliness at the auto-approve site, so the "only clean auto-activates" invariant is self-contained and not load-bearing on G5 alone (defends against a future gate refactor).
- **Flag-off = byte-identical prior behavior.** Clean candidates land in `staged` and surface in the Inbox.
- **Clean unwind.** Flipping back off leaves already-active skills untouched; future clean candidates route to `staged`. A human can still Reject an active skill (poisons its fingerprint).

## Tests

`TestAutoPromoteClean` (4): flag-off→staged · flag-on+clean→active · warn-but-clean→active · injected-gate-pass + dirty-scan→staged (proves the local re-assertion catches a dirty scan even if a gate is relaxed). Cron tests assert the flag is read from settings + threaded + `auto_approved` surfaces in stats.

## Validation

```
400/400 SF tests pass     (lifecycle + cron + schema + distill + sentinel
                           + cluster + outcome-inference + session-trace + eval)
mypy + ruff clean on core-api/src/
```
Validated against a local pgvector:pg16 container (the suite's autouse fixture needs Postgres).

## Depends on

Builds on #311 (Forge cron wiring, merged). The auto-approve path runs inside the same `run_forge_cron_tick` → `promote_pending_candidates` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)