### PR TITLE
feat(core-api): cross-worker settings-cache invalidation (CAURA-571)

### DIFF
--- a/common/events/base.py
+++ b/common/events/base.py
@@ -66,7 +66,9 @@ class EventBus(ABC):
         """
 
     @abstractmethod
-    def subscribe(self, topic: str, handler: EventHandler) -> None:
+    def subscribe(
+        self, topic: str, handler: EventHandler, *, broadcast: bool = False
+    ) -> None:
         """Register *handler* as a subscriber to *topic*. May be called
         at startup only — not thread-safe during `publish`.
 
@@ -75,6 +77,16 @@ class EventBus(ABC):
         handler raises, gets redelivered. Use `event.event_id` as a
         natural dedup key when the operation isn't inherently
         idempotent.
+
+        ``broadcast``: when True, *every* subscribing process must receive
+        each event (fan-out), not just one. The default (False) is the
+        work-queue semantics every existing consumer relies on — a shared
+        per-service subscription delivers each message to a single
+        process. Broadcast is for cross-process cache invalidation, where
+        one worker handling the event would leave the others stale. The
+        in-process bus dispatches to all local handlers regardless, so it
+        ignores the flag; the Pub/Sub bus gives broadcast topics a
+        per-process subscription.
         """
 
     async def start(self) -> None:

--- a/common/events/inprocess.py
+++ b/common/events/inprocess.py
@@ -33,7 +33,12 @@ class InProcessEventBus(EventBus):
         self._handlers: dict[str, list[EventHandler]] = defaultdict(list)
         self._tasks: set[asyncio.Task[None]] = set()
 
-    def subscribe(self, topic: str, handler: EventHandler) -> None:
+    def subscribe(
+        self, topic: str, handler: EventHandler, *, broadcast: bool = False
+    ) -> None:
+        # ``broadcast`` is a no-op here: a single-process bus already
+        # dispatches every event to all local handlers (fan-out within the
+        # process). Cross-worker fan-out is a Pub/Sub-backend concern.
         self._handlers[topic].append(handler)
 
     async def publish(self, topic: str, event: Event) -> None:

--- a/common/events/org_settings_changed_event.py
+++ b/common/events/org_settings_changed_event.py
@@ -1,0 +1,20 @@
+"""Typed payload for ``memclaw.org.settings-changed`` (CAURA-571).
+
+Published by core-api after an org's settings row is written. Carries
+the ``org_id`` whose settings changed so every core-api process can drop
+that key from its per-process settings cache (``organization_settings``
+TTLCache). The event intentionally carries no settings *values* — the
+consumer just invalidates and the next read re-resolves from storage, so
+there's nothing to keep in sync and no secret to leak on the wire.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class OrgSettingsChangedEvent(BaseModel):
+    """Payload of ``memclaw.org.settings-changed`` — the ``org_id`` whose
+    cached settings every process should evict."""
+
+    org_id: str

--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -4,10 +4,15 @@ Publishers push JSON-encoded `Event` payloads to per-topic Pub/Sub
 topics; subscribers pull messages from per-subscriber subscriptions and
 dispatch to async handlers.
 
-Topic + subscription provisioning is *not* done here — it's expected to
-be managed via Terraform / gcloud at deploy time so subscription
-configuration (ack deadlines, retry policies, dead-letter topics) lives
-with infra. This class assumes the topics/subscriptions already exist.
+Topic + *durable* subscription provisioning is *not* done here — it's
+expected to be managed via Terraform / gcloud at deploy time so
+subscription configuration (ack deadlines, retry policies, dead-letter
+topics) lives with infra. This class assumes those already exist. The
+SOLE exception is per-process *broadcast* subscriptions (see
+``subscribe(broadcast=True)``): their names embed a per-process id so
+Terraform can't pre-provision them, so ``_ensure_broadcast_subscription``
+creates one at ``start()`` (with an ``expiration_policy`` backstop) and
+deletes it at ``stop()``.
 
 Import is lazy so `common.events` can be imported in OSS standalone
 installs that don't have `google-cloud-pubsub` installed.
@@ -36,6 +41,7 @@ import concurrent.futures
 import functools
 import json
 import logging
+import uuid
 from collections import defaultdict
 from typing import Any
 
@@ -53,6 +59,13 @@ logger = logging.getLogger(__name__)
 # filters can only match attributes, never the message body. See the
 # cross-environment leakage note in the module docstring.
 SOURCE_ENV_ATTRIBUTE = "source_env"
+
+# Ephemeral broadcast subscriptions (``subscribe(broadcast=True)``) are created
+# per-process at ``start()`` and deleted at ``stop()``. This TTL is the backstop
+# for an unclean shutdown: Pub/Sub auto-deletes a subscription left idle this
+# long, so a crashed process can't leak its subscription forever. 1 day is the
+# Pub/Sub minimum for ``expiration_policy``.
+BROADCAST_SUBSCRIPTION_TTL_SECONDS = 86400
 
 
 class PubSubEventBus(EventBus):
@@ -174,6 +187,15 @@ class PubSubEventBus(EventBus):
         # warn against bare ``create_task(coro)``. The done-callback
         # auto-discards on completion so the set stays bounded.
         self._background_tasks: set[asyncio.Task[Any]] = set()
+        # Topics registered with ``broadcast=True`` get a PER-PROCESS
+        # subscription so every process receives every message (fan-out),
+        # instead of the shared per-service subscription that delivers each
+        # message to a single consumer. ``_instance_id`` makes this process's
+        # subscription name unique; ``_broadcast_sub_paths`` records the ones
+        # this process created so ``stop()`` can delete them.
+        self._broadcast_topics: set[str] = set()
+        self._broadcast_sub_paths: list[str] = []
+        self._instance_id = uuid.uuid4().hex[:12]
 
     def _spawn_background_task(self, coro: Any) -> asyncio.Task[Any]:
         """Schedule a fire-and-forget task; see ``_background_tasks`` for why."""
@@ -427,7 +449,9 @@ class PubSubEventBus(EventBus):
 
     # ── subscriber ─────────────────────────────────────────────────
 
-    def subscribe(self, topic: str, handler: EventHandler) -> None:
+    def subscribe(
+        self, topic: str, handler: EventHandler, *, broadcast: bool = False
+    ) -> None:
         # Late subscribes silently orphan the handler — pull tasks are
         # only spawned during start(). Fail loudly so the bug surfaces
         # at wire-up rather than appearing as "events aren't arriving".
@@ -440,6 +464,10 @@ class PubSubEventBus(EventBus):
                 "the pull loop for this topic won't be created otherwise."
             )
         self._handlers[topic].append(handler)
+        # ``broadcast`` topics get a per-process subscription at start() so
+        # every process receives every message (fan-out), not just one.
+        if broadcast:
+            self._broadcast_topics.add(topic)
 
     async def start(self) -> None:
         # Idempotent guard — a second call would leak the old
@@ -538,9 +566,66 @@ class PubSubEventBus(EventBus):
             )
             for topic, handlers in self._handlers.items():
                 sub_name = f"{self._subscription_prefix}--{self._topic_name(topic)}"
+                if topic in self._broadcast_topics:
+                    # Per-process subscription (unique suffix) for fan-out; skip
+                    # the pull loop if it can't be created (see the helper — it
+                    # degrades to TTL rather than crashing startup).
+                    sub_name = f"{sub_name}--{self._instance_id}"
+                    if not await self._ensure_broadcast_subscription(topic, sub_name):
+                        continue
                 task = asyncio.create_task(self._pull_loop(sub_name, handlers))
                 self._pull_tasks.append(task)
         self._started = True
+
+    async def _ensure_broadcast_subscription(self, topic: str, sub_name: str) -> bool:
+        """Create this process's ephemeral subscription for a broadcast topic.
+
+        Returns True if the subscription exists (so a pull loop should be
+        spawned), False if creation failed — the caller then degrades to no
+        fan-out for this topic (cross-process invalidation falls back to the
+        cache TTL) rather than crashing startup. Sets ``expiration_policy`` so a
+        subscription orphaned by an unclean shutdown self-deletes after
+        ``BROADCAST_SUBSCRIPTION_TTL_SECONDS``.
+        """
+        from google.api_core import exceptions as gexc
+
+        loop = asyncio.get_running_loop()
+        sub_path = self._subscriber.subscription_path(self._project_id, sub_name)
+        topic_path = f"projects/{self._project_id}/topics/{self._topic_name(topic)}"
+
+        def _create() -> None:
+            self._subscriber.create_subscription(
+                request={
+                    "name": sub_path,
+                    "topic": topic_path,
+                    "ack_deadline_seconds": 30,
+                    "expiration_policy": {
+                        "ttl": {"seconds": BROADCAST_SUBSCRIPTION_TTL_SECONDS}
+                    },
+                }
+            )
+
+        try:
+            await loop.run_in_executor(self._pull_executor, _create)
+        except gexc.AlreadyExists:
+            # A prior unclean shutdown left this process's subscription (same
+            # _instance_id) around — reuse it. The create failed, so its
+            # expiration_policy TTL is NOT reset here; the pull loop's ongoing
+            # activity is what keeps Pub/Sub from expiring it.
+            pass
+        except Exception:
+            logger.error(
+                "pubsub: failed to create broadcast subscription %s; this "
+                "process will NOT receive %s events (cross-process cache "
+                "invalidation falls back to the TTL). Check the service account "
+                "has pubsub.subscriptions.create on the project.",
+                sub_name,
+                topic,
+                exc_info=True,
+            )
+            return False
+        self._broadcast_sub_paths.append(sub_path)
+        return True
 
     def _foreign_source_env(self, message: Any) -> str | None:
         """Return the message's ``source_env`` when it was published by a
@@ -842,6 +927,30 @@ class PubSubEventBus(EventBus):
         # idempotency guard and create a fresh SubscriberClient that
         # the in-flight stop() would then close out from under the caller.
         try:
+            # Delete this process's ephemeral broadcast subscriptions BEFORE
+            # closing the subscriber (the delete needs the client). Best-effort:
+            # the ``expiration_policy`` set at creation reaps any subscription
+            # this misses (unclean shutdown). The close below then wakes the
+            # pull threads via the gRPC channel error, so they exit through the
+            # ``if self._stopping: return`` path rather than logging NotFound.
+            if self._subscriber is not None and self._broadcast_sub_paths:
+                for sub_path in self._broadcast_sub_paths:
+                    try:
+                        await loop.run_in_executor(
+                            None,
+                            functools.partial(
+                                self._subscriber.delete_subscription,
+                                request={"subscription": sub_path},
+                            ),
+                        )
+                    except Exception:
+                        logger.warning(
+                            "pubsub: failed to delete ephemeral broadcast "
+                            "subscription %s; expiration_policy will reap it",
+                            sub_path,
+                            exc_info=True,
+                        )
+                self._broadcast_sub_paths.clear()
             # Close the subscriber BEFORE cancelling/awaiting the pull
             # tasks. Pull threads are blocked inside a synchronous
             # `subscriber.pull(timeout=pull_timeout)` — asyncio

--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -43,6 +43,13 @@ class Org(enum.StrEnum):
     # affected tenants synchronously, even while the durable mirror
     # eventually catches up.
     SUPPRESSION_CHANGED = "memclaw.org.suppression-changed"
+    # CAURA-571: core-api publishes this after an org's settings are written so
+    # every process drops its per-process settings cache promptly — without it,
+    # a tightened governance control keeps applying its looser prior value on
+    # sibling workers for up to the cache TTL (5 min). Subscribe with
+    # ``broadcast=True`` (every process must receive it), not the work-queue
+    # default.
+    SETTINGS_CHANGED = "memclaw.org.settings-changed"
 
 
 class Lifecycle(enum.StrEnum):

--- a/core-api/src/core_api/consumer.py
+++ b/core-api/src/core_api/consumer.py
@@ -34,11 +34,12 @@ from common.events.base import Event
 from common.events.factory import get_event_bus
 from common.events.memory_embedded import MemoryEmbedded
 from common.events.memory_enriched import MemoryEnriched
+from common.events.org_settings_changed_event import OrgSettingsChangedEvent
 from common.events.topics import Topics
 from core_api.clients.storage_client import get_storage_client
 from core_api.services.contradiction_detector import detect_contradictions_async
 from core_api.services.governance_remediation import remediate_after_enrichment
-from core_api.services.organization_settings import resolve_config
+from core_api.services.organization_settings import invalidate_cache, resolve_config
 
 logger = logging.getLogger(__name__)
 
@@ -230,6 +231,38 @@ async def handle_memory_embedded(event: Event) -> None:
     )
 
 
+async def handle_org_settings_changed(event: Event) -> None:
+    """Process one ``Topics.Org.SETTINGS_CHANGED`` event (CAURA-571).
+
+    Drops the affected org's entry from THIS process's settings cache, so a
+    settings change made on any worker/instance takes effect here promptly
+    instead of waiting out the per-process 5-min TTL. The publishing worker
+    already invalidated its own cache locally; this is the fan-out to every
+    other process (the topic is subscribed with ``broadcast=True``).
+
+    Idempotent — evicting an absent or already-fresh entry is a harmless no-op —
+    so the at-least-once bus may redeliver freely. A malformed payload is
+    ack-dropped (no retry will make it parse).
+    """
+    try:
+        payload = OrgSettingsChangedEvent.model_validate(event.payload)
+    except ValidationError:
+        logger.exception(
+            "dropping malformed org-settings-changed payload",
+            extra={
+                "event_type": event.event_type,
+                "event_id": str(event.event_id),
+                "dropped": True,
+            },
+        )
+        return
+    invalidate_cache(payload.org_id)
+    logger.info(
+        "settings cache invalidated via broadcast",
+        extra={"event_id": str(event.event_id), "org_id": payload.org_id},
+    )
+
+
 def register_consumers() -> None:
     """Wire the consumers into the event bus.
 
@@ -240,3 +273,7 @@ def register_consumers() -> None:
     bus = get_event_bus()
     bus.subscribe(Topics.Memory.ENRICHED, handle_memory_enriched)
     bus.subscribe(Topics.Memory.EMBEDDED, handle_memory_embedded)
+    # Broadcast: EVERY core-api process must drop its settings cache, not just
+    # one — so this uses a per-process subscription, unlike the work-queue
+    # consumers above (CAURA-571).
+    bus.subscribe(Topics.Org.SETTINGS_CHANGED, handle_org_settings_changed, broadcast=True)

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -31,10 +31,14 @@ from sqlalchemy import func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from common.events.base import Event
+from common.events.factory import get_event_bus
 from common.events.lifecycle_purge_request import (
     MEMORY_RETENTION_MAX_DAYS,
     MEMORY_RETENTION_MIN_DAYS,
 )
+from common.events.org_settings_changed_event import OrgSettingsChangedEvent
+from common.events.topics import Topics
 from common.governance import PIICategory
 from common.models.organization_settings import OrganizationSettings, OrganizationSettingsAudit
 from common.provider_names import ProviderName
@@ -1120,7 +1124,28 @@ async def update_settings(
     )
     await db.commit()
 
-    # Local invalidation — other workers pick up the change within TTL.
+    # Invalidate THIS process's cache immediately...
     invalidate_cache(tenant_id)
+    # ...and broadcast so every other worker/instance drops its copy promptly
+    # too (CAURA-571), instead of serving the stale value for up to the TTL —
+    # which matters for a tightened governance control. Best-effort: a publish
+    # failure must not fail a settings write that already committed; siblings
+    # then fall back to the TTL, exactly as before this change.
+    try:
+        await get_event_bus().publish(
+            Topics.Org.SETTINGS_CHANGED,
+            Event(
+                event_type=Topics.Org.SETTINGS_CHANGED,
+                tenant_id=tenant_id,
+                payload=OrgSettingsChangedEvent(org_id=tenant_id).model_dump(mode="json"),
+            ),
+        )
+    except Exception:
+        logger.warning(
+            "failed to publish settings-changed for %s; sibling workers will "
+            "pick up the change within the cache TTL",
+            tenant_id,
+            exc_info=True,
+        )
 
     return _deep_merge(DEFAULT_SETTINGS, merged)

--- a/tests/test_consumer_enriched.py
+++ b/tests/test_consumer_enriched.py
@@ -259,19 +259,26 @@ async def test_register_consumers_subscribes_to_both_topics() -> None:
     back-channel topic — a typo on either side would silently orphan
     the handler.
 
-    Two subscriptions wired: ``ENRICHED`` (CAURA-595) and ``EMBEDDED``
+    Three subscriptions wired: ``ENRICHED`` (CAURA-595) and ``EMBEDDED``
     (the symmetric path that fires contradiction detection on the
     embed-after-enrich ordering — the only case under
-    ``EMBED_ON_HOT_PATH=false``).
+    ``EMBED_ON_HOT_PATH=false``), both work-queue; plus
+    ``Org.SETTINGS_CHANGED`` (CAURA-571) as a BROADCAST subscription so
+    every process drops its settings cache.
     """
     fake_bus = MagicMock()
     with patch("core_api.consumer.get_event_bus", return_value=fake_bus):
         consumer.register_consumers()
 
-    assert fake_bus.subscribe.call_count == 2
+    assert fake_bus.subscribe.call_count == 3
     fake_bus.subscribe.assert_any_call(
         Topics.Memory.ENRICHED, consumer.handle_memory_enriched
     )
     fake_bus.subscribe.assert_any_call(
         Topics.Memory.EMBEDDED, consumer.handle_memory_embedded
+    )
+    fake_bus.subscribe.assert_any_call(
+        Topics.Org.SETTINGS_CHANGED,
+        consumer.handle_org_settings_changed,
+        broadcast=True,
     )

--- a/tests/test_cross_worker_settings_invalidation.py
+++ b/tests/test_cross_worker_settings_invalidation.py
@@ -1,0 +1,71 @@
+"""Cross-worker settings-cache invalidation (CAURA-571).
+
+The org-settings write path publishes ``Topics.Org.SETTINGS_CHANGED``; every
+core-api process subscribes with ``broadcast=True`` and drops its cached
+settings for that org, so a change made on one worker/instance takes effect
+everywhere promptly instead of waiting out the per-process TTL.
+
+These cover the handler, the payload schema, and the broadcast wiring. The
+Pub/Sub-side per-process subscription mechanics live in
+``tests/test_events/test_pubsub_bus.py``.
+"""
+
+from __future__ import annotations
+
+import pydantic
+import pytest
+
+from common.events.base import Event
+from common.events.org_settings_changed_event import OrgSettingsChangedEvent
+from common.events.topics import Topics
+from core_api import consumer as consumer_mod
+
+
+def test_payload_model_validates_org_id() -> None:
+    assert OrgSettingsChangedEvent(org_id="org-1").org_id == "org-1"
+
+
+def test_payload_model_rejects_missing_org_id() -> None:
+    with pytest.raises(pydantic.ValidationError):
+        OrgSettingsChangedEvent.model_validate({})
+
+
+@pytest.mark.asyncio
+async def test_handler_invalidates_cache(monkeypatch) -> None:
+    seen: list[str] = []
+    monkeypatch.setattr(
+        consumer_mod, "invalidate_cache", lambda org_id: seen.append(org_id)
+    )
+    event = Event(event_type=Topics.Org.SETTINGS_CHANGED, payload={"org_id": "org-7"})
+    await consumer_mod.handle_org_settings_changed(event)
+    assert seen == ["org-7"]
+
+
+@pytest.mark.asyncio
+async def test_handler_ack_drops_malformed_payload(monkeypatch) -> None:
+    # Missing org_id → ValidationError → ack-drop (no invalidate, no raise), so
+    # a poison message can't nack-loop the broadcast subscription.
+    seen: list[str] = []
+    monkeypatch.setattr(
+        consumer_mod, "invalidate_cache", lambda org_id: seen.append(org_id)
+    )
+    event = Event(event_type=Topics.Org.SETTINGS_CHANGED, payload={})
+    await consumer_mod.handle_org_settings_changed(event)
+    assert seen == []
+
+
+def test_register_consumers_subscribes_settings_as_broadcast(monkeypatch) -> None:
+    # The invalidation consumer MUST be broadcast (every process), while the
+    # existing enrich/embed consumers stay work-queue (one process per event).
+    calls: list[tuple[str, bool]] = []
+
+    class FakeBus:
+        def subscribe(self, topic, handler, *, broadcast=False):
+            calls.append((topic, broadcast))
+
+    monkeypatch.setattr(consumer_mod, "get_event_bus", lambda: FakeBus())
+    consumer_mod.register_consumers()
+
+    assert (Topics.Org.SETTINGS_CHANGED, True) in calls
+    assert (Topics.Memory.ENRICHED, False) in calls
+    assert (Topics.Memory.EMBEDDED, False) in calls

--- a/tests/test_events/test_inprocess_bus.py
+++ b/tests/test_events/test_inprocess_bus.py
@@ -183,3 +183,22 @@ async def test_is_healthy_default_true() -> None:
     subscriber state in-process."""
     bus = InProcessEventBus()
     assert bus.is_healthy is True
+
+
+async def test_subscribe_broadcast_flag_accepted_and_dispatches() -> None:
+    """The in-process bus already dispatches to every local handler, so
+    ``broadcast=True`` is a no-op it must accept without error and still
+    deliver (CAURA-571 — the flag only changes Pub/Sub subscription shape)."""
+    bus = InProcessEventBus()
+    seen: list[str] = []
+
+    async def handler(event: Event) -> None:
+        seen.append(event.event_type)
+
+    bus.subscribe(Topics.Org.SETTINGS_CHANGED, handler, broadcast=True)
+    await bus.publish(
+        Topics.Org.SETTINGS_CHANGED,
+        Event(event_type=Topics.Org.SETTINGS_CHANGED, payload={"org_id": "o1"}),
+    )
+    await bus.drain()
+    assert seen == [Topics.Org.SETTINGS_CHANGED]

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from common.events import Event, PubSubEventBus, Topics
+from common.events.pubsub import BROADCAST_SUBSCRIPTION_TTL_SECONDS
 
 
 @pytest.fixture
@@ -1161,3 +1162,91 @@ async def test_pull_loop_processes_message_without_source_env_attribute() -> Non
 
     assert len(result["dispatched"]) == 1
     assert result["acked"] == ["ack-legacy"]
+
+
+# ── broadcast subscriptions (CAURA-571) ──────────────────────────────
+
+
+def test_subscribe_broadcast_records_topic() -> None:
+    # broadcast=True flags the topic for a per-process subscription; the
+    # default keeps the shared work-queue subscription.
+    b = PubSubEventBus(project_id="proj", subscription_prefix="core-api")
+
+    async def handler(event: Event) -> None: ...
+
+    b.subscribe(Topics.Org.SETTINGS_CHANGED, handler, broadcast=True)
+    b.subscribe(Topics.Memory.EMBEDDED, handler)
+    assert Topics.Org.SETTINGS_CHANGED in b._broadcast_topics
+    assert Topics.Memory.EMBEDDED not in b._broadcast_topics
+
+
+async def test_ensure_broadcast_subscription_creates_with_expiration(
+    bus: PubSubEventBus,
+) -> None:
+    # Each process creates its OWN subscription (unique name) so every process
+    # receives every event; expiration_policy reaps it if the process dies.
+    fake_sub = MagicMock()
+    fake_sub.subscription_path = (
+        lambda proj, name: f"projects/{proj}/subscriptions/{name}"
+    )
+    bus._subscriber = fake_sub
+    ok = await bus._ensure_broadcast_subscription(
+        Topics.Org.SETTINGS_CHANGED,
+        f"core-api--{Topics.Org.SETTINGS_CHANGED}--abc123",
+    )
+    assert ok is True
+    req = fake_sub.create_subscription.call_args.kwargs["request"]
+    assert req["topic"] == f"projects/proj/topics/{Topics.Org.SETTINGS_CHANGED}"
+    assert req["name"].endswith("--abc123")
+    assert (
+        req["expiration_policy"]["ttl"]["seconds"]
+        == BROADCAST_SUBSCRIPTION_TTL_SECONDS
+    )
+    # Tracked so stop() can delete it.
+    assert bus._broadcast_sub_paths == [req["name"]]
+
+
+async def test_ensure_broadcast_subscription_already_exists_is_ok(
+    bus: PubSubEventBus,
+) -> None:
+    from google.api_core import exceptions as gexc
+
+    fake_sub = MagicMock()
+    fake_sub.subscription_path = (
+        lambda proj, name: f"projects/{proj}/subscriptions/{name}"
+    )
+    fake_sub.create_subscription = MagicMock(side_effect=gexc.AlreadyExists("exists"))
+    bus._subscriber = fake_sub
+    ok = await bus._ensure_broadcast_subscription(Topics.Org.SETTINGS_CHANGED, "sub-x")
+    # Reuse a prior run's subscription (same _instance_id) rather than fail.
+    assert ok is True
+    assert len(bus._broadcast_sub_paths) == 1
+
+
+async def test_ensure_broadcast_subscription_failure_degrades(
+    bus: PubSubEventBus,
+) -> None:
+    # Missing IAM (pubsub.subscriptions.create) must NOT crash startup — the
+    # process degrades to no fan-out (invalidation falls back to the cache TTL).
+    fake_sub = MagicMock()
+    fake_sub.subscription_path = (
+        lambda proj, name: f"projects/{proj}/subscriptions/{name}"
+    )
+    fake_sub.create_subscription = MagicMock(
+        side_effect=RuntimeError("permission denied")
+    )
+    bus._subscriber = fake_sub
+    ok = await bus._ensure_broadcast_subscription(Topics.Org.SETTINGS_CHANGED, "sub-x")
+    assert ok is False
+    assert bus._broadcast_sub_paths == []
+
+
+async def test_stop_deletes_broadcast_subscriptions(bus: PubSubEventBus) -> None:
+    fake_sub = MagicMock()
+    bus._subscriber = fake_sub
+    bus._broadcast_sub_paths = ["projects/proj/subscriptions/core-api--x--abc"]
+    await bus.stop()
+    fake_sub.delete_subscription.assert_called_once()
+    req = fake_sub.delete_subscription.call_args.kwargs["request"]
+    assert req["subscription"] == "projects/proj/subscriptions/core-api--x--abc"
+    assert bus._broadcast_sub_paths == []


### PR DESCRIPTION
Closes the cross-worker settings-cache staleness gap (the PII findings' "5-min cross-worker settings staleness" — confirmed live).

## Problem
The per-process org-settings cache (`TTLCache`, 5-min TTL in `organization_settings.py`) only invalidates **locally** on a write — `invalidate_cache` evicts the serving worker only. Sibling uvicorn workers and other Cloud Run instances keep serving the **stale** value for up to the TTL. For a governance control that's a correctness gap: flipping a policy to a **stricter** action (e.g. PII `flag → drop/mask`) has an up-to-5-minute window where some workers still apply the looser one.

## Fix — fan out invalidation over the event bus
- New **broadcast** topic `Topics.Org.SETTINGS_CHANGED` + `OrgSettingsChangedEvent` payload (carries only `org_id` — nothing to keep in sync, no secret on the wire).
- `update_settings` publishes it after `commit()` (**best-effort**: a publish failure can't fail an already-committed write — siblings then fall back to the TTL, exactly as today).
- `core-api` consumer `handle_org_settings_changed` → `invalidate_cache(org_id)`.

### Broadcast vs work-queue (the crux)
The existing bus names subscriptions `{prefix}--{topic}` per **service**, so every core-api process shares one subscription → **competing consumers**: each message reaches exactly **one** worker. That's correct for the existing enrich/embed/suppression consumers, but wrong for cache invalidation, which needs **every** process to act.

So this adds `EventBus.subscribe(broadcast=True)`:
- **InProcessEventBus**: no-op (a single process already dispatches to all local handlers).
- **PubSubEventBus**: gives a broadcast topic a **per-process ephemeral subscription** (`{prefix}--{topic}--{instance_id}`), created at `start()` with an `expiration_policy` backstop (a crashed process's sub self-reaps after 1 day) and deleted at `stop()`. Create-failure (e.g. missing IAM) **degrades to TTL-only invalidation** rather than crashing startup; the consumer is idempotent + TTL-backstopped.

Honors the standing rules: no new direct DB pool (reuses the event bus), no ad-hoc migration.

## ⚠️ Deploy dependency — IAM grant required (infra)
Durable subscriptions are Terraform-provisioned, but per-process ephemeral subscriptions embed a runtime `instance_id`, so they're created at runtime. The **core-api service account** needs subscription create/delete. Until this lands, core-api boots fine and invalidation falls back to the cache TTL (no regression).

```hcl
# Grant the core-api runtime SA permission to create/delete its own
# ephemeral broadcast subscriptions (CAURA-571).
resource "google_pubsub_topic_iam_member" "core_api_settings_changed_subscriber" {
  topic  = google_pubsub_topic.memclaw_org_settings_changed.name  # new topic
  role   = "roles/pubsub.editor"   # or a custom role with
                                   # pubsub.subscriptions.{create,delete,consume}
  member = "serviceAccount:${var.core_api_service_account_email}"
}
```
Also provision the topic `memclaw.org.settings-changed` (mirroring the other `memclaw.*` topics; the per-env `EVENT_BUS_TOPIC_PREFIX` applies as usual). I can adjust to a tighter custom role if you prefer least-privilege over `pubsub.editor`.

## Verification
- New tests: `test_pubsub_bus.py` (per-process sub create / already-exists / degrade-on-failure / stop-delete), `test_inprocess_bus.py` (broadcast no-op dispatch), `test_cross_worker_settings_invalidation.py` (handler + payload + broadcast wiring); `test_consumer_enriched.py` register assertion updated. All green.
- `ruff check` + `ruff format --check` and `mypy` clean on core-api + core-storage-api.
- (Pre-existing DB-backed settings/e2e suites need a database — not runnable in this sandbox; they exercise the publish path under CI's DB.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)