### PR TITLE
feat(observability): sample below-floor near-misses on the /search recall log

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/log_recall_event.py
+++ b/core-api/src/core_api/pipeline/steps/search/log_recall_event.py
@@ -10,7 +10,11 @@ Gating (cheap, evaluated before any DB work) — two independent modes:
     → FULL log: returned candidates + a few below-floor near-misses.
   * ``source == "search"`` (the plugin's automatic path) +
     ``tenant_config.search_recall_logging_enabled`` → LIGHT log: returned
-    candidates only (no near-misses), since ``/search`` is high-volume.
+    candidates only, since ``/search`` is high-volume. Below-floor
+    near-misses are kept on a sampled fraction of events
+    (``search_recall_near_miss_sample_rate``, default 0.0) so the
+    "just-missed" distribution is still estimable without the full
+    candidate-row volume.
   * anything else → not logged.
 
 The actual writes run fire-and-forget in a background task (its own session),
@@ -21,6 +25,7 @@ swallowed so logging can never break a recall.
 from __future__ import annotations
 
 import logging
+import random
 
 from core_api.clients.storage_client import get_storage_client
 from core_api.pipeline.context import PipelineContext
@@ -69,7 +74,11 @@ class LogRecallEvent:
             elif source == "search":
                 if not getattr(cfg, "search_recall_logging_enabled", False):
                     return None
-                include_near_misses = False
+                # Returned-only by default; keep near-misses on a sampled
+                # fraction so the "just-missed" tail stays estimable on the
+                # high-volume path.
+                rate = getattr(cfg, "search_recall_near_miss_sample_rate", 0.0) or 0.0
+                include_near_misses = rate > 0 and random.random() < rate
             else:
                 return None
 

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -118,6 +118,15 @@ DEFAULT_SETTINGS: dict = {
         # be enabled for a short diagnostic window on a couple of tenants and
         # then turned back off.
         "search_recall_logging_enabled": None,
+        # Fraction (0.0-1.0) of ``/search`` events for which below-floor
+        # near-misses ARE recorded (only relevant when
+        # ``search_recall_logging_enabled`` is on). Default 0.0 = never (pure
+        # returned-only light mode). Set e.g. 0.01 to keep near-misses on ~1%
+        # of search events — enough to estimate the "just-missed" distribution
+        # (was the good memory rank 7 at cosine 0.27?) without the full
+        # candidate-row volume on the bulk path. Capped at the same
+        # ``_NEAR_MISS_LIMIT`` per sampled event as ``mcp_recall``.
+        "search_recall_near_miss_sample_rate": None,
     },
     "chunking": {
         "auto_chunk_enabled": None,
@@ -475,6 +484,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "insights.auto_insights_enabled": bool,
     "observability.recall_logging_enabled": bool,
     "observability.search_recall_logging_enabled": bool,
+    "observability.search_recall_near_miss_sample_rate": (int, float),
     "chunking.auto_chunk_enabled": bool,
     "agents.require_agent_approval": bool,
     "entity_blocklist": list,
@@ -841,6 +851,16 @@ class ResolvedConfig:
     def search_recall_logging_enabled(self) -> bool:
         val = self._ts.get("observability", {}).get("search_recall_logging_enabled")
         return val if val is not None else False
+
+    # Fraction of ``/search`` events that keep below-floor near-misses
+    # (default 0.0). Clamped to [0.0, 1.0]. Only consulted when
+    # ``search_recall_logging_enabled`` is on.
+    @property
+    def search_recall_near_miss_sample_rate(self) -> float:
+        val = self._ts.get("observability", {}).get("search_recall_near_miss_sample_rate")
+        if val is None:
+            return 0.0
+        return max(0.0, min(1.0, float(val)))
 
     # Chunking
     @property

--- a/tests/pipeline/test_log_recall_event.py
+++ b/tests/pipeline/test_log_recall_event.py
@@ -29,10 +29,11 @@ def _row(vec_sim, score, recall_boost=1.0):
     )
 
 
-def _cfg(recall=False, search=False):
+def _cfg(recall=False, search=False, near_miss_rate=0.0):
     return SimpleNamespace(
         recall_logging_enabled=recall,
         search_recall_logging_enabled=search,
+        search_recall_near_miss_sample_rate=near_miss_rate,
     )
 
 
@@ -147,6 +148,26 @@ async def test_search_logs_returned_only_no_near_misses(monkeypatch):
     assert candidates[0]["vec_sim"] == 0.60
     assert candidates[0]["final_score"] == 0.58
     assert all(isinstance(c["memory_id"], str) for c in candidates)
+
+
+@pytest.mark.asyncio
+async def test_search_keeps_near_misses_when_sampled(monkeypatch):
+    # near_miss_rate=1.0 → always sampled (random.random() < 1.0 is always True),
+    # so the /search path keeps near-misses on this event.
+    captured = _capture(monkeypatch)
+    returned = [_row(0.60, 0.58), _row(0.55, 0.54)]
+    near = [_row(0.28 - i * 0.01, 0.2) for i in range(7)]
+    raw = returned + near
+    ctx = _ctx("search", _cfg(search=True, near_miss_rate=1.0), returned, raw)
+
+    await LogRecallEvent().execute(ctx)
+
+    assert len(captured) == 1
+    event, candidates = captured[0]
+    assert event["source"] == "search"
+    # 2 returned + capped 5 near-misses = 7 (same cap as mcp_recall).
+    assert len(candidates) == 7
+    assert [c["returned"] for c in candidates] == [True, True, False, False, False, False, False]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
Follow-up to #503. The `/search` recall log is **returned-only** (to bound volume on the high-traffic auto path), which drops below-floor / outside-top-k **near-misses** — the exact signal needed to distinguish *just-missed* (the good memory was rank 7 at cosine 0.27) from *never close* when validating claims like eToro's "95% never recalled".

Adds a per-tenant knob **`observability.search_recall_near_miss_sample_rate`** (0.0–1.0, default **0.0**):
- `0.0` (default) → unchanged: returned-only.
- `>0` → keep near-misses on that random fraction of `/search` events, capped at the same `_NEAR_MISS_LIMIT` (5) as `mcp_recall`.

So e.g. `0.01` keeps the just-missed distribution estimable on ~1% of search events without the full candidate-row volume. `mcp_recall` is unchanged (always full incl. near-misses).

## Why
On the dominant path you could see *what was returned* but not *what just missed*. This restores that lens cheaply, behind a sampling rate, so it's safe to leave on for a busy tenant during a diagnostic window.

## Per-memory certainty (note)
Sampled near-misses characterise the **marginal band** (cap = 5). For the per-memory *"is THIS memory ever close to any query?"* question, offline replay against the logged queries remains the rigorous tool — no bulk near-miss firehose required.

## Tests
`tests/pipeline/test_log_recall_event.py`: added `test_search_keeps_near_misses_when_sampled` (rate=1.0 → near-misses kept); existing returned-only test now exercises the default rate=0.0. ruff + format + mypy clean; 30 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)