### PR TITLE
feat(core-api): reserve agent_id "main" on the write path (Phase 1)

### DIFF
--- a/core-api/src/core_api/agent_ids.py
+++ b/core-api/src/core_api/agent_ids.py
@@ -11,3 +11,17 @@ otherwise couple the route module to the whole MCP tool surface.
 # explicitly refused (see ``mcp_server._refuse_default_agent_on_gateway``) so
 # anonymous writes are never silently attributed to one shared identity.
 DEFAULT_AGENT_ID = "mcp-agent"
+
+# Bare ``"main"`` is the OpenClaw plugin's *unset* default agent_id: when an
+# operator never sets ``MEMCLAW_AGENT_ID`` every install collapses onto this one
+# shared identity (the eToro "firehose"). Unlike ``DEFAULT_AGENT_ID``
+# ("mcp-agent", legitimate on the standalone path), bare ``"main"`` is never a
+# valid *persisted* write identity and is refused on every write path.
+RESERVED_MAIN_AGENT_ID = "main"
+
+# Ids rejected on EVERY write path regardless of context (never legitimate,
+# including standalone), enforced by the write-path guard
+# (``services.agent_identity``). ``DEFAULT_AGENT_ID`` ("mcp-agent") is
+# intentionally excluded — standalone uses it and it is guarded *conditionally*
+# by ``mcp_server._refuse_default_agent_on_gateway`` instead.
+ALWAYS_RESERVED_AGENT_IDS = frozenset({RESERVED_MAIN_AGENT_ID})

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -49,6 +49,18 @@ class Settings(BaseSettings):
     # ``inline_embedding`` / ``inline_enrichment`` helpers; Phase 3
     # (this revision) deleted the legacy flags + derivation validator.
     deployment_mode: Literal["inline", "deferred"] = "inline"
+    # Reserved-agent-id write guard (`main` identity fix). Bare `agent_id="main"`
+    # is the plugin's unset default; many installs collapse onto it. Phase 1:
+    #   allow  → legacy behavior / instant rollback
+    #   warn   → attribute as today but log `reserved_agent_write` (observe)
+    #   reject → 409 with guidance; a write supplying a unique agent_id passes
+    # Roll out warn → (measure) → reject. The bare-`main` delete gates on reject.
+    reserved_agent_id_policy: Literal["allow", "warn", "reject"] = "warn"
+    # Phase 2 (spoof hardening), ships dark: bind a write's agent_id to the
+    # verified credential identity (auth.agent_id), ignoring a client-supplied
+    # body override. Enable ONLY after the reserved-`main` credentials are
+    # re-identified — otherwise it pins them back onto `main`.
+    bind_write_identity_to_auth: bool = False
     # Outer cap on the inline embed+enrich gather in ParallelEmbedEnrich.
     # Was hardcoded at 20.0 — too tight under load once embedding moved
     # off the hot path (CAURA-594) and enrichment LLM became the sole

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -811,6 +811,11 @@ async def _write_memory_inner(
     from core_api.services.organization_settings import resolve_config
 
     write_config = await resolve_config(body.tenant_id)
+    # Phase 2 (dark, default off): bind to the verified credential identity,
+    # ignoring a client-supplied body override. Enable ONLY after reserved-
+    # `main` creds are re-identified, else it pins them back onto `main`.
+    if app_settings.bind_write_identity_to_auth and auth.agent_id:
+        body.agent_id = auth.agent_id
     agent = await get_or_create_agent(
         body.tenant_id,
         body.agent_id,
@@ -1008,6 +1013,10 @@ async def _write_memories_bulk_inner(
     idem: IdempotencyGuard | None,
     bulk_attempt_id: str,
 ):
+    # Phase 2 (dark, default off): bind to the verified credential identity
+    # (see _write_memory_inner). Enabled only post-re-identification.
+    if app_settings.bind_write_identity_to_auth and auth.agent_id:
+        body.agent_id = auth.agent_id
     agent = await get_or_create_agent(body.tenant_id, body.agent_id, body.fleet_id)
     if not body.fleet_id and agent.get("fleet_id"):
         body.fleet_id = agent["fleet_id"]

--- a/core-api/src/core_api/services/agent_identity.py
+++ b/core-api/src/core_api/services/agent_identity.py
@@ -1,0 +1,91 @@
+"""Reserved-agent-id write guard (Phase 1 of the `main` identity fix).
+
+Bare ``agent_id="main"`` is the OpenClaw plugin's unset default; without a
+per-install ``MEMCLAW_AGENT_ID`` every install collapses onto one shared
+identity (the eToro "firehose"). This module reserves it on the write path so
+new writes can't keep refilling that bucket, and returns an actionable message
+telling the agent how to set a real identity.
+
+Enforced at the ``memory_service.create_memory`` / ``create_memories_bulk``
+service boundary — the single funnel for REST, MCP, and STM writes — so no
+entry point can bypass it. By the time those run, ``data.agent_id`` is the
+resolved *effective* identity, so a write that supplies a unique ``agent_id``
+(the escape hatch) always passes; only the reserved default is refused.
+
+Reserved-id set lives in ``core_api.agent_ids`` (shared with the MCP gateway
+guard). ``"mcp-agent"`` is deliberately NOT unconditionally reserved here —
+standalone uses it and it has its own gateway-conditional guard
+(``mcp_server._refuse_default_agent_on_gateway``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core_api.agent_ids import ALWAYS_RESERVED_AGENT_IDS
+from core_api.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class ReservedAgentIdError(Exception):
+    """Raised when a write targets an unconditionally reserved agent_id.
+
+    Domain exception — the service layer (``memory_service``) converts it to an
+    HTTP 409 at the ``create_memory`` / ``create_memories_bulk`` boundary, so
+    this guard stays framework-agnostic.
+    """
+
+
+RESERVED_WRITE_ID_MESSAGE = (
+    'agent_id "{agent_id}" is reserved and no longer accepts writes — it is the '
+    "unset plugin default and collides across every install. Retry with a "
+    "unique, STABLE agent_id for THIS install: (1) set MEMCLAW_AGENT_ID in "
+    '~/.openclaw/plugins/memclaw/.env to a stable name (e.g. "webclaw") and '
+    "restart the plugin; (2) or pass a unique agent_id argument on each write "
+    'call now; (3) if you have no name, use "main-<install_id>" with '
+    "<install_id> from ~/.openclaw/plugins/memclaw/install.json. The id must "
+    "not be reserved and must be identical on every run. Recall and existing "
+    "memories are unaffected."
+)
+
+
+def reserved_write_refusal(agent_id: str | None) -> str | None:
+    """Return a 409 detail string if ``agent_id`` is an unconditionally reserved
+    write identity under the active policy; otherwise ``None`` (proceed).
+
+    Escape hatch: any non-reserved id (including ``main-<install_id>``) returns
+    ``None``. Policy (``settings.reserved_agent_id_policy``):
+    ``allow`` → never refuse; ``warn`` → log + proceed (observe-only);
+    ``reject`` → refuse.
+    """
+    if not agent_id or agent_id not in ALWAYS_RESERVED_AGENT_IDS:
+        return None
+    policy = settings.reserved_agent_id_policy
+    if policy == "allow":
+        return None
+    # Structured signal so ops can count reserved writes and confirm the
+    # bare-"main" write rate drops to ~0 before flipping warn -> reject and
+    # before the firehose delete. core-api has no metrics backend, so the log
+    # IS the counter (the same channel the firehose was originally sourced
+    # from in the usage analysis).
+    logger.warning(
+        "reserved_agent_write",
+        extra={"reserved_agent_id": agent_id, "policy": policy},
+    )
+    if policy == "warn":
+        return None
+    return RESERVED_WRITE_ID_MESSAGE.format(agent_id=agent_id)
+
+
+def enforce_reserved_write_id(agent_id: str | None) -> None:
+    """Raise ``ReservedAgentIdError`` when the resolved write identity is
+    reserved under ``policy="reject"``. No-op under ``allow``/``warn``
+    (``warn`` logs).
+
+    The service layer converts this to an HTTP 409; REST surfaces it directly
+    and the MCP write tool's ``except HTTPException`` maps ``.detail`` into its
+    error envelope, so the agent sees the guidance.
+    """
+    if detail := reserved_write_refusal(agent_id):
+        raise ReservedAgentIdError(detail)

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
 from core_api.middleware.per_tenant_concurrency import per_tenant_slot, per_tenant_storage_slot
+from core_api.services.agent_identity import ReservedAgentIdError, enforce_reserved_write_id
 from core_api.tasks import track_task
 
 try:
@@ -237,6 +238,12 @@ def _memory_to_out(
 async def create_memory(data: MemoryCreate) -> MemoryOut:
     if not data.agent_id:
         raise ValueError("agent_id must be resolved before calling create_memory")
+    # Reserved-id guard (`main` fix): single chokepoint for REST + MCP + STM.
+    # data.agent_id is already the resolved effective identity here.
+    try:
+        enforce_reserved_write_id(data.agent_id)
+    except ReservedAgentIdError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     if _USE_PIPELINE_WRITE:
         return await _create_memory_pipeline(data)
     logger.warning("legacy write path invoked; this path is deprecated and scheduled for removal")
@@ -1050,6 +1057,14 @@ async def create_memories_bulk(
     ``client_request_id`` so input order is preserved without relying on
     Postgres ``RETURNING`` order.
     """
+    if not data.agent_id:
+        raise ValueError("agent_id must be resolved before calling create_memories_bulk")
+    # Reserved-id guard (`main` fix): the batch attributes every item to the
+    # parent's resolved agent_id, so one check covers the whole batch.
+    try:
+        enforce_reserved_write_id(data.agent_id)
+    except ReservedAgentIdError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     sc = get_storage_client()
     t0 = time.perf_counter()
     items = data.items

--- a/tests/test_agent_identity_guard.py
+++ b/tests/test_agent_identity_guard.py
@@ -1,0 +1,83 @@
+"""Unit tests for the reserved-agent-id write guard (`main` identity fix, Phase 1).
+
+Covers `services.agent_identity.reserved_write_refusal` / `enforce_reserved_write_id`
+across the allow/warn/reject policy ladder, the escape hatch (a unique agent_id
+always passes), and the standalone-safety carve-out for `mcp-agent`.
+"""
+
+import pytest
+
+from core_api.config import settings
+from core_api.services.agent_identity import (
+    ReservedAgentIdError,
+    enforce_reserved_write_id,
+    reserved_write_refusal,
+)
+
+
+@pytest.fixture
+def policy(monkeypatch):
+    """Set settings.reserved_agent_id_policy for a test."""
+
+    def _set(value: str):
+        monkeypatch.setattr(settings, "reserved_agent_id_policy", value)
+
+    return _set
+
+
+@pytest.mark.parametrize(
+    "value,refuses",
+    [("allow", False), ("warn", False), ("reject", True)],
+)
+def test_main_per_policy(policy, value, refuses):
+    policy(value)
+    assert (reserved_write_refusal("main") is not None) is refuses
+
+
+@pytest.mark.parametrize("value", ["allow", "warn", "reject"])
+@pytest.mark.parametrize("agent_id", ["webclaw", "main-7765cca229ab", "quantclaw-prod"])
+def test_unique_id_always_passes_escape_hatch(policy, value, agent_id):
+    """Any non-reserved id proceeds under every policy — including the plugin
+    default `main-<install_id>`. This is the escape hatch the 409 advertises."""
+    policy(value)
+    assert reserved_write_refusal(agent_id) is None
+
+
+def test_mcp_agent_not_unconditionally_reserved(policy):
+    """`mcp-agent` is legitimate on the standalone path and is guarded
+    *conditionally* by the MCP gateway guard — never by this unconditional
+    write-path guard. Reserving it here would regress standalone."""
+    policy("reject")
+    assert reserved_write_refusal("mcp-agent") is None
+
+
+@pytest.mark.parametrize("agent_id", [None, ""])
+def test_missing_id_passes_here(policy, agent_id):
+    """A missing id is the upstream `if not data.agent_id: raise ValueError`
+    contract's job, not this guard's — return None (no false 409)."""
+    policy("reject")
+    assert reserved_write_refusal(agent_id) is None
+
+
+def test_reject_raises_domain_error_with_actionable_guidance(policy):
+    policy("reject")
+    with pytest.raises(ReservedAgentIdError) as exc:
+        enforce_reserved_write_id("main")
+    detail = str(exc.value)
+    # The message must tell the agent where its identity comes from.
+    assert "MEMCLAW_AGENT_ID" in detail
+    assert "install.json" in detail
+    assert 'main-<install_id>' in detail
+
+
+@pytest.mark.parametrize("value", ["allow", "warn"])
+def test_no_raise_under_allow_or_warn(policy, value):
+    policy(value)
+    enforce_reserved_write_id("main")  # must not raise
+
+
+def test_warn_emits_structured_log(policy, caplog):
+    policy("warn")
+    with caplog.at_level("WARNING"):
+        assert reserved_write_refusal("main") is None
+    assert any(r.message == "reserved_agent_write" for r in caplog.records)


### PR DESCRIPTION
## Why

Bare `agent_id="main"` is the OpenClaw plugin's **unset default** — without a per-install `MEMCLAW_AGENT_ID`, every install collapses onto one shared identity (the eToro "firehose": ~52K memories, ≥15 installs under one id). This PR reserves `main` on the write path so new writes stop refilling that bucket. It's the **delete-gate** for the bare-`main` cleanup and the first slice of the identity fix.

## What (Phase 1 — behind a flag, default `warn`)

- **`enforce_reserved_write_id`** (new `services/agent_identity.py`) enforced at the **`create_memory` / `create_memories_bulk` service boundary** — the single funnel for **REST, MCP and STM**. `data.agent_id` is the resolved *effective* id there, so:
  - a write supplying a **unique** `agent_id` (incl. the plugin's `main-<install_id>`) **passes** — the escape hatch;
  - only bare `main` is refused, with an **actionable 409** telling the agent how to set its identity (`MEMCLAW_AGENT_ID` / per-call arg / `main-<install_id>` from `install.json`). The MCP write tool's existing `except HTTPException` surfaces the detail into its error envelope.
- Reserved-id set **unified** in `core_api.agent_ids` (shared with the existing `mcp-agent` gateway guard). `mcp-agent` stays **standalone-safe** (guarded conditionally there, not unconditionally here).
- `warn` mode logs `reserved_agent_write` (core-api has no metrics backend → the log is the counter) so we confirm bare-`main` writes → ~0 before flipping to `reject`.

## Phase 2 (ships dark, `bind_write_identity_to_auth=false`)

Binds a write's `agent_id` to the verified credential identity, ignoring a body override (spoof hardening). Wired into both REST inner handlers but **off**; enable only **after** the reserved-`main` credentials are re-identified (else it pins them back onto `main`).

## Rollout

`warn` → measure → flip `reserved_agent_id_policy=reject` (config, no deploy) → run the bare-`main` delete → re-identify creds → flip `bind_write_identity_to_auth=true`. Instant rollback via the flags.

## Tests

`tests/test_agent_identity_guard.py` — 19 cases (policy ladder, escape hatch, `mcp-agent` standalone-safety, 409 guidance content, warn log). All green locally.

## Reviewer notes

1. **`mcp-agent` intentionally *not* unconditionally reserved** — standalone uses it; only `main` is unconditional. (Softens the "absorb both" suggestion to avoid a standalone regression.)
2. Enforcement is at the **service boundary**, not the REST handlers, so the MCP path (`memclaw_write → create_memory`) is covered — the gap the design review caught.

Refs: design `pr-plan-reserved-main-identity.md`, sequencing `roadmap-main-identity-fix.md`. Companion: PR-2 (plugin default-id), enterprise provisioning guard, re-identify script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)