### PR TITLE
feat: add @caura/memclaw-client TypeScript SDK

### DIFF
--- a/.github/workflows/client-typescript-ci.yml
+++ b/.github/workflows/client-typescript-ci.yml
@@ -1,0 +1,28 @@
+name: Client (TypeScript) CI
+
+on:
+  pull_request:
+    paths:
+      - "clients/typescript/**"
+      - ".github/workflows/client-typescript-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "clients/typescript/**"
+      - ".github/workflows/client-typescript-ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: clients/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install
+        run: npm install
+      - name: Build + test
+        run: npm test

--- a/.github/workflows/publish-npm-client.yml
+++ b/.github/workflows/publish-npm-client.yml
@@ -1,0 +1,38 @@
+name: Publish @caura/memclaw-client to npm
+
+# Publishes the TypeScript client SDK to npm.
+#
+# One-time setup by a maintainer:
+#   1. Ensure the @caura npm org/scope exists and the publisher has access.
+#   2. Add an `NPM_TOKEN` repository secret (automation token with publish rights),
+#      OR configure npm trusted publishing for the package.
+#
+# Release: bump the version in clients/typescript/package.json, then push a tag
+# `memclaw-client-ts-v<version>` (or run this workflow manually).
+
+on:
+  push:
+    tags:
+      - "memclaw-client-ts-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # npm provenance
+    defaults:
+      run:
+        working-directory: clients/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install + build
+        run: npm install
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -326,6 +326,24 @@ print(mc.recall("Q3 revenue target").summary)
 
 A thin wrapper over the REST API — see [`clients/python/`](clients/python/) for the full client.
 
+### TypeScript client
+
+Same, from TypeScript / JavaScript (Node 18+, zero dependencies):
+
+```bash
+npm install @caura/memclaw-client
+```
+
+```ts
+import { MemClaw } from "@caura/memclaw-client";
+
+const mc = new MemClaw("mc_xxx", { tenantId: "my-team", agentId: "my-agent" });
+await mc.write("Q3 revenue target is $4M, set on 2026-04-15.");
+console.log((await mc.recall("Q3 revenue target")).summary);
+```
+
+See [`clients/typescript/`](clients/typescript/) for the full client.
+
 ---
 
 ## Features

--- a/clients/typescript/.gitignore
+++ b/clients/typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,0 +1,60 @@
+# @caura/memclaw-client
+
+Official TypeScript/JavaScript client for [MemClaw](https://memclaw.net) —
+governed shared memory for AI agent fleets (multi-agent, multi-tenant,
+MCP-native).
+
+A thin wrapper over the MemClaw REST API. Point it at a managed
+(`https://memclaw.net`) or self-hosted (`http://localhost:8000`) deployment.
+Zero runtime dependencies — uses native `fetch` (Node 18+).
+
+## Install
+
+```bash
+npm install @caura/memclaw-client
+```
+
+## Quickstart
+
+```ts
+import { MemClaw } from "@caura/memclaw-client";
+
+const mc = new MemClaw("mc_xxx", { tenantId: "my-team", agentId: "my-agent" });
+
+// Write a memory — enriched server-side with type, title, tags, importance.
+await mc.write("Q3 revenue target is $4M, set on 2026-04-15.");
+
+// Search (ranked raw results)
+for (const m of await mc.search("Q3 revenue target", { topK: 5 })) {
+  console.log(m.title, "—", m.content);
+}
+
+// Recall (LLM-synthesized context brief)
+console.log((await mc.recall("Q3 revenue target")).summary);
+```
+
+Self-hosted? Pass `baseUrl`:
+
+```ts
+const mc = new MemClaw("standalone", { tenantId: "default", baseUrl: "http://localhost:8000" });
+```
+
+## API
+
+| Method | Endpoint | Returns |
+|---|---|---|
+| `write(content, opts?)` | `POST /api/v1/memories` | `Memory` |
+| `search(query, opts?)` | `POST /api/v1/search` | `Memory[]` |
+| `recall(query, opts?)` | `POST /api/v1/recall` | `RecallResult` |
+| `health()` | `GET /api/v1/health` | `object` |
+
+Failures throw `AuthError` (401/403), `NotFoundError` (404), or
+`MemClawApiError`. Every result also exposes the full API payload on `.raw`.
+
+For credentials, scopes, and the full API surface, see the
+[MemClaw docs](https://memclaw.net/docs). Production fleets should use
+[per-agent keys](https://memclaw.net/docs/integrations/per-agent-keys).
+
+## License
+
+Apache-2.0

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "@caura/memclaw-client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@caura/memclaw-client",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^20",
+        "typescript": "^5.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@caura/memclaw-client",
+  "version": "0.1.0",
+  "description": "Official TypeScript/JavaScript client for MemClaw — governed shared memory for AI agent fleets (multi-agent, multi-tenant, MCP-native).",
+  "license": "Apache-2.0",
+  "author": "Caura <hello@caura.ai>",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist/index.js", "dist/index.d.ts", "README.md"],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "memclaw",
+    "agent-memory",
+    "ai-agents",
+    "llm-memory",
+    "rag",
+    "mcp",
+    "knowledge-graph",
+    "vector-search",
+    "multi-agent"
+  ],
+  "homepage": "https://memclaw.net",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/caura-ai/caura-memclaw.git",
+    "directory": "clients/typescript"
+  },
+  "bugs": {
+    "url": "https://github.com/caura-ai/caura-memclaw/issues"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "tsc && node --test dist/index.test.js",
+    "prepublishOnly": "tsc"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4"
+  }
+}

--- a/clients/typescript/src/index.test.ts
+++ b/clients/typescript/src/index.test.ts
@@ -1,0 +1,103 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { MemClaw, MemClawApiError, AuthError, NotFoundError } from "./index.js";
+
+type Handler = (url: string, init: RequestInit) => Response | Promise<Response>;
+
+function jsonResponse(status: number, data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function makeClient(handler: Handler, options: Record<string, unknown> = {}): MemClaw {
+  return new MemClaw("mc_test", {
+    tenantId: "t1",
+    baseUrl: "https://example.test",
+    fetch: ((url: string, init: RequestInit) => Promise.resolve(handler(url, init))) as typeof fetch,
+    ...options,
+  });
+}
+
+test("write posts to /memories and parses the response", async () => {
+  const client = makeClient((url, init) => {
+    assert.equal(new URL(url).pathname, "/api/v1/memories");
+    assert.equal((init.headers as Record<string, string>)["X-API-Key"], "mc_test");
+    assert.deepEqual(JSON.parse(init.body as string), {
+      tenant_id: "t1",
+      content: "hello",
+      agent_id: "a1",
+    });
+    return jsonResponse(201, { id: "m1", content: "hello", title: "Hi", agent_id: "a1" });
+  }, { agentId: "a1" });
+
+  const mem = await client.write("hello");
+  assert.equal(mem.id, "m1");
+  assert.equal(mem.title, "Hi");
+  assert.equal(mem.raw.agent_id, "a1");
+});
+
+test("write per-call agentId overrides the default", async () => {
+  const client = makeClient((_url, init) => {
+    assert.equal(JSON.parse(init.body as string).agent_id, "override");
+    return jsonResponse(201, { id: "m1", content: "x" });
+  }, { agentId: "default" });
+  await client.write("x", { agentId: "override" });
+});
+
+test("search posts to /search and returns a list", async () => {
+  const client = makeClient((url, init) => {
+    assert.equal(new URL(url).pathname, "/api/v1/search");
+    const body = JSON.parse(init.body as string);
+    assert.equal(body.query, "q");
+    assert.equal(body.top_k, 3);
+    return jsonResponse(200, { items: [{ id: "m1", content: "a" }, { id: "m2", content: "b" }] });
+  });
+  const results = await client.search("q", { topK: 3 });
+  assert.deepEqual(results.map((m) => m.id), ["m1", "m2"]);
+});
+
+test("recall returns the summary and supporting memories", async () => {
+  const client = makeClient((url) => {
+    assert.equal(new URL(url).pathname, "/api/v1/recall");
+    return jsonResponse(200, { summary: "S", supporting_memories: [{ id: "m1", content: "a" }] });
+  });
+  const result = await client.recall("q");
+  assert.equal(result.summary, "S");
+  assert.equal(result.supportingMemories[0].id, "m1");
+});
+
+test("health hits /health", async () => {
+  const client = makeClient((url) => {
+    assert.equal(new URL(url).pathname, "/api/v1/health");
+    return jsonResponse(200, { status: "ok" });
+  });
+  assert.equal((await client.health()).status, "ok");
+});
+
+test("403 maps to AuthError and parses the error envelope", async () => {
+  const client = makeClient(() => jsonResponse(403, { error: { message: "cross-fleet", details: { x: 1 } } }));
+  await assert.rejects(client.write("x"), (err: unknown) => {
+    assert.ok(err instanceof AuthError);
+    assert.equal((err as AuthError).statusCode, 403);
+    assert.deepEqual((err as AuthError).details, { x: 1 });
+    return true;
+  });
+});
+
+test("404 maps to NotFoundError", async () => {
+  const client = makeClient(() => jsonResponse(404, { detail: "nope" }));
+  await assert.rejects(client.search("q"), NotFoundError);
+});
+
+test("500 maps to MemClawApiError", async () => {
+  const client = makeClient(() => jsonResponse(500, { message: "boom" }));
+  await assert.rejects(client.recall("q"), MemClawApiError);
+});
+
+test("constructor validates apiKey and tenantId", () => {
+  assert.throws(() => new MemClaw("", { tenantId: "t" }));
+  assert.throws(() => new MemClaw("k", { tenantId: "" } as never));
+});

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -1,0 +1,198 @@
+/**
+ * Official TypeScript/JavaScript client for MemClaw — governed shared memory
+ * for AI agent fleets. A thin wrapper over the MemClaw REST API.
+ *
+ * Point it at a managed (`https://memclaw.net`) or self-hosted
+ * (`http://localhost:8000`) deployment.
+ */
+
+export const DEFAULT_BASE_URL = "https://memclaw.net";
+
+export class MemClawError extends Error {}
+
+export class MemClawApiError extends MemClawError {
+  readonly statusCode: number;
+  readonly details: unknown;
+  constructor(statusCode: number, message: string, details?: unknown) {
+    super(`[${statusCode}] ${message}`);
+    this.name = "MemClawApiError";
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+/** Raised on 401/403 — bad or insufficiently-scoped credential. */
+export class AuthError extends MemClawApiError {}
+
+/** Raised on 404. */
+export class NotFoundError extends MemClawApiError {}
+
+export interface Memory {
+  id: string | null;
+  content: string;
+  title: string | null;
+  memoryType: string | null;
+  tenantId: string | null;
+  agentId: string | null;
+  weight: number | null;
+  similarity: number | null;
+  metadata: Record<string, unknown> | null;
+  /** The full, unmapped API payload. */
+  raw: Record<string, unknown>;
+}
+
+export interface RecallResult {
+  summary: string | null;
+  supportingMemories: Memory[];
+  raw: Record<string, unknown>;
+}
+
+export interface MemClawOptions {
+  tenantId: string;
+  baseUrl?: string;
+  agentId?: string;
+  timeoutMs?: number;
+  /** Inject a custom fetch (e.g. for tests). Defaults to global fetch. */
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface WriteOptions {
+  agentId?: string;
+  memoryType?: string;
+  fleetId?: string;
+  metadata?: Record<string, unknown>;
+  [extra: string]: unknown;
+}
+
+export interface SearchOptions {
+  topK?: number;
+  fleetIds?: string[];
+  filterAgentId?: string;
+  [extra: string]: unknown;
+}
+
+function toMemory(d: Record<string, any>): Memory {
+  return {
+    id: d.id ?? null,
+    content: d.content ?? "",
+    title: d.title ?? null,
+    memoryType: d.memory_type ?? null,
+    tenantId: d.tenant_id ?? null,
+    agentId: d.agent_id ?? null,
+    weight: d.weight ?? null,
+    similarity: d.similarity ?? null,
+    metadata: d.metadata ?? null,
+    raw: d,
+  };
+}
+
+export class MemClaw {
+  readonly tenantId: string;
+  readonly agentId?: string;
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly headers: Record<string, string>;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(apiKey: string, options: MemClawOptions) {
+    if (!apiKey) throw new Error("apiKey is required");
+    if (!options || !options.tenantId) throw new Error("tenantId is required");
+    this.tenantId = options.tenantId;
+    this.agentId = options.agentId;
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+    this.timeoutMs = options.timeoutMs ?? 30000;
+    this.headers = { "X-API-Key": apiKey, "Content-Type": "application/json" };
+    const f = options.fetch ?? globalThis.fetch;
+    if (!f) throw new Error("global fetch is unavailable; pass options.fetch or use Node 18+");
+    this.fetchImpl = f;
+  }
+
+  /** Persist a memory. POST /api/v1/memories */
+  async write(content: string, options: WriteOptions = {}): Promise<Memory> {
+    const { agentId, memoryType, fleetId, metadata, ...extra } = options;
+    const body: Record<string, unknown> = { tenant_id: this.tenantId, content };
+    const resolvedAgent = agentId ?? this.agentId;
+    if (resolvedAgent) body.agent_id = resolvedAgent;
+    if (memoryType) body.memory_type = memoryType;
+    if (fleetId) body.fleet_id = fleetId;
+    if (metadata !== undefined) body.metadata = metadata;
+    Object.assign(body, extra);
+    return toMemory(await this.request("POST", "/api/v1/memories", body));
+  }
+
+  /** Hybrid vector + keyword search. POST /api/v1/search */
+  async search(query: string, options: SearchOptions = {}): Promise<Memory[]> {
+    const { topK = 5, fleetIds, filterAgentId, ...extra } = options;
+    const body: Record<string, unknown> = { tenant_id: this.tenantId, query, top_k: topK };
+    if (fleetIds) body.fleet_ids = fleetIds;
+    if (filterAgentId) body.filter_agent_id = filterAgentId;
+    Object.assign(body, extra);
+    const data = await this.request("POST", "/api/v1/search", body);
+    const items: unknown = data?.items;
+    return Array.isArray(items) ? items.map((m) => toMemory(m as Record<string, any>)) : [];
+  }
+
+  /** Search + LLM-synthesized context brief. POST /api/v1/recall */
+  async recall(query: string, options: { topK?: number } = {}): Promise<RecallResult> {
+    const body = { tenant_id: this.tenantId, query, top_k: options.topK ?? 5 };
+    const data = await this.request("POST", "/api/v1/recall", body);
+    const supporting: unknown = data?.supporting_memories;
+    return {
+      summary: data?.summary ?? null,
+      supportingMemories: Array.isArray(supporting)
+        ? supporting.map((m) => toMemory(m as Record<string, any>))
+        : [],
+      raw: data,
+    };
+  }
+
+  /** Liveness probe. GET /api/v1/health */
+  async health(): Promise<Record<string, unknown>> {
+    return this.request("GET", "/api/v1/health");
+  }
+
+  private async request(method: string, path: string, body?: unknown): Promise<any> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let res: Response;
+    try {
+      res = await this.fetchImpl(this.baseUrl + path, {
+        method,
+        headers: this.headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    await raiseForStatus(res);
+    return res.json();
+  }
+}
+
+async function raiseForStatus(res: Response): Promise<void> {
+  if (res.ok) return;
+  let payload: any = {};
+  try {
+    payload = await res.json();
+  } catch {
+    payload = {};
+  }
+  let message = "";
+  let details: unknown;
+  if (payload && typeof payload === "object") {
+    const err = payload.error;
+    if (err && typeof err === "object") {
+      message = err.message ?? "";
+      details = err.details;
+    }
+    message = message || payload.detail || payload.message || "";
+  }
+  if (res.status === 401 || res.status === 403) {
+    throw new AuthError(res.status, message || "authentication failed", details);
+  }
+  if (res.status === 404) {
+    throw new NotFoundError(res.status, message || "not found", details);
+  }
+  throw new MemClawApiError(res.status, message || "request failed", details);
+}

--- a/clients/typescript/tsconfig.json
+++ b/clients/typescript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

The TypeScript/JavaScript client for MemClaw, in `clients/typescript/` — a faithful port of the [Python client](https://github.com/caura-ai/caura-memclaw/tree/main/clients/python).

```ts
import { MemClaw } from "@caura/memclaw-client";
const mc = new MemClaw("mc_xxx", { tenantId: "my-team", agentId: "my-agent" });
await mc.write("Q3 revenue target is $4M.");
console.log((await mc.recall("Q3 revenue target")).summary);
```

- `write`/`search`/`recall`/`health`, typed interfaces, typed errors (`AuthError`/`NotFoundError`/`MemClawApiError`), `.raw` on every result.
- **Zero runtime deps** — native `fetch` (Node 18+), ESM, built with `tsc` (repo convention).
- Rich `package.json` metadata; README funnel gains a TypeScript snippet.

## Name

Ships as **`@caura/memclaw-client`**: the `plugin/` package already owns `@caura/memclaw`, and unscoped `memclaw` is taken on npm by an unrelated project. (Parallels PyPI `memclaw-client`.)

## CI / verification

- New **Client (TypeScript) CI** workflow: `npm test` (= `tsc` build + `node --test`) on changes under `clients/typescript/`. Tests mock `fetch` (no network). **Verified locally: 9/9 pass, build clean.**
- **Wet-tested against a live local stack** (core-api): `health()` and `write()` round-tripped successfully (real 201 + memory id); a 503/401 from the server mapped correctly to typed errors. `search`/`recall` reached the endpoint with valid auth but the local stack's embedding service was down (503) — a server/env condition, not a client issue; their response parsing is covered by the unit tests.
- Root CI untouched (root pytest only runs `tests/`).

## Publishing (maintainer action — not done here)

Adds `publish-npm-client.yml` (npm publish on a `memclaw-client-ts-v*` tag or manual dispatch, with provenance). One-time setup (`@caura` scope access + `NPM_TOKEN`) is documented in the workflow header. I did **not** publish.