### PR TITLE
fix(plugin): point agents at the memclaw skill by name, not by filesystem path (CAURA-000)

### DIFF
--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memclaw",
   "name": "MemClaw",
   "kind": "memory",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Central persistent memory for OpenClaw agents — write, search, and entity lookup tools.",
   "entry": "dist/index.js",
   "skills": [

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caura/memclaw",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "OpenClaw plugin for MemClaw central memory",
   "license": "Apache-2.0",
   "private": true,

--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -1193,11 +1193,18 @@ describe("buildToolsMd", () => {
     assert.ok(!tools.includes("### Error codes"), "error codes must live in SKILL.md, not TOOLS.md");
   });
 
-  test("points readers to SKILL.md for the deep dive", () => {
+  test("points readers to the memclaw skill (by name, not by path) for the deep dive", () => {
+    // CAURA-000: must NOT use a filesystem path — see the AGENTS.md
+    // test above for why (cron `search`-tool storm on a missing file).
     const tools = buildToolsMd();
+    const flat = tools.replace(/\s+/g, " ");
     assert.ok(
-      tools.includes("skills/memclaw/SKILL.md"),
-      "TOOLS.md must point readers at SKILL.md for per-tool signatures and error codes",
+      !flat.includes("skills/memclaw/SKILL.md"),
+      "TOOLS.md must NOT reference the skill by filesystem path",
+    );
+    assert.ok(
+      /\*\*memclaw\*\* skill/i.test(flat),
+      "TOOLS.md must point readers at the **memclaw** skill by name",
     );
   });
 
@@ -1357,19 +1364,41 @@ describe("buildAgentsMd", () => {
     assert.ok(skill.includes("NEVER silently drop"));
   });
 
-  test("nudges the model to read SKILL.md before the first MemClaw call", () => {
-    // The tool-reference deep dive lives in SKILL.md (loaded via `read` on
-    // demand). AGENTS.md — injected as bootstrap every turn — must direct
-    // the model to load SKILL.md before its first MemClaw tool call in a
-    // session so the signatures, decision guidance, and error codes are
-    // in context when needed.
+  test("nudges the model to open the memclaw skill before the first MemClaw call", () => {
+    // The tool-reference deep dive lives in the memclaw skill, loaded
+    // automatically by the runtime from the plugin manifest
+    // (openclaw.plugin.json:skills). AGENTS.md — injected as bootstrap
+    // every turn — must direct the model to open that skill before its
+    // first MemClaw tool call so the signatures, decision guidance, and
+    // error codes are in context when needed.
+    //
+    // CAURA-000: AGENTS.md must NOT reference the skill by a filesystem
+    // path (e.g. `skills/memclaw/SKILL.md`). The skill is no longer
+    // written per-workspace — it ships once at plugin-root and is
+    // manifest-discovered. A path-style pointer made cron agents run
+    // OpenClaw's `search` tool to locate a file that isn't in their
+    // workspace, burning ~3 min and failing the turn. The pointer must
+    // be skill-name-based and explicitly tell the agent not to search.
     const agents = buildAgentsMd();
+    // Collapse whitespace (incl. markdown line wraps) the way a reader /
+    // LLM consumes the text — key phrases may break across lines in the
+    // source template.
+    const flat = agents.replace(/\s+/g, " ");
     assert.ok(
-      agents.includes("skills/memclaw/SKILL.md"),
-      "AGENTS.md must reference skills/memclaw/SKILL.md by path",
+      !flat.includes("skills/memclaw/SKILL.md"),
+      "AGENTS.md must NOT reference the skill by filesystem path " +
+        "(triggers a doomed `search` tool call on cron agents — CAURA-000)",
     );
     assert.ok(
-      /before your first MemClaw/i.test(agents),
+      /\*\*memclaw\*\* skill/i.test(flat),
+      "AGENTS.md must reference the **memclaw** skill by name",
+    );
+    assert.ok(
+      /do NOT search the filesystem/i.test(flat),
+      "AGENTS.md must explicitly tell the agent not to filesystem-search for the skill",
+    );
+    assert.ok(
+      /before your first MemClaw/i.test(flat),
       "AGENTS.md must carry a 'before your first MemClaw call' nudge",
     );
   });

--- a/plugin/src/educate.ts
+++ b/plugin/src/educate.ts
@@ -342,8 +342,9 @@ export function buildToolsMd(): string {
 ## MemClaw — Tools Available
 
 Persistent, cross-session, multi-agent memory. For per-tool signatures,
-decision guidance, constraints, and error codes, read
-\`skills/memclaw/SKILL.md\` before your first call in a session.
+decision guidance, constraints, and error codes, open the **memclaw**
+skill (your runtime loads it automatically — do NOT search the
+filesystem for it) before your first call in a session.
 
 \`agent_id\` is resolved by your runtime — never fabricate.
 
@@ -415,10 +416,11 @@ memories, not shared); share via \`op=write doc_id=<slug>\`.
 **Recall auto-gated** on trivial turns; call \`memclaw_recall\`
 directly when a short message needs LTM.
 
-Before your first MemClaw call this session, read
-\`skills/memclaw/SKILL.md\` for signatures, cadences, quality,
-prohibitions, recall policy, and sharing. \`TOOLS.md\` carries the
-at-a-glance tool list and enum vocabulary every turn.
+Before your first MemClaw call this session, open the **memclaw**
+skill — your runtime loads it automatically, so do NOT search the
+filesystem for it — for signatures, cadences, quality, prohibitions,
+recall policy, and sharing. \`TOOLS.md\` carries the at-a-glance tool
+list and enum vocabulary every turn.
 `;
 }
 

--- a/plugin/src/prompt-section.ts
+++ b/plugin/src/prompt-section.ts
@@ -36,9 +36,10 @@ function buildRecallLines(availableTools: Set<string>): string[] {
       ". Every call MUST carry your `agent_id` (and `fleet_id` for " +
       "team / org / cross-fleet operations) — never fabricate. " +
       "Operating rules (recall before, write after, supersede don't " +
-      "delete), quality rules, and per-tool reference live in " +
-      "`skills/memclaw/SKILL.md` — read it before your first MemClaw " +
-      "call this session.",
+      "delete), quality rules, and per-tool reference live in the " +
+      "**memclaw** skill, which your runtime loads automatically — open " +
+      "it via your skill system before your first MemClaw call this " +
+      "session. Do NOT search the filesystem for it.",
   );
   lines.push("");
 

--- a/plugin/src/tool-definitions.test.ts
+++ b/plugin/src/tool-definitions.test.ts
@@ -245,14 +245,28 @@ describe("drift checks across tool surface artefacts", () => {
   describe("prompt-section.ts (per-turn system-prompt fragment)", () => {
     const tools = memclawPromptSectionText(new Set(MEMCLAW_TOOLS));
 
-    test("includes header, identity, and pointer to SKILL.md", () => {
+    test("includes header, identity, and pointer to the memclaw skill (by name)", () => {
       assert.ok(tools.includes("## MemClaw Memory"), "missing header");
       assert.ok(tools.includes("`agent_id`"), "missing agent_id mention");
       assert.ok(tools.includes("never fabricate") || tools.includes("Never fabricate"),
         "missing identity 'never fabricate' clause");
+      // CAURA-000: the per-turn fragment must point at the **memclaw**
+      // skill by NAME, not a filesystem path — a path pointer made cron
+      // agents run OpenClaw's `search` tool to find a file that isn't in
+      // their workspace (the skill is manifest-discovered at plugin-root),
+      // burning ~3 min and failing the turn.
+      const flat = tools.replace(/\s+/g, " ");
       assert.ok(
-        tools.includes("skills/memclaw/SKILL.md"),
-        "must reference skills/memclaw/SKILL.md by path",
+        !flat.includes("skills/memclaw/SKILL.md"),
+        "must NOT reference the skill by filesystem path (CAURA-000)",
+      );
+      assert.ok(
+        /\*\*memclaw\*\* skill/i.test(flat),
+        "must reference the **memclaw** skill by name",
+      );
+      assert.ok(
+        /do NOT search the filesystem/i.test(flat),
+        "must tell the agent not to filesystem-search for the skill",
       );
     });
 

--- a/plugin/src/version.ts
+++ b/plugin/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated from plugin/package.json by scripts/gen-version.sh — do not edit
-export const PLUGIN_VERSION = "2.9.0";
+export const PLUGIN_VERSION = "2.9.1";


### PR DESCRIPTION
## Summary

Cron-run error on bridgeclaw (plugin 2.9.0):

```
channel=cron sessionKey=agent:bridgeclaw:cron:... duration=171759ms outcome=error
error="search "~/.openclaw/agents/bridgeclaw/agent/codex-home"
       -> search "memclaw/SKILL.md$|memclaw" (agent) failed"
```

**Interpretation**: this is OpenClaw's built-in **`search` tool** failing — not a memclaw tool. The agent was trying to *locate* our skill file, driven by our own prompt/educate text: *"the operating contract lives in `skills/memclaw/SKILL.md` — read it before your first call."*

That path-style pointer was correct when the plugin wrote `SKILL.md` per-workspace. But the skill is now shipped **once at plugin-root** and **manifest-discovered** via `openclaw.plugin.json:skills` — there is no per-workspace file. A cron agent (no human in the loop) took the path literally, ran the `search` tool against its `codex-home` workspace, scanned for **2m51s**, found nothing, and failed the turn.

## Fix

Three emit sites carried the path-style pointer:
- `prompt-section.ts` — per-turn system-prompt fragment
- `educate.ts` `buildToolsMd()` — TOOLS.md (per-workspace bootstrap)
- `educate.ts` `buildAgentsMd()` — AGENTS.md (per-workspace bootstrap)

All three reworded to:
1. Reference the **memclaw** skill **by name** (not a path)
2. State the runtime loads it automatically
3. Explicitly instruct the agent **not to search the filesystem** for it

**No runtime or behavior change — prompt wording only.**

Example (AGENTS.md, after):
> Before your first MemClaw call this session, open the **memclaw** skill — your runtime loads it automatically, so do NOT search the filesystem for it — for signatures, cadences, quality, prohibitions, recall policy, and sharing.

## Tests

Three existing assertions *locked in the bug* (they required the `skills/memclaw/SKILL.md` path string). Updated all three to instead require:
- absence of the `skills/memclaw/SKILL.md` path string
- the by-name `**memclaw** skill` reference
- the `do NOT search the filesystem` guard

(`educate.test.ts` ×2, `tool-definitions.test.ts` ×1. Whitespace normalised before matching — the source template wraps phrases across lines.)

- 310/310 plugin tests pass
- manifest drift 11/11 pass
- tsc clean

## Wet test

Pure prompt-string change — there's no runtime code path to exercise on the VM beyond what the unit tests already render (they assert the exact emitted strings). Skipped the VM round-trip deliberately.

## Not in scope

- `plugin/skills/memclaw/SKILL.md` has one internal self-reference to `<workspace>/skills/memclaw/SKILL.md` (line ~352). That's *inside* the skill — by the time it's read, the skill is already loaded, so it can't trigger the search-storm. Left as-is to keep this change minimal.
- Why OpenClaw's `search` tool *throws* (rather than returning empty) on a no-match is OpenClaw-side behavior, not ours.

## Version

Plugin 2.9.0 → 2.9.1.

## Test plan
- [x] 310/310 unit tests
- [x] manifest drift 11/11
- [x] rendered TOOLS.md / AGENTS.md / system-prompt fragment inspected — path string gone, by-name + no-search guard present
- [ ] Customer: once 2.9.1 ships, cron agents stop emitting the `search ... memclaw/SKILL.md ... failed` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)