### PR TITLE
docs(core-api): clarify memclaw_recall top_k is soft-capped, not rejected

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -575,7 +575,9 @@ async def memclaw_recall(
     status: Annotated[str | None, Field(description="Filter by status.")] = None,
     fleet_ids: Annotated[list[str] | None, Field(description="Restrict fleets.")] = None,
     include_brief: Annotated[bool, Field(description="Add LLM summary.")] = False,
-    top_k: Annotated[int, Field(description="1-20.")] = DEFAULT_SEARCH_TOP_K,
+    top_k: Annotated[
+        int, Field(description="Max results, default 5. Values above 20 are capped to 20.")
+    ] = DEFAULT_SEARCH_TOP_K,
 ) -> str:
     """Hybrid semantic+keyword recall, with optional LLM brief."""
     t0 = time.perf_counter()

--- a/plugin/tools.json
+++ b/plugin/tools.json
@@ -680,7 +680,7 @@
       },
       {
         "default": 5,
-        "description": "1-20.",
+        "description": "Max results, default 5. Values above 20 are capped to 20.",
         "name": "top_k",
         "required": false,
         "type": "int"

--- a/tests/fixtures/tools_list_baseline_v1.json
+++ b/tests/fixtures/tools_list_baseline_v1.json
@@ -839,7 +839,7 @@
         },
         "top_k": {
           "default": 5,
-          "description": "1-20.",
+          "description": "Max results, default 5. Values above 20 are capped to 20.",
           "title": "Top K",
           "type": "integer"
         }


### PR DESCRIPTION
## Why
Validated follow-up **B6**. `memclaw_recall`'s `top_k` Field advertises `"1-20."` but has **no `le=` validator** — values above 20 are silently clamped (`min(top_k, MAX_SEARCH_TOP_K=20)`, `mcp_server.py:608`), not rejected. The declared contract didn't match enforcement.

## Change (doc-only)
- `memclaw_recall` `top_k` description → `"Max results, default 5. Values above 20 are capped to 20."` — states the actual soft-cap behavior.
- Updated the recall `top_k` entry in `tests/fixtures/tools_list_baseline_v1.json` so `test_v1_baseline_matches_live_registry` stays green (`memclaw_tune`'s identical `"1-20."` is a separate param, left as-is).

**Chosen over** adding `le=20`, which would convert today's safe soft-cap into a `422` for callers sending e.g. `top_k=30` — a behavior change. No validation/behavior change here.

## Validation
`tests/test_mcp_token_budget.py` (live==baseline match + token ceiling) and `tests/test_tool_descriptions_regression.py` — 7/7 pass. `ruff check core-api/src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)