### PR TITLE
fix(core-api): re-route third-party loggers from the ASGI lifespan startup

### DIFF
--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -395,7 +395,7 @@ def _route_third_party_to_root() -> None:
         # ``Config.configure_logging`` runs at server start).
         if not lg.handlers and lg.propagate:
             logging.getLogger(__name__).warning(
-                "logger %r has no own handlers at rerouting time; rerouting was a no-op (library may not be imported yet — call _route_third_party_to_root from an ASGI lifespan startup handler if this is a uvicorn-fronted service)",
+                "logger %r has no own handlers at rerouting time; rerouting was a no-op (library may not be imported yet — call reroute_third_party_loggers from an ASGI lifespan startup handler if this is a uvicorn-fronted service)",
                 name,
             )
             continue
@@ -427,6 +427,19 @@ def _route_third_party_to_root() -> None:
         # preserved.
         if had_own_handlers:
             lg.setLevel(logging.NOTSET)
+
+
+def reroute_third_party_loggers() -> None:
+    """Public entry point to (re-)route third-party loggers to the root handler.
+
+    ``configure_logging`` already calls this routing at import time, but on a
+    uvicorn-fronted service the third-party libraries (uvicorn / fastmcp / mcp
+    / slowapi) usually aren't imported yet at that point, so that pass no-ops
+    for them. Call this from the ASGI lifespan startup — after those libraries
+    are imported — to route them. Idempotent (guarded by the per-logger
+    snapshot), so the re-call is safe.
+    """
+    _route_third_party_to_root()
 
 
 def _reset_for_testing() -> None:

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -12,7 +12,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.types import ASGIApp as ASGIApplication
 from starlette.types import Receive, Scope, Send
 
-from common.structlog_config import configure_logging
+from common.structlog_config import configure_logging, reroute_third_party_loggers
 from core_api.config import settings as app_settings
 
 # Must run before any other module-level `logging.getLogger(...)` call emits
@@ -114,6 +114,17 @@ class SecurityHeadersMiddleware:
 
 @asynccontextmanager
 async def lifespan(app):
+    # Re-route third-party loggers (uvicorn / fastmcp / mcp / slowapi) to the
+    # root handler now that they're all imported. ``configure_logging()`` at
+    # import time (above) already runs this routing, but those libraries are
+    # imported AFTER that call (slowapi / mcp_server below, uvicorn by the
+    # server) — so the import-time pass no-ops for them (it logs a "rerouting
+    # was a no-op" warning) and their records never reach the JSON/GCP handler.
+    # Most consequentially, FastMCP's "Error executing tool ..." tool-error
+    # lines were invisible in prod logs. The re-route is idempotent, so this
+    # post-import re-run from the ASGI lifespan startup safely routes them.
+    reroute_third_party_loggers()
+
     # Increase default thread pool for concurrent LLM calls via asyncio.to_thread()
     import asyncio as _aio
     from concurrent.futures import ThreadPoolExecutor


### PR DESCRIPTION
## Why

`configure_logging()` runs at import time (`app.py`) and calls `_route_third_party_to_root()` then — but `uvicorn` / `fastmcp` / `mcp` / `slowapi` are imported **after** that call (slowapi + `mcp_server` further down in `app.py`, uvicorn by the server). So the import-time pass **no-ops for those loggers** — it even logs the warning it was built to emit:

> `logger 'fastmcp' has no own handlers at rerouting time; rerouting was a no-op (library may not be imported yet — call _route_third_party_to_root from an ASGI lifespan startup handler if this is a uvicorn-fronted service)`

Result: those libraries' records never reach the JSON/GCP handler. **Most consequentially, FastMCP's `Error executing tool …` tool-error lines are invisible in prod** — an MCP tool that raises surfaces the error to the client but leaves **no server-side log to debug from**. (Concretely: this is why a recently-surfaced MCP `memclaw_write` failure produced a client-side `'memory'` error with nothing in Cloud Logging from FastMCP.)

## What

Add an **idempotent** `_route_third_party_to_root()` call at the start of the ASGI **lifespan startup** — by then `uvicorn`/`fastmcp`/`mcp`/`slowapi` are imported, so the re-route actually takes. This is exactly what the no-op warning instructs. The import-time call in `configure_logging()` is unchanged (still routes everything imported by then).

## Verification

- `ruff check` ✓, `ruff format --check` ✓ (repo-pinned ruff 0.15.10), `mypy` ✓ on `core-api/src/core_api/app.py`.
- The routing function is already covered by `tests/test_logging.py` (incl. an idempotency test and a "re-call after a handlerless no-op reroute" test), so the second call is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)