### PR TITLE
fix(logging): reroute idempotency guard mis-keys on captured handlers

### DIFF
--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -329,7 +329,7 @@ def configure_logging(
 # ``Config.configure_logging()`` runs at server start; if our
 # ``configure_logging()`` is called at module import (the typical app.py
 # path), the uvicorn loggers may not yet have their handlers when we
-# iterate. The function logs a debug line in that case so the caller can
+# iterate. The function logs a WARNING in that case so the caller can
 # move the call into an ASGI lifespan startup handler if production logs
 # show un-rerouted output.
 _THIRD_PARTY_LOGGERS_TO_REROUTE: tuple[str, ...] = (
@@ -376,13 +376,16 @@ def _route_third_party_to_root() -> None:
     """
     for name in _THIRD_PARTY_LOGGERS_TO_REROUTE:
         lg = logging.getLogger(name)
-        # Skip iff the snapshot says we already did the work (had handlers
-        # captured). Lets a re-call (e.g. from an ASGI lifespan startup
-        # after uvicorn initialised) idempotently no-op.
-        already_rerouted = name in _third_party_logger_original_state and bool(
-            _third_party_logger_original_state[name][0]
-        )
-        if already_rerouted:
+        # Skip iff the snapshot has this logger: the snapshot is stored
+        # only when rerouting actually ran (the uninitialised early-exit
+        # below continues before it), so presence in the dict is the
+        # complete "work was done" signal. Keying on captured handlers
+        # instead would mis-handle a logger rerouted from
+        # ``propagate=False, no-handlers`` (snapshot ``([], False, lvl)``)
+        # — a re-call (e.g. from an ASGI lifespan startup after uvicorn
+        # initialised) would fall through to the early-exit branch and
+        # emit a spurious WARNING about rerouting being a no-op.
+        if name in _third_party_logger_original_state:
             continue
         # Library may not have initialised this logger yet — there's nothing
         # to reroute right now. Don't snapshot the empty state (would freeze

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -135,6 +135,39 @@ def test_route_third_party_to_root_is_idempotent() -> None:
         assert lg.propagate == snapshot[name][1]
 
 
+def test_route_third_party_to_root_recall_after_handlerless_reroute_no_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A logger rerouted from ``propagate=False, no-handlers`` (snapshot
+    ``([], False, lvl)``) must be treated as already-done on a re-call.
+    Pre-fix, the idempotency guard keyed on captured handlers being
+    non-empty, so the re-call fell through to the uninitialised early-exit
+    branch and emitted a spurious 'rerouting was a no-op' WARNING."""
+    target = logging.getLogger(_THIRD_PARTY_LOGGERS_TO_REROUTE[0])
+    _third_party_logger_original_state.clear()
+    for h in list(target.handlers):
+        target.removeHandler(h)
+    target.propagate = False
+    target.setLevel(logging.WARNING)
+    try:
+        _route_third_party_to_root()  # reroutes: propagate False→True
+        assert target.propagate is True
+        with caplog.at_level(logging.WARNING, logger="common.structlog_config"):
+            _route_third_party_to_root()  # re-call must be a silent no-op
+        # Other listed loggers may legitimately warn (uninitialised in the
+        # test env) — only the already-rerouted target must stay silent.
+        assert not [
+            r
+            for r in caplog.records
+            if "rerouting was a no-op" in r.getMessage()
+            and repr(target.name) in r.getMessage()
+        ], "re-call after a handler-less reroute must not warn for that logger"
+    finally:
+        target.setLevel(logging.NOTSET)
+        target.propagate = True
+        _third_party_logger_original_state.clear()
+
+
 def test_route_third_party_to_root_preserves_operator_set_level_when_no_handlers() -> (
     None
 ):


### PR DESCRIPTION
## Why

`_route_third_party_to_root`'s already-rerouted check required the snapshot's handler list to be non-empty, so a logger rerouted from `propagate=False, no-handlers` (snapshot `([], False, lvl)`) was never considered done — a re-call (e.g. ASGI lifespan startup after uvicorn initialised) fell through to the uninitialised early-exit branch and emitted a spurious **'rerouting was a no-op' WARNING** in Cloud Logging.

## What

- Key the idempotency guard on snapshot presence alone — the snapshot is only stored when rerouting actually ran, so `name in dict` is the complete signal.
- Fix the module comment claiming the uninitialised case 'logs a debug line' (it logs a WARNING).
- Regression test for the handler-less reroute + re-call path — verified to fail pre-fix and pass post-fix.

Found by review on caura-memclaw-enterprise#423 (the enterprise vendor of this file); the enterprise copy will be re-vendored from this.

## Verification
- `pytest tests/test_logging.py` → 21 passed.
- `ruff check` + `ruff format --check` clean.
- DCO signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)