### PR TITLE
feat(core-api): route organization_settings through core-storage-api (Fix 2 Phase 0)

### DIFF
--- a/common/organization_settings_merge.py
+++ b/common/organization_settings_merge.py
@@ -1,0 +1,50 @@
+"""Pure merge/diff helpers for organization-settings overrides.
+
+Shared by core-api (the settings service + display) and core-storage-api
+(the transactional ``POST /organization-settings`` upsert, which must compute
+the diff against the FOR-UPDATE'd row server-side so the read and write stay
+in one transaction). Kept dependency-free so both services can import it
+without pulling in a service's config.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def deep_merge(old: Any, new: Any) -> Any:
+    """Return ``old`` with ``new`` merged recursively for nested dicts.
+
+    Non-dict values in ``new`` overwrite ``old`` wholesale (including lists).
+    """
+    if not isinstance(old, dict) or not isinstance(new, dict):
+        return new
+    out = dict(old)
+    for k, v in new.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def diff_settings(old: dict, new: dict, prefix: str = "") -> dict:
+    """Flat diff: ``{"enrichment.provider": [old, new], ...}``.
+
+    Recurses into nested dicts; treats non-dict values as leaves. Only records
+    keys present in ``new`` whose value differs from ``old``; does not record
+    deletions (updates are additive).
+    """
+    out: dict = {}
+    for k, new_v in new.items():
+        path = f"{prefix}{k}"
+        old_v = old.get(k) if isinstance(old, dict) else None
+        if isinstance(new_v, dict):
+            # Recurse even when the old side is absent, so we always emit flat
+            # leaf keys (e.g. "security_audit.schedule_enabled") rather than a
+            # whole-dict diff ["enrichment": [None, {...}]].
+            old_dict = old_v if isinstance(old_v, dict) else {}
+            out.update(diff_settings(old_dict, new_v, prefix=f"{path}."))
+        elif new_v != old_v:
+            out[path] = [old_v, new_v]
+    return out

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1452,6 +1452,44 @@ class CoreStorageClient:
         return bool((result or {}).get("has_recent_success"))
 
     # =====================================================================
+    # Organization settings (Fix 2 Phase 0)
+    # =====================================================================
+
+    async def get_org_settings(self, org_id: str) -> dict:
+        """Return the org's raw setting overrides (``{}`` when unset).
+
+        Read path (rides the connect-phase retry budget). core-api fronts
+        this with a 5-min TTL cache, so it's hit only on a cache miss.
+        """
+        result = await self._get(f"/organization-settings/{org_id}")
+        return (result or {}).get("settings", {})
+
+    async def update_org_settings(
+        self, org_id: str, settings: dict, *, changed_by: str | None = None
+    ) -> dict:
+        """Transactional upsert + audit, server-side. Returns
+        ``{"settings": <merged overrides>, "changed": bool}``.
+
+        Non-idempotent ``_post`` (connection-phase retry only): a write whose
+        response was lost is never replayed. Re-applying the same payload is a
+        no-op anyway — the server diffs it to empty and writes nothing.
+        """
+        result = await self._post(
+            f"/organization-settings/{org_id}",
+            {"settings": settings, "changed_by": changed_by},
+        )
+        # _post is typed dict | list; the endpoint always returns an object.
+        # Guard so an unexpected shape (error envelope, schema drift) fails with
+        # a diagnostic here rather than a bare TypeError on result["settings"]
+        # in the caller — and the narrowing lets us drop the return-value ignore.
+        if not isinstance(result, dict):
+            raise ValueError(
+                f"core-storage-api returned unexpected type for org-settings update: "
+                f"{type(result).__name__!r}"
+            )
+        return result
+
+    # =====================================================================
     # Reports
     # =====================================================================
 

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -23,12 +23,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
 
 from cachetools import TTLCache
 from croniter import CroniterBadCronError, croniter
-from sqlalchemy import func, select, text
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from common.events.base import Event
@@ -40,8 +37,9 @@ from common.events.lifecycle_purge_request import (
 from common.events.org_settings_changed_event import OrgSettingsChangedEvent
 from common.events.topics import Topics
 from common.governance import PIICategory
-from common.models.organization_settings import OrganizationSettings, OrganizationSettingsAudit
+from common.organization_settings_merge import deep_merge as _deep_merge
 from common.provider_names import ProviderName
+from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings as global_settings
 
 logger = logging.getLogger(__name__)
@@ -374,44 +372,6 @@ def _remap_vertex(provider: str) -> str:
 # the query is an indexed PK lookup and the result is identical, so racing
 # populations are harmless.
 _settings_cache: TTLCache[str, dict] = TTLCache(maxsize=10_000, ttl=300)
-
-
-def _deep_merge(old: Any, new: Any) -> Any:
-    """Return ``old`` with ``new`` merged recursively for nested dicts.
-
-    Non-dict values in ``new`` overwrite ``old`` wholesale (including lists).
-    """
-    if not isinstance(old, dict) or not isinstance(new, dict):
-        return new
-    out = dict(old)
-    for k, v in new.items():
-        if isinstance(v, dict) and isinstance(out.get(k), dict):
-            out[k] = _deep_merge(out[k], v)
-        else:
-            out[k] = v
-    return out
-
-
-def _diff_settings(old: dict, new: dict, prefix: str = "") -> dict:
-    """Flat diff: ``{"enrichment.provider": [old, new], ...}``.
-
-    Recurses into nested dicts; treats non-dict values as leaves. Only records
-    keys present in ``new`` whose value differs from ``old``; does not record
-    deletions (updates are additive).
-    """
-    out: dict = {}
-    for k, new_v in new.items():
-        path = f"{prefix}{k}"
-        old_v = old.get(k) if isinstance(old, dict) else None
-        if isinstance(new_v, dict):
-            # Recurse even when the old side is absent, so we always emit flat
-            # leaf keys (e.g. "security_audit.schedule_enabled") rather than a
-            # whole-dict diff ["enrichment": [None, {...}]].
-            old_dict = old_v if isinstance(old_v, dict) else {}
-            out.update(_diff_settings(old_dict, new_v, prefix=f"{path}."))
-        elif new_v != old_v:
-            out[path] = [old_v, new_v]
-    return out
 
 
 def _validate_cron(expr: str) -> None:
@@ -1025,9 +985,10 @@ def invalidate_cache(tenant_id: str) -> None:
 async def resolve_config(db: AsyncSession | None, tenant_id: str) -> ResolvedConfig:
     """Resolve config for a tenant: tenant override → global env default.
 
-    ``db`` may be ``None`` for fire-and-forget callers (post-commit
-    contradiction detection, the CAURA-595 ENRICHED consumer) — see
-    :func:`get_raw_settings` for the cold-cache fallback.
+    ``db`` is retained for call-site back-compat and is IGNORED — settings now
+    load through core-storage-api (Fix 2 Phase 0). Fire-and-forget callers
+    (post-commit contradiction detection, the CAURA-595 ENRICHED consumer)
+    pass ``None`` and resolve correctly via the same storage-client path.
     """
     raw = await get_raw_settings(db, tenant_id)
     return ResolvedConfig(raw)
@@ -1036,45 +997,27 @@ async def resolve_config(db: AsyncSession | None, tenant_id: str) -> ResolvedCon
 async def get_raw_settings(db: AsyncSession | None, tenant_id: str) -> dict:
     """Return the tenant's raw override dict, or ``{}`` if no overrides set.
 
-    Cache-first: returns ``{}`` for tenants that have never been configured.
+    Cache-first (5-min TTL); on a miss, fetched via core-storage-api.
 
-    ``db is None`` is the fire-and-forget path: post-commit detection
-    (the request session has closed), the CAURA-595 ``ENRICHED``
-    consumer (Pub/Sub handler with no ambient request session), and
-    similar callers can pass ``None`` and rely on the cache. On a
-    cache miss with ``db is None`` we open a fresh session here
-    rather than crash with ``AttributeError: 'NoneType' object has
-    no attribute 'execute'`` — which is what happened in production
-    until this fallback landed (CAURA-595 Phase 5a brought the
-    consumer up; cold-start always missed the cache; every event
-    crashed inside detection before this guard).
+    ``db`` is retained for call-site back-compat and is IGNORED: there is no
+    longer a direct DB read here (Fix 2 Phase 0 routed it through the storage
+    client per the "no DB outside core-storage-api" rule). The old
+    ``db is None`` self-session fallback is therefore gone — request-scoped and
+    fire-and-forget callers (the ENRICHED consumer, post-commit detection) now
+    take the identical storage-client path, so a cold cache no longer needs a
+    DB session in scope (the original CAURA-595 Phase 5a crash mode).
     """
     cached = _settings_cache.get(tenant_id)
     if cached is not None:
         logger.debug("organization_settings cache hit for %s", tenant_id)
         return cached
-
-    if db is None:
-        # Lazy import — db.session imports SQLAlchemy engine which
-        # touches DATABASE_URL at module-import time; keeping this
-        # behind a cache miss means the standalone OSS path that
-        # never hits the cold-cache branch doesn't pay the cost.
-        from core_api.db.session import async_session
-
-        async with async_session() as session:
-            return await _load_and_cache(session, tenant_id)
-
-    return await _load_and_cache(db, tenant_id)
+    return await _load_and_cache(tenant_id)
 
 
-async def _load_and_cache(db: AsyncSession, tenant_id: str) -> dict:
-    result = await db.execute(
-        select(OrganizationSettings.settings).where(OrganizationSettings.org_id == tenant_id)
-    )
-    row = result.scalar_one_or_none()
-    resolved = row if isinstance(row, dict) else {}
+async def _load_and_cache(tenant_id: str) -> dict:
+    resolved = await get_storage_client().get_org_settings(tenant_id)
     _settings_cache[tenant_id] = resolved
-    logger.info("organization_settings cache miss for %s; loaded from DB and cached", tenant_id)
+    logger.info("organization_settings cache miss for %s; loaded via storage-api and cached", tenant_id)
     return resolved
 
 
@@ -1085,7 +1028,7 @@ async def get_settings_for_display(db: AsyncSession | None, tenant_id: str) -> d
 
 
 async def update_settings(
-    db: AsyncSession,
+    db: AsyncSession | None,
     tenant_id: str,
     new_settings: dict,
     *,
@@ -1096,6 +1039,12 @@ async def update_settings(
     Returns the merged display view (``DEFAULT_SETTINGS`` ⊕ tenant overrides)
     so callers can echo back the resulting state. No-ops when the submitted
     payload introduces no actual changes.
+
+    ``db`` is retained for call-site back-compat and is IGNORED — the
+    transactional upsert (``FOR UPDATE`` read → flat diff → JSONB ``||`` merge →
+    audit row, one transaction) now runs server-side in core-storage-api (Fix 2
+    Phase 0). Validation, the TTL-cache invalidate, and the ``SETTINGS_CHANGED``
+    broadcast stay here.
     """
     _check_keys(new_settings, DEFAULT_SETTINGS)
     _validate_leaf_types(new_settings)
@@ -1104,42 +1053,15 @@ async def update_settings(
     if cron_override is not None:
         _validate_cron(cron_override)
 
-    # Read current overrides straight from DB — we don't want to diff against a
-    # stale cache entry, and this path is rare compared to reads.
-    # FOR UPDATE prevents lost-update races under concurrent writes for the same tenant.
-    result = await db.execute(
-        select(OrganizationSettings.settings)
-        .where(OrganizationSettings.org_id == tenant_id)
-        .with_for_update()
-    )
-    current_row = result.scalar_one_or_none()
-    current: dict = current_row if isinstance(current_row, dict) else {}
-
-    diff = _diff_settings(current, new_settings)
-    if not diff:
-        # Identical payload — skip write and audit row entirely.
-        return _deep_merge(DEFAULT_SETTINGS, current)
-
-    merged = _deep_merge(current, new_settings)
-
-    # FOR UPDATE serialises all writes once the row exists. Concurrent first-time
-    # inserts (no row yet) use JSONB || to merge at the DB level so two racing
-    # inserts don't silently overwrite each other. The shallow || merge is safe
-    # because top-level schema keys (enrichment, recall, …) are independent.
-    upsert = pg_insert(OrganizationSettings).values(org_id=tenant_id, settings=merged)
-    await db.execute(
-        upsert.on_conflict_do_update(
-            index_elements=["org_id"],
-            set_={
-                "settings": text("organization_settings.settings || EXCLUDED.settings"),
-                "updated_at": func.now(),
-            },
-        )
-    )
-    await db.execute(
-        pg_insert(OrganizationSettingsAudit).values(org_id=tenant_id, changed_by=changed_by, diff=diff)
-    )
-    await db.commit()
+    # The diff-against-current + upsert + audit happen in one server-side
+    # transaction (the FOR UPDATE lost-update guard can't span an HTTP read +
+    # write, so it lives in storage-api). ``merged`` is the resulting raw
+    # overrides; ``changed`` is False when the payload was a no-op.
+    result = await get_storage_client().update_org_settings(tenant_id, new_settings, changed_by=changed_by)
+    merged = result["settings"]
+    if not result.get("changed"):
+        # Identical payload — storage wrote nothing; nothing to invalidate or broadcast.
+        return _deep_merge(DEFAULT_SETTINGS, merged)
 
     # Invalidate THIS process's cache immediately...
     invalidate_cache(tenant_id)

--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -37,6 +37,7 @@ from core_storage_api.routers import (
     keystones_router,
     lifecycle_audit_router,
     memories_router,
+    organization_settings_router,
     preview_router,
     purge_router,
     reports_router,
@@ -123,6 +124,10 @@ def create_app() -> FastAPI:
     app.include_router(tasks_router, prefix=prefix)
     app.include_router(idempotency_router, prefix=prefix)
     app.include_router(lifecycle_audit_router, prefix=prefix)
+    # Fix 2 Phase 0: per-org settings read/write, moved off core-api's
+    # direct DB pool. core-api calls these via its storage_client and keeps
+    # the TTL cache / SETTINGS_CHANGED publish / validators client-side.
+    app.include_router(organization_settings_router, prefix=prefix)
     app.include_router(purge_router, prefix=prefix)
     # CAURA-696: per-tenant row counts for the deletion-preview panel.
     # Mirrors ``purge``'s VPC-only trust model: no router-level auth,

--- a/core-storage-api/src/core_storage_api/routers/__init__.py
+++ b/core-storage-api/src/core_storage_api/routers/__init__.py
@@ -9,6 +9,7 @@ from core_storage_api.routers.idempotency import router as idempotency_router
 from core_storage_api.routers.keystones import router as keystones_router
 from core_storage_api.routers.lifecycle_audit import router as lifecycle_audit_router
 from core_storage_api.routers.memories import router as memories_router
+from core_storage_api.routers.organization_settings import router as organization_settings_router
 from core_storage_api.routers.preview import router as preview_router
 from core_storage_api.routers.purge import router as purge_router
 from core_storage_api.routers.reports import router as reports_router
@@ -27,6 +28,7 @@ __all__ = [
     "keystones_router",
     "lifecycle_audit_router",
     "memories_router",
+    "organization_settings_router",
     "preview_router",
     "purge_router",
     "reports_router",

--- a/core-storage-api/src/core_storage_api/routers/organization_settings.py
+++ b/core-storage-api/src/core_storage_api/routers/organization_settings.py
@@ -1,0 +1,64 @@
+"""Organization-settings endpoints (Fix 2, Phase 0).
+
+Moves the per-org settings read/write off core-api's direct DB pool and
+behind core-storage-api, per the "no DB outside core-storage-api" rule. The
+DB-touching half of ``core_api.services.organization_settings`` calls these:
+
+* ``GET``  returns the raw override JSONB (``{}`` when unset).
+* ``POST`` performs the transactional upsert — ``FOR UPDATE`` read → flat
+  diff → JSONB ``||`` merge → append an audit row — all in one transaction so
+  the lost-update guard holds. core-api keeps the TTL cache, the
+  ``Org.SETTINGS_CHANGED`` publish, the schema validators, and ``DEFAULT_SETTINGS``
+  resolution client-side; only the database access moves here.
+
+POST (not PUT) so it rides the storage_client's non-idempotent ``_post`` path
+(connection-phase retry only — a write whose response was lost is never
+replayed). Re-applying an identical payload is a no-op anyway (the diff is
+empty → no write, no audit row).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from core_storage_api.services.postgres_service import PostgresService
+
+router = APIRouter(prefix="/organization-settings", tags=["Settings"])
+_svc = PostgresService()
+
+
+@router.get("/{org_id}")
+async def get_organization_settings(org_id: str) -> dict:
+    """Return ``{"settings": <raw overrides>}`` — ``{}`` when the org has none."""
+    settings = await _svc.organization_settings_get(org_id)
+    return {"settings": settings}
+
+
+@router.post("/{org_id}")
+async def update_organization_settings(org_id: str, request: Request) -> dict:
+    """Transactional upsert + audit. Body: ``{settings, changed_by?}``.
+
+    Returns ``{"settings": <merged overrides>, "changed": bool}``. ``changed``
+    is ``False`` when the payload introduced no actual change (no row written).
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail="request body must be valid JSON") from exc
+    if not isinstance(body, dict):
+        # Valid JSON can still be a list/scalar; guard before .get() so a
+        # non-object body returns a clean 422 instead of an AttributeError 500.
+        raise HTTPException(status_code=422, detail="request body must be a JSON object")
+    new_settings = body.get("settings")
+    if not isinstance(new_settings, dict):
+        raise HTTPException(status_code=422, detail="'settings' must be an object")
+    changed_by = body.get("changed_by")
+    if changed_by is not None and not isinstance(changed_by, str):
+        # changed_by lands in OrganizationSettingsAudit.changed_by (Text); reject
+        # non-strings here rather than surfacing a confusing DB type error.
+        raise HTTPException(status_code=422, detail="'changed_by' must be a string or null")
+    return await _svc.organization_settings_update(
+        org_id=org_id,
+        new_settings=new_settings,
+        changed_by=changed_by,
+    )

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -59,6 +59,8 @@ from common.models import (
     MemoryEntityLink,
     Relation,
 )
+from common.models.organization_settings import OrganizationSettings, OrganizationSettingsAudit
+from common.organization_settings_merge import deep_merge, diff_settings
 from core_storage_api.observability import db_measure
 from core_storage_api.services.audit_chain import (
     GENESIS_PREV_HASH,
@@ -4762,6 +4764,78 @@ class PostgresService:
                 .limit(1)
             )
             return row.scalar_one_or_none() is not None
+
+    # ══════════════════════════════════════════════════════════════════════
+    #  ORGANIZATION SETTINGS (OrganizationSettings + audit)
+    # ══════════════════════════════════════════════════════════════════════
+
+    async def organization_settings_get(self, org_id: str) -> dict:
+        """Return the org's raw override JSONB, or ``{}`` when no row exists.
+
+        Read-only; safe on the reader replica. core-api fronts this with a
+        5-min TTL cache, so it's hit only on a cache miss.
+        """
+        async with get_read_session() as session:
+            row = await session.execute(
+                select(OrganizationSettings.settings).where(OrganizationSettings.org_id == org_id)
+            )
+            settings = row.scalar_one_or_none()
+            return settings if isinstance(settings, dict) else {}
+
+    async def organization_settings_update(
+        self,
+        *,
+        org_id: str,
+        new_settings: dict,
+        changed_by: str | None = None,
+    ) -> dict:
+        """Upsert org overrides + append an audit row, in ONE transaction.
+
+        The flat diff is computed against the ``FOR UPDATE``-locked current
+        row so the read and write can't interleave with a concurrent writer
+        for the same org (lost-update guard). Returns
+        ``{"settings": <merged overrides>, "changed": bool}``. A no-op payload
+        (the diff is empty) writes neither row and returns the current
+        overrides with ``changed=False``.
+
+        Schema validation is the caller's responsibility — core-api validates
+        keys / leaf types / governance enums / cron before calling.
+        """
+        async with get_session() as session:
+            result = await session.execute(
+                select(OrganizationSettings.settings)
+                .where(OrganizationSettings.org_id == org_id)
+                .with_for_update()
+            )
+            current_row = result.scalar_one_or_none()
+            current: dict = current_row if isinstance(current_row, dict) else {}
+
+            diff = diff_settings(current, new_settings)
+            if not diff:
+                # Identical payload — skip the write and the audit row entirely.
+                return {"settings": current, "changed": False}
+
+            merged = deep_merge(current, new_settings)
+
+            # FOR UPDATE serialises writes once the row exists. Concurrent
+            # first-time inserts (no row yet) use JSONB || to merge at the DB
+            # level so two racing inserts don't silently overwrite each other;
+            # the shallow || is safe because top-level schema keys (enrichment,
+            # recall, …) are independent.
+            upsert = pg_insert(OrganizationSettings).values(org_id=org_id, settings=merged)
+            await session.execute(
+                upsert.on_conflict_do_update(
+                    index_elements=["org_id"],
+                    set_={
+                        "settings": text("organization_settings.settings || EXCLUDED.settings"),
+                        "updated_at": func.now(),
+                    },
+                )
+            )
+            await session.execute(
+                pg_insert(OrganizationSettingsAudit).values(org_id=org_id, changed_by=changed_by, diff=diff)
+            )
+            return {"settings": merged, "changed": True}
 
     # ══════════════════════════════════════════════════════════════════════
     #  REPORTS (CrystallizationReport)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,18 @@ async def sc():
 
 
 @pytest.fixture
+def storage_http(_patch_storage_client):
+    """Raw httpx client bridged to the in-process core-storage-api app.
+
+    For tests that POST malformed/raw bodies the typed storage client would
+    never send (e.g. exercising a router's 422 input-validation guards).
+    Depends on ``_patch_storage_client`` so the ASGI bridge + test-engine
+    session factory are wired up first.
+    """
+    return _storage_asgi_http
+
+
+@pytest.fixture
 def tenant_id():
     """Unique tenant ID per test module."""
     return TENANT_ID

--- a/tests/test_organization_settings_storage.py
+++ b/tests/test_organization_settings_storage.py
@@ -5,12 +5,13 @@ import uuid
 import pytest
 from sqlalchemy import text
 
+from common.organization_settings_merge import deep_merge as _deep_merge
+from common.organization_settings_merge import diff_settings as _diff_settings
+from core_api.clients.storage_client import get_storage_client
 from core_api.services import organization_settings as ts_svc
 from core_api.services.organization_settings import (
     DEFAULT_SETTINGS,
     ResolvedConfig,
-    _deep_merge,
-    _diff_settings,
     get_raw_settings,
     get_settings_for_display,
     invalidate_cache,
@@ -226,23 +227,25 @@ async def test_resolve_config_reads_from_db(db):
 # ── Cache semantics ───────────────────────────────────────────────────────
 
 
-async def test_cache_hit_avoids_db_query(db, monkeypatch):
-    """Second call to get_raw_settings for the same tenant should not hit the DB."""
+async def test_cache_hit_avoids_storage_fetch(db, monkeypatch):
+    """Second call to get_raw_settings for the same tenant should not re-fetch
+    from core-storage-api — the TTL cache short-circuits before the HTTP call."""
     tid = _tid()
-    await get_raw_settings(db, tid)  # populates cache with {}
+    await get_raw_settings(db, tid)  # populates cache with {} (one storage fetch)
 
     calls = {"n": 0}
-    original_execute = db.execute
+    sc = get_storage_client()
+    original_get = sc.get_org_settings
 
-    async def counting_execute(*args, **kwargs):
+    async def counting_get(org_id):
         calls["n"] += 1
-        return await original_execute(*args, **kwargs)
+        return await original_get(org_id)
 
-    monkeypatch.setattr(db, "execute", counting_execute)
+    monkeypatch.setattr(sc, "get_org_settings", counting_get)
 
     await get_raw_settings(db, tid)
     await get_raw_settings(db, tid)
-    assert calls["n"] == 0, "Cache hits should not execute SQL"
+    assert calls["n"] == 0, "Cache hits should not fetch from storage"
 
 
 async def test_update_invalidates_local_cache(db):
@@ -257,60 +260,36 @@ async def test_update_invalidates_local_cache(db):
     assert raw["security_audit"]["alerts_enabled"] is True
 
 
-# ── db=None fire-and-forget callers (CAURA-595 Phase 5a follow-up) ────────
+# ── db=None fire-and-forget callers (CAURA-595 Phase 5a; Fix 2 Phase 0) ───
+#
+# After Fix 2 Phase 0 the ``db`` argument is vestigial — settings load via the
+# storage client, so the old "open a self-session on db=None" fallback is gone.
+# These pin that fire-and-forget callers (the ENRICHED consumer, post-commit
+# detection) still resolve settings with ``db=None`` and that a warm cache
+# short-circuits the storage fetch entirely.
 
 
-@pytest.fixture
-def _async_session_returns_test_db(db, monkeypatch):
-    """Make ``core_api.db.session.async_session`` (the sessionmaker
-    that ``get_raw_settings`` falls back to on ``db=None``) return
-    the test's transactional session as an async context manager,
-    so writes seeded via the ``db`` fixture are visible to the
-    cold-cache path inside the test's outer rolled-back transaction.
-    Without this, the cold-cache path opens a fresh session bound
-    to the same engine but outside the test's transaction and reads
-    an empty result."""
-    import contextlib
-
-    @contextlib.asynccontextmanager
-    async def _ctx():
-        yield db
-
-    def _factory(*_a, **_kw):
-        return _ctx()
-
-    monkeypatch.setattr("core_api.db.session.async_session", _factory)
-
-
-async def test_get_raw_settings_opens_session_when_db_is_none(
-    db, _async_session_returns_test_db
-):
-    """Cold-cache call with ``db=None`` (the ENRICHED consumer + post-
-    commit detection paths) must NOT crash with
-    ``AttributeError: 'NoneType' object has no attribute 'execute'``.
-    Open a fresh session internally; result still lands in the cache
-    so subsequent calls (with or without db) hit the cache hot."""
+async def test_get_raw_settings_works_when_db_is_none(db):
+    """Cold-cache call with ``db=None`` must resolve via the storage client
+    (no DB session needed) and land the result in the cache for next time."""
     tid = _tid()
-    # Seed an override row directly so we can prove the internal-
-    # session path actually executed and read from the DB.
+    # Seed an override row (via the storage-client write path) so we can prove
+    # the db=None read actually fetched and cached it.
     await update_settings(db, tid, {"enrichment": {"provider": "openai"}})
     ts_svc._settings_cache.clear()  # discard the warm cache from update_settings
 
     raw = await get_raw_settings(None, tid)
 
     assert raw["enrichment"]["provider"] == "openai"
-    # Cache populated by the internal session — next call (with or
-    # without db) is a cache hit, not a fresh fetch.
+    # Cache populated by the storage fetch — next call is a cache hit.
     assert tid in ts_svc._settings_cache
 
 
-async def test_resolve_config_works_without_db_session(
-    db, _async_session_returns_test_db
-):
+async def test_resolve_config_works_without_db_session(db):
     """End-to-end: ``resolve_config(None, tenant_id)`` (the path the
     fire-and-forget contradiction detector + the CAURA-595 Phase 5a
-    consumer take) must return a usable ``ResolvedConfig`` without
-    a request-scoped session in scope."""
+    consumer take) must return a usable ``ResolvedConfig`` without a
+    request-scoped session in scope."""
     tid = _tid()
     await update_settings(db, tid, {"enrichment": {"provider": "openai"}})
     ts_svc._settings_cache.clear()
@@ -320,18 +299,44 @@ async def test_resolve_config_works_without_db_session(
     assert config.enrichment_provider == "openai"
 
 
-async def test_get_raw_settings_skips_db_open_on_cache_hit(monkeypatch):
-    """``db=None`` with the cache already warm must NOT spin up a
-    session — opening one per detection event would be a hot-path
-    regression. The cache hit should short-circuit before
-    ``async_session()`` is even called."""
+async def test_get_raw_settings_skips_storage_fetch_on_cache_hit(monkeypatch):
+    """``db=None`` with the cache already warm must NOT hit storage — fetching
+    per detection event would be a hot-path regression. The cache hit should
+    short-circuit before the storage client is even called."""
     tid = _tid()
     ts_svc._settings_cache[tid] = {"enrichment": {"provider": "anthropic"}}
 
-    def _fail_async_session(*_a, **_kw):
-        raise AssertionError("async_session must not be opened on a cache hit")
+    async def _fail_fetch(_org_id):
+        raise AssertionError("storage must not be fetched on a cache hit")
 
-    monkeypatch.setattr("core_api.db.session.async_session", _fail_async_session)
+    monkeypatch.setattr(get_storage_client(), "get_org_settings", _fail_fetch)
 
     raw = await get_raw_settings(None, tid)
     assert raw == {"enrichment": {"provider": "anthropic"}}
+
+
+# ── Storage-API POST input validation (claude-review on #427) ─────────────
+#
+# These hit the core-storage-api router directly (via the storage_http bridge)
+# with malformed bodies the typed client would never send. Both guards reject
+# BEFORE any DB access.
+
+
+def _settings_path(org_id: str) -> str:
+    return f"/api/v1/storage/organization-settings/{org_id}"
+
+
+async def test_post_non_object_body_returns_422(storage_http):
+    """A valid-JSON-but-non-object body (list/scalar) must 422, not 500 — the
+    pre-guard fix for the AttributeError on ``body.get(...)``."""
+    resp = await storage_http.post(_settings_path(_tid()), json=["not", "an", "object"])
+    assert resp.status_code == 422, resp.text
+
+
+async def test_post_non_string_changed_by_returns_422(storage_http):
+    """``changed_by`` must be a string or null; a non-string returns a clean
+    422 rather than a confusing DB type error on the Text column."""
+    resp = await storage_http.post(
+        _settings_path(_tid()), json={"settings": {}, "changed_by": 123}
+    )
+    assert resp.status_code == 422, resp.text


### PR DESCRIPTION
**Fix 2 Phase 0** — first slice of the Tier-2 *"no DB outside core-storage-api"* migration (ticket task_eda5ab48). Moves the per-org settings read/write off core-api's direct SQLAlchemy pool and behind new core-storage-api endpoints.

Settings are the highest-traffic pool acquisition and were the root of the 06-19 prod `ConnectTimeout` — the fire-and-forget `get_raw_settings(db=None)` cold-cache path opened its own DB session. This removes that DB dependency entirely. **No schema change** (`organization_settings`/`_audit` already live in core-storage-api's migrations).

### core-storage-api (now owns the DB access)
- `postgres_service.organization_settings_get` — read overrides (reader replica).
- `postgres_service.organization_settings_update` — the transactional upsert (`FOR UPDATE` read → flat diff → JSONB `||` merge → audit row) kept in **one** server-side transaction so the lost-update guard still holds (it can't span an HTTP read+write). Returns `{settings, changed}`; a no-op payload writes neither row.
- `routers/organization_settings.py` — `GET` + `POST /organization-settings/{org_id}`. POST (not PUT) so the storage_client's non-idempotent `_post` path applies (connection-phase retry only); re-applying an identical payload is a no-op anyway.

### core-api (now a client)
- `storage_client.get_org_settings` / `update_org_settings`.
- `services/organization_settings.py` now calls the storage client. The **TTL cache** (cache hits still short-circuit before any HTTP call), the `SETTINGS_CHANGED` publish, the schema validators, and `DEFAULT_SETTINGS` resolution all stay client-side. The old `db=None` self-session fallback is gone — every caller takes the same storage-client path. The `db` params are retained (ignored) for call-site back-compat; removing them across ~49 sites is a later phase.

### common
- `common/organization_settings_merge.py` — `deep_merge` / `diff_settings` lifted here (dependency-free) so both services share one implementation.

### Validation
- ruff + mypy clean on **both** core-api and core-storage-api.
- Full core-api suite green: **3464 passed**.
- `/simplify` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)