### PR TITLE
fix(storage-client): retry POSTs on connection-phase failures — never-sent requests cannot double-insert

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -34,11 +34,18 @@ logger = logging.getLogger(__name__)
 #  - Max 3 attempts (1 initial + 2 retries)
 #  - Exponential backoff with jitter: ~0.2s, ~0.4s
 #  - Worst-case added latency: < 1s
-#  - Retryable on idempotent HTTP methods only (GET, PATCH, DELETE).
-#    POST is intentionally NOT retried: storage creates don't have
-#    server-side idempotency keys, so a POST retry after a partial
-#    success would double-insert. POST retries are a follow-up
-#    once idempotency-key support lands storage-side.
+#  - Idempotent HTTP methods (GET, PATCH, DELETE) retry the full
+#    transient set below plus retryable 5xx statuses.
+#  - POST retries connection-phase failures ONLY (ConnectTimeout /
+#    ConnectError / PoolTimeout — all raised before a single request
+#    byte is written, so a retry cannot double-insert). ReadTimeout
+#    and 5xx are NOT retried for POST: the request reached storage
+#    and may have committed; safe retry there needs idempotency-key
+#    support storage-side. Connection-phase loss was observed in prod
+#    2026-06-11: `find_similar_candidates` (contradiction detection,
+#    42 failures) and `create_audit_logs_bulk` (audit events dropped)
+#    both died on first-attempt ConnectTimeout behind the VPC
+#    connector while idempotent siblings recovered via retry.
 _RETRY_MAX_ATTEMPTS = 3
 _RETRY_BACKOFF_BASE_S = 0.2
 _RETRYABLE_EXCEPTIONS = (
@@ -52,27 +59,41 @@ _RETRYABLE_EXCEPTIONS = (
     # ConnectTimeout, when the upstream is temporarily unreachable.
     httpx.ConnectError,
 )
+# Failures raised while establishing/acquiring a connection — the
+# request body was never transmitted, so retrying is safe even for
+# non-idempotent methods. ReadTimeout is deliberately absent.
+_CONNECT_PHASE_EXCEPTIONS = (
+    httpx.ConnectTimeout,
+    httpx.ConnectError,
+    httpx.PoolTimeout,
+)
 _RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
+_NO_RETRYABLE_STATUSES: frozenset[int] = frozenset()
 
 
 async def _with_retry(
     do_request: Callable[[], Awaitable[httpx.Response]],
     *,
     label: str,
+    retryable_exceptions: tuple[type[Exception], ...] = _RETRYABLE_EXCEPTIONS,
+    retryable_statuses: frozenset[int] = _RETRYABLE_STATUS_CODES,
 ) -> httpx.Response:
-    """Wrap a single idempotent HTTP call with retry on transient errors.
+    """Wrap a single HTTP call with retry on transient errors.
 
-    Retries on ``ConnectTimeout`` / ``ReadTimeout`` / ``PoolTimeout``
-    (transient connection issues) and on 5xx responses in
+    Defaults match the idempotent-method policy: retry on
+    ``ConnectTimeout`` / ``ReadTimeout`` / ``PoolTimeout`` (transient
+    connection issues) and on 5xx responses in
     ``_RETRYABLE_STATUS_CODES`` (transient server-side). 4xx (including
     404) and other 2xx/3xx responses are returned immediately —
-    retrying won't change a client error.
+    retrying won't change a client error. Non-idempotent callers pass
+    ``_CONNECT_PHASE_EXCEPTIONS`` / empty statuses to retry only
+    failures where the request was provably never sent.
     """
     last_exc: BaseException | None = None
     for attempt in range(1, _RETRY_MAX_ATTEMPTS + 1):
         try:
             resp = await do_request()
-        except _RETRYABLE_EXCEPTIONS as e:
+        except retryable_exceptions as e:
             last_exc = e
             if attempt < _RETRY_MAX_ATTEMPTS:
                 delay = _RETRY_BACKOFF_BASE_S * (2 ** (attempt - 1))
@@ -95,7 +116,7 @@ async def _with_retry(
                 _RETRY_MAX_ATTEMPTS,
             )
             raise
-        if resp.status_code in _RETRYABLE_STATUS_CODES and attempt < _RETRY_MAX_ATTEMPTS:
+        if resp.status_code in retryable_statuses and attempt < _RETRY_MAX_ATTEMPTS:
             delay = _RETRY_BACKOFF_BASE_S * (2 ** (attempt - 1))
             delay *= 1.0 + random.uniform(-0.1, 0.1)
             logger.warning(
@@ -113,6 +134,24 @@ async def _with_retry(
     if last_exc is not None:
         raise last_exc
     raise RuntimeError("storage_client retry loop exited without response or exception")
+
+
+async def _post_with_retry(
+    do_request: Callable[[], Awaitable[httpx.Response]],
+    *,
+    label: str,
+) -> httpx.Response:
+    """Retry policy for non-idempotent POSTs, encoded in one place.
+
+    Connection-phase failures only — the request was provably never
+    sent, so a retry cannot double-insert. No status-based retries.
+    """
+    return await _with_retry(
+        do_request,
+        label=label,
+        retryable_exceptions=_CONNECT_PHASE_EXCEPTIONS,
+        retryable_statuses=_NO_RETRYABLE_STATUSES,
+    )
 
 
 class KeystoneUpsertPayload(TypedDict):
@@ -309,11 +348,15 @@ class CoreStorageClient:
         http = self._read_http if read else self._http
         prefix = self._read_prefix if read else self._prefix
         headers = await self._auth_headers(read=read)
-        resp = await http.post(
-            f"{prefix}{path}",
-            json=data if data is not None else {},
-            headers=headers,
-        )
+
+        async def _do() -> httpx.Response:
+            return await http.post(
+                f"{prefix}{path}",
+                json=data if data is not None else {},
+                headers=headers,
+            )
+
+        resp = await _post_with_retry(_do, label=f"POST {path}")
         self._maybe_evict_on_auth_error(resp, read=read)
         resp.raise_for_status()
         return resp.json()
@@ -348,11 +391,15 @@ class CoreStorageClient:
         http = self._read_http if read else self._http
         prefix = self._read_prefix if read else self._prefix
         headers = await self._auth_headers(read=read)
-        resp = await http.post(
-            f"{prefix}{path}",
-            json=data if data is not None else {},
-            headers=headers,
-        )
+
+        async def _do() -> httpx.Response:
+            return await http.post(
+                f"{prefix}{path}",
+                json=data if data is not None else {},
+                headers=headers,
+            )
+
+        resp = await _post_with_retry(_do, label=f"POST {path}")
         if resp.status_code == 404:
             return None
         self._maybe_evict_on_auth_error(resp, read=read)
@@ -1243,16 +1290,20 @@ class CoreStorageClient:
         between the conflicting INSERT and our follow-up SELECT.
         """
         headers = await self._auth_headers(read=False)
-        resp = await self._http.post(
-            f"{self._prefix}/idempotency/claim",
-            json={
-                "tenant_id": tenant_id,
-                "idempotency_key": idempotency_key,
-                "request_hash": request_hash,
-                "expires_at": expires_at,
-            },
-            headers=headers,
-        )
+
+        async def _do() -> httpx.Response:
+            return await self._http.post(
+                f"{self._prefix}/idempotency/claim",
+                json={
+                    "tenant_id": tenant_id,
+                    "idempotency_key": idempotency_key,
+                    "request_hash": request_hash,
+                    "expires_at": expires_at,
+                },
+                headers=headers,
+            )
+
+        resp = await _post_with_retry(_do, label="POST /idempotency/claim")
         self._maybe_evict_on_auth_error(resp, read=False)
         if resp.status_code == 201:
             return True, resp.json()

--- a/tests/test_storage_client_retry.py
+++ b/tests/test_storage_client_retry.py
@@ -12,18 +12,21 @@ current main (no retry logic exists in ``storage_client._get`` /
 ``_get_list`` / ``_patch`` / ``_delete``). Implementation makes
 them pass.
 
-Scope: retries are added ONLY to idempotent methods (GET, PATCH,
-DELETE). POST is left alone — entity-extraction's create path goes
-through POST and create-without-idempotency-key would risk double-
-inserts on retry. POST retries can be added later if needed once
-storage-side idempotency keys are in place.
+Scope: idempotent methods (GET, PATCH, DELETE) retry the full
+transient set. POST retries connection-phase failures ONLY
+(ConnectTimeout / ConnectError / PoolTimeout — raised before any
+request byte is written, so a retry cannot double-insert); it does
+NOT retry ReadTimeout or 5xx, where the request may have committed
+storage-side. Full POST retry semantics still require idempotency
+keys storage-side.
 
 Retry policy
 ────────────
 - Max 3 attempts (1 initial + 2 retries)
 - Retryable exceptions: ``httpx.ConnectTimeout``, ``httpx.ReadTimeout``,
-  ``httpx.PoolTimeout``
-- Retryable HTTP statuses: 502, 503, 504
+  ``httpx.PoolTimeout`` (idempotent methods); connection-phase subset
+  for POST
+- Retryable HTTP statuses: 502, 503, 504 (idempotent methods only)
 - Exponential backoff with small jitter, capped: ~0.2s, ~0.4s
 - Worst-case added latency: < 1s
 """
@@ -217,20 +220,95 @@ async def test_patch_does_not_retry_on_404() -> None:
 
 
 # ---------------------------------------------------------------------------
-# POST is NOT retried (non-idempotent without storage-side idempotency keys)
+# POST retries connection-phase failures ONLY (request provably never sent)
 # ---------------------------------------------------------------------------
+#
+# Prod 2026-06-11: contradiction detection (find_similar_candidates)
+# failed 42× and the audit flusher (create_audit_logs_bulk) dropped
+# events — every one a first-attempt ConnectTimeout behind the VPC
+# connector. ConnectTimeout / ConnectError / PoolTimeout are all raised
+# before a single request byte is written, so retrying them cannot
+# double-insert. ReadTimeout and 5xx stay non-retried for POST: the
+# request reached storage and may have committed.
 
 
-async def test_post_does_not_retry_on_connect_timeout() -> None:
-    """POST endpoints in storage_client include create operations.
-    Retrying a POST that may have succeeded server-side risks duplicate
-    inserts. Retry semantics for POST require an idempotency key
-    upstream — defer that to a follow-up. For now: POST raises on the
-    first transient failure, same as today."""
+async def test_post_retries_on_connect_timeout_then_succeeds() -> None:
+    """The exact prod failure mode: ConnectTimeout on the first attempt
+    (cold connection through the VPC connector), success on retry."""
     client, write, _read = await _make_client()
-    write.post = AsyncMock(side_effect=httpx.ConnectTimeout("would double-create"))
+    write.post = AsyncMock(
+        side_effect=[
+            httpx.ConnectTimeout("simulated cold connection"),
+            _ok_response(200, {"inserted": 1}),
+        ]
+    )
+
+    result = await client._post("/audit-logs/bulk", {"events": [{"a": 1}]})
+
+    assert result == {"inserted": 1}
+    assert write.post.await_count == 2
+
+
+async def test_post_retries_on_connect_error_then_succeeds() -> None:
+    client, write, _read = await _make_client()
+    write.post = AsyncMock(
+        side_effect=[
+            httpx.ConnectError("Name or service not known"),
+            _ok_response(200, {"id": "abc"}),
+        ]
+    )
+
+    result = await client._post("/entities", {"canonical_name": "x"})
+
+    assert result == {"id": "abc"}
+    assert write.post.await_count == 2
+
+
+async def test_post_gives_up_after_max_attempts_on_connect_timeout() -> None:
+    client, write, _read = await _make_client()
+    write.post = AsyncMock(side_effect=httpx.ConnectTimeout("storage unreachable"))
 
     with pytest.raises(httpx.ConnectTimeout):
         await client._post("/entities", {"canonical_name": "x"})
 
+    assert write.post.await_count == 3
+
+
+async def test_post_does_not_retry_on_read_timeout() -> None:
+    """ReadTimeout means the request was sent and the response never
+    arrived — storage may have committed the insert. Retrying would
+    risk a double-insert, so POST must raise immediately."""
+    client, write, _read = await _make_client()
+    write.post = AsyncMock(side_effect=httpx.ReadTimeout("response never arrived"))
+
+    with pytest.raises(httpx.ReadTimeout):
+        await client._post("/entities", {"canonical_name": "x"})
+
     assert write.post.await_count == 1
+
+
+async def test_post_does_not_retry_on_5xx() -> None:
+    """A 5xx response proves the request reached storage — it may have
+    partially committed before failing. No retry for POST."""
+    client, write, _read = await _make_client()
+    write.post = AsyncMock(return_value=_ok_response(503))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client._post("/entities", {"canonical_name": "x"})
+
+    assert write.post.await_count == 1
+
+
+async def test_post_optional_retries_on_connect_timeout_then_succeeds() -> None:
+    client, write, _read = await _make_client()
+    write.post = AsyncMock(
+        side_effect=[
+            httpx.ConnectTimeout("simulated"),
+            _ok_response(200, {"ok": True}),
+        ]
+    )
+
+    result = await client._post_optional("/verification-codes/c1/use")
+
+    assert result == {"ok": True}
+    assert write.post.await_count == 2


### PR DESCRIPTION
## Why

Prod 2026-06-11 (11:30–17:30Z): **42×** `Async contradiction detection failed` (`find_similar_candidates`) and **2×** audit flush failures (`create_audit_logs_bulk` — events permanently lost for the affected tenant). Every single one was a **first-attempt `httpx.ConnectTimeout`** reaching core-storage-api through the VPC connector during the Phase J re-embed backlog drain. Idempotent siblings (GET/PATCH/DELETE) recovered via the F5 retry wrapper; POST was excluded from retry because a retry after partial success could double-insert.

Note this is a **different leg** than #332: that fixed the AsyncOpenAI/LLM client's connect timeout; these failures are on the core-storage-api client's unretried POSTs and would have continued even with #332 deployed.

## What

The blanket POST exclusion is broader than the safety argument requires. `ConnectTimeout` / `ConnectError` / `PoolTimeout` are all raised **before a single request byte is written** — retrying them cannot duplicate anything. `ReadTimeout` and 5xx stay non-retried for POST (request reached storage, may have committed; safe retry there still needs storage-side idempotency keys).

- `_with_retry` gains `retryable_exceptions` / `retryable_statuses` params — defaults unchanged for idempotent callers.
- `_post_with_retry` encodes the POST policy once (connection-phase exceptions, no status retries); wired into `_post`, `_post_optional`, and the bespoke `claim_idempotency` POST.

## Verification

- `pytest tests/test_storage_client_retry.py tests/test_audit_queue.py tests/test_storage_client_routing.py` → 46 passed. New tests: POST retries ConnectTimeout/ConnectError and recovers; gives up after max attempts; does **not** retry ReadTimeout or 5xx; `_post_optional` covered.
- `ruff check` + `format --check` clean; mypy delta vs main: none (19 pre-existing transitive errors unchanged).

## Follow-up (separate PR)

core-worker's storage client has four unretried POSTs (`archive_expired`, `archive_stale`, `purge_soft_deleted`, `upsert_tenant_suppression`) with the same exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)