### PR TITLE
feat(plugin): per-target reconcile observability (PR3a)

### DIFF
--- a/docs/mcp-skill-delivery.md
+++ b/docs/mcp-skill-delivery.md
@@ -162,16 +162,24 @@ an agent may see.
 Gating decides what *should* land; observability confirms what *did*.
 Each heartbeat carries the reconciler's summary — `installed` (the
 active skills converged onto that node's disk right now), plus per-tick
-`added` / `removed` / `skipped` / `protected` deltas — which the backend
-stores as the latest snapshot at `nodes.metadata.reconcile` and surfaces
-via `GET /api/v1/fleet/nodes`. So an operator who flips a skill to
-`active` can confirm it actually reached each node, and see *why* a
-malformed catalog row was skipped — closing the loop from "approved" to
-"installed on the fleet."
+`added` / `removed` / `skipped` / `collisions` / `protected` deltas —
+which the backend stores as the latest snapshot at
+`nodes.metadata.reconcile` and surfaces via `GET /api/v1/fleet/nodes`. So
+an operator who flips a skill to `active` can confirm it actually reached
+each node, and see *why* a malformed catalog row was skipped — closing
+the loop from "approved" to "installed on the fleet."
 
 `installed` is the standing truth, not a delta: it's reported on every
 tick (even steady-state ticks with empty `added`/`removed`), so a node's
 current live-skill set is always legible.
+
+When more than one target dir is configured (see below), those top-level
+arrays are deduped *across* targets. The summary also carries a
+`targets[]` array with a **per-target** breakdown — one entry per dir
+(`{ dir, mode, installed, added, removed, collisions, protected }`) — so
+an operator can see exactly *which* dir a skill landed in or collided in.
+For the default single-target case it's one entry mirroring the top-level
+arrays.
 
 ### Reconcile targets: `owned` vs `additive`
 

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -597,6 +597,55 @@ describe("reconcileSkills — configured targets", () => {
     assert.ok(existsSync(join(SKILLS_ROOT, "deploy-runbook", "SKILL.md")));
     assert.ok(existsSync(join(EXTRA_OWNED, "deploy-runbook", "SKILL.md")));
   });
+
+  test("per-target: default single target yields one entry mirroring the aggregate", async () => {
+    plantOnDisk("memclaw");
+    mockCatalog = [
+      { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# deploy\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    assert.equal(summary.targets.length, 1, "one target reconciled");
+    const t = summary.targets[0];
+    assert.equal(t.mode, "owned");
+    assert.equal(t.dir, SKILLS_ROOT);
+    assert.deepEqual(t.installed, summary.installed);
+    assert.deepEqual(t.added, summary.added);
+    assert.deepEqual(t.protected, summary.protected);
+  });
+
+  test("per-target: owned + additive each report their own slice; aggregate dedups", async () => {
+    plantOnDisk("memclaw");
+    plantForeign("deploy-runbook", "# CLIENT version — keep\n"); // collides in the additive dir
+    useAdditive();
+    mockCatalog = [
+      { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# CATALOG deploy\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    assert.equal(summary.targets.length, 2, "owned (default) + additive");
+    const owned = summary.targets.find((t) => t.mode === "owned");
+    const additive = summary.targets.find((t) => t.mode === "additive");
+    assert.ok(owned && additive, "both targets present");
+
+    // Owned default dir installs the catalog skill; no collision there.
+    assert.equal(owned!.dir, SKILLS_ROOT);
+    assert.ok(owned!.installed.includes("deploy-runbook"));
+    assert.deepEqual(owned!.collisions, []);
+
+    // Additive dir reports the collision against the foreign occupant; it
+    // installs nothing for that slug.
+    assert.equal(additive!.dir, EXTERNAL);
+    assert.deepEqual(additive!.collisions, ["deploy-runbook"]);
+    assert.ok(!additive!.installed.includes("deploy-runbook"));
+
+    // Aggregate: the slug shows up once in installed (from owned) and once
+    // in collisions (from additive).
+    assert.ok(summary.installed.includes("deploy-runbook"));
+    assert.deepEqual(summary.collisions, ["deploy-runbook"]);
+  });
 });
 
 // Restore HOME after the suite so subsequent test files (run in

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -113,6 +113,25 @@ export interface ReconcileSummary {
   // target is configured.
   collisions: string[];
   protected: string[]; // catalog-absent but not deleted
+  // Per-target breakdown — one entry per dir reconciled this tick, in the
+  // order ``resolveSkillTargets()`` returns them (owned dir first). The
+  // top-level arrays above are these deduped+sorted across all targets;
+  // ``targets`` keeps them split so an operator can see WHICH dir a skill
+  // landed in (or collided in) when more than one target is configured.
+  // For the default single-target case this is one entry mirroring the
+  // top-level arrays.
+  targets: TargetReconcileResult[];
+}
+
+/** One target dir's contribution to a {@link ReconcileSummary}. */
+export interface TargetReconcileResult {
+  dir: string;
+  mode: SkillTargetMode;
+  installed: string[];
+  added: string[];
+  removed: string[];
+  collisions: string[];
+  protected: string[];
 }
 
 /**
@@ -120,10 +139,10 @@ export interface ReconcileSummary {
  *
  * - ``owned``: the dir is fully MemClaw-managed — every on-disk entry
  *   not in the catalog is deleted (except {@link PROTECTED_SKILLS}).
- * - ``additive``: a shared/foreign dir — MemClaw must only ever touch
- *   entries it wrote, never prune others. Parsed but NOT yet acted on
- *   here (a later PR implements ownership-tracked additive reconcile);
- *   until then such targets are skipped with a warning.
+ * - ``additive``: a shared/foreign dir — MemClaw only ever touches
+ *   entries it wrote, tracked by a per-skill {@link OWNED_MARKER}. A
+ *   foreign occupant of a desired slug is a collision (skipped, never
+ *   clobbered); unowned entries are never pruned.
  */
 export type SkillTargetMode = "owned" | "additive";
 
@@ -492,6 +511,7 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
     skipped: [],
     collisions: [],
     protected: [],
+    targets: [],
   };
 
   if (!MEMCLAW_TENANT_ID) {
@@ -586,6 +606,17 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
     protectedAll.push(...dirResult.protected);
     installedAll.push(...dirResult.installed);
     collisionsAll.push(...dirResult.collisions);
+    // Per-target breakdown — sorted within each target for a stable
+    // payload. The top-level arrays below dedup these across targets.
+    summary.targets.push({
+      dir: target.dir,
+      mode: target.mode,
+      installed: [...dirResult.installed].sort(),
+      added: [...dirResult.added].sort(),
+      removed: [...dirResult.removed].sort(),
+      collisions: [...dirResult.collisions].sort(),
+      protected: [...dirResult.protected].sort(),
+    });
   }
 
   // Aggregate across targets at slug granularity — a skill present in


### PR DESCRIPTION
## What

Third phase of the configurable-skill-targets track (after [#413](https://github.com/caura-ai/caura-memclaw/pull/413) PR1 and [#417](https://github.com/caura-ai/caura-memclaw/pull/417) PR2). This is **PR3a** — the observability half. The auto-register-into-OpenClaw half (**PR3b**) is deferred until the OpenClaw `customDirectories` key path + reload behavior are confirmed against OpenClaw source.

The reconcile summary aggregates `installed` / `added` / `removed` / `collisions` / `protected` across **all** configured targets (deduped + sorted). With more than one target — an extra `owned` dir, or an `additive` shared dir — an operator can't tell **which** dir a skill landed in, or collided in.

## Change

`ReconcileSummary` gains a `targets[]` field — one `TargetReconcileResult` per dir reconciled this tick:

```ts
{ dir, mode, installed, added, removed, collisions, protected }
```

in `resolveSkillTargets()` order (owned dir first), each array sorted. The existing top-level arrays are **unchanged** (still the cross-target dedup), so this is purely additive.

The whole summary already rides the heartbeat, and the backend stores `nodes.metadata.reconcile` as an opaque blob — so `targets[]` surfaces on `GET /api/v1/fleet/nodes` with **no backend change**.

Also fixes a stale doc comment on `SkillTargetMode` that still claimed `additive` was "parsed but NOT yet acted on … skipped with a warning" — PR2 implemented it.

## Tests

+2: default single target → one entry mirroring the aggregate; owned + additive each report their own slice while the aggregate dedups (install from owned, collision from additive). Docs updated. **333 plugin tests pass; tsc clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)