### PR TITLE
fix(search): dampen recall_boost so it can't hijack rankings (A26)

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -471,8 +471,16 @@ FTS_BOOST_MAX_TOKENS = 3  # queries with more meaningful tokens than this stay a
 FTS_BOOST_SPECIFICITY_RATIO = 0.4  # strict >; at N=2 this means >=1 specific token triggers boost
 SIMILARITY_BLEND = 0.85  # base_score = SIMILARITY_BLEND * similarity + (1 - SIMILARITY_BLEND) * weight (raised from 0.75 — LoCoMo sweep showed +13pp recall)
 SEARCH_OVERFETCH_FACTOR = 2  # fetch top_k * N candidates from storage, trim to top_k after min_similarity filter — gives post-filter headroom
-RECALL_BOOST_CAP = 1.5  # max multiplier from frequent recall
-RECALL_DECAY_WINDOW_DAYS = 90  # only recalls within this window contribute to boost
+# A26: recall_count is bumped for every RETURNED row, used or not (see
+# TrackRecalls + memory_increment_recall), and feeds recall_boost back into the
+# rank score — a self-reinforcing "returned → boosted → returned" loop with no
+# usefulness signal. Until a confirmation-gated bump lands (the real fix, tied to
+# D5/D1), the cap is dialed down so the boost can no longer hijack rankings: at
+# cap=1.1 a popular-but-useless row can only overtake a more-relevant one whose
+# base score is <10% higher (was <50% at cap=1.5), and the shorter decay window
+# lets stale popularity fade in ~2 weeks instead of a quarter.
+RECALL_BOOST_CAP = 1.1  # max multiplier from frequent recall (A26: dialed down from 1.5)
+RECALL_DECAY_WINDOW_DAYS = 14  # only recalls within this window contribute to boost (A26: from 90)
 
 # ── Recall summary ──
 MEMORY_RECALL_SUMMARY_TEMPERATURE = 0.3

--- a/tests/test_p0_3_recall_boost.py
+++ b/tests/test_p0_3_recall_boost.py
@@ -55,13 +55,19 @@ class TestRecallBoostDecay:
         assert b == pytest.approx(1.0)
 
     def test_recently_recalled_gets_boost(self):
-        """Recalled 1 hour ago with count=10 → meaningful boost."""
+        """Recalled 1 hour ago with count=10 → a boost, bounded by the cap.
+
+        A26: with RECALL_BOOST_CAP dialed down to 1.1 the boost is small by
+        design (count=10, recency≈1 → 1 + (cap-1)*0.5 ≈ 1.05). Assert the shape
+        relative to the constant, not a hard-coded magnitude, so this survives
+        future cap tuning.
+        """
         now = self._now()
         last = now - timedelta(hours=1)
         b = compute_recall_boost(10, last_recalled_at=last, now=now)
-        # recency ≈ 1.0, count=10 → boost ≈ 1 + 0.5 * 1.0 * 10/20 = 1.25
-        assert b > 1.2
-        assert b < RECALL_BOOST_CAP
+        expected = 1.0 + (RECALL_BOOST_CAP - 1.0) * 1.0 * 10 / (10 + RECALL_BOOST_SCALE)
+        assert b == pytest.approx(expected, abs=0.01)
+        assert 1.0 < b < RECALL_BOOST_CAP
 
     def test_old_recall_no_boost(self):
         """THE KEY FIX: recalled 50 times but last recall was 31 days ago → boost ≈ 1.0."""
@@ -131,24 +137,57 @@ class TestRecallBoostDecay:
     # -- Comparison: before vs after --
 
     def test_feedback_loop_broken_scenario(self):
-        """Scenario that demonstrates the fix.
+        """Decay + A26 dial-down both break the feedback loop.
 
-        Before: memory with 50 recalls always got ~1.42x boost regardless of when.
-        After: boost decays to 1.0 if not recalled within RECALL_DECAY_WINDOW_DAYS.
+        A non-stale popular memory gets at most a small boost (bounded by the
+        A26-dialed-down cap), and a stale one decays to exactly 1.0 regardless
+        of how many times it was recalled.
         """
         now = self._now()
-        # Old formula (broken): 1 + 0.5 * 50 / (50 + 10) ≈ 1.417
-        old_boost = 1.0 + (RECALL_BOOST_CAP - 1.0) * 50 / (50 + RECALL_BOOST_SCALE)
-        assert old_boost > 1.4  # confirm old behavior was problematic
+        # Non-stale: recalled just now, count=50 → a real but cap-bounded boost.
+        fresh_boost = compute_recall_boost(50, last_recalled_at=now, now=now)
+        assert 1.0 < fresh_boost <= RECALL_BOOST_CAP
 
-        # New formula: same memory, last recalled well past the decay window
-        new_boost = compute_recall_boost(
+        # Same memory, last recalled well past the decay window → boost ~1.0.
+        stale_boost = compute_recall_boost(
             50,
             last_recalled_at=now - timedelta(days=RECALL_DECAY_WINDOW_DAYS + 15),
             now=now,
         )
-        assert new_boost == pytest.approx(1.0), (
-            f"Old boost was {old_boost:.3f}, new should be ~1.0 but got {new_boost:.3f}"
+        assert stale_boost == pytest.approx(1.0), (
+            f"stale popular memory should decay to ~1.0, got {stale_boost:.3f}"
+        )
+        # The decay removes a genuine boost (fresh strictly beats stale).
+        assert fresh_boost > stale_boost
+
+    def test_a26_boost_cannot_hijack_a_more_relevant_memory(self):
+        """A26: recall_boost is dialed down so a popular-but-unused memory can
+        no longer out-rank a more-relevant one on boost alone.
+
+        score = base_score * ... * recall_boost. A saturated, just-recalled row
+        gets at most RECALL_BOOST_CAP; a fresh, more-relevant row gets 1.0. So a
+        row only needs to be >(cap-1) more relevant to be safe — the "hijack
+        zone". At the pre-A26 cap of 1.5 that zone was 50%; dialed to 1.1 it is
+        ~10%. Guards against silently raising the cap back toward 1.5.
+        """
+        now = self._now()
+        # P: useless but hammered + just recalled → the max possible boost.
+        boost_p = compute_recall_boost(1_000_000, last_recalled_at=now, now=now)
+        assert boost_p <= RECALL_BOOST_CAP + 1e-9
+
+        hijack_zone = RECALL_BOOST_CAP - 1.0
+        assert hijack_zone <= 0.15, (
+            f"A26: recall_boost leaves a {hijack_zone:.0%} hijack zone — a "
+            "popular-but-unused memory can out-rank a more-relevant one. Keep "
+            "the cap dialed down until confirmation-gated recall lands."
+        )
+
+        # Concrete: a 12%-more-relevant fresh memory must beat the saturated one.
+        base_p, base_r = 1.0, 1.12
+        boost_r = compute_recall_boost(0, last_recalled_at=now, now=now)  # 1.0
+        assert base_r * boost_r > base_p * boost_p, (
+            "a 12%-more-relevant fresh memory must out-rank a saturated popular "
+            "one — recall_boost must not be able to hijack the ranking"
         )
 
 


### PR DESCRIPTION
## What

`recall_count` is bumped for **every returned row, used or not** (`TrackRecalls` → `memory_increment_recall`) and feeds `recall_boost` back into the rank score (`memory_scored_search` / `memory_repository`) — a self-reinforcing **returned → boosted → returned** loop with no usefulness signal. Popular-but-unused memories asymptote toward the boost cap and entrench at the top; the S1 bench has to pin `recall_boost=false` to avoid run-over-run drift, which is the same bug in miniature.

## Why this PR is the interim, not the full fix

Truly breaking the loop requires a **usefulness signal** (confirmation-gated bump — only count a recall when the memory was actually used/cited). That needs new signal plumbing that overlaps the evals + write-time-signal work (D5/D1), so it's filed as a separate follow-up. This PR is the low-risk damage-reducer: dial the boost down so it can no longer overcome a base-score gap.

## Change

- `RECALL_BOOST_CAP` **1.5 → 1.1** — shrinks the "hijack zone" (how much more relevant a row must be to be safe from a saturated popular one) from **~50% → ~10%**.
- `RECALL_DECAY_WINDOW_DAYS` **90 → 14** — stale popularity fades in ~2 weeks instead of a quarter.

Single source of truth: `resolve_search_profile` propagates both to storage via `search_params` (verified). The boost stays enabled — bounded, not removed.

## Tests

- New guard `test_a26_boost_cannot_hijack_a_more_relevant_memory` — encodes the guarantee (a saturated popular row can't out-rank a >12%-more-relevant fresh one). **Verified to fail at cap=1.5 and pass at 1.1.**
- Updated two existing assertions that hard-coded the old 1.5-cap magnitude to assert *shape relative to the constant* (survives future tuning).
- Full recall/scoring unit suite: 29 passing; ruff/format/mypy clean.

Live S1 replay intentionally skipped: the bench runs with `recall_boost=false`, so a cap/window constant cannot change its result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)