### PR TITLE
fix(prompts): stop brace-escaping content before str.format

### DIFF
--- a/common/enrichment/service.py
+++ b/common/enrichment/service.py
@@ -169,7 +169,11 @@ def _validate_enrichment(raw: dict, llm_ms: int) -> EnrichmentResult:
     # Governance gate: clamp to the allowed set; anything off-spec (including a
     # missing value) falls back to "business" — the fail-closed-safe default, so
     # only a confident "personal" from the LLM ever triggers the disposition gate.
-    raw["business_relevance"] = raw.get("business_relevance") if raw.get("business_relevance") in ("business", "personal") else "business"
+    raw["business_relevance"] = (
+        raw.get("business_relevance")
+        if raw.get("business_relevance") in ("business", "personal")
+        else "business"
+    )
     raw["llm_ms"] = llm_ms
     return EnrichmentResult(**raw)
 
@@ -309,17 +313,13 @@ async def enrich_memory(
     ).isoformat()
 
     async def _do_enrich(llm: LLMProvider) -> EnrichmentResult:
-        # Escape ``{`` / ``}`` in user content before ``.format()`` —
-        # the prompt template uses them as field markers, so a memory
-        # whose content includes ``"I used {memory_type} in my code"``
-        # would raise ``KeyError`` from ``.format()``, get caught by
-        # the retry loop above, exhaust attempts, and silently fall to
-        # ``fake_enrich`` with no log surface for *why*. The template
-        # itself escapes its JSON example with literal ``{{ }}`` so
-        # there's no symmetry to preserve at the format-string layer
-        # — only user input needs the escape.
-        escaped_content = content.replace("{", "{{").replace("}", "}}")
-        prompt = ENRICHMENT_PROMPT.format(content=escaped_content, today=ref_date)
+        # ``str.format`` parses only the TEMPLATE for replacement fields; the
+        # substituted ``content`` value is inserted literally and never
+        # re-scanned, so it must NOT be brace-escaped — escaping would corrupt
+        # JSON / code / any ``{...}`` in the content before the LLM sees it (a
+        # substituted value never raises KeyError). The template's own JSON
+        # example is escaped with literal ``{{ }}``.
+        prompt = ENRICHMENT_PROMPT.format(content=content, today=ref_date)
         t0 = time.perf_counter()
         raw = await llm.complete_json(prompt)
         llm_ms = int((time.perf_counter() - t0) * 1000)

--- a/core-api/src/core_api/services/evolve_service.py
+++ b/core-api/src/core_api/services/evolve_service.py
@@ -494,16 +494,16 @@ async def _generate_rule(
         return ("no_memories_fetched", None)
 
     memories_text = "\n".join(memories_text_lines)
-    # Escape user-controlled braces before .format() — both outcome (agent input)
-    # and memories_text (DB content/titles) can contain literal {word} that would
-    # otherwise raise KeyError outside the call_with_fallback try/except.
-    # Also cap outcome size to bound prompt tokens.
-    safe_outcome = _sanitize_content(outcome, max_len=2000).replace("{", "{{").replace("}", "}}")
-    safe_memories = memories_text.replace("{", "{{").replace("}", "}}")
+    # ``str.format`` inserts substituted values literally (it never re-scans them
+    # for fields), so outcome/memories must NOT be brace-escaped — escaping would
+    # corrupt literal {word} / JSON / code in agent input or DB content. A
+    # substituted value never raises KeyError. Still cap the outcome to bound
+    # prompt tokens.
+    safe_outcome = _sanitize_content(outcome, max_len=2000)
     prompt = _RULE_GENERATION_PROMPT.format(
         outcome=safe_outcome,
         outcome_type=outcome_type,
-        memories=safe_memories,
+        memories=memories_text,
         count=len(memories_text_lines),
     )
 

--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -958,12 +958,11 @@ async def synthesize_insights(
         if focus == "discover":
             prompt_template = _PROMPT_DISPATCH["patterns"]
 
-    # Escape literal braces in memories_text before .format(). Cluster mode
-    # always includes Python dict reprs (type_distribution); content mode can
-    # include user-controlled `{...}` strings. Without escaping, str.format
-    # raises KeyError on any stray `{word}`.
-    safe_memories = memories_text.replace("{", "{{").replace("}", "}}")
-    prompt = prompt_template.format(memories=safe_memories, count=count)
+    # ``str.format`` inserts the substituted ``memories`` value literally (it
+    # never re-scans it for fields), so it must NOT be brace-escaped — escaping
+    # would corrupt the Python dict reprs (cluster mode) and any user-controlled
+    # {...} strings. A substituted value never raises KeyError.
+    prompt = prompt_template.format(memories=memories_text, count=count)
 
     analysis = await _run_llm_analysis(prompt, config)
 

--- a/tests/test_prompt_brace_escaping.py
+++ b/tests/test_prompt_brace_escaping.py
@@ -1,0 +1,85 @@
+"""Regression tests for the prompt-building brace bug.
+
+``str.format`` parses only the TEMPLATE for replacement fields — a substituted
+value is inserted literally and never re-scanned, so it never raises KeyError and
+must NOT be brace-escaped. Pre-escaping (``content.replace("{", "{{")``) corrupted
+any brace-containing content (JSON, code, dict reprs) before it reached the LLM.
+These guard the three call sites that had the bug: ``enrich_memory`` (calling-code
+capture) and the evolve / insights prompt templates (invariant).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Content that would be corrupted by escaping: JSON + a bare {field}-looking token.
+_BRACED = 'deploy config = {"replicas": 3}; for {i} in range(3): log({i})'
+
+
+@pytest.mark.asyncio
+async def test_enrich_memory_prompt_preserves_braces():
+    """enrich_memory must send brace-containing content to the LLM verbatim."""
+    from core_api.services.memory_enrichment import enrich_memory
+
+    captured: list[str] = []
+
+    async def fake_complete_json(prompt: str):
+        captured.append(prompt)
+        return {
+            "memory_type": "fact",
+            "weight": 0.5,
+            "title": "t",
+            "summary": "s",
+            "tags": [],
+            "status": "active",
+            "ts_valid_start": None,
+            "ts_valid_end": None,
+            "contains_pii": False,
+            "pii_types": [],
+        }
+
+    mock_llm = AsyncMock()
+    mock_llm.complete_json = fake_complete_json
+
+    tenant_config = MagicMock()
+    tenant_config.enrichment_provider = "openai"
+    tenant_config.enrichment_model = None
+
+    async def mock_fallback(*args, **kwargs):
+        call_fn = args[1] if len(args) > 1 else kwargs.get("call_fn")
+        return await call_fn(mock_llm)
+
+    with patch(
+        "common.enrichment.service.call_with_fallback", side_effect=mock_fallback
+    ):
+        await enrich_memory(_BRACED, tenant_config)
+
+    assert captured, "LLM was not called"
+    # Verbatim content in the prompt — not the corrupted {{...}} form the old
+    # brace-escaping produced (which would make this substring check fail).
+    assert _BRACED in captured[0]
+
+
+def test_rule_generation_template_preserves_braces():
+    """The evolve rule-generation template preserves braces in substituted values."""
+    from core_api.services.evolve_service import _RULE_GENERATION_PROMPT
+
+    out = _RULE_GENERATION_PROMPT.format(
+        outcome="set {x} and {y}",
+        outcome_type="success",
+        memories='cfg = {"a": 1}',
+        count=1,
+    )
+    assert "set {x} and {y}" in out
+    assert 'cfg = {"a": 1}' in out
+
+
+def test_insights_templates_preserve_braces():
+    """Every insights analysis template preserves braces (cluster mode passes
+    Python dict reprs; content mode can carry user-controlled {...} strings)."""
+    from core_api.services.insights_service import _PROMPT_DISPATCH
+
+    braced = "type_distribution = {'fact': 3}; note {placeholder}"
+    for key, template in _PROMPT_DISPATCH.items():
+        out = template.format(memories=braced, count=2)
+        assert braced in out, key


### PR DESCRIPTION
## The bug
`enrich_memory` (`common/enrichment/service.py`), `_generate_rule` (`evolve_service.py`), and `synthesize_insights` (`insights_service.py`) all pre-escaped content (`{` → `{{`) before passing it as a **substitution value** to `str.format()`, with comments claiming an un-escaped value would raise `KeyError`.

That's incorrect. `str.format()` parses only the **template** for replacement fields — a substituted value is inserted **literally** and never re-scanned, so it never raises `KeyError` and never needs escaping. The escaping instead **corrupts** any brace-containing content before the LLM sees it:

```python
>>> "{c}".format(c='{"a": 1}')      # substituted value, literal — no error
'{"a": 1}'
>>> "{c}".format(c='{{"a": 1}}')    # escaped form is inserted as-is → corrupted
'{{"a": 1}}'
```

So JSON, code, regex, templates, and dict reprs (insights cluster mode) reached the enrichment/rule/insight LLM with doubled braces — degrading exactly the technical/business content these paths handle.

## The fix
Pass `content` / `outcome` / `memories` directly to `.format()` at all three sites and correct the misleading comments. The evolve `_sanitize_content(outcome, max_len=2000)` size cap is preserved — only the escaping is removed.

## Tests
- `test_enrich_memory_prompt_preserves_braces` — exercises `enrich_memory` with a mocked provider and asserts brace-containing content reaches the prompt **verbatim** (fails on the old escaping).
- Brace-preservation invariants for the evolve (`_RULE_GENERATION_PROMPT`) and insights (`_PROMPT_DISPATCH`) templates.
- Verified empirically; `ruff check` + `format --check` + `mypy` clean; enrichment suites green (no regression).

## Context
Same class of bug was just fixed in `core_api/services/business_classifier.py` in #403 (the new pre-gate classifier was modeled on `enrich_memory`); this PR fixes the pre-existing occurrences in the enrichment / evolve / insights paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)