### PR TITLE
feat(observability): log auto /search recalls behind a separate flag

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/log_recall_event.py
+++ b/core-api/src/core_api/pipeline/steps/search/log_recall_event.py
@@ -5,10 +5,13 @@ returned top-k *and* a few near-misses below the similarity floor) so we can
 answer "why aren't good memories recalled?" — distinguishing *nobody asked*
 from *just missed the cutoff* from *outranked*.
 
-Gating (both cheap, evaluated before any DB work):
-  1. ``source == "mcp_recall"`` — ONLY the agent-chosen tool. The plugin's
-     automatic ``/search`` is never logged.
-  2. ``tenant_config.recall_logging_enabled`` — per-tenant opt-in (default off).
+Gating (cheap, evaluated before any DB work) — two independent modes:
+  * ``source == "mcp_recall"`` + ``tenant_config.recall_logging_enabled``
+    → FULL log: returned candidates + a few below-floor near-misses.
+  * ``source == "search"`` (the plugin's automatic path) +
+    ``tenant_config.search_recall_logging_enabled`` → LIGHT log: returned
+    candidates only (no near-misses), since ``/search`` is high-volume.
+  * anything else → not logged.
 
 The actual writes run fire-and-forget in a background task (its own session),
 exactly like ``TrackRecalls`` — zero added request latency, and any failure is
@@ -54,12 +57,20 @@ class LogRecallEvent:
 
     async def execute(self, ctx: PipelineContext) -> StepResult | None:
         try:
-            # Gate 1: only the agent-chosen tool.
-            if ctx.data.get("source") != "mcp_recall":
-                return None
-            # Gate 2: per-tenant opt-in.
+            source = ctx.data.get("source")
             cfg = ctx.tenant_config
-            if not getattr(cfg, "recall_logging_enabled", False):
+            # Two independent, per-tenant opt-in modes. ``mcp_recall`` (the
+            # agent-chosen tool) logs the full picture incl. near-misses;
+            # ``search`` (the high-volume automatic path) logs returned-only.
+            if source == "mcp_recall":
+                if not getattr(cfg, "recall_logging_enabled", False):
+                    return None
+                include_near_misses = True
+            elif source == "search":
+                if not getattr(cfg, "search_recall_logging_enabled", False):
+                    return None
+                include_near_misses = False
+            else:
                 return None
 
             sp = ctx.data.get("search_params", {}) or {}
@@ -86,8 +97,13 @@ class LogRecallEvent:
                     }
                 )
             # Near-misses: raw candidates not returned (below floor / outside
-            # top_k), best-first, capped.
-            near = [r for r in raw_rows if _mem_id(r) not in returned_ids][:_NEAR_MISS_LIMIT]
+            # top_k), best-first, capped. Skipped for the high-volume
+            # ``search`` path.
+            near = (
+                [r for r in raw_rows if _mem_id(r) not in returned_ids][:_NEAR_MISS_LIMIT]
+                if include_near_misses
+                else []
+            )
             for offset, row in enumerate(near):
                 candidates.append(
                     {
@@ -104,7 +120,7 @@ class LogRecallEvent:
             event = {
                 "tenant_id": ctx.data.get("tenant_id"),
                 "agent_id": ctx.data.get("caller_agent_id"),
-                "source": "mcp_recall",
+                "source": source,
                 "query_text": ctx.data.get("query"),
                 "strategy": strategy,
                 "filter_agent_id": ctx.data.get("filter_agent_id"),

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -107,10 +107,17 @@ DEFAULT_SETTINGS: dict = {
     },
     "observability": {
         # Opt-in (default off). When on, each agent-chosen ``memclaw_recall``
-        # call is logged (query + scope + candidate scores) to ``recall_event``
-        # / ``recall_candidate`` for "why aren't good memories recalled?"
-        # analysis. The plugin's automatic ``/search`` is never logged.
+        # call is logged (query + scope + candidate scores + below-floor
+        # near-misses) to ``recall_event`` / ``recall_candidate`` for "why
+        # aren't good memories recalled?" analysis.
         "recall_logging_enabled": None,
+        # Opt-in (default off). When on, the plugin's automatic ``/search``
+        # path is ALSO logged — but in a lighter form: returned candidates
+        # only (id + scores), no below-floor near-misses, since ``/search``
+        # is high-volume. Independent of ``recall_logging_enabled`` so it can
+        # be enabled for a short diagnostic window on a couple of tenants and
+        # then turned back off.
+        "search_recall_logging_enabled": None,
     },
     "chunking": {
         "auto_chunk_enabled": None,
@@ -467,6 +474,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "entity_linking.auto_entity_linking_enabled": bool,
     "insights.auto_insights_enabled": bool,
     "observability.recall_logging_enabled": bool,
+    "observability.search_recall_logging_enabled": bool,
     "chunking.auto_chunk_enabled": bool,
     "agents.require_agent_approval": bool,
     "entity_blocklist": list,
@@ -824,6 +832,14 @@ class ResolvedConfig:
     @property
     def recall_logging_enabled(self) -> bool:
         val = self._ts.get("observability", {}).get("recall_logging_enabled")
+        return val if val is not None else False
+
+    # Search-path recall logging — opt-in (default False). When on, the
+    # automatic ``/search`` path is logged too (lighter: returned-only, no
+    # near-misses). Independent of ``recall_logging_enabled``.
+    @property
+    def search_recall_logging_enabled(self) -> bool:
+        val = self._ts.get("observability", {}).get("search_recall_logging_enabled")
         return val if val is not None else False
 
     # Chunking

--- a/tests/pipeline/test_log_recall_event.py
+++ b/tests/pipeline/test_log_recall_event.py
@@ -1,15 +1,17 @@
 """Unit tests for LogRecallEvent — gating + candidate construction (no DB).
 
-The step must:
-  - skip unless source == "mcp_recall" (plugin /search is never logged),
-  - skip unless the tenant opted in (recall_logging_enabled),
-  - otherwise emit one event + returned candidates + capped near-misses.
-The actual DB write (`_persist`) and `track_task` are patched out.
+Two independent, per-tenant opt-in modes:
+  - source == "mcp_recall" + recall_logging_enabled
+      → FULL log: returned candidates + capped below-floor near-misses.
+  - source == "search" + search_recall_logging_enabled
+      → LIGHT log: returned candidates only (no near-misses).
+  - any other source, or the relevant flag off → not logged.
+The actual write (`_persist`, which posts to the storage client) and
+`track_task` are patched out.
 """
 
 import uuid
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -27,8 +29,11 @@ def _row(vec_sim, score, recall_boost=1.0):
     )
 
 
-def _cfg(enabled):
-    return SimpleNamespace(recall_logging_enabled=enabled)
+def _cfg(recall=False, search=False):
+    return SimpleNamespace(
+        recall_logging_enabled=recall,
+        search_recall_logging_enabled=search,
+    )
 
 
 def _capture(monkeypatch):
@@ -40,13 +45,13 @@ def _capture(monkeypatch):
         return "coro-sentinel"
 
     monkeypatch.setattr(mod, "_persist", fake_persist)
-    monkeypatch.setattr(mod, "track_task", lambda coro: None)
+    monkeypatch.setattr(mod, "track_task", lambda _coro: None)
     return captured
 
 
-def _ctx(source, enabled, returned_rows, raw_rows):
+def _ctx(source, cfg, returned_rows, raw_rows):
     return PipelineContext(
-                data={
+        data={
             "source": source,
             "query": "what is our brand rule",
             "tenant_id": "t1",
@@ -59,34 +64,43 @@ def _ctx(source, enabled, returned_rows, raw_rows):
             "filtered_rows": returned_rows,
             "raw_rows": raw_rows,
         },
-        tenant_config=_cfg(enabled),
+        tenant_config=cfg,
     )
 
 
 @pytest.mark.asyncio
-async def test_skips_when_source_is_not_mcp_recall(monkeypatch):
+async def test_skips_search_when_search_flag_off(monkeypatch):
     captured = _capture(monkeypatch)
-    ctx = _ctx("search", True, [_row(0.6, 0.55)], [_row(0.6, 0.55)])
-    await LogRecallEvent().execute(ctx)
-    assert captured == []  # plugin /search must never be logged
-
-
-@pytest.mark.asyncio
-async def test_skips_when_tenant_not_opted_in(monkeypatch):
-    captured = _capture(monkeypatch)
-    ctx = _ctx("mcp_recall", False, [_row(0.6, 0.55)], [_row(0.6, 0.55)])
+    # recall_logging_enabled on, but the search flag is off → /search not logged.
+    ctx = _ctx("search", _cfg(recall=True, search=False), [_row(0.6, 0.55)], [_row(0.6, 0.55)])
     await LogRecallEvent().execute(ctx)
     assert captured == []
 
 
 @pytest.mark.asyncio
-async def test_logs_event_with_returned_and_near_misses(monkeypatch):
+async def test_skips_mcp_when_recall_flag_off(monkeypatch):
+    captured = _capture(monkeypatch)
+    ctx = _ctx("mcp_recall", _cfg(recall=False, search=True), [_row(0.6, 0.55)], [_row(0.6, 0.55)])
+    await LogRecallEvent().execute(ctx)
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_skips_unknown_source(monkeypatch):
+    captured = _capture(monkeypatch)
+    ctx = _ctx("bulk", _cfg(recall=True, search=True), [_row(0.6, 0.55)], [_row(0.6, 0.55)])
+    await LogRecallEvent().execute(ctx)
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_mcp_logs_returned_and_near_misses(monkeypatch):
     captured = _capture(monkeypatch)
     returned = [_row(0.60, 0.58), _row(0.55, 0.54)]
     # raw_rows = the two returned + 7 below-floor near-misses
     near = [_row(0.28 - i * 0.01, 0.2) for i in range(7)]
     raw = returned + near
-    ctx = _ctx("mcp_recall", True, returned, raw)
+    ctx = _ctx("mcp_recall", _cfg(recall=True), returned, raw)
 
     await LogRecallEvent().execute(ctx)
 
@@ -108,6 +122,30 @@ async def test_logs_event_with_returned_and_near_misses(monkeypatch):
     assert candidates[0]["final_score"] == 0.58
     # memory_id is stringified — the payload now crosses an HTTP/JSON boundary,
     # so every candidate id must be a str (UUIDs aren't JSON-serializable).
+    assert all(isinstance(c["memory_id"], str) for c in candidates)
+
+
+@pytest.mark.asyncio
+async def test_search_logs_returned_only_no_near_misses(monkeypatch):
+    captured = _capture(monkeypatch)
+    returned = [_row(0.60, 0.58), _row(0.55, 0.54)]
+    near = [_row(0.28 - i * 0.01, 0.2) for i in range(7)]
+    raw = returned + near
+    ctx = _ctx("search", _cfg(search=True), returned, raw)
+
+    await LogRecallEvent().execute(ctx)
+
+    assert len(captured) == 1
+    event, candidates = captured[0]
+    assert event["source"] == "search"
+    assert event["result_count"] == 2
+    # LIGHT mode: only the 2 returned rows, NO near-misses.
+    assert len(candidates) == 2
+    assert [c["returned"] for c in candidates] == [True, True]
+    assert [c["rank"] for c in candidates] == [1, 2]
+    # scores still captured for the returned rows.
+    assert candidates[0]["vec_sim"] == 0.60
+    assert candidates[0]["final_score"] == 0.58
     assert all(isinstance(c["memory_id"], str) for c in candidates)
 
 


### PR DESCRIPTION
## What
Adds a second, independent per-tenant flag **`observability.search_recall_logging_enabled`** (default off) that turns on recall logging for the high-volume automatic plugin **`/search`** path — separately from the existing `recall_logging_enabled` (which gates the agent-chosen `memclaw_recall` tool).

`LogRecallEvent` now logs two modes through the one shared search pipeline:
| source | flag | what's logged |
|---|---|---|
| `mcp_recall` | `recall_logging_enabled` | full: returned candidates **+** below-floor near-misses |
| `search` | `search_recall_logging_enabled` | **light**: returned candidates only (id + `vec_sim` + `final_score`), no near-misses |

`event.source` now reflects the real source instead of being hardcoded to `mcp_recall`.

## Why
We want to study *why good memories aren't recalled* on the path that actually dominates real traffic — the auto `/search` (the MCP tool is rarely used). The light mode keeps write volume down on a busy path while still capturing which memories surfaced and their scores.

## Operational note (volume)
`/search` is high-volume (≈12.7k/day on a large tenant). This is intended to be enabled on **a couple of tenants for a short diagnostic window, then turned off** — no deploy needed to toggle (settings API). Near-misses are dropped for this path specifically to limit row growth. A retention/prune policy is advisable before any broad/long enablement.

## Tests
`tests/pipeline/test_log_recall_event.py` extended: search-flag-off skip, mcp-flag-off skip, unknown-source skip, mcp full (returned+near-misses), search light (returned-only). ruff + format + mypy clean; 28 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)