### PR TITLE
fix(plugin): send X-Bulk-Attempt-Id header on bulk memory writes

### DIFF
--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -19,6 +19,7 @@
  * - Signal forwarding to apiCall
  */
 
+import { randomUUID } from "crypto";
 import { apiCall, textResult } from "./transport.js";
 import {
   MEMCLAW_FLEET_ID,
@@ -337,7 +338,20 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
   memclaw_write: async (params, signal) => {
     const isBatch = Array.isArray(params.items);
     const body = await enrichBody(params);
-    if (isBatch) return apiCall("POST", "/memories/bulk", body, undefined, signal);
+    if (isBatch) {
+      // POST /memories/bulk requires a per-attempt idempotency token via
+      // the `X-Bulk-Attempt-Id` header (CAURA-602). The server derives each
+      // row's `client_request_id` from `${X-Bulk-Attempt-Id}:${index}`, so a
+      // retry with the same id resolves committed rows as `duplicate_attempt`
+      // instead of duplicating. Omitting it makes the endpoint return
+      // HTTP 400 "Missing required X-Bulk-Attempt-Id header" — which is why
+      // batch writes failed entirely. Generate one UUID per tool invocation
+      // (a 401-retry inside apiCall reuses it), mirroring the server's own
+      // MCP path which auto-generates `mcp:{uuid4()}`.
+      return apiCall("POST", "/memories/bulk", body, undefined, signal, undefined, {
+        "X-Bulk-Attempt-Id": randomUUID(),
+      });
+    }
     return apiCall("POST", "/memories", body, undefined, signal);
   },
 

--- a/plugin/src/transport.test.ts
+++ b/plugin/src/transport.test.ts
@@ -81,6 +81,47 @@ describe("apiCall — MEMCLAW_API_PREFIX handling", () => {
   });
 });
 
+describe("apiCall — extraHeaders (bulk X-Bulk-Attempt-Id support)", () => {
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    calls = [];
+    installOkFetch();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("merges extraHeaders into the request headers", async () => {
+    // No agent_id in the body: that would trigger resolveAgentKey() and add
+    // a second fetch, which isn't what this test is asserting.
+    await apiCall(
+      "POST",
+      "/memories/bulk",
+      { items: [{ content: "x" }], tenant_id: "t1" },
+      undefined,
+      undefined,
+      undefined,
+      { "X-Bulk-Attempt-Id": "attempt-123" },
+    );
+    assert.equal(calls.length, 1);
+    const headers = calls[0].init?.headers as Record<string, string>;
+    assert.equal(headers["X-Bulk-Attempt-Id"], "attempt-123");
+    // Default headers must survive alongside the caller-supplied ones.
+    // (Assert presence, not the exact key value, which env.ts may source
+    // from a local .env rather than the test's process.env.)
+    assert.ok(headers["X-API-Key"], "X-API-Key should still be sent");
+    assert.equal(headers["Content-Type"], "application/json");
+  });
+
+  test("omitting extraHeaders leaves only the default headers", async () => {
+    await apiCall("POST", "/memories", { content: "x" });
+    const headers = calls[0].init?.headers as Record<string, string>;
+    assert.equal(headers["X-Bulk-Attempt-Id"], undefined);
+    assert.ok(headers["X-API-Key"], "X-API-Key should still be sent");
+  });
+});
+
 describe("parseSearchItems — search-response shape handling", () => {
   // Regression guard: the REST /search endpoint returns { items: [...] }
   // (core-api SearchResponse), but the plugin historically read .results

--- a/plugin/src/transport.ts
+++ b/plugin/src/transport.ts
@@ -19,6 +19,7 @@ export async function apiCall(
   query?: Record<string, string>,
   signal?: AbortSignal,
   agentId?: string,
+  extraHeaders?: Record<string, string>,
 ): Promise<unknown> {
   const start = Date.now();
 
@@ -50,6 +51,10 @@ export async function apiCall(
   const headers: Record<string, string> = {};
   if (body) headers["Content-Type"] = "application/json";
   if (effectiveKey) headers["X-API-Key"] = effectiveKey;
+  // Caller-supplied headers (e.g. the per-attempt `X-Bulk-Attempt-Id`
+  // required by POST /memories/bulk). Applied after the defaults so a
+  // caller can override them deliberately if ever needed.
+  if (extraHeaders) Object.assign(headers, extraHeaders);
 
   // Use caller's signal if provided, otherwise create a default timeout
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -74,7 +79,9 @@ export async function apiCall(
       if (res.status === 401 && effectiveKey !== MEMCLAW_API_KEY && effectiveAgentId) {
         evictAgentKey(effectiveAgentId);
         console.warn(`[memclaw] Agent key rejected for '${effectiveAgentId}', retrying with tenant key`);
-        return apiCall(method, path, body, query, signal);  // retry without agentId → uses tenant key
+        // Forward extraHeaders so the retry reuses the same per-attempt
+        // idempotency id (a fresh id would defeat bulk de-dup on retry).
+        return apiCall(method, path, body, query, signal, undefined, extraHeaders);  // retry without agentId → uses tenant key
       }
       const text = await res.text();
       // Truncate server error body to avoid leaking internal details


### PR DESCRIPTION
## Summary

The OpenClaw MemClaw plugin's `memclaw_write` tool sends batch writes (when an `items` array is provided) to `POST /memories/bulk`, but **never sends the `X-Bulk-Attempt-Id` header that endpoint has required since CAURA-602**. The server rejects the request with **HTTP 400 `"Missing required X-Bulk-Attempt-Id header"`**, so every agent-driven *batch* write fails outright. Single-item writes (`POST /memories`) are unaffected.

This is impactful because models frequently route a single fact through the batch path (passing `items` rather than `content`), so in practice `memclaw_write` can fail on the very first write attempt.

## How it was found

Wet-testing the plugin against **memclaw.net** from an OpenClaw agent: every `memclaw_write` via the batch path returned `HTTP 400 "Missing required X-Bulk-Attempt-Id header"`. Reproduced directly:

```
POST /api/v1/memories/bulk          (no header)            → 400 "Missing required X-Bulk-Attempt-Id header"
POST /api/v1/memories/bulk          (+ X-Bulk-Attempt-Id)  → 200
POST /api/v1/memories  (single)     (no header)            → 201
```

Then **confirmed on a freshly-rebuilt local `core-api`** (same result, byte-identical error) — so this is the server's intended contract, not a prod-only quirk. The bug is entirely on the **client/plugin** side.

## Root cause

Server (`core-api/src/core_api/routes/memories.py:1089-1097`) requires the header for non-`install_credential` callers:

```python
if not bulk_attempt_id:
    raise HTTPException(status_code=400,
        detail=f"Missing required {BULK_ATTEMPT_ID_HEADER} header")
```

It's the **per-attempt idempotency key** (CAURA-602): the server derives each row's `client_request_id` from `${X-Bulk-Attempt-Id}:${index}`, so a retry with the same id resolves committed rows as `duplicate_attempt` instead of duplicating them.

Notably the server's **MCP path is immune** — `core-api/.../mcp_server.py` auto-generates `bulk_attempt_id=f"mcp:{uuid4()}"`. Only the **REST** bulk path requires the caller to supply it, and the plugin writes via REST:

- `plugin/src/tool-definitions.ts` → `memclaw_write` batch branch → `apiCall("POST", "/memories/bulk", …)`
- `plugin/src/transport.ts` → `apiCall` only ever set `Content-Type` + `X-API-Key`; no mechanism to add the header.

## Fix

1. **`transport.ts`** — add an optional `extraHeaders` arg to `apiCall`, merged into the request headers after the defaults. It is also **forwarded on the internal 401-retry**, so the retry reuses the same attempt id (a fresh id would defeat the server's bulk de-dup).
2. **`tool-definitions.ts`** — in the `memclaw_write` batch branch, generate **one `randomUUID()` per tool invocation** and pass it as `X-Bulk-Attempt-Id`. One id per call (not per HTTP attempt) keeps the idempotency semantics intact, mirroring the server's own MCP path.

Single-item writes (`POST /memories`) are left unchanged — they never required the header.

## Tests

Adds two cases to `plugin/src/transport.test.ts`:
- `extraHeaders` are merged into the outgoing request headers (and the default `X-API-Key` / `Content-Type` still ride along).
- omitting `extraHeaders` sends no `X-Bulk-Attempt-Id`.

Verified locally: `transport.test.js` 13/13 pass, `tool-definitions.test.js` 24/24 pass, `tsc` clean.

## Notes

- Versioning/CHANGELOG are owned by release-please; intentionally not bumped here. The `fix:` type drives the patch release.
- `X-Bulk-Attempt-Id` is validated server-side against `^[A-Za-z0-9._:\-]{1,128}$`; a bare `randomUUID()` (36 chars, hex + hyphens) satisfies this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)