### PR TITLE
fix(embedding): fall back to default model when OPENAI_EMBEDDING_MODEL is empty

### DIFF
--- a/common/embedding/constants.py
+++ b/common/embedding/constants.py
@@ -21,8 +21,14 @@ import os
 # Default model identifiers per provider. Override via env (e.g. swap
 # ``OPENAI_EMBEDDING_MODEL=text-embedding-3-large`` for a higher-dim
 # variant; pair with a ``VECTOR_DIM`` change at the schema level).
-OPENAI_EMBEDDING_MODEL: str = os.environ.get(
-    "OPENAI_EMBEDDING_MODEL", "text-embedding-3-small"
+#
+# Use ``or`` rather than the ``get`` default so an *empty* value falls back
+# too: docker-compose maps ``OPENAI_EMBEDDING_MODEL: "${OPENAI_EMBEDDING_MODEL:-}"``,
+# so an unset var in ``.env`` reaches the container as "" (present-but-empty),
+# which ``os.environ.get(key, default)`` would NOT replace — leaving model=""
+# and every embed call failing with OpenAI 400 "you must provide a model".
+OPENAI_EMBEDDING_MODEL: str = (
+    os.environ.get("OPENAI_EMBEDDING_MODEL") or "text-embedding-3-small"
 )
 
 # Per-call OpenAI timeout. Caps a single embed/embed_batch round trip


### PR DESCRIPTION
## Summary

Following the documented quickstart (`cp .env.example .env`, set `OPENAI_API_KEY`, `docker compose up -d`) leaves the stack **unable to embed anything**: every write logs `OpenAI 400 "you must provide a model parameter"`, `POST /api/v1/search` returns `{"error":{"code":"UNAVAILABLE","message":"Embedding service unavailable"}}`, and any memory written in the meantime stays permanently unembedded (the re-embed retries exhaust against the same broken config). This one-line change makes the embedding model default fire when the env var is **empty**, not just when it's absent.

## Root cause

The default lives in `common/embedding/constants.py`:

```python
OPENAI_EMBEDDING_MODEL: str = os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
```

But `docker-compose.yml` maps the var as:

```yaml
OPENAI_EMBEDDING_MODEL: "${OPENAI_EMBEDDING_MODEL:-}"
```

`.env.example` ships `OPENAI_EMBEDDING_MODEL` **commented out** (line 137). So for a clean quickstart `.env`, Compose's `:-` interpolation turns "absent from `.env`" into **`OPENAI_EMBEDDING_MODEL=` (present-but-empty)** inside the container.

`os.environ.get(key, default)` only substitutes the default when the key is **absent** — an empty string is a real value, so it returns `""`. The provider (`common/embedding/providers/openai.py`) then calls `embeddings.create(model="", ...)`, which OpenAI rejects with 400. The Python default is effectively dead code on the Docker path.

## Fix

```python
OPENAI_EMBEDDING_MODEL: str = (
    os.environ.get("OPENAI_EMBEDDING_MODEL") or "text-embedding-3-small"
)
```

`or` falls back on any falsy value, so it covers **all** entry paths uniformly: Compose's empty-string injection, an empty hand-written `.env`, and an empty shell export. Explicit overrides (`text-embedding-3-large`, a local `bge-m3` via the TEI sidecar, etc.) are untouched. The fix is at the single point the code actually reads the value, so it needs no coordinated change in `docker-compose.yml` or `.env.example`.

## Verification

Logic check across the three cases:

| `OPENAI_EMBEDDING_MODEL` | resolves to |
|---|---|
| unset | `text-embedding-3-small` |
| `""` (the Compose case) | `text-embedding-3-small` |
| `text-embedding-3-large` | `text-embedding-3-large` |

Reproduced end-to-end on a fresh Ubuntu 24.04 VM following the quickstart verbatim: before the change, writes 400'd and search returned "Embedding service unavailable"; setting the model (equivalent to this fallback) made writes enrich and hybrid search return results.

## Scope

Deliberately minimal — fixes the bug at its authoritative source. Two adjacent hardening options were considered and intentionally left out to avoid duplicating the default string across files:
- Compose default `${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}` (cosmetic: makes `printenv` show the real value).
- Uncommenting `OPENAI_EMBEDDING_MODEL=text-embedding-3-small` in `.env.example` (discoverability; note there's a second `OPENAI_EMBEDDING_MODEL=BAAI/bge-m3` line for the local-TEI sidecar that must stay commented).

Happy to fold either in if maintainers prefer the defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)