### PR TITLE
feat(plugin): auto-register additive skill dirs on OpenClaw's load path (PR3b)

### DIFF
--- a/docs/mcp-skill-delivery.md
+++ b/docs/mcp-skill-delivery.md
@@ -179,14 +179,16 @@ arrays are deduped *across* targets. The summary also carries a
 (`{ dir, mode, installed, added, removed, collisions, protected }`) — so
 an operator can see exactly *which* dir a skill landed in or collided in.
 For the default single-target case it's one entry mirroring the top-level
-arrays.
+arrays. A `registeredDirs[]` array lists the target dirs MemClaw has
+ensured are on OpenClaw's skill load path this tick (the `register: true`
+opt-in below); it's empty unless a target opts in.
 
 ### Reconcile targets: `owned` vs `additive`
 
 By default the reconciler manages one **`owned`** dir — the plugin's own
 `skills/` — where it has full authority: anything on disk not in the
 catalog is pruned. Operators can add extra target dirs via the
-`MEMCLAW_SKILL_TARGETS` env var (JSON array of `{ dir, mode }`):
+`MEMCLAW_SKILL_TARGETS` env var (JSON array of `{ dir, mode, register? }`):
 
 - **`owned`** — fully MemClaw-managed (destructive prune). Use only for
   dirs MemClaw exclusively controls.
@@ -201,9 +203,27 @@ catalog is pruned. Operators can add extra target dirs via the
 
 This makes the "empty catalog / wrong tenant wipes the dir" hazard apply
 only to `owned` dirs — `additive` dirs lose only MemClaw's own entries,
-never the client's. For an additive target to actually reach agents it
-must be on OpenClaw's skill load path (e.g. registered in
-`settings.skills.customDirectories`).
+never the client's.
+
+#### Reaching agents: `register`
+
+The plugin's own `owned` dir is already published as a plugin skill, so it
+reaches agents automatically. An **extra** target dir (typically
+`additive`) is *not* on OpenClaw's skill load path by default — its skills
+land on disk but stay invisible. Set **`register: true`** on the entry and
+the reconciler adds that dir to **`skills.load.extraDirs`** in
+`~/.openclaw/openclaw.json` — OpenClaw's documented, watched mechanism for
+extra skill directories (`docs/tools/skills-config.md`; consumed by the
+skills-snapshot refresh). The write is append-only and idempotent (existing
+entries preserved; written only when the dir is newly added), and fail-safe
+(a missing/unreadable config is logged, never fatal to the heartbeat). The
+owned dir is never registered this way.
+
+`skills.load.watch` defaults to `true`, so OpenClaw picks up a newly
+registered dir and refreshes its skills snapshot without a restart.
+**But** a long-lived agent *session* keeps its cached `<available_skills>`
+snapshot — a session that was already running won't see the newly
+registered skills until a fresh session starts (new `--session-key`).
 
 ## What makes a skill findable: the summary
 

--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -463,6 +463,20 @@ describe("ensureExtraSkillDirs", () => {
     }
   });
 
+  test("preserves non-string entries already in extraDirs (no data loss)", () => {
+    const ctx = _ensureExtraDirsWithConfig(
+      { skills: { load: { extraDirs: ["/keep/me", 42, { weird: true }] } } },
+      ["/srv/shared/skills"],
+    );
+    try {
+      assert.equal(ctx.result.changed, true);
+      const load = (ctx.written?.skills as { load?: { extraDirs?: unknown[] } }).load;
+      assert.deepEqual(load?.extraDirs, ["/keep/me", 42, { weird: true }, "/srv/shared/skills"]);
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
   test("fails safe when openclaw.json is missing — error, no throw", () => {
     const ctx = _ensureExtraDirsWithConfig(null, ["/srv/shared/skills"]);
     try {

--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -516,6 +516,28 @@ describe("ensureExtraSkillDirs", () => {
     }
   });
 
+  test("rejects a malformed non-object skills field — error, not clobbered", () => {
+    const ctx = _ensureExtraDirsWithConfig({ skills: "i am a string" }, ["/srv/shared/skills"]);
+    try {
+      assert.equal(ctx.result.changed, false);
+      assert.ok(ctx.result.error && /'skills' is not an object/.test(ctx.result.error));
+      assert.equal((ctx.written as { skills?: unknown }).skills, "i am a string", "untouched");
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  test("rejects a malformed non-object skills.load field — error, not clobbered", () => {
+    const ctx = _ensureExtraDirsWithConfig({ skills: { load: 42 } }, ["/srv/shared/skills"]);
+    try {
+      assert.equal(ctx.result.changed, false);
+      assert.ok(ctx.result.error && /'skills\.load' is not an object/.test(ctx.result.error));
+      assert.equal((ctx.written as { skills?: { load?: unknown } }).skills?.load, 42, "untouched");
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
   test("a relative existing entry is not falsely deduped against an absolute dir", () => {
     const ctx = _ensureExtraDirsWithConfig(
       { skills: { load: { extraDirs: ["./rel/skills"] } } },

--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -437,6 +437,20 @@ describe("ensureExtraSkillDirs", () => {
     }
   });
 
+  test("reports alreadyPresent alongside a newly added dir", () => {
+    const ctx = _ensureExtraDirsWithConfig(
+      { skills: { load: { extraDirs: ["/already/here"] } } },
+      ["/already/here", "/srv/new"],
+    );
+    try {
+      assert.equal(ctx.result.changed, true);
+      assert.deepEqual(ctx.result.added, ["/srv/new"]);
+      assert.deepEqual(ctx.result.alreadyPresent, ["/already/here"]);
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
   test("is idempotent — a dir already present is a no-op (no write)", () => {
     const ctx = _ensureExtraDirsWithConfig(
       { skills: { load: { extraDirs: ["/srv/shared/skills"] } } },

--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -487,6 +487,38 @@ describe("ensureExtraSkillDirs", () => {
     }
   });
 
+  test("rejects a top-level JSON array — error, file NOT clobbered", () => {
+    // A top-level array is truthy: a bare !config check would let it through,
+    // then JSON.stringify would silently drop the .skills prop and rewrite [].
+    const ctx = _ensureExtraDirsWithConfig(["/pre/existing"] as unknown as Record<string, unknown>, [
+      "/srv/shared/skills",
+    ]);
+    try {
+      assert.equal(ctx.result.changed, false);
+      assert.ok(ctx.result.error && /not a JSON object/.test(ctx.result.error));
+      assert.deepEqual(ctx.written, ["/pre/existing"], "original array left untouched");
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  test("a relative existing entry is not falsely deduped against an absolute dir", () => {
+    const ctx = _ensureExtraDirsWithConfig(
+      { skills: { load: { extraDirs: ["./rel/skills"] } } },
+      ["/srv/shared/skills"],
+    );
+    try {
+      // Relative entries are compared literally (no CWD guess), so the
+      // absolute dir is treated as distinct and appended; the relative
+      // entry is preserved.
+      assert.equal(ctx.result.changed, true);
+      const load = (ctx.written?.skills as { load?: { extraDirs?: string[] } }).load;
+      assert.deepEqual(load?.extraDirs, ["./rel/skills", "/srv/shared/skills"]);
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
   test("empty input is a no-op", () => {
     const ctx = _ensureExtraDirsWithConfig({ skills: {} }, []);
     try {

--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import {
   autoFixAllowlist,
+  ensureExtraSkillDirs,
   isContextEngineSlotClaimed,
   isMemclawAllowed,
   isMemclawFullyConfigured,
@@ -356,6 +357,127 @@ describe("autoFixAllowlist — plugins.allow non-creation (CAURA-000)", () => {
         1,
         `memclaw must appear exactly once; got: ${JSON.stringify(allow)}`,
       );
+    } finally {
+      ctx.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureExtraSkillDirs — append a dir to OpenClaw's skills.load.extraDirs
+// ---------------------------------------------------------------------------
+
+function _ensureExtraDirsWithConfig(
+  initial: Record<string, unknown> | null,
+  dirsOrFn: string[] | ((home: string) => string[]),
+): {
+  written: Record<string, unknown> | null;
+  result: ReturnType<typeof ensureExtraSkillDirs>;
+  cleanup: () => void;
+} {
+  const tmp = mkdtempSync(join(tmpdir(), "memclaw-extradirs-test-"));
+  mkdirSync(join(tmp, ".openclaw"), { recursive: true });
+  const cfgPath = join(tmp, ".openclaw", "openclaw.json");
+  if (initial !== null) {
+    writeFileSync(cfgPath, JSON.stringify(initial), "utf-8");
+  }
+  // Resolve dirs against the SAME home the function will see, so a test can
+  // build an absolute path that matches a ``~``-relative config entry.
+  const dirs = typeof dirsOrFn === "function" ? dirsOrFn(tmp) : dirsOrFn;
+  const prevHome = process.env.HOME;
+  process.env.HOME = tmp;
+  const result = ensureExtraSkillDirs(dirs);
+  process.env.HOME = prevHome;
+  let written: Record<string, unknown> | null = null;
+  try {
+    written = JSON.parse(readFileSync(cfgPath, "utf-8"));
+  } catch {
+    written = null;
+  }
+  return {
+    written,
+    result,
+    cleanup: () => {
+      try {
+        rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+describe("ensureExtraSkillDirs", () => {
+  test("creates skills.load.extraDirs and appends the dir when absent", () => {
+    const ctx = _ensureExtraDirsWithConfig({ tools: {} }, ["/srv/shared/skills"]);
+    try {
+      assert.equal(ctx.result.changed, true);
+      assert.deepEqual(ctx.result.added, ["/srv/shared/skills"]);
+      const skills = ctx.written?.skills as { load?: { extraDirs?: string[] } };
+      assert.deepEqual(skills.load?.extraDirs, ["/srv/shared/skills"]);
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  test("preserves existing extraDirs and appends only the missing one", () => {
+    const ctx = _ensureExtraDirsWithConfig(
+      { skills: { load: { extraDirs: ["/already/there"], watch: true } } },
+      ["/srv/shared/skills"],
+    );
+    try {
+      assert.equal(ctx.result.changed, true);
+      assert.deepEqual(ctx.result.added, ["/srv/shared/skills"]);
+      const load = (ctx.written?.skills as { load?: { extraDirs?: string[]; watch?: boolean } })
+        .load;
+      assert.deepEqual(load?.extraDirs, ["/already/there", "/srv/shared/skills"]);
+      assert.equal(load?.watch, true, "other load keys are preserved");
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  test("is idempotent — a dir already present is a no-op (no write)", () => {
+    const ctx = _ensureExtraDirsWithConfig(
+      { skills: { load: { extraDirs: ["/srv/shared/skills"] } } },
+      ["/srv/shared/skills"],
+    );
+    try {
+      assert.equal(ctx.result.changed, false);
+      assert.deepEqual(ctx.result.added, []);
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  test("matches an existing ~-relative entry against an absolute dir (no dup)", () => {
+    const ctx = _ensureExtraDirsWithConfig(
+      { skills: { load: { extraDirs: ["~/shared/skills"] } } },
+      (home) => [join(home, "shared", "skills")],
+    );
+    try {
+      assert.equal(ctx.result.changed, false, "~ entry should canonically match the absolute dir");
+      assert.deepEqual(ctx.result.added, []);
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  test("fails safe when openclaw.json is missing — error, no throw", () => {
+    const ctx = _ensureExtraDirsWithConfig(null, ["/srv/shared/skills"]);
+    try {
+      assert.equal(ctx.result.changed, false);
+      assert.ok(ctx.result.error && /not found/.test(ctx.result.error));
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  test("empty input is a no-op", () => {
+    const ctx = _ensureExtraDirsWithConfig({ skills: {} }, []);
+    try {
+      assert.equal(ctx.result.changed, false);
+      assert.deepEqual(ctx.result.added, []);
     } finally {
       ctx.cleanup();
     }

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -355,13 +355,19 @@ export function ensureExtraSkillDirs(dirs: string[]): {
   ) {
     config.skills.load = {};
   }
-  const existing: string[] = Array.isArray(config.skills.load.extraDirs)
-    ? config.skills.load.extraDirs.filter((x: unknown): x is string => typeof x === "string")
+  // Preserve the original array verbatim on write (including any non-string
+  // entries — future format extensions or user mistakes); use the
+  // string-only view solely for canonical-path dedup.
+  const originalExtraDirs: unknown[] = Array.isArray(config.skills.load.extraDirs)
+    ? config.skills.load.extraDirs
     : [];
+  const existing: string[] = originalExtraDirs.filter(
+    (x): x is string => typeof x === "string",
+  );
   const present = new Set(existing.map(canonicalDir));
 
   const added: string[] = [];
-  const next = [...existing];
+  const next: unknown[] = [...originalExtraDirs];
   for (const dir of wanted) {
     if (present.has(canonicalDir(dir))) continue;
     next.push(dir);

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -365,15 +365,29 @@ export function ensureExtraSkillDirs(dirs: string[]): {
     };
   }
 
-  if (!config.skills || typeof config.skills !== "object" || Array.isArray(config.skills)) {
+  // Normalize the nested containers, but only when ABSENT (null/undefined).
+  // A truthy non-object (e.g. ``"skills": "foo"`` or ``42``) is a malformed
+  // config we must not silently overwrite — detect-and-error, consistent
+  // with the top-level guard above.
+  if (config.skills == null) {
     config.skills = {};
+  } else if (typeof config.skills !== "object" || Array.isArray(config.skills)) {
+    return {
+      changed: false,
+      added: [],
+      alreadyPresent: [],
+      error: `openclaw.json 'skills' is not an object at ${getOpenClawConfigPath()}`,
+    };
   }
-  if (
-    !config.skills.load ||
-    typeof config.skills.load !== "object" ||
-    Array.isArray(config.skills.load)
-  ) {
+  if (config.skills.load == null) {
     config.skills.load = {};
+  } else if (typeof config.skills.load !== "object" || Array.isArray(config.skills.load)) {
+    return {
+      changed: false,
+      added: [],
+      alreadyPresent: [],
+      error: `openclaw.json 'skills.load' is not an object at ${getOpenClawConfigPath()}`,
+    };
   }
   // Preserve the original array verbatim on write (including any non-string
   // entries — future format extensions or user mistakes); use the

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -299,13 +299,17 @@ export function shouldRunAutoFix(params: {
   );
 }
 
-/** Expand a leading ``~`` / ``~/`` to the home dir, then resolve to an
- * absolute canonical path — for comparing config entries (which may use
- * ``~``) against our already-absolute target dirs. */
+/** Canonicalize a config entry for dedup comparison against our
+ * already-absolute target dirs. ``~``/``~/`` expand to the home dir;
+ * absolute paths are resolved; a RELATIVE entry is compared literally —
+ * resolving it against ``process.cwd()`` would guess a base that likely
+ * differs from how OpenClaw interprets relative ``extraDirs`` entries,
+ * causing false dedup misses. */
 function canonicalDir(p: string): string {
-  const expanded =
-    p === "~" ? homedir() : p.startsWith("~/") ? join(homedir(), p.slice(2)) : p;
-  return resolve(expanded);
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return resolve(join(homedir(), p.slice(2)));
+  if (p.startsWith("/")) return resolve(p);
+  return p; // relative path: compare literally, don't guess a base
 }
 
 /**
@@ -337,11 +341,15 @@ export function ensureExtraSkillDirs(dirs: string[]): {
   if (wanted.length === 0) return { changed: false, added: [] };
 
   const config = readOpenClawConfig() as Record<string, any> | null;
-  if (!config) {
+  // Must be a JSON object. A top-level array (or other non-object) is
+  // truthy and would slip past a bare ``!config`` check — then setting
+  // ``.skills`` on it is silently dropped by JSON.stringify and the file
+  // gets rewritten as ``[]``. Reject it instead of clobbering the config.
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
     return {
       changed: false,
       added: [],
-      error: `openclaw.json not found/unreadable at ${getOpenClawConfigPath()}`,
+      error: `openclaw.json not found/unreadable or not a JSON object at ${getOpenClawConfigPath()}`,
     };
   }
 

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -335,21 +335,33 @@ function canonicalDir(p: string): string {
 export function ensureExtraSkillDirs(dirs: string[]): {
   changed: boolean;
   added: string[];
+  /** Wanted dirs already on the load path before this call — genuinely
+   * registered regardless of whether a write for new additions failed. */
+  alreadyPresent: string[];
   error?: string;
 } {
   const wanted = [...new Set(dirs.filter((d) => typeof d === "string" && d.trim()))];
-  if (wanted.length === 0) return { changed: false, added: [] };
+  if (wanted.length === 0) return { changed: false, added: [], alreadyPresent: [] };
 
   const config = readOpenClawConfig() as Record<string, any> | null;
+  if (!config) {
+    return {
+      changed: false,
+      added: [],
+      alreadyPresent: [],
+      error: `openclaw.json not found or unreadable at ${getOpenClawConfigPath()}`,
+    };
+  }
   // Must be a JSON object. A top-level array (or other non-object) is
   // truthy and would slip past a bare ``!config`` check — then setting
   // ``.skills`` on it is silently dropped by JSON.stringify and the file
   // gets rewritten as ``[]``. Reject it instead of clobbering the config.
-  if (!config || typeof config !== "object" || Array.isArray(config)) {
+  if (typeof config !== "object" || Array.isArray(config)) {
     return {
       changed: false,
       added: [],
-      error: `openclaw.json not found/unreadable or not a JSON object at ${getOpenClawConfigPath()}`,
+      alreadyPresent: [],
+      error: `openclaw.json is not a JSON object at ${getOpenClawConfigPath()}`,
     };
   }
 
@@ -373,6 +385,7 @@ export function ensureExtraSkillDirs(dirs: string[]): {
     (x): x is string => typeof x === "string",
   );
   const present = new Set(existing.map(canonicalDir));
+  const alreadyPresent: string[] = wanted.filter((d) => present.has(canonicalDir(d)));
 
   const added: string[] = [];
   const next: unknown[] = [...originalExtraDirs];
@@ -382,14 +395,14 @@ export function ensureExtraSkillDirs(dirs: string[]): {
     present.add(canonicalDir(dir));
     added.push(dir);
   }
-  if (added.length === 0) return { changed: false, added: [] };
+  if (added.length === 0) return { changed: false, added: [], alreadyPresent };
 
   config.skills.load.extraDirs = next;
   try {
     writeFileSync(getOpenClawConfigPath(), JSON.stringify(config, null, 2) + "\n", "utf-8");
-    return { changed: true, added };
+    return { changed: true, added, alreadyPresent };
   } catch (e: unknown) {
     const msg = logError("ensureExtraSkillDirs write failed", e);
-    return { changed: false, added: [], error: msg };
+    return { changed: false, added: [], alreadyPresent, error: msg };
   }
 }

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -3,7 +3,8 @@
  */
 
 import { readFileSync, writeFileSync, existsSync } from "fs";
-import { join } from "path";
+import { join, resolve } from "path";
+import { homedir } from "os";
 import { MEMCLAW_TOOLS } from "./tools.js";
 import { getPluginDir, getOpenClawConfigPath } from "./paths.js";
 import { logError } from "./logger.js";
@@ -296,4 +297,85 @@ export function shouldRunAutoFix(params: {
     params.missingToolCount > 0 ||
     !params.contextEngineSlotClaimed
   );
+}
+
+/** Expand a leading ``~`` / ``~/`` to the home dir, then resolve to an
+ * absolute canonical path — for comparing config entries (which may use
+ * ``~``) against our already-absolute target dirs. */
+function canonicalDir(p: string): string {
+  const expanded =
+    p === "~" ? homedir() : p.startsWith("~/") ? join(homedir(), p.slice(2)) : p;
+  return resolve(expanded);
+}
+
+/**
+ * Ensure each dir in ``dirs`` is present in ``skills.load.extraDirs`` in
+ * ``openclaw.json`` — OpenClaw's documented, watched load path for extra
+ * skill directories (``docs/tools/skills-config.md``; consumed by
+ * ``src/skills/runtime/refresh.ts``). This is how a reconciled *additive*
+ * target dir (one MemClaw doesn't own and can't publish as a plugin skill)
+ * actually reaches agents.
+ *
+ * Append-only and idempotent: existing entries are preserved, a dir already
+ * present (compared by canonical path, so ``~`` entries match) is left
+ * alone, and the file is written ONLY when something was added. Mirrors the
+ * ``autoFixAllowlist`` write idiom and OpenClaw's own
+ * ``plugins-install-command`` extraDirs-merge pattern. Fails safe: a missing
+ * or unreadable config, or a write error, returns an ``error`` and never
+ * throws — the heartbeat must not crash on a registration failure.
+ *
+ * NOTE: adding a dir here makes its skills discoverable on the node, but an
+ * already-running agent session keeps its cached ``<available_skills>``
+ * snapshot until a fresh session starts.
+ */
+export function ensureExtraSkillDirs(dirs: string[]): {
+  changed: boolean;
+  added: string[];
+  error?: string;
+} {
+  const wanted = [...new Set(dirs.filter((d) => typeof d === "string" && d.trim()))];
+  if (wanted.length === 0) return { changed: false, added: [] };
+
+  const config = readOpenClawConfig() as Record<string, any> | null;
+  if (!config) {
+    return {
+      changed: false,
+      added: [],
+      error: `openclaw.json not found/unreadable at ${getOpenClawConfigPath()}`,
+    };
+  }
+
+  if (!config.skills || typeof config.skills !== "object" || Array.isArray(config.skills)) {
+    config.skills = {};
+  }
+  if (
+    !config.skills.load ||
+    typeof config.skills.load !== "object" ||
+    Array.isArray(config.skills.load)
+  ) {
+    config.skills.load = {};
+  }
+  const existing: string[] = Array.isArray(config.skills.load.extraDirs)
+    ? config.skills.load.extraDirs.filter((x: unknown): x is string => typeof x === "string")
+    : [];
+  const present = new Set(existing.map(canonicalDir));
+
+  const added: string[] = [];
+  const next = [...existing];
+  for (const dir of wanted) {
+    if (present.has(canonicalDir(dir))) continue;
+    next.push(dir);
+    present.add(canonicalDir(dir));
+    added.push(dir);
+  }
+  if (added.length === 0) return { changed: false, added: [] };
+
+  config.skills.load.extraDirs = next;
+  try {
+    writeFileSync(getOpenClawConfigPath(), JSON.stringify(config, null, 2) + "\n", "utf-8");
+    return { changed: true, added };
+  } catch (e: unknown) {
+    const msg = logError("ensureExtraSkillDirs write failed", e);
+    return { changed: false, added: [], error: msg };
+  }
 }

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -714,6 +714,24 @@ describe("reconcileSkills — configured targets", () => {
     assert.deepEqual(readExtraDirs(), ["/pre/existing"], "extraDirs unchanged");
   });
 
+  test("register: a write failure is NOT reported as registered", async () => {
+    plantOnDisk("memclaw");
+    // No openclaw.json written → ensureExtraSkillDirs fails closed.
+    if (existsSync(OPENCLAW_JSON)) rmSync(OPENCLAW_JSON, { force: true });
+    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+      { dir: EXTERNAL, mode: "additive", register: true },
+    ]);
+    mockCatalog = [
+      { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# deploy\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    // Skill still reconciled to disk, but registration failed → not claimed.
+    assert.ok(existsSync(ext("deploy-runbook", "SKILL.md")), "skill still written to disk");
+    assert.deepEqual(summary.registeredDirs, [], "failed registration is not reported as managed");
+  });
+
   test("register: idempotent — re-running does not duplicate the entry", async () => {
     plantOnDisk("memclaw");
     writeOpenClawJson({ skills: { load: { extraDirs: [EXTERNAL] } } }); // already present

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -391,6 +391,26 @@ describe("resolveSkillTargets (config plumbing)", () => {
     );
   });
 
+  test("register defaults to false; owned default dir is never register:true", () => {
+    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([{ dir: "/tmp/wt-a", mode: "additive" }]);
+    const targets = resolveSkillTargets();
+    assert.equal(targets[0].register, false, "owned default dir is never registered");
+    assert.equal(targets[1].register, false, "register omitted → false");
+  });
+
+  test("register: true is parsed per entry", () => {
+    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+      { dir: "/tmp/wt-a", mode: "additive", register: true },
+      { dir: "/tmp/wt-b", mode: "additive", register: false },
+      { dir: "/tmp/wt-c", mode: "additive", register: "yes" }, // non-true → false
+    ]);
+    const targets = resolveSkillTargets();
+    assert.deepEqual(
+      targets.slice(1).map((t) => [t.dir, t.register]),
+      [["/tmp/wt-a", true], ["/tmp/wt-b", false], ["/tmp/wt-c", false]],
+    );
+  });
+
   test("invalid JSON → fail safe to owned-only", () => {
     process.env.MEMCLAW_SKILL_TARGETS = "{not valid json";
     const targets = resolveSkillTargets();
@@ -444,10 +464,24 @@ describe("reconcileSkills — configured targets", () => {
     mockCatalog = [];
   });
 
+  const OPENCLAW_JSON = join(tmpHome, ".openclaw", "openclaw.json");
+
   afterEach(() => {
     restoreFetch();
     delete process.env.MEMCLAW_SKILL_TARGETS;
+    if (existsSync(OPENCLAW_JSON)) rmSync(OPENCLAW_JSON, { force: true });
   });
+
+  const writeOpenClawJson = (cfg: Record<string, unknown>) => {
+    mkdirSync(join(tmpHome, ".openclaw"), { recursive: true });
+    writeFileSync(OPENCLAW_JSON, JSON.stringify(cfg), "utf-8");
+  };
+  const readExtraDirs = (): string[] => {
+    const cfg = JSON.parse(readFileSync(OPENCLAW_JSON, "utf-8")) as {
+      skills?: { load?: { extraDirs?: string[] } };
+    };
+    return cfg.skills?.load?.extraDirs ?? [];
+  };
 
   // Helpers for the additive dir.
   const ext = (slug: string, ...rest: string[]) => join(EXTERNAL, slug, ...rest);
@@ -645,6 +679,53 @@ describe("reconcileSkills — configured targets", () => {
     // in collisions (from additive).
     assert.ok(summary.installed.includes("deploy-runbook"));
     assert.deepEqual(summary.collisions, ["deploy-runbook"]);
+  });
+
+  test("register: an additive target with register:true is added to skills.load.extraDirs", async () => {
+    plantOnDisk("memclaw");
+    writeOpenClawJson({ tools: {} }); // vanilla config, no skills block yet
+    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+      { dir: EXTERNAL, mode: "additive", register: true },
+    ]);
+    mockCatalog = [
+      { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# deploy\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    // The additive dir is registered on OpenClaw's load path...
+    assert.deepEqual(summary.registeredDirs, [EXTERNAL]);
+    assert.ok(readExtraDirs().includes(EXTERNAL), "extraDirs contains the additive dir");
+    // ...but never the plugin's own owned dir (published as a plugin skill).
+    assert.ok(!readExtraDirs().includes(SKILLS_ROOT), "owned dir is never registered");
+  });
+
+  test("register: omitted/false leaves openclaw.json untouched", async () => {
+    plantOnDisk("memclaw");
+    writeOpenClawJson({ skills: { load: { extraDirs: ["/pre/existing"] } } });
+    useAdditive(); // no register flag
+    mockCatalog = [
+      { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# deploy\n" } },
+    ];
+
+    const summary = await reconcileSkills();
+
+    assert.deepEqual(summary.registeredDirs, [], "nothing registered");
+    assert.deepEqual(readExtraDirs(), ["/pre/existing"], "extraDirs unchanged");
+  });
+
+  test("register: idempotent — re-running does not duplicate the entry", async () => {
+    plantOnDisk("memclaw");
+    writeOpenClawJson({ skills: { load: { extraDirs: [EXTERNAL] } } }); // already present
+    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+      { dir: EXTERNAL, mode: "additive", register: true },
+    ]);
+    mockCatalog = [];
+
+    const summary = await reconcileSkills();
+
+    assert.deepEqual(summary.registeredDirs, [EXTERNAL], "still reported as managed");
+    assert.deepEqual(readExtraDirs(), [EXTERNAL], "no duplicate appended");
   });
 });
 

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -660,11 +660,14 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
   if (registerDirs.length > 0) {
     const reg = ensureExtraSkillDirs(registerDirs);
     if (reg.error) {
-      // Registration failed — do NOT report these as managed; the field
-      // must reflect what's actually on the load path.
+      // The write for NEW additions failed — but any dirs that were already
+      // on the load path are genuinely registered, so still report those.
       console.warn(
         `[memclaw] reconcileSkills: could not register extra skill dir(s) in openclaw.json: ${reg.error}`,
       );
+      if (reg.alreadyPresent.length > 0) {
+        summary.registeredDirs = [...new Set(reg.alreadyPresent)].sort();
+      }
     } else {
       // Success or idempotent no-op (already present) → standing truth.
       summary.registeredDirs = [...new Set(registerDirs)].sort();

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -56,7 +56,7 @@ import { join, resolve } from "path";
 
 import { apiCall } from "./transport.js";
 import { MEMCLAW_TENANT_ID, MEMCLAW_FLEET_ID } from "./env.js";
-import { getPluginDir } from "./config.js";
+import { getPluginDir, ensureExtraSkillDirs } from "./config.js";
 import { logError } from "./logger.js";
 
 /**
@@ -121,6 +121,11 @@ export interface ReconcileSummary {
   // For the default single-target case this is one entry mirroring the
   // top-level arrays.
   targets: TargetReconcileResult[];
+  // Target dirs MemClaw ensured are present in OpenClaw's
+  // ``skills.load.extraDirs`` this tick (the ``register: true`` opt-in).
+  // Standing truth — the full set we manage, sorted — not a delta. Empty
+  // unless a configured target opts into registration.
+  registeredDirs: string[];
 }
 
 /** One target dir's contribution to a {@link ReconcileSummary}. */
@@ -149,6 +154,14 @@ export type SkillTargetMode = "owned" | "additive";
 export interface SkillTarget {
   dir: string;
   mode: SkillTargetMode;
+  /**
+   * Opt-in: also register this dir in OpenClaw's ``skills.load.extraDirs``
+   * (in ``openclaw.json``) so its reconciled skills actually reach agents.
+   * Off by default. The plugin's own owned dir is never registered — it's
+   * already published as a plugin skill. Use for a configured dir (usually
+   * ``additive``) that isn't otherwise on OpenClaw's skill load path.
+   */
+  register: boolean;
 }
 
 /** The plugin's own skills dir — always reconciled in ``owned`` mode. */
@@ -174,7 +187,9 @@ export function resolveSkillTargets(): SkillTarget[] {
   // (e.g. with ``..`` segments) would let an entry resolving to the same
   // dir slip past the seen-set and reconcile the owned dir twice.
   const ownedDir = resolve(ownedSkillsDir());
-  const targets: SkillTarget[] = [{ dir: ownedDir, mode: "owned" }];
+  // The plugin's own dir is published as a plugin skill, never registered
+  // as an extraDir.
+  const targets: SkillTarget[] = [{ dir: ownedDir, mode: "owned", register: false }];
 
   const raw = process.env.MEMCLAW_SKILL_TARGETS;
   if (!raw || !raw.trim()) return targets;
@@ -199,6 +214,7 @@ export function resolveSkillTargets(): SkillTarget[] {
     }
     const dir = (entry as { dir?: unknown }).dir;
     const mode = (entry as { mode?: unknown }).mode;
+    const register = (entry as { register?: unknown }).register === true;
     if (typeof dir !== "string" || !dir.trim()) {
       console.warn("[memclaw] MEMCLAW_SKILL_TARGETS: entry missing string 'dir'; skipping");
       continue;
@@ -220,7 +236,7 @@ export function resolveSkillTargets(): SkillTarget[] {
     }
     if (seen.has(normalized)) continue; // dedupe; owned dir already present
     seen.add(normalized);
-    targets.push({ dir: normalized, mode });
+    targets.push({ dir: normalized, mode, register });
   }
   return targets;
 }
@@ -512,6 +528,7 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
     collisions: [],
     protected: [],
     targets: [],
+    registeredDirs: [],
   };
 
   if (!MEMCLAW_TENANT_ID) {
@@ -596,7 +613,8 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
   const removedAll: string[] = [];
   const protectedAll: string[] = [];
   const collisionsAll: string[] = [];
-  for (const target of resolveSkillTargets()) {
+  const targets = resolveSkillTargets();
+  for (const target of targets) {
     const dirResult =
       target.mode === "additive"
         ? reconcileAdditiveDir(target.dir, desired)
@@ -633,6 +651,25 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
   // separately so the two failure modes don't get conflated.
   summary.skipped = [...new Set(summary.skipped)].sort();
   summary.collisions = [...new Set(collisionsAll)].sort();
+
+  // 4. Register any opt-in target dirs in OpenClaw's ``skills.load.extraDirs``
+  //    so their reconciled skills actually reach agents. Append-only,
+  //    idempotent, and fail-safe — a registration error is logged but never
+  //    aborts the heartbeat (the skills are already on disk regardless).
+  const registerDirs = targets.filter((t) => t.register).map((t) => t.dir);
+  if (registerDirs.length > 0) {
+    summary.registeredDirs = [...new Set(registerDirs)].sort();
+    const reg = ensureExtraSkillDirs(registerDirs);
+    if (reg.error) {
+      console.warn(
+        `[memclaw] reconcileSkills: could not register extra skill dir(s) in openclaw.json: ${reg.error}`,
+      );
+    } else if (reg.added.length > 0) {
+      console.log(
+        `[memclaw] reconcileSkills: registered skills.load.extraDirs: ${reg.added.join(", ")}`,
+      );
+    }
+  }
 
   return summary;
 }

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -658,16 +658,21 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
   //    aborts the heartbeat (the skills are already on disk regardless).
   const registerDirs = targets.filter((t) => t.register).map((t) => t.dir);
   if (registerDirs.length > 0) {
-    summary.registeredDirs = [...new Set(registerDirs)].sort();
     const reg = ensureExtraSkillDirs(registerDirs);
     if (reg.error) {
+      // Registration failed — do NOT report these as managed; the field
+      // must reflect what's actually on the load path.
       console.warn(
         `[memclaw] reconcileSkills: could not register extra skill dir(s) in openclaw.json: ${reg.error}`,
       );
-    } else if (reg.added.length > 0) {
-      console.log(
-        `[memclaw] reconcileSkills: registered skills.load.extraDirs: ${reg.added.join(", ")}`,
-      );
+    } else {
+      // Success or idempotent no-op (already present) → standing truth.
+      summary.registeredDirs = [...new Set(registerDirs)].sort();
+      if (reg.added.length > 0) {
+        console.log(
+          `[memclaw] reconcileSkills: registered skills.load.extraDirs: ${reg.added.join(", ")}`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## What

Final phase of the configurable-skill-targets track ([#413](https://github.com/caura-ai/caura-memclaw/pull/413) PR1 · [#417](https://github.com/caura-ai/caura-memclaw/pull/417) PR2 · [#424](https://github.com/caura-ai/caura-memclaw/pull/424) PR3a).

An `additive` target dir is reconciled to disk, but — unlike the plugin's own `owned` dir, which is published as a plugin skill — it is **not** on OpenClaw's skill load path, so its skills land yet stay invisible to agents. This closes that gap behind an explicit **opt-in**.

## Grounding (against `openclaw/openclaw`)

The documented, watched mechanism for extra skill dirs is **`skills.load.extraDirs: string[]` in `~/.openclaw/openclaw.json`** — `docs/tools/skills-config.md`, consumed by `src/skills/runtime/refresh.ts`.

- **NOT** `settings.skills.customDirectories` (the value the PR2 docs guessed) — that nested form is **deprecated**, auto-migrated by `settings-manager.ts` to a flat *per-agent* `settings.skills` array. This PR also corrects that stale doc line.
- `skills.load.watch` defaults `true` → a newly added dir is picked up **without a restart**. Caveat: a long-lived agent *session* keeps its cached `<available_skills>` snapshot until a fresh session (`--session-key`).
- OpenClaw's own `plugins-install-command` uses the same read→merge→write pattern for `hooks.internal.load.extraDirs` — direct precedent.

## Change

- `SkillTarget` gains **`register: boolean`** (default false; owned default dir always false). Parsed from `MEMCLAW_SKILL_TARGETS` entries (`{ dir, mode, register? }`).
- `config.ts: ensureExtraSkillDirs(dirs)` — append-only, **idempotent** (canonical-path dedup, so a `~` entry matches an absolute dir), writes `openclaw.json` only when a dir is newly added (mirrors the `autoFixAllowlist` write idiom). **Fail-safe**: missing/unreadable config or a write error returns an `error`, never throws.
- `reconcileSkills` registers `register: true` dirs after the reconcile loop and reports them in a new `summary.registeredDirs` (standing truth; rides the heartbeat → `/fleet/nodes`, **no backend change**). A registration failure is logged, never aborts the heartbeat.
- Docs corrected + `register`/watch/stale-session documented.

## Tests

+11: `ensureExtraSkillDirs` (create/append/preserve/idempotent/`~`-canonical-match/missing-config-fail-safe/empty-noop), `register` parsing (default false, per-entry, owned never registered), `reconcileSkills` integration (registers an additive dir, untouched without the flag, idempotent re-run). **344 plugin tests pass; tsc clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)