### PR TITLE
docs: comparison table — "PII detection & flagging", not "quarantine"

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ fleet capability and governance:
 | Cross-vendor memory sharing | ✅ | ❌ | ❌ | ❌ |
 | Contradiction detection + supersession | ✅ | ❌ | ❌ | ❌ |
 | Per-agent retrieval tuning | ✅ | ❌ | ❌ | ❌ |
-| PII detection & quarantine | ✅ | ❌ | ✅ | ❌ |
+| PII detection & flagging | ✅ | ❌ | ✅ | ❌ |
 | Audit trail / provenance | ✅ | ❌ | ⚠️ partial | ❌ |
 | Knowledge graph (auto-extracted) | ✅ | ⚠️ | ✅ | ❌ |
 | MCP-native | ✅ | ✅ | ✅ | ⚠️ |


### PR DESCRIPTION
## Summary

Follow-up to #344. That PR fixed the Governance bullet (PII *"auto-detected and flagged"*) but missed the **capability comparison table**, which still advertised **`PII detection & quarantine ✅`** for MemClaw.

The OSS engine only **detects and flags** PII — `merge_enrichment_fields.py` sets `metadata.contains_pii` / `pii_types` and nothing else (no status change, no visibility downgrade, no redaction, no blocking). Quarantine / boundary enforcement is an enterprise-gateway capability, not OSS.

Relabel the row to `PII detection & flagging` so the table matches both the OSS behavior and the corrected bullet.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)