### PR TITLE
fix(logging): demote handler-less reroute 'no-op' to DEBUG (records aren't lost)

### DIFF
--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -387,15 +387,20 @@ def _route_third_party_to_root() -> None:
         # emit a spurious WARNING about rerouting being a no-op.
         if name in _third_party_logger_original_state:
             continue
-        # Library may not have initialised this logger yet — there's nothing
-        # to reroute right now. Don't snapshot the empty state (would freeze
-        # us into "no work to do" forever) and warn the operator at WARNING
-        # so they notice in Cloud Logging if a uvicorn-fronted service is
-        # calling configure_logging at module import (before uvicorn's own
-        # ``Config.configure_logging`` runs at server start).
+        # Library hasn't installed its own handlers and still propagates — there
+        # is nothing to reroute, and crucially nothing is LOST: a handler-less,
+        # propagate=True logger already flows to the root handler (verified in
+        # prod — ``mcp.server.*`` / ``uvicorn.error`` records reach GCP as
+        # structured JSON this way). So this is the benign steady state, not a
+        # routing failure. Log at DEBUG, not WARNING — the old WARNING was a
+        # misleading false alarm (~per instance start) implying records wouldn't
+        # reach GCP. Don't snapshot the empty state (would freeze us into "no
+        # work to do" forever) so a later reroute can still act if the library
+        # ever installs handlers / sets propagate=False.
         if not lg.handlers and lg.propagate:
-            logging.getLogger(__name__).warning(
-                "logger %r has no own handlers at rerouting time; rerouting was a no-op (library may not be imported yet — call reroute_third_party_loggers from an ASGI lifespan startup handler if this is a uvicorn-fronted service)",
+            logging.getLogger(__name__).debug(
+                "logger %r has no own handlers at rerouting time; nothing to "
+                "reroute — it already propagates to the root handler",
                 name,
             )
             continue

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -168,6 +168,32 @@ def test_route_third_party_to_root_recall_after_handlerless_reroute_no_warning(
         _third_party_logger_original_state.clear()
 
 
+def test_route_third_party_to_root_pristine_logger_no_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A pristine listed logger (no own handlers, propagate=True) already
+    propagates to the root handler, so the 'nothing to reroute' note is DEBUG,
+    not a misleading WARNING. The old WARNING falsely implied records wouldn't
+    reach GCP, when they do via propagation (prod: ``mcp.server.*`` lands as
+    structured JSON)."""
+    target = logging.getLogger(_THIRD_PARTY_LOGGERS_TO_REROUTE[0])
+    _third_party_logger_original_state.clear()
+    for h in list(target.handlers):
+        target.removeHandler(h)
+    target.propagate = True  # pristine: handler-less + propagating
+    try:
+        with caplog.at_level(logging.WARNING, logger="common.structlog_config"):
+            _route_third_party_to_root()
+        assert not [
+            r
+            for r in caplog.records
+            if "no-op" in r.getMessage() or "nothing to reroute" in r.getMessage()
+        ], "a pristine handler-less logger must not WARN — it already reaches root"
+    finally:
+        target.propagate = True
+        _third_party_logger_original_state.clear()
+
+
 def test_route_third_party_to_root_preserves_operator_set_level_when_no_handlers() -> (
     None
 ):


### PR DESCRIPTION
## What

`common/structlog_config.py`'s `_route_third_party_to_root` emitted a **WARNING** ("logger X has no own handlers at rerouting time; rerouting was a no-op …") whenever a listed third-party logger (`mcp`/`fastmcp`/`uvicorn.error`/`slowapi`) was handler-less + `propagate=True`. Demote it to **DEBUG** + reword.

## Why

That state is **benign, not a routing failure**: a handler-less, `propagate=True` logger already flows to the root handler. **Verified in prod** — `mcp.server.streamable_http` / `uvicorn.error` records land in Cloud Logging as structured JSON via propagation. So the WARNING was a **misleading false alarm**, firing ~once per instance start (~57/day for `fastmcp` in prod core-api), implying records wouldn't reach GCP when they do. It nearly mis-led triage into thinking FastMCP tool-errors were invisible (the very thing #473 was about — which is actually working).

## Safety

Routing behavior is unchanged — only the log level + message. The snapshot/idempotency guard is untouched, and the empty state is still **not** snapshotted, so a later reroute can still act if a library ever installs its own handlers / sets `propagate=False`.

## Test

Existing 21 logging tests pass; adds `test_route_third_party_to_root_pristine_logger_no_warning` asserting a pristine handler-less logger emits no WARNING. ruff + mypy clean.