### PR TITLE
fix(core-api): resolve home fleet on omitted fleet_id for MCP writes

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -782,7 +782,19 @@ async def memclaw_write(
             # REST write path uses. Without this, MCP writes succeed without
             # ever creating an Agent row, so a follow-up
             # PATCH /agents/{id}/trust 404s.
-            await enforce_fleet_write(db, tenant_id, agent_id, fleet_id)
+            agent = await enforce_fleet_write(db, tenant_id, agent_id, fleet_id)
+            # Mirror the REST write paths (routes/memories.py:937, :1125): an
+            # omitted fleet_id resolves to the caller's home fleet, so an MCP
+            # write scopes like a REST write instead of persisting
+            # fleet_id=NULL — a NULL-fleet row silently drops out of
+            # teammates' scope_team / fleet-filtered recall. Fires only when
+            # fleet_id is falsy, so an explicit (incl. cross-fleet) fleet_id
+            # is left untouched and still passes through the trust gate
+            # enforce_fleet_write applied above. If the agent has no home
+            # fleet (never been scoped), this is a no-op and the row stays
+            # NULL — unchanged from prior behavior.
+            if not fleet_id and agent.get("fleet_id"):
+                fleet_id = agent["fleet_id"]
             if content is not None:
                 await check_and_increment(db, tenant_id, "write")
                 result = await create_memory(
@@ -1721,7 +1733,13 @@ async def memclaw_doc(
                 # Mirror memclaw_write's agent registration so a doc upsert
                 # via MCP creates the Agent row on first contact and enforces
                 # cross-fleet trust gating. WRITE → home tenant only.
-                await enforce_fleet_write(db, tenant_id, agent_id, fleet_id)
+                write_agent = await enforce_fleet_write(db, tenant_id, agent_id, fleet_id)
+                # Same home-fleet resolution as memclaw_write: keep an omitted
+                # fleet_id from publishing a fleet_id=NULL doc/skill row that
+                # fleet-scoped teammates can't discover. No-op when the agent
+                # has no home fleet.
+                if not fleet_id and write_agent.get("fleet_id"):
+                    fleet_id = write_agent["fleet_id"]
                 await check_and_increment(db, tenant_id, "write")
                 row = await sc.upsert_document_xmax(
                     {

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -306,6 +306,47 @@ async def test_doc_write_no_summary_stores_unindexed(mcp_env, monkeypatch):
     assert called["hit"] is False
 
 
+async def test_doc_write_omitted_fleet_resolves_home_fleet(mcp_env, monkeypatch):
+    """op=write resolves an omitted fleet_id to the agent's home fleet, so a
+    published doc/skill row isn't stranded at fleet_id=NULL (mirrors
+    memclaw_write; this is the path the 'publish a skill' flow uses)."""
+    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+    enforce = mcp_env["service"]("enforce_fleet_write")
+    enforce.return_value = {"agent_id": "a1", "fleet_id": "home-f", "trust_level": 1}
+
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="customers",
+        doc_id="acme",
+        data={"plan": "enterprise"},  # no summary → no embedding needed
+        agent_id="a1",
+    )
+    payload = parse_envelope(out)
+    assert payload["ok"] is True
+    # Backfilled to the home fleet; the trust gate still saw the original None.
+    assert sc.upsert_document_xmax.await_args.args[0]["fleet_id"] == "home-f"
+    assert enforce.await_args.args[3] is None
+
+
+async def test_doc_write_explicit_fleet_id_not_overridden(mcp_env, monkeypatch):
+    """An explicit fleet_id on op=write is never replaced by the home fleet."""
+    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+    enforce = mcp_env["service"]("enforce_fleet_write")
+    enforce.return_value = {"agent_id": "a1", "fleet_id": "home-f", "trust_level": 3}
+
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="customers",
+        doc_id="acme",
+        data={"plan": "pro"},
+        agent_id="a1",
+        fleet_id="explicit-f",
+    )
+    payload = parse_envelope(out)
+    assert payload["ok"] is True
+    assert sc.upsert_document_xmax.await_args.args[0]["fleet_id"] == "explicit-f"
+
+
 async def test_doc_write_summary_empty_string_is_rejected(mcp_env, monkeypatch):
     """When summary is provided but blank, embedding would be noise — reject."""
     monkeypatch.setattr(

--- a/tests/test_mcp_write.py
+++ b/tests/test_mcp_write.py
@@ -235,14 +235,59 @@ async def test_write_default_agent_in_standalone_ok(mcp_env):
     assert payload["id"] == "m-z"
 
 
-async def test_write_without_fleet_id_persists_null(mcp_env):
-    """Absent ``fleet_id`` → model carries ``None``. This is the current
-    server-side behavior; pairs with the skill guidance that tells
-    agents to pass the kwarg explicitly (URL param alone won't do it)."""
+async def test_write_without_fleet_id_no_home_fleet_persists_null(mcp_env):
+    """Absent ``fleet_id`` AND no home fleet on the agent → model carries
+    ``None``. The default ``mcp_env`` enforce stub echoes the passed
+    ``fleet_id`` (None here) as the agent's fleet, i.e. an agent never
+    scoped to a fleet — the home-fleet backfill is a no-op and the row
+    stays NULL (unchanged from prior behavior)."""
     mock = mcp_env["service"]("create_memory")
     mock.return_value = _OutStub()
 
     await mcp_server.memclaw_write(content="no fleet")
-    kwargs = mock.await_args.kwargs
-    model = kwargs.get("__self__", None) or mock.await_args.args[1]
+    model = mock.await_args.args[1]
     assert model.fleet_id is None
+
+
+async def test_write_omitted_fleet_resolves_home_fleet(mcp_env):
+    """Omitted ``fleet_id`` resolves to the agent's home fleet (REST parity,
+    routes/memories.py:937) instead of persisting NULL."""
+    enforce = mcp_env["service"]("enforce_fleet_write")
+    enforce.return_value = {"agent_id": "a1", "fleet_id": "home-f", "trust_level": 1}
+    cm = mcp_env["service"]("create_memory")
+    cm.return_value = _OutStub("m-hf")
+
+    await mcp_server.memclaw_write(content="x", agent_id="a1")  # fleet_id omitted
+
+    # The trust gate still saw the ORIGINAL (None) fleet_id — backfill happens
+    # after enforcement, so cross-fleet gating is unchanged.
+    assert enforce.await_args.args[3] is None
+    assert cm.await_args.args[1].fleet_id == "home-f"
+
+
+async def test_write_explicit_fleet_id_not_overridden(mcp_env):
+    """An explicit ``fleet_id`` is never replaced by the home fleet."""
+    enforce = mcp_env["service"]("enforce_fleet_write")
+    enforce.return_value = {"agent_id": "a1", "fleet_id": "home-f", "trust_level": 3}
+    cm = mcp_env["service"]("create_memory")
+    cm.return_value = _OutStub("m-x")
+
+    await mcp_server.memclaw_write(content="x", agent_id="a1", fleet_id="explicit-f")
+
+    assert enforce.await_args.args[3] == "explicit-f"
+    assert cm.await_args.args[1].fleet_id == "explicit-f"
+
+
+async def test_write_batch_omitted_fleet_resolves_home_fleet(mcp_env):
+    """Batch path resolves the home fleet at the top level — BulkMemoryItem
+    inherits fleet from the parent, so the whole batch lands in it."""
+    enforce = mcp_env["service"]("enforce_fleet_write")
+    enforce.return_value = {"agent_id": "a2", "fleet_id": "home-f", "trust_level": 1}
+    cmb = mcp_env["service"]("create_memories_bulk")
+    cmb.return_value = _OutStub("batch-hf")
+
+    await mcp_server.memclaw_write(
+        items=[{"content": "one"}, {"content": "two"}], agent_id="a2"
+    )
+
+    assert cmb.await_args.args[1].fleet_id == "home-f"


### PR DESCRIPTION
## Why

Validated follow-up **B1** from the "One Skill Company Brain" review. An MCP write that **omits `fleet_id`** persists `fleet_id=NULL`, and a NULL-fleet row silently drops out of teammates' `scope_team` / fleet-filtered recall. REST already resolves the agent's **home fleet** on omit (`routes/memories.py:937` single, `:1125` bulk) — MCP did not, so the *same* write scoped differently by transport. This also hit `memclaw_doc op=write collection=skills`, i.e. the "publish a skill, the fleet inherits it" flow could strand a skill at `fleet_id=NULL`.

Grounded: `enforce_fleet_write` returns the home-fleet-bearing agent but the MCP paths discarded it; the shared `create_memory` service uses `data.fleet_id` as-is (no backfill). No fleet ContextVar / `X-Fleet-ID` header / `?fleet_id=` parse exists at the MCP layer, so the kwarg was the only source.

## Change

Two sites in `core_api/mcp_server.py` (`memclaw_write` and `memclaw_doc op=write`): capture the agent `enforce_fleet_write` already returns and backfill before the write:

```python
agent = await enforce_fleet_write(db, tenant_id, agent_id, fleet_id)
if not fleet_id and agent.get("fleet_id"):
    fleet_id = agent["fleet_id"]
```

### Safety (no existing flow touched)
- **Explicit writes untouched** — backfill fires only when `fleet_id` is falsy; an explicit (incl. cross-fleet) value is unchanged.
- **No new cross-fleet surface** — `enforce_fleet_write` runs *first* with the original value; the backfill target is always the agent's **own** home fleet (always self-writable), so no re-enforcement needed (mirrors REST's order-independence here).
- **Worst case unchanged** — agent with no home fleet → no-op → row stays NULL. Closing that residual (seed home fleet from the connection `?fleet_id=`) is a separate decision, not this PR.
- **Batch** — `BulkMemoryItem` inherits fleet from the parent, so one top-level backfill covers the whole batch.

## Tests
`memclaw_write`: omit→home · explicit-untouched · batch omit→home · **no-home-fleet→NULL** (guards against over-claiming). `memclaw_doc op=write`: omit→home · explicit-untouched. The pre-existing `persists_null` test is clarified to the no-home-fleet case it actually covers. All 6 pass; `ruff check core-api/src/` + mypy clean on the touched file.

## Out of scope (flagged)
`memclaw_evolve` / `memclaw_insights` / `memclaw_keystones_set` also take `fleet_id` (different default scope) — audit separately. Layer 2 (connection-fleet seeding) is its own ticket. Static skill's `fleet_id` warning text becomes partially stale post-merge — to be updated in the separate skill-reconciliation work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)