### PR TITLE
refactor(api): unify evolve/insights caller-identity resolution; close F-7 tail (§2)

### DIFF
--- a/core-api/src/core_api/routes/evolve.py
+++ b/core-api/src/core_api/routes/evolve.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,10 +10,8 @@ from core_api.auth import AuthContext, get_auth_context
 from core_api.constants import EVOLVE_OUTCOME_TYPES, VALID_SCOPES
 from core_api.db.session import get_db
 from core_api.services.audit_service import log_action
-from core_api.services.trust_service import parse_trust_error, require_trust
+from core_api.services.caller_identity import resolve_caller_and_gate
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Evolve"])
 
@@ -122,45 +118,16 @@ async def report_outcome_endpoint(
             ),
         )
 
-    # Gateway-verified identity wins when present; otherwise fall back to
-    # body.agent_id, then to the "mcp-agent" placeholder so standalone
-    # callers still show up in audit logs. Warn only when the client sent
-    # an explicit body.agent_id that disagrees with the verified header —
-    # the Pydantic default would fire spuriously on every gateway call.
-    if auth.agent_id and body.agent_id is not None and auth.agent_id != body.agent_id:
-        logger.warning(
-            "evolve: verified agent_id=%s overrides body.agent_id=%s",
-            auth.agent_id,
-            body.agent_id,
-        )
-    caller_agent_id = auth.agent_id or body.agent_id or "mcp-agent"
-
-    # Admin bypass — super admins are tenant-free and trust enforcement
-    # assumes a tenant-scoped agent row.
-    if not auth.is_admin:
-        if not caller_agent_id:
-            raise HTTPException(status_code=422, detail="agent_id is required.")
-        min_level = 1 if body.scope == "agent" else 2
-        # ``require_trust`` soft-passes a missing Agent row at
-        # ``DEFAULT_TRUST_LEVEL`` so read-only callers don't 403 on a
-        # brand-new agent_id. Write paths still need identity pinning,
-        # though: this endpoint persists outcome and rule memories
-        # plus an audit-log entry keyed to ``caller_agent_id``, and
-        # without a registered row backing the name, attribution
-        # becomes unverifiable (a tenant-key holder could synthesise
-        # ``"admin-bot"`` and have that string appear in the audit
-        # trail). API-key admission proves authorization, not identity
-        # — re-block unregistered agents on writes specifically. The
-        # soft-pass remains useful for read-only consumers calling
-        # ``require_trust`` directly.
-        _, not_found, terr = await require_trust(db, body.tenant_id, caller_agent_id, min_level=min_level)
-        if not_found:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Agent '{caller_agent_id}' is not registered in tenant '{body.tenant_id}'.",
-            )
-        if terr:
-            raise HTTPException(status_code=403, detail=parse_trust_error(terr))
+    # Resolve the caller identity (verified > body > DEFAULT_AGENT_ID) and gate
+    # the write on trust. Shared with insights.py — see services/caller_identity.
+    caller_agent_id = await resolve_caller_and_gate(
+        db,
+        auth,
+        tenant_id=body.tenant_id,
+        body_agent_id=body.agent_id,
+        scope=body.scope,
+        action="evolve",
+    )
 
     await check_and_increment(db, body.tenant_id, "evolve")
 

--- a/core-api/src/core_api/routes/insights.py
+++ b/core-api/src/core_api/routes/insights.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,10 +10,8 @@ from core_api.auth import AuthContext, get_auth_context
 from core_api.constants import INSIGHTS_FOCUS_MODES, VALID_SCOPES
 from core_api.db.session import get_db
 from core_api.services.audit_service import log_action
-from core_api.services.trust_service import parse_trust_error, require_trust
+from core_api.services.caller_identity import resolve_caller_and_gate
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Insights"])
 
@@ -97,43 +93,16 @@ async def generate_insights_endpoint(
             detail=f"Invalid focus '{body.focus}'. Must be one of: {', '.join(INSIGHTS_FOCUS_MODES)}",
         )
 
-    # Gateway-verified identity wins when present; otherwise fall back to
-    # body.agent_id, then to the "mcp-agent" placeholder so standalone
-    # callers still show up in audit logs. Warn only when the client sent
-    # an explicit body.agent_id that disagrees with the verified header —
-    # the Pydantic default would fire spuriously on every gateway call.
-    if auth.agent_id and body.agent_id is not None and auth.agent_id != body.agent_id:
-        logger.warning(
-            "insights: verified agent_id=%s overrides body.agent_id=%s",
-            auth.agent_id,
-            body.agent_id,
-        )
-    caller_agent_id = auth.agent_id or body.agent_id or "mcp-agent"
-
-    # Admin bypass — super admins are tenant-free and trust enforcement
-    # assumes a tenant-scoped agent row.
-    if not auth.is_admin:
-        if not caller_agent_id:
-            raise HTTPException(status_code=422, detail="agent_id is required.")
-        min_level = 1 if body.scope == "agent" else 2
-        # ``require_trust`` soft-passes a missing Agent row at
-        # ``DEFAULT_TRUST_LEVEL`` so read-only callers don't 403 on a
-        # brand-new agent_id. Write paths still need identity pinning,
-        # though: this endpoint persists insight memories plus an
-        # audit-log entry keyed to ``caller_agent_id``, and without a
-        # registered row backing the name, attribution becomes
-        # unverifiable. API-key admission proves authorization, not
-        # identity — re-block unregistered agents on writes
-        # specifically. The soft-pass remains useful for read-only
-        # consumers calling ``require_trust`` directly.
-        _, not_found, terr = await require_trust(db, body.tenant_id, caller_agent_id, min_level=min_level)
-        if not_found:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Agent '{caller_agent_id}' is not registered in tenant '{body.tenant_id}'.",
-            )
-        if terr:
-            raise HTTPException(status_code=403, detail=parse_trust_error(terr))
+    # Resolve the caller identity (verified > body > DEFAULT_AGENT_ID) and gate
+    # the write on trust. Shared with evolve.py — see services/caller_identity.
+    caller_agent_id = await resolve_caller_and_gate(
+        db,
+        auth,
+        tenant_id=body.tenant_id,
+        body_agent_id=body.agent_id,
+        scope=body.scope,
+        action="insights",
+    )
 
     await check_and_increment(db, body.tenant_id, "insights")
 

--- a/core-api/src/core_api/routes/keystones.py
+++ b/core-api/src/core_api/routes/keystones.py
@@ -141,6 +141,13 @@ def _resolve_caller_identity(auth: AuthContext, x_agent_id: str | None) -> tuple
     Fallback ``"rest-admin"`` is preserved for legacy callers — the
     trust check 403s on it anyway (no agent row exists), but the
     fallback keeps the error surface predictable.
+
+    NOTE: keystones deliberately does NOT use ``services/caller_identity``
+    (the shared evolve/insights resolver). Governance writes must not fall
+    back to a *registerable* identity like ``DEFAULT_AGENT_ID`` — the
+    never-registered ``rest-admin`` sentinel forces an explicit identity on
+    the gateway — and this path needs stricter anti-spoof handling (X-Agent-ID
+    mismatch rejection + the verified-floor bump) than that resolver provides.
     """
     verified_id = getattr(auth, "agent_id", None)
     if verified_id and x_agent_id and verified_id != x_agent_id:

--- a/core-api/src/core_api/services/caller_identity.py
+++ b/core-api/src/core_api/services/caller_identity.py
@@ -1,0 +1,84 @@
+"""Shared caller-identity resolution for the outcome/insight REST routes.
+
+``routes/evolve.py`` and ``routes/insights.py`` resolved the calling agent with
+byte-identical, copy-pasted logic — verified gateway identity > ``body.agent_id``
+> the reserved ``DEFAULT_AGENT_ID`` — then gated the write on trust. This is the
+single source for that logic so the two routes can't drift (the standalone-operator
+bypass below was previously only on keystones, leaving evolve/insights to 403 the
+bare standalone operator).
+
+NOTE: ``routes/keystones.py`` deliberately does NOT use this. Governance writes
+must not fall back to a *registerable* identity — its ``rest-admin`` sentinel has
+no agent row so the fallback always 403s on the gateway, whereas ``DEFAULT_AGENT_ID``
+auto-registers — and keystones has stricter anti-spoof handling (X-Agent-ID
+mismatch rejection, verified-floor bump). Keep that path separate.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core_api.agent_ids import DEFAULT_AGENT_ID
+from core_api.auth import AuthContext
+from core_api.config import settings as app_settings
+from core_api.services.trust_service import parse_trust_error, require_trust
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_caller_and_gate(
+    db: AsyncSession,
+    auth: AuthContext,
+    *,
+    tenant_id: str,
+    body_agent_id: str | None,
+    scope: str,
+    action: str,
+) -> str:
+    """Resolve the caller's ``agent_id`` and gate the write on trust.
+
+    Precedence: gateway-verified ``auth.agent_id`` > ``body_agent_id`` >
+    ``DEFAULT_AGENT_ID`` (so standalone callers still show up in audit logs).
+    Returns the resolved ``caller_agent_id``; raises 403 when the resolved agent
+    isn't registered or lacks the required trust (``min_level`` is 1 for
+    ``scope=agent``, else 2).
+
+    The gate is skipped for (a) admins — tenant-free system callers — and (b)
+    the unidentified standalone operator: ``IS_STANDALONE`` with no asserted
+    identity is the single-tenant local admin (mirrors
+    ``keystones._is_standalone_admin`` and ``routes/memories``). ``action``
+    (``"evolve"`` / ``"insights"``) only labels the mismatch-warning log line.
+    """
+    if auth.agent_id and body_agent_id is not None and auth.agent_id != body_agent_id:
+        # Warn only on an explicit body.agent_id that disagrees with the
+        # verified header; the Pydantic default would fire on every gateway call.
+        logger.warning(
+            "%s: verified agent_id=%s overrides body.agent_id=%s",
+            action,
+            auth.agent_id,
+            body_agent_id,
+        )
+    caller_agent_id = auth.agent_id or body_agent_id or DEFAULT_AGENT_ID
+
+    if auth.is_admin:
+        return caller_agent_id
+    if app_settings.is_standalone and not auth.agent_id and not body_agent_id:
+        return caller_agent_id
+
+    min_level = 1 if scope == "agent" else 2
+    # Write paths must pin identity: outcome/insight memories + an audit-log row
+    # are keyed to caller_agent_id, so an unregistered name corrupts the audit
+    # trail. require_trust soft-passes a missing row (read ergonomics), so
+    # re-block not_found explicitly here.
+    _, not_found, terr = await require_trust(db, tenant_id, caller_agent_id, min_level=min_level)
+    if not_found:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Agent '{caller_agent_id}' is not registered in tenant '{tenant_id}'.",
+        )
+    if terr:
+        raise HTTPException(status_code=403, detail=parse_trust_error(terr))
+    return caller_agent_id

--- a/tests/test_caller_identity.py
+++ b/tests/test_caller_identity.py
@@ -1,0 +1,83 @@
+"""Unit tests for the shared evolve/insights caller-identity resolver (§2)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from core_api.agent_ids import DEFAULT_AGENT_ID
+from core_api.services import caller_identity
+from core_api.services.caller_identity import resolve_caller_and_gate
+
+pytestmark = pytest.mark.asyncio
+
+
+def _auth(*, agent_id=None, is_admin=False):
+    return SimpleNamespace(agent_id=agent_id, is_admin=is_admin)
+
+
+async def test_standalone_operator_bypasses_gate(monkeypatch):
+    """IS_STANDALONE + non-admin + no asserted identity → reserved default,
+    trust gate skipped. This is the F-7 standalone tail, now closed for
+    evolve/insights (the test env runs IS_STANDALONE=true)."""
+    gate = AsyncMock()
+    monkeypatch.setattr(caller_identity, "require_trust", gate)
+    result = await resolve_caller_and_gate(
+        AsyncMock(),
+        _auth(),
+        tenant_id="default",
+        body_agent_id=None,
+        scope="agent",
+        action="evolve",
+    )
+    assert result == DEFAULT_AGENT_ID
+    gate.assert_not_awaited()
+
+
+async def test_admin_bypasses_gate(monkeypatch):
+    """Admins are tenant-free system callers — gate skipped before the
+    standalone check even runs."""
+    gate = AsyncMock()
+    monkeypatch.setattr(caller_identity, "require_trust", gate)
+    result = await resolve_caller_and_gate(
+        AsyncMock(),
+        _auth(is_admin=True),
+        tenant_id="t",
+        body_agent_id=None,
+        scope="fleet",
+        action="insights",
+    )
+    assert result == DEFAULT_AGENT_ID
+    gate.assert_not_awaited()
+
+
+async def test_asserted_unregistered_identity_403(monkeypatch):
+    """An explicit (non-default) identity still goes through the gate — the
+    bypass only applies when NO identity is asserted. Unregistered → 403."""
+    monkeypatch.setattr(caller_identity, "require_trust", AsyncMock(return_value=(1, True, None)))
+    with pytest.raises(HTTPException) as exc:
+        await resolve_caller_and_gate(
+            AsyncMock(),
+            _auth(),
+            tenant_id="t",
+            body_agent_id="ghost",
+            scope="agent",
+            action="evolve",
+        )
+    assert exc.value.status_code == 403
+    assert "is not registered" in str(exc.value.detail)
+
+
+async def test_verified_registered_identity_passes(monkeypatch):
+    """Gateway-verified identity is gated and, when registered at trust, wins."""
+    monkeypatch.setattr(caller_identity, "require_trust", AsyncMock(return_value=(2, False, None)))
+    result = await resolve_caller_and_gate(
+        AsyncMock(),
+        _auth(agent_id="backend-dev"),
+        tenant_id="t",
+        body_agent_id=None,
+        scope="fleet",
+        action="evolve",
+    )
+    assert result == "backend-dev"


### PR DESCRIPTION
## Summary (addendum §2)

`routes/evolve.py` and `routes/insights.py` carried a **byte-identical, copy-pasted** caller-identity + trust-gate block, each **hardcoding the `"mcp-agent"` literal** instead of the shared `DEFAULT_AGENT_ID`. The duplication had already drifted: the standalone-operator bypass (F-7, #354) was added to **keystones only**, so a bare standalone operator still **403'd on evolve/insights**.

## Change
Extract the logic into **`services/caller_identity.resolve_caller_and_gate`**, used by both routes:
- precedence: verified `auth.agent_id` > `body.agent_id` > `DEFAULT_AGENT_ID` (kills the two hardcoded literals);
- warn-on-mismatch, then the trust gate (`not_found → 403`);
- skip the gate for **admins** and the **unidentified standalone operator** (`IS_STANDALONE` + no asserted identity), mirroring `keystones._is_standalone_admin` and `routes/memories`.

## Behavior change (standalone only)
`POST /evolve/report` and `POST /insights/generate` with **no `agent_id`** no longer 403 on a fresh standalone install — they proceed, attributing the outcome/insight to the reserved `mcp-agent` identity, matching `memories` (#339) and `keystones` (#354).

**Everything else is byte-for-byte unchanged:** non-standalone / gateway / admin / identity-asserted paths still gate exactly as before (unregistered callers still 403, with the identical message). Verified earlier with a full case-analysis.

## Deliberately scoped
- **keystones is NOT folded in** (added a note in its docstring): governance writes must not fall back to a *registerable* identity (the never-registered `rest-admin` sentinel forces explicit identity on the gateway), and keystones needs stricter anti-spoof handling (X-Agent-ID mismatch rejection + verified-floor bump).
- **MCP is already consistent** — every tool shares the `agent_id="mcp-agent"` param default; the divergence was REST-only.
- No single all-routes resolver (the report's headline) — it would weaken governance or bloat the helper with reject/warn + sentinel flags.

## Tests / validation
- New `tests/test_caller_identity.py`: standalone bypass, admin bypass, asserted-unregistered → 403, verified-registered → pass (4 pass locally).
- `ruff check` (incl. F401) + `ruff format` + `py_compile` clean; no circular import; no stray `require_trust`/`logger` left in the routes.
- No test asserts `"rest-admin"` or the evolve/insights 403 message; the message is preserved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)