### PR TITLE
build(core-*): adopt FastAPI 0.137 — drop the <0.137 caps, relock

### DIFF
--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -5,14 +5,11 @@ description = "MemClaw Core API service"
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
-    # Cap <0.137: FastAPI 0.137.0 (released 2026-06-14) changed
-    # include_router(prefix=...) to mount a sub-app instead of flattening the
-    # router's routes into app.routes. That breaks app.py's import-time
-    # request-timeout opt-out-path assertion (it scans app.routes for the
-    # prefixed paths) — which turned CI red repo-wide the moment 0.137 shipped,
-    # because CI re-resolves via ``uv pip install`` rather than the lockfile
-    # (same float-up reason as the greenlet cap below). Drop once 0.137+ is vetted.
-    "fastapi>=0.115,<0.137",
+    # FastAPI 0.137+ is OK since #364 made the startup guard read app.openapi()
+    # instead of walking app.routes (0.137's include_router mounts a sub-app,
+    # hiding prefixed paths from app.routes). The committed uv.lock pins the exact
+    # version; this range only bounds future re-locks.
+    "fastapi>=0.115,<1",
     "uvicorn[standard]>=0.34,<1",
     "sqlalchemy[asyncio]>=2.0,<3",
     # SQLAlchemy[asyncio] pulls in greenlet. Pin <3.5.0 — greenlet 3.5.0

--- a/core-api/uv.lock
+++ b/core-api/uv.lock
@@ -393,7 +393,7 @@ requires-dist = [
     { name = "core-api", extras = ["test", "pubsub"], marker = "extra == 'dev'" },
     { name = "croniter", specifier = ">=2.0" },
     { name = "cryptography", specifier = ">=42.0" },
-    { name = "fastapi", specifier = ">=0.115,<0.137" },
+    { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "google-cloud-aiplatform", specifier = ">=1.80,<2" },
     { name = "google-cloud-pubsub", marker = "extra == 'pubsub'", specifier = ">=2.23,<3" },
     { name = "google-genai", specifier = ">=0.3" },
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.137.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -627,9 +627,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/fe/fb25c287ff7e0f79fc6acf2e8b812725dad28d2a1446c0410bab1422ac90/fastapi-0.137.0.tar.gz", hash = "sha256:d0565d551f65a803ecff245390840867186f456ef98971f750724eed16e1541c", size = 408023, upload-time = "2026-06-14T12:51:30.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f1/b38481428e50131e5345b535414d11d196f14990122fe69c9020c64e5683/fastapi-0.137.0-py3-none-any.whl", hash = "sha256:6dcbde8d464f92117c1accb9e42720f8e423fa9b86cb563b1f5862f785a06498", size = 121777, upload-time = "2026-06-14T12:51:29.067Z" },
 ]
 
 [[package]]

--- a/core-operations/pyproject.toml
+++ b/core-operations/pyproject.toml
@@ -5,10 +5,9 @@ description = "MemClaw core-operations — host for cron/scheduled background jo
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
-    # Cap <0.137 to match core-api (FastAPI 0.137's include_router change broke
-    # core-api's startup guard). Pinned here for a uniform FastAPI across the
-    # core-* services until the guard fix lands; dropped repo-wide then.
-    "fastapi>=0.115,<0.137",
+    # FastAPI 0.137+ OK since #364 (core-api startup guard reads app.openapi()).
+    # The committed uv.lock pins the exact version; this range only bounds re-locks.
+    "fastapi>=0.115,<1",
     "uvicorn[standard]>=0.34,<1",
     "pydantic>=2.0,<3",
     "pydantic-settings>=2.0,<3",

--- a/core-operations/uv.lock
+++ b/core-operations/uv.lock
@@ -247,7 +247,7 @@ test = [
 requires-dist = [
     { name = "cachetools", specifier = ">=5.3,<6" },
     { name = "core-operations", extras = ["test", "pubsub"], marker = "extra == 'dev'" },
-    { name = "fastapi", specifier = ">=0.115,<0.137" },
+    { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "google-cloud-pubsub", marker = "extra == 'pubsub'", specifier = ">=2.23,<3" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27,<1.0" },
@@ -400,7 +400,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.137.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -409,9 +409,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/fe/fb25c287ff7e0f79fc6acf2e8b812725dad28d2a1446c0410bab1422ac90/fastapi-0.137.0.tar.gz", hash = "sha256:d0565d551f65a803ecff245390840867186f456ef98971f750724eed16e1541c", size = 408023, upload-time = "2026-06-14T12:51:30.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f1/b38481428e50131e5345b535414d11d196f14990122fe69c9020c64e5683/fastapi-0.137.0-py3-none-any.whl", hash = "sha256:6dcbde8d464f92117c1accb9e42720f8e423fa9b86cb563b1f5862f785a06498", size = 121777, upload-time = "2026-06-14T12:51:29.067Z" },
 ]
 
 [[package]]

--- a/core-storage-api/pyproject.toml
+++ b/core-storage-api/pyproject.toml
@@ -5,14 +5,10 @@ description = "MemClaw Core Storage API — PostgreSQL CRUD service"
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
-    # Cap <0.137: FastAPI 0.137.0 (released 2026-06-14) changed
-    # include_router(prefix=...) to mount a sub-app instead of flattening the
-    # router's routes into app.routes. That breaks app.py's import-time
-    # request-timeout opt-out-path assertion (it scans app.routes for the
-    # prefixed paths) — which turned CI red repo-wide the moment 0.137 shipped,
-    # because CI re-resolves via ``uv pip install`` rather than the lockfile
-    # (same float-up reason as the greenlet cap below). Drop once 0.137+ is vetted.
-    "fastapi>=0.115,<0.137",
+    # FastAPI 0.137+ is OK since #364 made core-api's startup guard read
+    # app.openapi() instead of walking app.routes. The committed uv.lock pins the
+    # exact version; this range only bounds future re-locks.
+    "fastapi>=0.115,<1",
     "uvicorn[standard]>=0.34,<1",
     "sqlalchemy[asyncio]>=2.0,<3",
     # SQLAlchemy[asyncio] pulls in greenlet. Pin <3.5.0 — greenlet 3.5.0

--- a/core-storage-api/uv.lock
+++ b/core-storage-api/uv.lock
@@ -297,7 +297,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.14,<2" },
     { name = "asyncpg", specifier = ">=0.30,<1" },
     { name = "core-storage-api", extras = ["test", "pubsub"], marker = "extra == 'dev'" },
-    { name = "fastapi", specifier = ">=0.115,<0.137" },
+    { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "google-cloud-pubsub", marker = "extra == 'pubsub'", specifier = ">=2.23,<3" },
     { name = "greenlet", specifier = "<3.5.0" },
     { name = "httpx", specifier = ">=0.27,<1" },
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.1"
+version = "0.137.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -474,9 +474,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/fe/fb25c287ff7e0f79fc6acf2e8b812725dad28d2a1446c0410bab1422ac90/fastapi-0.137.0.tar.gz", hash = "sha256:d0565d551f65a803ecff245390840867186f456ef98971f750724eed16e1541c", size = 408023, upload-time = "2026-06-14T12:51:30.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f1/b38481428e50131e5345b535414d11d196f14990122fe69c9020c64e5683/fastapi-0.137.0-py3-none-any.whl", hash = "sha256:6dcbde8d464f92117c1accb9e42720f8e423fa9b86cb563b1f5862f785a06498", size = 121777, upload-time = "2026-06-14T12:51:29.067Z" },
 ]
 
 [[package]]
@@ -1550,15 +1550,15 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]

--- a/core-worker/pyproject.toml
+++ b/core-worker/pyproject.toml
@@ -5,10 +5,9 @@ description = "MemClaw core async worker — subscribes to memclaw.memory.embed-
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
-    # Cap <0.137 to match core-api (FastAPI 0.137's include_router change broke
-    # core-api's startup guard). Pinned here for a uniform FastAPI across the
-    # core-* services until the guard fix lands; dropped repo-wide then.
-    "fastapi>=0.115,<0.137",
+    # FastAPI 0.137+ OK since #364 (core-api startup guard reads app.openapi()).
+    # The committed uv.lock pins the exact version; this range only bounds re-locks.
+    "fastapi>=0.115,<1",
     "uvicorn[standard]>=0.34,<1",
     "pydantic>=2.0,<3",
     "pydantic-settings>=2.0,<3",

--- a/core-worker/uv.lock
+++ b/core-worker/uv.lock
@@ -255,7 +255,7 @@ vertex = [
 requires-dist = [
     { name = "cachetools", specifier = ">=5.3" },
     { name = "core-worker", extras = ["test", "pubsub"], marker = "extra == 'dev'" },
-    { name = "fastapi", specifier = ">=0.115,<0.137" },
+    { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "google-cloud-aiplatform", marker = "extra == 'vertex'", specifier = ">=1.80,<2" },
     { name = "google-cloud-pubsub", marker = "extra == 'pubsub'", specifier = ">=2.23,<3" },
     { name = "httpx", specifier = ">=0.27,<1" },
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.1"
+version = "0.137.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -511,9 +511,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/fe/fb25c287ff7e0f79fc6acf2e8b812725dad28d2a1446c0410bab1422ac90/fastapi-0.137.0.tar.gz", hash = "sha256:d0565d551f65a803ecff245390840867186f456ef98971f750724eed16e1541c", size = 408023, upload-time = "2026-06-14T12:51:30.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f1/b38481428e50131e5345b535414d11d196f14990122fe69c9020c64e5683/fastapi-0.137.0-py3-none-any.whl", hash = "sha256:6dcbde8d464f92117c1accb9e42720f8e423fa9b86cb563b1f5862f785a06498", size = 121777, upload-time = "2026-06-14T12:51:29.067Z" },
 ]
 
 [[package]]
@@ -2203,15 +2203,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Now that **#364** made core-api's CAURA-602 startup guard read `app.openapi()` (robust to FastAPI 0.137's `include_router` sub-app mounting), the temporary `fastapi<0.137` caps added during the 2026-06-14 incident are no longer needed. This drops them and adopts 0.137 fleet-wide.

- All four `core-*` services: `fastapi>=0.115,<0.137` → **`<1`**.
- Relocked (`uv lock --upgrade-package fastapi`) → **fastapi 0.137.0 + starlette 1.3.1** across all four. The committed locks pin the exact versions; the Dockerfiles install frozen from them.
- `greenlet<3.5.0` kept (platform-wheel guardrail, unrelated).

## Verification
- **CI runs the test suites under 0.137** here — CI installs lock-less (`uv pip install -e …`), so with the caps gone it resolves 0.137 and runs lint/mypy/pytest against it. **This PR's green CI is the gate** (the "verify beyond import" step).
- Earlier proof that the guard holds under 0.137: a linux/amd64 build imported `core_api.app` green on fastapi 0.137.0 (#364).
- If CI surfaces any 0.137 runtime/route-behavior issue beyond the guard, it shows here before merge.

## Rollback
Trivial — revert this PR; the locks return to 0.136.x and the caps come back.

Signed-off-by: eldad-caura <eldad@caura.ai>

🤖 Generated with [Claude Code](https://claude.com/claude-code)