### PR TITLE
fix(extraction): re-fold split-off subject discriminators (A33)

### DIFF
--- a/core-api/src/core_api/services/entity_extraction.py
+++ b/core-api/src/core_api/services/entity_extraction.py
@@ -77,6 +77,53 @@ def _fake_extract(content: str) -> ExtractedGraph:
     return ExtractedGraph(entities=entities, relations=[])
 
 
+# A33 (mechanism ①): the extractor inconsistently splits a trailing
+# disambiguator off its subject — "Acme Corp #0033's …" becomes subject
+# "acme corp" + a SEPARATE identifier "#0033" (role=mentioned) — so every
+# "<Name> #NNNN" collapses onto one bare "<Name>" subject entity. With
+# same_subject = (entity_id == entity_id) (CAURA-133) that shared id is a
+# guaranteed false contradiction, and the bare hub also dilutes entity_lookup
+# (A30). Re-fold a trailing disambiguator (a "#tag" or a "(qualifier)") back
+# into its subject when the content shows the two adjacent. Only "#"/paren
+# shapes qualify, so real named identifiers ("pr-2025-a", "build-734") are
+# left untouched; the content-adjacency gate avoids folding an unrelated tag.
+_DISCRIMINATOR_RE = re.compile(r"#\w[\w.\-]*|\([^)]+\)")
+
+
+def _reattach_subject_discriminators(graph: ExtractedGraph, content: str) -> ExtractedGraph:
+    """Fold a split-off trailing disambiguator back into its subject (A33 ①)."""
+    subjects = [e for e in graph.entities if e.role == "subject"]
+    if not subjects:
+        return graph
+    content_l = content.lower()
+    renames: dict[str, str] = {}  # old canonical -> new, for relation/mention remap
+    folded: set[str] = set()  # canonical names of discriminators merged away
+    for e in graph.entities:
+        if e.role == "subject":
+            continue
+        disc = e.canonical_name.strip()
+        if not _DISCRIMINATOR_RE.fullmatch(disc.lower()):
+            continue
+        for s in subjects:
+            base = s.canonical_name.strip()
+            if base and f"{base.lower()} {disc.lower()}" in content_l:
+                new_name = f"{base} {disc}"
+                renames[s.canonical_name] = new_name
+                s.canonical_name = new_name
+                folded.add(e.canonical_name)
+                break
+    if not folded:
+        return graph
+    graph.entities = [e for e in graph.entities if not (e.role != "subject" and e.canonical_name in folded)]
+    for r in graph.relations:
+        r.from_entity = renames.get(r.from_entity, r.from_entity)
+        r.to_entity = renames.get(r.to_entity, r.to_entity)
+    for m in graph.mentions:
+        if m.entity_canonical in renames:
+            m.entity_canonical = renames[m.entity_canonical]
+    return graph
+
+
 async def extract_entities_from_content(
     content: str,
     memory_type: str,
@@ -126,7 +173,7 @@ async def extract_entities_from_content(
         or settings.entity_extraction_model
         or None
     )
-    return await call_with_fallback(
+    graph = await call_with_fallback(
         primary_provider_name=provider_name,
         call_fn=_do_extract,
         fake_fn=lambda: _fake_extract(content),
@@ -135,6 +182,8 @@ async def extract_entities_from_content(
         model_override=extraction_model,
         model_attr="entity_extraction_model",
     )
+    # A33 ①: undo the split-discriminator pattern before resolution.
+    return _reattach_subject_discriminators(graph, content)
 
 
 # Backward-compat re-exports for tests

--- a/tests/test_a33_subject_discriminator.py
+++ b/tests/test_a33_subject_discriminator.py
@@ -1,0 +1,189 @@
+"""A33 ①: re-fold a split-off trailing disambiguator back into its subject.
+
+The extractor inconsistently turns "Acme Corp #0033's …" into a bare subject
+"acme corp" + a separate identifier "#0033", collapsing every "<Name> #NNNN"
+onto one shared subject entity_id → false same_subject (CAURA-133) + a hub that
+dilutes entity_lookup (A30). ``_reattach_subject_discriminators`` undoes that on
+the extracted graph, before any resolution. These tests pin the fold rule and
+its guards (adjacency-gated; "#"/parenthetical shapes only).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_api.services.entity_extraction import (
+    ExtractedEntity,
+    ExtractedGraph,
+    ExtractedRelation,
+    Mention,
+    _reattach_subject_discriminators,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _graph(entities, relations=None, mentions=None):
+    return ExtractedGraph(
+        entities=entities,
+        relations=relations or [],
+        mentions=mentions or [],
+    )
+
+
+def test_folds_hash_discriminator_into_subject():
+    """The dominant A33 case: '#0033' split off 'acme corp' is re-folded."""
+    graph = _graph(
+        [
+            ExtractedEntity(
+                canonical_name="acme corp", entity_type="organization", role="subject"
+            ),
+            ExtractedEntity(
+                canonical_name="#0033", entity_type="identifier", role="mentioned"
+            ),
+        ]
+    )
+    out = _reattach_subject_discriminators(
+        graph, "Acme Corp #0033's employee_count is 13979."
+    )
+    names = {e.canonical_name for e in out.entities}
+    assert names == {"acme corp #0033"}, names
+    # the standalone discriminator entity is gone (folded into the subject)
+    assert all(e.role == "subject" for e in out.entities)
+
+
+def test_distinct_siblings_stay_distinct_after_fold():
+    """Two siblings that previously both collapsed to 'acme corp' now differ."""
+    g28 = _reattach_subject_discriminators(
+        _graph(
+            [
+                ExtractedEntity(
+                    canonical_name="acme corp",
+                    entity_type="organization",
+                    role="subject",
+                ),
+                ExtractedEntity(
+                    canonical_name="#0028", entity_type="identifier", role="mentioned"
+                ),
+            ]
+        ),
+        "Acme Corp #0028's employee_count is 48227.",
+    )
+    g33 = _reattach_subject_discriminators(
+        _graph(
+            [
+                ExtractedEntity(
+                    canonical_name="acme corp",
+                    entity_type="organization",
+                    role="subject",
+                ),
+                ExtractedEntity(
+                    canonical_name="#0033", entity_type="identifier", role="mentioned"
+                ),
+            ]
+        ),
+        "Acme Corp #0033's employee_count is 13979.",
+    )
+    s28 = next(e.canonical_name for e in g28.entities if e.role == "subject")
+    s33 = next(e.canonical_name for e in g33.entities if e.role == "subject")
+    assert s28 != s33, f"siblings must stay distinct, got {s28!r} and {s33!r}"
+
+
+def test_fold_remaps_relations_and_mentions():
+    """Relation endpoints + mention links that named the bare subject are remapped."""
+    graph = _graph(
+        [
+            ExtractedEntity(
+                canonical_name="acme corp", entity_type="organization", role="subject"
+            ),
+            ExtractedEntity(
+                canonical_name="#0033", entity_type="identifier", role="mentioned"
+            ),
+            ExtractedEntity(
+                canonical_name="13979", entity_type="identifier", role="object"
+            ),
+        ],
+        relations=[
+            ExtractedRelation(
+                from_entity="acme corp",
+                relation_type="has_employee_count",
+                to_entity="13979",
+            )
+        ],
+        mentions=[
+            Mention(
+                surface="Acme Corp #0033", cluster_id=0, entity_canonical="acme corp"
+            )
+        ],
+    )
+    out = _reattach_subject_discriminators(
+        graph, "Acme Corp #0033's employee_count is 13979."
+    )
+    assert out.relations[0].from_entity == "acme corp #0033"
+    assert out.mentions[0].entity_canonical == "acme corp #0033"
+
+
+def test_folds_parenthetical_qualifier():
+    """Generalises beyond '#': a split-off '(delaware)' folds back too."""
+    graph = _graph(
+        [
+            ExtractedEntity(
+                canonical_name="acme", entity_type="organization", role="subject"
+            ),
+            ExtractedEntity(
+                canonical_name="(delaware)", entity_type="identifier", role="mentioned"
+            ),
+        ]
+    )
+    out = _reattach_subject_discriminators(
+        graph, "Acme (Delaware)'s q3_revenue is $10M."
+    )
+    assert {e.canonical_name for e in out.entities} == {"acme (delaware)"}
+
+
+def test_no_fold_when_not_adjacent_in_content():
+    """The disambiguator only folds if it directly follows the subject in text."""
+    graph = _graph(
+        [
+            ExtractedEntity(
+                canonical_name="acme corp", entity_type="organization", role="subject"
+            ),
+            ExtractedEntity(
+                canonical_name="#0033", entity_type="identifier", role="mentioned"
+            ),
+        ]
+    )
+    # "#0033" refers to something else here — not adjacent to the subject.
+    out = _reattach_subject_discriminators(graph, "Acme Corp depends on widget #0033.")
+    names = {e.canonical_name for e in out.entities}
+    assert names == {"acme corp", "#0033"}, names
+
+
+def test_does_not_fold_real_named_identifiers():
+    """A real named identifier (not a '#'/paren disambiguator) is never folded,
+    even if adjacent — preserves entities like 'pr-2025-a' / 'build-734'."""
+    graph = _graph(
+        [
+            ExtractedEntity(
+                canonical_name="acme corp", entity_type="organization", role="subject"
+            ),
+            ExtractedEntity(
+                canonical_name="build-734", entity_type="identifier", role="mentioned"
+            ),
+        ]
+    )
+    out = _reattach_subject_discriminators(graph, "Acme Corp build-734 shipped today.")
+    names = {e.canonical_name for e in out.entities}
+    assert names == {"acme corp", "build-734"}, names
+
+
+def test_no_subjects_is_noop():
+    graph = _graph(
+        [
+            ExtractedEntity(
+                canonical_name="#0033", entity_type="identifier", role="mentioned"
+            )
+        ]
+    )
+    out = _reattach_subject_discriminators(graph, "#0033 is here")
+    assert {e.canonical_name for e in out.entities} == {"#0033"}


### PR DESCRIPTION
## What

Entity extraction inconsistently **splits a trailing disambiguator off its subject**: `"Acme Corp #0033's …"` becomes a bare subject `acme corp` **+** a separate identifier `#0033` (`role=mentioned`). So every `Acme Corp #NNNN` collapses onto one shared `acme corp` subject entity. With `same_subject = (entity_id == entity_id)` (CAURA-133), that shared id is a **guaranteed false contradiction**, and the bare hub also **dilutes `entity_lookup`** (the A30 person-hub class). This is the dominant mechanism behind the V2 ~6.3% false-`conflicted` rate.

The #304 B-guard can't help here — the name being resolved is literally `acme corp` (no digits), which correctly matches the existing bare entity. The discriminator already left the subject upstream, in extraction.

## Fix

`_reattach_subject_discriminators` — a deterministic normalization on the `ExtractedGraph` **before any resolution**: re-fold a trailing disambiguator (a `#tag` or a `(qualifier)`) back into its subject when the content shows the two adjacent, remapping relation endpoints + mention links.

Guards: only `#`/parenthetical shapes qualify, and only when **content-adjacent** to the subject — so real named identifiers (`pr-2025-a`, `build-734`) and non-adjacent tags are left untouched.

**Scope**: forward-only (corrects new extractions, not already-baked corpora). Covers mechanism ① (the split). The cosine-merge of *already-distinct* qualified names (two `John Smith`s, `Acme (Delaware)` vs `(Ohio)`) is a separate mechanism, tracked as a follow-up.

## Tests

- **7 unit** (`test_a33_subject_discriminator.py`): fold, sibling-distinctness, relation/mention remap, parenthetical, + 3 negatives (non-adjacent, real named identifier, no-subject).
- **Wet-tested on the local stack** (real OpenAI extraction): two sibling writes resolve to **distinct** subject entities — `acme corp #0028` (active) vs `acme corp #0033` (confirmed), **neither marked `conflicted`**. Pre-fix these collapsed to one bare `acme corp` + a false conflict (V2 trace).
- Entity-extraction/resolution suite: 49 passed, no regression. ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)