### PR TITLE
fix(core-api): don't 422 the whole heartbeat on an oversized observability blob

### DIFF
--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -74,6 +74,31 @@ class FleetCreateIn(BaseModel):
         return v
 
 
+def _cap_or_drop(v: dict | None, limit: int, field: str) -> dict | None:
+    """Cap an OPTIONAL observability blob without failing the whole heartbeat.
+
+    ``recall_metrics`` / ``reconcile`` are best-effort observability. A
+    ``field_validator`` that *raises* on an oversized value fails the entire
+    request model → 422 → the node's registration AND command channel are
+    dropped over one bloated optional field (eToro 2026-06-28: a node with a
+    large skill catalog 422'd every heartbeat, going stale + uncommandable).
+    Degrade gracefully instead: replace the oversized blob with a small marker
+    so the load-bearing heartbeat still lands; only the detailed snapshot is
+    lost for that tick. Still bounds ``nodes.metadata`` growth.
+    """
+    if v is not None:
+        size = len(json.dumps(v))
+        if size > limit:
+            logger.warning(
+                "fleet.heartbeat: %s is %d bytes (> %d cap) — dropping field, keeping heartbeat",
+                field,
+                size,
+                limit,
+            )
+            return {"_truncated": True, "_original_bytes": size}
+    return v
+
+
 class HeartbeatIn(BaseModel):
     tenant_id: str
     node_name: str
@@ -131,24 +156,18 @@ class HeartbeatIn(BaseModel):
     @field_validator("recall_metrics")
     @classmethod
     def _cap_recall_metrics(cls, v: dict | None) -> dict | None:
-        # Cap incoming counter blob to keep a misbehaving / malicious
-        # plugin from ballooning `nodes.metadata` rows. The plugin's
-        # actual `getRecallMetrics()` payload is well under 1 KB even
-        # with every reason populated; 4 KB is a comfortable headroom.
-        if v is not None and len(json.dumps(v)) > 4096:
-            raise ValueError("recall_metrics exceeds 4 KB limit")
-        return v
+        # Anti-ballooning cap on an OPTIONAL observability blob. Drop (not
+        # reject) when oversized so a bloated counter blob can't 422 the whole
+        # heartbeat. getRecallMetrics() is well under 1 KB normally; 4 KB cap.
+        return _cap_or_drop(v, 4096, "recall_metrics")
 
     @field_validator("reconcile")
     @classmethod
     def _cap_reconcile(cls, v: dict | None) -> dict | None:
-        # Same anti-ballooning cap as recall_metrics. The summary is a
-        # handful of slug lists; even a fleet sharing ~150 skills stays
-        # well under 8 KB. Reject beyond that at the API boundary so a
-        # misbehaving plugin can't bloat the node row.
-        if v is not None and len(json.dumps(v)) > 8192:
-            raise ValueError("reconcile summary exceeds 8 KB limit")
-        return v
+        # Anti-ballooning cap on an OPTIONAL observability blob. Drop (not
+        # reject) when oversized — see _cap_or_drop. A summary is normally a
+        # handful of slug lists; 8 KB cap.
+        return _cap_or_drop(v, 8192, "reconcile")
 
 
 class CommandIn(BaseModel):

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -328,9 +328,11 @@ async def test_heartbeat_reconcile_latest_snapshot_wins(client):
     assert node["metadata"]["reconcile"]["installed"] == ["alpha"]
 
 
-async def test_heartbeat_reconcile_oversized_rejected(client):
-    """A reconcile blob over the 8 KB cap is rejected at the API boundary
-    (anti-ballooning of nodes.metadata)."""
+async def test_heartbeat_reconcile_oversized_dropped_not_rejected(client):
+    """A reconcile blob over the 8 KB cap is DROPPED to a truncation marker,
+    NOT rejected. It's optional observability — an oversized value must never
+    422 the whole heartbeat (that would drop node registration + the command
+    channel). nodes.metadata growth is still bounded. See _cap_or_drop."""
     tenant_id, headers = get_test_auth()
     tag = _uid()
     oversized = {"installed": ["x" * 100 for _ in range(120)]}  # ~12 KB
@@ -344,4 +346,5 @@ async def test_heartbeat_reconcile_oversized_rejected(client):
         },
         headers=headers,
     )
-    assert resp.status_code == 422, resp.text
+    assert resp.status_code == 200, resp.text
+    assert resp.json().get("ok") is True

--- a/tests/test_fleet_heartbeat_auto_upgrade.py
+++ b/tests/test_fleet_heartbeat_auto_upgrade.py
@@ -485,24 +485,23 @@ def test_recall_metrics_under_cap_accepted():
     assert body.recall_metrics["calls_total"] == 142
 
 
-def test_recall_metrics_over_cap_rejected():
-    """A misbehaving plugin sending a huge counter blob is rejected at
-    the API boundary — protects nodes.metadata from unbounded growth.
+def test_recall_metrics_over_cap_dropped_not_rejected():
+    """A huge counter blob is DROPPED to a truncation marker, NOT rejected —
+    it must not 422 the whole heartbeat (which would drop the load-bearing
+    registration + command channel). nodes.metadata growth is still bounded.
     """
-    import pytest as _pt
-    from pydantic import ValidationError
-
     huge = {
         "calls_total": 1,
         "skipped_by_reason": {f"reason-{i}": i for i in range(500)},
     }
     # 500 keys × ~20 bytes ≈ 10 KB → well over the 4 KB cap.
-    with _pt.raises(ValidationError, match="exceeds 4 KB limit"):
-        fleet_mod.HeartbeatIn(
-            tenant_id="tenant-1",
-            node_name="node-a",
-            recall_metrics=huge,
-        )
+    hb = fleet_mod.HeartbeatIn(
+        tenant_id="tenant-1",
+        node_name="node-a",
+        recall_metrics=huge,
+    )
+    assert hb.recall_metrics is not None
+    assert hb.recall_metrics.get("_truncated") is True
 
 
 def test_recall_metrics_none_accepted():

--- a/tests/test_fleet_heartbeat_oversized_caps.py
+++ b/tests/test_fleet_heartbeat_oversized_caps.py
@@ -1,0 +1,52 @@
+"""Regression: an oversized OPTIONAL observability blob must not 422 the heartbeat.
+
+``recall_metrics`` (4 KB) and ``reconcile`` (8 KB) are best-effort observability
+fields on ``HeartbeatIn``. They used to ``raise`` in their field_validators when
+oversized — which fails the whole request model → 422 → the node's registration
+AND command channel are dropped over one bloated optional field.
+
+eToro 2026-06-28: a node whose skill catalog made the reconcile summary exceed
+8 KB 422'd every heartbeat, going stale + uncommandable (memory tooling, which
+uses a different path, was unaffected). The validators now DROP the oversized
+blob to a small marker instead of raising — the load-bearing heartbeat lands;
+only the detailed snapshot for that tick is lost.
+"""
+
+from __future__ import annotations
+
+import json
+
+from core_api.routes.fleet import HeartbeatIn
+
+
+def _oversized(min_bytes: int) -> dict:
+    """A dict whose JSON comfortably exceeds ``min_bytes``."""
+    blob = {"installed": [f"skill-{i:06d}" for i in range(min_bytes // 8 + 200)]}
+    assert len(json.dumps(blob)) > min_bytes
+    return blob
+
+
+def test_oversized_reconcile_is_dropped_not_rejected():
+    big = _oversized(8192)
+    # Must NOT raise ValidationError.
+    hb = HeartbeatIn(tenant_id="t", node_name="n", reconcile=big)
+    assert hb.reconcile == {"_truncated": True, "_original_bytes": len(json.dumps(big))}
+
+
+def test_oversized_recall_metrics_is_dropped_not_rejected():
+    big = _oversized(4096)
+    hb = HeartbeatIn(tenant_id="t", node_name="n", recall_metrics=big)
+    assert hb.recall_metrics is not None
+    assert hb.recall_metrics.get("_truncated") is True
+
+
+def test_normal_reconcile_passes_through_unchanged():
+    small = {"catalogCount": 1, "installed": ["memclaw"], "removed": []}
+    hb = HeartbeatIn(tenant_id="t", node_name="n", reconcile=small)
+    assert hb.reconcile == small
+
+
+def test_absent_fields_stay_none():
+    hb = HeartbeatIn(tenant_id="t", node_name="n")
+    assert hb.reconcile is None
+    assert hb.recall_metrics is None


### PR DESCRIPTION
## Why

`HeartbeatIn`'s `recall_metrics` (4 KB) and `reconcile` (8 KB) field-validators **raised** when oversized. A raised `field_validator` fails the *entire* request model → FastAPI **422** → the heartbeat is rejected wholesale, dropping the node's **registration + command channel** (auto-upgrade, remote ops) over one bloated **optional** observability field.

**eToro 2026-06-28:** a node whose (legacy, unfiltered) skill catalog pushed the `reconcile` summary past 8 KB 422'd on *every* heartbeat → went stale in the fleet view and uncommandable. Memory tooling was unaffected (different path) and the on-disk skill reconcile still ran (it happens client-side *before* the POST), so it was non-blocking for the agent — but the fleet control channel was broken for that node.

## Fix
Degrade gracefully. A shared `_cap_or_drop()` helper replaces an oversized blob with a small `{"_truncated": True, "_original_bytes": N}` marker (and logs a warning) instead of raising — so the load-bearing heartbeat still lands; only the detailed snapshot for that tick is lost. Still bounds `nodes.metadata` growth.

Applied to **both** caps (same bug class). It's unfixed on `main`, so this affects all deployments.

## Tests — `tests/test_fleet_heartbeat_oversized_caps.py`
- oversized `reconcile` / `recall_metrics` → **dropped, not rejected** (no `ValidationError`, replaced with the marker)
- normal blobs pass through unchanged
- absent fields stay `None`

Verified locally: 4/4 pass, `ruff check`, `ruff format --check`, `mypy` all clean.

## Context / rollout
Not urgent for eToro right now — the server skill catalog is empty there, so summaries are small and heartbeats are landing fleet-wide; the observed 422 was transient. This lands as **defense-in-depth** so a future catalog growth (or any large node) can't silently knock nodes off the fleet command channel. Can ride a normal release; no redeploy required immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)