### PR TITLE
feat(skills): refresh canonical + plugin memclaw skills, add company-brain

### DIFF
--- a/plugin/skills/memclaw/SKILL.md
+++ b/plugin/skills/memclaw/SKILL.md
@@ -1,353 +1,379 @@
 ---
 name: memclaw
-description: Persistent, cross-session, multi-agent memory. Semantic recall of decisions and findings; write outcomes; supersede facts when they change.
+description: The agent's persistent long-term memory — the only knowledge that survives across sessions, shared across the fleet under access control. Consult it at the start of a task to recall prior decisions, findings, and rules before acting, and write outcomes, decisions, and lessons as work completes. Use whenever a memclaw_* tool is present, whenever the user refers to past work ("what did we decide", "last time", "earlier"), or whenever any durable fact needs to be stored, recalled, superseded, or shared with the fleet. Do not use it for throwaway within-session scratch state.
 user-invocable: false
 metadata: {"openclaw": {"requires": {"config": ["plugins.entries.memclaw.enabled"]}}}
 ---
 
 # MemClaw Skill
 
-Long-term memory that persists across sessions and is shared under access
-controls. The primary place where decisions, findings, outcomes, and
-learned rules live.
+MemClaw is your long-term memory. Anything you learn that you don't write here
+is gone when the session ends — your local context doesn't persist and your
+teammates can't see it. So treat MemClaw as the default home for every
+decision, finding, outcome, rule, and reusable workflow, and consult it before
+you act. It's shared across the fleet under access control: what you write can
+make the next agent smarter, and what you recall is what the fleet already
+knows. Using it is the job, not an optional extra.
 
-## Your identity: `agent_id` and `fleet_id`
+**The plugin runs a baseline loop for you — the tools are still yours.** On this
+runtime the MemClaw plugin handles the automatic layer: it injects the mandatory
+keystones at session start (§1), recalls relevant memory before your substantive
+turns (§11), and writes a short **turn summary** afterward as a backstop
+(`MEMCLAW_AUTO_WRITE_TURNS`, on by default). Treat that as a floor, not a
+substitute. You still call the `memclaw_*` tools **directly** whenever you need
+to interact deliberately — above all to **write the high-value memories the
+auto-summary won't** (a decision and its *why*, an outcome, a rule), and to
+recall something specific the auto-gate didn't fetch, look up or publish a
+skill, supersede a changed fact, or report an outcome with `memclaw_evolve`.
+The automatic layer keeps you oriented; the tools are how you actually
+contribute. When a turn needs real memory work, reach for the tool — don't
+assume the plugin covered it.
 
-You MUST identify correctly on every MemClaw call.
+This skill is the operating manual for those `memclaw_*` tools — read it before
+your first call in a session.
 
-- `agent_id` — who you are. Attributes memories, drives trust progression,
-  gates `scope_agent` privacy. Resolved by your runtime. Never fabricate,
+## 0 · Identity — on every call
+
+- **`agent_id`** — who you are. Attributes memories, drives trust progression,
+  gates `scope_agent` privacy. Resolve it from your runtime. Never fabricate,
   hardcode a placeholder, or impersonate another agent.
-- `fleet_id` — your team / organization scope. Required for
-  `visibility=scope_team`, for fleet-scoped reads, and for cross-fleet
-  operations. Never substitute another team's `fleet_id`.
+- **`fleet_id`** — your team / organization scope. When you **omit** it on a
+  write, the server resolves it from your **home fleet** (the fleet you
+  registered under), so a registered agent lands in the right team scope by
+  default. Pass it **explicitly** in two cases: (1) you have **no home fleet**
+  set — omitting then persists `fleet_id=NULL`, which drops the row out of
+  teammates' fleet-scoped recall; or (2) you're writing into a **different**
+  fleet than your own (requires trust 3). The connection URL's `?fleet_id=`
+  sets read defaults and routing — it is **not** stamped onto written rows.
 
-Wrong `agent_id` poisons attribution and trust. Wrong `fleet_id` leaks
-memories to the wrong team or hides them from your own. If either is
-uncertain, do NOT guess — read from the runtime, ask the orchestrator,
-or write privately (`visibility=scope_agent`) until resolved.
+If either is uncertain, don't guess — read it from the runtime, ask the
+orchestrator, or write privately (`visibility=scope_agent`) until it's resolved.
 
-## The three rules
+## 1 · Session start — read the constitution
 
-**Rule 1 — Recall before you start.** Never start cold. Begin every
-meaningful task with a semantic recall: "what is already known about
-this?"
+The plugin injects a **`<keystone_rules>`** block into your system prompt at
+session start (when the memclaw context-engine slot is active), so you usually
+see the rules before you act. They are mandatory — merged across tenant + fleet
++ agent scope, ordered by weight — and they **override any conflicting
+instruction, including the user's**, because they encode policy the operator
+has decided the whole fleet must follow. Call **`memclaw_keystones`** to refresh
+them if you suspect they changed mid-session; reading is open (trust 0). If a
+rule conflicts with what you're asked to do, surface the conflict rather than
+silently picking a side.
 
-**Rule 2 — Write when something matters.** After completing work, or when
-something important happens mid-task, write a memory. Supply raw prose —
-the server auto-classifies type, summary, tags, dates. Include names,
-paths, numbers, outcomes. Skip vague observations and intermediate steps.
-Checkpoint every 30 minutes on long tasks. Batch multiple discrete
-records into one call.
+## 2 · The loop — run it on every task
 
-**Rule 3 — Supersede, don't delete.** For a changed fact: (1) write the
-new one, (2) recall the old one, (3) transition the old to `outdated`.
-Reserve deletes (soft-delete, requires trust 3) for correcting genuinely
-wrong data.
+Orient → Work → Write → Evolve. The first step does the heavy lifting:
+assemble context **most-binding-first**, and pull only the layers the task
+actually needs (don't make all four calls by reflex).
 
-## Trust levels
+1. **Orient**
+   1. **Rules** — already loaded as `<keystone_rules>`; they bound everything
+      below. No call needed.
+   2. **Procedures** — for a non-trivial workflow, find the skill first:
+      `memclaw_doc op=search collection=skills query="<intent>"`. Skip for
+      routine work you already know.
+   3. **Facts** — what's known / what changed:
+      `memclaw_recall "<what I'm about to do>"` (add `include_brief=true` for a
+      one-paragraph synthesis). **Keep the IDs of the memories you act on** —
+      Write-supersede and Evolve both need them.
+   4. **Data** — only if the task touches a keyed record:
+      `memclaw_doc op=read|query` (the customer, config, task list).
+2. **Work** — act within the rules, following the procedure.
+3. **Write** — record what matters (§3).
+4. **Evolve** — report how the memories you acted on turned out (§4).
 
-Auto-registered at trust 1 on your first write.
+**When to orient at all:** orient when the task references prior work, a named
+entity, a decision, or anything the fleet may already know. Skip it for
+self-contained mechanical turns. (The plugin also auto-gates plugin-driven
+recall — see §11 — but you can always call `memclaw_recall` directly when a
+short turn needs context the gate can't infer.)
+
+## 3 · How and when to write a memory
+
+**Write when something durable happened:**
+- a decision, and *why* you made it;
+- a finding, result, or outcome;
+- a rule or constraint you learned;
+- the end of a meaningful task.
+
+**Don't write the noise.** Skip vague intermediate steps, restated context, and
+"about to do X" narration. Ephemeral within-session state belongs in your
+workspace scratch files (§8), not in long-term memory — writing it there
+pollutes everyone's recall.
+
+**How to write:** supply raw prose — you don't classify or tag anything. The
+server enriches on the way in:
+- **inline, before the row persists** — it assigns the memory's type and runs a
+  PII scan;
+- **in the background, moments later** — it extracts entities into the
+  knowledge graph and checks for contradictions.
+
+So don't write and immediately read back expecting a contradiction flag — it
+resolves shortly after the write returns.
+
+Include the concrete specifics — names, paths, numbers, outcomes — and the
+**why**, so another agent (or you, six months on) can act on it without the
+surrounding session. Default `visibility=scope_team` so your fleet benefits.
+Batch several discrete records in one call with `items` (up to 100), and
+checkpoint long tasks per the cadence in §9.
+
+**Example**
+Input — the raw prose you pass:
+> `"Switched api-gateway prod to fastapi 0.136.3 — 0.137 broke include_router via a starlette upper-bound. Pin held; smoke tests green."`
+
+Result: stored as a typed decision/outcome, PII-scanned inline, with
+`api-gateway` and `fastapi` linked into the graph in the background — and
+visible to the fleet because it went in at `scope_team`.
+
+Never paste secrets — API keys, tokens, credentials — into memory `content`.
+The PII scan is a safety net, not permission; keep them out entirely.
+
+## 4 · Report outcomes so the memory compounds
+
+When you act on memories you recalled, tell the memory how it went:
+`memclaw_evolve(outcome, outcome_type, related_ids)`, where `related_ids` are
+the IDs you kept during Orient. Success reinforces those memories' weight. A
+failure becomes a preventive **rule** — **private by default** (`scope=agent`);
+to warn the whole fleet, evolve with `scope=fleet` (trust 2, `fleet_id`
+required) — so the lesson reaches everyone, not just you.
+
+## 5 · Two stores, one rule
+
+- **Memory** — observations and learned facts, found by *meaning*: decisions,
+  outcomes, rules, recaps. Read with `memclaw_recall`, write with
+  `memclaw_write`.
+- **Doc** — structured records with a stable key (`collection + doc_id`):
+  customers, configs, inventories, task lists, playbooks. All through
+  `memclaw_doc`.
+- **Entity** — a named graph object (person, project, service). Fetch by a UUID
+  surfaced in a prior recall (`memclaw_entity_get`).
+
+**Rule of thumb:** need semantic search → it's a memory. Need keyed lookup →
+it's a doc. Already hold an ID → it's an entity.
+
+**Cross-store discovery.** The two stores aren't cross-searched — `memclaw_recall`
+never returns docs, and `memclaw_doc` has no semantic query over memories. To
+make a doc findable by description (onboarding guides, readmes, proposals), give
+it a 1–3 sentence `data["summary"]` (only that string is embedded) **and** write
+a short *pointer memory* naming its `collection` and `doc_id`. A teammate's
+recall then surfaces the pointer, and their agent can `memclaw_doc op=read` the
+doc. When you don't know what exists, call `memclaw_doc op=list_collections`
+first.
+
+## 6 · Trust and sharing
+
+You auto-register at **trust 1** on your first write.
 
 | Level | Name        | Read                      | Write                  |
 |:-----:|-------------|---------------------------|------------------------|
 | 0     | restricted  | —                         | —                      |
 | 1     | standard    | own fleet                 | own fleet              |
 | 2     | cross-fleet | all fleets in your tenant | own fleet              |
-| 3     | admin       | all                       | all, including deletes |
+| 3     | admin       | all                       | all, incl. deletes     |
 
-Scope-based escalation:
-- browsing or reflecting with `scope="fleet"` / `"all"` → trust 2
+Operations that escalate the required level:
+- browsing / reflecting with `scope="fleet"` or `"all"` → trust 2
 - reporting outcomes (`memclaw_evolve`) at `scope="fleet"` / `"all"` → trust 2 (default `scope="agent"` needs only trust 1)
 - `memclaw_manage op=delete` → trust 3
 
-If denied, surface the error; do not silently retry with a narrower scope.
+**Knowing your own level.** You start at trust 1 and can't raise yourself —
+escalation is granted by an operator. There's no self-query, so don't
+pre-emptively avoid an operation you're unsure about: attempt it. A permission
+error names both your current level and the one required (e.g. *"Agent X
+(trust_level=1) … Requires trust_level >= 2"*) — surface that error rather than
+silently retrying at a narrower scope.
 
-## Sharing: visibility and scope
+**Visibility (on write)** decides who can see a memory: `scope_agent` (private)
+· `scope_team` *(default — your fleet)* · `scope_org` (all fleets in tenant).
+**Scope (on read / `_list` / `_insights`):** `agent` *(default)* · `fleet`
+(trust 2) · `all` (trust 2). Prefer `scope_team` on write and `scope=agent` on
+read unless you need cross-agent context. *Naming caveat:* writes take
+`visibility=scope_*`; reads/list/keystone filters take `scope=*` — two axes,
+similar spelling.
 
-**Visibility (on write):** `scope_agent` (private) · `scope_team`
-*(default — your fleet)* · `scope_org` (all fleets in tenant).
+## 7 · Keeping knowledge clean
 
-**Scope (on read — `_list` / `_insights`):** `agent` *(default)* ·
-`fleet` (trust 2) · `all` (trust 2).
+A few habits keep recall trustworthy and sharp:
 
-Prefer `scope_team` when writing; prefer `scope=agent` when reading
-unless you need cross-agent context.
+- **Make memories good** — dated, concrete, standalone, atomic, and updated (not
+  duplicated). Each should be readable by another agent later without the
+  surrounding session, and should carry the **why**, not just the what.
+- **Supersede, don't delete.** When a fact changes: (1) write the new one, (2)
+  recall the old one, (3) `memclaw_manage op=transition status=outdated`. This
+  keeps the lineage. Reserve `op=delete` (soft-delete, trust 3) for genuinely
+  wrong data, not for facts you've simply moved past.
+- **Resolve conflicts; don't pick one silently.** If recall surfaces a
+  `conflicted` or `outdated` memory, fix it — write the correct fact and
+  transition the stale one. Two live opposing beliefs degrade every future
+  recall for everyone.
 
-## Containers
-
-- **Memory** — unstructured, findable semantically. Decisions, observations, rules, outcomes, recaps.
-- **Doc** — structured record with a natural key (`collection + doc_id`). Customers, configs, task lists, inventories.
-- **Entity** — named graph object (person, project, service). Fetch by UUID from a prior recall.
-
-If you need semantic search, it's a memory. If you need keyed lookup,
-it's a doc. If you already hold an ID, it's an entity.
-
-## Where things go: MemClaw vs file scratchpads
+## 8 · MemClaw vs your workspace files
 
 MemClaw is the only place for cross-session, cross-agent knowledge. A
-file-based scratchpad in your workspace (e.g. `MEMORY.md`) is
-session-local — it lives in your bootstrap context every turn and pays
-input tokens for every byte.
+file-based scratchpad in your workspace (e.g. `MEMORY.md`) is **session-local**
+— it lives in your bootstrap context every turn and pays input tokens for every
+byte, and your teammates never see it.
 
-Keep `MEMORY.md` lean: only **active projects, current routing
-decisions, recent decisions (≤ 7 days), open threads**. Target a few
-KB; treat anything older or larger as smell. If the runtime promotes
-data into `MEMORY.md`, prune it on session start.
+- Keep `MEMORY.md` lean: only **active projects, current routing decisions,
+  recent decisions (≤ 7 days), open threads.** Target a few KB; prune anything
+  older or larger on session start.
+- Everything else goes to MemClaw via `memclaw_write` (history, finished work,
+  lessons), `memclaw_doc` collections (reference data with a natural key), or
+  entities (people / projects / services).
+- Never copy MemClaw recall results into `MEMORY.md` — they're already
+  retrievable. Never substitute a local file for a MemClaw write.
 
-Anything else goes to MemClaw via `memclaw_write`:
-- Historical decisions, finished projects, lessons → memories.
-- Reference data with a natural key (IP tables, contact lists, configs)
-  → `memclaw_doc` collections, fetched on demand.
-- People, projects, services as named graph objects → entities.
+## 9 · Capture cadence (L1 / L2 / L3)
 
-Never copy MemClaw recall results into `MEMORY.md` — they're already
-retrievable. Never let `MEMORY.md` accumulate by append-only; pruning
-is part of the L2 / L3 capture cadence below.
-
-## Quality
-
-Every memory MUST include a date. Prefer concrete over vague, atomic
-over sprawling, **update over near-duplicate**. Each memory should be
-**self-contained** — readable by another agent six months from now
-without the surrounding session. Include the **why** (motivation,
-constraint, trigger) alongside the *what* — facts without context
-become unactionable. Before writing a key fact, recall for
-contradictions and transition the older memory to `outdated` in the
-same turn. One topic per memory; batch multiple discrete records into
-one `memclaw_write` call.
-
-## Capture cadence (L1 / L2 / L3)
-
-- **L1 — per turn.** After each meaningful outcome, write with date,
-  what, who, outcome, next.
-- **L2 — session boundary.** At > 60 % context or session end, write
-  a full summary.
+- **L1 — per turn.** After each meaningful outcome, write with date, what, who,
+  outcome, next.
+- **L2 — session boundary.** At > 60 % context or session end, write a full
+  summary.
 - **L3 — consolidation.** On periodic runtime sweeps, find gaps, merge
   duplicates, transition contradicted facts to `outdated`.
 
-## Orchestrator + subagent protocol
+## 10 · Orchestrator + subagent protocol
 
 If your runtime dispatches subagents:
-- The spawning agent MUST write findings after every subagent completion.
-- The subagent MUST write its own findings before handing back.
-- Both writes MUST carry their own `agent_id`.
+- The spawning agent writes findings after each subagent completes.
+- The subagent writes its own findings before handing back.
+- Both writes carry their **own** `agent_id`.
 
 Single-agent runtimes ignore this section.
 
-## Prohibitions
+## 11 · Recall policy (auto-gating)
 
-- NEVER fabricate or impersonate `agent_id` / `fleet_id`.
-- NEVER delete memories you merely disagree with — transition them to
-  `outdated` or `archived`. `op=delete` is a soft-delete, requires
-  trust 3, and is reserved for genuinely wrong data.
-- NEVER write with org-wide visibility (`scope_org`) unless the memory
-  is genuinely org-relevant.
-- NEVER silently drop a denied call — surface the error so the
-  orchestrator can decide whether to escalate.
-- NEVER substitute local files or scratchpads for MemClaw writes.
+Before each model call the plugin's context engine decides whether to issue a
+plugin-driven recall, so trivial turns ("hi", "ok", `/help`, single-emoji acks)
+don't hit the backend and pay tokens for an unhelpful recall block.
 
-## Recall policy (auto-gating)
+- **Default** (`MEMCLAW_RECALL_POLICY=auto`): recall on substantive turns; skip
+  very short prompts, trivial pings, and short slash-commands.
+- **Recall keywords always force recall** (e.g. `remember`, `recall`, `last
+  time`, `we discussed`, `previously`, `history`); override the set with
+  `MEMCLAW_RECALL_TRIGGER_KEYWORDS`.
+- Other policies: `always`, `never` (education block only), `keywords`.
+- The gate only suppresses *plugin-driven* recall — **you can always call
+  `memclaw_recall` directly** when a short turn needs context the gate can't
+  infer.
 
-The plugin's context engine runs `assemble()` before every model call
-and, by default, decides whether to issue a recall against MemClaw
-based on the turn's content. This stops every trivial ping ("hi", "ok",
-"thanks", `/help`, single-emoji acks) from hitting the backend and
-paying input tokens for unhelpful recall blocks.
+Rolling skip counters (`recall_metrics`) ride the heartbeat for per-fleet
+visibility.
 
-**Default policy** (`MEMCLAW_RECALL_POLICY=auto`): recall on
-substantive turns, skip on:
-- prompts under 14 chars (no useful query) unless an explicit recall
-  keyword is present;
-- trivial pings: greetings, acks, single-emoji turns;
-- short slash commands (`/help`, `/clear`, `/foo bar`);
-- empty `prompt` with no buffered user message.
+The plugin also auto-writes a short **turn summary** after substantive turns
+(`MEMCLAW_AUTO_WRITE_TURNS`, on by default). That's a backstop, not a
+replacement for the deliberate, high-value writes in §3 — and it never evolves,
+supersedes, or files docs for you. Do that work yourself.
 
-**Recall keywords always force recall** even on otherwise-skip prompts.
-Defaults: `memclaw`, `LTM`, `long term`, `long-term`, `remember`,
-`recall`, `what did`, `earlier`, `previously`, `last time`, `before`,
-`we discussed`, `you said`, `i told`, `history`, `memory`, `lookup`.
-Override via `MEMCLAW_RECALL_TRIGGER_KEYWORDS=...` (comma-separated).
+## 12 · Reuse and publish workflows — the `skills` collection
 
-**Other policies**: `always` (recall every turn — pre-CAURA-444
-behaviour), `never` (education block only; agents can still call
-`memclaw_recall` explicitly), `keywords` (recall only when an explicit
-trigger fires).
+Proven workflows live as `SKILL.md` documents in the **`skills`** collection.
+You don't learn a new tool per playbook — it's the same `memclaw_doc`, so your
+vocabulary never grows with the library.
 
-**Important**: the auto-gate only suppresses the *plugin-driven*
-recall. Agents can always call `memclaw_recall` directly when they
-judge that a short turn needs LTM — the gate never blocks the tool
-call itself. Use this knob when a short message would benefit from
-context the gate can't infer.
+```text
+# Discover before improvising on a non-trivial workflow:
+memclaw_doc op=search collection=skills query="<intent>"
+memclaw_doc op=read   collection=skills doc_id=<slug>   # full body
 
-**Operational visibility**: rolling skip counters
-(`recall_metrics: {calls_total, skipped_total, skipped_by_reason}`)
-are sent in every heartbeat and persisted on the node row. SQL on
-`nodes.metadata->'recall_metrics'` answers "how often is the gate
-firing per fleet, by reason."
-
-## Sharing skills
-
-Skills are SKILL.md artifacts that agents share across the fleet —
-debugging recipes, ops runbooks, refactor playbooks. They live as
-documents in the `skills` collection: discovery and sharing both use
-`memclaw_doc`.
-
-```
-# Discover
-memclaw_doc op=search collection=skills query=<natural language>
-memclaw_doc op=query  collection=skills              # browse by recency
-memclaw_doc op=read   collection=skills doc_id=<slug>  # full body
-
-# Share — slug is `[a-z0-9][a-z0-9._-]{0,99}` (filesystem-safe)
+# Publish something reusable so the fleet inherits it:
 memclaw_doc op=write collection=skills doc_id=<slug> \
-  data={ "name": "<slug>", "summary": "<one-liner>", "content": "<full SKILL.md>" }
+  data={ "name": "<slug>",
+         "summary": "<1-line, intent-focused — this is what gets embedded>",
+         "content": "<full SKILL.md>" }
+# Re-uploading the same doc_id overwrites it (upsert; no version history).
 
-# Remove
+# Remove a wrong/superseded one:
 memclaw_doc op=delete collection=skills doc_id=<slug>
 ```
 
-The `data["summary"]` string is what gets embedded — that's what makes
-the skill discoverable by meaning ("how do I research scientific
-papers?") even when names don't match. For back-compat, the server
-also accepts `data["description"]` on `collection=skills` writes if no
-summary is provided.
+Slugs are filesystem-safe: `[a-z0-9][a-z0-9._-]{0,99}`. The `summary` is the
+only embedded field — write a sharp, intent-focused one ("Use when migrating
+SQLite→Postgres…") so the skill is found by meaning even when names don't match.
 
-Visibility follows the document — share at `fleet_id` scope so the
-catalog row is visible to every agent on that fleet. Re-uploading the
-same `doc_id` overwrites; this is how you publish a new version.
+## A full loop, end to end
 
-Built something reusable? Upsert it. Only mark a skill local (and
-document why) when it genuinely shouldn't be shared.
+One task — orient, work, write, evolve — with the IDs threaded through:
 
-## Session loop
+```text
+# 1. Orient — recall, and keep the IDs that come back
+memclaw_recall "deploy api-gateway to staging" include_brief=true
+#   → mem_8f2a (rule: "staging deploys need a smoke test"), mem_4d1c (last deploy)
 
-1. Recall — "what is known about this?" / "what happened since last session?"
-2. Work — act on the recalled context.
-3. Write — at checkpoints and session end (see L1/L2/L3 above).
-4. Evolve — if you acted on specific memories, report the outcome (default `scope="agent"`, trust 1; fleet/all needs trust 2).
+# 2. Work — run the deploy, following the rule in mem_8f2a
+
+# 3. Write — record the outcome (team-visible; home fleet resolved on omit)
+memclaw_write content="api-gateway v2.3 deployed to staging; smoke test green" \
+  visibility=scope_team
+
+# 4. Evolve — report against the memories you acted on
+memclaw_evolve outcome="deploy succeeded, smoke test passed" \
+  outcome_type=success related_ids=[mem_8f2a, mem_4d1c]
+#   if it had failed in a way the whole fleet should avoid:
+#   add scope=fleet (trust 2) so the preventive rule reaches teammates
+```
 
 ---
 
 ## Tool reference
 
-The at-a-glance tool list and enum vocabulary live in `TOOLS.md` in your
-workspace (bootstrap-injected every turn). This section holds the per-tool
-signatures, decision guidance, constraints, and error codes — load it before
-your first MemClaw call in a session.
-
-### Tool cards
-
-**`memclaw_recall(query, top_k=5, include_brief=false, memory_type=?, status=?, filter_agent_id=?, fleet_ids=?)`**
-Hybrid semantic+keyword search. For metadata browse → `memclaw_list`;
-for a known id → `memclaw_manage(op="read")`. `include_brief=true` adds
-an LLM-summarized paragraph. Superseded memories (`status` ∈
-{outdated, conflicted}) are excluded by default — pass `status` explicitly
-(e.g. `status="conflicted"`) to inspect the chain.
-
-**`memclaw_write(content=? | items=?, visibility="scope_team", memory_type=?, weight=?, metadata=?, write_mode="auto", source_uri=?, run_id=?)`**
-Provide exactly one of `content` / `items`. Server auto-classifies.
-`items` batches up to 100. `write_mode`: `fast` skips embed
-(keyword-only recall later); `strong` forces LLM enrichment; `auto` is
-usually right. `insight` / `outcome` / `rule` are server-generated only
-(via `memclaw_insights` / `memclaw_evolve`) — you cannot write them, and
-auto-classify will never assign them; record reflections as `semantic` or
-`fact` (or omit `memory_type`).
-
-**`memclaw_manage(op, memory_id, ...)`** — op ∈ {read, update, transition, delete}
-- `update`: patch `content` / `memory_type` / `weight` / `title` / `metadata` / `source_uri`; re-embeds if content changes.
-- `transition`: set `status` (see Vocabulary in `TOOLS.md`).
-- `delete`: soft-delete; trust 3. Prefer `transition` to `outdated` / `archived`.
-
-**`memclaw_list(scope="agent", memory_type=?, written_by=?, status=?, weight_min/max=?, created_after/before=?, sort="created_at", order="desc", limit=25, cursor=?)`**
-Non-semantic enumeration. Cursor pagination requires
-`sort=created_at order=desc`. `scope="fleet"` / `"all"` → trust 2.
-
-**`memclaw_doc(op, collection=?, doc_id=?, data=?, where=?, order_by=?, limit=20, offset=0, query=?)`** — op ∈ {write, read, query, delete, list_collections, search}
-Structured records by `collection + doc_id`. `write` upserts; include
-`data["summary"]` (1-3 sentences, intent-focused) to make the doc
-semantically searchable — that's the only field that gets embedded.
-
-**`memclaw_entity_get(entity_id)`**
-UUID from a prior call — never fabricate.
-
-**`memclaw_tune(top_k?, min_similarity?, fts_weight?, freshness_floor?, freshness_decay_days?, recall_boost_cap?, recall_decay_window_days?, graph_max_hops?, similarity_blend?)`**
-Persists — affects every future `memclaw_recall`. No fields → read the
-current profile. Change one or two at a time. `fts_weight` 0 = pure
-semantic, 1 = pure keyword.
-
-**`memclaw_insights(focus, scope="agent", fleet_id=?)`**
-Reflection. `focus` ∈ {contradictions, failures, stale, divergence,
-patterns, discover}. Results saved as `insight` memories. Run at
-boundaries, not every turn. `scope="fleet"` / `"all"` → trust 2;
-`focus="divergence"` requires non-agent scope.
-
-**`memclaw_evolve(outcome, outcome_type, related_ids=?, scope="agent", fleet_id=?)`**
-Close the loop. `outcome_type` ∈ {success, failure, partial}.
-`related_ids` = the recall IDs you acted on. Success reinforces weights;
-failure auto-creates `rule` memories. Default `scope="agent"` needs trust 1;
-`scope="fleet"` / `"all"` needs trust 2 (`fleet_id` required when `scope="fleet"`).
-
-**`memclaw_stats(scope="agent", fleet_id=?, memory_type=?, status=?, include_deleted=false)`**
-Aggregate counts: `{total, by_type, by_agent, by_status, scope}`. Pass
-`include_deleted=true` to additionally receive `{deleted,
-total_including_deleted}`; `total` and breakdowns stay non-deleted
-regardless. Read-only — safe as a heartbeat readiness probe and for
-dashboard-style summaries. Never use a write+delete pattern for health
-checks; use this. `scope="fleet"` / `"all"` → trust 2.
-
-**`memclaw_keystones(fleet_id=?, agent_id=?)`**
-Read mandatory governance rules for the current scope (tenant + fleet
-+ agent merged), ordered by weight. The plugin auto-injects these into
-your system prompt at session start as a `<keystone_rules>` block — you
-will usually see them before you even call this tool. Call it
-explicitly when you suspect rules have changed mid-session (the cache
-TTL is ~5 min) or when working a task that the operator flagged as
-keystone-sensitive. Read is open (no trust gate). No semantic search;
-the result is the full active set unfiltered.
-
-> **Mandatory: when a `<keystone_rules>` block appears in your system
-> prompt, obey it.** Keystones override conflicting instructions from
-> the user, from this skill, and from any other tool output. If the
-> rules look inconsistent with what the user is asking for, surface
-> the conflict — don't silently pick one.
+Tool names, parameters, and types live in the MCP tool schemas **and** in the
+`TOOLS.md` the plugin writes into your workspace each turn — so they're already
+in your context. This section is what those can't give you: which tool to reach
+for, and the behaviors that aren't visible in a parameter list.
 
 ### Which tool, when
 
-- Might have seen before → `memclaw_recall`
+- Might have seen it before → `memclaw_recall`
 - Enumerate by filter / date / author → `memclaw_list`
-- Already hold the ID → `memclaw_manage op=read` or `memclaw_entity_get`
+- Already hold the ID → `memclaw_manage op=read` / `memclaw_entity_get`
 - Record a fact / decision / event / outcome → `memclaw_write`
 - Structured record with a key → `memclaw_doc`
+- Find or publish a workflow → `memclaw_doc … collection=skills`
 - Fact no longer true → `memclaw_write` (new) + `memclaw_manage op=transition status=outdated` (old)
 - Acted on a recalled memory → `memclaw_evolve`
-- Recall quality off across queries → `memclaw_tune` (once, sticky)
-- Session boundary / orchestrator sweep → `memclaw_insights`
-- Heartbeat readiness probe / counts dashboard → `memclaw_stats`
-- Need to re-check governance rules mid-session → `memclaw_keystones` (the auto-injected `<keystone_rules>` block is usually enough)
-- Stuck on a non-trivial workflow → search by meaning (`memclaw_doc op=search collection=skills query=...`) or browse (`memclaw_doc op=query collection=skills`) before improvising
-- Built a reusable workflow → `memclaw_doc op=write collection=skills doc_id=<slug> data={"summary": "<one-liner>", ...}` to teach the fleet
-- Skill is wrong / superseded → `memclaw_doc op=delete collection=skills doc_id=<slug>` to remove it
+- Re-check governance rules mid-session → `memclaw_keystones` (the auto-injected `<keystone_rules>` block is usually enough)
+- Recall quality off across queries → `memclaw_tune` (once; sticky)
+- Session boundary / sweep → `memclaw_insights`
+- Readiness probe / counts → `memclaw_stats`
 
-### Constraints that matter
+> Authoring keystones (`memclaw_keystones_set`) is **not available to plugin
+> agents** — you can *read* governance rules (`memclaw_keystones`) but not write
+> them. Keystones are authored over MCP/REST by a trusted operator.
 
-- `memclaw_write`: exactly one of `content` / `items`; never both.
-- `items` capped at 100 → `BATCH_TOO_LARGE`.
-- Supersede via `transition`; reserve `delete` (trust 3) for wrong data.
+### Behaviors the schema won't tell you
+
+- **`memclaw_recall`** excludes superseded memories (`status` ∈ {outdated, conflicted}) by default — pass `status` explicitly to walk the chain.
+- **`memclaw_write`** can't write `insight` / `outcome` / `rule` types — those are server-generated (via `memclaw_insights` / `memclaw_evolve`). `write_mode`: `fast` skips embedding → keyword-only recall afterwards; `strong` forces full LLM enrichment; `auto` is usually right.
+- **`memclaw_manage op=transition`** targets: `active · pending · confirmed · cancelled · outdated · conflicted · archived · deleted` (also in `TOOLS.md`).
+- **`memclaw_doc`** — `where` is scalar exact-match only (no array descent). A doc is invisible to `op=search` unless it has a `data["summary"]` (the only embedded field). Scope the search to a collection when you know it; omit `collection` for the single best match across the tenant.
+- **`memclaw_tune`** persists and reshapes every later recall — change one or two knobs at a time; call with no arguments to read your current profile (`fts_weight` 0 = pure semantic, 1 = pure keyword).
+- **`memclaw_insights`** saves findings as `insight` memories; run it at boundaries, not every turn. `focus="divergence"` needs a non-agent scope.
+- **`memclaw_stats`** is read-only — use it as a readiness/health probe, never a write-then-delete check.
+
+### Anti-patterns
+
+- Saving every intermediate step as a memory — pollutes recall.
+- Storing narrative as a doc, or structured keyed records as memories.
+- Saving a discoverable doc with no pointer memory — teammates won't find it.
+- Guessing `agent_id` / `fleet_id`, or inventing UUIDs.
+- Deleting when you should supersede.
+- Writing org-wide (`scope_org`) anything that isn't genuinely org-relevant.
+- Substituting `MEMORY.md` / local files for a MemClaw write.
+- Silently dropping a denied call — surface the error so the orchestrator can decide.
+
+### Constraints & errors
+
+- `memclaw_write`: exactly one of `content` / `items`; `items` ≤ 100 → `BATCH_TOO_LARGE`.
 - Cursor pagination needs `sort=created_at` + `order=desc`.
 - `_entity_get` / `_manage` use real UUIDs — never invent.
-- `_tune` persists; do not call per-query.
-
-### Error codes
-
-`INVALID_ARGUMENTS` · `BATCH_TOO_LARGE` · `INVALID_BATCH_ITEM`. Other
-errors surface with HTTP status + message — return them to your caller,
-do not swallow.
+- Error codes: `INVALID_ARGUMENTS` · `BATCH_TOO_LARGE` · `INVALID_BATCH_ITEM`. Other errors surface with HTTP status + message — return them to your caller, don't swallow.
 
 ---
 
-*This skill ships with the MemClaw plugin at its install path; it is visible
-to every agent on the node that has the plugin enabled. To customize it for
-a specific agent, place a replacement file at
-`<workspace>/skills/memclaw/SKILL.md` in that agent's workspace — it takes
+*This skill ships with the MemClaw plugin at its install path; it is visible to
+every agent on a node that has the plugin enabled
+(`plugins.entries.memclaw.enabled`). To customize it for a specific agent, place
+a replacement file at `<workspace>/skills/memclaw/SKILL.md` — it takes
 precedence over this shared copy.*

--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -1086,21 +1086,32 @@ describe("shared SKILL.md (plugin/skills/memclaw/SKILL.md)", () => {
 
   test("required body sections are present", () => {
     const skill = readSharedSkill();
-    assert.ok(skill.includes("## Your identity"), "missing identity section");
+    assert.ok(skill.includes("## 0 · Identity"), "missing identity section");
     assert.ok(skill.includes("`agent_id`"), "missing agent_id");
     assert.ok(skill.includes("`fleet_id`"), "missing fleet_id");
-    assert.ok(skill.includes("## The three rules"), "missing three rules");
-    assert.ok(skill.includes("## Trust levels"), "missing trust section");
-    assert.ok(skill.includes("## Sharing"), "missing sharing section");
-    assert.ok(skill.includes("## Session loop"), "missing session loop");
+    assert.ok(skill.includes("## 2 · The loop"), "missing the loop");
+    assert.ok(skill.includes("## 6 · Trust and sharing"), "missing trust/sharing section");
+    assert.ok(
+      skill.includes("## 12 · Reuse and publish workflows"),
+      "missing skills-collection section",
+    );
   });
 
-  test("identity section uses MUST language", () => {
+  test("identity section pins both ids and the never-fabricate rule", () => {
+    // The canonical skill explains the *why* rather than leaning on MUST
+    // walls (deliberate, per skill-authoring guidance). The load-bearing
+    // invariant is that identity still covers both ids and forbids
+    // fabricating/impersonating an agent_id.
     const skill = readSharedSkill();
-    const idx = skill.indexOf("## Your identity");
-    assert.ok(idx >= 0);
-    const section = skill.slice(idx, skill.indexOf("## The three rules"));
-    assert.ok(section.includes("MUST"), "identity section lacks MUST language");
+    const idx = skill.indexOf("## 0 · Identity");
+    assert.ok(idx >= 0, "missing identity section");
+    const section = skill.slice(idx, skill.indexOf("## 1 ·"));
+    assert.ok(section.includes("`agent_id`"), "identity section missing agent_id");
+    assert.ok(section.includes("`fleet_id`"), "identity section missing fleet_id");
+    assert.ok(
+      section.includes("Never fabricate"),
+      "identity section must forbid fabricating/impersonating an agent_id",
+    );
   });
 
   test("Rule 3 describes delete as soft-delete requiring trust 3", () => {
@@ -1114,31 +1125,39 @@ describe("shared SKILL.md (plugin/skills/memclaw/SKILL.md)", () => {
     );
   });
 
-  test("holds the deep-dive tool reference relocated from TOOLS.md", () => {
-    // The tool cards, decision tree, constraints, and error codes were moved
-    // out of the bootstrap-every-turn TOOLS.md into this on-demand file as
-    // part of the per-turn token-footprint reduction. Each section must land
-    // here or the model loses the reference entirely.
+  test("holds the deep-dive tool reference (judgment + behaviors, not signature cards)", () => {
+    // Per-tool signatures are deferred to the live MCP schemas and the
+    // injected TOOLS.md; the on-demand SKILL.md carries the judgment those
+    // can't express. Each section must land here or the model loses it.
     const skill = readSharedSkill();
     assert.ok(skill.includes("## Tool reference"), "missing ## Tool reference section");
-    assert.ok(skill.includes("### Tool cards"), "missing ### Tool cards");
     assert.ok(skill.includes("### Which tool, when"), "missing ### Which tool, when");
-    assert.ok(skill.includes("### Constraints that matter"), "missing ### Constraints that matter");
-    assert.ok(skill.includes("### Error codes"), "missing ### Error codes");
+    assert.ok(
+      skill.includes("### Behaviors the schema won't tell you"),
+      "missing ### Behaviors the schema won't tell you",
+    );
+    assert.ok(skill.includes("### Constraints & errors"), "missing ### Constraints & errors");
   });
 
-  test("all 10 tool cards are present in SKILL.md", () => {
+  test("every plugin-exposed tool is named in SKILL.md (signatures deferred)", () => {
     const skill = readSharedSkill();
+    // The plugin exposes these 11 tools; each must be named so the model
+    // knows the surface. Signatures live in the MCP schemas + injected
+    // TOOLS.md, so we assert names, not signature cards.
     for (const tool of [
       "memclaw_recall", "memclaw_write", "memclaw_manage", "memclaw_list",
       "memclaw_doc", "memclaw_entity_get", "memclaw_tune",
-      "memclaw_insights", "memclaw_evolve", "memclaw_stats",
+      "memclaw_insights", "memclaw_evolve", "memclaw_stats", "memclaw_keystones",
     ]) {
-      assert.ok(
-        skill.includes(`**\`${tool}(`) || skill.includes(`\`${tool}(`),
-        `SKILL.md missing tool card for ${tool}`,
-      );
+      assert.ok(skill.includes(tool), `SKILL.md does not mention ${tool}`);
     }
+    // keystones_set is withheld from plugin agents (plugin_exposed=false in
+    // tools.ts) — it must NOT appear as a callable tool, only as the
+    // "not available to plugin agents" note.
+    assert.ok(
+      !/`memclaw_keystones_set\(/.test(skill),
+      "plugin SKILL.md must not present keystones_set as a callable tool",
+    );
   });
 
   test("error codes appear verbatim in SKILL.md", () => {
@@ -1334,8 +1353,12 @@ describe("buildAgentsMd", () => {
 
     const skill = readFileSync(SHARED_SKILL_PATH, "utf-8");
     assert.ok(
-      skill.includes("NEVER delete memories you merely disagree with"),
-      "SKILL.md must carry the 'merely disagree' framing for op=delete",
+      skill.includes("Supersede, don't delete"),
+      "SKILL.md must carry the supersede-over-delete framing",
+    );
+    assert.ok(
+      skill.includes("Deleting when you should supersede"),
+      "SKILL.md anti-patterns must flag delete-instead-of-supersede",
     );
     assert.ok(
       skill.includes("soft-delete"),
@@ -1359,9 +1382,14 @@ describe("buildAgentsMd", () => {
       skill.includes("Orchestrator + subagent"),
       "SKILL.md missing orchestrator/subagent protocol",
     );
-    assert.ok(skill.includes("Prohibitions"), "SKILL.md missing prohibitions section");
-    assert.ok(skill.includes("NEVER fabricate"));
-    assert.ok(skill.includes("NEVER silently drop"));
+    // Prohibitions folded into the canonical "### Anti-patterns" list; the
+    // load-bearing guards must survive there.
+    assert.ok(skill.includes("### Anti-patterns"), "SKILL.md missing anti-patterns section");
+    assert.ok(skill.includes("inventing UUIDs"), "SKILL.md must forbid inventing ids/UUIDs");
+    assert.ok(
+      skill.includes("Silently dropping a denied call"),
+      "SKILL.md must forbid silently dropping a denied call",
+    );
   });
 
   test("nudges the model to open the memclaw skill before the first MemClaw call", () => {

--- a/plugin/src/tool-definitions.test.ts
+++ b/plugin/src/tool-definitions.test.ts
@@ -188,10 +188,12 @@ describe("createToolFromSpec factory", () => {
 
 describe("drift checks across tool surface artefacts", () => {
   // SKILL.md ships with the plugin and is read on demand by every agent;
-  // it MUST list every plugin-exposed tool as a tool card. Without this
-  // gate, adding a tool (e.g. memclaw_stats in #64) silently leaves
-  // SKILL.md a version behind and agents see the wrong tool count.
-  test("SKILL.md has a tool card for every tool in MEMCLAW_TOOLS", () => {
+  // it MUST name every plugin-exposed tool. Per-tool *signatures* are
+  // deferred to the live MCP schemas + injected TOOLS.md, so this gate
+  // asserts presence by name (not a signature card). Without it, adding a
+  // tool (e.g. memclaw_stats in #64) silently leaves SKILL.md a version
+  // behind and agents see the wrong tool surface.
+  test("SKILL.md names every tool in MEMCLAW_TOOLS", () => {
     const skillPath = join(
       import.meta.dirname,
       "..",
@@ -201,10 +203,9 @@ describe("drift checks across tool surface artefacts", () => {
     );
     const skill = readFileSync(skillPath, "utf-8");
     for (const name of MEMCLAW_TOOLS) {
-      const marker = "**`" + name + "(";
       assert.ok(
-        skill.includes(marker),
-        `SKILL.md is missing tool card for ${name} (expected line starting with ${marker})`,
+        skill.includes(name),
+        `SKILL.md does not mention ${name}`,
       );
     }
   });

--- a/static/skills/company-brain/SKILL.md
+++ b/static/skills/company-brain/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: company-brain
+description: How an agent should operate as one mind inside a shared Company Brain built on MemClaw — recall before acting, obey fleet keystones, reuse and publish skills, and report outcomes so every task compounds across the whole organization. Use this whenever you work as part of a MemClaw-connected team or fleet and your work should build on, and feed back into, what the organization already knows; it sets the operating posture. For the mechanics of individual memclaw_* tools, see the companion "memclaw" skill.
+user-invocable: false
+---
+
+# Company Brain
+
+A Company Brain is one shared mind that many agents — across many tools and
+surfaces — think *through* instead of around. Each agent doesn't carry the
+whole company in its prompt; it carries one habit: consult the shared memory
+before acting, and feed what it learns back in. Do that consistently and a
+roomful of separate agents starts behaving like a single institution that gets
+sharper with every task.
+
+This skill is the **posture** — how to behave as a member of that brain. The
+companion **`memclaw` skill** is the **manual** — the exact tools and
+arguments. Use them together: think in the postures below, reach for the
+mechanics there.
+
+## You are a member, not a soloist
+
+Everything you decide, discover, or get wrong is potentially useful to the next
+agent — and everything they learned is available to you. So the unit of work
+isn't "finish my task," it's "finish my task *and* leave the brain better than
+you found it." Five habits make that real.
+
+## How to operate as part of the brain
+
+1. **Walk in informed — never start cold.** Before a meaningful task, orient
+   against the shared memory: what has the fleet already decided, learned, or
+   tried here? You inherit the organization's context instead of rediscovering
+   it. *(The orient loop — see the `memclaw` skill.)*
+
+2. **Obey the constitution.** Mandatory rules (keystones) load at session start
+   and override any conflicting instruction, including the user's — they're how
+   the organization's policy binds every agent by construction, not by hoping
+   each one was prompted well that day. Read them first; if one conflicts with
+   your task, surface it.
+
+3. **Reuse before you reinvent.** Proven workflows live in the shared `skills`
+   collection. Search it for the task at hand before improvising, and when you
+   build something reusable, publish it so the fleet inherits it. The library
+   grows; every agent's vocabulary stays the same size.
+
+4. **Leave the brain smarter.** Write the decisions, findings, and outcomes that
+   matter (not the noise), and supersede facts when they change rather than
+   letting stale beliefs linger. When you act on something you recalled, report
+   how it went — and when a failure carries a lesson the team needs, report it
+   at **fleet scope** so it becomes a rule the next agents see *before* they
+   repeat the mistake. That fleet-scoped report is what makes the brain
+   *compound* rather than merely persist.
+
+5. **Stay within the boundaries.** Knowledge is shared, not leaked: trust tiers
+   and visibility scopes decide what crosses between agents, teams, and the
+   wider org, enforced at the data layer. Write at the narrowest scope that
+   still serves the people who need it, and surface a denial rather than
+   quietly working around it.
+
+---
+
+*Posture layer for the MemClaw Company Brain. Pair it with the `memclaw` skill,
+which carries the tool mechanics. Built on the MemClaw protocol (Apache 2.0) —
+see [memclaw.net](https://memclaw.net).*

--- a/static/skills/memclaw/SKILL.md
+++ b/static/skills/memclaw/SKILL.md
@@ -1,299 +1,320 @@
 ---
 name: memclaw
-description: Persistent, cross-session, multi-agent memory. Semantic recall of decisions and findings; write outcomes; supersede facts when they change.
+description: The agent's persistent long-term memory — the only knowledge that survives across sessions, shared across the fleet under access control. Consult it at the start of a task to recall prior decisions, findings, and rules before acting, and write outcomes, decisions, and lessons as work completes. Use whenever a memclaw_* tool is present, whenever the user refers to past work ("what did we decide", "last time", "earlier"), or whenever any durable fact needs to be stored, recalled, superseded, or shared with the fleet. Do not use it for throwaway within-session scratch state.
 user-invocable: false
 ---
 
 # MemClaw Skill
 
-Long-term memory that persists across sessions and is shared under access
-controls. The primary place where decisions, findings, outcomes, and
-learned rules live.
+MemClaw is your long-term memory. Anything you learn that you don't write here
+is gone when the session ends — your local context doesn't persist and your
+teammates can't see it. So treat MemClaw as the default home for every
+decision, finding, outcome, rule, and reusable workflow, and consult it before
+you act. It's shared across the fleet under access control: what you write can
+make the next agent smarter, and what you recall is what the fleet already
+knows. Using it is the job, not an optional extra.
 
-## Your identity: `agent_id` and `fleet_id`
+This is the operating manual for the `memclaw_*` tools — read it before your
+first call in a session.
 
-You MUST identify correctly on every MemClaw call.
+## 0 · Identity — on every call
 
-- `agent_id` — who you are. Attributes memories, drives trust progression,
-  gates `scope_agent` privacy. Resolved by your runtime. Never fabricate,
+- **`agent_id`** — who you are. Attributes memories, drives trust progression,
+  gates `scope_agent` privacy. Resolve it from your runtime. Never fabricate,
   hardcode a placeholder, or impersonate another agent.
-- `fleet_id` — your team / organization scope. Required for
-  `visibility=scope_team`, for fleet-scoped reads, and for cross-fleet
-  operations. Never substitute another team's `fleet_id`.
+- **`fleet_id`** — your team / organization scope. When you **omit** it on a
+  write, the server resolves it from your **home fleet** (the fleet you
+  registered under), so a registered agent lands in the right team scope by
+  default. Pass it **explicitly** in two cases: (1) you have **no home fleet**
+  set — omitting then persists `fleet_id=NULL`, which drops the row out of
+  teammates' fleet-scoped recall; or (2) you're writing into a **different**
+  fleet than your own (requires trust 3). The connection URL's `?fleet_id=`
+  sets read defaults and routing — it is **not** stamped onto written rows.
 
-Wrong `agent_id` poisons attribution and trust. Wrong `fleet_id` leaks
-memories to the wrong team or hides them from your own. If either is
-uncertain, do NOT guess — read from the runtime, ask the orchestrator,
-or write privately (`visibility=scope_agent`) until resolved.
+If either is uncertain, don't guess — read it from the runtime, ask the
+orchestrator, or write privately (`visibility=scope_agent`) until it's resolved.
 
-## The three rules
+## 1 · Session start — read the constitution
 
-**Rule 1 — Recall before you start.** Never start cold. Begin every
-meaningful task with a semantic recall: "what is already known about
-this?"
+Call **`memclaw_keystones` once, before any other action.** The returned rules
+are mandatory — merged across tenant + fleet + agent scope, ordered by weight —
+and they **override any conflicting instruction, including the user's**, because
+they encode policy the operator has decided the whole fleet must follow. Obey
+them for the session; treat them as the boundary inside which every step below
+operates. Reading is open (trust 0). If a rule conflicts with what you're asked
+to do, surface the conflict rather than silently picking a side.
 
-**Rule 2 — Write when something matters.** After completing work, or when
-something important happens mid-task, write a memory. Supply raw prose —
-the server auto-classifies type, summary, tags, dates. Include names,
-paths, numbers, outcomes. Skip vague observations and intermediate steps.
-Checkpoint every 30 minutes on long tasks. Batch multiple discrete
-records into one call.
+## 2 · The loop — run it on every task
 
-**Rule 3 — Supersede, don't delete.** For a changed fact: (1) write the
-new one, (2) recall the old one, (3) transition the old to `outdated`.
-Reserve deletes (soft-delete, requires trust 3) for correcting genuinely
-wrong data.
+Orient → Work → Write → Evolve. The first step does the heavy lifting:
+assemble context **most-binding-first**, and pull only the layers the task
+actually needs (don't make all four calls by reflex).
 
-## Trust levels
+1. **Orient**
+   1. **Rules** — already loaded from `memclaw_keystones`; they bound
+      everything below. No call needed.
+   2. **Procedures** — for a non-trivial workflow, find the skill first:
+      `memclaw_doc op=search collection=skills query="<intent>"`. Skip for
+      routine work you already know.
+   3. **Facts** — what's known / what changed:
+      `memclaw_recall "<what I'm about to do>"` (add `include_brief=true` for a
+      one-paragraph synthesis). **Keep the IDs of the memories you act on** —
+      Write-supersede and Evolve both need them.
+   4. **Data** — only if the task touches a keyed record:
+      `memclaw_doc op=read|query` (the customer, config, task list).
+2. **Work** — act within the rules, following the procedure.
+3. **Write** — record what matters (§3).
+4. **Evolve** — report how the memories you acted on turned out (§4).
 
-Auto-registered at trust 1 on your first write.
+**When to orient at all:** orient when the task references prior work, a named
+entity, a decision, or anything the fleet may already know. Skip it for
+self-contained mechanical turns — recalling on every trivial ping is noise and
+wasted tokens.
+
+## 3 · How and when to write a memory
+
+**Write when something durable happened:**
+- a decision, and *why* you made it;
+- a finding, result, or outcome;
+- a rule or constraint you learned;
+- the end of a meaningful task.
+
+**Don't write the noise.** Skip vague intermediate steps, restated context, and
+"about to do X" narration. Ephemeral within-session state belongs in your
+runtime's scratch space, not in long-term memory — writing it there pollutes
+everyone's recall.
+
+**How to write:** supply raw prose — you don't classify or tag anything. The
+server enriches on the way in:
+- **inline, before the row persists** — it assigns the memory's type and runs a
+  PII scan;
+- **in the background, moments later** — it extracts entities into the
+  knowledge graph and checks for contradictions.
+
+So don't write and immediately read back expecting a contradiction flag — it
+resolves shortly after the write returns.
+
+Include the concrete specifics — names, paths, numbers, outcomes — and the
+**why**, so another agent (or you, six months on)
+can act on it without the surrounding session. Default `visibility=scope_team`
+so your fleet benefits. Batch several discrete records in one call with `items`
+(up to 100). On long tasks, checkpoint every ~30 minutes instead of dumping
+everything at the end.
+
+**Example**
+Input — the raw prose you pass:
+> `"Switched api-gateway prod to fastapi 0.136.3 — 0.137 broke include_router via a starlette upper-bound. Pin held; smoke tests green."`
+
+Result: stored as a typed decision/outcome, PII-scanned inline, with
+`api-gateway` and `fastapi` linked into the graph in the background — and
+visible to the fleet because it went in at `scope_team`.
+
+Never paste secrets — API keys, tokens, credentials — into memory `content`.
+The PII scan is a safety net, not permission; keep them out entirely.
+
+## 4 · Report outcomes so the memory compounds
+
+When you act on memories you recalled, tell the memory how it went:
+`memclaw_evolve(outcome, outcome_type, related_ids)`, where `related_ids` are
+the IDs you kept during Orient. Success reinforces those memories' weight. A
+failure becomes a preventive **rule** — **private by default** (`scope=agent`);
+to warn the whole fleet, evolve with `scope=fleet` (trust 2, `fleet_id`
+required) — so the lesson reaches everyone, not just you.
+
+## 5 · Two stores, one rule
+
+- **Memory** — observations and learned facts, found by *meaning*: decisions,
+  outcomes, rules, recaps. Read with `memclaw_recall`, write with
+  `memclaw_write`.
+- **Doc** — structured records with a stable key (`collection + doc_id`):
+  customers, configs, inventories, task lists, playbooks. All through
+  `memclaw_doc`.
+- **Entity** — a named graph object (person, project, service). Fetch by a UUID
+  surfaced in a prior recall (`memclaw_entity_get`).
+
+**Rule of thumb:** need semantic search → it's a memory. Need keyed lookup →
+it's a doc. Already hold an ID → it's an entity.
+
+**Cross-store discovery.** The two stores aren't cross-searched — `memclaw_recall`
+never returns docs, and `memclaw_doc` has no semantic query over memories. To
+make a doc findable by description (onboarding guides, readmes, proposals), give
+it a 1–3 sentence `data["summary"]` (only that string is embedded) **and** write
+a short *pointer memory* naming its `collection` and `doc_id`. A teammate's
+recall then surfaces the pointer, and their agent can `memclaw_doc op=read` the
+doc. When you don't know what exists, call `memclaw_doc op=list_collections`
+first.
+
+## 6 · Trust and sharing
+
+You auto-register at **trust 1** on your first write.
 
 | Level | Name        | Read                      | Write                  |
 |:-----:|-------------|---------------------------|------------------------|
 | 0     | restricted  | —                         | —                      |
 | 1     | standard    | own fleet                 | own fleet              |
 | 2     | cross-fleet | all fleets in your tenant | own fleet              |
-| 3     | admin       | all                       | all, including deletes |
+| 3     | admin       | all                       | all, incl. deletes     |
 
-Scope-based escalation:
-- browsing or reflecting with `scope="fleet"` / `"all"` → trust 2
+Operations that escalate the required level:
+- browsing / reflecting with `scope="fleet"` or `"all"` → trust 2
 - reporting outcomes (`memclaw_evolve`) at `scope="fleet"` / `"all"` → trust 2 (default `scope="agent"` needs only trust 1)
-- authoring your OWN `scope=agent` keystone (`memclaw_keystones_set`) → trust 1
-- authoring `scope=fleet` / `scope=tenant` / another agent's keystone → trust 2
+- authoring your **own** `scope=agent` keystone → trust 1; authoring `scope=fleet` / `scope=tenant` / another agent's keystone → trust 2
 - `memclaw_manage op=delete` → trust 3
 
-If denied, surface the error; do not silently retry with a narrower scope.
+**Knowing your own level.** You start at trust 1 and can't raise yourself —
+escalation is granted by an operator. There's no self-query tool, so don't
+pre-emptively avoid an operation you're unsure about: attempt it. A permission
+error names both your current level and the one required (e.g. *"Agent X
+(trust_level=1) … Requires trust_level >= 2"*) — surface that error rather than
+silently retrying at a narrower scope.
 
-## Sharing: visibility and scope
+**Visibility (on write)** decides who can see a memory: `scope_agent` (private)
+· `scope_team` *(default — your fleet)* · `scope_org` (all fleets in tenant).
+**Scope (on read / `_list` / `_insights`):** `agent` *(default)* · `fleet`
+(trust 2) · `all` (trust 2). Prefer `scope_team` on write and `scope=agent` on
+read unless you need cross-agent context. *Naming caveat:* writes take
+`visibility=scope_*`; reads/list/keystone filters take `scope=*` — two axes,
+similar spelling.
 
-**Visibility (on write):** `scope_agent` (private) · `scope_team`
-*(default — your fleet)* · `scope_org` (all fleets in tenant).
+## 7 · Keeping knowledge clean
 
-**Scope (on read — `_list` / `_insights`):** `agent` *(default)* ·
-`fleet` (trust 2) · `all` (trust 2).
+A few habits keep recall trustworthy and sharp:
 
-Prefer `scope_team` when writing; prefer `scope=agent` when reading
-unless you need cross-agent context.
+- **Make memories good** — dated, concrete, standalone, atomic, and updated (not
+  duplicated). Each should be readable by another agent later without the
+  surrounding session.
+- **Supersede, don't delete.** When a fact changes: (1) write the new one, (2)
+  recall the old one, (3) `memclaw_manage op=transition status=outdated`. This
+  keeps the lineage. Reserve `op=delete` (soft-delete, trust 3) for genuinely
+  wrong data, not for facts you've simply moved past.
+- **Resolve conflicts; don't pick one silently.** If recall surfaces a
+  `conflicted` or `outdated` memory, fix it — write the correct fact and
+  transition the stale one. Two live opposing beliefs degrade every future
+  recall for everyone.
 
-## Containers
+## 8 · Reuse and publish workflows — the `skills` collection
 
-- **Memory** — unstructured, findable semantically. Decisions, observations, rules, outcomes, recaps.
-- **Doc** — structured record with a natural key (`collection + doc_id`). Customers, configs, task lists, inventories.
-- **Entity** — named graph object (person, project, service). Fetch by UUID from a prior recall.
+Proven workflows live as `SKILL.md` documents in the **`skills`** collection.
+You don't learn a new tool per playbook — it's the same `memclaw_doc`, so your
+vocabulary never grows with the library.
 
-If you need semantic search, it's a memory. If you need keyed lookup,
-it's a doc. If you already hold an ID, it's an entity.
+```text
+# Discover before improvising on a non-trivial workflow:
+memclaw_doc op=search collection=skills query="<intent>"
+memclaw_doc op=read   collection=skills doc_id=<slug>   # full body
 
-**Cross-store discovery.** The memory and doc stores are not cross-searched.
-`memclaw_recall` never returns docs; `memclaw_doc` has no semantic query. If a
-doc needs to be findable by description — onboarding guides, fleet readmes,
-proposals others should discover — also write a short pointer memory whose
-content names the target (`collection`, `doc_id`) and describes it. A
-teammate's `memclaw_recall "onboarding"` then surfaces the pointer and their
-agent can `memclaw_doc op=read` the actual doc. Skip for docs only fetched
-by systems that already hold the id (caches, config).
-
-## Good memories
-
-Dated, concrete, standalone, atomic, updated (not duplicated).
-
-## Sharing skills
-
-Skills are SKILL.md artifacts that agents share across the fleet —
-debugging recipes, ops runbooks, refactor playbooks. They live as
-documents in the `skills` collection: discovery and sharing both go
-through `memclaw_doc`.
-
-```
-# Discover
-memclaw_doc op=search collection=skills query=<natural language>
-memclaw_doc op=query  collection=skills              # browse by recency
-memclaw_doc op=read   collection=skills doc_id=<slug>  # full body
-
-# Share — slug is `[a-z0-9][a-z0-9._-]{0,99}` (filesystem-safe)
+# Publish something reusable so the fleet inherits it:
 memclaw_doc op=write collection=skills doc_id=<slug> \
-  data={ "name": "<slug>", "summary": "<one-liner>", "content": "<full SKILL.md>" }
+  data={ "name": "<slug>",
+         "summary": "<1-line, intent-focused — this is what gets embedded>",
+         "content": "<full SKILL.md>" }
+# Re-uploading the same doc_id overwrites it (upsert; no version history).
 
-# Remove
+# Remove a wrong/superseded one:
 memclaw_doc op=delete collection=skills doc_id=<slug>
 ```
 
-The `data["summary"]` string (1-3 sentences, intent-focused) is what
-gets embedded — that's what makes the skill discoverable by meaning,
-even when names don't match. For back-compat the server also accepts
-`data["description"]` on `collection=skills` writes if no summary is
-provided. Re-uploading the same `doc_id` overwrites — that is how you
-publish a new version.
+Slugs are filesystem-safe: `[a-z0-9][a-z0-9._-]{0,99}`. The `summary` is the
+only embedded field — write a sharp, intent-focused one ("Use when migrating
+SQLite→Postgres…") so the skill is found by meaning even when names don't match.
 
-Direct-MCP clients (Claude Code, Codex) consume skills via
-`memclaw_doc op=read collection=skills doc_id=<slug>` — no filesystem
-write required, no plugin runtime needed.
+## 9 · Authoring governance rules — `memclaw_keystones_set`
 
-Built something reusable? Upsert it. Only mark a skill local (and
-document why) when it genuinely shouldn't be shared.
+Keystones are authored with `memclaw_keystones_set` (op `set` | `delete`),
+exposed over **MCP and REST**. Trust is tiered: a `scope=agent` keystone for
+your **own** `agent_id` is self-authoring (trust ≥ 1); `scope=fleet`,
+`scope=tenant`, or a keystone for another agent needs trust ≥ 2.
 
-## Session loop
+```text
+# For yourself (trust >= 1):
+memclaw_keystones_set op=set scope=agent agent_id=<you> \
+  title="…" content="…" weight=low|med|high
 
-1. Recall — "what is known about this?" / "what happened since last session?"
-2. Work — act on the recalled context.
-3. Write — at checkpoints and session end.
-4. Evolve — if you acted on specific memories, report the outcome (default `scope="agent"`, trust 1; fleet/all needs trust 2).
+# For the fleet or tenant (trust >= 2; OMIT agent_id for tenant/fleet):
+memclaw_keystones_set op=set scope=fleet|tenant \
+  title="…" content="…" weight=low|med|high [fleet_id=<fleet>]
+```
+
+## A full loop, end to end
+
+One task — orient, work, write, evolve — with the IDs threaded through:
+
+```text
+# 1. Orient — recall, and keep the IDs that come back
+memclaw_recall "deploy api-gateway to staging" include_brief=true
+#   → mem_8f2a (rule: "staging deploys need a smoke test"), mem_4d1c (last deploy)
+
+# 2. Work — run the deploy, following the rule in mem_8f2a
+
+# 3. Write — record the outcome (team-visible; home fleet resolved on omit)
+memclaw_write content="api-gateway v2.3 deployed to staging; smoke test green" \
+  visibility=scope_team
+
+# 4. Evolve — report against the memories you acted on
+memclaw_evolve outcome="deploy succeeded, smoke test passed" \
+  outcome_type=success related_ids=[mem_8f2a, mem_4d1c]
+#   if it had failed in a way the whole fleet should avoid:
+#   add scope=fleet (trust 2) so the preventive rule reaches teammates
+```
 
 ---
 
 ## Tool reference
 
-This section holds the per-tool signatures, decision guidance,
-constraints, and error codes — load it before your first MemClaw call in
-a session.
-
-### Tool cards
-
-**`memclaw_recall(query, top_k=5, include_brief=false, memory_type=?, status=?, filter_agent_id=?, fleet_ids=?)`**
-Hybrid semantic+keyword search. For metadata browse → `memclaw_list`;
-for a known id → `memclaw_manage(op="read")`. `include_brief=true` adds
-an LLM-summarized paragraph.
-
-**`memclaw_write(content=? | items=?, fleet_id=?, visibility="scope_team", memory_type=?, weight=?, metadata=?, write_mode="auto", source_uri=?, run_id=?)`**
-Provide exactly one of `content` / `items`. Server auto-classifies.
-`items` batches up to 100. `write_mode`: `fast` skips embed
-(keyword-only recall later); `strong` forces LLM enrichment; `auto` is
-usually right. `insight` / `outcome` / `rule` are server-generated only
-(via `memclaw_insights` / `memclaw_evolve`) — you cannot write them, and
-auto-classify will never assign them; record reflections as `semantic` or
-`fact` (or omit `memory_type`).
-
-**`fleet_id` MUST be passed explicitly when the write should land in a
-fleet.** The MCP connection URL's `?fleet_id=…` query param is used for
-routing and scope defaults on reads, but it is NOT auto-applied to
-memory rows on write — omitting the kwarg persists `fleet_id=NULL`,
-which bypasses `scope_team` enforcement for teammates filtering by
-fleet. Pass the kwarg on every memory that is meant for a team pool.
-Same rule applies to `memclaw_doc op=write`.
-
-**`memclaw_manage(op, memory_id, ...)`** — op ∈ {read, update, transition, delete}
-- `update`: patch `content` / `memory_type` / `weight` / `title` / `metadata` / `source_uri`; re-embeds if content changes.
-- `transition`: set `status` (active, pending, confirmed, cancelled, outdated, conflicted, archived, deleted).
-- `delete`: soft-delete; trust 3. Prefer `transition` to `outdated` / `archived`.
-
-**`memclaw_list(scope="agent", memory_type=?, written_by=?, status=?, weight_min/max=?, created_after/before=?, sort="created_at", order="desc", limit=25, cursor=?)`**
-Non-semantic enumeration. Cursor pagination requires
-`sort=created_at order=desc`. `scope="fleet"` / `"all"` → trust 2.
-
-**`memclaw_doc(op, collection=?, doc_id=?, data=?, where=?, order_by=?, limit=20, offset=0, query=?, top_k=5)`** — op ∈ {write, read, query, delete, list_collections, search}
-Structured records by `collection + doc_id`. `write` upserts. `where` is
-scalar exact-match only — does not descend into arrays; filter by scalar
-fields, or fetch by `doc_id` when you have it. When you don't know which
-collections a tenant has, call `op="list_collections"` first — it returns
-every collection name with per-collection document counts
-(`{collections: [{name, count}, ...]}`). `collection` is required for all
-ops except `list_collections`.
-
-**Semantic search for docs** — opt in at write time, retrieve at read time.
-To make a doc findable by meaning (not just by known `doc_id`), include
-`data["summary"]` on write — a short (1-3 sentence) intent-focused
-description. The server embeds that exact string and only that string.
-Docs without a summary are invisible to `op=search` — re-write them with
-a summary to index retroactively.
-
-Two search strategies the agent should know:
-- **Narrow (collection-scoped).** Use when you either know the collection
-  name, or you've just run `op="list_collections"` and picked one based on
-  its name/count. Call `op="search" collection="<name>" query="…"`.
-  Less noise, better signal.
-- **Broad (cross-collection).** Use when you don't know where the doc
-  lives, or you want the single best match across the whole tenant. Call
-  `op="search" query="…"` with `collection` omitted. Each result row
-  carries its own `collection` so you can follow up with
-  `op="read" collection=<result.collection> doc_id=<result.doc_id>`.
-
-Response shape: `{collection, count, results: [{collection, doc_id, data,
-similarity}, ...]}` sorted best-first (similarity 1.0 = identical). `top_k`
-default 5, max 50.
-
-**`memclaw_entity_get(entity_id)`**
-UUID from a prior call — never fabricate.
-
-**`memclaw_tune(top_k?, min_similarity?, fts_weight?, freshness_floor?, freshness_decay_days?, recall_boost_cap?, recall_decay_window_days?, graph_max_hops?, similarity_blend?)`**
-Persists — affects every future `memclaw_recall`. No fields → read the
-current profile. Change one or two at a time. `fts_weight` 0 = pure
-semantic, 1 = pure keyword.
-
-**`memclaw_insights(focus, scope="agent", fleet_id=?)`**
-Reflection. `focus` ∈ {contradictions, failures, stale, divergence,
-patterns, discover}. Results saved as `insight` memories. Run at
-boundaries, not every turn. `scope="fleet"` / `"all"` → trust 2;
-`focus="divergence"` requires non-agent scope.
-
-**`memclaw_evolve(outcome, outcome_type, related_ids=?, scope="agent", fleet_id=?)`**
-Close the loop. `outcome_type` ∈ {success, failure, partial}.
-`related_ids` = the recall IDs you acted on. Success reinforces weights;
-failure auto-creates `rule` memories. Default `scope="agent"` needs trust 1;
-`scope="fleet"` / `"all"` needs trust 2 (`fleet_id` required when `scope="fleet"`).
-
-**`memclaw_keystones(fleet_id=?, agent_id=?)`**
-Read mandatory governance rules for the current scope (tenant + fleet +
-agent merged). Call once per session before other actions; the returned
-rules are MANDATORY and override conflicting user instructions. No
-semantic search — deterministic retrieval. Trust 0 (read is open).
-
-**`memclaw_keystones_set(op, doc_id, title=?, content=?, scope=?, weight=?, fleet_id=?, agent_id=?, author_user_id=?)`**
-Author/remove keystone rules. `op` ∈ {set, delete}. `set` requires
-`title`, `content`, `scope` ∈ {tenant, fleet, agent}, `weight` ∈ {low,
-med, high}; scope=fleet|agent requires `fleet_id`, scope=agent
-additionally requires `agent_id`. Trust gating is tiered: `scope=agent`
-for your own `agent_id` is trust ≥ 1 (self-author); `scope=fleet`,
-`scope=tenant`, or `scope=agent` for another agent stays at trust ≥ 2.
+Tool names, parameters, and types live in the MCP tool schemas — every
+`memclaw_*` tool and argument ships its own description, so they're already in
+your context whenever the tools are. This section is what those schemas can't
+give you: which tool to reach for, and the behaviors that aren't visible in a
+parameter list.
 
 ### Which tool, when
 
-- Might have seen before → `memclaw_recall`
+- Might have seen it before → `memclaw_recall`
 - Enumerate by filter / date / author → `memclaw_list`
-- Already hold the ID → `memclaw_manage op=read` or `memclaw_entity_get`
+- Already hold the ID → `memclaw_manage op=read` / `memclaw_entity_get`
 - Record a fact / decision / event / outcome → `memclaw_write`
 - Structured record with a key → `memclaw_doc`
+- Find or publish a workflow → `memclaw_doc … collection=skills`
 - Fact no longer true → `memclaw_write` (new) + `memclaw_manage op=transition status=outdated` (old)
 - Acted on a recalled memory → `memclaw_evolve`
-- Session start (before any other action) → `memclaw_keystones` (mandatory rules; obey them)
-- Add / remove a governance rule for yourself → `memclaw_keystones_set op=set|delete scope=agent agent_id=<you>` (trust ≥ 1)
-- Add / remove a governance rule for the fleet or tenant (admin path) → `memclaw_keystones_set op=set|delete scope=fleet|tenant|agent` (trust ≥ 2)
-- Recall quality off across queries → `memclaw_tune` (once, sticky)
-- Session boundary / orchestrator sweep → `memclaw_insights`
-- Stuck on a non-trivial workflow → search by meaning (`memclaw_doc op=search collection=skills query=...`) or browse (`memclaw_doc op=query collection=skills`) before improvising
-- Built a reusable workflow → `memclaw_doc op=write collection=skills doc_id=<slug> data={"summary": "<one-liner>", ...}` to teach the fleet
-- Skill is wrong / superseded → `memclaw_doc op=delete collection=skills doc_id=<slug>` to remove it
+- Session start (before anything) → `memclaw_keystones`
+- Add / remove a governance rule → `memclaw_keystones_set`
+- Recall quality off across queries → `memclaw_tune` (once; sticky)
+- Session boundary / sweep → `memclaw_insights`
+- Readiness probe / counts → `memclaw_stats`
+
+### Behaviors the schema won't tell you
+
+- **`memclaw_recall`** excludes superseded memories (`status` ∈ {outdated, conflicted}) by default — pass `status` explicitly to walk the chain.
+- **`memclaw_write`** can't write `insight` / `outcome` / `rule` types — those are server-generated (via `memclaw_insights` / `memclaw_evolve`). `write_mode`: `fast` skips embedding → keyword-only recall afterwards; `strong` forces full LLM enrichment; `auto` is usually right.
+- **`memclaw_manage op=transition`** targets: `active · pending · confirmed · cancelled · outdated · conflicted · archived · deleted`.
+- **`memclaw_doc`** — `where` is scalar exact-match only (no array descent). A doc is invisible to `op=search` unless it has a `data["summary"]` (the only embedded field); re-write with one to index it retroactively. Scope the search to a collection when you know it; omit `collection` for the single best match across the tenant.
+- **`memclaw_tune`** persists and reshapes every later recall — change one or two knobs at a time; call with no arguments to read your current profile (`fts_weight` 0 = pure semantic, 1 = pure keyword).
+- **`memclaw_insights`** saves findings as `insight` memories; run it at boundaries, not every turn. `focus="divergence"` needs a non-agent scope.
+- **`memclaw_stats`** is read-only — use it as a readiness/health probe, never a write-then-delete check.
 
 ### Anti-patterns
 
-- Storing narrative / observations as docs → use `memclaw_write`.
-- Storing structured records with stable keys (configs, guides, plans) as
-  memories → use `memclaw_doc`.
-- Saving every intermediate task step as a memory → pollutes recall. Keep
-  ephemeral task state in your runtime's local memory.
-- Saving a doc without a pointer memory when teammates must discover it by
-  description → they won't find it (see *Cross-store discovery* above).
+- Saving every intermediate step as a memory — pollutes recall.
+- Storing narrative as a doc, or structured keyed records as memories.
+- Saving a discoverable doc with no pointer memory — teammates won't find it.
+- Guessing `agent_id` / `fleet_id`, or inventing UUIDs.
+- Deleting when you should supersede.
+- Recalling on every trivial turn, or making all four Orient calls by reflex
+  when the task needs one.
 
-### Constraints that matter
+### Constraints & errors
 
-- `memclaw_write`: exactly one of `content` / `items`; never both.
-- `items` capped at 100 → `BATCH_TOO_LARGE`.
-- Supersede via `transition`; reserve `delete` (trust 3) for wrong data.
+- `memclaw_write`: exactly one of `content` / `items`; `items` ≤ 100 → `BATCH_TOO_LARGE`.
 - Cursor pagination needs `sort=created_at` + `order=desc`.
 - `_entity_get` / `_manage` use real UUIDs — never invent.
-- `_tune` persists; do not call per-query.
-
-### Error codes
-
-`INVALID_ARGUMENTS` · `BATCH_TOO_LARGE` · `INVALID_BATCH_ITEM`. Other
-errors surface with HTTP status + message — return them to your caller,
-do not swallow.
+- Error codes: `INVALID_ARGUMENTS` · `BATCH_TOO_LARGE` · `INVALID_BATCH_ITEM`. Other errors surface with HTTP status + message — return them to your caller, don't swallow.
 
 ---
 
-*Direct-MCP adapter for Claude Code and Codex. Install via the installer
-at `https://memclaw.dev/api/v1/install-skill` or by copying this file to
-`~/.claude/skills/memclaw/SKILL.md` (Claude Code) or
-`~/.agents/skills/memclaw/SKILL.md` (Codex). Per-workspace override: place
-a copy under your project's `.claude/skills/memclaw/` or `.agents/skills/memclaw/`.
-For the OpenClaw-plugin runtime, use the shared SKILL.md shipped with the
-plugin instead.*
+*Install on a Claude Code / Codex runtime with
+`curl -s "https://memclaw.net/api/v1/install-skill?agent=both" | bash`, or copy
+this file to `~/.claude/skills/memclaw/SKILL.md` (Claude Code) or
+`~/.agents/skills/memclaw/SKILL.md` (Codex). Per-workspace override: place a copy
+under `.claude/skills/memclaw/` or `.agents/skills/memclaw/`. OpenClaw fleets use
+the variant shipped with the MemClaw plugin.*

--- a/tests/test_direct_mcp_skill.py
+++ b/tests/test_direct_mcp_skill.py
@@ -8,8 +8,13 @@ The adapter at ``static/skills/memclaw/SKILL.md`` is served by
 It is *intentionally* maintained independently of the OpenClaw plugin's
 SKILL.md. These tests pin the invariants specific to the direct-MCP
 distribution: runtime-neutral frontmatter, no OpenClaw config gate, no
-references to the plugin-runtime-generated TOOLS.md, and the four
-content additions this file carries.
+references to the plugin-runtime-generated TOOLS.md, the canonical section
+structure, and the content value-adds this file carries.
+
+Structure note: the adapter defers per-tool *signatures* to the live MCP tool
+schemas (always in context when the tools are) and instead documents the
+behaviors a parameter list can't express — so these tests assert tool *names*
+and the "Behaviors the schema won't tell you" section, not signature cards.
 """
 
 from __future__ import annotations
@@ -18,6 +23,23 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ADAPTER_PATH = REPO_ROOT / "static" / "skills" / "memclaw" / "SKILL.md"
+
+# Every tool the canonical adapter documents (direct-MCP exposes all 12,
+# including keystones_set — which the OpenClaw plugin variant withholds).
+ALL_TOOLS = (
+    "memclaw_recall",
+    "memclaw_write",
+    "memclaw_manage",
+    "memclaw_list",
+    "memclaw_doc",
+    "memclaw_entity_get",
+    "memclaw_tune",
+    "memclaw_insights",
+    "memclaw_evolve",
+    "memclaw_stats",
+    "memclaw_keystones",
+    "memclaw_keystones_set",
+)
 
 
 def _read_adapter() -> str:
@@ -68,38 +90,40 @@ def test_has_no_tools_md_references() -> None:
 def test_contains_required_body_sections() -> None:
     skill = _read_adapter()
     required = [
-        "## Your identity",
-        "## The three rules",
-        "## Trust levels",
-        "## Sharing",
-        "## Containers",
-        "## Session loop",
+        "## 0 · Identity",
+        "## 1 · Session start",
+        "## 2 · The loop",
+        "## 3 · How and when to write a memory",
+        "## 5 · Two stores, one rule",
+        "## 6 · Trust and sharing",
         "## Tool reference",
-        "### Tool cards",
         "### Which tool, when",
-        "### Constraints that matter",
-        "### Error codes",
+        "### Behaviors the schema won't tell you",
+        "### Anti-patterns",
+        "### Constraints & errors",
     ]
     for heading in required:
         assert heading in skill, f"adapter missing section {heading!r}"
 
 
-def test_contains_all_nine_tool_cards() -> None:
+def test_documents_every_tool_by_name() -> None:
+    """The adapter defers parameter signatures to the MCP schemas, but every
+    tool must still be named (in 'Which tool, when' / 'Behaviors') so the
+    model knows the surface exists. Presence by name, not by signature card."""
     skill = _read_adapter()
-    for tool in (
-        "memclaw_recall",
-        "memclaw_write",
-        "memclaw_manage",
-        "memclaw_list",
-        "memclaw_doc",
-        "memclaw_entity_get",
-        "memclaw_tune",
-        "memclaw_insights",
-        "memclaw_evolve",
-    ):
-        # Accept both **`tool(` (bolded) and `tool(` (plain) to tolerate
-        # formatting drift; the test's purpose is presence, not style.
-        assert f"`{tool}(" in skill, f"adapter missing tool card for {tool}"
+    for tool in ALL_TOOLS:
+        assert tool in skill, f"adapter does not mention {tool}"
+
+
+def test_does_not_reintroduce_signature_cards() -> None:
+    """Regression guard for the schema-deferral decision: the adapter should
+    NOT carry per-tool signature cards (``memclaw_x(arg, ...)``) that merely
+    duplicate the always-in-context MCP tool schemas."""
+    skill = _read_adapter()
+    assert "`memclaw_recall(" not in skill and "`memclaw_write(" not in skill, (
+        "adapter reintroduced signature cards; signatures live in the MCP "
+        "tool schemas — keep the lean 'Behaviors the schema won't tell you' form"
+    )
 
 
 def test_contains_error_codes_verbatim() -> None:
@@ -121,27 +145,27 @@ def test_footer_references_direct_mcp_install_targets() -> None:
     )
 
 
-def test_contains_direct_mcp_specific_content_additions() -> None:
-    """Pins the value-adds this adapter carries beyond the canonical plugin
-    SKILL.md. These landed from lived usage — hybrid-pattern,
-    collection-listing convention, where-filter scalar gotcha, anti-patterns
-    subsection. If you remove one, justify it; if you add a new one, add it
+def test_contains_canonical_content_invariants() -> None:
+    """Pins the load-bearing facts and value-adds of the canonical adapter.
+    If you remove one, justify it; if you add a new must-keep fact, add it
     here so it can't silently fall back out.
     """
     skill = _read_adapter()
     must_contain = [
-        # Foundation (present in canonical too; guards against regression)
-        "Rule 1 — Recall before you start",
-        "Rule 2 — Write when something matters",
-        "Rule 3 — Supersede, don't delete",
-        "Auto-registered at trust 1 on your first write",
-        # Direct-MCP-specific additions
-        "Cross-store discovery",  # hybrid-pattern for doc discoverability
-        'op="list_collections"',  # real op for enumerating collections
-        'op="search"',  # semantic search over docs
-        'data["summary"]',  # opt-in semantic indexing on write
-        "scalar exact-match only",  # memclaw_doc where-filter gotcha
-        "### Anti-patterns",  # explicit don't-do-this subsection
+        # The loop + write discipline
+        "most-binding-first",          # orient ordering
+        "## 3 · How and when to write a memory",
+        # Grounded accuracy facts (must not regress)
+        "home fleet",                  # fleet_id resolves home fleet on omit (post-#465)
+        "private by default",          # evolve failure -> private rule by default
+        # Two-stores hybrid pattern
+        "Cross-store discovery",       # pointer-memory workaround
+        "op=list_collections",         # enumerate collections
+        "op=search",                   # semantic search over docs
+        'data["summary"]',             # opt-in semantic indexing on write
+        "scalar exact-match only",     # memclaw_doc where-filter gotcha
+        # Trust self-awareness
+        "trust 1",                     # auto-register tier
     ]
     for phrase in must_contain:
         assert phrase in skill, f"adapter missing {phrase!r}"


### PR DESCRIPTION
Lands the reviewed, optimized skill texts and re-pins the structural invariant tests to the approved design. Skill-content only + their tests — no runtime/endpoint changes.

## Skills

- **`static/skills/memclaw/SKILL.md`** (direct-MCP canonical) — rewritten: stronger "THE long-term memory" framing; **`fleet_id`** corrected to home-fleet-resolve-on-omit (post-#465) + the no-home-fleet/cross-fleet residual; precise enrichment timing (type+PII **inline**, entities+contradiction **async**); `evolve` failure → **private rule by default**; loop spine (orient most-binding-first → write → evolve), dedicated **"How and when to write a memory"**, **trust self-awareness**, **cross-store pointer-memory**. Per-tool signature cards dropped → lean **"Behaviors the schema won't tell you"** (signatures already live in the always-in-context MCP schemas). Host normalised to **`memclaw.net`** (retires stale `.dev`).
- **`plugin/skills/memclaw/SKILL.md`** (OpenClaw variant) — same spine + fixes, OpenClaw layers kept (`<keystone_rules>` auto-injection, MEMORY.md vs workspace files, L1/L2/L3, orchestrator/subagent, recall auto-gating, TOOLS.md). Preface now makes the **automatic baseline explicit** (auto-recall, keystone inject, `MEMCLAW_AUTO_WRITE_TURNS` turn-summary) **and** that the agent must still use the tools deliberately. `keystones_set` stays withheld (`plugin_exposed=false`); `memclaw_stats` documented.
- **`static/skills/company-brain/SKILL.md`** (NEW) — concept-first posture skill layering on `memclaw`, deferring all mechanics to it.

## Tests re-pinned (approved structural change)

The redesign deliberately changed section names, **dropped signature cards** (schema-deferral), softened MUST-walls, and renamed Prohibitions → Anti-patterns. The invariant tests are updated to assert the **new** structure while keeping every meaningful guarantee (frontmatter, no-openclaw/no-TOOLS.md in static, install paths, error codes, all tool *names*, cross-store, etc.), plus a regression guard that signature cards are **not** reintroduced.

- `tests/test_direct_mcp_skill.py`
- `plugin/src/educate.test.ts`
- `plugin/src/tool-definitions.test.ts`

**Validation:** 351 plugin tests pass; 10 direct-MCP-adapter invariants pass.

## Follow-up (PR-2, intentionally split)
`company-brain` install path — an `?skill=` selector on `/api/v1/install-skill` (allowlist `{memclaw, company-brain}`, default `memclaw`) + endpoint tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)