### PR TITLE
docs: README write-response field names match payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ curl -X POST http://localhost:8000/api/v1/search \
   -d '{"tenant_id": "default", "query": "authentication token lifetime"}'
 ```
 
-The write response comes back enriched with an LLM-inferred `type`, `title`, `summary`, `tags`, `status`, and `importance_score` — all from a single `content` field.
+The write response comes back enriched with an LLM-inferred `memory_type`, `title`, `summary`, `tags`, `status`, and `weight` — all from a single `content` field.
 
 Ready for semantic recall, multi-tenant, a managed host, or an OpenClaw fleet? Pick a path below.
 


### PR DESCRIPTION
## Summary
- README Quick Start prose said the write response includes `type` and `importance_score`, but the actual `POST /memories` payload exposes `memory_type` and `weight`.
- Aligns the prose at `README.md:75` with the real field names so a reader following the Quick Start sees what they expect.

This closes finding **F-5** from the OSS engineering report (`memclaw-tutorials/ENGINEERING-REPORT-caura-memclaw.md`). The fix was claimed shipped in #344 but this one occurrence was missed.

## Test plan
- [ ] `POST /api/v1/memories` against a fresh standalone stack and confirm the returned JSON has `memory_type` and `weight` fields (no `type`, no `importance_score`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)