### PR TITLE
core-api: add Datadog APM (ddtrace + serverless-init)

### DIFF
--- a/core-api/Dockerfile
+++ b/core-api/Dockerfile
@@ -1,6 +1,23 @@
 # Dockerfile for Core API service
 # The main MemClaw API — auth, agents, memory, MCP, etc.
 
+# Optional Datadog serverless-init source (CAURA-0000 observability POC).
+# The Caura SaaS deploy builds with --build-arg DD_APM_ENABLED=true to pull in
+# Datadog's serverless-init binary; OSS / on-prem / local builds leave it
+# ``false`` so the binary is never fetched (BuildKit prunes the unreferenced
+# datadog/serverless-init stage) and never lands in the image. Runtime
+# activation is further gated by docker-entrypoint.sh on DD_API_KEY, so even a
+# SaaS image stays a no-op until a key is supplied.
+ARG DD_APM_ENABLED=false
+# Pinned by digest (tag :1 floats) so the embedded binary is reproducible.
+# datadog/serverless-init:1 as of 2026-06-30; bump deliberately.
+FROM datadog/serverless-init:1@sha256:2f498f4b1165ac3551c34129b4f0c0c7bd99d82c55c4e95cf494b55dad8d05d0 AS dd-bin
+FROM python:3.12-slim AS dd-apm-true
+COPY --from=dd-bin /datadog-init /dd/datadog-init
+FROM python:3.12-slim AS dd-apm-false
+RUN mkdir -p /dd
+FROM dd-apm-${DD_APM_ENABLED} AS dd-apm-src
+
 FROM python:3.12-slim AS builder
 
 WORKDIR /app
@@ -26,8 +43,12 @@ RUN mkdir -p core-api/src/core_api && touch core-api/src/core_api/__init__.py
 # keep the image small and cold-start fast. Build with --build-arg WITH_INGEST=1
 # for a deployment that serves the /ingest/* endpoints.
 ARG WITH_INGEST=0
+# DD_APM_ENABLED pulls in the ddtrace tracer via the ``datadog`` extra; only the
+# SaaS build sets it, so OSS / on-prem images carry no Datadog Python code.
+ARG DD_APM_ENABLED=false
 RUN EXTRAS="--extra pubsub"; \
     if [ "$WITH_INGEST" = "1" ]; then EXTRAS="$EXTRAS --extra ingest"; fi; \
+    if [ "$DD_APM_ENABLED" = "true" ]; then EXTRAS="$EXTRAS --extra datadog"; fi; \
     uv export --frozen --no-dev $EXTRAS --no-emit-project \
       --directory core-api -o /tmp/reqs.txt \
     && uv pip install --system --no-cache -r /tmp/reqs.txt
@@ -72,8 +93,23 @@ ENV PYTHONPATH="/app/core-api/src:/app"
 ENV PYTHONUNBUFFERED=1
 ENV ENVIRONMENT=production
 
+# Datadog APM (CAURA-0000 observability POC) — single-container Cloud Run
+# pattern. serverless-init starts an in-process trace/log agent on localhost and
+# execs the app under ``ddtrace-run`` (no sidecar; the datadog-ci sidecar path is
+# incompatible with our VPC-connector services, and this survives pipeline
+# redeploys). The wrapper is OPT-IN: docker-entrypoint.sh only invokes it when
+# DD_API_KEY is set (the SaaS deploy), so OSS / on-prem / local runs get plain
+# uvicorn with no Datadog. The binary is only present in DD_APM_ENABLED=true
+# builds (see the dd-apm-src stage at the top of this file); /app/dd is empty
+# otherwise.
+COPY --from=dd-apm-src --chown=appuser:appuser /dd /app/dd
+# docker-entrypoint.sh is committed with the executable bit set, so COPY
+# preserves it — no chmod layer needed.
+COPY --chown=appuser:appuser core-api/docker-entrypoint.sh /app/docker-entrypoint.sh
+
 USER appuser
 
 EXPOSE 8000
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["uvicorn", "core_api.app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--timeout-keep-alive", "65"]

--- a/core-api/docker-entrypoint.sh
+++ b/core-api/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# core-api container entrypoint.
+#
+# Datadog APM (CAURA-0000 observability POC) is OPT-IN and activates only when a
+# Datadog API key is supplied at runtime — i.e. the Caura SaaS deploy, which
+# injects DD_API_KEY + DD_TRACE_ENABLED. OSS / on-prem / local runs supply no
+# key, so they see no Datadog at all: no serverless-init, no ddtrace, no log
+# mutation — just the app. The serverless-init binary is only present in images
+# built with --build-arg DD_APM_ENABLED=true (see core-api/Dockerfile); the
+# -x check below is belt-and-suspenders for any image built without it.
+set -e
+
+# DD_TRACE_ENABLED is an explicit kill-switch; honor the common falsy spellings
+# (matches ddtrace's own asbool parsing) rather than only exact "false".
+case "${DD_TRACE_ENABLED:-true}" in
+  false|False|FALSE|0|no|No|NO|off|Off|OFF) dd_trace_on=0 ;;
+  *) dd_trace_on=1 ;;
+esac
+
+if [ -n "${DD_API_KEY:-}" ] && [ "$dd_trace_on" = "1" ] && [ -x /app/dd/datadog-init ]; then
+  exec /app/dd/datadog-init ddtrace-run "$@"
+fi
+
+exec "$@"

--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -58,6 +58,13 @@ dependencies = [
 # Optional: required only when EVENT_BUS_BACKEND=pubsub (SaaS deployments).
 # Standalone installs default to the in-process bus and don't need this.
 pubsub = ["google-cloud-pubsub>=2.23,<3"]
+# Datadog APM tracer (CAURA-0000 observability POC). Opt-in: the app runs under
+# ``ddtrace-run`` only in the Caura SaaS deploy (see Dockerfile /
+# docker-entrypoint.sh). Kept out of the default install so OSS / on-prem /
+# local images carry zero Datadog code. Build with `--extra datadog`
+# (Dockerfile: --build-arg DD_APM_ENABLED=true). Auto-instruments FastAPI /
+# SQLAlchemy / asyncpg / httpx / redis with no code changes.
+datadog = ["ddtrace>=4.10.6"]
 # Optional: multi-format document extraction for the /ingest/* endpoints.
 # Kreuzberg (~64MB, Elastic-2.0) is excluded from the default image to cut
 # cold-start pull + import time — the ingest endpoints return 501 without it

--- a/core-api/uv.lock
+++ b/core-api/uv.lock
@@ -195,6 +195,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bytecode"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/8f/7d12c539869a5cbd801d550b86cc0f030ecaeb12f57f8b3ff19f2d2a184c/bytecode-0.18.1.tar.gz", hash = "sha256:d9564f1565fe1ae6a1173e544ef43a85f093e83997ef45af65d0d250eb48d7a1", size = 104631, upload-time = "2026-06-03T14:17:59.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/ef/6a629424ec08adc3819ddfd7ec0a710361eaa29d1e5fffb4e02f074be5c9/bytecode-0.18.1-py3-none-any.whl", hash = "sha256:9535bfdd665260b2888ec4121569e3ca5106965a7fedbb6de6ba1bafebc5c7d7", size = 42868, upload-time = "2026-06-03T14:17:57.654Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -365,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "core-api"
-version = "2.16.0"
+version = "2.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -400,6 +409,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+datadog = [
+    { name = "ddtrace" },
+]
 dev = [
     { name = "aiosqlite" },
     { name = "google-cloud-pubsub" },
@@ -436,6 +448,7 @@ requires-dist = [
     { name = "core-api", extras = ["test", "pubsub", "ingest"], marker = "extra == 'dev'" },
     { name = "croniter", specifier = ">=2.0" },
     { name = "cryptography", specifier = ">=42.0" },
+    { name = "ddtrace", marker = "extra == 'datadog'", specifier = ">=4.10.6" },
     { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "google-cloud-aiplatform", specifier = ">=1.80,<2" },
     { name = "google-cloud-pubsub", marker = "extra == 'pubsub'", specifier = ">=2.23,<3" },
@@ -469,7 +482,7 @@ requires-dist = [
     { name = "types-croniter", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1" },
 ]
-provides-extras = ["pubsub", "ingest", "dev", "test"]
+provides-extras = ["pubsub", "datadog", "ingest", "dev", "test"]
 
 [[package]]
 name = "coverage"
@@ -618,6 +631,47 @@ wheels = [
 ]
 
 [[package]]
+name = "ddtrace"
+version = "4.10.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bytecode" },
+    { name = "envier" },
+    { name = "opentelemetry-api" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/22/2fd7af9bc4118d4223627e4a98b679d4111d058688798877427b4a2be6df/ddtrace-4.10.6.tar.gz", hash = "sha256:cd6c877c232bc82834cd068d454c31569e9ba68967ef9f15ef41711124b1fa66", size = 2343462, upload-time = "2026-06-29T15:48:13.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/ad/251cac89e99469c8a63ffc17703ad420d84df6ce35ad292620ed53011682/ddtrace-4.10.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8ad4eb33c30f03bd581ce675b9b49caafa946d30ba4d75bdfae8327961c8448a", size = 6980965, upload-time = "2026-06-29T15:46:24.085Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5f/fa5055fc5e4c08fff0a23a52d820c96037865493198a402afc3a89238f23/ddtrace-4.10.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:1524fc49eaa0b9bd08baea6e0249029c43e5d2971635f5b0341eedb694129b83", size = 7305894, upload-time = "2026-06-29T15:46:26.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c4/84d4b147fb3580515f7dc419719bc7be2fbcaea946e0aa671f1814caa9ee/ddtrace-4.10.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:99fa47d78bf0d5f3c053f28e406c488bf69019c2e7ce16f0efb621162dae34b0", size = 8412325, upload-time = "2026-06-29T15:46:29.362Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ae/4504a7db4e1b4bb4aef59c7012510c0b17ce7d95475a324f4e7e0f2a4bd9/ddtrace-4.10.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:764120dee8dde534154cd26229baa2fb812bb1157c39768c8410348453da3a2a", size = 8635843, upload-time = "2026-06-29T15:46:35.263Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/34/f369b7db72946ee95387e7f529d0413b41a1e27daa4cf28eb7e956651e50/ddtrace-4.10.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5ad0b4f7d50808fd210d6d52b78057308e39d336c078ecff10d0ea775881e6f8", size = 9418429, upload-time = "2026-06-29T15:46:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/16/9f199a55a2ea3affd053eb29728fcd5707b9966fb8bed2bcbbdfd65b3b24/ddtrace-4.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e1fe13af69cd34d897e7289fc56beb4b78cfd866b235304ddcc0b97050a5bd8f", size = 9688989, upload-time = "2026-06-29T15:46:40.841Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/fd0b549f1c19fd2e0bd69865db0113a1d1c741d8576adccc38f20ce0210e/ddtrace-4.10.6-cp312-cp312-win32.whl", hash = "sha256:e276cf348152a431d7348bdc1c69232d7a4ca71d6d6d504e01e4eb12a7e30bc9", size = 5587062, upload-time = "2026-06-29T15:46:43.387Z" },
+    { url = "https://files.pythonhosted.org/packages/73/2e/8a4fcfd8d53c46ec62eb02c5e5541f1c5fe073f2a3f3ed0ef6a2bd0f83b2/ddtrace-4.10.6-cp312-cp312-win_amd64.whl", hash = "sha256:e0674a637ee52e4396c47d15fadefa39f342741a289a912a6f90d1f3a00e0b00", size = 6159976, upload-time = "2026-06-29T15:46:45.566Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/c0bf3ae46c930d3d48252d57cd5640a5d40aba6e9f47bf1e57ea761c04da/ddtrace-4.10.6-cp312-cp312-win_arm64.whl", hash = "sha256:da83e10c7fec868b3c00db4dbb7f0d048fa048e4db14d8da558efbf1f8b4d285", size = 5840553, upload-time = "2026-06-29T15:46:48.163Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e5/7f5dbadf7dd21b64bd899b7bf07a49b6b09fc9ec2e865fa0835921c97d53/ddtrace-4.10.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:5bf629942ae7e691ce3f0e2565f0808717e03350bc6cf22f781873c26d65e121", size = 6974259, upload-time = "2026-06-29T15:46:50.648Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f3/dbdd6b59dc30dea877502b0613fb78d69f56afbb8c67bc562dd019f090c7/ddtrace-4.10.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:1870a0c36945f76ad6b7a9d8c57a7fbb247049a7b79c96d424b34fb3f24535c1", size = 7299104, upload-time = "2026-06-29T15:46:53.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7f/88a9670409049eda4004a42c32aa66884462099f64c27d9a6226dcc44bdd/ddtrace-4.10.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e5879341603df0bd3c9699abbd5da83ca5a38b638ac42b2b9355a3fd6ffca927", size = 8406135, upload-time = "2026-06-29T15:46:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f9/456981881162e9640b6e0105280ae55c1f2026c01a5c6b65876ebad94b53/ddtrace-4.10.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d05dc9a6449ad2cf3bcead2f757e509ec3d598dd83b39e3e884b52b49abffdce", size = 8627275, upload-time = "2026-06-29T15:46:58.73Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d8/8e8ab7370df76a43d55a09f72bd0592343185b67b5d4532c08571dbb33a3/ddtrace-4.10.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5a17da207152cb6eac06ad6e827bf74daa05eb6dff628f06b7d8e63b4abefe3e", size = 9414877, upload-time = "2026-06-29T15:47:01.505Z" },
+    { url = "https://files.pythonhosted.org/packages/23/68/a2e3f65f6b25d9ef7e5b9080198b268c8de36e12c0c06fdf5717bb6491e0/ddtrace-4.10.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d032f36cb8b92aca49a840d3c16fdf6da01d26431af3db361fc3b148f149977a", size = 9682496, upload-time = "2026-06-29T15:47:05.035Z" },
+    { url = "https://files.pythonhosted.org/packages/24/83/cbe28480206a85e0060a5ae9cf7e948b83543f71e876368389eb763633e0/ddtrace-4.10.6-cp313-cp313-win32.whl", hash = "sha256:09e963b4bb823855e7ac8729d81cfbadf20c88887b1a41fe2a4d60323bfc95d7", size = 5584250, upload-time = "2026-06-29T15:47:07.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/37/d149fc0f9c881e16a327fc0526d8385125d9262b2c2584b8446dc1011108/ddtrace-4.10.6-cp313-cp313-win_amd64.whl", hash = "sha256:be209b122b3d109beb06b2638c88005e51c67bf4ca5185341065b2b83b77202f", size = 6156992, upload-time = "2026-06-29T15:47:11.345Z" },
+    { url = "https://files.pythonhosted.org/packages/66/a8/3435ee577beab7a76ccf04572234d9c2c85ed1f7c758a7192e53920e2893/ddtrace-4.10.6-cp313-cp313-win_arm64.whl", hash = "sha256:9d6763dd7fcd3be2bb1af5a75c7ff1077ebc0178cccf059d8f152eda416c7ed4", size = 5837939, upload-time = "2026-06-29T15:47:14.445Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/e7fa5570a0fca203d81436d5d0260614876c3a0a72e38856340cd5764b16/ddtrace-4.10.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c59e74357df419db3b5d2ea2429ef38367c42e86f64e238b68dd5557ceeccfaf", size = 6978516, upload-time = "2026-06-29T15:47:17.019Z" },
+    { url = "https://files.pythonhosted.org/packages/34/96/4069b46232541e003e08939caf80704de747aae70fcba8aaef1aa3b6706c/ddtrace-4.10.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:d2f63a74cea172e781e4772b8d5389d9ed992566bba587e886fce50e63725cc6", size = 7302804, upload-time = "2026-06-29T15:47:19.824Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ab/ad5a4c82787e9795e9a2992b3c3c0c2f1657168f5381e54934a5808b4c30/ddtrace-4.10.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:65973689c313099d7ed8051aadc80977359a2c281ea879c34d874e0bcfc10c7b", size = 8415926, upload-time = "2026-06-29T15:47:22.598Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/22/72ab8920bb74eb27984f3dad62b1bfa218c9f185feb8b7a952b33b8c1773/ddtrace-4.10.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2cc7f73a5363a1ef55bb37634fc7924b966ea3cd6910c821b316276fd8a9b11b", size = 8630424, upload-time = "2026-06-29T15:47:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/0b/c067c5b878bcaa94166d5ee4333b8fa28d67b7d48c21d262de66c311422f/ddtrace-4.10.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:211a0bbc701b0b90dbec8592c4987bc8347fd1911d1ef3d2a22765837984ff04", size = 9426201, upload-time = "2026-06-29T15:47:29.111Z" },
+    { url = "https://files.pythonhosted.org/packages/25/16/4778aa38b57b25450a2bc324142adf9cb87a66b4976328c43af607fc325f/ddtrace-4.10.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4c4a07b52e3c3d9a095acc899ec59fb6d81e4f1cf373736b6c9f3fc844ae38cf", size = 9689078, upload-time = "2026-06-29T15:47:32.483Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c4/a1d862f437dc73b74174ba2d9a83d30b478f13195ca788e2b42ea89ec00c/ddtrace-4.10.6-cp314-cp314-win32.whl", hash = "sha256:2ae32626cd5bad9f38dc5b3e04fc5963e5a53c985cba313c5034be4451976b03", size = 5683008, upload-time = "2026-06-29T15:47:36.174Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c5/fd5e27176d9827c1e0807420066cf54ca418a474c1977f04e7b0053fc00c/ddtrace-4.10.6-cp314-cp314-win_amd64.whl", hash = "sha256:cd1d85d2e1867dbe04941cb4cb3eab616a6e69affd36bdfb31d2aba01eab15f2", size = 6298853, upload-time = "2026-06-29T15:47:39.082Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4d/9532f5c68b062798c462122726a8ea3d9743d1a8070a40a58625a00a5095/ddtrace-4.10.6-cp314-cp314-win_arm64.whl", hash = "sha256:525f2d61bf7a2b5a7faced7581a7a123fc533413d7a62398a0c2890a5bee3504", size = 5988797, upload-time = "2026-06-29T15:47:42.116Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -657,6 +711,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
+]
+
+[[package]]
+name = "envier"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e7/4fe4d3f6e21213cea9bcddc36ba60e6ae4003035f9ce8055e6a9f0322ddb/envier-0.6.1.tar.gz", hash = "sha256:3309a01bb3d8850c9e7a31a5166d5a836846db2faecb79b9cb32654dd50ca9f9", size = 10063, upload-time = "2024-10-22T09:56:47.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/e9/30493b1cc967f7c07869de4b2ab3929151a58e6bb04495015554d24b61db/envier-0.6.1-py3-none-any.whl", hash = "sha256:73609040a76be48bbcb97074d9969666484aa0de706183a6e9ef773156a8a6a9", size = 10638, upload-time = "2024-10-22T09:56:45.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Datadog APM instrumentation for **core-api** (CAURA-0000 observability POC).

- Add `ddtrace>=4.10.6` to `core-api/pyproject.toml` (+ refreshed frozen `uv.lock`).
- Instrument the image the single-container Cloud Run way: `datadog/serverless-init` becomes the entrypoint and runs the app under `ddtrace-run`, shipping spans to the in-process agent on localhost.

## Why this shape
- **No sidecar:** `datadog-ci cloud-run instrument` is incompatible with our VPC-connector services (it round-trips `vpc_access.connector` into a form the Cloud Run API rejects) **and** a live sidecar mutation would be wiped by the deploy pipeline. The in-image entrypoint survives redeploys.
- Tracing stays **dormant** unless the deploy supplies `DD_API_KEY`/`DD_SITE`/`DD_SERVICE`/`DD_ENV`.

## Verified
Image builds; `ddtrace 4.10.6` imports; `ddtrace-run` + `/app/datadog-init` present.

## Paired PR
Deploy wiring (env + Secret Manager key + `service` label) lives in **caura-memclaw-enterprise** — link added below. Merge both for APM to activate on `staging-memclaw-core-api`.