### PR TITLE
docs(core-api): document LLM free-form PII recall limit (recommend a capable enrichment model)

### DIFF
--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -233,6 +233,24 @@ DEFAULT_SETTINGS: dict = {
     # PII is enabled with NO category selected, the gate scans ALL categories
     # (the secure default — enabling protection shouldn't silently protect
     # nothing). See ``ResolvedConfig.governance_pii``.
+    #
+    # Two paths back the PII ``action`` (mask/drop/flag), with different recall:
+    #   1. Deterministic, span-aware validators (``GovernanceScanContent``):
+    #      regex/Luhn/IBAN/entropy. The strong, fail-closed path for structured
+    #      PII (email/phone/cards/IBAN/keys), and the only one that can honestly
+    #      ``mask`` (it has span offsets). Precision confirmed; high recall on
+    #      the patterns it covers.
+    #   2. The enrichment LLM's free-form ``contains_pii`` signal
+    #      (``GovernanceDecision``): catches unstructured/contextual PII the
+    #      patterns can't (e.g. "X is in addiction recovery"), but its RECALL is
+    #      bounded by the enrichment model — a small/cheap model (e.g. *-nano)
+    #      under-detects subtly-phrased free-form PII. A tenant relying on
+    #      ``drop``/``mask`` to catch FREE-FORM PII should set a capable
+    #      ``enrichment.model``; the deterministic path stays the precise
+    #      backstop, but free-form coverage is only as strong as that model's
+    #      recall. (The LLM path has no offsets, so a ``mask`` policy can only
+    #      flag a free-form match — see ``llm_pii_audit_detail`` /
+    #      ``configured_action``.)
     "governance": {
         "pii": {
             "enabled": False,


### PR DESCRIPTION
Closes the second PII caveat from the findings ("nano under-detects subtly-phrased free-form PII"). **Doc/comment only — no behavior change.**

## Why
The PII `action` (mask/drop/flag) is backed by two detection paths with very different recall, and the difference is load-bearing for a tenant relying on `drop`/`mask` for compliance:

1. **Deterministic span-aware validators** (`GovernanceScanContent`) — regex/Luhn/IBAN/entropy. Precise, fail-closed, and the only path that can honestly `mask` (it has span offsets). Precision confirmed live.
2. **The enrichment LLM's free-form `contains_pii` signal** (`GovernanceDecision`) — catches unstructured/contextual PII the patterns can't (e.g. *"X is in addiction recovery"*), but its **recall is bounded by the enrichment model**. Live testing confirmed a small/cheap model (e.g. `*-nano`) under-detects subtly-phrased free-form PII.

## What
A note in the `governance.pii` `DEFAULT_SETTINGS` block (right where `action` is chosen) spelling out the two paths and recommending a **capable `enrichment.model`** for tenants relying on free-form `drop`/`mask` — the deterministic path stays the precise backstop, but free-form coverage is only as strong as the model's recall. It also records that the LLM path has no offsets, so a `mask` policy can only flag a free-form match (`llm_pii_audit_detail` / `configured_action`).

This is a model-recall limitation, not a code bug — so the fix is to make the trade-off explicit at the configuration site rather than change enforcement.

ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)