### PR TITLE
fix(search): surface conflicted memories that exactly match the query

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1015,8 +1015,27 @@ class PostgresService:
         else:
             date_range_boost = literal_column("1.0").label("date_range_boost")
 
+        # Status demotion. ``outdated`` is always demoted (a definitively
+        # superseded fact). ``conflicted`` is demoted EXCEPT when the row is an
+        # exact lexical match for the query: a conflicted memory carries a
+        # competing claim, not a retraction, and when it is the exact thing the
+        # caller asked for it must not be buried beneath unrelated near-duplicate
+        # siblings (different entities that merely share a name prefix). The
+        # competing successor is still surfaced via load_and_serialize's
+        # supersedes-chain injection, so the caller sees both sides.
+        #
+        # Why an FTS match is the right gate: at corpus scale a conflicted row's
+        # blended relevance (vec+fts) sits only marginally above its near-dup
+        # siblings, so the 0.5 multiplier reliably sinks it below them even when
+        # it is the single best match — the exact-match signal is what
+        # distinguishes "the row the caller wants" from "a sibling about a
+        # different entity". Empty/stopword-only queries degrade ts_query to the
+        # empty tsquery (matches nothing here), so the gate is inert for
+        # vector-only / entity-only callers and conflicted stays demoted.
+        _exact_lexical_match = Memory.search_vector.op("@@")(ts_query) if query and query.strip() else false()
         status_penalty = case(
-            (Memory.status.in_(("outdated", "conflicted")), 0.5),
+            (Memory.status == "outdated", 0.5),
+            (and_(Memory.status == "conflicted", ~_exact_lexical_match), 0.5),
             else_=1.0,
         ).label("status_penalty")
 
@@ -1154,7 +1173,24 @@ class PostgresService:
             # ranking with stale claims agents shouldn't act on. Callers
             # that need to inspect superseded rows pass an explicit
             # ``status_filter`` to override.
-            scored_stmt = scored_stmt.where(Memory.status.notin_(("outdated", "conflicted")))
+            #
+            # Carve-out: a ``conflicted`` row that is an EXACT lexical match
+            # for the query is kept. ``conflicted`` (unlike ``outdated``) means
+            # "a competing claim exists", not "definitively retracted" — and the
+            # semantic contradiction path mismarks near-duplicate-but-distinct
+            # entities (e.g. ``Wayne #0000`` vs ``Wayne #0704``), so a blanket
+            # exclusion silently drops the very row the caller named. The
+            # exact-match gate scopes the carve-out to rows the caller clearly
+            # asked for; status_penalty above keeps a surfaced exact-match
+            # conflicted row un-demoted, and load_and_serialize still injects its
+            # supersedes successor so both sides are visible. ``outdated`` stays
+            # fully excluded.
+            scored_stmt = scored_stmt.where(
+                or_(
+                    Memory.status.notin_(("outdated", "conflicted")),
+                    and_(Memory.status == "conflicted", _exact_lexical_match),
+                )
+            )
         if valid_at:
             from datetime import date as _date_type
 
@@ -1312,9 +1348,16 @@ class PostgresService:
             if status_filter:
                 stmt = stmt.where(Memory.status == status_filter)
             else:
-                # Mirrors scored_search: exclude superseded memories from
-                # default results. Callers wanting them pass status_filter.
-                stmt = stmt.where(Memory.status.notin_(("outdated", "conflicted")))
+                # ENTITY_LOOKUP path: these memory IDs are already scoped to the
+                # entities the caller's query resolved to — every row here is
+                # "about" the named entity, the entity-graph analogue of the
+                # scored path's exact-lexical-match carve-out. So we keep
+                # ``conflicted`` rows (a competing claim about the very entity
+                # asked for, which the semantic contradiction path routinely
+                # mismarks across distinct ``#NNNN`` siblings) and exclude only
+                # ``outdated`` (definitively retracted). load_and_serialize still
+                # injects the supersedes successor so both sides remain visible.
+                stmt = stmt.where(Memory.status != "outdated")
             if valid_at:
                 from datetime import date as _date_type
 

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -379,3 +379,86 @@ class TestSearchPipelineEndToEnd:
         assert str(live_mem["id"]) in result_ids, (
             "live memory was not returned by scored search"
         )
+
+
+@pytest.mark.integration
+class TestConflictedExactMatchSurfaces:
+    """Conflicted memories that exactly match the query must not be hidden.
+
+    The semantic contradiction path marks the older of two embedding-near rows
+    ``conflicted`` and routinely mismarks distinct ``#NNNN`` siblings (different
+    entities sharing a name prefix). scored_search previously hard-excluded all
+    ``conflicted``/``outdated`` rows, so an exact-match gold buried under
+    confirmed near-duplicates vanished from results entirely. The carve-out
+    keeps a ``conflicted`` row when it is an exact lexical (FTS) match for the
+    query; ``outdated`` (a definitive retraction) stays excluded.
+    """
+
+    async def test_conflicted_exact_match_is_surfaced(self, db, tenant_id):
+        # Distinctive token "zylqx" appears only in the conflicted gold, so the
+        # query FTS-matches the gold and nothing else.
+        await _insert_memory(
+            db,
+            tenant_id,
+            "Division zylqx quarterly revenue is forty two million",
+            weight=0.7,
+            status="conflicted",
+        )
+        for sib in (
+            "Division abcde quarterly revenue is ninety one million",
+            "Division fghij quarterly revenue is twelve million",
+            "Division klmno quarterly revenue is sixty million",
+        ):
+            await _insert_memory(db, tenant_id, sib, weight=0.7, status="confirmed")
+
+        from core_api.services.memory_service import search_memories
+
+        results = await search_memories(
+            db, tenant_id, "zylqx quarterly revenue", top_k=10
+        )
+        assert any("zylqx" in r.content for r in results), (
+            "conflicted exact-match gold was excluded from results"
+        )
+
+    async def test_conflicted_non_match_still_excluded(self, db, tenant_id):
+        # A conflicted row that does NOT lexically match the query stays hidden
+        # (carve-out is scoped to exact matches, not all conflicted rows).
+        await _insert_memory(
+            db,
+            tenant_id,
+            "Division qqqqq headcount is two hundred",
+            weight=0.7,
+            status="conflicted",
+        )
+        await _insert_memory(
+            db,
+            tenant_id,
+            "Division wwwww quarterly revenue is five million",
+            weight=0.7,
+            status="confirmed",
+        )
+
+        from core_api.services.memory_service import search_memories
+
+        results = await search_memories(db, tenant_id, "quarterly revenue", top_k=10)
+        assert not any("qqqqq" in r.content for r in results), (
+            "conflicted non-matching row should remain excluded"
+        )
+
+    async def test_outdated_exact_match_still_excluded(self, db, tenant_id):
+        # ``outdated`` is a definitive retraction — it stays excluded even on an
+        # exact lexical match (only ``conflicted`` gets the carve-out).
+        await _insert_memory(
+            db,
+            tenant_id,
+            "Project vortex status is cancelled",
+            weight=0.7,
+            status="outdated",
+        )
+
+        from core_api.services.memory_service import search_memories
+
+        results = await search_memories(db, tenant_id, "vortex status", top_k=10)
+        assert not any("vortex" in r.content for r in results), (
+            "outdated exact-match should remain excluded"
+        )


### PR DESCRIPTION
## Problem

S1 retrieval@10 collapses at corpus scale even after #304/#327: **22/25 @ K=1000 → 18/25 @ K=10000**, and per-failure anatomy showed **every residual miss was a gold memory with `status='conflicted'`** — flipping just those statuses to `confirmed` recovered **25/25**.

Two retrieval paths hard-excluded `conflicted`/`outdated` rows from default results:
- `memory_scored_search` (semantic/keyword path): `WHERE status NOT IN ('outdated','conflicted')`
- `memory_load_by_ids` (entity_lookup short-circuit): same exclusion

The semantic contradiction detector marks the older of two embedding-near rows `conflicted`, and routinely mismarks **distinct entities that merely share a name prefix** (e.g. `Wayne Enterprises #0000` was marked conflicted against `Wayne Enterprises #0704`). The blanket exclusion then silently dropped the exact row the caller asked for, leaving only confirmed near-duplicate siblings about *other* entities. ~10% of a 10k-fact corpus was marked conflicted this way.

## Fix (retrieval-only — write/contradiction path untouched)

- **`memory_scored_search`**: keep a `conflicted` row when it is an exact lexical (FTS) match for the query, and exempt that row from the `0.5` `status_penalty` so it isn't re-buried beneath confirmed siblings. `outdated` (a definitive retraction) stays fully excluded.
- **`memory_load_by_ids`** (entity_lookup): rows here are already scoped to the resolved entity — the entity-graph analogue of an exact match — so keep `conflicted` and exclude only `outdated`.

`load_and_serialize` still injects the supersedes successor for any returned superseded row, so genuine knowledge-updates continue to show both sides.

## Results (S1 replay, local stack, retrieval@10)

| | before | after |
|---|---|---|
| **k10k** | 18/25 | **25/25** |
| k1k | 22/25 | 23/25 |

The 2 residual k1k misses are person-hub graph dilution in entity_lookup (gold's link dropped at the `GRAPH_MAX_BOOSTED_MEMORIES` cap) — a separate, deeper issue (tracked toward the exact-first cascade, A30).

## Regression safety

- New integration tests (`tests/test_integration_search.py::TestConflictedExactMatchSurfaces`) pin all three semantics: conflicted exact-match surfaces; conflicted non-match stays excluded; outdated exact-match stays excluded. They use `fake_embedding` (no external dependency).
- `knowledge-update` regression category (the relevant risk — surfacing conflicted rows): **acc 91.7%, recall 1.0** vs baseline 92.9% / 1.0 — within noise, no regression. (The full 5-category local run was blocked by unrelated write-path LLM timeouts in the local env; the categories that completed writes matched baseline exactly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)