### PR TITLE
feat(audit): tamper-evident per-tenant hash chain for audit_log (eToro governance)

### DIFF
--- a/common/models/__init__.py
+++ b/common/models/__init__.py
@@ -1,7 +1,7 @@
 # Shared SQLAlchemy models — used by core-api and core-storage-api.
 from common.models.agent import Agent
 from common.models.analysis_report import CrystallizationReport
-from common.models.audit import AuditLog
+from common.models.audit import AuditChainHead, AuditLog
 from common.models.background_task import BackgroundTaskLog
 from common.models.base import Base
 from common.models.capability_usage import CapabilityUsage
@@ -15,6 +15,7 @@ from common.models.memory import Memory
 
 __all__ = [
     "Agent",
+    "AuditChainHead",
     "AuditLog",
     "BackgroundTaskLog",
     "Base",

--- a/common/models/audit.py
+++ b/common/models/audit.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Text, text
+from sqlalchemy import BigInteger, DateTime, LargeBinary, Text, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -22,4 +22,36 @@ class AuditLog(Base):
     detail: Mapped[dict | None] = mapped_column(JSONB)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=text("now()")
+    )
+    # ── Tamper-evident hash chain (migration 025) ────────────────────
+    # Per-tenant linked-hash chain. These are NULL on pre-migration rows
+    # (legacy append-only): the chain genesis is the migration boundary,
+    # so existing rows are intentionally left unchained and excluded from
+    # verification (a partial unique index covers ``seq IS NOT NULL`` only).
+    # Chained rows carry a monotonic per-tenant ``seq`` (starts at 1), the
+    # prior event's ``event_hash`` as ``prev_hash`` (a genesis sentinel for
+    # seq=1), and ``event_hash = SHA256(canonical_event || prev_hash)``.
+    seq: Mapped[int | None] = mapped_column(BigInteger)
+    prev_hash: Mapped[bytes | None] = mapped_column(LargeBinary)
+    event_hash: Mapped[bytes | None] = mapped_column(LargeBinary)
+
+
+class AuditChainHead(Base):
+    """Per-tenant serialization point for the audit hash chain.
+
+    One row per tenant — locked ``FOR UPDATE`` during a chained insert so
+    concurrent same-tenant batches serialize against each other without
+    taking a lock on the (large, append-only) ``audit_log`` table, and
+    different tenants never block one another. ``last_hash`` is the
+    ``event_hash`` of the most recent chained event (a genesis sentinel
+    when ``last_seq=0``); the next insert chains onto it.
+    """
+
+    __tablename__ = "audit_chain_head"
+
+    tenant_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    last_seq: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default=text("0"))
+    last_hash: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
     )

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1246,6 +1246,21 @@ class CoreStorageClient:
             params["resource_type"] = resource_type
         return await self._get_list("/audit-logs", **params)
 
+    async def verify_audit_chain(self, tenant_id: str, limit: int = 100_000) -> dict:
+        """Verify a tenant's tamper-evident audit hash chain.
+
+        Returns ``{valid, verified_count, head_seq}`` (or ``first_broken``
+        on a detected break). Used by the enterprise governance UI's
+        "chain intact" check.
+        """
+        result = await self._get("/audit-logs/verify", tenant_id=tenant_id, limit=limit)
+        # Propagate failures: a None here means a network/5xx error. Returning
+        # {} would hand callers a dict with no "valid" key, turning the real
+        # error into a confusing KeyError downstream.
+        if result is None:
+            raise RuntimeError("verify_audit_chain: empty response from storage service")
+        return result
+
     # =====================================================================
     # Lifecycle audit (CAURA-655)
     # =====================================================================

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/025_audit_hash_chain.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/025_audit_hash_chain.py
@@ -1,0 +1,68 @@
+"""Tamper-evident linked-hash chain for audit_log (eToro governance).
+
+Adds the per-tenant chain columns (``seq``, ``prev_hash``, ``event_hash``) to
+``audit_log`` plus a dedicated ``audit_chain_head`` serialization-point table.
+
+The chain columns are NULLABLE on purpose: existing append-only rows predate
+the chain and are intentionally left unchained — the chain genesis is the
+migration boundary. Backfilling a tamper-evident log would launder unprovable
+history into a valid-looking chain, so we don't; pre-migration rows stay
+queryable but are excluded from verification by the partial unique index
+(``WHERE seq IS NOT NULL``).
+
+``ADD COLUMN`` of nullable columns with no default is metadata-only in
+PostgreSQL 11+ (no table rewrite, no long lock), so this is safe to run inside
+the migration transaction under the lifespan advisory lock even on a large
+prod ``audit_log``.
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-06-15
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "025"
+down_revision: str | None = "024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("audit_log", sa.Column("seq", sa.BigInteger(), nullable=True))
+    op.add_column("audit_log", sa.Column("prev_hash", sa.LargeBinary(), nullable=True))
+    op.add_column("audit_log", sa.Column("event_hash", sa.LargeBinary(), nullable=True))
+    # Partial indexes over chained rows only — pre-migration rows (seq IS NULL)
+    # are excluded, so legacy append-only history neither bloats the index nor
+    # collides on the unique constraint.
+    op.execute(
+        "CREATE UNIQUE INDEX uq_audit_log_tenant_seq ON audit_log (tenant_id, seq) WHERE seq IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX ix_audit_log_tenant_event_hash "
+        "ON audit_log (tenant_id, event_hash) WHERE event_hash IS NOT NULL"
+    )
+    op.create_table(
+        "audit_chain_head",
+        sa.Column("tenant_id", sa.Text(), primary_key=True),
+        sa.Column("last_seq", sa.BigInteger(), nullable=False, server_default=sa.text("0")),
+        sa.Column("last_hash", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("audit_chain_head")
+    op.execute("DROP INDEX IF EXISTS ix_audit_log_tenant_event_hash")
+    op.execute("DROP INDEX IF EXISTS uq_audit_log_tenant_seq")
+    op.drop_column("audit_log", "event_hash")
+    op.drop_column("audit_log", "prev_hash")
+    op.drop_column("audit_log", "seq")

--- a/core-storage-api/src/core_storage_api/routers/audit.py
+++ b/core-storage-api/src/core_storage_api/routers/audit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from core_storage_api.schemas import AUDIT_LOG_FIELDS, orm_to_dict
 from core_storage_api.services.postgres_service import PostgresService
@@ -142,6 +142,26 @@ async def create_audit_logs_bulk(request: Request) -> dict:
         normalised.append(normalised_event)
     await _svc.audit_add_batch(normalised)
     return {"ok": True, "count": len(normalised)}
+
+
+@router.get("/verify")
+async def verify_audit_chain(
+    tenant_id: str,
+    # Bounded so an authenticated caller can't pass ?limit=1e9 and force the
+    # service to load hundreds of millions of rows into memory (OOM).
+    limit: int = Query(default=100_000, ge=1, le=500_000),
+) -> dict:
+    """Verify a tenant's tamper-evident audit hash chain.
+
+    Walks the chain in ``seq`` order, recomputes each ``event_hash``, and
+    checks linkage + genesis + tail-against-head. Returns
+    ``{valid: true, verified_count, head_seq}`` when intact, else
+    ``{valid: false, verified_count, first_broken: {seq, id, reason}}``
+    where ``reason`` ∈ {seq_gap, prev_hash_mismatch, event_hash_mismatch,
+    tail_truncated}. Declared before the ``GET ""`` list route so
+    ``/audit-logs/verify`` matches here, not the list handler.
+    """
+    return await _svc.audit_verify_chain(tenant_id, limit=limit)
 
 
 @router.get("")

--- a/core-storage-api/src/core_storage_api/schemas.py
+++ b/core-storage-api/src/core_storage_api/schemas.py
@@ -185,6 +185,10 @@ AUDIT_LOG_FIELDS: list[str] = [
     "resource_id",
     "detail",
     "created_at",
+    # Chain seq surfaces in list responses (JSON-safe int); the raw
+    # ``prev_hash``/``event_hash`` bytes are intentionally NOT listed
+    # here — the /verify endpoint hex-encodes them in its own response.
+    "seq",
 ]
 
 REPORT_FIELDS: list[str] = [

--- a/core-storage-api/src/core_storage_api/services/audit_chain.py
+++ b/core-storage-api/src/core_storage_api/services/audit_chain.py
@@ -1,0 +1,186 @@
+"""Tamper-evident audit hash-chain primitives (eToro governance).
+
+Pure, side-effect-free helpers shared by the chained-insert path
+(:meth:`PostgresService.audit_add_batch_chained`) and the verifier
+(:meth:`PostgresService.audit_verify_chain`). Defining canonicalization +
+hashing in ONE place guarantees writer and verifier agree byte-for-byte —
+any drift between the two would make every chain look tampered.
+
+The chain is per-tenant: each event carries a monotonic ``seq`` (from 1),
+links to the prior event via ``prev_hash``, and commits
+``event_hash = SHA256(canonical_event || prev_hash)``. A tenant's first
+event (seq=1) chains onto :data:`GENESIS_PREV_HASH`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from uuid import UUID
+
+# 32 zero bytes — the prev_hash a tenant's first (seq=1) event chains onto.
+# A fixed, well-known sentinel so the verifier recomputes genesis exactly as
+# the writer produced it, with no special-casing.
+GENESIS_PREV_HASH: bytes = b"\x00" * 32
+
+
+def canonical_created_at(created_at: datetime) -> str:
+    """Render ``created_at`` deterministically (UTC, microseconds, trailing Z).
+
+    The hash binds the timestamp, so writer and verifier MUST format it
+    identically. Normalize to UTC at a fixed microsecond precision — never
+    hash a client-supplied or locale-dependent rendering.
+    """
+    return created_at.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+def _normalise_numbers(obj: object) -> object:
+    """Canonicalize numbers so the hash survives a JSONB round-trip.
+
+    A ``detail`` dict is hashed at write time from Python values, then
+    re-hashed at verify time from the value read back out of the JSONB column.
+    On some PostgreSQL versions an integral float (``1.0``) is rendered as an
+    int (``1``) through that round-trip, which changes ``json.dumps`` output
+    (``"1.0"`` vs ``"1"``) and would trip a false ``event_hash_mismatch`` on an
+    otherwise-intact row. Collapsing integral floats to ints on BOTH sides
+    (writer + verifier both call :func:`canonical_event`) makes them agree
+    regardless of the driver/PG numeric representation. (pg16 — the CI/staging
+    image — actually preserves ``1.0``; this is defense for other PG versions
+    and any future float-bearing audit detail.)
+    """
+    if isinstance(obj, bool):  # bool is an int subclass — leave it alone
+        return obj
+    if isinstance(obj, float) and obj.is_integer():
+        return int(obj)
+    if isinstance(obj, dict):
+        return {k: _normalise_numbers(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_normalise_numbers(v) for v in obj]
+    return obj
+
+
+def _canonical_resource_id(resource_id: str | UUID | None) -> str | None:
+    """Canonical string form of ``resource_id`` for hashing.
+
+    ``resource_id`` is persisted in a UUID column, so the verifier reads it
+    back as a ``uuid.UUID`` whose ``str()`` is lowercase-hyphenated — while a
+    batch event can supply it as a raw JSON string (possibly uppercase /
+    non-canonical). Normalizing through ``UUID`` here, inside
+    :func:`canonical_event`, makes writer and verifier hash the identical form
+    without either call site having to remember to pre-normalize — the same
+    guarantee :func:`_normalise_numbers` gives ``detail``. A non-UUID string is
+    returned unchanged (it would fail the UUID-column insert anyway, but
+    hash/verify stay consistent); falsy values collapse to ``None``.
+    """
+    if not resource_id:
+        return None
+    if isinstance(resource_id, str):
+        try:
+            return str(UUID(resource_id))
+        except ValueError:
+            return resource_id
+    return str(resource_id)
+
+
+def canonical_event(
+    *,
+    tenant_id: str,
+    seq: int,
+    agent_id: str | None,
+    action: str,
+    resource_type: str,
+    resource_id: str | UUID | None,
+    detail: dict | None,
+    created_at_iso: str,
+) -> bytes:
+    """Deterministic byte serialization of the hashed event fields.
+
+    Excludes the random ``id`` (adds nothing to integrity, unknown until
+    insert) and the chain columns themselves. ``sort_keys`` + compact
+    separators make key order and whitespace irrelevant, so an auditor can
+    reproduce this from the persisted row alone. ``detail`` numbers are
+    normalised (see :func:`_normalise_numbers`) and ``resource_id`` is
+    canonicalized (see :func:`_canonical_resource_id`) so the hash is stable
+    across the JSONB round-trip and the UUID-column read-back.
+    """
+    obj = {
+        "tenant_id": tenant_id,
+        "seq": seq,
+        "agent_id": agent_id,
+        "action": action,
+        "resource_type": resource_type,
+        "resource_id": _canonical_resource_id(resource_id),
+        "detail": _normalise_numbers(detail),
+        "created_at": created_at_iso,
+    }
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def compute_event_hash(canonical: bytes, prev_hash: bytes) -> bytes:
+    """``SHA256(canonical_event || prev_hash)`` → 32 raw bytes.
+
+    Named ``compute_event_hash`` (not ``event_hash``) so call sites don't
+    shadow the ``AuditLog.event_hash`` column attribute.
+    """
+    return hashlib.sha256(canonical + prev_hash).digest()
+
+
+# ── PII-safe detail guard (defense in depth) ─────────────────────────
+#
+# The audit log is long-lived, broadly readable and replicated; storing a
+# raw secret in ``detail`` would defeat the very masking it audits. Emit
+# sites build PII-free details (category + span offsets + content hash only),
+# but we re-check storage-side BEFORE hashing so the chain can never attest a
+# raw value.
+#
+# This is a deliberately CONSERVATIVE (precision-over-recall) backstop: a hit
+# rolls back the whole batch, which would leave a gap in the tamper-evident
+# chain, so a false positive is worse than a miss here — the authoritative
+# detector is the deterministic ``common.governance`` library on the write
+# path, not this guard. We therefore match only an UNAMBIGUOUSLY card-shaped
+# value (four groups of four digits, separated) rather than any 13-19 digit
+# run, which would also flag benign 16-digit order IDs / transaction refs /
+# phone numbers that legitimately appear in audit detail strings.
+_CARD_SHAPE = re.compile(r"\b\d{4}[ -]\d{4}[ -]\d{4}[ -]\d{4}\b")
+_SSN_SHAPE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+# Our own audit details legitimately carry hash tokens (e.g. content_sha256,
+# "hmac-sha256:<hex>"). Skip those leaves so a hash that happens to hold a long
+# digit run can't false-positive the card check.
+_HASH_TOKEN = re.compile(r"\A(?:[a-z0-9]+-[a-z0-9]+:)?[0-9a-fA-F]{32,}\Z")
+
+
+class PIIInAuditError(ValueError):
+    """Raised when an audit ``detail`` appears to embed a raw secret."""
+
+
+def assert_pii_safe(detail: dict | None) -> None:
+    """Reject an audit ``detail`` whose string leaves look like raw PII.
+
+    Backstop only — the contract is that emit sites never put raw values in
+    ``detail`` (they emit category + spans + hashes). Raising here fails the
+    audit write loudly rather than silently chaining a secret into the
+    tamper-evident log.
+    """
+    if not detail:
+        return
+    for value in _iter_str_leaves(detail):
+        if _HASH_TOKEN.match(value):
+            continue
+        if _CARD_SHAPE.search(value) or _SSN_SHAPE.search(value):
+            raise PIIInAuditError(
+                "audit detail appears to contain raw PII; emit category/spans/hashes instead"
+            )
+
+
+def _iter_str_leaves(obj: object) -> Iterator[str]:
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            yield from _iter_str_leaves(v)
+    elif isinstance(obj, (list, tuple)):
+        for v in obj:
+            yield from _iter_str_leaves(v)

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -10,6 +10,7 @@ shared engine from ``core_storage_api.database.init.get_engine``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from collections import OrderedDict
@@ -43,6 +44,7 @@ from common.constants import (
 from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
 from common.models import (
     Agent,
+    AuditChainHead,
     AuditLog,
     BackgroundTaskLog,
     CrystallizationReport,
@@ -58,6 +60,13 @@ from common.models import (
     Relation,
 )
 from core_storage_api.observability import db_measure
+from core_storage_api.services.audit_chain import (
+    GENESIS_PREV_HASH,
+    assert_pii_safe,
+    canonical_created_at,
+    canonical_event,
+    compute_event_hash,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -222,6 +231,75 @@ _PURGE_FLEET_TABLES: tuple[str, ...] = (
     "analysis_reports",
     "dedup_reviews",
 )
+
+
+def _verify_audit_chain_rows(
+    tenant_id: str, rows: list[AuditLog], head: AuditChainHead | None, limit: int
+) -> dict:
+    """Walk pre-fetched chain rows and verify integrity (pure CPU, no I/O).
+
+    Split out from :meth:`PostgresService.audit_verify_chain` so the SHA-256 /
+    JSON-canonicalization loop — up to ``limit`` (≤ 500k) rows — can run via
+    ``asyncio.to_thread`` instead of blocking the event loop. Operates only on
+    already-loaded ORM attributes, so it's safe off the event loop.
+    """
+    expected_prev = GENESIS_PREV_HASH
+    expected_seq = 1
+    for row in rows:
+        reason: str | None = None
+        if row.seq != expected_seq:
+            reason = "seq_gap"
+        elif row.prev_hash != expected_prev:
+            reason = "prev_hash_mismatch"
+        else:
+            canon = canonical_event(
+                tenant_id=row.tenant_id,
+                seq=row.seq,
+                agent_id=row.agent_id,
+                action=row.action,
+                resource_type=row.resource_type,
+                resource_id=row.resource_id,
+                detail=row.detail,
+                created_at_iso=canonical_created_at(row.created_at),
+            )
+            if compute_event_hash(canon, row.prev_hash) != row.event_hash:
+                reason = "event_hash_mismatch"
+        if reason is not None:
+            return {
+                "tenant_id": tenant_id,
+                "valid": False,
+                "verified_count": expected_seq - 1,
+                "first_broken": {
+                    "seq": row.seq,
+                    "id": str(row.id),
+                    "reason": reason,
+                    "created_at": row.created_at.astimezone(UTC).isoformat(),
+                },
+            }
+        expected_prev = row.event_hash
+        expected_seq += 1
+
+    truncated = len(rows) >= limit
+    head_seq, head_hash = (head.last_seq, head.last_hash) if head is not None else (0, GENESIS_PREV_HASH)
+    last_seq, last_hash = (rows[-1].seq, rows[-1].event_hash) if rows else (0, GENESIS_PREV_HASH)
+    if not truncated and (head_seq != last_seq or head_hash != last_hash):
+        return {
+            "tenant_id": tenant_id,
+            "valid": False,
+            "verified_count": len(rows),
+            "first_broken": {
+                "reason": "tail_truncated",
+                "head_seq": head_seq,
+                "chain_seq": last_seq,
+            },
+        }
+    return {
+        "tenant_id": tenant_id,
+        "valid": True,
+        "verified_count": len(rows),
+        "head_seq": last_seq,
+        "truncated": truncated,
+    }
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -4337,48 +4415,173 @@ class PostgresService:
         resource_id: UUID | None = None,
         detail: dict | None = None,
     ) -> None:
-        async with get_session() as session:
-            session.add(
-                AuditLog(
-                    tenant_id=tenant_id,
-                    agent_id=agent_id,
-                    action=action,
-                    resource_type=resource_type,
-                    resource_id=resource_id,
-                    detail=detail,
-                )
-            )
+        """Persist one audit event (single-event + sync-fallback path).
+
+        Chains the event so single-event inserts (the sync fallback in
+        core-api's ``log_action``, plus keystone audit writes) land in the
+        same per-tenant hash chain as the batched path — otherwise they
+        would write NULL-hash rows that break the chain (eToro governance).
+        Calls the per-tenant writer directly (one tenant, one event) rather
+        than paying the batch group-by for a singleton.
+        """
+        await self._audit_chain_one_tenant(
+            tenant_id,
+            [
+                {
+                    "agent_id": agent_id,
+                    "action": action,
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "detail": detail,
+                }
+            ],
+        )
 
     async def audit_add_batch(self, events: list[dict]) -> None:
-        """Persist N audit events in one transaction with one INSERT
-        statement (CAURA-628).
+        """Persist N audit events (CAURA-628 batched path).
 
-        ``session.add_all`` issues a single multi-row INSERT to
-        Postgres, vs ``audit_add`` which opens one transaction +
-        acquires the table write lock once per event. Reducing N
-        per-event lock acquisitions to one batched acquisition is the
-        whole point of the CAURA-628 refactor; the per-event legacy
-        path is preserved for the synchronous-fallback case in
-        core-api's ``log_action``.
+        Thin alias for :meth:`audit_add_batch_chained` so the existing
+        bulk router call site keeps working while every audit event now
+        joins the tamper-evident per-tenant hash chain.
+        """
+        await self.audit_add_batch_chained(events)
 
-        Empty ``events`` short-circuits without touching the
-        database — saves a no-op session open under the audit
-        flusher's interval-driven empty ticks.
+    async def audit_add_batch_chained(self, events: list[dict]) -> None:
+        """Persist audit events into the per-tenant tamper-evident chain.
+
+        Each event gets a monotonic per-tenant ``seq`` and an
+        ``event_hash = SHA256(canonical_event || prev_hash)`` linking it to
+        the prior event. Events are grouped by tenant and each tenant's
+        group is built + committed in its OWN transaction, so one tenant's
+        failure can't roll back another's and the per-tenant head-row lock
+        only serializes same-tenant writers.
+
+        Empty ``events`` short-circuits (the audit flusher ticks on an
+        interval even when idle).
         """
         if not events:
             return
+        by_tenant: dict[str, list[dict]] = {}
+        for ev in events:
+            by_tenant.setdefault(ev["tenant_id"], []).append(ev)
+        for tenant_id, tenant_events in by_tenant.items():
+            await self._audit_chain_one_tenant(tenant_id, tenant_events)
+
+    async def _audit_chain_one_tenant(self, tenant_id: str, events: list[dict]) -> None:
+        """Chain + insert one tenant's events inside a single transaction.
+
+        The ``audit_chain_head`` row is the serialization point: we
+        ``SELECT ... FOR UPDATE`` it so concurrent same-tenant writers run
+        one-at-a-time (different tenants lock different rows and never
+        block). ``ON CONFLICT DO NOTHING`` resolves the concurrent-genesis
+        race (two workers racing a tenant's first-ever event). The
+        ``FOR UPDATE`` lock releases atomically with the row inserts on
+        commit, so the chain can never interleave.
+        """
         async with get_session() as session:
-            session.add_all(
-                AuditLog(
-                    tenant_id=event["tenant_id"],
-                    agent_id=event.get("agent_id"),
-                    action=event["action"],
-                    resource_type=event["resource_type"],
-                    resource_id=event.get("resource_id"),
-                    detail=event.get("detail"),
-                )
-                for event in events
+            # Lock-or-create the head row. The insert is a no-op once the
+            # head exists; the unconditional FOR UPDATE select below is what
+            # actually serializes writers.
+            await session.execute(
+                pg_insert(AuditChainHead.__table__)
+                .values(tenant_id=tenant_id, last_seq=0, last_hash=GENESIS_PREV_HASH)
+                .on_conflict_do_nothing(index_elements=["tenant_id"])
             )
+            head = (
+                await session.execute(
+                    select(AuditChainHead).where(AuditChainHead.tenant_id == tenant_id).with_for_update()
+                )
+            ).scalar_one()
+
+            prev_hash = head.last_hash
+            seq = head.last_seq
+            now = datetime.now(UTC)
+            rows: list[AuditLog] = []
+            for ev in events:
+                # Scrub-before-hash: refuse to chain a raw secret. Runs
+                # BEFORE hashing so the chain only ever attests the redacted
+                # detail (raising here fails the write loudly instead).
+                assert_pii_safe(ev.get("detail"))
+                seq += 1
+                # Assign created_at in-app (not server_default now()) because
+                # the hash binds it — reading it back post-insert would risk
+                # the stored value differing from the hashed one. Events from
+                # the queue carry no created_at, so a batch shares one `now`;
+                # `seq` disambiguates same-timestamp events.
+                created = ev.get("created_at") or now
+                resource_id = ev.get("resource_id")
+                canon = canonical_event(
+                    tenant_id=tenant_id,
+                    seq=seq,
+                    agent_id=ev.get("agent_id"),
+                    action=ev["action"],
+                    resource_type=ev["resource_type"],
+                    resource_id=resource_id,
+                    detail=ev.get("detail"),
+                    created_at_iso=canonical_created_at(created),
+                )
+                this_hash = compute_event_hash(canon, prev_hash)
+                rows.append(
+                    AuditLog(
+                        tenant_id=tenant_id,
+                        agent_id=ev.get("agent_id"),
+                        action=ev["action"],
+                        resource_type=ev["resource_type"],
+                        resource_id=resource_id,
+                        detail=ev.get("detail"),
+                        created_at=created,
+                        seq=seq,
+                        prev_hash=prev_hash,
+                        event_hash=this_hash,
+                    )
+                )
+                prev_hash = this_hash
+            session.add_all(rows)
+            head.last_seq = seq
+            head.last_hash = prev_hash
+            head.updated_at = now
+
+    async def audit_verify_chain(self, tenant_id: str, *, limit: int = 100_000) -> dict:
+        """Walk a tenant's hash chain in ``seq`` order and verify integrity.
+
+        Recomputes each ``event_hash`` and checks ``prev_hash`` linkage +
+        genesis; stops at and reports the first broken link (everything
+        after it is untrustworthy). A final tail-check against
+        ``audit_chain_head`` catches rows deleted off the END of the chain
+        (a forward walk alone can't see a missing tail). ``limit`` bounds
+        the walk — when hit, the tail-check is skipped and ``truncated`` is
+        set so the caller knows to paginate.
+        """
+        async with get_read_session() as session:
+            # Pin one snapshot across BOTH reads (rows + head). Under READ
+            # COMMITTED each statement gets its own snapshot, so a concurrent
+            # same-tenant insert committing between the two reads makes the head
+            # look one seq ahead of the fetched rows and fires a FALSE
+            # tail_truncated "tampering" alert. REPEATABLE READ freezes the
+            # snapshot at the first query for the rest of the transaction
+            # (must be set before any query in the tx).
+            await session.execute(text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
+            rows = list(
+                (
+                    await session.execute(
+                        select(AuditLog)
+                        .where(AuditLog.tenant_id == tenant_id, AuditLog.seq.isnot(None))
+                        .order_by(AuditLog.seq.asc())
+                        .limit(limit)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            head = (
+                await session.execute(select(AuditChainHead).where(AuditChainHead.tenant_id == tenant_id))
+            ).scalar_one_or_none()
+
+        # The walk is pure CPU (SHA-256 + JSON canonicalization per row) and can
+        # cover up to `limit` (≤ 500k) rows — offload it so it doesn't block the
+        # event loop and starve concurrent requests. The rows/head are already
+        # fully loaded, so the thread only touches in-memory attributes.
+        return await asyncio.to_thread(_verify_audit_chain_rows, tenant_id, rows, head, limit)
 
     async def audit_list_by_tenant(
         self,

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -1,0 +1,367 @@
+"""Tests for the tamper-evident audit hash chain (eToro governance).
+
+Unit tests cover the pure chain primitives (canonicalization, hashing,
+genesis, the PII-safe guard). Integration tests exercise the chained insert +
+verifier against PostgreSQL via ``PostgresService``: chain continuity across
+batches, concurrent same-tenant serialization, cross-tenant independence, and
+tamper / seq-gap / tail-truncation detection.
+"""
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+from core_storage_api.services.audit_chain import (
+    GENESIS_PREV_HASH,
+    PIIInAuditError,
+    _canonical_resource_id,
+    assert_pii_safe,
+    canonical_event,
+    compute_event_hash,
+)
+from core_storage_api.services.postgres_service import PostgresService, get_session
+
+
+def _tenant() -> str:
+    return f"test-tenant-chain-{uuid4().hex[:8]}"
+
+
+def _event(
+    action: str, *, agent_id: str | None = None, detail: dict | None = None
+) -> dict:
+    return {
+        "tenant_id": None,  # set by the caller / _insert
+        "agent_id": agent_id,
+        "action": action,
+        "resource_type": "memory",
+        "resource_id": None,
+        "detail": detail,
+    }
+
+
+async def _insert(svc: PostgresService, tenant: str, events: list[dict]) -> None:
+    for e in events:
+        e["tenant_id"] = tenant
+    await svc.audit_add_batch_chained(events)
+
+
+# ── Unit: chain primitives (no DB) ───────────────────────────────────
+
+
+def test_canonical_event_is_key_order_independent():
+    a = canonical_event(
+        tenant_id="t",
+        seq=1,
+        agent_id="ag",
+        action="pii_mask",
+        resource_type="memory",
+        resource_id=None,
+        detail={"b": 2, "a": 1},
+        created_at_iso="2026-06-15T00:00:00.000000Z",
+    )
+    b = canonical_event(
+        tenant_id="t",
+        seq=1,
+        agent_id="ag",
+        action="pii_mask",
+        resource_type="memory",
+        resource_id=None,
+        detail={"a": 1, "b": 2},
+        created_at_iso="2026-06-15T00:00:00.000000Z",
+    )
+    assert a == b  # sort_keys makes detail key order irrelevant
+
+
+def _canon_detail(detail):
+    return canonical_event(
+        tenant_id="t",
+        seq=1,
+        agent_id=None,
+        action="x",
+        resource_type="memory",
+        resource_id=None,
+        detail=detail,
+        created_at_iso="2026-06-15T00:00:00.000000Z",
+    )
+
+
+def test_canonical_event_normalises_integral_floats():
+    # An integral float (1.0) and an int (1) must hash identically, so a JSONB
+    # round-trip that renders one as the other can't trip a false
+    # event_hash_mismatch on an intact row. Non-integral floats are preserved.
+    assert _canon_detail({"n": 1.0, "xs": [2.0, 3]}) == _canon_detail(
+        {"n": 1, "xs": [2, 3]}
+    )
+    assert _canon_detail({"n": 1.5}) != _canon_detail({"n": 1})
+    # bool must not be coerced to int (True != 1 in the hash).
+    assert _canon_detail({"b": True}) != _canon_detail({"b": 1})
+
+
+def test_canonical_event_normalises_resource_id_case_and_type():
+    # The writer may pass resource_id as a raw (uppercase) string while the
+    # verifier passes the uuid.UUID read back from the column; canonical_event
+    # must hash both identically so the chain doesn't look tampered.
+    u = uuid4()
+    kw = dict(
+        tenant_id="t",
+        seq=1,
+        agent_id=None,
+        action="x",
+        resource_type="memory",
+        detail=None,
+        created_at_iso="2026-06-15T00:00:00.000000Z",
+    )
+    from_upper_str = canonical_event(resource_id=str(u).upper(), **kw)
+    from_uuid_obj = canonical_event(resource_id=u, **kw)
+    assert from_upper_str == from_uuid_obj
+
+
+def test_event_hash_is_deterministic_and_links_history():
+    canon = canonical_event(
+        tenant_id="t",
+        seq=1,
+        agent_id=None,
+        action="x",
+        resource_type="memory",
+        resource_id=None,
+        detail=None,
+        created_at_iso="2026-06-15T00:00:00.000000Z",
+    )
+    h1 = compute_event_hash(canon, GENESIS_PREV_HASH)
+    assert h1 == compute_event_hash(canon, GENESIS_PREV_HASH)
+    assert len(h1) == 32
+    # A different prev_hash yields a different event hash — the chain binds
+    # every prior event into each new one.
+    assert compute_event_hash(canon, h1) != h1
+    assert GENESIS_PREV_HASH == b"\x00" * 32
+
+
+def test_assert_pii_safe_rejects_raw_card_and_ssn():
+    with pytest.raises(PIIInAuditError):
+        assert_pii_safe({"note": "card 4111 1111 1111 1111 leaked"})
+    with pytest.raises(PIIInAuditError):
+        assert_pii_safe({"nested": {"deep": "ssn 123-45-6789 here"}})
+
+
+def test_assert_pii_safe_allows_the_real_detail_shape():
+    # The actual governance audit detail: category labels, span offsets, and
+    # hash tokens — never raw values. Must not raise.
+    assert_pii_safe(
+        {
+            "action": "pii_mask",
+            "categories": ["credit_card", "email"],
+            "spans": [[10, 26], [40, 55]],
+            "finding_count": 2,
+            "content_sha256": "a1b2c3" + "0" * 58,  # 64-char hex hash token
+            "value_hash": "hmac-sha256:" + "9" * 40,
+        }
+    )
+    assert_pii_safe(None)
+    assert_pii_safe({})
+
+
+def test_assert_pii_safe_allows_benign_numeric_ids():
+    # The card guard is conservative (matches only separated 4-4-4-4) so benign
+    # numeric strings in detail — order IDs, transaction refs, phone numbers —
+    # are NOT flagged. A false positive would roll back the whole batch and gap
+    # the tamper-evident chain, which is worse than a miss (the authoritative
+    # detector is the write-path governance library, not this backstop).
+    assert_pii_safe({"transaction_ref": "2026061512345678"})  # 16 bare digits
+    assert_pii_safe({"order_id": "1234567890123456"})
+    assert_pii_safe({"phone": "+14155552671"})
+    # A clearly card-shaped (separated 4-4-4-4) value still trips the guard.
+    with pytest.raises(PIIInAuditError):
+        assert_pii_safe({"leak": "4111 1111 1111 1111"})
+
+
+def test_canonical_resource_id_normalises_case_and_type():
+    # The resource_id column is a UUID, so verify reads back a lowercase
+    # uuid.UUID; the write path must hash the same canonical form regardless of
+    # how the id arrived (raw uppercase string, UUID object, or None).
+    upper = "12345678-1234-5678-1234-567890ABCDEF"
+    canonical = "12345678-1234-5678-1234-567890abcdef"
+    assert _canonical_resource_id(upper) == canonical
+    assert _canonical_resource_id(canonical) == canonical
+    u = uuid4()
+    assert _canonical_resource_id(u) == str(u)  # UUID object → canonical str
+    assert _canonical_resource_id(None) is None
+    assert _canonical_resource_id("") is None  # falsy collapses to None
+    assert _canonical_resource_id("not-a-uuid") == "not-a-uuid"  # non-UUID left as-is
+
+
+# ── Integration: chained insert + verify ─────────────────────────────
+
+
+async def test_chain_verifies_batch_event_with_uppercase_uuid_resource_id():
+    # Regression: a batch event whose resource_id arrives as an UPPERCASE UUID
+    # string must still verify. The column is a UUID, so verify reads it back
+    # lowercase; before canonicalizing the write-time hash this produced a
+    # spurious event_hash_mismatch.
+    svc = PostgresService()
+    tenant = _tenant()
+    ev = {**_event("a"), "resource_id": str(uuid4()).upper()}
+    await _insert(svc, tenant, [ev])
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is True
+    assert res["verified_count"] == 1
+
+
+async def test_chain_single_batch_verifies_with_genesis():
+    svc = PostgresService()
+    tenant = _tenant()
+    await _insert(svc, tenant, [_event("a"), _event("b"), _event("c")])
+
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is True
+    assert res["verified_count"] == 3
+    assert res["head_seq"] == 3
+
+    async with get_session() as s:
+        rows = (
+            await s.execute(
+                text(
+                    "SELECT seq, prev_hash, event_hash FROM audit_log "
+                    "WHERE tenant_id=:t ORDER BY seq"
+                ),
+                {"t": tenant},
+            )
+        ).all()
+    assert [r[0] for r in rows] == [1, 2, 3]
+    assert bytes(rows[0][1]) == GENESIS_PREV_HASH  # seq=1 chains onto genesis
+    assert bytes(rows[1][1]) == bytes(rows[0][2])  # each prev_hash == prior event_hash
+    assert bytes(rows[2][1]) == bytes(rows[1][2])
+
+
+async def test_chain_continuity_across_batches():
+    svc = PostgresService()
+    tenant = _tenant()
+    await _insert(svc, tenant, [_event("a"), _event("b")])
+    await _insert(svc, tenant, [_event("c")])  # second batch chains onto the first
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is True
+    assert res["verified_count"] == 3
+    assert res["head_seq"] == 3
+
+
+async def test_single_audit_add_joins_the_chain():
+    # The single-event path (sync fallback / keystone audit) must chain too —
+    # otherwise it would write NULL-hash rows that break verification.
+    svc = PostgresService()
+    tenant = _tenant()
+    await svc.audit_add(tenant_id=tenant, action="single", resource_type="memory")
+    await svc.audit_add(tenant_id=tenant, action="single2", resource_type="memory")
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is True
+    assert res["head_seq"] == 2
+
+
+async def test_batch_with_multiple_tenants_chains_each_independently():
+    svc = PostgresService()
+    t1, t2 = _tenant(), _tenant()
+    events = [
+        {**_event("a"), "tenant_id": t1},
+        {**_event("x"), "tenant_id": t2},
+        {**_event("b"), "tenant_id": t1},
+    ]
+    await svc.audit_add_batch_chained(events)
+    assert (await svc.audit_verify_chain(t1))["head_seq"] == 2
+    assert (await svc.audit_verify_chain(t2))["head_seq"] == 1
+
+
+async def test_chains_are_independent_per_tenant_when_interleaved():
+    svc = PostgresService()
+    t1, t2 = _tenant(), _tenant()
+    await _insert(svc, t1, [_event("a")])
+    await _insert(svc, t2, [_event("x")])
+    await _insert(svc, t1, [_event("b")])
+    await _insert(svc, t2, [_event("y")])
+    r1 = await svc.audit_verify_chain(t1)
+    r2 = await svc.audit_verify_chain(t2)
+    assert r1["valid"] and r1["head_seq"] == 2
+    assert r2["valid"] and r2["head_seq"] == 2
+
+
+async def test_concurrent_same_tenant_inserts_serialize():
+    # 5 concurrent batches of 4 events for ONE tenant. The audit_chain_head
+    # FOR UPDATE lock must serialize them into a single gap-free chain (no seq
+    # collisions, no lost events) despite the concurrency.
+    svc = PostgresService()
+    tenant = _tenant()
+
+    async def one(i: int) -> None:
+        await _insert(svc, tenant, [_event(f"a{i}-{j}") for j in range(4)])
+
+    await asyncio.gather(*(one(i) for i in range(5)))
+
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is True, res
+    assert res["verified_count"] == 20
+    assert res["head_seq"] == 20
+
+
+async def test_verify_detects_tampered_row():
+    svc = PostgresService()
+    tenant = _tenant()
+    await _insert(svc, tenant, [_event("a"), _event("b"), _event("c")])
+    # Mutate seq=2's action — the hash binds it, so verification must fail there.
+    async with get_session() as s:
+        await s.execute(
+            text("UPDATE audit_log SET action='tampered' WHERE tenant_id=:t AND seq=2"),
+            {"t": tenant},
+        )
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is False
+    assert res["first_broken"]["seq"] == 2
+    assert res["first_broken"]["reason"] == "event_hash_mismatch"
+    assert res["verified_count"] == 1  # seq=1 verified before the break
+
+
+async def test_verify_detects_seq_gap():
+    svc = PostgresService()
+    tenant = _tenant()
+    await _insert(svc, tenant, [_event("a"), _event("b"), _event("c")])
+    async with get_session() as s:
+        await s.execute(
+            text("DELETE FROM audit_log WHERE tenant_id=:t AND seq=2"), {"t": tenant}
+        )
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is False
+    assert res["first_broken"]["reason"] == "seq_gap"
+    assert res["first_broken"]["seq"] == 3  # seq=3 found where 2 expected
+
+
+async def test_verify_detects_tail_truncation():
+    svc = PostgresService()
+    tenant = _tenant()
+    await _insert(svc, tenant, [_event("a"), _event("b"), _event("c")])
+    # Delete the last row: the walk of 1..2 verifies, but the head still
+    # remembers seq=3 — only the head-vs-tail check catches this.
+    async with get_session() as s:
+        await s.execute(
+            text("DELETE FROM audit_log WHERE tenant_id=:t AND seq=3"), {"t": tenant}
+        )
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is False
+    assert res["first_broken"]["reason"] == "tail_truncated"
+    assert res["first_broken"]["head_seq"] == 3
+    assert res["first_broken"]["chain_seq"] == 2
+
+
+async def test_chained_insert_rejects_raw_pii_and_persists_nothing():
+    svc = PostgresService()
+    tenant = _tenant()
+    with pytest.raises(PIIInAuditError):
+        await _insert(
+            svc, tenant, [_event("leak", detail={"raw": "4111 1111 1111 1111"})]
+        )
+    # The transaction rolled back on the raise — no head row, no audit rows.
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is True
+    assert res["verified_count"] == 0
+
+
+async def test_empty_batch_is_a_noop():
+    svc = PostgresService()
+    await svc.audit_add_batch_chained([])  # must not raise or open a session

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"024"}, f"Expected single head '024', got {sorted(heads)}"
+        assert heads == {"025"}, f"Expected single head '025', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -674,6 +674,8 @@ class TestMigrationChain:
         assert chain.get("023") == "022", "023 must follow 022"
         # 024: fleet_commands auto-upgrade partial index (CAURA-000)
         assert chain.get("024") == "023", "024 must follow 023"
+        # 025: tamper-evident audit hash chain (eToro governance)
+        assert chain.get("025") == "024", "025 must follow 024"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What & why

First of three coordinated PRs delivering the **eToro governance increment** (PII masking/drop/flag + business-vs-personal gate + admin UI, due 18 Jun). This PR makes the audit log **tamper-evident**: every audit event (and specifically every future PII mask/drop/flag and non-business drop) is bound into a per-tenant linked-hash chain, so silent mutation, deletion, or reordering is detectable.

This PR is **independent** and lands first — the governance gate (PR-B) and admin UI (PR-C) build on top of it.

## How it works

- **migration 025** adds nullable `seq` / `prev_hash` / `event_hash` to `audit_log` + an `audit_chain_head` serialization-point table. Columns are nullable on purpose: the chain **genesis is the migration boundary** — pre-existing append-only rows stay unchained (excluded by a partial unique index). We deliberately do **not** backfill, since hashing historical rows would launder unprovable history into a valid-looking chain.
- **`audit_chain.py`** holds the pure primitives — deterministic canonicalization (`sort_keys` JSON, UTC µs timestamp) and `event_hash = SHA256(canonical_event ‖ prev_hash)` — defined once so the writer and verifier agree byte-for-byte. Plus a scrub-before-hash `assert_pii_safe` guard (the audit log must never store the raw secret it audits).
- **chained insert** (`_audit_chain_one_tenant`) folds a batch under a per-tenant `audit_chain_head` `SELECT … FOR UPDATE` lock — same-tenant writers serialize, different tenants never block, and the concurrent-genesis race is handled with `ON CONFLICT DO NOTHING`. `audit_add` / `audit_add_batch` route through it, so single-event, sync-fallback and keystone audit writes all join the chain.
- **`GET /audit-logs/verify`** walks the chain in `seq` order, recomputes hashes, checks linkage + genesis + tail-vs-head, and returns the first broken link (`seq_gap` / `prev_hash_mismatch` / `event_hash_mismatch` / `tail_truncated`). Exposed to the enterprise governance UI via a storage-client method.

## Tests (`tests/test_audit_chain.py`, 15 cases)

Chain continuity across batches, **concurrent same-tenant serialization** (5×4 events → gap-free chain of 20), cross-tenant independence, and detection of **tampered rows / seq gaps / tail truncation**; PII-safe rejection rolls back without persisting. Unit tests cover canonicalization determinism + genesis. Migration verified to apply cleanly 024→025 against pgvector pg16; existing audit + keystone + lifecycle suites pass unchanged.

## Notes
- All DB logic stays in core-storage-api (Rule 14); schema change is via the internal Alembic flow only (Rule 11). ruff check + format + mypy clean on both projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)