### PR TITLE
feat(core-api): fast business/personal pre-gate before enrichment (opt-in)

### DIFF
--- a/core-api/src/core_api/pipeline/compositions/write.py
+++ b/core-api/src/core_api/pipeline/compositions/write.py
@@ -2,6 +2,7 @@
 
 from core_api.pipeline.runner import Pipeline
 from core_api.pipeline.steps.write import (
+    BusinessPersonalPregate,
     CheckContentLength,
     CheckExactDuplicate,
     CheckSemanticDuplicate,
@@ -69,6 +70,9 @@ def build_fast_write_pipeline() -> Pipeline:
             CheckContentLength(),
             LoadTenantConfig(),
             GovernanceScanContent(),
+            # Opt-in fast business/personal go/no-go: reject personal content
+            # (disposition=drop) before enrichment/embedding/extraction run.
+            BusinessPersonalPregate(),
             ComputeContentHash(),
             ParallelEmbedEnrich(),
             MergeEnrichmentFields(),
@@ -105,6 +109,9 @@ def build_strong_write_pipeline() -> Pipeline:
             CheckContentLength(),
             LoadTenantConfig(),
             GovernanceScanContent(),
+            # Opt-in fast business/personal go/no-go: reject personal content
+            # (disposition=drop) before enrichment/embedding/extraction run.
+            BusinessPersonalPregate(),
             ComputeContentHash(),
             ParallelEmbedEnrich(),
             MergeEnrichmentFields(),

--- a/core-api/src/core_api/pipeline/steps/write/__init__.py
+++ b/core-api/src/core_api/pipeline/steps/write/__init__.py
@@ -1,5 +1,6 @@
 """Write pipeline steps — decomposed phases of create_memory()."""
 
+from core_api.pipeline.steps.write.business_personal_pregate import BusinessPersonalPregate
 from core_api.pipeline.steps.write.check_content_length import CheckContentLength
 from core_api.pipeline.steps.write.check_exact_duplicate import CheckExactDuplicate
 from core_api.pipeline.steps.write.check_semantic_duplicate import CheckSemanticDuplicate
@@ -19,6 +20,7 @@ from core_api.pipeline.steps.write.write_memory_row import WriteMemoryRow
 from core_api.pipeline.steps.write.write_stm_note import WriteSTMNote
 
 __all__ = [
+    "BusinessPersonalPregate",
     "CheckContentLength",
     "CheckExactDuplicate",
     "CheckSemanticDuplicate",

--- a/core-api/src/core_api/pipeline/steps/write/business_personal_pregate.py
+++ b/core-api/src/core_api/pipeline/steps/write/business_personal_pregate.py
@@ -1,0 +1,75 @@
+"""BusinessPersonalPregate — fast business/personal go/no-go BEFORE enrichment.
+
+Opt-in (``governance.non_business.pregate.enabled``) and only active when the
+tenant's non-business disposition is ``drop``. Positioned right after the
+deterministic ``GovernanceScanContent`` and before ``ComputeContentHash`` /
+``ParallelEmbedEnrich``, so a confident "personal" verdict rejects the write
+with 422 *before* the expensive enrichment, embedding, and (downstream)
+background entity extraction run — and before any row is written.
+
+``keep_private`` / ``store`` dispositions persist the row, so an early exit
+saves nothing; they stay with the post-enrichment ``GovernanceDecision`` (which
+also remains the accurate backstop when the pre-gate says "business"). Fail-open:
+a classifier failure or a ``none`` provider never blocks a write.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.step import StepOutcome, StepResult
+from core_api.services.business_classifier import classify_business_personal
+from core_api.services.governance_gate import (
+    ACTION_NB_PREGATE_DROP,
+    emit_governance_audit,
+    nonbusiness_pregate_audit_detail,
+)
+
+
+class BusinessPersonalPregate:
+    @property
+    def name(self) -> str:
+        return "business_personal_pregate"
+
+    async def execute(self, ctx: PipelineContext) -> StepResult | None:
+        cfg = ctx.tenant_config
+        if cfg is None:
+            return StepResult(outcome=StepOutcome.SKIPPED)
+        nb = cfg.governance_non_business
+        pregate = cfg.governance_non_business_pregate
+        # Only a "drop" disposition benefits from an early gate.
+        if not (nb.enabled and pregate.enabled and nb.disposition == "drop"):
+            return StepResult(outcome=StepOutcome.SKIPPED)
+
+        data = ctx.data["input"]
+        write_mode = ctx.data.get("resolved_write_mode")
+        # Pre-gate's own provider; fall back to the tenant's enrichment provider
+        # so an org can enable it without re-specifying a provider. Setting it
+        # explicitly is what makes the signal independent of the enrichment one.
+        provider = pregate.provider or cfg.enrichment_provider
+        result = await classify_business_personal(data.content, cfg, provider=provider, model=pregate.model)
+
+        # Fail-open: only a confident "personal" verdict blocks. min_confidence
+        # None → 0.0 → act on any "personal" (matches the post-enrichment gate).
+        threshold = pregate.min_confidence or 0.0
+        if result.business_relevance == "personal" and result.confidence >= threshold:
+            await emit_governance_audit(
+                ctx.db,
+                tenant_id=data.tenant_id,
+                agent_id=data.agent_id,
+                action=ACTION_NB_PREGATE_DROP,
+                detail=nonbusiness_pregate_audit_detail(
+                    ACTION_NB_PREGATE_DROP,
+                    data.content,
+                    write_mode,
+                    provider=provider,
+                    model=pregate.model,
+                    confidence=result.confidence,
+                ),
+            )
+            raise HTTPException(
+                status_code=422,
+                detail="Memory rejected by content policy: non-business content",
+            )
+        return None

--- a/core-api/src/core_api/services/business_classifier.py
+++ b/core-api/src/core_api/services/business_classifier.py
@@ -1,0 +1,97 @@
+"""Fast business-vs-personal classifier for the ingestion pre-gate.
+
+A minimal, cheap LLM call answering a single question — is this memory
+business-relevant or personal? — used by ``BusinessPersonalPregate`` to reject
+personal content *before* the expensive enrichment / embedding / entity
+extraction run. It takes its own provider/model (resolved by the caller), so the
+signal is independent of the enrichment provider and survives
+``enrichment_provider=none`` (e.g. CI).
+
+Never raises: on a ``none`` provider or any LLM failure it returns a fail-open
+"business" verdict, so the pre-gate can never block a write merely because the
+classifier was unavailable. (The accurate post-enrichment ``GovernanceDecision``
+remains the backstop.)
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from common.llm.protocols import LLMProvider
+from common.llm.retry import call_with_fallback
+from common.provider_names import ProviderName
+
+# Kept deliberately short and structured: one classification, low token cost.
+_PROMPT = """Classify whether the following content is BUSINESS-relevant or PERSONAL.
+
+BUSINESS: work, projects, customers, code, decisions, operations — anything an
+organization would keep in shared memory.
+PERSONAL: private individual matters unrelated to work (health, family, personal
+opinions or plans).
+
+Return ONLY JSON: {{"business_relevance": "business" | "personal", "confidence": 0.0-1.0}}
+
+Content:
+{content}"""
+
+
+@dataclass(frozen=True)
+class BusinessClassification:
+    business_relevance: str  # "business" | "personal"
+    confidence: float  # 0.0 to 1.0
+    llm_ms: int  # 0 when no live model ran (fail-open)
+
+
+def _fail_open() -> BusinessClassification:
+    """Safe default: treat as business so the pre-gate never blocks on failure."""
+    return BusinessClassification(business_relevance="business", confidence=0.0, llm_ms=0)
+
+
+def _build_prompt(content: str) -> str:
+    """Build the classifier prompt. ``str.format`` only parses the TEMPLATE for
+    fields — the substituted ``content`` value is inserted literally — so the
+    content must NOT be brace-escaped (escaping would corrupt JSON / code / any
+    braces in it). The template's own JSON example is escaped with ``{{ }}``."""
+    return _PROMPT.format(content=content)
+
+
+async def classify_business_personal(
+    content: str,
+    tenant_config: object | None = None,
+    *,
+    provider: str | None,
+    model: str | None,
+) -> BusinessClassification:
+    """Classify *content* as business/personal via a fast LLM call.
+
+    ``provider``/``model`` are the pre-gate's own settings (the caller resolves
+    a fallback). A ``none`` provider short-circuits to the fail-open default.
+    """
+    provider_name = provider or ProviderName.OPENAI
+    if provider_name == ProviderName.NONE:
+        return _fail_open()
+
+    async def _do(llm: LLMProvider) -> BusinessClassification:
+        prompt = _build_prompt(content)
+        t0 = time.perf_counter()
+        raw = await llm.complete_json(prompt)
+        llm_ms = int((time.perf_counter() - t0) * 1000)
+        rel = raw.get("business_relevance")
+        rel = rel if rel in ("business", "personal") else "business"
+        try:
+            conf = float(raw.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            conf = 0.0
+        return BusinessClassification(
+            business_relevance=rel, confidence=min(1.0, max(0.0, conf)), llm_ms=llm_ms
+        )
+
+    return await call_with_fallback(
+        primary_provider_name=provider_name,
+        call_fn=_do,
+        fake_fn=_fail_open,
+        tenant_config=tenant_config,
+        service_label="business_pregate",
+        model_override=model,
+    )

--- a/core-api/src/core_api/services/governance_gate.py
+++ b/core-api/src/core_api/services/governance_gate.py
@@ -22,6 +22,11 @@ ACTION_PII_DROP = "pii_drop"
 ACTION_PII_FLAG = "pii_flag"
 ACTION_NB_DROP = "nonbusiness_drop"
 ACTION_NB_KEEP_PRIVATE = "nonbusiness_keep_private"
+# Pre-gate drop: rejected by the fast business/personal classifier BEFORE any
+# persistence. Distinct from ``nonbusiness_drop`` (which in fast-mode remediation
+# soft-deletes an already-stored row) — the verb must describe what physically
+# happened, and here nothing was ever written.
+ACTION_NB_PREGATE_DROP = "nonbusiness_pregate_drop"
 
 
 def _content_sha256(content: str) -> str:
@@ -76,6 +81,23 @@ def llm_pii_audit_detail(
 
 def nonbusiness_audit_detail(action: str, content: str, write_mode: str | None) -> dict:
     return _base_audit_detail(action, content, write_mode)
+
+
+def nonbusiness_pregate_audit_detail(
+    action: str,
+    content: str,
+    write_mode: str | None,
+    *,
+    provider: str | None,
+    model: str | None,
+    confidence: float | None,
+) -> dict:
+    """Audit detail for the fast pre-gate's business/personal decision. Records
+    the classifier provider/model + confidence (metadata only — never the raw
+    content) so a compliance review can see what made the early-reject call."""
+    detail = _base_audit_detail(action, content, write_mode)
+    detail.update({"source": "llm_pregate", "provider": provider, "model": model, "confidence": confidence})
+    return detail
 
 
 def mark_pii_flagged(metadata: dict, findings: list[Finding]) -> None:

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -250,6 +250,21 @@ DEFAULT_SETTINGS: dict = {
         "non_business": {
             "enabled": False,
             "disposition": None,  # None → "store"; one of drop | keep_private | store
+            # Fast pre-gate (opt-in): a cheap business-vs-personal go/no-go that
+            # runs BEFORE enrichment / embedding / entity extraction and rejects
+            # personal content early when ``disposition="drop"``. Disabled by
+            # default like every other security control. Its own provider/model
+            # so the signal is independent of the enrichment provider (survives
+            # ``enrichment_provider=none``, e.g. CI). ``min_confidence`` None →
+            # act on any "personal" verdict (matches the post-enrichment gate);
+            # set it to require higher confidence before dropping (fewer false
+            # rejects). Fail-open: a classifier failure never blocks a write.
+            "pregate": {
+                "enabled": False,
+                "provider": None,
+                "model": None,
+                "min_confidence": None,
+            },
         },
     },
     "api_keys": {},
@@ -377,6 +392,9 @@ def _validate_cron(expr: str) -> None:
 
 _PII_ACTIONS = frozenset({"mask", "drop", "flag"})
 _NON_BUSINESS_DISPOSITIONS = frozenset({"drop", "keep_private", "store"})
+# The fast pre-gate accepts any known LLM provider name (incl. ``none``/``fake``
+# for disable/test). Membership-checked so a typo can't silently disable the gate.
+_PREGATE_PROVIDERS = frozenset(p.value for p in ProviderName)
 
 
 def _validate_governance_enums(payload: dict) -> None:
@@ -392,11 +410,24 @@ def _validate_governance_enums(payload: dict) -> None:
     action = gov.get("pii", {}).get("action")
     if action is not None and action not in _PII_ACTIONS:
         raise ValueError(f"governance.pii.action must be one of {sorted(_PII_ACTIONS)}, got {action!r}")
-    disposition = gov.get("non_business", {}).get("disposition")
+    nb = gov.get("non_business", {})
+    disposition = nb.get("disposition")
     if disposition is not None and disposition not in _NON_BUSINESS_DISPOSITIONS:
         raise ValueError(
             f"governance.non_business.disposition must be one of "
             f"{sorted(_NON_BUSINESS_DISPOSITIONS)}, got {disposition!r}"
+        )
+    pregate = nb.get("pregate", {})
+    provider = pregate.get("provider")
+    if provider is not None and provider not in _PREGATE_PROVIDERS:
+        raise ValueError(
+            f"governance.non_business.pregate.provider must be one of "
+            f"{sorted(_PREGATE_PROVIDERS)}, got {provider!r}"
+        )
+    min_conf = pregate.get("min_confidence")
+    if min_conf is not None and not (0.0 <= min_conf <= 1.0):
+        raise ValueError(
+            f"governance.non_business.pregate.min_confidence must be in [0.0, 1.0], got {min_conf!r}"
         )
 
 
@@ -472,6 +503,10 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "governance.pii.categories.secret": bool,
     "governance.non_business.enabled": bool,
     "governance.non_business.disposition": str,
+    "governance.non_business.pregate.enabled": bool,
+    "governance.non_business.pregate.provider": str,
+    "governance.non_business.pregate.model": str,
+    "governance.non_business.pregate.min_confidence": (int, float),
 }
 
 # Inclusive range constraints applied AFTER type validation. Listed
@@ -556,6 +591,18 @@ class _GovNB:
     disposition: str  # "drop" | "keep_private" | "store"
 
 
+@dataclass(frozen=True)
+class _GovNBPregate:
+    """Resolved fast pre-gate policy: a business/personal go/no-go before
+    enrichment. ``provider``/``model`` None → resolved by the step (falls back to
+    the enrichment provider). ``min_confidence`` None → act on any "personal"."""
+
+    enabled: bool
+    provider: str | None
+    model: str | None
+    min_confidence: float | None
+
+
 class ResolvedConfig:
     """Resolves LLM/feature config from organization overrides + global fallbacks."""
 
@@ -592,6 +639,16 @@ class ResolvedConfig:
         return _GovNB(
             enabled=bool(g.get("enabled", False)),
             disposition=g.get("disposition") or "store",
+        )
+
+    @property
+    def governance_non_business_pregate(self) -> _GovNBPregate:
+        g = self._ts.get("governance", {}).get("non_business", {}).get("pregate", {})
+        return _GovNBPregate(
+            enabled=bool(g.get("enabled", False)),
+            provider=g.get("provider") or None,
+            model=g.get("model") or None,
+            min_confidence=g.get("min_confidence"),
         )
 
     # Enrichment

--- a/tests/test_business_personal_pregate.py
+++ b/tests/test_business_personal_pregate.py
@@ -1,0 +1,314 @@
+"""Tests for the fast business/personal pre-gate (BusinessPersonalPregate).
+
+Layers, all deterministic (no HTTP/settings round-trip):
+  * Step-level: enablement gating, drop/flow-through, min_confidence, and that
+    the pre-gate uses its OWN provider independent of the enrichment provider
+    (the green-local/red-CI lesson — the signal must survive
+    ``enrichment_provider=none``). The classifier is monkeypatched at the step
+    level so the decision logic is exercised without a live model.
+  * Classifier: the ``provider=none`` fail-open path, exercised directly.
+  * Settings: default-off + validation of the new pregate keys.
+  * Pipeline wiring: the step is composed into strong + fast at the right spot.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.step import StepOutcome
+from core_api.pipeline.steps.write import business_personal_pregate as pregate_mod
+from core_api.pipeline.steps.write.business_personal_pregate import (
+    BusinessPersonalPregate,
+)
+from core_api.services.business_classifier import (
+    BusinessClassification,
+    classify_business_personal,
+)
+from core_api.services.organization_settings import (
+    ResolvedConfig,
+    _validate_governance_enums,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def emitted(monkeypatch):
+    """Capture governance audit emissions in the step module."""
+    calls: list[dict] = []
+
+    async def _record(*args, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(f"{pregate_mod.__name__}.emit_governance_audit", _record)
+    return calls
+
+
+def _data(content="some content", **kw):
+    return SimpleNamespace(
+        content=content,
+        metadata=kw.get("metadata"),
+        tenant_id="t1",
+        agent_id="a1",
+        fleet_id=None,
+        persist=True,
+        visibility=kw.get("visibility"),
+    )
+
+
+def _cfg(*, nb=None, enrichment_provider=None) -> ResolvedConfig:
+    ts: dict = {}
+    if nb is not None:
+        ts["governance"] = {"non_business": nb}
+    if enrichment_provider is not None:
+        ts["enrichment"] = {"provider": enrichment_provider}
+    return ResolvedConfig(ts)
+
+
+def _ctx(data, *, cfg, mode="strong") -> PipelineContext:
+    return PipelineContext(
+        db=None,
+        data={"input": data, "resolved_write_mode": mode},
+        tenant_config=cfg,
+    )
+
+
+def _patch_classifier(monkeypatch, *, relevance="personal", confidence=0.95):
+    """Replace the step's classifier with a canned result; capture call kwargs."""
+    captured: dict = {}
+
+    async def _fake(content, tenant_config=None, *, provider, model):
+        captured.update(content=content, provider=provider, model=model)
+        return BusinessClassification(
+            business_relevance=relevance, confidence=confidence, llm_ms=3
+        )
+
+    monkeypatch.setattr(pregate_mod, "classify_business_personal", _fake)
+    return captured
+
+
+# ── enablement gating ────────────────────────────────────────────────
+
+
+async def test_pregate_skips_when_pregate_disabled():
+    cfg = _cfg(
+        nb={"enabled": True, "disposition": "drop", "pregate": {"enabled": False}}
+    )
+    res = await BusinessPersonalPregate().execute(_ctx(_data(), cfg=cfg))
+    assert res.outcome == StepOutcome.SKIPPED
+
+
+async def test_pregate_skips_when_non_business_disabled():
+    cfg = _cfg(
+        nb={"enabled": False, "disposition": "drop", "pregate": {"enabled": True}}
+    )
+    res = await BusinessPersonalPregate().execute(_ctx(_data(), cfg=cfg))
+    assert res.outcome == StepOutcome.SKIPPED
+
+
+async def test_pregate_skips_when_disposition_not_drop():
+    # keep_private/store persist the row → left to the post-enrichment decision.
+    cfg = _cfg(
+        nb={
+            "enabled": True,
+            "disposition": "keep_private",
+            "pregate": {"enabled": True},
+        }
+    )
+    res = await BusinessPersonalPregate().execute(_ctx(_data(), cfg=cfg))
+    assert res.outcome == StepOutcome.SKIPPED
+
+
+# ── decision logic ───────────────────────────────────────────────────
+
+
+async def test_pregate_personal_drop_raises_422(monkeypatch, emitted):
+    _patch_classifier(monkeypatch, relevance="personal", confidence=0.9)
+    cfg = _cfg(
+        nb={
+            "enabled": True,
+            "disposition": "drop",
+            "pregate": {"enabled": True, "provider": "openai"},
+        }
+    )
+    with pytest.raises(HTTPException) as exc:
+        await BusinessPersonalPregate().execute(_ctx(_data("my vacation"), cfg=cfg))
+    assert exc.value.status_code == 422
+    drop = next(c for c in emitted if c["action"] == "nonbusiness_pregate_drop")
+    assert drop["detail"]["source"] == "llm_pregate"
+    assert drop["detail"]["confidence"] == 0.9
+
+
+async def test_pregate_business_flows_through(monkeypatch, emitted):
+    _patch_classifier(monkeypatch, relevance="business", confidence=0.9)
+    cfg = _cfg(
+        nb={
+            "enabled": True,
+            "disposition": "drop",
+            "pregate": {"enabled": True, "provider": "openai"},
+        }
+    )
+    res = await BusinessPersonalPregate().execute(_ctx(_data("q3 revenue"), cfg=cfg))
+    assert res is None
+    assert emitted == []
+
+
+async def test_pregate_respects_min_confidence(monkeypatch, emitted):
+    # personal but below the configured confidence floor → no drop (fail-open).
+    _patch_classifier(monkeypatch, relevance="personal", confidence=0.4)
+    cfg = _cfg(
+        nb={
+            "enabled": True,
+            "disposition": "drop",
+            "pregate": {"enabled": True, "provider": "openai", "min_confidence": 0.8},
+        }
+    )
+    res = await BusinessPersonalPregate().execute(
+        _ctx(_data("maybe personal"), cfg=cfg)
+    )
+    assert res is None
+    assert emitted == []
+
+
+# ── provider independence + fail-open (the green-local/red-CI lesson) ──
+
+
+async def test_pregate_uses_own_provider_independent_of_enrichment(monkeypatch):
+    captured = _patch_classifier(monkeypatch, relevance="business")
+    # Enrichment provider is none (e.g. CI), but the pre-gate has its own.
+    cfg = _cfg(
+        nb={
+            "enabled": True,
+            "disposition": "drop",
+            "pregate": {"enabled": True, "provider": "openai", "model": "gpt-5.4-nano"},
+        },
+        enrichment_provider="none",
+    )
+    await BusinessPersonalPregate().execute(_ctx(_data(), cfg=cfg))
+    assert captured["provider"] == "openai"  # NOT "none"
+    assert captured["model"] == "gpt-5.4-nano"
+
+
+async def test_pregate_falls_back_to_enrichment_provider_when_unset(monkeypatch):
+    captured = _patch_classifier(monkeypatch, relevance="business")
+    cfg = _cfg(
+        nb={"enabled": True, "disposition": "drop", "pregate": {"enabled": True}},
+        enrichment_provider="gemini",
+    )
+    await BusinessPersonalPregate().execute(_ctx(_data(), cfg=cfg))
+    assert captured["provider"] == "gemini"
+
+
+async def test_classifier_none_provider_fail_open():
+    # No live model (provider=none): never block — return a "business" verdict.
+    res = await classify_business_personal(
+        "anything", None, provider="none", model=None
+    )
+    assert res.business_relevance == "business"
+    assert res.llm_ms == 0
+
+
+async def test_classifier_prompt_preserves_braces():
+    # str.format inserts the substituted value literally; the content must NOT be
+    # brace-escaped, or JSON/code/braces in it get corrupted before the LLM sees
+    # them (e.g. {"a": 1} → {{"a": 1}}).
+    from core_api.services.business_classifier import _build_prompt
+
+    content = 'config = {"a": 1}; for {i} in range(3): pass'
+    prompt = _build_prompt(content)
+    assert content in prompt
+    assert "{{" not in prompt.split("Content:")[-1]
+
+
+# ── settings: default-off + validation ───────────────────────────────
+
+
+async def test_pregate_default_off():
+    pg = ResolvedConfig({}).governance_non_business_pregate
+    assert pg.enabled is False
+    assert pg.provider is None and pg.model is None and pg.min_confidence is None
+
+
+async def test_pregate_settings_resolve():
+    pg = ResolvedConfig(
+        {
+            "governance": {
+                "non_business": {
+                    "pregate": {
+                        "enabled": True,
+                        "provider": "openai",
+                        "model": "gpt-5.4-nano",
+                        "min_confidence": 0.7,
+                    }
+                }
+            }
+        }
+    ).governance_non_business_pregate
+    assert (
+        pg.enabled
+        and pg.provider == "openai"
+        and pg.model == "gpt-5.4-nano"
+        and pg.min_confidence == 0.7
+    )
+
+
+async def test_pregate_validation_rejects_bad_provider():
+    with pytest.raises(ValueError):
+        _validate_governance_enums(
+            {"governance": {"non_business": {"pregate": {"provider": "bogus"}}}}
+        )
+
+
+async def test_pregate_validation_rejects_out_of_range_confidence():
+    with pytest.raises(ValueError):
+        _validate_governance_enums(
+            {"governance": {"non_business": {"pregate": {"min_confidence": 1.5}}}}
+        )
+
+
+async def test_pregate_validation_accepts_valid():
+    _validate_governance_enums(
+        {
+            "governance": {
+                "non_business": {
+                    "pregate": {"provider": "gemini", "min_confidence": 0.5}
+                }
+            }
+        }
+    )
+
+
+# ── pipeline wiring ──────────────────────────────────────────────────
+
+
+def _names(pipeline) -> list[str]:
+    return [s.name for s in pipeline._steps]
+
+
+async def test_pregate_wired_into_strong_and_fast_before_enrich():
+    from core_api.pipeline.compositions.write import (
+        build_fast_write_pipeline,
+        build_strong_write_pipeline,
+    )
+
+    for build in (build_strong_write_pipeline, build_fast_write_pipeline):
+        names = _names(build())
+        assert "business_personal_pregate" in names, build.__name__
+        # After the deterministic scan, before the expensive enrichment.
+        assert (
+            names.index("governance_scan_content")
+            < names.index("business_personal_pregate")
+            < names.index("parallel_embed_enrich")
+        ), build.__name__
+
+
+async def test_pregate_not_in_stm_or_enrichment_only():
+    from core_api.pipeline.compositions.write import (
+        build_enrichment_pipeline,
+        build_stm_write_pipeline,
+    )
+
+    assert "business_personal_pregate" not in _names(build_stm_write_pipeline())
+    assert "business_personal_pregate" not in _names(build_enrichment_pipeline())


### PR DESCRIPTION
Implements the approved design (`DESIGN-business-personal-pregate.md`) — **Design A (additive), disabled by default.**

## What it does
Adds an optional **fast business-vs-personal go/no-go** at the front of the write pipeline — after the deterministic PII scan, **before** enrichment, embedding, and the (already-deferred) entity extraction. On a confident **`personal`** verdict when the tenant's disposition is **`drop`**, the write is rejected with `422` *before* any of that work runs and before a row is written.

## Highlights
- **New step `BusinessPersonalPregate`**, wired into the **strong + fast** write pipelines (after `GovernanceScanContent`, before `ParallelEmbedEnrich`); correctly absent from STM / enrichment-only.
- **Its own provider/model** (via `common.llm` `call_with_fallback`), so the signal is **independent of the enrichment provider** — it survives `ENTITY_EXTRACTION_PROVIDER=none` (the green-local/red-CI blind spot).
- **Disabled by default.** New `governance.non_business.pregate` settings (`enabled` / `provider` / `model` / `min_confidence`), all opt-in, validated + resolved alongside the existing governance settings. **Prod behavior is unchanged until a tenant enables it.**
- **Truthful audit verb** `nonbusiness_pregate_drop` (nothing persisted — distinct from `nonbusiness_drop` which soft-deletes a stored row), emitted **before** the raise.
- **Additive (Design A):** the post-enrichment `GovernanceDecision` remains the accurate backstop; `keep_private`/`store` stay there (they persist the row, so an early exit saves nothing).
- **Fail-open:** a `none` provider or any classifier failure never blocks a write.

## Open design decisions (per the doc, as approved)
D1 additive-first · D2 model configurable (defaults to the cheap tier) · D3 drop-only · D4 fail-open default with a `min_confidence` knob · D5 default-off. Graduating to full separation (B) remains a documented follow-up.

## Verification
- 43 tests green (new `tests/test_business_personal_pregate.py` + existing governance suites — no regression): enablement gating, drop/flow-through, `min_confidence`, **provider-independence + fail-open reproduced under `provider=none`**, settings default-off + validation, and pipeline wiring.
- `ruff check` + `ruff format --check` clean; `mypy` clean on touched files.
- `/simplify` run before commit (one cleanup applied: removed dead `isinstance` guards + a redundant cast in the settings validator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)