### PR TITLE
refactor(core-storage-api): consolidate router validation guards into _validation

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/_validation.py
+++ b/core-storage-api/src/core_storage_api/routers/_validation.py
@@ -1,0 +1,30 @@
+"""Shared fail-closed request-body validation guards for the storage routers.
+
+Each storage router validates its own request contract (it never trusts the
+calling service). ``_require`` / ``_require_number`` are the common primitives,
+kept in one place so the four routers that use them don't drift.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+
+def _require(body: dict, key: str) -> str:
+    """Fail-closed required-field guard — 422 if ``key`` is missing/falsy."""
+    val = body.get(key)
+    if not val:
+        raise HTTPException(status_code=422, detail=f"{key} is required")
+    return val
+
+
+def _require_number(body: dict, key: str) -> float:
+    """Fail-closed numeric guard — 422 on missing / non-numeric.
+
+    ``bool`` is a subclass of ``int`` but is never a valid numeric value here,
+    so reject it explicitly.
+    """
+    val = body.get(key)
+    if isinstance(val, bool) or not isinstance(val, (int, float)):
+        raise HTTPException(status_code=422, detail=f"{key} (number) is required")
+    return float(val)

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
 
+from core_storage_api.routers._validation import _require, _require_number
 from core_storage_api.schemas import (
     ENTITY_FIELDS,
     MEMORY_ENTITY_LINK_FIELDS,
@@ -17,25 +18,6 @@ from core_storage_api.services.postgres_service import PostgresService
 
 router = APIRouter(prefix="/entities", tags=["Entities"])
 _svc = PostgresService()
-
-
-def _require(body: dict, key: str) -> str:
-    """Fail-closed required-field guard (mirrors evolve.py)."""
-    val = body.get(key)
-    if not val:
-        raise HTTPException(status_code=422, detail=f"{key} is required")
-    return val
-
-
-def _require_number(body: dict, key: str) -> float:
-    """Fail-closed numeric guard — 422 on missing / non-numeric.
-
-    ``bool`` is a subclass of ``int`` but is never a valid tuning value here,
-    so reject it explicitly."""
-    val = body.get(key)
-    if isinstance(val, bool) or not isinstance(val, (int, float)):
-        raise HTTPException(status_code=422, detail=f"{key} (number) is required")
-    return float(val)
 
 
 def _validate_input_idxs(items: list[dict]) -> None:

--- a/core-storage-api/src/core_storage_api/routers/evolve.py
+++ b/core-storage-api/src/core_storage_api/routers/evolve.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
 
+from core_storage_api.routers._validation import _require, _require_number
 from core_storage_api.services.postgres_service import PostgresService
 
 router = APIRouter(tags=["Evolve"])
@@ -34,13 +35,6 @@ _svc = PostgresService()
 # is an independent service and must not depend on the core-api package. Keep in
 # sync if the scope vocabulary changes.
 _VALID_SCOPES = {"agent", "fleet", "all"}
-
-
-def _require(body: dict, key: str) -> str:
-    val = body.get(key)
-    if not val:
-        raise HTTPException(status_code=422, detail=f"{key} is required")
-    return val
 
 
 @router.post("/evolve/filter-by-scope")
@@ -98,15 +92,15 @@ async def evolve_apply_weights(request: Request) -> dict:
     ids = body.get("ids")
     if not isinstance(ids, list):
         raise HTTPException(status_code=422, detail="ids (list) is required")
-    for key in ("delta", "floor", "cap"):
-        if not isinstance(body.get(key), (int, float)):
-            raise HTTPException(status_code=422, detail=f"{key} (number) is required")
+    delta = _require_number(body, "delta")
+    floor = _require_number(body, "floor")
+    cap = _require_number(body, "cap")
     return await _svc.evolve_apply_weights(
         tenant_id=tenant_id,
         ids=ids,
-        delta=float(body["delta"]),
-        floor=float(body["floor"]),
-        cap=float(body["cap"]),
+        delta=delta,
+        floor=floor,
+        cap=cap,
         rule_id=body.get("rule_id"),
         outcome_id=body.get("outcome_id"),
     )

--- a/core-storage-api/src/core_storage_api/routers/insights.py
+++ b/core-storage-api/src/core_storage_api/routers/insights.py
@@ -21,17 +21,11 @@ from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Request
 
+from core_storage_api.routers._validation import _require
 from core_storage_api.services.postgres_service import PostgresService
 
 router = APIRouter(tags=["Insights"])
 _svc = PostgresService()
-
-
-def _require(body: dict, key: str) -> str:
-    val = body.get(key)
-    if not val:
-        raise HTTPException(status_code=422, detail=f"{key} is required")
-    return val
 
 
 def _scope_args(body: dict) -> tuple[str, str | None, str, str]:

--- a/core-storage-api/src/core_storage_api/routers/skill_factory.py
+++ b/core-storage-api/src/core_storage_api/routers/skill_factory.py
@@ -18,17 +18,11 @@ from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Request
 
+from core_storage_api.routers._validation import _require
 from core_storage_api.services.postgres_service import PostgresService
 
 router = APIRouter(tags=["SkillFactory"])
 _svc = PostgresService()
-
-
-def _require(body: dict, key: str) -> str:
-    val = body.get(key)
-    if not val:
-        raise HTTPException(status_code=422, detail=f"{key} is required")
-    return val
 
 
 def _parse_window(body: dict) -> tuple[datetime, datetime]:


### PR DESCRIPTION
## Consolidate the duplicated router validation guards

The fail-closed `_require(body, key)` guard was **byte-identical across four routers** (`evolve`, `skill_factory`, `insights`, `entities`), and `entities` had added `_require_number` while `evolve` still hand-rolled the same numeric check inline. This extracts both into `core_storage_api/routers/_validation.py` and imports them across the four routers, replacing evolve's inline `isinstance(..., (int, float))` loop with `_require_number`.

Surfaced during the Fix 2 Ph6 (#477) `/simplify` review (the duplication was flagged as out-of-scope for that PR and spun off here).

**Pure refactor** — no change to the happy path or the 422 detail messages. One intentional tightening: evolve's `delta`/`floor`/`cap` now go through `_require_number`, which rejects `bool` (a subclass of `int` that was never a valid tuning value); the 422 message is unchanged.

### Verification
- `ruff@0.15.4 check` + `format --check` — clean
- `mypy` core-api + core-storage-api — clean
- full suite — **3633 passed** (clean DB), unchanged (behavior-preserving; existing evolve/entities numeric-422 tests exercise the shared guards)
- Net −6 lines across the routers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)