### PR TITLE
fix(audit): idempotent bulk flush via client_event_id — stop dropping audit rows

### DIFF
--- a/common/models/audit.py
+++ b/common/models/audit.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, LargeBinary, Text, text
+from sqlalchemy import BigInteger, DateTime, Index, LargeBinary, Text, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -34,6 +34,28 @@ class AuditLog(Base):
     seq: Mapped[int | None] = mapped_column(BigInteger)
     prev_hash: Mapped[bytes | None] = mapped_column(LargeBinary)
     event_hash: Mapped[bytes | None] = mapped_column(LargeBinary)
+    # ── Per-event idempotency key (migration 026) ────────────────────
+    # A UUID minted per event by core-api's ``log_action``. Storage dedups
+    # on it (under the per-tenant head lock, BEFORE seq assignment) so the
+    # async audit bulk flush can safely retry a lost-ack POST without
+    # double-appending to the chain. NULL on the legacy single-event path
+    # and pre-026 rows (the partial unique index covers NON-NULL only).
+    client_event_id: Mapped[str | None] = mapped_column(Text)
+
+    __table_args__ = (
+        # Backs per-event audit-flush idempotency (migration 026). Created
+        # ``CONCURRENTLY`` there with the same predicate; declared here so
+        # SQLAlchemy reflection / Alembic autogen round-trips match the live
+        # schema. NULL ``client_event_id`` rows are excluded so the legacy
+        # single-event path and pre-026 rows are unaffected.
+        Index(
+            "ix_audit_log_client_event_id_unique",
+            "tenant_id",
+            "client_event_id",
+            unique=True,
+            postgresql_where=text("client_event_id IS NOT NULL"),
+        ),
+    )
 
 
 class AuditChainHead(Base):

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -213,7 +213,9 @@ class CoreStorageClient:
         resp.raise_for_status()
         return resp.json()
 
-    async def _post(self, path: str, data: Any = None, *, read: bool = False) -> dict | list:
+    async def _post(
+        self, path: str, data: Any = None, *, read: bool = False, idempotent: bool = False
+    ) -> dict | list:
         http = self._read_http if read else self._http
         prefix = self._read_prefix if read else self._prefix
         headers = await self._auth_headers(read=read)
@@ -225,7 +227,12 @@ class CoreStorageClient:
                 headers=headers,
             )
 
-        resp = await with_connect_phase_retry(_do, label=f"POST {path}")
+        # Non-idempotent POSTs retry connection-phase failures ONLY (the request
+        # was provably never sent). ``idempotent=True`` opts a POST into the full
+        # transient set (ReadTimeout + 5xx too) — safe ONLY when the endpoint
+        # dedups replays storage-side (e.g. /audit-logs/bulk on client_event_id).
+        retry = with_retry if idempotent else with_connect_phase_retry
+        resp = await retry(_do, label=f"POST {path}")
         self._maybe_evict_on_auth_error(resp, read=read)
         resp.raise_for_status()
         return resp.json()
@@ -1224,8 +1231,17 @@ class CoreStorageClient:
     async def create_audit_logs_bulk(self, events: list[dict]) -> dict:
         """Batched audit insert (CAURA-628). One HTTP POST + one
         multi-row INSERT regardless of batch size, vs N round-trips +
-        N table-lock acquisitions on the legacy single-event path."""
-        return await self._post("/audit-logs/bulk", {"events": events})  # type: ignore[return-value]
+        N table-lock acquisitions on the legacy single-event path.
+
+        ``idempotent=True``: each event carries a ``client_event_id`` (minted in
+        ``log_action``) and storage dedups on it under the per-tenant chain-head
+        lock, so a retry on ReadTimeout / 5xx re-sends the same ids and any
+        already-committed events are skipped — no double-append to the
+        tamper-evident chain. This recovers the lost-ack case that previously
+        dropped a whole tenant's audit slice (connect-phase-only retry)."""
+        return await self._post(  # type: ignore[return-value]
+            "/audit-logs/bulk", {"events": events}, idempotent=True
+        )
 
     async def list_audit_logs(
         self,

--- a/core-api/src/core_api/services/audit_service.py
+++ b/core-api/src/core_api/services/audit_service.py
@@ -21,7 +21,7 @@ without a redeploy.
 
 from __future__ import annotations
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -56,6 +56,11 @@ async def log_action(
         "resource_type": resource_type,
         "resource_id": str(resource_id) if resource_id else None,
         "detail": detail,
+        # Per-event dedup key: lets the async bulk flush retry a lost-ack POST
+        # without double-appending to the tamper-evident chain (storage dedups
+        # on it under the per-tenant head lock). Minted here so it's stable
+        # across a retry of the same enqueued event.
+        "client_event_id": str(uuid4()),
     }
     queue = get_audit_queue()
     if queue is not None:

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/026_audit_client_event_id.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/026_audit_client_event_id.py
@@ -1,0 +1,82 @@
+"""Per-event idempotency on audit_log: ``client_event_id`` + partial unique.
+
+Makes the audit bulk flush (``POST /audit-logs/bulk``) safely retryable on
+transient storage errors (ReadTimeout / 5xx) without double-appending to the
+tamper-evident hash chain. core-api mints a UUID ``client_event_id`` per event
+in ``log_action``; ``PostgresService._audit_chain_one_tenant`` dedups
+already-chained events under the per-tenant ``audit_chain_head`` lock — BEFORE
+assigning ``seq`` — so a retry of a lost-ack batch re-sends the same ids, the
+already-committed events are skipped, and the survivors get contiguous seqs (no
+gap, head stays consistent).
+
+The partial unique index ``(tenant_id, client_event_id) WHERE client_event_id
+IS NOT NULL`` is the DB-level backstop. NULL values are excluded so the legacy
+single-event path (``POST /audit-logs``) and pre-026 rows are unaffected.
+``CREATE UNIQUE INDEX CONCURRENTLY`` keeps the build off the audit_log write
+lock — required on the large append-only ``audit_log`` at any non-trivial row
+count. (This deliberately follows migration 007's online pattern and NOT
+migration 025, whose plain in-transaction ``CREATE INDEX`` on ``audit_log``
+stalled storage-writer startup past the 300s migration-lock timeout.)
+
+Revision ID: 026
+Revises: 025
+Create Date: 2026-06-16
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "026"
+down_revision: str | None = "025"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX_NAME = "ix_audit_log_client_event_id_unique"
+
+
+def upgrade() -> None:
+    # ``ADD COLUMN IF NOT EXISTS`` (not op.add_column) keeps upgrade() retry-safe:
+    # entering autocommit_block() below COMMITS this column add, so if the
+    # CONCURRENTLY index build then fails (timeout / operator cancel), the column
+    # persists but alembic_version is NOT stamped — a plain ADD COLUMN would raise
+    # "column already exists" on the retry and wedge the deploy. IF NOT EXISTS makes
+    # the add idempotent. Metadata-only on a clean run (no row rewrite, just the
+    # AccessExclusive flash to update pg_class). The index build is the online part.
+    op.execute("ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS client_event_id text")
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction. Mirrors 007:
+    # clean up an interrupted prior build (``indisvalid = false``) so the
+    # rebuild completes instead of silently skipping via IF NOT EXISTS and
+    # leaving a useless invalid index behind.
+    with op.get_context().autocommit_block():
+        connection = op.get_context().connection
+        if connection is None:
+            raise RuntimeError("online migration requires a connection")
+        result = connection.execute(
+            sa.text(
+                """
+                SELECT 1 FROM pg_index i
+                JOIN pg_class c ON c.oid = i.indexrelid
+                WHERE c.relname = :name
+                  AND NOT i.indisvalid
+                """
+            ),
+            {"name": _INDEX_NAME},
+        )
+        if result.fetchone():
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")
+        op.execute(
+            f"""
+            CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+                {_INDEX_NAME}
+            ON audit_log (tenant_id, client_event_id)
+            WHERE client_event_id IS NOT NULL
+            """
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")
+    op.drop_column("audit_log", "client_event_id")

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -4493,11 +4493,45 @@ class PostgresService:
                 )
             ).scalar_one()
 
+            # Idempotent retry: the audit bulk flush retries transient errors,
+            # so a lost-ack batch is re-sent with the SAME client_event_ids.
+            # Drop any event already chained for this tenant — looked up here,
+            # under the head FOR UPDATE lock, so the read is serialized with
+            # concurrent same-tenant writers — plus any duplicated within this
+            # batch. Survivors below get contiguous seqs, so the chain stays
+            # gap-free and the head consistent. Events with no client_event_id
+            # (legacy single-event path) are never deduped.
+            # ``is not None`` (not a truthy check) to match the per-event loop's
+            # guard below, so both paths treat the field identically.
+            incoming_ids = [ev["client_event_id"] for ev in events if ev.get("client_event_id") is not None]
+            already_chained: set[str | None] = set()
+            if incoming_ids:
+                already_chained = set(
+                    (
+                        await session.execute(
+                            select(AuditLog.client_event_id).where(
+                                AuditLog.tenant_id == tenant_id,
+                                AuditLog.client_event_id.in_(incoming_ids),
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+
             prev_hash = head.last_hash
             seq = head.last_seq
             now = datetime.now(UTC)
+            seen_in_batch: set[str] = set()
             rows: list[AuditLog] = []
             for ev in events:
+                client_event_id = ev.get("client_event_id")
+                if client_event_id is not None:
+                    # Already committed by a prior attempt, or a duplicate
+                    # within this batch — skip without consuming a seq.
+                    if client_event_id in already_chained or client_event_id in seen_in_batch:
+                        continue
+                    seen_in_batch.add(client_event_id)
                 # Scrub-before-hash: refuse to chain a raw secret. Runs
                 # BEFORE hashing so the chain only ever attests the redacted
                 # detail (raising here fails the write loudly instead).
@@ -4533,6 +4567,7 @@ class PostgresService:
                         seq=seq,
                         prev_hash=prev_hash,
                         event_hash=this_hash,
+                        client_event_id=client_event_id,
                     )
                 )
                 prev_hash = this_hash

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -365,3 +365,52 @@ async def test_chained_insert_rejects_raw_pii_and_persists_nothing():
 async def test_empty_batch_is_a_noop():
     svc = PostgresService()
     await svc.audit_add_batch_chained([])  # must not raise or open a session
+
+
+async def test_chained_insert_dedups_replayed_client_event_id():
+    """A retried bulk flush re-sends the same client_event_ids (lost-ack); the
+    chain must dedup the already-committed ones — no duplicate rows, seqs stay
+    contiguous (no gap), and the chain stays valid — while a genuinely new event
+    in the replay still appends."""
+    svc = PostgresService()
+    tenant = _tenant()
+    ev1 = {**_event("create"), "tenant_id": tenant, "client_event_id": uuid4().hex}
+    ev2 = {**_event("update"), "tenant_id": tenant, "client_event_id": uuid4().hex}
+    ev3 = {**_event("delete"), "tenant_id": tenant, "client_event_id": uuid4().hex}
+
+    # First flush commits ev1 + ev2.
+    await svc.audit_add_batch_chained([dict(ev1), dict(ev2)])
+    # Lost-ack retry: re-send ev1 + ev2 (already chained) plus a new ev3.
+    await svc.audit_add_batch_chained([dict(ev1), dict(ev2), dict(ev3)])
+
+    async with get_session() as s:
+        seqs = (
+            (
+                await s.execute(
+                    text("SELECT seq FROM audit_log WHERE tenant_id = :t ORDER BY seq"),
+                    {"t": tenant},
+                )
+            )
+            .scalars()
+            .all()
+        )
+    # ev1, ev2 once each + ev3 = 3 rows with contiguous seqs (the dedup must not
+    # leave a gap — survivors are seq'd after the existing ones are filtered).
+    assert seqs == [1, 2, 3]
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is True
+    assert res["verified_count"] == 3
+
+
+async def test_dedup_within_a_single_batch():
+    """A client_event_id duplicated within ONE batch is chained once (defends
+    against a caller accidentally re-listing the same event)."""
+    svc = PostgresService()
+    tenant = _tenant()
+    ev = {**_event("create"), "tenant_id": tenant, "client_event_id": uuid4().hex}
+
+    await svc.audit_add_batch_chained([dict(ev), dict(ev)])
+
+    res = await svc.audit_verify_chain(tenant)
+    assert res["valid"] is True
+    assert res["verified_count"] == 1

--- a/tests/test_audit_queue.py
+++ b/tests/test_audit_queue.py
@@ -308,3 +308,32 @@ async def test_stop_with_hung_flusher_falls_back_to_cancel() -> None:
     # stop() must return within a small multiple of its own timeout
     # rather than waiting for the hung sleep.
     await asyncio.wait_for(q.stop(timeout=0.1), timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_log_action_mints_unique_client_event_id() -> None:
+    """log_action stamps a per-event ``client_event_id`` (a fresh UUID) so the
+    storage-side bulk flush can dedup a retried (lost-ack) batch instead of
+    double-appending to the tamper-evident chain."""
+    from unittest.mock import MagicMock, patch
+    from uuid import UUID
+
+    from core_api.services import audit_service
+
+    captured: list[dict] = []
+    fake_queue = MagicMock()
+    fake_queue.enqueue = captured.append
+    with patch.object(audit_service, "get_audit_queue", return_value=fake_queue):
+        await audit_service.log_action(
+            None, tenant_id="t", action="create", resource_type="memory"
+        )
+        await audit_service.log_action(
+            None, tenant_id="t", action="create", resource_type="memory"
+        )
+
+    assert len(captured) == 2
+    # Present and a valid UUID on each event...
+    UUID(captured[0]["client_event_id"])
+    UUID(captured[1]["client_event_id"])
+    # ...and distinct per event, so two different mutations never collide.
+    assert captured[0]["client_event_id"] != captured[1]["client_event_id"]

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"025"}, f"Expected single head '025', got {sorted(heads)}"
+        assert heads == {"026"}, f"Expected single head '026', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -676,6 +676,8 @@ class TestMigrationChain:
         assert chain.get("024") == "023", "024 must follow 023"
         # 025: tamper-evident audit hash chain (eToro governance)
         assert chain.get("025") == "024", "025 must follow 024"
+        # 026: per-event audit idempotency (client_event_id + partial unique)
+        assert chain.get("026") == "025", "026 must follow 025"
 
 
 @pytest.mark.unit

--- a/tests/test_storage_client_retry.py
+++ b/tests/test_storage_client_retry.py
@@ -349,3 +349,52 @@ async def test_backoff_delay_cap_is_a_hard_ceiling() -> None:
     for attempt in range(1, 9):
         for _ in range(200):
             assert 0.0 <= _backoff_delay(attempt) <= RETRY_BACKOFF_MAX_S
+
+
+# ---------------------------------------------------------------------------
+# Audit bulk flush — idempotent POST retries the FULL transient set
+# ---------------------------------------------------------------------------
+#
+# Each event carries a ``client_event_id`` and storage dedups on it under the
+# per-tenant chain-head lock, so a retry of a lost-ack batch can't double-append
+# to the tamper-evident hash chain. That makes ReadTimeout / 5xx safe to retry
+# for create_audit_logs_bulk (idempotent=True) — unlike a bare POST, which must
+# raise on those because the request may have committed (the POST tests above).
+# Recovers the silent audit-slice drop from the connect-phase-only path.
+
+_AUDIT_EVENT = {
+    "tenant_id": "t",
+    "action": "a",
+    "resource_type": "r",
+    "client_event_id": "ev-1",
+}
+
+
+async def test_audit_bulk_retries_on_read_timeout_then_succeeds() -> None:
+    client, write, _read = await _make_client()
+    write.post = AsyncMock(
+        side_effect=[
+            httpx.ReadTimeout("response never arrived"),
+            _ok_response(200, {"ok": True, "count": 1}),
+        ]
+    )
+
+    result = await client.create_audit_logs_bulk([dict(_AUDIT_EVENT)])
+
+    assert result == {"ok": True, "count": 1}
+    assert write.post.await_count == 2
+
+
+async def test_audit_bulk_retries_on_5xx_then_succeeds() -> None:
+    client, write, _read = await _make_client()
+    write.post = AsyncMock(
+        side_effect=[
+            _ok_response(503),
+            _ok_response(200, {"ok": True, "count": 1}),
+        ]
+    )
+
+    result = await client.create_audit_logs_bulk([dict(_AUDIT_EVENT)])
+
+    assert result == {"ok": True, "count": 1}
+    assert write.post.await_count == 2


### PR DESCRIPTION
## Problem

The async audit flush (`POST /audit-logs/bulk`) used **connect-phase-only retry**, so a `ReadTimeout`/5xx dropped a whole tenant's slice (logged `audit batch flush failed … events lost`, never requeued) — **silent audit-log data loss**. This was the known gap behind the `audit chunk flush failed` / `audit batch flush failed` signatures (the connect-timeout occurrences are separately addressed by widening connect-phase retry).

Naively switching to full retry was **unsafe**: `audit_log` is a tamper-evident **per-tenant hash chain** with **no per-event identity**, so re-sending an already-committed batch would re-append every event with fresh `seq`s and silently **double the chain** — and it would still pass `verify_chain`, so the corruption is invisible.

## Fix — make the flush idempotent, then retry is safe

1. **core-api `log_action`** mints a UUID `client_event_id` per event (stable across a retry of the same enqueued event).
2. **Migration 026**: `audit_log` gains a nullable `client_event_id` column + a partial unique index `(tenant_id, client_event_id) WHERE client_event_id IS NOT NULL`, built with `CREATE UNIQUE INDEX CONCURRENTLY` inside an `autocommit_block`. This follows the **007** online pattern and deliberately **not** the **025** plain in-transaction `CREATE INDEX` that stalled storage-writer startup past the 300s migration-lock timeout.
3. **`_audit_chain_one_tenant`** dedups already-chained `client_event_id`s **under the per-tenant head `FOR UPDATE` lock, BEFORE assigning `seq`** (plus intra-batch duplicates). Survivors get **contiguous** seqs, so the chain stays gap-free and the head consistent — avoiding the seq-gap trap a bare `ON CONFLICT` would create. Events with no `client_event_id` (legacy single-event path) are never deduped.
4. **`create_audit_logs_bulk`** switches to full `with_retry` (`ReadTimeout` + 5xx), now safe: a replayed batch dedups instead of double-appending. Recovers the lost-ack case that previously dropped the slice.

## Why it's safe

`_audit_chain_one_tenant` already commits one atomic transaction per tenant. With the dedup, the three retry cases are all correct:
- **pre-commit failure** → rolled back, nothing chained → retry re-inserts.
- **committed but lost ack** (`ReadTimeout`) → retry's dedup SELECT (under the head lock) sees the committed rows → skips them, no double-append.
- **partial** → impossible (single transaction).

## Deploy ordering

Storage-first (storage owns the schema; the migration runs in the lifespan startup before serving). New core-api + old storage is safe (extra field ignored); new storage + old core-api is safe (column nullable).

## Tests

- `test_audit_chain.py` *(integration, runs against Postgres in CI)*: a replayed batch dedups — no duplicate rows, contiguous seqs, `verify_chain` stays valid; intra-batch duplicate chained once.
- `test_storage_client_retry.py`: `create_audit_logs_bulk` retries `ReadTimeout` and 5xx (unlike a bare POST).
- `test_audit_queue.py`: `log_action` mints a unique `client_event_id` per event.
- `ruff check` / `ruff format --check` / `mypy` clean on the `core-api/src` + `core-storage-api/src` files (28 mock tests pass locally; the chain-integration tests run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)