### PR TITLE
fix(keystones): let the standalone operator author keystones out-of-the-box (F-7)

### DIFF
--- a/core-api/src/core_api/routes/keystones.py
+++ b/core-api/src/core_api/routes/keystones.py
@@ -32,6 +32,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import KeystoneUpsertPayload, get_storage_client
+from core_api.config import settings as app_settings
 from core_api.db.session import get_db
 from core_api.services.audit_service import log_action
 from core_api.services.trust_service import parse_trust_error
@@ -76,6 +77,7 @@ async def _enforce_author_trust(
     agent_id: str,
     *,
     min_level: int,
+    standalone_admin: bool = False,
 ) -> None:
     """Block keystone writes / deletes from principals below ``min_level``.
 
@@ -95,11 +97,22 @@ async def _enforce_author_trust(
     for any fleet within T — finer-grained scope authority (admin/org
     role, fleet pinning) is tracked separately (#119).
     """
+    # Standalone single-tenant operator: the API-key holder IS the admin and
+    # there is no other agent to impersonate, so the anti-spoof trust gate is
+    # pure friction. Skip it (the caller still passes storage-side shape
+    # validation). See ``_is_standalone_admin``.
+    if standalone_admin:
+        return
     _trust, not_found, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
     if not_found:
         raise HTTPException(
             status_code=403,
-            detail=(f"Agent '{agent_id}' is not registered. Register the agent by writing one memory first."),
+            detail=(
+                f"Agent '{agent_id}' has no registered agent row, so its keystone-author "
+                "trust can't be verified. Register it (write one memory as that agent, then "
+                "promote its trust), or call with X-Agent-ID / an agent-scoped credential for "
+                "an agent at trust ≥ 2."
+            ),
         )
     if terr:
         raise HTTPException(status_code=403, detail=parse_trust_error(terr))
@@ -143,6 +156,25 @@ def _resolve_caller_identity(auth: AuthContext, x_agent_id: str | None) -> tuple
     if x_agent_id:
         return x_agent_id, False
     return "rest-admin", False
+
+
+def _is_standalone_admin(auth: AuthContext, x_agent_id: str | None) -> bool:
+    """True for the unidentified single-tenant operator on a standalone box.
+
+    Under ``IS_STANDALONE`` there is exactly one principal — the API-key
+    holder — and no other agent to impersonate, so the keystone trust gate
+    that protects multi-tenant / gateway deployments is pure friction here
+    (the flagship governance feature otherwise 403s on a fresh install).
+
+    Deliberately narrow: fires ONLY when the caller asserts no agent identity
+    at all — no agent-scoped credential (``auth.agent_id``) and no
+    ``X-Agent-ID`` header — i.e. the ``rest-admin`` fallback in
+    ``_resolve_caller_identity``. A request that names an agent via
+    ``X-Agent-ID`` still goes through the normal trust gate, so the anti-spoof
+    defenses (floor bump, mismatch rejection) are untouched, and this is a
+    no-op whenever ``IS_STANDALONE`` is false.
+    """
+    return app_settings.is_standalone and getattr(auth, "agent_id", None) is None and x_agent_id is None
 
 
 def _effective_min_for_caller(scope_floor: int, caller_verified: bool) -> int:
@@ -229,6 +261,7 @@ async def upsert_keystone(
     auth.enforce_read_only()
     auth.enforce_usage_limits()
     caller_agent_id, caller_verified = _resolve_caller_identity(auth, x_agent_id)
+    standalone_admin = _is_standalone_admin(auth, x_agent_id)
 
     # Early registration check — anti-probing parity with delete. Without
     # this, an unregistered caller could probe ``doc_id`` existence
@@ -236,7 +269,9 @@ async def upsert_keystone(
     # fires. Use the minimum floor (1) here so a trust-1 caller passes;
     # the full floor (which may be 2 once the stored shape is known) is
     # re-enforced after the storage read.
-    await _enforce_author_trust(db, body.tenant_id, caller_agent_id, min_level=1)
+    await _enforce_author_trust(
+        db, body.tenant_id, caller_agent_id, min_level=1, standalone_admin=standalone_admin
+    )
 
     sc = get_storage_client()
     # Look up the existing rule (if any) so the trust floor combines
@@ -263,7 +298,9 @@ async def upsert_keystone(
     # ``scope=agent``+``agent_id=<victim>`` and forge a rule in the
     # victim's name at trust 1.
     min_level = _effective_min_for_caller(scope_floor, caller_verified)
-    await _enforce_author_trust(db, body.tenant_id, caller_agent_id, min_level=min_level)
+    await _enforce_author_trust(
+        db, body.tenant_id, caller_agent_id, min_level=min_level, standalone_admin=standalone_admin
+    )
     # TOCTOU narrowing: re-fetch the stored row immediately before the
     # upsert and abort with 409 if the shape changed. A legitimate
     # concurrent upsert could otherwise promote the stored scope
@@ -355,27 +392,33 @@ async def delete_keystone(
     auth.enforce_tenant(tenant_id)
     auth.enforce_read_only()
     caller_agent_id, caller_verified = _resolve_caller_identity(auth, x_agent_id)
+    standalone_admin = _is_standalone_admin(auth, x_agent_id)
+    trust: int = 0  # assigned in the trust-gate block below; default unused (read is in the same not-standalone_admin guard)
 
     # ONE trust round-trip for both the pre-lookup registration check
     # (≥ 1, anti-probing) and the post-lookup floor check. We ask
     # ``_require_trust`` for the minimum the caller could possibly
     # need (1), then compare the returned trust level against the
     # floor computed from the stored rule. This collapses two DB
-    # queries into one without losing either guarantee.
-    trust, not_found, terr = await _require_trust(db, tenant_id, caller_agent_id, min_level=1)
-    # Anti-probing: an unregistered caller must NOT learn whether a
-    # ``doc_id`` exists (404 would leak presence; trust check below
-    # would 403). 403 unconditionally on missing identity.
-    if not_found:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                f"Agent '{caller_agent_id}' is not registered. "
-                "Register the agent by writing one memory first."
-            ),
-        )
-    if terr:
-        raise HTTPException(status_code=403, detail=parse_trust_error(terr))
+    # queries into one without losing either guarantee. Skipped for the
+    # standalone single-tenant operator (see ``_is_standalone_admin``).
+    if not standalone_admin:
+        trust, not_found, terr = await _require_trust(db, tenant_id, caller_agent_id, min_level=1)
+        # Anti-probing: an unregistered caller must NOT learn whether a
+        # ``doc_id`` exists (404 would leak presence; trust check below
+        # would 403). 403 unconditionally on missing identity.
+        if not_found:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    f"Agent '{caller_agent_id}' has no registered agent row, so its "
+                    "keystone-author trust can't be verified. Register it (write one memory "
+                    "as that agent, then promote its trust), or call with X-Agent-ID / an "
+                    "agent-scoped credential for an agent at trust ≥ 2."
+                ),
+            )
+        if terr:
+            raise HTTPException(status_code=403, detail=parse_trust_error(terr))
 
     sc = get_storage_client()
     # Look up the rule before computing the scope-derived floor — the
@@ -385,20 +428,21 @@ async def delete_keystone(
     if not existing:
         raise HTTPException(status_code=404, detail="Keystone not found")
     data = existing.get("data") or {}
-    scope_floor = keystone_min_trust(
-        data.get("scope", ""),
-        data.get("agent_id"),
-        caller_agent_id,
-    )
-    # Bump to ≥ 2 if the caller's identity is unverified (admin key
-    # with ``X-Agent-ID`` claim only) — same anti-spoof rationale as
-    # the upsert path.
-    min_level = _effective_min_for_caller(scope_floor, caller_verified)
-    if trust < min_level:
-        raise HTTPException(
-            status_code=403,
-            detail=(f"Agent '{caller_agent_id}' (trust_level={trust}) < required {min_level}."),
+    if not standalone_admin:
+        scope_floor = keystone_min_trust(
+            data.get("scope", ""),
+            data.get("agent_id"),
+            caller_agent_id,
         )
+        # Bump to ≥ 2 if the caller's identity is unverified (admin key
+        # with ``X-Agent-ID`` claim only) — same anti-spoof rationale as
+        # the upsert path.
+        min_level = _effective_min_for_caller(scope_floor, caller_verified)
+        if trust < min_level:
+            raise HTTPException(
+                status_code=403,
+                detail=(f"Agent '{caller_agent_id}' (trust_level={trust}) < required {min_level}."),
+            )
 
     # TOCTOU narrowing: re-fetch the stored row immediately before the
     # delete and abort with 409 if the shape changed. Without this, a

--- a/tests/test_api_keystones.py
+++ b/tests/test_api_keystones.py
@@ -157,6 +157,22 @@ async def test_set_allowed_for_trusted_agent(client):
     assert body["data"]["weight"] == 100  # 'high' bucket → 100 at storage
 
 
+async def test_set_allowed_for_standalone_admin_without_agent_id(client):
+    """F-7: on a standalone box the unidentified operator (no X-Agent-ID)
+    can author a keystone out-of-the-box. Pre-fix this 403'd with
+    'Agent rest-admin is not registered' because the caller fell back to the
+    synthetic, unregistered ``rest-admin`` principal. The bypass is narrow:
+    it only applies when no agent identity is asserted at all — the
+    X-Agent-ID-bearing tests below still go through the full trust gate."""
+    tenant_id, headers = get_test_auth()  # bare standalone admin — NO X-Agent-ID
+    tag = _uid()
+    resp = await _set_keystone(client, headers, tenant_id, doc_id=f"ks-{tag}", weight="high")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["doc_id"] == f"ks-{tag}"
+    assert body["data"]["scope"] == "tenant"
+
+
 # ---------------------------------------------------------------------------
 # Round-trip + scope merge passthrough
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary (audit finding F-7)

On a fresh **standalone** install, authoring a keystone over REST 403s:
```
POST /api/v1/memclaw/keystones   (X-API-Key: standalone, no X-Agent-ID)
→ 403 "Agent 'rest-admin' is not registered. Register the agent by writing one memory first."
```
A bare standalone request has no caller agent identity, so `_resolve_caller_identity` falls back to the synthetic **`rest-admin`**, which has no agent row → `_require_trust` not_found → 403 with a misleading message. The flagship governance feature looks broken on first contact.

The trust gate is **correct and necessary for multi-tenant / gateway** deployments — it's the anti-spoof defense (`_effective_min_for_caller` floor-bump + X-Agent-ID mismatch rejection). But under `IS_STANDALONE` the API-key holder *is* the admin and there's nobody to impersonate, so the gate is pure friction.

## Change (REST keystone route only)
- **`_is_standalone_admin(auth, x_agent_id)`** — true **only** when `IS_STANDALONE` *and* the caller asserts no identity at all (no agent-scoped credential, no `X-Agent-ID`). The `upsert`/`delete` handlers skip the caller-trust gate for that caller; storage-side shape validation (scope/fleet_id/agent_id) still applies.
- **Reworded the not_found 403** to name the real cause: register the agent, or pass `X-Agent-ID` / an agent-scoped credential for an agent at trust ≥ 2.

## Why it's safe (validated against code + tests)
- **No-op off standalone** — the bypass requires `IS_STANDALONE` *and* the no-identity fallback, so the multi-tenant/gateway anti-spoof defenses are fully intact.
- **Doesn't disturb existing tests** — audited every keystone endpoint call in `test_api_keystones.py`: all authenticate via the `_author_headers` helper (`X-Agent-ID` set), so they hit the `x_agent_id` branch, never the `rest-admin` fallback the bypass keys on. `test_set_rejected_when_agent_unknown` (X-Agent-ID=`ghost`) still 403s.
- **No test pins the reworded string** — keystone tests assert only `status_code`; the `"is not registered"` assertions live on the MCP path + `trust_service`, neither touched.
- **MCP keystone path unaffected** — it resolves the caller to `mcp-agent`, not `rest-admin`.

## Tests
Adds `test_set_allowed_for_standalone_admin_without_agent_id` — bare standalone admin (no X-Agent-ID) can now author a keystone (200), locking the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)