### PR TITLE
feat: add memclaw-client Python SDK

### DIFF
--- a/.github/workflows/client-python-ci.yml
+++ b/.github/workflows/client-python-ci.yml
@@ -1,0 +1,30 @@
+name: Client (Python) CI
+
+on:
+  pull_request:
+    paths:
+      - "clients/python/**"
+      - ".github/workflows/client-python-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "clients/python/**"
+      - ".github/workflows/client-python-ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: clients/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: pip install -e ".[dev]"
+      - name: Lint (ruff)
+        run: ruff check src tests
+      - name: Test (pytest)
+        run: pytest -q

--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -1,0 +1,39 @@
+name: Publish memclaw-client to PyPI
+
+# Publishes the Python client SDK to PyPI via trusted publishing (OIDC — no token).
+#
+# One-time setup by a maintainer:
+#   1. Create the PyPI project `memclaw-client`.
+#   2. On PyPI, add a Trusted Publisher: repo `caura-ai/caura-memclaw`,
+#      workflow `publish-python-client.yml`, environment `pypi`.
+#   3. Create a GitHub environment named `pypi`.
+#
+# Release: bump the version in clients/python/pyproject.toml, then push a tag
+# `memclaw-client-v<version>` (or run this workflow manually).
+
+on:
+  push:
+    tags:
+      - "memclaw-client-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # required for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build
+        run: |
+          pip install build
+          python -m build
+        working-directory: clients/python
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: clients/python/dist/

--- a/README.md
+++ b/README.md
@@ -308,6 +308,24 @@ openclaw gateway restart
 
 The plugin claims the OpenClaw `memory` slot (replacing `memory-core`) and exposes the same 12 MCP tools. Full setup, agent prompts, and trust levels: [static/docs/integration-guide.md](static/docs/integration-guide.md).
 
+### Python client
+
+Talk to any MemClaw deployment (managed or self-hosted) from Python:
+
+```bash
+pip install memclaw-client
+```
+
+```python
+from memclaw_client import MemClaw
+
+mc = MemClaw("mc_xxx", tenant_id="my-team", agent_id="my-agent")
+mc.write("Q3 revenue target is $4M, set on 2026-04-15.")
+print(mc.recall("Q3 revenue target").summary)
+```
+
+A thin wrapper over the REST API — see [`clients/python/`](clients/python/) for the full client.
+
 ---
 
 ## Features

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,0 +1,58 @@
+# memclaw-client
+
+Official Python client for [MemClaw](https://memclaw.net) — governed shared
+memory for AI agent fleets (multi-agent, multi-tenant, MCP-native).
+
+A thin wrapper over the MemClaw REST API. Point it at a managed
+(`https://memclaw.net`) or self-hosted (`http://localhost:8000`) deployment.
+
+## Install
+
+```bash
+pip install memclaw-client
+```
+
+## Quickstart
+
+```python
+from memclaw_client import MemClaw
+
+mc = MemClaw("mc_xxx", tenant_id="my-team", agent_id="my-agent")
+
+# Write a memory — enriched server-side with type, title, tags, importance.
+mc.write("Q3 revenue target is $4M, set on 2026-04-15.")
+
+# Search (ranked raw results)
+for m in mc.search("Q3 revenue target", top_k=5):
+    print(m.title, "—", m.content)
+
+# Recall (LLM-synthesized context brief)
+print(mc.recall("Q3 revenue target").summary)
+```
+
+Self-hosted? Pass `base_url`:
+
+```python
+mc = MemClaw("standalone", tenant_id="default", base_url="http://localhost:8000")
+```
+
+## API
+
+| Method | Endpoint | Returns |
+|---|---|---|
+| `write(content, ...)` | `POST /api/v1/memories` | `Memory` |
+| `search(query, top_k=5, ...)` | `POST /api/v1/search` | `list[Memory]` |
+| `recall(query, top_k=5, ...)` | `POST /api/v1/recall` | `RecallResult` |
+| `health()` | `GET /api/v1/health` | `dict` |
+
+The client is a context manager (`with MemClaw(...) as mc:`) and raises
+`AuthError` (401/403), `NotFoundError` (404), or `MemClawAPIError` on failures.
+Every result also exposes the full API payload on `.raw`.
+
+For credentials, scopes, and the full API surface, see the
+[MemClaw docs](https://memclaw.net/docs). Production fleets should use
+[per-agent keys](https://memclaw.net/docs/integrations/per-agent-keys).
+
+## License
+
+Apache-2.0

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+requires = ["setuptools>=75"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "memclaw-client"
+version = "0.1.0"
+description = "Official Python client for MemClaw — governed shared memory for AI agent fleets (multi-agent, multi-tenant, MCP-native)."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Caura", email = "hello@caura.ai" }]
+keywords = [
+    "memclaw",
+    "agent-memory",
+    "ai-agents",
+    "llm-memory",
+    "rag",
+    "mcp",
+    "knowledge-graph",
+    "vector-search",
+    "multi-agent",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+dependencies = ["httpx>=0.27"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8", "ruff>=0.6"]
+
+[project.urls]
+Homepage = "https://memclaw.net"
+Documentation = "https://memclaw.net/docs"
+Repository = "https://github.com/caura-ai/caura-memclaw"
+Issues = "https://github.com/caura-ai/caura-memclaw/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+memclaw_client = ["py.typed"]
+
+[tool.ruff]
+target-version = "py39"
+line-length = 110
+src = ["src", "tests"]
+
+[tool.pytest.ini_options]
+# Self-contained config so the client suite doesn't inherit the repo-root
+# pytest.ini (which configures pytest-asyncio for the backend services).
+testpaths = ["tests"]

--- a/clients/python/src/memclaw_client/__init__.py
+++ b/clients/python/src/memclaw_client/__init__.py
@@ -1,0 +1,20 @@
+"""Official Python client for MemClaw — governed shared memory for AI agent fleets."""
+
+from __future__ import annotations
+
+from .client import DEFAULT_BASE_URL, MemClaw
+from .exceptions import AuthError, MemClawAPIError, MemClawError, NotFoundError
+from .models import Memory, RecallResult
+
+__all__ = [
+    "MemClaw",
+    "Memory",
+    "RecallResult",
+    "MemClawError",
+    "MemClawAPIError",
+    "AuthError",
+    "NotFoundError",
+    "DEFAULT_BASE_URL",
+]
+
+__version__ = "0.1.0"

--- a/clients/python/src/memclaw_client/client.py
+++ b/clients/python/src/memclaw_client/client.py
@@ -1,0 +1,149 @@
+"""Synchronous MemClaw client.
+
+A thin wrapper over the MemClaw REST API. Point it at a managed
+(``https://memclaw.net``) or self-hosted (``http://localhost:8000``) deployment.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .exceptions import AuthError, MemClawAPIError, NotFoundError
+from .models import Memory, RecallResult
+
+DEFAULT_BASE_URL = "https://memclaw.net"
+
+
+class MemClaw:
+    """Client for a MemClaw deployment.
+
+    Example::
+
+        from memclaw_client import MemClaw
+
+        mc = MemClaw("mc_xxx", tenant_id="my-team", agent_id="my-agent")
+        mc.write("Q3 revenue target is $4M, set on 2026-04-15.")
+        for m in mc.search("Q3 revenue target"):
+            print(m.title, m.content)
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        tenant_id: str,
+        base_url: str = DEFAULT_BASE_URL,
+        agent_id: str | None = None,
+        timeout: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key is required")
+        if not tenant_id:
+            raise ValueError("tenant_id is required")
+        self.tenant_id = tenant_id
+        self.agent_id = agent_id
+        self._http = httpx.Client(
+            base_url=base_url.rstrip("/"),
+            headers={"X-API-Key": api_key, "Content-Type": "application/json"},
+            timeout=timeout,
+            transport=transport,
+        )
+
+    # ------------------------------------------------------------------ ops
+    def write(
+        self,
+        content: str,
+        *,
+        agent_id: str | None = None,
+        memory_type: str | None = None,
+        fleet_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        **extra: Any,
+    ) -> Memory:
+        """Persist a memory. Returns the enriched ``Memory`` (POST /api/v1/memories)."""
+        body: dict[str, Any] = {"tenant_id": self.tenant_id, "content": content}
+        resolved_agent = agent_id or self.agent_id
+        if resolved_agent:
+            body["agent_id"] = resolved_agent
+        if memory_type:
+            body["memory_type"] = memory_type
+        if fleet_id:
+            body["fleet_id"] = fleet_id
+        if metadata is not None:
+            body["metadata"] = metadata
+        body.update(extra)
+        return Memory.from_dict(self._post("/api/v1/memories", body))
+
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+        fleet_ids: list[str] | None = None,
+        filter_agent_id: str | None = None,
+        **extra: Any,
+    ) -> list[Memory]:
+        """Hybrid vector + keyword search. Returns ranked ``Memory`` objects (POST /api/v1/search)."""
+        body: dict[str, Any] = {"tenant_id": self.tenant_id, "query": query, "top_k": top_k}
+        if fleet_ids:
+            body["fleet_ids"] = fleet_ids
+        if filter_agent_id:
+            body["filter_agent_id"] = filter_agent_id
+        body.update(extra)
+        data = self._post("/api/v1/search", body)
+        items = data.get("items", []) if isinstance(data, dict) else []
+        return [Memory.from_dict(m) for m in items]
+
+    def recall(self, query: str, *, top_k: int = 5, **extra: Any) -> RecallResult:
+        """Search + LLM summary. Returns a ``RecallResult`` context brief (POST /api/v1/recall)."""
+        body: dict[str, Any] = {"tenant_id": self.tenant_id, "query": query, "top_k": top_k}
+        body.update(extra)
+        return RecallResult.from_dict(self._post("/api/v1/recall", body))
+
+    def health(self) -> dict[str, Any]:
+        """Liveness probe (GET /api/v1/health)."""
+        response = self._http.get("/api/v1/health")
+        return response.json()
+
+    # ------------------------------------------------------------- internals
+    def _post(self, path: str, body: dict[str, Any]) -> Any:
+        response = self._http.post(path, json=body)
+        self._raise_for_status(response)
+        return response.json()
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.is_success:
+            return
+        try:
+            payload: Any = response.json()
+        except ValueError:
+            payload = {}
+        message = ""
+        details: Any = None
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict):
+                message = error.get("message") or ""
+                details = error.get("details")
+            message = message or payload.get("detail") or payload.get("message") or response.text
+        else:
+            message = response.text
+        if response.status_code in (401, 403):
+            raise AuthError(response.status_code, message or "authentication failed", details=details)
+        if response.status_code == 404:
+            raise NotFoundError(response.status_code, message or "not found", details=details)
+        raise MemClawAPIError(response.status_code, message or "request failed", details=details)
+
+    # ------------------------------------------------------------- lifecycle
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self) -> MemClaw:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()

--- a/clients/python/src/memclaw_client/exceptions.py
+++ b/clients/python/src/memclaw_client/exceptions.py
@@ -1,0 +1,30 @@
+"""Exceptions raised by the MemClaw client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class MemClawError(Exception):
+    """Base class for all MemClaw client errors."""
+
+
+class MemClawAPIError(MemClawError):
+    """Raised when the MemClaw API returns a non-success status code.
+
+    The structured ``error`` envelope (``{"error": {"code", "message", "details"}}``)
+    is parsed when present; otherwise the raw body is used as the message.
+    """
+
+    def __init__(self, status_code: int, message: str, *, details: Any = None) -> None:
+        self.status_code = status_code
+        self.details = details
+        super().__init__(f"[{status_code}] {message}")
+
+
+class AuthError(MemClawAPIError):
+    """Raised on 401/403 — bad or insufficiently-scoped credential."""
+
+
+class NotFoundError(MemClawAPIError):
+    """Raised on 404."""

--- a/clients/python/src/memclaw_client/models.py
+++ b/clients/python/src/memclaw_client/models.py
@@ -1,0 +1,56 @@
+"""Lightweight result types returned by the client.
+
+These are thin, tolerant wrappers over the API JSON — the most common fields are
+promoted to attributes, and the full payload is always available on ``.raw`` so
+nothing is lost.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Memory:
+    """A single memory, as returned by write and search."""
+
+    id: str | None
+    content: str
+    title: str | None = None
+    memory_type: str | None = None
+    tenant_id: str | None = None
+    agent_id: str | None = None
+    weight: float | None = None
+    similarity: float | None = None
+    metadata: dict[str, Any] | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Memory:
+        return cls(
+            id=data.get("id"),
+            content=data.get("content", ""),
+            title=data.get("title"),
+            memory_type=data.get("memory_type"),
+            tenant_id=data.get("tenant_id"),
+            agent_id=data.get("agent_id"),
+            weight=data.get("weight"),
+            similarity=data.get("similarity"),
+            metadata=data.get("metadata"),
+            raw=data,
+        )
+
+
+@dataclass
+class RecallResult:
+    """The LLM-synthesized context brief returned by ``recall``."""
+
+    summary: str | None
+    supporting_memories: list[Memory]
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RecallResult:
+        memories = [Memory.from_dict(m) for m in (data.get("supporting_memories") or [])]
+        return cls(summary=data.get("summary"), supporting_memories=memories, raw=data)

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,0 +1,123 @@
+"""Unit tests for the MemClaw client — fully mocked via httpx.MockTransport, no network."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from memclaw_client import (
+    AuthError,
+    MemClaw,
+    MemClawAPIError,
+    Memory,
+    NotFoundError,
+    RecallResult,
+)
+
+
+def make_client(handler, **kwargs):
+    transport = httpx.MockTransport(handler)
+    return MemClaw(
+        "mc_test",
+        tenant_id="t1",
+        base_url="https://example.test",
+        transport=transport,
+        **kwargs,
+    )
+
+
+def test_write_returns_memory():
+    def handler(request):
+        assert request.url.path == "/api/v1/memories"
+        assert request.headers["X-API-Key"] == "mc_test"
+        body = json.loads(request.content)
+        assert body == {"tenant_id": "t1", "content": "hello", "agent_id": "a1"}
+        return httpx.Response(201, json={"id": "m1", "content": "hello", "title": "Hi", "agent_id": "a1"})
+
+    mem = make_client(handler, agent_id="a1").write("hello")
+    assert isinstance(mem, Memory)
+    assert mem.id == "m1"
+    assert mem.title == "Hi"
+    assert mem.raw["agent_id"] == "a1"
+
+
+def test_write_per_call_agent_overrides_default():
+    def handler(request):
+        assert json.loads(request.content)["agent_id"] == "override"
+        return httpx.Response(201, json={"id": "m1", "content": "x"})
+
+    make_client(handler, agent_id="default").write("x", agent_id="override")
+
+
+def test_search_returns_list():
+    def handler(request):
+        assert request.url.path == "/api/v1/search"
+        body = json.loads(request.content)
+        assert body["query"] == "q"
+        assert body["top_k"] == 3
+        return httpx.Response(200, json={"items": [{"id": "m1", "content": "a"}, {"id": "m2", "content": "b"}]})
+
+    results = make_client(handler).search("q", top_k=3)
+    assert [m.id for m in results] == ["m1", "m2"]
+
+
+def test_recall_returns_summary():
+    def handler(request):
+        assert request.url.path == "/api/v1/recall"
+        return httpx.Response(200, json={"summary": "S", "supporting_memories": [{"id": "m1", "content": "a"}]})
+
+    result = make_client(handler).recall("q")
+    assert isinstance(result, RecallResult)
+    assert result.summary == "S"
+    assert result.supporting_memories[0].id == "m1"
+
+
+def test_health():
+    def handler(request):
+        assert request.url.path == "/api/v1/health"
+        return httpx.Response(200, json={"status": "ok"})
+
+    assert make_client(handler).health()["status"] == "ok"
+
+
+def test_auth_error_parses_envelope():
+    def handler(request):
+        return httpx.Response(403, json={"error": {"message": "cross-fleet", "details": {"x": 1}}})
+
+    with pytest.raises(AuthError) as exc:
+        make_client(handler).write("x")
+    assert exc.value.status_code == 403
+    assert exc.value.details == {"x": 1}
+
+
+def test_not_found_error():
+    def handler(request):
+        return httpx.Response(404, json={"detail": "nope"})
+
+    with pytest.raises(NotFoundError):
+        make_client(handler).search("q")
+
+
+def test_generic_api_error():
+    def handler(request):
+        return httpx.Response(500, json={"message": "boom"})
+
+    with pytest.raises(MemClawAPIError):
+        make_client(handler).recall("q")
+
+
+def test_context_manager():
+    def handler(request):
+        return httpx.Response(200, json={"status": "ok"})
+
+    with make_client(handler) as mc:
+        assert mc.health()["status"] == "ok"
+
+
+def test_requires_api_key_and_tenant():
+    with pytest.raises(ValueError):
+        MemClaw("", tenant_id="t")
+    with pytest.raises(ValueError):
+        MemClaw("k", tenant_id="")


### PR DESCRIPTION
## What

A thin Python client SDK for MemClaw, packaged as **`memclaw-client`** for PyPI. Lives in `clients/python/`.

```python
from memclaw_client import MemClaw
mc = MemClaw("mc_xxx", tenant_id="my-team", agent_id="my-agent")
mc.write("Q3 revenue target is $4M.")
print(mc.recall("Q3 revenue target").summary)
```

- `write` → `POST /api/v1/memories`, `search` → `POST /api/v1/search`, `recall` → `POST /api/v1/recall`, `health` → `GET /api/v1/health`.
- Single dependency (`httpx`), typed (ships `py.typed`), context-manager, typed exceptions (`AuthError`/`NotFoundError`/`MemClawAPIError`), `.raw` on every result.
- Rich PyPI metadata (description, keywords, classifiers, project URLs).
- README gains a **Python client** quickstart funnel (`pip install memclaw-client`).

## Why

From the OSS SEO/adoption review (Gap 1 — install funnel): evaluating MemClaw previously meant `git clone` + Docker, with no `pip install` one-liner. Competitors' growth is built on exactly that. This gives the lowest-friction path for talking to a deployment.

## Naming

`memclaw` is already taken on PyPI **and** npm by unrelated projects, so the package ships as **`memclaw-client`** (import `memclaw_client`). The TS/npm client (`@caura/memclaw`) is a planned follow-up.

## CI / verification

- New **Client (Python) CI** workflow runs `ruff` + `pytest` on changes under `clients/python/`. Tests are fully mocked with `httpx.MockTransport` (no network/DB). **Verified locally: 10 passed, ruff clean.**
- The root CI (core services) is untouched — root pytest only runs `tests/`, so this doesn't affect the backend suite.

## Publishing (maintainer action — not done here)

Adds a `publish-python-client.yml` workflow using PyPI **trusted publishing** (OIDC, no token), triggered by a `memclaw-client-v*` tag or manual dispatch. One-time setup (create the PyPI project + trusted-publisher + `pypi` environment) is documented in the workflow header. I did **not** publish — that's a maintainer action requiring the org's PyPI access.