### PR TITLE
docs: add top-level BENCHMARKS.md as a citable benchmark asset

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,98 @@
+# MemClaw Benchmarks
+
+How MemClaw performs on the two most-cited public agent-memory benchmarks —
+**LoCoMo** and **LongMemEval** — plus the fleet-shaped dimensions those
+single-agent benchmarks can't measure.
+
+> **TL;DR** — On accuracy, MemClaw sits inside the leading cluster (MemClaw,
+> Mem0, Zep land in a narrow band). Where we push hardest, and where it
+> compounds at fleet scale, is **latency, token efficiency, and governance
+> correctness**.
+
+## Results
+
+|  | LoCoMo | LongMemEval | Search latency |
+|---|---|---|---|
+| Accuracy (LLM-judge) | **77.6%** | **72.5%** | — |
+| Token savings vs full context | **96.6%** | **98.2%** | — |
+| Latency | — | — | **23 ms p50 · 27 ms p95** (warm) |
+
+LoCoMo and LongMemEval both measure one agent, one user, one long
+conversation — the single-chatbot shape. Accuracy across the leading systems
+clusters in a narrow band, so the meaningful differences show up on the other
+axes.
+
+**Numbers are point-in-time (last run 2026-04-19) and move when we re-run.** The
+canonical, current version lives in the blog write-up linked below.
+
+## What we measure, and how
+
+- **Accuracy** — an LLM judge scores the answer the retrieval-then-answer
+  pipeline produces against each benchmark's question, rather than `recall@k`
+  over a fixed gold set. The whole pipeline gets the credit, because that's what
+  maps to product behavior.
+- **Token efficiency** — total tokens sent to the answering LLM divided by the
+  same prompt with the full prior conversation inlined (the "no memory system"
+  baseline). The ratio, not the absolute count, is what scales into your bill.
+- **Search latency** — p50 / p95 of `POST /api/v1/search` against a warm
+  pgvector cache, single-tenant. Cold-cache p50 is higher; we publish warm
+  because that's the steady state under real load.
+
+## What these benchmarks can't measure
+
+Single-agent benchmarks can't ask the questions that decide whether a memory
+system is deployable inside a company:
+
+- Did agent #17's mistake this morning stop agents #1–#40 from repeating it this
+  afternoon? (cross-agent outcome propagation)
+- Does a new agent joining the fleet inherit what the fleet already knows?
+- Is a memory written by the sales fleet correctly **invisible** to a support
+  agent? (scoped visibility)
+- Does cross-tenant data ever leak when the recall query is ambiguous?
+
+None of this moves a `recall@k` number; all of it moves whether you can deploy.
+MemClaw is built around these — scoped memory (agent / fleet / cross-fleet),
+per-agent trust tiers, keystone policies, PII quarantine before cross-fleet
+exposure, a full audit log, and the `memclaw_evolve` → `memclaw_insights`
+outcome-propagation loop. The field still needs a benchmark for the
+fleet-shaped problem; we're working toward one.
+
+## Reproduce it yourself
+
+The accuracy and token-efficiency numbers run against the **public** datasets,
+so you can reproduce the methodology against your own MemClaw instance:
+
+1. **Stand up MemClaw locally** — follow the [Quick Start](README.md#quick-start)
+   (`docker compose up -d`). Set an embedding/LLM provider key so memories are
+   embedded and enriched (standalone dummy-embedding mode runs but won't produce
+   meaningful recall).
+2. **Get the datasets** — [LoCoMo](https://arxiv.org/abs/2402.17753) and
+   [LongMemEval](https://arxiv.org/abs/2410.10813) are publicly available.
+3. **Ingest** — for each conversation, write its turns with
+   `POST /api/v1/memories` (one memory per turn / fact).
+4. **Query** — for each benchmark question, call `POST /api/v1/search` and pass
+   the retrieved memories to your answering LLM.
+5. **Score** — judge each answer against the benchmark's expected answer with an
+   LLM judge, and compute token usage against the full-context baseline.
+6. **Latency** — measure p50/p95 of `POST /api/v1/search` under your expected
+   concurrency against a warm cache.
+
+> A turnkey harness isn't bundled in this repo yet — the datasets are large and
+> publicly hosted, and the runner is being prepared for open release. Until
+> then the steps above describe the exact methodology. Operator-scale guidance
+> and caveats live in [`docs/performance.md`](docs/performance.md).
+
+## How MemClaw compares
+
+For a single chatbot, the public-benchmark leaders (MemClaw, Mem0, Zep) cluster
+in a narrow accuracy band — the choice usually comes down to stack fit, latency,
+and token budget. MemClaw differentiates on the dimensions a single-agent
+benchmark can't see; see [`docs/performance.md`](docs/performance.md#how-memclaw-compares)
+for the fleet-scale breakdown and the [feature comparison](README.md#how-memclaw-compares)
+in the README.
+
+## Sources
+
+- **Blog write-up (canonical, current):** [Fast, Token-Efficient, and Built for Fleets](https://memclaw.net/blog/memclaw-benchmarks) (2026-04-19)
+- **Operator companion:** [`docs/performance.md`](docs/performance.md)
+- **Public benchmarks:** [LoCoMo](https://arxiv.org/abs/2402.17753) · [LongMemEval](https://arxiv.org/abs/2410.10813)

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ of public docs as of June 2026 — corrections welcome via issue or PR.
 
 ## Performance
 
-Benchmarked against the two most-cited public agent-memory benchmarks. Methodology and operator-scale context live in [`docs/performance.md`](docs/performance.md); the full write-up is on the blog.
+Benchmarked against the two most-cited public agent-memory benchmarks. Full results, methodology, and how to reproduce them live in [`BENCHMARKS.md`](BENCHMARKS.md); operator-scale context is in [`docs/performance.md`](docs/performance.md); the full write-up is on the blog.
 
 |  | LoCoMo | LongMemEval | Search latency |
 |---|---|---|---|

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -65,7 +65,7 @@ The published numbers are warm-cache, single-tenant, on our reference hardware. 
 - Hit `POST /search` under your expected concurrency to confirm latency holds — the search-path optimizer assumes a warm pgvector cache.
 - Audit `tenant_id` and `fleet_id` filtering on every recall path you care about; the test suite covers scope correctness, but your tenancy model is yours to validate.
 
-For benchmark methodology, the raw harness, and the underlying scoring code, see the [`keystone-benchmark`](https://github.com/caura-ai/keystone-benchmark) repo (in development).
+For the results table, the methodology, and step-by-step reproduction against the public LoCoMo and LongMemEval datasets, see [`BENCHMARKS.md`](../BENCHMARKS.md).
 
 ## Sources
 


### PR DESCRIPTION
## What

Adds a root-level **`BENCHMARKS.md`** — the LoCoMo / LongMemEval results table, what we measure and how, the fleet-shape dimensions single-agent benchmarks can't capture, and a step-by-step reproduction recipe against the **public** datasets + the OSS local stack.

- Cross-links it from the README **Performance** section.
- Repoints `docs/performance.md` at `BENCHMARKS.md` for methodology/reproduction (it previously pointed readers to the **private**, different-purpose `keystone-benchmark` repo — that's a policy-enforcement benchmark, not the memory benchmark these numbers come from, so the old link would 404 for the public).

## Why

From the OSS SEO/GEO review: a reproducible, in-repo benchmark is our most citation-worthy asset, but it was only reachable via a blog link and a buried `docs/performance.md`. `BENCHMARKS.md` at the repo root is the conventional, citable location evaluators and AI engines look for.

## Notes

- Numbers are unchanged — reused verbatim from `docs/performance.md` / the blog (point-in-time, last run 2026-04-19; blog remains canonical).
- No turnkey runner is bundled (datasets are large + public; the internal runner isn't open yet). The doc is explicit about that and describes the exact methodology instead — chosen over shipping an unverifiable script.