### PR TITLE
fix(core-api): pin starlette<1 — 1.x routing change crashes the startup guard

### DIFF
--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -6,6 +6,15 @@ license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115,<1",
+    # Pin Starlette below the 1.x major. FastAPI's range otherwise pulls
+    # Starlette 1.x (released 2026-06-14), whose routing internals changed how
+    # included-router paths surface in ``app.routes`` — which trips the CAURA-602
+    # startup guard in app.py (it verifies every RequestTimeoutMiddleware opt-out
+    # path is a registered route) and crashes core-api on boot. uv.lock is
+    # gitignored so every build re-resolves; without this cap the drift recurs.
+    # Drop once core-api is validated against Starlette 1.x (and the guard is made
+    # route-nesting aware).
+    "starlette<1",
     "uvicorn[standard]>=0.34,<1",
     "sqlalchemy[asyncio]>=2.0,<3",
     # SQLAlchemy[asyncio] pulls in greenlet. Pin <3.5.0 — greenlet 3.5.0


### PR DESCRIPTION
## Problem
Every `staging` deploy since ~13:27 UTC 2026-06-14 fails: `staging-memclaw-core-api` crashes on startup and the Cloud Run probe times out on PORT 8000.

Root cause — `core-api/src/core_api/app.py:700` (the CAURA-602 guard):
```
RuntimeError: RequestTimeoutMiddleware opt-out path '/api/v1/admin/org/purge-data'
is not registered on the FastAPI app...
```
The route **is** defined (`routes/org_deletion.py`) and included unconditionally. What changed is **not the source** — the same `main` commit deployed fine at 12:06 UTC and failed after 13:27 UTC.

## Why: unpinned Starlette drifted to a 1.x major
`core-api/uv.lock` is gitignored and re-resolved on every build, and `fastapi>=0.115,<1` has no Starlette bound. **Starlette released 1.3.1 on 2026-06-14**; builds after it began resolving `fastapi 0.137.0 + starlette 1.3.1`. Starlette's 1.x major changed routing internals so included-router paths no longer surface where the guard scans `app.routes` → the opt-out path isn't found → import-time `RuntimeError` → `exit(1)`.

## Fix
Pin `starlette<1`. Verified with `uv lock`: FastAPI **stays at 0.137.0** and Starlette resolves to **0.52.1** (the last 0.x) — no FastAPI downgrade — restoring the pre-1.x routing behavior the guard relies on.

```
fastapi   0.137.0   (unchanged)
starlette 0.52.1    (was 1.3.1)
```

## Follow-up (not in this PR)
The CAURA-602 guard is fragile — it string-matches top-level `app.routes` and hard-crashes on any routing-internals change. A future change should make it route-nesting aware (warn, don't crash) so Starlette 1.x can be adopted deliberately. This PR is the minimal unblock.

Signed-off-by: eldad-caura <eldad@caura.ai>

🤖 Generated with [Claude Code](https://claude.com/claude-code)