### PR TITLE
feat(plugin): additive-mode skill reconcile with ownership marker (PR2)

### DIFF
--- a/docs/mcp-skill-delivery.md
+++ b/docs/mcp-skill-delivery.md
@@ -173,6 +173,29 @@ malformed catalog row was skipped — closing the loop from "approved" to
 tick (even steady-state ticks with empty `added`/`removed`), so a node's
 current live-skill set is always legible.
 
+### Reconcile targets: `owned` vs `additive`
+
+By default the reconciler manages one **`owned`** dir — the plugin's own
+`skills/` — where it has full authority: anything on disk not in the
+catalog is pruned. Operators can add extra target dirs via the
+`MEMCLAW_SKILL_TARGETS` env var (JSON array of `{ dir, mode }`):
+
+- **`owned`** — fully MemClaw-managed (destructive prune). Use only for
+  dirs MemClaw exclusively controls.
+- **`additive`** — a **shared/foreign** dir. MemClaw writes its active
+  skills there but **only ever touches entries it wrote**, tracked by a
+  per-skill `.memclaw-owned` marker file:
+  - a slug already occupied by an *unowned* skill is a **collision** —
+    skipped, never overwritten (reported in `skipped`);
+  - an unowned skill is **never removed**, even on an empty catalog;
+  - only marker-bearing entries are updated/pruned.
+
+This makes the "empty catalog / wrong tenant wipes the dir" hazard apply
+only to `owned` dirs — `additive` dirs lose only MemClaw's own entries,
+never the client's. For an additive target to actually reach agents it
+must be on OpenClaw's skill load path (e.g. registered in
+`settings.skills.customDirectories`).
+
 ## What makes a skill findable: the summary
 
 Scoped `op=search` ranks on the embedded `data.summary`. So the

--- a/docs/mcp-skill-delivery.md
+++ b/docs/mcp-skill-delivery.md
@@ -186,7 +186,8 @@ catalog is pruned. Operators can add extra target dirs via the
   skills there but **only ever touches entries it wrote**, tracked by a
   per-skill `.memclaw-owned` marker file:
   - a slug already occupied by an *unowned* skill is a **collision** —
-    skipped, never overwritten (reported in `skipped`);
+    skipped, never overwritten (reported in the summary's `collisions`
+    list, kept distinct from the catalog-shape `skipped` list);
   - an unowned skill is **never removed**, even on an empty catalog;
   - only marker-bearing entries are updated/pruned.
 

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -556,6 +556,34 @@ describe("reconcileSkills — configured targets", () => {
     assert.ok(summary.collisions.includes("deploy-runbook"), "marker-less dir is a collision");
   });
 
+  test("additive: a FOREIGN dir whose name matches a protected slug is ignored, not reported protected", async () => {
+    // No memclaw in the default owned dir (resetSkillsDir cleared it), so any
+    // "memclaw" in summary.protected could only come from the additive dir.
+    plantForeign("memclaw", "# client's own thing named memclaw\n"); // foreign, no marker
+    useAdditive();
+    mockCatalog = []; // nothing active
+
+    const summary = await reconcileSkills();
+
+    // Ownership gates first: the foreign dir is left untouched AND is not
+    // misreported as a MemClaw-protected skill.
+    assert.equal(readFileSync(ext("memclaw", "SKILL.md"), "utf-8"), "# client's own thing named memclaw\n");
+    assert.ok(!summary.removed.includes("memclaw"), "foreign protected-name dir not removed");
+    assert.ok(!summary.protected.includes("memclaw"), "foreign dir not reported as protected");
+  });
+
+  test("additive: an OWNED dir matching a protected slug survives (reported protected)", async () => {
+    plantOwned("memclaw", "# memclaw we wrote\n"); // owned (marker present)
+    useAdditive();
+    mockCatalog = []; // not in catalog
+
+    const summary = await reconcileSkills();
+
+    assert.ok(existsSync(ext("memclaw", "SKILL.md")), "owned protected dir survives");
+    assert.ok(!summary.removed.includes("memclaw"), "owned protected dir not removed");
+    assert.ok(summary.protected.includes("memclaw"), "owned protected dir reported in protected");
+  });
+
   test("an extra owned target is reconciled alongside the default", async () => {
     plantOnDisk("memclaw");
     process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([{ dir: EXTRA_OWNED, mode: "owned" }]);

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -38,7 +38,7 @@ const originalHome = process.env.HOME;
 const tmpHome = mkdtempSync(join(tmpdir(), "reconcile-skills-test-home-"));
 process.env.HOME = tmpHome;
 
-const { reconcileSkills, PROTECTED_SKILLS, resolveSkillTargets } = await import("./reconcile-skills.js");
+const { reconcileSkills, PROTECTED_SKILLS, resolveSkillTargets, OWNED_MARKER } = await import("./reconcile-skills.js");
 
 const SKILLS_ROOT = join(tmpHome, ".openclaw", "plugins", "memclaw", "skills");
 
@@ -449,28 +449,93 @@ describe("reconcileSkills — configured targets", () => {
     delete process.env.MEMCLAW_SKILL_TARGETS;
   });
 
-  test("additive target is parsed but SKIPPED (not implemented) — foreign dir untouched", async () => {
-    plantOnDisk("memclaw");
-    // a client-owned skill living in the additive target dir
-    mkdirSync(join(EXTERNAL, "client-skill"), { recursive: true });
-    writeFileSync(join(EXTERNAL, "client-skill", "SKILL.md"), "# client owned\n", "utf-8");
+  // Helpers for the additive dir.
+  const ext = (slug: string, ...rest: string[]) => join(EXTERNAL, slug, ...rest);
+  const plantForeign = (slug: string, body = "# client owned\n") => {
+    mkdirSync(ext(slug), { recursive: true });
+    writeFileSync(ext(slug, "SKILL.md"), body, "utf-8");
+  };
+  const plantOwned = (slug: string, body = "# memclaw owned\n") => {
+    mkdirSync(ext(slug), { recursive: true });
+    writeFileSync(ext(slug, "SKILL.md"), body, "utf-8");
+    writeFileSync(ext(slug, OWNED_MARKER), "x", "utf-8");
+  };
+  const useAdditive = () => {
     process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([{ dir: EXTERNAL, mode: "additive" }]);
+  };
+
+  test("additive: writes a catalog skill into the dir, stamps the ownership marker", async () => {
+    plantOnDisk("memclaw");
+    useAdditive();
     mockCatalog = [
       { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# deploy\n" } },
     ];
 
     const summary = await reconcileSkills();
 
-    // Owned dir reconciles normally.
-    assert.ok(listSkillDirs().includes("deploy-runbook"));
-    assert.deepEqual(summary.installed, ["deploy-runbook"]);
-    // The additive dir + its foreign skill are completely untouched: not
-    // pruned, not overwritten, and the catalog skill is NOT written there.
-    assert.equal(
-      readFileSync(join(EXTERNAL, "client-skill", "SKILL.md"), "utf-8"),
-      "# client owned\n",
-    );
-    assert.ok(!existsSync(join(EXTERNAL, "deploy-runbook")));
+    assert.ok(existsSync(ext("deploy-runbook", "SKILL.md")), "skill written");
+    assert.ok(existsSync(ext("deploy-runbook", OWNED_MARKER)), "ownership marker stamped");
+    assert.ok(summary.installed.includes("deploy-runbook"));
+  });
+
+  test("additive: a foreign (unowned) skill not in the catalog is NEVER removed", async () => {
+    plantOnDisk("memclaw");
+    plantForeign("client-skill");
+    useAdditive();
+    mockCatalog = []; // empty catalog — owned dir would prune, additive must not touch foreign
+
+    const summary = await reconcileSkills();
+
+    assert.equal(readFileSync(ext("client-skill", "SKILL.md"), "utf-8"), "# client owned\n");
+    assert.ok(!summary.removed.includes("client-skill"));
+    assert.ok(!existsSync(ext("client-skill", OWNED_MARKER)), "never stamps a foreign skill");
+  });
+
+  test("additive: collision — catalog slug occupied by a foreign skill is skipped, not clobbered", async () => {
+    plantOnDisk("memclaw");
+    plantForeign("deploy-runbook", "# CLIENT version — keep me\n");
+    useAdditive();
+    mockCatalog = [
+      { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# CATALOG deploy\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    // Foreign bytes untouched in the additive dir; catalog version NOT
+    // written over it; collision reported. (The default owned dir still
+    // installs it — that's a different target; per-target detail is PR3.)
+    assert.equal(readFileSync(ext("deploy-runbook", "SKILL.md"), "utf-8"), "# CLIENT version — keep me\n");
+    assert.ok(!existsSync(ext("deploy-runbook", OWNED_MARKER)));
+    assert.ok(summary.skipped.includes("deploy-runbook"), "collision reported in skipped");
+  });
+
+  test("additive: a MemClaw-owned skill dropped from the catalog IS removed", async () => {
+    plantOnDisk("memclaw");
+    plantOwned("old-skill"); // previously written by MemClaw (has marker)
+    plantForeign("client-skill"); // foreign neighbour — must survive
+    useAdditive();
+    mockCatalog = []; // old-skill no longer active
+
+    const summary = await reconcileSkills();
+
+    assert.ok(!existsSync(ext("old-skill")), "owned orphan removed");
+    assert.ok(summary.removed.includes("old-skill"));
+    assert.ok(existsSync(ext("client-skill", "SKILL.md")), "foreign neighbour untouched");
+  });
+
+  test("additive: an owned skill still in the catalog is updated in place", async () => {
+    plantOnDisk("memclaw");
+    plantOwned("deploy-runbook", "# stale owned\n");
+    useAdditive();
+    mockCatalog = [
+      { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# fresh deploy\n" } },
+    ];
+
+    await reconcileSkills();
+
+    const written = readFileSync(ext("deploy-runbook", "SKILL.md"), "utf-8");
+    assert.ok(written.includes("# fresh deploy"), "owned skill overwritten with catalog content");
+    assert.ok(existsSync(ext("deploy-runbook", OWNED_MARKER)), "marker preserved");
   });
 
   test("an extra owned target is reconciled alongside the default", async () => {

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -539,6 +539,23 @@ describe("reconcileSkills — configured targets", () => {
     assert.ok(existsSync(ext("deploy-runbook", OWNED_MARKER)), "marker preserved");
   });
 
+  test("additive: a skill whose marker was deleted is treated as foreign (collision, not clobbered)", async () => {
+    plantOnDisk("memclaw");
+    plantOwned("deploy-runbook", "# was owned, marker now gone\n");
+    rmSync(ext("deploy-runbook", OWNED_MARKER), { force: true }); // marker wiped → no longer recognisable as ours
+    useAdditive();
+    mockCatalog = [
+      { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# catalog version\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    // The marker IS the ownership signal: without it the dir is foreign, so
+    // we refuse to overwrite it and report a collision (fail-safe).
+    assert.equal(readFileSync(ext("deploy-runbook", "SKILL.md"), "utf-8"), "# was owned, marker now gone\n");
+    assert.ok(summary.collisions.includes("deploy-runbook"), "marker-less dir is a collision");
+  });
+
   test("an extra owned target is reconciled alongside the default", async () => {
     plantOnDisk("memclaw");
     process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([{ dir: EXTRA_OWNED, mode: "owned" }]);

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -506,7 +506,8 @@ describe("reconcileSkills — configured targets", () => {
     // installs it — that's a different target; per-target detail is PR3.)
     assert.equal(readFileSync(ext("deploy-runbook", "SKILL.md"), "utf-8"), "# CLIENT version — keep me\n");
     assert.ok(!existsSync(ext("deploy-runbook", OWNED_MARKER)));
-    assert.ok(summary.skipped.includes("deploy-runbook"), "collision reported in skipped");
+    assert.ok(summary.collisions.includes("deploy-runbook"), "collision reported in collisions");
+    assert.ok(!summary.skipped.includes("deploy-runbook"), "collisions are not conflated into skipped");
   });
 
   test("additive: a MemClaw-owned skill dropped from the catalog IS removed", async () => {

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -221,6 +221,30 @@ interface DirReconcileResult {
 }
 
 /**
+ * Read the immediate subdirectory names (candidate skill slugs) of
+ * ``root``. Non-directory entries are skipped so a stray file isn't
+ * treated as a managed slug; a stat failure on one entry is non-fatal.
+ * Returns ``null`` (and logs) if the directory itself can't be read, so
+ * callers bail out rather than acting on an empty set.
+ */
+function readDirSlugs(root: string, caller: string): Set<string> | null {
+  const slugs = new Set<string>();
+  try {
+    for (const name of readdirSync(root)) {
+      try {
+        if (statSync(join(root, name)).isDirectory()) slugs.add(name);
+      } catch {
+        // stat failure on one entry is non-fatal for the rest
+      }
+    }
+  } catch (e: unknown) {
+    logError(`${caller}: failed to read skills directory`, e);
+    return null;
+  }
+  return slugs;
+}
+
+/**
  * Reconcile ONE ``owned`` target dir against the desired catalog set:
  * prune orphans (anything on disk not in ``desired``, except
  * {@link PROTECTED_SKILLS}), then write/update the desired skills.
@@ -243,21 +267,8 @@ function reconcileOwnedDir(
   if (!existsSync(skillsRoot)) {
     mkdirSync(skillsRoot, { recursive: true });
   }
-  const onDisk = new Set<string>();
-  try {
-    for (const name of readdirSync(skillsRoot)) {
-      try {
-        if (statSync(join(skillsRoot, name)).isDirectory()) {
-          onDisk.add(name);
-        }
-      } catch {
-        // stat failure on one entry is non-fatal for the rest
-      }
-    }
-  } catch (e: unknown) {
-    logError("reconcileOwnedDir: failed to read skills directory", e);
-    return result;
-  }
+  const onDisk = readDirSlugs(skillsRoot, "reconcileOwnedDir");
+  if (!onDisk) return result;
 
   // Apply diff. Order: removals first, then writes — so a rename
   // (slug A → slug B) lands cleanly even if the operator does both in
@@ -355,21 +366,8 @@ function reconcileAdditiveDir(
   if (!existsSync(skillsRoot)) {
     mkdirSync(skillsRoot, { recursive: true });
   }
-  const onDisk = new Set<string>();
-  try {
-    for (const name of readdirSync(skillsRoot)) {
-      try {
-        if (statSync(join(skillsRoot, name)).isDirectory()) {
-          onDisk.add(name);
-        }
-      } catch {
-        // stat failure on one entry is non-fatal for the rest
-      }
-    }
-  } catch (e: unknown) {
-    logError("reconcileAdditiveDir: failed to read skills directory", e);
-    return result;
-  }
+  const onDisk = readDirSlugs(skillsRoot, "reconcileAdditiveDir");
+  if (!onDisk) return result;
 
   // Removals first — but ONLY for MemClaw-owned (marker-bearing) orphans.
   // Anything without the marker is foreign and is never touched.
@@ -389,17 +387,30 @@ function reconcileAdditiveDir(
     }
   }
 
+  // Track CONFIRMED on-disk state for ``installed``. Pre-seed with skills
+  // already on disk, MemClaw-owned, AND catalog-active this tick — mirrors
+  // reconcileOwnedDir so a transient read/write I/O failure doesn't drop a
+  // physically-present skill from the installed report. (Unlike the owned
+  // dir we additionally require the ownership marker — a foreign occupant
+  // of a desired slug is never "ours" and is reported as a collision.)
+  const installedSet = new Set<string>(
+    [...onDisk].filter(
+      (s) => desired.has(s) && isMemclawOwned(join(skillsRoot, s)),
+    ),
+  );
+
   // Writes — only into absent or already-owned slots. A foreign occupant
   // of the same slug is a collision: skip it, never clobber.
-  const installedSet = new Set<string>();
   for (const [slug, content] of desired) {
     const skillDir = join(skillsRoot, slug);
-    // Re-check liveness here, not just the start-of-function ``onDisk``
-    // snapshot: a foreign dir created between the readdir and now would
-    // otherwise slip past the collision guard (present=false), get its
-    // SKILL.md clobbered, and be wrongly stamped as MemClaw-owned. The
-    // ``existsSync`` re-stat closes that TOCTOU window.
-    const dirExistsNow = onDisk.has(slug) || existsSync(skillDir);
+    // Re-stat live, not from the start-of-function ``onDisk`` snapshot: a
+    // dir created OR removed between the readdir and now would otherwise be
+    // misclassified (a fresh foreign dir slipping past the collision guard,
+    // or a since-deleted owned dir wrongly read as a foreign collision).
+    // The ``existsSync`` re-stat narrows the TOCTOU window; the
+    // non-recursive ``mkdirSync`` below provides the actual atomic guard
+    // via EEXIST.
+    const dirExistsNow = existsSync(skillDir);
     if (dirExistsNow && !isMemclawOwned(skillDir)) {
       result.collisions.push(slug);
       console.warn(
@@ -421,17 +432,38 @@ function reconcileAdditiveDir(
       }
     }
     try {
-      mkdirSync(skillDir, { recursive: true });
-      // Stamp ownership only on genuinely new dirs; an already-existing
-      // owned dir keeps its marker.
-      if (!dirExistsNow) {
+      // Atomic create-or-detect: a non-recursive mkdir throws EEXIST if the
+      // dir appeared after our existsSync check, closing the TOCTOU window
+      // that a recursive (idempotent) mkdir would leave open.
+      let isNew = false;
+      try {
+        mkdirSync(skillDir);
+        isNew = true;
+      } catch (mkdirErr: unknown) {
+        if ((mkdirErr as NodeJS.ErrnoException).code !== "EEXIST") throw mkdirErr;
+        // Dir raced into existence after our existsSync check — re-verify
+        // ownership before touching it; a foreign winner is a collision.
+        if (!isMemclawOwned(skillDir)) {
+          result.collisions.push(slug);
+          console.warn(
+            `[memclaw] additive: ${slug} collision (post-existsSync race in ${skillsRoot}); skipping`,
+          );
+          continue;
+        }
+      }
+      // Stamp ownership on a genuinely new dir. For an existing dir we only
+      // reach here after the ownership check passed, so the marker should
+      // already be present — but re-stamp defensively if it vanished
+      // between that check and now (a marker IS the ownership signal, and a
+      // dir missing it at guard time is treated as a foreign collision).
+      if (isNew || !existsSync(join(skillDir, OWNED_MARKER))) {
         writeFileSync(join(skillDir, OWNED_MARKER), OWNED_MARKER_BODY, "utf-8");
       }
       writeFileSync(target, content, "utf-8");
       installedSet.add(slug);
       result.added.push(slug);
       console.log(
-        `[memclaw] additive: ${dirExistsNow ? "updated" : "pulled"} skill ${slug} in ${skillsRoot}`,
+        `[memclaw] additive: ${isNew ? "pulled" : "updated"} skill ${slug} in ${skillsRoot}`,
       );
     } catch (e: unknown) {
       logError(`reconcileAdditiveDir: write failed for ${slug}`, e);

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -106,6 +106,12 @@ export interface ReconcileSummary {
   added: string[];
   removed: string[];
   skipped: string[];   // catalog entries with bad shape (no doc_id / no content)
+  // Slugs not written because an unowned dir already occupies the slot in
+  // an ``additive`` target (a foreign skill we refuse to clobber). Distinct
+  // from ``skipped`` so a caller can tell a catalog-shape error apart from a
+  // naming conflict with a client-owned skill. Empty unless an ``additive``
+  // target is configured.
+  collisions: string[];
   protected: string[]; // catalog-absent but not deleted
 }
 
@@ -211,7 +217,7 @@ interface DirReconcileResult {
    * by a foreign (non-MemClaw-owned) entry in an ``additive`` dir. Always
    * empty for ``owned`` dirs (which fully own their contents).
    */
-  skipped: string[];
+  collisions: string[];
 }
 
 /**
@@ -229,7 +235,7 @@ function reconcileOwnedDir(
     removed: [],
     protected: [],
     installed: [],
-    skipped: [],
+    collisions: [],
   };
 
   // Read disk. Skip non-directories so a stray file in the target dir
@@ -343,7 +349,7 @@ function reconcileAdditiveDir(
     removed: [],
     protected: [],
     installed: [],
-    skipped: [],
+    collisions: [],
   };
 
   if (!existsSync(skillsRoot)) {
@@ -388,9 +394,14 @@ function reconcileAdditiveDir(
   const installedSet = new Set<string>();
   for (const [slug, content] of desired) {
     const skillDir = join(skillsRoot, slug);
-    const present = onDisk.has(slug);
-    if (present && !isMemclawOwned(skillDir)) {
-      result.skipped.push(slug);
+    // Re-check liveness here, not just the start-of-function ``onDisk``
+    // snapshot: a foreign dir created between the readdir and now would
+    // otherwise slip past the collision guard (present=false), get its
+    // SKILL.md clobbered, and be wrongly stamped as MemClaw-owned. The
+    // ``existsSync`` re-stat closes that TOCTOU window.
+    const dirExistsNow = onDisk.has(slug) || existsSync(skillDir);
+    if (dirExistsNow && !isMemclawOwned(skillDir)) {
+      result.collisions.push(slug);
       console.warn(
         `[memclaw] additive: ${slug} is occupied by an unowned skill in ` +
           `${skillsRoot}; skipping (collision)`,
@@ -399,7 +410,7 @@ function reconcileAdditiveDir(
     }
     const target = join(skillDir, "SKILL.md");
     // Owned + unchanged content → already installed; skip the rewrite.
-    if (present) {
+    if (dirExistsNow) {
       try {
         if (existsSync(target) && readFileSync(target, "utf-8") === content) {
           installedSet.add(slug);
@@ -411,15 +422,16 @@ function reconcileAdditiveDir(
     }
     try {
       mkdirSync(skillDir, { recursive: true });
-      // Stamp ownership on first write; an already-owned dir keeps its marker.
-      if (!present) {
+      // Stamp ownership only on genuinely new dirs; an already-existing
+      // owned dir keeps its marker.
+      if (!dirExistsNow) {
         writeFileSync(join(skillDir, OWNED_MARKER), OWNED_MARKER_BODY, "utf-8");
       }
       writeFileSync(target, content, "utf-8");
       installedSet.add(slug);
       result.added.push(slug);
       console.log(
-        `[memclaw] additive: ${present ? "updated" : "pulled"} skill ${slug} in ${skillsRoot}`,
+        `[memclaw] additive: ${dirExistsNow ? "updated" : "pulled"} skill ${slug} in ${skillsRoot}`,
       );
     } catch (e: unknown) {
       logError(`reconcileAdditiveDir: write failed for ${slug}`, e);
@@ -441,6 +453,7 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
     added: [],
     removed: [],
     skipped: [],
+    collisions: [],
     protected: [],
   };
 
@@ -525,7 +538,7 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
   const addedAll: string[] = [];
   const removedAll: string[] = [];
   const protectedAll: string[] = [];
-  const skippedAll: string[] = [];
+  const collisionsAll: string[] = [];
   for (const target of resolveSkillTargets()) {
     const dirResult =
       target.mode === "additive"
@@ -535,7 +548,7 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
     removedAll.push(...dirResult.removed);
     protectedAll.push(...dirResult.protected);
     installedAll.push(...dirResult.installed);
-    skippedAll.push(...dirResult.skipped);
+    collisionsAll.push(...dirResult.collisions);
   }
 
   // Aggregate across targets at slug granularity — a skill present in
@@ -547,9 +560,11 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
   summary.removed = [...new Set(removedAll)].sort();
   summary.protected = [...new Set(protectedAll)].sort();
   summary.installed = [...new Set(installedAll)].sort();
-  // ``skipped`` combines bad-shape catalog rows (collected above during
-  // ``desired`` construction) with additive-dir collisions.
-  summary.skipped = [...new Set([...summary.skipped, ...skippedAll])].sort();
+  // ``skipped`` stays catalog-shape errors only (populated above during
+  // ``desired`` construction); additive-dir collisions are reported
+  // separately so the two failure modes don't get conflated.
+  summary.skipped = [...new Set(summary.skipped)].sort();
+  summary.collisions = [...new Set(collisionsAll)].sort();
 
   return summary;
 }

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -10,14 +10,16 @@
  * Targets: by default the reconciler converges the plugin's own skills
  * dir (``getPluginDir()/skills``) in ``owned`` mode. Additional targets
  * can be configured via ``MEMCLAW_SKILL_TARGETS`` (see
- * {@link resolveSkillTargets}). Two modes exist in the type system —
- * ``owned`` (the dir is fully MemClaw-managed; orphans are pruned) and
- * ``additive`` (a shared/foreign dir; MemClaw only manages entries it
- * wrote). NOTE: this change ships the refactor + config plumbing only —
- * ``owned`` is implemented; ``additive`` targets are parsed but skipped
- * with a warning until the additive-mode follow-up lands. This keeps the
- * default (no config) behaviour byte-identical and makes a misconfigured
- * additive target a no-op rather than a destructive prune.
+ * {@link resolveSkillTargets}). Two modes:
+ *   - ``owned`` ({@link reconcileOwnedDir}): the dir is fully
+ *     MemClaw-managed; any on-disk skill not in the catalog is pruned
+ *     (except {@link PROTECTED_SKILLS}).
+ *   - ``additive`` ({@link reconcileAdditiveDir}): a shared/foreign dir.
+ *     MemClaw only ever touches entries it wrote, tracked per-skill via
+ *     the {@link OWNED_MARKER} sentinel — foreign skills are never
+ *     overwritten (collisions are skipped) or removed.
+ * With no config, the single default ``owned`` target makes behaviour
+ * byte-identical to before targets were configurable.
  *
  * Properties:
  *
@@ -64,6 +66,26 @@ import { logError } from "./logger.js";
  * agent's onboarding skill).
  */
 export const PROTECTED_SKILLS: ReadonlySet<string> = new Set(["memclaw"]);
+
+// Per-skill ownership marker for ``additive`` (shared/foreign) target
+// dirs. MemClaw writes this sentinel inside every skill dir it creates
+// there, and only ever updates/removes a ``<slug>`` that carries it — so
+// a skill it doesn't own is never touched. The marker lives INSIDE the
+// skill dir (``<dir>/<slug>/.memclaw-owned``); OpenClaw's loader reads
+// only ``SKILL.md`` and halts recursion at a skill root, so the marker is
+// invisible to it (verified against agent-core skills.ts / session.ts).
+// Choosing a per-skill marker over a central manifest makes the safety
+// property fail-safe: a missing marker means "leave it alone", never
+// "delete it".
+export const OWNED_MARKER = ".memclaw-owned";
+const OWNED_MARKER_BODY =
+  "This skill directory is managed by the MemClaw plugin reconciler.\n" +
+  "Do not edit by hand — it is overwritten/removed to match the catalog.\n";
+
+/** True if ``skillDir`` carries the MemClaw ownership marker. */
+function isMemclawOwned(skillDir: string): boolean {
+  return existsSync(join(skillDir, OWNED_MARKER));
+}
 
 interface CatalogDoc {
   doc_id?: string;
@@ -184,6 +206,12 @@ interface DirReconcileResult {
   protected: string[];
   /** Confirmed-on-disk catalog skills for this dir, excluding PROTECTED. */
   installed: string[];
+  /**
+   * Desired skills NOT materialised because the slug is already occupied
+   * by a foreign (non-MemClaw-owned) entry in an ``additive`` dir. Always
+   * empty for ``owned`` dirs (which fully own their contents).
+   */
+  skipped: string[];
 }
 
 /**
@@ -201,6 +229,7 @@ function reconcileOwnedDir(
     removed: [],
     protected: [],
     installed: [],
+    skipped: [],
   };
 
   // Read disk. Skip non-directories so a stray file in the target dir
@@ -280,6 +309,120 @@ function reconcileOwnedDir(
       );
     } catch (e: unknown) {
       logError(`reconcileOwnedDir: write failed for ${slug}`, e);
+    }
+  }
+
+  result.installed = [...installedSet].filter((s) => !PROTECTED_SKILLS.has(s));
+  return result;
+}
+
+/**
+ * Reconcile ONE ``additive`` (shared / foreign) target dir.
+ *
+ * Unlike {@link reconcileOwnedDir}, MemClaw does NOT own this dir, so it
+ * must never touch an entry it didn't write. Safety is enforced by the
+ * per-skill {@link OWNED_MARKER}:
+ *
+ *  - **write**: a desired slug is written only when its dir is absent
+ *    (new → stamp the marker) or already MemClaw-owned (update in place).
+ *    A slug occupied by an UNOWNED dir is a collision → skipped, never
+ *    overwritten.
+ *  - **remove**: an on-disk slug not in the catalog is removed only when
+ *    it carries the marker; unowned (foreign) entries are left untouched.
+ *
+ * Consequence: an empty catalog (or a misconfigured tenant returning an
+ * empty installable set) prunes only MemClaw-owned entries here —
+ * foreign skills survive. Never throws.
+ */
+function reconcileAdditiveDir(
+  skillsRoot: string,
+  desired: Map<string, string>,
+): DirReconcileResult {
+  const result: DirReconcileResult = {
+    added: [],
+    removed: [],
+    protected: [],
+    installed: [],
+    skipped: [],
+  };
+
+  if (!existsSync(skillsRoot)) {
+    mkdirSync(skillsRoot, { recursive: true });
+  }
+  const onDisk = new Set<string>();
+  try {
+    for (const name of readdirSync(skillsRoot)) {
+      try {
+        if (statSync(join(skillsRoot, name)).isDirectory()) {
+          onDisk.add(name);
+        }
+      } catch {
+        // stat failure on one entry is non-fatal for the rest
+      }
+    }
+  } catch (e: unknown) {
+    logError("reconcileAdditiveDir: failed to read skills directory", e);
+    return result;
+  }
+
+  // Removals first — but ONLY for MemClaw-owned (marker-bearing) orphans.
+  // Anything without the marker is foreign and is never touched.
+  for (const slug of onDisk) {
+    if (desired.has(slug)) continue;
+    if (PROTECTED_SKILLS.has(slug)) {
+      result.protected.push(slug);
+      continue;
+    }
+    if (!isMemclawOwned(join(skillsRoot, slug))) continue; // foreign — leave alone
+    try {
+      rmSync(join(skillsRoot, slug), { recursive: true, force: true });
+      result.removed.push(slug);
+      console.log(`[memclaw] Reconciler (additive) removed owned orphan: ${slug}`);
+    } catch (e: unknown) {
+      logError(`reconcileAdditiveDir: rm failed for ${slug}`, e);
+    }
+  }
+
+  // Writes — only into absent or already-owned slots. A foreign occupant
+  // of the same slug is a collision: skip it, never clobber.
+  const installedSet = new Set<string>();
+  for (const [slug, content] of desired) {
+    const skillDir = join(skillsRoot, slug);
+    const present = onDisk.has(slug);
+    if (present && !isMemclawOwned(skillDir)) {
+      result.skipped.push(slug);
+      console.warn(
+        `[memclaw] additive: ${slug} is occupied by an unowned skill in ` +
+          `${skillsRoot}; skipping (collision)`,
+      );
+      continue;
+    }
+    const target = join(skillDir, "SKILL.md");
+    // Owned + unchanged content → already installed; skip the rewrite.
+    if (present) {
+      try {
+        if (existsSync(target) && readFileSync(target, "utf-8") === content) {
+          installedSet.add(slug);
+          continue;
+        }
+      } catch {
+        // Read failure → fall through and overwrite
+      }
+    }
+    try {
+      mkdirSync(skillDir, { recursive: true });
+      // Stamp ownership on first write; an already-owned dir keeps its marker.
+      if (!present) {
+        writeFileSync(join(skillDir, OWNED_MARKER), OWNED_MARKER_BODY, "utf-8");
+      }
+      writeFileSync(target, content, "utf-8");
+      installedSet.add(slug);
+      result.added.push(slug);
+      console.log(
+        `[memclaw] additive: ${present ? "updated" : "pulled"} skill ${slug} in ${skillsRoot}`,
+      );
+    } catch (e: unknown) {
+      logError(`reconcileAdditiveDir: write failed for ${slug}`, e);
     }
   }
 
@@ -375,26 +518,24 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
 
   // 3. Reconcile each configured target. Default is a single ``owned``
   //    target (the plugin's skills dir) → behaviour identical to before
-  //    targets were configurable. ``additive`` targets are not yet
-  //    implemented here; skip them with a warning rather than applying
-  //    the destructive ``owned`` prune to a shared dir.
+  //    targets were configurable. ``owned`` dirs are fully managed
+  //    (destructive prune); ``additive`` dirs are shared/foreign and are
+  //    reconciled non-destructively via the ownership marker.
   const installedAll: string[] = [];
   const addedAll: string[] = [];
   const removedAll: string[] = [];
   const protectedAll: string[] = [];
+  const skippedAll: string[] = [];
   for (const target of resolveSkillTargets()) {
-    if (target.mode !== "owned") {
-      console.warn(
-        `[memclaw] skill target ${target.dir} (mode=${target.mode}) skipped — ` +
-          "additive mode not yet implemented",
-      );
-      continue;
-    }
-    const dirResult = reconcileOwnedDir(target.dir, desired);
+    const dirResult =
+      target.mode === "additive"
+        ? reconcileAdditiveDir(target.dir, desired)
+        : reconcileOwnedDir(target.dir, desired);
     addedAll.push(...dirResult.added);
     removedAll.push(...dirResult.removed);
     protectedAll.push(...dirResult.protected);
     installedAll.push(...dirResult.installed);
+    skippedAll.push(...dirResult.skipped);
   }
 
   // Aggregate across targets at slug granularity — a skill present in
@@ -406,6 +547,9 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
   summary.removed = [...new Set(removedAll)].sort();
   summary.protected = [...new Set(protectedAll)].sort();
   summary.installed = [...new Set(installedAll)].sort();
+  // ``skipped`` combines bad-shape catalog rows (collected above during
+  // ``desired`` construction) with additive-dir collisions.
+  summary.skipped = [...new Set([...summary.skipped, ...skippedAll])].sort();
 
   return summary;
 }

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -373,11 +373,16 @@ function reconcileAdditiveDir(
   // Anything without the marker is foreign and is never touched.
   for (const slug of onDisk) {
     if (desired.has(slug)) continue;
+    // Ownership gates everything in an additive dir: a foreign slug is left
+    // alone even if its name collides with a PROTECTED one. A foreign
+    // "memclaw" dir (no marker) is the client's, not ours — ignore it
+    // rather than misreport it as a MemClaw-protected skill. An OWNED
+    // protected dir still survives via the protected check below.
+    if (!isMemclawOwned(join(skillsRoot, slug))) continue; // foreign — leave alone
     if (PROTECTED_SKILLS.has(slug)) {
       result.protected.push(slug);
       continue;
     }
-    if (!isMemclawOwned(join(skillsRoot, slug))) continue; // foreign — leave alone
     try {
       rmSync(join(skillsRoot, slug), { recursive: true, force: true });
       result.removed.push(slug);


### PR DESCRIPTION
## What

PR1 (#413) made reconcile targets configurable but left **`additive`** mode a warn-skip no-op. This PR implements it: MemClaw can now reconcile its active skills into **shared/foreign** target dirs **without ever deleting or overwriting an entry it does not own**.

## Mechanism — per-skill ownership marker

A sentinel file `<dir>/<slug>/.memclaw-owned` stamps every skill MemClaw writes into an `additive` dir. `reconcileAdditiveDir`:

- **write** — a desired slug is written only when its dir is **absent** (new → stamp marker) or **already MemClaw-owned** (update in place). A slug occupied by an **unowned** dir is a **collision** → skipped, never overwritten (reported in `summary.skipped`).
- **remove** — an on-disk slug not in the catalog is removed **only if it carries the marker**. Unowned (foreign) entries are left untouched.

This is **fail-safe**: a missing marker means *"leave it alone"*, never *"delete it"*. So an empty catalog — or a misconfigured tenant returning an empty installable set — prunes only MemClaw's own entries in additive dirs. The destructive "wipe the dir" hazard stays confined to **`owned`** dirs.

The marker lives **inside** the skill dir; OpenClaw's loader reads only `SKILL.md` and halts recursion at a skill root, so the marker is invisible to the agent (verified against agent-core `skills.ts` / `session.ts`).

## Changes

- `OWNED_MARKER` + `isMemclawOwned` helpers.
- `DirReconcileResult.skipped` (additive collisions); `owned` dirs always return it empty.
- `reconcileAdditiveDir` — mirrors `reconcileOwnedDir`'s shape with marker-gated removal + collision-skip writes.
- `reconcileSkills` loop dispatches `additive` → the new path; `summary.skipped` now merges bad-shape catalog rows + collisions (deduped + sorted, consistent with the other arrays).
- `reconcileOwnedDir` and the default single-target behavior are **unchanged**.
- Docs (`mcp-skill-delivery.md`) section describing `owned` vs `additive` (collision/never-remove/marker semantics).

## Tests

5 new `additive` tests: write + marker stamp; foreign skill never removed (incl. empty catalog); collision → skipped + foreign bytes untouched; owned orphan removed (foreign neighbour survives); owned skill updated in place. Replaces the PR1 "additive not implemented" placeholder. **328 plugin tests pass; tsc clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)