### PR TITLE
fix(core-api): stop passing removed positional db to log_action on write path

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
+++ b/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
@@ -106,7 +106,8 @@ class WriteMemoryRow:
         if _hooks.audit_log:
             try:
                 await _hooks.audit_log(
-                    ctx.db,  # log_action ignores db (storage-routed) — allow STM path
+                    # log_action is keyword-only since #491 dropped the direct DB
+                    # pool (storage-routed); do NOT pass ctx.db positionally.
                     tenant_id=data.tenant_id,
                     agent_id=data.agent_id,
                     action="create",

--- a/tests/test_write_path_audit_signature_regression.py
+++ b/tests/test_write_path_audit_signature_regression.py
@@ -1,0 +1,98 @@
+"""Regression: the pipeline write path must invoke the audit hook successfully.
+
+``#491`` (delete core-api's direct DB pool; route all DB via core-storage)
+dropped the ``db`` parameter from ``audit_service.log_action`` — its signature
+became fully keyword-only. It updated the other call sites (mcp_server,
+agents, documents) but MISSED ``write_memory_row.py``, which kept passing
+``ctx.db`` positionally. Result on eToro v2.11.0 (backend 2.18.0): every memory
+create raised ``TypeError: log_action() takes 0 positional arguments`` inside
+``write_memory_row``'s ``try/except`` — swallowed as "Audit hook failed
+(non-critical)", so the row still wrote but NO audit-log entry was recorded.
+
+Why this slipped through: ``test_mcp_write_db_none_regression`` drives the same
+pipeline but only asserts the row persists — the swallowed audit failure leaves
+the write succeeding, so it stays green. The integration test below asserts the
+audit hook does NOT fail; the unit test guards the ``log_action`` contract.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import uuid
+
+import pytest
+
+from core_api.services.audit_service import log_action
+
+
+def test_log_action_is_keyword_only_no_positional_db():
+    """``log_action`` is storage-routed (no ``db``) and must stay fully
+    keyword-only, so callers cannot pass a positional. Re-adding any
+    positional/positional-or-keyword param reintroduces the #491 mismatch."""
+    positional = [
+        p.name
+        for p in inspect.signature(log_action).parameters.values()
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+    ]
+    assert not positional, (
+        f"log_action must remain keyword-only (storage-routed, no db); "
+        f"found positional params: {positional}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: drive the real write pipeline and assert the audit hook ran.
+# ---------------------------------------------------------------------------
+pytestmark_integration = [pytest.mark.integration, pytest.mark.asyncio]
+
+_PADDING = (
+    " This memory carries enough surrounding context to pass the content-length gate."
+)
+
+
+@pytest.fixture
+def _use_pipeline_write():
+    import core_api.services.memory_service as memory_service
+
+    original = memory_service._USE_PIPELINE_WRITE
+    memory_service._USE_PIPELINE_WRITE = True
+    yield
+    memory_service._USE_PIPELINE_WRITE = original
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_memory_write_audit_hook_does_not_fail(db, caplog, _use_pipeline_write):
+    """A memory create must invoke the audit hook WITHOUT the swallowed
+    TypeError. Captures ``write_memory_row``'s logger: if the hook raises
+    (the #491 regression — positional ``ctx.db`` into keyword-only
+    ``log_action``), it logs "Audit hook failed" and this test fails."""
+    from core_api.schemas import MemoryCreate, MemoryOut
+    from core_api.services.memory_service import create_memory
+
+    tenant = f"test-tenant-auditsig-{uuid.uuid4().hex[:8]}"
+    content = "The Danube flows through ten countries." + _PADDING
+
+    with caplog.at_level(
+        logging.WARNING, logger="core_api.pipeline.steps.write.write_memory_row"
+    ):
+        result = await create_memory(
+            MemoryCreate(
+                tenant_id=tenant,
+                fleet_id="test-fleet",
+                agent_id="test-agent",
+                content=content,
+                persist=True,
+                entity_links=[],
+            )
+        )
+
+    assert isinstance(result, MemoryOut)
+    audit_failures = [
+        r for r in caplog.records if "Audit hook failed" in r.getMessage()
+    ]
+    assert not audit_failures, (
+        "write_memory_row's audit hook failed (non-critical swallow) — "
+        f"#491 signature regression: {[r.getMessage() for r in audit_failures]}"
+    )


### PR DESCRIPTION
## Why (production regression — found on eToro v2.11.0 cutover)

`#491` (delete core-api's direct DB pool; route all DB via core-storage) made `audit_service.log_action` **fully keyword-only** by dropping its `db` parameter, and updated the `mcp_server` / `agents` / `documents` call sites — **but missed the pipeline write path.**

`write_memory_row.execute()` still passed `ctx.db` **positionally** to the `audit_log` hook (wired directly to `log_action`), so on **every memory create**:

```
TypeError: log_action() takes 0 positional arguments but 1 positional argument (and 6 keyword-only arguments) were given
```

This is caught by the step's `try/except` and logged as `Audit hook failed (non-critical)` — so **writes still persist, but no audit-log entry is recorded for memory creates.** Other audited actions (agents, documents, MCP) are unaffected (their call sites were updated by #491).

**Still present on `main`** → affects all v2.18.0 deployments, including SaaS.

## Fix
Drop the positional `ctx.db` argument (the call is otherwise correct — keyword-only). One line.

## Tests — `tests/test_write_path_audit_signature_regression.py`
- **unit:** asserts `log_action` stays fully keyword-only (no positional `db`) — guards the contract callers rely on. (Runs without a DB.)
- **integration:** drives the real write pipeline and asserts the audit hook does **not** log `Audit hook failed`. The existing `test_mcp_write_db_none_regression` can't catch this — it only asserts the row persists, which it does *despite* the swallowed audit failure.

Verified locally: unit test passes, `ruff check`, `ruff format --check`, `mypy` clean. (Integration test runs in CI — needs the pgvector DB.)

## Rollout
Targets `caura-memclaw`. eToro is live on v2.11.0 with this regression (memory-write audit gap since cutover); once merged we cut `backend-v2.18.1` → rebuild on-prem `v2.11.1` → redeploy eToro via the gated `upgrade.sh`. Service is otherwise healthy (pool fix working); rollback was rejected (would reintroduce the pool leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)