### PR TITLE
fix(core-api): make the CAURA-602 startup guard FastAPI-0.137-proof

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -686,15 +686,20 @@ app.router.routes.append(
 
 
 # CAURA-602: turn a silent regression into a startup crash. The
-# request-timeout middleware skips a hardcoded path-allowlist; if a
-# router prefix or path ever moves and the allowlist isn't updated to
-# match, the silent-create class would re-emerge with no error. Verify
-# at import time that every opt-out path is actually mounted on this
-# app — string-matching is forced by the ASGI scope shape, but at
-# least the divergence will fail loudly. ``getattr`` filters out
-# ``Host`` route entries (no ``.path``); ``Mount`` and ``APIRoute``
-# both carry it.
-_registered_paths = {getattr(r, "path", None) for r in app.routes if getattr(r, "path", None)}
+# request-timeout middleware skips a hardcoded path-allowlist; if a router prefix
+# or path ever moves and the allowlist isn't updated to match, the silent-create
+# class would re-emerge with no error. Verify at import time that every opt-out
+# path is a registered route.
+#
+# Read the paths from the OpenAPI schema rather than walking ``app.routes``:
+# FastAPI 0.137 changed ``include_router(prefix=...)`` to mount the router as an
+# opaque ``_IncludedRouter`` (path=None, no public ``.routes``), so the prefixed
+# paths are no longer top-level ``APIRoute.path`` entries — which is exactly what
+# silently broke this guard when 0.137 shipped. ``app.openapi()`` is the stable,
+# public surface and lists the prefixed paths under both old (flatten) and new
+# (mount) FastAPI. Every core-api route is ``include_in_schema=True``, so none is
+# hidden from this check.
+_registered_paths = set(app.openapi().get("paths", {}))
 for _opt_out in _TIMEOUT_OPT_OUT_PATHS:
     if _opt_out not in _registered_paths:
         raise RuntimeError(


### PR DESCRIPTION
## Why
The CAURA-602 startup guard asserts every `RequestTimeoutMiddleware` opt-out path (`/api/v1/memories/bulk`, `/api/v1/admin/org/purge-data`) is a registered route. It walked `app.routes` and string-matched top-level `.path` entries.

**FastAPI 0.137 broke that:** `include_router(prefix=...)` now mounts the router as an opaque `_IncludedRouter` (`path=None`, no public `.routes`), so the prefixed opt-out paths are no longer top-level `APIRoute.path` entries → the guard raised at import → core-api crashed on boot. That was the **2026-06-14 outage** (currently mitigated by the reactive `fastapi<0.137` caps).

## Fix
Read the registered paths from **`app.openapi()`** — the stable, public surface — instead of walking the internal route objects. The OpenAPI schema lists the prefixed paths under **both** old (flatten) and new (mount) FastAPI. All core-api routes are `include_in_schema=True`, so none is hidden from the check.

```python
_registered_paths = set(app.openapi().get("paths", {}))
```

## Verification (linux/amd64)
Built core-api and imported `core_api.app` under both versions:

| FastAPI | `import core_api.app` | guard |
|---|---|---|
| 0.136.3 (committed lock) | ✅ green, 106 routes | passes (no regression) |
| 0.137.0 | ✅ green | **passes** — finds the opt-out paths via openapi despite `_IncludedRouter` |

## Impact
This makes the guard robust to FastAPI's routing-internals changes and **unblocks dropping the `fastapi<0.137` caps** (core-api + core-storage-api + core-worker + core-operations) once the team chooses to adopt 0.137+. Recommend dropping the caps + a deliberate `uv lock --upgrade` to 0.137 in a follow-up, after this lands.

Signed-off-by: eldad-caura <eldad@caura.ai>

🤖 Generated with [Claude Code](https://claude.com/claude-code)