### PR TITLE
feat(core-api): route mcp_server's 9 ready tools through core-storage-api (Fix 2 Phase 4)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -448,10 +448,16 @@ class CoreStorageClient:
         status: str,
         supersedes_id: str | None = None,
         *,
+        tenant_id: str,
         unset_supersedes: bool = False,
         expected_supersedes_id: str | None = None,
     ) -> dict | None:
         """Update status and optionally set or clear ``supersedes_id``.
+
+        ``tenant_id`` is the home tenant of the target memory and is REQUIRED:
+        the storage route scopes every write to ``tenant_id == memory.tenant_id``
+        so a caller in tenant B cannot flip the status of tenant A's memory by
+        id (cross-tenant write guard).
 
         Set path (existing behaviour):
             ``supersedes_id=<uuid>`` sets the row's pointer, guarded by
@@ -484,7 +490,7 @@ class CoreStorageClient:
                     "for the CAS anchor; clearing without one would race "
                     "concurrent setters."
                 )
-        payload: dict[str, Any] = {"status": status}
+        payload: dict[str, Any] = {"status": status, "tenant_id": tenant_id}
         if supersedes_id is not None:
             payload["supersedes_id"] = supersedes_id
         if unset_supersedes:
@@ -820,8 +826,16 @@ class CoreStorageClient:
     async def mark_dedup_checked(self, memory_ids: list[str]) -> dict:
         return await self._post("/memories/mark-dedup-checked", {"memory_ids": memory_ids})  # type: ignore[return-value]
 
-    async def batch_update_status(self, data: dict) -> dict:
-        return await self._post("/memories/batch-update-status", data)  # type: ignore[return-value]
+    async def batch_update_status(self, data: dict, *, tenant_id: str) -> dict:
+        """Apply status updates to many memories within one tenant.
+
+        ``tenant_id`` is the trigger tenant shared by every memory in the
+        batch and is REQUIRED: the storage route scopes each row's write to
+        ``tenant_id == memory.tenant_id`` (cross-tenant write guard). It is
+        injected at the batch level rather than per row.
+        """
+        payload = {**data, "tenant_id": tenant_id}
+        return await self._post("/memories/batch-update-status", payload)  # type: ignore[return-value]
 
     async def bulk_get_memories(
         self,
@@ -921,6 +935,35 @@ class CoreStorageClient:
         """Soft-delete live memories by id (tenant-scoped); returns count."""
         result = await self._post("/memories/soft-delete-by-ids", {"tenant_id": tenant_id, "ids": ids})
         return (result or {}).get("deleted", 0)  # type: ignore[union-attr]
+
+    async def list_memories_by_filters(self, data: dict) -> list[dict]:
+        """Non-admin memory list WITH visibility scoping (MCP ``memclaw_list``).
+
+        ``data`` carries the filter/sort/cursor params (incl. ``caller_agent_id``
+        for the scope_agent visibility gate and an optional ``readable_tenant_ids``
+        widening) plus ``limit`` (the desired page size). The storage service
+        over-fetches ``limit+1`` internally for has_more detection; the caller
+        slices to ``limit`` + builds the next cursor. Distinct from
+        ``admin_list_memories`` (NO visibility scoping).
+        """
+        result = await self._post("/memories/list", data, read=True)
+        if result is None:
+            raise RuntimeError("core-storage-api /memories/list returned 404")
+        return result  # type: ignore[return-value]
+
+    async def memory_stats_breakdown(self, data: dict) -> dict:
+        """Visibility-scoped stats breakdown (MCP ``memclaw_stats``).
+
+        ``data`` carries ``{tenant_id?, fleet_id?, agent_id?, memory_type?,
+        status?, include_deleted?, readable_tenant_ids?}``. Returns
+        ``{total, by_type, by_agent, by_status}`` plus optional ``by_tenant`` /
+        ``deleted`` / ``total_including_deleted``. Distinct from
+        ``admin_memory_stats`` (no scoping).
+        """
+        result = await self._post("/memories/stats-breakdown", data, read=True)
+        if result is None:
+            raise RuntimeError("core-storage-api /memories/stats-breakdown returned 404")
+        return result  # type: ignore[return-value]
 
     async def soft_delete_by_run(
         self,
@@ -1232,14 +1275,41 @@ class CoreStorageClient:
         doc_id: str,
         *,
         read: bool = True,
+        readable_tenant_ids: list[str] | None = None,
     ) -> dict | None:
         # read=False forces the primary — use it for read-after-write re-fetches
         # (e.g. immediately after an upsert) so replication lag can't yield None.
+        # ``readable_tenant_ids`` widens the tenant predicate to ANY($readable)
+        # for cross-tenant credentials (omit ⇒ home-tenant only).
+        params: dict[str, Any] = {"tenant_id": tenant_id}
+        if readable_tenant_ids is not None:
+            params["readable_tenant_ids"] = readable_tenant_ids
         return await self._get(
             f"/documents/{collection}/{doc_id}",
             read=read,
-            tenant_id=tenant_id,
+            **params,
         )
+
+    async def document_count_in_collection(
+        self,
+        tenant_id: str,
+        collection: str,
+        *,
+        status: str | None = None,
+        fleet_id: str | None = None,
+        readable_tenant_ids: list[str] | None = None,
+    ) -> int:
+        """Count docs in one collection, optionally filtered by
+        ``data->>'status'``. Backs the MCP skills active-only count."""
+        params: dict[str, Any] = {"tenant_id": tenant_id, "collection": collection}
+        if status is not None:
+            params["status"] = status
+        if fleet_id is not None:
+            params["fleet_id"] = fleet_id
+        if readable_tenant_ids is not None:
+            params["readable_tenant_ids"] = readable_tenant_ids
+        result = await self._get("/documents/collection-count", read=True, **params)
+        return (result or {}).get("count", 0)
 
     async def query_documents(self, data: dict) -> list[dict]:
         return await self._post("/documents/query", data, read=True)  # type: ignore[return-value]
@@ -1262,10 +1332,19 @@ class CoreStorageClient:
         tenant_id: str,
         collection: str,
         doc_id: str,
+        *,
+        require_status: str | None = None,
     ) -> bool:
+        # ``require_status`` folds a ``data->>'status' = :status`` guard into the
+        # DELETE atomically (the MCP skills active-only gate): a non-matching /
+        # missing row deletes nothing and returns False, indistinguishable from
+        # a missing one. Home-tenant scoped (deletes never span readable tenants).
+        params: dict[str, Any] = {"tenant_id": tenant_id}
+        if require_status is not None:
+            params["require_status"] = require_status
         return await self._delete(
             f"/documents/{collection}/{doc_id}",
-            tenant_id=tenant_id,
+            **params,
         )
 
     # =====================================================================

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -13,6 +13,7 @@ import json
 import logging
 import re
 import time
+from datetime import datetime as _dt
 from typing import Annotated, Any, cast
 from uuid import UUID, uuid4
 
@@ -41,24 +42,44 @@ from core_api.constants import (
 )
 from core_api.db.session import async_session
 from core_api.errors import code_for_status
-from core_api.repositories import memory_repo
-from core_api.schemas import BulkMemoryCreate, BulkMemoryItem, MemoryCreate, MemoryUpdate
+from core_api.pagination import decode_cursor, encode_cursor
+from core_api.schemas import (
+    BulkMemoryCreate,
+    BulkMemoryItem,
+    MemoryCreate,
+    MemoryUpdate,
+    SearchProfileUpdate,
+)
 from core_api.services.agent_service import (
     authorize_memory_access,
     enforce_delete,
     enforce_fleet_read,
     enforce_fleet_write,
+    get_or_create_agent,
 )
 from core_api.services.audit_service import log_action, log_cross_tenant_read
 from core_api.services.capability_usage import record_usage
 from core_api.services.entity_service import get_entity
 from core_api.services.memory_service import (
+    _memory_to_out,
     create_memories_bulk,
     create_memory,
     search_memories,
     soft_delete_memory,
     update_memory,
 )
+
+# Org-settings helpers (Fix 2 Phase 0): these are storage-backed (cache-first)
+# and IGNORE the ``db`` arg — MCP tools that no longer open ``_mcp_session``
+# pass ``None``. ``validate_search_profile`` is a pure validator (no DB). Do NOT
+# re-migrate these here (Ph0 owns them); we only call them.
+from core_api.services.organization_settings import (
+    get_raw_settings,
+    get_settings_for_display,
+    resolve_config,
+    validate_search_profile,
+)
+from core_api.services.recall_service import summarize_memories
 
 # Re-export so existing `monkeypatch.setattr(mcp_server, "_require_trust", ...)`
 # sites in tests keep working; production callers should import ``require_trust``
@@ -428,6 +449,24 @@ async def _mcp_session():
         yield session
 
 
+@contextlib.asynccontextmanager
+async def _no_db():
+    """Yield ``None`` in place of a DB session.
+
+    Fix 2 Phase 4 routed the 9 ready MCP tools through the core-storage-api
+    HTTP client, so they no longer set RLS GUCs via ``_mcp_session()``. The
+    storage-routed services they call (``create_memory``, ``search_memories``,
+    ``enforce_fleet_*``, ``log_action`` …) keep a ``db``-first signature for
+    REST back-compat but IGNORE it — they carry tenant context explicitly.
+    This helper lets those tools keep the ``async with … as db`` shape (so the
+    handler body and its ``try/except`` stay structurally identical to the
+    pre-migration code) while making the absence of a session explicit at the
+    call site. Tenant isolation is enforced by the explicit ``tenant_id`` /
+    ``readable_tenant_ids`` arguments on each storage call, NOT by GUCs.
+    """
+    yield None
+
+
 # ── FastMCP instance ──
 
 
@@ -528,6 +567,19 @@ def _with_latency(result: str, t0: float) -> str | CallToolResult:
     return result + f"\n\n_latency_ms: {ms}"
 
 
+def _storage_error_envelope(e: httpx.HTTPStatusError, t0: float) -> str | CallToolResult:
+    """Translate a storage_client ``HTTPStatusError`` (raised on any non-2xx) into
+    the canonical MCP error envelope — surfaces the upstream status + JSON/text
+    detail instead of letting a storage 4xx/5xx escape as an unwrapped exception.
+    Shared tail for every storage-routed tool.
+    """
+    try:
+        detail = e.response.json()
+    except ValueError:
+        detail = e.response.text or str(e)
+    return _with_latency(_error_response(code_for_status(e.response.status_code), str(detail)), t0)
+
+
 # ── Tools ──
 
 
@@ -581,74 +633,75 @@ async def memclaw_recall(
     # closing the session before invoking ``summarize_memories`` for
     # the LLM brief.
     try:
-        async with _mcp_session() as db:
-            await check_and_increment(db, tenant_id, "search")
-            from core_api.repositories import agent_repo
-            from core_api.services.organization_settings import resolve_config
-
-            config = await resolve_config(db, tenant_id)
-            _ag = await agent_repo.get_by_id(db, agent_id, tenant_id)
-            agent_profile = None
-            if _ag:
-                agent_profile = _ag.get("search_profile") if isinstance(_ag, dict) else _ag.search_profile
-            # Fleet scope enforcement (parity with REST /search): a constrained
-            # agent that omits fleet_ids is scoped to its own fleet, and a single
-            # explicit fleet goes through the cross-fleet trust ladder. Closes the
-            # recall side of the cross-fleet content leak.
-            if _ag is not None and not fleet_ids:
-                ag_fleet = _ag.get("fleet_id") if isinstance(_ag, dict) else getattr(_ag, "fleet_id", None)
-                ag_trust = (
-                    _ag.get("trust_level", 0) if isinstance(_ag, dict) else getattr(_ag, "trust_level", 0)
-                )
-                if ag_fleet and ag_trust < 2:
-                    fleet_ids = [ag_fleet]
-            if fleet_ids and len(fleet_ids) == 1:
-                await enforce_fleet_read(db, tenant_id, agent_id, fleet_ids[0])
-            # Cross-tenant recall widens via readable_tenant_ids when
-            # the caller authenticated with a cross-tenant credential
-            # (kind=cross_tenant) — the gateway plumbs
-            # ``X-Readable-Tenant-IDs`` and the MCP middleware parks
-            # it on ``_readable_tenant_ids_var``. Single-tenant
-            # credentials leave the var empty; ``search_memories`` falls
-            # back to ``WHERE tenant_id = $1`` in that case.
-            results = await search_memories(
-                db,
-                tenant_id=tenant_id,
-                query=query,
-                fleet_ids=fleet_ids,
-                filter_agent_id=filter_agent_id,
-                caller_agent_id=agent_id,
-                memory_type_filter=memory_type,
-                status_filter=status,
-                top_k=capped_top_k,
-                recall_boost=config.recall_boost,
-                graph_expand=config.graph_expand,
-                tenant_config=config,
-                search_profile=agent_profile,
-                readable_tenant_ids=_get_readable_tenants() or None,
+        # All DB-touching work here is storage-routed: ``check_and_increment``
+        # (db unused), ``resolve_config`` (db ignored — cache-first storage
+        # read), ``enforce_fleet_read`` (agent_service → storage client),
+        # ``search_memories`` (pipeline → storage client), and
+        # ``log_cross_tenant_read`` (db unused — audit queue → storage). The
+        # only previously db-bound call, ``agent_repo.get_by_id``, becomes the
+        # storage client's ``get_agent`` (home-tenant scoped). So no
+        # ``_mcp_session`` / RLS GUCs — tenant isolation is carried explicitly:
+        # the agent lookup + write quota pin to the HOME tenant, while the READ
+        # (search + audit) widens via ``readable_tenant_ids`` exactly as before.
+        sc = get_storage_client()
+        await check_and_increment(None, tenant_id, "search")
+        config = await resolve_config(None, tenant_id)
+        # Agent profile + fleet-scope signals are HOME-tenant only — never
+        # widened by the readable set.
+        _ag = await sc.get_agent(agent_id, tenant_id)
+        agent_profile = None
+        if _ag:
+            agent_profile = _ag.get("search_profile")
+        # Fleet scope enforcement (parity with REST /search): a constrained
+        # agent that omits fleet_ids is scoped to its own fleet, and a single
+        # explicit fleet goes through the cross-fleet trust ladder. Closes the
+        # recall side of the cross-fleet content leak.
+        if _ag is not None and not fleet_ids:
+            ag_fleet = _ag.get("fleet_id")
+            ag_trust = _ag.get("trust_level", 0)
+            if ag_fleet and ag_trust < 2:
+                fleet_ids = [ag_fleet]
+        if fleet_ids and len(fleet_ids) == 1:
+            await enforce_fleet_read(None, tenant_id, agent_id, fleet_ids[0])
+        # Cross-tenant recall widens via readable_tenant_ids when the caller
+        # authenticated with a cross-tenant credential (kind=cross_tenant) — the
+        # gateway plumbs ``X-Readable-Tenant-IDs`` and the MCP middleware parks
+        # it on ``_readable_tenant_ids_var``. Single-tenant credentials leave
+        # the var empty; ``search_memories`` falls back to the home tenant only.
+        results = await search_memories(
+            None,
+            tenant_id=tenant_id,
+            query=query,
+            fleet_ids=fleet_ids,
+            filter_agent_id=filter_agent_id,
+            caller_agent_id=agent_id,
+            memory_type_filter=memory_type,
+            status_filter=status,
+            top_k=capped_top_k,
+            recall_boost=config.recall_boost,
+            graph_expand=config.graph_expand,
+            tenant_config=config,
+            search_profile=agent_profile,
+            readable_tenant_ids=_get_readable_tenants() or None,
+        )
+        # Cross-tenant read audit (F2): emit one event per source tenant when
+        # the credential widened beyond home. Async queue — non-blocking.
+        readable = _get_readable_tenants()
+        source_tenants = [t for t in readable if t and t != tenant_id]
+        if source_tenants:
+            await log_cross_tenant_read(
+                None,
+                home_tenant_id=tenant_id,
+                home_agent_id=agent_id,
+                source_tenants=source_tenants,
+                surface="memclaw_recall",
+                query_summary=(query or "")[:200],
             )
-            # Cross-tenant read audit (F2): emit one event per source
-            # tenant when the credential widened beyond home. Async
-            # queue — does not block the response.
-            readable = _get_readable_tenants()
-            source_tenants = [t for t in readable if t and t != tenant_id]
-            if source_tenants:
-                await log_cross_tenant_read(
-                    db,
-                    home_tenant_id=tenant_id,
-                    home_agent_id=agent_id,
-                    source_tenants=source_tenants,
-                    surface="memclaw_recall",
-                    query_summary=(query or "")[:200],
-                )
-        # ── Session closed; the LLM brief (when requested) runs without
-        # holding a DB connection.
+        # The LLM brief (when requested) runs without any DB connection held.
         payload: dict = {
             "results": [r.model_dump(mode="json") for r in results] if results else [],
         }
         if include_brief:
-            from core_api.services.recall_service import summarize_memories
-
             payload["brief"] = await summarize_memories(
                 results,
                 query,
@@ -659,6 +712,10 @@ async def memclaw_recall(
     except HTTPException as e:
         logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
         return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+    except httpx.HTTPStatusError as e:
+        # sc.get_agent() / enforce_fleet_read() are storage HTTP calls now —
+        # surface a storage 4xx/5xx as the canonical envelope, not a raw raise.
+        return _storage_error_envelope(e, t0)
 
 
 async def memclaw_write(
@@ -710,7 +767,15 @@ async def memclaw_write(
     if content is not None and (refuse := _refuse_reserved_memory_type(memory_type)):
         return _with_latency(refuse, t0)
 
-    async with _mcp_session() as db:
+    # WRITES → home tenant only. ``enforce_fleet_write`` (agent_service →
+    # storage client), ``check_and_increment`` (db unused), ``create_memory`` /
+    # ``create_memories_bulk`` (memory_service pipeline → storage client) are all
+    # storage-routed and pin to the home tenant via the ``tenant_id`` carried in
+    # the ``MemoryCreate`` / ``BulkMemoryCreate`` payload — never a foreign
+    # tenant, and no readable-set widening on the write path. ``_no_db()`` yields
+    # ``None`` (no RLS session) while keeping the storage-routed services'
+    # ``db``-first signatures satisfied.
+    async with _no_db() as db:
         try:
             # Register the calling agent (auto-create row on first write) and
             # enforce trust gating for cross-fleet writes — same surface the
@@ -881,7 +946,15 @@ async def memclaw_manage(
     ):
         return _with_latency(refuse, t0)
 
-    async with _mcp_session() as db:
+    # All ops are storage-routed (``_no_db()`` ⇒ db=None): reads/writes carry
+    # tenant context explicitly. WRITES (bulk_delete / transition / update /
+    # delete) target the HOME tenant only — the storage methods scope by the
+    # explicit ``tenant_id``; READS (read / lineage) also pin to the home
+    # tenant here (per-id manage never widens to the readable set — same as
+    # pre-migration, which scoped every ``get_by_id_for_tenant`` to ``tenant_id``
+    # and never consulted ``readable_tenant_ids``).
+    sc = get_storage_client()
+    async with _no_db() as db:
         try:
             if op == "bulk_delete":
                 if not memory_ids:
@@ -910,94 +983,74 @@ async def memclaw_manage(
                 # enforce_fleet_write). No-op for tenant-scoped credentials.
                 if caller_agent_id:
                     await enforce_delete(db, tenant_id, caller_agent_id)
-                from datetime import UTC
-                from datetime import datetime as _dt
-
-                from sqlalchemy import update as _sa_update
-
-                from common.models.memory import Memory as _Mem
-
-                stmt = (
-                    _sa_update(_Mem)
-                    .where(
-                        _Mem.tenant_id == tenant_id,
-                        _Mem.id.in_(uids),
-                        _Mem.deleted_at.is_(None),
-                    )
-                    .values(deleted_at=_dt.now(UTC), status="deleted")
-                )
-                result = await db.execute(stmt)
+                # HOME-tenant scoped soft-delete: the storage method applies the
+                # exact pre-migration predicate (tenant_id + id IN (...) +
+                # deleted_at IS NULL → set deleted_at=now, status='deleted') and
+                # returns the affected count. No cross-tenant widening.
+                deleted_count = await sc.soft_delete_by_ids(tenant_id, [str(u) for u in uids])
                 await log_action(
                     db,
                     tenant_id=tenant_id,
                     agent_id=agent_id,
                     action="bulk_delete",
                     resource_type="memory",
-                    detail={"count": result.rowcount, "method": "by_ids", "via": "mcp"},
+                    detail={"count": deleted_count, "method": "by_ids", "via": "mcp"},
                 )
-                await db.commit()
-                return _with_latency(json.dumps({"deleted": result.rowcount, "requested": len(uids)}), t0)
+                return _with_latency(json.dumps({"deleted": deleted_count, "requested": len(uids)}), t0)
             if op == "lineage":
-                from sqlalchemy import select as _sa_select
-
-                from common.models.memory import Memory as _Mem
-
-                this = await memory_repo.get_by_id_for_tenant(db, uid, tenant_id)
-                if not this:
+                # HOME-tenant scoped. ``get_memory_contradictions`` bundles the
+                # three reads (this row + supersessors + older) in one storage
+                # round-trip. Storage enforces tenant match + ``deleted_at IS
+                # NULL`` on the target and the supersessors, plus the
+                # cross-tenant ``older`` guard. It returns None on the target
+                # being absent/soft-deleted/wrong-tenant — same NOT_FOUND as
+                # before. NOTE: storage returns ``older`` regardless of its
+                # ``deleted_at`` (so the consumer can decide per-field, mirroring
+                # REST ``/memories/{id}/contradictions``); the pre-migration
+                # inline query excluded a soft-deleted ``older`` from
+                # ``superseded_by``, so we re-apply that filter client-side below.
+                bundle = await sc.get_memory_contradictions(tenant_id, str(uid))
+                if not bundle:
                     return _with_latency(_error_response("NOT_FOUND", "Memory not found."), t0)
+                this = bundle["memory"]
                 # Fleet/agent-scope authorization (mirrors op=read): the
                 # supersession chain would otherwise leak a scoped row by id.
                 if not await authorize_memory_access(
                     db,
                     tenant_id,
                     caller_agent_id,
-                    visibility=this.visibility,
-                    owner_agent_id=this.agent_id,
-                    fleet_id=this.fleet_id,
+                    visibility=this.get("visibility"),
+                    owner_agent_id=this.get("agent_id"),
+                    fleet_id=this.get("fleet_id"),
                 ):
                     return _with_latency(_error_response("NOT_FOUND", "Memory not found."), t0)
 
-                # The older memory this row replaced (if any). The
-                # supersedes_id field points at the OLDER row (the
-                # detector's "loser"); this row was the winner.
-                superseded_by = None
-                if this.supersedes_id:
-                    older = await db.get(_Mem, this.supersedes_id)
-                    if older and older.tenant_id == tenant_id and older.deleted_at is None:
-                        superseded_by = {
-                            "id": str(older.id),
-                            "content_preview": older.content[:200],
-                            "status": older.status,
-                            "created_at": (older.created_at.isoformat() if older.created_at else None),
-                        }
-
-                # Newer rows whose supersedes_id points at this row
-                # (this row was their "loser").
-                stmt = (
-                    _sa_select(_Mem)
-                    .where(
-                        _Mem.supersedes_id == uid,
-                        _Mem.tenant_id == tenant_id,
-                        _Mem.deleted_at.is_(None),
-                    )
-                    .order_by(_Mem.created_at.desc())
-                )
-                supersessors = [
-                    {
-                        "id": str(m.id),
-                        "content_preview": m.content[:200],
-                        "status": m.status,
-                        "created_at": m.created_at.isoformat() if m.created_at else None,
+                def _chain_row(row: dict) -> dict:
+                    content = row.get("content") or ""
+                    return {
+                        "id": str(row.get("id")),
+                        "content_preview": content[:200],
+                        "status": row.get("status"),
+                        "created_at": row.get("created_at"),
                     }
-                    for m in (await db.execute(stmt)).scalars().all()
-                ]
+
+                # The older memory this row replaced (if any). Storage applied
+                # the same-tenant guard; re-apply the soft-deleted filter here so
+                # a soft-deleted ``older`` is excluded exactly as the
+                # pre-migration inline query did (``older.deleted_at is None``).
+                older = bundle.get("older")
+                superseded_by = _chain_row(older) if older and older.get("deleted_at") is None else None
+                # Newer rows whose supersedes_id points at this row.
+                supersessors = [_chain_row(m) for m in bundle.get("supersessors", [])]
                 return _with_latency(
                     json.dumps(
                         {
                             "this": {
-                                "id": str(this.id),
-                                "status": this.status,
-                                "supersedes_id": (str(this.supersedes_id) if this.supersedes_id else None),
+                                "id": str(this.get("id")),
+                                "status": this.get("status"),
+                                "supersedes_id": (
+                                    str(this["supersedes_id"]) if this.get("supersedes_id") else None
+                                ),
                             },
                             "superseded_by": superseded_by,  # the OLDER row this replaced
                             "supersessors": supersessors,  # NEWER rows that replaced this
@@ -1007,7 +1060,7 @@ async def memclaw_manage(
                     t0,
                 )
             if op == "read":
-                memory = await memory_repo.get_by_id_for_tenant(db, uid, tenant_id)
+                memory = await sc.get_memory_for_tenant(tenant_id, str(uid))
                 if not memory:
                     return _with_latency(_error_response("NOT_FOUND", "Memory not found."), t0)
                 # Fleet/agent-scope authorization: honor the same scope_agent +
@@ -1018,34 +1071,28 @@ async def memclaw_manage(
                     db,
                     tenant_id,
                     caller_agent_id,
-                    visibility=memory.visibility,
-                    owner_agent_id=memory.agent_id,
-                    fleet_id=memory.fleet_id,
+                    visibility=memory.get("visibility"),
+                    owner_agent_id=memory.get("agent_id"),
+                    fleet_id=memory.get("fleet_id"),
                 ):
                     return _with_latency(_error_response("NOT_FOUND", "Memory not found."), t0)
                 return _with_latency(
                     json.dumps(
                         {
-                            "id": str(memory.id),
-                            "content": memory.content,
-                            "memory_type": memory.memory_type,
-                            "status": memory.status,
-                            "weight": memory.weight,
-                            "agent_id": memory.agent_id,
-                            "fleet_id": memory.fleet_id,
-                            "visibility": memory.visibility,
-                            "title": getattr(memory, "title", None),
-                            "created_at": memory.created_at.isoformat() if memory.created_at else None,
-                            "last_recalled_at": (
-                                memory.last_recalled_at.isoformat()
-                                if getattr(memory, "last_recalled_at", None)
-                                else None
-                            ),
-                            "recall_count": getattr(memory, "recall_count", 0),
-                            "deleted_at": (
-                                memory.deleted_at.isoformat() if getattr(memory, "deleted_at", None) else None
-                            ),
-                            "metadata": getattr(memory, "metadata_", None),
+                            "id": str(memory.get("id")),
+                            "content": memory.get("content"),
+                            "memory_type": memory.get("memory_type"),
+                            "status": memory.get("status"),
+                            "weight": memory.get("weight"),
+                            "agent_id": memory.get("agent_id"),
+                            "fleet_id": memory.get("fleet_id"),
+                            "visibility": memory.get("visibility"),
+                            "title": memory.get("title"),
+                            "created_at": memory.get("created_at"),
+                            "last_recalled_at": memory.get("last_recalled_at"),
+                            "recall_count": memory.get("recall_count", 0),
+                            "deleted_at": memory.get("deleted_at"),
+                            "metadata": memory.get("metadata_"),
                         },
                         default=str,
                     ),
@@ -1064,7 +1111,8 @@ async def memclaw_manage(
                         ),
                         t0,
                     )
-                memory = await memory_repo.get_by_id_for_tenant(db, uid, tenant_id)
+                # WRITE → home tenant only.
+                memory = await sc.get_memory_for_tenant(tenant_id, str(uid))
                 if not memory:
                     return _with_latency(_error_response("NOT_FOUND", "Memory not found."), t0)
                 # Cross-fleet / scope_agent authorization (write threshold).
@@ -1072,30 +1120,29 @@ async def memclaw_manage(
                     db,
                     tenant_id,
                     caller_agent_id,
-                    visibility=memory.visibility,
-                    owner_agent_id=memory.agent_id,
-                    fleet_id=memory.fleet_id,
+                    visibility=memory.get("visibility"),
+                    owner_agent_id=memory.get("agent_id"),
+                    fleet_id=memory.get("fleet_id"),
                     write=True,
                 ):
                     return _with_latency(
                         _error_response(
                             "PERMISSION_DENIED",
-                            f"Agent cannot modify memory in fleet '{memory.fleet_id}'.",
+                            f"Agent cannot modify memory in fleet '{memory.get('fleet_id')}'.",
                         ),
                         t0,
                     )
-                old_status = memory.status
-                await memory_repo.update_status(db, uid, status)
+                old_status = memory.get("status")
+                await sc.update_memory_status(str(uid), status, tenant_id=tenant_id)
                 await log_action(
                     db,
                     tenant_id=tenant_id,
-                    agent_id=memory.agent_id,
+                    agent_id=memory.get("agent_id"),
                     action="status_update",
                     resource_type="memory",
                     resource_id=uid,
                     detail={"old_status": old_status, "new_status": status},
                 )
-                await db.commit()
                 return _with_latency(f"Memory {memory_id} status updated: {old_status} -> {status}", t0)
             if op == "update":
                 fields: dict = {}
@@ -1121,28 +1168,30 @@ async def memclaw_manage(
                         ),
                         t0,
                     )
+                # WRITE → home tenant only. ``update_memory`` is storage-routed
+                # and scopes the row to the explicit ``tenant_id``.
                 await check_and_increment(db, tenant_id, "write")
                 result = await update_memory(db, uid, tenant_id, MemoryUpdate(**fields), agent_id=agent_id)
                 return _with_latency(_serialize(result), t0)
-            # op == "delete"
+            # op == "delete" — WRITE → home tenant only.
             if caller_agent_id:
                 # Trust gate (>= 3) + cross-fleet / scope_agent row authorization,
                 # mirroring REST DELETE /memories/{id}.
                 await enforce_delete(db, tenant_id, caller_agent_id)
-                target = await memory_repo.get_by_id_for_tenant(db, uid, tenant_id)
+                target = await sc.get_memory_for_tenant(tenant_id, str(uid))
                 if target and not await authorize_memory_access(
                     db,
                     tenant_id,
                     caller_agent_id,
-                    visibility=target.visibility,
-                    owner_agent_id=target.agent_id,
-                    fleet_id=target.fleet_id,
+                    visibility=target.get("visibility"),
+                    owner_agent_id=target.get("agent_id"),
+                    fleet_id=target.get("fleet_id"),
                     write=True,
                 ):
                     return _with_latency(
                         _error_response(
                             "PERMISSION_DENIED",
-                            f"Agent cannot delete memory in fleet '{target.fleet_id}'.",
+                            f"Agent cannot delete memory in fleet '{target.get('fleet_id')}'.",
                         ),
                         t0,
                     )
@@ -1151,6 +1200,10 @@ async def memclaw_manage(
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
             return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+        except httpx.HTTPStatusError as e:
+            # storage_client raises on non-2xx — surface the upstream status +
+            # detail in the canonical envelope (parity with sibling tools).
+            return _storage_error_envelope(e, t0)
 
 
 async def memclaw_entity_get(
@@ -1167,29 +1220,22 @@ async def memclaw_entity_get(
             t0,
         )
 
-    async with _mcp_session() as db:
-        try:
-            result = await get_entity(db, uid, _get_tenant(), caller_agent_id=_get_agent_id())
-        except HTTPException as e:
-            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
-        except httpx.HTTPStatusError as e:
-            # storage_client raises this on non-2xx — surface the upstream
-            # status + detail in the canonical envelope so a storage 4xx/5xx
-            # doesn't escape as an unwrapped exception (every sibling tool
-            # has this tail).
-            try:
-                detail = e.response.json()
-            except ValueError:
-                detail = e.response.text or str(e)
-            return _with_latency(
-                _error_response(code_for_status(e.response.status_code), str(detail)),
-                t0,
-            )
-        except Exception as e:
-            logger.exception("Unhandled error in memclaw_entity_get")
-            return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
-        text = "Entity not found." if not result else _serialize(result)
-        return _with_latency(text, t0)
+    # ``get_entity`` is storage-routed (entity_service → storage client); the
+    # ``db`` arg is used only by a best-effort on_recall hook that swallows its
+    # own errors, so pass ``None`` rather than open an RLS session. Tenant
+    # isolation is carried by the explicit ``tenant_id`` + ``caller_agent_id``
+    # the service already forwards to the storage client.
+    try:
+        result = await get_entity(None, uid, _get_tenant(), caller_agent_id=_get_agent_id())
+    except HTTPException as e:
+        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+    except httpx.HTTPStatusError as e:
+        return _storage_error_envelope(e, t0)
+    except Exception as e:
+        logger.exception("Unhandled error in memclaw_entity_get")
+        return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
+    text = "Entity not found." if not result else _serialize(result)
+    return _with_latency(text, t0)
 
 
 async def memclaw_tune(
@@ -1214,8 +1260,6 @@ async def memclaw_tune(
     if refuse := _refuse_default_agent_on_gateway(agent_id):
         return _with_latency(refuse, t0)
 
-    from core_api.schemas import SearchProfileUpdate
-
     try:
         profile = SearchProfileUpdate(
             top_k=top_k,
@@ -1232,24 +1276,23 @@ async def memclaw_tune(
         return _with_latency(_error_response("INVALID_ARGUMENTS", f"{e}"), t0)
 
     updates = profile.model_dump(exclude_none=True)
-    async with _mcp_session() as db:
-        try:
-            from core_api.repositories import agent_repo
-            from core_api.services.agent_service import get_or_create_agent
-
-            agent = await get_or_create_agent(db, tenant_id, agent_id)
-            current = agent.get("search_profile") or {}
-            if updates:
-                current.update(updates)
-                from core_api.services.organization_settings import validate_search_profile
-
-                current = validate_search_profile(current)
-                await agent_repo.update_search_profile(db, agent["id"], current)
-                await db.commit()
-            return _with_latency(json.dumps({"agent_id": agent_id, "search_profile": current}, indent=2), t0)
-        except HTTPException as e:
-            logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+    # WRITE → home tenant only. ``get_or_create_agent`` is storage-routed and
+    # scopes the lookup/create to ``tenant_id``; the search-profile PATCH then
+    # targets that agent's PK (``agent["id"]``). No cross-tenant widening — a
+    # tune never touches a foreign tenant's agent row.
+    try:
+        agent = await get_or_create_agent(None, tenant_id, agent_id)
+        current = agent.get("search_profile") or {}
+        if updates:
+            current.update(updates)
+            current = validate_search_profile(current)
+            await get_storage_client().update_search_profile(agent["id"], {"search_profile": current})
+        return _with_latency(json.dumps({"agent_id": agent_id, "search_profile": current}, indent=2), t0)
+    except HTTPException as e:
+        logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
+        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+    except httpx.HTTPStatusError as e:
+        return _storage_error_envelope(e, t0)
 
 
 # ---------------------------------------------------------------------------
@@ -1285,8 +1328,6 @@ async def _skills_factory_flag(db: Any, tenant_id: str) -> bool:
     ``get_raw_settings`` is cache-first (5-min TTL), so this is a cheap
     hot-path check.
     """
-    from core_api.services.organization_settings import get_raw_settings
-
     raw = await get_raw_settings(db, tenant_id)
     return (
         isinstance(raw, dict)
@@ -1342,6 +1383,18 @@ def _safe_int(val: Any, default: int) -> int:
         return default
 
 
+def _doc_field(doc: Any, name: str, default: Any = None) -> Any:
+    """Read a document field from either a storage-client dict or an ORM row.
+
+    Fix 2 Phase 4 routes ``memclaw_doc`` through the storage HTTP client, so the
+    documents come back as plain dicts; pre-migration tests (and any residual
+    ORM caller) pass an attribute-bearing object. Normalise both so the
+    skill-gate / response-shaping code stays shape-agnostic."""
+    if isinstance(doc, dict):
+        return doc.get(name, default)
+    return getattr(doc, name, default)
+
+
 def _skill_hidden_from_agent(doc: Any, *, caller_tenant_id: str, caller_opted_in: bool) -> bool:
     """Whether a fetched row must NOT surface on the agent MCP skill
     surface.
@@ -1360,12 +1413,16 @@ def _skill_hidden_from_agent(doc: Any, *, caller_tenant_id: str, caller_opted_in
 
     Non-skills rows are never hidden. Keyed off the row's own
     ``tenant_id`` so the decision follows the OWNING tenant, not just
-    the caller's flag (closes the cross-tenant read leak)."""
-    if getattr(doc, "collection", None) != SKILLS_COLLECTION:
+    the caller's flag (closes the cross-tenant read leak).
+
+    Accepts either an ORM Document or a storage-client dict (Fix 2 Phase 4
+    routes ``memclaw_doc`` through the storage HTTP client, which returns
+    dicts) — ``_doc_field`` normalises field access across both shapes."""
+    if _doc_field(doc, "collection") != SKILLS_COLLECTION:
         return False
-    if (getattr(doc, "data", None) or {}).get("status") == _AGENT_VISIBLE_SKILL_STATUS:
+    if (_doc_field(doc, "data") or {}).get("status") == _AGENT_VISIBLE_SKILL_STATUS:
         return False
-    return caller_opted_in or getattr(doc, "tenant_id", caller_tenant_id) != caller_tenant_id
+    return caller_opted_in or _doc_field(doc, "tenant_id", caller_tenant_id) != caller_tenant_id
 
 
 async def memclaw_doc(
@@ -1433,25 +1490,25 @@ async def memclaw_doc(
     if refuse := _refuse_default_agent_on_gateway(agent_id):
         return _with_latency(refuse, t0)
 
-    from core_api.repositories import document_repo
-
-    # Cross-tenant credentials widen read ops (list_collections, read,
-    # query, search) via ``readable_tenant_ids``. Write/delete pin to
-    # home_tenant — same contract as recall vs write. ``readable``
-    # stays None for single-tenant callers; document_repo falls back to
-    # ``tenant_id = $1``.
+    # Cross-tenant credentials widen READ ops (list_collections, read, query,
+    # search) via ``readable_tenant_ids``. WRITE/DELETE pin to the HOME tenant —
+    # same contract as recall vs write. ``readable`` stays None for
+    # single-tenant callers; storage falls back to ``tenant_id = $1``. All doc
+    # access is now storage-routed (``_no_db()`` ⇒ db=None); the org-settings /
+    # skills-gate helpers below are storage-backed and ignore the ``None`` db.
+    sc = get_storage_client()
     readable = _get_readable_tenants() or None
     READ_OPS = {"list_collections", "read", "query", "search"}
 
-    async with _mcp_session() as db:
+    async with _no_db() as db:
         try:
             if op == "list_collections":
-                rows = await document_repo.list_collections(
-                    db,
+                collections_resp = await sc.list_document_collections(
                     tenant_id=tenant_id,
                     fleet_id=fleet_id,
                     readable_tenant_ids=readable if op in READ_OPS else None,
                 )
+                rows = [(c["name"], c["count"]) for c in collections_resp.get("collections", [])]
                 # Active-only count correction for skills: an opted-in
                 # tenant's listing must not advertise non-active skills
                 # in the count — they're invisible to read/query/search,
@@ -1463,22 +1520,13 @@ async def memclaw_doc(
                 if any(name == SKILLS_COLLECTION for name, _ in rows) and await _skills_factory_enabled(
                     db, tenant_id
                 ):
-                    from sqlalchemy import func as sa_func
-                    from sqlalchemy import select as sa_select
-
-                    from common.models.document import Document
-
-                    tenant_pred = (
-                        Document.tenant_id.in_(readable) if readable else Document.tenant_id == tenant_id
+                    active_count = await sc.document_count_in_collection(
+                        tenant_id,
+                        SKILLS_COLLECTION,
+                        status=_AGENT_VISIBLE_SKILL_STATUS,
+                        fleet_id=fleet_id,
+                        readable_tenant_ids=readable,
                     )
-                    cnt_stmt = sa_select(sa_func.count()).where(
-                        tenant_pred,
-                        Document.collection == SKILLS_COLLECTION,
-                        Document.data["status"].astext == _AGENT_VISIBLE_SKILL_STATUS,
-                    )
-                    if fleet_id:
-                        cnt_stmt = cnt_stmt.where(Document.fleet_id == fleet_id)
-                    active_count = int((await db.execute(cnt_stmt)).scalar_one())
                     rows = [
                         (name, active_count if name == SKILLS_COLLECTION else count) for name, count in rows
                     ]
@@ -1544,10 +1592,6 @@ async def memclaw_doc(
                     # ``get_raw_settings``) — one fewer cold-cache lookup.
                     # read/query/search/delete keep the cheap helper since
                     # they don't need the caps.
-                    from core_api.services.organization_settings import (
-                        get_settings_for_display,
-                    )
-
                     # Fail CLOSED: this settings read gates a security
                     # decision (whether the lifecycle validator runs). If
                     # it fails we must NOT fall through and upsert the
@@ -1676,27 +1720,26 @@ async def memclaw_doc(
                         )
                 # Mirror memclaw_write's agent registration so a doc upsert
                 # via MCP creates the Agent row on first contact and enforces
-                # cross-fleet trust gating.
+                # cross-fleet trust gating. WRITE → home tenant only.
                 await enforce_fleet_write(db, tenant_id, agent_id, fleet_id)
                 await check_and_increment(db, tenant_id, "write")
-                row = await document_repo.upsert_returning_xmax(
-                    db,
-                    tenant_id=tenant_id,
-                    fleet_id=fleet_id,
-                    collection=collection,
-                    doc_id=doc_id,
-                    data=data,
-                    embedding=embedding,
+                row = await sc.upsert_document_xmax(
+                    {
+                        "tenant_id": tenant_id,
+                        "fleet_id": fleet_id,
+                        "collection": collection,
+                        "doc_id": doc_id,
+                        "data": data,
+                        "embedding": embedding,
+                    }
                 )
                 if row is None:
                     return _with_latency(
                         _error_response("INTERNAL_ERROR", "document upsert returned no rows"), t0
                     )
-                await db.commit()
-                # `text("xmax")` is unlabeled in SQLAlchemy ≥ 2; access by
-                # tuple position. Returning columns are: id, created_at,
-                # updated_at, xmax — so xmax sits at index 3.
-                is_new = int(row[3]) == 0
+                # Storage returns ``{id, created_at, updated_at, xmax}``; ``xmax
+                # == 0`` ⇒ INSERT (new), else the on-conflict UPDATE fired.
+                is_new = int(row["xmax"]) == 0
                 return _with_latency(
                     json.dumps(
                         {
@@ -1714,8 +1757,9 @@ async def memclaw_doc(
                     return _with_latency(
                         _error_response("INVALID_ARGUMENTS", "op=read requires 'doc_id'."), t0
                     )
-                doc = await document_repo.get_by_doc_id(
-                    db,
+                # READ — widens via ``readable_tenant_ids`` for cross-tenant
+                # credentials (home-only when single-tenant).
+                doc = await sc.get_document(
                     tenant_id=tenant_id,
                     collection=collection,
                     doc_id=doc_id,
@@ -1734,7 +1778,7 @@ async def memclaw_doc(
                 # never surface a sibling tenant's in-flight skill).
                 # The collection check short-circuits the flag lookup for
                 # non-skills reads.
-                if doc.collection == SKILLS_COLLECTION:
+                if _doc_field(doc, "collection") == SKILLS_COLLECTION:
                     caller_opted_in = await _skills_factory_enabled(db, tenant_id)
                     if _skill_hidden_from_agent(
                         doc, caller_tenant_id=tenant_id, caller_opted_in=caller_opted_in
@@ -1743,10 +1787,10 @@ async def memclaw_doc(
                 return _with_latency(
                     json.dumps(
                         {
-                            "collection": doc.collection,
-                            "doc_id": doc.doc_id,
-                            "data": doc.data,
-                            "updated_at": doc.updated_at.isoformat(),
+                            "collection": _doc_field(doc, "collection"),
+                            "doc_id": _doc_field(doc, "doc_id"),
+                            "data": _doc_field(doc, "data"),
+                            "updated_at": _doc_field(doc, "updated_at"),
                         },
                         default=str,
                     ),
@@ -1808,16 +1852,18 @@ async def memclaw_doc(
                         caller_opted_in = await _skills_factory_enabled(db, tenant_id)
                         if caller_opted_in:
                             effective_where["status"] = _AGENT_VISIBLE_SKILL_STATUS
-                docs = await document_repo.query(
-                    db,
-                    tenant_id=tenant_id,
-                    collection=collection,
-                    where=effective_where,
-                    order_by=order_by,
-                    order=order,
-                    limit=min(limit, 100),
-                    offset=offset,
-                    readable_tenant_ids=readable,
+                # READ — widens via ``readable_tenant_ids`` for cross-tenant.
+                docs = await sc.query_documents(
+                    {
+                        "tenant_id": tenant_id,
+                        "collection": collection,
+                        "where": effective_where,
+                        "order_by": order_by,
+                        "order": order,
+                        "limit": min(limit, 100),
+                        "offset": offset,
+                        "readable_tenant_ids": readable,
+                    }
                 )
                 # Cross-tenant safety net: when the caller's tenant is NOT
                 # opted in, the SQL status filter above never ran, so
@@ -1831,7 +1877,7 @@ async def memclaw_doc(
                         for d in docs
                         if not _skill_hidden_from_agent(d, caller_tenant_id=tenant_id, caller_opted_in=False)
                     ]
-                items = [{"doc_id": d.doc_id, "data": d.data} for d in docs]
+                items = [{"doc_id": _doc_field(d, "doc_id"), "data": _doc_field(d, "data")} for d in docs]
                 return _with_latency(
                     json.dumps(
                         {"collection": collection, "count": len(items), "results": items},
@@ -1868,16 +1914,19 @@ async def memclaw_doc(
                 )
                 if scoped_skills_opted_in:
                     search_status = _AGENT_VISIBLE_SKILL_STATUS
-                pairs = await document_repo.search(
-                    db,
-                    tenant_id=tenant_id,
-                    collection=collection,  # None = span every collection (broad)
-                    query_embedding=query_embedding,
-                    top_k=capped_top_k,
-                    fleet_id=fleet_id,
-                    readable_tenant_ids=readable,
-                    status=search_status,
-                )
+                # READ — widens via ``readable_tenant_ids``. Storage returns a
+                # list of doc dicts each carrying an inline ``similarity`` key
+                # (vs the repo's ``(Document, similarity)`` tuples).
+                search_data: dict[str, Any] = {
+                    "tenant_id": tenant_id,
+                    "collection": collection,  # None = span every collection (broad)
+                    "query_embedding": query_embedding,
+                    "top_k": capped_top_k,
+                    "fleet_id": fleet_id,
+                    "readable_tenant_ids": readable,
+                    "status": search_status,
+                }
+                pairs = await sc.search_documents_vector(search_data)
                 # Safety net for every skill row that the scoped SQL
                 # filter didn't already remove:
                 #   • broad search (collection=None) — skill rows the SQL
@@ -1890,7 +1939,7 @@ async def memclaw_doc(
                 # ``_skill_hidden_from_agent`` encodes both rules per-row.
                 # The cheap ``any()`` scan short-circuits the cached flag
                 # lookup when no skill rows are present.
-                if any(d.collection == SKILLS_COLLECTION for d, _ in pairs):
+                if any(_doc_field(d, "collection") == SKILLS_COLLECTION for d in pairs):
                     # For a scoped skills search we already resolved the
                     # flag; for a broad search resolve it now.
                     caller_opted_in = (
@@ -1899,8 +1948,8 @@ async def memclaw_doc(
                         else await _skills_factory_enabled(db, tenant_id)
                     )
                     pairs = [
-                        (d, sim)
-                        for d, sim in pairs
+                        d
+                        for d in pairs
                         if not _skill_hidden_from_agent(
                             d, caller_tenant_id=tenant_id, caller_opted_in=caller_opted_in
                         )
@@ -1908,8 +1957,8 @@ async def memclaw_doc(
                 source_tenants = [t for t in (readable or []) if t and t != tenant_id]
                 if source_tenants:
                     counts: dict[str, int] = {}
-                    for d, _sim in pairs:
-                        rt = getattr(d, "tenant_id", None)
+                    for d in pairs:
+                        rt = _doc_field(d, "tenant_id")
                         if rt:
                             counts[rt] = counts.get(rt, 0) + 1
                     await log_cross_tenant_read(
@@ -1927,12 +1976,12 @@ async def memclaw_doc(
                 # response shape.
                 items = [
                     {
-                        "collection": d.collection,
-                        "doc_id": d.doc_id,
-                        "data": d.data,
-                        "similarity": round(sim, 4),
+                        "collection": _doc_field(d, "collection"),
+                        "doc_id": _doc_field(d, "doc_id"),
+                        "data": _doc_field(d, "data"),
+                        "similarity": round(_doc_field(d, "similarity", 0.0), 4),
                     }
-                    for d, sim in pairs
+                    for d in pairs
                 ]
                 return _with_latency(
                     json.dumps(
@@ -1952,29 +2001,22 @@ async def memclaw_doc(
             # deletes — a routine trust-1 agent must not destroy tenant documents.
             if caller_agent_id:
                 await enforce_delete(db, tenant_id, caller_agent_id)
-            from sqlalchemy import delete as sa_delete
-
-            from common.models.document import Document
-
             # Active-only existence gate for skills: an agent must not be
             # able to delete (or probe the existence of) a non-active
             # skill via MCP — those are operator-managed through the
-            # Inbox (reject/quarantine), not the agent surface. We fold
-            # the status guard directly into the DELETE's WHERE so the
-            # check and the delete are a single atomic statement — no
-            # TOCTOU window where a concurrent admin promote/demote could
-            # change status between a separate pre-fetch and the delete.
-            # A non-active (or missing) skill deletes zero rows and falls
-            # through to the SAME generic not-found response a missing doc
-            # returns — so a non-active skill is byte-for-byte
-            # indistinguishable from a missing one (no existence leak),
-            # and the response stays valid JSON (``_with_latency`` only
-            # injects ``_latency_ms`` into a parsed dict; a bare string
-            # would break json.loads() callers on the delete path).
-            # Home-tenant scoped (deletes never span readable tenants).
-            # Fail CLOSED: the status guard is a security gate, so use the
-            # strict (raising) flag check and abort the delete on a
-            # settings-lookup failure rather than the lenient helper
+            # Inbox (reject/quarantine), not the agent surface. The status
+            # guard is folded directly into the storage DELETE's WHERE
+            # (``require_status``) so the check and the delete are a single
+            # atomic statement — no TOCTOU window where a concurrent admin
+            # promote/demote could change status between a separate pre-fetch
+            # and the delete. A non-active (or missing) skill deletes zero
+            # rows and falls through to the SAME generic not-found response a
+            # missing doc returns — so a non-active skill is byte-for-byte
+            # indistinguishable from a missing one (no existence leak), and
+            # the response stays valid JSON. WRITE → home tenant only (deletes
+            # never span readable tenants). Fail CLOSED: the status guard is a
+            # security gate, so use the strict (raising) flag check and abort
+            # on a settings-lookup failure rather than the lenient helper
             # (which returns False → no status guard → fail-open delete).
             # Short-circuits for non-skills collections (never touches
             # settings).
@@ -1985,22 +2027,17 @@ async def memclaw_doc(
                 return _with_latency(
                     _error_response("INTERNAL_ERROR", "skill lifecycle gate unavailable"), t0
                 )
-            stmt = sa_delete(Document).where(
-                Document.tenant_id == tenant_id,
-                Document.collection == collection,
-                Document.doc_id == doc_id,
+            deleted = await sc.delete_document(
+                tenant_id,
+                collection,
+                doc_id,
+                require_status=_AGENT_VISIBLE_SKILL_STATUS if skills_gate_on else None,
             )
-            if skills_gate_on:
-                stmt = stmt.where(Document.data["status"].astext == _AGENT_VISIBLE_SKILL_STATUS)
-            stmt = stmt.returning(Document.id)
-            result = await db.execute(stmt)
-            deleted_id = result.scalar_one_or_none()
-            if not deleted_id:
+            if not deleted:
                 return _with_latency(
                     json.dumps({"error": f"Document '{doc_id}' not found in collection '{collection}'"}),
                     t0,
                 )
-            await db.commit()
             return _with_latency(
                 json.dumps({"ok": True, "collection": collection, "doc_id": doc_id, "deleted": True}),
                 t0,
@@ -2008,6 +2045,8 @@ async def memclaw_doc(
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
             return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+        except httpx.HTTPStatusError as e:
+            return _storage_error_envelope(e, t0)
         except Exception as e:
             logger.error("MCP doc op=%s error: %s", op, e, exc_info=True)
             return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
@@ -2085,11 +2124,6 @@ async def memclaw_list(
         )
     capped_limit = max(1, min(int(limit), 50))
 
-    from datetime import datetime as _dt
-
-    from core_api.pagination import decode_cursor, encode_cursor
-    from core_api.services.memory_service import _memory_to_out
-
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
     if refuse := _refuse_default_agent_on_gateway(agent_id):
@@ -2107,98 +2141,118 @@ async def memclaw_list(
     # Dynamic trust: scope='agent' requires trust ≥ 1, 'fleet'/'all' requires ≥ 2.
     min_level = 1 if scope == "agent" else 2
 
-    async with _mcp_session() as db:
-        trust, _, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
-        if terr:
-            return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
+    # ``_require_trust`` is storage-routed (trust_service → storage client) and
+    # ``log_cross_tenant_read`` is fire-and-forget (audit queue → storage); the
+    # only db-bound call, ``memory_repo.list_by_filters``, becomes the storage
+    # client's ``list_memories_by_filters`` (same visibility predicate + cursor
+    # + readable widening, ported verbatim into PostgresService). ``_no_db()`` ⇒
+    # db=None. Tenant isolation: the READ widens via ``readable_tenant_ids`` ONLY
+    # for scope!='agent' (exactly as before); scope='agent' stays home-only and
+    # forces ``written_by`` to the caller. ``caller_agent_id`` carries the
+    # scope_agent visibility gate explicitly to storage.
+    async with _no_db() as db:
+        try:
+            trust, _, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
+            if terr:
+                return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
 
-        # scope='agent': force written_by to the caller's agent_id so they
-        # can only see their own memories regardless of other filters.
-        effective_written_by = agent_id if scope == "agent" else written_by
+            # scope='agent': force written_by to the caller's agent_id so they
+            # can only see their own memories regardless of other filters.
+            effective_written_by = agent_id if scope == "agent" else written_by
 
-        # include_deleted is silently ignored below trust 3
-        effective_include_deleted = include_deleted and trust >= 3
+            # include_deleted is silently ignored below trust 3
+            effective_include_deleted = include_deleted and trust >= 3
 
-        # Parse ISO date strings (validated early to avoid repo-level errors).
-        ts_after = ts_before = None
-        if created_after:
-            try:
-                ts_after = _dt.fromisoformat(created_after)
-            except ValueError:
-                return _with_latency(
-                    _error_response("INVALID_ARGUMENTS", "created_after must be ISO8601."), t0
+            # Parse ISO date strings (validated early to avoid repo-level errors).
+            ts_after = ts_before = None
+            if created_after:
+                try:
+                    ts_after = _dt.fromisoformat(created_after)
+                except ValueError:
+                    return _with_latency(
+                        _error_response("INVALID_ARGUMENTS", "created_after must be ISO8601."), t0
+                    )
+            if created_before:
+                try:
+                    ts_before = _dt.fromisoformat(created_before)
+                except ValueError:
+                    return _with_latency(
+                        _error_response("INVALID_ARGUMENTS", "created_before must be ISO8601."), t0
+                    )
+
+            c_ts = c_id = None
+            if cursor:
+                try:
+                    c_ts, c_id = decode_cursor(cursor)
+                except Exception:
+                    return _with_latency(_error_response("INVALID_ARGUMENTS", "Invalid cursor."), t0)
+
+            # Cross-tenant credentials widen via ``readable_tenant_ids`` —
+            # the gateway plumbs ``X-Readable-Tenant-IDs`` into the MCP
+            # context var. ``scope='all'`` aggregates across the widened set;
+            # ``scope='agent'`` still filters to the caller's own writes
+            # in the home tenant. Single-tenant credentials leave the var
+            # empty; storage falls back to ``tenant_id = $1``. Request
+            # ``limit + 1`` so we detect ``has_more`` + build the next cursor.
+            readable = _get_readable_tenants() or None
+            list_payload: dict[str, Any] = {
+                "tenant_id": tenant_id,
+                "caller_agent_id": agent_id,
+                "fleet_id": fleet_id,
+                "written_by": effective_written_by,
+                "memory_type": memory_type,
+                "status": status,
+                "weight_min": weight_min,
+                "weight_max": weight_max,
+                "created_after": ts_after.isoformat() if ts_after else None,
+                "created_before": ts_before.isoformat() if ts_before else None,
+                "include_deleted": effective_include_deleted,
+                "sort": sort,
+                "order": order,
+                "limit": capped_limit,
+                "cursor_ts": c_ts.isoformat() if c_ts else None,
+                "cursor_id": str(c_id) if c_id else None,
+                "readable_tenant_ids": readable if scope != "agent" else None,
+            }
+            rows = await get_storage_client().list_memories_by_filters(list_payload)
+            has_more = len(rows) > capped_limit
+            # ``_memory_to_out`` accepts either an ORM row or a storage dict.
+            items = [_memory_to_out(m).model_dump(mode="json") for m in rows[:capped_limit]]
+            next_cursor = None
+            if has_more and rows:
+                last = rows[capped_limit - 1]
+                next_cursor = encode_cursor(_dt.fromisoformat(last["created_at"]), UUID(last["id"]))
+            # Cross-tenant audit (F2): count per tenant from the served rows.
+            source_tenants = [t for t in (readable or []) if t and t != tenant_id]
+            if source_tenants:
+                counts: dict[str, int] = {}
+                for row in rows[:capped_limit]:
+                    rt = row.get("tenant_id")
+                    if rt:
+                        counts[rt] = counts.get(rt, 0) + 1
+                await log_cross_tenant_read(
+                    db,
+                    home_tenant_id=tenant_id,
+                    home_agent_id=agent_id,
+                    source_tenants=source_tenants,
+                    surface="memclaw_list",
+                    result_count_by_tenant=counts,
                 )
-        if created_before:
-            try:
-                ts_before = _dt.fromisoformat(created_before)
-            except ValueError:
-                return _with_latency(
-                    _error_response("INVALID_ARGUMENTS", "created_before must be ISO8601."), t0
-                )
-
-        c_ts = c_id = None
-        if cursor:
-            try:
-                c_ts, c_id = decode_cursor(cursor)
-            except Exception:
-                return _with_latency(_error_response("INVALID_ARGUMENTS", "Invalid cursor."), t0)
-
-        # Cross-tenant credentials widen via ``readable_tenant_ids`` —
-        # the gateway plumbs ``X-Readable-Tenant-IDs`` into the MCP
-        # context var. ``scope='all'`` aggregates across the widened set;
-        # ``scope='agent'`` still filters to the caller's own writes
-        # in the home tenant. Single-tenant credentials leave the var
-        # empty; ``list_by_filters`` falls back to ``tenant_id = $1``.
-        readable = _get_readable_tenants() or None
-        rows = await memory_repo.list_by_filters(
-            db,
-            tenant_id=tenant_id,
-            caller_agent_id=agent_id,
-            fleet_id=fleet_id,
-            written_by=effective_written_by,
-            memory_type=memory_type,
-            status=status,
-            weight_min=weight_min,
-            weight_max=weight_max,
-            created_after=ts_after,
-            created_before=ts_before,
-            include_deleted=effective_include_deleted,
-            sort=sort,
-            order=order,
-            limit=capped_limit,
-            cursor_ts=c_ts,
-            cursor_id=c_id,
-            readable_tenant_ids=readable if scope != "agent" else None,
-        )
-        has_more = len(rows) > capped_limit
-        items = [_memory_to_out(m).model_dump(mode="json") for m in rows[:capped_limit]]
-        next_cursor = None
-        if has_more and rows:
-            last = rows[capped_limit - 1]
-            next_cursor = encode_cursor(last.created_at, last.id)
-        # Cross-tenant audit (F2): count per tenant from the served rows.
-        source_tenants = [t for t in (readable or []) if t and t != tenant_id]
-        if source_tenants:
-            counts: dict[str, int] = {}
-            for row in rows[:capped_limit]:
-                rt = getattr(row, "tenant_id", None)
-                if rt:
-                    counts[rt] = counts.get(rt, 0) + 1
-            await log_cross_tenant_read(
-                db,
-                home_tenant_id=tenant_id,
-                home_agent_id=agent_id,
-                source_tenants=source_tenants,
-                surface="memclaw_list",
-                result_count_by_tenant=counts,
+            return _with_latency(
+                json.dumps(
+                    {"count": len(items), "results": items, "next_cursor": next_cursor, "scope": scope},
+                    default=str,
+                ),
+                t0,
             )
-        return _with_latency(
-            json.dumps(
-                {"count": len(items), "results": items, "next_cursor": next_cursor, "scope": scope},
-                default=str,
-            ),
-            t0,
-        )
+        except HTTPException as e:
+            logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
+            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+        except httpx.HTTPStatusError as e:
+            return _storage_error_envelope(e, t0)
+        except Exception as e:
+            logger.error("MCP list error: %s", e, exc_info=True)
+            return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
 
 
 async def memclaw_stats(
@@ -2256,7 +2310,15 @@ async def memclaw_stats(
         return _with_latency(refuse, t0)
     min_level = 1 if scope == "agent" else 2
 
-    async with _mcp_session() as db:
+    # ``_require_trust`` is storage-routed; ``compute_memory_stats`` (db-bound
+    # GROUPING SETS) becomes the storage client's ``memory_stats_breakdown``
+    # (ported verbatim into PostgresService — same visibility scoping, GROUPING
+    # SETS, ``by_tenant`` widening, and ``include_deleted`` CTE). ``_no_db()`` ⇒
+    # db=None. Tenant isolation: scope='agent' pins the read to the HOME tenant
+    # and to the caller's own visibility (``agent_id`` doubles as the visibility
+    # identity); scope='fleet'/'all' widens via ``readable_tenant_ids`` exactly
+    # as before.
+    async with _no_db() as db:
         trust, _, terr = await _require_trust(db, tenant_id, agent_id, min_level=min_level)
         if terr:
             return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
@@ -2267,23 +2329,22 @@ async def memclaw_stats(
         effective_agent_id = agent_id if scope == "agent" else None
         effective_include_deleted = include_deleted and trust >= 3
 
-        from core_api.services.memory_stats import compute_memory_stats
-
         try:
             # Cross-tenant credentials with scope='fleet'/'all' aggregate
             # across the widened readable set; scope='agent' stays
             # home-only because per-agent stats are intrinsically tied
             # to the home tenant identity.
             readable = _get_readable_tenants() or None
-            stats = await compute_memory_stats(
-                db,
-                tenant_id=tenant_id,
-                fleet_id=fleet_id,
-                agent_id=effective_agent_id,
-                memory_type=memory_type,
-                status=status,
-                include_deleted=effective_include_deleted,
-                readable_tenant_ids=readable if scope != "agent" else None,
+            stats = await get_storage_client().memory_stats_breakdown(
+                {
+                    "tenant_id": tenant_id,
+                    "fleet_id": fleet_id,
+                    "agent_id": effective_agent_id,
+                    "memory_type": memory_type,
+                    "status": status,
+                    "include_deleted": effective_include_deleted,
+                    "readable_tenant_ids": readable if scope != "agent" else None,
+                }
             )
             source_tenants = [t for t in (readable or []) if t and t != tenant_id]
             if source_tenants and scope != "agent":
@@ -2781,12 +2842,19 @@ async def memclaw_keystones_set(
     if refuse := _refuse_default_agent_on_gateway(caller_agent_id):
         return _with_latency(refuse, t0)
 
-    async with _mcp_session() as db:
+    # Already storage-routed for the keystone CRUD (``sc.get_document`` /
+    # ``upsert_keystone`` / ``delete_keystone``); Fix 2 Phase 4 only drops the
+    # residual ``_mcp_session`` (``_no_db()`` ⇒ db=None) since ``_require_trust``
+    # is storage-routed, ``log_action`` / ``check_and_increment`` ignore the
+    # ``db`` arg (audit queue / usage stub), and the keystone writes commit
+    # storage-side — so the ``db.commit()`` calls are gone. Tenant isolation is
+    # unchanged: every keystone op is scoped to the explicit home ``tenant_id``
+    # (writes never widen to a readable set).
+    async with _no_db() as db:
         # The whole body sits inside the try so the catch-all also covers
-        # ``_require_trust`` (DB lookup), the trust-error return paths,
-        # ``log_action``, and ``db.commit()`` — any of which can raise
-        # SQLAlchemy / connection errors that aren't ``HTTPStatusError``
-        # or ``HTTPException``. Mirrors memclaw_keystones' fallback.
+        # ``_require_trust`` and the trust-error return paths — any of which can
+        # raise errors that aren't ``HTTPStatusError`` or ``HTTPException``.
+        # Mirrors memclaw_keystones' fallback.
         try:
             sc = get_storage_client()
 
@@ -2948,7 +3016,6 @@ async def memclaw_keystones_set(
                         "via": "mcp",
                     },
                 )
-                await db.commit()
                 return _with_latency(
                     json.dumps({"ok": True, "action": "set", "doc_id": doc_id}, default=str),
                     t0,
@@ -3036,7 +3103,6 @@ async def memclaw_keystones_set(
                 resource_id=None,
                 detail={"doc_id": doc_id, "via": "mcp"},
             )
-            await db.commit()
             return _with_latency(json.dumps({"ok": True, "action": "delete", "doc_id": doc_id}), t0)
         except httpx.HTTPStatusError as e:
             # storage_client._post / _delete call raise_for_status(); a

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1342,7 +1342,7 @@ async def update_memory_status(
                 detail=f"Agent '{auth.agent_id}' cannot modify memory in fleet '{memory.get('fleet_id')}'.",
             )
     old_status = memory.get("status")
-    await sc.update_memory_status(str(memory_id), status)
+    await sc.update_memory_status(str(memory_id), status, tenant_id=tenant_id)
 
     # Audit stays a decoupled async POST (not folded into the storage txn).
     await log_action(

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -428,7 +428,9 @@ async def _detect(
             )
 
         if rdf_updates:
-            rdf_result = await sc.batch_update_status({"updates": list(rdf_updates.values())})
+            rdf_result = await sc.batch_update_status(
+                {"updates": list(rdf_updates.values())}, tenant_id=tenant_id
+            )
             if rdf_result.get("skipped"):
                 # ``skipped`` carries rows the storage-side dropped — CAS
                 # gate fail (caller-supplied ``expected_supersedes_id``
@@ -586,7 +588,9 @@ async def _detect(
                     )
 
             if updates:
-                sem_result = await sc.batch_update_status({"updates": list(updates.values())})
+                sem_result = await sc.batch_update_status(
+                    {"updates": list(updates.values())}, tenant_id=tenant_id
+                )
                 if sem_result.get("skipped"):
                     # See RDF path above for the ``skipped`` semantics.
                     logger.warning(
@@ -1542,12 +1546,28 @@ async def _attempt_path_c_retraction(
         )
         return False
 
-    # Two-step retraction via A4 #10.
-    await sc.update_memory_status(str(candidate.get("id")), "active")
+    # Two-step retraction via A4 #10. Each write is scoped to the HOME tenant
+    # of the row it touches — the candidate and new_memory live in the same
+    # (trigger) tenant, but we pass each row's own ``tenant_id`` so the
+    # storage-layer cross-tenant guard never silently no-ops a legitimate write.
+    # Extract each row's home tenant explicitly. ``get_memory`` always
+    # serialises ``tenant_id`` (NOT NULL column in MEMORY_FIELDS), so this
+    # never fires in practice — but raising beats ``str(None)`` -> "None",
+    # which would silently match no row and turn the retraction into a
+    # no-op rather than surfacing the broken invariant.
+    cand_tenant = candidate.get("tenant_id")
+    new_tenant = new_memory.get("tenant_id")
+    if not cand_tenant or not new_tenant:
+        raise ValueError(
+            f"Path C retraction missing tenant_id (candidate={candidate.get('id')}, "
+            f"new_memory={new_memory.get('id')})"
+        )
+    await sc.update_memory_status(str(candidate.get("id")), "active", tenant_id=cand_tenant)
     try:
         await sc.update_memory_status(
             str(new_memory.get("id")),
             new_memory.get("status", "active"),
+            tenant_id=new_tenant,
             unset_supersedes=True,
             expected_supersedes_id=str(candidate.get("id")),
         )
@@ -1998,7 +2018,9 @@ async def detect_contradictions_by_entities_async(
                 )
 
         if updates:
-            path_c_result = await sc.batch_update_status({"updates": list(updates.values())})
+            path_c_result = await sc.batch_update_status(
+                {"updates": list(updates.values())}, tenant_id=tenant_id
+            )
             if path_c_result.get("skipped"):
                 # See RDF path in ``_detect`` for the ``skipped`` semantics.
                 logger.warning(

--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -369,7 +369,9 @@ async def _run_crystallization(
             {"memory_id": str(mem.get("id")), "status": "archived"} for mem in cluster_memories
         ]
         try:
-            batch_result = await sc.batch_update_status({"updates": cluster_ids_to_archive})
+            batch_result = await sc.batch_update_status(
+                {"updates": cluster_ids_to_archive}, tenant_id=tenant_id
+            )
             skipped_set = set(batch_result.get("skipped") or [])
             for item in cluster_ids_to_archive:
                 if item["memory_id"] not in skipped_set:

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2165,7 +2165,7 @@ async def _enrich_memory_background(
                 # Fall back to update via scored-search patch endpoint
                 await sc._patch(f"/memories/{memory_id}", patch)
             if status_val:
-                await sc.update_memory_status(str(memory_id), status_val)
+                await sc.update_memory_status(str(memory_id), status_val, tenant_id=tenant_id)
 
         memory_type = patch.get("memory_type") or mem.get("memory_type")
 

--- a/core-storage-api/src/core_storage_api/routers/documents.py
+++ b/core-storage-api/src/core_storage_api/routers/documents.py
@@ -90,6 +90,7 @@ async def query_documents(request: Request) -> list[dict]:
         order=body.get("order", "asc"),
         limit=body.get("limit", 20),
         offset=body.get("offset", 0),
+        readable_tenant_ids=body.get("readable_tenant_ids"),
     )
     return [orm_to_dict(d, DOCUMENT_FIELDS) for d in docs]
 
@@ -114,16 +115,40 @@ async def list_collections(
     }
 
 
+# NOTE: registered BEFORE /{collection}/{doc_id} and /{collection} so the
+# literal "collection-count" path doesn't bind ``collection="collection-count"``.
+@router.get("/collection-count")
+async def collection_count(
+    tenant_id: str,
+    collection: str,
+    status: str | None = None,
+    fleet_id: str | None = None,
+    readable_tenant_ids: list[str] | None = Query(default=None),
+) -> dict:
+    """Count documents in ``collection``, optionally filtered by
+    ``data->>'status'``. Backs the MCP skills active-only count correction."""
+    count = await _svc.document_count_in_collection(
+        tenant_id=tenant_id,
+        collection=collection,
+        status=status,
+        fleet_id=fleet_id,
+        readable_tenant_ids=readable_tenant_ids,
+    )
+    return {"count": count}
+
+
 @router.get("/{collection}/{doc_id}")
 async def get_document(
     collection: str,
     doc_id: str,
     tenant_id: str,
+    readable_tenant_ids: list[str] | None = Query(default=None),
 ) -> dict:
     doc = await _svc.document_get_by_doc_id(
         tenant_id=tenant_id,
         collection=collection,
         doc_id=doc_id,
+        readable_tenant_ids=readable_tenant_ids,
     )
     if doc is None:
         raise HTTPException(status_code=404, detail="Document not found")
@@ -153,12 +178,18 @@ async def delete_document(
     collection: str,
     doc_id: str,
     tenant_id: str,
+    require_status: str | None = None,
 ) -> dict:
+    """Delete one document. ``require_status`` (optional) folds a
+    ``data->>'status' = :status`` guard into the DELETE atomically — a
+    non-matching/missing row deletes zero rows and 404s, indistinguishable
+    from a missing one (the MCP skills active-only delete gate)."""
     try:
         deleted_id = await _svc.document_delete_by_doc_id(
             tenant_id=tenant_id,
             collection=collection,
             doc_id=doc_id,
+            require_status=require_status,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -542,6 +542,17 @@ async def batch_update_status(request: Request) -> dict:
     """
     body: dict = await request.json()
 
+    # The batch is per-tenant: every memory in one batch shares the trigger
+    # tenant, so ``tenant_id`` is carried at the batch level (not per row) and
+    # threaded into each ``memory_update_status`` as the cross-tenant write
+    # guard. Explicit 422 on missing tenant_id, mirroring the sibling routes.
+    tenant_id: str | None = body.get("tenant_id")
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_id' is required and must be a non-empty string",
+        )
+
     # Two passes: validate everything FIRST, then execute. A malformed
     # item in the middle of the batch would otherwise commit rows
     # 0..K-1 before the 422 lands, leaving the caller no receipt of
@@ -583,6 +594,7 @@ async def batch_update_status(request: Request) -> dict:
         ok = await _svc.memory_update_status(
             mid,
             new_status,
+            tenant_id=tenant_id,
             supersedes_id=sup_uuid,
             unset_supersedes=unset_sup,
             expected_supersedes_id=exp_sup_uuid,
@@ -963,6 +975,101 @@ async def admin_list(request: Request) -> list[dict]:
     return [orm_to_dict(m, MEMORY_LIST_FIELDS) for m in memories]
 
 
+@router.post("/list")
+async def list_by_filters(request: Request) -> list[dict]:
+    """Non-admin memory list WITH visibility scoping (MCP ``memclaw_list``).
+
+    Body: ``{tenant_id, caller_agent_id?, fleet_id?, written_by?, memory_type?,
+    status?, run_id?, weight_min?, weight_max?, created_after?, created_before?,
+    include_deleted, sort, order, limit, offset, cursor_ts?, cursor_id?,
+    readable_tenant_ids?}``. ``limit`` is the caller's desired page size; this
+    endpoint over-fetches ``limit+1`` rows internally for has_more detection and
+    the caller slices to ``limit`` / builds the next cursor. Distinct from
+    ``/admin-list`` which has NO visibility scoping.
+    """
+    body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    if not tenant_id:
+        raise HTTPException(status_code=422, detail="tenant_id is required")
+    # Cap the page size: the service over-fetches ``limit + 1``, so an
+    # unbounded ``limit`` would let a caller pull the whole table in one
+    # request. [1, 5000] matches the /null-embedding-ids bound in this file.
+    raw_limit = body.get("limit", 25)
+    try:
+        limit = max(1, min(int(raw_limit), 5000))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=422, detail="'limit' must be a positive integer") from None
+    cursor_ts_raw = body.get("cursor_ts")
+    cursor_id_raw = body.get("cursor_id")
+    created_after_raw = body.get("created_after")
+    created_before_raw = body.get("created_before")
+    try:
+        cursor_ts = datetime.fromisoformat(cursor_ts_raw) if isinstance(cursor_ts_raw, str) else cursor_ts_raw
+        cursor_id = UUID(cursor_id_raw) if cursor_id_raw else None
+        created_after = (
+            datetime.fromisoformat(created_after_raw)
+            if isinstance(created_after_raw, str)
+            else created_after_raw
+        )
+        created_before = (
+            datetime.fromisoformat(created_before_raw)
+            if isinstance(created_before_raw, str)
+            else created_before_raw
+        )
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=422, detail=f"invalid datetime fields: {exc}") from exc
+    memories = await _svc.memory_list_by_filters(
+        tenant_id=tenant_id,
+        caller_agent_id=body.get("caller_agent_id"),
+        fleet_id=body.get("fleet_id"),
+        written_by=body.get("written_by"),
+        memory_type=body.get("memory_type"),
+        status=body.get("status"),
+        run_id=body.get("run_id"),
+        weight_min=body.get("weight_min"),
+        weight_max=body.get("weight_max"),
+        created_after=created_after,
+        created_before=created_before,
+        include_deleted=bool(body.get("include_deleted", False)),
+        sort=body.get("sort", "created_at"),
+        order=body.get("order", "desc"),
+        limit=limit,
+        offset=body.get("offset", 0),
+        cursor_ts=cursor_ts,
+        cursor_id=cursor_id,
+        readable_tenant_ids=body.get("readable_tenant_ids"),
+    )
+    return [orm_to_dict(m, MEMORY_LIST_FIELDS) for m in memories]
+
+
+@router.post("/stats-breakdown")
+async def stats_breakdown(request: Request) -> dict:
+    """Visibility-scoped stats breakdown (MCP ``memclaw_stats``).
+
+    Body: ``{tenant_id?, fleet_id?, agent_id?, memory_type?, status?,
+    include_deleted?, readable_tenant_ids?}``. Returns ``{total, by_type,
+    by_agent, by_status}`` plus optional ``by_tenant`` (when the readable set
+    spans >1 tenant) and ``deleted`` / ``total_including_deleted`` (when
+    ``include_deleted``). Distinct from ``/admin-stats`` (no scoping) and
+    ``/stats`` (health-stats shape).
+    """
+    body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    if not tenant_id:
+        # Mirror /list: a binding/home tenant is mandatory. Without it (and with no
+        # readable set) the aggregation would run unscoped across all tenants.
+        raise HTTPException(status_code=422, detail="tenant_id is required")
+    return await _svc.memory_stats_breakdown(
+        tenant_id=tenant_id,
+        fleet_id=body.get("fleet_id"),
+        agent_id=body.get("agent_id"),
+        memory_type=body.get("memory_type"),
+        status=body.get("status"),
+        include_deleted=bool(body.get("include_deleted", False)),
+        readable_tenant_ids=body.get("readable_tenant_ids"),
+    )
+
+
 @router.post("/soft-delete-by-filter")
 async def soft_delete_by_filter(request: Request) -> dict:
     """Soft-delete every matching live memory for a tenant.
@@ -1153,6 +1260,17 @@ async def update_memory_status(memory_id: UUID, request: Request) -> dict:
     unset_supersedes = bool(body.get("unset_supersedes", False))
     expected_supersedes_id = body.get("expected_supersedes_id")
 
+    # ``tenant_id`` scopes every write path in this route (the CAS retraction,
+    # the ``memory_update_status`` status flip, and the set-supersedes update)
+    # so a caller in tenant B can't touch tenant A's memory by id. Explicit 422
+    # on a missing tenant_id, mirroring the sibling routes.
+    tenant_id: str | None = body.get("tenant_id")
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_id' is required and must be a non-empty string",
+        )
+
     if unset_supersedes and supersedes_id is not None:
         raise HTTPException(
             status_code=422,
@@ -1186,6 +1304,7 @@ async def update_memory_status(memory_id: UUID, request: Request) -> dict:
                 sql_update(Memory)
                 .where(
                     Memory.id == memory_id,
+                    Memory.tenant_id == tenant_id,
                     or_(
                         Memory.supersedes_id == expected_uuid,
                         Memory.supersedes_id.is_(None),
@@ -1207,7 +1326,7 @@ async def update_memory_status(memory_id: UUID, request: Request) -> dict:
     # Set or status-only paths. ``memory_update_status`` returns False
     # when the target row doesn't exist (or was already deleted); surface
     # as 404 so the caller doesn't silently treat a no-op as success.
-    ok = await _svc.memory_update_status(memory_id, status)
+    ok = await _svc.memory_update_status(memory_id, status, tenant_id=tenant_id)
     if not ok:
         raise HTTPException(status_code=404, detail=f"memory {memory_id} not found")
 
@@ -1226,7 +1345,11 @@ async def update_memory_status(memory_id: UUID, request: Request) -> dict:
         async with get_session() as session:
             await session.execute(
                 sql_update(Memory)
-                .where(Memory.id == memory_id, Memory.supersedes_id.is_(None))
+                .where(
+                    Memory.id == memory_id,
+                    Memory.tenant_id == tenant_id,
+                    Memory.supersedes_id.is_(None),
+                )
                 .values(supersedes_id=UUID(supersedes_id))
             )
     return {"ok": True}

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -23,6 +23,7 @@ from uuid import UUID
 
 from sqlalchemy import and_, bindparam, case, delete, false, func, literal_column, or_, select, text, tuple_
 from sqlalchemy import update as sql_update
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -641,6 +642,7 @@ class PostgresService:
         memory_id: UUID,
         status: str,
         *,
+        tenant_id: str,
         supersedes_id: UUID | None = None,
         unset_supersedes: bool = False,
         expected_supersedes_id: UUID | None = None,
@@ -650,6 +652,10 @@ class PostgresService:
         Args:
             memory_id: Target row.
             status: New status value.
+            tenant_id: Home tenant of the target memory. REQUIRED — the WHERE
+                clause is scoped to ``Memory.tenant_id == tenant_id`` so a
+                caller in tenant B can never flip the status of tenant A's
+                memory by id (cross-tenant write guard).
             supersedes_id: If provided, set ``supersedes_id`` to this UUID.
                 Ignored when ``unset_supersedes`` is True.
             unset_supersedes: If True, clear ``supersedes_id`` to NULL.
@@ -662,8 +668,9 @@ class PostgresService:
 
         Returns:
             True if the row was updated, False if the ``expected_supersedes_id``
-            CAS check failed (or the row id doesn't exist). Existing callers
-            ignore the return value — adding it is backward-compatible.
+            CAS check failed, the tenant didn't match, or the row id doesn't
+            exist. Existing callers ignore the return value — adding it is
+            backward-compatible.
         """
         values: dict[str, Any] = {"status": status}
         if unset_supersedes:
@@ -672,7 +679,10 @@ class PostgresService:
             values["supersedes_id"] = supersedes_id
 
         async with get_session() as session:
-            stmt = sql_update(Memory).where(Memory.id == memory_id)
+            stmt = sql_update(Memory).where(
+                Memory.id == memory_id,
+                Memory.tenant_id == tenant_id,
+            )
             if expected_supersedes_id is not None:
                 stmt = stmt.where(Memory.supersedes_id == expected_supersedes_id)
             stmt = stmt.values(**values)
@@ -3022,6 +3032,289 @@ class PostgresService:
                 by_status[row[3]] = cnt
         return {"total": total, "by_type": by_type, "by_agent": by_agent, "by_status": by_status}
 
+    async def memory_list_by_filters(
+        self,
+        *,
+        tenant_id: str,
+        caller_agent_id: str | None = None,
+        fleet_id: str | None = None,
+        written_by: str | None = None,
+        memory_type: str | None = None,
+        status: str | None = None,
+        run_id: str | None = None,
+        weight_min: float | None = None,
+        weight_max: float | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+        include_deleted: bool = False,
+        sort: str = "created_at",
+        order: str = "desc",
+        limit: int = 25,
+        offset: int = 0,
+        cursor_ts: datetime | None = None,
+        cursor_id: UUID | None = None,
+        readable_tenant_ids: list[str] | None = None,
+    ) -> list[Memory]:
+        """Filter, sort, paginate memories WITH visibility scoping.
+
+        Ports core-api ``memory_repository.list_by_filters`` verbatim — same
+        visibility predicate, filters, cursor predicate, ``(sort, id)``
+        tiebreaker, and ``limit + 1`` over-fetch (the caller slices + builds
+        the next cursor). Distinct from ``memory_admin_list`` which has NO
+        visibility scoping. Read-only (reader replica).
+
+        **Visibility:** when ``caller_agent_id`` is set, ``scope_agent`` rows
+        are visible only to the authoring agent; team/org always visible. When
+        unset, all ``scope_agent`` rows are excluded. **Cross-tenant widening:**
+        a non-empty ``readable_tenant_ids`` expands ``tenant_id = $1`` to
+        ``tenant_id = ANY($1)``; ``tenant_id`` stays the binding/home tenant.
+        """
+        if readable_tenant_ids:
+            stmt = select(Memory).where(Memory.tenant_id.in_(readable_tenant_ids))
+        else:
+            stmt = select(Memory).where(Memory.tenant_id == tenant_id)
+
+        # Visibility predicate (critical: prevents scope_agent leaks).
+        if caller_agent_id:
+            stmt = stmt.where(
+                or_(
+                    Memory.visibility == "scope_org",
+                    Memory.visibility == "scope_team",
+                    and_(
+                        Memory.visibility == "scope_agent",
+                        Memory.agent_id == caller_agent_id,
+                    ),
+                )
+            )
+        else:
+            stmt = stmt.where(Memory.visibility != "scope_agent")
+
+        if fleet_id:
+            stmt = stmt.where(Memory.fleet_id == fleet_id)
+        if written_by:
+            stmt = stmt.where(Memory.agent_id == written_by)
+        if memory_type:
+            stmt = stmt.where(Memory.memory_type == memory_type)
+        if status:
+            stmt = stmt.where(Memory.status == status)
+        if run_id is not None:
+            stmt = stmt.where(Memory.run_id == run_id)
+        if weight_min is not None:
+            stmt = stmt.where(Memory.weight >= weight_min)
+        if weight_max is not None:
+            stmt = stmt.where(Memory.weight <= weight_max)
+        if created_after is not None:
+            stmt = stmt.where(Memory.created_at >= created_after)
+        if created_before is not None:
+            stmt = stmt.where(Memory.created_at <= created_before)
+        if not include_deleted:
+            stmt = stmt.where(Memory.deleted_at.is_(None))
+
+        if cursor_ts is not None and cursor_id is not None:
+            # Cursor predicate direction must match the ORDER BY below: a desc
+            # page walks toward older rows (tuple `<` cursor), an asc page
+            # toward newer rows (tuple `>` cursor). Splitting on `order` keeps
+            # asc pagination moving forward (regression-covered by
+            # test_list_by_filters_asc_cursor_returns_forward_page).
+            if order == "desc":
+                stmt = stmt.where(tuple_(Memory.created_at, Memory.id) < tuple_(cursor_ts, cursor_id))  # type: ignore[arg-type]
+            else:
+                stmt = stmt.where(tuple_(Memory.created_at, Memory.id) > tuple_(cursor_ts, cursor_id))  # type: ignore[arg-type]
+
+        # Allowlist the sort column — this endpoint is independently callable,
+        # so an unknown value falls back to created_at rather than
+        # AttributeError-ing (500) on getattr(Memory, sort). core-api applies
+        # its own stricter allowlist upstream.
+        if sort not in _ADMIN_LIST_SORTABLE:
+            sort = "created_at"
+        col = getattr(Memory, sort)
+        if order == "desc":
+            stmt = stmt.order_by(col.desc(), Memory.id.desc())
+        else:
+            stmt = stmt.order_by(col.asc(), Memory.id.asc())
+        if offset and cursor_ts is None:
+            stmt = stmt.offset(offset)
+        stmt = stmt.limit(limit + 1)
+
+        async with get_read_session() as session:
+            return list((await session.execute(stmt)).scalars().all())
+
+    async def memory_stats_breakdown(
+        self,
+        *,
+        tenant_id: str | None,
+        fleet_id: str | None = None,
+        agent_id: str | None = None,
+        memory_type: str | None = None,
+        status: str | None = None,
+        include_deleted: bool = False,
+        readable_tenant_ids: list[str] | None = None,
+    ) -> dict:
+        """Return ``{total, by_type, by_agent, by_status}`` (+ optional
+        ``by_tenant`` / ``deleted`` / ``total_including_deleted``).
+
+        Ports core-api ``services.memory_stats.compute_memory_stats`` verbatim —
+        same visibility scoping (``agent_id`` doubles as visibility identity AND
+        author filter; when omitted, ``scope_agent`` rows are excluded so totals
+        match what a non-semantic list would return), same single-pass GROUPING
+        SETS aggregation, same cross-tenant widening + ``by_tenant`` breakdown,
+        and same ``include_deleted`` CTE. Read-only (reader replica).
+        """
+        scope_filters = []
+        if readable_tenant_ids:
+            scope_filters.append(Memory.tenant_id.in_(readable_tenant_ids))
+        else:
+            # Always bind a tenant predicate — never run unscoped. With tenant_id
+            # None this renders ``tenant_id IS NULL`` (matches nothing), so a caller
+            # that omits tenant scope gets empty stats, never cross-tenant rows.
+            scope_filters.append(Memory.tenant_id == tenant_id)
+        if fleet_id:
+            scope_filters.append(Memory.fleet_id == fleet_id)
+        if agent_id:
+            scope_filters.append(Memory.agent_id == agent_id)
+            scope_filters.append(
+                or_(
+                    Memory.visibility == "scope_org",
+                    Memory.visibility == "scope_team",
+                    and_(
+                        Memory.visibility == "scope_agent",
+                        Memory.agent_id == agent_id,
+                    ),
+                )
+            )
+        else:
+            scope_filters.append(Memory.visibility != "scope_agent")
+        if memory_type:
+            scope_filters.append(Memory.memory_type == memory_type)
+        if status:
+            scope_filters.append(Memory.status == status)
+
+        filters = [Memory.deleted_at.is_(None), *scope_filters]
+
+        include_by_tenant = bool(readable_tenant_ids and len(readable_tenant_ids) > 1)
+
+        grouping_sets = ["()", "(memory_type)", "(agent_id)", "(status)"]
+        if include_by_tenant:
+            grouping_sets.append("(tenant_id)")
+        grouping_sets_sql = ", ".join(grouping_sets)
+
+        grouping_total_cols = ["memory_type", "agent_id", "status"]
+        if include_by_tenant:
+            grouping_total_cols.append("tenant_id")
+        grouping_total_arg = ", ".join(grouping_total_cols)
+        grouping_total_value = (1 << len(grouping_total_cols)) - 1
+        bucket_when = [
+            f"WHEN GROUPING({grouping_total_arg}) = {grouping_total_value} THEN 'total'",
+            "WHEN GROUPING(memory_type) = 0 THEN 'by_type'",
+            "WHEN GROUPING(agent_id) = 0 THEN 'by_agent'",
+            "WHEN GROUPING(status) = 0 THEN 'by_status'",
+        ]
+        if include_by_tenant:
+            bucket_when.append("WHEN GROUPING(tenant_id) = 0 THEN 'by_tenant'")
+        bucket_when_sql = "\n                ".join(bucket_when)
+
+        # Compile the SQLAlchemy filter expressions to a WHERE fragment with BOUND
+        # parameters (not literal_binds) — keeps the dynamic visibility / scoping
+        # rules out of hand-written SQL while leaving user-supplied filter values
+        # (fleet_id/agent_id/memory_type/status) parameterised, never inlined.
+        # Returns (where_fragment, params) to thread into the ``text()`` execute.
+        def _predicate_sql(filter_list) -> tuple[str, dict]:
+            compiled = (
+                select(Memory.id).where(*filter_list).compile(dialect=postgresql.dialect(paramstyle="named"))
+            )
+            rendered = str(compiled)
+            idx = rendered.upper().find("WHERE ")
+            if idx < 0:
+                # Never fall back to "TRUE": a missing WHERE would run the
+                # aggregation UNSCOPED across all tenants. If SQLAlchemy ever
+                # changes its compiled format, fail loudly instead.
+                raise RuntimeError(
+                    "memory_stats_breakdown: no WHERE clause in compiled output "
+                    f"(refusing to run unscoped): {rendered[:200]!r}"
+                )
+            fragment = rendered[idx + len("WHERE ") :]
+            return fragment, dict(compiled.params)
+
+        select_cols = "memory_type, agent_id, status"
+        if include_by_tenant:
+            select_cols = f"{select_cols}, tenant_id"
+
+        if include_deleted:
+            all_predicate, pred_params = _predicate_sql(scope_filters)
+            sql = f"""
+            WITH base AS (
+                SELECT memory_type, agent_id, status, tenant_id,
+                       (deleted_at IS NULL) AS alive
+                FROM memories
+                WHERE {all_predicate}
+            )
+            SELECT
+                CASE
+                    {bucket_when_sql}
+                END                                              AS bucket,
+                {select_cols},
+                COUNT(*) FILTER (WHERE alive)                    AS live_cnt,
+                COUNT(*) FILTER (WHERE NOT alive)                AS deleted_cnt
+            FROM base
+            GROUP BY GROUPING SETS ({grouping_sets_sql})
+            """
+        else:
+            predicate, pred_params = _predicate_sql(filters)
+            sql = f"""
+            SELECT
+                CASE
+                    {bucket_when_sql}
+                END                                              AS bucket,
+                {select_cols},
+                COUNT(*)                                         AS live_cnt,
+                0                                                AS deleted_cnt
+            FROM memories
+            WHERE {predicate}
+            GROUP BY GROUPING SETS ({grouping_sets_sql})
+            """
+
+        async with get_read_session() as session:
+            rows = (await session.execute(text(sql), pred_params)).all()
+
+        total = 0
+        by_type: dict = {}
+        by_agent: dict = {}
+        by_status: dict = {}
+        by_tenant: dict = {}
+        deleted = 0
+
+        live_idx = 5 if include_by_tenant else 4
+        deleted_idx = live_idx + 1
+
+        for row in rows:
+            bucket = row[0]
+            live = int(row[live_idx] or 0)
+            dead = int(row[deleted_idx] or 0)
+            if bucket == "total":
+                total = live
+                deleted = dead
+            elif bucket == "by_type":
+                by_type[row[1]] = live
+            elif bucket == "by_agent":
+                by_agent[row[2]] = live
+            elif bucket == "by_status":
+                by_status[row[3]] = live
+            elif bucket == "by_tenant":
+                by_tenant[row[4]] = live
+
+        result = {
+            "total": total,
+            "by_type": by_type,
+            "by_agent": by_agent,
+            "by_status": by_status,
+        }
+        if include_by_tenant:
+            result["by_tenant"] = by_tenant
+        if include_deleted:
+            result["deleted"] = deleted
+            result["total_including_deleted"] = total + deleted
+        return result
+
     # ══════════════════════════════════════════════════════════════════════
     #  ENTITIES
     # ══════════════════════════════════════════════════════════════════════
@@ -4404,6 +4697,37 @@ class PostgresService:
             # tuple method) under the type checker; index by position instead.
             return [(row[0], int(row[1])) for row in result.all()]
 
+    async def document_count_in_collection(
+        self,
+        *,
+        tenant_id: str,
+        collection: str,
+        status: str | None = None,
+        fleet_id: str | None = None,
+        readable_tenant_ids: list[str] | None = None,
+    ) -> int:
+        """Count documents in one collection, optionally filtered by a
+        ``data->>'status'`` value.
+
+        Backs the MCP ``list_collections`` skills active-only count correction
+        (the server-owned active-only gate): an opted-in tenant's listing must
+        not advertise non-active skills in the count. ``readable_tenant_ids``
+        widens to ``ANY($readable)`` over the same scope the listing used.
+        """
+        if readable_tenant_ids:
+            tenant_pred = Document.tenant_id.in_(readable_tenant_ids)
+        else:
+            tenant_pred = Document.tenant_id == tenant_id
+        stmt = (
+            select(func.count()).select_from(Document).where(tenant_pred, Document.collection == collection)
+        )
+        if status is not None:
+            stmt = stmt.where(Document.data["status"].astext == status)
+        if fleet_id:
+            stmt = stmt.where(Document.fleet_id == fleet_id)
+        async with get_read_session() as session:
+            return int((await session.execute(stmt)).scalar_one())
+
     async def document_search(
         self,
         *,
@@ -4460,10 +4784,22 @@ class PostgresService:
         tenant_id: str,
         collection: str,
         doc_id: str,
+        readable_tenant_ids: list[str] | None = None,
     ) -> Document | None:
+        """Fetch one document by (tenant, collection, doc_id).
+
+        ``readable_tenant_ids`` widens the tenant predicate to
+        ``ANY($readable)`` so cross-tenant credentials can read docs from
+        sibling tenants; ``tenant_id`` stays the binding/home tenant.
+        Mirrors core-api ``document_repository.get_by_doc_id``.
+        """
+        if readable_tenant_ids:
+            tenant_pred = Document.tenant_id.in_(readable_tenant_ids)
+        else:
+            tenant_pred = Document.tenant_id == tenant_id
         async with get_session() as session:
             stmt = select(Document).where(
-                Document.tenant_id == tenant_id,
+                tenant_pred,
                 Document.collection == collection,
                 Document.doc_id == doc_id,
             )
@@ -4481,11 +4817,21 @@ class PostgresService:
         order: str = "asc",
         limit: int = 20,
         offset: int = 0,
+        readable_tenant_ids: list[str] | None = None,
     ) -> list[Document]:
-        """Query documents with optional JSONB field-equality filters."""
+        """Query documents with optional JSONB field-equality filters.
+
+        ``readable_tenant_ids`` widens ``tenant_id`` to ``ANY($readable)``
+        for cross-tenant credentials. Mirrors core-api
+        ``document_repository.query``.
+        """
+        if readable_tenant_ids:
+            tenant_pred = Document.tenant_id.in_(readable_tenant_ids)
+        else:
+            tenant_pred = Document.tenant_id == tenant_id
         async with get_session() as session:
             stmt = select(Document).where(
-                Document.tenant_id == tenant_id,
+                tenant_pred,
                 Document.collection == collection,
             )
             if fleet_id:
@@ -4536,24 +4882,32 @@ class PostgresService:
         collection: str,
         doc_id: str,
         system: bool = False,
+        require_status: str | None = None,
     ) -> UUID | None:
         """Delete by (tenant_id, collection, doc_id). Returns the deleted id or None.
 
         Mirrors the ``system`` guard on ``document_upsert`` — deletes against
         system-managed collections (``_``-prefixed) require ``system=True``.
+
+        ``require_status`` (optional) folds a ``data->>'status' = :status``
+        guard directly into the DELETE's WHERE so the check and the delete are
+        a single atomic statement — no TOCTOU window. Backs the MCP skills
+        active-only delete gate: a non-matching (or missing) doc deletes zero
+        rows and returns ``None``, indistinguishable from a missing one (no
+        existence leak). Home-tenant scoped (deletes never span readable
+        tenants).
         """
         if collection.startswith("_") and not system:
             raise ValueError(f"Collection '{collection}' is system-managed; use the dedicated endpoint.")
         async with get_session() as session:
-            stmt = (
-                delete(Document)
-                .where(
-                    Document.tenant_id == tenant_id,
-                    Document.collection == collection,
-                    Document.doc_id == doc_id,
-                )
-                .returning(Document.id)
+            base = delete(Document).where(
+                Document.tenant_id == tenant_id,
+                Document.collection == collection,
+                Document.doc_id == doc_id,
             )
+            if require_status is not None:
+                base = base.where(Document.data["status"].astext == require_status)
+            stmt = base.returning(Document.id)
             result = await session.execute(stmt)
             return result.scalar_one_or_none()
 

--- a/tests/_contradiction_batch_compat.py
+++ b/tests/_contradiction_batch_compat.py
@@ -42,7 +42,11 @@ def install_batch_status_replay_shim(mock_sc: Any) -> None:
 
     update_mock = mock_sc.update_memory_status
 
-    async def _replay(payload: dict) -> dict:
+    async def _replay(payload: dict, *, tenant_id: str | None = None) -> dict:
+        # ``tenant_id`` is the batch-level cross-tenant guard threaded by the
+        # detector (Ph4 round-3 FIX 1). Accept-and-ignore here so the replay
+        # shim keeps the legacy per-row ``update_memory_status`` assertions
+        # valid without each test having to thread it.
         for row in payload.get("updates", []):
             mid = row["memory_id"]
             status = row["status"]

--- a/tests/_mcp_test_helpers.py
+++ b/tests/_mcp_test_helpers.py
@@ -84,6 +84,35 @@ def is_error_envelope(result: Any) -> bool:
     return isinstance(result, CallToolResult) and result.isError is True
 
 
+def stub_storage_client(monkeypatch, **method_returns):
+    """Replace ``get_storage_client`` with a MagicMock whose methods return
+    the requested values. Each kwarg is the method name (e.g. ``get_agent``,
+    ``list_document_collections``) and the value is the awaited result.
+
+    Fix 2 Phase 4 routed the 9 ready MCP tools through the core-storage-api
+    HTTP client, so the handlers resolve their DB access via
+    ``get_storage_client().<method>`` rather than the old ``db``-bound repo /
+    service calls. Unit tests that want deterministic returns / call-arg
+    assertions stub the client here. (The conftest's autouse ASGI bridge would
+    otherwise serve real in-process storage on the test engine — fine for
+    integration coverage, but these unit tests assert on the exact storage
+    interaction.) Mirrors the helper ``test_mcp_keystones`` introduced for the
+    already-routed keystone tools.
+    """
+    sc = MagicMock(name="storage_client")
+    for name, ret in method_returns.items():
+        setattr(sc, name, AsyncMock(return_value=ret))
+
+    def _factory():
+        return sc
+
+    # The handler binds ``get_storage_client`` at module import time, so the
+    # test must patch the alias on ``mcp_server`` (where Python resolves it at
+    # call time) — not the original module path.
+    monkeypatch.setattr("core_api.mcp_server.get_storage_client", _factory)
+    return sc
+
+
 @pytest.fixture
 def mcp_env(monkeypatch):
     """Patch the common MCP handler dependencies and yield a control dict.

--- a/tests/test_a4_11_overlap_includes_conflicted_supersedes.py
+++ b/tests/test_a4_11_overlap_includes_conflicted_supersedes.py
@@ -94,8 +94,10 @@ async def _wire_path_a_retraction(sc, *, newer_id: str, older_id: str) -> None:
     ``newer_id``'s ``supersedes_id`` to point at it. This is the
     bidirectional state Path A produces: older.status=conflicted,
     older.supersedes_id=NULL, newer.supersedes_id=older."""
-    await sc.update_memory_status(older_id, "conflicted")
-    await sc.update_memory_status(newer_id, "active", supersedes_id=older_id)
+    await sc.update_memory_status(older_id, "conflicted", tenant_id=TENANT_ID)
+    await sc.update_memory_status(
+        newer_id, "active", tenant_id=TENANT_ID, supersedes_id=older_id
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_a4_status_retraction.py
+++ b/tests/test_a4_status_retraction.py
@@ -71,7 +71,7 @@ async def _establish_conflicted(sc, *, conflicted: dict, by: dict) -> None:
     """Set ``conflicted.status=conflicted`` and ``conflicted.supersedes_id=by.id``
     using the existing (pre-A4) update_memory_status surface."""
     await sc.update_memory_status(
-        conflicted["id"], "conflicted", supersedes_id=by["id"]
+        conflicted["id"], "conflicted", tenant_id=TENANT_ID, supersedes_id=by["id"]
     )
 
 
@@ -98,6 +98,7 @@ async def test_retraction_clears_supersedes_and_sets_status_active(sc):
     result = await sc.update_memory_status(
         b["id"],
         status="active",
+        tenant_id=TENANT_ID,
         unset_supersedes=True,
         expected_supersedes_id=a["id"],
     )
@@ -136,6 +137,7 @@ async def test_retraction_rejects_when_supersedes_changed_under_us(sc):
         await sc.update_memory_status(
             b["id"],
             status="active",
+            tenant_id=TENANT_ID,
             unset_supersedes=True,
             expected_supersedes_id=a["id"],  # caller's stale view
         )
@@ -170,12 +172,20 @@ async def test_retraction_is_idempotent_on_already_cleared_row(sc):
 
     # First retraction — clears the pointer.
     await sc.update_memory_status(
-        b["id"], status="active", unset_supersedes=True, expected_supersedes_id=a["id"]
+        b["id"],
+        status="active",
+        tenant_id=TENANT_ID,
+        unset_supersedes=True,
+        expected_supersedes_id=a["id"],
     )
 
     # Second retraction — must not error; row is already in target state.
     result = await sc.update_memory_status(
-        b["id"], status="active", unset_supersedes=True, expected_supersedes_id=a["id"]
+        b["id"],
+        status="active",
+        tenant_id=TENANT_ID,
+        unset_supersedes=True,
+        expected_supersedes_id=a["id"],
     )
     assert result is not None
 
@@ -218,7 +228,7 @@ async def test_client_rejects_unset_without_expected_supersedes_id():
     fake_id = str(uuid.uuid4())
     with pytest.raises(ValueError, match="expected_supersedes_id"):
         await client.update_memory_status(
-            fake_id, status="active", unset_supersedes=True
+            fake_id, status="active", tenant_id=TENANT_ID, unset_supersedes=True
         )
 
 
@@ -233,6 +243,7 @@ async def test_client_rejects_set_and_unset_in_same_call():
         await client.update_memory_status(
             fake_id,
             status="active",
+            tenant_id=TENANT_ID,
             supersedes_id=other_id,
             unset_supersedes=True,
         )

--- a/tests/test_api_contradictions.py
+++ b/tests/test_api_contradictions.py
@@ -92,8 +92,10 @@ async def test_contradictions_completed_with_supersedes_chain(client, sc):
     # Simulate detector side-effects via the storage client (same path
     # the real detector uses): old becomes outdated, new.supersedes_id
     # points at old.
-    await sc.update_memory_status(old["id"], "outdated")
-    await sc.update_memory_status(new["id"], "active", supersedes_id=old["id"])
+    await sc.update_memory_status(old["id"], "outdated", tenant_id=tenant_id)
+    await sc.update_memory_status(
+        new["id"], "active", tenant_id=tenant_id, supersedes_id=old["id"]
+    )
 
     # ---- From the OLDER memory's perspective: it was superseded.
     resp_old = await client.get(

--- a/tests/test_cross_tenant_audit_surfaces.py
+++ b/tests/test_cross_tenant_audit_surfaces.py
@@ -30,6 +30,8 @@ from uuid import UUID
 
 import pytest
 
+from tests._mcp_test_helpers import stub_storage_client
+
 pytestmark = [pytest.mark.unit]
 
 
@@ -93,6 +95,34 @@ class _MemoryRow:
         return {"id": self.id, "tenant_id": self.tenant_id}
 
 
+def _memory_row_dict(tenant_id: str) -> dict:
+    """Storage-client memory row (a dict) carrying the ``tenant_id`` the
+    cross-tenant audit count reads. Fix 2 Phase 4: ``memclaw_list`` consumes
+    ``sc.list_memories_by_filters`` dict rows (``row.get("tenant_id")`` /
+    ``_memory_to_out(dict)``), not ORM rows."""
+    return {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "tenant_id": tenant_id,
+        "fleet_id": None,
+        "agent_id": "test-agent",
+        "memory_type": "fact",
+        "title": None,
+        "content": "x",
+        "weight": 0.5,
+        "source_uri": None,
+        "run_id": None,
+        "metadata_": {},
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC).isoformat(),
+        "expires_at": None,
+        "status": "active",
+        "visibility": "scope_team",
+        "recall_count": 0,
+        "last_recalled_at": None,
+        "supersedes_id": None,
+        "deleted_at": None,
+    }
+
+
 # ===========================================================================
 # MCP surfaces (cross-tenant ContextVars + spy on mcp_server.log_cross_tenant_read)
 # ===========================================================================
@@ -128,13 +158,14 @@ async def test_memclaw_recall_emits_cross_tenant_audit(
         _MemoryRow("tenant-home"),
         _MemoryRow("tenant-sibling"),
     ]
+    # Fix 2 Phase 4: ``resolve_config`` is a top-level import on mcp_server, and
+    # the agent profile lookup routes through the storage client's ``get_agent``.
     monkeypatch.setattr(
-        "core_api.services.organization_settings.resolve_config",
+        mcp_server,
+        "resolve_config",
         AsyncMock(return_value=SimpleNamespace(recall_boost=False, graph_expand=False)),
     )
-    monkeypatch.setattr(
-        "core_api.repositories.agent_repo.get_by_id", AsyncMock(return_value=None)
-    )
+    stub_storage_client(monkeypatch, get_agent=None)
 
     await mcp_server.memclaw_recall(query="cross-tenant probe", agent_id="a1")
 
@@ -155,13 +186,14 @@ async def test_memclaw_list_emits_cross_tenant_audit(
     audits with ``surface=memclaw_list``."""
     from core_api import mcp_server
 
-    monkeypatch.setattr(
-        "core_api.repositories.memory_repo.list_by_filters",
-        AsyncMock(
-            return_value=[_MemoryRow("tenant-home"), _MemoryRow("tenant-sibling")]
-        ),
+    stub_storage_client(
+        monkeypatch,
+        list_memories_by_filters=[
+            _memory_row_dict("tenant-home"),
+            _memory_row_dict("tenant-sibling"),
+        ],
     )
-    # Trust gate stubbed so the handler doesn't 403 before reaching list_by_filters.
+    # Trust gate stubbed so the handler doesn't 403 before reaching the list.
     monkeypatch.setattr(
         mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None))
     )
@@ -188,19 +220,18 @@ async def test_memclaw_stats_emits_cross_tenant_audit(
     monkeypatch.setattr(
         mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None))
     )
-    # ``compute_memory_stats`` is imported INSIDE the handler — patch
-    # at the source so the late import resolves to our mock.
-    monkeypatch.setattr(
-        "core_api.services.memory_stats.compute_memory_stats",
-        AsyncMock(
-            return_value={
-                "total": 5,
-                "by_type": {"fact": 5},
-                "by_agent": {},
-                "by_status": {"active": 5},
-                "by_tenant": {"tenant-home": 3, "tenant-sibling": 2},
-            }
-        ),
+    # Fix 2 Phase 4: stats route through the storage client's
+    # ``memory_stats_breakdown`` (the GROUPING-SETS aggregation moved into
+    # core-storage-api). Stub it so the handler reaches the audit emission.
+    stub_storage_client(
+        monkeypatch,
+        memory_stats_breakdown={
+            "total": 5,
+            "by_type": {"fact": 5},
+            "by_agent": {},
+            "by_status": {"active": 5},
+            "by_tenant": {"tenant-home": 3, "tenant-sibling": 2},
+        },
     )
 
     await mcp_server.memclaw_stats(scope="fleet", agent_id="a1")
@@ -222,21 +253,27 @@ async def test_memclaw_doc_search_emits_cross_tenant_audit(
     the query, calls ``document_repo.search``, then emits."""
     from core_api import mcp_server
 
-    fake_doc = SimpleNamespace(tenant_id="tenant-sibling", id="d1", collection="things")
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.search",
-        AsyncMock(return_value=[(fake_doc, 0.91)]),
+    # Fix 2 Phase 4: ``op=search`` routes through ``sc.search_documents_vector``,
+    # which returns plain dict rows each carrying ``tenant_id`` + inline
+    # ``similarity`` (vs the repo's ``(Document, sim)`` tuples).
+    stub_storage_client(
+        monkeypatch,
+        search_documents_vector=[
+            {
+                "tenant_id": "tenant-sibling",
+                "doc_id": "d1",
+                "collection": "things",
+                "data": {},
+                "similarity": 0.91,
+            }
+        ],
     )
-    # The embed step is gated by an embed-provider call we'd rather not
-    # touch in a unit test — patch the helper that wraps it.
+    # The embed step is gated by an embed-provider call we'd rather not touch in
+    # a unit test — the handler resolves ``get_embedding`` from
+    # ``common.embedding`` (inline import), so patch it at the source.
     monkeypatch.setattr(
-        "core_api.services.memory_service.get_query_embedding",
+        "common.embedding.get_embedding",
         AsyncMock(return_value=[0.1] * 8),
-    )
-    # ``tenant_config`` resolution short-circuits to a fake.
-    monkeypatch.setattr(
-        "core_api.services.organization_settings.resolve_config",
-        AsyncMock(return_value=SimpleNamespace(embedding_model=None)),
     )
 
     await mcp_server.memclaw_doc(op="search", query="hello world", agent_id="a1")

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -6,40 +6,46 @@ Covers:
 - Happy paths for all four ops (action/payload/count fields).
 - ``op=read`` not-found → "Not found:" text.
 - ``op=delete`` not-found → structured error envelope.
+
+Fix 2 Phase 4 routed ``memclaw_doc`` through the core-storage-api HTTP
+client (``get_storage_client()``), so these tests stub the storage client
+(``stub_storage_client``) and assert on the new dict-shaped payloads /
+single-positional-dict call args, rather than the old ``document_repo.*``
+ORM-row / tuple shapes.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
 
 import pytest
 
 from core_api import mcp_server
 from core_api.constants import VECTOR_DIM
-from tests._mcp_test_helpers import parse_envelope, strip_latency
+from tests._mcp_test_helpers import parse_envelope, strip_latency, stub_storage_client
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
 
-class _DocRow:
-    def __init__(self, doc_id: str = "acme", collection: str = "customers"):
-        self.collection = collection
-        self.doc_id = doc_id
-        self.data = {"plan": "business"}
-        self.updated_at = datetime.now(timezone.utc)
+def _doc(doc_id: str = "acme", collection: str = "customers", **extra) -> dict:
+    """A storage-client document dict (Fix 2 Phase 4 shape)."""
+    doc = {
+        "collection": collection,
+        "doc_id": doc_id,
+        "tenant_id": "test-tenant",
+        "data": {"plan": "business"},
+        "updated_at": datetime.now(timezone.utc),
+    }
+    doc.update(extra)
+    return doc
 
 
-class _UpsertRow:
-    """Stand-in for the unlabeled Row returned by upsert_returning_xmax.
-    xmax sits at index 3 (id=0, created_at=1, updated_at=2, xmax=3).
-    """
-
-    def __init__(self, xmax: int):
-        self._data = (None, None, None, xmax)
-
-    def __getitem__(self, idx):
-        return self._data[idx]
+def _search_hit(
+    doc_id: str, similarity: float, collection: str = "customers", **extra
+) -> dict:
+    """A storage-client search result: a doc dict with an inline
+    ``similarity`` float (vs the repo's ``(Document, sim)`` tuples)."""
+    return _doc(doc_id, collection=collection, similarity=similarity, **extra)
 
 
 async def test_doc_invalid_op_errors(mcp_env):
@@ -68,10 +74,7 @@ async def test_doc_write_missing_data(mcp_env):
 
 async def test_doc_write_happy_path_new(mcp_env, monkeypatch):
     """xmax=0 means a brand-new row was inserted."""
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax",
-        _async_return(_UpsertRow(xmax=0)),
-    )
+    stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
     out = await mcp_server.memclaw_doc(
         op="write", collection="customers", doc_id="acme", data={"plan": "enterprise"}
     )
@@ -85,10 +88,7 @@ async def test_doc_write_happy_path_new(mcp_env, monkeypatch):
 
 async def test_doc_write_happy_path_updated(mcp_env, monkeypatch):
     """xmax!=0 means an existing row was updated."""
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax",
-        _async_return(_UpsertRow(xmax=42)),
-    )
+    stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 42})
     out = await mcp_server.memclaw_doc(
         op="write", collection="customers", doc_id="acme", data={"plan": "pro"}
     )
@@ -102,9 +102,7 @@ async def test_doc_read_missing_doc_id(mcp_env):
 
 
 async def test_doc_read_not_found(mcp_env, monkeypatch):
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.get_by_doc_id", _async_return(None)
-    )
+    stub_storage_client(monkeypatch, get_document=None)
     out = await mcp_server.memclaw_doc(
         op="read", collection="customers", doc_id="ghost"
     )
@@ -112,10 +110,7 @@ async def test_doc_read_not_found(mcp_env, monkeypatch):
 
 
 async def test_doc_read_happy_path(mcp_env, monkeypatch):
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.get_by_doc_id",
-        _async_return(_DocRow("acme")),
-    )
+    stub_storage_client(monkeypatch, get_document=_doc("acme"))
     out = await mcp_server.memclaw_doc(op="read", collection="customers", doc_id="acme")
     payload = parse_envelope(out)
     assert payload["doc_id"] == "acme"
@@ -123,10 +118,8 @@ async def test_doc_read_happy_path(mcp_env, monkeypatch):
 
 
 async def test_doc_query_happy_path(mcp_env, monkeypatch):
-    rows = [_DocRow("acme"), _DocRow("initech")]
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.query", _async_return(rows)
-    )
+    rows = [_doc("acme"), _doc("initech")]
+    stub_storage_client(monkeypatch, query_documents=rows)
     out = await mcp_server.memclaw_doc(
         op="query", collection="customers", where={"plan": "business"}
     )
@@ -137,15 +130,9 @@ async def test_doc_query_happy_path(mcp_env, monkeypatch):
 
 
 async def test_doc_query_where_defaults_to_empty_dict(mcp_env, monkeypatch):
-    captured = {}
-
-    async def fake_query(db, **kwargs):
-        captured.update(kwargs)
-        return []
-
-    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
+    sc = stub_storage_client(monkeypatch, query_documents=[])
     await mcp_server.memclaw_doc(op="query", collection="customers")
-    assert captured["where"] == {}
+    assert sc.query_documents.await_args.args[0]["where"] == {}
 
 
 async def test_doc_delete_missing_doc_id(mcp_env):
@@ -153,28 +140,21 @@ async def test_doc_delete_missing_doc_id(mcp_env):
     assert "op=delete requires 'doc_id'" in strip_latency(out)
 
 
-async def test_doc_delete_not_found_envelope(mcp_env):
-    """The DELETE scalar_one_or_none path returns a {"error": "…"} JSON blob."""
-    # db.execute(...) → result with scalar_one_or_none() returning None.
-    result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = None
-    mcp_env["db"].execute.return_value = result_mock
-
+async def test_doc_delete_not_found_envelope(mcp_env, monkeypatch):
+    """A storage delete that matched nothing returns False → the handler
+    emits a ``{"error": "…"}`` JSON blob."""
+    sc = stub_storage_client(monkeypatch, delete_document=False)
     out = await mcp_server.memclaw_doc(
         op="delete", collection="customers", doc_id="ghost"
     )
     payload = parse_envelope(out)
     assert "not found" in payload["error"].lower()
     assert "ghost" in payload["error"]
+    sc.delete_document.assert_awaited_once()
 
 
-async def test_doc_delete_happy_path(mcp_env):
-    from uuid import uuid4
-
-    result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = uuid4()
-    mcp_env["db"].execute.return_value = result_mock
-
+async def test_doc_delete_happy_path(mcp_env, monkeypatch):
+    sc = stub_storage_client(monkeypatch, delete_document=True)
     out = await mcp_server.memclaw_doc(
         op="delete", collection="customers", doc_id="acme"
     )
@@ -182,7 +162,7 @@ async def test_doc_delete_happy_path(mcp_env):
     assert payload["ok"] is True
     assert payload["deleted"] is True
     assert payload["doc_id"] == "acme"
-    mcp_env["db"].commit.assert_awaited_once()
+    sc.delete_document.assert_awaited_once()
 
 
 async def test_doc_auth_failure_shortcircuits(monkeypatch):
@@ -198,9 +178,15 @@ async def test_doc_auth_failure_shortcircuits(monkeypatch):
 
 async def test_doc_list_collections_happy_path(mcp_env, monkeypatch):
     """Returns each collection with its document count."""
-    rows = [("customers", 3), ("onboarding_guides", 1), ("proposals", 2)]
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.list_collections", _async_return(rows)
+    stub_storage_client(
+        monkeypatch,
+        list_document_collections={
+            "collections": [
+                {"name": "customers", "count": 3},
+                {"name": "onboarding_guides", "count": 1},
+                {"name": "proposals", "count": 2},
+            ]
+        },
     )
     out = await mcp_server.memclaw_doc(op="list_collections")
     payload = parse_envelope(out)
@@ -214,9 +200,7 @@ async def test_doc_list_collections_happy_path(mcp_env, monkeypatch):
 
 async def test_doc_list_collections_empty_tenant(mcp_env, monkeypatch):
     """Empty tenant returns an empty list, not an error."""
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.list_collections", _async_return([])
-    )
+    stub_storage_client(monkeypatch, list_document_collections={"collections": []})
     out = await mcp_server.memclaw_doc(op="list_collections")
     payload = parse_envelope(out)
     assert payload["collections"] == []
@@ -227,9 +211,7 @@ async def test_doc_list_collections_does_not_require_collection(mcp_env, monkeyp
     """Unlike every other op, list_collections has no required params — the
     whole point is to discover collection names when you don't know them yet.
     """
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.list_collections", _async_return([])
-    )
+    stub_storage_client(monkeypatch, list_document_collections={"collections": []})
     out = await mcp_server.memclaw_doc(op="list_collections")
     payload = parse_envelope(out)
     assert "error" not in payload
@@ -237,17 +219,14 @@ async def test_doc_list_collections_does_not_require_collection(mcp_env, monkeyp
 
 async def test_doc_list_collections_passes_fleet_id_filter(mcp_env, monkeypatch):
     """fleet_id scopes the count; not a mandatory param."""
-    captured = {}
-
-    async def fake_list(db, *, tenant_id, fleet_id=None, readable_tenant_ids=None):  # noqa: ARG001
-        captured["fleet_id"] = fleet_id
-        return [("customers", 1)]
-
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.list_collections", fake_list
+    sc = stub_storage_client(
+        monkeypatch,
+        list_document_collections={"collections": [{"name": "customers", "count": 1}]},
     )
     await mcp_server.memclaw_doc(op="list_collections", fleet_id="caura-rnd-fleet")
-    assert captured["fleet_id"] == "caura-rnd-fleet"
+    assert (
+        sc.list_document_collections.await_args.kwargs["fleet_id"] == "caura-rnd-fleet"
+    )
 
 
 async def test_doc_write_requires_collection(mcp_env):
@@ -274,20 +253,14 @@ async def test_doc_query_requires_collection(mcp_env):
 
 async def test_doc_write_summary_embeds_and_forwards(mcp_env, monkeypatch):
     """When data["summary"] is present, the server embeds that string and
-    forwards the vector to the repo. Response reports indexed=True."""
+    forwards the vector to the storage client. Response reports indexed=True."""
     captured: dict = {}
-
-    async def fake_upsert(db, **kwargs):  # noqa: ARG001
-        captured.update(kwargs)
-        return _UpsertRow(xmax=0)
 
     async def fake_embed(text):
         captured["embed_text"] = text
         return [0.1] * VECTOR_DIM
 
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
-    )
+    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
     monkeypatch.setattr("common.embedding.get_embedding", fake_embed)
 
     out = await mcp_server.memclaw_doc(
@@ -304,7 +277,9 @@ async def test_doc_write_summary_embeds_and_forwards(mcp_env, monkeypatch):
     assert payload["indexed"] is True
     # Only the summary is embedded — the body is stored but not indexed.
     assert captured["embed_text"] == "Claude Code setup runbook"
-    assert len(captured["embedding"]) == VECTOR_DIM
+    # The embedding is forwarded in the dict passed to upsert_document_xmax.
+    sent = sc.upsert_document_xmax.await_args.args[0]
+    assert len(sent["embedding"]) == VECTOR_DIM
 
 
 async def test_doc_write_no_summary_stores_unindexed(mcp_env, monkeypatch):
@@ -316,10 +291,7 @@ async def test_doc_write_no_summary_stores_unindexed(mcp_env, monkeypatch):
         called["hit"] = True
         return [0.0] * VECTOR_DIM
 
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax",
-        _async_return(_UpsertRow(xmax=0)),
-    )
+    stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
     monkeypatch.setattr("common.embedding.get_embedding", should_not_embed)
 
     out = await mcp_server.memclaw_doc(
@@ -369,23 +341,17 @@ async def test_doc_write_embedding_provider_failure_aborts(mcp_env, monkeypatch)
 async def test_doc_search_without_collection_spans_all(mcp_env, monkeypatch):
     """Collection is intentionally optional on search — omitting it triggers
     the cross-collection strategy. Handler must pass collection=None to the
-    repo, not reject the call."""
-    captured: dict = {}
-
-    async def fake_search(db, **kwargs):  # noqa: ARG001
-        captured.update(kwargs)
-        return []
-
+    storage client, not reject the call."""
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    monkeypatch.setattr("core_api.repositories.document_repo.search", fake_search)
+    sc = stub_storage_client(monkeypatch, search_documents_vector=[])
 
     out = await mcp_server.memclaw_doc(op="search", query="onboarding")
     payload = parse_envelope(out)
     # No 422 — broad search is a legitimate call
     assert "error" not in payload
-    assert captured["collection"] is None
+    assert sc.search_documents_vector.await_args.args[0]["collection"] is None
 
 
 async def test_doc_search_broad_results_include_per_row_collection(
@@ -396,13 +362,11 @@ async def test_doc_search_broad_results_include_per_row_collection(
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    pairs = [
-        (_DocRow("acme", collection="customers"), 0.9),
-        (_DocRow("guide-1", collection="onboarding_guides"), 0.6),
+    hits = [
+        _search_hit("acme", 0.9, collection="customers"),
+        _search_hit("guide-1", 0.6, collection="onboarding_guides"),
     ]
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.search", _async_return(pairs)
-    )
+    stub_storage_client(monkeypatch, search_documents_vector=hits)
     out = await mcp_server.memclaw_doc(op="search", query="signup flow")
     payload = parse_envelope(out)
     assert payload["collection"] is None
@@ -422,14 +386,12 @@ async def test_doc_search_empty_query_rejected(mcp_env):
 
 
 async def test_doc_search_happy_path(mcp_env, monkeypatch):
-    """Happy path: embedding → repo.search → results sorted by similarity."""
+    """Happy path: embedding → storage search → results sorted by similarity."""
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    pairs = [(_DocRow("acme"), 0.92), (_DocRow("initech"), 0.81)]
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.search", _async_return(pairs)
-    )
+    hits = [_search_hit("acme", 0.92), _search_hit("initech", 0.81)]
+    stub_storage_client(monkeypatch, search_documents_vector=hits)
     out = await mcp_server.memclaw_doc(
         op="search",
         collection="customers",
@@ -448,7 +410,7 @@ async def test_doc_search_empty_results(mcp_env, monkeypatch):
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    monkeypatch.setattr("core_api.repositories.document_repo.search", _async_return([]))
+    stub_storage_client(monkeypatch, search_documents_vector=[])
     out = await mcp_server.memclaw_doc(op="search", collection="c", query="anything")
     payload = parse_envelope(out)
     assert payload["count"] == 0
@@ -457,19 +419,13 @@ async def test_doc_search_empty_results(mcp_env, monkeypatch):
 
 async def test_doc_search_top_k_capped_at_50(mcp_env, monkeypatch):
     """top_k above 50 is capped server-side."""
-    captured: dict = {}
-
-    async def fake_search(db, **kwargs):  # noqa: ARG001
-        captured.update(kwargs)
-        return []
-
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    monkeypatch.setattr("core_api.repositories.document_repo.search", fake_search)
+    sc = stub_storage_client(monkeypatch, search_documents_vector=[])
 
     await mcp_server.memclaw_doc(op="search", collection="c", query="q", top_k=9999)
-    assert captured["top_k"] == 50
+    assert sc.search_documents_vector.await_args.args[0]["top_k"] == 50
 
 
 async def test_doc_search_embedding_provider_failure_aborts(mcp_env, monkeypatch):
@@ -480,36 +436,22 @@ async def test_doc_search_embedding_provider_failure_aborts(mcp_env, monkeypatch
 
 
 # ---------------------------------------------------------------------------
-# Read-op widening: ``_readable_tenant_ids_var`` reaches the repo call
+# Read-op widening: ``_readable_tenant_ids_var`` reaches the storage call
 # (audit T1)
 # ---------------------------------------------------------------------------
 #
 # Cross-tenant credentials surface as a non-empty
 # ``_readable_tenant_ids_var``; the tool reads it via
 # ``_get_readable_tenants()`` and passes the list as ``readable_tenant_ids``
-# to whichever ``document_repo`` function backs the requested op:
+# to whichever storage method backs the requested op:
 #
-#   list_collections → document_repo.list_collections
-#   read             → document_repo.get_by_doc_id
-#   query            → document_repo.query
-#   search           → document_repo.search
+#   list_collections → sc.list_document_collections   (kwarg)
+#   read             → sc.get_document                 (kwarg)
+#   query            → sc.query_documents              (dict key)
+#   search           → sc.search_documents_vector      (dict key)
 #
 # T1 locks in the wiring: a regression that silently drops the list on
 # any of those four paths would fail the corresponding test below.
-
-
-async def _capture_readable_tenant_ids(monkeypatch, repo_attr: str, return_value):
-    """Patch the named ``document_repo`` function with a capture stub
-    that records the ``readable_tenant_ids`` kwarg and returns the
-    given value."""
-    captured: dict = {}
-
-    async def fake(*args, **kwargs):  # noqa: ARG001
-        captured["readable_tenant_ids"] = kwargs.get("readable_tenant_ids")
-        return return_value
-
-    monkeypatch.setattr(f"core_api.repositories.document_repo.{repo_attr}", fake)
-    return captured
 
 
 async def test_doc_list_collections_passes_readable_tenants(mcp_env, monkeypatch):
@@ -518,33 +460,37 @@ async def test_doc_list_collections_passes_readable_tenants(mcp_env, monkeypatch
     monkeypatch.setattr(
         mcp_server, "_get_readable_tenants", lambda: ["home", "sibling"]
     )
-    captured = await _capture_readable_tenant_ids(monkeypatch, "list_collections", [])
+    sc = stub_storage_client(monkeypatch, list_document_collections={"collections": []})
     await mcp_server.memclaw_doc(op="list_collections")
-    assert captured["readable_tenant_ids"] == ["home", "sibling"]
+    assert sc.list_document_collections.await_args.kwargs["readable_tenant_ids"] == [
+        "home",
+        "sibling",
+    ]
 
 
 async def test_doc_list_collections_single_tenant_passes_none(mcp_env, monkeypatch):
     """Single-tenant credential: ``_get_readable_tenants()`` returns
-    ``[]`` → the tool collapses it to ``None`` before calling the repo
-    (so the repo's single-tenant fast path runs)."""
+    ``[]`` → the tool collapses it to ``None`` before calling storage
+    (so the storage single-tenant fast path runs)."""
     monkeypatch.setattr(mcp_server, "_get_readable_tenants", lambda: [])
-    captured = await _capture_readable_tenant_ids(monkeypatch, "list_collections", [])
+    sc = stub_storage_client(monkeypatch, list_document_collections={"collections": []})
     await mcp_server.memclaw_doc(op="list_collections")
-    assert captured["readable_tenant_ids"] is None
+    assert sc.list_document_collections.await_args.kwargs["readable_tenant_ids"] is None
 
 
 async def test_doc_read_passes_readable_tenants(mcp_env, monkeypatch):
-    """``op=read`` widens via ``readable_tenant_ids``. The repo can
+    """``op=read`` widens via ``readable_tenant_ids``. Storage can
     then resolve a doc that lives in a sibling tenant when the caller
     is authorized to read from it."""
     monkeypatch.setattr(
         mcp_server, "_get_readable_tenants", lambda: ["home", "sibling"]
     )
-    captured = await _capture_readable_tenant_ids(
-        monkeypatch, "get_by_doc_id", _DocRow()
-    )
+    sc = stub_storage_client(monkeypatch, get_document=_doc())
     await mcp_server.memclaw_doc(op="read", collection="customers", doc_id="acme")
-    assert captured["readable_tenant_ids"] == ["home", "sibling"]
+    assert sc.get_document.await_args.kwargs["readable_tenant_ids"] == [
+        "home",
+        "sibling",
+    ]
 
 
 async def test_doc_query_passes_readable_tenants(mcp_env, monkeypatch):
@@ -552,25 +498,31 @@ async def test_doc_query_passes_readable_tenants(mcp_env, monkeypatch):
     monkeypatch.setattr(
         mcp_server, "_get_readable_tenants", lambda: ["home", "sibling"]
     )
-    captured = await _capture_readable_tenant_ids(monkeypatch, "query", [])
+    sc = stub_storage_client(monkeypatch, query_documents=[])
     await mcp_server.memclaw_doc(op="query", collection="customers", where={"k": 1})
-    assert captured["readable_tenant_ids"] == ["home", "sibling"]
+    assert sc.query_documents.await_args.args[0]["readable_tenant_ids"] == [
+        "home",
+        "sibling",
+    ]
 
 
 async def test_doc_search_passes_readable_tenants(mcp_env, monkeypatch):
     """``op=search`` (vector recall) widens the same way. The audit
     emission has its own assertion in
     ``tests/test_cross_tenant_audit_surfaces.py``; this test only
-    confirms the wiring from the context var to the repo arg."""
+    confirms the wiring from the context var to the storage arg."""
     monkeypatch.setattr(
         mcp_server, "_get_readable_tenants", lambda: ["home", "sibling"]
     )
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    captured = await _capture_readable_tenant_ids(monkeypatch, "search", [])
+    sc = stub_storage_client(monkeypatch, search_documents_vector=[])
     await mcp_server.memclaw_doc(op="search", query="hello")
-    assert captured["readable_tenant_ids"] == ["home", "sibling"]
+    assert sc.search_documents_vector.await_args.args[0]["readable_tenant_ids"] == [
+        "home",
+        "sibling",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -583,13 +535,22 @@ async def test_doc_search_passes_readable_tenants(mcp_env, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-class _SkillRow:
-    def __init__(self, doc_id: str, status: str, tenant_id: str = "test-tenant"):
-        self.collection = "skills"
-        self.doc_id = doc_id
-        self.tenant_id = tenant_id
-        self.data = {"slug": doc_id, "status": status, "summary": "a skill"}
-        self.updated_at = datetime.now(timezone.utc)
+def _skill_doc(doc_id: str, status: str, tenant_id: str = "test-tenant") -> dict:
+    """A storage-client skills document dict."""
+    return {
+        "collection": "skills",
+        "doc_id": doc_id,
+        "tenant_id": tenant_id,
+        "data": {"slug": doc_id, "status": status, "summary": "a skill"},
+        "updated_at": datetime.now(timezone.utc),
+    }
+
+
+def _skill_hit(
+    doc_id: str, status: str, similarity: float, tenant_id: str = "test-tenant"
+) -> dict:
+    """A storage-client skills search result (skill doc + inline similarity)."""
+    return {**_skill_doc(doc_id, status, tenant_id), "similarity": similarity}
 
 
 def _patch_flag(monkeypatch, enabled: bool):
@@ -606,11 +567,17 @@ def _patch_sf_settings(monkeypatch, *, enabled: bool = True, **caps):
     path now derives BOTH the opt-in flag and the byte caps from this one
     ``get_settings_for_display`` call (no separate ``_skills_factory_enabled``
     read), so tests set ``skills_factory.enabled`` here. Extra kwargs land
-    as ``skills_factory`` leaves (e.g. ``description_max_bytes=None``)."""
+    as ``skills_factory`` leaves (e.g. ``description_max_bytes=None``).
+
+    The handler calls the module-level ``mcp_server.get_settings_for_display``
+    name, so patch that alias (patching the original
+    ``core_api.services.organization_settings.get_settings_for_display`` would
+    not rebind the name the handler resolves)."""
     sf: dict = {"enabled": enabled}
     sf.update(caps)
     monkeypatch.setattr(
-        "core_api.services.organization_settings.get_settings_for_display",
+        mcp_server,
+        "get_settings_for_display",
         _async_return({"skills_factory": sf}),
     )
 
@@ -639,9 +606,8 @@ def _valid_skill_data(**overrides):
 
 async def test_skill_read_hides_non_active_when_flag_on(mcp_env, monkeypatch):
     _patch_flag(monkeypatch, True)
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.get_by_doc_id",
-        _async_return(_SkillRow("forge/x", status="staged")),
+    stub_storage_client(
+        monkeypatch, get_document=_skill_doc("forge/x", status="staged")
     )
     out = await mcp_server.memclaw_doc(op="read", collection="skills", doc_id="forge/x")
     # Non-active skill → same "Not found" as a missing doc (no existence leak).
@@ -650,9 +616,8 @@ async def test_skill_read_hides_non_active_when_flag_on(mcp_env, monkeypatch):
 
 async def test_skill_read_returns_active_when_flag_on(mcp_env, monkeypatch):
     _patch_flag(monkeypatch, True)
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.get_by_doc_id",
-        _async_return(_SkillRow("forge/x", status="active")),
+    stub_storage_client(
+        monkeypatch, get_document=_skill_doc("forge/x", status="active")
     )
     out = await mcp_server.memclaw_doc(op="read", collection="skills", doc_id="forge/x")
     payload = parse_envelope(out)
@@ -664,9 +629,8 @@ async def test_skill_read_no_filter_when_flag_off(mcp_env, monkeypatch):
     # Non-opted-in tenant: byte-identical to pre-Skill-Factory — a
     # staged (or status-less) skill is still readable.
     _patch_flag(monkeypatch, False)
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.get_by_doc_id",
-        _async_return(_SkillRow("forge/x", status="staged")),
+    stub_storage_client(
+        monkeypatch, get_document=_skill_doc("forge/x", status="staged")
     )
     out = await mcp_server.memclaw_doc(op="read", collection="skills", doc_id="forge/x")
     payload = parse_envelope(out)
@@ -683,20 +647,14 @@ async def test_skill_query_rejects_explicit_non_active_status_when_flag_on(
     # to active — that would mislead the caller into thinking they
     # queried 'staged'). Points them to the Inbox API.
     _patch_flag(monkeypatch, True)
-    called = {"query": False}
-
-    async def fake_query(db, **kwargs):  # noqa: ARG001
-        called["query"] = True
-        return []
-
-    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
+    sc = stub_storage_client(monkeypatch, query_documents=[])
     out = await mcp_server.memclaw_doc(
         op="query", collection="skills", where={"status": "staged"}
     )
     payload = parse_envelope(out)
     assert payload["error"]["code"] == "INVALID_ARGUMENTS"
     assert "skills-inbox" in payload["error"]["message"].lower()
-    assert called["query"] is False
+    sc.query_documents.assert_not_awaited()
 
 
 async def test_skill_query_scopes_to_active_when_no_status_when_flag_on(
@@ -706,33 +664,24 @@ async def test_skill_query_scopes_to_active_when_no_status_when_flag_on(
     # 'active' (no error), so an agent's plain skills query only ever
     # sees live skills.
     _patch_flag(monkeypatch, True)
-    captured: dict = {}
-
-    async def fake_query(db, **kwargs):  # noqa: ARG001
-        captured.update(kwargs)
-        return []
-
-    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
-    await mcp_server.memclaw_doc(op="query", collection="skills", where={"domain": "ops"})
-    assert captured["where"]["status"] == "active"
-    assert captured["where"]["domain"] == "ops"
+    sc = stub_storage_client(monkeypatch, query_documents=[])
+    await mcp_server.memclaw_doc(
+        op="query", collection="skills", where={"domain": "ops"}
+    )
+    sent = sc.query_documents.await_args.args[0]
+    assert sent["where"]["status"] == "active"
+    assert sent["where"]["domain"] == "ops"
 
 
 async def test_skill_query_no_filter_when_flag_off(mcp_env, monkeypatch):
     _patch_flag(monkeypatch, False)
-    captured: dict = {}
-
-    async def fake_query(db, **kwargs):  # noqa: ARG001
-        captured.update(kwargs)
-        return []
-
-    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
+    sc = stub_storage_client(monkeypatch, query_documents=[])
     await mcp_server.memclaw_doc(
         op="query", collection="skills", where={"status": "staged"}
     )
     # Genuinely not opted in → caller's where passes through untouched
     # (legacy), NOT the confusing Inbox-API rejection.
-    assert captured["where"] == {"status": "staged"}
+    assert sc.query_documents.await_args.args[0]["where"] == {"status": "staged"}
 
 
 async def test_skill_query_explicit_status_fails_closed_on_settings_error(
@@ -746,36 +695,24 @@ async def test_skill_query_explicit_status_fails_closed_on_settings_error(
         raise RuntimeError("settings store down")
 
     monkeypatch.setattr(mcp_server, "_skills_factory_flag", _boom)
-    called = {"query": False}
-
-    async def fake_query(db, **kwargs):  # noqa: ARG001
-        called["query"] = True
-        return []
-
-    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
+    sc = stub_storage_client(monkeypatch, query_documents=[])
     out = await mcp_server.memclaw_doc(
         op="query", collection="skills", where={"status": "staged"}
     )
     payload = parse_envelope(out)
     assert payload["error"]["code"] == "INTERNAL_ERROR"
-    assert called["query"] is False
+    sc.query_documents.assert_not_awaited()
 
 
 async def test_non_skills_query_unaffected_by_flag(mcp_env, monkeypatch):
     # The active-only policy is skills-only — a customers query must not
     # get a status filter injected even when the flag is on.
     _patch_flag(monkeypatch, True)
-    captured: dict = {}
-
-    async def fake_query(db, **kwargs):  # noqa: ARG001
-        captured.update(kwargs)
-        return []
-
-    monkeypatch.setattr("core_api.repositories.document_repo.query", fake_query)
+    sc = stub_storage_client(monkeypatch, query_documents=[])
     await mcp_server.memclaw_doc(
         op="query", collection="customers", where={"plan": "biz"}
     )
-    assert "status" not in captured["where"]
+    assert "status" not in sc.query_documents.await_args.args[0]["where"]
 
 
 # ── op=search (scoped) ─────────────────────────────────────────────
@@ -785,38 +722,26 @@ async def test_skill_search_scoped_passes_active_status_when_flag_on(
     mcp_env, monkeypatch
 ):
     _patch_flag(monkeypatch, True)
-    captured: dict = {}
-
-    async def fake_search(db, **kwargs):  # noqa: ARG001
-        captured.update(kwargs)
-        return []
-
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    monkeypatch.setattr("core_api.repositories.document_repo.search", fake_search)
+    sc = stub_storage_client(monkeypatch, search_documents_vector=[])
     await mcp_server.memclaw_doc(
         op="search", collection="skills", query="deploy eu-west"
     )
-    assert captured["status"] == "active"
+    assert sc.search_documents_vector.await_args.args[0]["status"] == "active"
 
 
 async def test_skill_search_scoped_no_status_when_flag_off(mcp_env, monkeypatch):
     _patch_flag(monkeypatch, False)
-    captured: dict = {}
-
-    async def fake_search(db, **kwargs):  # noqa: ARG001
-        captured.update(kwargs)
-        return []
-
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    monkeypatch.setattr("core_api.repositories.document_repo.search", fake_search)
+    sc = stub_storage_client(monkeypatch, search_documents_vector=[])
     await mcp_server.memclaw_doc(
         op="search", collection="skills", query="deploy eu-west"
     )
-    assert captured["status"] is None
+    assert sc.search_documents_vector.await_args.args[0]["status"] is None
 
 
 # ── op=search (broad / cross-collection) ───────────────────────────
@@ -827,14 +752,12 @@ async def test_skill_search_broad_drops_non_active_when_flag_on(mcp_env, monkeyp
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    pairs = [
-        (_DocRow("acme", collection="customers"), 0.9),  # non-skill: always kept
-        (_SkillRow("forge/active", status="active"), 0.8),  # kept
-        (_SkillRow("forge/staged", status="staged"), 0.7),  # DROPPED
+    hits = [
+        _search_hit("acme", 0.9, collection="customers"),  # non-skill: always kept
+        _skill_hit("forge/active", status="active", similarity=0.8),  # kept
+        _skill_hit("forge/staged", status="staged", similarity=0.7),  # DROPPED
     ]
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.search", _async_return(pairs)
-    )
+    stub_storage_client(monkeypatch, search_documents_vector=hits)
     out = await mcp_server.memclaw_doc(op="search", query="anything")
     payload = parse_envelope(out)
     returned = {(r["collection"], r["doc_id"]) for r in payload["results"]}
@@ -848,10 +771,8 @@ async def test_skill_search_broad_no_filter_when_flag_off(mcp_env, monkeypatch):
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    pairs = [(_SkillRow("forge/staged", status="staged"), 0.7)]
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.search", _async_return(pairs)
-    )
+    hits = [_skill_hit("forge/staged", status="staged", similarity=0.7)]
+    stub_storage_client(monkeypatch, search_documents_vector=hits)
     out = await mcp_server.memclaw_doc(op="search", query="anything")
     payload = parse_envelope(out)
     # Flag off → no broad post-filter; the staged skill surfaces as before.
@@ -861,7 +782,9 @@ async def test_skill_search_broad_no_filter_when_flag_off(mcp_env, monkeypatch):
 # ── op=write (self-promotion guard) ────────────────────────────────
 
 
-async def test_skill_write_rejects_caller_active_status_when_flag_on(mcp_env, monkeypatch):
+async def test_skill_write_rejects_caller_active_status_when_flag_on(
+    mcp_env, monkeypatch
+):
     # The MCP write path now runs the SF-002 lifecycle validator. An
     # agent-direct write carries is_admin=False, so a caller-supplied
     # status='active' hits ADMIN_ONLY_STATUSES and 403s — this is what
@@ -871,15 +794,7 @@ async def test_skill_write_rejects_caller_active_status_when_flag_on(mcp_env, mo
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    called = {"upsert": False}
-
-    async def fake_upsert(db, **kwargs):  # noqa: ARG001
-        called["upsert"] = True
-        return _UpsertRow(xmax=0)
-
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
-    )
+    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
     out = await mcp_server.memclaw_doc(
         op="write",
         collection="skills",
@@ -890,8 +805,8 @@ async def test_skill_write_rejects_caller_active_status_when_flag_on(mcp_env, mo
     # Validator raises HTTPException(403) → outer handler maps to FORBIDDEN.
     assert payload["error"]["code"] == "FORBIDDEN"
     assert "admin" in payload["error"]["message"].lower()
-    # The write must NOT have reached the DB.
-    assert called["upsert"] is False
+    # The write must NOT have reached storage.
+    sc.upsert_document_xmax.assert_not_awaited()
 
 
 async def test_skill_write_rejects_forge_source_when_flag_on(mcp_env, monkeypatch):
@@ -904,15 +819,7 @@ async def test_skill_write_rejects_forge_source_when_flag_on(mcp_env, monkeypatc
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    called = {"upsert": False}
-
-    async def fake_upsert(db, **kwargs):  # noqa: ARG001
-        called["upsert"] = True
-        return _UpsertRow(xmax=0)
-
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
-    )
+    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
     out = await mcp_server.memclaw_doc(
         op="write",
         collection="skills",
@@ -921,7 +828,7 @@ async def test_skill_write_rejects_forge_source_when_flag_on(mcp_env, monkeypatc
     )
     payload = parse_envelope(out)
     assert payload["error"]["code"] == "FORBIDDEN"
-    assert called["upsert"] is False
+    sc.upsert_document_xmax.assert_not_awaited()
 
 
 async def test_skill_write_defaults_to_staged_when_flag_on(mcp_env, monkeypatch):
@@ -934,15 +841,7 @@ async def test_skill_write_defaults_to_staged_when_flag_on(mcp_env, monkeypatch)
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    captured = {}
-
-    async def fake_upsert(db, **kwargs):  # noqa: ARG001
-        captured.update(kwargs)
-        return _UpsertRow(xmax=0)
-
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
-    )
+    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
     out = await mcp_server.memclaw_doc(
         op="write",
         collection="skills",
@@ -952,10 +851,11 @@ async def test_skill_write_defaults_to_staged_when_flag_on(mcp_env, monkeypatch)
     payload = parse_envelope(out)
     assert payload["ok"] is True
     # Validator-normalized data was passed through to the upsert.
-    assert captured["data"]["status"] == "staged"
-    assert captured["data"]["source"] == "agent"
+    sent_data = sc.upsert_document_xmax.await_args.args[0]["data"]
+    assert sent_data["status"] == "staged"
+    assert sent_data["source"] == "agent"
     # content_hash is server-stamped, never trusted from the body.
-    assert captured["data"]["content_hash"].startswith("sha256:")
+    assert sent_data["content_hash"].startswith("sha256:")
 
 
 async def test_skill_write_tolerates_misconfigured_byte_caps(mcp_env, monkeypatch):
@@ -971,10 +871,7 @@ async def test_skill_write_tolerates_misconfigured_byte_caps(mcp_env, monkeypatc
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax",
-        _async_return(_UpsertRow(xmax=0)),
-    )
+    stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
     out = await mcp_server.memclaw_doc(
         op="write",
         collection="skills",
@@ -992,24 +889,14 @@ async def test_skill_write_fails_closed_on_settings_error(mcp_env, monkeypatch):
     async def _boom(*_a, **_k):
         raise RuntimeError("settings store down")
 
-    monkeypatch.setattr(
-        "core_api.services.organization_settings.get_settings_for_display", _boom
-    )
-    called = {"upsert": False}
-
-    async def fake_upsert(db, **kwargs):  # noqa: ARG001
-        called["upsert"] = True
-        return _UpsertRow(xmax=0)
-
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
-    )
+    monkeypatch.setattr(mcp_server, "get_settings_for_display", _boom)
+    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
     out = await mcp_server.memclaw_doc(
         op="write", collection="skills", doc_id="forge-x", data=_valid_skill_data()
     )
     payload = parse_envelope(out)
     assert payload["error"]["code"] == "INTERNAL_ERROR"
-    assert called["upsert"] is False
+    sc.upsert_document_xmax.assert_not_awaited()
 
 
 async def test_skill_update_write_fails_closed_on_live_doc_fetch_error(
@@ -1024,20 +911,12 @@ async def test_skill_update_write_fails_closed_on_live_doc_fetch_error(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
 
-    class _BoomClient:
-        async def get_document(self, **_kwargs):
-            raise RuntimeError("storage down")
+    async def _boom_get_document(**_kwargs):
+        raise RuntimeError("storage down")
 
-    monkeypatch.setattr(mcp_server, "get_storage_client", lambda: _BoomClient())
-    called = {"upsert": False}
-
-    async def fake_upsert(db, **kwargs):  # noqa: ARG001
-        called["upsert"] = True
-        return _UpsertRow(xmax=0)
-
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
-    )
+    # The live-doc fetch (get_document) raises; the upsert must never run.
+    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+    sc.get_document.side_effect = _boom_get_document
     out = await mcp_server.memclaw_doc(
         op="write",
         collection="skills",
@@ -1048,7 +927,7 @@ async def test_skill_update_write_fails_closed_on_live_doc_fetch_error(
     )
     payload = parse_envelope(out)
     assert payload["error"]["code"] == "INTERNAL_ERROR"
-    assert called["upsert"] is False
+    sc.upsert_document_xmax.assert_not_awaited()
 
 
 async def test_skill_write_status_allowed_when_flag_off(mcp_env, monkeypatch):
@@ -1060,15 +939,7 @@ async def test_skill_write_status_allowed_when_flag_off(mcp_env, monkeypatch):
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    captured = {}
-
-    async def fake_upsert(db, **kwargs):  # noqa: ARG001
-        captured.update(kwargs)
-        return _UpsertRow(xmax=0)
-
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
-    )
+    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
     out = await mcp_server.memclaw_doc(
         op="write",
         collection="skills",
@@ -1078,22 +949,22 @@ async def test_skill_write_status_allowed_when_flag_off(mcp_env, monkeypatch):
     payload = parse_envelope(out)
     assert payload["ok"] is True
     # Untouched: no validator ran, so status stays exactly as supplied.
-    assert captured["data"]["status"] == "active"
+    assert sc.upsert_document_xmax.await_args.args[0]["data"]["status"] == "active"
 
 
 # ── op=delete (active-only existence gate) ─────────────────────────
 
 
 async def test_skill_delete_hides_non_active_when_flag_on(mcp_env, monkeypatch):
-    # The status guard is folded into the DELETE's WHERE (atomic, no
-    # pre-fetch). A staged skill matches zero rows → the DELETE returns
-    # no id → the SAME generic JSON not-found a MISSING doc returns, so
-    # a non-active skill is byte-for-byte indistinguishable from a
-    # missing one (no existence leak) and the response is valid JSON.
+    # The status guard is folded into the storage DELETE's WHERE
+    # (atomic, via ``require_status``). A staged skill matches zero rows →
+    # storage returns False → the SAME generic JSON not-found a MISSING
+    # doc returns, so a non-active skill is byte-for-byte indistinguishable
+    # from a missing one (no existence leak) and the response is valid JSON.
     _patch_flag(monkeypatch, True)
-    result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = None  # status=active matched nothing
-    mcp_env["db"].execute.return_value = result_mock
+    stub_storage_client(
+        monkeypatch, delete_document=False
+    )  # status guard matched nothing
     out = await mcp_server.memclaw_doc(
         op="delete", collection="skills", doc_id="forge/x"
     )
@@ -1102,14 +973,10 @@ async def test_skill_delete_hides_non_active_when_flag_on(mcp_env, monkeypatch):
 
 
 async def test_skill_delete_allows_active_when_flag_on(mcp_env, monkeypatch):
-    from uuid import uuid4
-
-    # An active skill matches the WHERE status='active' guard → one row
-    # deleted, returns its id.
+    # An active skill matches the require_status='active' guard → one row
+    # deleted, storage returns True.
     _patch_flag(monkeypatch, True)
-    result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = uuid4()
-    mcp_env["db"].execute.return_value = result_mock
+    stub_storage_client(monkeypatch, delete_document=True)
     out = await mcp_server.memclaw_doc(
         op="delete", collection="skills", doc_id="forge/x"
     )
@@ -1126,13 +993,14 @@ async def test_skill_delete_fails_closed_on_settings_error(mcp_env, monkeypatch)
         raise RuntimeError("settings store down")
 
     monkeypatch.setattr(mcp_server, "_skills_factory_flag", _boom)
+    sc = stub_storage_client(monkeypatch, delete_document=True)
     out = await mcp_server.memclaw_doc(
         op="delete", collection="skills", doc_id="forge/x"
     )
     payload = parse_envelope(out)
     assert payload["error"]["code"] == "INTERNAL_ERROR"
     # The DELETE must never have run.
-    mcp_env["db"].execute.assert_not_called()
+    sc.delete_document.assert_not_awaited()
 
 
 # ── Cross-tenant leak: a sibling tenant's non-active skill must never
@@ -1150,9 +1018,9 @@ async def test_skill_read_hides_cross_tenant_non_active_even_when_caller_off(
     monkeypatch.setattr(
         mcp_server, "_get_readable_tenants", lambda: ["test-tenant", "sibling"]
     )
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.get_by_doc_id",
-        _async_return(_SkillRow("forge/x", status="staged", tenant_id="sibling")),
+    stub_storage_client(
+        monkeypatch,
+        get_document=_skill_doc("forge/x", status="staged", tenant_id="sibling"),
     )
     out = await mcp_server.memclaw_doc(op="read", collection="skills", doc_id="forge/x")
     assert "Not found: skills/forge/x" in strip_latency(out)
@@ -1166,14 +1034,16 @@ async def test_skill_query_drops_cross_tenant_non_active_when_caller_off(
         mcp_server, "_get_readable_tenants", lambda: ["test-tenant", "sibling"]
     )
     rows = [
-        _SkillRow("own/active", status="active", tenant_id="test-tenant"),
-        _SkillRow("own/staged", status="staged", tenant_id="test-tenant"),  # kept: caller off, same tenant
-        _SkillRow("sib/staged", status="staged", tenant_id="sibling"),  # dropped: cross-tenant non-active
-        _SkillRow("sib/active", status="active", tenant_id="sibling"),  # kept: active
+        _skill_doc("own/active", status="active", tenant_id="test-tenant"),
+        _skill_doc(
+            "own/staged", status="staged", tenant_id="test-tenant"
+        ),  # kept: caller off, same tenant
+        _skill_doc(
+            "sib/staged", status="staged", tenant_id="sibling"
+        ),  # dropped: cross-tenant non-active
+        _skill_doc("sib/active", status="active", tenant_id="sibling"),  # kept: active
     ]
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.query", _async_return(rows)
-    )
+    stub_storage_client(monkeypatch, query_documents=rows)
     out = await mcp_server.memclaw_doc(op="query", collection="skills")
     payload = parse_envelope(out)
     ids = {r["doc_id"] for r in payload["results"]}
@@ -1191,14 +1061,14 @@ async def test_skill_search_drops_cross_tenant_non_active_when_caller_off(
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    pairs = [
-        (_SkillRow("sib/staged", status="staged", tenant_id="sibling"), 0.9),
-        (_SkillRow("sib/active", status="active", tenant_id="sibling"), 0.8),
-        (_SkillRow("own/staged", status="staged", tenant_id="test-tenant"), 0.7),
+    hits = [
+        _skill_hit("sib/staged", status="staged", similarity=0.9, tenant_id="sibling"),
+        _skill_hit("sib/active", status="active", similarity=0.8, tenant_id="sibling"),
+        _skill_hit(
+            "own/staged", status="staged", similarity=0.7, tenant_id="test-tenant"
+        ),
     ]
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.search", _async_return(pairs)
-    )
+    stub_storage_client(monkeypatch, search_documents_vector=hits)
     # Broad search (collection=None) over the readable set.
     out = await mcp_server.memclaw_doc(op="search", query="deploy")
     payload = parse_envelope(out)
@@ -1214,14 +1084,17 @@ async def test_list_collections_skill_count_active_only_when_flag_on(
     mcp_env, monkeypatch
 ):
     _patch_flag(monkeypatch, True)
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.list_collections",
-        _async_return([("customers", 5), ("skills", 9)]),
+    # The active-only recount issues one COUNT via the storage client.
+    stub_storage_client(
+        monkeypatch,
+        list_document_collections={
+            "collections": [
+                {"name": "customers", "count": 5},
+                {"name": "skills", "count": 9},
+            ]
+        },
+        document_count_in_collection=3,  # only 3 of the 9 skills are active
     )
-    # The active-only recount issues one COUNT via db.execute.
-    result_mock = MagicMock()
-    result_mock.scalar_one.return_value = 3  # only 3 of the 9 skills are active
-    mcp_env["db"].execute.return_value = result_mock
     out = await mcp_server.memclaw_doc(op="list_collections")
     payload = parse_envelope(out)
     counts = {c["name"]: c["count"] for c in payload["collections"]}
@@ -1233,9 +1106,9 @@ async def test_list_collections_skill_count_unchanged_when_flag_off(
     mcp_env, monkeypatch
 ):
     _patch_flag(monkeypatch, False)
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.list_collections",
-        _async_return([("skills", 9)]),
+    stub_storage_client(
+        monkeypatch,
+        list_document_collections={"collections": [{"name": "skills", "count": 9}]},
     )
     out = await mcp_server.memclaw_doc(op="list_collections")
     payload = parse_envelope(out)
@@ -1254,15 +1127,7 @@ async def test_skill_write_rejects_case_variant_status_key_when_flag_on(
     # field. Reject it outright.
     _patch_flag(monkeypatch, True)
     _patch_sf_settings(monkeypatch)
-    called = {"upsert": False}
-
-    async def fake_upsert(db, **kwargs):  # noqa: ARG001
-        called["upsert"] = True
-        return _UpsertRow(xmax=0)
-
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.upsert_returning_xmax", fake_upsert
-    )
+    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
     out = await mcp_server.memclaw_doc(
         op="write",
         collection="skills",
@@ -1272,7 +1137,7 @@ async def test_skill_write_rejects_case_variant_status_key_when_flag_on(
     payload = parse_envelope(out)
     assert payload["error"]["code"] == "INVALID_ARGUMENTS"
     assert "status" in payload["error"]["message"].lower()
-    assert called["upsert"] is False
+    sc.upsert_document_xmax.assert_not_awaited()
 
 
 async def test_safe_int_degrades_bool_and_garbage_to_default():
@@ -1288,7 +1153,9 @@ async def test_safe_int_degrades_bool_and_garbage_to_default():
     assert mcp_server._safe_int("4096", 160) == 4096
 
 
-async def test_skills_factory_enabled_fails_closed_on_settings_error(mcp_env, monkeypatch):
+async def test_skills_factory_enabled_fails_closed_on_settings_error(
+    mcp_env, monkeypatch
+):
     # The read-path helper must fail CLOSED: if the strict flag lookup
     # raises, assume enabled (True) so the active-only filter is applied
     # and non-active skills can't leak during a settings outage.
@@ -1300,16 +1167,17 @@ async def test_skills_factory_enabled_fails_closed_on_settings_error(mcp_env, mo
     assert result is True
 
 
-async def test_skill_read_hides_non_active_when_flag_lookup_errors(mcp_env, monkeypatch):
+async def test_skill_read_hides_non_active_when_flag_lookup_errors(
+    mcp_env, monkeypatch
+):
     # End-to-end: a settings outage during a skill read filters (hides
     # the non-active skill), it does not 500 or leak.
     async def _boom(*_a, **_k):
         raise RuntimeError("settings store down")
 
     monkeypatch.setattr(mcp_server, "_skills_factory_flag", _boom)
-    monkeypatch.setattr(
-        "core_api.repositories.document_repo.get_by_doc_id",
-        _async_return(_SkillRow("forge/x", status="staged")),
+    stub_storage_client(
+        monkeypatch, get_document=_skill_doc("forge/x", status="staged")
     )
     out = await mcp_server.memclaw_doc(op="read", collection="skills", doc_id="forge/x")
     assert "Not found: skills/forge/x" in strip_latency(out)

--- a/tests/test_mcp_list.py
+++ b/tests/test_mcp_list.py
@@ -9,27 +9,26 @@ Covers:
 - Cursor vs sort/order constraint (only created_at/desc).
 - Happy path (zero rows) shape: ``{count, results, next_cursor, scope}``.
 """
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
 
 from core_api import mcp_server
-from tests._mcp_test_helpers import as_text, parse_envelope
+from tests._mcp_test_helpers import as_text, parse_envelope, stub_storage_client
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
-
-def _mock_result(rows):
-    """Build a fake SQLAlchemy Result whose .scalars().all() returns `rows`."""
-    scalars = MagicMock()
-    scalars.all.return_value = rows
-    result = MagicMock()
-    result.scalars.return_value = scalars
-    return result
+# Fix 2 Phase 4: ``memclaw_list`` ports ``memory_repo.list_by_filters`` into the
+# storage layer (``PostgresService.memory_list_by_filters``) and calls it via
+# ``sc.list_memories_by_filters(payload)``. The visibility / cursor / deleted_at
+# SQL now lives in core-storage-api (covered by its own service tests against the
+# real test DB); the core-api unit tests here assert the PAYLOAD the tool sends
+# (scope→written_by, include_deleted gating, limit clamp) and the response
+# shaping (slice + next_cursor) over stubbed storage rows.
 
 
 def _out_stub(mid: str):
@@ -45,11 +44,15 @@ async def test_list_scope_agent_allowed_at_trust_1(mcp_env, monkeypatch):
 
     async def _trust_1(db, tenant_id, agent_id, min_level):  # noqa: ARG001
         if min_level > 1:
-            return 1, False, f"Error (403): Agent 'alice' (trust_level=1) < required {min_level}."
+            return (
+                1,
+                False,
+                f"Error (403): Agent 'alice' (trust_level=1) < required {min_level}.",
+            )
         return 1, False, None
 
     monkeypatch.setattr(mcp_server, "_require_trust", _trust_1)
-    mcp_env["db"].execute.return_value = _mock_result([])
+    stub_storage_client(monkeypatch, list_memories_by_filters=[])
     out = await mcp_server.memclaw_list(agent_id="alice")  # scope='agent' by default
     assert "FORBIDDEN" not in as_text(out)
     payload = parse_envelope(out)
@@ -61,7 +64,11 @@ async def test_list_scope_fleet_blocked_at_trust_1(mcp_env, monkeypatch):
 
     async def _trust_1(db, tenant_id, agent_id, min_level):  # noqa: ARG001
         if min_level > 1:
-            return 1, False, f"Error (403): Agent 'alice' (trust_level=1) < required {min_level}."
+            return (
+                1,
+                False,
+                f"Error (403): Agent 'alice' (trust_level=1) < required {min_level}.",
+            )
         return 1, False, None
 
     monkeypatch.setattr(mcp_server, "_require_trust", _trust_1)
@@ -75,7 +82,11 @@ async def test_list_scope_all_blocked_at_trust_1(mcp_env, monkeypatch):
 
     async def _trust_1(db, tenant_id, agent_id, min_level):  # noqa: ARG001
         if min_level > 1:
-            return 1, False, f"Error (403): Agent 'alice' (trust_level=1) < required {min_level}."
+            return (
+                1,
+                False,
+                f"Error (403): Agent 'alice' (trust_level=1) < required {min_level}.",
+            )
         return 1, False, None
 
     monkeypatch.setattr(mcp_server, "_require_trust", _trust_1)
@@ -91,23 +102,22 @@ async def test_list_invalid_scope(mcp_env):
 
 async def test_list_scope_agent_rejects_foreign_written_by(mcp_env):
     """scope='agent' + written_by != caller returns 422."""
-    out = await mcp_server.memclaw_list(agent_id="alice", scope="agent", written_by="bob")
+    out = await mcp_server.memclaw_list(
+        agent_id="alice", scope="agent", written_by="bob"
+    )
     assert "INVALID_ARGUMENTS" in as_text(out)
     assert "written_by must be omitted" in as_text(out)
 
 
 async def test_list_scope_agent_forces_written_by(mcp_env, monkeypatch):
     """scope='agent' forces written_by to the caller's agent_id."""
-    captured_kwargs = {}
-
-    async def capture_list(db, **kwargs):
-        captured_kwargs.update(kwargs)
-        return []
-
-    monkeypatch.setattr(mcp_server.memory_repo, "list_by_filters", capture_list)
-    mcp_env["db"].execute.return_value = _mock_result([])
+    sc = stub_storage_client(monkeypatch, list_memories_by_filters=[])
     await mcp_server.memclaw_list(agent_id="alice", scope="agent")
-    assert captured_kwargs["written_by"] == "alice"
+    payload = sc.list_memories_by_filters.await_args.args[0]
+    assert payload["written_by"] == "alice"
+    # scope='agent' must NOT widen via the readable set.
+    assert payload["readable_tenant_ids"] is None
+    assert payload["caller_agent_id"] == "alice"
 
 
 async def test_list_invalid_memory_type(mcp_env):
@@ -145,49 +155,43 @@ async def test_list_cursor_with_asc_order_errors(mcp_env):
 
 
 async def test_list_invalid_cursor_payload(mcp_env):
-    mcp_env["db"].execute.return_value = _mock_result([])
     out = await mcp_server.memclaw_list(cursor="@@not-base64@@")
     assert "INVALID_ARGUMENTS" in as_text(out)
     assert "Invalid cursor" in as_text(out)
 
 
 async def test_list_invalid_created_after_iso(mcp_env):
-    mcp_env["db"].execute.return_value = _mock_result([])
     out = await mcp_server.memclaw_list(created_after="not-iso")
     assert "INVALID_ARGUMENTS" in as_text(out)
     assert "created_after must be ISO8601" in as_text(out)
 
 
 async def test_list_invalid_created_before_iso(mcp_env):
-    mcp_env["db"].execute.return_value = _mock_result([])
     out = await mcp_server.memclaw_list(created_before="not-iso")
     assert "INVALID_ARGUMENTS" in as_text(out)
     assert "created_before must be ISO8601" in as_text(out)
 
 
 async def test_list_happy_path_empty_results(mcp_env, monkeypatch):
-    mcp_env["db"].execute.return_value = _mock_result([])
-    monkeypatch.setattr(
-        "core_api.services.memory_service._memory_to_out", _out_stub
-    )
+    stub_storage_client(monkeypatch, list_memories_by_filters=[])
     out = await mcp_server.memclaw_list()
     payload = parse_envelope(out)
     assert payload == {"count": 0, "results": [], "next_cursor": None, "scope": "agent"}
 
 
 async def test_list_happy_path_with_rows_and_next_cursor(mcp_env, monkeypatch):
-    """Page of 3 with limit=2 → 2 items returned + next_cursor non-null."""
-    rows = []
-    for i in range(3):
-        row = MagicMock()
-        row.id = uuid4()
-        row.created_at = datetime.now(timezone.utc)
-        rows.append(row)
-    mcp_env["db"].execute.return_value = _mock_result(rows)
-    monkeypatch.setattr(
-        "core_api.services.memory_service._memory_to_out",
-        lambda m: _out_stub(str(m.id)),
-    )
+    """Page of 3 with limit=2 → 2 items returned + next_cursor non-null.
+
+    Storage returns dict rows (``limit+1`` over-fetched); the tool slices to
+    ``limit`` and builds ``next_cursor`` from the last served row's
+    ``created_at`` + ``id``. ``_memory_to_out`` (top-level import on mcp_server)
+    accepts a dict row, so patch it there for a deterministic shape."""
+    rows = [
+        {"id": str(uuid4()), "created_at": datetime.now(timezone.utc).isoformat()}
+        for _ in range(3)
+    ]
+    stub_storage_client(monkeypatch, list_memories_by_filters=rows)
+    monkeypatch.setattr(mcp_server, "_memory_to_out", lambda m: _out_stub(m["id"]))
     out = await mcp_server.memclaw_list(limit=2)
     payload = parse_envelope(out)
     assert payload["count"] == 2
@@ -196,48 +200,35 @@ async def test_list_happy_path_with_rows_and_next_cursor(mcp_env, monkeypatch):
 
 
 async def test_list_include_deleted_requires_trust_3(mcp_env, monkeypatch):
-    """Trust 2 + include_deleted=True is silently ignored (filter still applied)."""
-    captured_where = []
+    """Trust 2 + include_deleted=True is silently ignored — core-api sends
+    ``include_deleted=False`` to storage (which keeps the deleted_at filter).
+
+    (Fix 2 Phase 4: the deleted_at SQL itself now lives in
+    ``PostgresService.memory_list_by_filters``; the trust gate is core-api's, so
+    we assert the flag core-api forwards.)"""
 
     async def _trust_2(db, tenant_id, agent_id, min_level):  # noqa: ARG001
         return 2, False, None
 
     monkeypatch.setattr(mcp_server, "_require_trust", _trust_2)
-
-    original_execute = mcp_env["db"].execute
-
-    async def capture_execute(stmt, *a, **kw):
-        # Serialize the whereclause to text for a loose structural check.
-        captured_where.append(str(stmt.whereclause))
-        return _mock_result([])
-
-    mcp_env["db"].execute = capture_execute
-    try:
-        await mcp_server.memclaw_list(agent_id="alice", include_deleted=True)
-    finally:
-        mcp_env["db"].execute = original_execute
-
-    # Deleted-at IS NULL filter should still be present for trust 2.
-    assert any("deleted_at IS NULL" in w for w in captured_where)
+    sc = stub_storage_client(monkeypatch, list_memories_by_filters=[])
+    await mcp_server.memclaw_list(agent_id="alice", include_deleted=True)
+    payload = sc.list_memories_by_filters.await_args.args[0]
+    assert payload["include_deleted"] is False
 
 
 async def test_list_include_deleted_honored_at_trust_3(mcp_env, monkeypatch):
-    """Trust 3 with include_deleted=True drops the deleted_at filter."""
-    captured_where = []
+    """Trust 3 with include_deleted=True forwards ``include_deleted=True`` to
+    storage (which then drops the deleted_at filter)."""
 
     async def _trust_3(db, tenant_id, agent_id, min_level):  # noqa: ARG001
         return 3, False, None
 
     monkeypatch.setattr(mcp_server, "_require_trust", _trust_3)
-
-    async def capture_execute(stmt, *a, **kw):
-        captured_where.append(str(stmt.whereclause))
-        return _mock_result([])
-
-    mcp_env["db"].execute = capture_execute
+    sc = stub_storage_client(monkeypatch, list_memories_by_filters=[])
     await mcp_server.memclaw_list(agent_id="admin", include_deleted=True)
-    # deleted_at IS NULL must not be in the predicate.
-    assert all("deleted_at IS NULL" not in w for w in captured_where)
+    payload = sc.list_memories_by_filters.await_args.args[0]
+    assert payload["include_deleted"] is True
 
 
 async def test_list_auth_failure_shortcircuits(monkeypatch):
@@ -247,23 +238,15 @@ async def test_list_auth_failure_shortcircuits(monkeypatch):
 
 
 async def test_list_limit_clamped_to_1_50(mcp_env, monkeypatch):
-    """limit=999 gets clamped to 50; limit=0 gets clamped to 1."""
-    captured_limits = []
+    """limit=999 gets clamped to 50; limit=0 gets clamped to 1.
 
-    async def capture_execute(stmt, *a, **kw):
-        compiled = stmt.compile(compile_kwargs={"literal_binds": True})
-        text = str(compiled)
-        # SQL "LIMIT N" — look for the integer after the last LIMIT keyword.
-        import re
+    Fix 2 Phase 4: core-api forwards the CLAMPED ``limit`` in the storage
+    payload; ``PostgresService.memory_list_by_filters`` adds the ``+1``
+    over-fetch internally. So we assert the clamped value core-api sends."""
+    sc = stub_storage_client(monkeypatch, list_memories_by_filters=[])
 
-        m = re.search(r"LIMIT\s+(\d+)", text)
-        captured_limits.append(int(m.group(1)) if m else -1)
-        return _mock_result([])
-
-    mcp_env["db"].execute = capture_execute
     await mcp_server.memclaw_list(limit=999)
-    # Handler passes limit+1 to SQL; clamp is 50 → 51 reaches SQL.
-    assert captured_limits[-1] == 51
+    assert sc.list_memories_by_filters.await_args.args[0]["limit"] == 50
 
     await mcp_server.memclaw_list(limit=0)
-    assert captured_limits[-1] == 2  # clamped to 1 → passed limit+1=2
+    assert sc.list_memories_by_filters.await_args.args[0]["limit"] == 1

--- a/tests/test_mcp_manage.py
+++ b/tests/test_mcp_manage.py
@@ -9,6 +9,7 @@ Covers:
 - ``op=delete`` success.
 - Service ``HTTPException`` → ``Error (…)`` envelope.
 """
+
 from __future__ import annotations
 
 from uuid import uuid4
@@ -17,7 +18,12 @@ import pytest
 from fastapi import HTTPException
 
 from core_api import mcp_server
-from tests._mcp_test_helpers import as_text, parse_envelope, strip_latency
+from tests._mcp_test_helpers import (
+    as_text,
+    parse_envelope,
+    stub_storage_client,
+    strip_latency,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
@@ -25,25 +31,33 @@ pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 VALID_UID = str(uuid4())
 
 
-class _MemoryRow:
-    """Stand-in for the SQLAlchemy Memory row returned by get_by_id_for_tenant."""
+def _memory_dict(status="active", agent_id="alice", content="hello"):
+    """Storage-client memory row (Fix 2 Phase 4: ``sc.get_memory_for_tenant``
+    returns a plain dict, not an ORM row). ``memclaw_manage`` reads it via
+    ``.get(...)`` so all the fields the read/transition shaping touches are
+    present as dict keys."""
+    from datetime import datetime, timezone
 
-    def __init__(self, status="active", agent_id="alice", content="hello"):
-        from datetime import datetime, timezone
-
-        self.id = uuid4()
-        self.agent_id = agent_id
-        self.fleet_id = None
-        self.memory_type = "fact"
-        self.status = status
-        self.weight = 0.5
-        self.visibility = "scope_team"
-        self.title = "t"
-        self.summary = "s"
-        self.content = content
-        self.created_at = datetime.now(timezone.utc)
-        self.updated_at = self.created_at
-        self.metadata_ = {}
+    mid = uuid4()
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "id": str(mid),
+        "agent_id": agent_id,
+        "fleet_id": None,
+        "memory_type": "fact",
+        "status": status,
+        "weight": 0.5,
+        "visibility": "scope_team",
+        "title": "t",
+        "summary": "s",
+        "content": content,
+        "created_at": now,
+        "updated_at": now,
+        "last_recalled_at": None,
+        "recall_count": 0,
+        "deleted_at": None,
+        "metadata_": {},
+    }
 
 
 async def test_manage_invalid_op_errors(mcp_env):
@@ -68,23 +82,18 @@ async def test_manage_invalid_uuid_errors(mcp_env):
 
 
 async def test_manage_read_not_found(mcp_env, monkeypatch):
-    monkeypatch.setattr(
-        "core_api.repositories.memory_repo.get_by_id_for_tenant",
-        _async_return(None),
-    )
+    stub_storage_client(monkeypatch, get_memory_for_tenant=None)
     out = await mcp_server.memclaw_manage(op="read", memory_id=VALID_UID)
     assert "Memory not found" in strip_latency(out)
 
 
 async def test_manage_read_happy_path(mcp_env, monkeypatch):
-    memory = _MemoryRow()
-    monkeypatch.setattr(
-        "core_api.repositories.memory_repo.get_by_id_for_tenant",
-        _async_return(memory),
-    )
+    memory = _memory_dict()
+    stub_storage_client(monkeypatch, get_memory_for_tenant=memory)
+    monkeypatch.setattr(mcp_server, "authorize_memory_access", _async_return(True))
     out = await mcp_server.memclaw_manage(op="read", memory_id=VALID_UID)
     payload = parse_envelope(out)
-    assert payload["id"] == str(memory.id)
+    assert payload["id"] == memory["id"]
     assert payload["content"] == "hello"
     assert payload["memory_type"] == "fact"
 
@@ -104,10 +113,7 @@ async def test_manage_transition_invalid_status_errors(mcp_env):
 
 
 async def test_manage_transition_not_found(mcp_env, monkeypatch):
-    monkeypatch.setattr(
-        "core_api.repositories.memory_repo.get_by_id_for_tenant",
-        _async_return(None),
-    )
+    stub_storage_client(monkeypatch, get_memory_for_tenant=None)
     out = await mcp_server.memclaw_manage(
         op="transition", memory_id=VALID_UID, status="archived"
     )
@@ -115,21 +121,19 @@ async def test_manage_transition_not_found(mcp_env, monkeypatch):
 
 
 async def test_manage_transition_happy_path(mcp_env, monkeypatch):
-    memory = _MemoryRow(status="active")
-    monkeypatch.setattr(
-        "core_api.repositories.memory_repo.get_by_id_for_tenant",
-        _async_return(memory),
+    memory = _memory_dict(status="active")
+    sc = stub_storage_client(
+        monkeypatch,
+        get_memory_for_tenant=memory,
+        update_memory_status=None,
     )
-    monkeypatch.setattr(
-        "core_api.repositories.memory_repo.update_status", _async_return(None)
-    )
-    monkeypatch.setattr(
-        "core_api.services.audit_service.log_action", _async_return(None)
-    )
+    monkeypatch.setattr(mcp_server, "authorize_memory_access", _async_return(True))
+    monkeypatch.setattr(mcp_server, "log_action", _async_return(None))
     out = await mcp_server.memclaw_manage(
         op="transition", memory_id=VALID_UID, status="archived"
     )
     assert "active -> archived" in strip_latency(out)
+    sc.update_memory_status.assert_awaited_once()
 
 
 async def test_manage_update_no_fields_errors(mcp_env):

--- a/tests/test_mcp_recall.py
+++ b/tests/test_mcp_recall.py
@@ -8,6 +8,13 @@ Covers:
 - ``top_k`` is capped at ``MAX_SEARCH_TOP_K``.
 - ``HTTPException`` from the service → ``Error (…)`` envelope.
 - Auth failure short-circuits.
+
+Fix 2 Phase 4: ``memclaw_recall`` routes its DB access through the storage
+client (``sc.get_agent`` replaces ``agent_repo.get_by_id``) and resolves
+``resolve_config`` / ``summarize_memories`` via top-level imports bound on the
+``mcp_server`` module, so tests patch those names on ``mcp_server`` and stub the
+storage client's ``get_agent`` rather than the legacy repo path. No
+``_mcp_session`` is opened on this path anymore.
 """
 
 from __future__ import annotations
@@ -16,7 +23,7 @@ import pytest
 from fastapi import HTTPException
 
 from core_api import mcp_server
-from tests._mcp_test_helpers import as_text, parse_envelope
+from tests._mcp_test_helpers import as_text, parse_envelope, stub_storage_client
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
@@ -32,17 +39,22 @@ class _MemoryStub:
         return {"id": self.mid, "score": self.score}
 
 
+def _wire_recall_deps(monkeypatch):
+    """Patch the storage-routed deps recall now resolves on ``mcp_server``.
+
+    - ``resolve_config`` (top-level import on mcp_server) → fake config.
+    - storage client ``get_agent`` → None (no agent profile / fleet scope).
+    """
+    monkeypatch.setattr(mcp_server, "resolve_config", _fake_resolve_config)
+    return stub_storage_client(monkeypatch, get_agent=None)
+
+
 async def test_recall_happy_path(mcp_env, monkeypatch):
     """Standard query returns JSON with `results` and no `brief`."""
     search_mock = mcp_env["service"]("search_memories")
     search_mock.return_value = [_MemoryStub("m-1"), _MemoryStub("m-2")]
 
-    # Patch the late-imported config/profile dependencies.
-    monkeypatch.setattr(
-        "core_api.services.organization_settings.resolve_config",
-        _fake_resolve_config,
-    )
-    monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
+    _wire_recall_deps(monkeypatch)
 
     out = await mcp_server.memclaw_recall(query="what do I know about onboarding?")
     payload = parse_envelope(out)
@@ -55,21 +67,15 @@ async def test_recall_happy_path(mcp_env, monkeypatch):
 async def test_recall_with_include_brief(mcp_env, monkeypatch):
     """`include_brief=True` runs the brief call and merges it.
 
-    Audit P3: ``memclaw_recall`` now closes its DB session before
-    invoking the brief LLM step. Patch ``summarize_memories`` (the
-    LLM-only helper) rather than the legacy ``recall()`` wrapper —
-    the tool no longer reaches the wrapper path.
+    Patch ``summarize_memories`` (the LLM-only helper) on ``mcp_server`` — it's
+    a top-level import there, so patching the source module would not rebind the
+    name the handler calls.
     """
     mcp_env["service"]("search_memories").return_value = [_MemoryStub("m-1")]
 
     brief_mock = _fake_async_return({"summary": "alice onboarded last quarter"})
-    monkeypatch.setattr(
-        "core_api.services.recall_service.summarize_memories", brief_mock
-    )
-    monkeypatch.setattr(
-        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
-    )
-    monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
+    monkeypatch.setattr(mcp_server, "summarize_memories", brief_mock)
+    _wire_recall_deps(monkeypatch)
 
     out = await mcp_server.memclaw_recall(query="status?", include_brief=True)
     payload = parse_envelope(out)
@@ -79,10 +85,7 @@ async def test_recall_with_include_brief(mcp_env, monkeypatch):
 
 async def test_recall_empty_results(mcp_env, monkeypatch):
     mcp_env["service"]("search_memories").return_value = []
-    monkeypatch.setattr(
-        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
-    )
-    monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
+    _wire_recall_deps(monkeypatch)
 
     out = await mcp_server.memclaw_recall(query="nothing matches")
     payload = parse_envelope(out)
@@ -107,10 +110,7 @@ async def test_recall_top_k_is_capped(mcp_env, monkeypatch):
 
     search_mock = mcp_env["service"]("search_memories")
     search_mock.return_value = []
-    monkeypatch.setattr(
-        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
-    )
-    monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
+    _wire_recall_deps(monkeypatch)
 
     await mcp_server.memclaw_recall(query="x", top_k=1000)
     kwargs = search_mock.await_args.kwargs
@@ -122,10 +122,7 @@ async def test_recall_http_exception_becomes_error_envelope(mcp_env, monkeypatch
     mcp_env["service"]("search_memories").side_effect = HTTPException(
         status_code=429, detail="rate limited"
     )
-    monkeypatch.setattr(
-        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
-    )
-    monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
+    _wire_recall_deps(monkeypatch)
 
     out = await mcp_server.memclaw_recall(query="x")
     assert "RATE_LIMITED" in as_text(out)
@@ -140,49 +137,45 @@ async def test_recall_auth_failure_shortcircuits(monkeypatch):
     assert out == mcp_server._AUTH_ERROR
 
 
-async def test_recall_closes_session_before_brief_llm_call(mcp_env, monkeypatch):
-    """Audit P3: the DB session must be closed before the LLM brief
-    fires, otherwise a pooled connection is pinned across the multi-
-    second OpenAI round-trip. We assert this by patching
-    ``_mcp_session`` to track its enter/exit timestamps and patching
-    ``summarize_memories`` to record when it ran, then comparing the
-    timestamps."""
+async def test_recall_brief_runs_after_search_no_db_held(mcp_env, monkeypatch):
+    """Audit P3 (post-Fix-2-Phase-4): recall no longer opens ``_mcp_session``,
+    so a pooled DB connection can never be pinned across the multi-second LLM
+    brief. We assert the structural invariant directly: the brief runs strictly
+    AFTER ``search_memories`` returns, and ``_mcp_session`` is never entered."""
+    import contextlib
     import time as _time
-    from contextlib import asynccontextmanager
-    from unittest.mock import MagicMock
 
-    mcp_env["service"]("search_memories").return_value = [_MemoryStub("m-1")]
-
-    session_exited_at: dict = {"t": None}
+    search_returned_at: dict = {"t": None}
     brief_started_at: dict = {"t": None}
+    session_opened: dict = {"v": False}
 
-    @asynccontextmanager
-    async def _tracking_session():
-        db = MagicMock()
-        try:
-            yield db
-        finally:
-            session_exited_at["t"] = _time.perf_counter()
+    async def _tracking_search(*_args, **_kwargs):
+        search_returned_at["t"] = _time.perf_counter()
+        return [_MemoryStub("m-1")]
 
     async def _tracking_summarize(*_args, **_kwargs):
         brief_started_at["t"] = _time.perf_counter()
         return {"summary": "anything"}
 
+    @contextlib.asynccontextmanager
+    async def _tracking_session():
+        session_opened["v"] = True
+        yield None
+
+    monkeypatch.setattr(mcp_server, "search_memories", _tracking_search)
+    monkeypatch.setattr(mcp_server, "summarize_memories", _tracking_summarize)
     monkeypatch.setattr(mcp_server, "_mcp_session", _tracking_session)
-    monkeypatch.setattr(
-        "core_api.services.recall_service.summarize_memories", _tracking_summarize
-    )
-    monkeypatch.setattr(
-        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
-    )
-    monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
+    _wire_recall_deps(monkeypatch)
 
     await mcp_server.memclaw_recall(query="x", include_brief=True)
 
-    assert session_exited_at["t"] is not None, "session never exited"
+    assert search_returned_at["t"] is not None, "search never ran"
     assert brief_started_at["t"] is not None, "brief never ran"
-    assert brief_started_at["t"] >= session_exited_at["t"], (
-        "brief LLM call started while session was still open — P3 fix regressed"
+    assert brief_started_at["t"] >= search_returned_at["t"], (
+        "brief LLM call started before search returned"
+    )
+    assert session_opened["v"] is False, (
+        "recall must not open _mcp_session post-Phase-4"
     )
 
 
@@ -196,11 +189,8 @@ async def test_recall_brief_skipped_when_include_brief_false(mcp_env, monkeypatc
         calls.append(1)
         return {"summary": "should not run"}
 
-    monkeypatch.setattr("core_api.services.recall_service.summarize_memories", _spy)
-    monkeypatch.setattr(
-        "core_api.services.organization_settings.resolve_config", _fake_resolve_config
-    )
-    monkeypatch.setattr("core_api.repositories.agent_repo.get_by_id", _async_none)
+    monkeypatch.setattr(mcp_server, "summarize_memories", _spy)
+    _wire_recall_deps(monkeypatch)
 
     out = await mcp_server.memclaw_recall(query="x")
     payload = parse_envelope(out)

--- a/tests/test_memory_byid_authz.py
+++ b/tests/test_memory_byid_authz.py
@@ -21,6 +21,7 @@ import pytest
 from core_api.services import agent_service
 from core_api.services.agent_service import authorize_memory_access
 
+from tests._mcp_test_helpers import stub_storage_client
 from tests.conftest import parse_envelope  # noqa: F401  (re-exported MCP helper)
 
 
@@ -29,15 +30,6 @@ from tests.conftest import parse_envelope  # noqa: F401  (re-exported MCP helper
 # ---------------------------------------------------------------------------
 
 pytestmark_unit = pytest.mark.unit
-
-
-class _FakeMem:
-    def __init__(self, *, visibility, agent_id, fleet_id, **extra):
-        self.visibility = visibility
-        self.agent_id = agent_id
-        self.fleet_id = fleet_id
-        for k, v in extra.items():
-            setattr(self, k, v)
 
 
 @pytest.fixture
@@ -134,35 +126,38 @@ async def test_unknown_agent_allowed(patch_lookup):
 
 
 def _fake_read_row(*, visibility, agent_id, fleet_id):
+    # Fix 2 Phase 4: ``memclaw_manage`` op=read fetches via the storage client
+    # (``sc.get_memory_for_tenant``), which returns a plain dict — not an ORM
+    # row. The authz contract under test (``authorize_memory_access`` over the
+    # row's visibility / owner / fleet) is unchanged; only the row SHAPE is.
     mid = uuid.uuid4()
-    return mid, _FakeMem(
-        visibility=visibility,
-        agent_id=agent_id,
-        fleet_id=fleet_id,
-        id=mid,
-        content="cross-fleet secret",
-        memory_type="fact",
-        status="active",
-        weight=0.5,
-        title=None,
-        created_at=None,
-        last_recalled_at=None,
-        recall_count=0,
-        deleted_at=None,
-        metadata_=None,
-    )
+    return mid, {
+        "id": str(mid),
+        "visibility": visibility,
+        "agent_id": agent_id,
+        "fleet_id": fleet_id,
+        "content": "cross-fleet secret",
+        "memory_type": "fact",
+        "status": "active",
+        "weight": 0.5,
+        "title": None,
+        "created_at": None,
+        "last_recalled_at": None,
+        "recall_count": 0,
+        "deleted_at": None,
+        "metadata_": None,
+    }
 
 
 async def _mcp_read(mcp_env, monkeypatch, *, caller, row):
     from core_api import mcp_server
-    from core_api.repositories import memory_repo
 
     mid, mem = row
 
-    async def fake_get(db, _uid, _tenant):
-        return mem
-
-    monkeypatch.setattr(memory_repo, "get_by_id_for_tenant", fake_get)
+    # Stub the storage client's by-id read; the real ``authorize_memory_access``
+    # then runs over the returned row (``lookup_agent`` is controlled by
+    # ``patch_lookup``), exactly as the pre-migration test exercised it.
+    stub_storage_client(monkeypatch, get_memory_for_tenant=mem)
     monkeypatch.setattr(mcp_server, "_get_agent_id", lambda: caller)
     return await mcp_server.memclaw_manage(op="read", memory_id=str(mid))
 

--- a/tests/test_memory_storage_phase2.py
+++ b/tests/test_memory_storage_phase2.py
@@ -212,7 +212,9 @@ async def test_contradictions_bundle_supersessor(sc):
     older = await _write_memory(sc, tid, content="older fact", status="outdated")
     newer = await _write_memory(sc, tid, content="newer fact")
     # newer supersedes older
-    await sc.update_memory_status(newer["id"], "active", supersedes_id=older["id"])
+    await sc.update_memory_status(
+        newer["id"], "active", tenant_id=tid, supersedes_id=older["id"]
+    )
 
     # Older row sees the newer one as a supersessor.
     bundle = await sc.get_memory_contradictions(tid, older["id"])

--- a/tests/test_ph4_mcp_storage_error_envelope.py
+++ b/tests/test_ph4_mcp_storage_error_envelope.py
@@ -1,0 +1,43 @@
+"""Fix 2 Phase 4 — MCP tools surface storage HTTP errors as the canonical envelope.
+
+Regression test for the claude-review finding on PR #432: `memclaw_recall` and
+`memclaw_list` route through the storage HTTP client, whose calls raise
+`httpx.HTTPStatusError` on a non-2xx. Both must catch it and return the canonical
+error envelope rather than letting the exception escape to the MCP framework raw.
+`memclaw_recall` was missing the `except httpx.HTTPStatusError` clause its siblings
+have; `memclaw_list` had no try/except around its storage call at all.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from core_api import mcp_server
+from tests._mcp_test_helpers import parse_envelope, stub_storage_client
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+def _storage_err(status: int = 503) -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "http://storage/x")
+    return httpx.HTTPStatusError("storage down", request=req, response=httpx.Response(status, request=req))
+
+
+async def test_list_surfaces_storage_error_as_envelope(mcp_env, monkeypatch):
+    """A storage 5xx from list_memories_by_filters → error envelope, not a raw raise."""
+    sc = stub_storage_client(monkeypatch, list_memories_by_filters=[])
+    sc.list_memories_by_filters.side_effect = _storage_err()
+    out = await mcp_server.memclaw_list(agent_id="alice", scope="agent")
+    assert "error" in parse_envelope(out)
+
+
+async def test_recall_surfaces_storage_error_as_envelope(mcp_env, monkeypatch):
+    """A storage 5xx from sc.get_agent → error envelope, not a raw raise."""
+    monkeypatch.setattr(mcp_server, "resolve_config", AsyncMock(return_value=MagicMock()))
+    sc = stub_storage_client(monkeypatch, get_agent=None)
+    sc.get_agent.side_effect = _storage_err()
+    out = await mcp_server.memclaw_recall(query="anything")
+    assert "error" in parse_envelope(out)

--- a/tests/test_ph4_stats_tenant_guard.py
+++ b/tests/test_ph4_stats_tenant_guard.py
@@ -1,0 +1,22 @@
+"""Fix 2 Phase 4 — cross-tenant guard on /memories/stats-breakdown.
+
+Regression test for the claude-review finding on PR #432: the stats-breakdown
+endpoint must reject a request with no tenant scope (mirroring /list) rather than
+running its aggregation unscoped across every tenant. Exercised through the typed
+storage client bridged in-process to the storage app by the conftest ASGI fixture.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_stats_breakdown_requires_tenant_id(sc):
+    # A body lacking tenant_id (and readable_tenant_ids) must 422 — pre-fix this
+    # produced WHERE-unscoped aggregates spanning all tenants.
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await sc.memory_stats_breakdown({})
+    assert exc_info.value.response.status_code == 422

--- a/tests/test_ph4_status_tenant_guard.py
+++ b/tests/test_ph4_status_tenant_guard.py
@@ -1,0 +1,179 @@
+"""Ph4 PR #432 round-3 review fixes — storage-layer regression tests.
+
+Two findings exercised here, both at the storage service / typed-client level
+(bridged in-process to the storage app by the conftest ASGI fixture, against the
+test DB):
+
+- FIX 1 (HIGH): ``memory_update_status`` now requires a ``tenant_id`` and scopes
+  its UPDATE to ``Memory.tenant_id == tenant_id``. A caller in tenant B must not
+  be able to flip the status of tenant A's memory by id (cross-tenant write gap).
+- FIX 2 (MED): ``memory_list_by_filters`` cursor predicate now branches on
+  ``order`` — an ``order="asc"`` page must walk FORWARD (toward newer rows), not
+  backward.
+
+Rows are seeded directly via the storage write path (committed, independent
+session) with explicit ``created_at`` so the cursor ordering is deterministic.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+
+from core_storage_api.services.postgres_service import PostgresService
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _t() -> str:
+    """Unique tenant id per test so concurrent suite runs don't collide."""
+    return f"test-tenant-ph4guard-{uuid4().hex[:8]}"
+
+
+async def _add_memory(
+    svc: PostgresService,
+    tenant: str,
+    *,
+    content: str = "fact",
+    status: str = "active",
+    created_at: datetime | None = None,
+) -> str:
+    data: dict = {
+        "tenant_id": tenant,
+        "agent_id": "test-agent",
+        "memory_type": "fact",
+        "content": f"{content} [{uuid4().hex[:8]}]",
+        "status": status,
+    }
+    if created_at is not None:
+        data["created_at"] = created_at
+    mem = await svc.memory_add(data)
+    return str(mem.id)
+
+
+# ---------------------------------------------------------------------------
+# FIX 1 — cross-tenant write guard on memory_update_status
+# ---------------------------------------------------------------------------
+
+
+async def test_update_status_wrong_tenant_is_a_noop():
+    """A status update for a memory in tenant A, called with the WRONG tenant,
+    must not touch the row (rowcount 0 → returns False)."""
+    svc = PostgresService()
+    tenant_a = _t()
+    tenant_b = _t()
+    mid = await _add_memory(svc, tenant_a, status="active")
+
+    # Wrong tenant → guarded out, no row updated.
+    updated = await svc.memory_update_status(UUID(mid), "archived", tenant_id=tenant_b)
+    assert updated is False
+
+    # Row is untouched: still active.
+    rows = await svc.memory_list_by_filters(tenant_id=tenant_a, include_deleted=True)
+    by_id = {str(m.id): m for m in rows}
+    assert by_id[mid].status == "active"
+
+
+async def test_update_status_correct_tenant_updates():
+    """The same call with the correct (home) tenant updates the row."""
+    svc = PostgresService()
+    tenant_a = _t()
+    mid = await _add_memory(svc, tenant_a, status="active")
+
+    updated = await svc.memory_update_status(UUID(mid), "archived", tenant_id=tenant_a)
+    assert updated is True
+
+    rows = await svc.memory_list_by_filters(tenant_id=tenant_a, include_deleted=True)
+    by_id = {str(m.id): m for m in rows}
+    assert by_id[mid].status == "archived"
+
+
+async def test_route_status_update_cross_tenant_finds_no_row(sc):
+    """End-to-end through the typed client + PATCH route: a cross-tenant status
+    update matches no row (guarded WHERE) → the route 404s, which the client's
+    ``_patch`` helper translates to ``None`` (same convention as a nonexistent
+    id). The row's status is unchanged. The correct tenant then succeeds.
+    Confirms the full tenant_id thread (client → route → service)."""
+    svc = PostgresService()
+    tenant_a = _t()
+    tenant_b = _t()
+    mid = await _add_memory(svc, tenant_a, status="active")
+
+    # Wrong tenant: guarded out → 404 → None, and the row is untouched.
+    result = await sc.update_memory_status(mid, "archived", tenant_id=tenant_b)
+    assert result is None
+    untouched = await sc.get_memory(mid)
+    assert untouched["status"] == "active"
+
+    # Correct tenant succeeds.
+    result = await sc.update_memory_status(mid, "archived", tenant_id=tenant_a)
+    assert result is not None
+    post = await sc.get_memory(mid)
+    assert post["status"] == "archived"
+
+
+# ---------------------------------------------------------------------------
+# FIX 2 — cursor direction respects order="asc"
+# ---------------------------------------------------------------------------
+
+
+async def test_list_by_filters_asc_cursor_returns_forward_page():
+    """``order="asc"`` + a cursor must return the FORWARD page (rows NEWER than
+    the cursor). Pre-fix the predicate hardcoded ``<`` and paginated backward,
+    returning rows older than the cursor (an empty / wrong page)."""
+    svc = PostgresService()
+    tenant = _t()
+    base = datetime.now(UTC) - timedelta(hours=1)
+    # Three rows, strictly increasing created_at.
+    m1 = await _add_memory(svc, tenant, content="oldest", created_at=base)
+    m2 = await _add_memory(
+        svc, tenant, content="middle", created_at=base + timedelta(minutes=10)
+    )
+    m3 = await _add_memory(
+        svc, tenant, content="newest", created_at=base + timedelta(minutes=20)
+    )
+
+    # Full asc list establishes the expected order.
+    full = await svc.memory_list_by_filters(tenant_id=tenant, order="asc")
+    full_ids = [str(m.id) for m in full]
+    assert full_ids == [m1, m2, m3]
+
+    # Page forward from the OLDEST row's cursor — must yield the two NEWER rows.
+    cursor = full[0]
+    page = await svc.memory_list_by_filters(
+        tenant_id=tenant,
+        order="asc",
+        cursor_ts=cursor.created_at,
+        cursor_id=cursor.id,
+    )
+    assert [str(m.id) for m in page] == [m2, m3]
+
+
+async def test_list_by_filters_desc_cursor_unchanged():
+    """``order="desc"`` (the default) still walks toward OLDER rows — the FIX 2
+    branch must not regress the desc path."""
+    svc = PostgresService()
+    tenant = _t()
+    base = datetime.now(UTC) - timedelta(hours=1)
+    m1 = await _add_memory(svc, tenant, content="oldest", created_at=base)
+    m2 = await _add_memory(
+        svc, tenant, content="middle", created_at=base + timedelta(minutes=10)
+    )
+    m3 = await _add_memory(
+        svc, tenant, content="newest", created_at=base + timedelta(minutes=20)
+    )
+
+    full = await svc.memory_list_by_filters(tenant_id=tenant, order="desc")
+    assert [str(m.id) for m in full] == [m3, m2, m1]
+
+    # Page forward from the NEWEST row's cursor — must yield the two OLDER rows.
+    cursor = full[0]
+    page = await svc.memory_list_by_filters(
+        tenant_id=tenant,
+        order="desc",
+        cursor_ts=cursor.created_at,
+        cursor_id=cursor.id,
+    )
+    assert [str(m.id) for m in page] == [m2, m1]

--- a/tests/test_storage_bulk_endpoints.py
+++ b/tests/test_storage_bulk_endpoints.py
@@ -64,7 +64,8 @@ async def test_batch_update_status_backward_compat_2field_shape(sc):
                 {"memory_id": a["id"], "status": "archived"},
                 {"memory_id": b["id"], "status": "conflicted"},
             ]
-        }
+        },
+        tenant_id=tid,
     )
     assert result["ok"] is True
     assert result["skipped"] == []
@@ -90,7 +91,8 @@ async def test_batch_update_status_sets_supersedes(sc):
                     "supersedes_id": older["id"],
                 },
             ]
-        }
+        },
+        tenant_id=tid,
     )
     assert result["ok"] is True
     assert result["skipped"] == []
@@ -106,7 +108,9 @@ async def test_batch_update_status_unset_supersedes(sc):
     newer = await _write_memory(sc, tid, "newer")
     # First set the pointer via the single-row PATCH so the unset case
     # has something to clear.
-    await sc.update_memory_status(newer["id"], "active", supersedes_id=older["id"])
+    await sc.update_memory_status(
+        newer["id"], "active", tenant_id=tid, supersedes_id=older["id"]
+    )
 
     result = await sc.batch_update_status(
         {
@@ -117,7 +121,8 @@ async def test_batch_update_status_unset_supersedes(sc):
                     "unset_supersedes": True,
                 },
             ]
-        }
+        },
+        tenant_id=tid,
     )
     assert result["ok"] is True
 
@@ -133,7 +138,9 @@ async def test_batch_update_status_cas_skip_on_mismatch(sc):
     newer = await _write_memory(sc, tid, "newer")
     other = await _write_memory(sc, tid, "third")
     # Row currently points at ``other``.
-    await sc.update_memory_status(newer["id"], "conflicted", supersedes_id=other["id"])
+    await sc.update_memory_status(
+        newer["id"], "conflicted", tenant_id=tid, supersedes_id=other["id"]
+    )
 
     # Caller's stale view: thinks the row points at ``older``.
     result = await sc.batch_update_status(
@@ -146,7 +153,8 @@ async def test_batch_update_status_cas_skip_on_mismatch(sc):
                     "expected_supersedes_id": older["id"],
                 },
             ]
-        }
+        },
+        tenant_id=tid,
     )
     # CAS gate fires: row reported as skipped, status untouched.
     assert newer["id"] in result["skipped"]
@@ -596,7 +604,7 @@ async def test_patch_memory_status_returns_404_on_missing(sc):
     a silent ``{ok: True}`` they can't distinguish from a real update.
     """
     ghost = str(uuid4())
-    result = await sc.update_memory_status(ghost, "active")
+    result = await sc.update_memory_status(ghost, "active", tenant_id=_t())
     assert result is None
 
 
@@ -705,7 +713,8 @@ async def test_batch_update_status_malformed_uuid_returns_422(sc):
 
     with pytest.raises(httpx.HTTPStatusError) as exc:
         await sc.batch_update_status(
-            {"updates": [{"memory_id": "not-a-uuid", "status": "active"}]}
+            {"updates": [{"memory_id": "not-a-uuid", "status": "active"}]},
+            tenant_id=_t(),
         )
     assert exc.value.response.status_code == 422
 
@@ -717,7 +726,8 @@ async def test_batch_update_status_missing_required_key_returns_422(sc):
 
     with pytest.raises(httpx.HTTPStatusError) as exc:
         await sc.batch_update_status(
-            {"updates": [{"memory_id": str(uuid4())}]}  # missing "status"
+            {"updates": [{"memory_id": str(uuid4())}]},  # missing "status"
+            tenant_id=_t(),
         )
     assert exc.value.response.status_code == 422
 
@@ -740,7 +750,8 @@ async def test_batch_update_status_partial_validation_failure_writes_nothing(sc)
                     {"memory_id": target["id"], "status": "archived"},
                     {"memory_id": "garbage", "status": "active"},  # crash pt
                 ]
-            }
+            },
+            tenant_id=tid,
         )
     assert exc.value.response.status_code == 422
 
@@ -944,13 +955,14 @@ async def test_batch_update_status_error_detail_omits_raw_item_repr(sc):
     resp = await sc._http.post(
         f"{sc._prefix}/memories/batch-update-status",
         json={
+            "tenant_id": _t(),
             "updates": [
                 {
                     "memory_id": str(uuid4()),
                     # status intentionally absent → KeyError
                     "supersedes_id": "secret-value-must-not-leak",
                 },
-            ]
+            ],
         },
         headers=await sc._auth_headers(read=False),
     )
@@ -972,6 +984,7 @@ async def test_batch_update_status_error_omits_malformed_uuid_value(sc):
     resp = await sc._http.post(
         f"{sc._prefix}/memories/batch-update-status",
         json={
+            "tenant_id": _t(),
             "updates": [
                 {
                     "memory_id": str(uuid4()),
@@ -979,7 +992,7 @@ async def test_batch_update_status_error_omits_malformed_uuid_value(sc):
                     # Bad UUID in supersedes_id, NOT memory_id.
                     "supersedes_id": "secret-uuid-must-not-leak-back",
                 },
-            ]
+            ],
         },
         headers=await sc._auth_headers(read=False),
     )


### PR DESCRIPTION
## Fix 2 Phase 4 — route mcp_server's 9 ready tools through core-storage-api

Continues the "no DB outside core-storage-api" migration. Routes the DB access of **9 MCP tools** off the local `_mcp_session()` (which set the RLS GUCs `app.tenant_id` / `app.readable_tenant_ids`) onto the storage HTTP client, carrying tenant scope **explicitly** as params. Builds on Ph0–3 (#427/#428/#429/#431).

**Tools migrated:** `memclaw_recall`, `memclaw_write`, `memclaw_manage`, `memclaw_entity_get`, `memclaw_tune`, `memclaw_doc`, `memclaw_list`, `memclaw_stats`, `memclaw_keystones_set`.

### New core-storage-api endpoints (+ `PostgresService` methods, + storage_client methods)
| Endpoint | Notes |
|---|---|
| `POST /memories/list` → `memory_list_by_filters` | **Visibility-scoped** list + cursor pagination + `readable_tenant_ids` widening. Verbatim port of `memory_repository.list_by_filters`. Distinct from the existing *unscoped* admin-list. |
| `POST /memories/stats-breakdown` → `memory_stats_breakdown` | GROUPING SETS (`total`/`by_type`/`by_agent`/`by_status`/`by_tenant`) + `include_deleted` CTE. Verbatim port of `compute_memory_stats`. |
| `GET /documents/collection-count` | Status-filtered active-only skills count (was a raw `db.execute` in mcp_server). |
| Widened `GET /documents/{collection}/{doc_id}` (+`readable_tenant_ids`), `DELETE` (+`require_status` atomic guard) | Cross-tenant read widening + atomic status-guarded skills delete. |

Everything else **reuses** existing Ph2/Ph3 client methods (memory CRUD/search/`soft_delete_by_ids`/`update_search_profile`, the `/documents/*` + `/fleet/*` surface, audit).

### Tenant isolation (the correctness-critical part)
Removing `_mcp_session()` for these tools means isolation is carried explicitly. Preserved exactly: **writes → home tenant only**; **reads → home + `readable_tenant_ids` only on cross-tenant reads**; **`scope='agent'` stays home-only** (forces `caller_agent_id`/`written_by`); `_UNAUTH`/`_ADMIN`/`_NO_AUTH` → empty readable ⇒ no widening. The new SQL ports keep the `tenant_id == X` vs `IN (readable)` split and the `scope_agent` visibility predicate verbatim.

**Verification beyond the gates:** ran an adversarial tenant-isolation review across the diff (writes, read-widening, the new SQL ports, sentinel handling, and whether any test assertion was weakened) — clean on all axes (one list-scope test was *strengthened*). It also caught + fixed one real regression in the in-progress work: a soft-deleted `older` memory could have leaked into lineage's `superseded_by`; restored the `older.deleted_at is None` filter client-side (matching REST `/contradictions`).

### Deferred to Ph5 (unchanged roadmap)
`memclaw_insights` + `memclaw_evolve` stay on `_mcp_session()`; capability_usage; **`_mcp_session()` deletion is the last step of Ph5**. After this PR, `fleet_repo` is fully unused and `document_repo`'s last callers are gone (both dropped at cleanup).

### Quality (`/simplify`)
Extracted `_storage_error_envelope()` (folded 6 duplicate `httpx`-error tails → 1 helper); dropped now-dead ORM-shape fallbacks in `memclaw_recall` (`sc.get_agent` returns `dict | None`).

### Gates
`ruff check` + `format --check` ✓ · `mypy` (core-api + core-storage-api) ✓ · **3507 tests pass** (incl. all `tests/test_mcp_*.py` + the cross-tenant-audit / by-id-authz isolation guards). conftest ASGI-bridges the client to in-process storage on the test engine, so the migration is test-transparent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
