### PR TITLE
feat(skills): gate the OpenClaw install path to active-only skills

### DIFF
--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -107,6 +107,19 @@ class DocQueryRequest(BaseModel):
     offset: int = Field(default=0, ge=0)
 
 
+class InstallableSkillsRequest(BaseModel):
+    """Request for the agent-harness install surface (`/skills/installable`).
+
+    Deliberately narrower than ``DocQueryRequest``: the collection is
+    fixed to ``skills`` and the ``where`` filter is server-decided (the
+    caller cannot widen it), so a harness can't ask for non-active skills.
+    """
+
+    tenant_id: str
+    fleet_id: str | None = None
+    limit: int = Field(default=1000, ge=1, le=1000)
+
+
 class DocSearchRequest(BaseModel):
     """Vector search over indexed documents.
 
@@ -422,6 +435,71 @@ async def query_documents(
         }
     )
 
+    return [_dict_to_out(d) for d in docs]
+
+
+@router.post("/skills/installable")
+async def installable_skills(
+    body: InstallableSkillsRequest,
+    auth: AuthContext = Depends(get_auth_context),
+    db: AsyncSession = Depends(get_db),
+):
+    """Skills an agent harness should INSTALL onto a node's disk.
+
+    The push-to-disk install path (the OpenClaw plugin reconciler)
+    consumes this instead of a raw ``/documents/query`` so the active-only
+    + opt-in gate is enforced server-side — the SAME contract the MCP pull
+    surface applies (PR #315). One enforcement point for both delivery
+    modes; the client carries no policy and cannot widen the filter.
+
+    - **Opted-in** tenant (``skills_factory.enabled``): only
+      ``status='active'`` skills are returned — ``candidate`` / ``staged``
+      / ``quarantined`` never reach a node's disk or the agent's palette.
+    - **Not opted in**: every visible skill is returned, byte-identical to
+      the legacy reconcile (``where={}``) — preserves the merge-day no-op
+      invariant (a non-opted-in tenant's legacy skills may lack a
+      ``status`` field; forcing ``status='active'`` would wrongly drop
+      them, so we don't filter at all in this case).
+    - **Fail CLOSED**: a settings-lookup failure raises 503. The
+      reconciler fails *safe* on a non-2xx (it preserves on-disk skills
+      and adds nothing), so an outage can never push a non-active skill
+      to disk.
+
+    Fleet/tenant visibility scoping is identical to ``/documents/query``.
+    """
+    auth.enforce_readable_tenant(body.tenant_id)
+
+    # Opt-in gate, server-owned and fail-closed. Mirrors the upsert
+    # path's cache-first ``get_raw_settings`` (returns just the tenant's
+    # override dict — cheap, aggressively cached).
+    try:
+        raw_settings = await get_raw_settings(db, body.tenant_id)
+    except Exception:
+        logger.exception(
+            "skills_factory flag lookup failed for %s; cannot gate installable skills",
+            body.tenant_id,
+        )
+        raise HTTPException(status_code=503, detail="skill lifecycle gate unavailable") from None
+
+    sf_enabled = (
+        isinstance(raw_settings, dict)
+        and isinstance(raw_settings.get("skills_factory"), dict)
+        and raw_settings["skills_factory"].get("enabled") is True
+    )
+
+    # Opted-in → active-only; otherwise no status filter (legacy no-op).
+    where = {"status": "active"} if sf_enabled else {}
+
+    sc = get_storage_client()
+    docs = await sc.query_documents(
+        {
+            "tenant_id": body.tenant_id,
+            "collection": SKILLS_COLLECTION,
+            "fleet_id": body.fleet_id,
+            "where": where,
+            "limit": body.limit,
+        }
+    )
     return [_dict_to_out(d) for d in docs]
 
 

--- a/docs/mcp-skill-delivery.md
+++ b/docs/mcp-skill-delivery.md
@@ -122,12 +122,40 @@ So the tiers are:
 
 - **MCP-direct (this PR)** — universal, zero-integration, *probabilistic*.
   Works on any MCP-capable harness; the agent has to choose to look.
-- **Per-harness install (future)** — a reliability layer for harnesses
-  we integrate deeply (e.g. writing `~/.claude/skills/<slug>/SKILL.md`).
-  Guarantees presence; requires a harness-specific adapter.
+- **Per-harness install** — a reliability layer for harnesses we
+  integrate deeply (writing `<harness>/skills/<slug>/SKILL.md` so the
+  skill is present before the model thinks). Guarantees presence;
+  requires a harness-specific adapter. **OpenClaw is the first such
+  harness** (the MemClaw plugin reconciles the catalog to disk every
+  heartbeat).
 
 They're complementary: MCP-direct is the floor that works everywhere;
 install is the guarantee for chosen harnesses.
+
+### The push path is gated by the same rule
+
+Per-harness install is a **push** (catalog → node disk → native loader),
+the mirror of MCP's pull. It must enforce the *same* active-only + opt-in
+gate, or an opted-in tenant's `candidate` / `staged` / `quarantined`
+skills would land on every node's disk even though MCP hides them.
+
+So the OpenClaw plugin reconciler pulls from a dedicated server surface,
+**`POST /api/v1/skills/installable`**, instead of a raw
+`/documents/query`:
+
+- opted-in tenant → server returns only `status='active'` skills;
+- non-opted-in tenant → every visible skill (byte-identical to the
+  legacy reconcile — preserves the merge-day no-op invariant);
+- settings outage → `503` (fail closed); the reconciler fails *safe* on
+  a non-2xx (preserves on-disk skills, writes nothing), so an outage
+  never pushes a non-active skill to disk.
+
+The policy lives entirely server-side — the plugin sends no `status`
+filter and carries no opt-in flag, so it can't be made to pull a
+non-active skill. A skill flipping `active → rejected/quarantined` drops
+out of `installable` and the reconciler removes it from disk on the next
+tick. Push (OpenClaw) and pull (`memclaw_doc`) now agree on exactly what
+an agent may see.
 
 ## What makes a skill findable: the summary
 
@@ -139,6 +167,8 @@ read like a trigger ("Use when deploying to eu-west…"), not a label
 
 ## Related
 
-- `core-api/src/core_api/mcp_server.py` — `memclaw_doc` handler (the filter)
+- `core-api/src/core_api/mcp_server.py` — `memclaw_doc` handler (the pull filter)
+- `core-api/src/core_api/routes/documents.py` — `POST /skills/installable` (the push filter)
+- `plugin/src/reconcile-skills.ts` — the OpenClaw reconciler that consumes it
 - `core-api/src/core_api/repositories/document_repository.py` — `search(status=…)` mechanism
 - `docs/operator-forge-cron.md` — how skills reach `active` autonomously

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -63,7 +63,11 @@ function installMockFetch(): void {
   originalFetch = globalThis.fetch;
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url = String(input);
-    if (url.endsWith("/api/v1/documents/query")) {
+    // The reconciler now pulls from the server-gated install surface,
+    // which applies the active-only + opt-in filter server-side. The
+    // mock returns whatever ``mockCatalog`` holds — i.e. only what the
+    // server would have already deemed installable.
+    if (url.endsWith("/api/v1/skills/installable")) {
       return new Response(JSON.stringify({ documents: mockCatalog }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -286,6 +290,42 @@ describe("reconcileSkills", () => {
     await reconcileSkills();
 
     assert.equal(readSkill("skill-a"), withSynthFrontmatter("skill-a", "alpha", "# canonical from catalog\n"));
+  });
+
+  test("de-activation: a skill withheld by the server (active→rejected/quarantined) is removed from disk next tick", async () => {
+    // Tick 1: skill is active → server returns it → lands on disk.
+    plantOnDisk("memclaw");
+    mockCatalog = [
+      { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "deploy steps", content: "# deploy\n" } },
+    ];
+    const first = await reconcileSkills();
+    assert.deepEqual(first.added, ["deploy-runbook"]);
+    assert.ok(listSkillDirs().includes("deploy-runbook"));
+
+    // Tick 2: the skill flipped to a non-active status, so the install
+    // surface stops returning it. The reconciler must remove it from
+    // disk — keeping push (disk) in sync with the active-only gate.
+    mockCatalog = [];
+    const second = await reconcileSkills();
+    assert.deepEqual(second.removed, ["deploy-runbook"]);
+    assert.deepEqual(listSkillDirs(), ["memclaw"]); // gone; bundled survives
+  });
+
+  test("server fail-closed (503) → reconciler fails safe: disk preserved, nothing pushed", async () => {
+    // The install surface raises 503 during a settings outage (fail
+    // closed). apiCall throws on non-2xx, so the reconciler catches it
+    // and leaves disk untouched — no non-active skill can be pushed.
+    plantOnDisk("memclaw");
+    plantOnDisk("skill-a", "# from a healthy prior tick\n");
+    globalThis.fetch = (async () =>
+      new Response("skill lifecycle gate unavailable", { status: 503 })) as typeof fetch;
+
+    const summary = await reconcileSkills();
+
+    assert.deepEqual(listSkillDirs(), ["memclaw", "skill-a"]); // untouched
+    assert.equal(summary.catalogCount, 0);
+    assert.deepEqual(summary.added, []);
+    assert.deepEqual(summary.removed, []);
   });
 });
 

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -14,14 +14,24 @@
  * - **Self-healing**: missed heartbeats catch up on the next tick.
  *   No queue, no "lost install command" failure mode.
  * - **Idempotent**: re-running is a no-op when disk already matches.
- * - **Pull-everything-visible** (locked in 2026-05-05): tenant + fleet
- *   visibility scoping happens at the catalog query layer, so the
- *   reconciler doesn't need its own opt-in flag. Skills the agent's
- *   fleet can see → on disk; can't see → not on disk.
+ * - **Server-gated catalog**: the reconciler pulls from
+ *   ``/skills/installable``, which applies ALL policy server-side —
+ *   tenant + fleet visibility AND (for Skill-Factory-opted-in tenants)
+ *   the active-only lifecycle gate. So the reconciler carries no opt-in
+ *   flag and no status filter: skills the server returns → on disk;
+ *   anything it withholds (a sibling fleet's skill, or a candidate /
+ *   staged / quarantined skill on an opted-in tenant) → never on disk.
+ *   This is the SAME gate the MCP pull surface enforces (PR #315), so
+ *   push (this reconciler) and pull (memclaw_doc) agree on what an agent
+ *   may see. A skill flipping active→rejected/quarantined drops out of
+ *   the catalog and is removed from disk on the next tick (step 4).
  *
- * Failure mode: fail open. If the catalog query throws (network,
- * server, schema), the reconciler logs and returns; existing on-disk
- * skills are preserved untouched. The heartbeat loop continues.
+ * Failure mode: fail open. If the catalog query throws or the server
+ * returns non-2xx (network, server, schema, or the fail-closed 503 the
+ * install surface raises during a settings outage), the reconciler logs
+ * and returns; existing on-disk skills are preserved untouched and
+ * nothing new is written — so an outage can never push a non-active
+ * skill to disk. The heartbeat loop continues.
  */
 
 import {
@@ -75,18 +85,20 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
     return summary;
   }
 
-  // 1. Fetch the catalog. Visibility filtering (fleet_id) happens
-  //    server-side; we just pass our local fleet binding through.
+  // 1. Fetch the installable catalog. ALL policy — tenant + fleet
+  //    visibility AND the active-only Skill-Factory gate (for opted-in
+  //    tenants) — is applied server-side by ``/skills/installable``; we
+  //    just pass our tenant + fleet binding through. The endpoint
+  //    cannot be widened by the client (no caller ``where``), so a node
+  //    can never pull a non-active skill.
   let catalog: CatalogDoc[];
   try {
     const resp = (await apiCall(
       "POST",
-      "/documents/query",
+      "/skills/installable",
       {
         tenant_id: MEMCLAW_TENANT_ID,
-        collection: "skills",
         fleet_id: MEMCLAW_FLEET_ID || undefined,
-        where: {},
         limit: 1000,
       },
     )) as { documents?: CatalogDoc[] } | CatalogDoc[];

--- a/tests/test_skills_installable_endpoint.py
+++ b/tests/test_skills_installable_endpoint.py
@@ -1,0 +1,138 @@
+"""Tests for ``POST /api/v1/skills/installable``.
+
+The agent-harness install surface the OpenClaw plugin reconciler pulls
+from. It applies the SAME active-only + opt-in gate the MCP pull surface
+applies (PR #315), server-side, so push (reconciler → disk) and pull
+(``memclaw_doc``) agree on what an agent may see.
+
+Asserted contract:
+  - opted-in tenant → storage query forced to ``where={"status":"active"}``;
+  - non-opted-in tenant → ``where={}`` (byte-identical legacy reconcile,
+    preserving the merge-day no-op invariant);
+  - settings-lookup failure → 503 (fail closed), storage never queried;
+  - the caller cannot widen the filter (the request model has no ``where``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import get_test_auth
+
+
+def _areturn(value):
+    async def _fn(*_args, **_kwargs):
+        return value
+
+    return _fn
+
+
+class _CapturingStorage:
+    """Fake storage client recording the params the route passes."""
+
+    def __init__(self, captured: dict, rows: list | None = None):
+        self._captured = captured
+        self._rows = rows or []
+
+    async def query_documents(self, params):
+        self._captured.update(params)
+        return self._rows
+
+
+async def test_installable_forces_active_only_when_opted_in(client, monkeypatch):
+    tenant_id, headers = get_test_auth()
+    monkeypatch.setattr(
+        "core_api.routes.documents.get_raw_settings",
+        _areturn({"skills_factory": {"enabled": True}}),
+    )
+    captured: dict = {}
+    monkeypatch.setattr(
+        "core_api.routes.documents.get_storage_client",
+        lambda: _CapturingStorage(captured),
+    )
+    resp = await client.post(
+        "/api/v1/skills/installable",
+        json={"tenant_id": tenant_id, "fleet_id": "fleet-a"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["where"] == {"status": "active"}
+    assert captured["collection"] == "skills"
+    assert captured["fleet_id"] == "fleet-a"
+
+
+async def test_installable_no_status_filter_when_not_opted_in(client, monkeypatch):
+    # Non-opted-in tenant: byte-identical to the legacy reconcile
+    # (where={}), so a legacy skill that predates Skill Factory and lacks
+    # a status field is NOT silently dropped.
+    tenant_id, headers = get_test_auth()
+    monkeypatch.setattr(
+        "core_api.routes.documents.get_raw_settings",
+        _areturn({}),  # no skills_factory block → not opted in
+    )
+    captured: dict = {}
+    monkeypatch.setattr(
+        "core_api.routes.documents.get_storage_client",
+        lambda: _CapturingStorage(captured),
+    )
+    resp = await client.post(
+        "/api/v1/skills/installable",
+        json={"tenant_id": tenant_id},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["where"] == {}
+
+
+async def test_installable_fails_closed_on_settings_error(client, monkeypatch):
+    # A settings-lookup failure must 503 (fail closed) and never reach
+    # storage — so the reconciler (fail-safe on non-2xx) adds nothing and
+    # can't push a non-active skill to disk during an outage.
+    tenant_id, headers = get_test_auth()
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("settings store down")
+
+    monkeypatch.setattr("core_api.routes.documents.get_raw_settings", _boom)
+    queried = {"called": False}
+
+    class _NeverStorage:
+        async def query_documents(self, params):  # noqa: ARG002
+            queried["called"] = True
+            return []
+
+    monkeypatch.setattr(
+        "core_api.routes.documents.get_storage_client", lambda: _NeverStorage()
+    )
+    resp = await client.post(
+        "/api/v1/skills/installable",
+        json={"tenant_id": tenant_id},
+        headers=headers,
+    )
+    assert resp.status_code == 503, resp.text
+    assert queried["called"] is False
+
+
+async def test_installable_rejects_caller_where(client, monkeypatch):
+    # Defense in depth: the request model has no ``where`` field, so a
+    # caller-supplied one is ignored — it can never widen the filter to
+    # pull non-active skills. (Pydantic ignores the unknown field; the
+    # server still forces its own ``where``.)
+    tenant_id, headers = get_test_auth()
+    monkeypatch.setattr(
+        "core_api.routes.documents.get_raw_settings",
+        _areturn({"skills_factory": {"enabled": True}}),
+    )
+    captured: dict = {}
+    monkeypatch.setattr(
+        "core_api.routes.documents.get_storage_client",
+        lambda: _CapturingStorage(captured),
+    )
+    resp = await client.post(
+        "/api/v1/skills/installable",
+        json={"tenant_id": tenant_id, "where": {"status": "staged"}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    # Server-decided filter wins; the caller's "staged" is discarded.
+    assert captured["where"] == {"status": "active"}


### PR DESCRIPTION
## Why

PR #315 closed the active-only leak on the MCP **pull** surface (`memclaw_doc`), but the **push** surface stayed open. The OpenClaw plugin reconciler (`plugin/src/reconcile-skills.ts`) mirrors the `skills` catalog to each node's disk via `POST /documents/query` with `where={}` — **all statuses**. For a Skill-Factory-opted-in tenant that pushes `candidate` / `staged` / `quarantined` skills onto every node's disk and into the agent's palette — exactly the leak #315 closed for pull, still open on push.

This wires push and pull behind **one server-side gate**.

## What's new

**`POST /api/v1/skills/installable`** (`core-api/.../routes/documents.py`) — the agent-harness install surface. Same active-only + opt-in gate as the MCP path, enforced server-side:
- opted-in tenant → only `status='active'` skills;
- non-opted-in → every visible skill (`where={}`), byte-identical to the legacy reconcile (a legacy skill predating Skill Factory may lack a `status` field; forcing `active` would wrongly drop it — so we don't filter at all);
- settings-lookup failure → **503, fail closed**, storage never queried.

The request model has **no `where`** — a caller can't widen the filter to pull non-active skills.

**Reconciler switch-over** (`plugin/src/reconcile-skills.ts`) — pulls from `/skills/installable` instead of `/documents/query{where:{}}`. The client carries zero policy: no status filter, no opt-in flag.

## Consequences

- **De-activation reactivity (free):** a skill flipping `active → rejected/quarantined` drops out of `installable`; the reconciler's existing orphan-removal path deletes it from disk next tick. Push stays in sync with the gate.
- **Fail-safe end-to-end:** server fails closed (503); reconciler fails safe on a non-2xx (preserves on-disk skills, writes nothing) — an outage can never push a non-active skill to disk.
- **No blast radius:** `/documents/query` untouched (dashboards / inbox that legitimately need non-active skills unaffected). Old plugins keep working (ungated, as before — `/documents/query` still exists); new plugins are gated. The plugin sends no version-coupled change beyond the endpoint URL.

## Scope

This is the **first** of the OpenClaw-install PRs (the "close the gate gap" slice). Deliberately out of scope, for follow-ups: install/bootstrap hardening (`/install-plugin`, gateway restart, version pinning) and operator-facing per-node reconcile observability.

## Tests

- `tests/test_skills_installable_endpoint.py` — active-only when opted-in; `where={}` when not; 503 + storage-not-queried on settings error; caller `where` ignored.
- `plugin/src/reconcile-skills.test.ts` — endpoint switch-over; de-activation removes from disk next tick; server 503 → reconciler fails safe.
- 246 server tests across the documents/installable/mcp_doc/skill sweep; 312 plugin tests. ruff + format clean; 0 mypy errors in the touched route.

## Docs

`docs/mcp-skill-delivery.md` — documents the push path and the shared gate; OpenClaw promoted from "future" to the first per-harness install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)