### PR TITLE
docs: correct Claude Code MCP setup — claude mcp add -s user, not settings.json

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -124,6 +124,11 @@ Add this to your MCP client configuration (Claude Code, Claude Desktop, Cursor, 
 
 Replace `standalone` with your admin key (Path 2) or the shared gate key (Path 3) as appropriate.
 
+> **Claude Code** doesn't read MCP servers from `settings.json` — register with `claude mcp add` instead (the block above maps to a project-root `.mcp.json`). Use `-s user` so the server is available in every directory, not just the one you ran the command in:
+> ```bash
+> claude mcp add --transport http -s user memclaw http://localhost:8000/mcp --header "X-API-Key: standalone"
+> ```
+
 ## Connect via OpenClaw Plugin (alternative to MCP)
 
 If you're an OpenClaw agent running on a gateway, install the plugin instead:

--- a/README.md
+++ b/README.md
@@ -370,7 +370,11 @@ Add MemClaw to any MCP client with one config block.
 > For team or production use, swap the tenant-scoped key for an **agent-scoped credential** — atomic provisioning via `POST /api/v1/admin/agent-keys/provision` (or the `/settings/organization/api-credentials` wizard) mints the credential + Agent row + initial trust + fleet membership in one round trip. Both kinds use the `mc_` prefix; scope is set at mint time on the credential. See [`docs/integration-without-plugin.md`](docs/integration-without-plugin.md). Using a tenant-scoped credential? Pass an explicit `agent_id` on every MCP tool call — the gateway refuses the reserved default (`mcp-agent`) on the tenant-scoped path.
 
 **Where to add this config:**
-- **Claude Code** — `~/.claude/settings.json` under `"mcpServers"`
+- **Claude Code** — Claude Code does **not** read MCP servers from `settings.json`. Register the server with `claude mcp add` instead. Use `-s user` so it's available in **every** working directory — the default scope (`local`) only registers it for the current directory, which bites when you run agents from multiple folders:
+  ```bash
+  claude mcp add --transport http -s user memclaw http://localhost:8000/mcp --header "X-API-Key: standalone"
+  ```
+  (Or commit the JSON block above to a project-root `.mcp.json` for a project-scoped server.)
 - **Claude Desktop** — `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows)
 - **Cursor** — Settings > MCP Servers > Add Server
 
@@ -401,7 +405,7 @@ Install MemClaw's usage guide as a **skill** so your agent knows *when* and
 anti-patterns. The skill is loaded on-demand (not per-turn), so it costs
 nothing until the agent reaches for MemClaw.
 
-> **Prerequisite:** the MCP server is already registered (via `claude mcp add` for Claude Code or the equivalent for Codex — see the config block above). Confirm with `claude mcp list` — you should see `memclaw: ... ✓ Connected`.
+> **Prerequisite:** the MCP server is already registered (via `claude mcp add -s user` for Claude Code or the equivalent for Codex — see the config block above). Confirm with `claude mcp list` — you should see `memclaw: ... ✓ Connected`.
 
 #### Option A — one-liner (fastest)
 


### PR DESCRIPTION
## Summary

Two MCP-setup errors in the install docs prevent Claude Code from ever connecting to MemClaw, even when the user follows them exactly.

### 1. `settings.json` block is silently ignored (#4)

`README.md` and `AGENT-INSTALL.md` told Claude Code users to add an `mcpServers` block to `~/.claude/settings.json`:

```
- **Claude Code** — `~/.claude/settings.json` under `"mcpServers"`
```

Claude Code does **not** read MCP servers from `settings.json`. MCP config lives in `~/.claude.json` (written by `claude mcp add`) or a project `.mcp.json`. The block is accepted into the file but never loaded — `claude mcp list` shows nothing, with no error. (Verified empirically: the block yields "No MCP servers configured.")

### 2. Default `claude mcp add` scope is `local` (#3)

The prerequisite note pointed at a bare `claude mcp add` with no scope. That defaults to **`local`** scope — the server is registered only for the directory it was run in. Anyone running agents from multiple working directories (e.g. a fleet of per-agent dirs) finds the server present in the first folder and missing everywhere else.

## Fix

- **Claude Code** bullet now points at `claude mcp add -s user` (available in every directory) as the primary path, explains why `local` bites, and notes `.mcp.json` for project scope.
- Prerequisite note's command made explicit (`-s user`).
- Claude Desktop / Cursor guidance — which genuinely use a config-file block — left unchanged.

## Accuracy

Verified against **Claude Code 2.1.154**:
```
-s, --scope <scope>   Configuration scope (local, user, or project) (default: "local")
```
`.mcp.json` (project scope) and `~/.claude.json` (local/user, via `claude mcp add`) are the real config locations; `settings.json` is not one of them.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)