### PR TITLE
build(deps): manage core-* uv.lock via Dependabot's uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,10 @@ updates:
     commit-message:
       prefix: "deps"
 
-  # --- Python: core-api ---
-  - package-ecosystem: "pip"
+  # --- Python (uv): core-api — manages pyproject + the committed uv.lock ---
+  # uv (not pip): core-api installs FROZEN from uv.lock, so only the uv ecosystem
+  # bumps both the lock and pyproject together (pip would leave the lock stale).
+  - package-ecosystem: "uv"
     directory: "/core-api"
     schedule:
       interval: "weekly"
@@ -34,8 +36,8 @@ updates:
     commit-message:
       prefix: "deps(core-api)"
 
-  # --- Python: core-storage-api ---
-  - package-ecosystem: "pip"
+  # --- Python (uv): core-storage-api — manages pyproject + the committed uv.lock ---
+  - package-ecosystem: "uv"
     directory: "/core-storage-api"
     schedule:
       interval: "weekly"
@@ -46,6 +48,33 @@ updates:
       - "area/core-storage-api"
     commit-message:
       prefix: "deps(core-storage-api)"
+
+  # --- Python (uv): core-worker — manages pyproject + the committed uv.lock ---
+  - package-ecosystem: "uv"
+    directory: "/core-worker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "kind/chore"
+      - "area/core-worker"
+    commit-message:
+      prefix: "deps(core-worker)"
+
+  # --- Python (uv): core-operations — manages pyproject + the committed uv.lock ---
+  # No area/core-operations label in labels.yml yet — using area/infra.
+  - package-ecosystem: "uv"
+    directory: "/core-operations"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "kind/chore"
+      - "area/infra"
+    commit-message:
+      prefix: "deps(core-operations)"
 
   # --- npm: root (Playwright e2e) ---
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Why
The `core-*` services now commit `uv.lock` and install **frozen** from it (#362, #363), so a dependency only changes when the lock changes. The existing Dependabot config pointed those services at the **`pip`** ecosystem — which only bumps `pyproject.toml` and **never touches `uv.lock`**, so it would leave the frozen lock (the thing the image actually installs) stale and divergent. This points Dependabot at the locks so bumps land as reviewed PRs — the last piece closing the loop on the 2026-06-14 FastAPI 0.137 drift.

## Changes (to the existing `.github/dependabot.yml`)
- **`core-api` + `core-storage-api`:** `package-ecosystem: pip` → **`uv`** (updates pyproject **and** uv.lock together).
- **Add `uv` blocks for `core-worker` + `core-operations`** — they had **no** Dependabot coverage at all.
- Everything else unchanged: root `pip` (real `requirements.txt`), root + plugin `npm`, `github-actions`, `docker`.

Resulting ecosystem map:
```
pip            /                  (unchanged — root requirements.txt)
uv             /core-api          (was pip)
uv             /core-storage-api  (was pip)
uv             /core-worker       (new)
uv             /core-operations   (new)
npm            / , /plugin        (unchanged)
github-actions /                  (unchanged)
docker         /                  (unchanged)
```

## Notes
- `core-operations` uses `area/infra` — there's no `area/core-operations` label in `labels.yml` (adding one is a trivial optional follow-up).
- Kept the repo's existing ungrouped, weekly, labelled style; no behavior change beyond the ecosystem switch + the two new services.

Signed-off-by: eldad-caura <eldad@caura.ai>

🤖 Generated with [Claude Code](https://claude.com/claude-code)