### PR TITLE
feat(core-api): route memory REST surface through core-storage-api (Fix 2 Phase 2)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -835,6 +835,118 @@ class CoreStorageClient:
         )
 
     # =====================================================================
+    # Fix 2 Phase 2 — fleet/admin discovery, detail, bulk mutations
+    # =====================================================================
+    #
+    # The list/dict GET helpers below always return 200 with an envelope
+    # (an empty list / zeroed stats when there's no data), so a None / 404
+    # from ``_get`` means the endpoint is MISSING (version skew / routing),
+    # not "no data" — raise rather than silently degrade (mirrors the
+    # Phase 1 tenant-discovery methods). The two by-id reads
+    # (``get_memory_detail`` / ``get_memory_contradictions``) DO treat 404
+    # as a legitimate "memory not found" and return None for the caller to
+    # translate into its own 404.
+
+    async def memory_fleet_distribution(
+        self,
+        tenant_id: str | None = None,
+        *,
+        exclude_scope_agent: bool = False,
+    ) -> list[dict]:
+        """Distinct ``fleet_id`` with memory + agent counts, desc."""
+        params: dict[str, Any] = {"exclude_scope_agent": exclude_scope_agent}
+        if tenant_id is not None:
+            params["tenant_id"] = tenant_id
+        return await self._get_list("/memories/fleet-distribution", **params)
+
+    async def get_memory_detail(self, tenant_id: str, memory_id: str) -> dict | None:
+        """Full memory row + entity links + server-computed embedding stats.
+
+        Returns None on 404 (absent / soft-deleted / cross-tenant) — the
+        caller raises its own 404.
+        """
+        return await self._get(f"/memories/{memory_id}/detail", tenant_id=tenant_id)
+
+    async def get_memory_contradictions(self, tenant_id: str, memory_id: str) -> dict | None:
+        """Raw contradiction rows ``{memory, supersessors[], older|null}``.
+
+        Returns None on 404 (absent / soft-deleted / cross-tenant) — the
+        caller raises its own 404.
+        """
+        return await self._get(f"/memories/{memory_id}/contradictions", tenant_id=tenant_id)
+
+    async def admin_memory_stats(
+        self,
+        tenant_id: str | None = None,
+        fleet_id: str | None = None,
+    ) -> dict:
+        """Admin ``{total, by_type, by_agent, by_status}`` (cross-tenant when
+        ``tenant_id`` is omitted)."""
+        params: dict[str, Any] = {}
+        if tenant_id is not None:
+            params["tenant_id"] = tenant_id
+        if fleet_id is not None:
+            params["fleet_id"] = fleet_id
+        result = await self._get("/memories/admin-stats", **params)
+        if result is None:
+            raise RuntimeError("core-storage-api /memories/admin-stats returned 404")
+        return result
+
+    async def admin_list_memories(self, data: dict) -> list[dict]:
+        """Admin cross-tenant memory list (NO visibility scoping).
+
+        ``data`` carries the filter/sort/cursor params plus ``limit`` already
+        widened to ``limit+1``; the caller slices + builds the next cursor.
+        """
+        result = await self._post("/memories/admin-list", data, read=True)
+        if result is None:
+            raise RuntimeError("core-storage-api /memories/admin-list returned 404")
+        return result  # type: ignore[return-value]
+
+    async def soft_delete_by_filter(self, data: dict) -> int:
+        """Soft-delete every matching live memory for a tenant; returns count."""
+        result = await self._post("/memories/soft-delete-by-filter", data)
+        return (result or {}).get("deleted", 0)  # type: ignore[union-attr]
+
+    async def soft_delete_by_ids(self, tenant_id: str, ids: list[str]) -> int:
+        """Soft-delete live memories by id (tenant-scoped); returns count."""
+        result = await self._post("/memories/soft-delete-by-ids", {"tenant_id": tenant_id, "ids": ids})
+        return (result or {}).get("deleted", 0)  # type: ignore[union-attr]
+
+    async def soft_delete_by_run(
+        self,
+        tenant_id: str,
+        run_id: str,
+        *,
+        metadata_source: str = "ingest",
+    ) -> int:
+        """Soft-delete live memories tagged with ``run_id`` AND
+        ``metadata.source = metadata_source``; returns count."""
+        result = await self._post(
+            "/memories/soft-delete-by-run",
+            {"tenant_id": tenant_id, "run_id": run_id, "metadata_source": metadata_source},
+        )
+        return (result or {}).get("deleted", 0)  # type: ignore[union-attr]
+
+    async def redistribute_memories(
+        self,
+        tenant_id: str,
+        memory_ids: list[str],
+        target_agent_id: str,
+    ) -> dict:
+        """Bulk-reassign memories in ONE storage transaction.
+
+        Returns ``{moved, promoted, skipped, from_agents[], not_found[]}``.
+        """
+        result = await self._post(
+            "/memories/redistribute",
+            {"tenant_id": tenant_id, "memory_ids": memory_ids, "target_agent_id": target_agent_id},
+        )
+        if result is None:
+            raise RuntimeError("core-storage-api /memories/redistribute returned 404")
+        return result  # type: ignore[return-value]
+
+    # =====================================================================
     # Entities
     # =====================================================================
 

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import re
 import time
-from datetime import UTC, datetime
+from datetime import datetime
 from uuid import UUID
 
 import httpx
@@ -21,8 +21,8 @@ from fastapi import (
 )
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from sqlalchemy import func, select, tuple_, update
-from sqlalchemy.exc import OperationalError, SQLAlchemyError
+from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import TimeoutError as SQLATimeoutError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -35,7 +35,6 @@ from core_api.config import settings as app_settings
 from core_api.constants import (
     DEFAULT_LIST_LIMIT,
     MAX_LIST_LIMIT,
-    MEMORY_VISIBILITY_SCOPE_AGENT,
 )
 from core_api.db.session import get_db
 from core_api.middleware.idempotency import (
@@ -46,7 +45,7 @@ from core_api.middleware.idempotency import (
 )
 from core_api.middleware.per_tenant_concurrency import per_tenant_slot
 from core_api.middleware.rate_limit import search_limit, write_bulk_limit, write_limit
-from core_api.pagination import decode_cursor, encode_cursor, paginated_order_by
+from core_api.pagination import decode_cursor, encode_cursor
 from core_api.schemas import (
     BulkMemoryCreate,
     BulkMemoryResponse,
@@ -68,7 +67,6 @@ from core_api.services.agent_service import (
     enforce_delete,
     enforce_fleet_read,
     enforce_fleet_write,
-    enforce_memory_read,
     get_or_create_agent,
     lookup_agent,
 )
@@ -222,7 +220,6 @@ async def list_tenants(
 async def list_fleets(
     tenant_id: str | None = Query(default=None),
     auth: AuthContext = Depends(get_auth_context),
-    db: AsyncSession = Depends(get_db),
 ):
     """Return distinct fleet_ids with memory counts."""
     if tenant_id:
@@ -233,36 +230,13 @@ async def list_fleets(
         if not auth.tenant_id:
             raise HTTPException(status_code=400, detail="tenant_id is required")
         tenant_id = auth.tenant_id
-    filters = [
-        Memory.deleted_at.is_(None),
-        Memory.fleet_id.isnot(None),
-        # No ``agent_id`` accepted on this route, so there's no caller
-        # identity that could legitimately see ``scope_agent`` rows.
-        # Exclude them the same way ``memory_repository.list_by_filters``
-        # does (line 137) and ``/memories/stats`` does. Without this,
-        # ``memory_count``/``agent_count`` overstate what
-        # ``GET /api/v1/memories?fleet_id=X`` would actually return.
-        # ``Memory.visibility`` is ``nullable=False`` with a server
-        # default (common/models/memory.py:62-66), so the SQL three-
-        # valued-logic pitfall (NULL != 'scope_agent' = NULL → row
-        # silently dropped) doesn't apply here.
-        Memory.visibility != MEMORY_VISIBILITY_SCOPE_AGENT,
-    ]
-    if tenant_id:
-        filters.append(Memory.tenant_id == tenant_id)
-    rows = (
-        await db.execute(
-            select(
-                Memory.fleet_id,
-                func.count(),
-                func.count(func.distinct(Memory.agent_id)),
-            )
-            .where(*filters)
-            .group_by(Memory.fleet_id)
-            .order_by(func.count().desc())
-        )
-    ).all()
-    return [{"fleet_id": r[0], "memory_count": r[1], "agent_count": r[2]} for r in rows]
+    # No ``agent_id`` accepted on this route, so there's no caller identity
+    # that could legitimately see ``scope_agent`` rows — exclude them the same
+    # way ``memory_repository.list_by_filters`` and ``/memories/stats`` do, so
+    # the counts don't overstate what ``GET /api/v1/memories?fleet_id=X`` would
+    # actually return. The storage endpoint applies this exclusion server-side
+    # when ``exclude_scope_agent=True``.
+    return await get_storage_client().memory_fleet_distribution(tenant_id, exclude_scope_agent=True)
 
 
 @router.get("/memories", response_model=PaginatedMemoryResponse)
@@ -528,22 +502,12 @@ async def delete_all_memories(
     # owner) keep full reach (dashboard reset, tagged cleanup) unchanged.
     if auth.tenant_id and auth.agent_id:
         await enforce_delete(db, tenant_id, auth.agent_id)
-    from sqlalchemy import update
-
-    stmt = update(Memory).where(Memory.tenant_id == tenant_id, Memory.deleted_at.is_(None))
-    if fleet_id:
-        stmt = stmt.where(Memory.fleet_id == fleet_id)
-    if agent_id:
-        stmt = stmt.where(Memory.agent_id == agent_id)
-    if memory_type:
-        stmt = stmt.where(Memory.memory_type == memory_type)
-    if status:
-        stmt = stmt.where(Memory.status == status)
     exclude_ids = (body or {}).get("exclude_ids", [])
-    if exclude_ids:
-        stmt = stmt.where(Memory.id.notin_([UUID(i) for i in exclude_ids]))
     metadata_filter = (body or {}).get("metadata_filter") or {}
     if metadata_filter:
+        # Validation stays in core-api so the exact 400 messages are preserved;
+        # the storage endpoint builds the JSONB predicate via SQLAlchemy bound
+        # params from the validated dict.
         if not isinstance(metadata_filter, dict):
             raise HTTPException(
                 status_code=400,
@@ -570,12 +534,18 @@ async def delete_all_memories(
                         f"(got {type(value).__name__!r} for key {key!r})"
                     ),
                 )
-            # ``Memory.metadata_`` maps to the JSONB ``metadata`` column.
-            # ``[key].astext == value`` compiles to PG ``metadata->>'key' = 'value'``.
-            stmt = stmt.where(Memory.metadata_[str(key)].astext == value)
-    stmt = stmt.values(deleted_at=datetime.now(UTC), status="deleted")
-    result = await db.execute(stmt)
-    deleted_count = result.rowcount
+    deleted_count = await get_storage_client().soft_delete_by_filter(
+        {
+            "tenant_id": tenant_id,
+            "fleet_id": fleet_id,
+            "agent_id": agent_id,
+            "memory_type": memory_type,
+            "status": status,
+            "exclude_ids": exclude_ids,
+            "metadata_filter": metadata_filter or None,
+        }
+    )
+    # Audit stays a decoupled async POST (not folded into the storage txn).
     await log_action(
         db,
         tenant_id=tenant_id,
@@ -590,7 +560,6 @@ async def delete_all_memories(
             "metadata_filter": metadata_filter or None,
         },
     )
-    await db.commit()
 
 
 @router.post("/memories/bulk-delete")
@@ -614,25 +583,16 @@ async def bulk_delete_by_ids(
     if not ids or len(ids) > 1000:
         raise HTTPException(status_code=400, detail="ids must be 1-1000 items")
 
-    stmt = (
-        update(Memory)
-        .where(
-            Memory.tenant_id == tenant_id,
-            Memory.id.in_([UUID(i) for i in ids]),
-            Memory.deleted_at.is_(None),
-        )
-        .values(deleted_at=datetime.now(UTC), status="deleted")
-    )
-    result = await db.execute(stmt)
+    deleted = await get_storage_client().soft_delete_by_ids(tenant_id, ids)
+    # Audit stays a decoupled async POST (not folded into the storage txn).
     await log_action(
         db,
         tenant_id=tenant_id,
         action="bulk_delete",
         resource_type="memory",
-        detail={"count": result.rowcount, "method": "by_ids"},
+        detail={"count": deleted, "method": "by_ids"},
     )
-    await db.commit()
-    return {"deleted": result.rowcount}
+    return {"deleted": deleted}
 
 
 @router.get("/memories/{memory_id}")
@@ -645,58 +605,38 @@ async def get_memory(
     """Get a single memory with full details including embedding and entity links."""
     from fastapi.responses import JSONResponse
 
-    from common.models.entity import Entity, MemoryEntityLink
-
     auth.enforce_readable_tenant(tenant_id)
 
     t_start = time.perf_counter()
     hit = False
     error = False
     try:
-        memory = await db.get(Memory, memory_id)
-        if not memory or memory.tenant_id != tenant_id or memory.deleted_at is not None:
+        # Storage bundles the row + entity-link outerjoin + server-computed
+        # embedding stats (raw pgvector never crosses the wire) in one call.
+        detail = await get_storage_client().get_memory_detail(tenant_id, str(memory_id))
+        if detail is None:
             raise HTTPException(status_code=404, detail="Memory not found")
+        memory = detail["memory"]
 
         # Fleet/agent-scope authorization: a by-id read must honor the same
         # scope_agent + cross-fleet trust ladder the list/search paths enforce,
         # so a same-tenant agent credential can't read a peer's scoped row by id.
-        await enforce_memory_read(db, tenant_id, auth.agent_id, memory)
-
-        # Get entity links with entity details
-        entity_links = []
-        try:
-            links_result = await db.execute(
-                select(MemoryEntityLink, Entity)
-                .outerjoin(Entity, MemoryEntityLink.entity_id == Entity.id)
-                .where(MemoryEntityLink.memory_id == memory_id)
-            )
-            for row in links_result.all():
-                link, entity = row
-                entry = {"entity_id": str(link.entity_id), "role": link.role}
-                if entity:
-                    entry["entity_type"] = entity.entity_type
-                    entry["canonical_name"] = entity.canonical_name
-                    entry["attributes"] = entity.attributes
-                entity_links.append(entry)
-        except (SQLAlchemyError, ValueError) as e:
-            logger.warning("Failed to fetch entity links for memory %s: %s", memory_id, e)
-
-        # Embedding stats
-        embedding_preview = None
-        embedding_stats = None
-        try:
-            if memory.embedding is not None:
-                vec = [float(v) for v in memory.embedding]
-                embedding_preview = vec[:20]
-                embedding_stats = {
-                    "dimensions": len(vec),
-                    "min": round(min(vec), 6),
-                    "max": round(max(vec), 6),
-                    "mean": round(sum(vec) / len(vec), 6),
-                    "non_zero": sum(1 for v in vec if abs(v) > 1e-8),
-                }
-        except (ValueError, TypeError) as e:
-            logger.warning("Failed to compute embedding stats for memory %s: %s", memory_id, e)
+        # 404 (not 403) mirrors ``enforce_memory_read`` — out-of-scope rows
+        # simply don't exist for the caller. ``authorize_memory_access`` no
+        # longer issues a DB query (its agent lookup routes through the storage
+        # client), so ``db`` is threaded through but unused here; the ``get_db``
+        # dependency stays only until the authz-helper ``db`` params are dropped
+        # in the dedicated cleanup phase (then this read opens no connection).
+        allowed = await authorize_memory_access(
+            db,
+            tenant_id,
+            auth.agent_id,
+            visibility=memory.get("visibility"),
+            owner_agent_id=memory.get("agent_id"),
+            fleet_id=memory.get("fleet_id"),
+        )
+        if not allowed:
+            raise HTTPException(status_code=404, detail="Memory not found")
 
         hit = True
     except HTTPException:
@@ -721,34 +661,36 @@ async def get_memory(
 
     return JSONResponse(
         {
-            "id": str(memory.id),
-            "tenant_id": memory.tenant_id,
-            "fleet_id": memory.fleet_id,
-            "agent_id": memory.agent_id,
-            "memory_type": memory.memory_type,
-            "title": memory.title,
-            "content": memory.content,
-            "weight": float(memory.weight),
-            "source_uri": memory.source_uri,
-            "run_id": memory.run_id,
-            "metadata": memory.metadata_,
-            "content_hash": memory.content_hash,
-            "created_at": memory.created_at.isoformat() if memory.created_at else None,
-            "expires_at": memory.expires_at.isoformat() if memory.expires_at else None,
-            "deleted_at": memory.deleted_at.isoformat() if memory.deleted_at else None,
-            "subject_entity_id": str(memory.subject_entity_id) if memory.subject_entity_id else None,
-            "predicate": memory.predicate,
-            "object_value": memory.object_value,
-            "ts_valid_start": memory.ts_valid_start.isoformat() if memory.ts_valid_start else None,
-            "ts_valid_end": memory.ts_valid_end.isoformat() if memory.ts_valid_end else None,
-            "status": memory.status,
-            "visibility": memory.visibility,
-            "recall_count": memory.recall_count,
-            "last_recalled_at": memory.last_recalled_at.isoformat() if memory.last_recalled_at else None,
-            "supersedes_id": str(memory.supersedes_id) if memory.supersedes_id else None,
-            "entity_links": entity_links,
-            "embedding_preview": embedding_preview,
-            "embedding_stats": embedding_stats,
+            "id": memory["id"],
+            "tenant_id": memory["tenant_id"],
+            "fleet_id": memory["fleet_id"],
+            "agent_id": memory["agent_id"],
+            "memory_type": memory["memory_type"],
+            "title": memory["title"],
+            "content": memory["content"],
+            "weight": float(memory["weight"]) if memory["weight"] is not None else None,
+            "source_uri": memory["source_uri"],
+            "run_id": memory["run_id"],
+            # Storage serialises the JSONB column under ``metadata_``; the API
+            # response exposes it as ``metadata``.
+            "metadata": memory.get("metadata_"),
+            "content_hash": memory["content_hash"],
+            "created_at": memory["created_at"],
+            "expires_at": memory["expires_at"],
+            "deleted_at": memory["deleted_at"],
+            "subject_entity_id": memory["subject_entity_id"],
+            "predicate": memory["predicate"],
+            "object_value": memory["object_value"],
+            "ts_valid_start": memory["ts_valid_start"],
+            "ts_valid_end": memory["ts_valid_end"],
+            "status": memory["status"],
+            "visibility": memory["visibility"],
+            "recall_count": memory["recall_count"],
+            "last_recalled_at": memory["last_recalled_at"],
+            "supersedes_id": memory["supersedes_id"],
+            "entity_links": detail["entity_links"],
+            "embedding_preview": detail["embedding_preview"],
+            "embedding_stats": detail["embedding_stats"],
         }
     )
 
@@ -796,52 +738,51 @@ async def get_contradictions(
     """
     auth.enforce_readable_tenant(tenant_id)
 
-    memory = await db.get(Memory, memory_id)
-    if not memory or memory.tenant_id != tenant_id or memory.deleted_at is not None:
+    # Storage bundles the 3 reads (target row, supersessors, older) in one
+    # round-trip and applies the cross-tenant ``older`` guard server-side.
+    bundle = await get_storage_client().get_memory_contradictions(tenant_id, str(memory_id))
+    if bundle is None:
         raise HTTPException(status_code=404, detail="Memory not found")
+    memory = bundle["memory"]
 
     # Fleet/agent-scope authorization (mirrors GET /memories/{id}): the
     # supersession chain below would otherwise leak a scoped row's contradiction
     # metadata to a same-tenant caller outside its fleet/agent scope.
-    await enforce_memory_read(db, tenant_id, auth.agent_id, memory)
-
-    # Newer rows that point at this one as the row they replace
-    # (i.e. detector found a contradiction and this memory was the
-    # losing side). These are the "supersessors".
-    stmt = (
-        select(Memory)
-        .where(
-            Memory.supersedes_id == memory_id,
-            Memory.tenant_id == tenant_id,
-            Memory.deleted_at.is_(None),
-        )
-        .order_by(Memory.created_at.desc())
+    # ``authorize_memory_access`` issues no DB query (its agent lookup routes
+    # through the storage client), so ``db`` is threaded through but unused; the
+    # ``get_db`` dependency stays only until the authz-helper ``db`` params are
+    # dropped in the dedicated cleanup phase.
+    allowed = await authorize_memory_access(
+        db,
+        tenant_id,
+        auth.agent_id,
+        visibility=memory.get("visibility"),
+        owner_agent_id=memory.get("agent_id"),
+        fleet_id=memory.get("fleet_id"),
     )
-    result = await db.execute(stmt)
-    supersessors = result.scalars().all()
+    if not allowed:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    supersessors = bundle["supersessors"]
 
     # The older row this memory replaced (if any). Despite the field
     # name, ``memory.supersedes_id`` points at the OLDER memory (the
     # detector's loser); this memory was the winner. The variable name
     # ``superseded_by`` in the response is preserved as-is for
     # back-compat; ``contradictions`` below uses unambiguous direction
-    # labels.
+    # labels. The cross-tenant guard already ran server-side; here we keep
+    # the soft-deleted ``older`` filter (storage returns it regardless of
+    # ``deleted_at`` so we can decide per-field).
+    older = bundle["older"]
+    older_live = older is not None and older.get("deleted_at") is None
     superseded_by = None
-    older = None
-    if memory.supersedes_id:
-        older = await db.get(Memory, memory.supersedes_id)
-        # ``db.get`` is a bare PK lookup — guard against a corrupted
-        # cross-tenant ``supersedes_id`` leaking another tenant's content
-        # into ``superseded_by`` / ``contradictions``.
-        if older and older.tenant_id != tenant_id:
-            older = None
-        if older and older.deleted_at is None:
-            superseded_by = {
-                "id": str(older.id),
-                "content_preview": older.content[:200],
-                "status": older.status,
-                "created_at": older.created_at.isoformat() if older.created_at else None,
-            }
+    if older_live:
+        superseded_by = {
+            "id": older["id"],
+            "content_preview": older["content"][:200],
+            "status": older["status"],
+            "created_at": older["created_at"],
+        }
 
     def _reason_for(status: str | None) -> str:
         if status == "outdated":
@@ -857,28 +798,28 @@ async def get_contradictions(
     # window where the supersessor exists but ``memory.status`` hasn't been
     # updated yet.
     for m in supersessors:
-        primary = _reason_for(memory.status)
-        reason = primary if primary != "unknown" else _reason_for(m.status)
+        primary = _reason_for(memory.get("status"))
+        reason = primary if primary != "unknown" else _reason_for(m.get("status"))
         contradictions.append(
             {
-                "memory_id": str(m.id),
-                "status": m.status,
+                "memory_id": m["id"],
+                "status": m["status"],
                 "reason": reason,
-                "content_preview": m.content[:200],
+                "content_preview": m["content"][:200],
                 "direction": "superseded_by",
-                "created_at": m.created_at.isoformat() if m.created_at else None,
+                "created_at": m["created_at"],
             }
         )
     # Direction "supersedes": the older row THIS memory replaced.
-    if older is not None and older.deleted_at is None:
+    if older_live:
         contradictions.append(
             {
-                "memory_id": str(older.id),
-                "status": older.status,
-                "reason": _reason_for(older.status),
-                "content_preview": older.content[:200],
+                "memory_id": older["id"],
+                "status": older["status"],
+                "reason": _reason_for(older["status"]),
+                "content_preview": older["content"][:200],
                 "direction": "supersedes",
-                "created_at": older.created_at.isoformat() if older.created_at else None,
+                "created_at": older["created_at"],
             }
         )
 
@@ -894,14 +835,14 @@ async def get_contradictions(
 
     return {
         "memory_id": str(memory_id),
-        "status": memory.status,
+        "status": memory.get("status"),
         "superseded_by": superseded_by,
         "superseded_memories": [
             {
-                "id": str(m.id),
-                "content_preview": m.content[:200],
-                "status": m.status,
-                "created_at": m.created_at.isoformat() if m.created_at else None,
+                "id": m["id"],
+                "content_preview": m["content"][:200],
+                "status": m["status"],
+                "created_at": m["created_at"],
             }
             for m in supersessors
         ],
@@ -1321,22 +1262,28 @@ async def delete_memory(
     if auth.tenant_id and caller_agent_id:
         await enforce_delete(db, tenant_id, caller_agent_id)
         # Cross-fleet / scope_agent row authorization (write threshold).
-        target = await db.get(Memory, memory_id)
-        if target and target.tenant_id == tenant_id and target.deleted_at is None:
+        # ``get_memory_for_tenant`` already filters out soft-deleted /
+        # cross-tenant rows server-side, so a returned row is live + owned.
+        target = await get_storage_client().get_memory_for_tenant(tenant_id, str(memory_id))
+        if target:
             allowed = await authorize_memory_access(
                 db,
                 tenant_id,
                 caller_agent_id,
-                visibility=target.visibility,
-                owner_agent_id=target.agent_id,
-                fleet_id=target.fleet_id,
+                visibility=target.get("visibility"),
+                owner_agent_id=target.get("agent_id"),
+                fleet_id=target.get("fleet_id"),
                 write=True,
             )
             if not allowed:
                 raise HTTPException(
                     status_code=403,
-                    detail=(f"Agent '{caller_agent_id}' cannot delete memory in fleet '{target.fleet_id}'."),
+                    detail=(
+                        f"Agent '{caller_agent_id}' cannot delete memory in fleet '{target.get('fleet_id')}'."
+                    ),
                 )
+    # ``soft_delete_memory`` already routes the fetch + delete through the
+    # storage client (and logs its own ``soft_delete`` audit row).
     await soft_delete_memory(db, memory_id, tenant_id)
     await log_action(
         db,
@@ -1349,7 +1296,6 @@ async def delete_memory(
         resource_type="memory",
         resource_id=memory_id,
     )
-    await db.commit()
 
 
 @router.patch("/memories/{memory_id}/status")
@@ -1372,8 +1318,11 @@ async def update_memory_status(
             status_code=400,
             detail=f"Invalid status. Must be one of: {', '.join(MEMORY_STATUSES)}",
         )
-    memory = await db.get(Memory, memory_id)
-    if not memory or memory.tenant_id != tenant_id or memory.deleted_at is not None:
+    sc = get_storage_client()
+    # ``get_memory_for_tenant`` filters out soft-deleted / cross-tenant rows
+    # server-side, so a returned row is live + owned.
+    memory = await sc.get_memory_for_tenant(tenant_id, str(memory_id))
+    if not memory:
         raise HTTPException(status_code=404, detail="Memory not found")
     # Cross-fleet / scope_agent row authorization for the authenticated agent
     # (no-op for tenant-scoped dashboard credentials, where auth.agent_id is None).
@@ -1382,29 +1331,29 @@ async def update_memory_status(
             db,
             tenant_id,
             auth.agent_id,
-            visibility=memory.visibility,
-            owner_agent_id=memory.agent_id,
-            fleet_id=memory.fleet_id,
+            visibility=memory.get("visibility"),
+            owner_agent_id=memory.get("agent_id"),
+            fleet_id=memory.get("fleet_id"),
             write=True,
         )
         if not allowed:
             raise HTTPException(
                 status_code=403,
-                detail=f"Agent '{auth.agent_id}' cannot modify memory in fleet '{memory.fleet_id}'.",
+                detail=f"Agent '{auth.agent_id}' cannot modify memory in fleet '{memory.get('fleet_id')}'.",
             )
-    old_status = memory.status
-    memory.status = status
+    old_status = memory.get("status")
+    await sc.update_memory_status(str(memory_id), status)
 
+    # Audit stays a decoupled async POST (not folded into the storage txn).
     await log_action(
         db,
         tenant_id=tenant_id,
-        agent_id=memory.agent_id,
+        agent_id=memory.get("agent_id"),
         action="status_update",
         resource_type="memory",
         resource_id=memory_id,
         detail={"old_status": old_status, "new_status": status},
     )
-    await db.commit()
     return {"memory_id": str(memory_id), "old_status": old_status, "new_status": status}
 
 
@@ -1695,25 +1644,18 @@ async def ingest_undo_endpoint(
     auth.enforce_read_only()
     auth.enforce_tenant(tenant_id)
 
-    stmt = (
-        update(Memory)
-        .where(
-            Memory.tenant_id == tenant_id,
-            Memory.deleted_at.is_(None),
-            Memory.run_id == run_id,
-            Memory.metadata_["source"].astext == "ingest",
-        )
-        .values(deleted_at=datetime.now(UTC), status="deleted")
-    )
-    result = await db.execute(stmt)
-    deleted_count = result.rowcount
+    sc = get_storage_client()
+    # Soft-delete the memory rows server-side (filters by run_id AND
+    # ``metadata.source = "ingest"`` AND tenant ownership, same predicate as
+    # the prior inline UPDATE).
+    deleted_count = await sc.soft_delete_by_run(tenant_id, run_id, metadata_source="ingest")
 
     # Delete the parent Document for this batch (introduced by the
     # parent-doc PR). Best-effort: older batches predate the parent-doc
     # write and won't have one, which is fine — undo on those still
     # soft-deletes the memories, just without a parent record to drop.
+    # Kept as a separate storage call in the same order as before.
     try:
-        sc = get_storage_client()
         await sc.delete_document(tenant_id=tenant_id, collection=INGEST_DOCUMENTS_COLLECTION, doc_id=run_id)
     except Exception:
         logger.info(
@@ -1723,6 +1665,7 @@ async def ingest_undo_endpoint(
             exc_info=False,
         )
 
+    # Audit stays a decoupled async POST (not folded into the storage txn).
     await log_action(
         db,
         tenant_id=tenant_id,
@@ -1730,7 +1673,6 @@ async def ingest_undo_endpoint(
         resource_type="memory",
         detail={"run_id": run_id, "count": deleted_count},
     )
-    await db.commit()
     return {"deleted": deleted_count, "run_id": run_id}
 
 
@@ -1878,40 +1820,18 @@ async def redistribute_memories(
     if auth.tenant_id:  # skip usage metering for admin tokens
         await bulk_check_and_increment(db, tenant_id, len(body.memory_ids))
 
-    # Fetch matching memories (tenant-scoped, not deleted)
-    stmt = select(Memory).where(
-        Memory.id.in_(body.memory_ids),
-        Memory.tenant_id == tenant_id,
-        Memory.deleted_at.is_(None),
+    # The SELECT … FOR UPDATE, the moved/promoted/skipped/from_agents loop,
+    # the scope_agent→scope_team auto-promotion, and the not_found computation
+    # all run server-side in ONE storage transaction (NOT N per-row HTTP
+    # calls). The trust gates + agent_id==auth precedence above stay in
+    # core-api, BEFORE the call.
+    outcome = await get_storage_client().redistribute_memories(
+        tenant_id,
+        [str(mid) for mid in body.memory_ids],
+        body.target_agent_id,
     )
-    result = await db.execute(stmt)
-    memories = result.scalars().all()
 
-    # Track IDs not found (deleted, wrong tenant, or non-existent)
-    found_ids = {mem.id for mem in memories}
-    not_found = [str(mid) for mid in body.memory_ids if mid not in found_ids]
-
-    moved = 0
-    promoted = 0
-    skipped = 0
-    from_agents: set[str] = set()
-
-    for mem in memories:
-        if mem.agent_id == body.target_agent_id:
-            skipped += 1
-            continue
-
-        from_agents.add(mem.agent_id)
-        mem.agent_id = body.target_agent_id
-
-        # Auto-promote scope_agent to scope_team to prevent data loss
-        if mem.visibility == "scope_agent":
-            mem.visibility = "scope_team"
-            promoted += 1
-
-        moved += 1
-
-    # Audit log (same transaction as memory mutations — single atomic commit)
+    # Audit stays a decoupled async POST (not folded into the storage txn).
     await log_action(
         db,
         tenant_id=tenant_id,
@@ -1920,21 +1840,20 @@ async def redistribute_memories(
         resource_type="memory",
         detail={
             "target_agent_id": body.target_agent_id,
-            "from_agents": sorted(from_agents),
-            "moved": moved,
-            "promoted": promoted,
-            "skipped": skipped,
+            "from_agents": outcome["from_agents"],
+            "moved": outcome["moved"],
+            "promoted": outcome["promoted"],
+            "skipped": outcome["skipped"],
             "requested": len(body.memory_ids),
         },
     )
-    await db.commit()
 
     elapsed_ms = int((time.perf_counter() - t0) * 1000)
     return RedistributeResponse(
-        moved=moved,
-        promoted=promoted,
-        skipped=skipped,
-        errors=not_found,
+        moved=outcome["moved"],
+        promoted=outcome["promoted"],
+        skipped=outcome["skipped"],
+        errors=outcome["not_found"],
         redistribute_ms=elapsed_ms,
     )
 
@@ -1959,26 +1878,12 @@ async def admin_list_tenants(
 async def admin_list_fleets(
     tenant_id: str | None = Query(default=None),
     auth: AuthContext = Depends(get_auth_context),
-    db: AsyncSession = Depends(get_db),
 ):
     """Admin: list distinct fleet_ids with memory counts."""
     auth.enforce_admin()
-    filters = [Memory.deleted_at.is_(None), Memory.fleet_id.isnot(None)]
-    if tenant_id:
-        filters.append(Memory.tenant_id == tenant_id)
-    rows = (
-        await db.execute(
-            select(
-                Memory.fleet_id,
-                func.count(),
-                func.count(func.distinct(Memory.agent_id)),
-            )
-            .where(*filters)
-            .group_by(Memory.fleet_id)
-            .order_by(func.count().desc())
-        )
-    ).all()
-    return [{"fleet_id": r[0], "memory_count": r[1], "agent_count": r[2]} for r in rows]
+    # Admin view: no ``scope_agent`` exclusion (admins see everything), and
+    # cross-tenant when ``tenant_id`` is omitted.
+    return await get_storage_client().memory_fleet_distribution(tenant_id, exclude_scope_agent=False)
 
 
 @admin_memories_router.get("/admin/memories", response_model=PaginatedMemoryResponse)
@@ -1998,52 +1903,61 @@ async def admin_list_memories(
     limit: int = Query(default=DEFAULT_LIST_LIMIT, ge=1, le=MAX_LIST_LIMIT),
     include_deleted: bool = Query(default=False),
     auth: AuthContext = Depends(get_auth_context),
-    db: AsyncSession = Depends(get_db),
 ):
     """Admin: list memories across all tenants with full pagination."""
     auth.enforce_admin()
-    stmt = select(Memory)
-    if tenant_id:
-        stmt = stmt.where(Memory.tenant_id == tenant_id)
-    if fleet_id:
-        stmt = stmt.where(Memory.fleet_id == fleet_id)
-    if not include_deleted:
-        stmt = stmt.where(Memory.deleted_at.is_(None))
-    if agent_id:
-        stmt = stmt.where(Memory.agent_id == agent_id)
-    if memory_type:
-        stmt = stmt.where(Memory.memory_type == memory_type)
-    if status:
-        stmt = stmt.where(Memory.status == status)
 
     if cursor and (sort != "created_at" or order != "desc"):
         raise HTTPException(
             status_code=400,
             detail="Cursor pagination is only supported with sort=created_at and order=desc",
         )
+    cursor_ts = cursor_id = None
     if cursor:
         try:
             cursor_ts, cursor_id = decode_cursor(cursor)
         except Exception:
             raise HTTPException(status_code=400, detail="Invalid cursor")
-        stmt = stmt.where(tuple_(Memory.created_at, Memory.id) < tuple_(cursor_ts, cursor_id))
 
-    col = getattr(Memory, sort)
-    stmt = stmt.order_by(*paginated_order_by(col, Memory.id, order))
-    if not cursor:
-        stmt = stmt.offset(offset)
-    stmt = stmt.limit(limit + 1)
+    # Request ``limit + 1`` rows from storage so we can detect ``has_more``
+    # and build the next cursor here; storage applies the same filter,
+    # cursor predicate, and ``(sort, id)`` tiebreaker the prior inline query
+    # used. NO visibility scoping (admin view).
+    payload: dict = {
+        "include_deleted": include_deleted,
+        "sort": sort,
+        "order": order,
+        "offset": offset,
+        "limit": limit + 1,
+    }
+    if tenant_id:
+        payload["tenant_id"] = tenant_id
+    if fleet_id:
+        payload["fleet_id"] = fleet_id
+    if agent_id:
+        payload["agent_id"] = agent_id
+    if memory_type:
+        payload["memory_type"] = memory_type
+    if status:
+        payload["status"] = status
+    if cursor_ts is not None and cursor_id is not None:
+        payload["cursor_ts"] = cursor_ts.isoformat()
+        payload["cursor_id"] = str(cursor_id)
 
-    result = await db.execute(stmt)
-    rows = result.scalars().all()
+    rows = await get_storage_client().admin_list_memories(payload)
 
     has_more = len(rows) > limit
-    items = [_memory_to_out(m) for m in rows[:limit]]
+    page = rows[:limit]
+    # ``_memory_to_out`` accepts either an ORM row or a storage dict.
+    items = [_memory_to_out(r) for r in page]
 
     next_cursor = None
-    if has_more and items:
-        last = rows[limit - 1]
-        next_cursor = encode_cursor(last.created_at, last.id)
+    if has_more and page:
+        last = page[limit - 1]
+        next_cursor = encode_cursor(
+            datetime.fromisoformat(last["created_at"]),
+            UUID(last["id"]),
+        )
 
     return PaginatedMemoryResponse(items=items, next_cursor=next_cursor)
 
@@ -2053,63 +1967,12 @@ async def admin_memory_stats(
     tenant_id: str | None = Query(default=None),
     fleet_id: str | None = Query(default=None),
     auth: AuthContext = Depends(get_auth_context),
-    db: AsyncSession = Depends(get_db),
 ):
     """Admin: memory stats across all tenants (or filtered by tenant_id)."""
     auth.enforce_admin()
-    filters = [Memory.deleted_at.is_(None)]
-    if tenant_id:
-        filters.append(Memory.tenant_id == tenant_id)
-    if fleet_id:
-        filters.append(Memory.fleet_id == fleet_id)
-    base = select(Memory).where(*filters)
-
-    try:
-        total = (await db.execute(select(func.count()).select_from(base.subquery()))).scalar()
-        by_type = dict(
-            (
-                await db.execute(
-                    select(Memory.memory_type, func.count()).where(*filters).group_by(Memory.memory_type)
-                )
-            ).all()
-        )
-        by_agent = dict(
-            (
-                await db.execute(
-                    select(Memory.agent_id, func.count()).where(*filters).group_by(Memory.agent_id)
-                )
-            ).all()
-        )
-        by_status = dict(
-            (
-                await db.execute(select(Memory.status, func.count()).where(*filters).group_by(Memory.status))
-            ).all()
-        )
-        return {
-            "total": total,
-            "by_type": by_type,
-            "by_agent": by_agent,
-            "by_status": by_status,
-        }
-    except (OperationalError, SQLATimeoutError):
-        # Same transient-only fallback as the tenant-facing /memories/stats
-        # above. ``warning`` (not ``exception``) avoids log floods under
-        # sustained pool exhaustion. The admin endpoint cannot pass an
-        # unbounded tenant_id to storage-api (storage_client requires
-        # one), so the cross-tenant case has no fallback path and
-        # re-raises.
-        if not tenant_id:
-            logger.warning(
-                "admin_memory_stats: direct DB query failed; raising 503 "
-                "(cross-tenant admin call has no fallback path)",
-                exc_info=True,
-            )
-            raise HTTPException(
-                status_code=503,
-                detail="memory stats unavailable: database connection failed",
-            ) from None
-        logger.warning(
-            "admin_memory_stats: direct DB query failed; falling back to storage-api",
-            exc_info=True,
-        )
-        return await _stats_fallback(tenant_id, fleet_id)
+    # Single GROUPING SETS scan server-side (storage-api), shaped as
+    # {total, by_type, by_agent, by_status}. The prior inline 4-query
+    # implementation + transient-DB fallback are gone — storage-api owns the
+    # DB and the storage client carries its own retry budget for transient
+    # blips.
+    return await get_storage_client().admin_memory_stats(tenant_id, fleet_id)

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -13,7 +13,7 @@ from common.events.lifecycle_purge_request import (
     MEMORY_RETENTION_MIN_DAYS,
 )
 from core_storage_api.observability import bind_timer, log_request
-from core_storage_api.schemas import MEMORY_FIELDS, orm_to_dict
+from core_storage_api.schemas import MEMORY_FIELDS, MEMORY_LIST_FIELDS, orm_to_dict
 from core_storage_api.services.postgres_service import PostgresService
 
 router = APIRouter(prefix="/memories", tags=["Memories"])
@@ -888,8 +888,202 @@ async def decide_dedup_review(review_id: UUID, request: Request) -> dict:
 
 
 # ------------------------------------------------------------------
+# Fix 2 Phase 2 — fleet/admin discovery + detail + bulk mutations
+#
+# Literal-path routes; MUST stay above the parameterised ``/{memory_id}``
+# block below so segments like ``fleet-distribution`` / ``admin-list`` /
+# ``redistribute`` aren't parsed as a memory UUID.
+# ------------------------------------------------------------------
+
+
+@router.get("/fleet-distribution")
+async def fleet_distribution(
+    tenant_id: str | None = None,
+    exclude_scope_agent: bool = False,
+) -> list[dict]:
+    """Distinct ``fleet_id`` with memory + agent counts, desc.
+
+    Serves both ``GET /fleets`` (``exclude_scope_agent=true``) and
+    ``GET /admin/fleets`` (``exclude_scope_agent=false``, cross-tenant when
+    ``tenant_id`` is omitted) upstream.
+    """
+    return await _svc.memory_fleet_distribution(tenant_id, exclude_scope_agent=exclude_scope_agent)
+
+
+@router.get("/admin-stats")
+async def admin_stats(
+    tenant_id: str | None = None,
+    fleet_id: str | None = None,
+) -> dict:
+    """Admin memory stats — ``{total, by_type, by_agent, by_status}``.
+
+    Single GROUPING SETS scan, no visibility scoping, cross-tenant when
+    ``tenant_id`` is omitted.
+    """
+    return await _svc.memory_admin_stats(tenant_id, fleet_id)
+
+
+@router.post("/admin-list")
+async def admin_list(request: Request) -> list[dict]:
+    """Admin cross-tenant memory list (NO visibility scoping).
+
+    Body: ``{tenant_id?, fleet_id?, agent_id?, memory_type?, status?,
+    include_deleted, sort, order, offset, limit, cursor_ts?, cursor_id?}``.
+    Returns up to ``limit`` rows in input cursor order — the caller passes
+    ``limit`` already widened to ``limit+1`` and slices / builds the next
+    cursor itself.
+    """
+    body: dict = await request.json()
+    # Guard cursor parsing (matches the sibling soft-delete/redistribute routes):
+    # a malformed cursor in the raw body must 422, not 500 on an unhandled
+    # ValueError/TypeError from fromisoformat / UUID.
+    cursor_ts_raw = body.get("cursor_ts")
+    cursor_id_raw = body.get("cursor_id")
+    try:
+        cursor_ts = datetime.fromisoformat(cursor_ts_raw) if isinstance(cursor_ts_raw, str) else cursor_ts_raw
+        cursor_id = UUID(cursor_id_raw) if cursor_id_raw else None
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=422, detail=f"invalid cursor fields: {exc}") from exc
+    memories = await _svc.memory_admin_list(
+        tenant_id=body.get("tenant_id"),
+        fleet_id=body.get("fleet_id"),
+        agent_id=body.get("agent_id"),
+        memory_type=body.get("memory_type"),
+        status=body.get("status"),
+        include_deleted=bool(body.get("include_deleted", False)),
+        sort=body.get("sort", "created_at"),
+        order=body.get("order", "desc"),
+        offset=body.get("offset", 0),
+        limit=body.get("limit", 50),
+        cursor_ts=cursor_ts,
+        cursor_id=cursor_id,
+    )
+    # MEMORY_LIST_FIELDS (no embedding/search_vector): core-api's _memory_to_out
+    # discards the vector, so don't ship it over the wire for a list.
+    return [orm_to_dict(m, MEMORY_LIST_FIELDS) for m in memories]
+
+
+@router.post("/soft-delete-by-filter")
+async def soft_delete_by_filter(request: Request) -> dict:
+    """Soft-delete every matching live memory for a tenant.
+
+    Body: ``{tenant_id, fleet_id?, agent_id?, memory_type?, status?,
+    exclude_ids?[], metadata_filter?{k:v}}``. The ≤20-pair + string-value
+    validation stays in core-api (for its exact 400 messages); this route
+    builds the JSONB predicate via SQLAlchemy bound params.
+    """
+    body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    if not tenant_id:
+        raise HTTPException(status_code=422, detail="tenant_id is required")
+    try:
+        exclude_ids = [UUID(i) for i in body.get("exclude_ids") or []]
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=422, detail=f"invalid UUID in exclude_ids: {exc}")
+    metadata_filter = body.get("metadata_filter") or None
+    if metadata_filter is not None and not isinstance(metadata_filter, dict):
+        raise HTTPException(status_code=422, detail="metadata_filter must be an object")
+    deleted = await _svc.memory_soft_delete_by_filter(
+        tenant_id=tenant_id,
+        fleet_id=body.get("fleet_id"),
+        agent_id=body.get("agent_id"),
+        memory_type=body.get("memory_type"),
+        status=body.get("status"),
+        exclude_ids=exclude_ids,
+        metadata_filter=metadata_filter,
+    )
+    return {"deleted": deleted}
+
+
+@router.post("/soft-delete-by-ids")
+async def soft_delete_by_ids(request: Request) -> dict:
+    """Soft-delete live memories by id (tenant-scoped). Body: ``{tenant_id,
+    ids[]}``. The 1-1000 cap stays in core-api."""
+    body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    if not tenant_id:
+        raise HTTPException(status_code=422, detail="tenant_id is required")
+    try:
+        ids = [UUID(i) for i in body.get("ids") or []]
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=422, detail=f"invalid UUID in ids: {exc}")
+    deleted = await _svc.memory_soft_delete_by_ids(tenant_id, ids)
+    return {"deleted": deleted}
+
+
+@router.post("/soft-delete-by-run")
+async def soft_delete_by_run(request: Request) -> dict:
+    """Soft-delete live memories tagged with ``run_id`` AND
+    ``metadata.source = metadata_source``. Body: ``{tenant_id, run_id,
+    metadata_source}``."""
+    body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    run_id = body.get("run_id")
+    if not tenant_id or not run_id:
+        raise HTTPException(status_code=422, detail="tenant_id and run_id are required")
+    deleted = await _svc.memory_soft_delete_by_run(
+        tenant_id,
+        run_id,
+        metadata_source=body.get("metadata_source", "ingest"),
+    )
+    return {"deleted": deleted}
+
+
+@router.post("/redistribute")
+async def redistribute(request: Request) -> dict:
+    """Bulk-reassign memories to ``target_agent_id`` in ONE transaction.
+
+    Body: ``{tenant_id, memory_ids[], target_agent_id}``. Returns
+    ``{moved, promoted, skipped, from_agents[], not_found[]}``. Trust gates
+    + the agent_id==auth precedence check stay in core-api.
+    """
+    body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    target_agent_id = body.get("target_agent_id")
+    if not tenant_id or not target_agent_id:
+        raise HTTPException(status_code=422, detail="tenant_id and target_agent_id are required")
+    try:
+        memory_ids = [UUID(i) for i in body.get("memory_ids") or []]
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=422, detail=f"invalid UUID in memory_ids: {exc}")
+    return await _svc.memory_redistribute(
+        tenant_id=tenant_id,
+        memory_ids=memory_ids,
+        target_agent_id=target_agent_id,
+    )
+
+
+# ------------------------------------------------------------------
 # Parameterised paths — MUST come last to avoid catching /count etc.
 # ------------------------------------------------------------------
+
+
+@router.get("/{memory_id}/detail")
+async def get_memory_detail(memory_id: UUID, tenant_id: str) -> dict:
+    """Full memory row + entity links + server-computed embedding stats.
+
+    The raw pgvector is never returned — only a first-20 preview and
+    {dimensions,min,max,mean,non_zero}. 404 when the row is absent,
+    soft-deleted, or belongs to another tenant.
+    """
+    detail = await _svc.memory_get_detail(memory_id, tenant_id)
+    if detail is None:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return detail
+
+
+@router.get("/{memory_id}/contradictions")
+async def get_memory_contradictions(memory_id: UUID, tenant_id: str) -> dict:
+    """Raw contradiction rows: ``{memory, supersessors[], older|null}``.
+
+    The cross-tenant ``older`` guard is enforced server-side; core-api keeps
+    the reason/direction/detection_status shaping. 404 when the target
+    memory is absent/soft-deleted/wrong tenant.
+    """
+    rows = await _svc.memory_contradiction_rows(memory_id, tenant_id)
+    if rows is None:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return rows
 
 
 @router.get("/{memory_id}")

--- a/core-storage-api/src/core_storage_api/schemas.py
+++ b/core-storage-api/src/core_storage_api/schemas.py
@@ -82,6 +82,13 @@ MEMORY_FIELDS: list[str] = [
     "supersedes_id",
 ]
 
+# Same as MEMORY_FIELDS minus the two large columns (a 1536-dim ``embedding``
+# vector + the ``search_vector`` tsvector). Use for list/bundle endpoints whose
+# core-api consumers don't read the vector (admin list, contradiction rows):
+# serialising the full vector ships ~hundreds of KB per row over the internal
+# network only for ``_memory_to_out`` to discard it.
+MEMORY_LIST_FIELDS: list[str] = [f for f in MEMORY_FIELDS if f not in ("embedding", "search_vector")]
+
 ENTITY_FIELDS: list[str] = [
     "id",
     "tenant_id",

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -21,7 +21,7 @@ from types import SimpleNamespace
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, case, delete, false, func, literal_column, or_, select, text, tuple_
+from sqlalchemy import and_, bindparam, case, delete, false, func, literal_column, or_, select, text, tuple_
 from sqlalchemy import update as sql_update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
@@ -62,6 +62,7 @@ from common.models import (
 from common.models.organization_settings import OrganizationSettings, OrganizationSettingsAudit
 from common.organization_settings_merge import deep_merge, diff_settings
 from core_storage_api.observability import db_measure
+from core_storage_api.schemas import MEMORY_LIST_FIELDS, orm_to_dict
 from core_storage_api.services.audit_chain import (
     GENESIS_PREV_HASH,
     assert_pii_safe,
@@ -168,6 +169,25 @@ def _relation_weight(relation_type: str, row_weight: float) -> float:
 # on every call. Both sets are static for the lifetime of the process.
 _MEMORY_VALID_FIELDS = frozenset(
     {c.key for c in Memory.__table__.columns} | {a.key for a in Memory.__mapper__.column_attrs}
+)
+
+# Columns the admin memory-list endpoint may sort by. Allowlisted so an
+# unexpected ``sort`` value falls back to created_at instead of raising
+# AttributeError (500) at ``getattr(Memory, sort)`` — the endpoint is callable
+# independently of core-api's route-level regex guard.
+_ADMIN_LIST_SORTABLE = frozenset(
+    {
+        "created_at",
+        "weight",
+        "memory_type",
+        "agent_id",
+        "status",
+        "recall_count",
+        "fleet_id",
+        "tenant_id",
+        "expires_at",
+        "deleted_at",
+    }
 )
 
 
@@ -2574,6 +2594,433 @@ class PostgresService:
             )
             result = await session.execute(stmt)
             return {m.id: m for m in result.scalars().all()}
+
+    # ------------------------------------------------------------------
+    # B) Fix 2 Phase 2 — fleet/admin discovery + detail + bulk mutations
+    # ------------------------------------------------------------------
+
+    async def memory_fleet_distribution(
+        self,
+        tenant_id: str | None,
+        *,
+        exclude_scope_agent: bool,
+    ) -> list[dict]:
+        """Distinct ``fleet_id`` with memory + distinct-agent counts, desc.
+
+        Serves both the tenant-facing ``/fleets`` (``exclude_scope_agent``
+        True — no caller identity to legitimately see ``scope_agent`` rows,
+        so they're excluded the same way ``list_by_filters`` does) and the
+        admin ``/admin/fleets`` (``exclude_scope_agent`` False, cross-tenant
+        when ``tenant_id`` is None). Read-only (reader replica).
+        """
+        filters = [Memory.deleted_at.is_(None), Memory.fleet_id.isnot(None)]
+        if exclude_scope_agent:
+            # ``Memory.visibility`` is NOT NULL with a server default, so the
+            # three-valued-logic NULL pitfall doesn't apply.
+            filters.append(Memory.visibility != "scope_agent")
+        if tenant_id is not None:
+            filters.append(Memory.tenant_id == tenant_id)
+        async with get_read_session() as session:
+            rows = (
+                await session.execute(
+                    select(
+                        Memory.fleet_id,
+                        func.count(),
+                        func.count(func.distinct(Memory.agent_id)),
+                    )
+                    .where(*filters)
+                    .group_by(Memory.fleet_id)
+                    .order_by(func.count().desc())
+                )
+            ).all()
+        return [{"fleet_id": r[0], "memory_count": r[1], "agent_count": r[2]} for r in rows]
+
+    async def memory_get_detail(
+        self,
+        memory_id: UUID,
+        tenant_id: str,
+    ) -> dict | None:
+        """Bundle a single memory's full row + entity links + embedding stats.
+
+        The raw pgvector NEVER crosses the wire: embedding min/max/mean/
+        non_zero/dimensions and a first-20 preview are computed here and the
+        embedding column is stripped from the returned row dict. The memory
+        row and its entity-link outerjoin are fetched in two queries in one
+        session (no per-link N+1). Returns None when the row is absent, soft-
+        deleted, or belongs to another tenant. Read-only (reader replica).
+        """
+        async with get_read_session() as session:
+            memory = await session.get(Memory, memory_id)
+            if memory is None or memory.tenant_id != tenant_id or memory.deleted_at is not None:
+                return None
+
+            link_rows = (
+                await session.execute(
+                    select(MemoryEntityLink, Entity)
+                    .outerjoin(Entity, MemoryEntityLink.entity_id == Entity.id)
+                    .where(MemoryEntityLink.memory_id == memory_id)
+                )
+            ).all()
+            entity_links: list[dict] = []
+            for link, entity in link_rows:
+                entry: dict = {"entity_id": str(link.entity_id), "role": link.role}
+                if entity is not None:
+                    entry["entity_type"] = entity.entity_type
+                    entry["canonical_name"] = entity.canonical_name
+                    entry["attributes"] = entity.attributes
+                entity_links.append(entry)
+
+            embedding_preview: list[float] | None = None
+            embedding_stats: dict | None = None
+            if memory.embedding is not None:
+                vec = [float(v) for v in memory.embedding]
+                if vec:
+                    embedding_preview = vec[:20]
+                    embedding_stats = {
+                        "dimensions": len(vec),
+                        "min": round(min(vec), 6),
+                        "max": round(max(vec), 6),
+                        "mean": round(sum(vec) / len(vec), 6),
+                        "non_zero": sum(1 for v in vec if abs(v) > 1e-8),
+                    }
+
+            # MEMORY_LIST_FIELDS excludes embedding + search_vector: the client
+            # consumes the server-computed preview/stats, never the raw vector,
+            # so it's neither serialised nor shipped.
+            row = orm_to_dict(memory, MEMORY_LIST_FIELDS)
+        return {
+            "memory": row,
+            "entity_links": entity_links,
+            "embedding_preview": embedding_preview,
+            "embedding_stats": embedding_stats,
+        }
+
+    async def memory_contradiction_rows(
+        self,
+        memory_id: UUID,
+        tenant_id: str,
+    ) -> dict | None:
+        """Bundle the 3 contradiction reads in one round-trip.
+
+        Returns ``{memory, supersessors[], older|null}`` as flat row dicts;
+        the upstream core-api keeps the ``_reason_for`` / direction /
+        ``detection_status`` shaping. The cross-tenant ``older`` guard
+        (a corrupted ``supersedes_id`` pointing at another tenant's row)
+        is enforced here so the leak never crosses the wire. Returns None
+        when the target memory is absent/soft-deleted/wrong tenant.
+        Read-only (reader replica).
+        """
+        async with get_read_session() as session:
+            memory = await session.get(Memory, memory_id)
+            if memory is None or memory.tenant_id != tenant_id or memory.deleted_at is not None:
+                return None
+
+            supersessors = (
+                (
+                    await session.execute(
+                        select(Memory)
+                        .where(
+                            Memory.supersedes_id == memory_id,
+                            Memory.tenant_id == tenant_id,
+                            Memory.deleted_at.is_(None),
+                        )
+                        .order_by(Memory.created_at.desc())
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+            older = None
+            if memory.supersedes_id:
+                older_row = await session.get(Memory, memory.supersedes_id)
+                # ``session.get`` is a bare PK lookup — guard against a
+                # corrupted cross-tenant ``supersedes_id`` leaking another
+                # tenant's content.
+                if older_row is not None and older_row.tenant_id == tenant_id:
+                    older = older_row
+
+            return {
+                # MEMORY_LIST_FIELDS: core-api's contradiction shaping never
+                # reads the embedding/search_vector, so don't ship them.
+                "memory": orm_to_dict(memory, MEMORY_LIST_FIELDS),
+                "supersessors": [orm_to_dict(m, MEMORY_LIST_FIELDS) for m in supersessors],
+                "older": orm_to_dict(older, MEMORY_LIST_FIELDS) if older is not None else None,
+            }
+
+    async def memory_soft_delete_by_filter(
+        self,
+        *,
+        tenant_id: str,
+        fleet_id: str | None = None,
+        agent_id: str | None = None,
+        memory_type: str | None = None,
+        status: str | None = None,
+        exclude_ids: list[UUID] | None = None,
+        metadata_filter: dict[str, str] | None = None,
+    ) -> int:
+        """Soft-delete every matching live memory for a tenant; returns count.
+
+        The JSONB ``metadata->>'key' = 'value'`` predicates are built with
+        SQLAlchemy bound params (``Memory.metadata_[key].astext == bindparam(...)``)
+        — never string interpolation. Transactional (writer session).
+        """
+        stmt = sql_update(Memory).where(
+            Memory.tenant_id == tenant_id,
+            Memory.deleted_at.is_(None),
+        )
+        if fleet_id:
+            stmt = stmt.where(Memory.fleet_id == fleet_id)
+        if agent_id:
+            stmt = stmt.where(Memory.agent_id == agent_id)
+        if memory_type:
+            stmt = stmt.where(Memory.memory_type == memory_type)
+        if status:
+            stmt = stmt.where(Memory.status == status)
+        if exclude_ids:
+            stmt = stmt.where(Memory.id.notin_(exclude_ids))
+        if metadata_filter:
+            for i, (key, value) in enumerate(metadata_filter.items()):
+                # Distinct bindparam name per pair so multiple predicates
+                # don't collide; the KEY indexes the JSONB column (a SQL
+                # expression, not a bound value) while the VALUE is bound.
+                param: Any = bindparam(f"meta_val_{i}", value)
+                stmt = stmt.where(Memory.metadata_[str(key)].astext == param)
+        stmt = stmt.values(deleted_at=datetime.now(UTC), status="deleted")
+        async with get_session() as session:
+            result = await session.execute(stmt)
+            return result.rowcount or 0  # type: ignore[attr-defined]
+
+    async def memory_soft_delete_by_ids(
+        self,
+        tenant_id: str,
+        ids: list[UUID],
+    ) -> int:
+        """Soft-delete live memories by id (tenant-scoped); returns count.
+
+        Transactional (writer session). The 1-1000 cap stays in core-api.
+        """
+        if not ids:
+            return 0
+        async with get_session() as session:
+            result = await session.execute(
+                sql_update(Memory)
+                .where(
+                    Memory.tenant_id == tenant_id,
+                    Memory.id.in_(ids),
+                    Memory.deleted_at.is_(None),
+                )
+                .values(deleted_at=datetime.now(UTC), status="deleted")
+            )
+            return result.rowcount or 0  # type: ignore[attr-defined]
+
+    async def memory_soft_delete_by_run(
+        self,
+        tenant_id: str,
+        run_id: str,
+        *,
+        metadata_source: str = "ingest",
+    ) -> int:
+        """Soft-delete live memories tagged with ``run_id`` AND
+        ``metadata.source = metadata_source`` (belt-and-braces so non-ingest
+        memories sharing a run_id aren't touched); returns count.
+        Transactional (writer session).
+        """
+        async with get_session() as session:
+            result = await session.execute(
+                sql_update(Memory)
+                .where(
+                    Memory.tenant_id == tenant_id,
+                    Memory.deleted_at.is_(None),
+                    Memory.run_id == run_id,
+                    Memory.metadata_["source"].astext == metadata_source,
+                )
+                .values(deleted_at=datetime.now(UTC), status="deleted")
+            )
+            return result.rowcount or 0  # type: ignore[attr-defined]
+
+    async def memory_redistribute(
+        self,
+        *,
+        tenant_id: str,
+        memory_ids: list[UUID],
+        target_agent_id: str,
+    ) -> dict:
+        """Bulk-reassign memories to ``target_agent_id`` in ONE transaction.
+
+        Locks the matching live rows ``FOR UPDATE``, loops computing
+        moved/promoted/skipped/from_agents, sets ``agent_id`` and auto-promotes
+        ``scope_agent`` → ``scope_team`` to prevent data loss, and computes
+        ``not_found`` for ids that didn't match (deleted, wrong tenant, or
+        non-existent). Trust gates + the agent_id==auth precedence check stay
+        in core-api BEFORE the call. Transactional (writer session).
+        """
+        async with get_session() as session:
+            memories = (
+                (
+                    await session.execute(
+                        select(Memory)
+                        .where(
+                            Memory.id.in_(memory_ids),
+                            Memory.tenant_id == tenant_id,
+                            Memory.deleted_at.is_(None),
+                        )
+                        .with_for_update()
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+            found_ids = {mem.id for mem in memories}
+            not_found = [str(mid) for mid in memory_ids if mid not in found_ids]
+
+            moved = 0
+            promoted = 0
+            skipped = 0
+            from_agents: set[str] = set()
+
+            for mem in memories:
+                if mem.agent_id == target_agent_id:
+                    skipped += 1
+                    continue
+                from_agents.add(mem.agent_id)
+                mem.agent_id = target_agent_id
+                if mem.visibility == "scope_agent":
+                    mem.visibility = "scope_team"
+                    promoted += 1
+                moved += 1
+
+        return {
+            "moved": moved,
+            "promoted": promoted,
+            "skipped": skipped,
+            "from_agents": sorted(from_agents),
+            "not_found": not_found,
+        }
+
+    async def memory_admin_list(
+        self,
+        *,
+        tenant_id: str | None = None,
+        fleet_id: str | None = None,
+        agent_id: str | None = None,
+        memory_type: str | None = None,
+        status: str | None = None,
+        include_deleted: bool = False,
+        sort: str = "created_at",
+        order: str = "desc",
+        offset: int = 0,
+        limit: int = 50,
+        cursor_ts: datetime | None = None,
+        cursor_id: UUID | None = None,
+    ) -> list[Memory]:
+        """Admin cross-tenant memory list (NO visibility scoping).
+
+        Returns up to ``limit`` rows (the route passes ``limit`` already
+        widened to ``limit+1`` so it can detect ``has_more`` and build the
+        next cursor). Mirrors the prior inline admin query's filter, cursor,
+        and tiebreaker exactly. Read-only (reader replica).
+        """
+        stmt = select(Memory)
+        if tenant_id:
+            stmt = stmt.where(Memory.tenant_id == tenant_id)
+        if fleet_id:
+            stmt = stmt.where(Memory.fleet_id == fleet_id)
+        if not include_deleted:
+            stmt = stmt.where(Memory.deleted_at.is_(None))
+        if agent_id:
+            stmt = stmt.where(Memory.agent_id == agent_id)
+        if memory_type:
+            stmt = stmt.where(Memory.memory_type == memory_type)
+        if status:
+            stmt = stmt.where(Memory.status == status)
+
+        using_cursor = cursor_ts is not None and cursor_id is not None
+        if using_cursor:
+            # Row-value comparison ``(created_at, id) < (cursor_ts, cursor_id)``
+            # — same form core-api's ``memory_repository.list_by_filters`` uses.
+            # ``type: ignore`` because the SQLAlchemy stubs don't model bare
+            # Python literals as ``tuple_`` args.
+            stmt = stmt.where(tuple_(Memory.created_at, Memory.id) < tuple_(cursor_ts, cursor_id))  # type: ignore[arg-type]
+
+        # core-api restricts ``sort`` via a route regex, but this endpoint is
+        # independently callable — allowlist the column so an unknown value
+        # falls back to created_at instead of AttributeError-ing (500) on
+        # getattr(Memory, sort).
+        if sort not in _ADMIN_LIST_SORTABLE:
+            sort = "created_at"
+        col = getattr(Memory, sort)
+        if order == "desc":
+            stmt = stmt.order_by(col.desc(), Memory.id.desc())
+        else:
+            stmt = stmt.order_by(col.asc(), Memory.id.asc())
+        if not using_cursor:
+            stmt = stmt.offset(offset)
+        stmt = stmt.limit(limit)
+
+        async with get_read_session() as session:
+            result = await session.execute(stmt)
+            return list(result.scalars().all())
+
+    async def memory_admin_stats(
+        self,
+        tenant_id: str | None,
+        fleet_id: str | None,
+    ) -> dict:
+        """Admin memory stats — ``{total, by_type, by_agent, by_status}``.
+
+        Single GROUPING SETS scan over ``(memory_type), (agent_id), (status),
+        ()``. Unlike ``memory_compute_health_stats`` (which has no ``by_agent``
+        and a different shape), this matches the admin route's response. NO
+        visibility scoping (admin sees everything). Cross-tenant when
+        ``tenant_id`` is None. Read-only (reader replica).
+        """
+        # Single GROUPING SETS scan. Optional filters use the
+        # ``(:p IS NULL OR col = :p)`` idiom with bound params — no compiled-SQL
+        # splicing, injection-safe by construction. ``CAST(:p AS text)`` (not
+        # ``:p::text`` — the ``::`` collides with text()'s ``:param`` colon
+        # syntax) is required so asyncpg can infer the type of a NULL bound
+        # param used in ``IS NULL`` (else AmbiguousParameterError).
+        # ``GROUPING(col)=0`` ⇒ this output row groups on that column; the
+        # all-bits-set value (7) flags the overall total (the empty grouping set).
+        sql = text(
+            """
+            SELECT
+                CASE
+                    WHEN GROUPING(memory_type, agent_id, status) = 7 THEN 'total'
+                    WHEN GROUPING(memory_type) = 0 THEN 'by_type'
+                    WHEN GROUPING(agent_id) = 0 THEN 'by_agent'
+                    WHEN GROUPING(status) = 0 THEN 'by_status'
+                END                                              AS bucket,
+                memory_type, agent_id, status,
+                COUNT(*)                                         AS cnt
+            FROM memories
+            WHERE deleted_at IS NULL
+              AND (CAST(:tenant_id AS text) IS NULL OR tenant_id = CAST(:tenant_id AS text))
+              AND (CAST(:fleet_id AS text) IS NULL OR fleet_id = CAST(:fleet_id AS text))
+            GROUP BY GROUPING SETS ((memory_type), (agent_id), (status), ())
+            """
+        ).bindparams(tenant_id=tenant_id, fleet_id=fleet_id)
+
+        total = 0
+        by_type: dict = {}
+        by_agent: dict = {}
+        by_status: dict = {}
+        async with get_read_session() as session:
+            rows = (await session.execute(sql)).all()
+        for row in rows:
+            bucket = row[0]
+            cnt = int(row[4] or 0)
+            if bucket == "total":
+                total = cnt
+            elif bucket == "by_type":
+                by_type[row[1]] = cnt
+            elif bucket == "by_agent":
+                by_agent[row[2]] = cnt
+            elif bucket == "by_status":
+                by_status[row[3]] = cnt
+        return {"total": total, "by_type": by_type, "by_agent": by_agent, "by_status": by_status}
 
     # ══════════════════════════════════════════════════════════════════════
     #  ENTITIES

--- a/tests/test_memory_storage_phase2.py
+++ b/tests/test_memory_storage_phase2.py
@@ -1,0 +1,409 @@
+"""Fix 2 Phase 2 — core-api memory handlers now read/write through core-storage-api.
+
+These exercise the full path (core-api routes/memories.py + storage_client ->
+the in-process storage-api app via the conftest ASGI bridge -> test DB). Rows
+are seeded via the storage client (committed, independent session) — NOT via the
+``db`` fixture, whose outer transaction rolls back and is invisible to the
+storage session's separate connection.
+
+Covered:
+- GET /memories/fleet-distribution (list_fleets + admin_list_fleets)
+- GET /memories/admin-stats
+- POST /memories/admin-list (cursor + limit+1 slicing)
+- GET /memories/{id}/detail (server-side embedding stats; no raw vector)
+- GET /memories/{id}/contradictions (3-read bundle + cross-tenant older guard)
+- POST /memories/soft-delete-by-ids
+- POST /memories/soft-delete-by-filter (JSONB bound-param predicate)
+- POST /memories/soft-delete-by-run
+- POST /memories/redistribute (one txn: move + auto-promote + skip + not_found)
+- storage-router 422 input validation (raw bodies the typed client never sends)
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from core_api.constants import VECTOR_DIM
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _t() -> str:
+    """Unique tenant id per test so concurrent suite runs don't collide."""
+    return f"test-tenant-p2-{uuid4().hex[:8]}"
+
+
+async def _write_memory(
+    sc,
+    tenant_id: str,
+    *,
+    content: str = "hello world",
+    agent_id: str = "test-agent",
+    fleet_id: str | None = "fleet-a",
+    memory_type: str = "fact",
+    status: str = "active",
+    visibility: str = "scope_team",
+    metadata: dict | None = None,
+    run_id: str | None = None,
+    embedding: list[float] | None = None,
+) -> dict:
+    """Create a committed memory and return the storage-side dict."""
+    payload: dict = {
+        "tenant_id": tenant_id,
+        "agent_id": agent_id,
+        "content": content,
+        "memory_type": memory_type,
+        "weight": 0.5,
+        "status": status,
+        "visibility": visibility,
+    }
+    if fleet_id is not None:
+        payload["fleet_id"] = fleet_id
+    if metadata is not None:
+        payload["metadata_"] = metadata
+    if run_id is not None:
+        payload["run_id"] = run_id
+    if embedding is not None:
+        payload["embedding"] = embedding
+    return await sc.create_memory(payload)
+
+
+# ---------------------------------------------------------------------------
+# fleet-distribution
+# ---------------------------------------------------------------------------
+
+
+async def test_fleet_distribution_counts(sc):
+    tid = _t()
+    await _write_memory(sc, tid, agent_id="a1", fleet_id="fleet-x")
+    await _write_memory(sc, tid, agent_id="a2", fleet_id="fleet-x", content="other")
+    await _write_memory(sc, tid, agent_id="a3", fleet_id="fleet-y", content="third")
+
+    rows = await sc.memory_fleet_distribution(tid, exclude_scope_agent=False)
+    by_fleet = {r["fleet_id"]: r for r in rows}
+    assert by_fleet["fleet-x"]["memory_count"] == 2
+    assert by_fleet["fleet-x"]["agent_count"] == 2
+    assert by_fleet["fleet-y"]["memory_count"] == 1
+    # Desc by memory_count: fleet-x (2) precedes fleet-y (1).
+    fleet_ids = [r["fleet_id"] for r in rows if r["fleet_id"] in ("fleet-x", "fleet-y")]
+    assert fleet_ids.index("fleet-x") < fleet_ids.index("fleet-y")
+
+
+async def test_fleet_distribution_excludes_scope_agent(sc):
+    """``exclude_scope_agent=True`` (the /fleets path) drops scope_agent rows."""
+    tid = _t()
+    await _write_memory(sc, tid, fleet_id="fleet-z", visibility="scope_team")
+    await _write_memory(
+        sc, tid, fleet_id="fleet-z", visibility="scope_agent", content="private"
+    )
+
+    incl = await sc.memory_fleet_distribution(tid, exclude_scope_agent=False)
+    excl = await sc.memory_fleet_distribution(tid, exclude_scope_agent=True)
+    assert {r["fleet_id"]: r["memory_count"] for r in incl}["fleet-z"] == 2
+    assert {r["fleet_id"]: r["memory_count"] for r in excl}["fleet-z"] == 1
+
+
+# ---------------------------------------------------------------------------
+# admin-stats
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_stats_shape_and_counts(sc):
+    tid = _t()
+    await _write_memory(sc, tid, agent_id="agent-1", memory_type="fact")
+    await _write_memory(sc, tid, agent_id="agent-1", memory_type="fact", content="b")
+    await _write_memory(
+        sc, tid, agent_id="agent-2", memory_type="semantic", content="c"
+    )
+
+    stats = await sc.admin_memory_stats(tid)
+    assert stats["total"] == 3
+    assert stats["by_type"] == {"fact": 2, "semantic": 1}
+    assert stats["by_agent"] == {"agent-1": 2, "agent-2": 1}
+    # All seeded rows are active.
+    assert stats["by_status"].get("active") == 3
+    # Distinct from health-stats: by_agent is present, no type_distribution key.
+    assert "by_agent" in stats
+    assert "type_distribution" not in stats
+
+
+async def test_admin_stats_empty_tenant_is_zeroed(sc):
+    stats = await sc.admin_memory_stats(_t())
+    assert stats == {"total": 0, "by_type": {}, "by_agent": {}, "by_status": {}}
+
+
+# ---------------------------------------------------------------------------
+# admin-list (cursor + limit+1 slicing)
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_list_returns_rows_for_tenant(sc):
+    tid = _t()
+    await _write_memory(sc, tid, content="m1")
+    await _write_memory(sc, tid, content="m2")
+
+    rows = await sc.admin_list_memories(
+        {"tenant_id": tid, "sort": "created_at", "order": "desc", "limit": 51}
+    )
+    assert {r["tenant_id"] for r in rows} == {tid}
+    assert len(rows) == 2
+
+
+async def test_admin_list_limit_plus_one_detects_more(sc):
+    tid = _t()
+    for i in range(3):
+        await _write_memory(sc, tid, content=f"row-{i}")
+
+    # Request limit=2 widened to 3 — the route uses the extra row to set
+    # has_more + the next cursor.
+    rows = await sc.admin_list_memories(
+        {"tenant_id": tid, "sort": "created_at", "order": "desc", "limit": 3}
+    )
+    assert len(rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# get_memory_detail — server-side embedding stats, no raw vector
+# ---------------------------------------------------------------------------
+
+
+async def test_get_memory_detail_embedding_stats_no_raw_vector(sc):
+    tid = _t()
+    emb = [0.0] * VECTOR_DIM
+    emb[0] = 1.0
+    emb[1] = -0.5
+    mem = await _write_memory(sc, tid, embedding=emb)
+
+    detail = await sc.get_memory_detail(tid, mem["id"])
+    assert detail is not None
+    # Raw pgvector must NOT cross the wire.
+    assert "embedding" not in detail["memory"]
+    assert "search_vector" not in detail["memory"]
+    stats = detail["embedding_stats"]
+    assert stats["dimensions"] == VECTOR_DIM
+    assert stats["max"] == 1.0
+    assert stats["min"] == -0.5
+    assert stats["non_zero"] == 2
+    # Preview is the first 20 components only.
+    assert detail["embedding_preview"][:2] == [1.0, -0.5]
+    assert len(detail["embedding_preview"]) == 20
+
+
+async def test_get_memory_detail_missing_returns_none(sc):
+    assert await sc.get_memory_detail(_t(), str(uuid4())) is None
+
+
+async def test_get_memory_detail_cross_tenant_returns_none(sc):
+    tid_a, tid_b = _t(), _t()
+    mem = await _write_memory(sc, tid_a)
+    # Asking for tenant B's view of tenant A's row → not found.
+    assert await sc.get_memory_detail(tid_b, mem["id"]) is None
+
+
+# ---------------------------------------------------------------------------
+# get_memory_contradictions — 3-read bundle
+# ---------------------------------------------------------------------------
+
+
+async def test_contradictions_bundle_supersessor(sc):
+    tid = _t()
+    older = await _write_memory(sc, tid, content="older fact", status="outdated")
+    newer = await _write_memory(sc, tid, content="newer fact")
+    # newer supersedes older
+    await sc.update_memory_status(newer["id"], "active", supersedes_id=older["id"])
+
+    # Older row sees the newer one as a supersessor.
+    bundle = await sc.get_memory_contradictions(tid, older["id"])
+    assert bundle is not None
+    assert bundle["memory"]["id"] == older["id"]
+    sup_ids = {s["id"] for s in bundle["supersessors"]}
+    assert newer["id"] in sup_ids
+
+    # Newer row points back at older via ``older``.
+    bundle2 = await sc.get_memory_contradictions(tid, newer["id"])
+    assert bundle2["older"] is not None
+    assert bundle2["older"]["id"] == older["id"]
+
+
+async def test_contradictions_missing_returns_none(sc):
+    assert await sc.get_memory_contradictions(_t(), str(uuid4())) is None
+
+
+# ---------------------------------------------------------------------------
+# soft-delete-by-ids
+# ---------------------------------------------------------------------------
+
+
+async def test_soft_delete_by_ids(sc):
+    tid = _t()
+    a = await _write_memory(sc, tid, content="del-a")
+    b = await _write_memory(sc, tid, content="del-b")
+    c = await _write_memory(sc, tid, content="keep-c")
+
+    deleted = await sc.soft_delete_by_ids(tid, [a["id"], b["id"]])
+    assert deleted == 2
+
+    # Re-deleting already-deleted rows is a no-op (deleted_at filter).
+    assert await sc.soft_delete_by_ids(tid, [a["id"], b["id"]]) == 0
+    # The untouched row is still live.
+    assert await sc.get_memory_for_tenant(tid, c["id"]) is not None
+    assert await sc.get_memory_for_tenant(tid, a["id"]) is None
+
+
+async def test_soft_delete_by_ids_tenant_scoped(sc):
+    tid_a, tid_b = _t(), _t()
+    mem = await _write_memory(sc, tid_a)
+    # Deleting under the wrong tenant matches nothing.
+    assert await sc.soft_delete_by_ids(tid_b, [mem["id"]]) == 0
+    assert await sc.get_memory_for_tenant(tid_a, mem["id"]) is not None
+
+
+# ---------------------------------------------------------------------------
+# soft-delete-by-filter — JSONB bound-param predicate
+# ---------------------------------------------------------------------------
+
+
+async def test_soft_delete_by_filter_metadata_exact_match(sc):
+    tid = _t()
+    keep = await _write_memory(sc, tid, content="keep", metadata={"run": "r1"})
+    drop = await _write_memory(sc, tid, content="drop", metadata={"run": "r2"})
+
+    deleted = await sc.soft_delete_by_filter(
+        {"tenant_id": tid, "metadata_filter": {"run": "r2"}}
+    )
+    assert deleted == 1
+    assert await sc.get_memory_for_tenant(tid, drop["id"]) is None
+    assert await sc.get_memory_for_tenant(tid, keep["id"]) is not None
+
+
+async def test_soft_delete_by_filter_multi_pair_and_semantics(sc):
+    """Multiple metadata pairs combine with AND (distinct bound params)."""
+    tid = _t()
+    match = await _write_memory(sc, tid, content="m", metadata={"k1": "v1", "k2": "v2"})
+    partial = await _write_memory(
+        sc, tid, content="p", metadata={"k1": "v1", "k2": "x"}
+    )
+
+    deleted = await sc.soft_delete_by_filter(
+        {"tenant_id": tid, "metadata_filter": {"k1": "v1", "k2": "v2"}}
+    )
+    assert deleted == 1
+    assert await sc.get_memory_for_tenant(tid, match["id"]) is None
+    assert await sc.get_memory_for_tenant(tid, partial["id"]) is not None
+
+
+async def test_soft_delete_by_filter_exclude_ids(sc):
+    tid = _t()
+    a = await _write_memory(sc, tid, content="a", agent_id="ag")
+    b = await _write_memory(sc, tid, content="b", agent_id="ag")
+
+    deleted = await sc.soft_delete_by_filter(
+        {"tenant_id": tid, "agent_id": "ag", "exclude_ids": [a["id"]]}
+    )
+    assert deleted == 1
+    assert await sc.get_memory_for_tenant(tid, a["id"]) is not None
+    assert await sc.get_memory_for_tenant(tid, b["id"]) is None
+
+
+# ---------------------------------------------------------------------------
+# soft-delete-by-run
+# ---------------------------------------------------------------------------
+
+
+async def test_soft_delete_by_run_requires_ingest_source(sc):
+    tid = _t()
+    run = f"run-{uuid4().hex[:8]}"
+    ingest = await _write_memory(
+        sc, tid, content="ingest", run_id=run, metadata={"source": "ingest"}
+    )
+    other = await _write_memory(
+        sc, tid, content="manual", run_id=run, metadata={"source": "manual"}
+    )
+
+    deleted = await sc.soft_delete_by_run(tid, run, metadata_source="ingest")
+    assert deleted == 1
+    assert await sc.get_memory_for_tenant(tid, ingest["id"]) is None
+    # Same run_id but non-ingest source is untouched (belt-and-braces).
+    assert await sc.get_memory_for_tenant(tid, other["id"]) is not None
+
+
+# ---------------------------------------------------------------------------
+# redistribute — one transaction: move + auto-promote + skip + not_found
+# ---------------------------------------------------------------------------
+
+
+async def test_redistribute_moves_promotes_skips_and_reports_not_found(sc):
+    tid = _t()
+    team = await _write_memory(sc, tid, agent_id="old", visibility="scope_team")
+    private = await _write_memory(
+        sc, tid, agent_id="old", visibility="scope_agent", content="private"
+    )
+    already = await _write_memory(sc, tid, agent_id="target", content="already there")
+    ghost = str(uuid4())
+
+    outcome = await sc.redistribute_memories(
+        tid, [team["id"], private["id"], already["id"], ghost], "target"
+    )
+    assert outcome["moved"] == 2  # team + private
+    assert outcome["promoted"] == 1  # scope_agent -> scope_team
+    assert outcome["skipped"] == 1  # already owned by target
+    assert outcome["from_agents"] == ["old"]
+    assert outcome["not_found"] == [ghost]
+
+    # The scope_agent row was promoted and reassigned.
+    moved_private = await sc.get_memory_for_tenant(tid, private["id"])
+    assert moved_private["agent_id"] == "target"
+    assert moved_private["visibility"] == "scope_team"
+    # The scope_team row kept its visibility.
+    moved_team = await sc.get_memory_for_tenant(tid, team["id"])
+    assert moved_team["agent_id"] == "target"
+    assert moved_team["visibility"] == "scope_team"
+
+
+# ---------------------------------------------------------------------------
+# Storage-router input validation (raw bodies the typed client never sends)
+# ---------------------------------------------------------------------------
+
+
+def _path(suffix: str) -> str:
+    return f"/api/v1/storage/memories/{suffix}"
+
+
+async def test_soft_delete_by_ids_missing_tenant_422(storage_http):
+    resp = await storage_http.post(_path("soft-delete-by-ids"), json={"ids": []})
+    assert resp.status_code == 422, resp.text
+
+
+async def test_soft_delete_by_filter_bad_exclude_uuid_422(storage_http):
+    resp = await storage_http.post(
+        _path("soft-delete-by-filter"),
+        json={"tenant_id": _t(), "exclude_ids": ["not-a-uuid"]},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_redistribute_missing_target_422(storage_http):
+    resp = await storage_http.post(
+        _path("redistribute"), json={"tenant_id": _t(), "memory_ids": []}
+    )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_admin_list_malformed_cursor_422(storage_http):
+    """A malformed cursor in the raw body must 422, not 500 (claude-review)."""
+    resp = await storage_http.post(
+        _path("admin-list"), json={"tenant_id": _t(), "cursor_ts": "not-a-date"}
+    )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_admin_list_unknown_sort_falls_back_not_500(storage_http):
+    """An unrecognised ``sort`` must fall back to created_at, not AttributeError
+    (500) at getattr(Memory, sort) (claude-review)."""
+    resp = await storage_http.post(
+        _path("admin-list"), json={"tenant_id": _t(), "sort": "definitely_not_a_column"}
+    )
+    assert resp.status_code == 200, resp.text
+    assert isinstance(resp.json(), list)


### PR DESCRIPTION
**Fix 2 Phase 2** — third slice of the Tier-2 *"no DB outside core-storage-api"* migration (after Phase 0 settings #427, Phase 1 tenant-discovery #428). Moves the remaining direct-DB handlers in `routes/memories.py` off core-api's pool and behind new core-storage-api endpoints. **No schema change.**

**Key framing:** the feared "mutation + audit in one transaction" requirement doesn't exist today — `log_action` is already a decoupled async `POST /audit-logs`, `usage_service` is a no-op stub in OSS, and `soft_delete`/`update`/`agent_service` already route through the storage client. So this migrates the inline `db.execute`/`db.get`/`db.commit` that remained; the `db.commit()`s become no-ops and are removed; **audit stays the existing async POST** (not folded into storage transactions).

### core-storage-api (now owns the DB access) — 9 `postgres_service` methods + routes on the memories router
- `memory_fleet_distribution` (reader) — serves `/fleets` + `/admin/fleets` via an `exclude_scope_agent` flag.
- `memory_get_detail` (reader) — row + entity-link outerjoin in one round-trip; **embedding stats computed server-side**, raw vector + `search_vector` stripped.
- `memory_contradiction_rows` (reader) — 3 reads bundled; cross-tenant `older` guard server-side.
- `memory_soft_delete_by_filter` / `_by_ids` / `_by_run` (writer) — by-filter JSONB metadata predicate via **bound params** (no string interpolation).
- `memory_redistribute` (writer) — `SELECT … FOR UPDATE` + reassign + auto-promote `scope_agent`→`scope_team` + `not_found`, all in **one transaction**.
- `memory_admin_list` (reader) — cross-tenant, no visibility scoping, cursor.
- `memory_admin_stats` (reader) — single **GROUPING SETS** scan → `{total,by_type,by_agent,by_status}` (bound-param `text()` with `CAST(:p AS text)` so asyncpg can type the optional NULL filters).

### core-api
- `storage_client` gains 9 methods; list/dict GETs raise on 404, by-id reads return `None` for the caller to 404-translate.
- 12 handlers switched to the client. Trust gates / validation / cursor encode-decode / response shaping / audit stay in core-api. **`get_db` is retained** on the router (write/search/recall/ingest/list handlers still use it — deferred to later phases); the `db` Depends is dropped only from handlers that no longer touch db at all.

### Validation
- ruff@0.15.4 + mypy clean on **both** projects.
- Full core-api suite green: **3490 passed**.
- `/simplify` ran (clean); I reviewed the correctness-critical methods (redistribute txn, JSONB binding, server-side embedding stats, GROUPING SETS) by hand.
- New `tests/test_memory_storage_phase2.py` (21 tests) exercises the full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)