### PR TITLE
feat(skills): per-node skill-reconcile observability on the heartbeat

### DIFF
--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -100,6 +100,15 @@ class HeartbeatIn(BaseModel):
     # reading the column (e.g. "blocked since 1970?"). Fail-loud here
     # instead.
     deploy_blocked_until: int | None = Field(None, ge=1)
+    # Skill-reconcile observability: the plugin's latest
+    # ``reconcileSkills()`` summary — ``installed`` (the active skills
+    # converged onto this node's disk), per-tick ``added``/``removed``
+    # deltas, ``skipped`` (bad-shape catalog rows), ``protected``, and
+    # ``catalogCount``. Stored as the newest snapshot on the node row
+    # (``nodes.metadata.reconcile``) so an operator can confirm an
+    # approved/active skill actually landed on the fleet. Optional —
+    # older plugin versions don't send it.
+    reconcile: dict | None = None
 
     @field_validator("recall_metrics")
     @classmethod
@@ -110,6 +119,17 @@ class HeartbeatIn(BaseModel):
         # with every reason populated; 4 KB is a comfortable headroom.
         if v is not None and len(json.dumps(v)) > 4096:
             raise ValueError("recall_metrics exceeds 4 KB limit")
+        return v
+
+    @field_validator("reconcile")
+    @classmethod
+    def _cap_reconcile(cls, v: dict | None) -> dict | None:
+        # Same anti-ballooning cap as recall_metrics. The summary is a
+        # handful of slug lists; even a fleet sharing ~150 skills stays
+        # well under 8 KB. Reject beyond that at the API boundary so a
+        # misbehaving plugin can't bloat the node row.
+        if v is not None and len(json.dumps(v)) > 8192:
+            raise ValueError("reconcile summary exceeds 8 KB limit")
         return v
 
 
@@ -533,10 +553,15 @@ async def heartbeat(
     # exposing the data via the existing /fleet/nodes endpoint and
     # ad-hoc SQL on `nodes.metadata`.
     merged_metadata: dict | None = body.metadata
-    if body.recall_metrics is not None or body.deploy_blocked_until is not None:
+    if body.recall_metrics is not None or body.deploy_blocked_until is not None or body.reconcile is not None:
         merged_metadata = dict(merged_metadata or {})
         if body.recall_metrics is not None:
             merged_metadata["recall_metrics"] = body.recall_metrics
+        if body.reconcile is not None:
+            # Latest snapshot wins — overwrites the prior tick's summary
+            # so nodes.metadata.reconcile always reflects the current
+            # on-disk skill state, not an accumulation.
+            merged_metadata["reconcile"] = body.reconcile
         if body.deploy_blocked_until is not None:
             # Mirror the gate's MAX_BLOCK_MS cap at write time. The gate
             # already ignores beyond-cap values (treats them as if the
@@ -821,7 +846,17 @@ async def list_nodes(
                 "agents": n.get("agents_json"),
                 "tools": n.get("tools_json"),
                 "channels": n.get("channels_json"),
-                "metadata": n.get("metadata"),
+                # Storage serialises the JSONB column under its ORM
+                # attribute name ``extra`` (the column is ``metadata`` but
+                # the model maps it to ``extra`` to avoid shadowing
+                # SQLAlchemy's ``MetaData``). The storage field list emits
+                # ``extra``, so reading ``"metadata"`` here always yielded
+                # ``None`` — node metadata (recall_metrics,
+                # deploy_blocked_until, and the reconcile summary) never
+                # surfaced through this endpoint. Read ``extra`` (with a
+                # ``metadata`` fallback in case a future serializer renames
+                # it back).
+                "metadata": n.get("extra", n.get("metadata")),
                 "last_heartbeat": n.get("last_heartbeat"),
                 "created_at": n.get("created_at"),
             }

--- a/docs/mcp-skill-delivery.md
+++ b/docs/mcp-skill-delivery.md
@@ -157,6 +157,22 @@ out of `installable` and the reconciler removes it from disk on the next
 tick. Push (OpenClaw) and pull (`memclaw_doc`) now agree on exactly what
 an agent may see.
 
+### Verifying installs reached the fleet
+
+Gating decides what *should* land; observability confirms what *did*.
+Each heartbeat carries the reconciler's summary — `installed` (the
+active skills converged onto that node's disk right now), plus per-tick
+`added` / `removed` / `skipped` / `protected` deltas — which the backend
+stores as the latest snapshot at `nodes.metadata.reconcile` and surfaces
+via `GET /api/v1/fleet/nodes`. So an operator who flips a skill to
+`active` can confirm it actually reached each node, and see *why* a
+malformed catalog row was skipped — closing the loop from "approved" to
+"installed on the fleet."
+
+`installed` is the standing truth, not a delta: it's reported on every
+tick (even steady-state ticks with empty `added`/`removed`), so a node's
+current live-skill set is always legible.
+
 ## What makes a skill findable: the summary
 
 Scoped `op=search` ranks on the embedded `data.summary`. So the

--- a/plugin/src/heartbeat.ts
+++ b/plugin/src/heartbeat.ts
@@ -59,7 +59,7 @@ import {
 import { logError } from "./logger.js";
 import { getInstallId } from "./install-id.js";
 import { getDisplayName } from "./identity.js";
-import { reconcileSkills } from "./reconcile-skills.js";
+import { reconcileSkills, type ReconcileSummary } from "./reconcile-skills.js";
 
 let heartbeatCount = 0;
 let bakCleanupDone = false;
@@ -352,8 +352,12 @@ export async function sendHeartbeat(): Promise<void> {
   // Skill reconciler — converge plugin/skills/ with the catalog before
   // anything else. Failures are non-fatal (best-effort distribution).
   // Replaces the dropped install_skill / uninstall_skill push commands.
+  // Capture the summary so this tick's outcome (which active skills are
+  // installed on this node, plus deltas/skips) rides the heartbeat for
+  // operator observability. Left undefined if reconciliation throws.
+  let reconcile: ReconcileSummary | undefined;
   try {
-    await reconcileSkills();
+    reconcile = await reconcileSkills();
   } catch (e: unknown) {
     logError("reconcileSkills failed", e);
   }
@@ -570,6 +574,12 @@ export async function sendHeartbeat(): Promise<void> {
     // Cooldown signal: when set, the backend's auto-upgrade trigger
     // refuses to queue further deploy commands until this timestamp.
     deploy_blocked_until,
+    // Latest skill-reconcile summary for this node. Backend stores it as
+    // the newest snapshot on the node row (nodes.metadata.reconcile),
+    // surfaced via /fleet/nodes — so an operator can confirm an
+    // approved/active skill actually landed. Omitted if reconciliation
+    // threw this tick (older backends ignore the unknown field).
+    reconcile,
   };
 
   try {

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -123,6 +123,9 @@ describe("reconcileSkills", () => {
     assert.deepEqual(listSkillDirs(), ["memclaw"]); // foo gone, memclaw stays
     assert.deepEqual(summary.removed, ["foo"]);
     assert.deepEqual(summary.protected, ["memclaw"]);
+    // No catalog-active skills → nothing installed (the bundled memclaw
+    // is protected, not "installed" from the catalog).
+    assert.deepEqual(summary.installed, []);
     // Bundled content must be untouched
     assert.match(readSkill("memclaw"), /should survive/);
   });
@@ -146,6 +149,11 @@ describe("reconcileSkills", () => {
     ]);
     assert.deepEqual(summary.added.sort(), ["deploy-runbook", "git-rebase-safety", "incident-triage"]);
     assert.deepEqual(summary.removed, []);
+    // ``installed`` = the converged catalog-active set on disk (sorted),
+    // excluding the bundled ``memclaw`` skill.
+    assert.deepEqual(summary.installed, [
+      "deploy-runbook", "git-rebase-safety", "incident-triage",
+    ]);
     // Frontmatter synthesised from data.{name, description}; body preserved.
     const written = readSkill("git-rebase-safety");
     assert.match(written, /^---\nname: git-rebase-safety\ndescription: "rebase steps"\n---\n\n# rebase safely\n$/);
@@ -181,6 +189,10 @@ describe("reconcileSkills", () => {
     assert.deepEqual(first.added, ["skill-a"]);
     assert.deepEqual(second.added, []);
     assert.deepEqual(second.removed, []);
+    // The standing-truth value: even on the steady-state tick (no
+    // deltas), ``installed`` still reports what's live — this is exactly
+    // why ``installed`` exists rather than reading the empty ``added``.
+    assert.deepEqual(second.installed, ["skill-a"]);
     // The skill on disk hasn't been overwritten (same content → skipped)
     assert.equal(readSkill("skill-a"), withSynthFrontmatter("skill-a", "alpha", "# A\n"));
   });
@@ -300,6 +312,7 @@ describe("reconcileSkills", () => {
     ];
     const first = await reconcileSkills();
     assert.deepEqual(first.added, ["deploy-runbook"]);
+    assert.deepEqual(first.installed, ["deploy-runbook"]);
     assert.ok(listSkillDirs().includes("deploy-runbook"));
 
     // Tick 2: the skill flipped to a non-active status, so the install
@@ -308,6 +321,9 @@ describe("reconcileSkills", () => {
     mockCatalog = [];
     const second = await reconcileSkills();
     assert.deepEqual(second.removed, ["deploy-runbook"]);
+    // The heartbeat now reports an empty installed set — the operator
+    // sees the skill is no longer live on this node.
+    assert.deepEqual(second.installed, []);
     assert.deepEqual(listSkillDirs(), ["memclaw"]); // gone; bundled survives
   });
 
@@ -326,6 +342,26 @@ describe("reconcileSkills", () => {
     assert.equal(summary.catalogCount, 0);
     assert.deepEqual(summary.added, []);
     assert.deepEqual(summary.removed, []);
+  });
+
+  test("installed reflects CONFIRMED disk, not desired intent: a failed write is excluded", async () => {
+    plantOnDisk("memclaw");
+    // Plant a FILE where the reconciler wants a directory, so
+    // mkdirSync(skills/bad-skill) throws and its write fails — without
+    // mocking fs. ``good-skill`` writes cleanly.
+    writeFileSync(join(SKILLS_ROOT, "bad-skill"), "i am a file, not a dir\n", "utf-8");
+    mockCatalog = [
+      { doc_id: "good-skill", data: { name: "good-skill", description: "ok",  content: "# good\n" } },
+      { doc_id: "bad-skill",  data: { name: "bad-skill",  description: "nope", content: "# bad\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    // The failed write must NOT be reported as installed (it never
+    // converged to disk); the clean one must be.
+    assert.deepEqual(summary.installed, ["good-skill"]);
+    assert.ok(summary.added.includes("good-skill"));
+    assert.ok(!summary.added.includes("bad-skill"));
   });
 });
 

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -58,8 +58,16 @@ interface CatalogDoc {
   data?: Record<string, unknown>;
 }
 
-interface ReconcileSummary {
+export interface ReconcileSummary {
   catalogCount: number;
+  // The converged catalog-active skills now materialised on disk (the
+  // desired set this tick). Unlike ``added``/``removed`` — which are
+  // per-tick DELTAS, empty once a node is steady-state — ``installed`` is
+  // the standing truth: "these active skills are present on this node
+  // right now." Surfaced on the heartbeat so an operator can confirm an
+  // approved/active skill actually landed on the fleet. Excludes the
+  // bundled ``memclaw`` onboarding skill (reported via ``protected``).
+  installed: string[];
   added: string[];
   removed: string[];
   skipped: string[];   // catalog entries with bad shape (no doc_id / no content)
@@ -73,6 +81,7 @@ interface ReconcileSummary {
 export async function reconcileSkills(): Promise<ReconcileSummary> {
   const summary: ReconcileSummary = {
     catalogCount: 0,
+    installed: [],
     added: [],
     removed: [],
     skipped: [],
@@ -191,6 +200,22 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
       logError(`reconcileSkills: rm failed for ${slug}`, e);
     }
   }
+
+  // Track CONFIRMED on-disk state for ``summary.installed``. Seed with
+  // skills that are BOTH already on disk AND catalog-active this tick
+  // (``onDisk ∩ desired``); the write loop then adds each fresh
+  // successful write. Intersecting with ``desired`` — rather than
+  // ``onDisk`` minus successful removals — is what makes this correct in
+  // every case:
+  //   • same-content skill skipped by the no-op-match branch below:
+  //     in onDisk ∩ desired → kept (it's genuinely present);
+  //   • new install: not on disk → added only on a successful write;
+  //   • cleanly removed orphan: not in desired → excluded;
+  //   • FAILED removal of a deactivated skill (rmSync threw, so it's
+  //     absent from summary.removed but still on disk): not in desired
+  //     → excluded, so a stale skill is never reported as installed.
+  const desiredSlugs = new Set(desired.keys());
+  const installedSet = new Set([...onDisk].filter((s) => desiredSlugs.has(s)));
   for (const [slug, content] of desired) {
     const dir = join(skillsRoot, slug);
     const target = join(dir, "SKILL.md");
@@ -207,6 +232,7 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
     try {
       mkdirSync(dir, { recursive: true });
       writeFileSync(target, content, "utf-8");
+      installedSet.add(slug);
       summary.added.push(slug);
       console.log(
         `[memclaw] Reconciler ${onDisk.has(slug) ? "updated" : "pulled"} skill: ${slug}`,
@@ -215,6 +241,17 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
       logError(`reconcileSkills: write failed for ${slug}`, e);
     }
   }
+
+  // The standing on-disk truth: skills CONFIRMED present on disk this
+  // tick (sorted for a stable heartbeat payload / diff), excluding the
+  // bundled ``memclaw`` onboarding skill (reported via ``protected``).
+  // Built from confirmed writes + already-present survivors, NOT from
+  // ``desired`` — so a skill whose write failed above is correctly
+  // absent. Reported even when ``added``/``removed`` are empty (steady
+  // state) so an operator always sees what's live, not just what changed.
+  summary.installed = [...installedSet]
+    .filter((s) => !PROTECTED_SKILLS.has(s))
+    .sort();
 
   return summary;
 }

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -251,3 +251,97 @@ async def test_node_agents_from_heartbeat(client):
     node = next(n for n in nodes if n["node_name"] == f"node-agents-{tag}")
     assert node["agents"] == agents
     assert len(node["agents"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Skill-reconcile observability — the plugin's reconcileSkills() summary
+# rides the heartbeat into nodes.metadata.reconcile and out via /fleet/nodes.
+# ---------------------------------------------------------------------------
+
+
+async def test_heartbeat_persists_reconcile_summary(client):
+    """A heartbeat carrying ``reconcile`` lands at
+    ``node.metadata.reconcile`` and is readable via /fleet/nodes — so an
+    operator can confirm which active skills are installed on the node."""
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fid = f"fleet-{tag}"
+    node_name = f"node-recon-{tag}"
+    summary = {
+        "catalogCount": 3,
+        "installed": ["deploy-runbook", "git-rebase-safety"],
+        "added": ["deploy-runbook"],
+        "removed": [],
+        "skipped": ["../evil"],
+        "protected": ["memclaw"],
+    }
+    resp = await client.post(
+        "/api/v1/fleet/heartbeat",
+        json={
+            "tenant_id": tenant_id,
+            "fleet_id": fid,
+            "node_name": node_name,
+            "reconcile": summary,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    nodes = await _get_nodes(client, tenant_id, headers)
+    node = next(n for n in nodes if n["node_name"] == node_name)
+    assert node["metadata"]["reconcile"] == summary
+
+
+async def test_heartbeat_reconcile_latest_snapshot_wins(client):
+    """The newest tick's summary overwrites the prior one (snapshot, not
+    accumulation) — operators see current state, not history."""
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fid = f"fleet-{tag}"
+    node_name = f"node-recon2-{tag}"
+
+    async def _send(installed: list[str]) -> None:
+        resp = await client.post(
+            "/api/v1/fleet/heartbeat",
+            json={
+                "tenant_id": tenant_id,
+                "fleet_id": fid,
+                "node_name": node_name,
+                "reconcile": {
+                    "catalogCount": len(installed),
+                    "installed": installed,
+                    "added": [],
+                    "removed": [],
+                    "skipped": [],
+                    "protected": ["memclaw"],
+                },
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+    await _send(["alpha", "beta"])
+    await _send(["alpha"])  # beta de-activated
+
+    nodes = await _get_nodes(client, tenant_id, headers)
+    node = next(n for n in nodes if n["node_name"] == node_name)
+    assert node["metadata"]["reconcile"]["installed"] == ["alpha"]
+
+
+async def test_heartbeat_reconcile_oversized_rejected(client):
+    """A reconcile blob over the 8 KB cap is rejected at the API boundary
+    (anti-ballooning of nodes.metadata)."""
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    oversized = {"installed": ["x" * 100 for _ in range(120)]}  # ~12 KB
+    resp = await client.post(
+        "/api/v1/fleet/heartbeat",
+        json={
+            "tenant_id": tenant_id,
+            "fleet_id": f"fleet-{tag}",
+            "node_name": f"node-big-{tag}",
+            "reconcile": oversized,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422, resp.text


### PR DESCRIPTION
## Why

#317 gated which skills *should* land on each OpenClaw node, but there was no way to confirm which actually *did*. This closes the loop: the plugin's reconcile summary rides the heartbeat to the backend and is readable per-node, so an operator who flips a skill to `active` can confirm it reached the fleet — and see *why* a malformed catalog row was skipped.

## What's new

**Plugin**
- `reconcile-skills.ts`: adds `installed: string[]` to `ReconcileSummary` — the catalog-active skills converged onto disk *this tick*. Unlike `added`/`removed` (per-tick deltas, empty at steady state), `installed` is the **standing truth**: what's live on this node right now.
- `heartbeat.ts`: captures the `reconcileSkills()` result (previously discarded) and sends it as a typed top-level `reconcile` field.

**Backend**
- `fleet.py` `HeartbeatIn` gains `reconcile` (8 KB anti-ballooning cap, mirroring `recall_metrics`), merged into `nodes.metadata.reconcile` (latest snapshot wins). No migration — `metadata` is already JSONB. Surfaces via `GET /api/v1/fleet/nodes`.

## Latent bug fixed (required for the read path)

`GET /fleet/nodes` read `n.get("metadata")`, but the storage layer serialises that JSONB column under its ORM attribute name **`extra`** (the column is `metadata`; the model renames it to avoid shadowing SQLAlchemy's `MetaData`). So node metadata — `recall_metrics`, `deploy_blocked_until`, and now `reconcile` — **never** surfaced through this endpoint; the field was always `null`. Fixed to read `extra` (with a `metadata` fallback). Purely additive (`null` → the actual snapshot).

## Tests

- `plugin/src/reconcile-skills.test.ts` — `installed` reflects the converged set (cold start), empty on empty catalog, **reported even on steady-state ticks with no deltas**, and shrinks on de-activation.
- `tests/test_api_fleet.py` — a heartbeat `reconcile` lands at `node.metadata.reconcile` and is readable via `/fleet/nodes` (exercises the latent-bug fix); latest snapshot wins; over-cap blob → 422.
- 312 plugin tests pass; 61 across the fleet/heartbeat sweep. ruff + format clean; 0 mypy errors in the touched route.

## Docs

`docs/mcp-skill-delivery.md` — "Verifying installs reached the fleet": the heartbeat summary, `nodes.metadata.reconcile`, and `installed` as standing truth.

## Scope

Deliberately deferred to follow-ups: install/bootstrap hardening (`/install-plugin`, gateway restart, version pinning); skipped-reason enrichment; an MCP fleet-status tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)