### PR TITLE
fix(http-retry): widen connection-phase retry to ride out storage cold starts

### DIFF
--- a/common/http_retry.py
+++ b/common/http_retry.py
@@ -15,19 +15,29 @@ History (load-bearing for the policy split):
   dropped) both died on first-attempt ``ConnectTimeout`` behind the VPC
   connector because POSTs had no retry at all. Connection-phase retry
   for non-idempotent methods landed in response (caura-memclaw#333).
+* 2026-06-16 prod — a steady trickle of ``httpx.ConnectTimeout`` still
+  reached core-api on the Pub/Sub enrichment, entity-extraction,
+  contradiction and audit-flush paths (storage-api cold starts /
+  instance recycles). 3 attempts (~0.6s of backoff) is too short to
+  ride out a cold start, so the connect-phase path now retries more
+  times — see ``CONNECT_PHASE_MAX_ATTEMPTS``. This complements, not
+  replaces, keeping storage-api warm (Cloud Run min-instances).
 
 Retry policy:
- - Max 3 attempts (1 initial + 2 retries)
- - Exponential backoff with jitter: ~0.2s, ~0.4s
- - Worst-case added latency: < 1s
- - Idempotent HTTP methods retry ``RETRYABLE_EXCEPTIONS`` plus
-   ``RETRYABLE_STATUS_CODES`` (use :func:`with_retry` defaults).
- - Non-idempotent methods retry ``CONNECT_PHASE_EXCEPTIONS`` ONLY
-   (use :func:`with_connect_phase_retry`): ConnectTimeout /
-   ConnectError / PoolTimeout are all raised before a single request
-   byte is written, so a retry cannot double-insert. ReadTimeout and
-   5xx are NOT retried there — the request reached storage and may
-   have committed; safe retry needs storage-side idempotency keys.
+ - Idempotent methods: max 3 attempts (1 initial + 2 retries), retry
+   ``RETRYABLE_EXCEPTIONS`` plus ``RETRYABLE_STATUS_CODES``
+   (use :func:`with_retry` defaults). Kept at 3 so a genuine 5xx
+   storm isn't amplified by extra load against a struggling server.
+ - Non-idempotent methods: ``CONNECT_PHASE_EXCEPTIONS`` ONLY
+   (use :func:`with_connect_phase_retry`), max ``CONNECT_PHASE_MAX_ATTEMPTS``
+   attempts. ConnectTimeout / ConnectError / PoolTimeout are all raised
+   before a single request byte is written, so a retry cannot
+   double-insert — and against an instance that isn't accepting yet
+   they add no server load, so retrying more times just rides out the
+   cold start. ReadTimeout and 5xx are NOT retried there — the request
+   reached storage and may have committed; safe retry needs
+   storage-side idempotency keys.
+ - Exponential backoff with jitter, capped at ``RETRY_BACKOFF_MAX_S``.
 """
 
 from __future__ import annotations
@@ -43,6 +53,16 @@ logger = logging.getLogger(__name__)
 
 RETRY_MAX_ATTEMPTS = 3
 RETRY_BACKOFF_BASE_S = 0.2
+# Cap any single backoff sleep so a higher attempt count can't grow the delay
+# unboundedly (matters once CONNECT_PHASE_MAX_ATTEMPTS pushes past 3 attempts).
+RETRY_BACKOFF_MAX_S = 2.0
+# Connection-phase failures (CONNECT_PHASE_EXCEPTIONS) are raised before the
+# request is sent and against an instance that isn't accepting yet, so retrying
+# them adds no load to a healthy server — it just rides out a Cloud Run cold
+# start / instance recycle. We retry them MORE times than the idempotent default
+# so a transient storage blip doesn't surface as a handler failure (and, on the
+# Pub/Sub path, a nack → immediate-redelivery storm).
+CONNECT_PHASE_MAX_ATTEMPTS = 5
 RETRYABLE_EXCEPTIONS = (
     httpx.ConnectTimeout,
     httpx.ReadTimeout,
@@ -66,12 +86,22 @@ RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
 NO_RETRYABLE_STATUSES: frozenset[int] = frozenset()
 
 
+def _backoff_delay(attempt: int) -> float:
+    """Exponential backoff for a 1-based ``attempt``, with ±10% jitter and a
+    hard ceiling of ``RETRY_BACKOFF_MAX_S``. The cap is applied AFTER jitter so
+    a single sleep never exceeds it (jitter on the already-capped value would
+    push the real ceiling to RETRY_BACKOFF_MAX_S * 1.1)."""
+    delay = RETRY_BACKOFF_BASE_S * (2 ** (attempt - 1))
+    return min(delay * (1.0 + random.uniform(-0.1, 0.1)), RETRY_BACKOFF_MAX_S)
+
+
 async def with_retry(
     do_request: Callable[[], Awaitable[httpx.Response]],
     *,
     label: str,
     retryable_exceptions: tuple[type[Exception], ...] = RETRYABLE_EXCEPTIONS,
     retryable_statuses: frozenset[int] = RETRYABLE_STATUS_CODES,
+    max_attempts: int = RETRY_MAX_ATTEMPTS,
 ) -> httpx.Response:
     """Wrap a single HTTP call with retry on transient errors.
 
@@ -85,20 +115,19 @@ async def with_retry(
     where the request was provably never sent.
     """
     last_exc: BaseException | None = None
-    for attempt in range(1, RETRY_MAX_ATTEMPTS + 1):
+    for attempt in range(1, max_attempts + 1):
         try:
             resp = await do_request()
         except retryable_exceptions as e:
             last_exc = e
-            if attempt < RETRY_MAX_ATTEMPTS:
-                delay = RETRY_BACKOFF_BASE_S * (2 ** (attempt - 1))
-                delay *= 1.0 + random.uniform(-0.1, 0.1)  # ±10% jitter
+            if attempt < max_attempts:
+                delay = _backoff_delay(attempt)
                 logger.warning(
                     "storage_client.%s: %s on attempt %d/%d, retrying in %.2fs",
                     label,
                     type(e).__name__,
                     attempt,
-                    RETRY_MAX_ATTEMPTS,
+                    max_attempts,
                     delay,
                 )
                 await asyncio.sleep(delay)
@@ -108,18 +137,17 @@ async def with_retry(
                 label,
                 type(e).__name__,
                 attempt,
-                RETRY_MAX_ATTEMPTS,
+                max_attempts,
             )
             raise
-        if resp.status_code in retryable_statuses and attempt < RETRY_MAX_ATTEMPTS:
-            delay = RETRY_BACKOFF_BASE_S * (2 ** (attempt - 1))
-            delay *= 1.0 + random.uniform(-0.1, 0.1)
+        if resp.status_code in retryable_statuses and attempt < max_attempts:
+            delay = _backoff_delay(attempt)
             logger.warning(
                 "storage_client.%s: HTTP %d on attempt %d/%d, retrying in %.2fs",
                 label,
                 resp.status_code,
                 attempt,
-                RETRY_MAX_ATTEMPTS,
+                max_attempts,
                 delay,
             )
             await asyncio.sleep(delay)
@@ -134,7 +162,7 @@ async def with_retry(
                 label,
                 resp.status_code,
                 attempt,
-                RETRY_MAX_ATTEMPTS,
+                max_attempts,
             )
         return resp
     # Unreachable — the loop either returns a response or raises.
@@ -152,10 +180,14 @@ async def with_connect_phase_retry(
 
     Connection-phase failures only — the request was provably never
     sent, so a retry cannot double-insert. No status-based retries.
+    Uses ``CONNECT_PHASE_MAX_ATTEMPTS`` (> the idempotent default): these
+    failures add no load to a healthy server, so retrying more times just
+    rides out a cold start / instance recycle.
     """
     return await with_retry(
         do_request,
         label=label,
         retryable_exceptions=CONNECT_PHASE_EXCEPTIONS,
         retryable_statuses=NO_RETRYABLE_STATUSES,
+        max_attempts=CONNECT_PHASE_MAX_ATTEMPTS,
     )

--- a/tests/test_storage_client_retry.py
+++ b/tests/test_storage_client_retry.py
@@ -22,13 +22,14 @@ keys storage-side.
 
 Retry policy
 ────────────
-- Max 3 attempts (1 initial + 2 retries)
+- Idempotent methods: max 3 attempts (1 initial + 2 retries)
+- Connection-phase (POST) failures: max ``CONNECT_PHASE_MAX_ATTEMPTS`` (5) —
+  they add no server load, so retrying more rides out a cold start
 - Retryable exceptions: ``httpx.ConnectTimeout``, ``httpx.ReadTimeout``,
   ``httpx.PoolTimeout`` (idempotent methods); connection-phase subset
   for POST
 - Retryable HTTP statuses: 502, 503, 504 (idempotent methods only)
-- Exponential backoff with small jitter, capped: ~0.2s, ~0.4s
-- Worst-case added latency: < 1s
+- Exponential backoff with small jitter, capped at ``RETRY_BACKOFF_MAX_S``
 """
 
 from __future__ import annotations
@@ -283,13 +284,19 @@ async def test_post_retries_on_connect_error_then_succeeds() -> None:
 
 
 async def test_post_gives_up_after_max_attempts_on_connect_timeout() -> None:
+    """Connection-phase failures retry CONNECT_PHASE_MAX_ATTEMPTS (5) times —
+    more than the idempotent default (3, see
+    test_get_retries_then_gives_up_after_max_attempts) — because they add no
+    load to a healthy server and just ride out a cold start."""
+    from common.http_retry import CONNECT_PHASE_MAX_ATTEMPTS
+
     client, write, _read = await _make_client()
     write.post = AsyncMock(side_effect=httpx.ConnectTimeout("storage unreachable"))
 
     with pytest.raises(httpx.ConnectTimeout):
         await client._post("/entities", {"canonical_name": "x"})
 
-    assert write.post.await_count == 3
+    assert write.post.await_count == CONNECT_PHASE_MAX_ATTEMPTS == 5
 
 
 async def test_post_does_not_retry_on_read_timeout() -> None:
@@ -330,3 +337,15 @@ async def test_post_optional_retries_on_connect_timeout_then_succeeds() -> None:
 
     assert result == {"ok": True}
     assert write.post.await_count == 2
+
+
+async def test_backoff_delay_cap_is_a_hard_ceiling() -> None:
+    """``RETRY_BACKOFF_MAX_S`` is a HARD ceiling — jitter is applied before the
+    cap, so no single backoff sleep exceeds it even at the highest attempt.
+    (Regression: capping before jitter let the real ceiling reach MAX * 1.1.)"""
+    from common.http_retry import RETRY_BACKOFF_MAX_S, _backoff_delay
+
+    # Attempts 5+ saturate the cap; sample widely to catch the jittered maximum.
+    for attempt in range(1, 9):
+        for _ in range(200):
+            assert 0.0 <= _backoff_delay(attempt) <= RETRY_BACKOFF_MAX_S


### PR DESCRIPTION
## Prod signal (2026-06-16)

A steady trickle of `httpx.ConnectTimeout` reached `prod-memclaw-core-api` across **every** core-api → core-storage-api path — Pub/Sub enrichment (`pubsub handler raised; nacking for redelivery`), entity extraction, contradiction detection, and audit flush. All are storage-api connect timeouts during cold starts / instance recycles.

The current policy is 3 attempts (~0.6s of backoff). That is too short to ride out a Cloud Run cold start, so a transient connect blip surfaces as a handler failure — and on the Pub/Sub path it triggers a nack → immediate-redelivery storm (`common/events/pubsub.py` nacks with `ack_deadline=0`).

## Change

Widen **only** the connection-phase path (`with_connect_phase_retry`) to `CONNECT_PHASE_MAX_ATTEMPTS = 5`.

Why only that path: `ConnectTimeout` / `ConnectError` / `PoolTimeout` are raised *before* the request is sent, and against an instance that isn't accepting connections yet — so retrying them:
- cannot double-insert (request provably never sent), and
- adds **zero load to a healthy server** (the connection never lands), so extra attempts just wait out the cold start.

The idempotent path (`with_retry`, which also retries `ReadTimeout`/5xx) **stays at 3 attempts** so a genuine 5xx storm isn't amplified by extra load against a struggling server.

Also:
- `RETRY_BACKOFF_MAX_S = 2.0` caps a single backoff sleep so the higher attempt count stays bounded.
- Factored the capped + jittered delay into a small `_backoff_delay()` helper (dedups the two call sites).

This **complements, not replaces**, keeping storage-api warm (Cloud Run min-instances) — the durable fix for the cold starts themselves.

## Tests

- `test_post_gives_up_after_max_attempts_on_connect_timeout` now asserts 5 attempts for the connect-phase path; `test_get_retries_then_gives_up_after_max_attempts` still asserts 3 for the idempotent path — the contrast is the regression guard.
- `pytest tests/test_storage_client_retry.py` → 16 passed. `ruff check` / `ruff format --check` / `mypy common/http_retry.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)