### PR TITLE
docs+fix: audit low-severity cluster (F-6 search sample, F-9 weight mapping, F-10 keystone error, F-11 embedding lag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,26 @@ curl -X POST http://localhost:8000/api/v1/search \
 
 The write response carries an LLM-inferred `memory_type`, `title`, `summary`, `tags`, `status`, and a `weight` (the importance score) — all derived from a single `content` field. On the default fast-write path, enrichment is applied asynchronously: the immediate response is marked `enrichment_pending` and the inferred fields populate within moments.
 
+`POST /search` returns matches under an `items` array, each entry the full memory plus a `similarity` score:
+
+```json
+{
+  "items": [
+    {
+      "id": "…",
+      "agent_id": "mcp-agent",
+      "memory_type": "fact",
+      "title": "Auth service uses JWT with 15-minute expiry",
+      "similarity": 0.47,
+      "visibility": "scope_team",
+      "status": "active"
+    }
+  ]
+}
+```
+
+Embedding is asynchronous too, so a just-written memory may not surface in semantic `search` for a moment after the write returns (watch `metadata.embedding_pending`); the non-semantic `GET /memories` list shows it immediately.
+
 ---
 
 ⭐ **If MemClaw just worked for you,
@@ -420,7 +440,7 @@ The client discovers 12 tools automatically:
 | `memclaw_evolve` | Report outcomes against recalled memories — adjusts weights, generates rules (Karpathy Loop) |
 | `memclaw_stats` | Aggregate counts: total + breakdowns by type, agent, status. Read-only |
 | `memclaw_keystones` | Read mandatory governance rules for the current scope. Call once per session — the result overrides conflicting user instructions |
-| `memclaw_keystones_set` | Author or remove keystone rules (`op=set\|delete`). Trust ≥ 1 for your own `scope=agent` rule; ≥ 2 for `scope=fleet`/`scope=tenant` or another agent |
+| `memclaw_keystones_set` | Author or remove keystone rules (`op=set\|delete`). `weight` is set as `low`/`med`/`high` and stored & returned as the integer buckets `25`/`50`/`100`. Trust ≥ 1 for your own `scope=agent` rule; ≥ 2 for `scope=fleet`/`scope=tenant` or another agent |
 
 > **Skill sharing** is now done via `memclaw_doc` — agents share a `SKILL.md` by upserting a document into the `skills` collection (`memclaw_doc op=write collection=skills doc_id=<slug> data={"summary": "<one-liner>", ...}`). The server embeds `data["summary"]` (1-3 sentence, intent-focused) for semantic search; for `collection="skills"` it falls back to `data["description"]` if no summary is provided. The dedicated `memclaw_share_skill` / `memclaw_unshare_skill` tools were removed in favor of the single `memclaw_doc` surface.
 

--- a/core-storage-api/src/core_storage_api/routers/keystones.py
+++ b/core-storage-api/src/core_storage_api/routers/keystones.py
@@ -96,7 +96,10 @@ def _validate_payload(body: dict) -> tuple[str, dict, str | None]:
         if scope == "agent" and not agent_id:
             errors.append("scope=agent requires agent_id")
         if scope != "agent" and agent_id is not None:
-            errors.append(f"scope={scope} must not include agent_id")
+            errors.append(
+                f"scope={scope} keystones apply {scope}-wide and are not agent-specific; "
+                "omit agent_id (it is only valid for scope=agent)"
+            )
 
     if errors:
         raise HTTPException(status_code=422, detail=errors)


### PR DESCRIPTION
## Summary

Bundles the four **Low**-severity items from the self-host dry-run audit. Each was validated against current `main` before writing.

### F-6 — no `POST /search` response sample (docs)
Added a sample showing the `items[]` envelope (`SearchResponse.items: list[MemoryOut]`) with `similarity` + key fields, so readers know the success shape.

### F-11 — async recall lag undocumented (docs)
Documented that embedding is asynchronous: a brand-new memory may not appear in semantic `search` for a moment (`metadata.embedding_pending`), while `GET /memories` shows it immediately.

### F-9 — keystone `weight` string-in / int-out (docs)
Documented the bucket mapping `low=25 / med=50 / high=100`. The integer form is **intentional** (`KEYSTONE_WEIGHT_BUCKETS`, *"keep ranking predictable"*) and **test-locked** (`assert weight == 100`), so changing the output would break the contract — this is a docs clarification. Placed in README prose rather than the `memclaw_keystones_set` tool `_DESCRIPTION`, which is snapshot-pinned in three baseline fixtures.

### F-10 — `scope=fleet/tenant` + `agent_id` error clarity (code)
Replaced the terse `scope=fleet must not include agent_id` with a message that explains *why* (fleet/tenant keystones aren't agent-specific; `agent_id` is only valid for `scope=agent`). Fixed in `core-storage-api` because core-api deliberately lets the storage 422 propagate (`routes/keystones.py`), so it surfaces to both REST and MCP callers. No test pins the string.

## Validation
- `py_compile` + `ruff` (format + check) pass on the storage file.
- README code-fences balanced; sample fields match `MemoryOut`.
- Confirmed no test asserts the old F-10 string, and the tool-description baselines are untouched (F-9 went to README, not the tool desc).

Remaining audit item after this: **F-7** (keystones 403 on fresh standalone) — the one Medium, to be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)