### PR TITLE
test(security): de-flake test_own_tenant_memory_access_ok

### DIFF
--- a/tests/test_security_tenant_isolation.py
+++ b/tests/test_security_tenant_isolation.py
@@ -6,7 +6,7 @@ Every test runs against a real PostgreSQL instance.
 
 import pytest
 
-from tests.conftest import get_admin_headers, get_test_auth
+from tests.conftest import get_test_auth, uid
 
 
 async def _write_memory(
@@ -108,9 +108,12 @@ async def test_list_tenants_with_api_key(client):
 @pytest.mark.integration
 async def test_own_tenant_memory_access_ok(client):
     """A tenant can read their own memories normally."""
-    import uuid
-    tenant_id, headers = get_test_auth("self-org")
-    await _write_memory(client, tenant_id, headers, f"My data for tenant isolation test [{uuid.uuid4().hex[:8]}]")
+    # Unique per-run tenant: the test DB keeps storage-committed rows across
+    # sessions (they aren't rolled back like the `db` fixture), so a shared
+    # tenant accumulates memories and a freshly-written one can fall outside the
+    # default list page — making a bare ``len >= 1`` presence check flaky.
+    tenant_id, headers = get_test_auth(f"self-org-{uid()}")
+    written = await _write_memory(client, tenant_id, headers, f"My data for tenant isolation test [{uid()}]")
 
     resp = await client.get(
         f"/api/v1/memories?tenant_id={tenant_id}",
@@ -119,7 +122,9 @@ async def test_own_tenant_memory_access_ok(client):
     assert resp.status_code == 200
     data = resp.json()
     items = data.get("items", data) if isinstance(data, dict) and "items" in data else data
-    assert len(items) >= 1
+    # The just-written memory is readable (robust to ambient rows) ...
+    assert any(m["id"] == written["id"] for m in items)
+    # ... and the tenant-scoped list never leaks another tenant's rows.
     assert all(m["tenant_id"] == tenant_id for m in items)
 
 


### PR DESCRIPTION
## De-flake `test_security_tenant_isolation::test_own_tenant_memory_access_ok`

`test_own_tenant_memory_access_ok` wrote a memory to a **shared** `"self-org"` tenant and asserted the listing returned `len(items) >= 1`. It intermittently failed under full-suite load (observed ~1/4 runs).

### Root cause
The test DB keeps **storage-committed rows across pytest sessions** — the storage write path commits on its own connection, so those rows are *not* rolled back like the `db` fixture's transaction. Under accumulated data, a freshly-written row can fall outside the **default list page**, so the bare `len >= 1` presence check flakes. (Confirmed the same mechanism by reproducing a sibling failure: `test_api_keystones::test_set_then_list_round_trip` fails once the shared `"default"` tenant accumulates enough keystones to push the just-set one off the page — see "Related" below.)

The cross-tenant `all(m["tenant_id"] == tenant_id)` assertion is **not** the flaky part and is **kept unchanged** — a pinned `tenant_id` scopes the list to a single tenant even for the admin key (verified in `routes/memories.py`: `tenant_id_explicit` forces `readable_tenant_ids=None`), so it's a genuine isolation invariant.

### Fix (test-only)
- Use a **unique per-run tenant** (`self-org-{uid()}`) → the listing can't pick up ambient / cross-session rows.
- Assert the **just-written memory is present by id**, not a bare count.
- Keep the cross-tenant isolation assertion unchanged.
- Drop a now-unused `get_admin_headers` import on the edited line.

### Verification
- Passes **3×** against a heavily-accumulated DB (strong stress) and on a clean full-suite run (**3507 passed**).
- `ruff check` ✓, `mypy` (core-api + core-storage-api) ✓.

Pre-existing flake; unrelated to the Fix 2 migration.

### Related (not fixed here)
The same class — *present-after-create assertions against a shared-tenant list with a default page limit* — affects other tests (e.g. `test_api_keystones::test_set_then_list_round_trip`, which uses the shared `"default"` tenant). Worth a broader pass (unique tenants / present-by-id, or a session-level committed-data reset in conftest), but out of scope for this one-test fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
