### PR TITLE
fix(deps): cap fastapi <0.137 to unbreak CI

### DIFF
--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -5,7 +5,14 @@ description = "MemClaw Core API service"
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
-    "fastapi>=0.115,<1",
+    # Cap <0.137: FastAPI 0.137.0 (released 2026-06-14) changed
+    # include_router(prefix=...) to mount a sub-app instead of flattening the
+    # router's routes into app.routes. That breaks app.py's import-time
+    # request-timeout opt-out-path assertion (it scans app.routes for the
+    # prefixed paths) — which turned CI red repo-wide the moment 0.137 shipped,
+    # because CI re-resolves via ``uv pip install`` rather than the lockfile
+    # (same float-up reason as the greenlet cap below). Drop once 0.137+ is vetted.
+    "fastapi>=0.115,<0.137",
     "uvicorn[standard]>=0.34,<1",
     "sqlalchemy[asyncio]>=2.0,<3",
     # SQLAlchemy[asyncio] pulls in greenlet. Pin <3.5.0 — greenlet 3.5.0

--- a/core-storage-api/pyproject.toml
+++ b/core-storage-api/pyproject.toml
@@ -5,7 +5,14 @@ description = "MemClaw Core Storage API — PostgreSQL CRUD service"
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
-    "fastapi>=0.115,<1",
+    # Cap <0.137: FastAPI 0.137.0 (released 2026-06-14) changed
+    # include_router(prefix=...) to mount a sub-app instead of flattening the
+    # router's routes into app.routes. That breaks app.py's import-time
+    # request-timeout opt-out-path assertion (it scans app.routes for the
+    # prefixed paths) — which turned CI red repo-wide the moment 0.137 shipped,
+    # because CI re-resolves via ``uv pip install`` rather than the lockfile
+    # (same float-up reason as the greenlet cap below). Drop once 0.137+ is vetted.
+    "fastapi>=0.115,<0.137",
     "uvicorn[standard]>=0.34,<1",
     "sqlalchemy[asyncio]>=2.0,<3",
     # SQLAlchemy[asyncio] pulls in greenlet. Pin <3.5.0 — greenlet 3.5.0


### PR DESCRIPTION
## Why main's CI is red (no code change caused it)

FastAPI **0.137.0** was released **2026-06-14 12:51 UTC** and changed `include_router(prefix=...)` to **mount a sub-app** instead of flattening the router's routes into `app.routes`. `app.py`'s import-time assertion — that every `RequestTimeoutMiddleware` opt-out path (`/api/v1/memories/bulk`, `/api/v1/admin/org/purge-data`) is registered — scans `app.routes` for those prefixed paths, no longer finds them, and raises at import. That errors every app-building test: **5 failed + 270 errors**.

CI re-resolves dependencies with `uv pip install -e …[dev]` (lockfiles are gitignored), so the loose `fastapi>=0.115,<1` pin floated up to 0.137.0 the instant it shipped — turning `main` red mid-day with **zero commits**.

### Proof it's the dependency, not any commit
- All of `main`'s commits that day landed ≤12:06 UTC, before the 12:51 release.
- A throwaway PR on pristine `main` (empty commit) failed identically.
- **Bisect:** commit `4d2d6ef` (2026-06-13, green CI the prior day) re-run today resolves 0.137.0 and throws the same `RuntimeError`. Same old code, new dep, fails.
- Reproduced the mechanism directly: under 0.137.0 `include_router(prefix=…)` adds **1 route** (a Mount) instead of the router's **20**; under 0.136.x it adds all 20.

## Fix

Cap `fastapi>=0.115,<0.137` in both `core-api` and `core-storage-api` pyprojects (same float-up rationale as the existing greenlet cap). 

**Verified:** the combined lock-less install (CI's exact failure mode) now resolves fastapi 0.136.x and `import core_api.app` passes. Drop the cap once 0.137+'s mount-based routing is vetted against the route-introspection assertion.

Unblocks all PRs (incl. #357).

🤖 Generated with [Claude Code](https://claude.com/claude-code)