### PR TITLE
feat(core-storage-api): route evolve through storage + delete _mcp_session (Fix 2 Ph5b, PR2)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1727,6 +1727,68 @@ class CoreStorageClient:
         )
 
     # =====================================================================
+    # Evolve (Fix 2 Ph5b, PR2)
+    # =====================================================================
+    #
+    # The scope-filter SELECT (read → replica; the filter is a pre-write
+    # visibility check and replica lag is harmless) and the atomic
+    # weight-adjust + rule→outcome backfill (write → primary, ONE txn). Each
+    # takes an explicit tenant_id (+ scope params) — there are no RLS GUCs
+    # server-side. The dedup / UUID-parse / cap / rounding / skip-reason logic
+    # stays client-side in ``evolve_service``; only the DB passes route here.
+
+    async def evolve_filter_by_scope(
+        self,
+        *,
+        tenant_id: str,
+        caller_agent_id: str,
+        fleet_id: str | None,
+        scope: str,
+        ids: list[str],
+    ) -> list[str]:
+        """Return the subset of ``ids`` the caller can touch under ``scope``."""
+        resp = await self._post(
+            "/evolve/filter-by-scope",
+            {
+                "tenant_id": tenant_id,
+                "caller_agent_id": caller_agent_id,
+                "fleet_id": fleet_id,
+                "scope": scope,
+                "ids": ids,
+            },
+            read=True,
+        )
+        return resp["allowed_ids"]  # type: ignore[index,return-value]
+
+    async def evolve_apply_weights(
+        self,
+        *,
+        tenant_id: str,
+        ids: list[str],
+        delta: float,
+        floor: float,
+        cap: float,
+        rule_id: str | None = None,
+        outcome_id: str | None = None,
+    ) -> dict:
+        """Clamp-adjust weights + (atomically) backfill the rule→outcome link;
+        primary write, ONE transaction. Returns
+        ``{adjustments:[{id, old_weight, new_weight}], backfilled}``."""
+        return await self._post(  # type: ignore[return-value]
+            "/evolve/apply-weights",
+            {
+                "tenant_id": tenant_id,
+                "ids": ids,
+                "delta": delta,
+                "floor": floor,
+                "cap": cap,
+                "rule_id": rule_id,
+                "outcome_id": outcome_id,
+            },
+            read=False,
+        )
+
+    # =====================================================================
     # Keystones (CAURA-000)
     # =====================================================================
     #

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -23,7 +23,6 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import CallToolResult, TextContent
 from pydantic import Field, ValidationError
-from sqlalchemy import text as sa_text
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from common.enrichment.constants import SERVER_RESERVED_MEMORY_TYPES
@@ -40,7 +39,6 @@ from core_api.constants import (
     VALID_SCOPES,
     VERSION,
 )
-from core_api.db.session import async_session
 from core_api.errors import code_for_status
 from core_api.pagination import decode_cursor, encode_cursor
 from core_api.schemas import (
@@ -426,35 +424,21 @@ def _check_write_scope() -> CallToolResult | None:
     return _READ_ONLY_ERROR
 
 
-@contextlib.asynccontextmanager
-async def _mcp_session():
-    """Session with RLS tenant context set from MCP auth."""
-    async with async_session() as session:
-        tenant_id = _get_tenant()
-        if tenant_id and tenant_id not in (_UNAUTH, _ADMIN, _NO_AUTH):
-            await session.execute(
-                sa_text("SELECT set_config('app.tenant_id', :tid, true)"),
-                {"tid": tenant_id},
-            )
-        else:
-            await session.execute(sa_text("SELECT set_config('app.tenant_id', '', true)"))
-        # Plumb the cross-tenant read set as a second GUC alongside
-        # ``app.tenant_id``. Deployments may extend RLS policies to honor
-        # it for reads; OSS-default deployments use the app-layer filter.
-        readable = _get_readable_tenants()
-        await session.execute(
-            sa_text("SELECT set_config('app.readable_tenant_ids', :csv, true)"),
-            {"csv": ",".join(readable) if readable else ""},
-        )
-        yield session
+# Fix 2 Ph5b (PR2 — evolve) removed the last ``_mcp_session()`` consumer
+# (``memclaw_evolve`` now opens ``_no_db()`` like every other migrated tool),
+# so the RLS-GUC session helper and its ``async_session`` import / ``sa_text``
+# helper were deleted. Every MCP tool is storage-routed; tenant isolation is
+# carried by explicit ``tenant_id`` / ``readable_tenant_ids`` arguments, NOT by
+# session-scoped GUCs.
 
 
 @contextlib.asynccontextmanager
 async def _no_db():
     """Yield ``None`` in place of a DB session.
 
-    Fix 2 Phase 4 routed the 9 ready MCP tools through the core-storage-api
-    HTTP client, so they no longer set RLS GUCs via ``_mcp_session()``. The
+    Fix 2 routed every MCP tool through the core-storage-api HTTP client, so
+    none set RLS GUCs via a session helper (the prior ``_mcp_session()`` was
+    deleted once ``memclaw_evolve`` migrated in Ph5b PR2). The
     storage-routed services they call (``create_memory``, ``search_memories``,
     ``enforce_fleet_*``, ``log_action`` …) keep a ``db``-first signature for
     REST back-compat but IGNORE it — they carry tenant context explicitly.
@@ -2598,10 +2582,12 @@ async def memclaw_evolve(
     # single ``_mcp_session()`` open across the rule-generation LLM
     # round-trip — multiple seconds during which a pooled DB connection
     # was pinned for work that is entirely network-bound to the LLM
-    # provider. Three-phase restructure (same pattern as insights):
-    #   1. session 1 — trust + usage gates, filter_by_scope, resolve_config
-    #   2. no DB     — _maybe_generate_rule (LLM)
-    #   3. session 2 — _apply_outcome_to_db (weights + persist + backfill + commit)
+    # provider. The three-phase split is retained, and post-Fix-2-Ph5b-PR2
+    # every phase is storage-routed (no pooled connection held):
+    #   1. ``_no_db`` — trust + usage gates, filter_by_scope, resolve_config
+    #   2. no DB      — _maybe_generate_rule (LLM)
+    #   3. ``_no_db`` — _apply_outcome_to_db (persist + weights + backfill;
+    #                   storage-committed, no local commit)
     from core_api.services.evolve_service import (
         _apply_outcome_to_db,
         _filter_by_scope,
@@ -2611,8 +2597,12 @@ async def memclaw_evolve(
     from core_api.services.organization_settings import resolve_config
 
     try:
-        # ── Phase 1: DB reads ──────────────────────────────────────
-        async with _mcp_session() as db:
+        # ── Phase 1: gates + storage-routed reads ──────────────────
+        # Fix 2 Ph5b (PR2): the trust/usage gates and the scope-filter read are
+        # storage-routed (``_no_db()`` ⇒ db=None) — ``_require_trust`` /
+        # ``check_and_increment`` ignore db and ``_filter_by_scope`` calls
+        # core-storage-api. No pooled DB connection is held.
+        async with _no_db() as db:
             # Mirror the REST evolve gate (and ``memclaw_insights`` above):
             # block unregistered agents on the write path so the
             # outcome/rule memories + audit-log rows have a real
@@ -2679,8 +2669,11 @@ async def memclaw_evolve(
             fleet_id,
         )
 
-        # ── Phase 3: persist + commit ──────────────────────────────
-        async with _mcp_session() as db:
+        # ── Phase 3: persist (storage-routed) ──────────────────────
+        # Fix 2 Ph5b (PR2): the rule/outcome create_memory writes + the atomic
+        # weight-adjust/backfill all route through core-storage-api, so there's
+        # no session to open or commit here (``_no_db()`` ⇒ db=None).
+        async with _no_db() as db:
             result = await _apply_outcome_to_db(
                 db,
                 tenant_id=tenant_id,

--- a/core-api/src/core_api/pipeline/steps/write/check_semantic_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/check_semantic_duplicate.py
@@ -125,7 +125,7 @@ class CheckSemanticDuplicate:
         # Surface candidates down to the JUDGE band so this step can
         # decide auto-reject vs judge-dispatch vs accept by tier.
         sem_dup = await _find_semantic_duplicate(
-            ctx.require_db,
+            ctx.db,  # storage-routed (ignores db) — tolerate the db=None STM path
             data.tenant_id,
             data.fleet_id,
             embedding,

--- a/core-api/src/core_api/pipeline/steps/write/detect_near_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/detect_near_duplicate.py
@@ -84,7 +84,7 @@ class DetectNearDuplicate:
         # false-positive cost (advisory signal only, no hard reject),
         # and let callers decide what to do with the candidate.
         sem_dup = await _find_semantic_duplicate(
-            ctx.require_db,
+            ctx.db,  # storage-routed (ignores db) — tolerate the db=None STM path
             data.tenant_id,
             data.fleet_id,
             embedding,

--- a/core-api/src/core_api/pipeline/steps/write/load_tenant_config.py
+++ b/core-api/src/core_api/pipeline/steps/write/load_tenant_config.py
@@ -15,7 +15,11 @@ class LoadTenantConfig:
         from core_api.services.organization_settings import resolve_config
 
         data = ctx.data["input"]
-        tenant_config = await resolve_config(ctx.require_db, data.tenant_id)
+        # ``ctx.db`` (nullable), NOT ``require_db``: ``resolve_config`` ignores
+        # ``db`` entirely (settings load through core-storage-api since Fix 2
+        # Phase 0), so the STM/db=None write path (e.g. evolve's outcome/rule
+        # persist) must not be forced to carry a pooled session just for config.
+        tenant_config = await resolve_config(ctx.db, data.tenant_id)
         ctx.data["tenant_config"] = tenant_config
         ctx.tenant_config = tenant_config
         return None

--- a/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
+++ b/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
@@ -106,7 +106,7 @@ class WriteMemoryRow:
         if _hooks.audit_log:
             try:
                 await _hooks.audit_log(
-                    ctx.require_db,
+                    ctx.db,  # log_action ignores db (storage-routed) — allow STM path
                     tenant_id=data.tenant_id,
                     agent_id=data.agent_id,
                     action="create",

--- a/core-api/src/core_api/routes/evolve.py
+++ b/core-api/src/core_api/routes/evolve.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator, model_validator
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from core_api.auth import AuthContext, get_auth_context
 from core_api.constants import EVOLVE_OUTCOME_TYPES, VALID_SCOPES
-from core_api.db.session import get_db
 from core_api.services.audit_service import log_action
 from core_api.services.caller_identity import resolve_caller_and_gate
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
@@ -87,7 +85,6 @@ class EvolveRequest(BaseModel):
 async def report_outcome_endpoint(
     body: EvolveRequest,
     auth: AuthContext = Depends(get_auth_context),
-    db: AsyncSession = Depends(get_db),
 ):
     """Report an action outcome to evolve memory weights and generate rules.
 
@@ -120,8 +117,13 @@ async def report_outcome_endpoint(
 
     # Resolve the caller identity (verified > body > DEFAULT_AGENT_ID) and gate
     # the write on trust. Shared with insights.py — see services/caller_identity.
+    # Fix 2 Ph5b (PR2): all DB access for evolve is storage-routed, so this route
+    # holds no session — ``None`` is forwarded to the db-ignoring helpers
+    # (``resolve_caller_and_gate`` only passes db to the storage-routed
+    # ``require_trust``; ``check_and_increment`` / ``report_outcome`` /
+    # ``log_action`` ignore db). There is no local session to commit.
     caller_agent_id = await resolve_caller_and_gate(
-        db,
+        None,
         auth,
         tenant_id=body.tenant_id,
         body_agent_id=body.agent_id,
@@ -129,7 +131,7 @@ async def report_outcome_endpoint(
         action="evolve",
     )
 
-    await check_and_increment(db, body.tenant_id, "evolve")
+    await check_and_increment(None, body.tenant_id, "evolve")
 
     from core_api.services.evolve_service import report_outcome
 
@@ -140,7 +142,7 @@ async def report_outcome_endpoint(
     # simply malformed in a way Pydantic couldn't catch.
     try:
         result = await report_outcome(
-            db,
+            None,
             tenant_id=body.tenant_id,
             outcome=body.outcome,
             outcome_type=body.outcome_type,
@@ -153,7 +155,7 @@ async def report_outcome_endpoint(
         raise HTTPException(status_code=422, detail=str(e)) from e
 
     await log_action(
-        db,
+        None,
         tenant_id=body.tenant_id,
         action="evolve_report",
         resource_type="outcome",
@@ -164,6 +166,5 @@ async def report_outcome_endpoint(
             "related_ids": body.related_ids,
         },
     )
-    await db.commit()
 
     return result

--- a/core-api/src/core_api/services/evolve_service.py
+++ b/core-api/src/core_api/services/evolve_service.py
@@ -6,11 +6,11 @@ optionally generates preventive rules via LLM on failure/partial outcomes.
 """
 
 import asyncio
+import contextlib
 import logging
 import time
 from uuid import UUID
 
-from sqlalchemy import bindparam, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core_api.constants import (
@@ -142,48 +142,18 @@ Respond with JSON:
 
 
 # -- Weight adjustment --------------------------------------------------------
-
-
-_ADJUST_WEIGHTS_BULK_SQL = text(
-    """
-    WITH old_vals AS (
-        SELECT id, weight AS old_weight
-          FROM memories
-         WHERE id IN :mids
-           AND tenant_id = :tid
-           AND deleted_at IS NULL
-    )
-    UPDATE memories
-       SET weight = GREATEST(:floor, LEAST(:cap, weight + :delta))
-      FROM old_vals
-     WHERE memories.id = old_vals.id
-       AND memories.tenant_id = :tid
-       AND memories.deleted_at IS NULL
-    RETURNING memories.id AS id, old_vals.old_weight AS old_weight,
-              memories.weight AS new_weight
-    """
-).bindparams(bindparam("mids", expanding=True))
-
-
-# Backfill the rule memory's metadata.source_outcome_id after the outcome
-# exists. Rule persistence happens before outcome persistence (so the outcome
-# can record the rule_memory_id), so at rule-write time the outcome_id is
-# unknown. This UPDATE completes the rule→outcome traceability link.
-_BACKFILL_RULE_OUTCOME_SQL = text(
-    """
-    UPDATE memories
-       SET metadata = jsonb_set(
-           COALESCE(metadata, '{}'::jsonb),
-           '{source_outcome_id}',
-           to_jsonb(CAST(:outcome_id AS text))
-       )
-     WHERE id = :rule_id AND tenant_id = :tid
-    """
-)
+#
+# Fix 2 Ph5b (PR2): the weight-clamp CTE and the rule→outcome jsonb_set backfill
+# moved to core-storage-api (``sc.evolve_apply_weights`` — they were ported
+# VERBATIM there and now run in ONE atomic storage transaction). The
+# scope-filter SELECT moved too (``sc.evolve_filter_by_scope``). The module no
+# longer holds those SQL constants or a direct ``db.execute`` against
+# ``memories``; the dedup / UUID-parse / cap / rounding / skip-reason logic
+# stays here on the client side.
 
 
 async def _filter_by_scope(
-    db: AsyncSession,
+    db: AsyncSession | None,
     tenant_id: str,
     caller_agent_id: str,
     fleet_id: str | None,
@@ -207,8 +177,13 @@ async def _filter_by_scope(
     Returns (in_scope_ids, out_of_scope_count). The returned list is
     deduplicated and preserves first-seen order of the input so downstream
     consumers get a stable, canonical view of the caller's intent.
+
+    Fix 2 Ph5b (PR2): the scope SELECT moved to core-storage-api
+    (``sc.evolve_filter_by_scope``); the UUID-parse + first-seen dedup +
+    ``out_of_scope_count`` arithmetic stays here. ``db`` is retained in the
+    signature for REST back-compat but is ignored.
     """
-    from common.models.memory import Memory
+    from core_api.clients.storage_client import get_storage_client
 
     if not related_ids:
         return [], 0
@@ -238,25 +213,21 @@ async def _filter_by_scope(
         # ``len(related_ids) - len(valid_uuids) = len(related_ids) - 0``.
         return [], len(related_ids)
 
-    # Build the scope filter via SQLAlchemy's expression API rather than
-    # interpolating a SQL fragment. All user-derived values remain bound
-    # parameters and the query plan is visible to tooling (EXPLAIN, SQLA
-    # event hooks). Comparing UUID objects — not stringified forms — also
-    # eliminates the canonical-form mismatch that ``id::text`` would have
-    # produced for callers passing uppercase or unhyphenated UUIDs.
-    stmt = (
-        select(Memory.id)
-        .where(Memory.id.in_(list(valid_uuids.values())))
-        .where(Memory.tenant_id == tenant_id)
-        .where(Memory.deleted_at.is_(None))
+    # The scope SELECT runs storage-side (``sc.evolve_filter_by_scope`` ports it
+    # VERBATIM — UUID-object comparison via ``select(Memory.id).in_(...)``, so
+    # the canonical-form mismatch that ``id::text`` would produce for uppercase
+    # or unhyphenated callers is still avoided). The allowed ids come back as
+    # canonical strings; normalise to UUID so membership against the caller's
+    # ``valid_uuids`` (also UUIDs) doesn't miss on string-vs-UUID identity.
+    sc = get_storage_client()
+    allowed_strs = await sc.evolve_filter_by_scope(
+        tenant_id=tenant_id,
+        caller_agent_id=caller_agent_id,
+        fleet_id=fleet_id,
+        scope=scope,
+        ids=[str(u) for u in valid_uuids.values()],
     )
-    if scope == "agent":
-        stmt = stmt.where(Memory.agent_id == caller_agent_id)
-    elif scope == "fleet":
-        stmt = stmt.where(Memory.fleet_id == fleet_id)
-
-    result = await db.execute(stmt)
-    allowed: set[UUID] = {row[0] for row in result}
+    allowed: set[UUID] = {UUID(s) for s in allowed_strs}
 
     in_scope = [s for s, uid in valid_uuids.items() if uid in allowed]
     # out_of_scope_count has two components we keep separate so the name
@@ -286,42 +257,50 @@ async def _filter_by_scope(
 
 
 async def _adjust_weights(
-    db: AsyncSession,
+    db: AsyncSession | None,
     tenant_id: str,
     related_ids: list[str],
     outcome_type: str,
     agent_id: str,
+    *,
+    rule_id: str | None = None,
+    outcome_id: str | None = None,
 ) -> tuple[str | None, list[str], list[dict]]:
     """Adjust weights on related memories atomically.
 
-    Executes a CTE-based UPDATE per memory so each row is read, clamped, and
-    written in a single statement — eliminating the TOCTOU race that existed
-    when the read (via storage-client HTTP) and the write crossed transaction
-    boundaries. The CTE captures the pre-update weight so `old_weight` in the
-    response is exact even when clamping occurs at the floor or cap.
+    Fix 2 Ph5b (PR2): the clamp-and-return CTE now runs storage-side
+    (``sc.evolve_apply_weights`` ports ``_ADJUST_WEIGHTS_BULK_SQL`` VERBATIM and
+    executes it in ONE transaction), eliminating core-api's direct
+    ``db.execute`` against ``memories``. The CTE still captures the pre-update
+    weight so ``old_weight`` is exact even when clamping at the floor or cap.
+    The same storage call folds in the rule→outcome ``jsonb_set`` backfill when
+    ``rule_id`` and ``outcome_id`` are supplied, so the weight clamp and the
+    backfill commit atomically without a second HTTP round-trip — the caller
+    re-sequences so both ids are resolved before invoking this. ``db`` is
+    retained in the signature for REST back-compat but is ignored.
 
-    Concurrency: `related_ids` is deduped and sorted before iteration so all
-    concurrent callers acquire row locks in the same order, preventing the
-    cycle that would otherwise trigger PostgreSQL deadlocks when two evolve
-    calls touch overlapping memory sets.
+    Concurrency: ``related_ids`` is still deduped + sorted before the call so
+    the storage-side UPDATE locks rows in a deterministic global order,
+    avoiding cycle-based deadlocks across concurrent evolve calls.
 
     Audit: update_memory's audit hook is bypassed; the outcome memory's
-    metadata (`weight_adjustments`) records the change as a compensating trail.
+    metadata records the change as a compensating trail.
 
     Returns a tuple of (skip_reason, processed_ids, adjustments):
     - skip_reason: A15 — ``None`` when at least one row was updated;
       ``"no_rows_updated"`` when every supplied id failed UUID parsing,
-      the bulk UPDATE returned no rows (row deleted between filter and
-      update), or the bulk UPDATE raised an exception. Callers feed this
-      into ``report_outcome``'s ``weight_adjustment_skipped_reason``
-      response field so a 200 OK with empty adjustments is no longer
-      indistinguishable from success.
+      the apply-weights call returned no rows (row deleted between filter and
+      update), or the call raised. Callers feed this into ``report_outcome``'s
+      ``weight_adjustment_skipped_reason`` response field so a 200 OK with
+      empty adjustments is no longer indistinguishable from success.
     - processed_ids: IDs whose weights were actually updated in the DB.
       Excludes invalid UUIDs, missing rows, and rows whose UPDATE raised.
       Callers persist this in the outcome metadata so it reflects reality
       rather than the caller's optimistic input.
     - adjustments: [{memory_id, old_weight, new_weight, delta}].
     """
+    from core_api.clients.storage_client import get_storage_client
+
     # Dedup + sort first so the cap counts unique IDs (truncating before
     # dedup can leave fewer than EVOLVE_MAX_RELATED_IDS distinct items when
     # the caller passes duplicates). Sorted order also ensures every
@@ -355,43 +334,32 @@ async def _adjust_weights(
 
     valid_uuids = [u for _, u in parsed]
 
-    # Single bulk UPDATE keyed by the validated UUID set; collapses the
-    # prior N+1 round-trips and N savepoint pairs into one statement
-    # (audit finding #25). Single savepoint isolates the entire weight-
-    # adjustment batch from the outer evolve transaction; per-row
-    # isolation is not preserved — a DB error aborts all weight updates
-    # as a unit. The outer evolve transaction still gets to persist the
-    # outcome / rule memory rows downstream regardless.
+    # Single atomic storage call: the clamp-and-return CTE (+ the conditional
+    # rule→outcome backfill) commits in ONE transaction storage-side. A failure
+    # is surfaced as the ``no_rows_updated`` slug rather than aborting the whole
+    # evolve call — the rule/outcome memories were already persisted.
+    sc = get_storage_client()
     try:
-        async with db.begin_nested():
-            result = await db.execute(
-                _ADJUST_WEIGHTS_BULK_SQL,
-                {
-                    "mids": valid_uuids,
-                    "tid": tenant_id,
-                    "floor": EVOLVE_WEIGHT_FLOOR,
-                    "cap": EVOLVE_WEIGHT_CAP,
-                    "delta": delta,
-                },
-            )
-            rows = result.fetchall()
+        resp = await sc.evolve_apply_weights(
+            tenant_id=tenant_id,
+            ids=[str(u) for u in valid_uuids],
+            delta=delta,
+            floor=EVOLVE_WEIGHT_FLOOR,
+            cap=EVOLVE_WEIGHT_CAP,
+            rule_id=rule_id,
+            outcome_id=outcome_id,
+        )
     except Exception:
         logger.warning("evolve: bulk weight update failed for %d memories", len(valid_uuids), exc_info=True)
         return "no_rows_updated", [], []
 
-    # Map returned rows by id so we can preserve the caller's input
-    # ordering when building the response. Rows missing from the
-    # result set correspond to ids not found (or filtered by the
-    # tenant + deleted_at predicate); skip them with the same
-    # warning the per-row path emitted previously.
-    #
-    # ``UUID(str(row.id))`` normalises the key — some DB drivers /
-    # cursor result shapes hand ``row.id`` back as ``str`` rather than
-    # ``uuid.UUID``. Without normalisation the lookup below
-    # (``row_by_id.get(mid)`` with a real ``UUID`` key) silently
-    # misses every row, falling through to the "not found" warning
-    # branch and dropping the whole batch from the response.
-    row_by_id = {UUID(str(row.id)): row for row in rows}
+    # Map returned rows by id so we can preserve the caller's input ordering
+    # when building the response. Rows missing from the result correspond to
+    # ids not found (or filtered by the tenant + deleted_at predicate); skip
+    # them with the same warning the prior path emitted. ``UUID(row["id"])``
+    # normalises the canonical string back to a UUID so the lookup against the
+    # parsed ``UUID`` keys can't silently miss.
+    row_by_id = {UUID(row["id"]): row for row in resp.get("adjustments", [])}
     for mid_str, mid in parsed:
         row = row_by_id.get(mid)
         if row is None:
@@ -401,8 +369,8 @@ async def _adjust_weights(
         adjustments.append(
             {
                 "memory_id": mid_str,
-                "old_weight": round(float(row.old_weight), 4),
-                "new_weight": round(float(row.new_weight), 4),
+                "old_weight": round(float(row["old_weight"]), 4),
+                "new_weight": round(float(row["new_weight"]), 4),
                 "delta": round(delta, 4),
             }
         )
@@ -549,7 +517,7 @@ async def _generate_rule(
 
 
 async def _persist_outcome(
-    db: AsyncSession,
+    db: AsyncSession | None,
     tenant_id: str,
     agent_id: str,
     fleet_id: str | None,
@@ -570,6 +538,11 @@ async def _persist_outcome(
     `scope` determines the outcome memory's visibility via _SCOPE_TO_VISIBILITY
     so scope='agent' outcomes stay private and scope='all' outcomes are visible
     tenant-wide.
+
+    Fix 2 Ph5b (PR2): ``create_memory`` is fully storage-routed and commits
+    independently, so ``db`` may be ``None`` (MCP ``_no_db`` path). The savepoint
+    only isolates a real REST-path session; with ``db=None`` there is no session
+    to protect, so the savepoint is skipped via ``nullcontext``.
     """
     from core_api.schemas import MemoryCreate
     from core_api.services.memory_service import create_memory
@@ -602,9 +575,11 @@ async def _persist_outcome(
     # Savepoint isolates a DB error inside create_memory so the outer
     # transaction stays usable. Outcome persistence is mandatory (unlike
     # the rule), so re-raise after the savepoint rolls back to signal
-    # failure to the caller.
+    # failure to the caller. With db=None (storage-routed MCP path) there
+    # is no session to isolate — create_memory commits independently.
+    savepoint = db.begin_nested() if db is not None else contextlib.nullcontext()
     try:
-        async with db.begin_nested():
+        async with savepoint:
             result = await create_memory(db, data)
     except Exception:
         logger.exception("evolve: failed to persist outcome")
@@ -613,7 +588,7 @@ async def _persist_outcome(
 
 
 async def _persist_rule(
-    db: AsyncSession,
+    db: AsyncSession | None,
     tenant_id: str,
     agent_id: str,
     fleet_id: str | None,
@@ -667,9 +642,11 @@ async def _persist_rule(
     # Savepoint isolates the rule write: if create_memory raises after dirtying
     # the session (e.g. a side-effect DB write fails before the HTTP call), the
     # outer transaction can still proceed with weight adjustments and the
-    # outcome write without the session being in a failed state.
+    # outcome write without the session being in a failed state. With db=None
+    # (storage-routed MCP path) there is no session to isolate.
+    savepoint = db.begin_nested() if db is not None else contextlib.nullcontext()
     try:
-        async with db.begin_nested():
+        async with savepoint:
             result = await create_memory(db, data)
         return str(result.id)
     except Exception:
@@ -681,7 +658,7 @@ async def _persist_rule(
 
 
 async def report_outcome(
-    db: AsyncSession,
+    db: AsyncSession | None,
     tenant_id: str,
     outcome: str,
     outcome_type: str,
@@ -858,7 +835,7 @@ async def _maybe_generate_rule(
 
 
 async def _apply_outcome_to_db(
-    db: AsyncSession,
+    db: AsyncSession | None,
     *,
     tenant_id: str,
     agent_id: str,
@@ -873,36 +850,31 @@ async def _apply_outcome_to_db(
     weight_adjustment_skipped_reason: str | None,
     t0: float,
 ) -> dict:
-    """Phases 2-5 + commit: the entire DB-bound write side of evolve.
+    """Phases 2-5: the entire write side of evolve, fully storage-routed.
 
-    Audit P3 (evolve): split out of ``report_outcome`` so the MCP tool
-    can call it from a fresh DB session, opened AFTER the LLM rule
-    generation. Atomicity contract is preserved — every local write
-    (weight UPDATEs, backfill UPDATE) commits in this one session;
-    the storage-api writes (rule + outcome memories) commit eagerly
-    via HTTP and are not rolled back if the local commit fails, same
-    as before.
+    Audit P3 (evolve): split out of ``report_outcome`` so the MCP tool can call
+    it from a fresh session opened AFTER the LLM rule generation.
+
+    Fix 2 Ph5b (PR2): every write now routes through core-storage-api — the rule
+    + outcome memories via ``create_memory`` (storage-committed independently,
+    as before), and the weight clamp + the rule→outcome ``jsonb_set`` backfill
+    via ONE ``sc.evolve_apply_weights`` call (ONE atomic storage transaction).
+    There is no local ``db`` session to commit, so the final ``db.commit()`` is
+    gone. The phases are RE-SEQUENCED so ``rule_id``/``outcome_id`` are resolved
+    BEFORE the single apply-weights call (the backfill needs the outcome_id, and
+    the source-outcome link is folded into the same transaction as the clamp):
+      1. persist rule (if confident)        → rule_memory_id
+      2. persist outcome                    → outcome_id
+      3. apply-weights (clamp + backfill)   → adjustments
+
+    Split-commit contract (unchanged in spirit): the rule/outcome memories are
+    storage-committed before the apply-weights call; if apply-weights fails the
+    memories remain and the weights/backfill are lost — surfaced as the
+    ``no_rows_updated`` slug rather than a raised exception.
     """
-    # Phase 2: Adjust weights atomically. Row locks are acquired and released
-    # entirely within this block — no long-running work runs while locks are held.
-    processed_ids: list[str] = []
-    weight_adjustments: list[dict] = []
-    if related_ids:
-        adjust_skip_reason, processed_ids, weight_adjustments = await _adjust_weights(
-            db, tenant_id, related_ids, outcome_type, agent_id
-        )
-        # A15: the deeper stage's slug wins. The upstream slug from
-        # ``report_outcome`` only fires when the scope filter dropped
-        # every id; if we got here, the filter passed at least one
-        # but the bulk UPDATE didn't update any (race / parse error).
-        if adjust_skip_reason is not None:
-            weight_adjustment_skipped_reason = adjust_skip_reason
-            _log_weight_adjustment_skip(
-                adjust_skip_reason, tenant_id, scope, related_ids_count=len(related_ids)
-            )
-
-    # Phase 3: Persist rule memory if confidence meets threshold. outcome_id
-    # is not known yet; it is backfilled in Phase 5 after the outcome exists.
+    # Phase 2: Persist rule memory if confidence meets threshold. The outcome_id
+    # is not known yet; the rule→outcome link is backfilled inside the
+    # apply-weights call in Phase 4 once the outcome exists.
     rule_memory_id: str | None = None
     if rule_result is not None:
         confidence = rule_result.get("confidence", 0)
@@ -921,8 +893,15 @@ async def _apply_outcome_to_db(
                 rule_skipped_reason = "persist_failed"
                 _log_rule_skip(rule_skipped_reason, tenant_id, outcome_type)
 
-    # Phase 4: Persist outcome memory — records rule_memory_id and the IDs
-    # that actually got their weights updated.
+    # Phase 3: Persist outcome memory. It must exist before the apply-weights
+    # call so the rule→outcome backfill (folded into that single atomic call)
+    # has the outcome_id. The outcome records the rule_memory_id and the
+    # in-scope related_ids. ``weight_adjustments`` is persisted EMPTY here BY
+    # DESIGN: the post-clamp deltas aren't known until Phase 4, and writing them
+    # back would need a second outcome-memory write that we deliberately skip to
+    # keep the clamp + rule→outcome backfill in one atomic apply-weights txn. The
+    # real deltas live in the report_outcome response built below and in the
+    # audit log; nothing reads the persisted ``metadata.weight_adjustments``.
     outcome_id = await _persist_outcome(
         db,
         tenant_id,
@@ -930,52 +909,45 @@ async def _apply_outcome_to_db(
         fleet_id,
         outcome,
         outcome_type,
-        processed_ids,
-        weight_adjustments,
+        related_ids,
+        [],
         rule_memory_id,
         scope=scope,
     )
 
-    # Phase 5: Backfill the rule's source_outcome_id so rules are queryable
-    # back to their originating outcome without scanning every outcome's
-    # related_memory_ids list. Best-effort — a failure here doesn't abort
-    # the whole call since the outcome already references the rule.
-    if rule_memory_id and outcome_id:
-        # Savepoint isolates the backfill: a failure here (e.g. snapshot
-        # visibility race when the rule was committed on a separate connection)
-        # would otherwise abort the outer transaction and surface as a
-        # `RELEASE SAVEPOINT` error on the final db.commit().
-        try:
-            async with db.begin_nested():
-                await db.execute(
-                    _BACKFILL_RULE_OUTCOME_SQL,
-                    {
-                        "rule_id": UUID(rule_memory_id),
-                        "outcome_id": outcome_id,
-                        "tid": tenant_id,
-                    },
-                )
-        except Exception:
-            logger.exception("evolve: failed to backfill source_outcome_id on rule %s", rule_memory_id)
-
-    # Commit local DB-session writes (weight UPDATEs + the rule→outcome
-    # backfill UPDATE). Split-commit contract: rule/outcome memories were
-    # already persisted independently by storage-api over HTTP and are NOT
-    # rolled back if this commit fails. On commit failure the outcome and
-    # rule remain in storage but weight adjustments are lost and the rule
-    # lacks source_outcome_id — log loudly so operators can reconcile.
-    try:
-        await db.commit()
-    except Exception:
-        logger.error(
-            "evolve: db.commit() failed after storage-api writes succeeded; "
-            "rule_memory_id=%s outcome_id=%s — weights and rule→outcome backfill "
-            "are lost but the memories remain in storage",
-            rule_memory_id,
-            outcome_id,
-            exc_info=True,
+    # Phase 4: Adjust weights + (atomically) backfill the rule→outcome link in
+    # ONE storage transaction. rule_id/outcome_id are now resolved, so the
+    # backfill rides along with the clamp rather than a second HTTP call.
+    weight_adjustments: list[dict] = []
+    if related_ids:
+        # ``_processed_ids`` (the subset actually clamped) is intentionally
+        # discarded, not merely unused: the outcome memory was already persisted
+        # in Phase 3 with the scope-filtered ``related_ids`` and is deliberately
+        # not rewritten, and the per-id post-clamp deltas live in the response's
+        # ``weight_adjustments`` below.
+        adjust_skip_reason, _processed_ids, weight_adjustments = await _adjust_weights(
+            db,
+            tenant_id,
+            related_ids,
+            outcome_type,
+            agent_id,
+            rule_id=rule_memory_id,
+            outcome_id=outcome_id,
         )
-        raise
+        # A15: the deeper stage's slug wins. The upstream slug from
+        # ``report_outcome`` only fires when the scope filter dropped every id;
+        # if we got here, the filter passed at least one but the bulk UPDATE
+        # didn't update any (race / parse error).
+        if adjust_skip_reason is not None:
+            weight_adjustment_skipped_reason = adjust_skip_reason
+            _log_weight_adjustment_skip(
+                adjust_skip_reason, tenant_id, scope, related_ids_count=len(related_ids)
+            )
+    # Note: a rule is only ever generated when related_ids is non-empty
+    # (``_maybe_generate_rule`` returns the ``no_related_ids`` skip otherwise),
+    # so the rule→outcome backfill always rides along with a non-empty clamp
+    # call above — there is no no-related-ids-with-rule backfill path to drive
+    # separately. The backfill therefore commits atomically with the clamp.
 
     return {
         "outcome_id": outcome_id,

--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -31,6 +31,7 @@ from core_storage_api.routers import (
     debug_router,
     documents_router,
     entities_router,
+    evolve_router,
     fleet_router,
     health_router,
     idempotency_router,
@@ -133,6 +134,11 @@ def create_app() -> FastAPI:
     # calls these via its storage_client; the LLM analysis + numpy k-means stay
     # client-side.
     app.include_router(insights_router, prefix=prefix)
+    # Fix 2 Ph5b (PR2): evolve scope-filter read + the atomic weight-adjust/
+    # backfill write, moved off core-api's direct DB pool. core-api calls these
+    # via its storage_client; the rule-generation LLM round-trip stays
+    # client-side.
+    app.include_router(evolve_router, prefix=prefix)
     app.include_router(tasks_router, prefix=prefix)
     app.include_router(idempotency_router, prefix=prefix)
     app.include_router(lifecycle_audit_router, prefix=prefix)

--- a/core-storage-api/src/core_storage_api/routers/__init__.py
+++ b/core-storage-api/src/core_storage_api/routers/__init__.py
@@ -3,6 +3,7 @@ from core_storage_api.routers.audit import router as audit_router
 from core_storage_api.routers.debug import router as debug_router
 from core_storage_api.routers.documents import router as documents_router
 from core_storage_api.routers.entities import router as entities_router
+from core_storage_api.routers.evolve import router as evolve_router
 from core_storage_api.routers.fleet import router as fleet_router
 from core_storage_api.routers.health import router as health_router
 from core_storage_api.routers.idempotency import router as idempotency_router
@@ -25,6 +26,7 @@ __all__ = [
     "debug_router",
     "documents_router",
     "entities_router",
+    "evolve_router",
     "fleet_router",
     "health_router",
     "idempotency_router",

--- a/core-storage-api/src/core_storage_api/routers/evolve.py
+++ b/core-storage-api/src/core_storage_api/routers/evolve.py
@@ -1,0 +1,112 @@
+"""Evolve scope-filter read + atomic weight-adjust/backfill write (Fix 2 Ph5b, PR2).
+
+Routes the two raw-DB passes the core-api evolve service held against
+``memories`` (services/evolve_service.py ``_filter_by_scope`` SELECT and the
+``_ADJUST_WEIGHTS_BULK_SQL`` CTE + ``_BACKFILL_RULE_OUTCOME_SQL`` UPDATE)
+through core-storage-api HTTP so core-api stops holding a direct ``db.execute``
+for the evolve adapt step.
+
+Two endpoints:
+
+- ``POST /evolve/filter-by-scope`` (READ) — the scope SELECT; returns
+  ``{allowed_ids}``. The UUID-parse + first-seen dedup + ``out_of_scope_count``
+  arithmetic stays client-side in ``_filter_by_scope``.
+- ``POST /evolve/apply-weights`` (WRITE, ONE atomic txn) — folds the weight
+  clamp CTE AND the rule→outcome ``jsonb_set`` backfill into ONE transaction so
+  evolve's documented split-commit isn't widened into two HTTP calls. Returns
+  ``{adjustments, backfilled}``.
+
+Every endpoint takes an explicit ``tenant_id`` (422 if missing) and scopes all
+SQL by it — there are NO RLS GUCs server-side (mirrors the sibling routers).
+The PostgresService methods these call port the source ORM/SQL VERBATIM.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from core_storage_api.services.postgres_service import PostgresService
+
+router = APIRouter(tags=["Evolve"])
+_svc = PostgresService()
+
+# Mirrors core-api's VALID_SCOPES. Inlined (not imported) because core-storage-api
+# is an independent service and must not depend on the core-api package. Keep in
+# sync if the scope vocabulary changes.
+_VALID_SCOPES = {"agent", "fleet", "all"}
+
+
+def _require(body: dict, key: str) -> str:
+    val = body.get(key)
+    if not val:
+        raise HTTPException(status_code=422, detail=f"{key} is required")
+    return val
+
+
+@router.post("/evolve/filter-by-scope")
+async def evolve_filter_by_scope(request: Request) -> dict:
+    """Return the subset of ``ids`` the caller can touch under ``scope``.
+
+    Body ``{tenant_id, caller_agent_id, scope, ids:[...], fleet_id?}``. Returns
+    ``{allowed_ids:[str,...]}``. Returns 422 when ``scope='fleet'`` and
+    ``fleet_id`` is absent, or when ``ids`` contains a non-UUID string — the
+    underlying service raises ``ValueError`` on both, so guarding here gives
+    direct storage callers a proper validation error instead of an unhandled
+    500."""
+    body: dict = await request.json()
+    tenant_id = _require(body, "tenant_id")
+    caller_agent_id = _require(body, "caller_agent_id")
+    scope = _require(body, "scope")
+    if scope not in _VALID_SCOPES:
+        # Fail closed: an unrecognized scope must 422, not fall through to the
+        # service's no-extra-filter (scope='all') arm, which would return all
+        # tenant-visible ids — a fail-open leak for a direct storage caller.
+        raise HTTPException(status_code=422, detail=f"scope must be one of {sorted(_VALID_SCOPES)}")
+    fleet_id = body.get("fleet_id")
+    if scope == "fleet" and not fleet_id:
+        raise HTTPException(status_code=422, detail="fleet_id is required when scope is 'fleet'")
+    ids = body.get("ids")
+    if not isinstance(ids, list):
+        raise HTTPException(status_code=422, detail="ids (list) is required")
+    try:
+        allowed = await _svc.evolve_filter_by_scope(
+            tenant_id=tenant_id,
+            caller_agent_id=caller_agent_id,
+            fleet_id=fleet_id,
+            scope=scope,
+            ids=ids,
+        )
+    except ValueError as exc:
+        # The service parses each id with ``UUID(s)`` — a non-UUID string raises
+        # ValueError. Surface it as a 422 for direct storage callers rather than
+        # an unhandled 500 (the typed client always sends pre-validated UUIDs;
+        # same boundary-hardening as the fleet_id guard above).
+        raise HTTPException(status_code=422, detail=f"invalid ids: {exc}") from exc
+    return {"allowed_ids": allowed}
+
+
+@router.post("/evolve/apply-weights")
+async def evolve_apply_weights(request: Request) -> dict:
+    """Clamp-and-adjust weights and (atomically) backfill the rule→outcome link.
+
+    Body ``{tenant_id, ids:[...], delta, floor, cap, rule_id?, outcome_id?}``.
+    Returns ``{adjustments:[{id, old_weight, new_weight}], backfilled: bool}``.
+    The clamp CTE and the conditional ``jsonb_set`` backfill commit in ONE
+    transaction."""
+    body: dict = await request.json()
+    tenant_id = _require(body, "tenant_id")
+    ids = body.get("ids")
+    if not isinstance(ids, list):
+        raise HTTPException(status_code=422, detail="ids (list) is required")
+    for key in ("delta", "floor", "cap"):
+        if not isinstance(body.get(key), (int, float)):
+            raise HTTPException(status_code=422, detail=f"{key} (number) is required")
+    return await _svc.evolve_apply_weights(
+        tenant_id=tenant_id,
+        ids=ids,
+        delta=float(body["delta"]),
+        floor=float(body["floor"]),
+        cap=float(body["cap"]),
+        rule_id=body.get("rule_id"),
+        outcome_id=body.get("outcome_id"),
+    )

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -5924,6 +5924,161 @@ class PostgresService:
         }
 
     # ══════════════════════════════════════════════════════════════════════
+    #  EVOLVE — scope-filter read + atomic weight-adjust/backfill write
+    #  (Fix 2 Ph5b, PR2)
+    # ══════════════════════════════════════════════════════════════════════
+    #
+    # Ports the two raw-DB passes the core-api evolve service held against
+    # ``memories`` (services/evolve_service.py): the ``_filter_by_scope``
+    # SELECT and the ``_ADJUST_WEIGHTS_BULK_SQL`` CTE + ``_BACKFILL_RULE_OUTCOME_SQL``
+    # UPDATE. The filter-by-scope READ uses ``select(Memory.id)`` (sidesteps the
+    # asyncpg array-cast risk, mirrors insights/skill_factory); the apply-weights
+    # WRITE ports the CTE + jsonb_set backfill VERBATIM as raw ``text()`` (ORM-
+    # awkward) inside ONE transaction so the weight clamp and the rule→outcome
+    # backfill commit atomically. The ``IN :mids`` expanding-bindparam from the
+    # source becomes ``ANY(CAST(:ids AS uuid[]))`` for the asyncpg driver. Each
+    # method takes an explicit ``tenant_id`` and scopes every statement by it —
+    # there are no RLS GUCs server-side. The dedup / UUID-parse / cap / rounding
+    # / skip-reason logic stays client-side in ``_adjust_weights`` /
+    # ``_filter_by_scope``; only the DB passes move here.
+
+    async def evolve_filter_by_scope(
+        self,
+        *,
+        tenant_id: str,
+        caller_agent_id: str,
+        fleet_id: str | None,
+        scope: str,
+        ids: list[str],
+    ) -> list[str]:
+        """Return the subset of ``ids`` visible to the caller under ``scope``.
+
+        Ports ``_filter_by_scope``'s SELECT verbatim: base
+        ``id IN (...) AND tenant_id == :tid AND deleted_at IS NULL``; scope
+        ='agent' adds ``agent_id == :caller``, scope='fleet' adds
+        ``fleet_id == :fid`` (fleet_id required), scope='all' adds nothing.
+        Uses ``select(Memory.id).where(Memory.id.in_(...))`` (UUID objects,
+        not stringified) so the asyncpg array-cast risk is avoided and
+        canonical-form mismatches don't drop valid ids. Returns the matched
+        ids as plain strings; the caller maps these back to its first-seen
+        ordering + tallies ``out_of_scope_count``."""
+        if not ids:
+            return []
+        if scope == "fleet" and fleet_id is None:
+            raise ValueError("evolve_filter_by_scope: fleet_id is required when scope is 'fleet'")
+        uuids = [UUID(s) for s in ids]
+        stmt = (
+            select(Memory.id)
+            .where(Memory.id.in_(uuids))
+            .where(Memory.tenant_id == tenant_id)
+            .where(Memory.deleted_at.is_(None))
+        )
+        if scope == "agent":
+            stmt = stmt.where(Memory.agent_id == caller_agent_id)
+        elif scope == "fleet":
+            stmt = stmt.where(Memory.fleet_id == fleet_id)
+        async with get_read_session() as session:
+            result = await session.execute(stmt)
+            return [str(row[0]) for row in result]
+
+    async def evolve_apply_weights(
+        self,
+        *,
+        tenant_id: str,
+        ids: list[str],
+        delta: float,
+        floor: float,
+        cap: float,
+        rule_id: str | None = None,
+        outcome_id: str | None = None,
+    ) -> dict:
+        """Clamp-and-adjust weights for ``ids`` and (atomically) backfill the
+        rule→outcome link, in ONE transaction.
+
+        Stmt 1 ports ``_ADJUST_WEIGHTS_BULK_SQL`` verbatim: an ``old_vals`` CTE
+        captures the pre-update weight, the UPDATE clamps
+        ``GREATEST(:floor, LEAST(:cap, weight + :delta))`` and RETURNs
+        ``(id, old_weight, new_weight)``. The source's ``id IN :mids``
+        expanding bindparam becomes ``ANY(CAST(:ids AS uuid[]))`` for asyncpg.
+
+        Stmt 2 ports ``_BACKFILL_RULE_OUTCOME_SQL`` verbatim and runs ONLY when
+        both ``rule_id`` and ``outcome_id`` are present: a ``jsonb_set`` of
+        ``metadata.source_outcome_id`` on the rule memory. Folding it into this
+        endpoint keeps the weight clamp + the backfill in a single storage
+        transaction so evolve's documented split-commit isn't widened into two
+        HTTP calls.
+
+        Every statement is scoped by ``tenant_id``. Returns
+        ``{adjustments:[{id, old_weight, new_weight}], backfilled: bool}`` —
+        the caller (``_adjust_weights``) applies rounding / ordering / the
+        ``delta`` + ``memory_id`` key shape from these rows."""
+        if not ids:
+            return {"adjustments": [], "backfilled": False}
+        async with get_session() as session:
+            result = await session.execute(
+                text(
+                    """
+                    WITH old_vals AS (
+                        SELECT id, weight AS old_weight
+                          FROM memories
+                         WHERE id = ANY(CAST(:ids AS uuid[]))
+                           AND tenant_id = :tid
+                           AND deleted_at IS NULL
+                    )
+                    UPDATE memories
+                       SET weight = GREATEST(:floor, LEAST(:cap, weight + :delta))
+                      FROM old_vals
+                     WHERE memories.id = old_vals.id
+                       AND memories.tenant_id = :tid
+                       AND memories.deleted_at IS NULL
+                    RETURNING memories.id AS id, old_vals.old_weight AS old_weight,
+                              memories.weight AS new_weight
+                    """
+                ),
+                {
+                    "ids": list(ids),
+                    "tid": tenant_id,
+                    "floor": floor,
+                    "cap": cap,
+                    "delta": delta,
+                },
+            )
+            adjustments = [
+                {
+                    "id": str(row.id),
+                    "old_weight": float(row.old_weight),
+                    "new_weight": float(row.new_weight),
+                }
+                for row in result.fetchall()
+            ]
+            backfilled = False
+            if rule_id and outcome_id:
+                br = await session.execute(
+                    text(
+                        """
+                        UPDATE memories
+                           SET metadata = jsonb_set(
+                               -- ``metadata::jsonb`` cast: legacy/test rows store
+                               -- the column as ``json`` (CAURA-595 drift); without
+                               -- it COALESCE(json, '{}'::jsonb) raises CannotCoerceError.
+                               -- Mirrors memory_update's metadata-merge.
+                               COALESCE(metadata::jsonb, '{}'::jsonb),
+                               '{source_outcome_id}',
+                               to_jsonb(CAST(:outcome_id AS text))
+                           )
+                         WHERE id = CAST(:rule_id AS uuid) AND tenant_id = :tid
+                        """
+                    ),
+                    {"rule_id": rule_id, "outcome_id": outcome_id, "tid": tenant_id},
+                )
+                # Report ``backfilled`` honestly: a soft-deleted, never-committed,
+                # or cross-tenant ``rule_id`` matches 0 rows, so the link wasn't
+                # actually written. ``rowcount`` is reliable for an UPDATE on the
+                # asyncpg dialect (parsed from the ``UPDATE N`` command tag).
+                backfilled = (br.rowcount or 0) > 0  # type: ignore[attr-defined]
+        return {"adjustments": adjustments, "backfilled": backfilled}
+
+    # ══════════════════════════════════════════════════════════════════════
     #  FLEET
     # ══════════════════════════════════════════════════════════════════════
 

--- a/tests/_mcp_test_helpers.py
+++ b/tests/_mcp_test_helpers.py
@@ -146,7 +146,12 @@ def mcp_env(monkeypatch):
 
     monkeypatch.setattr(mcp_server, "_check_auth", lambda: None)
     monkeypatch.setattr(mcp_server, "_get_tenant", lambda: tenant)
-    monkeypatch.setattr(mcp_server, "_mcp_session", fake_session)
+    # Fix 2 Ph5b (PR2): ``_mcp_session`` was deleted once ``memclaw_evolve`` —
+    # its last consumer — migrated to ``_no_db()``. Every MCP handler now opens
+    # ``_no_db()`` (yields None; storage-routed services carry tenant context
+    # explicitly). Patch it with the MagicMock-yielding session so handlers that
+    # still bind ``async with _no_db() as db`` get a harmless stand-in.
+    monkeypatch.setattr(mcp_server, "_no_db", fake_session)
 
     # Stub out usage metering so it doesn't hit the DB.
     monkeypatch.setattr(mcp_server, "check_and_increment", AsyncMock(return_value=None))

--- a/tests/test_evolve_service.py
+++ b/tests/test_evolve_service.py
@@ -175,27 +175,87 @@ async def _create_test_memory_via_sc(
     return str(mem["id"]), tag
 
 
-async def _create_test_memory(
-    db, tenant_id, agent_id="evolve-test-agent", weight=0.5, fleet_id=None
+async def _seed_memory_committed(
+    tenant_id, agent_id="evolve-test-agent", weight=0.5, fleet_id=None
 ):
-    """Create a memory directly in DB session (for tests that don't need cross-session visibility)."""
-    from common.models.memory import Memory
+    """Seed a committed memory visible to core-storage-api.
+
+    Fix 2 Ph5b (PR2): the evolve service now routes ``_filter_by_scope`` and
+    ``_adjust_weights`` through core-storage-api, so seeds MUST be committed and
+    visible across sessions — the conftest ``db`` fixture rolls back on its own
+    connection and storage would never see ``db.add`` rows. Uses a raw committed
+    INSERT on an independent storage session so fields the public create
+    endpoint doesn't expose (agent_id / fleet_id / weight) are set directly,
+    without the agent-upsert HTTP dance ``_create_test_memory_via_sc`` requires.
+    """
+    from uuid import uuid4
+
+    from sqlalchemy import text
+
+    from core_storage_api.services.postgres_service import get_session
 
     tag = _uid()
-    mem = Memory(
-        tenant_id=tenant_id,
-        agent_id=agent_id,
-        fleet_id=fleet_id or f"evolve-fleet-{tag}",
-        memory_type="fact",
-        content=f"Test memory for evolve [{tag}]",
-        weight=weight,
-        status="active",
-        recall_count=0,
-        visibility="scope_team",
-    )
-    db.add(mem)
-    await db.flush()
-    return str(mem.id), tag
+    mem_id = str(uuid4())
+    async with get_session() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO memories
+                    (id, tenant_id, fleet_id, agent_id, content, memory_type,
+                     status, weight, recall_count, visibility)
+                VALUES
+                    (CAST(:id AS uuid), :tenant_id, :fleet_id, :agent_id, :content, 'fact',
+                     'active', :weight, 0, 'scope_team')
+                """
+            ),
+            {
+                "id": mem_id,
+                "tenant_id": tenant_id,
+                "fleet_id": fleet_id or f"evolve-fleet-{tag}",
+                "agent_id": agent_id,
+                "content": f"Test memory for evolve [{tag}]",
+                "weight": weight,
+            },
+        )
+    return mem_id, tag
+
+
+async def _outcome_memories(tenant_id):
+    """Fetch committed outcome-type memories for a tenant from storage.
+
+    Returns lightweight namespaces with ``content`` / ``metadata`` (parsed to a
+    dict regardless of whether the asyncpg JSONB codec hands it back as a dict
+    or a JSON string) / ``visibility`` so the assertions read uniformly.
+    """
+    import json as _json
+    from types import SimpleNamespace
+
+    from sqlalchemy import text
+
+    from core_storage_api.services.postgres_service import get_session
+
+    async with get_session() as session:
+        rows = (
+            await session.execute(
+                text(
+                    """
+                    SELECT content, metadata, visibility
+                      FROM memories
+                     WHERE tenant_id = :tid AND memory_type = 'outcome'
+                       AND deleted_at IS NULL
+                    """
+                ),
+                {"tid": tenant_id},
+            )
+        ).fetchall()
+
+    out = []
+    for r in rows:
+        meta = r.metadata
+        if isinstance(meta, str):
+            meta = _json.loads(meta)
+        out.append(SimpleNamespace(content=r.content, metadata=meta, visibility=r.visibility))
+    return out
 
 
 @pytest.mark.asyncio
@@ -210,7 +270,7 @@ async def test_evolve_success_increases_weight(db, sc):
     from core_api.services.evolve_service import _adjust_weights
 
     _, _, adjustments = await _adjust_weights(
-        db, tenant_id, [mid], "success", "evolve-test-agent"
+        None, tenant_id, [mid], "success", "evolve-test-agent"
     )
 
     assert len(adjustments) == 1
@@ -233,7 +293,7 @@ async def test_evolve_failure_decreases_weight(db, sc):
     from core_api.services.evolve_service import _adjust_weights
 
     _, _, adjustments = await _adjust_weights(
-        db, tenant_id, [mid], "failure", "evolve-test-agent"
+        None, tenant_id, [mid], "failure", "evolve-test-agent"
     )
 
     assert len(adjustments) == 1
@@ -255,7 +315,7 @@ async def test_evolve_partial_slight_increase(db, sc):
     from core_api.services.evolve_service import _adjust_weights
 
     _, _, adjustments = await _adjust_weights(
-        db, tenant_id, [mid], "partial", "evolve-test-agent"
+        None, tenant_id, [mid], "partial", "evolve-test-agent"
     )
 
     assert len(adjustments) == 1
@@ -276,7 +336,7 @@ async def test_evolve_weight_floor(db, sc):
     from core_api.services.evolve_service import _adjust_weights
 
     _, _, adjustments = await _adjust_weights(
-        db, tenant_id, [mid], "failure", "evolve-test-agent"
+        None, tenant_id, [mid], "failure", "evolve-test-agent"
     )
 
     assert len(adjustments) == 1
@@ -295,7 +355,7 @@ async def test_evolve_weight_cap(db, sc):
     from core_api.services.evolve_service import _adjust_weights
 
     _, _, adjustments = await _adjust_weights(
-        db, tenant_id, [mid], "success", "evolve-test-agent"
+        None, tenant_id, [mid], "success", "evolve-test-agent"
     )
 
     assert len(adjustments) == 1
@@ -312,7 +372,7 @@ async def test_evolve_nonexistent_memory_skipped(db):
     from core_api.services.evolve_service import _adjust_weights
 
     _, _, adjustments = await _adjust_weights(
-        db, tenant_id, [fake_id], "success", "test-agent"
+        None, tenant_id, [fake_id], "success", "test-agent"
     )
     assert len(adjustments) == 0
 
@@ -326,7 +386,7 @@ async def test_evolve_invalid_uuid_skipped(db):
     from core_api.services.evolve_service import _adjust_weights
 
     _, _, adjustments = await _adjust_weights(
-        db, tenant_id, ["not-a-uuid"], "success", "test-agent"
+        None, tenant_id, ["not-a-uuid"], "success", "test-agent"
     )
     assert len(adjustments) == 0
 
@@ -346,7 +406,7 @@ async def test_evolve_truncates_related_ids_above_cap(db, caplog):
 
     with caplog.at_level(logging.WARNING, logger="core_api.services.evolve_service"):
         _, _, adjustments = await _adjust_weights(
-            db, tenant_id, oversized, "success", "test-agent"
+            None, tenant_id, oversized, "success", "test-agent"
         )
 
     assert adjustments == []
@@ -376,7 +436,7 @@ class TestConfidenceParsing:
 
 
 @pytest.mark.asyncio
-async def test_evolve_no_related_ids(db):
+async def test_evolve_no_related_ids():
     """Reporting outcome with no related_ids → only outcome memory, no adjustments."""
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
@@ -384,7 +444,7 @@ async def test_evolve_no_related_ids(db):
     from core_api.services.evolve_service import report_outcome
 
     result = await report_outcome(
-        db,
+        None,
         tenant_id=tenant_id,
         outcome=f"Something happened [{tag}]",
         outcome_type="success",
@@ -400,19 +460,20 @@ async def test_evolve_no_related_ids(db):
 
 
 @pytest.mark.asyncio
-async def test_evolve_persists_outcome_memory(db):
-    """Outcome is persisted as a memory of type 'outcome'."""
-    from sqlalchemy import select
+async def test_evolve_persists_outcome_memory():
+    """Outcome is persisted as a memory of type 'outcome'.
 
-    from common.models.memory import Memory
-
+    Fix 2 Ph5b (PR2): the outcome ``create_memory`` is storage-committed, so the
+    assertion reads from storage (``_outcome_memories``) rather than the
+    rolled-back ``db`` fixture.
+    """
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
 
     from core_api.services.evolve_service import report_outcome
 
     result = await report_outcome(
-        db,
+        None,
         tenant_id=tenant_id,
         outcome=f"Test outcome [{tag}]",
         outcome_type="failure",
@@ -421,23 +482,16 @@ async def test_evolve_persists_outcome_memory(db):
     )
     assert result["outcome_id"] is not None
 
-    # Query for the outcome memory
-    stmt = select(Memory).where(
-        Memory.tenant_id == tenant_id,
-        Memory.memory_type == "outcome",
-    )
-    rows = (await db.execute(stmt)).scalars().all()
+    rows = await _outcome_memories(tenant_id)
     assert len(rows) >= 1
-
     outcome_mem = rows[0]
-    assert outcome_mem.memory_type == "outcome"
     assert tag in outcome_mem.content
-    assert outcome_mem.metadata_ is not None
-    assert outcome_mem.metadata_.get("outcome_type") == "failure"
+    assert outcome_mem.metadata is not None
+    assert outcome_mem.metadata.get("outcome_type") == "failure"
 
 
 @pytest.mark.asyncio
-async def test_evolve_generate_rule_returns_valid_structure(db, sc):
+async def test_evolve_generate_rule_returns_valid_structure(sc):
     """_generate_rule with fake LLM returns a valid rule structure."""
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
@@ -449,7 +503,8 @@ async def test_evolve_generate_rule_returns_valid_structure(db, sc):
     # Audit P3 (evolve): ``_generate_rule`` no longer takes ``db`` —
     # callers resolve the tenant config first and pass it in. This
     # lets the MCP tool close its session before the LLM round-trip.
-    config = await resolve_config(db, tenant_id)
+    # Fix 2 Ph5b (PR2): resolve_config is storage-routed; db=None.
+    config = await resolve_config(None, tenant_id)
 
     # A10: _generate_rule now returns (skip_reason, rule_dict) tuple.
     reason, rule = await _generate_rule(
@@ -486,12 +541,8 @@ class TestFakeRuleFallback:
 
 
 @pytest.mark.asyncio
-async def test_evolve_failure_with_related_ids_adjusts_and_records(db, sc):
+async def test_evolve_failure_with_related_ids_adjusts_and_records(sc):
     """Failure with related_ids adjusts weights and persists outcome."""
-    from sqlalchemy import select
-
-    from common.models.memory import Memory
-
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
     mid, _ = await _create_test_memory_via_sc(sc, tenant_id, weight=0.5)
@@ -499,7 +550,7 @@ async def test_evolve_failure_with_related_ids_adjusts_and_records(db, sc):
     from core_api.services.evolve_service import report_outcome
 
     result = await report_outcome(
-        db,
+        None,
         tenant_id=tenant_id,
         outcome=f"Failed because of bad info [{tag}]",
         outcome_type="failure",
@@ -513,18 +564,14 @@ async def test_evolve_failure_with_related_ids_adjusts_and_records(db, sc):
     assert result["outcome_id"] is not None
     assert result["outcome_type"] == "failure"
 
-    # Outcome memory should exist
-    stmt = select(Memory).where(
-        Memory.tenant_id == tenant_id,
-        Memory.memory_type == "outcome",
-    )
-    rows = (await db.execute(stmt)).scalars().all()
+    # Outcome memory should exist (storage-committed).
+    rows = await _outcome_memories(tenant_id)
     assert len(rows) >= 1
-    assert rows[0].metadata_.get("outcome_type") == "failure"
+    assert rows[0].metadata.get("outcome_type") == "failure"
 
 
 @pytest.mark.asyncio
-async def test_evolve_success_no_rule(db, sc):
+async def test_evolve_success_no_rule(sc):
     """Success outcome does NOT generate a rule."""
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
@@ -533,7 +580,7 @@ async def test_evolve_success_no_rule(db, sc):
     from core_api.services.evolve_service import report_outcome
 
     result = await report_outcome(
-        db,
+        None,
         tenant_id=tenant_id,
         outcome=f"Worked great [{tag}]",
         outcome_type="success",
@@ -545,7 +592,7 @@ async def test_evolve_success_no_rule(db, sc):
 
 
 @pytest.mark.asyncio
-async def test_evolve_response_shape(db):
+async def test_evolve_response_shape():
     """Full response has all expected fields."""
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
@@ -553,7 +600,7 @@ async def test_evolve_response_shape(db):
     from core_api.services.evolve_service import report_outcome
 
     result = await report_outcome(
-        db,
+        None,
         tenant_id=tenant_id,
         outcome=f"Test shape [{tag}]",
         outcome_type="partial",
@@ -645,25 +692,24 @@ class TestScopeValidation:
 
 
 @pytest.mark.asyncio
-async def test_filter_by_scope_agent_drops_other_agents_memories(db):
+async def test_filter_by_scope_agent_drops_other_agents_memories():
     """scope='agent' keeps only memories owned by the caller.
 
-    Uses the direct-DB helper (_create_test_memory) rather than the
-    storage-client path so the test doesn't go through the HTTP
-    agent-upsert dance — it only needs rows visible to the ``db``
-    session, which is exactly where ``_filter_by_scope`` queries.
+    Fix 2 Ph5b (PR2): ``_filter_by_scope``'s SELECT is storage-routed, so seeds
+    must be committed and visible across sessions (``_seed_memory_committed``);
+    ``db`` is no longer passed.
     """
     from core_api.services.evolve_service import _filter_by_scope
 
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
 
-    mine_a, _ = await _create_test_memory(db, tenant_id, agent_id="agent-a")
-    mine_b, _ = await _create_test_memory(db, tenant_id, agent_id="agent-a")
-    other, _ = await _create_test_memory(db, tenant_id, agent_id="agent-b")
+    mine_a, _ = await _seed_memory_committed(tenant_id, agent_id="agent-a")
+    mine_b, _ = await _seed_memory_committed(tenant_id, agent_id="agent-a")
+    other, _ = await _seed_memory_committed(tenant_id, agent_id="agent-b")
 
     kept, dropped = await _filter_by_scope(
-        db,
+        None,
         tenant_id=tenant_id,
         caller_agent_id="agent-a",
         fleet_id=None,
@@ -675,20 +721,18 @@ async def test_filter_by_scope_agent_drops_other_agents_memories(db):
 
 
 @pytest.mark.asyncio
-async def test_filter_by_scope_fleet_drops_other_fleets(db):
+async def test_filter_by_scope_fleet_drops_other_fleets():
     """scope='fleet' keeps only memories in the caller's fleet_id."""
     from core_api.services.evolve_service import _filter_by_scope
 
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
 
-    ours, _ = await _create_test_memory(db, tenant_id, agent_id="a", fleet_id="fleet-x")
-    theirs, _ = await _create_test_memory(
-        db, tenant_id, agent_id="b", fleet_id="fleet-y"
-    )
+    ours, _ = await _seed_memory_committed(tenant_id, agent_id="a", fleet_id="fleet-x")
+    theirs, _ = await _seed_memory_committed(tenant_id, agent_id="b", fleet_id="fleet-y")
 
     kept, dropped = await _filter_by_scope(
-        db,
+        None,
         tenant_id=tenant_id,
         caller_agent_id="a",
         fleet_id="fleet-x",
@@ -700,18 +744,18 @@ async def test_filter_by_scope_fleet_drops_other_fleets(db):
 
 
 @pytest.mark.asyncio
-async def test_filter_by_scope_all_keeps_everything_in_tenant(db):
+async def test_filter_by_scope_all_keeps_everything_in_tenant():
     """scope='all' keeps any memory in the tenant regardless of owner/fleet."""
     from core_api.services.evolve_service import _filter_by_scope
 
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
 
-    m1, _ = await _create_test_memory(db, tenant_id, agent_id="a", fleet_id="fa")
-    m2, _ = await _create_test_memory(db, tenant_id, agent_id="b", fleet_id="fb")
+    m1, _ = await _seed_memory_committed(tenant_id, agent_id="a", fleet_id="fa")
+    m2, _ = await _seed_memory_committed(tenant_id, agent_id="b", fleet_id="fb")
 
     kept, dropped = await _filter_by_scope(
-        db,
+        None,
         tenant_id=tenant_id,
         caller_agent_id="a",
         fleet_id=None,
@@ -723,16 +767,16 @@ async def test_filter_by_scope_all_keeps_everything_in_tenant(db):
 
 
 @pytest.mark.asyncio
-async def test_filter_by_scope_drops_invalid_uuid_and_missing(db):
+async def test_filter_by_scope_drops_invalid_uuid_and_missing():
     """Non-parseable UUIDs and missing rows count toward out_of_scope_count."""
     from core_api.services.evolve_service import _filter_by_scope
 
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
-    mine, _ = await _create_test_memory(db, tenant_id, agent_id="a")
+    mine, _ = await _seed_memory_committed(tenant_id, agent_id="a")
 
     kept, dropped = await _filter_by_scope(
-        db,
+        None,
         tenant_id=tenant_id,
         caller_agent_id="a",
         fleet_id=None,
@@ -744,12 +788,12 @@ async def test_filter_by_scope_drops_invalid_uuid_and_missing(db):
 
 
 @pytest.mark.asyncio
-async def test_filter_by_scope_empty_input(db):
-    """None / empty input returns ([], 0) without touching the DB."""
+async def test_filter_by_scope_empty_input():
+    """None / empty input returns ([], 0) without touching storage."""
     from core_api.services.evolve_service import _filter_by_scope
 
     kept, dropped = await _filter_by_scope(
-        db,
+        None,
         tenant_id="t1",
         caller_agent_id="a",
         fleet_id=None,
@@ -761,25 +805,25 @@ async def test_filter_by_scope_empty_input(db):
 
 
 @pytest.mark.asyncio
-async def test_evolve_scope_agent_filters_out_other_agent_ids(db):
+async def test_evolve_scope_agent_filters_out_other_agent_ids():
     """report_outcome with scope='agent' silently drops memories owned by
     other agents — only the caller's memories get weight-adjusted, and
     out_of_scope_count reflects the drop.
 
-    Uses outcome_type='success' so the rule-generation path (which calls
-    storage-api over HTTP) is not exercised — this test cares only about
-    scope filtering + weight adjustment, both of which live on ``db``.
+    Uses outcome_type='success' so the rule-generation path is not exercised —
+    this test cares only about scope filtering + weight adjustment, both of
+    which are storage-routed (so seeds are committed; db=None).
     """
     from core_api.services.evolve_service import report_outcome
 
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
 
-    mine, _ = await _create_test_memory(db, tenant_id, agent_id="caller-a", weight=0.5)
-    other, _ = await _create_test_memory(db, tenant_id, agent_id="agent-b", weight=0.5)
+    mine, _ = await _seed_memory_committed(tenant_id, agent_id="caller-a", weight=0.5)
+    other, _ = await _seed_memory_committed(tenant_id, agent_id="agent-b", weight=0.5)
 
     result = await report_outcome(
-        db,
+        None,
         tenant_id=tenant_id,
         outcome=f"agent-scope test [{tag}]",
         outcome_type="success",
@@ -795,18 +839,18 @@ async def test_evolve_scope_agent_filters_out_other_agent_ids(db):
 
 
 @pytest.mark.asyncio
-async def test_evolve_scope_all_adjusts_any_memory(db):
+async def test_evolve_scope_all_adjusts_any_memory():
     """scope='all' lets the caller adjust memories they don't own (within tenant)."""
     from core_api.services.evolve_service import report_outcome
 
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
 
-    m1, _ = await _create_test_memory(db, tenant_id, agent_id="caller")
-    m2, _ = await _create_test_memory(db, tenant_id, agent_id="other")
+    m1, _ = await _seed_memory_committed(tenant_id, agent_id="caller")
+    m2, _ = await _seed_memory_committed(tenant_id, agent_id="other")
 
     result = await report_outcome(
-        db,
+        None,
         tenant_id=tenant_id,
         outcome=f"all-scope test [{tag}]",
         outcome_type="success",
@@ -821,11 +865,12 @@ async def test_evolve_scope_all_adjusts_any_memory(db):
 
 
 @pytest.mark.asyncio
-async def test_evolve_outcome_memory_visibility_matches_scope(db, sc):
-    """The persisted outcome memory's visibility follows _SCOPE_TO_VISIBILITY."""
-    from sqlalchemy import select
+async def test_evolve_outcome_memory_visibility_matches_scope():
+    """The persisted outcome memory's visibility follows _SCOPE_TO_VISIBILITY.
 
-    from common.models.memory import Memory
+    Fix 2 Ph5b (PR2): the outcome ``create_memory`` is storage-committed, so the
+    assertion reads from storage (``_outcome_memories``); db=None.
+    """
     from core_api.services.evolve_service import (
         _SCOPE_TO_VISIBILITY,
         report_outcome,
@@ -836,7 +881,7 @@ async def test_evolve_outcome_memory_visibility_matches_scope(db, sc):
         tenant_id = f"test-tenant-{tag}"
 
         result = await report_outcome(
-            db,
+            None,
             tenant_id=tenant_id,
             outcome=f"vis test {scope} [{tag}]",
             outcome_type="success",
@@ -846,18 +891,14 @@ async def test_evolve_outcome_memory_visibility_matches_scope(db, sc):
             fleet_id="fleet-x" if scope == "fleet" else None,
         )
 
-        stmt = select(Memory).where(
-            Memory.tenant_id == tenant_id,
-            Memory.memory_type == "outcome",
-        )
-        rows = (await db.execute(stmt)).scalars().all()
+        rows = await _outcome_memories(tenant_id)
         assert len(rows) == 1, (
             f"scope={scope}: expected 1 outcome memory, got {len(rows)}"
         )
         assert rows[0].visibility == _SCOPE_TO_VISIBILITY[scope], (
             f"scope={scope}: visibility {rows[0].visibility} != {_SCOPE_TO_VISIBILITY[scope]}"
         )
-        assert rows[0].metadata_.get("scope") == scope
+        assert rows[0].metadata.get("scope") == scope
         assert result["scope"] == scope
 
 
@@ -1194,3 +1235,25 @@ async def test_evolve_rest_translates_service_valueerror_to_422(monkeypatch, cli
     )
     assert resp.status_code == 422
     assert "synthetic" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 Ph5b (PR2) — _mcp_session is deleted (evolve was its last consumer)
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_session_helper_is_deleted():
+    """``memclaw_evolve`` was the final ``_mcp_session()`` consumer; once it
+    migrated to ``_no_db()`` the RLS-GUC session helper + its ``async_session``
+    import were deleted. Guard against a reintroduction: the symbol must be
+    gone from mcp_server, and the source must not redefine it."""
+    import inspect
+
+    from core_api import mcp_server
+
+    assert not hasattr(mcp_server, "_mcp_session"), (
+        "_mcp_session must be deleted — evolve was its last consumer (Fix 2 Ph5b PR2)"
+    )
+    src = inspect.getsource(mcp_server)
+    assert "async def _mcp_session" not in src
+    assert "from core_api.db.session import async_session" not in src

--- a/tests/test_mcp_evolve_session_split.py
+++ b/tests/test_mcp_evolve_session_split.py
@@ -4,14 +4,18 @@ The handler previously held a single ``_mcp_session()`` open across
 the rule-generation LLM round-trip in ``_generate_rule``, pinning a
 pooled DB connection. The refactor splits the work into three phases:
 
-  1. Session 1 — trust + usage gates, ``_filter_by_scope``, resolve config.
-  2. No DB     — ``_maybe_generate_rule`` (LLM).
-  3. Session 2 — ``_apply_outcome_to_db`` (weights + persist + backfill + commit).
+  1. Phase 1 — trust + usage gates, ``_filter_by_scope``, resolve config.
+  2. No DB   — ``_maybe_generate_rule`` (LLM).
+  3. Phase 3 — ``_apply_outcome_to_db`` (persist + weights + backfill).
 
-This module asserts the timing invariant with a patched
-``_mcp_session`` capturing enter/exit events and a patched
-``_maybe_generate_rule`` recording its entry. A regression that
-re-merges phases 1+2 would flip the order and fail.
+Fix 2 Ph5b (PR2): all three phases are now storage-routed via ``_no_db()``
+(``db=None``) — the scope filter, gates, rule/outcome create, and the atomic
+weight-adjust/backfill go through core-storage-api, so no pooled DB connection
+is held at any point (``_mcp_session`` was deleted; evolve was its last
+consumer). This module still asserts the *phasing* invariant (phase-1 block
+closes BEFORE the LLM, phase-3 opens after) by patching the ``_no_db`` context
+manager to capture enter/exit events; a regression that re-merges phases 1+2
+around the LLM call would flip the order and fail.
 """
 
 from __future__ import annotations
@@ -48,13 +52,13 @@ async def _run_evolve_capturing_apply_kwargs(monkeypatch, *, related_ids, filter
 
     @asynccontextmanager
     async def _session():
-        yield MagicMock(name="db")
+        yield None
 
     async def _spy_apply(_db, **kwargs):
         captured.update(kwargs)
         return _APPLY_OUTCOME_RESULT
 
-    monkeypatch.setattr(mcp_server, "_mcp_session", _session)
+    monkeypatch.setattr(mcp_server, "_no_db", _session)
     monkeypatch.setattr(mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None)))
     monkeypatch.setattr(mcp_server, "check_and_increment", AsyncMock())
     monkeypatch.setattr(
@@ -146,11 +150,11 @@ async def test_evolve_closes_first_session_before_llm(mcp_env, monkeypatch):
     async def _captured_session():
         events.append("session-enter")
         try:
-            yield MagicMock(name="db")
+            yield None
         finally:
             events.append("session-exit")
 
-    monkeypatch.setattr(mcp_server, "_mcp_session", _captured_session)
+    monkeypatch.setattr(mcp_server, "_no_db", _captured_session)
     monkeypatch.setattr(
         mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None))
     )
@@ -227,11 +231,11 @@ async def test_evolve_uses_two_distinct_sessions(mcp_env, monkeypatch):
         nonlocal session_count
         session_count += 1
         try:
-            yield MagicMock(name=f"db-{session_count}")
+            yield None
         finally:
             pass
 
-    monkeypatch.setattr(mcp_server, "_mcp_session", _counting_session)
+    monkeypatch.setattr(mcp_server, "_no_db", _counting_session)
     monkeypatch.setattr(
         mcp_server, "_require_trust", AsyncMock(return_value=(3, False, None))
     )

--- a/tests/test_mcp_recall.py
+++ b/tests/test_mcp_recall.py
@@ -138,16 +138,16 @@ async def test_recall_auth_failure_shortcircuits(monkeypatch):
 
 
 async def test_recall_brief_runs_after_search_no_db_held(mcp_env, monkeypatch):
-    """Audit P3 (post-Fix-2-Phase-4): recall no longer opens ``_mcp_session``,
-    so a pooled DB connection can never be pinned across the multi-second LLM
-    brief. We assert the structural invariant directly: the brief runs strictly
-    AFTER ``search_memories`` returns, and ``_mcp_session`` is never entered."""
-    import contextlib
+    """Audit P3 (post-Fix-2): recall holds no pooled DB connection across the
+    multi-second LLM brief — it is fully storage-routed. Fix 2 Ph5b (PR2)
+    deleted ``_mcp_session`` entirely (evolve was its last consumer), so the
+    "never opens _mcp_session" guard is now structurally guaranteed by the
+    helper's absence; we assert the remaining structural invariant: the brief
+    runs strictly AFTER ``search_memories`` returns."""
     import time as _time
 
     search_returned_at: dict = {"t": None}
     brief_started_at: dict = {"t": None}
-    session_opened: dict = {"v": False}
 
     async def _tracking_search(*_args, **_kwargs):
         search_returned_at["t"] = _time.perf_counter()
@@ -157,14 +157,10 @@ async def test_recall_brief_runs_after_search_no_db_held(mcp_env, monkeypatch):
         brief_started_at["t"] = _time.perf_counter()
         return {"summary": "anything"}
 
-    @contextlib.asynccontextmanager
-    async def _tracking_session():
-        session_opened["v"] = True
-        yield None
-
     monkeypatch.setattr(mcp_server, "search_memories", _tracking_search)
     monkeypatch.setattr(mcp_server, "summarize_memories", _tracking_summarize)
-    monkeypatch.setattr(mcp_server, "_mcp_session", _tracking_session)
+    # ``_mcp_session`` no longer exists to patch; recall opens ``_no_db()`` only.
+    assert not hasattr(mcp_server, "_mcp_session")
     _wire_recall_deps(monkeypatch)
 
     await mcp_server.memclaw_recall(query="x", include_brief=True)
@@ -173,9 +169,6 @@ async def test_recall_brief_runs_after_search_no_db_held(mcp_env, monkeypatch):
     assert brief_started_at["t"] is not None, "brief never ran"
     assert brief_started_at["t"] >= search_returned_at["t"], (
         "brief LLM call started before search returned"
-    )
-    assert session_opened["v"] is False, (
-        "recall must not open _mcp_session post-Phase-4"
     )
 
 

--- a/tests/test_ph5b_evolve_storage.py
+++ b/tests/test_ph5b_evolve_storage.py
@@ -1,0 +1,372 @@
+"""Fix 2 Ph5b (PR2) — evolve scope-filter + weight-adjust routed through core-storage-api.
+
+Exercises the 2 new core-storage-api endpoints via the typed storage client
+(bridged in-process to the storage app by the conftest ASGI fixture, against
+the test DB):
+
+- POST /evolve/filter-by-scope   (sc.evolve_filter_by_scope)  — scope SELECT
+- POST /evolve/apply-weights     (sc.evolve_apply_weights)    — clamp CTE + jsonb_set backfill (ONE txn)
+
+Rows are seeded via a raw committed INSERT on an independent session (the
+public create endpoint doesn't expose weight / agent_id / fleet_id / metadata
+directly, which these passes filter + mutate). A unique tenant per test keeps
+concurrent suite runs isolated. Mirrors test_ph5b_insights_storage.py.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+from core_storage_api.services.postgres_service import get_session
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _t() -> str:
+    return f"test-tenant-ph5b-evolve-{uuid4().hex[:8]}"
+
+
+async def _seed_memory(
+    *,
+    tenant_id: str,
+    content: str = "x",
+    agent_id: str = "agent-1",
+    fleet_id: str | None = None,
+    memory_type: str = "fact",
+    status: str = "active",
+    weight: float = 0.5,
+    metadata: dict | None = None,
+    visibility: str = "scope_team",
+) -> str:
+    """Raw committed INSERT covering the columns the evolve passes touch."""
+    mem_id = str(uuid4())
+    async with get_session() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO memories
+                    (id, tenant_id, fleet_id, agent_id, content, memory_type,
+                     status, weight, metadata, visibility)
+                VALUES
+                    (CAST(:id AS uuid), :tenant_id, :fleet_id, :agent_id, :content, :memory_type,
+                     :status, :weight, CAST(:metadata AS jsonb), :visibility)
+                """
+            ),
+            {
+                "id": mem_id,
+                "tenant_id": tenant_id,
+                "fleet_id": fleet_id,
+                "agent_id": agent_id,
+                "content": content,
+                "memory_type": memory_type,
+                "status": status,
+                "weight": weight,
+                "metadata": _json.dumps(metadata) if metadata is not None else None,
+                "visibility": visibility,
+            },
+        )
+    return mem_id
+
+
+async def _weight(mem_id: str) -> float:
+    async with get_session() as session:
+        row = (
+            await session.execute(
+                text("SELECT weight FROM memories WHERE id = CAST(:id AS uuid)"), {"id": mem_id}
+            )
+        ).fetchone()
+    return float(row.weight)
+
+
+async def _metadata(mem_id: str) -> dict | None:
+    async with get_session() as session:
+        row = (
+            await session.execute(
+                text("SELECT metadata FROM memories WHERE id = CAST(:id AS uuid)"), {"id": mem_id}
+            )
+        ).fetchone()
+    meta = row.metadata
+    # asyncpg's JSONB codec may hand jsonb back as a JSON string on a raw
+    # text() read; normalise to a dict so the assertions read uniformly.
+    if isinstance(meta, str):
+        meta = _json.loads(meta)
+    return meta
+
+
+async def _soft_delete(mem_id: str) -> None:
+    async with get_session() as session:
+        await session.execute(
+            text("UPDATE memories SET deleted_at = now() WHERE id = CAST(:id AS uuid)"),
+            {"id": mem_id},
+        )
+
+
+# ===========================================================================
+# A. filter-by-scope
+# ===========================================================================
+
+
+async def test_filter_scope_agent_keeps_only_caller(sc):
+    tenant = _t()
+    mine_a = await _seed_memory(tenant_id=tenant, agent_id="a1", content="mine-a")
+    mine_b = await _seed_memory(tenant_id=tenant, agent_id="a1", content="mine-b")
+    other = await _seed_memory(tenant_id=tenant, agent_id="a2", content="other")
+    allowed = await sc.evolve_filter_by_scope(
+        tenant_id=tenant,
+        caller_agent_id="a1",
+        fleet_id=None,
+        scope="agent",
+        ids=[mine_a, mine_b, other],
+    )
+    assert set(allowed) == {mine_a, mine_b}
+
+
+async def test_filter_scope_fleet_keeps_only_fleet(sc):
+    tenant = _t()
+    ours = await _seed_memory(tenant_id=tenant, agent_id="a", fleet_id="fleet-x", content="ours")
+    theirs = await _seed_memory(tenant_id=tenant, agent_id="b", fleet_id="fleet-y", content="theirs")
+    allowed = await sc.evolve_filter_by_scope(
+        tenant_id=tenant,
+        caller_agent_id="a",
+        fleet_id="fleet-x",
+        scope="fleet",
+        ids=[ours, theirs],
+    )
+    assert allowed == [ours]
+
+
+async def test_filter_scope_all_keeps_everything_in_tenant(sc):
+    tenant = _t()
+    m1 = await _seed_memory(tenant_id=tenant, agent_id="a", fleet_id="fa", content="m1")
+    m2 = await _seed_memory(tenant_id=tenant, agent_id="b", fleet_id="fb", content="m2")
+    allowed = await sc.evolve_filter_by_scope(
+        tenant_id=tenant,
+        caller_agent_id="a",
+        fleet_id=None,
+        scope="all",
+        ids=[m1, m2],
+    )
+    assert set(allowed) == {m1, m2}
+
+
+async def test_filter_drops_soft_deleted_and_missing(sc):
+    tenant = _t()
+    mine = await _seed_memory(tenant_id=tenant, agent_id="a", content="mine")
+    gone = await _seed_memory(tenant_id=tenant, agent_id="a", content="gone")
+    await _soft_delete(gone)
+    missing = str(uuid4())
+    allowed = await sc.evolve_filter_by_scope(
+        tenant_id=tenant,
+        caller_agent_id="a",
+        fleet_id=None,
+        scope="agent",
+        ids=[mine, gone, missing],
+    )
+    assert allowed == [mine]
+
+
+async def test_filter_tenant_isolation(sc):
+    t_a, t_b = _t(), _t()
+    mine = await _seed_memory(tenant_id=t_a, agent_id="a", content="a")
+    # Same id queried under a different tenant must not match.
+    allowed = await sc.evolve_filter_by_scope(
+        tenant_id=t_b,
+        caller_agent_id="a",
+        fleet_id=None,
+        scope="all",
+        ids=[mine],
+    )
+    assert allowed == []
+
+
+async def test_filter_empty_ids(sc):
+    allowed = await sc.evolve_filter_by_scope(
+        tenant_id=_t(),
+        caller_agent_id="a",
+        fleet_id=None,
+        scope="agent",
+        ids=[],
+    )
+    assert allowed == []
+
+
+# ===========================================================================
+# B. apply-weights — clamp CTE + RETURNING + backfill
+# ===========================================================================
+
+
+async def test_apply_weights_returns_old_and_new(sc):
+    tenant = _t()
+    mid = await _seed_memory(tenant_id=tenant, agent_id="a", weight=0.5)
+    resp = await sc.evolve_apply_weights(
+        tenant_id=tenant, ids=[mid], delta=0.1, floor=0.05, cap=1.0
+    )
+    assert resp["backfilled"] is False
+    assert len(resp["adjustments"]) == 1
+    adj = resp["adjustments"][0]
+    assert adj["id"] == mid
+    assert adj["old_weight"] == pytest.approx(0.5)
+    assert adj["new_weight"] == pytest.approx(0.6)
+    assert await _weight(mid) == pytest.approx(0.6)
+
+
+async def test_apply_weights_clamps_at_floor(sc):
+    tenant = _t()
+    mid = await _seed_memory(tenant_id=tenant, agent_id="a", weight=0.1)
+    resp = await sc.evolve_apply_weights(
+        tenant_id=tenant, ids=[mid], delta=-0.5, floor=0.05, cap=1.0
+    )
+    assert resp["adjustments"][0]["new_weight"] == pytest.approx(0.05)
+    assert await _weight(mid) == pytest.approx(0.05)
+
+
+async def test_apply_weights_clamps_at_cap(sc):
+    tenant = _t()
+    mid = await _seed_memory(tenant_id=tenant, agent_id="a", weight=0.95)
+    resp = await sc.evolve_apply_weights(
+        tenant_id=tenant, ids=[mid], delta=0.5, floor=0.05, cap=1.0
+    )
+    assert resp["adjustments"][0]["new_weight"] == pytest.approx(1.0)
+    assert await _weight(mid) == pytest.approx(1.0)
+
+
+async def test_apply_weights_backfills_source_outcome_id(sc):
+    tenant = _t()
+    target = await _seed_memory(tenant_id=tenant, agent_id="a", weight=0.5)
+    rule = await _seed_memory(tenant_id=tenant, agent_id="a", memory_type="rule", metadata={"generated_by": "evolve"})
+    outcome_id = "11111111-1111-1111-1111-111111111111"
+    resp = await sc.evolve_apply_weights(
+        tenant_id=tenant,
+        ids=[target],
+        delta=0.1,
+        floor=0.05,
+        cap=1.0,
+        rule_id=rule,
+        outcome_id=outcome_id,
+    )
+    assert resp["backfilled"] is True
+    meta = await _metadata(rule)
+    assert meta.get("source_outcome_id") == outcome_id
+    # The pre-existing key must be preserved (jsonb_set, not replace).
+    assert meta.get("generated_by") == "evolve"
+
+
+async def test_apply_weights_no_backfill_when_rule_or_outcome_absent(sc):
+    tenant = _t()
+    target = await _seed_memory(tenant_id=tenant, agent_id="a", weight=0.5)
+    rule = await _seed_memory(tenant_id=tenant, agent_id="a", memory_type="rule")
+    # rule_id present but no outcome_id → no backfill.
+    resp = await sc.evolve_apply_weights(
+        tenant_id=tenant, ids=[target], delta=0.1, floor=0.05, cap=1.0, rule_id=rule
+    )
+    assert resp["backfilled"] is False
+    meta = await _metadata(rule)
+    assert meta is None or "source_outcome_id" not in meta
+
+
+async def test_apply_weights_tenant_isolation(sc):
+    t_a, t_b = _t(), _t()
+    mid = await _seed_memory(tenant_id=t_a, agent_id="a", weight=0.5)
+    # Tenant B cannot move tenant A's weight.
+    resp = await sc.evolve_apply_weights(
+        tenant_id=t_b, ids=[mid], delta=0.5, floor=0.05, cap=1.0
+    )
+    assert resp["adjustments"] == []
+    assert await _weight(mid) == pytest.approx(0.5)
+
+
+async def test_apply_weights_skips_soft_deleted(sc):
+    tenant = _t()
+    mid = await _seed_memory(tenant_id=tenant, agent_id="a", weight=0.5)
+    await _soft_delete(mid)
+    resp = await sc.evolve_apply_weights(
+        tenant_id=tenant, ids=[mid], delta=0.1, floor=0.05, cap=1.0
+    )
+    assert resp["adjustments"] == []
+
+
+async def test_apply_weights_empty_ids(sc):
+    resp = await sc.evolve_apply_weights(
+        tenant_id=_t(), ids=[], delta=0.1, floor=0.05, cap=1.0
+    )
+    assert resp == {"adjustments": [], "backfilled": False}
+
+
+# ===========================================================================
+# C. 422 input-validation guards (raw httpx — typed client never sends these)
+# ===========================================================================
+
+
+async def test_filter_missing_tenant_422(storage_http):
+    resp = await storage_http.post(
+        "/api/v1/storage/evolve/filter-by-scope",
+        json={"caller_agent_id": "a", "scope": "agent", "ids": []},
+    )
+    assert resp.status_code == 422
+
+
+async def test_filter_missing_caller_agent_422(storage_http):
+    resp = await storage_http.post(
+        "/api/v1/storage/evolve/filter-by-scope",
+        json={"tenant_id": "t", "scope": "agent", "ids": []},
+    )
+    assert resp.status_code == 422
+
+
+async def test_filter_missing_ids_422(storage_http):
+    resp = await storage_http.post(
+        "/api/v1/storage/evolve/filter-by-scope",
+        json={"tenant_id": "t", "caller_agent_id": "a", "scope": "agent"},
+    )
+    assert resp.status_code == 422
+
+
+async def test_filter_fleet_scope_missing_fleet_id_422(storage_http):
+    # scope='fleet' without fleet_id would raise ValueError in the service
+    # (-> 500); the router guards it as a 422 for direct storage callers. A
+    # valid ids list isolates this to the fleet guard, not the ids check.
+    resp = await storage_http.post(
+        "/api/v1/storage/evolve/filter-by-scope",
+        json={"tenant_id": "t", "caller_agent_id": "a", "scope": "fleet", "ids": ["x"]},
+    )
+    assert resp.status_code == 422
+
+
+async def test_filter_invalid_uuid_in_ids_422(storage_http):
+    # A non-UUID id raises ValueError in the service (UUID parse); the router
+    # converts it to a 422 for direct storage callers instead of a 500.
+    resp = await storage_http.post(
+        "/api/v1/storage/evolve/filter-by-scope",
+        json={"tenant_id": "t", "caller_agent_id": "a", "scope": "agent", "ids": ["not-a-uuid"]},
+    )
+    assert resp.status_code == 422
+
+
+async def test_filter_invalid_scope_422(storage_http):
+    # An unrecognized scope must 422, not silently fall through to scope='all'
+    # (no-extra-filter) behavior in the service — that would be fail-open.
+    resp = await storage_http.post(
+        "/api/v1/storage/evolve/filter-by-scope",
+        json={"tenant_id": "t", "caller_agent_id": "a", "scope": "AGENT", "ids": ["x"]},
+    )
+    assert resp.status_code == 422
+
+
+async def test_apply_weights_missing_tenant_422(storage_http):
+    resp = await storage_http.post(
+        "/api/v1/storage/evolve/apply-weights",
+        json={"ids": [], "delta": 0.1, "floor": 0.05, "cap": 1.0},
+    )
+    assert resp.status_code == 422
+
+
+async def test_apply_weights_missing_delta_422(storage_http):
+    resp = await storage_http.post(
+        "/api/v1/storage/evolve/apply-weights",
+        json={"tenant_id": "t", "ids": [], "floor": 0.05, "cap": 1.0},
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Fix 2 Ph5b — PR2: route evolve through storage + **delete `_mcp_session`**

Second of the two Ph5b PRs (PR1 insights = #471, merged). Routes `evolve_service` + `memclaw_evolve` + `/evolve/report` off core-api's direct DB, and as the final step **deletes `_mcp_session`** — `memclaw_evolve` was its last consumer once PR1 moved insights to `_no_db`. This completes the mcp_server DB migration.

### New core-storage-api endpoints
- `POST /evolve/filter-by-scope` — SELECT ids by tenant+scope (ORM `.in_()`).
- `POST /evolve/apply-weights` — the weight-clamp CTE (`GREATEST`/`LEAST`, `RETURNING` old/new) **and** the rule→outcome `jsonb_set` backfill, folded into **one atomic transaction** so evolve's documented split-commit doesn't widen. `_apply_outcome_to_db` is re-sequenced so rule/outcome ids exist before this single call.

### `_mcp_session` deleted
Removed the `_mcp_session` def + the `async_session` import + an orphaned `sa_text` import. `grep -rn "_mcp_session" core-api/src/` → zero consumers.

### ⚠️ Write-pipeline made db-free (broader than evolve — flagging for review)
Evolve's outcome/rule persist now calls `create_memory(db=None)` (the STM path). Four `write_fast` steps — `load_tenant_config`, `detect_near_duplicate`, `check_semantic_duplicate`, and `write_memory_row`'s audit hook — used `ctx.require_db` (which **raises** on `db=None`) to call functions that are **already storage-routed and ignore `db`** (`resolve_config`, `_find_semantic_duplicate`, `log_action`). Switched all four to the nullable `ctx.db`: transparent for db-present callers, and it unblocks the db-free STM write path. The warm-cache full suite masked this (near-dup got skipped under the cached org config); a **clean-DB** run surfaced it.

Also cast `metadata::jsonb` in the apply-weights backfill — CAURA-595 `json`/`jsonb` column drift (mirrors the merged `memory_update` fix).

### Deviation (documented in-code)
The persisted outcome memory's `metadata.weight_adjustments` is `[]` on the apply path — the exact post-clamp deltas are in the `report_outcome` response and the audit log, but the outcome must be persisted *before* apply-weights to fold the backfill atomically. Nothing reads the persisted field.

### Gates
ruff@0.15.4 check + `format --check`, mypy both projects, **full suite 3604 passed on a clean DB** (the rigorous run — no warm-cache masking). New `tests/test_ph5b_evolve_storage.py` (filter-by-scope agent/fleet/all + tenant isolation; apply-weights clamp at floor/cap, RETURNING, backfill / no-backfill, isolation; 422 guards); reworked `test_evolve_service.py` to seed/assert via the storage client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
