### PR TITLE
fix(entity-linking): backfill embeddings via Core table, not ORM bulk-by-PK

### DIFF
--- a/core-api/src/core_api/pipeline/steps/entity_linking/backfill_entity_embeddings.py
+++ b/core-api/src/core_api/pipeline/steps/entity_linking/backfill_entity_embeddings.py
@@ -66,16 +66,23 @@ class BackfillEntityEmbeddings:
         backfill_count = 0
         if updates:
             await ctx.require_db.execute(
-                # ``synchronize_session=False``: this is a bulk ORM UPDATE with
-                # extra WHERE criteria over an executemany param list, which
-                # SQLAlchemy refuses to session-synchronize (InvalidRequestError,
-                # prod 2026-06-13). There is no live ORM session state to keep in
-                # sync here — the backfill writes name_embedding and moves on — so
-                # skipping synchronization is correct, not just a silencer.
-                update(Entity)
-                .where(Entity.id == sa.bindparam("eid"), Entity.tenant_id == tenant_id)
-                .values(name_embedding=sa.bindparam("emb"))
-                .execution_options(synchronize_session=False),
+                # Target the Core ``entities`` table, NOT the ORM-mapped ``Entity``.
+                # ``session.execute(update(Entity), <list of param dicts>)`` routes to
+                # SQLAlchemy's "ORM Bulk UPDATE by Primary Key", which requires every
+                # dict to carry the PK column ``id`` — but our dicts key the PK off a
+                # custom ``eid`` bindparam in the WHERE clause, so that path raised
+                # ``InvalidRequestError: No primary key value supplied for column(s)
+                # entities.id`` (prod 2026-06-16). The earlier ``synchronize_session=
+                # False`` (prod 2026-06-13) only silenced a *different* error on that
+                # same ORM path. ``update(Entity.__table__)`` is a plain Core executemany
+                # UPDATE that honours the custom bindparams and has no ORM bulk-by-PK or
+                # session-synchronisation behaviour at all.
+                update(Entity.__table__)
+                .where(
+                    Entity.__table__.c.id == sa.bindparam("eid"),
+                    Entity.__table__.c.tenant_id == tenant_id,
+                )
+                .values(name_embedding=sa.bindparam("emb")),
                 updates,
             )
             backfill_count = len(updates)

--- a/tests/pipeline/test_backfill_entity_embeddings.py
+++ b/tests/pipeline/test_backfill_entity_embeddings.py
@@ -1,15 +1,20 @@
 """Unit tests for BackfillEntityEmbeddings.
 
-Regression anchor (prod 2026-06-13): the bulk-update execute raised
-``sqlalchemy.exc.InvalidRequestError: bulk synchronize of persistent
-objects not supported when using bulk update with additional WHERE
-criteria`` — an ORM ``update(Entity).where(...).values(...)`` over an
-executemany param list needs ``synchronize_session=False``. Every
-backfill batch failed (6 occurrences in ~10h; entity name_embeddings
-silently not backfilled). Same ``entity_linking_full`` family as the
-discover_cross_links (#337) and infer_relations (#341) fixes.
+Regression anchor (prod 2026-06-16): the bulk-update execute raised
+``sqlalchemy.exc.InvalidRequestError: No primary key value supplied for
+column(s) entities.id; per-row ORM Bulk UPDATE by Primary Key requires
+that records contain primary key values``. ``session.execute(update(Entity),
+[param dicts])`` routes to SQLAlchemy's ORM Bulk UPDATE by Primary Key, which
+needs each dict keyed by ``id`` — but the dicts key the PK off a custom
+``eid`` bindparam, so it failed. (The earlier prod 2026-06-13 ``InvalidRequestError:
+bulk synchronize ...`` on the same ORM path was only silenced by
+``synchronize_session=False``, which masked this second failure mode.) The fix:
+target the Core table ``update(Entity.__table__)`` — a plain executemany UPDATE
+with no ORM bulk-by-PK behaviour. Every backfill batch failed (6 occurrences in
+~10h; entity name_embeddings silently not backfilled). Same ``entity_linking_full``
+family as the discover_cross_links (#337) and infer_relations (#341) fixes.
 
-Mock-based — assert the statement carries synchronize_session=False.
+Mock-based — assert the statement is a Core UPDATE, not an ORM-enabled one.
 """
 
 from __future__ import annotations
@@ -40,10 +45,12 @@ def _ctx(db, **extra):
 
 
 @pytest.mark.asyncio
-async def test_bulk_update_sets_synchronize_session_false():
-    """The backfill UPDATE must carry execution_option
-    synchronize_session=False, or SQLAlchemy raises InvalidRequestError
-    on the bulk-update-with-WHERE path."""
+async def test_bulk_update_targets_core_table_not_orm_entity():
+    """The backfill UPDATE must be a Core ``update(Entity.__table__)``, not an
+    ORM ``update(Entity)``. The ORM form routes ``session.execute(stmt, [params])``
+    through "ORM Bulk UPDATE by Primary Key" and raised "No primary key value
+    supplied for column(s) entities.id" in prod (2026-06-16). A Core statement
+    carries no ORM compile plugin, so it never takes that path."""
     eid = uuid.uuid4()
     db = AsyncMock()
     db.execute.side_effect = [
@@ -64,8 +71,15 @@ async def test_bulk_update_sets_synchronize_session_false():
 
     assert result.outcome == StepOutcome.SUCCESS
     assert ctx.data["backfill_count"] == 1
-    update_stmt = db.execute.call_args_list[1].args[0]
-    assert update_stmt.get_execution_options().get("synchronize_session") is False
+
+    update_stmt, exec_params = db.execute.call_args_list[1].args
+    assert update_stmt.is_dml
+    assert update_stmt.table.name == "entities"
+    # No ORM compile plugin => plain Core UPDATE => no "ORM Bulk UPDATE by
+    # Primary Key" path (which is what raised in prod).
+    assert "compile_state_plugin" not in update_stmt._propagate_attrs
+    # The custom-bindparam executemany param list is passed through unchanged.
+    assert exec_params == [{"eid": eid, "emb": [0.1] * 8}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Prod incident

The nightly `entity_linking_full` pipeline's **`backfill_entity_embeddings`** step has been failing in prod (observed 2026-06-16, ~6 occurrences/night, all in the 02:00–02:11 UTC cron window) with:

```
entity_linking_full.backfill_entity_embeddings: FAILED — No primary key value supplied
for column(s) entities.id; per-row ORM Bulk UPDATE by Primary Key requires that records
contain primary key values
```

Effect: entity `name_embedding`s are silently **not** backfilled for affected tenants, and the runner `break`s the rest of that org's linking run for the night.

## Root cause

`session.execute(update(Entity), [param dicts])` (an **ORM-mapped** class + an executemany param list) routes to SQLAlchemy's *"ORM Bulk UPDATE by Primary Key"*, which requires every param dict to carry the PK column `id`. Our dicts key the PK off a custom `eid` bindparam in the `WHERE` clause, so the bulk-by-PK machinery finds no `id` and raises.

The earlier `synchronize_session=False` change (prod 2026-06-13) only silenced a *different* error on the same ORM path — it masked this second failure mode rather than removing the ORM bulk-update path.

This is the same `entity_linking_full` family as the prior `discover_cross_links` (#337) and `infer_relations` (#341) fixes.

## Fix

Target the **Core table** `update(Entity.__table__)` instead of the ORM-mapped `Entity`. That is a plain Core executemany `UPDATE` which honours the custom `eid`/`emb` bindparams and has **no** ORM bulk-by-PK or session-synchronisation behaviour at all. The `.execution_options(synchronize_session=False)` is removed (irrelevant on a Core statement).

## Verification

- Reproduced against **SQLAlchemy 2.0.49**: the ORM form (`update(Entity)` + executemany) raises the exact prod `InvalidRequestError`; the Core form (`update(Entity.__table__)`) succeeds.
- The regression test now asserts the statement is a Core `UPDATE` (no ORM compile plugin) — the precise property that prevents the bulk-by-PK path — instead of the now-removed `synchronize_session` option.
- `pytest tests/pipeline/` → 88 passed. `ruff check` / `ruff format --check` / `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)