### PR TITLE
fix(search): rank entity-lookup fan-out cap by query-match count (A30)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -312,7 +312,11 @@ class ClassifyQuery:
         )
 
         # Best (lowest hop → highest boost) per memory + collect entity links.
+        # ``memory_match_count`` tracks how many DIRECTLY-MATCHED (hop-0) query
+        # entities each memory links to — the pre-load relevance signal that
+        # survives the fan-out cap below.
         memory_boost: dict[str, float] = {}
+        memory_match_count: dict[str, int] = {}
         memory_entity_links: dict[str, list[EntityLinkOut]] = {}
         for link in all_links:
             mem_id, ent_id_str, role = link["memory_id"], link["entity_id"], link.get("role")
@@ -323,16 +327,29 @@ class ClassifyQuery:
             boost = GRAPH_HOP_BOOST.get(hop_dist, _GRAPH_HOP_BOOST_FALLBACK) * rel_weight
             if mem_id not in memory_boost or boost > memory_boost[mem_id]:
                 memory_boost[mem_id] = boost
+            if hop_dist == 0:
+                memory_match_count[mem_id] = memory_match_count.get(mem_id, 0) + 1
             memory_entity_links.setdefault(mem_id, []).append(EntityLinkOut(entity_id=ent_id, role=role))
 
         if not memory_boost:
             return []
 
-        # Cap to prevent popular-entity fan-out.
+        # Cap to prevent popular-entity fan-out. A30: a hub entity (e.g. a bare
+        # "john smith" linking 100+ memories) floods the pool, and a cap by
+        # near-uniform hop-boost alone drops the gold BEFORE the query-overlap
+        # rerank (below) can see it. Rank the cap by how many of the query's
+        # matched entities each memory links to FIRST (a "X's manager" gold
+        # links to both the person hub AND the "manager" role → count 2, vs 1
+        # for sibling facts about other attributes), with hop-boost as the
+        # tiebreak. This collapses the pool to the relevant subset regardless of
+        # hub size; the discriminator (e.g. "#0000") is then resolved by
+        # _query_overlap after load.
         if len(memory_boost) > GRAPH_MAX_BOOSTED_MEMORIES:
-            memory_ids_sorted = sorted(memory_boost, key=memory_boost.__getitem__, reverse=True)[
-                :GRAPH_MAX_BOOSTED_MEMORIES
-            ]
+            memory_ids_sorted = sorted(
+                memory_boost,
+                key=lambda mid: (memory_match_count.get(mid, 0), memory_boost[mid]),
+                reverse=True,
+            )[:GRAPH_MAX_BOOSTED_MEMORIES]
             memory_boost = {mid: memory_boost[mid] for mid in memory_ids_sorted}
 
         # CAURA-687: load memories by ID via the dedicated short-circuit

--- a/tests/test_entity_lookup_short_circuit.py
+++ b/tests/test_entity_lookup_short_circuit.py
@@ -169,7 +169,11 @@ async def test_collect_memories_forwards_valid_at_and_readable_tenant_ids():
     )
     fake_storage.get_memory_ids_by_entity_ids = AsyncMock(
         return_value=[
-            {"memory_id": matched_memory_id, "entity_id": str(matched_entity_id), "role": "subject"}
+            {
+                "memory_id": matched_memory_id,
+                "entity_id": str(matched_entity_id),
+                "role": "subject",
+            }
         ]
     )
     fake_storage.load_memories_by_ids = AsyncMock(
@@ -241,7 +245,11 @@ async def test_collect_memories_omits_readable_tenant_ids_when_single_tenant():
     )
     fake_storage.get_memory_ids_by_entity_ids = AsyncMock(
         return_value=[
-            {"memory_id": matched_memory_id, "entity_id": str(matched_entity_id), "role": "subject"}
+            {
+                "memory_id": matched_memory_id,
+                "entity_id": str(matched_entity_id),
+                "role": "subject",
+            }
         ]
     )
     fake_storage.load_memories_by_ids = AsyncMock(
@@ -306,7 +314,11 @@ async def test_collect_memories_forwards_single_element_when_different_from_home
     )
     fake_storage.get_memory_ids_by_entity_ids = AsyncMock(
         return_value=[
-            {"memory_id": matched_memory_id, "entity_id": str(matched_entity_id), "role": "subject"}
+            {
+                "memory_id": matched_memory_id,
+                "entity_id": str(matched_entity_id),
+                "role": "subject",
+            }
         ]
     )
     fake_storage.load_memories_by_ids = AsyncMock(
@@ -357,7 +369,6 @@ async def test_collect_memories_forwards_single_element_when_different_from_home
 async def test_entity_lookup_fires_when_match_count_at_threshold():
     """Match count exactly at the threshold is still allowed through —
     the gate is `> threshold`, not `>= threshold`."""
-    import logging
 
     from core_api.constants import ENTITY_LOOKUP_MAX_MATCHES
     from core_api.pipeline.context import PipelineContext
@@ -369,13 +380,19 @@ async def test_entity_lookup_fires_when_match_count_at_threshold():
     matched_memory_id = str(uuid4())
 
     fake_storage = AsyncMock()
-    fake_storage.fts_search_entities = AsyncMock(return_value=[str(e) for e in matched_entity_ids])
+    fake_storage.fts_search_entities = AsyncMock(
+        return_value=[str(e) for e in matched_entity_ids]
+    )
     fake_storage.expand_graph = AsyncMock(
         return_value={str(matched_entity_ids[0]): {"hop": 0, "weight": 1.0}}
     )
     fake_storage.get_memory_ids_by_entity_ids = AsyncMock(
         return_value=[
-            {"memory_id": matched_memory_id, "entity_id": str(matched_entity_ids[0]), "role": "subject"}
+            {
+                "memory_id": matched_memory_id,
+                "entity_id": str(matched_entity_ids[0]),
+                "role": "subject",
+            }
         ]
     )
     fake_storage.load_memories_by_ids = AsyncMock(
@@ -429,7 +446,9 @@ async def test_entity_lookup_falls_through_when_match_count_exceeds_threshold(ca
     matched_entity_ids = [uuid4() for _ in range(ENTITY_LOOKUP_MAX_MATCHES + 1)]
 
     fake_storage = AsyncMock()
-    fake_storage.fts_search_entities = AsyncMock(return_value=[str(e) for e in matched_entity_ids])
+    fake_storage.fts_search_entities = AsyncMock(
+        return_value=[str(e) for e in matched_entity_ids]
+    )
     # These must NOT be called once the gate fires.
     fake_storage.expand_graph = AsyncMock(return_value={})
     fake_storage.get_memory_ids_by_entity_ids = AsyncMock(return_value=[])
@@ -443,10 +462,15 @@ async def test_entity_lookup_falls_through_when_match_count_exceeds_threshold(ca
         "temporal_window": None,
     }
 
-    with patch(
-        "core_api.pipeline.steps.search.classify_query.get_storage_client",
-        return_value=fake_storage,
-    ), caplog.at_level(logging.INFO, logger="core_api.pipeline.steps.search.classify_query"):
+    with (
+        patch(
+            "core_api.pipeline.steps.search.classify_query.get_storage_client",
+            return_value=fake_storage,
+        ),
+        caplog.at_level(
+            logging.INFO, logger="core_api.pipeline.steps.search.classify_query"
+        ),
+    ):
         await ClassifyQuery().execute(ctx)
 
     # Downstream calls must NOT have happened — short-circuit was declined.
@@ -465,4 +489,108 @@ async def test_entity_lookup_falls_through_when_match_count_exceeds_threshold(ca
     assert declined, (
         "decline decision must be logged at INFO so ops can see how often the gate fires; "
         f"got: {[r.message for r in caplog.records]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A30: person-hub dilution — match-count-aware fan-out cap
+# ---------------------------------------------------------------------------
+
+
+async def test_collect_memories_cap_prefers_multi_matched_entity_gold_over_hub_siblings():
+    """A30: when a hub entity floods the candidate pool beyond
+    GRAPH_MAX_BOOSTED_MEMORIES, the fan-out cap must keep the memory that
+    links to MORE of the query's matched (hop-0) entities over single-link
+    siblings, even though hop-boost is near-uniform.
+
+    Concretely: "What is John Smith #0000's manager?" matches the bare
+    "john smith" hub (100+ sibling memories) AND the "manager" role. The
+    gold "John Smith #0000's manager is Mark Lin" links to BOTH (match
+    count 2); sibling facts about other attributes link to only the hub
+    (count 1). A cap by near-uniform hop-boost alone drops the gold before
+    the _query_overlap rerank can see it (the original A30 bug).
+
+    Regression guard: the gold's links are returned LAST, so a cap by boost
+    alone (stable sort over equal boosts) cuts it; only the match-count
+    primary key rescues it. This test fails on the pre-A30 code.
+    """
+    from core_api.constants import GRAPH_MAX_BOOSTED_MEMORIES
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.search.classify_query import ClassifyQuery
+    from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
+
+    hub_entity = uuid4()  # bare "john smith" — matched, hop 0, popular
+    role_entity = uuid4()  # "manager" role — matched, hop 0
+    gold_id = str(uuid4())
+
+    # More siblings than the cap, each linking ONLY to the hub.
+    n_siblings = GRAPH_MAX_BOOSTED_MEMORIES + 30
+    sibling_ids = [str(uuid4()) for _ in range(n_siblings)]
+
+    fake_storage = AsyncMock()
+    fake_storage.fts_search_entities = AsyncMock(
+        return_value=[str(hub_entity), str(role_entity)]
+    )
+    fake_storage.expand_graph = AsyncMock(
+        return_value={
+            str(hub_entity): {"hop": 0, "weight": 1.0},
+            str(role_entity): {"hop": 0, "weight": 1.0},
+        }
+    )
+    # Siblings -> hub only (1 matched entity each); gold -> hub AND role
+    # (2 matched entities). Gold links appended LAST so a boost-only
+    # stable-sort cap would drop it at the GRAPH_MAX_BOOSTED_MEMORIES cut.
+    links = [
+        {"memory_id": sid, "entity_id": str(hub_entity), "role": "subject"}
+        for sid in sibling_ids
+    ] + [
+        {"memory_id": gold_id, "entity_id": str(hub_entity), "role": "subject"},
+        {"memory_id": gold_id, "entity_id": str(role_entity), "role": "mentioned"},
+    ]
+    fake_storage.get_memory_ids_by_entity_ids = AsyncMock(return_value=links)
+
+    captured: dict = {}
+
+    async def _load(payload):
+        captured["ids"] = list(payload["memory_ids"])
+        return [
+            {
+                "id": mid,
+                "tenant_id": "t1",
+                "content": "x",
+                "memory_type": "fact",
+                "weight": 0.5,
+                "status": "active",
+                "ts_valid_start": None,
+                "ts_valid_end": None,
+                "metadata_": {},
+                "fleet_id": None,
+            }
+            for mid in payload["memory_ids"]
+        ]
+
+    fake_storage.load_memories_by_ids = AsyncMock(side_effect=_load)
+
+    ctx = PipelineContext()
+    ctx.data = {
+        "query": "What is John Smith #0000's manager?",
+        "tenant_id": "t1",
+        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 10},
+        "temporal_window": None,
+    }
+
+    with patch(
+        "core_api.pipeline.steps.search.classify_query.get_storage_client",
+        return_value=fake_storage,
+    ):
+        await ClassifyQuery().execute(ctx)
+
+    assert ctx.data["retrieval_plan"].strategy == RetrievalStrategy.ENTITY_LOOKUP
+    # The cap keeps exactly GRAPH_MAX_BOOSTED_MEMORIES ids for loading...
+    assert len(captured["ids"]) == GRAPH_MAX_BOOSTED_MEMORIES
+    # ...and the gold (2 matched entities) must be among them despite being
+    # enqueued last — this is the A30 fix.
+    assert gold_id in captured["ids"], (
+        "A30 regression: the multi-matched-entity gold was dropped by the "
+        "fan-out cap — match-count must rank ahead of near-uniform hop-boost."
     )


### PR DESCRIPTION
## What

`ClassifyQuery._collect_memories` caps the entity-lookup candidate pool to `GRAPH_MAX_BOOSTED_MEMORIES` (50) **before** loading content, sorting only by **near-uniform hop-boost**. When a query hits a hub entity (e.g. a bare `john smith` linking 100+ memories), the gold is one of N near-equal-boost candidates and gets cut by the arbitrary cap — *before* the discriminator-aware `_query_overlap` rerank ever runs. This is the person-hub dilution behind the S1 K=10000 residual misses (**A30**).

## Fix

Rank the cap by **how many of the query's directly-matched (hop-0) entities each memory links to** first, with hop-boost as the tiebreak. A `"What is X's manager?"` gold links to **both** the person hub *and* the matched `manager` role (match-count 2), whereas sibling facts about other attributes link to only the hub (count 1) — so the gold survives the cut regardless of hub size (robust even for the 1000+-member hubs seen at K=10000). The `#NNNN` discriminator is then resolved by the existing `_query_overlap` rerank after load.

- No new constants, no routing change (strategy split unchanged).
- 21-line change, isolated to `_collect_memories`.

## Validation

S1 retrieval bench (replay-only against already-seeded tenants, `text-embedding-3-small@1024`):

| Tenant | Before | After |
|---|---|---|
| k1k | 23/25 | **25/25** |
| k10k | 25/25 | **25/25** (no regression) |

Distractors 25/25 on both; strategy split unchanged (k1k 34/16, k10k 42/8).

New regression test `test_collect_memories_cap_prefers_multi_matched_entity_gold_over_hub_siblings` — constructed so the gold is enqueued **last** (a boost-only stable-sort cap drops it); **verified to fail on pre-A30 code** and pass with the fix.

`ruff check` / `ruff format` / `mypy` clean; related search-pipeline tests (45 + 8) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)