### PR TITLE
chore(core-api): attribute single_write latency (dedup lookup + storage_total_ms)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/check_exact_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/check_exact_duplicate.py
@@ -4,6 +4,8 @@ writes of identical content no longer collide (friction §2.8)."""
 
 from __future__ import annotations
 
+import time
+
 from fastapi import HTTPException
 
 from core_api.clients.storage_client import get_storage_client
@@ -21,11 +23,19 @@ class CheckExactDuplicate:
         ch = ctx.data["content_hash"]
 
         sc = get_storage_client()
+        # Time just the storage roundtrip so write-latency attribution can
+        # separate the dedup lookup (GET /memories/by-content-hash) from the
+        # insert (``storage_ms``) and from core-api-side overhead. Mirrors the
+        # ``storage_ms`` / ``entity_links_ms`` timing in WriteMemoryRow.
+        dedup_t0 = time.perf_counter()
         dup = await sc.find_by_content_hash(
             data.tenant_id,
             ch,
             fleet_id=data.fleet_id,
             agent_id=data.agent_id,
+        )
+        ctx.data.setdefault("phase_timings", {})["dedup_lookup_ms"] = round(
+            (time.perf_counter() - dedup_t0) * 1000
         )
         if dup:
             raise HTTPException(

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -396,7 +396,17 @@ async def _create_memory_pipeline(db: AsyncSession, data: MemoryCreate) -> Memor
                 "embedding_ms": timings.get("embedding_ms"),
                 "enrichment_ms": timings.get("enrichment_ms"),
                 "storage_ms": timings.get("storage_ms"),
+                "dedup_lookup_ms": timings.get("dedup_lookup_ms"),
                 "entity_links_ms": timings.get("entity_links_ms"),
+                # Sum of every storage roundtrip on the write path (dedup
+                # lookup + insert + entity-link upsert). ``total_ms`` minus
+                # this is pure core-api-side time — the split that attributes
+                # the single_write p99 tail to storage-DB vs core-api.
+                "storage_total_ms": (
+                    (timings.get("storage_ms") or 0)
+                    + (timings.get("dedup_lookup_ms") or 0)
+                    + (timings.get("entity_links_ms") or 0)
+                ),
                 "total_ms": round((time.perf_counter() - ctx.data["t0"]) * 1000),
                 "embedding_pending": bool(memory_metadata.get("embedding_pending")),
                 "enrichment_pending": bool(memory_metadata.get("enrichment_pending")),

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -124,6 +124,35 @@ async def test_compute_content_hash_still_looks_up_when_embedding_inline(
 
 
 @pytest.mark.asyncio
+async def test_check_exact_duplicate_records_dedup_lookup_ms():
+    """CheckExactDuplicate times just its storage roundtrip into
+    ``phase_timings["dedup_lookup_ms"]`` so the ``memory_write_latency``
+    emit can separate the dedup lookup (GET /by-content-hash) from the
+    insert (``storage_ms``) and from core-api-side overhead — the split
+    that attributes the single_write p99 tail."""
+    from unittest.mock import AsyncMock, patch
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.write.check_exact_duplicate import CheckExactDuplicate
+
+    ctx = PipelineContext(
+        db=AsyncMock(),
+        data={"input": _make_input(), "content_hash": "deadbeef"},
+    )
+    mock_sc = AsyncMock()
+    mock_sc.find_by_content_hash.return_value = None  # no duplicate
+    with patch(
+        "core_api.pipeline.steps.write.check_exact_duplicate.get_storage_client",
+        return_value=mock_sc,
+    ):
+        result = await CheckExactDuplicate().execute(ctx)
+
+    assert result is None
+    mock_sc.find_by_content_hash.assert_called_once()
+    dedup_ms = ctx.data["phase_timings"]["dedup_lookup_ms"]
+    assert isinstance(dedup_ms, int) and dedup_ms >= 0
+
+
+@pytest.mark.asyncio
 async def test_apply_enrichment_step_defaults():
     """MergeEnrichmentFields applies correct defaults when no enrichment."""
     from unittest.mock import AsyncMock


### PR DESCRIPTION
## Why
`slo-p99-single_write`: ~**18.6s p99** with ~**575ms p50** on staging. Investigation showed the report's "move enrichment to a worker" fix is **already live** (staging defers both enrichment and embedding off the hot path), so the tail is downstream — storage-DB contention (likely **CAURA-686** PG row-lock on the insert) or core-api-side overhead. To localise it before changing code, the write path needs to attribute time across its storage roundtrips.

## What
Today only `WriteMemoryRow`'s insert is timed (`storage_ms`). The dedup lookup (`GET /memories/by-content-hash` in `CheckExactDuplicate`) was an **untimed** slice of `total_ms`, leaving `total_ms - storage_ms` an undifferentiated bucket. This PR:
- Times the dedup lookup → `phase_timings["dedup_lookup_ms"]` (mirrors `storage_ms`/`entity_links_ms`).
- Surfaces `dedup_lookup_ms` + a derived `storage_total_ms` (dedup + insert + entity-links) in the existing `memory_write_latency` log.

`total_ms - storage_total_ms` is then **pure core-api-side time** — the split that tells us whether the 18.6s tail is storage-DB or core-api. Additive only, no behaviour change.

## How we'll use it
Query `memory_write_latency` p99 of `storage_total_ms` vs the residual, and pair with the existing `GET /api/v1/storage/_debug/pg_locks` toolkit (+ `scripts/capture_pg_locks_during_storm.py`) under a same-(tenant,fleet) write burst to confirm/refute `Lock/transactionid` on `INSERT INTO memories` (CAURA-686).

## Tests
`tests/pipeline/test_write_pipeline.py::test_check_exact_duplicate_records_dedup_lookup_ms` (pure unit). Local gate: `ruff check core-api/src/` ✓, `ruff format --check` ✓, `mypy core-api/src/` ✓ (192 files), unit tests ✓.

Companion to the noisy-neighbor fix in #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)