### PR TITLE
perf(core-api): make document-ingest (kreuzberg) an opt-in extra to cut cold start

### DIFF
--- a/core-api/Dockerfile
+++ b/core-api/Dockerfile
@@ -22,7 +22,13 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.18 /uv /usr/local/bin/uv
 COPY core-api/pyproject.toml core-api/uv.lock core-api/README.md* ./core-api/
 # Dummy src so the project metadata resolves during export.
 RUN mkdir -p core-api/src/core_api && touch core-api/src/core_api/__init__.py
-RUN uv export --frozen --no-dev --extra pubsub --no-emit-project \
+# Document-ingest (kreuzberg, ~64MB) is an opt-in extra — off by default to
+# keep the image small and cold-start fast. Build with --build-arg WITH_INGEST=1
+# for a deployment that serves the /ingest/* endpoints.
+ARG WITH_INGEST=0
+RUN EXTRAS="--extra pubsub"; \
+    if [ "$WITH_INGEST" = "1" ]; then EXTRAS="$EXTRAS --extra ingest"; fi; \
+    uv export --frozen --no-dev $EXTRAS --no-emit-project \
       --directory core-api -o /tmp/reqs.txt \
     && uv pip install --system --no-cache -r /tmp/reqs.txt
 

--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -48,13 +48,6 @@ dependencies = [
     "markdown-it-py>=4.0,<5",  # markdown AST walker
     "tiktoken>=0.10,<1",  # cl100k_base token counter for size caps
     "pysbd>=0.3,<1",  # sentence boundary detection for sub-chunk splits
-    # PR #8 (Tier-1 ingest, optional multi-format): Kreuzberg replaces
-    # what would otherwise be pypdf + python-docx + python-pptx + … (88+
-    # formats). Provides ``extract_bytes(data, mime) -> ExtractionResult``;
-    # text-PDF works out of the box, scanned-PDF OCR requires Tesseract on
-    # the host (deferred to a follow-up — image-only PDFs raise 422 for now).
-    # License Elastic-2.0.
-    "kreuzberg>=4.9,<5",
     # PR #9: FastAPI's UploadFile / Form support needs python-multipart at
     # runtime. Pulled in transitively today via ``mcp`` but declaring
     # explicitly so removing/upgrading mcp can't silently break uploads.
@@ -65,8 +58,14 @@ dependencies = [
 # Optional: required only when EVENT_BUS_BACKEND=pubsub (SaaS deployments).
 # Standalone installs default to the in-process bus and don't need this.
 pubsub = ["google-cloud-pubsub>=2.23,<3"]
+# Optional: multi-format document extraction for the /ingest/* endpoints.
+# Kreuzberg (~64MB, Elastic-2.0) is excluded from the default image to cut
+# cold-start pull + import time — the ingest endpoints return 501 without it
+# (see core_api.services.ingest_service guarded import). Build with
+# `--extra ingest` (Dockerfile: --build-arg WITH_INGEST=1) to enable ingest.
+ingest = ["kreuzberg>=4.9,<5"]
 dev = [
-    "core-api[test,pubsub]",
+    "core-api[test,pubsub,ingest]",
     "mypy>=1.13,<3.0",
     "ruff>=0.8,<1.0",
     "types-croniter>=2.0",

--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -12,7 +12,6 @@ from datetime import UTC, datetime
 from urllib.parse import urlparse
 
 import httpx
-import kreuzberg
 from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -36,6 +35,15 @@ from core_api.services.ingest_chunking import (
 )
 from core_api.services.memory_service import _content_hash, create_memories_bulk
 from core_api.services.organization_settings import resolve_config
+
+# Document extraction (PDF / Office / EPUB / …) is an optional ``ingest`` extra:
+# kreuzberg is ~64MB and is excluded from the default image to cut cold-start
+# pull + import time. When absent, the ingest endpoints return 501 (see
+# ``_extract_with_kreuzberg``); every other code path works unchanged.
+try:
+    import kreuzberg
+except ImportError:  # pragma: no cover - only in slim (no-ingest) builds
+    kreuzberg = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -418,7 +426,11 @@ def _check_hostname_safe(url: str) -> None:
 # extracted PDFs/Office docs and produce breadcrumb-tagged sections, instead
 # of dumping one giant plaintext blob. Created once at module load to avoid
 # rebuilding it on every request.
-_KREUZBERG_CFG = kreuzberg.ExtractionConfig(output_format=kreuzberg.OutputFormat.MARKDOWN)
+_KREUZBERG_CFG = (
+    kreuzberg.ExtractionConfig(output_format=kreuzberg.OutputFormat.MARKDOWN)
+    if kreuzberg is not None
+    else None
+)
 
 
 def decode_text_body(body: bytes, mime: str, encoding: str | None = None) -> str:
@@ -458,6 +470,11 @@ async def _extract_with_kreuzberg(body: bytes, mime: str) -> str:
     - Empty extracted content (image-only PDF with no Tesseract installed)
       → 422 — better to fail loudly than to send the LLM 0 bytes.
     """
+    if kreuzberg is None:
+        raise HTTPException(
+            status_code=501,
+            detail="Document ingest is not available in this build — install the 'ingest' extra (kreuzberg).",
+        )
     try:
         result = await kreuzberg.extract_bytes(body, mime, _KREUZBERG_CFG)
     except kreuzberg.ParsingError as e:

--- a/core-api/uv.lock
+++ b/core-api/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "core-api"
-version = "2.15.0"
+version = "2.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -379,7 +379,6 @@ dependencies = [
     { name = "google-genai" },
     { name = "greenlet" },
     { name = "httpx" },
-    { name = "kreuzberg" },
     { name = "markdown-it-py" },
     { name = "mcp" },
     { name = "openai" },
@@ -405,12 +404,16 @@ dev = [
     { name = "aiosqlite" },
     { name = "google-cloud-pubsub" },
     { name = "httpx" },
+    { name = "kreuzberg" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-croniter" },
+]
+ingest = [
+    { name = "kreuzberg" },
 ]
 pubsub = [
     { name = "google-cloud-pubsub" },
@@ -430,7 +433,7 @@ requires-dist = [
     { name = "argon2-cffi", specifier = ">=23.1" },
     { name = "asyncpg", specifier = ">=0.30,<1" },
     { name = "cachetools", specifier = ">=5.3" },
-    { name = "core-api", extras = ["test", "pubsub"], marker = "extra == 'dev'" },
+    { name = "core-api", extras = ["test", "pubsub", "ingest"], marker = "extra == 'dev'" },
     { name = "croniter", specifier = ">=2.0" },
     { name = "cryptography", specifier = ">=42.0" },
     { name = "fastapi", specifier = ">=0.115,<1" },
@@ -440,7 +443,7 @@ requires-dist = [
     { name = "greenlet", specifier = "<3.6.0" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27,<1.0" },
-    { name = "kreuzberg", specifier = ">=4.9,<5" },
+    { name = "kreuzberg", marker = "extra == 'ingest'", specifier = ">=4.9,<5" },
     { name = "markdown-it-py", specifier = ">=4.0,<5" },
     { name = "mcp", specifier = ">=1.26,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13,<3.0" },
@@ -466,7 +469,7 @@ requires-dist = [
     { name = "types-croniter", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1" },
 ]
-provides-extras = ["pubsub", "dev", "test"]
+provides-extras = ["pubsub", "ingest", "dev", "test"]
 
 [[package]]
 name = "coverage"

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -15,7 +15,9 @@ from unittest.mock import patch
 
 import httpx
 import pytest
+from fastapi import HTTPException
 
+from core_api.services import ingest_service
 from core_api.services.ingest_service import (
     INGEST_MAX_INPUT_BYTES,
     MAX_INGEST_CONTENT_BYTES,
@@ -549,3 +551,14 @@ def test_unified_cap_is_3mb() -> None:
     assert INGEST_MAX_INPUT_BYTES == 3_000_000
     # MAX_INGEST_CONTENT_BYTES is kept as a back-compat alias.
     assert MAX_INGEST_CONTENT_BYTES == INGEST_MAX_INPUT_BYTES
+
+
+@pytest.mark.unit
+async def test_extract_with_kreuzberg_501_when_extra_absent(monkeypatch) -> None:
+    """Slim build (no ``ingest`` extra): kreuzberg is None, so the extractor
+    must fail clearly with 501 — not a NameError/500 — and point at the extra."""
+    monkeypatch.setattr(ingest_service, "kreuzberg", None)
+    with pytest.raises(HTTPException) as exc:
+        await ingest_service._extract_with_kreuzberg(b"%PDF-1.4 fake", "application/pdf")
+    assert exc.value.status_code == 501
+    assert "ingest" in exc.value.detail.lower()


### PR DESCRIPTION
## Why
core-api Cloud Run `startup_latencies` p99 is **36–58s** — the real source of the load-test `single_write`/search latency tails (the handler is fast: p99 ~1.6s; pgvector 241ms; TEI 17ms). Profiling showed the **logged** app startup is only ~9s (and the `agent-backfill` lifespan step is already a no-op in this mode), so the remaining 30s+ is **pre-process**: container image pull (**183MB** compressed) + cold-instance interpreter/imports.

## What
Shrink the default image by making the **64MB `kreuzberg`** document-extraction lib an **opt-in `ingest` extra**:
- `kreuzberg` → `[project.optional-dependencies] ingest`; the `dev` extra keeps it so CI/local still run the ingest tests.
- `ingest_service` guards the import at **top level** (`try/except ImportError → kreuzberg = None`, rule-compliant — no inline imports); `_extract_with_kreuzberg` raises a clear **501** when the extra is absent. Every non-ingest path is unchanged.
- Dockerfile builds the slim image by default; **`--build-arg WITH_INGEST=1`** re-adds the extra for deployments serving `/ingest/*`.

## Honest scope
This is a **moderate** cold-start reduction (drops the kreuzberg tree + its import cost), **not** a full fix — a 150MB+ Python image has an inherent ~20s+ cold-start floor. The next-largest lever is **google-cloud-aiplatform (~99MB)**; making it conditional on the Vertex provider is a follow-up.

## Verification
- `ruff check` + `ruff format --check` (core-api/src) ✓; `mypy core-api/src` ✓ (192 files).
- `uv.lock` regenerated: default export (`--extra pubsub`) **excludes** kreuzberg; `--extra ingest` **includes** it.
- `pytest` ✓ — **54 ingest tests pass**, including a new test that `_extract_with_kreuzberg` returns 501 when kreuzberg is absent.

Companion to the harness cold-start-attribution finding ([caura-test-automation #172](https://github.com/caura-ai/caura-test-automation/pull/172)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)