### PR TITLE
fix(core-worker): retry connection-phase failures on storage calls — shared policy in common/http_retry

### DIFF
--- a/common/http_retry.py
+++ b/common/http_retry.py
@@ -1,0 +1,161 @@
+"""Transient-error retry policy for core-storage-api HTTP clients.
+
+Shared by core-api's ``CoreStorageClient`` and core-worker's storage
+client so the two cannot silently diverge on what is safe to retry.
+
+History (load-bearing for the policy split):
+
+* F5 — Cloud Run logs over 7 days showed a 31% silent-failure rate on
+  ``process_entity_extraction`` on ``staging-memclaw-core-api``. Every
+  failure traced to ``httpx.ConnectTimeout`` reaching core-storage-api
+  (cold starts / autoscaling). Retry landed for idempotent methods
+  (GET, PATCH, DELETE) only.
+* 2026-06-11 prod incident — ``find_similar_candidates`` (contradiction
+  detection, 42 failures) and ``create_audit_logs_bulk`` (audit events
+  dropped) both died on first-attempt ``ConnectTimeout`` behind the VPC
+  connector because POSTs had no retry at all. Connection-phase retry
+  for non-idempotent methods landed in response (caura-memclaw#333).
+
+Retry policy:
+ - Max 3 attempts (1 initial + 2 retries)
+ - Exponential backoff with jitter: ~0.2s, ~0.4s
+ - Worst-case added latency: < 1s
+ - Idempotent HTTP methods retry ``RETRYABLE_EXCEPTIONS`` plus
+   ``RETRYABLE_STATUS_CODES`` (use :func:`with_retry` defaults).
+ - Non-idempotent methods retry ``CONNECT_PHASE_EXCEPTIONS`` ONLY
+   (use :func:`with_connect_phase_retry`): ConnectTimeout /
+   ConnectError / PoolTimeout are all raised before a single request
+   byte is written, so a retry cannot double-insert. ReadTimeout and
+   5xx are NOT retried there — the request reached storage and may
+   have committed; safe retry needs storage-side idempotency keys.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from collections.abc import Awaitable, Callable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+RETRY_MAX_ATTEMPTS = 3
+RETRY_BACKOFF_BASE_S = 0.2
+RETRYABLE_EXCEPTIONS = (
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+    httpx.PoolTimeout,
+    # ConnectError covers refused / DNS-not-yet-resolved / route-down —
+    # all transient during Cloud Run autoscaling and storage-api
+    # restarts. Local chaos test (docker network disconnect) showed
+    # httpx raises ConnectError("Name or service not known"), not
+    # ConnectTimeout, when the upstream is temporarily unreachable.
+    httpx.ConnectError,
+)
+# Failures raised while establishing/acquiring a connection — the
+# request body was never transmitted, so retrying is safe even for
+# non-idempotent methods. ReadTimeout is deliberately absent.
+CONNECT_PHASE_EXCEPTIONS = (
+    httpx.ConnectTimeout,
+    httpx.ConnectError,
+    httpx.PoolTimeout,
+)
+RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
+NO_RETRYABLE_STATUSES: frozenset[int] = frozenset()
+
+
+async def with_retry(
+    do_request: Callable[[], Awaitable[httpx.Response]],
+    *,
+    label: str,
+    retryable_exceptions: tuple[type[Exception], ...] = RETRYABLE_EXCEPTIONS,
+    retryable_statuses: frozenset[int] = RETRYABLE_STATUS_CODES,
+) -> httpx.Response:
+    """Wrap a single HTTP call with retry on transient errors.
+
+    Defaults match the idempotent-method policy: retry on
+    ``ConnectTimeout`` / ``ReadTimeout`` / ``PoolTimeout`` (transient
+    connection issues) and on 5xx responses in
+    ``RETRYABLE_STATUS_CODES`` (transient server-side). 4xx (including
+    404) and other 2xx/3xx responses are returned immediately —
+    retrying won't change a client error. Non-idempotent callers go
+    through :func:`with_connect_phase_retry` to retry only failures
+    where the request was provably never sent.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, RETRY_MAX_ATTEMPTS + 1):
+        try:
+            resp = await do_request()
+        except retryable_exceptions as e:
+            last_exc = e
+            if attempt < RETRY_MAX_ATTEMPTS:
+                delay = RETRY_BACKOFF_BASE_S * (2 ** (attempt - 1))
+                delay *= 1.0 + random.uniform(-0.1, 0.1)  # ±10% jitter
+                logger.warning(
+                    "storage_client.%s: %s on attempt %d/%d, retrying in %.2fs",
+                    label,
+                    type(e).__name__,
+                    attempt,
+                    RETRY_MAX_ATTEMPTS,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                continue
+            logger.warning(
+                "storage_client.%s: %s on final attempt %d/%d, giving up",
+                label,
+                type(e).__name__,
+                attempt,
+                RETRY_MAX_ATTEMPTS,
+            )
+            raise
+        if resp.status_code in retryable_statuses and attempt < RETRY_MAX_ATTEMPTS:
+            delay = RETRY_BACKOFF_BASE_S * (2 ** (attempt - 1))
+            delay *= 1.0 + random.uniform(-0.1, 0.1)
+            logger.warning(
+                "storage_client.%s: HTTP %d on attempt %d/%d, retrying in %.2fs",
+                label,
+                resp.status_code,
+                attempt,
+                RETRY_MAX_ATTEMPTS,
+                delay,
+            )
+            await asyncio.sleep(delay)
+            continue
+        if resp.status_code in retryable_statuses:
+            # Final attempt still returned a retryable status — mirror the
+            # exception path's "giving up" signal so a 3x-502 incident is
+            # visible as exhausted retries, not just a bare HTTPStatusError
+            # from the caller's raise_for_status().
+            logger.warning(
+                "storage_client.%s: HTTP %d on final attempt %d/%d, giving up",
+                label,
+                resp.status_code,
+                attempt,
+                RETRY_MAX_ATTEMPTS,
+            )
+        return resp
+    # Unreachable — the loop either returns a response or raises.
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("storage_client retry loop exited without response or exception")
+
+
+async def with_connect_phase_retry(
+    do_request: Callable[[], Awaitable[httpx.Response]],
+    *,
+    label: str,
+) -> httpx.Response:
+    """Retry policy for non-idempotent calls, encoded in one place.
+
+    Connection-phase failures only — the request was provably never
+    sent, so a retry cannot double-insert. No status-based retries.
+    """
+    return await with_retry(
+        do_request,
+        label=label,
+        retryable_exceptions=CONNECT_PHASE_EXCEPTIONS,
+        retryable_statuses=NO_RETRYABLE_STATUSES,
+    )

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import random
-from collections.abc import Awaitable, Callable
 from typing import Any, Literal, NotRequired, TypedDict
 
 import httpx
 
 from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
+from common.http_retry import with_connect_phase_retry, with_retry
 from core_api.clients.identity_token import evict as _evict_id_token
 from core_api.clients.identity_token import fetch_auth_header
 from core_api.config import settings
@@ -18,140 +16,11 @@ from core_api.config import settings
 logger = logging.getLogger(__name__)
 
 
-# F5 — transient-error retry policy for idempotent storage calls.
-#
-# Cloud Run logs over 7 days showed a 31% silent-failure rate on
-# ``process_entity_extraction`` (61 failed / 138 succeeded) on
-# ``staging-memclaw-core-api``. Every failure traced to
-# ``httpx.ConnectTimeout`` reaching ``core-storage-api`` from
-# ``upsert_entity`` — storage-api cold starts / autoscaling
-# inconsistencies. The outer ``except Exception`` in
-# ``entity_extraction_worker.process_entity_extraction`` then
-# silently absorbed the timeout, leaving ``entity_links`` empty
-# on user-visible memory rows.
-#
-# Retry policy:
-#  - Max 3 attempts (1 initial + 2 retries)
-#  - Exponential backoff with jitter: ~0.2s, ~0.4s
-#  - Worst-case added latency: < 1s
-#  - Idempotent HTTP methods (GET, PATCH, DELETE) retry the full
-#    transient set below plus retryable 5xx statuses.
-#  - POST retries connection-phase failures ONLY (ConnectTimeout /
-#    ConnectError / PoolTimeout — all raised before a single request
-#    byte is written, so a retry cannot double-insert). ReadTimeout
-#    and 5xx are NOT retried for POST: the request reached storage
-#    and may have committed; safe retry there needs idempotency-key
-#    support storage-side. Connection-phase loss was observed in prod
-#    2026-06-11: `find_similar_candidates` (contradiction detection,
-#    42 failures) and `create_audit_logs_bulk` (audit events dropped)
-#    both died on first-attempt ConnectTimeout behind the VPC
-#    connector while idempotent siblings recovered via retry.
-_RETRY_MAX_ATTEMPTS = 3
-_RETRY_BACKOFF_BASE_S = 0.2
-_RETRYABLE_EXCEPTIONS = (
-    httpx.ConnectTimeout,
-    httpx.ReadTimeout,
-    httpx.PoolTimeout,
-    # ConnectError covers refused / DNS-not-yet-resolved / route-down —
-    # all transient during Cloud Run autoscaling and storage-api
-    # restarts. Local chaos test (docker network disconnect) showed
-    # httpx raises ConnectError("Name or service not known"), not
-    # ConnectTimeout, when the upstream is temporarily unreachable.
-    httpx.ConnectError,
-)
-# Failures raised while establishing/acquiring a connection — the
-# request body was never transmitted, so retrying is safe even for
-# non-idempotent methods. ReadTimeout is deliberately absent.
-_CONNECT_PHASE_EXCEPTIONS = (
-    httpx.ConnectTimeout,
-    httpx.ConnectError,
-    httpx.PoolTimeout,
-)
-_RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
-_NO_RETRYABLE_STATUSES: frozenset[int] = frozenset()
-
-
-async def _with_retry(
-    do_request: Callable[[], Awaitable[httpx.Response]],
-    *,
-    label: str,
-    retryable_exceptions: tuple[type[Exception], ...] = _RETRYABLE_EXCEPTIONS,
-    retryable_statuses: frozenset[int] = _RETRYABLE_STATUS_CODES,
-) -> httpx.Response:
-    """Wrap a single HTTP call with retry on transient errors.
-
-    Defaults match the idempotent-method policy: retry on
-    ``ConnectTimeout`` / ``ReadTimeout`` / ``PoolTimeout`` (transient
-    connection issues) and on 5xx responses in
-    ``_RETRYABLE_STATUS_CODES`` (transient server-side). 4xx (including
-    404) and other 2xx/3xx responses are returned immediately —
-    retrying won't change a client error. Non-idempotent callers pass
-    ``_CONNECT_PHASE_EXCEPTIONS`` / empty statuses to retry only
-    failures where the request was provably never sent.
-    """
-    last_exc: BaseException | None = None
-    for attempt in range(1, _RETRY_MAX_ATTEMPTS + 1):
-        try:
-            resp = await do_request()
-        except retryable_exceptions as e:
-            last_exc = e
-            if attempt < _RETRY_MAX_ATTEMPTS:
-                delay = _RETRY_BACKOFF_BASE_S * (2 ** (attempt - 1))
-                delay *= 1.0 + random.uniform(-0.1, 0.1)  # ±10% jitter
-                logger.warning(
-                    "storage_client.%s: %s on attempt %d/%d, retrying in %.2fs",
-                    label,
-                    type(e).__name__,
-                    attempt,
-                    _RETRY_MAX_ATTEMPTS,
-                    delay,
-                )
-                await asyncio.sleep(delay)
-                continue
-            logger.warning(
-                "storage_client.%s: %s on final attempt %d/%d, giving up",
-                label,
-                type(e).__name__,
-                attempt,
-                _RETRY_MAX_ATTEMPTS,
-            )
-            raise
-        if resp.status_code in retryable_statuses and attempt < _RETRY_MAX_ATTEMPTS:
-            delay = _RETRY_BACKOFF_BASE_S * (2 ** (attempt - 1))
-            delay *= 1.0 + random.uniform(-0.1, 0.1)
-            logger.warning(
-                "storage_client.%s: HTTP %d on attempt %d/%d, retrying in %.2fs",
-                label,
-                resp.status_code,
-                attempt,
-                _RETRY_MAX_ATTEMPTS,
-                delay,
-            )
-            await asyncio.sleep(delay)
-            continue
-        return resp
-    # Unreachable — the loop either returns a response or raises.
-    if last_exc is not None:
-        raise last_exc
-    raise RuntimeError("storage_client retry loop exited without response or exception")
-
-
-async def _post_with_retry(
-    do_request: Callable[[], Awaitable[httpx.Response]],
-    *,
-    label: str,
-) -> httpx.Response:
-    """Retry policy for non-idempotent POSTs, encoded in one place.
-
-    Connection-phase failures only — the request was provably never
-    sent, so a retry cannot double-insert. No status-based retries.
-    """
-    return await _with_retry(
-        do_request,
-        label=label,
-        retryable_exceptions=_CONNECT_PHASE_EXCEPTIONS,
-        retryable_statuses=_NO_RETRYABLE_STATUSES,
-    )
+# Retry policy (F5 + the 2026-06-11 connect-timeout incident) lives in
+# ``common/http_retry.py``, shared with core-worker's storage client:
+# GET/PATCH/DELETE retry the full transient set + retryable 5xx;
+# POSTs retry connection-phase failures only (request provably never
+# sent, so a retry cannot double-insert).
 
 
 class KeystoneUpsertPayload(TypedDict):
@@ -324,7 +193,7 @@ class CoreStorageClient:
         async def _do() -> httpx.Response:
             return await http.get(f"{prefix}{path}", params=params, headers=headers)
 
-        resp = await _with_retry(_do, label=f"GET {path}")
+        resp = await with_retry(_do, label=f"GET {path}")
         if resp.status_code == 404:
             return None
         self._maybe_evict_on_auth_error(resp, read=read)
@@ -339,7 +208,7 @@ class CoreStorageClient:
         async def _do() -> httpx.Response:
             return await self._read_http.get(f"{self._read_prefix}{path}", params=params, headers=headers)
 
-        resp = await _with_retry(_do, label=f"GET-list {path}")
+        resp = await with_retry(_do, label=f"GET-list {path}")
         self._maybe_evict_on_auth_error(resp, read=True)
         resp.raise_for_status()
         return resp.json()
@@ -356,7 +225,7 @@ class CoreStorageClient:
                 headers=headers,
             )
 
-        resp = await _post_with_retry(_do, label=f"POST {path}")
+        resp = await with_connect_phase_retry(_do, label=f"POST {path}")
         self._maybe_evict_on_auth_error(resp, read=read)
         resp.raise_for_status()
         return resp.json()
@@ -367,7 +236,7 @@ class CoreStorageClient:
         async def _do() -> httpx.Response:
             return await self._http.patch(f"{self._prefix}{path}", json=data, headers=headers)
 
-        resp = await _with_retry(_do, label=f"PATCH {path}")
+        resp = await with_retry(_do, label=f"PATCH {path}")
         if resp.status_code == 404:
             return None
         self._maybe_evict_on_auth_error(resp, read=False)
@@ -380,7 +249,7 @@ class CoreStorageClient:
         async def _do() -> httpx.Response:
             return await self._http.delete(f"{self._prefix}{path}", params=params, headers=headers)
 
-        resp = await _with_retry(_do, label=f"DELETE {path}")
+        resp = await with_retry(_do, label=f"DELETE {path}")
         if resp.status_code == 404:
             return False
         self._maybe_evict_on_auth_error(resp, read=False)
@@ -399,7 +268,7 @@ class CoreStorageClient:
                 headers=headers,
             )
 
-        resp = await _post_with_retry(_do, label=f"POST {path}")
+        resp = await with_connect_phase_retry(_do, label=f"POST {path}")
         if resp.status_code == 404:
             return None
         self._maybe_evict_on_auth_error(resp, read=read)
@@ -1303,7 +1172,7 @@ class CoreStorageClient:
                 headers=headers,
             )
 
-        resp = await _post_with_retry(_do, label="POST /idempotency/claim")
+        resp = await with_connect_phase_retry(_do, label="POST /idempotency/claim")
         self._maybe_evict_on_auth_error(resp, read=False)
         if resp.status_code == 201:
             return True, resp.json()

--- a/core-worker/src/core_worker/clients/storage_client.py
+++ b/core-worker/src/core_worker/clients/storage_client.py
@@ -31,6 +31,7 @@ from uuid import UUID
 import httpx
 
 from common.constants import LIFECYCLE_STALE_ARCHIVE_WEIGHT
+from common.http_retry import with_connect_phase_retry
 from core_worker.clients.identity_token import evict as _evict_id_token
 from core_worker.clients.identity_token import fetch_auth_header
 
@@ -107,11 +108,24 @@ async def _signed_call(
     writer. 403 is intentionally NOT a trigger for eviction: 403 means
     the token was accepted but IAM rejected the caller, which the
     cache cannot fix.
+
+    Each attempt also retries connection-phase failures in-process via
+    ``with_connect_phase_retry`` (policy + safety argument in
+    ``common/http_retry.py``). Deliberately NOT the full idempotent
+    retry set: the worker's designed retry path for sent-but-failed
+    requests is raise → nack → Pub/Sub redelivery, and an in-process
+    ReadTimeout/5xx retry would double-layer that. Connection-phase
+    failures are the exception because each one otherwise burns a
+    Pub/Sub delivery attempt against the DLQ budget for a request
+    that never even reached storage (the 2026-06-11 incident shape).
     """
     headers = dict(kwargs.pop("headers", None) or {})
     if _audience is not None:
         headers.update(await fetch_auth_header(_audience))
-    resp = await fn(*args, headers=headers, **kwargs)
+    method = getattr(fn, "__name__", "?").upper()
+    path = args[0] if args else ""
+    label = f"{method} {path}".rstrip()
+    resp = await with_connect_phase_retry(lambda: fn(*args, headers=headers, **kwargs), label=label)
     if resp.status_code == 401 and _audience is not None:
         _evict_id_token(_audience)
         # Rebind to a NEW dict rather than ``.update()`` in place — the
@@ -120,8 +134,8 @@ async def _signed_call(
         # or test inspector that snapshots the call args would
         # otherwise see the rotated token retro-fitted into the first
         # call's record).
-        headers = {**headers, **await fetch_auth_header(_audience)}
-        resp = await fn(*args, headers=headers, **kwargs)
+        fresh_headers = {**headers, **await fetch_auth_header(_audience)}
+        resp = await with_connect_phase_retry(lambda: fn(*args, headers=fresh_headers, **kwargs), label=label)
     return resp
 
 

--- a/core-worker/tests/test_storage_client_retry.py
+++ b/core-worker/tests/test_storage_client_retry.py
@@ -1,0 +1,162 @@
+"""Connection-phase retry in ``_signed_call`` (port of caura-memclaw#333).
+
+Prod 2026-06-11: core-api's unretried storage POSTs died on
+first-attempt ``httpx.ConnectTimeout`` behind the VPC connector
+(contradiction detection 42x, audit events dropped). The worker's
+storage client had the same exposure on its four POSTed SQL
+primitives — and worse, each connect failure burns a Pub/Sub delivery
+attempt against the DLQ budget for a request that never reached
+storage.
+
+Policy under test (see ``common/http_retry.py``): every request
+through ``_signed_call`` retries ConnectTimeout / ConnectError /
+PoolTimeout up to 3 attempts. ReadTimeout and 5xx are NOT retried
+in-process — the worker's designed retry path for sent-but-failed
+requests is raise → nack → Pub/Sub redelivery.
+
+Mirrors ``tests/test_storage_client_retry.py`` (core-api) and the
+harness conventions of ``test_storage_client_auth.py`` — retry is
+exercised indirectly via the public endpoint helpers so a future
+helper can't drift around the ``_signed_call`` choke point.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from core_worker.clients import identity_token, storage_client
+
+pytestmark = pytest.mark.asyncio
+
+
+def _reset_module_state() -> None:
+    storage_client._client = None
+    storage_client._audience = None
+    identity_token._cache.clear()
+    identity_token._failure_cache.clear()
+    identity_token._audience_locks.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    _reset_module_state()
+    yield
+    _reset_module_state()
+
+
+def _ok_response(body: object) -> MagicMock:
+    resp = MagicMock(status_code=200)
+    resp.raise_for_status = MagicMock(return_value=None)
+    resp.json = MagicMock(return_value=body)
+    return resp
+
+
+def _server_error_response(status: int = 500) -> MagicMock:
+    resp = MagicMock(status_code=status)
+    resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("boom", request=MagicMock(), response=resp)
+    )
+    return resp
+
+
+# ── POST — the four lifecycle/suppression SQL primitives ─────────────
+
+
+async def test_post_retries_on_connect_timeout_then_succeeds() -> None:
+    """The exact prod failure mode: ConnectTimeout on the first
+    attempt (cold connection through the VPC connector), success on
+    the in-process retry — no Pub/Sub delivery attempt burned."""
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock(
+        side_effect=[
+            httpx.ConnectTimeout("simulated cold connection"),
+            _ok_response({"count": 3}),
+        ]
+    )
+
+    count = await storage_client.archive_expired(client, tenant_id="t1", fleet_id=None)
+
+    assert count == 3
+    assert client.post.await_count == 2
+
+
+async def test_post_gives_up_after_max_attempts_on_connect_timeout() -> None:
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock(side_effect=httpx.ConnectTimeout("storage unreachable"))
+
+    with pytest.raises(httpx.ConnectTimeout):
+        await storage_client.archive_stale(client, tenant_id="t1", fleet_id=None)
+
+    assert client.post.await_count == 3
+
+
+async def test_post_does_not_retry_on_read_timeout() -> None:
+    """ReadTimeout means the request was sent — the SQL primitive may
+    have committed. Propagate so the consumer nacks and Pub/Sub
+    redelivers (the worker's designed retry path)."""
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock(side_effect=httpx.ReadTimeout("response never arrived"))
+
+    with pytest.raises(httpx.ReadTimeout):
+        await storage_client.upsert_tenant_suppression(
+            client, tenant_id="t1", action="suppress", updated_by=None
+        )
+
+    assert client.post.await_count == 1
+
+
+async def test_post_5xx_not_retried_in_process() -> None:
+    """A 5xx reached storage; ``raise_for_status`` propagates so the
+    consumer nacks → Pub/Sub redelivers. No in-process double-layer."""
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock(return_value=_server_error_response())
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await storage_client.purge_soft_deleted(client, tenant_id="t1", fleet_id=None, retention_days=30)
+
+    assert client.post.await_count == 1
+
+
+# ── GET / PATCH ride the same choke point ────────────────────────────
+
+
+async def test_get_retries_on_connect_timeout_then_succeeds() -> None:
+    """Without the retry, a connect blip turns a cache HIT into a miss
+    and the worker pays a full provider embed call."""
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(
+        side_effect=[
+            httpx.ConnectTimeout("simulated"),
+            _ok_response([0.1, 0.2]),
+        ]
+    )
+
+    embedding = await storage_client.find_embedding_by_content_hash(
+        client, tenant_id="t1", content_hash="abc"
+    )
+
+    assert embedding == [0.1, 0.2]
+    assert client.get.await_count == 2
+
+
+async def test_patch_retries_on_connect_error_then_succeeds() -> None:
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.patch = AsyncMock(
+        side_effect=[
+            httpx.ConnectError("Name or service not known"),
+            _ok_response({}),
+        ]
+    )
+
+    await storage_client.update_memory_embedding(
+        client,
+        memory_id=uuid4(),
+        tenant_id="t1",
+        embedding=[0.1],
+    )
+
+    assert client.patch.await_count == 2

--- a/tests/test_storage_client_retry.py
+++ b/tests/test_storage_client_retry.py
@@ -148,6 +148,24 @@ async def test_get_retries_on_5xx_status() -> None:
     assert read.get.await_count == 2
 
 
+async def test_get_logs_giving_up_when_5xx_exhausts_retries(caplog) -> None:
+    """All attempts returning a retryable status must emit the same
+    "giving up" signal as the exception-exhaustion path — a 3x-502
+    incident should read as exhausted retries in the logs, not just a
+    bare HTTPStatusError from the caller."""
+    import logging
+
+    client, _write, read = await _make_client()
+    read.get = AsyncMock(return_value=_ok_response(502))
+
+    with caplog.at_level(logging.WARNING, logger="common.http_retry"):
+        with pytest.raises(httpx.HTTPStatusError):
+            await client._get("/entities/exact", read=True)
+
+    assert read.get.await_count == 3
+    assert any("giving up" in r.message for r in caplog.records), caplog.records
+
+
 async def test_get_does_not_retry_on_success_first_try() -> None:
     """No retry overhead on the happy path — the retry helper must
     short-circuit cleanly when the first attempt succeeds."""


### PR DESCRIPTION
## Why

Follow-up to #333, which gave core-api's storage POSTs connection-phase retry after the 2026-06-11 prod incident (42× contradiction-detection failures + dropped audit events — all first-attempt `ConnectTimeout` behind the VPC connector). core-worker's storage client had the **same exposure with no retry at all** on its four POSTed SQL primitives (`archive_expired`, `archive_stale`, `purge_soft_deleted`, `upsert_tenant_suppression`) — and in the worker each connect failure is worse: it burns a Pub/Sub delivery attempt against the DLQ budget for a request that never reached storage.

## What

- **`common/http_retry.py` (new)** — the retry policy extracted from core-api's client (`with_retry`, `with_connect_phase_retry`, exception/status constants, incident history) so the two storage clients cannot silently diverge. core-api behavior is unchanged — its helpers now import the shared module (its retry tests pass unmodified).
- **core-worker** — `with_connect_phase_retry` wired into `_signed_call`, the single choke point every storage call already goes through (same drift-proofing argument as its auth signing). **Connection-phase only, for all methods**: the worker's designed retry path for sent-but-failed requests is raise → nack → Pub/Sub redelivery; an in-process ReadTimeout/5xx retry would double-layer that. Connection-phase failures are the exception because the request provably never reached storage.

## Verification

- `core-worker/tests/test_storage_client_retry.py` (new, mirrors the core-api retry tests through the public endpoint helpers): POST primitives retry ConnectTimeout/ConnectError and recover; give up after 3 attempts; ReadTimeout and 5xx propagate un-retried for the nack path; GET/PATCH ride the same choke point. → 18 passed (incl. existing `test_storage_client_auth.py` — the 401-rotation interleaving is unchanged).
- `pytest tests/test_storage_client_retry.py tests/test_audit_queue.py tests/test_storage_client_routing.py tests/test_embedding_backfill.py` (core-api side) → 53 passed.
- `ruff check` + `format --check` clean; `mypy core-worker/src` clean; core-api mypy delta vs main: none. (`test_consumer_enrich.py::test_enrichment_pending_cleared_even_with_heuristic_fallback` fails identically on clean main — pre-existing.)

## Enterprise vendoring note

No manifest obligation: `scripts/check_vendored_drift.py` in the enterprise repo only requires classification for `common/` files present in **both** trees. `common/http_retry.py` is OSS-only until enterprise chooses to vendor it (at which point it should be added as `identical`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)