### PR TITLE
fix(core-api): route recall/capability writes through storage (Fix-2 cleanup PR2)

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -198,16 +198,15 @@ async def lifespan(app):
 
             init_standalone()
 
-        # Backfill agent rows for any memories written before agent tracking
+        # Backfill agent rows for any memories written before agent tracking.
+        # Fully storage-routed (backfill_agents → sc.backfill_from_memories), so
+        # no core-api DB session is opened here.
         try:
-            from core_api.db.session import async_session
             from core_api.services.agent_service import backfill_agents
 
-            async with async_session() as db:
-                count = await backfill_agents(db)
-                if count:
-                    await db.commit()
-                    print(f"[startup] Backfilled {count} agent(s) from memories")
+            count = await backfill_agents()
+            if count:
+                print(f"[startup] Backfilled {count} agent(s) from memories")
         except Exception as e:
             print(f"[startup] Agent backfill skipped: {e}")
 

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1012,6 +1012,43 @@ class CoreStorageClient:
         return result  # type: ignore[return-value]
 
     # =====================================================================
+    # Recall logging + capability usage (Fix 2 final cleanup — the last
+    # core-api direct-DB writes, now routed through storage). All three are
+    # fire-and-forget background writes, so ``read=False`` (writer fleet).
+    # Payloads MUST be JSON-safe: ``_post`` does NOT auto-encode UUIDs /
+    # datetimes, so callers stringify UUIDs + ISO-format datetimes first.
+    # =====================================================================
+
+    async def increment_recall(self, memory_ids: list[str]) -> int:
+        """Bump ``recall_count`` + ``last_recalled_at`` for memories by id.
+
+        ``memory_ids`` must already be stringified (the storage endpoint
+        re-parses each as a UUID). Returns the rows-updated count.
+        """
+        result = await self._post("/memories/increment-recall", {"memory_ids": memory_ids})
+        return result.get("updated", 0)  # type: ignore[union-attr]
+
+    async def log_recall(self, event: dict, candidates: list[dict]) -> str:
+        """Persist one ``recall_event`` + its ``recall_candidate`` rows, ONE txn.
+
+        ``event`` + every ``candidate`` dict must be JSON-safe — stringify
+        UUIDs (e.g. ``candidate["memory_id"]``) and ISO-format any datetimes
+        BEFORE calling. Returns the new ``recall_event.id`` as a string.
+        """
+        result = await self._post("/memories/recall-log", {"event": event, "candidates": candidates})
+        return result["recall_event_id"]  # type: ignore[index,return-value]
+
+    async def flush_capability_usage(self, rows: list[dict]) -> int:
+        """Bulk-append adoption-counter rows to ``capability_usage``.
+
+        Cross-tenant by design (each row carries its own ``tenant_id``); the
+        endpoint applies no per-tenant scoping. ``ts_bucket`` must be an ISO
+        string (JSON has no datetime). Returns the rows-inserted count.
+        """
+        result = await self._post("/capability-usage", {"rows": rows})
+        return result.get("inserted", 0)  # type: ignore[union-attr]
+
+    # =====================================================================
     # Entities
     # =====================================================================
 

--- a/core-api/src/core_api/pipeline/steps/search/log_recall_event.py
+++ b/core-api/src/core_api/pipeline/steps/search/log_recall_event.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 
+from core_api.clients.storage_client import get_storage_client
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
 from core_api.tasks import track_task
@@ -36,17 +37,12 @@ def _mem_id(row) -> object:
 
 
 async def _persist(event: dict, candidates: list[dict]) -> None:
-    from common.models.recall_log import RecallCandidate, RecallEvent
-    from core_api.db.session import async_session
-
+    # Routes the write through core-storage (no core-api DB pool). The payload
+    # goes over JSON, so every value must already be JSON-safe — the candidate
+    # ``memory_id`` UUIDs are stringified at construction in ``execute`` and the
+    # event dict carries only str/int/float/None values (no UUID/datetime).
     try:
-        async with async_session() as db:
-            ev = RecallEvent(**event)
-            db.add(ev)
-            await db.flush()  # assign ev.id
-            for c in candidates:
-                db.add(RecallCandidate(recall_event_id=ev.id, **c))
-            await db.commit()
+        await get_storage_client().log_recall(event, candidates)
     except Exception:
         logger.warning("recall-event logging failed", exc_info=True)
 
@@ -80,7 +76,9 @@ class LogRecallEvent:
                 candidates.append(
                     {
                         "rank": rank,
-                        "memory_id": _mem_id(row),
+                        # JSON-safe: _mem_id returns a UUID — the payload now
+                        # crosses an HTTP boundary, so stringify it.
+                        "memory_id": str(_mem_id(row)),
                         "vec_sim": _f(getattr(row, "vec_sim", None)),
                         "final_score": _f(getattr(row, "score", None)),
                         "recall_boost": _f(getattr(row, "recall_boost", None)),
@@ -94,7 +92,7 @@ class LogRecallEvent:
                 candidates.append(
                     {
                         "rank": len(returned_rows) + offset + 1,
-                        "memory_id": _mem_id(row),
+                        "memory_id": str(_mem_id(row)),
                         "vec_sim": _f(getattr(row, "vec_sim", None)),
                         "final_score": _f(getattr(row, "score", None)),
                         "recall_boost": _f(getattr(row, "recall_boost", None)),

--- a/core-api/src/core_api/pipeline/steps/search/track_recalls.py
+++ b/core-api/src/core_api/pipeline/steps/search/track_recalls.py
@@ -1,7 +1,8 @@
 """TrackRecalls — fire-and-forget recall tracking in a background task.
 
-Uses its own DB session so the search response returns immediately without
-waiting for the recall_count UPDATE + COMMIT round-trip.
+Routes the recall_count UPDATE through core-storage (no core-api DB pool) in a
+background task so the search response returns immediately without waiting for
+the HTTP round-trip.
 """
 
 from __future__ import annotations
@@ -9,24 +10,28 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
+from core_api.clients.storage_client import get_storage_client
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
-from core_api.services.hooks import get_hooks
 from core_api.tasks import track_task
 
 logger = logging.getLogger(__name__)
 
 
 async def _track_recalls_background(memory_ids: list[UUID]) -> None:
-    """Background task: update recall stats in an independent DB session."""
-    from core_api.db.session import async_session
+    """Background task: bump recall stats via the storage client.
 
+    ``memory_ids`` are stringified for the JSON payload (``_post`` does not
+    auto-encode UUIDs); the storage endpoint re-parses each as a UUID.
+
+    This intentionally calls ``increment_recall`` directly rather than the
+    ``ServiceHooks.on_recall`` extension hook: the hook's only registration is
+    ``memory_repo.increment_recall`` (app.py), i.e. exactly this recall-count
+    bump, which now lives behind storage. The hook itself stays for its other
+    consumers (memory_service/entity_service) until they migrate (PR3).
+    """
     try:
-        _hooks = get_hooks()
-        if _hooks.on_recall:
-            async with async_session() as db:
-                await _hooks.on_recall(db, memory_ids)
-                await db.commit()
+        await get_storage_client().increment_recall([str(m) for m in memory_ids])
     except Exception:
         logger.warning("Background recall tracking failed", exc_info=True)
 

--- a/core-api/src/core_api/services/agent_service.py
+++ b/core-api/src/core_api/services/agent_service.py
@@ -330,8 +330,11 @@ async def enforce_update(
         )
 
 
-async def backfill_agents(db: AsyncSession) -> int:
-    """Create agent rows for any (tenant_id, agent_id) pairs in memories that don't have one yet."""
+async def backfill_agents() -> int:
+    """Create agent rows for any (tenant_id, agent_id) pairs in memories that
+    don't have one yet. Fully storage-routed (one ``sc.backfill_from_memories``
+    call) — no DB session needed.
+    """
     sc = get_storage_client()
     # Use the first available tenant_id — in standalone mode there's only one
     from core_api.standalone import get_standalone_tenant_id

--- a/core-api/src/core_api/services/capability_usage.py
+++ b/core-api/src/core_api/services/capability_usage.py
@@ -28,6 +28,8 @@ import asyncio
 import logging
 from datetime import UTC, datetime
 
+from core_api.clients.storage_client import get_storage_client
+
 logger = logging.getLogger(__name__)
 
 # Tenant values that are not real orgs — never attribute usage to them.
@@ -186,18 +188,19 @@ class CapabilityUsageAggregator:
 
 
 async def _default_flush(rows: list[dict]) -> None:
-    """Append rows to ``capability_usage`` via a plain (RLS-free) session.
+    """Append rows to ``capability_usage`` via the storage client (RLS-free).
 
-    Cross-tenant by design — the flush carries many tenants' counters in
-    one batch, so it runs WITHOUT an ``app.tenant_id`` context. The table
-    has no RLS policy, so the insert is unrestricted (see the migration).
+    Cross-tenant by design — the flush carries many tenants' counters in one
+    batch, so storage applies no per-tenant scoping (each row carries its own
+    ``tenant_id`` grouping dimension); the table has no RLS policy.
+
+    ``ts_bucket`` is a ``datetime`` here (``_drain_rows``), but the payload now
+    crosses an HTTP/JSON boundary — httpx can't encode a bare datetime — so it
+    is ISO-formatted before the call. The storage endpoint coerces the ISO
+    string back to ``datetime`` for the timestamptz column.
     """
-    from common.models.capability_usage import CapabilityUsage
-    from core_api.db.session import async_session
-
-    async with async_session() as session:
-        session.add_all([CapabilityUsage(**r) for r in rows])
-        await session.commit()
+    payload = [{**r, "ts_bucket": r["ts_bucket"].isoformat()} for r in rows]
+    await get_storage_client().flush_capability_usage(payload)
 
 
 # Module-level singleton bound at lifespan startup. None → recording is a

--- a/tests/pipeline/test_log_recall_event.py
+++ b/tests/pipeline/test_log_recall_event.py
@@ -107,3 +107,23 @@ async def test_logs_event_with_returned_and_near_misses(monkeypatch):
     # raw cosine + final score are captured (this is the signal we were missing)
     assert candidates[0]["vec_sim"] == 0.60
     assert candidates[0]["final_score"] == 0.58
+    # memory_id is stringified — the payload now crosses an HTTP/JSON boundary,
+    # so every candidate id must be a str (UUIDs aren't JSON-serializable).
+    assert all(isinstance(c["memory_id"], str) for c in candidates)
+
+
+@pytest.mark.asyncio
+async def test_persist_routes_to_storage_client():
+    """``_persist`` posts the event + candidates through the storage client
+    (no direct DB session) and swallows failures."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    event = {"tenant_id": "t1", "source": "mcp_recall"}
+    candidates = [{"rank": 1, "memory_id": str(uuid.uuid4()), "returned": True}]
+
+    sc = MagicMock()
+    sc.log_recall = AsyncMock(return_value="evt-1")
+    with patch.object(mod, "get_storage_client", return_value=sc):
+        await mod._persist(event, candidates)
+
+    sc.log_recall.assert_awaited_once_with(event, candidates)

--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -309,6 +309,27 @@ async def test_track_recalls_fire_and_forget():
     mock_db.commit.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_track_recalls_background_routes_to_storage():
+    """The background task routes the recall bump through the storage client
+    with stringified memory ids (no direct DB session)."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from core_api.pipeline.steps.search.track_recalls import _track_recalls_background
+
+    ids = [uuid.uuid4(), uuid.uuid4()]
+
+    sc = MagicMock()
+    sc.increment_recall = AsyncMock(return_value=2)
+    with patch(
+        "core_api.pipeline.steps.search.track_recalls.get_storage_client",
+        return_value=sc,
+    ):
+        await _track_recalls_background(ids)
+
+    sc.increment_recall.assert_awaited_once_with([str(ids[0]), str(ids[1])])
+
+
 # ---------------------------------------------------------------------------
 # Fix A — Pipeline failure surfaces original error
 # ---------------------------------------------------------------------------

--- a/tests/test_capability_usage.py
+++ b/tests/test_capability_usage.py
@@ -103,6 +103,42 @@ async def test_record_usage_noop_when_unwired():
     cu.record_usage(capability="recall", transport="mcp", tenant_id="t1")
 
 
+async def test_default_flush_routes_to_storage_with_iso_ts_bucket(monkeypatch):
+    """``_default_flush`` posts rows through the storage client (no direct DB
+    session) and ISO-formats the ``datetime`` ``ts_bucket`` so the JSON payload
+    is serializable; the storage endpoint coerces it back to datetime."""
+    from datetime import UTC, datetime
+    from unittest.mock import AsyncMock, MagicMock
+
+    bucket = datetime(2026, 6, 23, 12, 0, tzinfo=UTC)
+    rows = [
+        {
+            "tenant_id": "t1",
+            "capability": "recall",
+            "op": None,
+            "transport": "mcp",
+            "ts_bucket": bucket,
+            "count": 3,
+            "error_count": 0,
+            "duration_ms_sum": 30,
+        }
+    ]
+
+    sc = MagicMock()
+    sc.flush_capability_usage = AsyncMock(return_value=1)
+    monkeypatch.setattr(cu, "get_storage_client", lambda: sc)
+
+    await cu._default_flush(rows)
+
+    sc.flush_capability_usage.assert_awaited_once()
+    sent = sc.flush_capability_usage.await_args.args[0]
+    assert sent[0]["ts_bucket"] == bucket.isoformat()
+    assert isinstance(sent[0]["ts_bucket"], str)
+    # other fields pass through unchanged
+    assert sent[0]["tenant_id"] == "t1"
+    assert sent[0]["count"] == 3
+
+
 # ── REST emitter (middleware route→capability map) ──────────────────────
 
 


### PR DESCRIPTION
## Fix-2 final cleanup — PR2 of 3 (regression fix)

Removes core-api's last recall/capability **direct-DB writes**, restoring rule `6440b9a6`. One was a **fresh regression**: the recall-logging feature shipped `log_recall_event.py` writing directly via `async_session` (bypassing storage). Builds on PR1 ([#484](https://github.com/caura-ai/caura-memclaw/pull/484), deployed to staging).

### Changes
- **`storage_client`** — adds `increment_recall` / `log_recall` / `flush_capability_usage` (thin `_post` wrappers over PR1's endpoints).
- **`log_recall_event._persist`** → `log_recall(event, candidates)`; candidate `memory_id` UUIDs stringified for the JSON payload; inline `async_session`/model imports replaced with a top-level client import.
- **`track_recalls`** → `increment_recall([str(m) for m in memory_ids])`.
- **`capability_usage._default_flush`** → `flush_capability_usage(rows)` with `ts_bucket` ISO-formatted (httpx can't encode a bare datetime; the endpoint coerces it back).
- **`app.py`** lifespan backfill drops the `async_session` wrapper (`backfill_agents` is already storage-routed; its `db` param is now optional).

### Scope note
The `on_recall` hook (`memory_repo.increment_recall`) is **kept** — it still has live `db`-bound consumers in `memory_service`/`entity_service`. Those + `memory_repo`/`db/session.py`/`repositories/*` deletion are **PR3**. (The build-spec's "no db-bound consumer" premise was inaccurate; this is the minimal consistent split.)

### Verification
- `ruff@0.15.4 check` + `format --check` — clean
- `mypy` core-api + core-storage-api — clean
- full suite — **3672 passed** clean-DB; +3 tests (each rewired site asserts it routes to the client with the right serialized payload — stringified ids, ISO `ts_bucket`); the end-to-end recall test passes via the conftest ASGI bridge to the new endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)