### PR TITLE
test(authz): de-flake search scope_agent test (query exact content, not bare marker)

### DIFF
--- a/tests/test_memory_byid_authz.py
+++ b/tests/test_memory_byid_authz.py
@@ -335,9 +335,10 @@ async def test_rest_search_scope_agent_uses_authenticated_identity(client, as_ag
 
     tenant_id, headers = get_test_auth()
     marker = f"PRIVATEMARKER{uuid.uuid4().hex[:10]}"
+    content = f"alice private note {marker}"
     priv = await _write(
         client, headers, tenant_id, agent_id="alice", fleet_id="fleet-alpha",
-        visibility="scope_agent", content=f"alice private note {marker}",
+        visibility="scope_agent", content=content,
         write_mode="strong",  # synchronous embedding ⇒ the row is searchable immediately (de-flakes)
     )
 
@@ -346,11 +347,17 @@ async def test_rest_search_scope_agent_uses_authenticated_identity(client, as_ag
         assert r.status_code == 200, r.text
         return [m["id"] for m in r.json()["items"]]
 
+    # Query the row's EXACT content, not just the bare marker. The deterministic
+    # word-set fake embedder makes that a similarity-1.0 hit, so alice's freshly
+    # written row clears any relevance cutoff and is returned — the assertions
+    # then depend only on the scope_agent VISIBILITY filter, not on stochastic
+    # vector-rank ordering over the shared test corpus. (A marker-only query
+    # ranked the row out of top_k and flaked: "author cannot see own row".)
     as_agent(tenant_id, "bob")
-    assert priv not in await _search(marker), "scope_agent row leaked to another agent in search"
+    assert priv not in await _search(content), "scope_agent row leaked to another agent in search"
 
     as_agent(tenant_id, "alice")
-    assert priv in await _search(marker), "author cannot see own scope_agent row in search"
+    assert priv in await _search(content), "author cannot see own scope_agent row in search"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Hardens `tests/test_memory_byid_authz.py::test_rest_search_scope_agent_uses_authenticated_identity`, which flaked in CI on its positive assertion ("author cannot see own scope_agent row in search") — e.g. the failure on #416's run.

## Root cause
`/search` ranks by a composite vector+relevance score over the **shared test corpus**. The test queried the **bare random marker**, which under the word-set fake embedder (`text.lower().split()`) is only a *partial* match to the row's full content — so the author's row ranked **out of `top_k` / below the relevance cutoff** (observed: `top_k=20` returned only ~5 rows). The scope_agent *visibility* logic was always correct; only the ranking-dependent retrieval was non-deterministic. `write_mode="strong"` already removed the embed-timing race, but not the ranking one.

## Fix (robust, kept on /search)
Query the row's **exact content** instead of the bare marker. The fake embedder is symmetric and deterministic, so an exact-content query is a **similarity-1.0** hit — the author's freshly-written row clears any cutoff and is returned **regardless of corpus noise**. The assertions now hinge only on the scope_agent **filter** (bob excluded; author included), not on stochastic rank ordering. Bob is filtered out pre-ranking regardless, so the security assertion stays deterministic too.

Kept on `/search` (the test's purpose) rather than moving the positive to `/list` — the adjacent `test_rest_list_uses_authenticated_identity_not_param` already covers list-side scope_agent visibility deterministically, so a `/list` assertion here would just duplicate it.

`ruff check` clean for the file; the change is test-only. (Note: this PR does **not** touch the pre-existing ruff-version-skew formatting drift elsewhere in the file — `tests/` isn't part of CI's ruff paths.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)