### PR TITLE
fix(core-api): keep-alive pool + bounded entity-context fan-out (VPC-connector ConnectTimeout residual)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -151,7 +151,14 @@ class CoreStorageClient:
             # Sized for 20 concurrent storm writes x ~5 storage calls
             # each = 100 in-flight at peak, plus tenant-B probe headroom
             # and a 33% burst margin.
-            limits=httpx.Limits(max_connections=200, max_keepalive_connections=150),
+            # ``keepalive_expiry`` defaults to 5s in httpx — too short for the
+            # bursty entity-context / enrichment fan-out, whose bursts arrive
+            # seconds-to-tens-of-seconds apart. At 5s the warm pool drains
+            # between bursts, so the next burst opens cold TCP handshakes that
+            # pile up at the Cloud Run VPC connector (the residual ConnectTimeout
+            # class). 90s keeps connections warm across the inter-burst gap so the
+            # fan-out reuses them instead of re-handshaking.
+            limits=httpx.Limits(max_connections=200, max_keepalive_connections=150, keepalive_expiry=90.0),
             follow_redirects=True,
         )
 

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1214,6 +1214,31 @@ def _extract_subject_canonical_identity(
     return None
 
 
+_ENTITY_CTX_FANOUT_LIMIT = 8
+
+
+async def _bounded_gather(coros, limit=_ENTITY_CTX_FANOUT_LIMIT):
+    """``asyncio.gather`` capped at ``limit`` concurrent coroutines.
+
+    The Path-C entity-context fan-out (one ``_fetch_entity_context`` per
+    candidate — up to ``_ENTITY_LINKS_DETECTION_FETCH_MAX_CANDIDATES`` — each
+    hydrating N entity links) would otherwise open dozens of simultaneous
+    storage handshakes that saturate the Cloud Run VPC connector and surface as
+    ``ConnectTimeout`` storms. Capping concurrency keeps each burst within the
+    connector's handshake headroom; combined with the storage client's warm
+    keep-alive pool the calls reuse connections instead of re-handshaking. A
+    fresh semaphore per call (bound to the running loop) sidesteps cross-loop
+    binding issues in tests. Order is preserved (``gather`` semantics).
+    """
+    sem = asyncio.Semaphore(limit)
+
+    async def _run(coro):
+        async with sem:
+            return await coro
+
+    return await asyncio.gather(*(_run(c) for c in coros))
+
+
 async def _fetch_entity_context(sc, memory_id: str) -> list[dict]:
     """Fetch and denormalise ``MemoryEntityLink`` rows for a single memory.
 
@@ -1269,7 +1294,7 @@ async def _fetch_entity_context(sc, memory_id: str) -> list[dict]:
             "entity_id": str(entity_id),
         }
 
-    hydrated = await asyncio.gather(*(_hydrate(link) for link in links))
+    hydrated = await _bounded_gather([_hydrate(link) for link in links])
     return [h for h in hydrated if h is not None]
 
 
@@ -1739,9 +1764,11 @@ async def detect_contradictions_by_entities_async(
         else:
             try:
                 fetched = await asyncio.wait_for(
-                    asyncio.gather(
-                        _fetch_entity_context(sc, str(memory_id)),
-                        *(_fetch_entity_context(sc, str(c.get("id"))) for c in candidates),
+                    _bounded_gather(
+                        [
+                            _fetch_entity_context(sc, str(memory_id)),
+                            *(_fetch_entity_context(sc, str(c.get("id"))) for c in candidates),
+                        ]
                     ),
                     timeout=_CONTEXT_FETCH_TIMEOUT_SECONDS,
                 )

--- a/tests/test_contradiction_fanout_bounded.py
+++ b/tests/test_contradiction_fanout_bounded.py
@@ -1,0 +1,38 @@
+"""The Path-C entity-context fan-out is concurrency-bounded.
+
+Guards the connector-residual reliability fix: ``_bounded_gather`` must cap how
+many entity-context coroutines run at once (so the fan-out can't open dozens of
+simultaneous storage handshakes and saturate the VPC connector) while preserving
+result order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from core_api.services.contradiction_detector import _bounded_gather
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+async def test_bounded_gather_caps_concurrency_and_preserves_order():
+    active = 0
+    peak = 0
+
+    async def _work(i: int) -> int:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        try:
+            await asyncio.sleep(0.005)
+            return i
+        finally:
+            active -= 1
+
+    results = await _bounded_gather([_work(i) for i in range(30)], limit=5)
+
+    assert results == list(range(30)), "order must be preserved (gather semantics)"
+    assert peak <= 5, f"concurrency exceeded the cap: peak={peak}"
+    assert peak > 1, "sanity: work did run concurrently up to the cap"


### PR DESCRIPTION
## Keep-alive pool + bounded entity-context fan-out — stop the VPC-connector ConnectTimeout storms

Addresses the **residual VPC-connector cold-handshake class** (Ran's `BUG-staging-vpc-connector-saturation`, re-confirmed in the 2026-06-21 post-promote triage). The `e2-standard-4` connector upgrade raised the ceiling, but **bursts of simultaneous cold TCP handshakes** still trip it. Triage data (staging core-api, 6h): **174 `ConnectTimeout`s**, dominated by the Path-C entity-context fan-out — `GET /memories/<id>` ×124, `/entities/*` ×26 — plus `/audit-logs/bulk` ×16 (the audit "events lost"). Almost all `attempt 1/5` = brand-new connections.

### Two app-side levers (no infra change)
1. **`storage_client._make_pool`: `keepalive_expiry=90s`** (was httpx's 5s default). The fan-out's bursts arrive seconds-to-tens-of-seconds apart; at 5s the warm keep-alive pool drained *between* bursts, so the next burst re-handshook. 90s keeps connections warm across the gap → the fan-out **reuses** them. (`max_keepalive_connections=150` was already generous — expiry was the missing piece.)
2. **`contradiction_detector`: bound the Path-C entity-context fan-out** via a `_bounded_gather` helper (limit 8), applied to both the per-candidate `_fetch_entity_context` fan-out (candidates up to **40**) and the per-link `_hydrate` fan-out — so one burst can't open dozens of simultaneous handshakes. Order preserved (gather semantics); fresh per-call semaphore (loop-safe).

Together: warm reuse eliminates the cold handshakes; the cap keeps any cold burst within the connector's handshake headroom. **Benefits all storage callers** (entity-context, audit-flush, etc.), so it also reduces the `/audit-logs/bulk` connect-timeout "events lost".

### Verification
- New unit test: `_bounded_gather` caps concurrency (peak ≤ limit) + preserves order.
- The **41 existing Path-C tests** (`caura_131` entity-aware detection, `caura_130` safety, `a4_13` retraction, storage-client pool recovery) still pass — behavior unchanged.
- `ruff check` + `format --check` ✓, `mypy` (core-api + core-storage-api) ✓, full suite green.

Independent of the Fix 2 migration.

### Related / not in this PR
- **Embedding (TEI) timeouts** ride a *separate* httpx client (already timeout-tuned per #332). Same `keepalive_expiry` idea may apply there — flagging as a follow-up rather than touching a second client here.
- **Audit-flush durability** (don't silently drop events on connect failure — retry/dead-letter) is the other lever from triage; this PR removes most of the *triggering* timeouts, but durable audit is worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
