### PR TITLE
fix(rate-limit): fail open on Redis outage instead of 500 (view_rate_limit AttributeError)

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -488,7 +488,14 @@ async def _json_rate_limit_handler(request: Request, exc: RateLimitExceeded) -> 
     detail_str = f"Rate limit exceeded: {exc.detail}. Try again later."
     body = {"detail": detail_str, **make_error_payload("RATE_LIMITED", detail_str)}
     response = JSONResponse(body, status_code=429)
-    response = request.app.state.limiter._inject_headers(response, request.state.view_rate_limit)
+    # Inject X-RateLimit headers only when the limit was actually evaluated. A
+    # swallowed storage error (see _key_func) leaves view_rate_limit None; skip
+    # the private _inject_headers call entirely rather than depending on slowapi's
+    # None-handling for OUR call site. (On the 429 path it's normally set — a 429
+    # means a limit was hit — so this is defence in depth.)
+    view_rate_limit = getattr(request.state, "view_rate_limit", None)
+    if view_rate_limit is not None:
+        response = request.app.state.limiter._inject_headers(response, view_rate_limit)
     return response
 
 

--- a/core-api/src/core_api/middleware/rate_limit.py
+++ b/core-api/src/core_api/middleware/rate_limit.py
@@ -41,6 +41,29 @@ def _key_func(request: Request) -> str:
     storage backend or access logs, while keeping buckets unique for
     keys that happen to share a prefix.
     """
+    # Fail-open seed for slowapi 0.1.10's swallow_errors gap. slowapi sets
+    # ``request.state.view_rate_limit`` only AFTER it hits the storage backend
+    # (extension.py: ``self.limiter.hit(...)`` then ``view_rate_limit = ...``).
+    # With ``swallow_errors=True`` a Redis outage is swallowed BEFORE that
+    # assignment ("Failed to rate limit. Swallowing error"), yet the limit
+    # decorator then reads ``request.state.view_rate_limit`` unconditionally to
+    # inject headers — so the swallow path raised AttributeError → 500 instead of
+    # failing open (prod 2026-06-17: Redis connection reset → 500s on
+    # /api/v1/search). key_func runs first in every check and never touches the
+    # backend, so seed None here: a successful check overwrites it, a swallowed
+    # one leaves it None — which slowapi's ``_inject_headers`` no-ops on (verified
+    # 0.1.10 extension.py: ``if ... and current_limit is not None``; pinned by
+    # test_inject_headers_is_noop_for_none_limit so a slowapi upgrade that breaks
+    # it fails CI, not prod) — making ``swallow_errors`` actually fail open.
+    #
+    # Guard with ``hasattr``: slowapi calls key_func once PER applied limit (and
+    # per limit in a multi-part "10/s;100/h" string), so an unconditional seed
+    # would reset a value an earlier limit's successful ``hit()`` already wrote.
+    # Only seed when unset — the attribute still always exists before the first
+    # ``hit()``, so the fail-open guarantee holds.
+    if not hasattr(request.state, "view_rate_limit"):
+        request.state.view_rate_limit = None
+
     api_key = request.headers.get("x-api-key")
     if not api_key:
         auth = request.headers.get("authorization", "")

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -14,6 +14,7 @@ anyway, and it makes the test runner-speed-independent.
 """
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -43,6 +44,9 @@ class _FakeRequest:
         self.client = type("C", (), {"host": client_host})()
         # slowapi's get_remote_address looks at scope too; emulate it.
         self.scope = {"client": (client_host, 0)}
+        # _key_func seeds request.state.view_rate_limit (the fail-open default);
+        # a real Starlette request always has .state.
+        self.state = SimpleNamespace()
 
 
 async def test_key_func_prefers_api_key_over_ip():
@@ -72,6 +76,40 @@ async def test_key_func_different_keys_yield_different_buckets():
 async def test_key_func_falls_back_to_ip_without_api_key():
     req = _FakeRequest(headers={}, client_host="198.51.100.7")
     assert _key_func(req) == "ip:198.51.100.7"
+
+
+async def test_key_func_seeds_fail_open_default_without_clobbering():
+    """key_func seeds request.state.view_rate_limit=None (fail-open default) on
+    first call, but — since slowapi calls it once per applied limit — must NOT
+    reset a value a prior limit's hit() already wrote (else multi-limit routes
+    drop X-RateLimit headers on a partial Redis outage)."""
+    req = _FakeRequest(headers={"x-api-key": "mc_multi_limit_probe"})
+    # First call (before any hit) seeds the fail-open default.
+    _key_func(req)
+    assert req.state.view_rate_limit is None
+    # Simulate an earlier limit's successful hit() setting the real value.
+    req.state.view_rate_limit = ("limit-1", ["result"])
+    # A later key_func call (second stacked limit) must leave it intact.
+    _key_func(req)
+    assert req.state.view_rate_limit == ("limit-1", ["result"])
+
+
+async def test_inject_headers_is_noop_for_none_limit():
+    """The fail-open path relies on slowapi's ``_inject_headers`` being a no-op
+    when ``current_limit`` is None (slowapi 0.1.10 extension.py:
+    ``if ... and current_limit is not None``). Pin that assumption at CI so a
+    slowapi upgrade that drops the guard fails here, not by 500ing the
+    swallowed-error path in prod. ``headers_enabled=True`` so the None guard is
+    the operative one (not the earlier headers-disabled short-circuit)."""
+    from slowapi import Limiter
+    from slowapi.util import get_remote_address
+    from starlette.responses import Response
+
+    lim = Limiter(key_func=get_remote_address, headers_enabled=True)
+    lim.enabled = True
+    resp = Response()
+    # Must return the response unchanged and must not raise on a None limit.
+    assert lim._inject_headers(resp, None) is resp
 
 
 # ── HTTP layer: 429 on burst ──
@@ -146,3 +184,32 @@ async def test_health_is_not_rate_limited(client):
         resp = await client.get("/api/v1/health")
         codes.append(resp.status_code)
     assert 429 not in codes
+
+
+# ── fail-open: rate-limit storage (Redis) outage must not 500 ──
+
+
+async def test_search_fails_open_when_rate_limit_storage_errors(client, monkeypatch):
+    """A Redis/storage outage must FAIL OPEN, not 500. With ``swallow_errors=True``
+    slowapi swallows the backend error ("Failed to rate limit. Swallowing error"),
+    but its limit decorator still reads ``request.state.view_rate_limit`` on the way
+    out — which is unset on the swallowed path. Without ``_key_func``'s ``None``
+    seed that's an ``AttributeError`` → 500 (prod 2026-06-17 on /api/v1/search when
+    Redis connection reset). The request must be served normally, not 500'd."""
+
+    def _boom(*args, **kwargs):
+        raise ConnectionError("simulated Redis down")
+
+    # slowapi calls ``limiter.limiter.hit(...)`` against the backend during the
+    # per-route check; make that raise to emulate Redis being unreachable.
+    monkeypatch.setattr(limiter.limiter, "hit", _boom)
+
+    resp = await client.post(
+        "/api/v1/search",
+        json={"tenant_id": "default", "query": "hello"},
+        headers={"x-api-key": "mc_failopen_probe"},
+    )
+
+    assert resp.status_code == 200, (
+        f"rate-limit storage outage must fail open, got {resp.text}"
+    )


### PR DESCRIPTION
## Prod incident (2026-06-17)

A Redis connection reset turned into **500s on `POST /api/v1/search`** (found while reviewing today's prod alerts):
```
slowapi: Failed to rate limit. Swallowing error → redis.ConnectionError: Connection reset by peer
Unhandled exception on POST /api/v1/search → AttributeError: 'State' object has no attribute 'view_rate_limit'
```
The limiter is configured `swallow_errors=True` — the *intent* is to fail open when the rate-limit backend is down. But it doesn't fully work.

## Root cause (slowapi 0.1.10)

slowapi sets `request.state.view_rate_limit` only **after** it hits the storage backend:
```
extension.py:514   if not self.limiter.hit(lim.limit, *args, cost=cost): ...
extension.py:530   request.state.view_rate_limit = limit_for_header
```
When `hit()` raises (Redis down) and `swallow_errors=True` catches it (extension.py:647, the `"Failed to rate limit. Swallowing error"` log), line 530 is **skipped**. But the limit decorator then reads `request.state.view_rate_limit` **unconditionally** on the way out to inject headers (extension.py `async_wrapper`), so the swallow path `AttributeError`s → 500 instead of failing open. (`_inject_headers` itself tolerates `None`, and headers are off — the crash is purely the eager attribute read.)

## Fix

Seed `request.state.view_rate_limit = None` in **`_key_func`**, which runs first in every limit check (to compute the bucket key) and never touches the backend:
- a successful check overwrites it with the real limit;
- a swallowed one leaves it `None`, which `_inject_headers` tolerates — so `swallow_errors` now genuinely fails open.

Also harden the 429 handler (`app.py`) to read it via `getattr(request.state, "view_rate_limit", None)` for defense in depth.

**Why `_key_func` and not a new middleware:** it runs in the route's own execution context (no BaseHTTPMiddleware scope-propagation caveat — see the existing `SlowAPIMiddleware` note in `app.py`) and adds **zero** request-path overhead.

## Test

`test_search_fails_open_when_rate_limit_storage_errors` monkeypatches the limiter backend (`limiter.limiter.hit`) to raise and asserts `/api/v1/search` returns **200, not 500** — reproduces the prod crash without the seed. Full `tests/test_rate_limit.py` → 8 passed; `ruff`/`mypy` clean.

Found during the 2026-06-17 alert review; the only new category not already covered by #405–#408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)