### PR TITLE
feat(skills): MCP-direct delivery — agents discover only active skills

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -13,7 +13,7 @@ import json
 import logging
 import re
 import time
-from typing import Annotated, cast
+from typing import Annotated, Any, cast
 from uuid import UUID, uuid4
 
 import httpx
@@ -1165,6 +1165,107 @@ async def memclaw_tune(
 SKILLS_COLLECTION = "skills"
 _SKILL_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,99}$")
 
+# The agent-facing MCP surface only exposes skills in this status. The
+# Skill Factory lifecycle (candidate → staged → active) gates what an
+# agent can discover: candidate/staged/quarantined/rejected skills are
+# in-flight or blocked and must NOT surface to agents. Only this filter
+# turns "an operator approved it" into "agents can find it".
+_AGENT_VISIBLE_SKILL_STATUS = "active"
+
+
+async def _skills_factory_flag(db: Any, tenant_id: str) -> bool:
+    """Strict opt-in check — RAISES on a settings-lookup failure.
+
+    Is ``skills_factory.enabled`` true for this tenant? Callers that gate
+    a SECURITY decision (op=write / op=delete) wrap this and **fail
+    closed** (abort the mutation) on error — they must never proceed
+    unvalidated just because the flag couldn't be read. Read-path callers
+    use the lenient ``_skills_factory_enabled`` wrapper instead.
+    ``get_raw_settings`` is cache-first (5-min TTL), so this is a cheap
+    hot-path check.
+    """
+    from core_api.services.organization_settings import get_raw_settings
+
+    raw = await get_raw_settings(db, tenant_id)
+    return (
+        isinstance(raw, dict)
+        and isinstance(raw.get("skills_factory"), dict)
+        and bool(raw["skills_factory"].get("enabled"))
+    )
+
+
+async def _skills_factory_enabled(db: Any, tenant_id: str) -> bool:
+    """Non-raising opt-in check for the active-only skill-read filter
+    (read / query / search) — fails CLOSED on a settings-lookup failure.
+
+    On success returns the tenant's true ``skills_factory.enabled`` flag,
+    so non-opted-in tenants keep byte-identical (unfiltered) read
+    behavior — the merge-day no-op invariant.
+
+    On a settings-lookup FAILURE it returns ``True`` (assume enabled), so
+    the active-only filter IS applied: a transient settings outage must
+    not let a non-active skill (candidate / staged / quarantined) leak to
+    an agent. The read still succeeds — it's filtered, not 500'd — so the
+    cost is only that, during an outage, a tenant temporarily sees just
+    their ``active`` skills. For non-opted-in tenants that is a near
+    no-op (their skills are all ``active`` post-migration). This keeps
+    ALL skill gates fail-closed: write/delete abort, reads filter.
+    """
+    try:
+        return await _skills_factory_flag(db, tenant_id)
+    except Exception:
+        logger.warning(
+            "skills_factory flag lookup failed for %s; failing CLOSED — active-only "
+            "filter APPLIED (only status='active' skills surface) until cache recovers",
+            tenant_id,
+        )
+        return True
+
+
+def _safe_int(val: Any, default: int) -> int:
+    """Coerce a settings value to int, falling back to ``default`` on a
+    null, boolean, or non-numeric value. The per-tenant byte caps are
+    operator-editable JSON, so a misconfiguration (``null``, ``"auto"``,
+    ``true``/``false``) must degrade to the documented default — not
+    crash (or silently mis-cap) the skills write path.
+
+    ``bool`` is checked first because it is a subclass of ``int`` in
+    Python: ``int(True) == 1`` / ``int(False) == 0`` would otherwise pass
+    through silently and produce a 1- or 0-byte cap rather than the
+    intended default."""
+    if isinstance(val, bool):
+        return default
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def _skill_hidden_from_agent(doc: Any, *, caller_tenant_id: str, caller_opted_in: bool) -> bool:
+    """Whether a fetched row must NOT surface on the agent MCP skill
+    surface.
+
+    A skills-collection row is hidden when it is non-active AND either:
+
+      • the caller's tenant opted in (the active-only gate applies to
+        the caller's own skills), or
+      • the row belongs to a DIFFERENT tenant than the caller — a
+        sibling tenant's in-flight / blocked skill must never leak
+        through cross-tenant credentials, regardless of the *caller's*
+        own opt-in flag. This is safe: a non-opted-in owning tenant's
+        skills are all ``active`` (backfilled by migration 022), so this
+        only ever hides a genuinely non-active row, never a legitimately
+        visible one.
+
+    Non-skills rows are never hidden. Keyed off the row's own
+    ``tenant_id`` so the decision follows the OWNING tenant, not just
+    the caller's flag (closes the cross-tenant read leak)."""
+    if getattr(doc, "collection", None) != SKILLS_COLLECTION:
+        return False
+    if (getattr(doc, "data", None) or {}).get("status") == _AGENT_VISIBLE_SKILL_STATUS:
+        return False
+    return caller_opted_in or getattr(doc, "tenant_id", caller_tenant_id) != caller_tenant_id
+
 
 async def memclaw_doc(
     op: Annotated[str, Field(description="write|read|query|delete|list_collections|search.")],
@@ -1250,6 +1351,36 @@ async def memclaw_doc(
                     fleet_id=fleet_id,
                     readable_tenant_ids=readable if op in READ_OPS else None,
                 )
+                # Active-only count correction for skills: an opted-in
+                # tenant's listing must not advertise non-active skills
+                # in the count — they're invisible to read/query/search,
+                # so a count that includes them is misleading. Recompute
+                # the skills row restricted to status='active', over the
+                # same (possibly cross-tenant) scope the listing used.
+                # One COUNT, only when a skills row is present AND the
+                # tenant opted in.
+                if any(name == SKILLS_COLLECTION for name, _ in rows) and await _skills_factory_enabled(
+                    db, tenant_id
+                ):
+                    from sqlalchemy import func as sa_func
+                    from sqlalchemy import select as sa_select
+
+                    from common.models.document import Document
+
+                    tenant_pred = (
+                        Document.tenant_id.in_(readable) if readable else Document.tenant_id == tenant_id
+                    )
+                    cnt_stmt = sa_select(sa_func.count()).where(
+                        tenant_pred,
+                        Document.collection == SKILLS_COLLECTION,
+                        Document.data["status"].astext == _AGENT_VISIBLE_SKILL_STATUS,
+                    )
+                    if fleet_id:
+                        cnt_stmt = cnt_stmt.where(Document.fleet_id == fleet_id)
+                    active_count = int((await db.execute(cnt_stmt)).scalar_one())
+                    rows = [
+                        (name, active_count if name == SKILLS_COLLECTION else count) for name, count in rows
+                    ]
                 return _with_latency(
                     json.dumps(
                         {
@@ -1280,6 +1411,140 @@ async def memclaw_doc(
                         ),
                         t0,
                     )
+                # ── Skill Factory SF-002 lifecycle validator ─────────
+                # The agent-facing MCP write path runs the SAME validator
+                # the REST route does (routes/documents.py §SF-002), so an
+                # agent-direct skill write flows through the planned
+                # lifecycle instead of landing unvalidated in limbo:
+                #   • status defaults to 'staged' → HITL Inbox (a skill is
+                #     never agent-visible until approved to 'active')
+                #   • status RBAC 403s a caller-supplied 'active' /
+                #     'candidate' / system status — this is what actually
+                #     closes self-promotion (not a blanket status reject)
+                #   • source RBAC 403s source='forge'/'manual' from an
+                #     agent caller (they must use source='agent')
+                #   • Sentinel pre-scan + content_hash + byte/slug caps
+                # MCP callers carry NO admin/forge identity — there is no
+                # is_admin/org_role accessor on this surface — so both
+                # is_admin and is_internal_forge are False. An admin who
+                # needs to author an 'active' skill uses the REST/dashboard
+                # path, which has the real auth context. Gated on the
+                # opt-in flag: non-opted-in tenants skip the validator
+                # entirely (byte-identical legacy behavior). The validator
+                # raises HTTPException (403/422/409/404); the outer
+                # ``except HTTPException`` maps it to the right error code.
+                if collection == SKILLS_COLLECTION:
+                    # ONE settings read for both the opt-in flag and the
+                    # per-tenant byte caps. ``get_settings_for_display``
+                    # returns the merged settings (which already include
+                    # ``skills_factory.enabled``), so the write path reads
+                    # the flag from it directly rather than calling
+                    # ``_skills_factory_enabled`` (a second DB-backed
+                    # ``get_raw_settings``) — one fewer cold-cache lookup.
+                    # read/query/search/delete keep the cheap helper since
+                    # they don't need the caps.
+                    from core_api.services.organization_settings import (
+                        get_settings_for_display,
+                    )
+
+                    # Fail CLOSED: this settings read gates a security
+                    # decision (whether the lifecycle validator runs). If
+                    # it fails we must NOT fall through and upsert the
+                    # skill unvalidated — abort the write instead.
+                    try:
+                        settings_display = await get_settings_for_display(db, tenant_id)
+                    except Exception:
+                        logger.exception(
+                            "skills_factory settings lookup failed for %s; cannot gate write",
+                            tenant_id,
+                        )
+                        return _with_latency(
+                            _error_response("INTERNAL_ERROR", "skill lifecycle gate unavailable"),
+                            t0,
+                        )
+                    sf_settings = (
+                        (settings_display.get("skills_factory") or {})
+                        if isinstance(settings_display, dict)
+                        else {}
+                    )
+                    if isinstance(sf_settings, dict) and bool(sf_settings.get("enabled")):
+                        # Defense-in-depth: reject a case-variant 'status'
+                        # key (e.g. 'STATUS', 'Status'). The validator
+                        # owns the canonical lowercase 'status' and
+                        # defaults it to 'staged', and every downstream
+                        # gate reads data->>'status' (case-sensitive in
+                        # JSONB), so a variant key cannot self-promote —
+                        # but it WOULD persist as a confusing shadow
+                        # field. Reject it rather than silently store it.
+                        if isinstance(data, dict):
+                            variant = next(
+                                (k for k in data if k != "status" and k.lower() == "status"),
+                                None,
+                            )
+                            if variant is not None:
+                                return _with_latency(
+                                    _error_response(
+                                        "INVALID_ARGUMENTS",
+                                        f"skills write: ambiguous status key {variant!r}. "
+                                        "Use lowercase 'status' only — and note status is "
+                                        "managed by the lifecycle (an agent write defaults "
+                                        "to 'staged'; transitions go through the Inbox).",
+                                    ),
+                                    t0,
+                                )
+                        from core_api.services.skill_lifecycle import (
+                            SkillWriteContext,
+                            validate_and_normalize_skill_write,
+                        )
+
+                        sf_ctx = SkillWriteContext(
+                            caller_agent_id=agent_id,
+                            is_admin=False,
+                            is_internal_forge=False,
+                            description_max_bytes=_safe_int(sf_settings.get("description_max_bytes"), 160),
+                            body_max_bytes=_safe_int(sf_settings.get("body_max_bytes"), 40_000),
+                        )
+                        # For kind='update' the validator needs the live
+                        # skill to bind against its current content_hash.
+                        # Mirror the REST path's read-through storage
+                        # fetch; the validator handles the not-found case.
+                        # ``isinstance`` guards a non-dict data (the
+                        # validator 422s it cleanly rather than us
+                        # AttributeError-ing into a 500 here).
+                        live_doc: dict | None = None
+                        if isinstance(data, dict) and data.get("kind") == "update":
+                            # Fail CLOSED, like the settings/flag gates: the
+                            # live-doc fetch feeds the validator's hash-
+                            # binding check, so a transient DB/network error
+                            # must abort with a curated message rather than
+                            # fall through to the outer handler (which would
+                            # leak the raw exception string).
+                            try:
+                                sc_live = get_storage_client()
+                                live_doc = await sc_live.get_document(
+                                    tenant_id=tenant_id,
+                                    collection=SKILLS_COLLECTION,
+                                    doc_id=doc_id,
+                                )
+                            except Exception:
+                                logger.exception(
+                                    "skills live-doc fetch failed for %s/%s; cannot gate update write",
+                                    tenant_id,
+                                    doc_id,
+                                )
+                                return _with_latency(
+                                    _error_response("INTERNAL_ERROR", "skill lifecycle gate unavailable"),
+                                    t0,
+                                )
+                        normalized, _scan = await validate_and_normalize_skill_write(
+                            data,
+                            ctx=sf_ctx,
+                            live_skill_doc=live_doc,
+                        )
+                        # Swap normalized data in for the rest of the flow
+                        # (embed + upsert). Status/source/scan/content_hash
+                        # and other server-controlled fields are merged.
+                        data = normalized
                 # Resolve which string in `data` gets embedded. The only
                 # embeddable field is data["summary"]; skills writes also
                 # accept data["description"] for back-compat. Non-skills
@@ -1357,6 +1622,23 @@ async def memclaw_doc(
                 )
                 if not doc:
                     return _with_latency(f"Not found: {collection}/{doc_id}", t0)
+                # Active-only gate for agent-facing skill reads. A
+                # candidate / staged / quarantined / rejected skill is
+                # in-flight or blocked and must not surface to agents —
+                # return the same "Not found" as a missing doc so we
+                # don't leak the EXISTENCE of an unapproved skill. The
+                # decision follows the row's OWNING tenant: hidden when
+                # the caller's tenant opted in, OR when the row belongs
+                # to a different tenant (cross-tenant credentials must
+                # never surface a sibling tenant's in-flight skill).
+                # The collection check short-circuits the flag lookup for
+                # non-skills reads.
+                if doc.collection == SKILLS_COLLECTION:
+                    caller_opted_in = await _skills_factory_enabled(db, tenant_id)
+                    if _skill_hidden_from_agent(
+                        doc, caller_tenant_id=tenant_id, caller_opted_in=caller_opted_in
+                    ):
+                        return _with_latency(f"Not found: {collection}/{doc_id}", t0)
                 return _with_latency(
                     json.dumps(
                         {
@@ -1370,17 +1652,84 @@ async def memclaw_doc(
                     t0,
                 )
             if op == "query":
+                effective_where = dict(where or {})
+                caller_opted_in = False
+                if collection == SKILLS_COLLECTION:
+                    caller_status = effective_where.get("status")
+                    if caller_status is not None and caller_status != _AGENT_VISIBLE_SKILL_STATUS:
+                        # Security-sensitive REJECTION path: refusing an
+                        # explicit non-active status only makes sense for
+                        # an opted-in tenant — for a tenant that never
+                        # opted in, the "use the Inbox API" message is
+                        # nonsense. So gate it on the STRICT flag and
+                        # fail CLOSED on a settings outage (INTERNAL_ERROR,
+                        # same as op=delete) rather than the lenient helper
+                        # (which assumes-enabled on error and would emit
+                        # the confusing pointer to a non-opted-in tenant).
+                        try:
+                            opted_in = await _skills_factory_flag(db, tenant_id)
+                        except Exception:
+                            logger.exception(
+                                "skills_factory flag lookup failed for %s; cannot gate query",
+                                tenant_id,
+                            )
+                            return _with_latency(
+                                _error_response("INTERNAL_ERROR", "skill lifecycle gate unavailable"),
+                                t0,
+                            )
+                        if opted_in:
+                            # An agent must not query for staged /
+                            # candidate skills. Reject (rather than
+                            # silently rewriting to 'active', which would
+                            # mislead the caller into thinking they
+                            # queried 'staged' and got nothing).
+                            return _with_latency(
+                                _error_response(
+                                    "INVALID_ARGUMENTS",
+                                    f"collection='skills' on the agent MCP surface only "
+                                    f"exposes status='active' docs; "
+                                    f"where={{'status': {caller_status!r}}} is not supported. "
+                                    "Inspect non-active skills via the Skills Inbox API "
+                                    "(/api/v1/skills-inbox/*).",
+                                ),
+                                t0,
+                            )
+                        # Genuinely not opted in: legacy behavior — the
+                        # caller's explicit status passes through untouched
+                        # (caller_opted_in stays False; the cross-tenant
+                        # net below still hides sibling non-active skills).
+                    else:
+                        # Common, SAFE path (no status, or status='active'
+                        # already): transparently scope to 'active'. Lenient
+                        # helper — fail-closed by FILTERING on a settings
+                        # outage (consistent with op=read), never errors a
+                        # plain query.
+                        caller_opted_in = await _skills_factory_enabled(db, tenant_id)
+                        if caller_opted_in:
+                            effective_where["status"] = _AGENT_VISIBLE_SKILL_STATUS
                 docs = await document_repo.query(
                     db,
                     tenant_id=tenant_id,
                     collection=collection,
-                    where=where or {},
+                    where=effective_where,
                     order_by=order_by,
                     order=order,
                     limit=min(limit, 100),
                     offset=offset,
                     readable_tenant_ids=readable,
                 )
+                # Cross-tenant safety net: when the caller's tenant is NOT
+                # opted in, the SQL status filter above never ran, so
+                # cross-tenant credentials could pull a sibling tenant's
+                # non-active skills. Drop them (the helper hides only
+                # rows owned by a different tenant in this branch; the
+                # caller's own rows are untouched — invariant preserved).
+                if collection == SKILLS_COLLECTION and not caller_opted_in:
+                    docs = [
+                        d
+                        for d in docs
+                        if not _skill_hidden_from_agent(d, caller_tenant_id=tenant_id, caller_opted_in=False)
+                    ]
                 items = [{"doc_id": d.doc_id, "data": d.data} for d in docs]
                 return _with_latency(
                     json.dumps(
@@ -1407,6 +1756,17 @@ async def memclaw_doc(
                         t0,
                     )
                 capped_top_k = max(1, min(top_k, 50))
+                # Active-only gate for a SCOPED skills search: push the
+                # status filter into the SQL so top_k stays exact (a
+                # post-filter alone would silently shrink the result
+                # set). For a broad search (collection=None) we can't
+                # filter in SQL without excluding non-skills collections.
+                search_status = None
+                scoped_skills_opted_in = collection == SKILLS_COLLECTION and await _skills_factory_enabled(
+                    db, tenant_id
+                )
+                if scoped_skills_opted_in:
+                    search_status = _AGENT_VISIBLE_SKILL_STATUS
                 pairs = await document_repo.search(
                     db,
                     tenant_id=tenant_id,
@@ -1415,7 +1775,35 @@ async def memclaw_doc(
                     top_k=capped_top_k,
                     fleet_id=fleet_id,
                     readable_tenant_ids=readable,
+                    status=search_status,
                 )
+                # Safety net for every skill row that the scoped SQL
+                # filter didn't already remove:
+                #   • broad search (collection=None) — skill rows the SQL
+                #     never touched, hidden when the caller opted in;
+                #   • cross-tenant rows (any search) — a sibling tenant's
+                #     non-active skill, hidden regardless of the caller's
+                #     own opt-in (the SQL status push only ran when the
+                #     CALLER opted in, so a non-opted-in caller reading
+                #     an opted-in sibling's skills would otherwise leak).
+                # ``_skill_hidden_from_agent`` encodes both rules per-row.
+                # The cheap ``any()`` scan short-circuits the cached flag
+                # lookup when no skill rows are present.
+                if any(d.collection == SKILLS_COLLECTION for d, _ in pairs):
+                    # For a scoped skills search we already resolved the
+                    # flag; for a broad search resolve it now.
+                    caller_opted_in = (
+                        scoped_skills_opted_in
+                        if collection == SKILLS_COLLECTION
+                        else await _skills_factory_enabled(db, tenant_id)
+                    )
+                    pairs = [
+                        (d, sim)
+                        for d, sim in pairs
+                        if not _skill_hidden_from_agent(
+                            d, caller_tenant_id=tenant_id, caller_opted_in=caller_opted_in
+                        )
+                    ]
                 source_tenants = [t for t in (readable or []) if t and t != tenant_id]
                 if source_tenants:
                     counts: dict[str, int] = {}
@@ -1467,15 +1855,43 @@ async def memclaw_doc(
 
             from common.models.document import Document
 
-            stmt = (
-                sa_delete(Document)
-                .where(
-                    Document.tenant_id == tenant_id,
-                    Document.collection == collection,
-                    Document.doc_id == doc_id,
+            # Active-only existence gate for skills: an agent must not be
+            # able to delete (or probe the existence of) a non-active
+            # skill via MCP — those are operator-managed through the
+            # Inbox (reject/quarantine), not the agent surface. We fold
+            # the status guard directly into the DELETE's WHERE so the
+            # check and the delete are a single atomic statement — no
+            # TOCTOU window where a concurrent admin promote/demote could
+            # change status between a separate pre-fetch and the delete.
+            # A non-active (or missing) skill deletes zero rows and falls
+            # through to the SAME generic not-found response a missing doc
+            # returns — so a non-active skill is byte-for-byte
+            # indistinguishable from a missing one (no existence leak),
+            # and the response stays valid JSON (``_with_latency`` only
+            # injects ``_latency_ms`` into a parsed dict; a bare string
+            # would break json.loads() callers on the delete path).
+            # Home-tenant scoped (deletes never span readable tenants).
+            # Fail CLOSED: the status guard is a security gate, so use the
+            # strict (raising) flag check and abort the delete on a
+            # settings-lookup failure rather than the lenient helper
+            # (which returns False → no status guard → fail-open delete).
+            # Short-circuits for non-skills collections (never touches
+            # settings).
+            try:
+                skills_gate_on = collection == SKILLS_COLLECTION and await _skills_factory_flag(db, tenant_id)
+            except Exception:
+                logger.exception("skills_factory flag lookup failed for %s; cannot gate delete", tenant_id)
+                return _with_latency(
+                    _error_response("INTERNAL_ERROR", "skill lifecycle gate unavailable"), t0
                 )
-                .returning(Document.id)
+            stmt = sa_delete(Document).where(
+                Document.tenant_id == tenant_id,
+                Document.collection == collection,
+                Document.doc_id == doc_id,
             )
+            if skills_gate_on:
+                stmt = stmt.where(Document.data["status"].astext == _AGENT_VISIBLE_SKILL_STATUS)
+            stmt = stmt.returning(Document.id)
             result = await db.execute(stmt)
             deleted_id = result.scalar_one_or_none()
             if not deleted_id:

--- a/core-api/src/core_api/repositories/document_repository.py
+++ b/core-api/src/core_api/repositories/document_repository.py
@@ -239,6 +239,7 @@ class DocumentRepository:
         top_k: int = 5,
         fleet_id: str | None = None,
         readable_tenant_ids: list[str] | None = None,
+        status: str | None = None,
     ) -> list[tuple[Document, float]]:
         """Semantic search over docs — scoped or cross-collection.
 
@@ -251,6 +252,13 @@ class DocumentRepository:
         ``readable_tenant_ids`` widens to ``ANY($readable)`` — semantic
         search then spans every document across the readable set, sorted
         by global cosine distance.
+
+        ``status`` (optional) adds a ``data->>'status' = :status``
+        equality filter — used by the MCP agent surface to restrict
+        skill discovery to ``status='active'``. Pure mechanism: the
+        caller decides the policy (which collection, when to apply).
+        Left ``None`` by the REST search path, so that path is
+        unaffected.
 
         Orders by cosine distance against ``query_embedding`` using the
         partial HNSW index from migration 003. Returns ``(Document,
@@ -276,6 +284,8 @@ class DocumentRepository:
             stmt = stmt.where(Document.collection == collection)
         if fleet_id:
             stmt = stmt.where(Document.fleet_id == fleet_id)
+        if status is not None:
+            stmt = stmt.where(Document.data["status"].astext == status)
         result = await db.execute(stmt)
         return [(row.Document, 1.0 - float(row.distance)) for row in result.all()]
 

--- a/docs/mcp-skill-delivery.md
+++ b/docs/mcp-skill-delivery.md
@@ -1,0 +1,144 @@
+# MCP-direct skill delivery
+
+How a Forge-produced (or human-authored) skill reaches an agent over
+MCP — and the rule that gates it.
+
+## The model
+
+For MCP clients, **"delivery" is a read, not a push.** A skill lives as
+a doc in the `skills` collection; the agent pulls it on demand through
+the `memclaw_doc` tool it already has. There is no filesystem install,
+no plugin runtime, no registration step.
+
+```
+1. Skill becomes status='active'   (approve, or auto_promote_clean)
+2. Agent asks: "is there a skill for X?"
+3. memclaw_doc op=search collection=skills query="…"
+4. Server returns the matching ACTIVE skill; agent reads
+   data.content (the SKILL.md body) and follows it
+```
+
+## The rule this PR adds: agents see only `active`
+
+The Skill Factory lifecycle is `candidate → staged → active`. Before
+this change, `memclaw_doc` returned skills regardless of status — so a
+`candidate` (Forge just minted it) or `staged` (awaiting human review)
+or `quarantined` (Sentinel blocked it) skill could surface to an agent.
+
+Now, for the agent-facing `memclaw_doc` surface, **only `status='active'`
+skills are discoverable**:
+
+| op | behavior on `collection='skills'` |
+|---|---|
+| `read` | non-active doc → `Not found` (no existence leak) |
+| `query` | `status='active'` forced (overrides any caller-supplied status) |
+| `search` (scoped) | `status='active'` pushed into the SQL (exact top_k) |
+| `search` (broad, no collection) | non-active skill rows dropped from results |
+| `write` | runs the SF-002 lifecycle validator → defaults to `staged` (see below) |
+| `delete` | non-active doc → `Not found` (atomic status guard in the DELETE WHERE) |
+| `query` | `status='active'` scoped in; an explicit non-active `status` → 422 (use the Inbox) |
+| `list_collections` | the `skills` count is corrected to active-only |
+
+### The filter follows the *owning* tenant, not just the caller
+
+The active-only decision is made per-row against the row's own
+`tenant_id`, not solely the caller's opt-in flag. A skill is hidden when
+it's non-active AND **either** the caller's tenant opted in **or** the
+row belongs to a different tenant. The second arm closes a cross-tenant
+leak: a caller whose own tenant hasn't opted in must still never see a
+*sibling* tenant's in-flight skill through cross-tenant credentials.
+This is safe — a non-opted-in owning tenant's skills are all `active`
+(migration 022 backfill), so the cross-tenant arm only ever hides a
+genuinely non-active row, never a legitimately visible one.
+
+## Writes go through the lifecycle, not around it
+
+An agent *can* write a skill over MCP — but the write is not a back door
+past review. The MCP `op=write` path runs the **same SF-002 validator**
+(`validate_and_normalize_skill_write`) the REST route does, so an
+agent-direct skill write flows through the planned lifecycle instead of
+landing in an unvalidated limbo:
+
+- **status defaults to `staged`** — the doc lands in the HITL Inbox, not
+  agent-visible, until an operator approves it to `active` (or
+  `auto_promote_clean` does). No caller-supplied status is needed or
+  honored for promotion.
+- **status RBAC** — MCP callers carry no admin/forge identity (there is
+  no such accessor on this surface), so a caller-supplied
+  `status='active'` / `'candidate'` / system status is **403 FORBIDDEN**.
+  This is what closes self-promotion. An admin who legitimately authors
+  an `active` skill uses the REST/dashboard path, which has the real
+  auth context.
+- **source RBAC** — `source='forge'` (internal-only) and `source='manual'`
+  (admin-only) are 403'd; agents write `source='agent'`.
+- **Sentinel pre-scan + content_hash + byte/slug caps** — a dirty scan
+  quarantines the doc; the body/description caps and slug regex are
+  enforced; `content_hash` is server-stamped, never trusted from the body.
+
+So the full agent loop has no dead end:
+`agent MCP write → staged → Inbox → approve → active → discoverable`.
+The validator runs only for opted-in tenants; non-opted-in tenants keep
+byte-identical legacy write behavior.
+
+This is the single mechanism that turns *"an operator approved it"*
+into *"agents can find it."* Approval (or `auto_promote_clean`) is what
+flips a skill to `active`; this filter is what makes `active` mean
+discoverable.
+
+## Gated on opt-in — zero change for non-opted-in tenants
+
+The filter applies **only when `org_settings.skills_factory.enabled=true`**.
+A tenant that hasn't opted in sees every skill exactly as before (their
+skills are all `active` anyway — backfilled by migration 022 — so the
+filter would be a no-op, but we skip it entirely to guarantee
+byte-identical behavior). This preserves the merge-day invariant the
+whole Skill Factory has held: **merging changes nothing until a tenant
+explicitly opts in.**
+
+## Operators inspect non-active skills via the Inbox, not MCP
+
+The agent-facing MCP surface is intentionally active-only with **no
+admin bypass**. An operator who needs to see `staged` / `candidate` /
+`quarantined` skills uses the HITL Inbox API
+(`/api/v1/skills-inbox/*`) — that's its purpose. Keeping the bypass out
+of the MCP path means there's exactly one way for a non-active skill to
+reach an agent: it doesn't.
+
+## The hard ceiling (why this is the baseline, not the whole story)
+
+MCP delivery is **pull** — the agent must *decide* to call
+`memclaw_doc`. We can raise that probability (tool-description framing,
+keystones, folding skill-search into the recall agents already do) but
+never guarantee it: anything reached through a tool is an agent
+decision.
+
+To make skill use *reliable* rather than probabilistic, a skill must be
+installed into the harness's own startup surface (its skill registry /
+filesystem / system-prompt) so it's present before the model thinks —
+which is necessarily per-harness and can't be done from the MemClaw
+side alone.
+
+So the tiers are:
+
+- **MCP-direct (this PR)** — universal, zero-integration, *probabilistic*.
+  Works on any MCP-capable harness; the agent has to choose to look.
+- **Per-harness install (future)** — a reliability layer for harnesses
+  we integrate deeply (e.g. writing `~/.claude/skills/<slug>/SKILL.md`).
+  Guarantees presence; requires a harness-specific adapter.
+
+They're complementary: MCP-direct is the floor that works everywhere;
+install is the guarantee for chosen harnesses.
+
+## What makes a skill findable: the summary
+
+Scoped `op=search` ranks on the embedded `data.summary`. So the
+Forge-distilled `summary` IS the discoverability surface — it should
+read like a trigger ("Use when deploying to eu-west…"), not a label
+("Deployment skill"). Same embedding path as hand-authored skills
+(`doc_indexing.resolve_embed_source`).
+
+## Related
+
+- `core-api/src/core_api/mcp_server.py` — `memclaw_doc` handler (the filter)
+- `core-api/src/core_api/repositories/document_repository.py` — `search(status=…)` mechanism
+- `docs/operator-forge-cron.md` — how skills reach `active` autonomously

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -574,6 +574,748 @@ async def test_doc_search_passes_readable_tenants(mcp_env, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Active-only skill discovery (MCP-direct delivery)
+#
+# The agent-facing memclaw_doc surface must expose only ``status='active'``
+# skills to opted-in tenants — candidate / staged / quarantined skills are
+# in-flight or blocked and must not surface. Gated on
+# ``skills_factory.enabled``: a non-opted-in tenant's reads are unchanged.
+# ---------------------------------------------------------------------------
+
+
+class _SkillRow:
+    def __init__(self, doc_id: str, status: str, tenant_id: str = "test-tenant"):
+        self.collection = "skills"
+        self.doc_id = doc_id
+        self.tenant_id = tenant_id
+        self.data = {"slug": doc_id, "status": status, "summary": "a skill"}
+        self.updated_at = datetime.now(timezone.utc)
+
+
+def _patch_flag(monkeypatch, enabled: bool):
+    """Force the opt-in check to a fixed bool. Patches BOTH the lenient
+    ``_skills_factory_enabled`` (read/query/search/delete gates) and the
+    strict ``_skills_factory_flag`` (query's explicit-status rejection
+    path), so a test's ``enabled`` is honored consistently across both."""
+    monkeypatch.setattr(mcp_server, "_skills_factory_enabled", _async_return(enabled))
+    monkeypatch.setattr(mcp_server, "_skills_factory_flag", _async_return(enabled))
+
+
+def _patch_sf_settings(monkeypatch, *, enabled: bool = True, **caps):
+    """Stub the merged-settings lookup the op=write path makes. The write
+    path now derives BOTH the opt-in flag and the byte caps from this one
+    ``get_settings_for_display`` call (no separate ``_skills_factory_enabled``
+    read), so tests set ``skills_factory.enabled`` here. Extra kwargs land
+    as ``skills_factory`` leaves (e.g. ``description_max_bytes=None``)."""
+    sf: dict = {"enabled": enabled}
+    sf.update(caps)
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.get_settings_for_display",
+        _async_return({"skills_factory": sf}),
+    )
+
+
+def _valid_skill_data(**overrides):
+    """A minimal SF-002-valid agent-direct skills write payload.
+
+    Carries every REQUIRED_TOP_LEVEL_KEY plus a clean body so the
+    Sentinel pre-scan passes. Override individual fields per test."""
+    data = {
+        "name": "Forge X",
+        "slug": "forge-x",
+        "description": "what this skill does",
+        "domain": "ops",
+        "kind": "create",
+        "source": "agent",
+        "content": "# Forge X\n\nDo the thing safely.",
+        "summary": "Use when doing the thing in ops.",
+    }
+    data.update(overrides)
+    return data
+
+
+# ── op=read ────────────────────────────────────────────────────────
+
+
+async def test_skill_read_hides_non_active_when_flag_on(mcp_env, monkeypatch):
+    _patch_flag(monkeypatch, True)
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.get_by_doc_id",
+        _async_return(_SkillRow("forge/x", status="staged")),
+    )
+    out = await mcp_server.memclaw_doc(op="read", collection="skills", doc_id="forge/x")
+    # Non-active skill → same "Not found" as a missing doc (no existence leak).
+    assert "Not found: skills/forge/x" in strip_latency(out)
+
+
+async def test_skill_read_returns_active_when_flag_on(mcp_env, monkeypatch):
+    _patch_flag(monkeypatch, True)
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.get_by_doc_id",
+        _async_return(_SkillRow("forge/x", status="active")),
+    )
+    out = await mcp_server.memclaw_doc(op="read", collection="skills", doc_id="forge/x")
+    payload = parse_envelope(out)
+    assert payload["doc_id"] == "forge/x"
+    assert payload["data"]["status"] == "active"
+
+
+async def test_skill_read_no_filter_when_flag_off(mcp_env, monkeypatch):
+    # Non-opted-in tenant: byte-identical to pre-Skill-Factory — a
+    # staged (or status-less) skill is still readable.
+    _patch_flag(monkeypatch, False)
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.get_by_doc_id",
+        _async_return(_SkillRow("forge/x", status="staged")),
+    )
+    out = await mcp_server.memclaw_doc(op="read", collection="skills", doc_id="forge/x")
+    payload = parse_envelope(out)
+    assert payload["doc_id"] == "forge/x"
+
+
+# ── op=query ───────────────────────────────────────────────────────
+
+
+async def test_skill_query_rejects_explicit_non_active_status_when_flag_on(
+    mcp_env, monkeypatch
+):
+    # An explicit non-active status is REJECTED (not silently rewritten
+    # to active — that would mislead the caller into thinking they
+    # queried 'staged'). Points them to the Inbox API.
+    _patch_flag(monkeypatch, True)
+    called = {"query": False}
+
+    async def fake_query(db, **kwargs):  # noqa: ARG001
+        called["query"] = True
+        return []
+
+    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
+    out = await mcp_server.memclaw_doc(
+        op="query", collection="skills", where={"status": "staged"}
+    )
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert "skills-inbox" in payload["error"]["message"].lower()
+    assert called["query"] is False
+
+
+async def test_skill_query_scopes_to_active_when_no_status_when_flag_on(
+    mcp_env, monkeypatch
+):
+    # The common case — no status supplied — is transparently scoped to
+    # 'active' (no error), so an agent's plain skills query only ever
+    # sees live skills.
+    _patch_flag(monkeypatch, True)
+    captured: dict = {}
+
+    async def fake_query(db, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
+    await mcp_server.memclaw_doc(op="query", collection="skills", where={"domain": "ops"})
+    assert captured["where"]["status"] == "active"
+    assert captured["where"]["domain"] == "ops"
+
+
+async def test_skill_query_no_filter_when_flag_off(mcp_env, monkeypatch):
+    _patch_flag(monkeypatch, False)
+    captured: dict = {}
+
+    async def fake_query(db, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
+    await mcp_server.memclaw_doc(
+        op="query", collection="skills", where={"status": "staged"}
+    )
+    # Genuinely not opted in → caller's where passes through untouched
+    # (legacy), NOT the confusing Inbox-API rejection.
+    assert captured["where"] == {"status": "staged"}
+
+
+async def test_skill_query_explicit_status_fails_closed_on_settings_error(
+    mcp_env, monkeypatch
+):
+    # An explicit non-active status query is the security-sensitive
+    # rejection path: a settings outage must fail CLOSED (INTERNAL_ERROR),
+    # NOT emit the Inbox-API pointer to a tenant we can't confirm opted
+    # in. Uses the strict _skills_factory_flag.
+    async def _boom(*_a, **_k):
+        raise RuntimeError("settings store down")
+
+    monkeypatch.setattr(mcp_server, "_skills_factory_flag", _boom)
+    called = {"query": False}
+
+    async def fake_query(db, **kwargs):  # noqa: ARG001
+        called["query"] = True
+        return []
+
+    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
+    out = await mcp_server.memclaw_doc(
+        op="query", collection="skills", where={"status": "staged"}
+    )
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "INTERNAL_ERROR"
+    assert called["query"] is False
+
+
+async def test_non_skills_query_unaffected_by_flag(mcp_env, monkeypatch):
+    # The active-only policy is skills-only — a customers query must not
+    # get a status filter injected even when the flag is on.
+    _patch_flag(monkeypatch, True)
+    captured: dict = {}
+
+    async def fake_query(db, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
+    await mcp_server.memclaw_doc(
+        op="query", collection="customers", where={"plan": "biz"}
+    )
+    assert "status" not in captured["where"]
+
+
+# ── op=search (scoped) ─────────────────────────────────────────────
+
+
+async def test_skill_search_scoped_passes_active_status_when_flag_on(
+    mcp_env, monkeypatch
+):
+    _patch_flag(monkeypatch, True)
+    captured: dict = {}
+
+    async def fake_search(db, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    monkeypatch.setattr("core_api.repositories.document_repo.search", fake_search)
+    await mcp_server.memclaw_doc(
+        op="search", collection="skills", query="deploy eu-west"
+    )
+    assert captured["status"] == "active"
+
+
+async def test_skill_search_scoped_no_status_when_flag_off(mcp_env, monkeypatch):
+    _patch_flag(monkeypatch, False)
+    captured: dict = {}
+
+    async def fake_search(db, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    monkeypatch.setattr("core_api.repositories.document_repo.search", fake_search)
+    await mcp_server.memclaw_doc(
+        op="search", collection="skills", query="deploy eu-west"
+    )
+    assert captured["status"] is None
+
+
+# ── op=search (broad / cross-collection) ───────────────────────────
+
+
+async def test_skill_search_broad_drops_non_active_when_flag_on(mcp_env, monkeypatch):
+    _patch_flag(monkeypatch, True)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    pairs = [
+        (_DocRow("acme", collection="customers"), 0.9),  # non-skill: always kept
+        (_SkillRow("forge/active", status="active"), 0.8),  # kept
+        (_SkillRow("forge/staged", status="staged"), 0.7),  # DROPPED
+    ]
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.search", _async_return(pairs)
+    )
+    out = await mcp_server.memclaw_doc(op="search", query="anything")
+    payload = parse_envelope(out)
+    returned = {(r["collection"], r["doc_id"]) for r in payload["results"]}
+    assert ("customers", "acme") in returned
+    assert ("skills", "forge/active") in returned
+    assert ("skills", "forge/staged") not in returned  # in-flight skill never leaks
+
+
+async def test_skill_search_broad_no_filter_when_flag_off(mcp_env, monkeypatch):
+    _patch_flag(monkeypatch, False)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    pairs = [(_SkillRow("forge/staged", status="staged"), 0.7)]
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.search", _async_return(pairs)
+    )
+    out = await mcp_server.memclaw_doc(op="search", query="anything")
+    payload = parse_envelope(out)
+    # Flag off → no broad post-filter; the staged skill surfaces as before.
+    assert payload["results"][0]["doc_id"] == "forge/staged"
+
+
+# ── op=write (self-promotion guard) ────────────────────────────────
+
+
+async def test_skill_write_rejects_caller_active_status_when_flag_on(mcp_env, monkeypatch):
+    # The MCP write path now runs the SF-002 lifecycle validator. An
+    # agent-direct write carries is_admin=False, so a caller-supplied
+    # status='active' hits ADMIN_ONLY_STATUSES and 403s — this is what
+    # closes self-promotion past review.
+    _patch_flag(monkeypatch, True)
+    _patch_sf_settings(monkeypatch)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    called = {"upsert": False}
+
+    async def fake_upsert(db, **kwargs):  # noqa: ARG001
+        called["upsert"] = True
+        return _UpsertRow(xmax=0)
+
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
+    )
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="skills",
+        doc_id="forge-x",
+        data=_valid_skill_data(status="active"),
+    )
+    payload = parse_envelope(out)
+    # Validator raises HTTPException(403) → outer handler maps to FORBIDDEN.
+    assert payload["error"]["code"] == "FORBIDDEN"
+    assert "admin" in payload["error"]["message"].lower()
+    # The write must NOT have reached the DB.
+    assert called["upsert"] is False
+
+
+async def test_skill_write_rejects_forge_source_when_flag_on(mcp_env, monkeypatch):
+    # source='forge' is reserved for the internal lifecycle worker.
+    # An MCP caller is never is_internal_forge, so minting a forge-
+    # sourced skill 403s (INTERNAL_ONLY_SOURCES). Agents use
+    # source='agent'.
+    _patch_flag(monkeypatch, True)
+    _patch_sf_settings(monkeypatch)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    called = {"upsert": False}
+
+    async def fake_upsert(db, **kwargs):  # noqa: ARG001
+        called["upsert"] = True
+        return _UpsertRow(xmax=0)
+
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
+    )
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="skills",
+        doc_id="forge-x",
+        data=_valid_skill_data(source="forge"),
+    )
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "FORBIDDEN"
+    assert called["upsert"] is False
+
+
+async def test_skill_write_defaults_to_staged_when_flag_on(mcp_env, monkeypatch):
+    # An agent-direct write with no status defaults to 'staged' (per
+    # plan §4 / SF-002): it lands in the HITL inbox, NOT agent-visible,
+    # until approved to 'active'. We capture the upserted data to assert
+    # the validator normalized status → 'staged'.
+    _patch_flag(monkeypatch, True)
+    _patch_sf_settings(monkeypatch)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    captured = {}
+
+    async def fake_upsert(db, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        return _UpsertRow(xmax=0)
+
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
+    )
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="skills",
+        doc_id="forge-x",
+        data=_valid_skill_data(),  # no status
+    )
+    payload = parse_envelope(out)
+    assert payload["ok"] is True
+    # Validator-normalized data was passed through to the upsert.
+    assert captured["data"]["status"] == "staged"
+    assert captured["data"]["source"] == "agent"
+    # content_hash is server-stamped, never trusted from the body.
+    assert captured["data"]["content_hash"].startswith("sha256:")
+
+
+async def test_skill_write_tolerates_misconfigured_byte_caps(mcp_env, monkeypatch):
+    # A null / non-numeric per-tenant byte cap is a realistic admin
+    # misconfiguration. It must degrade to the documented default via
+    # _safe_int, not crash the write path with an opaque INTERNAL_ERROR.
+    _patch_flag(monkeypatch, True)
+    # enabled=True so the validator actually RUNS (and exercises
+    # _safe_int on the null / non-numeric caps).
+    _patch_sf_settings(
+        monkeypatch, enabled=True, description_max_bytes=None, body_max_bytes="auto"
+    )
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.upsert_returning_xmax",
+        _async_return(_UpsertRow(xmax=0)),
+    )
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="skills",
+        doc_id="forge-x",
+        data=_valid_skill_data(),
+    )
+    payload = parse_envelope(out)
+    assert payload["ok"] is True
+
+
+async def test_skill_write_fails_closed_on_settings_error(mcp_env, monkeypatch):
+    # The settings read gates whether the lifecycle validator runs. If it
+    # raises, the write must ABORT (INTERNAL_ERROR) — never fall through
+    # and upsert an unvalidated skill.
+    async def _boom(*_a, **_k):
+        raise RuntimeError("settings store down")
+
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.get_settings_for_display", _boom
+    )
+    called = {"upsert": False}
+
+    async def fake_upsert(db, **kwargs):  # noqa: ARG001
+        called["upsert"] = True
+        return _UpsertRow(xmax=0)
+
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
+    )
+    out = await mcp_server.memclaw_doc(
+        op="write", collection="skills", doc_id="forge-x", data=_valid_skill_data()
+    )
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "INTERNAL_ERROR"
+    assert called["upsert"] is False
+
+
+async def test_skill_update_write_fails_closed_on_live_doc_fetch_error(
+    mcp_env, monkeypatch
+):
+    # A kind='update' write fetches the live skill for the validator's
+    # hash-binding check. A transient storage error there must ABORT with
+    # a curated INTERNAL_ERROR (not leak the raw exception), and never
+    # reach the upsert.
+    _patch_sf_settings(monkeypatch, enabled=True)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+
+    class _BoomClient:
+        async def get_document(self, **_kwargs):
+            raise RuntimeError("storage down")
+
+    monkeypatch.setattr(mcp_server, "get_storage_client", lambda: _BoomClient())
+    called = {"upsert": False}
+
+    async def fake_upsert(db, **kwargs):  # noqa: ARG001
+        called["upsert"] = True
+        return _UpsertRow(xmax=0)
+
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
+    )
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="skills",
+        doc_id="forge-x",
+        data=_valid_skill_data(
+            kind="update", target={"target_content_hash": "sha256:abc"}
+        ),
+    )
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "INTERNAL_ERROR"
+    assert called["upsert"] is False
+
+
+async def test_skill_write_status_allowed_when_flag_off(mcp_env, monkeypatch):
+    # Non-opted-in tenant: validator is skipped entirely, legacy
+    # behavior — a minimal body with a caller-set status passes through
+    # unchanged (byte-identical to pre-Skill-Factory behavior).
+    _patch_flag(monkeypatch, False)
+    _patch_sf_settings(monkeypatch, enabled=False)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    captured = {}
+
+    async def fake_upsert(db, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        return _UpsertRow(xmax=0)
+
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
+    )
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="skills",
+        doc_id="forge-x",
+        data={"slug": "forge-x", "summary": "s", "status": "active"},
+    )
+    payload = parse_envelope(out)
+    assert payload["ok"] is True
+    # Untouched: no validator ran, so status stays exactly as supplied.
+    assert captured["data"]["status"] == "active"
+
+
+# ── op=delete (active-only existence gate) ─────────────────────────
+
+
+async def test_skill_delete_hides_non_active_when_flag_on(mcp_env, monkeypatch):
+    # The status guard is folded into the DELETE's WHERE (atomic, no
+    # pre-fetch). A staged skill matches zero rows → the DELETE returns
+    # no id → the SAME generic JSON not-found a MISSING doc returns, so
+    # a non-active skill is byte-for-byte indistinguishable from a
+    # missing one (no existence leak) and the response is valid JSON.
+    _patch_flag(monkeypatch, True)
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = None  # status=active matched nothing
+    mcp_env["db"].execute.return_value = result_mock
+    out = await mcp_server.memclaw_doc(
+        op="delete", collection="skills", doc_id="forge/x"
+    )
+    payload = parse_envelope(out)  # must be valid JSON
+    assert payload["error"] == "Document 'forge/x' not found in collection 'skills'"
+
+
+async def test_skill_delete_allows_active_when_flag_on(mcp_env, monkeypatch):
+    from uuid import uuid4
+
+    # An active skill matches the WHERE status='active' guard → one row
+    # deleted, returns its id.
+    _patch_flag(monkeypatch, True)
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = uuid4()
+    mcp_env["db"].execute.return_value = result_mock
+    out = await mcp_server.memclaw_doc(
+        op="delete", collection="skills", doc_id="forge/x"
+    )
+    payload = parse_envelope(out)
+    assert payload["deleted"] is True
+
+
+async def test_skill_delete_fails_closed_on_settings_error(mcp_env, monkeypatch):
+    # The status guard is a security gate: a settings-lookup failure must
+    # ABORT the delete (INTERNAL_ERROR), not fall through to an
+    # unguarded DELETE (which would let an agent delete a non-active
+    # skill during an outage). Uses the strict _skills_factory_flag.
+    async def _boom(*_a, **_k):
+        raise RuntimeError("settings store down")
+
+    monkeypatch.setattr(mcp_server, "_skills_factory_flag", _boom)
+    out = await mcp_server.memclaw_doc(
+        op="delete", collection="skills", doc_id="forge/x"
+    )
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "INTERNAL_ERROR"
+    # The DELETE must never have run.
+    mcp_env["db"].execute.assert_not_called()
+
+
+# ── Cross-tenant leak: a sibling tenant's non-active skill must never
+# surface, even when the CALLER's own tenant has not opted in ──────────
+
+
+async def test_skill_read_hides_cross_tenant_non_active_even_when_caller_off(
+    mcp_env, monkeypatch
+):
+    # Caller tenant ('test-tenant') is NOT opted in, but reads a sibling
+    # tenant's staged skill via cross-tenant credentials. The owning
+    # tenant's in-flight skill must stay hidden regardless of the
+    # caller's flag.
+    _patch_flag(monkeypatch, False)
+    monkeypatch.setattr(
+        mcp_server, "_get_readable_tenants", lambda: ["test-tenant", "sibling"]
+    )
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.get_by_doc_id",
+        _async_return(_SkillRow("forge/x", status="staged", tenant_id="sibling")),
+    )
+    out = await mcp_server.memclaw_doc(op="read", collection="skills", doc_id="forge/x")
+    assert "Not found: skills/forge/x" in strip_latency(out)
+
+
+async def test_skill_query_drops_cross_tenant_non_active_when_caller_off(
+    mcp_env, monkeypatch
+):
+    _patch_flag(monkeypatch, False)
+    monkeypatch.setattr(
+        mcp_server, "_get_readable_tenants", lambda: ["test-tenant", "sibling"]
+    )
+    rows = [
+        _SkillRow("own/active", status="active", tenant_id="test-tenant"),
+        _SkillRow("own/staged", status="staged", tenant_id="test-tenant"),  # kept: caller off, same tenant
+        _SkillRow("sib/staged", status="staged", tenant_id="sibling"),  # dropped: cross-tenant non-active
+        _SkillRow("sib/active", status="active", tenant_id="sibling"),  # kept: active
+    ]
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.query", _async_return(rows)
+    )
+    out = await mcp_server.memclaw_doc(op="query", collection="skills")
+    payload = parse_envelope(out)
+    ids = {r["doc_id"] for r in payload["results"]}
+    assert "sib/staged" not in ids  # cross-tenant non-active leaked → blocked
+    assert ids == {"own/active", "own/staged", "sib/active"}
+
+
+async def test_skill_search_drops_cross_tenant_non_active_when_caller_off(
+    mcp_env, monkeypatch
+):
+    _patch_flag(monkeypatch, False)
+    monkeypatch.setattr(
+        mcp_server, "_get_readable_tenants", lambda: ["test-tenant", "sibling"]
+    )
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    pairs = [
+        (_SkillRow("sib/staged", status="staged", tenant_id="sibling"), 0.9),
+        (_SkillRow("sib/active", status="active", tenant_id="sibling"), 0.8),
+        (_SkillRow("own/staged", status="staged", tenant_id="test-tenant"), 0.7),
+    ]
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.search", _async_return(pairs)
+    )
+    # Broad search (collection=None) over the readable set.
+    out = await mcp_server.memclaw_doc(op="search", query="deploy")
+    payload = parse_envelope(out)
+    ids = {r["doc_id"] for r in payload["results"]}
+    assert "sib/staged" not in ids  # cross-tenant non-active dropped
+    assert ids == {"sib/active", "own/staged"}  # own staged stays (caller off)
+
+
+# ── op=list_collections (active-only count for skills) ─────────────────
+
+
+async def test_list_collections_skill_count_active_only_when_flag_on(
+    mcp_env, monkeypatch
+):
+    _patch_flag(monkeypatch, True)
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.list_collections",
+        _async_return([("customers", 5), ("skills", 9)]),
+    )
+    # The active-only recount issues one COUNT via db.execute.
+    result_mock = MagicMock()
+    result_mock.scalar_one.return_value = 3  # only 3 of the 9 skills are active
+    mcp_env["db"].execute.return_value = result_mock
+    out = await mcp_server.memclaw_doc(op="list_collections")
+    payload = parse_envelope(out)
+    counts = {c["name"]: c["count"] for c in payload["collections"]}
+    assert counts["skills"] == 3  # corrected to active-only
+    assert counts["customers"] == 5  # non-skills untouched
+
+
+async def test_list_collections_skill_count_unchanged_when_flag_off(
+    mcp_env, monkeypatch
+):
+    _patch_flag(monkeypatch, False)
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.list_collections",
+        _async_return([("skills", 9)]),
+    )
+    out = await mcp_server.memclaw_doc(op="list_collections")
+    payload = parse_envelope(out)
+    counts = {c["name"]: c["count"] for c in payload["collections"]}
+    assert counts["skills"] == 9  # legacy: full count, no recount
+
+
+# ── op=write (case-variant status key) ─────────────────────────────────
+
+
+async def test_skill_write_rejects_case_variant_status_key_when_flag_on(
+    mcp_env, monkeypatch
+):
+    # A 'STATUS' key can't self-promote (gates read lowercase
+    # data->>'status'), but it would persist as a confusing shadow
+    # field. Reject it outright.
+    _patch_flag(monkeypatch, True)
+    _patch_sf_settings(monkeypatch)
+    called = {"upsert": False}
+
+    async def fake_upsert(db, **kwargs):  # noqa: ARG001
+        called["upsert"] = True
+        return _UpsertRow(xmax=0)
+
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
+    )
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="skills",
+        doc_id="forge-x",
+        data=_valid_skill_data(STATUS="active"),
+    )
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert "status" in payload["error"]["message"].lower()
+    assert called["upsert"] is False
+
+
+async def test_safe_int_degrades_bool_and_garbage_to_default():
+    # bool is an int subclass — int(True)==1 — so it must be rejected
+    # explicitly, alongside null / non-numeric strings.
+    assert mcp_server._safe_int(True, 160) == 160
+    assert mcp_server._safe_int(False, 160) == 160
+    assert mcp_server._safe_int(None, 160) == 160
+    assert mcp_server._safe_int("auto", 160) == 160
+    assert mcp_server._safe_int([], 160) == 160
+    # Valid values still pass through (ints and numeric strings).
+    assert mcp_server._safe_int(40_000, 160) == 40_000
+    assert mcp_server._safe_int("4096", 160) == 4096
+
+
+async def test_skills_factory_enabled_fails_closed_on_settings_error(mcp_env, monkeypatch):
+    # The read-path helper must fail CLOSED: if the strict flag lookup
+    # raises, assume enabled (True) so the active-only filter is applied
+    # and non-active skills can't leak during a settings outage.
+    async def _boom(*_a, **_k):
+        raise RuntimeError("settings store down")
+
+    monkeypatch.setattr(mcp_server, "_skills_factory_flag", _boom)
+    result = await mcp_server._skills_factory_enabled(mcp_env["db"], "test-tenant")
+    assert result is True
+
+
+async def test_skill_read_hides_non_active_when_flag_lookup_errors(mcp_env, monkeypatch):
+    # End-to-end: a settings outage during a skill read filters (hides
+    # the non-active skill), it does not 500 or leak.
+    async def _boom(*_a, **_k):
+        raise RuntimeError("settings store down")
+
+    monkeypatch.setattr(mcp_server, "_skills_factory_flag", _boom)
+    monkeypatch.setattr(
+        "core_api.repositories.document_repo.get_by_doc_id",
+        _async_return(_SkillRow("forge/x", status="staged")),
+    )
+    out = await mcp_server.memclaw_doc(op="read", collection="skills", doc_id="forge/x")
+    assert "Not found: skills/forge/x" in strip_latency(out)
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Gates the agent-facing `memclaw_doc` surface so a skill is **discoverable only when `status='active'`**. This is the mechanism that turns *"an operator approved it"* (or `auto_promote_clean` fired) into *"agents can find it"* — `candidate`/`staged`/`quarantined` skills are in-flight or blocked and must not surface to agents.

## The model (MCP-direct delivery)

For MCP clients, delivery is a **read, not a push** — the skill lives in the `skills` collection; the agent pulls it via `memclaw_doc op=search/read/query`. No install, no plugin runtime. This PR makes the lifecycle (`candidate → staged → active`) actually control what agents see.

## What's new

| File | Change |
|---|---|
| `document_repository.py` | `search()` gains optional `status` param (pure mechanism: `data->>'status' = :status`). REST path passes nothing → unaffected |
| `mcp_server.py` | `memclaw_doc` active-only policy for `collection='skills'` when opted in — see table below. New non-raising `_skills_factory_enabled` helper |

| op | behavior on skills (flag on) |
|---|---|
| `read` | non-active → `Not found` (no existence leak) |
| `query` | forces `where['status']='active'` (overrides caller) |
| `search` scoped | pushes `status='active'` into SQL (exact top_k) |
| `search` broad | post-filters skill rows so a candidate never leaks cross-collection |

## Invariants

- **Opt-in gated.** Applies ONLY when `skills_factory.enabled=true`. Non-opted-in tenants are **byte-identical** to pre-Skill-Factory — preserves the merge-day no-op guarantee.
- **No admin bypass on MCP.** Operators inspect non-active skills via the Inbox API, not the agent surface. Exactly one way for a non-active skill to reach an agent: it can't.
- **Skills-only.** Other collections never touched.

## Tests

`tests/test_mcp_doc.py` +12 covering all 4 ops × flag on/off + non-skills-untouched + broad-search leak prevention.

```
188 tests pass (mcp_doc + api_documents_skills + skill_schema + lifecycle + direct_mcp_skill)
mypy + ruff clean on core-api/src/
```

## Docs

`docs/mcp-skill-delivery.md` — the active-only contract, the opt-in gate, why operators use the Inbox, and the **pull-vs-install ceiling**: MCP-direct is the universal *probabilistic* floor (agent must choose to look); reliable delivery needs a per-harness install adapter (future). They're complementary.

## Context

Builds on the merged Skill Factory stack (#293 schema/inbox, #311 cron, #313 auto-approve). This is the read side — it makes `active` skills reachable by agents over any MCP-capable harness with zero integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)