### PR TITLE
fix(core-api): per-tenant embed concurrency cap (noisy-neighbor-search)

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -208,6 +208,20 @@ class Settings(BaseSettings):
     # search/list ops) while still tripping under a genuine storm.
     per_tenant_search_concurrency: int = 32
     per_tenant_write_concurrency: int = 16
+    # Per-tenant cap on concurrent embedding-backend (TEI) calls. Gates
+    # only the single-flight cold-miss leader in
+    # ``memory_service._get_or_cache_embedding`` (cache hits / in-flight
+    # joiners take no slot), so one hot tenant's search storm can't
+    # occupy the whole embedding service and starve other tenants
+    # (noisy-neighbor-search). The TEI backend is a fixed pool
+    # (``staging-memclaw-tei``: 2 instances x containerConcurrency 10 =
+    # ~20 slots, no autoscale); with cap N on M core-api instances a
+    # single tenant holds at most ``N * M`` of those, leaving headroom
+    # for everyone else. Tighter than ``per_tenant_search_concurrency``
+    # on purpose: a tenant may have many searches in flight but only a
+    # few concurrent cold embeds. Fast-fails 429 like the other
+    # route-entry caps rather than queueing behind TEI.
+    per_tenant_embed_concurrency: int = 6
     # Deeper bulkhead at the storage roundtrip itself
     # (CAURA-602 follow-up). Smaller than the route-entry caps above
     # because each request only holds the storage slot for the actual

--- a/core-api/src/core_api/middleware/per_tenant_concurrency.py
+++ b/core-api/src/core_api/middleware/per_tenant_concurrency.py
@@ -41,7 +41,7 @@ from core_api.config import settings
 
 logger = logging.getLogger(__name__)
 
-Scope = Literal["write", "search", "storage_write", "storage_search"]
+Scope = Literal["write", "search", "embed", "storage_write", "storage_search"]
 
 # Per-(scope, tenant) state. Read-modify-write of ``_TENANT_SEMAPHORES``
 # in ``_get_semaphore`` is safe without a lock because asyncio runs one
@@ -63,6 +63,8 @@ def _cap_for(scope: Scope) -> int:
         return settings.per_tenant_write_concurrency
     if scope == "search":
         return settings.per_tenant_search_concurrency
+    if scope == "embed":
+        return settings.per_tenant_embed_concurrency
     if scope == "storage_write":
         return settings.per_tenant_storage_write_concurrency
     if scope == "storage_search":
@@ -93,25 +95,26 @@ def _get_semaphore(scope: Scope, tenant_id: str) -> asyncio.Semaphore:
 
 @asynccontextmanager
 async def per_tenant_slot(
-    scope: Literal["write", "search"],
+    scope: Literal["write", "search", "embed"],
     tenant_id: str,
 ) -> AsyncIterator[None]:
     """Acquire one of the per-tenant slots for ``scope``, or raise 429
     fast.
 
     Cap is read from ``Settings`` (``per_tenant_write_concurrency`` /
-    ``per_tenant_search_concurrency``) at semaphore-creation time.
-    Use as a context manager around the request handler body. Releases
-    on exit (success or exception) so a handler raising 5xx still
-    frees the slot.
+    ``per_tenant_search_concurrency`` / ``per_tenant_embed_concurrency``)
+    at semaphore-creation time. Use as a context manager around the
+    request handler body (or, for ``"embed"``, around the embedding
+    backend call). Releases on exit (success or exception) so a handler
+    raising 5xx still frees the slot.
 
-    The ``scope`` parameter is narrowed to the route-entry literals
-    only — the deeper ``"storage_*"`` scopes have different semantics
-    (unbounded queue) and live behind :func:`per_tenant_storage_slot`.
-    Passing a storage scope here would create a fast-fail 429
-    semaphore against the same ``(scope, tenant_id)`` key that the
-    storage variant uses, with no warning; the type-checker rejects
-    that mistake instead.
+    The ``scope`` parameter is narrowed to the fast-fail-429 scopes
+    (``"write"`` / ``"search"`` / ``"embed"``) — the deeper ``"storage_*"``
+    scopes have different semantics (unbounded queue) and live behind
+    :func:`per_tenant_storage_slot`. Passing a storage scope here would
+    create a fast-fail 429 semaphore against the same ``(scope,
+    tenant_id)`` key that the storage variant uses, with no warning; the
+    type-checker rejects that mistake instead.
     """
     sem = _get_semaphore(scope, tenant_id)
     try:

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
-from core_api.middleware.per_tenant_concurrency import per_tenant_storage_slot
+from core_api.middleware.per_tenant_concurrency import per_tenant_slot, per_tenant_storage_slot
 from core_api.tasks import track_task
 
 try:
@@ -2762,7 +2762,16 @@ async def _get_or_cache_embedding(query: str, tenant_id: str, tenant_config):
         # task instruction (env: ``EMBEDDING_QUERY_INSTRUCTION``) so the query
         # is encoded with the same instruction prefix the model was trained on.
         # Documents (writes) embed unmodified text.
-        embedding = await asyncio.wait_for(get_query_embedding(query, tenant_config), timeout=10.0)
+        #
+        # Per-tenant embed slot: gate the cold-miss leader so one tenant's
+        # search storm can't occupy the whole fixed TEI pool and starve
+        # other tenants (noisy-neighbor-search). Only the leader reaches
+        # here — cache hits and in-flight joiners returned above and take
+        # no slot. Held strictly across the TEI call; a 429 on acquire
+        # propagates through the ``except`` below (future + joiners) and
+        # the ``finally`` still pops the in-flight entry.
+        async with per_tenant_slot("embed", tenant_id):
+            embedding = await asyncio.wait_for(get_query_embedding(query, tenant_config), timeout=10.0)
         if embedding is None:
             raise ValueError("Embedding service unavailable")
         await cache_set(_cache_key, json.dumps(embedding), ttl=EMBEDDING_CACHE_TTL)

--- a/tests/test_per_tenant_concurrency.py
+++ b/tests/test_per_tenant_concurrency.py
@@ -39,11 +39,13 @@ def tight_caps(monkeypatch):
         *,
         write: int = 2,
         search: int = 2,
+        embed: int = 2,
         storage_write: int = 2,
         storage_search: int = 2,
     ) -> None:
         monkeypatch.setattr(settings, "per_tenant_write_concurrency", write)
         monkeypatch.setattr(settings, "per_tenant_search_concurrency", search)
+        monkeypatch.setattr(settings, "per_tenant_embed_concurrency", embed)
         monkeypatch.setattr(settings, "per_tenant_storage_write_concurrency", storage_write)
         monkeypatch.setattr(settings, "per_tenant_storage_search_concurrency", storage_search)
         per_tenant_concurrency._reset_for_tests()
@@ -136,6 +138,92 @@ async def test_tenants_isolated(tight_caps):
     finally:
         release.set()
         await holder
+
+
+# ── Embedding-backend slot (noisy-neighbor-search) ──
+
+
+async def test_embed_slot_429s_when_cap_exhausted(tight_caps):
+    """The first ``cap`` embed slots succeed; the next fast-fails 429 —
+    so a hot tenant's cold-miss search storm can't occupy the whole
+    fixed TEI pool."""
+    tight_caps(embed=2)
+
+    async def hold_slot(release: asyncio.Event) -> None:
+        async with per_tenant_slot("embed", "tenant-a"):
+            await release.wait()
+
+    release = asyncio.Event()
+    holders = [
+        asyncio.create_task(hold_slot(release)),
+        asyncio.create_task(hold_slot(release)),
+    ]
+    await asyncio.sleep(0.01)
+    try:
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            async with per_tenant_slot("embed", "tenant-a"):
+                pass
+        assert exc.value.status_code == 429
+        assert "embed" in exc.value.detail
+    finally:
+        release.set()
+        await asyncio.gather(*holders)
+
+
+async def test_embed_scope_isolated_from_search(tight_caps):
+    """``embed`` and ``search`` track separate caps for the same tenant,
+    so the nested embed gate never consumes the route-entry search
+    budget (and vice versa)."""
+    tight_caps(search=1, embed=1)
+
+    async def hold_embed(release: asyncio.Event) -> None:
+        async with per_tenant_slot("embed", "tenant-a"):
+            await release.wait()
+
+    release = asyncio.Event()
+    holder = asyncio.create_task(hold_embed(release))
+    await asyncio.sleep(0.01)
+    try:
+        # search slot for the same tenant must still be free.
+        async with per_tenant_slot("search", "tenant-a"):
+            pass
+    finally:
+        release.set()
+        await holder
+
+
+async def test_embed_tenants_isolated(tight_caps):
+    """Saturating tenant A's embed cap doesn't affect tenant B — the
+    noisy-neighbor target case for the embedding backend."""
+    tight_caps(embed=1)
+
+    async def hold(release: asyncio.Event) -> None:
+        async with per_tenant_slot("embed", "tenant-a"):
+            await release.wait()
+
+    release = asyncio.Event()
+    holder = asyncio.create_task(hold(release))
+    await asyncio.sleep(0.01)
+    try:
+        async with per_tenant_slot("embed", "tenant-b"):
+            pass
+    finally:
+        release.set()
+        await holder
+
+
+async def test_embed_slot_release_on_exception(tight_caps):
+    """An exception inside the embed slot (e.g. a TEI timeout) releases
+    it for the next caller."""
+    tight_caps(embed=1)
+    with pytest.raises(RuntimeError):
+        async with per_tenant_slot("embed", "tenant-a"):
+            raise RuntimeError("boom")
+    # Cap was 1; if the slot wasn't released we'd 429 here.
+    async with per_tenant_slot("embed", "tenant-a"):
+        pass
 
 
 # ── Storage-call slot (CAURA-602 follow-up) ──

--- a/tests/test_query_embedding_stampede_guard.py
+++ b/tests/test_query_embedding_stampede_guard.py
@@ -17,6 +17,8 @@ from unittest.mock import patch
 
 import pytest
 
+from core_api.config import settings
+from core_api.middleware import per_tenant_concurrency
 from core_api.services import memory_service
 
 pytestmark = [pytest.mark.unit]
@@ -287,3 +289,52 @@ async def test_solo_leader_failure_future_exception_is_consumed():
         c for c in handler_calls if "never retrieved" in (c.get("message") or "")
     ]
     assert not unretrieved, unretrieved
+
+
+async def test_embed_slot_only_held_by_leader(monkeypatch):
+    """The per-tenant embed slot (noisy-neighbor-search guard) is taken
+    only by the single-flight leader. With the cap pinned to 1, N
+    concurrent cold callers for the SAME query must all succeed: the
+    leader holds the one slot and joiners await its future without
+    touching the slot. If joiners each tried to acquire, callers 2..N
+    would 429 — so a clean run proves joiners are slot-free.
+    """
+    monkeypatch.setattr(settings, "per_tenant_embed_concurrency", 1)
+    per_tenant_concurrency._reset_for_tests()
+
+    embed_calls = 0
+
+    async def _slow_embed(query, tenant_config):
+        nonlocal embed_calls
+        embed_calls += 1
+        await asyncio.sleep(0.05)
+        return _FAKE_EMBED
+
+    async def _miss(_key):
+        return None
+
+    async def _noop_set(_key, _value, ttl=0):
+        return None
+
+    try:
+        with (
+            patch.object(memory_service, "get_query_embedding", new=_slow_embed),
+            patch("core_api.cache.cache_get", new=_miss),
+            patch("core_api.cache.cache_set", new=_noop_set),
+        ):
+            results = await asyncio.gather(
+                *[
+                    memory_service._get_or_cache_embedding("novel q", "tenant-A", None)
+                    for _ in range(5)
+                ],
+                return_exceptions=True,
+            )
+        # Leader released its single slot — a fresh acquire succeeds (cap=1).
+        async with per_tenant_concurrency.per_tenant_slot("embed", "tenant-A"):
+            pass
+    finally:
+        per_tenant_concurrency._reset_for_tests()
+
+    # No 429s despite cap=1: joiners never tried to take the slot.
+    assert all(r == _FAKE_EMBED for r in results), results
+    assert embed_calls == 1


### PR DESCRIPTION
## Problem
`noisy-neighbor-search` from the latest loadtest: a single tenant's 20-concurrency search storm degraded **another** tenant's search p95 by **6.43×** while Cloud Run CPU was idle. Root cause confirmed via live infra pull — the embedding backend `staging-memclaw-tei` is pinned at `minScale=2, maxScale=2, containerConcurrency=10` (1 GPU each) → only **~20 concurrent embedding slots platform-wide, no autoscale**. A hot tenant's query embeddings fill all 20 slots; other tenants' query embeds queue behind them. Route-level `per_tenant_slot("search")=32` is per-tenant and too coarse — it doesn't protect *across* tenants at the shared embedding backend.

## Fix
Cap concurrent embedding-backend calls **per tenant**, reusing the existing `per_tenant_slot` bulkhead:
- New `"embed"` scope in `middleware/per_tenant_concurrency.py` + `per_tenant_embed_concurrency` config knob (**default 6**).
- The slot wraps **only the single-flight cold-miss leader** in `memory_service._get_or_cache_embedding` (the one call that actually hits TEI) — cache hits and in-flight joiners return earlier and take no slot.
- A hot tenant fast-fails **429** on excess concurrent cold embeds rather than starving the shared pool. With cap `N` on `M` core-api instances, one tenant holds at most `N*M` of the ~20 TEI slots, leaving headroom for others.

Cap rationale: on 2 staging core-api instances a single tenant holds ≤`6×2=12`/20 (60%), ≥8 free — enough that a cold tenant-B query never queues (failure mode was 100% occupancy). Sits under the route-level search cap of 32 (many searches in flight, few concurrent cold embeds).

## Tests
`tests/test_per_tenant_concurrency.py`: `embed`-scope 429-on-exhaustion, scope isolation vs `search`, tenant isolation, release-on-exception. `tests/test_query_embedding_stampede_guard.py`: `test_embed_slot_only_held_by_leader` — N concurrent same-key cold callers all succeed at cap=1, proving joiners/cache-hits take no slot.

Local gate (CI-exact): `ruff check core-api/src/` ✓, `ruff format --check core-api/src/` ✓, `mypy core-api/src/` ✓ (192 files), `pytest` ✓ (20 passed, no DB needed for these).

## Follow-up (not in this PR)
- Ingest/worker batch embed (`ingest_service.py`) left ungated — storm is search-side; worker already bulkheaded by `per_tenant_storage_write_concurrency`.
- Pairs with a staging infra bump to TEI capacity (raise maxScale) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)