### PR TITLE
docs: point all memclaw.dev links to memclaw.net

### DIFF
--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -670,8 +670,8 @@ def _derive_api_url_from_request(request: Request) -> str:
     When the endpoint sits behind a proxy (nginx, Cloud Run, etc.) the
     reverse proxy forwards the original scheme and host via
     ``X-Forwarded-Proto`` and ``X-Forwarded-Host``. We prefer those — that
-    way a ``curl https://memclaw.dev/api/v1/install-skill | bash`` yields a
-    script that keeps fetching from ``https://memclaw.dev``, not from the
+    way a ``curl https://memclaw.net/api/v1/install-skill | bash`` yields a
+    script that keeps fetching from ``https://memclaw.net``, not from the
     internal ``http://127.0.0.1:8000`` the upstream service sees.
     """
     scheme = request.headers.get("x-forwarded-proto") or request.url.scheme
@@ -688,7 +688,7 @@ def _generate_skill_install_script(*, api_url: str, agent: str, api_key: str = "
 
     ``api_key`` — when non-empty, embedded into the script and forwarded
     as ``-H "X-API-Key: ..."`` on the internal curl calls. Required for
-    edge-auth-gated deploys (memclaw.dev's nginx rejects unauthenticated
+    edge-auth-gated deploys (memclaw.net's nginx rejects unauthenticated
     requests on every path). Empty when the deploy is standalone / lets
     the skill file be fetched without a key.
     """
@@ -769,7 +769,7 @@ async def install_skill_script(
         description=(
             "Override the server URL the script will install from. Auto-derived "
             "from the request Host (and X-Forwarded-Proto) when omitted — so "
-            "``curl https://memclaw.dev/api/v1/install-skill | bash`` just works."
+            "``curl https://memclaw.net/api/v1/install-skill | bash`` just works."
         ),
     ),
 ):

--- a/docs/integration-without-plugin.md
+++ b/docs/integration-without-plugin.md
@@ -1,6 +1,6 @@
 # Integrate with memclaw without the plugin
 
-**Audience:** developers building Python, Node, or any other SDK client against `memclaw.dev` or a self-hosted memclaw instance, without installing the OpenClaw plugin runtime.
+**Audience:** developers building Python, Node, or any other SDK client against `memclaw.net` or a self-hosted memclaw instance, without installing the OpenClaw plugin runtime.
 
 **Time to first tool call:** ~5 minutes.
 
@@ -10,7 +10,7 @@
 
 ## What you need
 
-- A tenant-scoped `mc_` credential — get one from `memclaw.dev/settings/api-keys` (or self-host).
+- A tenant-scoped `mc_` credential — get one from `memclaw.net/settings/api-keys` (or self-host).
 - An MCP client. Examples below use `mcp` (Python) and `curl`. The same flow works with `anthropic` (Python SDK's remote-MCP integration), `openai`, or any client that speaks MCP streamable-http.
 
 ---
@@ -19,11 +19,11 @@
 
 Every long-lived integration should bind to a named agent identity rather than calling under a tenant-scoped credential. Two ways:
 
-- **Dashboard (recommended for humans):** `memclaw.dev/settings/organization/api-credentials` — single-card wizard, one-time raw-key reveal, manages cross-tenant + read-scope settings.
+- **Dashboard (recommended for humans):** `memclaw.net/settings/organization/api-credentials` — single-card wizard, one-time raw-key reveal, manages cross-tenant + read-scope settings.
 - **API (for scripted provisioning, shown below):** `POST /api/v1/admin/agent-keys/provision` — atomic call that creates the Agent row eagerly so subsequent trust-elevation or fleet-assignment endpoints work immediately:
 
 ```bash
-curl -X POST https://memclaw.dev/api/v1/admin/agent-keys/provision \
+curl -X POST https://memclaw.net/api/v1/admin/agent-keys/provision \
   -H "X-API-Key: $MC_TENANT_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -62,7 +62,7 @@ Save `raw_key` immediately — it's only returned once. The returned credential 
 Before making real tool calls, confirm memclaw resolves your credentials the way you expect:
 
 ```bash
-curl https://memclaw.dev/api/v1/whoami \
+curl https://memclaw.net/api/v1/whoami \
   -H "X-API-Key: $AGENT_KEY"
 ```
 
@@ -108,7 +108,7 @@ from mcp.client.streamable_http import streamablehttp_client
 
 async def main():
     headers = {"X-API-Key": "mc_..."}   # agent-scoped credential
-    url = "https://memclaw.dev/mcp/"
+    url = "https://memclaw.net/mcp/"
 
     async with streamablehttp_client(url, headers=headers) as (read, write, _):
         async with ClientSession(read, write) as session:
@@ -139,7 +139,7 @@ msg = client.messages.create(
         "mcp_servers": [
             {
                 "type": "url",
-                "url": "https://memclaw.dev/mcp/",
+                "url": "https://memclaw.net/mcp/",
                 "name": "memclaw",
                 "authorization_token": "mc_...",   # agent-scoped credential
             }
@@ -158,7 +158,7 @@ The SDK forwards `authorization_token` as `Authorization: Bearer mc_…`. memcla
 The default `trust_level=1` lets the agent write to its home fleet. Elevate when you need cross-fleet writes, keystone authoring, or deletes:
 
 ```bash
-curl -X PATCH "https://memclaw.dev/api/v1/agents/quote-agent-na/trust?tenant_id=$TENANT_ID" \
+curl -X PATCH "https://memclaw.net/api/v1/agents/quote-agent-na/trust?tenant_id=$TENANT_ID" \
   -H "X-API-Key: $MC_TENANT_KEY" \
   -H "Content-Type: application/json" \
   -d '{"trust_level": 2}'
@@ -180,7 +180,7 @@ Keystones are mandatory rules that override conflicting instructions. Authoring 
 `scope=fleet`/`scope=tenant` rule needs trust ≥ 2 (see above).
 
 ```bash
-curl -X POST "https://memclaw.dev/api/v1/memclaw/keystones" \
+curl -X POST "https://memclaw.net/api/v1/memclaw/keystones" \
   -H "X-API-Key: $MC_TENANT_KEY" \
   -H "X-Agent-ID: quote-agent-na" \
   -H "Content-Type: application/json" \
@@ -211,7 +211,7 @@ AGENT_ID="quote-agent-na"
 FLEET_ID="na-sales"
 
 # 1. Provision agent + Agent row + trust + fleet in one call.
-RESP=$(curl -s -X POST https://memclaw.dev/api/v1/admin/agent-keys/provision \
+RESP=$(curl -s -X POST https://memclaw.net/api/v1/admin/agent-keys/provision \
   -H "X-API-Key: $TENANT_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"agent_id\":\"$AGENT_ID\",\"initial_trust\":1,\"initial_fleet\":\"$FLEET_ID\"}")
@@ -219,10 +219,10 @@ AGENT_KEY=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdi
 # AGENT_KEY is an mc_… agent-scoped credential.
 
 # 2. Verify.
-curl -s https://memclaw.dev/api/v1/whoami -H "X-API-Key: $AGENT_KEY"
+curl -s https://memclaw.net/api/v1/whoami -H "X-API-Key: $AGENT_KEY"
 
 # 3. Use.
-curl -s https://memclaw.dev/api/v1/memories \
+curl -s https://memclaw.net/api/v1/memories \
   -H "X-API-Key: $AGENT_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"tenant_id\":\"$TENANT_ID\",\"agent_id\":\"$AGENT_ID\",\"fleet_id\":\"$FLEET_ID\",\"content\":\"Hello world\"}"

--- a/docs/plugin-upgrade.md
+++ b/docs/plugin-upgrade.md
@@ -1,6 +1,6 @@
 # Upgrading the memclaw plugin
 
-**Audience:** operators running OpenClaw with the memclaw plugin against a memclaw server (memclaw.dev, memclaw.net, on-prem). Two flows are documented: the **automatic** path (heartbeat-driven) and the **manual** path (`/api/v1/install-plugin`).
+**Audience:** operators running OpenClaw with the memclaw plugin against a memclaw server (memclaw.net, on-prem). Two flows are documented: the **automatic** path (heartbeat-driven) and the **manual** path (`/api/v1/install-plugin`).
 
 ## When auto-upgrade runs
 

--- a/scripts/repro_contradictions_collision.py
+++ b/scripts/repro_contradictions_collision.py
@@ -29,7 +29,7 @@ The verdict logic inspects the entity_links after the writes settle
 and reports which arm fired.
 
 Usage:
-    export MEMCLAW_API_URL=https://memclaw.dev
+    export MEMCLAW_API_URL=https://memclaw.net
     export MEMCLAW_API_KEY=mc_...
     export MEMCLAW_TENANT_ID=rantaig-...
     python scripts/repro_contradictions_collision.py

--- a/scripts/repro_contradictions_not_detected.py
+++ b/scripts/repro_contradictions_not_detected.py
@@ -24,7 +24,7 @@ prints a structured diagnostic dump showing exactly what the server
 reported.
 
 Usage:
-    export MEMCLAW_API_URL=https://memclaw.dev      # or https://memclaw.net
+    export MEMCLAW_API_URL=https://memclaw.net
     export MEMCLAW_API_KEY=mc_...
     python scripts/repro_contradictions_not_detected.py
 

--- a/scripts/repro_contradictions_proper_noun.py
+++ b/scripts/repro_contradictions_proper_noun.py
@@ -28,7 +28,7 @@ This script probes that exact gap with two arms:
   If both succeed → S1 is closed; move to S2 (enrichment-lag race).
 
 Usage:
-    export MEMCLAW_API_URL=https://memclaw.net      # or memclaw.dev
+    export MEMCLAW_API_URL=https://memclaw.net
     export MEMCLAW_API_KEY=mc_...
     python scripts/repro_contradictions_proper_noun.py
 


### PR DESCRIPTION
## Why
`memclaw.net` is the canonical host. This repoints every **user-facing link** and **illustrative example URL** from `memclaw.dev` → `memclaw.net`.

## Changed
- **`docs/integration-without-plugin.md`** — all dev-facing API / dashboard / install / MCP URLs (12).
- **`docs/plugin-upgrade.md`** — server-examples parenthetical.
- **`core-api/.../routes/plugin.py`** — install-skill docstring + `api_url` Query description examples. **Comment-only** — the endpoint stays host-agnostic via `X-Forwarded-Host` (`_derive_api_url_from_request`); no logic change.
- **`scripts/repro_contradictions_*.py`** — example `MEMCLAW_API_URL` env in usage docstrings.

## Deliberately NOT changed (and why)
These `.dev` references are **factual records / behavior-test data, not site links** — rewriting them to `.net` would misrepresent what happened:
- `tests/test_enrichment_inline_timeout.py`, `tests/test_query_embedding_stampede_guard.py`, `tests/test_storage_client_retry.py` — provenance docstrings ("observed/wet-tested on memclaw.dev" — where the prod incident actually occurred).
- `tests/test_install_skill_endpoint.py` — the forwarded-host **echo test**: it sets `X-Forwarded-Host: memclaw.dev` and asserts the generated script echoes that host. `.dev` is deliberate fixture data proving the script isn't hardcoded to localhost.
- `plugin/src/tool-definitions.ts:189` — a historical wet-test comment.

(Happy to genericize those to "in production" in a follow-up if we want zero `.dev` in the tree — flagged separately.)

## Out of scope
The shipped skill texts (`static/` + `plugin/` `SKILL.md`) are being updated separately.

## Validation
`ruff check core-api/src/` clean; `tests/test_install_skill_endpoint.py` 9/9 pass (confirms the comment-only `plugin.py` edit didn't disturb the endpoint). No logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)