### PR TITLE
fix(core-storage-api): 404 (not silent 200) on wrong-tenant embedding write

### DIFF
--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -242,8 +242,12 @@ async def _remediate_missing_embeddings(
         embedding = await get_embedding(content)
         if embedding is None:
             continue
-        await sc.update_embedding(str(mem_id), tenant_id, embedding)
-        patched += 1
+        # Count only writes that actually landed: update_embedding returns
+        # None when the row didn't match (404), so a no-op never inflates
+        # the remediated tally. (Candidates are tenant-scoped, so a mismatch
+        # shouldn't occur here — this just keeps the counter honest.)
+        if await sc.update_embedding(str(mem_id), tenant_id, embedding) is not None:
+            patched += 1
 
     if patched:
         logger.info(

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1371,12 +1371,17 @@ async def update_embedding(memory_id: UUID, request: Request) -> dict:
     tenant_id = body.get("tenant_id")
     if not tenant_id:
         raise HTTPException(status_code=422, detail="tenant_id is required")
-    await _svc.memory_update_embedding(
+    updated = await _svc.memory_update_embedding(
         memory_id,
         tenant_id=tenant_id,
         embedding=body["embedding"],
         metadata=body.get("metadata"),
     )
+    if not updated:
+        # No row for this (id, tenant) — surface 404 rather than a silent
+        # 200 (consistent with PATCH /memories/{id}); the client returns
+        # None so callers don't count a no-op as a successful write.
+        raise HTTPException(status_code=404, detail=f"Memory {memory_id} not found")
     return {"ok": True}
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -706,19 +706,23 @@ class PostgresService:
         tenant_id: str,
         embedding: list[float],
         metadata: dict | None = None,
-    ) -> None:
+    ) -> bool:
         # ``tenant_id`` scopes the write to the row's home tenant: a
         # memory_id from another tenant matches no row, so a stale or
         # spoofed worker payload can never overwrite a foreign embedding.
+        # Returns whether a row matched so the route can surface a 404 on
+        # a no-op (mirrors memory_update / memory_update_status) instead of
+        # a silent 200 that lets callers over-count successful writes.
         async with get_session() as session:
             values: dict = {"embedding": embedding}
             if metadata is not None:
                 values["metadata_"] = metadata
-            await session.execute(
+            result = await session.execute(
                 sql_update(Memory)
                 .where(Memory.id == memory_id, Memory.tenant_id == tenant_id)
                 .values(**values)
             )
+            return (result.rowcount or 0) > 0  # type: ignore[attr-defined]
 
     # ------------------------------------------------------------------
     # B) Content hash / dedup

--- a/tests/test_tenant_guard_byid_updates.py
+++ b/tests/test_tenant_guard_byid_updates.py
@@ -117,12 +117,15 @@ async def test_update_embedding_wrong_tenant_is_noop(sc):
     mem_id = await _seed_memory(sc, owner)  # seeded without an embedding
     assert (await svc.memory_get_by_id(UUID(mem_id))).embedding is None
 
-    await sc.update_embedding(mem_id, _t(), fake_embedding("vector"))
+    # Wrong tenant matches no row -> route 404 -> client returns None, no write.
+    wrong = await sc.update_embedding(mem_id, _t(), fake_embedding("vector"))
+    assert wrong is None, "wrong-tenant embedding write 404s -> client None"
     assert (await svc.memory_get_by_id(UUID(mem_id))).embedding is None, (
         "wrong tenant must not write the embedding"
     )
 
-    await sc.update_embedding(mem_id, owner, fake_embedding("vector"))
+    ok = await sc.update_embedding(mem_id, owner, fake_embedding("vector"))
+    assert ok == {"ok": True}
     assert (await svc.memory_get_by_id(UUID(mem_id))).embedding is not None
 
 


### PR DESCRIPTION
## 404 (not silent 200) on wrong-tenant embedding write

Follow-up to the post-merge review on [#467](https://github.com/caura-ai/caura-memclaw/pull/467#issuecomment-4767916672).

#467 scoped `memory_update_embedding`'s UPDATE to `tenant_id`, but the method stayed `-> None` and the route always returned `{"ok": True}` — so a wrong-tenant call was a silent 200 no-op, and `crystallizer_service._remediate_missing_embeddings` counted it as a successful patch (inflating the remediated tally in its log).

### Change
- `memory_update_embedding` → `-> bool`, returns `(result.rowcount or 0) > 0` (mirrors `memory_update_status`).
- `PATCH /memories/{id}/embedding` raises **404** on a no-op instead of 200 (consistent with `PATCH /memories/{id}`); the client then returns `None`.
- crystallizer increments `patched` only when the write actually landed.

### Reachability
The mismatch is **unreachable in practice today** — `_remediate_missing_embeddings` fetches candidates scoped to `tenant_id` and writes with that same tenant, so the counter was already accurate. This is a consistency + defense-in-depth fix so the three by-id ops behave uniformly. (`mark_dedup_checked` is intentionally left as a bulk 200 — per-row 404 doesn't fit a bulk stamp, and it has no success-counter caller.)

### Tests
Extended `test_update_embedding_wrong_tenant_is_noop` to assert the wrong-tenant call now returns `None` (404) and the same-tenant call returns `{"ok": True}`. Gates: ruff@0.15.4 check + `format --check`, mypy both projects, full suite **3530 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
