### PR TITLE
fix(storage): harden migration advisory-lock so a slow migration can't crash booting writers

### DIFF
--- a/core-storage-api/src/core_storage_api/config.py
+++ b/core-storage-api/src/core_storage_api/config.py
@@ -47,6 +47,19 @@ class Settings(BaseSettings):
     db_pool_timeout: int = 60
     db_pool_recycle: int = 1800
 
+    # How long a booting writer waits to acquire the migration advisory lock
+    # before giving up. One replica runs ``alembic upgrade head`` while holding
+    # the lock; the others poll for it and only serve once it's released. This
+    # must comfortably exceed the slowest real migration — a large
+    # ``CREATE INDEX CONCURRENTLY`` / backfill can run for minutes, and the lock
+    # is held for the whole run — so a legitimately slow migration doesn't crash
+    # the N-1 booting replicas waiting on it. It was a hardcoded 300s, which
+    # migration 025 blew past on 2026-06-16, failing 6 writer boots. The wait is
+    # now a STUCK-migration backstop, not a routine cap. Keep it <= the Cloud Run
+    # startup-probe deadline, or the probe kills the instance before this fires.
+    # Env: MIGRATION_LOCK_WAIT_SECONDS.
+    migration_lock_wait_seconds: int = 1800
+
     # Service role (CAURA-591 Part B). "hybrid" keeps the original
     # single-service behaviour and is the safe default for OSS + any
     # deploy that hasn't opted into the split. Enterprise SaaS runs

--- a/core-storage-api/src/core_storage_api/database/init.py
+++ b/core-storage-api/src/core_storage_api/database/init.py
@@ -91,8 +91,15 @@ async def init_database() -> None:
     # variant would be released by those commits, breaking the multi-worker
     # serialisation guarantee.
     _MIGRATION_LOCK_ID = 8_675_309  # arbitrary unique int
-    _LOCK_WAIT_SECONDS = 300
     _LOCK_POLL_INTERVAL = 0.5
+    _LOCK_LOG_EVERY_SECONDS = 30.0
+    # The winning replica holds this lock for the WHOLE ``alembic upgrade head``
+    # (including minutes-long ``CREATE INDEX CONCURRENTLY`` builds / backfills),
+    # so the wait is a stuck-migration backstop, not a routine cap. It must
+    # exceed the slowest real migration or a slow-but-progressing one crashes the
+    # N-1 booting replicas waiting on it (2026-06-16: a hardcoded 300s cap that
+    # migration 025 blew past, failing 6 writer boots). Tunable via env.
+    lock_wait_seconds = settings.migration_lock_wait_seconds
     async with engine.connect() as lock_conn:
         # AUTOCOMMIT so the lock_conn never sits "idle in transaction": a
         # blocking ``pg_advisory_lock`` waiter keeps an open tx for the full
@@ -102,7 +109,9 @@ async def init_database() -> None:
         # holds a tx for sub-ms per attempt and avoids that interaction.
         lock_conn = await lock_conn.execution_options(isolation_level="AUTOCOMMIT")
         loop = asyncio.get_event_loop()
-        deadline = loop.time() + _LOCK_WAIT_SECONDS
+        start = loop.time()
+        deadline = start + lock_wait_seconds
+        next_log = start + _LOCK_LOG_EVERY_SECONDS
         while True:
             got = await lock_conn.scalar(
                 text("SELECT pg_try_advisory_lock(:lock_id)"),
@@ -110,12 +119,26 @@ async def init_database() -> None:
             )
             if got:
                 break
-            if loop.time() >= deadline:
+            now = loop.time()
+            if now >= deadline:
                 raise TimeoutError(
-                    f"Migration advisory lock {_MIGRATION_LOCK_ID} not "
-                    f"acquired within {_LOCK_WAIT_SECONDS}s — another worker "
-                    "still running migrations or stuck"
+                    f"Migration advisory lock {_MIGRATION_LOCK_ID} not acquired "
+                    f"within {lock_wait_seconds}s — another worker is likely stuck "
+                    "running migrations. A healthy slow migration should finish "
+                    "within this window; if a legitimate migration needs longer, "
+                    "raise MIGRATION_LOCK_WAIT_SECONDS (keeping it <= the Cloud Run "
+                    "startup-probe deadline)."
                 )
+            # Surface the wait so a long-but-healthy migration looks like progress
+            # in the logs, not a silently hung boot.
+            if now >= next_log:
+                logger.info(
+                    "Waiting on migration advisory lock (%.0fs of %ds elapsed) — "
+                    "another worker is running migrations",
+                    now - start,
+                    lock_wait_seconds,
+                )
+                next_log = now + _LOCK_LOG_EVERY_SECONDS
             await asyncio.sleep(_LOCK_POLL_INTERVAL)
         try:
             async with engine.connect() as work_conn:

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -679,6 +679,62 @@ class TestMigrationChain:
         # 026: per-event audit idempotency (client_event_id + partial unique)
         assert chain.get("026") == "025", "026 must follow 025"
 
+    def test_no_plain_create_index_on_large_tables(self):
+        """Indexes on large, pre-existing tables MUST be built ``CONCURRENTLY``
+        (inside an ``op.get_context().autocommit_block()``). A plain,
+        in-transaction ``CREATE INDEX`` takes an AccessExclusive lock that blocks
+        writes AND holds the migration advisory lock for the whole build — which
+        crashed 6 storage-writer boots on 2026-06-16 (migration 025 indexed
+        ``audit_log`` without CONCURRENTLY). This guards the raw-SQL
+        ``op.execute("CREATE INDEX ...")`` path on the known-large tables; indexes
+        created on a brand-new table in the same migration are unaffected."""
+        import re
+
+        large_tables = {
+            "audit_log",
+            "memories",
+            "entities",
+            "documents",
+            "memory_entity_links",
+            "relations",
+        }
+        # The CONCURRENTLY convention for indexes on already-populated large
+        # tables is enforced from migration 005 onward (see 005/007/011/016/017).
+        # 001–004 build the initial schema and index tables that are empty at
+        # creation, so a plain CREATE INDEX there is harmless. 025 postdates the
+        # convention but predates enforcement and is already applied in prod (the
+        # index exists; the migration can't be rewritten) — documented debt.
+        convention_from = 5
+        applied_debt = {25}
+        # CREATE [UNIQUE] INDEX [CONCURRENTLY] [IF NOT EXISTS] <name> ON <table>
+        pat = re.compile(
+            r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(CONCURRENTLY\s+)?"
+            r"(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+(\w+)",
+            re.IGNORECASE,
+        )
+        versions = pathlib.Path(
+            "core-storage-api/src/core_storage_api/database/migrations/versions"
+        )
+        violations: list[str] = []
+        for f in sorted(versions.glob("*.py")):
+            prefix = f.stem.split("_")[0]
+            if (
+                not prefix.isdigit()
+                or int(prefix) < convention_from
+                or int(prefix) in applied_debt
+            ):
+                continue
+            for concurrently, table in pat.findall(f.read_text()):
+                if table.lower() in large_tables and not concurrently:
+                    violations.append(f"{f.name}: plain CREATE INDEX on '{table}'")
+        assert not violations, (
+            "Plain (non-CONCURRENTLY) CREATE INDEX on a large table blocks writes "
+            "and holds the migration advisory lock for the whole build (crashed "
+            "storage-writer boots on 2026-06-16). Use CREATE INDEX CONCURRENTLY in "
+            "an op.get_context().autocommit_block() — see migration 007 / 026. "
+            f"Violations: {'; '.join(violations)}"
+        )
+
 
 @pytest.mark.unit
 class TestForgeEventPayloadNaming:


### PR DESCRIPTION
## Background — the 2026-06-16 incident

On a `core-storage-writer` deploy, all N replicas race for a Postgres advisory lock (`8675309`); one wins and runs `alembic upgrade head` **while holding the lock**, the rest poll for it and only serve once it's released. The wait was a **hardcoded 300s**. But the lock is held for the *entire* migration — including minutes-long `CREATE INDEX CONCURRENTLY` builds — so a slow-but-healthy migration crashes the N-1 waiting replicas.

On 2026-06-16, migration **025** (a plain, non-`CONCURRENTLY` `CREATE INDEX` on the large `audit_log` table) ran past 300s and failed **6** `prod-memclaw-core-storage-writer` boots:
```
TimeoutError: Migration advisory lock 8675309 not acquired within 300s → Application startup failed. Exiting.
```
It self-healed (Cloud Run restarted them once the winner finished), but the next slow migration repeats it.

## Approach (A + B + D, chosen with the team)

Keeps migrations in the lifespan startup — the deliberate **CAURA-621** atomic-deploy property stays intact (no pre-deploy migration job / deploy-ordering orchestration).

1. **Configurable + generous wait (A):** `MIGRATION_LOCK_WAIT_SECONDS` (`settings.migration_lock_wait_seconds`), default raised **300s → 1800s**. The wait is now a *stuck-migration backstop*, not a routine cap — it must exceed the slowest real migration so a progressing one never crashes a booting replica.
2. **Wait-don't-crash, observably (B):** keeps the **safe** `pg_try_advisory_lock`-in-`AUTOCOMMIT` poll (a blocking `pg_advisory_lock` would hold an idle-in-transaction that stalls the winner's `CONCURRENTLY` build — the existing comment documents this), and **logs progress every 30s** while waiting, so a long-but-healthy migration reads as progress in the logs instead of a silently hung boot. The deadline still raises a clear *stuck-migration* error (better than letting the Cloud Run probe kill the instance silently).
3. **CI guard (D):** `test_no_plain_create_index_on_large_tables` fails if a migration from **005 onward** does a plain `CREATE INDEX` on a large pre-existing table (`audit_log` / `memories` / `entities` / `documents` / `memory_entity_links` / `relations`) — it must be `CREATE INDEX CONCURRENTLY` in an `autocommit_block` (see 007 / 026). `025` is allow-listed as documented, already-applied debt; `001–004` build the initial schema (indexes on empty tables) and are exempt.

**Caveat:** the effective wait is `min(MIGRATION_LOCK_WAIT_SECONDS, Cloud Run startup-probe deadline)`. The 300s error fired first in the incident, so the probe grace was ≥300s — but the storage-writer's Cloud Run startup timeout should be confirmed ≥ 1800s (Terraform, out of this repo) or raised alongside, else the probe kills the instance before the longer wait helps.

This is the root-cause follow-up to #407's migration 026 (which already follows the `CONCURRENTLY` pattern). It does **not** retroactively change 025 (already applied in prod) — it stops the *next* slow migration from repeating the crash.

## Tests
- `test_no_plain_create_index_on_large_tables` (the new guard) + the existing migration-chain tests pass; full `test_skill_schema_v1.py` → 79 passed.
- `ruff check` / `ruff format --check` / `mypy` clean on `config.py` + `init.py`. The acquire→upgrade happy path is exercised by CI's "Run migrations" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)