### PR TITLE
feat(core-api): route tenant-discovery through core-storage-api (Fix 2 Phase 1)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1490,6 +1490,36 @@ class CoreStorageClient:
         return result
 
     # =====================================================================
+    # Tenant discovery (Fix 2 Phase 1) — lifecycle-fanout target lists
+    # =====================================================================
+
+    # ``_get`` returns None on HTTP 404. These endpoints always return 200 with
+    # an envelope (an empty list when there are no tenants), so None means the
+    # endpoint is MISSING (wrong prefix / version skew / routing). Raise rather
+    # than degrade to [] — a silent empty list would make the lifecycle fanout
+    # publish zero messages and report success, hiding the misconfiguration.
+    async def list_active_tenants(self) -> list[str]:
+        """Orgs with at least one live (non-soft-deleted) memory."""
+        result = await self._get("/tenants/active")
+        if result is None:
+            raise RuntimeError("core-storage-api /tenants/active returned 404")
+        return result.get("tenant_ids", [])
+
+    async def list_purgeable_tenants(self) -> list[str]:
+        """Orgs with soft-deleted memories older than the max retention window."""
+        result = await self._get("/tenants/purgeable")
+        if result is None:
+            raise RuntimeError("core-storage-api /tenants/purgeable returned 404")
+        return result.get("tenant_ids", [])
+
+    async def list_skills_factory_enabled_orgs(self) -> list[str]:
+        """Orgs whose ``skills_factory.enabled`` setting is True."""
+        result = await self._get("/tenants/skills-factory-enabled")
+        if result is None:
+            raise RuntimeError("core-storage-api /tenants/skills-factory-enabled returned 404")
+        return result.get("org_ids", [])
+
+    # =====================================================================
     # Reports
     # =====================================================================
 

--- a/core-api/src/core_api/routes/lifecycle.py
+++ b/core-api/src/core_api/routes/lifecycle.py
@@ -39,7 +39,6 @@ from common.events.lifecycle_purge_request import (
 )
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
-from core_api.db.session import async_session
 from core_api.services.lifecycle_audit import audit_begin, resolve_publisher_kwargs
 from core_api.services.tenants import (
     list_active_tenant_ids,
@@ -80,7 +79,7 @@ _ACTION_PUBLISHERS: dict[str, _PublisherFn] = {
 _FANOUT_CONCURRENCY = 50
 
 
-async def _list_tenants_for_action(action: str, db) -> list[str]:
+async def _list_tenants_for_action(action: str) -> list[str]:
     """Discovery query for the fanout — purge is the odd action here:
     its target is orgs whose soft-deleted rows have aged past the
     retention window. The archive ``deleted_at IS NULL`` filter would
@@ -88,16 +87,19 @@ async def _list_tenants_for_action(action: str, db) -> list[str]:
     that 100%-soft-deleted its memories), so purge gets its own
     helper bounded to soft-deleted rows older than
     ``MEMORY_RETENTION_MAX_DAYS``.
+
+    Each helper now reads through core-storage-api (Fix 2 Phase 1), so no
+    core-api DB session is involved.
     """
     if action == "purge-soft-deleted":
-        return await list_tenants_with_purgeable_memories(db)
+        return await list_tenants_with_purgeable_memories()
     if action == "forge-distill":
         # Per-tick zero-cost for non-opted-in tenants: filter to orgs
         # that flipped ``skills_factory.enabled=true``. Any tenant
         # without an org_settings row (or with the flag false) is
         # excluded from the fanout entirely.
-        return await list_tenants_with_skills_factory_enabled(db)
-    return await list_active_tenant_ids(db)
+        return await list_tenants_with_skills_factory_enabled()
+    return await list_active_tenant_ids()
 
 
 def _resolve_publisher(action: str) -> _PublisherFn:
@@ -160,16 +162,14 @@ async def fanout_lifecycle_action(
     Returns ``{"action", "published", "failed"}`` — counts only, no
     per-org id list, so the response stays bounded at scale.
 
-    The DB session is opened locally and released BEFORE the
-    ``asyncio.gather`` fan-out so a slow per-org Pub/Sub publish can't
-    park a connection for the whole loop. The fan-out only needs the
-    org list, not the session.
+    The org list is fetched up front (via core-storage-api) before the
+    ``asyncio.gather`` fan-out; the fan-out itself holds no DB session, so a
+    slow per-org Pub/Sub publish can't park a connection for the whole loop.
     """
     auth.enforce_admin()
     publisher = _resolve_publisher(action)
 
-    async with async_session() as db:
-        org_ids = await _list_tenants_for_action(action, db)
+    org_ids = await _list_tenants_for_action(action)
 
     # Fan out concurrently with a semaphore cap (see _FANOUT_CONCURRENCY)
     # so a deployment with N orgs doesn't fire N simultaneous storage

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1949,11 +1949,10 @@ admin_memories_router = APIRouter(tags=["Admin"])
 @admin_memories_router.get("/admin/tenants")
 async def admin_list_tenants(
     auth: AuthContext = Depends(get_auth_context),
-    db: AsyncSession = Depends(get_db),
 ):
     """Admin: list all tenant IDs that have memories."""
     auth.enforce_admin()
-    return await list_active_tenant_ids(db)
+    return await list_active_tenant_ids()
 
 
 @admin_memories_router.get("/admin/fleets")

--- a/core-api/src/core_api/services/tenants.py
+++ b/core-api/src/core_api/services/tenants.py
@@ -1,72 +1,47 @@
-"""Tenant-listing helpers shared by admin endpoints (CAURA-655)."""
+"""Tenant-listing helpers shared by admin endpoints (CAURA-655).
+
+These read through core-storage-api (Fix 2 Phase 1) — the discovery queries no
+longer touch a core-api DB pool (the underlying SQL now lives in
+``postgres_service.tenants_list_*``). The ``db`` parameter is retained for
+call-site back-compat and is IGNORED.
+"""
 
 from __future__ import annotations
 
-from datetime import timedelta
-
-from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
-from common.models.memory import Memory
-from common.models.organization_settings import OrganizationSettings
+from core_api.clients.storage_client import get_storage_client
 
 
-async def list_active_tenant_ids(db: AsyncSession) -> list[str]:
-    """Distinct ``tenant_id`` from non-soft-deleted memories.
+async def list_active_tenant_ids(db: AsyncSession | None = None) -> list[str]:
+    """Distinct ``tenant_id`` from non-soft-deleted memories, sorted.
 
-    Use for archive ops — orgs with no live memories have nothing to
-    archive. CAURA-656 purge needs the broader variant below: an org
-    that soft-deleted all its memories is exactly who we want to purge.
+    Use for archive ops — orgs with no live memories have nothing to archive.
+    CAURA-656 purge needs the broader variant below. ``db`` is ignored (reads
+    via core-storage-api).
     """
-    result = await db.execute(select(Memory.tenant_id).where(Memory.deleted_at.is_(None)).distinct())
-    return sorted([row[0] for row in result.all()])
+    return await get_storage_client().list_active_tenants()
 
 
-async def list_tenants_with_purgeable_memories(db: AsyncSession) -> list[str]:
-    """Distinct ``tenant_id`` from soft-deleted memories old enough to
-    be eligible for hard-deletion under any org's retention window
-    (CAURA-656 purge fanout target).
+async def list_tenants_with_purgeable_memories(db: AsyncSession | None = None) -> list[str]:
+    """Distinct ``tenant_id`` from soft-deleted memories old enough to be
+    eligible for hard-deletion under any org's retention window (CAURA-656 purge
+    fanout target), sorted.
 
-    Orgs whose soft-deleted rows are all newer than the maximum
-    retention window (``MEMORY_RETENTION_MAX_DAYS``) are guaranteed
-    no-ops on the purge primitive, so excluding them from the fanout
-    keeps the discovery scan bounded as ``memories`` grows. Per-org
-    retention may be tighter than the max — the storage primitive
-    still no-ops for rows inside the org's specific window.
-
-    Uses ``func.now()`` (DB clock) rather than the Python clock to
-    match the storage-side primitive's cutoff and avoid client-clock
-    drift across the fanout / consume boundary.
+    Orgs whose soft-deleted rows are all newer than ``MEMORY_RETENTION_MAX_DAYS``
+    are guaranteed purge no-ops, so the storage query excludes them to keep the
+    discovery scan bounded as ``memories`` grows (cutoff uses the DB clock).
+    ``db`` is ignored (reads via core-storage-api).
     """
-    cutoff = func.now() - timedelta(days=MEMORY_RETENTION_MAX_DAYS)
-    result = await db.execute(
-        select(Memory.tenant_id)
-        .where(Memory.deleted_at.is_not(None))
-        .where(Memory.deleted_at < cutoff)
-        .distinct()
-    )
-    return sorted([row[0] for row in result.all()])
+    return await get_storage_client().list_purgeable_tenants()
 
 
-async def list_tenants_with_skills_factory_enabled(db: AsyncSession) -> list[str]:
-    """Return ``org_id`` values whose ``skills_factory.enabled`` is True.
+async def list_tenants_with_skills_factory_enabled(db: AsyncSession | None = None) -> list[str]:
+    """Return ``org_id`` values whose ``skills_factory.enabled`` is True, sorted.
 
-    Used by the lifecycle-fanout entry point for the ``forge-distill``
-    action so a tenant that hasn't opted in pays ZERO per-cron-tick
-    cost (no message published, no audit row written, no consumer
-    work). Non-opted-in tenants stay invisible to the cron until they
-    explicitly flip the flag — the merge-day invariant from PR #293
-    extends through every tick of the autonomous scheduler.
-
-    Queries the ``settings`` JSONB column directly; orgs without a
-    settings row are silently excluded (default ``enabled=False`` from
-    ``DEFAULT_SETTINGS`` applies). Sorted for stable fanout ordering
-    so flaky-test re-runs see the same per-tick sequence.
+    Used by the lifecycle-fanout entry point for the ``forge-distill`` action so
+    a tenant that hasn't opted in pays ZERO per-cron-tick cost (no message, no
+    audit row, no consumer work). Orgs without a settings row are excluded
+    (default ``enabled=False``). ``db`` is ignored (reads via core-storage-api).
     """
-    result = await db.execute(
-        select(OrganizationSettings.org_id).where(
-            OrganizationSettings.settings["skills_factory"]["enabled"].as_boolean().is_(True)
-        )
-    )
-    return sorted([row[0] for row in result.all()])
+    return await get_storage_client().list_skills_factory_enabled_orgs()

--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -43,6 +43,7 @@ from core_storage_api.routers import (
     reports_router,
     tasks_router,
     tenant_suppression_router,
+    tenants_router,
 )
 
 logger = logging.getLogger(__name__)
@@ -128,6 +129,9 @@ def create_app() -> FastAPI:
     # direct DB pool. core-api calls these via its storage_client and keeps
     # the TTL cache / SETTINGS_CHANGED publish / validators client-side.
     app.include_router(organization_settings_router, prefix=prefix)
+    # Fix 2 Phase 1: tenant-discovery lists for the lifecycle fanout, moved off
+    # core-api's direct DB pool (active / purgeable / skills-factory-enabled).
+    app.include_router(tenants_router, prefix=prefix)
     app.include_router(purge_router, prefix=prefix)
     # CAURA-696: per-tenant row counts for the deletion-preview panel.
     # Mirrors ``purge``'s VPC-only trust model: no router-level auth,

--- a/core-storage-api/src/core_storage_api/routers/__init__.py
+++ b/core-storage-api/src/core_storage_api/routers/__init__.py
@@ -15,6 +15,7 @@ from core_storage_api.routers.purge import router as purge_router
 from core_storage_api.routers.reports import router as reports_router
 from core_storage_api.routers.tasks import router as tasks_router
 from core_storage_api.routers.tenant_suppression import router as tenant_suppression_router
+from core_storage_api.routers.tenants import router as tenants_router
 
 __all__ = [
     "agents_router",
@@ -34,4 +35,5 @@ __all__ = [
     "reports_router",
     "tasks_router",
     "tenant_suppression_router",
+    "tenants_router",
 ]

--- a/core-storage-api/src/core_storage_api/routers/tenants.py
+++ b/core-storage-api/src/core_storage_api/routers/tenants.py
@@ -1,0 +1,51 @@
+"""Tenant-discovery endpoints (Fix 2 Phase 1).
+
+The lifecycle-fanout entry point (core-api ``routes/lifecycle.py``) needs the
+list of orgs to publish a per-org message to, per action. Those discovery
+queries used to run on core-api's own DB pool; they move here behind
+core-storage-api per the "no DB outside core-storage-api" rule. All reads
+(reader replica); core-api calls them via its storage_client.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from core_storage_api.services.postgres_service import PostgresService
+
+router = APIRouter(prefix="/tenants", tags=["Tenants"])
+_svc = PostgresService()
+
+
+class TenantIdsResponse(BaseModel):
+    """Memory-backed discovery lists are keyed by ``tenant_id``."""
+
+    tenant_ids: list[str]
+
+
+class OrgIdsResponse(BaseModel):
+    """Settings-backed discovery list is keyed by ``org_id``."""
+
+    org_ids: list[str]
+
+
+@router.get("/active")
+async def list_active_tenants() -> TenantIdsResponse:
+    """Orgs with at least one live (non-soft-deleted) memory. Archive/lifecycle
+    fanout target."""
+    return TenantIdsResponse(tenant_ids=await _svc.tenants_list_active())
+
+
+@router.get("/purgeable")
+async def list_purgeable_tenants() -> TenantIdsResponse:
+    """Orgs with soft-deleted memories older than the max retention window
+    (CAURA-656 purge fanout target)."""
+    return TenantIdsResponse(tenant_ids=await _svc.tenants_list_purgeable())
+
+
+@router.get("/skills-factory-enabled")
+async def list_skills_factory_enabled_orgs() -> OrgIdsResponse:
+    """Orgs whose ``skills_factory.enabled`` setting is True (forge-distill
+    fanout target)."""
+    return OrgIdsResponse(org_ids=await _svc.tenants_list_skills_factory_enabled())

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -4838,6 +4838,57 @@ class PostgresService:
             return {"settings": merged, "changed": True}
 
     # ══════════════════════════════════════════════════════════════════════
+    #  TENANT DISCOVERY (lifecycle fanout target lists)
+    # ══════════════════════════════════════════════════════════════════════
+
+    async def tenants_list_active(self) -> list[str]:
+        """Distinct ``tenant_id`` from non-soft-deleted memories, sorted.
+
+        Archive/lifecycle fanout target: an org with no live memories has
+        nothing to archive. Read-only (reader replica).
+        """
+        async with get_read_session() as session:
+            result = await session.execute(
+                select(Memory.tenant_id).where(Memory.deleted_at.is_(None)).distinct()
+            )
+            return sorted(row[0] for row in result.all())
+
+    async def tenants_list_purgeable(self) -> list[str]:
+        """Distinct ``tenant_id`` from soft-deleted memories older than the max
+        retention window (``MEMORY_RETENTION_MAX_DAYS``), sorted.
+
+        Orgs whose soft-deleted rows are all newer than the max window are
+        guaranteed no-ops on the purge primitive, so excluding them keeps the
+        discovery scan bounded as ``memories`` grows. ``func.now()`` (DB clock)
+        matches the purge primitive's cutoff and avoids client-clock drift.
+        """
+        cutoff = func.now() - timedelta(days=MEMORY_RETENTION_MAX_DAYS)
+        async with get_read_session() as session:
+            result = await session.execute(
+                select(Memory.tenant_id)
+                .where(Memory.deleted_at.is_not(None))
+                .where(Memory.deleted_at < cutoff)
+                .distinct()
+            )
+            return sorted(row[0] for row in result.all())
+
+    async def tenants_list_skills_factory_enabled(self) -> list[str]:
+        """``org_id`` values whose ``skills_factory.enabled`` JSONB flag is True,
+        sorted.
+
+        The forge-distill lifecycle fanout uses this so a tenant that hasn't
+        opted in pays ZERO per-tick cost. Orgs with no settings row are excluded
+        (the ``DEFAULT_SETTINGS`` default of ``enabled=False`` applies).
+        """
+        async with get_read_session() as session:
+            result = await session.execute(
+                select(OrganizationSettings.org_id).where(
+                    OrganizationSettings.settings["skills_factory"]["enabled"].as_boolean().is_(True)
+                )
+            )
+            return sorted(row[0] for row in result.all())
+
+    # ══════════════════════════════════════════════════════════════════════
     #  REPORTS (CrystallizationReport)
     # ══════════════════════════════════════════════════════════════════════
 

--- a/tests/test_forge_cron_tick.py
+++ b/tests/test_forge_cron_tick.py
@@ -55,7 +55,7 @@ class TestTenantFilter:
                 "core_api.routes.lifecycle.list_active_tenant_ids",
                 new=AsyncMock(return_value=["all-other-tenants"]),
             ) as active_all:
-                result = await _list_tenants_for_action("forge-distill", db=None)
+                result = await _list_tenants_for_action("forge-distill")
         assert result == ["tenant-a", "tenant-c"]
         opted_in.assert_awaited_once()
         # Critical invariant: the broad "active tenants" helper MUST NOT
@@ -78,7 +78,7 @@ class TestTenantFilter:
                 "core_api.routes.lifecycle.list_tenants_with_skills_factory_enabled",
                 new=AsyncMock(return_value=["should-not-be-called"]),
             ) as opted_in:
-                result = await _list_tenants_for_action("archive-expired", db=None)
+                result = await _list_tenants_for_action("archive-expired")
         assert result == ["a", "b"]
         active_all.assert_awaited_once()
         opted_in.assert_not_awaited()

--- a/tests/test_tenant_discovery_storage.py
+++ b/tests/test_tenant_discovery_storage.py
@@ -1,0 +1,47 @@
+"""Fix 2 Phase 1 — tenant-discovery helpers now read through core-storage-api.
+
+These exercise the full path (core-api tenants.py -> storage_client -> the
+in-process storage-api app via the conftest ASGI bridge -> test DB). The ``db``
+argument to the helpers is vestigial (ignored); passed through for back-compat.
+"""
+
+import uuid
+
+from core_api.services.organization_settings import invalidate_cache, update_settings
+from core_api.services.tenants import (
+    list_active_tenant_ids,
+    list_tenants_with_purgeable_memories,
+    list_tenants_with_skills_factory_enabled,
+)
+
+
+def _org() -> str:
+    return f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+
+async def test_list_active_tenant_ids_returns_sorted_str_list(db):
+    """Reads via storage-api and returns a sorted list of tenant-id strings."""
+    result = await list_active_tenant_ids(db)
+    assert isinstance(result, list)
+    assert all(isinstance(t, str) for t in result)
+    assert result == sorted(result)
+
+
+async def test_list_purgeable_returns_sorted_str_list(db):
+    """purgeable variant: same shape contract; SQL bounded to old soft-deleted rows."""
+    result = await list_tenants_with_purgeable_memories(db)
+    assert isinstance(result, list)
+    assert all(isinstance(t, str) for t in result)
+    assert result == sorted(result)
+
+
+async def test_skills_factory_enabled_lists_opted_in_org(db):
+    """End-to-end JSONB filter: an org that flips ``skills_factory.enabled`` via
+    the settings write path shows up in the discovery list (read via storage-api)."""
+    org = _org()
+    await update_settings(None, org, {"skills_factory": {"enabled": True}})
+    invalidate_cache(org)
+
+    enabled = await list_tenants_with_skills_factory_enabled(db)
+    assert org in enabled
+    assert enabled == sorted(enabled)


### PR DESCRIPTION
**Fix 2 Phase 1** — second slice of the Tier-2 *"no DB outside core-storage-api"* migration (after Phase 0 settings, #427). Moves the lifecycle-fanout's tenant-discovery queries off core-api's direct SQLAlchemy pool and behind new core-storage-api endpoints. **No schema change.**

### core-storage-api (now owns the DB access)
- `postgres_service.tenants_list_active / _purgeable / _skills_factory_enabled` — the distinct-tenant and JSONB-flag SELECTs, on the **reader replica** (`get_read_session`). Same SQL that lived in `core-api/services/tenants.py`.
- `routers/tenants.py` — `GET /tenants/active`, `/tenants/purgeable`, `/tenants/skills-factory-enabled`. Envelope responses: `{tenant_ids:[...]}` for the memory-backed reads, `{org_ids:[...]}` for the settings-backed one.

### core-api (now a client)
- `storage_client.list_active_tenants / list_purgeable_tenants / list_skills_factory_enabled_orgs`.
- `services/tenants.py` — the 3 helpers are now thin storage-client wrappers (domain "why" stays in docstrings; SQL moved to storage). The `db` param is retained (ignored) for call-site back-compat (e.g. `routes/memories.py` still passes it), matching the Phase 0 pattern.
- `routes/lifecycle.py` — the cron fanout no longer opens its own `async_session` just to fetch the org list; it calls the now-sessionless discovery helpers directly, so the fan-out holds **no DB connection at all**. Drops the `core_api.db.session` import.

### Validation
- ruff + mypy clean on **both** core-api and core-storage-api.
- Full core-api suite green: **3469 passed**.
- `/simplify` ran (clean). New `test_tenant_discovery_storage` exercises the full core-api → storage-api → DB path; forge-cron routing tests updated for the dropped `db` arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)