### PR TITLE
feat(skill): curb trivial memory writes in agent guidance

### DIFF
--- a/plugin/skills/memclaw/SKILL.md
+++ b/plugin/skills/memclaw/SKILL.md
@@ -226,8 +226,9 @@ byte, and your teammates never see it.
 
 ## 9 · Capture cadence (L1 / L2 / L3)
 
-- **L1 — per turn.** After each meaningful outcome, write with date, what, who,
-  outcome, next.
+- **L1 — per task.** At task completion or a real decision point (not every
+  turn), write with date, what, who, outcome, next. Tool-by-tool progress is
+  not an L1 write — that's scratchpad (§3).
 - **L2 — session boundary.** At > 60 % context or session end, write a full
   summary.
 - **L3 — consolidation.** On periodic runtime sweeps, find gaps, merge

--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -1375,7 +1375,7 @@ describe("buildAgentsMd", () => {
     // (on-demand). This test guards against the move regressing.
     const skill = readFileSync(SHARED_SKILL_PATH, "utf-8");
     assert.ok(skill.includes("Capture cadence"), "SKILL.md missing L1/L2/L3 capture cadence");
-    assert.ok(skill.includes("L1 — per turn"));
+    assert.ok(skill.includes("L1 — per task"));
     assert.ok(skill.includes("L2 — session boundary"));
     assert.ok(skill.includes("L3 — consolidation"));
     assert.ok(

--- a/plugin/src/educate.ts
+++ b/plugin/src/educate.ts
@@ -401,13 +401,14 @@ to other agents → write it to MemClaw.
 operations). Never fabricate. If uncertain, write privately
 (\`visibility=scope_agent\`) until resolved.
 
-**Completion contract.** No silent completions — every meaningful
-outcome MUST produce a write. No write = not done. Checkpoint every
-30 min on long tasks.
+**What to write.** Durable knowledge, not activity. Tool calls, command
+output, and intermediate steps are scratchpad, not memories — they
+pollute recall. Write only what helps another agent in a *later
+session*; if it dies with this task, don't.
 
 **Write triggers.** Task done · bug · deploy · decision · API change ·
 blocker · commitment · config change · error pattern · skill created
-or updated. If in doubt: write.
+or updated. If in doubt, don't.
 
 **Skills.** Team-knowledge catalog at \`collection=skills\`. Search via
 \`memclaw_doc op=search collection=skills\` (\`memclaw_recall\` is YOUR

--- a/plugin/src/prompt-section.ts
+++ b/plugin/src/prompt-section.ts
@@ -35,8 +35,11 @@ function buildRecallLines(availableTools: Set<string>): string[] {
       present.join(", ") +
       ". Every call MUST carry your `agent_id` (and `fleet_id` for " +
       "team / org / cross-fleet operations) — never fabricate. " +
-      "Operating rules (recall before, write after, supersede don't " +
-      "delete), quality rules, and per-tool reference live in the " +
+      "Write durable, reusable knowledge only — never tool calls, " +
+      "intermediate steps, or session-local logs (those go to the " +
+      "scratchpad). Operating rules (recall before; write durable " +
+      "outcomes, supersede don't delete), quality rules, and per-tool " +
+      "reference live in the " +
       "**memclaw** skill, which your runtime loads automatically — open " +
       "it via your skill system before your first MemClaw call this " +
       "session. Do NOT search the filesystem for it.",


### PR DESCRIPTION
## Summary

Reduce trivial / episodic memory writes. The every-turn agent guidance pushed agents to write everything — in practice they logged tool calls and play-by-play as memories, polluting recall. This removes the "always write" pressure from the every-turn guidance and aligns the SKILL.md L1 cadence with its own anti-noise rule.

## Related Issue

N/A (behavioral tuning observed in production agent usage).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

### What changed

- **`AGENTS.md`** (`buildAgentsMd`, injected every turn): replaced the completion-contract mandate (*"no silent completions — every meaningful outcome MUST produce a write. No write = not done."*) with a durability bar + an explicit *"never write tool calls / command output / intermediate steps"* line; flipped *"If in doubt: write"* → *"If in doubt, don't."*
- **`prompt-section.ts`** (the leanest every-turn fragment): now states *"write durable, reusable knowledge only — never tool calls, intermediate steps, or session-local logs."*
- **`SKILL.md` §9**: L1 cadence is **per-task**, not per-turn — resolving its contradiction with §3 *"Don't write the noise"* and the Anti-patterns section.
- **`educate.test.ts`**: updated the assertion that pinned the old `L1 — per turn` wording.

## How Has This Been Tested?

```
cd plugin && npm test
# tests 351 | pass 351 | fail 0
```

Also verified `buildAgentsMd()` stays under the enforced 1700-char every-turn slim budget (**1695 chars**).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes (updated the SKILL.md cadence assertion; AGENTS.md slim-budget test guards length)
- [ ] `ruff check` / `ruff format --check` — **N/A** (TypeScript + Markdown only; no Python touched)
- [ ] `mypy` — **N/A** (no Python touched)
- [ ] `pytest` — **N/A**; ran plugin suite instead: `npm test` (351 pass)
- [x] I have updated relevant documentation (the SKILL.md skill doc is part of this change)
- [x] CHANGELOG — auto-generated by release-please from the Conventional Commit; no manual edit (repo has no `Unreleased` section)

## Additional Notes

- The high-leverage surface is the **every-turn** files (`AGENTS.md` + `prompt-section.ts`), not the on-demand `SKILL.md` — agents act on what's in context every turn.
- The **`static/` (MCP/canonical) `SKILL.md` is intentionally unchanged**: it has no per-turn capture-cadence section and already carries the §3 "Don't write the noise" + Anti-patterns guidance.
- `dist/` is gitignored; only source + skill content is committed.
- Branched from `origin/main` (the shipping skill version), not the in-flight feature branch the investigation started on.
