### PR TITLE
fix(entity-linking): synchronize_session=False on the entity-embedding backfill bulk update

### DIFF
--- a/core-api/src/core_api/pipeline/steps/entity_linking/backfill_entity_embeddings.py
+++ b/core-api/src/core_api/pipeline/steps/entity_linking/backfill_entity_embeddings.py
@@ -66,9 +66,16 @@ class BackfillEntityEmbeddings:
         backfill_count = 0
         if updates:
             await ctx.require_db.execute(
+                # ``synchronize_session=False``: this is a bulk ORM UPDATE with
+                # extra WHERE criteria over an executemany param list, which
+                # SQLAlchemy refuses to session-synchronize (InvalidRequestError,
+                # prod 2026-06-13). There is no live ORM session state to keep in
+                # sync here — the backfill writes name_embedding and moves on — so
+                # skipping synchronization is correct, not just a silencer.
                 update(Entity)
                 .where(Entity.id == sa.bindparam("eid"), Entity.tenant_id == tenant_id)
-                .values(name_embedding=sa.bindparam("emb")),
+                .values(name_embedding=sa.bindparam("emb"))
+                .execution_options(synchronize_session=False),
                 updates,
             )
             backfill_count = len(updates)

--- a/tests/pipeline/test_backfill_entity_embeddings.py
+++ b/tests/pipeline/test_backfill_entity_embeddings.py
@@ -1,0 +1,77 @@
+"""Unit tests for BackfillEntityEmbeddings.
+
+Regression anchor (prod 2026-06-13): the bulk-update execute raised
+``sqlalchemy.exc.InvalidRequestError: bulk synchronize of persistent
+objects not supported when using bulk update with additional WHERE
+criteria`` — an ORM ``update(Entity).where(...).values(...)`` over an
+executemany param list needs ``synchronize_session=False``. Every
+backfill batch failed (6 occurrences in ~10h; entity name_embeddings
+silently not backfilled). Same ``entity_linking_full`` family as the
+discover_cross_links (#337) and infer_relations (#341) fixes.
+
+Mock-based — assert the statement carries synchronize_session=False.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.step import StepOutcome
+from core_api.pipeline.steps.entity_linking.backfill_entity_embeddings import (
+    BackfillEntityEmbeddings,
+)
+
+TENANT = "test-tenant"
+
+
+def _mock_result(rows):
+    m = MagicMock()
+    m.all.return_value = rows
+    return m
+
+
+def _ctx(db, **extra):
+    ctx = PipelineContext(db=db, data={"tenant_id": TENANT, **extra})
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_sets_synchronize_session_false():
+    """The backfill UPDATE must carry execution_option
+    synchronize_session=False, or SQLAlchemy raises InvalidRequestError
+    on the bulk-update-with-WHERE path."""
+    eid = uuid.uuid4()
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_result([(eid, "Globex")]),  # 1. select NULL-embedding entities
+        _mock_result([]),  # 2. the bulk UPDATE
+    ]
+    db.flush = AsyncMock()
+
+    async def _fake_embed(text, tenant_config):
+        return [0.1] * 8
+
+    with patch(
+        "core_api.pipeline.steps.entity_linking.backfill_entity_embeddings.get_embedding",
+        new=_fake_embed,
+    ):
+        ctx = _ctx(db)  # tenant_config defaults to None
+        result = await BackfillEntityEmbeddings().execute(ctx)
+
+    assert result.outcome == StepOutcome.SUCCESS
+    assert ctx.data["backfill_count"] == 1
+    update_stmt = db.execute.call_args_list[1].args[0]
+    assert update_stmt.get_execution_options().get("synchronize_session") is False
+
+
+@pytest.mark.asyncio
+async def test_no_null_embedding_entities_skips():
+    db = AsyncMock()
+    db.execute.side_effect = [_mock_result([])]
+    db.flush = AsyncMock()
+    result = await BackfillEntityEmbeddings().execute(_ctx(db))
+    assert result.outcome == StepOutcome.SKIPPED


### PR DESCRIPTION
## Why

Prod 2026-06-13: **every** `backfill_entity_embeddings` batch fails with

```
sqlalchemy.exc.InvalidRequestError: bulk synchronize of persistent objects not supported
when using bulk update with additional WHERE criteria right now.
add synchronize_session=None execution option to bypass synchronize of persistent objects.
  at core-api/.../entity_linking/backfill_entity_embeddings.py:68
```

6 occurrences in ~10h. The step runs an ORM `update(Entity).where(id==:eid, tenant_id==…).values(name_embedding=:emb)` over an **executemany param list**; SQLAlchemy refuses to session-synchronize that shape. Result: entities with a NULL `name_embedding` are **silently never backfilled**, degrading entity-name vector matching. (Surfaced from the same full prod-error sweep that found infer_relations / #341.)

## What

Add `.execution_options(synchronize_session=False)` — there's no live ORM session state to keep in sync (the backfill writes the embedding and moves on), so skipping synchronization is correct, exactly as the error message instructs.

**Third `entity_linking_full` sibling to surface post-Phase-J** (the re-embed created the entities/links that make these steps fire): `discover_cross_links` (#337, executemany+RETURNING), `infer_relations` (#341, LEAST over untyped binds), and now this. A repo-wide sweep found **no other** `update().where().values()` over a param list with this latent bug.

## Verification

- New `tests/pipeline/test_backfill_entity_embeddings.py`: asserts the UPDATE statement carries `synchronize_session=False` (mock-based shape pin, **verified red** against the unfixed step) + the empty-rows skip path.
- `ruff check` + `format --check` clean; `mypy` clean. DCO signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)