### PR TITLE
fix(core-storage-api): tenant-guard by-id memory UPDATEs

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -436,8 +436,12 @@ class CoreStorageClient:
     async def get_memory_for_tenant(self, tenant_id: str, memory_id: str) -> dict | None:
         return await self._get(f"/memories/{memory_id}", tenant_id=tenant_id)
 
-    async def update_memory(self, memory_id: str, data: dict) -> dict | None:
-        return await self._patch(f"/memories/{memory_id}", data)
+    async def update_memory(self, memory_id: str, tenant_id: str, data: dict) -> dict | None:
+        # ``tenant_id`` (the row's home tenant) scopes the by-id UPDATE on
+        # the storage side so a content PATCH can't cross tenants; sent in
+        # the body and popped there before the remaining keys become the
+        # patch. The explicit arg wins over any ``tenant_id`` in ``data``.
+        return await self._patch(f"/memories/{memory_id}", {**data, "tenant_id": tenant_id})
 
     async def soft_delete_memory(self, memory_id: str) -> bool:
         return await self._delete(f"/memories/{memory_id}")
@@ -750,11 +754,15 @@ class CoreStorageClient:
     async def update_embedding(
         self,
         memory_id: str,
+        tenant_id: str,
         embedding: list[float],
     ) -> dict | None:
+        # ``tenant_id`` (the row's home tenant) scopes the by-id embedding
+        # write so a worker/backfill can't overwrite a foreign tenant's
+        # vector.
         return await self._patch(
             f"/memories/{memory_id}/embedding",
-            {"embedding": embedding},
+            {"embedding": embedding, "tenant_id": tenant_id},
         )
 
     async def update_memory_entities(
@@ -823,8 +831,13 @@ class CoreStorageClient:
     async def find_neighbors_by_embedding(self, data: dict) -> list[dict]:
         return await self._post("/memories/neighbors-by-embedding", data) or []  # type: ignore[return-value]
 
-    async def mark_dedup_checked(self, memory_ids: list[str]) -> dict:
-        return await self._post("/memories/mark-dedup-checked", {"memory_ids": memory_ids})  # type: ignore[return-value]
+    async def mark_dedup_checked(self, memory_ids: list[str], tenant_id: str) -> dict:
+        # ``tenant_id`` (the row's home tenant) bounds the bulk dedup-checked
+        # stamp to the caller's tenant.
+        return await self._post(
+            "/memories/mark-dedup-checked",
+            {"memory_ids": memory_ids, "tenant_id": tenant_id},
+        )  # type: ignore[return-value]
 
     async def batch_update_status(self, data: dict, *, tenant_id: str) -> dict:
         """Apply status updates to many memories within one tenant.

--- a/core-api/src/core_api/routes/testing.py
+++ b/core-api/src/core_api/routes/testing.py
@@ -116,7 +116,10 @@ async def _handle_set_field(body: TimeWarpRequest, auth: AuthContext) -> TimeWar
             raise HTTPException(status_code=404, detail="Memory not found")
         if row.get("tenant_id") != auth.tenant_id:
             raise HTTPException(status_code=403, detail="Tenant mismatch")
-        result = await sc.update_memory(body.id, {body.field: parsed_value.isoformat()})
+        # Pass the row's HOME tenant (verified == auth.tenant_id just above) so
+        # the storage-side guard scopes the write; row["tenant_id"] is a non-null
+        # column, unlike the Optional auth.tenant_id.
+        result = await sc.update_memory(body.id, row["tenant_id"], {body.field: parsed_value.isoformat()})
         affected = 1 if result else 0
     else:
         affected = 0

--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -242,7 +242,7 @@ async def _remediate_missing_embeddings(
         embedding = await get_embedding(content)
         if embedding is None:
             continue
-        await sc.update_embedding(str(mem_id), embedding)
+        await sc.update_embedding(str(mem_id), tenant_id, embedding)
         patched += 1
 
     if patched:
@@ -551,7 +551,7 @@ async def _check_near_duplicates(
 
     # Mark all processed memories as dedup-checked
     if checked_ids:
-        await sc.mark_dedup_checked(checked_ids)
+        await sc.mark_dedup_checked(checked_ids, tenant_id)
 
     pairs_list = [{"id1": k[0], "id2": k[1], "similarity": v} for k, v in pairs.items()]
     return {"count": len(pairs_list), "pairs": pairs_list}

--- a/core-api/src/core_api/services/governance_remediation.py
+++ b/core-api/src/core_api/services/governance_remediation.py
@@ -118,7 +118,7 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> bool:
             logger.info("governance: dropped fast-mode memory %s (non-business)", memory_id)
             return True
         if nb_cfg.disposition == "keep_private":
-            await sc.update_memory(memory_id, {"visibility": "scope_agent"})
+            await sc.update_memory(memory_id, tenant_id, {"visibility": "scope_agent"})
             await emit_governance_audit(
                 None,
                 tenant_id=tenant_id,

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -1863,7 +1863,7 @@ async def _reembed_memory(
                 )
             )
             return
-        await sc.update_embedding(str(memory_id), embedding)
+        await sc.update_embedding(str(memory_id), tenant_id, embedding)
         logger.info("Background re-embed succeeded for memory %s", memory_id)
     except (TimeoutError, ValueError, RuntimeError, OpenAIError, GoogleAPIError):
         logger.exception("Background re-embed error for memory %s", memory_id)
@@ -2032,7 +2032,7 @@ async def _reembed_memories_bulk(
             )
             continue
         try:
-            await sc.update_embedding(str(memory_id), embedding)
+            await sc.update_embedding(str(memory_id), tenant_id, embedding)
         except Exception:
             # Broad match for the same reason as the outer batch-call
             # except: httpx-layer errors, pool exhaustion, auth, etc.
@@ -2173,7 +2173,7 @@ async def _enrich_memory_background(
             if patch:
                 # Use a generic memory patch (metadata, type, weight, etc.)
                 # Fall back to update via scored-search patch endpoint
-                await sc._patch(f"/memories/{memory_id}", patch)
+                await sc.update_memory(str(memory_id), tenant_id, patch)
             if status_val:
                 await sc.update_memory_status(str(memory_id), status_val, tenant_id=tenant_id)
 
@@ -2516,7 +2516,7 @@ async def update_memory(
 
     # Apply the patch via storage client
     if patch:
-        await sc._patch(f"/memories/{memory_id}", patch)
+        await sc.update_memory(str(memory_id), tenant_id, patch)
 
     # Audit log — only fire when something actually changed. The
     # ``elif data.metadata`` guard above already prevents falsy

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -499,8 +499,11 @@ async def find_neighbors_by_embedding(request: Request) -> list[dict]:
 @router.post("/mark-dedup-checked")
 async def mark_dedup_checked(request: Request) -> dict:
     body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    if not tenant_id:
+        raise HTTPException(status_code=422, detail="tenant_id is required")
     memory_ids = [UUID(mid) for mid in body["memory_ids"]]
-    await _svc.memory_mark_dedup_checked(memory_ids)
+    await _svc.memory_mark_dedup_checked(memory_ids, tenant_id)
     return {"ok": True}
 
 
@@ -1225,6 +1228,13 @@ async def get_memory(memory_id: UUID, tenant_id: str | None = None) -> dict:
 @router.patch("/{memory_id}")
 async def update_memory(memory_id: UUID, request: Request) -> dict:
     body: dict = await request.json()
+    # Tenant guard: ``tenant_id`` is the row's home tenant, popped out of
+    # the body so it scopes the UPDATE rather than landing as a patched
+    # column (``Memory`` has a ``tenant_id`` column). A PATCH for a row
+    # owned by another tenant matches nothing → 404 below.
+    tenant_id = body.pop("tenant_id", None)
+    if not tenant_id:
+        raise HTTPException(status_code=422, detail="tenant_id is required")
     # ``_parse_datetimes`` mirrors the POST route's ingress contract:
     # asyncpg requires datetime instances on ``DateTime(timezone=True)``
     # columns and rejects ISO strings with ``CannotCoerceError``. The
@@ -1241,7 +1251,7 @@ async def update_memory(memory_id: UUID, request: Request) -> dict:
     # earlier short-circuit would let a PATCH ``{}`` on a deleted row
     # answer 200 — inconsistent with the 404 the same row gets on a
     # non-empty PATCH.
-    found = await _svc.memory_update(memory_id, body or {})
+    found = await _svc.memory_update(memory_id, tenant_id, body or {})
     if not found:
         # Pre-this-fix the route returned ``200 {"ok": True}`` regardless
         # of whether the row was missing or soft-deleted, so a PATCH on
@@ -1358,8 +1368,12 @@ async def update_memory_status(memory_id: UUID, request: Request) -> dict:
 @router.patch("/{memory_id}/embedding")
 async def update_embedding(memory_id: UUID, request: Request) -> dict:
     body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    if not tenant_id:
+        raise HTTPException(status_code=422, detail="tenant_id is required")
     await _svc.memory_update_embedding(
         memory_id,
+        tenant_id=tenant_id,
         embedding=body["embedding"],
         metadata=body.get("metadata"),
     )

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -524,7 +524,7 @@ class PostgresService:
                 memory.deleted_at = datetime.now(UTC)
                 memory.status = "deleted"
 
-    async def memory_update(self, memory_id: UUID, patch: dict) -> bool:
+    async def memory_update(self, memory_id: UUID, tenant_id: str, patch: dict) -> bool:
         """Apply arbitrary field updates to a memory.
 
         Two patch shapes are supported in the same request:
@@ -540,6 +540,11 @@ class PostgresService:
 
         Other top-level keys whose names don't match a ``Memory`` column
         are silently dropped — callers validate upstream.
+
+        Every statement is scoped to ``tenant_id`` (the row's home
+        tenant): a ``memory_id`` owned by a different tenant matches no
+        row, so the existence check returns ``False`` (→ 404) and neither
+        UPDATE can touch a foreign tenant's row.
 
         Returns ``True`` when the row exists and is live (the patch was
         applied or was a no-op due to all-unknown keys); ``False`` when
@@ -580,7 +585,9 @@ class PostgresService:
             # ``deleted_at`` alone would collapse both into None.
             row = (
                 await session.execute(
-                    select(Memory.id, Memory.deleted_at).where(Memory.id == memory_id).with_for_update()
+                    select(Memory.id, Memory.deleted_at)
+                    .where(Memory.id == memory_id, Memory.tenant_id == tenant_id)
+                    .with_for_update()
                 )
             ).first()
             if row is None:
@@ -603,7 +610,11 @@ class PostgresService:
             if values:
                 await session.execute(
                     sql_update(Memory)
-                    .where(Memory.id == memory_id, Memory.deleted_at.is_(None))
+                    .where(
+                        Memory.id == memory_id,
+                        Memory.tenant_id == tenant_id,
+                        Memory.deleted_at.is_(None),
+                    )
                     .values(**values)
                 )
             if metadata_patch:
@@ -632,8 +643,8 @@ class PostgresService:
                     text(
                         "UPDATE memories "
                         "SET metadata = COALESCE(metadata::jsonb, '{}'::jsonb) || (:patch)::jsonb "
-                        "WHERE id = :id AND deleted_at IS NULL"
-                    ).bindparams(patch=json.dumps(metadata_patch), id=memory_id),
+                        "WHERE id = :id AND tenant_id = :tenant_id AND deleted_at IS NULL"
+                    ).bindparams(patch=json.dumps(metadata_patch), id=memory_id, tenant_id=tenant_id),
                 )
         return True
 
@@ -692,14 +703,22 @@ class PostgresService:
     async def memory_update_embedding(
         self,
         memory_id: UUID,
+        tenant_id: str,
         embedding: list[float],
         metadata: dict | None = None,
     ) -> None:
+        # ``tenant_id`` scopes the write to the row's home tenant: a
+        # memory_id from another tenant matches no row, so a stale or
+        # spoofed worker payload can never overwrite a foreign embedding.
         async with get_session() as session:
             values: dict = {"embedding": embedding}
             if metadata is not None:
                 values["metadata_"] = metadata
-            await session.execute(sql_update(Memory).where(Memory.id == memory_id).values(**values))
+            await session.execute(
+                sql_update(Memory)
+                .where(Memory.id == memory_id, Memory.tenant_id == tenant_id)
+                .values(**values)
+            )
 
     # ------------------------------------------------------------------
     # B) Content hash / dedup
@@ -2267,12 +2286,18 @@ class PostgresService:
     async def memory_mark_dedup_checked(
         self,
         memory_ids: list[UUID],
+        tenant_id: str,
     ) -> None:
         if not memory_ids:
             return
+        # ``tenant_id`` bounds the bulk stamp to the caller's tenant: any
+        # id in the list that belongs to another tenant is silently
+        # skipped rather than having its dedup-checked timestamp moved.
         async with get_session() as session:
             await session.execute(
-                sql_update(Memory).where(Memory.id.in_(memory_ids)).values(last_dedup_checked_at=func.now())
+                sql_update(Memory)
+                .where(Memory.id.in_(memory_ids), Memory.tenant_id == tenant_id)
+                .values(last_dedup_checked_at=func.now())
             )
 
     async def memory_find_expired_still_active(

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -545,7 +545,7 @@ async def test_enrich_no_contradiction_when_no_prior_embedding() -> None:
     sc = MagicMock()
     sc.get_memory = AsyncMock(return_value=mem_row)
     sc.update_embedding = AsyncMock()
-    sc._patch = AsyncMock()
+    sc.update_memory = AsyncMock()
 
     enrichment = SimpleNamespace(
         memory_type="fact",
@@ -807,7 +807,7 @@ async def test_bulk_reembed_reschedules_items_whose_get_memory_failed() -> None:
         )
 
     # Item B went through the normal write pass.
-    sc.update_embedding.assert_awaited_once_with(str(mem_b_id), [0.2] * VECTOR_DIM)
+    sc.update_embedding.assert_awaited_once_with(str(mem_b_id), TENANT_ID, [0.2] * VECTOR_DIM)
     # Item A was rescheduled as a per-item retry (reembed task) AND
     # item B scheduled contradiction detection — both tracked.
     names = [call.args[1] for call in tracked.call_args_list]
@@ -832,7 +832,7 @@ async def test_bulk_reembed_patch_failure_reschedules_item() -> None:
     async def _get_memory(mid: str):
         return {"id": mid, "deleted_at": None, "fleet_id": "f", "embedding": None}
 
-    async def _update_embedding(mid: str, _emb):
+    async def _update_embedding(mid: str, _tenant, _emb):
         if mid == str(mem_a_id):
             raise _MockHTTPError("connection pool exhausted for item A")
 
@@ -954,7 +954,7 @@ async def test_bulk_reembed_respects_existing_embedding_per_item() -> None:
 
     # mem_a: race guard → no PATCH, contradiction on the EXISTING embedding
     # mem_b: normal path → PATCH fresh, contradiction on the fresh embedding
-    sc.update_embedding.assert_awaited_once_with(str(mem_b_id), fresh)
+    sc.update_embedding.assert_awaited_once_with(str(mem_b_id), TENANT_ID, fresh)
     assert len(detect_calls) == 2
     # Order matches the input order; arg[0]=memory_id, arg[4]=embedding
     by_id = {args[0]: args[4] for args in detect_calls}

--- a/tests/test_embed_stability.py
+++ b/tests/test_embed_stability.py
@@ -184,7 +184,7 @@ async def test_atomic_fact_children_embed_raw_fact_content() -> None:
     sc.update_memory_status = AsyncMock()
     install_batch_status_replay_shim(sc)
     sc.create_memory = AsyncMock()
-    sc._patch = AsyncMock()
+    sc.update_memory = AsyncMock()
 
     def _stub_tracked_task(coro, _name, *_a, **_k):
         coro.close()

--- a/tests/test_governance_consumer.py
+++ b/tests/test_governance_consumer.py
@@ -117,7 +117,7 @@ async def test_keep_private_updates_visibility_and_still_runs_detection(
 
     await consumer.handle_memory_enriched(_event(mid))
 
-    sc.update_memory.assert_awaited_once_with(str(mid), {"visibility": "scope_agent"})
+    sc.update_memory.assert_awaited_once_with(str(mid), "tenant-gov", {"visibility": "scope_agent"})
     detect.assert_awaited_once()  # not dropped → detection proceeds on the kept row
 
 

--- a/tests/test_governance_remediation.py
+++ b/tests/test_governance_remediation.py
@@ -37,8 +37,8 @@ def storage(monkeypatch):
         async def soft_delete_memory(self, mid):
             actions.append(("soft_delete", mid))
 
-        async def update_memory(self, mid, patch):
-            actions.append(("update", mid, patch))
+        async def update_memory(self, mid, tenant_id, patch):
+            actions.append(("update", mid, tenant_id, patch))
 
     monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
     return actions
@@ -115,7 +115,7 @@ async def test_nonbusiness_keep_private_updates_visibility(emitted, storage):
     mem = _mem(metadata={"business_relevance": "personal"})
     dropped = await governance_remediation.remediate_after_enrichment(mem, cfg)
     assert dropped is False
-    assert ("update", "m1", {"visibility": "scope_agent"}) in storage
+    assert ("update", "m1", "t1", {"visibility": "scope_agent"}) in storage
     assert any(c["action"] == "nonbusiness_keep_private" for c in emitted)
 
 

--- a/tests/test_storage_client_routing.py
+++ b/tests/test_storage_client_routing.py
@@ -136,7 +136,7 @@ async def test_patch_goes_to_writer() -> None:
     client, writer, reader = await _fresh_client(
         writer_url="http://writer:8002", reader_url="http://reader:8002"
     )
-    await client.update_embedding("11111111-1111-1111-1111-111111111111", [0.1])
+    await client.update_embedding("11111111-1111-1111-1111-111111111111", "t", [0.1])
     assert len(writer.requests) == 1
     assert len(reader.requests) == 0
 
@@ -289,7 +289,7 @@ async def test_authorization_header_attached_on_patch() -> None:
         client, writer, reader = await _fresh_client(
             writer_url="https://writer:8002", reader_url="https://reader:8002"
         )
-        await client.update_embedding("11111111-1111-1111-1111-111111111111", [0.1])
+        await client.update_embedding("11111111-1111-1111-1111-111111111111", "t", [0.1])
     assert writer.requests[0].headers["Authorization"] == "Bearer tok-writer"
 
 

--- a/tests/test_tenant_guard_byid_updates.py
+++ b/tests/test_tenant_guard_byid_updates.py
@@ -1,0 +1,160 @@
+"""Tenant-guard on by-id memory UPDATEs (CAURA-000).
+
+Every by-id write that core-api routes through core-storage-api must be
+scoped to the row's home tenant, so a wrong-tenant ``memory_id`` can never
+mutate a foreign row. Covers the three storage ops hardened here:
+
+- PATCH /memories/{id}                -> memory_update            (content PATCH)
+- PATCH /memories/{id}/embedding      -> memory_update_embedding  (worker/backfill)
+- POST  /memories/mark-dedup-checked  -> memory_mark_dedup_checked
+
+Wrong-tenant calls must be no-ops; same-tenant calls apply. Rows are seeded
+via the storage write path (committed, independent session) and asserted via
+``PostgresService`` directly — mirrors tests/test_ph3_storage_documents_fleet.py.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from common.embedding import fake_embedding
+from core_storage_api.services.postgres_service import PostgresService
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _t() -> str:
+    """Unique tenant id per test so concurrent suite runs don't collide."""
+    return f"test-tenant-guard-{uuid4().hex[:8]}"
+
+
+async def _seed_memory(sc, tenant: str, *, embedding=None, metadata=None) -> str:
+    payload: dict = {
+        "tenant_id": tenant,
+        "agent_id": "test-agent",
+        "content": f"content {uuid4().hex[:8]}",
+        "memory_type": "fact",
+        "weight": 0.5,
+        "status": "active",
+        "visibility": "scope_team",
+    }
+    if embedding is not None:
+        payload["embedding"] = embedding
+    if metadata is not None:
+        payload["metadata_"] = metadata
+    row = await sc.create_memory(payload)
+    return row["id"]
+
+
+# ---------------------------------------------------------------------------
+# memory_update — content PATCH (PATCH /memories/{id})
+# ---------------------------------------------------------------------------
+
+
+async def test_memory_update_wrong_tenant_is_noop(sc):
+    svc = PostgresService()
+    owner = _t()
+    mem_id = UUID(await _seed_memory(sc, owner))
+
+    applied = await svc.memory_update(mem_id, _t(), {"weight": 0.99})
+    assert applied is False, "wrong-tenant update matches no row"
+    row = await svc.memory_get_by_id(mem_id)
+    assert row is not None and row.weight == 0.5, "weight untouched by wrong tenant"
+
+    applied_owner = await svc.memory_update(mem_id, owner, {"weight": 0.99})
+    assert applied_owner is True
+    assert (await svc.memory_get_by_id(mem_id)).weight == 0.99
+
+
+async def test_memory_update_metadata_patch_wrong_tenant_is_noop(sc):
+    svc = PostgresService()
+    owner = _t()
+    mem_id = UUID(await _seed_memory(sc, owner, metadata={"k": "orig"}))
+
+    await svc.memory_update(mem_id, _t(), {"metadata_patch": {"k": "hacked"}})
+    assert (await svc.memory_get_by_id(mem_id)).metadata_ == {"k": "orig"}, (
+        "metadata merge blocked for wrong tenant"
+    )
+
+    await svc.memory_update(mem_id, owner, {"metadata_patch": {"k": "new", "added": 1}})
+    assert (await svc.memory_get_by_id(mem_id)).metadata_ == {"k": "new", "added": 1}
+
+
+async def test_update_memory_route_wrong_tenant_returns_none(sc):
+    # End-to-end through the typed client: wrong tenant -> route 404 -> None.
+    owner = _t()
+    mem_id = await _seed_memory(sc, owner)
+
+    result = await sc.update_memory(mem_id, _t(), {"weight": 0.42})
+    assert result is None, "wrong-tenant PATCH 404s -> client returns None"
+    assert (await PostgresService().memory_get_by_id(UUID(mem_id))).weight == 0.5
+
+    ok = await sc.update_memory(mem_id, owner, {"weight": 0.42})
+    assert ok == {"ok": True}
+    assert (await PostgresService().memory_get_by_id(UUID(mem_id))).weight == 0.42
+
+
+async def test_update_memory_route_requires_tenant(sc):
+    # The route's belt-and-suspenders guard: a raw PATCH with no tenant_id
+    # is rejected 422 rather than running an unscoped UPDATE.
+    mem_id = await _seed_memory(sc, _t())
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc._patch(f"/memories/{mem_id}", {"weight": 0.1})
+    assert exc.value.response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# memory_update_embedding (PATCH /memories/{id}/embedding)
+# ---------------------------------------------------------------------------
+
+
+async def test_update_embedding_wrong_tenant_is_noop(sc):
+    svc = PostgresService()
+    owner = _t()
+    mem_id = await _seed_memory(sc, owner)  # seeded without an embedding
+    assert (await svc.memory_get_by_id(UUID(mem_id))).embedding is None
+
+    await sc.update_embedding(mem_id, _t(), fake_embedding("vector"))
+    assert (await svc.memory_get_by_id(UUID(mem_id))).embedding is None, (
+        "wrong tenant must not write the embedding"
+    )
+
+    await sc.update_embedding(mem_id, owner, fake_embedding("vector"))
+    assert (await svc.memory_get_by_id(UUID(mem_id))).embedding is not None
+
+
+async def test_update_embedding_requires_tenant(sc):
+    mem_id = await _seed_memory(sc, _t())
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc._patch(f"/memories/{mem_id}/embedding", {"embedding": fake_embedding("x")})
+    assert exc.value.response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# memory_mark_dedup_checked (POST /memories/mark-dedup-checked)
+# ---------------------------------------------------------------------------
+
+
+async def test_mark_dedup_checked_wrong_tenant_is_noop(sc):
+    svc = PostgresService()
+    owner = _t()
+    mem_id = await _seed_memory(sc, owner)
+    assert (await svc.memory_get_by_id(UUID(mem_id))).last_dedup_checked_at is None
+
+    await sc.mark_dedup_checked([mem_id], _t())
+    assert (await svc.memory_get_by_id(UUID(mem_id))).last_dedup_checked_at is None, (
+        "wrong tenant must not stamp last_dedup_checked_at"
+    )
+
+    await sc.mark_dedup_checked([mem_id], owner)
+    assert (await svc.memory_get_by_id(UUID(mem_id))).last_dedup_checked_at is not None
+
+
+async def test_mark_dedup_checked_requires_tenant(sc):
+    mem_id = await _seed_memory(sc, _t())
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await sc._post("/memories/mark-dedup-checked", {"memory_ids": [mem_id]})
+    assert exc.value.response.status_code == 422


### PR DESCRIPTION
## Tenant-guard the by-id memory UPDATEs

Continues the "no DB outside core-storage-api" migration's hardening: every by-id memory **write** that core-api routes through core-storage-api is now scoped to the row's **home tenant**, so a wrong-tenant `memory_id` can never mutate a foreign row.

### Ops hardened (`PostgresService`)
| Op | Route | Guard |
|---|---|---|
| `memory_update` | `PATCH /memories/{id}` (content PATCH — user-reachable) | scope the `SELECT … FOR UPDATE` existence check **and both** UPDATEs (column `values` + the raw JSONB metadata-merge) to `tenant_id` |
| `memory_update_embedding` | `PATCH /memories/{id}/embedding` (worker/backfill) | scope the UPDATE |
| `memory_mark_dedup_checked` | `POST /memories/mark-dedup-checked` | scope the bulk `last_dedup_checked_at` stamp to `Memory.id.in_(ids) AND tenant_id` |

### Threading
`tenant_id` is a **required** argument end-to-end: storage routes (422 if missing) → typed storage client → every caller. Each caller passes the row's **HOME** tenant — `routes/testing.py` uses the already-verified `row["tenant_id"]`; the governance / crystallizer / memory_service callers pass their in-scope `tenant_id`. The two `memory_service` callers that previously reached into the private `sc._patch` now go through the guarded `sc.update_memory`.

### Out of scope (by design)
- `memory_update_status` — its cross-tenant write guard lands on the Phase 4 PR (#432); left untouched here to avoid a merge conflict.
- `memory_increment_recall` — deferred (internal counter, repo-direct, already tenant-scoped ids).
- Entity by-id updates are already tenant-guarded.

### Tests
`tests/test_tenant_guard_byid_updates.py` (mirrors `tests/test_ph3_storage_documents_fleet.py`): wrong-tenant write = no-op (row untouched / 404 / silent skip), same-tenant write applies, and each route 422s without `tenant_id`. Existing caller tests updated for the new signature.

Gates: ruff check + `format --check` (0.15.4), mypy both projects, full suite **3516 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
