### PR TITLE
fix(core-api): self-heal storage pool + cancellation-safe requests (CAURA-000)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Any, Literal, NotRequired, TypedDict
 
 import httpx
@@ -96,6 +98,16 @@ class CoreStorageClient:
             # against a single service for no benefit.
             self._read_http = self._http
 
+        # Pool self-healing (incident 2026-06-16): the singleton pool could
+        # leak connection slots when in-flight calls were cancelled and never
+        # recovered without a process restart. ``_pool_generation`` lets
+        # concurrent ``PoolTimeout``s collapse into exactly one rebuild.
+        self._pool_lock = asyncio.Lock()
+        self._pool_generation = 0
+        # Anchor fire-and-forget pool-close tasks so they aren't GC'd while
+        # pending (Python 3.12+ warns otherwise); discard on completion.
+        self._background_tasks: set[asyncio.Task] = set()
+
     @staticmethod
     def _make_pool() -> httpx.AsyncClient:
         """Construct an httpx pool with the tuned timeouts + limits.
@@ -153,6 +165,94 @@ class CoreStorageClient:
             if self._read_http is not self._http:
                 await self._read_http.aclose()
 
+    # -- pool resilience (incident 2026-06-16) ---------------------------
+
+    async def _cancel_safe(self, coro: Awaitable[httpx.Response]) -> httpx.Response:
+        """Run an in-flight storage request so cancellation cannot strand its
+        pooled connection.
+
+        When the 35s enrichment ``wait_for`` or the 45s request-timeout
+        cancels the awaiting task mid-request, httpcore (1.0.9, current)
+        does not return the connection to the pool — leaked slots accumulate
+        until the ``max_connections=200`` ceiling is hit and every acquire
+        ``PoolTimeout``s (incident 2026-06-16). Shielding lets the request
+        run to completion (returning its slot) while the caller still
+        observes ``CancelledError`` immediately; the orphaned result is
+        consumed so it is not logged as never-retrieved.
+        """
+        task = asyncio.create_task(coro)
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+
+            def _consume_result(t: asyncio.Task) -> None:
+                if t.cancelled():
+                    return
+                exc = t.exception()
+                if exc is not None:
+                    logger.debug("storage_client: shielded request failed after caller cancellation: %r", exc)
+
+            task.add_done_callback(_consume_result)
+            raise
+
+    @staticmethod
+    async def _safe_aclose(client: httpx.AsyncClient) -> None:
+        try:
+            await client.aclose()
+        except Exception as exc:  # pool teardown must never surface to callers
+            logger.warning("storage_client: error closing recycled pool: %r", exc)
+
+    async def _recycle_pools(self, *, observed_gen: int, label: str) -> None:
+        """Rebuild the httpx pool(s) after exhaustion so a leaked-out singleton
+        self-heals in seconds instead of requiring a process restart. The
+        generation guard means concurrent ``PoolTimeout``s trigger exactly one
+        rebuild; later arrivals see the bumped generation and return."""
+        async with self._pool_lock:
+            if self._pool_generation != observed_gen:
+                return
+            old_write, old_read = self._http, self._read_http
+            shared = old_read is old_write
+            self._http = self._make_pool()
+            self._read_http = self._http if shared else self._make_pool()
+            self._pool_generation += 1
+            logger.error(
+                "storage_client.%s: core-storage pool exhausted (PoolTimeout) — "
+                "recycled connection pool (generation %d→%d); see incident 2026-06-16",
+                label,
+                observed_gen,
+                self._pool_generation,
+            )
+        # Force-close the old pool(s) in the background. Safe to drop mid-flight:
+        # a pool only reaches this path once it can no longer hand out
+        # connections, so there is no healthy in-flight work left to disrupt.
+        for old in {old_write, old_read}:
+            t = asyncio.create_task(self._safe_aclose(old))
+            self._background_tasks.add(t)
+            t.add_done_callback(self._background_tasks.discard)
+
+    async def _execute(
+        self,
+        do_request: Callable[[], Awaitable[httpx.Response]],
+        *,
+        retry: Callable[..., Awaitable[httpx.Response]],
+        label: str,
+    ) -> httpx.Response:
+        """Run ``do_request`` through the ``retry`` policy, made cancellation-safe
+        and pool-self-healing. ``do_request`` must read ``self._http`` /
+        ``self._read_http`` lazily so a recycled pool is picked up on retry.
+        If ``PoolTimeout`` survives the retry policy the pool is exhausted —
+        recycle it once and retry on the fresh pool."""
+
+        def _shielded() -> Awaitable[httpx.Response]:
+            return self._cancel_safe(do_request())
+
+        observed_gen = self._pool_generation
+        try:
+            return await retry(_shielded, label=label)
+        except httpx.PoolTimeout:
+            await self._recycle_pools(observed_gen=observed_gen, label=label)
+            return await retry(_shielded, label=label)
+
     # -- internal helpers ------------------------------------------------
 
     async def _auth_headers(self, *, read: bool) -> dict[str, str]:
@@ -186,14 +286,15 @@ class CoreStorageClient:
             _evict_id_token(audience)
 
     async def _get(self, path: str, *, read: bool = True, **params: Any) -> dict | None:
-        http = self._read_http if read else self._http
         prefix = self._read_prefix if read else self._prefix
         headers = await self._auth_headers(read=read)
 
-        async def _do() -> httpx.Response:
-            return await http.get(f"{prefix}{path}", params=params, headers=headers)
+        def _do() -> Awaitable[httpx.Response]:
+            # Read the pool lazily so a mid-call recycle is picked up on retry.
+            http = self._read_http if read else self._http
+            return http.get(f"{prefix}{path}", params=params, headers=headers)
 
-        resp = await with_retry(_do, label=f"GET {path}")
+        resp = await self._execute(_do, retry=with_retry, label=f"GET {path}")
         if resp.status_code == 404:
             return None
         self._maybe_evict_on_auth_error(resp, read=read)
@@ -205,10 +306,10 @@ class CoreStorageClient:
         # sit on the write path, so no per-call opt-out is needed yet.
         headers = await self._auth_headers(read=True)
 
-        async def _do() -> httpx.Response:
-            return await self._read_http.get(f"{self._read_prefix}{path}", params=params, headers=headers)
+        def _do() -> Awaitable[httpx.Response]:
+            return self._read_http.get(f"{self._read_prefix}{path}", params=params, headers=headers)
 
-        resp = await with_retry(_do, label=f"GET-list {path}")
+        resp = await self._execute(_do, retry=with_retry, label=f"GET-list {path}")
         self._maybe_evict_on_auth_error(resp, read=True)
         resp.raise_for_status()
         return resp.json()
@@ -216,12 +317,12 @@ class CoreStorageClient:
     async def _post(
         self, path: str, data: Any = None, *, read: bool = False, idempotent: bool = False
     ) -> dict | list:
-        http = self._read_http if read else self._http
         prefix = self._read_prefix if read else self._prefix
         headers = await self._auth_headers(read=read)
 
-        async def _do() -> httpx.Response:
-            return await http.post(
+        def _do() -> Awaitable[httpx.Response]:
+            http = self._read_http if read else self._http
+            return http.post(
                 f"{prefix}{path}",
                 json=data if data is not None else {},
                 headers=headers,
@@ -232,7 +333,7 @@ class CoreStorageClient:
         # transient set (ReadTimeout + 5xx too) — safe ONLY when the endpoint
         # dedups replays storage-side (e.g. /audit-logs/bulk on client_event_id).
         retry = with_retry if idempotent else with_connect_phase_retry
-        resp = await retry(_do, label=f"POST {path}")
+        resp = await self._execute(_do, retry=retry, label=f"POST {path}")
         self._maybe_evict_on_auth_error(resp, read=read)
         resp.raise_for_status()
         return resp.json()
@@ -240,10 +341,10 @@ class CoreStorageClient:
     async def _patch(self, path: str, data: dict) -> dict | None:
         headers = await self._auth_headers(read=False)
 
-        async def _do() -> httpx.Response:
-            return await self._http.patch(f"{self._prefix}{path}", json=data, headers=headers)
+        def _do() -> Awaitable[httpx.Response]:
+            return self._http.patch(f"{self._prefix}{path}", json=data, headers=headers)
 
-        resp = await with_retry(_do, label=f"PATCH {path}")
+        resp = await self._execute(_do, retry=with_retry, label=f"PATCH {path}")
         if resp.status_code == 404:
             return None
         self._maybe_evict_on_auth_error(resp, read=False)
@@ -253,10 +354,10 @@ class CoreStorageClient:
     async def _delete(self, path: str, **params: Any) -> bool:
         headers = await self._auth_headers(read=False)
 
-        async def _do() -> httpx.Response:
-            return await self._http.delete(f"{self._prefix}{path}", params=params, headers=headers)
+        def _do() -> Awaitable[httpx.Response]:
+            return self._http.delete(f"{self._prefix}{path}", params=params, headers=headers)
 
-        resp = await with_retry(_do, label=f"DELETE {path}")
+        resp = await self._execute(_do, retry=with_retry, label=f"DELETE {path}")
         if resp.status_code == 404:
             return False
         self._maybe_evict_on_auth_error(resp, read=False)
@@ -264,18 +365,18 @@ class CoreStorageClient:
         return True
 
     async def _post_optional(self, path: str, data: Any = None, *, read: bool = False) -> dict | None:
-        http = self._read_http if read else self._http
         prefix = self._read_prefix if read else self._prefix
         headers = await self._auth_headers(read=read)
 
-        async def _do() -> httpx.Response:
-            return await http.post(
+        def _do() -> Awaitable[httpx.Response]:
+            http = self._read_http if read else self._http
+            return http.post(
                 f"{prefix}{path}",
                 json=data if data is not None else {},
                 headers=headers,
             )
 
-        resp = await with_connect_phase_retry(_do, label=f"POST {path}")
+        resp = await self._execute(_do, retry=with_connect_phase_retry, label=f"POST {path}")
         if resp.status_code == 404:
             return None
         self._maybe_evict_on_auth_error(resp, read=read)
@@ -1025,11 +1126,15 @@ class CoreStorageClient:
         if agent_id is not None:
             params["agent_id"] = agent_id
         headers = await self._auth_headers(read=True)
-        resp = await self._read_http.get(
-            f"{self._read_prefix}/keystones",
-            params=params,
-            headers=headers,
-        )
+
+        def _do() -> Awaitable[httpx.Response]:
+            return self._read_http.get(
+                f"{self._read_prefix}/keystones",
+                params=params,
+                headers=headers,
+            )
+
+        resp = await self._execute(_do, retry=with_retry, label="GET /keystones")
         self._maybe_evict_on_auth_error(resp, read=True)
         resp.raise_for_status()
         truncated = resp.headers.get("X-Truncated", "").lower() == "true"
@@ -1167,8 +1272,8 @@ class CoreStorageClient:
         """
         headers = await self._auth_headers(read=False)
 
-        async def _do() -> httpx.Response:
-            return await self._http.post(
+        def _do() -> Awaitable[httpx.Response]:
+            return self._http.post(
                 f"{self._prefix}/idempotency/claim",
                 json={
                     "tenant_id": tenant_id,
@@ -1179,7 +1284,7 @@ class CoreStorageClient:
                 headers=headers,
             )
 
-        resp = await with_connect_phase_retry(_do, label="POST /idempotency/claim")
+        resp = await self._execute(_do, retry=with_connect_phase_retry, label="POST /idempotency/claim")
         self._maybe_evict_on_auth_error(resp, read=False)
         if resp.status_code == 201:
             return True, resp.json()

--- a/tests/test_storage_client_pool_recovery.py
+++ b/tests/test_storage_client_pool_recovery.py
@@ -1,0 +1,166 @@
+"""Incident 2026-06-16 — storage_client connection-pool slot leak + recovery.
+
+Root cause: ``CoreStorageClient`` holds a process-wide singleton httpx pool
+(``max_connections=200``, ``pool=5s``). When an in-flight storage call was
+cancelled — the 35s enrichment ``wait_for`` or the 45s request-timeout firing
+mid-request — httpcore (1.0.9) did not return the connection to the pool.
+Leaked slots accumulated over ~4.5 days of uptime until every acquire hit
+``PoolTimeout``; the singleton never self-healed, so recovery was restart-only
+(a ~2h SEV-2 on eToro on-prem).
+
+Two fixes, one regression test each:
+
+* Fix B (prevention) — ``_cancel_safe`` shields the in-flight request so a
+  cancelled caller still lets the request finish and release its slot.
+* Fix A (recovery) — ``_execute`` recycles the pool once on ``PoolTimeout``
+  exhaustion so a leaked-out client self-heals in seconds.
+
+Plus a guard test: a transient ``PoolTimeout`` that the retry policy rides out
+must NOT trigger a recycle (don't churn the pool on a single blip).
+
+Tests mirror ``test_storage_client_retry.py``'s AsyncMock-client convention.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _ok_response(status: int = 200, body: dict | None = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.json.return_value = body if body is not None else {"id": "x"}
+    resp.raise_for_status = MagicMock()
+    if status >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+async def _make_client():
+    from core_api.clients.storage_client import CoreStorageClient
+
+    write_client = AsyncMock(spec=httpx.AsyncClient)
+    read_client = AsyncMock(spec=httpx.AsyncClient)
+    return (
+        CoreStorageClient(
+            base_url="http://test-storage",
+            read_url="",
+            http=write_client,
+            read_http=read_client,
+        ),
+        write_client,
+        read_client,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix B — cancellation must not strand the in-flight request (slot leak)
+# ---------------------------------------------------------------------------
+
+
+async def test_cancellation_lets_inflight_request_finish_and_release() -> None:
+    """The leak's trigger: the caller is cancelled mid-request (35s/45s budget).
+
+    With the shield, the underlying storage call still runs to completion —
+    so httpx returns its pooled connection — even though the caller observes
+    ``CancelledError`` immediately. Without it, cancelling the caller cancels
+    the request mid-flight and the connection is the one that leaks.
+    """
+    client, _write, read = await _make_client()
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+
+    async def slow_get(*_args, **_kwargs):
+        started.set()
+        await release.wait()  # request "in flight" against the pool
+        finished.set()
+        return _ok_response(200, {"id": "ok"})
+
+    read.get = slow_get
+
+    task = asyncio.create_task(client._get("/slow", read=True))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    task.cancel()  # mimic the enrichment/request budget cancelling the caller
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Fix B: the shielded request is allowed to complete → slot returned.
+    release.set()
+    await asyncio.wait_for(finished.wait(), timeout=1.0)
+    assert finished.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Fix A — pool self-heals on exhaustion (was restart-only)
+# ---------------------------------------------------------------------------
+
+
+async def test_post_recycles_pool_on_exhaustion_then_succeeds(monkeypatch) -> None:
+    """A POST whose pool is exhausted (``PoolTimeout`` survives the connect-phase
+    retries) recycles the pool once and succeeds on the fresh one — converting a
+    restart-only outage into a seconds-long self-heal."""
+    client, write, _read = await _make_client()
+    write.post = AsyncMock(side_effect=httpx.PoolTimeout("pool exhausted"))
+
+    healed = AsyncMock(spec=httpx.AsyncClient)
+    healed.post = AsyncMock(return_value=_ok_response(200, {"id": "healed"}))
+    monkeypatch.setattr(client, "_make_pool", lambda: healed)
+
+    result = await client._post("/entities", {"canonical_name": "x"})
+
+    assert result == {"id": "healed"}
+    assert client._pool_generation == 1  # exactly one rebuild
+    # Exhausted on every connect-phase attempt, then one success on the new pool.
+    from common.http_retry import CONNECT_PHASE_MAX_ATTEMPTS
+
+    assert write.post.await_count == CONNECT_PHASE_MAX_ATTEMPTS
+    assert healed.post.await_count == 1
+    # The old, exhausted pool is force-closed in the background.
+    await asyncio.sleep(0)
+    write.aclose.assert_awaited()
+
+
+async def test_get_recycles_pool_on_exhaustion_then_succeeds(monkeypatch) -> None:
+    """Read path heals too: the suppression GET on every authed request was the
+    most-visible victim, so its recovery is what restores service."""
+    client, _write, read = await _make_client()
+    read.get = AsyncMock(side_effect=httpx.PoolTimeout("pool exhausted"))
+
+    healed = AsyncMock(spec=httpx.AsyncClient)
+    healed.get = AsyncMock(return_value=_ok_response(200, {"id": "healed"}))
+    monkeypatch.setattr(client, "_make_pool", lambda: healed)
+
+    result = await client._get("/tenant-suppression/t1", read=True)
+
+    assert result == {"id": "healed"}
+    assert client._pool_generation == 1
+    assert healed.get.await_count == 1
+
+
+async def test_transient_pooltimeout_does_not_recycle(monkeypatch) -> None:
+    """Guard: a single ``PoolTimeout`` that the retry policy rides out must NOT
+    recycle the pool — recycling is reserved for genuine exhaustion, not a blip."""
+    client, _write, read = await _make_client()
+    read.get = AsyncMock(
+        side_effect=[httpx.PoolTimeout("blip"), _ok_response(200, {"id": "abc"})]
+    )
+    rebuilt = MagicMock(return_value=AsyncMock(spec=httpx.AsyncClient))
+    monkeypatch.setattr(client, "_make_pool", rebuilt)
+
+    result = await client._get("/entities/exact", read=True)
+
+    assert result == {"id": "abc"}
+    assert client._pool_generation == 0  # no recycle
+    rebuilt.assert_not_called()
+    assert read.get.await_count == 2  # recovered within the normal retry budget


### PR DESCRIPTION
## Why

Root cause of the **2026-06-16 core-api pool-starvation SEV-2** on eToro on-prem (~2h recall/write stall). `CoreStorageClient` holds a process-wide httpx pool to core-storage (`max_connections=200`, `pool=5s`). When an in-flight call was cancelled mid-request — the 35s enrichment `wait_for` or the 45s request timeout — httpcore (1.0.9, current) did **not** return the connection to the pool. Leaked slots accumulated over ~4.5 days of uninterrupted uptime until every acquire hit `PoolTimeout`; the singleton never self-healed → **restart-only recovery**.

Forensics (incident addendum): there was **no acute trigger** that morning — the prior day had *more* slow upstream calls and *more* timeouts yet survived; the leak simply crossed the 200-slot ceiling at 07:37. So this recurs on a cadence set by the cancellation rate until the pool defect is fixed — which is what this PR does.

## What

Two layered fixes in `CoreStorageClient`, both routed through a single `_execute()` funnel that all six request helpers (`_get`/`_get_list`/`_post`/`_post_optional`/`_patch`/`_delete`) **and** the two direct call sites (`list_keystones`, `claim_idempotency`) now use:

- **Fix B — prevention (`_cancel_safe`)**: shields the in-flight request via `asyncio.shield` so a cancelled caller still lets the request finish and release its slot. The caller observes `CancelledError` immediately; the orphaned result is consumed so it isn't logged as never-retrieved. Bounded by the existing 120s read timeout, so worst case it self-releases instead of leaking forever.
- **Fix A — recovery (`_recycle_pools`)**: on a `PoolTimeout` that survives the retry policy (i.e. genuine exhaustion), rebuild the pool **once** under a lock with a generation guard (concurrent `PoolTimeout`s collapse to one rebuild), background-close the old pool, and retry on the fresh one. Converts a restart-only outage into a **seconds-long self-heal** and emits an `ERROR` log (also closes the observability gap from the incident).

Helpers read `self._http`/`self._read_http` **lazily** so a recycle is picked up on retry. No behavioural change on the happy path or to existing retry semantics.

## Tests

New `tests/test_storage_client_pool_recovery.py`:
- cancellation mid-request lets the shielded call complete (no leak)
- POST + GET recycle the pool on exhaustion, then succeed on the fresh pool
- a transient `PoolTimeout` ridden out by retries does **not** recycle (no churn)

The existing F5 / 2026-06-11 retry suite (`test_storage_client_retry.py`, 19 tests) passes unchanged — the `_execute` refactor preserves all retry behaviour. `ruff check`, `ruff format --check`, and `mypy` are clean.

## Tradeoff

A write cancelled by the 45s budget now completes in the background rather than being abandoned — benign, because writes are idempotency-keyed (`client_request_id`) and reads are side-effect-free.

## Rollout

- Targets `caura-memclaw`; rides the next on-prem release. **Do not merge without staging on erni-onprem first** per the 5-phase upgrade protocol, then eToro.
- Rename `CAURA-000` to the real ticket before merge.
- Out of scope (separate, fill-rate-only PRs): the `cluster_id` ValidationError fix and 429-aware backoff — they reduce how fast the pool fills, not the leak itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)