### PR TITLE
chore(labels): add area/core-operations + use it in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,7 +63,6 @@ updates:
       prefix: "deps(core-worker)"
 
   # --- Python (uv): core-operations — manages pyproject + the committed uv.lock ---
-  # No area/core-operations label in labels.yml yet — using area/infra.
   - package-ecosystem: "uv"
     directory: "/core-operations"
     schedule:
@@ -72,7 +71,7 @@ updates:
     labels:
       - "dependencies"
       - "kind/chore"
-      - "area/infra"
+      - "area/core-operations"
     commit-message:
       prefix: "deps(core-operations)"
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -70,6 +70,9 @@
 - name: area/core-worker
   color: "1d76db"
   description: Background worker — embeddings, enrichment, contradiction detection.
+- name: area/core-operations
+  color: "1d76db"
+  description: Cron/scheduled background jobs — lifecycle, retention, fan-out.
 - name: area/plugin
   color: "1d76db"
   description: OpenClaw plugin (TypeScript) — heartbeat, context-engine, agent-auth.


### PR DESCRIPTION
Small follow-up to #365: `core-operations` had no `area/*` label, so its Dependabot PRs were routed through `area/infra`.

- Add **`area/core-operations`** to `.github/labels.yml` (mirrors the other `core-*` area labels; `labels-sync` will create it).
- Point the `core-operations` `uv` block in `.github/dependabot.yml` at the new label (was `area/infra`).

Signed-off-by: eldad-caura <eldad@caura.ai>

🤖 Generated with [Claude Code](https://claude.com/claude-code)