### PR TITLE
fix(search): skip entity hop-boost when classifier declined the entity match as over-broad

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -94,6 +94,13 @@ class ClassifyQuery:
                         len(matched_ids),
                         ENTITY_LOOKUP_MAX_MATCHES,
                     )
+                    # The same over-broad match must not be re-derived by
+                    # ParallelEmbedAndEntityBoost and used for hop-boosting:
+                    # with N >> GRAPH_MAX_BOOSTED_MEMORIES sibling entities all
+                    # at hop 0, the boost degenerates into an arbitrary-50
+                    # lottery that buries rows pure scoring ranks first
+                    # (S1 @K=10000: 11/25 vs rank-1 on unboosted score).
+                    ctx.data["entity_match_declined"] = True
                     matched_ids = []
 
                 if matched_ids:

--- a/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
+++ b/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
@@ -177,15 +177,23 @@ class ParallelEmbedAndEntityBoost:
         emb_task = asyncio.ensure_future(
             _get_or_cache_embedding(data["query"], data["tenant_id"], data["tenant_config"])
         )
-        ent_task = asyncio.ensure_future(
-            _entity_boost_via_storage(
-                data["query"],
-                data["tenant_id"],
-                data.get("fleet_ids"),
-                data.get("graph_expand", True),
-                sp["graph_max_hops"],
-                use_union=True,
-                precomputed_hops=data.pop("_classified_entity_hops", None),
+        # ClassifyQuery already ran the same tokenizer + entity FTS and
+        # declined the match as over-broad (CAURA-698). Re-deriving it here
+        # would hand GRAPH_HOP_BOOST to an arbitrary GRAPH_MAX_BOOSTED_MEMORIES
+        # subset of the sibling pool, outranking rows the scorer puts first.
+        ent_task = (
+            None
+            if data.get("entity_match_declined")
+            else asyncio.ensure_future(
+                _entity_boost_via_storage(
+                    data["query"],
+                    data["tenant_id"],
+                    data.get("fleet_ids"),
+                    data.get("graph_expand", True),
+                    sp["graph_max_hops"],
+                    use_union=True,
+                    precomputed_hops=data.pop("_classified_entity_hops", None),
+                )
             )
         )
         # D7 — split the prior shared ``gather`` timeout into per-task budgets.
@@ -199,13 +207,16 @@ class ParallelEmbedAndEntityBoost:
         try:
             embedding = await asyncio.wait_for(emb_task, timeout=_OVERALL_TIMEOUT_S)
         except TimeoutError:
-            ent_task.cancel()
+            if ent_task is not None:
+                ent_task.cancel()
             raise HTTPException(status_code=504, detail="Search embedding timed out")
         except ValueError as exc:
-            ent_task.cancel()
+            if ent_task is not None:
+                ent_task.cancel()
             raise HTTPException(status_code=503, detail=str(exc))
         except BaseException:
-            ent_task.cancel()
+            if ent_task is not None:
+                ent_task.cancel()
             raise
 
         # ent_task has been running in parallel with emb_task since the
@@ -214,7 +225,14 @@ class ParallelEmbedAndEntityBoost:
         # only fires when entity_boost outlasts the embedding.
         remaining = max(_MIN_ENTITY_BUDGET_S, _OVERALL_TIMEOUT_S - (time.perf_counter() - t0))
         try:
-            boosted_memory_ids, memory_boost_factor = await asyncio.wait_for(ent_task, timeout=remaining)
+            if ent_task is None:
+                logger.info(
+                    "parallel_embed_entity_boost: entity boost skipped "
+                    "(entity match declined as over-broad in classify_query)"
+                )
+                boosted_memory_ids, memory_boost_factor = set(), {}
+            else:
+                boosted_memory_ids, memory_boost_factor = await asyncio.wait_for(ent_task, timeout=remaining)
         except TimeoutError:
             logger.warning(
                 "entity_boost timed out after %.2fs remaining budget; continuing with vector-only search",

--- a/tests/test_skip_entity_boost_on_decline.py
+++ b/tests/test_skip_entity_boost_on_decline.py
@@ -1,0 +1,154 @@
+"""Skip entity boost when ClassifyQuery declined the entity match (CAURA-698).
+
+``ClassifyQuery`` and ``ParallelEmbedAndEntityBoost`` run the same tokenizer
+and the same OR-semantics entity FTS. When the classifier declines the match
+as over-broad (``> ENTITY_LOOKUP_MAX_MATCHES``), the boost step used to
+re-derive the identical match and hand ``GRAPH_HOP_BOOST`` to an arbitrary
+``GRAPH_MAX_BOOSTED_MEMORIES``-sized subset of the sibling pool — a lottery
+that outranks rows pure scoring puts first. Measured on the S1 bench: the
+gold row ranks #1 on unboosted score yet falls out of top-10 whenever it
+misses a boost slot (P ≈ 50/N_siblings: 57% at K=1000, 6% at K=10000).
+
+The fix threads the classifier's verdict through ``ctx.data``:
+
+- ``ClassifyQuery`` sets ``entity_match_declined=True`` when it declines.
+- ``ParallelEmbedAndEntityBoost`` skips the boost leg entirely on that flag
+  (embedding still runs — it is the critical path).
+
+These tests pin both halves plus the no-flag default. Pure unit tests, no DB.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from core_api.constants import ENTITY_LOOKUP_MAX_MATCHES
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search.classify_query import ClassifyQuery
+from core_api.pipeline.steps.search.parallel_embed_entity_boost import (
+    ParallelEmbedAndEntityBoost,
+)
+from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+_EMBED_PATH = "core_api.pipeline.steps.search.parallel_embed_entity_boost._get_or_cache_embedding"
+_BOOST_PATH = "core_api.pipeline.steps.search.parallel_embed_entity_boost._entity_boost_via_storage"
+_CLASSIFY_SC_PATH = "core_api.pipeline.steps.search.classify_query.get_storage_client"
+
+_BOOST_LOGGER = "core_api.pipeline.steps.search.parallel_embed_entity_boost"
+
+_DUMMY_EMBED = [0.1] * 1536
+
+
+def _boost_ctx(extra: dict | None = None) -> PipelineContext:
+    data = {
+        "query": "test",
+        "tenant_id": "t1",
+        "tenant_config": None,
+        "search_params": {"graph_max_hops": 2},
+        "graph_expand": True,
+        "fleet_ids": ["fleet-1"],
+    }
+    if extra:
+        data.update(extra)
+    return PipelineContext(db=AsyncMock(), data=data)
+
+
+def _classify_ctx() -> PipelineContext:
+    return PipelineContext(
+        db=AsyncMock(),
+        data={
+            "query": "What is Comet 0002's launch_date?",
+            "tenant_id": "t1",
+            "fleet_ids": ["fleet-1"],
+            "search_params": {"graph_max_hops": 2, "top_k": 10, "fts_weight": 0.3},
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# ParallelEmbedAndEntityBoost honours the flag
+# ---------------------------------------------------------------------------
+
+
+async def test_declined_flag_skips_entity_boost(caplog):
+    """Flag set → boost helper never invoked; embedding still populated."""
+    caplog.set_level(logging.INFO, logger=_BOOST_LOGGER)
+
+    async def fast_embed(*args, **kwargs):
+        return _DUMMY_EMBED
+
+    boost_mock = AsyncMock(return_value=({uuid4()}, {uuid4(): 1.3}))
+
+    ctx = _boost_ctx({"entity_match_declined": True})
+    with (
+        patch(_EMBED_PATH, side_effect=fast_embed),
+        patch(_BOOST_PATH, boost_mock),
+    ):
+        await ParallelEmbedAndEntityBoost().execute(ctx)
+
+    boost_mock.assert_not_called()
+    assert ctx.data["embedding"] == _DUMMY_EMBED
+    assert ctx.data["boosted_memory_ids"] == set()
+    assert ctx.data["memory_boost_factor"] == {}
+    assert any("entity boost skipped" in r.message for r in caplog.records)
+
+
+async def test_without_flag_entity_boost_still_runs():
+    """No flag → prior behaviour intact: boost results flow into ctx.data."""
+    boosted = {uuid4()}
+    factors = {next(iter(boosted)): 1.3}
+
+    async def fast_embed(*args, **kwargs):
+        return _DUMMY_EMBED
+
+    boost_mock = AsyncMock(return_value=(boosted, factors))
+
+    ctx = _boost_ctx()
+    with (
+        patch(_EMBED_PATH, side_effect=fast_embed),
+        patch(_BOOST_PATH, boost_mock),
+    ):
+        await ParallelEmbedAndEntityBoost().execute(ctx)
+
+    boost_mock.assert_called_once()
+    assert ctx.data["boosted_memory_ids"] == boosted
+    assert ctx.data["memory_boost_factor"] == factors
+
+
+# ---------------------------------------------------------------------------
+# ClassifyQuery sets the flag
+# ---------------------------------------------------------------------------
+
+
+async def test_classifier_sets_flag_on_overbroad_decline():
+    """> ENTITY_LOOKUP_MAX_MATCHES entity matches → decline + flag + fallthrough."""
+    over_broad = [uuid4() for _ in range(ENTITY_LOOKUP_MAX_MATCHES + 1)]
+
+    ctx = _classify_ctx()
+    with (
+        patch(_CLASSIFY_SC_PATH, return_value=AsyncMock()),
+        patch.object(ClassifyQuery, "_entity_fts", AsyncMock(return_value=over_broad)),
+    ):
+        await ClassifyQuery().execute(ctx)
+
+    assert ctx.data.get("entity_match_declined") is True
+    assert ctx.data["retrieval_plan"].strategy is RetrievalStrategy.SEMANTIC_SEARCH
+
+
+async def test_classifier_leaves_flag_unset_when_no_entity_match():
+    """Zero entity matches → ordinary fallthrough, flag absent."""
+    ctx = _classify_ctx()
+    with (
+        patch(_CLASSIFY_SC_PATH, return_value=AsyncMock()),
+        patch.object(ClassifyQuery, "_entity_fts", AsyncMock(return_value=[])),
+    ):
+        await ClassifyQuery().execute(ctx)
+
+    assert "entity_match_declined" not in ctx.data
+    assert ctx.data["retrieval_plan"].strategy is RetrievalStrategy.SEMANTIC_SEARCH


### PR DESCRIPTION
## Problem

S1 retrieval@10 collapses at corpus scale even after #304: **22/25 @ K=1000 → 11/25 @ K=10000** (10,000 entity-attribute facts, 50-query replay).

Per-failure anatomy (`Comet #0002's launch_date`, gold present in DB among 272 `Comet #NNNN launch_date` siblings / 813 distinct Comet entities):

- The CAURA-698 decline fires identically at both corpus sizes (86 and 815 entity-FTS matches > `ENTITY_LOOKUP_MAX_MATCHES=20`; the entity FTS is OR-over-tokens, so `comet` alone matches every sibling). Both route to `semantic_search` — the decline does not explain the collapse.
- On pure hybrid scoring the gold ranks **#1**: vec_sim 0.9084 vs 0.8651 for the best sibling, and it is the only row matching the FTS query (its tsvector contains `0002`).
- What buries it: `ParallelEmbedAndEntityBoost` re-runs the same tokenizer + entity FTS **with no knowledge of the classifier's decline**, re-derives the same over-broad match, and hands `GRAPH_HOP_BOOST[0]=1.3` to the first `GRAPH_MAX_BOOSTED_MEMORIES=50` memory links it encounters. With hundreds of entities tied at hop 0, link order is arbitrary — the boost is a fixed-50 lottery over the sibling pool. P(gold boosted) ≈ 50/N_siblings: ~57% at K=1000 (gold boosted → rank 1, verified live), ~6% at K=10000 (gold unboosted at ~0.66 buried under ~50 boosted siblings at 0.78–0.85).

One step concludes the entity match is too broad to mean anything and discards it; the next step recomputes the identical match and acts on it.

## Fix

Thread the verdict through the pipeline context:

- `ClassifyQuery` sets `ctx.data["entity_match_declined"] = True` when the CAURA-698 decline fires.
- `ParallelEmbedAndEntityBoost` skips its entity-boost leg on that flag (embedding — the critical path — is unaffected; without the flag, behavior is unchanged).

## Measurements (S1 replay, local stack, retrieval@10)

| configuration | K=1000 | K=10000 |
|---|---|---|
| main (#304) | 22/25 | 11/25 |
| this fix | 22/25 (no regression) | 16/25 |
| this fix, `search.recall_boost=false` pinned (deterministic replay) | 22/25 | **18/25** |

The recall_boost pin removes reused-tenant contamination: `TrackRecalls` increments `recall_count` on returned rows, so earlier replays had fed recall_boost to the wrong siblings they returned. Remaining K=10000 misses are pre-existing classes (person-hub expansion, true semantic near-duplicate dilution) tracked as A30 — the exact-first cascade.

## Tests

- `tests/test_skip_entity_boost_on_decline.py` — 4 new unit tests pinning both halves of the flag plus the no-flag default (boost still runs).
- Adjacent `tests/test_d7_parallel_embed_per_task_timeout.py` (7 tests) still green — the None-task guards preserve the D7 split-budget contract.
- `ruff check` / `ruff format` / `mypy` clean on touched files.

Regression bench used for the numbers: `caura-bench-memcomp/scripts/s1_regression_bench.py` (replay-only against seeded k1k/k10k tenants, committed baselines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)