### PR TITLE
fix(core-storage-api): followers skip the migration lock once schema is at head

### DIFF
--- a/core-storage-api/src/core_storage_api/database/init.py
+++ b/core-storage-api/src/core_storage_api/database/init.py
@@ -17,6 +17,31 @@ _engine: AsyncEngine | None = None
 _read_engine: AsyncEngine | None = None
 
 
+def _schema_is_at_head(connection: Connection, head: str | None) -> bool:
+    """True when the DB's Alembic revision already equals ``head``.
+
+    Lets a replica that isn't the one running the migration start serving as
+    soon as the schema is current — WITHOUT acquiring the migration advisory
+    lock — instead of queueing behind every other booting replica to acquire
+    the lock and run a redundant no-op ``upgrade``. That serialized
+    acquire-then-no-op is what pushed tail replicas past the Cloud Run startup
+    probe during multi-replica scale-ups (prod 2026-06-24 02:04: storage-writer
+    instances killed on a 240s STARTUP TCP probe DEADLINE_EXCEEDED).
+
+    ``head`` (the script head) is computed once by the caller and passed in —
+    it's constant for the process lifetime, so the per-poll follower check stays
+    a single ``alembic_version`` SELECT rather than re-walking the migrations
+    directory each poll. Returns False on a fresh DB (no ``alembic_version`` row
+    → current is None), so the bootstrap/stamp path still runs under the lock.
+    """
+    # Deferred alembic import to match this module's existing convention
+    # (``init_database`` imports ``command``/``Config`` inside the function).
+    from alembic.runtime.migration import MigrationContext
+
+    current = MigrationContext.configure(connection).get_current_revision()
+    return current is not None and current == head
+
+
 def _build_engine(url: str) -> AsyncEngine:
     return create_async_engine(
         url,
@@ -76,6 +101,7 @@ async def init_database() -> None:
 
     from alembic import command
     from alembic.config import Config
+    from alembic.script import ScriptDirectory
     from sqlalchemy import text
 
     engine = get_engine()
@@ -83,6 +109,23 @@ async def init_database() -> None:
 
     alembic_cfg = Config()
     alembic_cfg.set_main_option("script_location", migrations_dir)
+
+    # The script head is constant for the process lifetime — compute it once
+    # (a migrations-dir walk) and reuse it for every at-head check, so the
+    # follower poll loop below stays a single ``alembic_version`` SELECT per
+    # poll rather than re-walking the migrations directory each time.
+    schema_head = ScriptDirectory.from_config(alembic_cfg).get_current_head()
+
+    # Fast path: if the schema is already at head there's no migration to run,
+    # so start serving immediately without contending on the advisory lock.
+    # This is the steady-state boot (nothing pending), and it lets
+    # simultaneously-booting replicas skip the lock entirely when there's no
+    # work — only a genuine pending migration falls through to the serialized
+    # leader/follower path below.
+    async with engine.connect() as check_conn:
+        if await check_conn.run_sync(_schema_is_at_head, schema_head):
+            logger.info("Schema already at head — starting without migration lock")
+            return
 
     # Session-scoped advisory lock on a dedicated connection so it survives
     # the per-migration commits Alembic performs — migrations that use
@@ -119,6 +162,15 @@ async def init_database() -> None:
             )
             if got:
                 break
+            # Not the leader. Start as soon as the leader's migration lands
+            # (schema reaches head) WITHOUT acquiring the lock — so every
+            # waiting follower unblocks together when the migration completes,
+            # instead of serializing through acquire→no-op-upgrade→release one
+            # at a time (whose tail exceeded the startup probe). Reuse the
+            # AUTOCOMMIT ``lock_conn`` for the read — no per-poll connection churn.
+            if await lock_conn.run_sync(_schema_is_at_head, schema_head):
+                logger.info("Migration completed by another replica — starting without lock")
+                return
             now = loop.time()
             if now >= deadline:
                 raise TimeoutError(

--- a/core-storage-api/tests/test_init_schema_at_head.py
+++ b/core-storage-api/tests/test_init_schema_at_head.py
@@ -1,0 +1,42 @@
+"""Unit tests for ``_schema_is_at_head`` (core_storage_api.database.init).
+
+Guards the predicate that lets a non-leader replica start serving without
+acquiring the migration advisory lock: True only when the DB's Alembic revision
+equals the precomputed script head, and False on a fresh DB (no
+``alembic_version`` row → ``current is None``) so the bootstrap/stamp path still
+runs under the lock. Stubs alembic's ``MigrationContext`` so the logic is tested
+without a DB; ``head`` is passed in directly (the caller precomputes it once).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_storage_api.database import init as init_mod
+
+
+def _patch_current(monkeypatch: pytest.MonkeyPatch, *, current: str | None) -> None:
+    class _Ctx:
+        @staticmethod
+        def configure(connection: object) -> _Ctx:
+            return _Ctx()
+
+        def get_current_revision(self) -> str | None:
+            return current
+
+    monkeypatch.setattr("alembic.runtime.migration.MigrationContext", _Ctx)
+
+
+@pytest.mark.parametrize(
+    ("current", "head", "expected"),
+    [
+        ("rev_head", "rev_head", True),  # at head → start serving, skip the lock
+        ("rev_old", "rev_head", False),  # migration pending → must wait for the leader
+        (None, "rev_head", False),  # fresh DB (no alembic_version) → run under the lock
+    ],
+)
+def test_schema_is_at_head(
+    monkeypatch: pytest.MonkeyPatch, current: str | None, head: str, expected: bool
+) -> None:
+    _patch_current(monkeypatch, current=current)
+    assert init_mod._schema_is_at_head(None, head) is expected  # type: ignore[arg-type]


### PR DESCRIPTION
## Problem

core-storage-api runs alembic migrations on startup, serialized by a Postgres advisory lock: one replica (leader) migrates; the others (followers) **poll to acquire the lock, then run a redundant no-op `upgrade`**. During a multi-replica scale-up, that serialized `acquire → no-op → release` tail means tail replicas wait far longer than the leader's actual migration — long enough to blow the Cloud Run **240s startup TCP probe** (`failureThreshold: 1`), so Cloud Run kills them.

**Observed (prod 2026-06-24 02:04Z):** `prod-memclaw-core-storage-writer` — `Default STARTUP TCP probe failed … DEADLINE_EXCEEDED. The instance was not started.` Killed instances → brief storage capacity dips → the `core-api → core-storage-api` `httpx.ConnectTimeout`s that raise + nack the `memclaw.memory.embedded` pubsub handler (`consumer.py:184 → storage_client.get_memory`). This PR addresses the storage-startup root cause of that connect-timeout class.

## Change

`_schema_is_at_head(connection, head)` lets a non-leader replica start serving **as soon as the schema reaches head, without acquiring the lock**:
- **Fast path** before the lock loop: if nothing is pending, return immediately — no replica even contends on the lock (steady-state boot).
- **Follower poll loop**: bail the moment the leader's migration lands, so all waiting followers unblock *together* instead of draining one-at-a-time through the lock.

Unchanged / preserved:
- **Leader path** still acquires the advisory lock and runs the real `upgrade`/`stamp`.
- **Fresh DB** (`current is None`) still falls through to the stamp/upgrade path under the lock.
- `head` is computed **once** (constant per process), so the per-poll follower check is a single `alembic_version` SELECT — not a migrations-dir re-walk each poll.

## Test

`tests/test_init_schema_at_head.py` — unit-tests the predicate (at-head → True; pending → False; fresh/`None` → False) by stubbing `MigrationContext` (no DB). `ruff`/`mypy` clean.

## Residual (by design)

This removes the **serialization** overhead, not the **per-migration runtime floor**: a single migration that runs longer than the startup-probe deadline still kills followers (they legitimately can't serve until the schema is ready). That case requires raising the startup-probe deadline or moving migrations off the boot path (the known longer-term direction) — out of scope here.