### PR TITLE
fix(events): publisher candidate cleanups also called the nonexistent close()

### DIFF
--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -240,7 +240,11 @@ class PubSubEventBus(EventBus):
             async def _close_pending() -> None:
                 try:
                     client = await ctor_fut
-                    await loop.run_in_executor(None, client.close)
+                    # stop(), not close(): PublisherClient has no close()
+                    # (same nonexistent-method bug as the stop() teardown
+                    # below — here it only leaked the SDK's commit thread
+                    # since an uninstalled candidate has no batches).
+                    await loop.run_in_executor(None, client.stop)
                 except BaseException:
                     # ``BaseException`` (not ``Exception``) — this is a
                     # fire-and-forget background task; if the event loop
@@ -248,7 +252,7 @@ class PubSubEventBus(EventBus):
                     # ``CancelledError`` would otherwise surface as
                     # "Task exception was never retrieved" log noise.
                     logger.debug(
-                        "pubsub: cancelled-publisher close failed", exc_info=True
+                        "pubsub: cancelled-publisher stop failed", exc_info=True
                     )
 
             self._spawn_background_task(_close_pending())
@@ -267,10 +271,10 @@ class PubSubEventBus(EventBus):
 
             async def _close_post_stop() -> None:
                 try:
-                    await loop.run_in_executor(None, candidate.close)
+                    await loop.run_in_executor(None, candidate.stop)
                 except BaseException:
                     logger.debug(
-                        "pubsub: post-stop candidate close failed", exc_info=True
+                        "pubsub: post-stop candidate stop failed", exc_info=True
                     )
 
             self._spawn_background_task(_close_post_stop())
@@ -293,7 +297,7 @@ class PubSubEventBus(EventBus):
             # is synchronous and doesn't yield.)
             async def _close_loser() -> None:
                 try:
-                    await loop.run_in_executor(None, candidate.close)
+                    await loop.run_in_executor(None, candidate.stop)
                 except BaseException:
                     # ``BaseException`` so a shutdown-time cancellation
                     # of this background task doesn't surface as "Task

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -706,10 +706,11 @@ async def test_ensure_publisher_closes_losing_candidate_on_toctou_race(
 
     class FakePublisherClient:
         def __init__(self):
-            self.closed = False
+            self.stopped = False
 
-        def close(self):
-            self.closed = True
+        def stop(self):
+            # The real PublisherClient teardown API (it has no close()).
+            self.stopped = True
             closed.append(self)
 
     fake_sdk = types.SimpleNamespace(PublisherClient=FakePublisherClient)
@@ -754,7 +755,7 @@ async def test_ensure_publisher_closes_losing_candidate_on_toctou_race(
 async def test_ensure_publisher_returns_winner_when_stop_races_close(
     bus: PubSubEventBus,
 ) -> None:
-    """3-way race: TOCTOU loser awaits ``candidate.close()`` and during
+    """3-way race: TOCTOU loser awaits ``candidate.stop()`` and during
     that yield ``stop()`` clears ``_publisher``. The loser must return
     the captured winner — not the now-None ``_publisher`` — otherwise
     ``publish()`` crashes on ``None.topic_path(...)``."""
@@ -763,10 +764,11 @@ async def test_ensure_publisher_returns_winner_when_stop_races_close(
 
     class FakePublisherClient:
         def __init__(self):
-            self.closed = False
+            self.stopped = False
 
-        def close(self):
-            self.closed = True
+        def stop(self):
+            # The real PublisherClient teardown API (it has no close()).
+            self.stopped = True
 
     fake_sdk = types.SimpleNamespace(PublisherClient=FakePublisherClient)
     bus._publisher = None
@@ -779,7 +781,7 @@ async def test_ensure_publisher_returns_winner_when_stop_races_close(
             # Inject the winner before the candidate-construction await resolves.
             bus._publisher = winning
             return await real_run(executor, fn, *args)
-        # Second call is candidate.close() — simulate stop() racing in.
+        # Second call is candidate.stop() — simulate stop() racing in.
         bus._publisher = None
         return await real_run(executor, fn, *args)
 


### PR DESCRIPTION
Follow-up to #330 (raced its merge — this was meant as an amendment). The three fire-and-forget publisher-**candidate** cleanup paths (`_close_pending`, `_close_post_stop`, `_close_loser`) had the same nonexistent-`PublisherClient.close()` bug: no data loss (an uninstalled candidate has no batches), but the swallowed AttributeError meant the SDK commit thread was never joined — a thread leak + debug-log noise on every TOCTOU/cancelled construction.

- All three now call `candidate.stop()`; log messages updated.
- TOCTOU test fakes now model the real `PublisherClient` surface (`stop()`, no `close()`) so a regression can't pass.
- Subscriber-side `close()` calls untouched (valid API there).

80 events tests green; ruff check + format clean; DCO signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)