### PR TITLE
fix(core-api): cut prod connect-timeout + rate-limit-Redis log noise

### DIFF
--- a/common/http_retry.py
+++ b/common/http_retry.py
@@ -102,6 +102,7 @@ async def with_retry(
     retryable_exceptions: tuple[type[Exception], ...] = RETRYABLE_EXCEPTIONS,
     retryable_statuses: frozenset[int] = RETRYABLE_STATUS_CODES,
     max_attempts: int = RETRY_MAX_ATTEMPTS,
+    connect_phase_max_attempts: int | None = None,
 ) -> httpx.Response:
     """Wrap a single HTTP call with retry on transient errors.
 
@@ -113,31 +114,55 @@ async def with_retry(
     retrying won't change a client error. Non-idempotent callers go
     through :func:`with_connect_phase_retry` to retry only failures
     where the request was provably never sent.
+
+    ``connect_phase_max_attempts`` (default = ``max_attempts``) gives the
+    connection-phase exceptions (``CONNECT_PHASE_EXCEPTIONS``) their own,
+    typically higher, attempt budget while ReadTimeout and 5xx stay capped
+    at ``max_attempts``. Idempotent reads use this to ride out a storage
+    cold start (a connect failure was provably never sent, so the extra
+    retries add no load) without over-retrying a genuine 5xx storm — the
+    same rationale as :func:`with_connect_phase_retry`, applied to GETs so a
+    transient ``ConnectTimeout`` doesn't surface as a handler failure (and,
+    on the Pub/Sub path, a nack → immediate-redelivery storm).
     """
+    cp_max = (
+        connect_phase_max_attempts
+        if connect_phase_max_attempts is not None
+        else max_attempts
+    )
+    effective_max = max(max_attempts, cp_max)
     last_exc: BaseException | None = None
-    for attempt in range(1, max_attempts + 1):
+    for attempt in range(1, effective_max + 1):
         try:
             resp = await do_request()
         except retryable_exceptions as e:
             last_exc = e
-            if attempt < max_attempts:
+            # Connection-phase failures get their own (typically higher)
+            # budget; ReadTimeout and other transients stay at max_attempts.
+            limit = cp_max if isinstance(e, CONNECT_PHASE_EXCEPTIONS) else max_attempts
+            if attempt < limit:
                 delay = _backoff_delay(attempt)
                 logger.warning(
                     "storage_client.%s: %s on attempt %d/%d, retrying in %.2fs",
                     label,
                     type(e).__name__,
                     attempt,
-                    max_attempts,
+                    limit,
                     delay,
                 )
                 await asyncio.sleep(delay)
                 continue
+            # Don't print "attempt N/M": when connect-phase retries burn past
+            # max_attempts (cp_max > max_attempts) and a ReadTimeout/5xx then
+            # hits at attempt N > max_attempts, "N/M" reads as a self-
+            # contradictory "4/3" during triage. Name the per-error budget
+            # instead so the asymmetric limit is self-explanatory.
             logger.warning(
-                "storage_client.%s: %s on final attempt %d/%d, giving up",
+                "storage_client.%s: giving up on attempt %d (budget for %s: %d)",
                 label,
-                type(e).__name__,
                 attempt,
-                max_attempts,
+                type(e).__name__,
+                limit,
             )
             raise
         if resp.status_code in retryable_statuses and attempt < max_attempts:
@@ -156,12 +181,15 @@ async def with_retry(
             # Final attempt still returned a retryable status — mirror the
             # exception path's "giving up" signal so a 3x-502 incident is
             # visible as exhausted retries, not just a bare HTTPStatusError
-            # from the caller's raise_for_status().
+            # from the caller's raise_for_status(). Budget-not-"N/M" framing
+            # for the same reason as the exception path above (a 5xx at
+            # attempt N > max_attempts after connect-phase retries would
+            # otherwise log a contradictory "4/3").
             logger.warning(
-                "storage_client.%s: HTTP %d on final attempt %d/%d, giving up",
+                "storage_client.%s: giving up on attempt %d (budget for HTTP %d: %d)",
                 label,
-                resp.status_code,
                 attempt,
+                resp.status_code,
                 max_attempts,
             )
         return resp

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -10,7 +10,7 @@ from typing import Any, Literal, NotRequired, TypedDict
 import httpx
 
 from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
-from common.http_retry import with_connect_phase_retry, with_retry
+from common.http_retry import CONNECT_PHASE_MAX_ATTEMPTS, with_connect_phase_retry, with_retry
 from core_api.clients.identity_token import evict as _evict_id_token
 from core_api.clients.identity_token import fetch_auth_header
 from core_api.config import settings
@@ -23,6 +23,17 @@ logger = logging.getLogger(__name__)
 # GET/PATCH/DELETE retry the full transient set + retryable 5xx;
 # POSTs retry connection-phase failures only (request provably never
 # sent, so a retry cannot double-insert).
+
+
+# Idempotent reads (GET) ride out a storage cold start / instance recycle on
+# the connection-phase retry budget (CONNECT_PHASE_MAX_ATTEMPTS) — a connect
+# failure is provably never sent, so the extra attempts add no load — while
+# ReadTimeout/5xx stay at the default 3. Without this, a multi-second storage
+# blip exhausted the 3 GET attempts and surfaced on the Pub/Sub enrichment
+# path as a handler failure → nack → redelivery (the "pubsub handler raised"
+# tail; the POST connect-phase path was already on this budget).
+async def _read_retry(do_request: Callable[[], Awaitable[httpx.Response]], *, label: str) -> httpx.Response:
+    return await with_retry(do_request, label=label, connect_phase_max_attempts=CONNECT_PHASE_MAX_ATTEMPTS)
 
 
 class KeystoneUpsertPayload(TypedDict):
@@ -294,7 +305,7 @@ class CoreStorageClient:
             http = self._read_http if read else self._http
             return http.get(f"{prefix}{path}", params=params, headers=headers)
 
-        resp = await self._execute(_do, retry=with_retry, label=f"GET {path}")
+        resp = await self._execute(_do, retry=_read_retry, label=f"GET {path}")
         if resp.status_code == 404:
             return None
         self._maybe_evict_on_auth_error(resp, read=read)
@@ -309,7 +320,7 @@ class CoreStorageClient:
         def _do() -> Awaitable[httpx.Response]:
             return self._read_http.get(f"{self._read_prefix}{path}", params=params, headers=headers)
 
-        resp = await self._execute(_do, retry=with_retry, label=f"GET-list {path}")
+        resp = await self._execute(_do, retry=_read_retry, label=f"GET-list {path}")
         self._maybe_evict_on_auth_error(resp, read=True)
         resp.raise_for_status()
         return resp.json()

--- a/core-api/src/core_api/middleware/rate_limit.py
+++ b/core-api/src/core_api/middleware/rate_limit.py
@@ -32,6 +32,26 @@ from core_api.config import settings
 # An empty redis_url (OSS default) → memory store, single-instance only.
 _STORAGE_URI = settings.redis_url or "memory://"
 
+# Redis connection resilience (cuts the "Failed to rate limit. Swallowing
+# error" ConnectionReset tail seen in prod): forwarded to the redis client
+# behind the limiter. ``health_check_interval`` PINGs a connection idle >30s
+# before reuse so one the server already closed (Memorystore maintenance /
+# single-zone failover, or idle eviction) is detected + reconnected rather
+# than reset mid-command; ``socket_keepalive`` keeps the TCP alive so
+# intermediaries don't drop it; the bounded connect/op timeouts fail fast into
+# the ``swallow_errors`` fail-open path instead of hanging. Empty for the
+# in-memory store (memory://), which takes no connection options.
+_STORAGE_OPTIONS: dict[str, object] = (
+    {
+        "socket_keepalive": True,
+        "socket_connect_timeout": 5,
+        "socket_timeout": 5,
+        "health_check_interval": 30,
+    }
+    if settings.redis_url
+    else {}
+)
+
 
 def _key_func(request: Request) -> str:
     """Rate-limit key. Prefers API key over IP so NAT'd agents don't
@@ -77,6 +97,10 @@ def _key_func(request: Request) -> str:
 limiter = Limiter(
     key_func=_key_func,
     storage_uri=_STORAGE_URI,
+    # slowapi types storage_options as dict[str, str], but it forwards them to
+    # the limits → redis client, which wants bool/int for these connection
+    # kwargs (socket_keepalive, *_timeout, health_check_interval).
+    storage_options=_STORAGE_OPTIONS,  # type: ignore[arg-type]
     # Redis outages degrade gracefully — requests pass through rather
     # than all rate-limited routes returning 500.
     swallow_errors=True,

--- a/tests/test_storage_client_retry.py
+++ b/tests/test_storage_client_retry.py
@@ -103,14 +103,20 @@ async def test_get_retries_on_connect_timeout_then_succeeds() -> None:
 async def test_get_retries_then_gives_up_after_max_attempts() -> None:
     """When storage stays unreachable, we eventually raise the original
     timeout so the caller (the worker's except-block) still sees a
-    clear failure mode in logs."""
+    clear failure mode in logs. A perma ConnectTimeout is a connection-phase
+    failure, so an idempotent GET rides the higher CONNECT_PHASE_MAX_ATTEMPTS
+    (5) budget — same as POST — to ride out a storage cold start. ReadTimeout
+    / 5xx stay capped at the default 3 (see
+    test_get_logs_giving_up_when_5xx_exhausts_retries)."""
+    from common.http_retry import CONNECT_PHASE_MAX_ATTEMPTS
+
     client, _write, read = await _make_client()
     read.get = AsyncMock(side_effect=httpx.ConnectTimeout("perma down"))
 
     with pytest.raises(httpx.ConnectTimeout):
         await client._get("/entities/exact", read=True)
 
-    assert read.get.await_count == 3  # 1 initial + 2 retries = max attempts
+    assert read.get.await_count == CONNECT_PHASE_MAX_ATTEMPTS == 5
 
 
 async def test_get_retries_on_connect_error_then_succeeds() -> None:
@@ -285,9 +291,11 @@ async def test_post_retries_on_connect_error_then_succeeds() -> None:
 
 async def test_post_gives_up_after_max_attempts_on_connect_timeout() -> None:
     """Connection-phase failures retry CONNECT_PHASE_MAX_ATTEMPTS (5) times —
-    more than the idempotent default (3, see
-    test_get_retries_then_gives_up_after_max_attempts) — because they add no
-    load to a healthy server and just ride out a cold start."""
+    more than the ReadTimeout/5xx default (3, see
+    test_get_logs_giving_up_when_5xx_exhausts_retries) — because a connect
+    failure was provably never sent: it adds no load to a healthy server and
+    just rides out a cold start. Idempotent GETs share this connect-phase
+    budget too (see test_get_retries_then_gives_up_after_max_attempts)."""
     from common.http_retry import CONNECT_PHASE_MAX_ATTEMPTS
 
     client, write, _read = await _make_client()


### PR DESCRIPTION
## Why
Follow-up from the 2026-06-19 prod error review. Two transient signatures dominate the (low) prod error volume — both already retry-handled / fail-open, so this **reduces noise**, not a correctness fix:
- `pubsub handler raised; nacking for redelivery` — `httpx.ConnectTimeout` from the `memory.embedded`/`enriched` consumers' `get_memory` reads to core-storage during cold starts/recycles.
- `Failed to rate limit. Swallowing error` — Redis `ConnectionReset` (single-zone Memorystore maintenance / idle eviction) → slowapi fails open.

## What
**1. Idempotent storage reads ride out a storage cold start** (`common/http_retry.py` + `storage_client.py`)
`with_retry` gains `connect_phase_max_attempts`: connection-phase exceptions (`ConnectTimeout`/`ConnectError`/`PoolTimeout` — provably never sent) get a higher retry budget, while `ReadTimeout`/5xx stay capped at `max_attempts` (no 5xx-storm amplification; backoff still capped at `RETRY_BACKOFF_MAX_S`). `_get`/`_get_list` opt in via a small `_read_retry` wrapper using `CONNECT_PHASE_MAX_ATTEMPTS` — **the same budget POSTs already use** (`with_connect_phase_retry`). So a multi-second storage blip no longer exhausts the 3 GET attempts and surfaces as a handler failure → nack → redelivery on the Pub/Sub path.

**2. Rate-limiter Redis resilience** (`rate_limit.py`)
The slowapi `Limiter`'s Redis client now gets `socket_keepalive` + `health_check_interval=30s` + bounded connect/op timeouts via `storage_options` (Redis-only — `memory://` takes none). A connection the server already closed is PING-detected and reconnected **before** use rather than reset mid-command. `swallow_errors` fail-open stays the safety net.

## Scope / safety
- GET-only (the connect-timeout noise is on the read path); `_patch`/`_delete` unchanged (no documented noise there).
- No behavior change when healthy; backoff bounded; 5xx not over-retried.
- `ruff check` + `ruff format --check` + `mypy` clean on core-api + core-storage-api; `/simplify` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
