### PR TITLE
fix(search): return raw cosine in similarity, not the ranking composite (F-14)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
+++ b/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
@@ -86,7 +86,15 @@ class LoadAndSerialize:
             _memory_to_out(
                 row.Memory,
                 entity_links=row.entity_links,
-                similarity=(round(float(row.score), 4) if row.score is not None else None),
+                # Expose the raw vector cosine (``vec_sim``), NOT ``row.score`` —
+                # ``score`` is the multiplicative ranking composite (similarity *
+                # freshness * entity/recall/temporal boosts) which routinely
+                # exceeds 1.0, so it's useless for client-side threshold gating.
+                # ``vec_sim`` is the 0..1 cosine and matches the ``min_similarity``
+                # gate in PostFilterResults. Rank order is unchanged (rows are
+                # already ordered by ``score`` upstream). None for FTS-only hits,
+                # which have no vector similarity.
+                similarity=(round(float(row.vec_sim), 4) if row.vec_sim is not None else None),
             )
             for row in rows
         ]

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -3224,7 +3224,11 @@ async def _search_memories_legacy(
             _dict_to_memory_out(
                 row,
                 entity_links=entity_links,
-                similarity=round(float(row.get("score", 0)), 4) if row.get("score") is not None else None,
+                # Raw vector cosine (``vec_sim``), NOT ``score`` (the ranking
+                # composite, which exceeds 1.0 and is useless for threshold
+                # gating). Mirrors LoadAndSerialize in the pipeline path so both
+                # surfaces agree (test_search_pipeline_equivalence) — see F-14.
+                similarity=round(float(row["vec_sim"]), 4) if row.get("vec_sim") is not None else None,
             )
         )
 

--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -263,6 +263,9 @@ async def test_load_and_serialize_uses_preloaded_entity_links():
     results = ctx.data["results"]
     assert len(results) == 1
     assert len(results[0].entity_links) == 1
+    # similarity must be the raw vector cosine (vec_sim=0.9), NOT the ranking
+    # composite (score=0.85) or the vec/FTS blend (similarity=0.8) — see F-14.
+    assert results[0].similarity == 0.9
     assert results[0].entity_links[0].entity_id == entity_link.entity_id
 
 


### PR DESCRIPTION
## Summary (audit finding F-14)

`POST /api/v1/search` (and MCP `memclaw_recall` — same pipeline) returned each item's `similarity` as the **multiplicative ranking composite** (`row.score`), not the raw vector cosine. The composite is `base_similarity * freshness * entity/recall/temporal boosts`, which routinely **exceeds 1.0** — an in-window hit saturates `temporal_boost≈1.3`, which is exactly the "every hit is `1.300`" the report observed. Rank order is fine, but the field is useless for client-side threshold gating.

## Root cause
`pipeline/steps/search/load_and_serialize.py` filled `MemoryOut.similarity` from `row.score` (the composite) instead of `row.vec_sim` (the raw 0..1 cosine), even though `vec_sim` is computed and carried on the row — and is what the server's own `min_similarity` gate (`PostFilterResults`) uses.

## Fix
Source `similarity` from `row.vec_sim`:
- 0..1 range → client gating now matches the server's `min_similarity` semantics.
- **Rank order unchanged** — rows are still ordered by `score` upstream; only the surfaced number changes.
- FTS-only hits (no vector match) → `similarity: null`, honest and already allowed by the schema.

Covers REST **and** MCP recall (shared `build_search_pipeline` → `LoadAndSerialize`).

## Tests
Extended `test_load_and_serialize_uses_preloaded_entity_links` (its row already has distinct `score=0.85 / blend-similarity=0.8 / vec_sim=0.9`) to assert the serialized `similarity == 0.9` — locking it to `vec_sim`, not `score` or the blend. Passes locally.

## Validation
- `ruff check` + `ruff format --check` + `py_compile` clean.
- Confirmed no other test asserts the serialized `similarity` value; the `PostFilterResults` test gates on `vec_sim` (unaffected); core-storage `test_integration` asserts the *storage-layer* `similarity` blend (a different field, unaffected).
- "Exactly constant 1.3" and the v2.5→v2.15 "regression" framing are runtime/history claims (squashed git history) — not relied on; the mis-sourcing is the demonstrable defect.

Intentionally does **not** add a separate `score` field for the composite (additive schema change across many endpoints) — possible follow-up if ranking-score transparency is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)