### PR TITLE
docs: fix README/AGENT-INSTALL inaccuracies (PII, health shape, write response)

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -25,7 +25,7 @@ docker compose ps   # all services should show "healthy"
 
 # 4. Verify
 curl http://localhost:8000/api/v1/health
-# Expected: {"status":"ok","database":"connected",...}
+# Expected: {"status":"ok","storage":"connected","redis":"connected","event_bus":"ok"}
 ```
 
 That's it. The core API is running at `http://localhost:8000` (core-storage-api on `:8002`, postgres on `:5432`, redis on `:6379` — see `docker-compose.yml`). Skip to **Create Your API Key** below.
@@ -76,7 +76,7 @@ PYTHONPATH=core-api/src uvicorn core_api.app:app --host 0.0.0.0 --port 8000
 
 # 8. Verify (in another terminal)
 curl http://localhost:8000/api/v1/health
-# Expected: {"status":"ok","database":"connected",...}
+# Expected: {"status":"ok","storage":"connected","redis":"connected","event_bus":"ok"}
 ```
 
 MemClaw is running at `http://localhost:8000`.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ To upgrade to a newer image at the same tag (e.g. `:latest` after we cut a new r
 
 ```bash
 curl http://localhost:8000/api/v1/health
-# {"status":"ok","database":"connected",...}
+# {"status":"ok","storage":"connected","redis":"connected","event_bus":"ok"}
 ```
 
 #### 4. Write and search
@@ -184,7 +184,7 @@ curl -X POST http://localhost:8000/api/v1/search \
   -d '{"tenant_id": "default", "query": "authentication token lifetime"}'
 ```
 
-The write response includes LLM-inferred `type`, `title`, `summary`, `tags`, `status`, and `importance_score` — all from a single `content` field.
+The write response carries an LLM-inferred `memory_type`, `title`, `summary`, `tags`, `status`, and a `weight` (the importance score) — all derived from a single `content` field. On the default fast-write path, enrichment is applied asynchronously: the immediate response is marked `enrichment_pending` and the inferred fields populate within moments.
 
 ---
 
@@ -267,7 +267,7 @@ The plugin claims the OpenClaw `memory` slot (replacing `memory-core`) and expos
 
 ### Governance
 
-- **Tenant isolation** — row-level database separation per tenant; PII auto-detected and quarantined before it can cross fleet boundaries
+- **Tenant isolation** — row-level database separation per tenant; PII auto-detected and flagged on every write (surfaced in memory metadata as `contains_pii`/`pii_types`)
 - **Visibility scopes** — every memory is stamped at write time: `scope_agent` (private), `scope_team` (fleet-wide, default), or `scope_org` (cross-fleet). Cross-fleet recall is permissioned, not open
 - **Agent trust tiers** — four levels control cross-fleet reads, writes, and deletes. Agents are either provisioned atomically via `POST /admin/agent-keys/provision` (recommended — mints key + row + trust + fleet in one call) or auto-registered on first write (legacy fallback)
 - **Full audit log** — every write, delete, and transition logged with tenant and scope context


### PR DESCRIPTION
## Summary

Three doc claims that don't match the running OSS stack. All verified against a live instance.

### 1. PII is detected & tagged, not "quarantined"

`README.md` (Governance) claimed:
> PII auto-detected **and quarantined before it can cross fleet boundaries**

The code only sets `metadata.contains_pii` / `pii_types` on write (see `merge_enrichment_fields.py`). Nothing changes a memory's `status`, `visibility`, or content, and it stays `scope_team` and fully recallable. Reworded to "flagged on every write (surfaced in memory metadata as `contains_pii`/`pii_types`)".

### 2. `/api/v1/health` key is `storage`, not `database`

Docs showed `{"status":"ok","database":"connected",...}`. Actual response:
```json
{"status":"ok","storage":"connected","redis":"connected","event_bus":"ok"}
```
Fixed in `README.md` and both `AGENT-INSTALL.md` verify steps (3 spots).

### 3. Write response: `weight`, and async on fast-write

`README.md` said the write response includes `importance_score`. The field is **`weight`** (the importance score); there is no `importance_score`. Also, on the **default fast-write path** the immediate response is `enrichment_pending` and the inferred `title`/`summary`/`tags` populate asynchronously — the previous wording implied a synchronous, fully-enriched response.

## Scope

Docs-only; no code changes. Kept separate from the MCP-setup docs PR (#343) since these are unrelated accuracy fixes.

(Three further tutorial-only items — the `memclaw_evolve` `scope="fleet"` nuance for cross-agent reinforcement, the "9 tools" undercount vs the actual 12, and the simplified architecture diagram — live only in the external tutorial draft and aren't repo-doc bugs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)