### PR TITLE
fix(search): consume the inflight embedding future's exception when no joiner awaits it

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2698,6 +2698,13 @@ async def _get_or_cache_embedding(query: str, tenant_id: str, tenant_config):
         # finally block.
         if not fut.done():
             fut.set_exception(exc)
+            # Mark the exception retrieved immediately: in the common
+            # single-caller case there are no joiners, nobody ever awaits
+            # ``fut``, and its GC logs ERROR "Future exception was never
+            # retrieved" (prod 2026-06-12 — fired on every solo
+            # search-embed timeout). Joiners are unaffected — ``await
+            # fut`` still raises; this only clears the GC log flag.
+            fut.exception()
         raise
     finally:
         # Drop the inflight slot only after the future has been resolved.

--- a/tests/test_query_embedding_stampede_guard.py
+++ b/tests/test_query_embedding_stampede_guard.py
@@ -243,3 +243,47 @@ async def test_timeout_propagates_to_all_waiters():
     for r in results:
         assert isinstance(r, asyncio.TimeoutError)
     assert memory_service._inflight_embeddings == {}
+
+
+async def test_solo_leader_failure_future_exception_is_consumed():
+    """REGRESSION (prod 2026-06-12): with NO joiners — the common
+    single-caller case — the leader's ``set_exception`` on the inflight
+    future was never retrieved, so the future's GC logged ERROR
+    "Future exception was never retrieved" through the loop exception
+    handler on every solo search-embed timeout. The leader must mark
+    the exception retrieved after setting it; joiners still see the
+    raise from ``await fut``.
+    """
+    import gc
+
+    async def _boom(query, tenant_config):
+        raise TimeoutError
+
+    async def _miss(_key):
+        return None
+
+    handler_calls: list[dict] = []
+    loop = asyncio.get_running_loop()
+    prev_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, ctx: handler_calls.append(ctx))
+    try:
+        with (
+            patch.object(memory_service, "get_query_embedding", new=_boom),
+            patch("core_api.cache.cache_get", new=_miss),
+        ):
+            with pytest.raises(TimeoutError):
+                await memory_service._get_or_cache_embedding(
+                    "q-solo-timeout", "t1", None
+                )
+        # The orphaned future only logs at GC time — force it, then yield
+        # once so anything the handler scheduled gets to run.
+        gc.collect()
+        await asyncio.sleep(0)
+        gc.collect()
+    finally:
+        loop.set_exception_handler(prev_handler)
+
+    unretrieved = [
+        c for c in handler_calls if "never retrieved" in (c.get("message") or "")
+    ]
+    assert not unretrieved, unretrieved


### PR DESCRIPTION
## Why

Prod 2026-06-12 12:27Z (`prod-memclaw-core-api`) and staging under the same day's loadtest: ERROR `Future exception was never retrieved / future: <Future finished exception=TimeoutError()>` from logger `asyncio`.

## Origin

The query-embedding stampede guard in `memory_service._get_or_cache_embedding`: the leader registers a dedup `asyncio.Future` in `_inflight_embeddings` so concurrent cold-cache callers share one embed round-trip. On failure — the logged case is the inner 10s `wait_for` timing out while the openai client sat in an uncancellable `run_in_executor` thread (`get_platform`) — the leader does `fut.set_exception(exc)` for the joiners. In the common **single-caller** case there are no joiners: nobody ever awaits the future, and its GC emits the unretrieved-exception ERROR on every solo search-embed timeout.

Same class as the platform-auth touch-task fix ([enterprise#430](https://github.com/caura-ai/caura-memclaw-enterprise/pull/430)), different mechanism — a plain dedup future, not a fire-and-forget task.

## What

One line: `fut.exception()` immediately after `set_exception()` — the idiomatic asyncio "mark retrieved" signal. It only clears the GC log flag; joiners awaiting the future still get the raise (covered by the existing joiner-propagation tests, incl. the BaseException/cancel paths). A repo sweep found no other `set_exception` sites.

## Verification

- New regression test in `tests/test_query_embedding_stampede_guard.py`: captures the loop exception handler, forces GC after a solo-leader failure, asserts no "never retrieved" context — **verified to fail against the unfixed code**.
- `pytest tests/test_query_embedding_stampede_guard.py tests/test_d7_parallel_embed_per_task_timeout.py tests/test_c9_embedding_cache_instruction_key.py` → 18 passed.
- `ruff check` + `format --check` clean. DCO signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)