### PR TITLE
fix(events): pubsub shutdown never flushed the publisher — final batches silently lost

### DIFF
--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -396,11 +396,16 @@ class PubSubEventBus(EventBus):
         # (admin-API request handlers await this, so queued publish
         # threads translate directly to queued requests).
         #
-        # At-least-once is preserved: stop()'s shutdown(wait=True) on the
-        # publish executor drains any in-flight batches before the
-        # process exits. The tradeoff is that we no longer surface
-        # per-message publish errors to the caller — publisher-side
-        # failures land in the SDK's background-thread log instead.
+        # At-least-once is preserved ONLY if stop() runs before process
+        # exit: the executor shutdown drains the enqueue calls, and
+        # stop()'s publisher.stop() commits the client's outstanding
+        # batches (the actual transmission happens on the SDK's
+        # background commit thread, NOT in the executor). Short-lived
+        # processes that publish and exit without awaiting stop() lose
+        # whatever is still batched. The tradeoff is that we no longer
+        # surface per-message publish errors to the caller —
+        # publisher-side failures (e.g. a 403 on the topic) land in the
+        # SDK's background-thread log instead.
         # For a fire-and-forget audit path that is the right shape.
         # Stamp the publishing environment so sibling environments that
         # share this project's topics can drop our fan-out copies (see
@@ -893,11 +898,23 @@ class PubSubEventBus(EventBus):
                 pub = self._publisher
                 self._publisher = None
                 try:
-                    await loop.run_in_executor(None, pub.close)
+                    # PublisherClient has no close(); its shutdown API is
+                    # stop(): commits every outstanding batch and joins
+                    # the background commit thread. This is the ONLY real
+                    # flush in the pipeline — publish() is fire-and-forget
+                    # into the client's batch queue, so the old code here
+                    # (calling the nonexistent close() and swallowing the
+                    # AttributeError) silently lost any batch still queued
+                    # at shutdown. Long-running services rarely noticed
+                    # (the commit thread transmits within ~10 ms of wall
+                    # clock), but a short-lived process lost its entire
+                    # final batch — verified in prod 2026-06-11 when a
+                    # backfill CLI run lost all 16 published events.
+                    await loop.run_in_executor(None, pub.stop)
                 except Exception:
                     close_failure_count += 1
                     logger.exception(
-                        "pubsub publisher.close() failed; continuing teardown"
+                        "pubsub publisher.stop() failed; continuing teardown"
                     )
             teardown_complete = True
         finally:

--- a/core-worker/src/core_worker/cli.py
+++ b/core-worker/src/core_worker/cli.py
@@ -18,6 +18,7 @@ import asyncio
 import logging
 import sys
 
+from common.events.factory import get_event_bus
 from core_worker.backfill import run_embedding_backfill
 from core_worker.clients.storage_client import close_storage_client
 
@@ -66,6 +67,24 @@ async def _amain(argv: list[str]) -> int:
                 dry_run=args.dry_run,
             )
         finally:
+            # Drain the event bus BEFORE exiting: publish() is
+            # fire-and-forget into the Pub/Sub client's batch queue, and
+            # only bus.stop() (→ PublisherClient.stop()) commits the
+            # outstanding batches. Without this, a short-lived CLI run
+            # exits with its final batch un-transmitted — the backfill
+            # reports published=N while zero events reach the topic
+            # (observed in prod 2026-06-11: all 16 events of a tenant
+            # backfill silently lost).
+            #
+            # Guarded: get_event_bus() itself can raise (RuntimeError on
+            # missing pubsub env vars, ValueError on unknown backend) if
+            # the singleton was never constructed during the run — a
+            # raise here inside the finally would mask the backfill's
+            # original exception, hiding the real failure.
+            try:
+                await get_event_bus().stop()
+            except Exception:
+                logging.getLogger(__name__).exception("event bus stop failed; continuing teardown")
             # Close the singleton httpx client so the event-loop exits
             # cleanly. Mirrors the FastAPI lifespan shutdown.
             await close_storage_client()

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -21,7 +21,11 @@ from common.events import Event, PubSubEventBus, Topics
 def bus() -> PubSubEventBus:
     b = PubSubEventBus(project_id="proj", subscription_prefix="test")
     # Pre-install a fake publisher so publish() doesn't touch the SDK.
-    fake_publisher = MagicMock()
+    # spec-limited to the real PublisherClient surface we rely on: a
+    # permissive MagicMock happily accepts .close(), which is exactly
+    # how the stop()-calls-nonexistent-close() bug survived these tests
+    # (PublisherClient has stop(), not close()).
+    fake_publisher = MagicMock(spec=["topic_path", "publish", "stop"])
     fake_publisher.topic_path = lambda proj, topic: f"projects/{proj}/topics/{topic}"
     future = MagicMock()
     future.result = MagicMock(return_value="msg-id-1")
@@ -247,16 +251,22 @@ async def test_stop_cancels_pending_pull_tasks_cleanly(bus: PubSubEventBus) -> N
 
 
 async def test_stop_closes_publisher_and_subscriber(bus: PubSubEventBus) -> None:
-    # Both clients own gRPC channels + threads; stop() must call close()
-    # on each and null the references out.
+    # Both clients own gRPC channels + threads; stop() must shut each
+    # down via its REAL API and null the references out. The APIs are
+    # asymmetric: SubscriberClient has close(); PublisherClient has
+    # stop() (commits outstanding batches + joins the commit thread —
+    # the only flush in the pipeline, since publish() is fire-and-
+    # forget). The fixture's publisher mock is spec-limited so calling
+    # a nonexistent close() on it would raise instead of silently
+    # passing.
     fake_subscriber = MagicMock()
     bus._subscriber = fake_subscriber
-    # bus._publisher is already a MagicMock from the fixture.
+    # bus._publisher is already a spec-limited MagicMock from the fixture.
     publisher_ref = bus._publisher
 
     await bus.stop()
 
-    publisher_ref.close.assert_called_once()
+    publisher_ref.stop.assert_called_once()
     fake_subscriber.close.assert_called_once()
     assert bus._publisher is None
     assert bus._subscriber is None
@@ -271,11 +281,12 @@ async def test_stop_teardown_order(
     #              `_pull_loop` short-circuits on `_stopping` so the
     #              gRPC error is absorbed quietly.
     #   - PUBLISH: drain exec FIRST so in-flight publish() threads
-    #              complete on a live channel, then close publisher.
-    #              Reverse order would lose messages already en route.
+    #              complete on a live channel, then publisher.stop()
+    #              commits the outstanding client batches. Reverse
+    #              order would lose messages already en route.
     # Expected call order:
     #   subscriber.close → pull-exec.shutdown
-    #     → publish-exec.shutdown → publisher.close
+    #     → publish-exec.shutdown → publisher.stop
     calls: list[str] = []
 
     pull_exec = MagicMock()
@@ -296,7 +307,7 @@ async def test_stop_teardown_order(
     bus._subscriber = fake_subscriber
 
     publisher = bus._publisher
-    publisher.close = MagicMock(side_effect=lambda: calls.append("publisher.close"))
+    publisher.stop = MagicMock(side_effect=lambda: calls.append("publisher.stop"))
 
     await bus.stop()
 
@@ -304,7 +315,7 @@ async def test_stop_teardown_order(
         "subscriber.close",
         "pull-exec.shutdown",
         "pub-exec.shutdown",
-        "publisher.close",
+        "publisher.stop",
     ]
     pull_exec.shutdown.assert_called_once_with(True)
     pub_exec.shutdown.assert_called_once_with(True)
@@ -491,7 +502,7 @@ async def test_stop_keeps_pull_tasks_populated_through_teardown(
     sub_mock.close = MagicMock(side_effect=record_len_during_close)
     bus._subscriber = sub_mock
 
-    bus._publisher.close = MagicMock(side_effect=record_len_during_close)
+    bus._publisher.stop = MagicMock(side_effect=record_len_during_close)
 
     await bus.stop()
 
@@ -1041,7 +1052,9 @@ async def _drive_one_batch(bus: PubSubEventBus, received: list[Any]) -> dict[str
 
 
 async def test_publish_stamps_source_env_attribute() -> None:
-    bus = PubSubEventBus(project_id="proj", subscription_prefix="test", env="production")
+    bus = PubSubEventBus(
+        project_id="proj", subscription_prefix="test", env="production"
+    )
     fake_publisher = MagicMock()
     fake_publisher.topic_path = lambda proj, topic: f"projects/{proj}/topics/{topic}"
     fake_publisher.publish = MagicMock(return_value=MagicMock())
@@ -1071,7 +1084,9 @@ async def test_env_is_normalised_and_empty_collapses_to_none() -> None:
         PubSubEventBus(project_id="p", subscription_prefix="s", env=" production ")._env
         == "production"
     )
-    assert PubSubEventBus(project_id="p", subscription_prefix="s", env="   ")._env is None
+    assert (
+        PubSubEventBus(project_id="p", subscription_prefix="s", env="   ")._env is None
+    )
     assert PubSubEventBus(project_id="p", subscription_prefix="s", env="")._env is None
     assert PubSubEventBus(project_id="p", subscription_prefix="s")._env is None
 
@@ -1097,7 +1112,9 @@ async def test_foreign_source_env_decision_matrix() -> None:
 
 
 async def test_pull_loop_drops_foreign_env_message_before_dispatch() -> None:
-    bus = PubSubEventBus(project_id="proj", subscription_prefix="test", env="production")
+    bus = PubSubEventBus(
+        project_id="proj", subscription_prefix="test", env="production"
+    )
     foreign = _make_received(
         b'{"event_type": "memclaw.memory.embedded"}',
         "ack-foreign",
@@ -1113,7 +1130,9 @@ async def test_pull_loop_drops_foreign_env_message_before_dispatch() -> None:
 
 
 async def test_pull_loop_processes_same_env_message() -> None:
-    bus = PubSubEventBus(project_id="proj", subscription_prefix="test", env="production")
+    bus = PubSubEventBus(
+        project_id="proj", subscription_prefix="test", env="production"
+    )
     local = _make_received(
         b'{"event_type": "memclaw.memory.embedded"}',
         "ack-local",
@@ -1129,7 +1148,9 @@ async def test_pull_loop_processes_same_env_message() -> None:
 async def test_pull_loop_processes_message_without_source_env_attribute() -> None:
     # A publisher that predates the attribute (or an external producer) must
     # still be processed — the guard only drops *provably* foreign messages.
-    bus = PubSubEventBus(project_id="proj", subscription_prefix="test", env="production")
+    bus = PubSubEventBus(
+        project_id="proj", subscription_prefix="test", env="production"
+    )
     legacy = _make_received(
         b'{"event_type": "memclaw.memory.embedded"}', "ack-legacy", {}
     )


### PR DESCRIPTION
## Why

`PubSubEventBus.stop()` calls `publisher.close()` — **which doesn't exist on `PublisherClient`** (that's a SubscriberClient method). The AttributeError is swallowed by the per-step guard and logged as `publisher.close() failed; continuing teardown` on every service shutdown (visible in prod logs today). The real API is `PublisherClient.stop()`: commits outstanding batches + joins the commit thread — and it's the **only** flush in the pipeline, since `publish()` is fire-and-forget into the client's batch queue.

**Impact**: long-running services rarely notice (the commit thread transmits within ~10ms), but short-lived processes lose their entire final batch. Verified in prod 2026-06-11: a tenant re-embed backfill (`core_worker.cli backfill-embeddings`) reported `published=16` while **zero events reached the topic** — confirmed via topic `send_message_operation_count` and a probe job that awaited the publish future.

## What

- `stop()` → `publisher.stop()` (drains); log message updated.
- `core_worker.cli` drains the bus in its `finally` (the prod incident's direct trigger).
- Corrected `publish()`'s at-least-once comment (only holds when `stop()` runs before exit).
- Test publisher mocks **spec-limited** to the real client surface — a permissive `MagicMock` accepting `.close()` is exactly how this survived the existing `stop()` tests. Assertions moved to `.stop()`.

## Verification

- `pytest tests/test_events/` → 80 passed; `tests/test_logging.py` unaffected (21 passed).
- `ruff check` + `ruff format --check` clean. DCO signed.
- Operationally proven in prod: re-running the same backfill with an explicit `PublisherClient.stop()` flush delivered 16/16 events (tenant fully re-embedded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)