### PR TITLE
fix(core-api): correct get_memory_ids_by_entity_ids return type to list[dict]

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1239,7 +1239,7 @@ class CoreStorageClient:
     async def get_memory_ids_by_entity_ids(
         self,
         entity_ids: list[str],
-    ) -> list[tuple]:
+    ) -> list[dict]:
         result = await self._post(
             "/entities/memory-ids-by-entity-ids",
             {"entity_ids": entity_ids},


### PR DESCRIPTION
## What

Correct a misleading return-type annotation on `CoreStorageClient.get_memory_ids_by_entity_ids`.

The method was annotated `-> list[tuple]`, but the storage endpoint it calls (`POST /entities/memory-ids-by-entity-ids`, see `core-storage-api/.../routers/entities.py`) returns `-> list[dict]` — rows of `{"memory_id", "entity_id", "role"}`. The sole consumer, `memory_service._entity_boost_pipeline`, already reads the result by key (`item["memory_id"]` / `item["entity_id"]`) and constructs tuples *from* those dicts — which is likely how the `list[tuple]` annotation crept in.

## Why it's safe

Annotation-only change — no runtime behaviour changes. The method already returned dicts; this just makes the type hint match reality (and the storage endpoint's own signature). `storage_client` is in core-api's mypy `ignore_errors` set, so this was never type-checked; the fix is purely for human readers. Spun out of the #491 review as a noted non-blocking follow-up.

## Verification

- `ruff check` + `ruff format --check` (core-api/src, core-storage-api/src, common) — clean
- `mypy` core-api (182 files) — clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
