### PR TITLE
chore(fleet): reconcile plugin auto-upgrade floor to 2.12.0

### DIFF
--- a/core-api/src/core_api/version_compat.py
+++ b/core-api/src/core_api/version_compat.py
@@ -6,7 +6,10 @@ We log a warning when a heartbeat reports a plugin older than the minimum
 recommended version; no hard rejection — operators decide when to upgrade.
 """
 
-MIN_RECOMMENDED_PLUGIN_VERSION = "2.9.0"
+# Auto-upgrade target / "outdated" floor. The fleet heartbeat queues a deploy
+# to this version for eligible nodes (>= MIN_AUTO_DEPLOY, auto-upgrade enabled).
+# Reconciled to the current shipped plugin release.
+MIN_RECOMMENDED_PLUGIN_VERSION = "2.12.0"
 
 # Server-side floor below which plugins must NOT auto-upgrade — the
 # heartbeat path in ``routes/fleet.py`` enforces this hard, and

--- a/tests/test_plugin_floor_invariant.py
+++ b/tests/test_plugin_floor_invariant.py
@@ -1,0 +1,40 @@
+"""Guard the plugin-version floors across a floor reconcile.
+
+The auto-upgrade TARGET (``MIN_RECOMMENDED_PLUGIN_VERSION``) must stay at or
+above the auto-deploy ELIGIBILITY floor (``MIN_AUTO_DEPLOY_PLUGIN_VERSION``);
+otherwise the heartbeat could queue an auto-deploy to a version below the
+safe-to-self-deploy line. These run without a DB.
+"""
+
+from __future__ import annotations
+
+from core_api.version_compat import (
+    MIN_AUTO_DEPLOY_PLUGIN_VERSION,
+    MIN_RECOMMENDED_PLUGIN_VERSION,
+    _parse,
+    is_plugin_outdated,
+)
+
+
+def test_recommended_at_or_above_auto_deploy_floor():
+    assert _parse(MIN_RECOMMENDED_PLUGIN_VERSION) >= _parse(
+        MIN_AUTO_DEPLOY_PLUGIN_VERSION
+    ), (
+        f"recommended floor {MIN_RECOMMENDED_PLUGIN_VERSION} must be >= "
+        f"auto-deploy floor {MIN_AUTO_DEPLOY_PLUGIN_VERSION}"
+    )
+
+
+def test_recommended_floor_parses_to_nonempty():
+    assert _parse(MIN_RECOMMENDED_PLUGIN_VERSION), (
+        "recommended floor must be a parseable version"
+    )
+
+
+def test_outdated_semantics_around_floor():
+    # Anything clearly below the floor is outdated; the floor itself and
+    # anything above are current. (Floor-value-agnostic so it survives bumps.)
+    assert is_plugin_outdated("0.0.1") is True
+    assert is_plugin_outdated(MIN_RECOMMENDED_PLUGIN_VERSION) is False
+    assert is_plugin_outdated("999.0.0") is False
+    assert is_plugin_outdated(None) is False


### PR DESCRIPTION
## What
Bump `MIN_RECOMMENDED_PLUGIN_VERSION` **`2.9.0` → `2.12.0`** in `core_api/version_compat.py`.

This constant is the fleet **auto-upgrade target / "outdated" floor**. On each heartbeat, `routes/fleet.py::_maybe_queue_auto_upgrade` queues a `deploy` command to this version for an eligible node — one that is `>= MIN_AUTO_DEPLOY_PLUGIN_VERSION` (2.6.0), has tenant auto-upgrade enabled, isn't in `KNOWN_BROKEN_DEPLOY_VERSIONS`, and has no deploy already pending — when it reports a plugin `<` this floor. It's also the `is_plugin_outdated` threshold and is surfaced via `/api/v1/health`.

## Why
Reconcile the floor to the current shipped plugin release (`plugin-v2.12.0`) so fleets self-upgrade and converge to 2.12.0.

## Scope / impact
- **`MIN_AUTO_DEPLOY_PLUGIN_VERSION` (2.6.0) unchanged** — nodes below it (pre-manifest-aware: `0.98.x` / `2.0–2.5`) are still skipped and need a one-time **manual reinstall**.
- **No mechanism change** — the auto-upgrade logic just reads the constant. The existing auto-upgrade suite (which monkeypatches the floor) passes unchanged (59 tests green locally).
- Eligible nodes (≥2.6.0) converge over their heartbeat cadence once a core-api carrying this floor is deployed.

## Test
`tests/test_plugin_floor_invariant.py` — guards the invariant that the recommended floor stays **≥** the auto-deploy eligibility floor (a misconfig would queue deploys below the safe-to-self-deploy line), plus floor-value-agnostic `is_plugin_outdated` semantics.

## Deploy prereq
Confirm `plugin@2.12.0` is published where on-prem nodes self-fetch it before deploying a core-api with this floor (so the queued `deploy` commands can actually install). `plugin-v2.12.0` is cut, so this should already hold.

`ruff check` / `ruff format --check` / `mypy` clean on the changed source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)