### PR TITLE
fix(core-api): stamp version into image so /api/v1/version stops serving "dev" (CAURA-000)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,11 @@ node_modules
 memclaw/node_modules
 memclaw/.next
 *.egg-info
+# Bare globs only match the context root — add a recursive form so a stray
+# nested build artifact (e.g. core-api/src/core_api.egg-info from a local
+# editable install) can't bake into the image and shadow the version stamp.
+**/*.egg-info
+**/__pycache__
 .pytest_cache
 .mypy_cache
 .venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,3 +144,39 @@ jobs:
         run: |
           cd core-api && uv build && cd ..
           cd core-storage-api && uv build
+
+  image-version:
+    # Guards the /api/v1/version surface end-to-end: builds the actual
+    # core-api image and asserts it bakes a real semver (== pyproject),
+    # not "dev". This is the regression that silently shipped for weeks —
+    # the prod Dockerfile installs deps via ``uv export --no-emit-project``
+    # so core-api is never installed as a package, leaving importlib.metadata
+    # with nothing to resolve → "dev". A pytest check can't catch it: CI
+    # installs core-api editable, so the bug only exists inside the built
+    # image. See core-api/Dockerfile version stamp +
+    # core_api.constants._resolve_version().
+    name: core-api image bakes a real version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Build core-api image
+        run: docker build --platform linux/amd64 --target runtime -t core-api-versiontest -f core-api/Dockerfile .
+
+      - name: Assert baked version is a real semver matching pyproject
+        run: |
+          BAKED=$(docker run --rm core-api-versiontest python -c "from core_api.constants import VERSION; print(VERSION)")
+          EXPECTED=$(python3 -c "import tomllib; print(tomllib.load(open('core-api/pyproject.toml','rb'))['project']['version'])")
+          echo "baked=$BAKED expected=$EXPECTED"
+          if [ "$BAKED" = "dev" ] || ! echo "$BAKED" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::core-api image did not bake a real semver (got '$BAKED'). /api/v1/version would serve a bogus value — see core-api/Dockerfile + core_api.constants._resolve_version."
+            exit 1
+          fi
+          if [ "$BAKED" != "$EXPECTED" ]; then
+            echo "::error::baked version '$BAKED' != pyproject '$EXPECTED' — the version stamp drifted from the source of truth."
+            exit 1
+          fi

--- a/core-api/Dockerfile
+++ b/core-api/Dockerfile
@@ -26,6 +26,18 @@ RUN uv export --frozen --no-dev --extra pubsub --no-emit-project \
       --directory core-api -o /tmp/reqs.txt \
     && uv pip install --system --no-cache -r /tmp/reqs.txt
 
+# Stamp the service version into a file the app reads at runtime. Source of
+# truth is pyproject.toml; an optional MEMCLAW_VERSION build-arg (e.g. the
+# release tag) overrides it. Deterministic and independent of installed-
+# package metadata — deps install via ``--no-emit-project`` so core-api is
+# never installed as a package, leaving importlib.metadata with no version
+# to find (the endpoint silently served "dev"). Read by
+# core_api.constants._resolve_version().
+ARG MEMCLAW_VERSION=
+RUN VER="${MEMCLAW_VERSION:-$(python -c "import tomllib; print(tomllib.load(open('core-api/pyproject.toml','rb'))['project']['version'])")}" \
+    && printf '%s' "$VER" > /app/VERSION \
+    && echo "Stamped MemClaw version: $VER"
+
 # Copy actual source
 COPY common/ /app/common/
 COPY core-api/src/ /app/core-api/src/

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -2,6 +2,7 @@
 
 import importlib.metadata
 import os
+from pathlib import Path
 
 # Re-export DB-query constants from common (shared with core-storage-api).
 from common.constants import (  # noqa: F401
@@ -58,12 +59,39 @@ def is_mcp_path(path: str) -> bool:
 
 
 # ── Version ──
-# Source-only dev (PYTHONPATH set but no `pip install -e`) has no
-# package metadata; fall back to "dev" rather than crashing import.
-try:
-    VERSION = importlib.metadata.version("core-api")
-except importlib.metadata.PackageNotFoundError:
-    VERSION = "dev"
+def _resolve_version() -> str:
+    """Resolve the running service version.
+
+    Precedence (most to least authoritative):
+
+    1. ``MEMCLAW_VERSION`` env — explicit deploy/ad-hoc override.
+    2. ``VERSION`` file baked into the image at build time from
+       ``pyproject.toml`` (see ``core-api/Dockerfile``). Deterministic and
+       independent of installed-package metadata — the prod Dockerfile
+       installs deps via ``uv export --no-emit-project`` (the project
+       itself is never installed), so ``importlib.metadata`` finds no
+       ``core-api`` dist and the endpoint silently served ``"dev"``.
+    3. Installed package metadata — editable dev installs (``pip install -e``).
+    4. ``"dev"`` — source-only checkout with none of the above.
+    """
+    env = os.environ.get("MEMCLAW_VERSION")
+    if env and env.strip():
+        return env.strip()
+    # constants.py → core_api → src → core-api → repo root (image: /app).
+    version_file = Path(__file__).resolve().parents[3] / "VERSION"
+    try:
+        stamped = version_file.read_text().strip()
+        if stamped:
+            return stamped
+    except OSError:
+        pass
+    try:
+        return importlib.metadata.version("core-api")
+    except importlib.metadata.PackageNotFoundError:
+        return "dev"
+
+
+VERSION = _resolve_version()
 OPENAI_EMBEDDING_MODEL = os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
 EMBEDDING_RETRY_ATTEMPTS = 2
 EMBEDDING_RETRY_DELAY_S = 1.0

--- a/tests/test_api_status.py
+++ b/tests/test_api_status.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
+import re
 
-from core_api.constants import VERSION
+from core_api.constants import VERSION, _resolve_version
 
 
 # ---------------------------------------------------------------------------
@@ -163,3 +164,30 @@ async def test_status_is_valid_json(client):
     resp = await client.get("/api/v1/status")
     assert resp.status_code == 200
     json.loads(resp.text)  # raises if the body isn't strict JSON
+
+
+# ---------------------------------------------------------------------------
+# Version resolution (regression guard — /api/v1/version once served "dev")
+# ---------------------------------------------------------------------------
+
+
+def test_version_is_resolved_not_dev():
+    """In CI core-api is installed editable, so metadata resolution yields a
+    real semver. ``"dev"`` here means the resolution chain is broken."""
+    assert VERSION != "dev"
+    assert re.match(r"^\d+\.\d+\.\d+", VERSION), VERSION
+
+
+def test_version_env_override_wins(monkeypatch):
+    """An explicit ``MEMCLAW_VERSION`` env beats file/metadata resolution."""
+    monkeypatch.setenv("MEMCLAW_VERSION", "9.9.9-test")
+    assert _resolve_version() == "9.9.9-test"
+
+
+def test_version_blank_env_override_ignored(monkeypatch):
+    """A blank/whitespace ``MEMCLAW_VERSION`` must not win — it falls through
+    to the file/metadata chain rather than serving an empty version."""
+    monkeypatch.setenv("MEMCLAW_VERSION", "   ")
+    resolved = _resolve_version()
+    assert resolved.strip() == resolved
+    assert resolved not in ("", "dev")


### PR DESCRIPTION
## Summary

`/api/v1/version` (and the `version` field of `/api/v1/status`) returns `"dev"` instead of the real release version.

**Root cause:** the Dockerfile installs dependencies with `uv export --frozen --no-emit-project`, which deliberately excludes the project itself — so **core-api is never installed as a package** in the image. `core_api.constants.VERSION` resolves via `importlib.metadata.version("core-api")`, which raises `PackageNotFoundError`, and the silent `except` fallback returns `"dev"`. Confirmed by inspecting the built image: `pip show core-api` → not found, and the module loads from source via `PYTHONPATH`.

This is invisible in CI (which installs core-api editable, so metadata resolves) — the bug only exists inside the built image.

## Fix

Bake the version into the image at build time and read it deterministically:

- **Dockerfile** — stamp `/app/VERSION` from `pyproject.toml` (the source of truth) in the builder, with an optional `MEMCLAW_VERSION` build-arg override (e.g. a release tag).
- **constants.py** — `_resolve_version()` precedence: `MEMCLAW_VERSION` env → `/app/VERSION` file → installed-package metadata → `"dev"`. Independent of install method / `PYTHONPATH` ordering.
- **.dockerignore** — add recursive `**/*.egg-info` (a bare `*.egg-info` only matches the context root) so a stray nested `core_api.egg-info` from a local editable install can't bake into the image and shadow the stamp.
- **ci.yml** — new `image-version` job that builds the image and asserts the baked version is a real semver matching `pyproject.toml` (not `"dev"`). A pytest assertion can't catch this; the job builds the actual image.
- **tests** — version-resolution precedence guards in `test_api_status.py`.

## Test plan

- [x] `docker build` of the image → `VERSION = <pyproject version>` (was `"dev"`)
- [x] Verified `pip show core-api` is absent in the image — the stamp is the sole source
- [x] `ruff check` / `ruff format --check` clean; `mypy` clean
- [x] `pytest tests/test_api_status.py -k version` — 3 passed
- [x] New `image-version` CI job fails loudly if the baked version is `"dev"` or drifts from `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)