### PR TITLE
fix(core-api): harden business/personal pre-gate (timeout, audit truth, fail-closed, audit durability)

### DIFF
--- a/common/llm/constants.py
+++ b/common/llm/constants.py
@@ -83,6 +83,20 @@ def _read_float_env(name: str, default: float | None) -> float | None:
 OPENAI_REQUEST_TIMEOUT_SECONDS = _read_float_env("OPENAI_REQUEST_TIMEOUT_SECONDS", 25.0)
 
 
+# Hard ceiling on the *whole* business/personal pre-gate classification —
+# across retries and any provider fallback — enforced by the classifier itself
+# (``classify_business_personal`` wraps the call in ``asyncio.wait_for``). The
+# pre-gate is a fast, fail-open go/no-go that runs inline on the write path
+# BEFORE the row is written, so a slow or unreachable provider must never stall
+# a write: exceeding this ceiling fails open (the post-enrichment gate remains
+# the backstop). Deliberately aggressive — much tighter than the per-call SDK
+# read timeout above — because the cost of a too-low value is only a missed
+# early-reject, never a blocked write. Env-tunable per deployment.
+PREGATE_CLASSIFIER_TIMEOUT_SECONDS = _read_float_env(
+    "PREGATE_CLASSIFIER_TIMEOUT_SECONDS", 5.0
+)
+
+
 # ── httpx pool sizing for OpenAI-compatible providers ────────────────
 #
 # CAURA-627: the SDK rides httpx's default (100 max_connections / 20

--- a/core-api/src/core_api/pipeline/steps/write/business_personal_pregate.py
+++ b/core-api/src/core_api/pipeline/steps/write/business_personal_pregate.py
@@ -15,6 +15,8 @@ a classifier failure or a ``none`` provider never blocks a write.
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import HTTPException
 
 from core_api.pipeline.context import PipelineContext
@@ -22,9 +24,12 @@ from core_api.pipeline.step import StepOutcome, StepResult
 from core_api.services.business_classifier import classify_business_personal
 from core_api.services.governance_gate import (
     ACTION_NB_PREGATE_DROP,
+    ACTION_NB_PREGATE_UNAVAILABLE,
     emit_governance_audit,
     nonbusiness_pregate_audit_detail,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class BusinessPersonalPregate:
@@ -50,6 +55,50 @@ class BusinessPersonalPregate:
         provider = pregate.provider or cfg.enrichment_provider
         result = await classify_business_personal(data.content, cfg, provider=provider, model=pregate.model)
 
+        # No live model evaluated this write (``provider is None`` ⇔ the
+        # fail-open path: ``none`` provider, timeout, or classifier error), so a
+        # "drop" policy isn't actually being enforced on it. Act per the
+        # tenant's fail-open (default) vs fail-closed choice.
+        if result.provider is None:
+            if pregate.fail_closed:
+                # Fail-closed: reject rather than store unclassified content.
+                logger.warning(
+                    "business_personal_pregate: classifier unavailable while a non-business "
+                    "'drop' policy is active — REJECTING write (fail_closed) (tenant=%s, provider=%s)",
+                    data.tenant_id,
+                    provider,
+                )
+                await emit_governance_audit(
+                    ctx.db,
+                    tenant_id=data.tenant_id,
+                    agent_id=data.agent_id,
+                    action=ACTION_NB_PREGATE_UNAVAILABLE,
+                    detail=nonbusiness_pregate_audit_detail(
+                        ACTION_NB_PREGATE_UNAVAILABLE,
+                        data.content,
+                        write_mode,
+                        provider=provider,
+                        model=pregate.model,
+                        confidence=None,
+                    ),
+                    critical=True,
+                )
+                raise HTTPException(
+                    status_code=503,
+                    detail="Content policy classifier unavailable; write rejected (fail-closed)",
+                )
+            # Fail-open (default): store the write but surface the silent bypass
+            # so a compliance tenant can detect it (the post-enrichment gate is
+            # the backstop).
+            logger.warning(
+                "business_personal_pregate: classifier unavailable (fail-open) while a "
+                "non-business 'drop' policy is active — content stored WITHOUT pre-gate "
+                "enforcement (tenant=%s, provider=%s)",
+                data.tenant_id,
+                provider,
+            )
+            return None
+
         # Fail-open: only a confident "personal" verdict blocks. min_confidence
         # None → 0.0 → act on any "personal" (matches the post-enrichment gate).
         threshold = pregate.min_confidence or 0.0
@@ -63,10 +112,15 @@ class BusinessPersonalPregate:
                     ACTION_NB_PREGATE_DROP,
                     data.content,
                     write_mode,
-                    provider=provider,
-                    model=pregate.model,
+                    # The provider/model that ACTUALLY classified (may be the
+                    # fallback) — not the intended ones — so audit is truthful.
+                    provider=result.provider,
+                    model=result.model,
                     confidence=result.confidence,
                 ),
+                # Reject path: the write is refused, so its audit must not be
+                # lost to queue overflow — sync-fallback rather than drop.
+                critical=True,
             )
             raise HTTPException(
                 status_code=422,

--- a/core-api/src/core_api/pipeline/steps/write/governance_decision.py
+++ b/core-api/src/core_api/pipeline/steps/write/governance_decision.py
@@ -71,6 +71,9 @@ class GovernanceDecision:
                     agent_id=data.agent_id,
                     action=ACTION_PII_DROP,
                     detail=llm_pii_audit_detail(ACTION_PII_DROP, enr.pii_types, data.content, write_mode),
+                    # Reject path: audit must survive queue overflow (the write
+                    # is refused, so a dropped audit would erase the only record).
+                    critical=True,
                 )
                 raise HTTPException(
                     status_code=422,
@@ -106,6 +109,8 @@ class GovernanceDecision:
                     agent_id=data.agent_id,
                     action=ACTION_NB_DROP,
                     detail=nonbusiness_audit_detail(ACTION_NB_DROP, data.content, write_mode),
+                    # Reject path: audit must survive queue overflow (see above).
+                    critical=True,
                 )
                 raise HTTPException(
                     status_code=422,

--- a/core-api/src/core_api/pipeline/steps/write/governance_scan_content.py
+++ b/core-api/src/core_api/pipeline/steps/write/governance_scan_content.py
@@ -60,6 +60,9 @@ class GovernanceScanContent:
                 agent_id=data.agent_id,
                 action=ACTION_PII_DROP,
                 detail=pii_audit_detail(ACTION_PII_DROP, findings, data.content, write_mode),
+                # Reject path: the write is refused, so this audit is the only
+                # record — must survive queue overflow (sync-fallback, not drop).
+                critical=True,
             )
             raise HTTPException(
                 status_code=422,

--- a/core-api/src/core_api/services/audit_queue.py
+++ b/core-api/src/core_api/services/audit_queue.py
@@ -101,8 +101,21 @@ class AuditEventQueue:
     def queue_size(self) -> int:
         return self._queue.qsize()
 
-    def enqueue(self, event: dict) -> None:
+    def enqueue(self, event: dict, *, silent: bool = False) -> bool:
         """Non-blocking enqueue. Drops + warns when the queue is full.
+
+        Returns ``True`` when the event was queued, ``False`` when the
+        queue was full and the event dropped. Fire-and-forget callers ignore
+        the return — the prior ``None`` was already falsy, so existing call
+        sites are unaffected. A compliance-critical caller inspects it to fall
+        back to a synchronous write for an event that must not be lost (see
+        ``log_action(critical=True)``).
+
+        ``silent``: when True, a full-queue rejection returns ``False``
+        without incrementing the drop counter or logging — for a caller that
+        recovers the event itself (e.g. ``log_action(critical=True)``, which
+        falls back to a synchronous write), so a recovered event isn't
+        miscounted as a loss.
 
         Synchronous (no ``await``) so callers in fire-and-forget paths
         don't pay an extra event-loop hop. ``Queue.put_nowait`` returns
@@ -114,6 +127,10 @@ class AuditEventQueue:
         try:
             self._queue.put_nowait(event)
         except asyncio.QueueFull:
+            if silent:
+                # Caller will recover this event synchronously — not a real
+                # drop, so leave the metric and the warning untouched.
+                return False
             self._dropped_count += 1
             # Log every 100th drop so a sustained overload produces a
             # finite, informative log volume rather than one line per
@@ -126,11 +143,12 @@ class AuditEventQueue:
                     self._dropped_count,
                     self._max_queue_size,
                 )
-            return
+            return False
         # Wake the flusher early when we reach the batch threshold so a
         # storm doesn't have to wait for the interval timer.
         if self._queue.qsize() >= self._flush_threshold:
             self._wake_event.set()
+        return True
 
     async def start(self) -> None:
         """Idempotent: a second call is a no-op."""

--- a/core-api/src/core_api/services/audit_service.py
+++ b/core-api/src/core_api/services/audit_service.py
@@ -21,12 +21,23 @@ without a redeploy.
 
 from __future__ import annotations
 
+import logging
 from uuid import UUID, uuid4
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core_api.clients.storage_client import get_storage_client
 from core_api.services.audit_queue import get_audit_queue
+
+logger = logging.getLogger(__name__)
+
+
+async def _post_audit_sync(payload: dict) -> None:
+    """Synchronous fallback write to core-storage-api (same shape as
+    pre-CAURA-628). Used both when the async queue is inactive and as the
+    ``critical`` overflow fallback, so a compliance event isn't dropped."""
+    sc = get_storage_client()
+    await sc.create_audit_log(payload)
 
 
 async def log_action(
@@ -38,6 +49,7 @@ async def log_action(
     resource_type: str,
     resource_id: UUID | str | None = None,
     detail: dict | None = None,
+    critical: bool = False,
 ) -> None:
     """Record an audit event. Async-batched via queue when available;
     falls through to a synchronous POST otherwise.
@@ -48,6 +60,13 @@ async def log_action(
     arg is a separate, scoped change. ``None`` is accepted for
     fire-and-forget callers with no ambient session (the post-enrichment
     governance remediation in the ENRICHED consumer).
+
+    ``critical`` marks a compliance-critical event (e.g. a governance
+    enforcement *rejection*) that must not be silently dropped under
+    queue overflow: when the queue is full, it falls back to a
+    synchronous storage POST instead of dropping. Non-critical events
+    keep the fire-and-forget enqueue (drop-with-counter on overflow), so
+    the high-volume hot path is unaffected.
     """
     payload = {
         "tenant_id": tenant_id,
@@ -66,13 +85,35 @@ async def log_action(
     if queue is not None:
         # Non-blocking enqueue. Overflow is mapped to a structured
         # warning + drop counter inside the queue — the request hot
-        # path stays fast even when storage-api is degraded.
-        queue.enqueue(payload)
+        # path stays fast even when storage-api is degraded. For a
+        # ``critical`` event pass ``silent=True``: we recover it via the
+        # sync write below on overflow, so the queue must NOT count it as a
+        # drop or log it as lost (it isn't).
+        enqueued = queue.enqueue(payload, silent=critical)
+        if enqueued or not critical:
+            return
+        # Critical event rejected by a full queue: sync POST so the decision
+        # isn't dropped. If that ALSO fails (queue saturated AND storage down),
+        # log loudly but do NOT propagate — a critical audit precedes an
+        # enforcement action (a 4xx reject or a soft-delete), and a failing
+        # audit must not block it (else the row the policy means to drop stays).
+        logger.warning("audit queue full; writing critical %r event synchronously", action)
+        try:
+            await _post_audit_sync(payload)
+        except Exception:
+            logger.exception(
+                "audit queue full AND sync fallback failed; critical %r event LOST "
+                "(storage degraded?) — proceeding so enforcement isn't blocked",
+                action,
+            )
         return
 
-    # Fallback: synchronous POST. Same shape as pre-CAURA-628.
-    sc = get_storage_client()
-    await sc.create_audit_log(payload)
+    # Queue inactive (early startup / tests / kill-switch): synchronous POST.
+    # This is the PRIMARY write for ALL events in this mode (not just critical),
+    # so it must RAISE on failure — do NOT swallow like the critical-overflow
+    # fallback above, or an operator's deliberate fallback-to-legacy would
+    # become a silent audit blackout.
+    await _post_audit_sync(payload)
 
 
 async def log_cross_tenant_read(

--- a/core-api/src/core_api/services/business_classifier.py
+++ b/core-api/src/core_api/services/business_classifier.py
@@ -15,12 +15,17 @@ remains the backstop.)
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import time
 from dataclasses import dataclass
 
+from common.llm.constants import PREGATE_CLASSIFIER_TIMEOUT_SECONDS
 from common.llm.protocols import LLMProvider
 from common.llm.retry import call_with_fallback
 from common.provider_names import ProviderName
+
+logger = logging.getLogger(__name__)
 
 # Kept deliberately short and structured: one classification, low token cost.
 _PROMPT = """Classify whether the following content is BUSINESS-relevant or PERSONAL.
@@ -41,6 +46,13 @@ class BusinessClassification:
     business_relevance: str  # "business" | "personal"
     confidence: float  # 0.0 to 1.0
     llm_ms: int  # 0 when no live model ran (fail-open)
+    # The provider/model that ACTUALLY produced this verdict, captured from the
+    # live ``LLMProvider`` instance. ``call_with_fallback`` may run the primary
+    # OR the tenant's fallback, so recording the intended provider/model would
+    # mis-attribute the decision in the audit log when a fallback hop occurred.
+    # ``None`` on the fail-open paths (no live model ran).
+    provider: str | None = None
+    model: str | None = None
 
 
 def _fail_open() -> BusinessClassification:
@@ -84,14 +96,42 @@ async def classify_business_personal(
         except (TypeError, ValueError):
             conf = 0.0
         return BusinessClassification(
-            business_relevance=rel, confidence=min(1.0, max(0.0, conf)), llm_ms=llm_ms
+            business_relevance=rel,
+            confidence=min(1.0, max(0.0, conf)),
+            llm_ms=llm_ms,
+            # The provider actually used (primary or fallback) — see the field docs.
+            provider=llm.provider_name,
+            model=llm.model,
         )
 
-    return await call_with_fallback(
-        primary_provider_name=provider_name,
-        call_fn=_do,
-        fake_fn=_fail_open,
-        tenant_config=tenant_config,
-        service_label="business_pregate",
-        model_override=model,
-    )
+    # Hard ceiling across the whole chain (retries + fallback). The pre-gate is
+    # fail-open and inline on the write path, so a slow/unreachable provider must
+    # never stall a write: on timeout we fail open and surface an alertable
+    # signal (a sustained outage silently disables the gate otherwise).
+    # ``call_with_fallback``'s own ``timeout=`` is applied PER ATTEMPT, so it
+    # can't bound the whole chain (N retries per provider) — hence the outer
+    # ``wait_for``. Don't "simplify" this to the param: the semantics differ.
+    try:
+        return await asyncio.wait_for(
+            call_with_fallback(
+                primary_provider_name=provider_name,
+                call_fn=_do,
+                fake_fn=_fail_open,
+                tenant_config=tenant_config,
+                service_label="business_pregate",
+                model_override=model,
+            ),
+            timeout=PREGATE_CLASSIFIER_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        # asyncio.wait_for raises asyncio.TimeoutError, which IS the builtin
+        # TimeoutError on 3.11+ (this project is 3.12+) — and ruff UP041 enforces
+        # the builtin spelling, so don't "fix" this to asyncio.TimeoutError. Fail
+        # open on it so a slow/unreachable provider never escapes as a 500.
+        logger.warning(
+            "business_pregate: classifier timed out after %ss; failing open (provider=%s, model=%s)",
+            PREGATE_CLASSIFIER_TIMEOUT_SECONDS,
+            provider_name,
+            model,
+        )
+        return _fail_open()

--- a/core-api/src/core_api/services/governance_gate.py
+++ b/core-api/src/core_api/services/governance_gate.py
@@ -27,6 +27,11 @@ ACTION_NB_KEEP_PRIVATE = "nonbusiness_keep_private"
 # soft-deletes an already-stored row) — the verb must describe what physically
 # happened, and here nothing was ever written.
 ACTION_NB_PREGATE_DROP = "nonbusiness_pregate_drop"
+# Pre-gate could not classify (provider ``none`` / timeout / error) while a
+# "drop" policy was active AND the tenant opted into fail-closed, so the write
+# was rejected (503) rather than stored unclassified. Distinct from a drop
+# (nothing was classified) — records the unavailability-turned-rejection.
+ACTION_NB_PREGATE_UNAVAILABLE = "nonbusiness_pregate_unavailable"
 
 
 def _content_sha256(content: str) -> str:
@@ -116,11 +121,20 @@ async def emit_governance_audit(
     action: str,
     detail: dict,
     resource_id: str | None = None,
+    critical: bool = False,
 ) -> None:
     """Record a governance enforcement action to the tamper-evident audit log.
 
-    Always emits (compliance) via ``log_action`` directly rather than the
-    optional audit hook, so governance events can't be silently disabled.
+    Emits via ``log_action`` directly (not the optional audit hook), so a
+    governance event can't be silently disabled by hook configuration.
+
+    ``critical`` is for enforcement decisions whose audit must not be lost even
+    when the async audit queue is saturated: the rare *reject* paths (a write
+    was refused with 4xx/5xx) pass ``critical=True`` so ``log_action`` falls
+    back to a synchronous storage write on queue overflow instead of dropping
+    the event. Higher-volume non-reject signals (flag / keep-private) stay
+    best-effort and ride the queue's normal back-pressure (drop-with-counter
+    under sustained overload) — the request hot path is never blocked for them.
     """
     await log_action(
         db,
@@ -130,4 +144,5 @@ async def emit_governance_audit(
         resource_type="memory",
         resource_id=resource_id,
         detail=detail,
+        critical=critical,
     )

--- a/core-api/src/core_api/services/governance_remediation.py
+++ b/core-api/src/core_api/services/governance_remediation.py
@@ -73,6 +73,9 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> bool:
                 action=ACTION_PII_DROP,
                 detail=llm_pii_audit_detail(ACTION_PII_DROP, pii_types, content, "fast"),
                 resource_id=memory_id,
+                # Destructive: the soft-delete below removes the row, so this
+                # audit is the only trace — must survive queue overflow.
+                critical=True,
             )
             await sc.soft_delete_memory(memory_id)
             logger.info("governance: dropped fast-mode memory %s (pii)", memory_id)
@@ -108,6 +111,8 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> bool:
                 action=ACTION_NB_DROP,
                 detail=nonbusiness_audit_detail(ACTION_NB_DROP, content, "fast"),
                 resource_id=memory_id,
+                # Destructive: see the PII-drop branch — audit is the only trace.
+                critical=True,
             )
             await sc.soft_delete_memory(memory_id)
             logger.info("governance: dropped fast-mode memory %s (non-business)", memory_id)

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -1075,6 +1075,9 @@ async def create_memories_bulk(
                     agent_id=data.agent_id,
                     action=ACTION_PII_DROP,
                     detail=pii_audit_detail(ACTION_PII_DROP, findings, item.content, "bulk"),
+                    # Reject path: the item is refused, so this audit is the only
+                    # record — must survive queue overflow (sync-fallback).
+                    critical=True,
                 )
                 governance_errors[i] = "rejected by content policy: sensitive data detected"
             elif gov_pii.action == "mask":

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -278,14 +278,24 @@ DEFAULT_SETTINGS: dict = {
             # default like every other security control. Its own provider/model
             # so the signal is independent of the enrichment provider (survives
             # ``enrichment_provider=none``, e.g. CI). ``min_confidence`` None →
-            # act on any "personal" verdict (matches the post-enrichment gate);
-            # set it to require higher confidence before dropping (fewer false
-            # rejects). Fail-open: a classifier failure never blocks a write.
+            # act on any "personal" verdict. Raising it makes the pre-gate SKIP
+            # the early drop for low-confidence "personal" verdicts and defer
+            # them to the more accurate post-enrichment gate; it does NOT add a
+            # confidence floor to the final decision (that backstop drops any
+            # "personal" verdict unconditionally — there is no enrichment
+            # confidence to gate on). So it trades a little extra compute for
+            # fewer *early* rejects on borderline content, not a blanket
+            # reduction in drops. ``fail_closed`` False → fail-open: a classifier
+            # failure/timeout never blocks a write (the post-enrichment gate
+            # remains the backstop). Set ``fail_closed`` True so a tenant that
+            # requires enforcement REJECTS writes (503) when the classifier is
+            # unavailable rather than storing unclassified content.
             "pregate": {
                 "enabled": False,
                 "provider": None,
                 "model": None,
                 "min_confidence": None,
+                "fail_closed": False,
             },
         },
     },
@@ -529,6 +539,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "governance.non_business.pregate.provider": str,
     "governance.non_business.pregate.model": str,
     "governance.non_business.pregate.min_confidence": (int, float),
+    "governance.non_business.pregate.fail_closed": bool,
 }
 
 # Inclusive range constraints applied AFTER type validation. Listed
@@ -617,12 +628,17 @@ class _GovNB:
 class _GovNBPregate:
     """Resolved fast pre-gate policy: a business/personal go/no-go before
     enrichment. ``provider``/``model`` None → resolved by the step (falls back to
-    the enrichment provider). ``min_confidence`` None → act on any "personal"."""
+    the enrichment provider). ``min_confidence`` None → act on any "personal"
+    verdict; raising it defers low-confidence verdicts to the post-enrichment
+    backstop rather than dropping them early (it does not floor the final drop).
+    ``fail_closed`` → reject the write (503) when the classifier is unavailable
+    instead of failing open."""
 
     enabled: bool
     provider: str | None
     model: str | None
     min_confidence: float | None
+    fail_closed: bool
 
 
 class ResolvedConfig:
@@ -671,6 +687,7 @@ class ResolvedConfig:
             provider=g.get("provider") or None,
             model=g.get("model") or None,
             min_confidence=g.get("min_confidence"),
+            fail_closed=bool(g.get("fail_closed", False)),
         )
 
     # Enrichment

--- a/tests/test_audit_queue.py
+++ b/tests/test_audit_queue.py
@@ -134,11 +134,54 @@ async def test_overflow_drops_and_increments_counter() -> None:
     assert q.queue_size == 2
     assert q.dropped_count == 0
 
-    q.enqueue({"i": 2})  # full
-    q.enqueue({"i": 3})  # still full
+    assert q.enqueue({"i": 2}) is False  # full → dropped
+    assert q.enqueue({"i": 3}) is False  # still full
 
     assert q.queue_size == 2
     assert q.dropped_count == 2
+
+
+@pytest.mark.asyncio
+async def test_enqueue_returns_true_when_queued() -> None:
+    """enqueue reports success so a compliance-critical caller can tell a
+    queued event from a dropped one (see log_action critical fallback)."""
+
+    async def flush(events: list[dict]) -> None:
+        pass
+
+    q = AuditEventQueue(
+        max_queue_size=2,
+        flush_threshold=1000,
+        flush_interval_seconds=1000.0,
+        flush_callable=flush,
+    )
+    assert q.enqueue({"i": 0}) is True
+    assert q.enqueue({"i": 1}) is True
+    assert q.enqueue({"i": 2}) is False  # now full
+
+
+@pytest.mark.asyncio
+async def test_enqueue_silent_drop_does_not_count_or_warn() -> None:
+    """A ``silent=True`` full-queue rejection returns False but leaves the
+    drop counter untouched — the critical path recovers the event via a sync
+    write, so counting it as dropped would over-count the metric and emit a
+    false 'dropped' warning for an event that was never lost."""
+
+    async def flush(events: list[dict]) -> None:
+        pass
+
+    q = AuditEventQueue(
+        max_queue_size=1,
+        flush_threshold=1000,
+        flush_interval_seconds=1000.0,
+        flush_callable=flush,
+    )
+    assert q.enqueue({"i": 0}) is True
+    # Full now: a silent reject doesn't move the counter; a loud one does.
+    assert q.enqueue({"i": 1}, silent=True) is False
+    assert q.dropped_count == 0
+    assert q.enqueue({"i": 2}) is False
+    assert q.dropped_count == 1
 
 
 @pytest.mark.asyncio
@@ -321,8 +364,13 @@ async def test_log_action_mints_unique_client_event_id() -> None:
     from core_api.services import audit_service
 
     captured: list[dict] = []
+
+    def _capture(payload: dict, *, silent: bool = False) -> bool:
+        captured.append(payload)
+        return True
+
     fake_queue = MagicMock()
-    fake_queue.enqueue = captured.append
+    fake_queue.enqueue = _capture
     with patch.object(audit_service, "get_audit_queue", return_value=fake_queue):
         await audit_service.log_action(
             None, tenant_id="t", action="create", resource_type="memory"
@@ -337,3 +385,104 @@ async def test_log_action_mints_unique_client_event_id() -> None:
     UUID(captured[1]["client_event_id"])
     # ...and distinct per event, so two different mutations never collide.
     assert captured[0]["client_event_id"] != captured[1]["client_event_id"]
+
+
+@pytest.mark.asyncio
+async def test_log_action_critical_falls_back_to_sync_on_full_queue() -> None:
+    """A ``critical`` event whose enqueue is rejected (queue full → enqueue
+    returns False) falls back to a synchronous storage POST instead of being
+    silently dropped. Non-critical events stay fire-and-forget."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from core_api.services import audit_service
+
+    full_queue = MagicMock()
+    full_queue.enqueue = MagicMock(return_value=False)  # always "full"
+    fake_storage = MagicMock()
+    fake_storage.create_audit_log = AsyncMock()
+
+    with (
+        patch.object(audit_service, "get_audit_queue", return_value=full_queue),
+        patch.object(audit_service, "get_storage_client", return_value=fake_storage),
+    ):
+        # Non-critical: dropped on overflow, no synchronous write.
+        await audit_service.log_action(
+            None, tenant_id="t", action="create", resource_type="memory"
+        )
+        fake_storage.create_audit_log.assert_not_called()
+
+        # Critical: falls back to the synchronous storage write.
+        await audit_service.log_action(
+            None,
+            tenant_id="t",
+            action="nonbusiness_pregate_drop",
+            resource_type="memory",
+            critical=True,
+        )
+    fake_storage.create_audit_log.assert_awaited_once()
+    payload = fake_storage.create_audit_log.await_args.args[0]
+    assert payload["action"] == "nonbusiness_pregate_drop"
+    # The non-critical enqueue must NOT be silent (a real drop should count +
+    # warn); the critical one MUST be silent (it's recovered via the sync
+    # write, so it isn't a real drop and shouldn't inflate the metric).
+    silent_flags = [c.kwargs.get("silent", False) for c in full_queue.enqueue.call_args_list]
+    assert silent_flags == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_log_action_critical_uses_queue_when_not_full() -> None:
+    """A ``critical`` event that the queue accepts (enqueue returns True) does
+    NOT pay the synchronous fallback — the hot path stays fast."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from core_api.services import audit_service
+
+    ok_queue = MagicMock()
+    ok_queue.enqueue = MagicMock(return_value=True)
+    fake_storage = MagicMock()
+    fake_storage.create_audit_log = AsyncMock()
+
+    with (
+        patch.object(audit_service, "get_audit_queue", return_value=ok_queue),
+        patch.object(audit_service, "get_storage_client", return_value=fake_storage),
+    ):
+        await audit_service.log_action(
+            None,
+            tenant_id="t",
+            action="nonbusiness_pregate_drop",
+            resource_type="memory",
+            critical=True,
+        )
+    ok_queue.enqueue.assert_called_once()
+    fake_storage.create_audit_log.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_log_action_critical_sync_failure_does_not_propagate() -> None:
+    """If the critical sync fallback ALSO fails (queue full AND storage down),
+    log_action logs loudly but does NOT raise. A critical audit is emitted
+    right before a governance enforcement action (a 4xx reject or a
+    soft-delete); a failing audit write must not block that action — otherwise
+    the row the policy means to drop would be left in place."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from core_api.services import audit_service
+
+    full_queue = MagicMock()
+    full_queue.enqueue = MagicMock(return_value=False)  # queue full
+    fake_storage = MagicMock()
+    fake_storage.create_audit_log = AsyncMock(side_effect=RuntimeError("storage down"))
+
+    with (
+        patch.object(audit_service, "get_audit_queue", return_value=full_queue),
+        patch.object(audit_service, "get_storage_client", return_value=fake_storage),
+    ):
+        # Must NOT raise despite both the queue and the sync write failing.
+        await audit_service.log_action(
+            None,
+            tenant_id="t",
+            action="nonbusiness_pregate_drop",
+            resource_type="memory",
+            critical=True,
+        )
+    fake_storage.create_audit_log.assert_awaited_once()

--- a/tests/test_business_personal_pregate.py
+++ b/tests/test_business_personal_pregate.py
@@ -11,6 +11,7 @@ Layers, all deterministic (no HTTP/settings round-trip):
   * Pipeline wiring: the step is composed into strong + fast at the right spot.
 """
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -22,6 +23,7 @@ from core_api.pipeline.steps.write import business_personal_pregate as pregate_m
 from core_api.pipeline.steps.write.business_personal_pregate import (
     BusinessPersonalPregate,
 )
+from core_api.services import business_classifier as bc_mod
 from core_api.services.business_classifier import (
     BusinessClassification,
     classify_business_personal,
@@ -75,14 +77,31 @@ def _ctx(data, *, cfg, mode="strong") -> PipelineContext:
     )
 
 
-def _patch_classifier(monkeypatch, *, relevance="personal", confidence=0.95):
-    """Replace the step's classifier with a canned result; capture call kwargs."""
+def _patch_classifier(
+    monkeypatch,
+    *,
+    relevance="personal",
+    confidence=0.95,
+    llm_ms=3,
+    result_provider="openai",
+    result_model="gpt-5.4-nano",
+):
+    """Replace the step's classifier with a canned result; capture call kwargs.
+
+    ``provider``/``model`` here are the verdict's ACTUAL provider/model (what the
+    classifier reports it used, possibly a fallback) — distinct from the intended
+    provider/model the step passes in, which we capture. ``llm_ms=0`` simulates a
+    fail-open verdict (no live model ran)."""
     captured: dict = {}
 
     async def _fake(content, tenant_config=None, *, provider, model):
         captured.update(content=content, provider=provider, model=model)
         return BusinessClassification(
-            business_relevance=relevance, confidence=confidence, llm_ms=3
+            business_relevance=relevance,
+            confidence=confidence,
+            llm_ms=llm_ms,
+            provider=result_provider,
+            model=result_model,
         )
 
     monkeypatch.setattr(pregate_mod, "classify_business_personal", _fake)
@@ -139,6 +158,35 @@ async def test_pregate_personal_drop_raises_422(monkeypatch, emitted):
     drop = next(c for c in emitted if c["action"] == "nonbusiness_pregate_drop")
     assert drop["detail"]["source"] == "llm_pregate"
     assert drop["detail"]["confidence"] == 0.9
+    # Reject path → the audit must survive queue overflow (sync fallback).
+    assert drop["critical"] is True
+
+
+async def test_pregate_drop_audit_records_actual_provider_under_fallback(
+    monkeypatch, emitted
+):
+    # Intended provider is "openai", but the verdict actually came from the
+    # tenant's fallback ("gemini"/"gemini-2.0-flash"). The audit must name the
+    # provider/model that ACTUALLY decided, not the intended one (audit truth).
+    _patch_classifier(
+        monkeypatch,
+        relevance="personal",
+        confidence=0.9,
+        result_provider="gemini",
+        result_model="gemini-2.0-flash",
+    )
+    cfg = _cfg(
+        nb={
+            "enabled": True,
+            "disposition": "drop",
+            "pregate": {"enabled": True, "provider": "openai", "model": "gpt-5.4-nano"},
+        }
+    )
+    with pytest.raises(HTTPException):
+        await BusinessPersonalPregate().execute(_ctx(_data("my vacation"), cfg=cfg))
+    drop = next(c for c in emitted if c["action"] == "nonbusiness_pregate_drop")
+    assert drop["detail"]["provider"] == "gemini"
+    assert drop["detail"]["model"] == "gemini-2.0-flash"
 
 
 async def test_pregate_business_flows_through(monkeypatch, emitted):
@@ -208,6 +256,86 @@ async def test_classifier_none_provider_fail_open():
     )
     assert res.business_relevance == "business"
     assert res.llm_ms == 0
+    # No live model ran → no provider/model attribution.
+    assert res.provider is None and res.model is None
+
+
+async def test_classifier_times_out_fails_open(monkeypatch):
+    # A slow/unreachable provider must never stall a write: the hard ceiling
+    # cancels the chain and the classifier fails open (business, llm_ms=0).
+    monkeypatch.setattr(bc_mod, "PREGATE_CLASSIFIER_TIMEOUT_SECONDS", 0.01)
+
+    async def _slow(**kwargs):
+        await asyncio.sleep(1.0)
+        raise AssertionError("should have been cancelled by the timeout")
+
+    monkeypatch.setattr(bc_mod, "call_with_fallback", _slow)
+    res = await classify_business_personal(
+        "anything", None, provider="openai", model=None
+    )
+    assert res.business_relevance == "business"
+    assert res.llm_ms == 0
+
+
+async def test_pregate_failopen_stores_without_enforcement_by_default(
+    monkeypatch, emitted, caplog
+):
+    # Classifier unavailable (fail-open: provider/model unset) + fail_closed
+    # default False → the write proceeds (no exception, no drop audit), but an
+    # alertable warning surfaces the silent enforcement bypass.
+    _patch_classifier(
+        monkeypatch,
+        relevance="business",
+        confidence=0.0,
+        llm_ms=0,
+        result_provider=None,
+        result_model=None,
+    )
+    cfg = _cfg(
+        nb={
+            "enabled": True,
+            "disposition": "drop",
+            "pregate": {"enabled": True, "provider": "none"},
+        }
+    )
+    with caplog.at_level("WARNING"):
+        res = await BusinessPersonalPregate().execute(_ctx(_data(), cfg=cfg))
+    assert res is None
+    assert emitted == []  # fail-open: nothing dropped, nothing audited
+    assert any("WITHOUT pre-gate enforcement" in r.message for r in caplog.records)
+
+
+async def test_pregate_failclosed_rejects_when_classifier_unavailable(
+    monkeypatch, emitted, caplog
+):
+    # Same unavailable classifier, but fail_closed=True → reject the write (503)
+    # rather than store unclassified content, with a distinct critical audit.
+    _patch_classifier(
+        monkeypatch,
+        relevance="business",
+        confidence=0.0,
+        llm_ms=0,
+        result_provider=None,
+        result_model=None,
+    )
+    cfg = _cfg(
+        nb={
+            "enabled": True,
+            "disposition": "drop",
+            "pregate": {"enabled": True, "provider": "none", "fail_closed": True},
+        }
+    )
+    with caplog.at_level("WARNING"), pytest.raises(HTTPException) as exc:
+        await BusinessPersonalPregate().execute(_ctx(_data(), cfg=cfg))
+    assert exc.value.status_code == 503
+    unavail = next(
+        c for c in emitted if c["action"] == "nonbusiness_pregate_unavailable"
+    )
+    assert unavail["detail"]["source"] == "llm_pregate"
+    assert unavail["critical"] is True
+    # The log must reflect the rejection, not claim the content was stored.
+    assert any("REJECTING write" in r.message for r in caplog.records)
+    assert not any("content stored WITHOUT" in r.message for r in caplog.records)
 
 
 async def test_classifier_prompt_preserves_braces():
@@ -229,6 +357,7 @@ async def test_pregate_default_off():
     pg = ResolvedConfig({}).governance_non_business_pregate
     assert pg.enabled is False
     assert pg.provider is None and pg.model is None and pg.min_confidence is None
+    assert pg.fail_closed is False  # opt-in: default fail-open
 
 
 async def test_pregate_settings_resolve():
@@ -241,6 +370,7 @@ async def test_pregate_settings_resolve():
                         "provider": "openai",
                         "model": "gpt-5.4-nano",
                         "min_confidence": 0.7,
+                        "fail_closed": True,
                     }
                 }
             }
@@ -251,6 +381,7 @@ async def test_pregate_settings_resolve():
         and pg.provider == "openai"
         and pg.model == "gpt-5.4-nano"
         and pg.min_confidence == 0.7
+        and pg.fail_closed is True
     )
 
 


### PR DESCRIPTION
Hardens the opt-in business/personal pre-gate ([#403](https://github.com/caura-ai/caura-memclaw/pull/403)) against five findings. **Opt-in throughout — no behavior change for tenants that haven't enabled it; `fail_closed` defaults to false (current fail-open preserved).**

## Findings addressed

| # | Finding | Fix |
|---|---------|-----|
| **1** | Classifier ran inline on the write path with **no whole-chain timeout** — a slow/unreachable provider could stall a write ~100s (retries × fallback). | Hard ceiling `PREGATE_CLASSIFIER_TIMEOUT_SECONDS` (env-tunable, default **5s**) via `asyncio.wait_for`; on timeout fail-open + alertable warning. `call_with_fallback`'s `timeout=` is per-attempt, so it can't bound the chain — hence the outer wrap. |
| **2** | `min_confidence` does **not** reduce false rejects as documented — the post-enrichment backstop drops any `"personal"` verdict unconditionally (no enrichment confidence exists to gate on). | Doc-only: corrected the settings comment + `_GovNBPregate` docstring to describe the real behavior (gates the *early* drop only; defers borderline content to the accurate backstop). |
| **3** | Under provider fallback the audit recorded the **intended** provider/model, not the one that actually classified. | Capture the live `provider`/`model` on `BusinessClassification` (from the `LLMProvider` instance) and audit those. |
| **4** | A `drop` tenant whose classifier is unavailable **silently stored** unclassified content. | Detect it (`result.provider is None`) + alertable warning; add opt-in `pregate.fail_closed` (default false) that rejects the write (**503** + `nonbusiness_pregate_unavailable` audit) instead of storing unclassified content. |
| **5** | Governance enforcement audits could be **dropped under audit-queue overflow** while the write was still refused — contradicting `emit_governance_audit`'s "can't be silently disabled" promise. | `log_action(critical=True)`: on overflow, critical events fall back to a synchronous storage write instead of dropping; `enqueue()` now reports whether it queued. Applied to **every** reject/destructive-enforcement audit (pregate drop + unavailable, deterministic + LLM PII drop, non-business drop, fast-mode remediation soft-deletes, bulk drop). Flag/mask/keep-private stay best-effort. |

## Decisions
- **Finding 2** is doc-only because the enrichment signal carries no confidence (`business_relevance: str` in `common/enrichment/schema.py`), so wiring a confidence floor into the backstop would need a broad enrichment-schema change affecting all tenants.
- **Finding 4** `fail_closed` setting lives in OSS `organization_settings` `DEFAULT_SETTINGS` (no split). Enterprise "Content Policy" UI toggle is a follow-up in the enterprise repo.
- **Finding 5** `critical` is scoped to reject/destructive paths (audit is the only record); high-volume flag/keep-private paths keep the fire-and-forget queue, so the hot path is unaffected.

## Verification
- New/updated tests: `tests/test_business_personal_pregate.py` (timeout→fail-open, fallback audit attribution, fail-open observability default, `fail_closed` 503) and `tests/test_audit_queue.py` (`enqueue` bool contract, critical sync-fallback on overflow). All green.
- `ruff check` + `ruff format --check` clean (core-api/src, core-storage-api/src); `mypy` clean on **both** core-api and core-storage-api.
- The DB-backed `test_governance_e2e.py` / `test_audit_chain.py` integration suites fail identically on clean `main` in this sandbox (no database) — they'll exercise these changes under CI's DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)