### PR TITLE
test(core-worker): fix invalid memory_type fixture in enrich consumer test

### DIFF
--- a/core-worker/tests/test_consumer_enrich.py
+++ b/core-worker/tests/test_consumer_enrich.py
@@ -416,7 +416,7 @@ async def test_enrichment_pending_cleared_even_with_heuristic_fallback(monkeypat
     # all skip per the ``llm_ms > 0`` guard. Empty metadata_patch is
     # exactly the regression scenario we're guarding against.
     heuristic = EnrichmentResult(
-        memory_type="generic",
+        memory_type="fact",
         weight=0.5,
         title="",
         summary="",


### PR DESCRIPTION
## What & why

`core-worker/tests/test_consumer_enrich.py::test_enrichment_pending_cleared_even_with_heuristic_fallback` constructs `EnrichmentResult(memory_type="generic", ...)`, but **`"generic"` is not a valid `MemoryType`** (valid: fact, episode, decision, preference, task, semantic, intention, plan, commitment, action, outcome, cancellation, rule, insight). Pydantic raises a `ValidationError`, so the test has been **failing since v1.0.0**.

It went unnoticed because **no GitHub Actions workflow runs `core-worker/tests/`** — main CI only runs the top-level `tests/`.

## Fix

Change `memory_type="generic"` → `"fact"` so the test exercises its intended path (heuristic fallback: `llm_ms=0` → the always-write metadata fields skip, and `enrichment_pending` is still cleared). The whole file now passes **20/20**.

## Follow-up (not in this PR)

Worth gating `core-worker/tests/` in a CI workflow so this suite can't silently rot again. Left out here to keep this a focused one-line fix — wiring the job up may surface other latent failures in that suite that deserve their own triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)