### PR TITLE
core-{storage-api,worker,operations}: add opt-in Datadog APM

### DIFF
--- a/core-operations/Dockerfile
+++ b/core-operations/Dockerfile
@@ -2,6 +2,20 @@
 # Single-purpose service that hosts cron/scheduled background jobs.
 # Minimal HTTP surface (only /healthz) — Cloud Run probes hit it.
 
+# Optional Datadog serverless-init source (CAURA-0000 observability POC).
+# SaaS builds pass --build-arg DD_APM_ENABLED=true to pull in Datadog's
+# serverless-init binary; OSS / on-prem / local builds leave it false so the
+# binary is never fetched (BuildKit prunes the unreferenced stage) and never
+# lands in the image. Runtime activation is further gated by
+# docker-entrypoint.sh on DD_API_KEY.
+ARG DD_APM_ENABLED=false
+FROM datadog/serverless-init:1@sha256:2f498f4b1165ac3551c34129b4f0c0c7bd99d82c55c4e95cf494b55dad8d05d0 AS dd-bin
+FROM python:3.12-slim AS dd-apm-true
+COPY --from=dd-bin /datadog-init /dd/datadog-init
+FROM python:3.12-slim AS dd-apm-false
+RUN mkdir -p /dd
+FROM dd-apm-${DD_APM_ENABLED} AS dd-apm-src
+
 FROM python:3.12-slim AS builder
 
 WORKDIR /app
@@ -13,7 +27,12 @@ WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:0.9.18 /uv /usr/local/bin/uv
 COPY core-operations/pyproject.toml core-operations/uv.lock ./core-operations/
 RUN mkdir -p core-operations/src/core_operations && touch core-operations/src/core_operations/__init__.py
-RUN uv export --frozen --no-dev --extra pubsub --no-emit-project \
+# DD_APM_ENABLED pulls in the ddtrace tracer via the ``datadog`` extra; only the
+# SaaS build sets it, so OSS / on-prem images carry no Datadog Python code.
+ARG DD_APM_ENABLED=false
+RUN EXTRAS="--extra pubsub"; \
+    if [ "$DD_APM_ENABLED" = "true" ]; then EXTRAS="$EXTRAS --extra datadog"; fi; \
+    uv export --frozen --no-dev $EXTRAS --no-emit-project \
       --directory core-operations -o /tmp/reqs.txt \
     && uv pip install --system --no-cache -r /tmp/reqs.txt
 
@@ -35,10 +54,18 @@ COPY --from=builder --chown=appuser:appuser /app /app
 ENV PYTHONPATH="/app/core-operations/src:/app"
 ENV PYTHONUNBUFFERED=1
 
+# Datadog APM (opt-in; see top-of-file dd-apm stage + docker-entrypoint.sh).
+# /app/dd is empty unless built with DD_APM_ENABLED=true.
+COPY --from=dd-apm-src --chown=appuser:appuser /dd /app/dd
+COPY --chown=appuser:appuser core-operations/docker-entrypoint.sh /app/docker-entrypoint.sh
+
 USER appuser
 
 EXPOSE 8080
 
+# ENTRYPOINT is the opt-in Datadog shim; it exec's the CMD (plain, or wrapped
+# under serverless-init + ddtrace-run when DD_API_KEY is set).
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 # `sh -c "exec …"` so PID 1 ends up as uvicorn (not dash). Without
 # `exec` the shell stays as PID 1 and Debian's dash does NOT forward
 # SIGTERM to its child — Cloud Run's grace period would then expire

--- a/core-operations/docker-entrypoint.sh
+++ b/core-operations/docker-entrypoint.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
-# core-api container entrypoint.
+# Core service container entrypoint.
 #
 # Datadog APM (CAURA-0000 observability POC) is OPT-IN and activates only when a
 # Datadog API key is supplied at runtime — i.e. the Caura SaaS deploy, which
 # injects DD_API_KEY + DD_TRACE_ENABLED. OSS / on-prem / local runs supply no
 # key, so they see no Datadog at all: no serverless-init, no ddtrace, no log
 # mutation — just the app. The serverless-init binary is only present in images
-# built with --build-arg DD_APM_ENABLED=true (see core-api/Dockerfile); the
-# -x check below is belt-and-suspenders for any image built without it.
+# built with --build-arg DD_APM_ENABLED=true (see the Dockerfile); the -x check
+# below is belt-and-suspenders for any image built without it.
 set -e
 
 # DD_TRACE_ENABLED is an explicit kill-switch; honor the common falsy spellings

--- a/core-operations/pyproject.toml
+++ b/core-operations/pyproject.toml
@@ -19,6 +19,10 @@ dependencies = [
 
 [project.optional-dependencies]
 pubsub = ["google-cloud-pubsub>=2.23,<3"]
+# Datadog APM tracer (CAURA-0000). Opt-in: installed only in SaaS builds via
+# --build-arg DD_APM_ENABLED=true (--extra datadog); OSS/on-prem carry no
+# Datadog code. Auto-instruments FastAPI/httpx/pubsub.
+datadog = ["ddtrace>=4.10.6"]
 dev = [
     "core-operations[test,pubsub]",
     "mypy>=1.13,<3.0",

--- a/core-operations/uv.lock
+++ b/core-operations/uv.lock
@@ -80,6 +80,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bytecode"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/8f/7d12c539869a5cbd801d550b86cc0f030ecaeb12f57f8b3ff19f2d2a184c/bytecode-0.18.1.tar.gz", hash = "sha256:d9564f1565fe1ae6a1173e544ef43a85f093e83997ef45af65d0d250eb48d7a1", size = 104631, upload-time = "2026-06-03T14:17:59.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/ef/6a629424ec08adc3819ddfd7ec0a710361eaa29d1e5fffb4e02f074be5c9/bytecode-0.18.1-py3-none-any.whl", hash = "sha256:9535bfdd665260b2888ec4121569e3ca5106965a7fedbb6de6ba1bafebc5c7d7", size = 42868, upload-time = "2026-06-03T14:17:57.654Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -264,6 +273,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+datadog = [
+    { name = "ddtrace" },
+]
 dev = [
     { name = "google-cloud-pubsub" },
     { name = "httpx" },
@@ -287,6 +299,7 @@ test = [
 requires-dist = [
     { name = "cachetools", specifier = ">=5.3,<8" },
     { name = "core-operations", extras = ["test", "pubsub"], marker = "extra == 'dev'" },
+    { name = "ddtrace", marker = "extra == 'datadog'", specifier = ">=4.10.6" },
     { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "google-cloud-pubsub", marker = "extra == 'pubsub'", specifier = ">=2.23,<3" },
     { name = "httpx", specifier = ">=0.27,<1" },
@@ -302,7 +315,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.4,<27" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1" },
 ]
-provides-extras = ["pubsub", "dev", "test"]
+provides-extras = ["pubsub", "datadog", "dev", "test"]
 
 [[package]]
 name = "coverage"
@@ -436,6 +449,56 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
     { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
     { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
+name = "ddtrace"
+version = "4.10.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bytecode" },
+    { name = "envier" },
+    { name = "opentelemetry-api" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/22/2fd7af9bc4118d4223627e4a98b679d4111d058688798877427b4a2be6df/ddtrace-4.10.6.tar.gz", hash = "sha256:cd6c877c232bc82834cd068d454c31569e9ba68967ef9f15ef41711124b1fa66", size = 2343462, upload-time = "2026-06-29T15:48:13.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/ad/251cac89e99469c8a63ffc17703ad420d84df6ce35ad292620ed53011682/ddtrace-4.10.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8ad4eb33c30f03bd581ce675b9b49caafa946d30ba4d75bdfae8327961c8448a", size = 6980965, upload-time = "2026-06-29T15:46:24.085Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5f/fa5055fc5e4c08fff0a23a52d820c96037865493198a402afc3a89238f23/ddtrace-4.10.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:1524fc49eaa0b9bd08baea6e0249029c43e5d2971635f5b0341eedb694129b83", size = 7305894, upload-time = "2026-06-29T15:46:26.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c4/84d4b147fb3580515f7dc419719bc7be2fbcaea946e0aa671f1814caa9ee/ddtrace-4.10.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:99fa47d78bf0d5f3c053f28e406c488bf69019c2e7ce16f0efb621162dae34b0", size = 8412325, upload-time = "2026-06-29T15:46:29.362Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ae/4504a7db4e1b4bb4aef59c7012510c0b17ce7d95475a324f4e7e0f2a4bd9/ddtrace-4.10.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:764120dee8dde534154cd26229baa2fb812bb1157c39768c8410348453da3a2a", size = 8635843, upload-time = "2026-06-29T15:46:35.263Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/34/f369b7db72946ee95387e7f529d0413b41a1e27daa4cf28eb7e956651e50/ddtrace-4.10.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5ad0b4f7d50808fd210d6d52b78057308e39d336c078ecff10d0ea775881e6f8", size = 9418429, upload-time = "2026-06-29T15:46:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/16/9f199a55a2ea3affd053eb29728fcd5707b9966fb8bed2bcbbdfd65b3b24/ddtrace-4.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e1fe13af69cd34d897e7289fc56beb4b78cfd866b235304ddcc0b97050a5bd8f", size = 9688989, upload-time = "2026-06-29T15:46:40.841Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/fd0b549f1c19fd2e0bd69865db0113a1d1c741d8576adccc38f20ce0210e/ddtrace-4.10.6-cp312-cp312-win32.whl", hash = "sha256:e276cf348152a431d7348bdc1c69232d7a4ca71d6d6d504e01e4eb12a7e30bc9", size = 5587062, upload-time = "2026-06-29T15:46:43.387Z" },
+    { url = "https://files.pythonhosted.org/packages/73/2e/8a4fcfd8d53c46ec62eb02c5e5541f1c5fe073f2a3f3ed0ef6a2bd0f83b2/ddtrace-4.10.6-cp312-cp312-win_amd64.whl", hash = "sha256:e0674a637ee52e4396c47d15fadefa39f342741a289a912a6f90d1f3a00e0b00", size = 6159976, upload-time = "2026-06-29T15:46:45.566Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/c0bf3ae46c930d3d48252d57cd5640a5d40aba6e9f47bf1e57ea761c04da/ddtrace-4.10.6-cp312-cp312-win_arm64.whl", hash = "sha256:da83e10c7fec868b3c00db4dbb7f0d048fa048e4db14d8da558efbf1f8b4d285", size = 5840553, upload-time = "2026-06-29T15:46:48.163Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e5/7f5dbadf7dd21b64bd899b7bf07a49b6b09fc9ec2e865fa0835921c97d53/ddtrace-4.10.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:5bf629942ae7e691ce3f0e2565f0808717e03350bc6cf22f781873c26d65e121", size = 6974259, upload-time = "2026-06-29T15:46:50.648Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f3/dbdd6b59dc30dea877502b0613fb78d69f56afbb8c67bc562dd019f090c7/ddtrace-4.10.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:1870a0c36945f76ad6b7a9d8c57a7fbb247049a7b79c96d424b34fb3f24535c1", size = 7299104, upload-time = "2026-06-29T15:46:53.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7f/88a9670409049eda4004a42c32aa66884462099f64c27d9a6226dcc44bdd/ddtrace-4.10.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e5879341603df0bd3c9699abbd5da83ca5a38b638ac42b2b9355a3fd6ffca927", size = 8406135, upload-time = "2026-06-29T15:46:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f9/456981881162e9640b6e0105280ae55c1f2026c01a5c6b65876ebad94b53/ddtrace-4.10.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d05dc9a6449ad2cf3bcead2f757e509ec3d598dd83b39e3e884b52b49abffdce", size = 8627275, upload-time = "2026-06-29T15:46:58.73Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d8/8e8ab7370df76a43d55a09f72bd0592343185b67b5d4532c08571dbb33a3/ddtrace-4.10.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5a17da207152cb6eac06ad6e827bf74daa05eb6dff628f06b7d8e63b4abefe3e", size = 9414877, upload-time = "2026-06-29T15:47:01.505Z" },
+    { url = "https://files.pythonhosted.org/packages/23/68/a2e3f65f6b25d9ef7e5b9080198b268c8de36e12c0c06fdf5717bb6491e0/ddtrace-4.10.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d032f36cb8b92aca49a840d3c16fdf6da01d26431af3db361fc3b148f149977a", size = 9682496, upload-time = "2026-06-29T15:47:05.035Z" },
+    { url = "https://files.pythonhosted.org/packages/24/83/cbe28480206a85e0060a5ae9cf7e948b83543f71e876368389eb763633e0/ddtrace-4.10.6-cp313-cp313-win32.whl", hash = "sha256:09e963b4bb823855e7ac8729d81cfbadf20c88887b1a41fe2a4d60323bfc95d7", size = 5584250, upload-time = "2026-06-29T15:47:07.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/37/d149fc0f9c881e16a327fc0526d8385125d9262b2c2584b8446dc1011108/ddtrace-4.10.6-cp313-cp313-win_amd64.whl", hash = "sha256:be209b122b3d109beb06b2638c88005e51c67bf4ca5185341065b2b83b77202f", size = 6156992, upload-time = "2026-06-29T15:47:11.345Z" },
+    { url = "https://files.pythonhosted.org/packages/66/a8/3435ee577beab7a76ccf04572234d9c2c85ed1f7c758a7192e53920e2893/ddtrace-4.10.6-cp313-cp313-win_arm64.whl", hash = "sha256:9d6763dd7fcd3be2bb1af5a75c7ff1077ebc0178cccf059d8f152eda416c7ed4", size = 5837939, upload-time = "2026-06-29T15:47:14.445Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/e7fa5570a0fca203d81436d5d0260614876c3a0a72e38856340cd5764b16/ddtrace-4.10.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c59e74357df419db3b5d2ea2429ef38367c42e86f64e238b68dd5557ceeccfaf", size = 6978516, upload-time = "2026-06-29T15:47:17.019Z" },
+    { url = "https://files.pythonhosted.org/packages/34/96/4069b46232541e003e08939caf80704de747aae70fcba8aaef1aa3b6706c/ddtrace-4.10.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:d2f63a74cea172e781e4772b8d5389d9ed992566bba587e886fce50e63725cc6", size = 7302804, upload-time = "2026-06-29T15:47:19.824Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ab/ad5a4c82787e9795e9a2992b3c3c0c2f1657168f5381e54934a5808b4c30/ddtrace-4.10.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:65973689c313099d7ed8051aadc80977359a2c281ea879c34d874e0bcfc10c7b", size = 8415926, upload-time = "2026-06-29T15:47:22.598Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/22/72ab8920bb74eb27984f3dad62b1bfa218c9f185feb8b7a952b33b8c1773/ddtrace-4.10.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2cc7f73a5363a1ef55bb37634fc7924b966ea3cd6910c821b316276fd8a9b11b", size = 8630424, upload-time = "2026-06-29T15:47:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/0b/c067c5b878bcaa94166d5ee4333b8fa28d67b7d48c21d262de66c311422f/ddtrace-4.10.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:211a0bbc701b0b90dbec8592c4987bc8347fd1911d1ef3d2a22765837984ff04", size = 9426201, upload-time = "2026-06-29T15:47:29.111Z" },
+    { url = "https://files.pythonhosted.org/packages/25/16/4778aa38b57b25450a2bc324142adf9cb87a66b4976328c43af607fc325f/ddtrace-4.10.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4c4a07b52e3c3d9a095acc899ec59fb6d81e4f1cf373736b6c9f3fc844ae38cf", size = 9689078, upload-time = "2026-06-29T15:47:32.483Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c4/a1d862f437dc73b74174ba2d9a83d30b478f13195ca788e2b42ea89ec00c/ddtrace-4.10.6-cp314-cp314-win32.whl", hash = "sha256:2ae32626cd5bad9f38dc5b3e04fc5963e5a53c985cba313c5034be4451976b03", size = 5683008, upload-time = "2026-06-29T15:47:36.174Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c5/fd5e27176d9827c1e0807420066cf54ca418a474c1977f04e7b0053fc00c/ddtrace-4.10.6-cp314-cp314-win_amd64.whl", hash = "sha256:cd1d85d2e1867dbe04941cb4cb3eab616a6e69affd36bdfb31d2aba01eab15f2", size = 6298853, upload-time = "2026-06-29T15:47:39.082Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4d/9532f5c68b062798c462122726a8ea3d9743d1a8070a40a58625a00a5095/ddtrace-4.10.6-cp314-cp314-win_arm64.whl", hash = "sha256:525f2d61bf7a2b5a7faced7581a7a123fc533413d7a62398a0c2890a5bee3504", size = 5988797, upload-time = "2026-06-29T15:47:42.116Z" },
+]
+
+[[package]]
+name = "envier"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e7/4fe4d3f6e21213cea9bcddc36ba60e6ae4003035f9ce8055e6a9f0322ddb/envier-0.6.1.tar.gz", hash = "sha256:3309a01bb3d8850c9e7a31a5166d5a836846db2faecb79b9cb32654dd50ca9f9", size = 10063, upload-time = "2024-10-22T09:56:47.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/e9/30493b1cc967f7c07869de4b2ab3929151a58e6bb04495015554d24b61db/envier-0.6.1-py3-none-any.whl", hash = "sha256:73609040a76be48bbcb97074d9969666484aa0de706183a6e9ef773156a8a6a9", size = 10638, upload-time = "2024-10-22T09:56:45.968Z" },
 ]
 
 [[package]]
@@ -1431,4 +1494,68 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]

--- a/core-storage-api/Dockerfile
+++ b/core-storage-api/Dockerfile
@@ -1,6 +1,20 @@
 # Dockerfile for Core Storage API service
 # PostgreSQL CRUD service for MemClaw core tables
 
+# Optional Datadog serverless-init source (CAURA-0000 observability POC).
+# SaaS builds pass --build-arg DD_APM_ENABLED=true to pull in Datadog's
+# serverless-init binary; OSS / on-prem / local builds leave it false so the
+# binary is never fetched (BuildKit prunes the unreferenced stage) and never
+# lands in the image. Runtime activation is further gated by
+# docker-entrypoint.sh on DD_API_KEY.
+ARG DD_APM_ENABLED=false
+FROM datadog/serverless-init:1@sha256:2f498f4b1165ac3551c34129b4f0c0c7bd99d82c55c4e95cf494b55dad8d05d0 AS dd-bin
+FROM python:3.12-slim AS dd-apm-true
+COPY --from=dd-bin /datadog-init /dd/datadog-init
+FROM python:3.12-slim AS dd-apm-false
+RUN mkdir -p /dd
+FROM dd-apm-${DD_APM_ENABLED} AS dd-apm-src
+
 FROM python:3.12-slim AS builder
 
 WORKDIR /app
@@ -18,7 +32,12 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.18 /uv /usr/local/bin/uv
 COPY core-storage-api/pyproject.toml core-storage-api/uv.lock core-storage-api/README.md* ./core-storage-api/
 # Dummy src so the project metadata resolves during export.
 RUN mkdir -p core-storage-api/src/core_storage_api && touch core-storage-api/src/core_storage_api/__init__.py
-RUN uv export --frozen --no-dev --no-emit-project \
+# DD_APM_ENABLED pulls in the ddtrace tracer via the ``datadog`` extra; only the
+# SaaS build sets it, so OSS / on-prem images carry no Datadog Python code.
+ARG DD_APM_ENABLED=false
+RUN EXTRAS=""; \
+    if [ "$DD_APM_ENABLED" = "true" ]; then EXTRAS="--extra datadog"; fi; \
+    uv export --frozen --no-dev $EXTRAS --no-emit-project \
       --directory core-storage-api -o /tmp/reqs.txt \
     && uv pip install --system --no-cache -r /tmp/reqs.txt
 
@@ -47,8 +66,14 @@ ENV PYTHONPATH="/app/core-storage-api/src:/app"
 ENV PYTHONUNBUFFERED=1
 ENV ENVIRONMENT=production
 
+# Datadog APM (opt-in; see top-of-file dd-apm stage + docker-entrypoint.sh).
+# /app/dd is empty unless built with DD_APM_ENABLED=true.
+COPY --from=dd-apm-src --chown=appuser:appuser /dd /app/dd
+COPY --chown=appuser:appuser core-storage-api/docker-entrypoint.sh /app/docker-entrypoint.sh
+
 USER appuser
 
 EXPOSE 8002
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["uvicorn", "core_storage_api.app:app", "--host", "0.0.0.0", "--port", "8002", "--workers", "2", "--timeout-keep-alive", "65"]

--- a/core-storage-api/docker-entrypoint.sh
+++ b/core-storage-api/docker-entrypoint.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
-# core-api container entrypoint.
+# Core service container entrypoint.
 #
 # Datadog APM (CAURA-0000 observability POC) is OPT-IN and activates only when a
 # Datadog API key is supplied at runtime — i.e. the Caura SaaS deploy, which
 # injects DD_API_KEY + DD_TRACE_ENABLED. OSS / on-prem / local runs supply no
 # key, so they see no Datadog at all: no serverless-init, no ddtrace, no log
 # mutation — just the app. The serverless-init binary is only present in images
-# built with --build-arg DD_APM_ENABLED=true (see core-api/Dockerfile); the
-# -x check below is belt-and-suspenders for any image built without it.
+# built with --build-arg DD_APM_ENABLED=true (see the Dockerfile); the -x check
+# below is belt-and-suspenders for any image built without it.
 set -e
 
 # DD_TRACE_ENABLED is an explicit kill-switch; honor the common falsy spellings

--- a/core-storage-api/pyproject.toml
+++ b/core-storage-api/pyproject.toml
@@ -38,6 +38,10 @@ dependencies = [
 # Optional: required only when EVENT_BUS_BACKEND=pubsub (SaaS deployments).
 # Standalone installs default to the in-process bus and don't need this.
 pubsub = ["google-cloud-pubsub>=2.23,<3"]
+# Datadog APM tracer (CAURA-0000). Opt-in: installed only in SaaS builds via
+# --build-arg DD_APM_ENABLED=true (--extra datadog); OSS/on-prem carry no
+# Datadog code. Auto-instruments FastAPI/SQLAlchemy/asyncpg/httpx.
+datadog = ["ddtrace>=4.10.6"]
 dev = [
     "core-storage-api[test,pubsub]",
     "mypy>=1.13,<3.0",

--- a/core-storage-api/uv.lock
+++ b/core-storage-api/uv.lock
@@ -134,6 +134,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bytecode"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/8f/7d12c539869a5cbd801d550b86cc0f030ecaeb12f57f8b3ff19f2d2a184c/bytecode-0.18.1.tar.gz", hash = "sha256:d9564f1565fe1ae6a1173e544ef43a85f093e83997ef45af65d0d250eb48d7a1", size = 104631, upload-time = "2026-06-03T14:17:59.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/ef/6a629424ec08adc3819ddfd7ec0a710361eaa29d1e5fffb4e02f074be5c9/bytecode-0.18.1-py3-none-any.whl", hash = "sha256:9535bfdd665260b2888ec4121569e3ca5106965a7fedbb6de6ba1bafebc5c7d7", size = 42868, upload-time = "2026-06-03T14:17:57.654Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
@@ -295,7 +304,7 @@ wheels = [
 
 [[package]]
 name = "core-storage-api"
-version = "2.16.0"
+version = "2.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -313,6 +322,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+datadog = [
+    { name = "ddtrace" },
+]
 dev = [
     { name = "google-cloud-pubsub" },
     { name = "httpx" },
@@ -337,6 +349,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.14,<2" },
     { name = "asyncpg", specifier = ">=0.30,<1" },
     { name = "core-storage-api", extras = ["test", "pubsub"], marker = "extra == 'dev'" },
+    { name = "ddtrace", marker = "extra == 'datadog'", specifier = ">=4.10.6" },
     { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "google-cloud-pubsub", marker = "extra == 'pubsub'", specifier = ">=2.23,<3" },
     { name = "greenlet", specifier = "<3.6.0" },
@@ -355,7 +368,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.4,<27" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1" },
 ]
-provides-extras = ["pubsub", "dev", "test"]
+provides-extras = ["pubsub", "datadog", "dev", "test"]
 
 [[package]]
 name = "coverage"
@@ -492,12 +505,62 @@ wheels = [
 ]
 
 [[package]]
+name = "ddtrace"
+version = "4.10.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bytecode" },
+    { name = "envier" },
+    { name = "opentelemetry-api" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/22/2fd7af9bc4118d4223627e4a98b679d4111d058688798877427b4a2be6df/ddtrace-4.10.6.tar.gz", hash = "sha256:cd6c877c232bc82834cd068d454c31569e9ba68967ef9f15ef41711124b1fa66", size = 2343462, upload-time = "2026-06-29T15:48:13.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/ad/251cac89e99469c8a63ffc17703ad420d84df6ce35ad292620ed53011682/ddtrace-4.10.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8ad4eb33c30f03bd581ce675b9b49caafa946d30ba4d75bdfae8327961c8448a", size = 6980965, upload-time = "2026-06-29T15:46:24.085Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5f/fa5055fc5e4c08fff0a23a52d820c96037865493198a402afc3a89238f23/ddtrace-4.10.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:1524fc49eaa0b9bd08baea6e0249029c43e5d2971635f5b0341eedb694129b83", size = 7305894, upload-time = "2026-06-29T15:46:26.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c4/84d4b147fb3580515f7dc419719bc7be2fbcaea946e0aa671f1814caa9ee/ddtrace-4.10.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:99fa47d78bf0d5f3c053f28e406c488bf69019c2e7ce16f0efb621162dae34b0", size = 8412325, upload-time = "2026-06-29T15:46:29.362Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ae/4504a7db4e1b4bb4aef59c7012510c0b17ce7d95475a324f4e7e0f2a4bd9/ddtrace-4.10.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:764120dee8dde534154cd26229baa2fb812bb1157c39768c8410348453da3a2a", size = 8635843, upload-time = "2026-06-29T15:46:35.263Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/34/f369b7db72946ee95387e7f529d0413b41a1e27daa4cf28eb7e956651e50/ddtrace-4.10.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5ad0b4f7d50808fd210d6d52b78057308e39d336c078ecff10d0ea775881e6f8", size = 9418429, upload-time = "2026-06-29T15:46:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/16/9f199a55a2ea3affd053eb29728fcd5707b9966fb8bed2bcbbdfd65b3b24/ddtrace-4.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e1fe13af69cd34d897e7289fc56beb4b78cfd866b235304ddcc0b97050a5bd8f", size = 9688989, upload-time = "2026-06-29T15:46:40.841Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/fd0b549f1c19fd2e0bd69865db0113a1d1c741d8576adccc38f20ce0210e/ddtrace-4.10.6-cp312-cp312-win32.whl", hash = "sha256:e276cf348152a431d7348bdc1c69232d7a4ca71d6d6d504e01e4eb12a7e30bc9", size = 5587062, upload-time = "2026-06-29T15:46:43.387Z" },
+    { url = "https://files.pythonhosted.org/packages/73/2e/8a4fcfd8d53c46ec62eb02c5e5541f1c5fe073f2a3f3ed0ef6a2bd0f83b2/ddtrace-4.10.6-cp312-cp312-win_amd64.whl", hash = "sha256:e0674a637ee52e4396c47d15fadefa39f342741a289a912a6f90d1f3a00e0b00", size = 6159976, upload-time = "2026-06-29T15:46:45.566Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/c0bf3ae46c930d3d48252d57cd5640a5d40aba6e9f47bf1e57ea761c04da/ddtrace-4.10.6-cp312-cp312-win_arm64.whl", hash = "sha256:da83e10c7fec868b3c00db4dbb7f0d048fa048e4db14d8da558efbf1f8b4d285", size = 5840553, upload-time = "2026-06-29T15:46:48.163Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e5/7f5dbadf7dd21b64bd899b7bf07a49b6b09fc9ec2e865fa0835921c97d53/ddtrace-4.10.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:5bf629942ae7e691ce3f0e2565f0808717e03350bc6cf22f781873c26d65e121", size = 6974259, upload-time = "2026-06-29T15:46:50.648Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f3/dbdd6b59dc30dea877502b0613fb78d69f56afbb8c67bc562dd019f090c7/ddtrace-4.10.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:1870a0c36945f76ad6b7a9d8c57a7fbb247049a7b79c96d424b34fb3f24535c1", size = 7299104, upload-time = "2026-06-29T15:46:53.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7f/88a9670409049eda4004a42c32aa66884462099f64c27d9a6226dcc44bdd/ddtrace-4.10.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e5879341603df0bd3c9699abbd5da83ca5a38b638ac42b2b9355a3fd6ffca927", size = 8406135, upload-time = "2026-06-29T15:46:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f9/456981881162e9640b6e0105280ae55c1f2026c01a5c6b65876ebad94b53/ddtrace-4.10.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d05dc9a6449ad2cf3bcead2f757e509ec3d598dd83b39e3e884b52b49abffdce", size = 8627275, upload-time = "2026-06-29T15:46:58.73Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d8/8e8ab7370df76a43d55a09f72bd0592343185b67b5d4532c08571dbb33a3/ddtrace-4.10.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5a17da207152cb6eac06ad6e827bf74daa05eb6dff628f06b7d8e63b4abefe3e", size = 9414877, upload-time = "2026-06-29T15:47:01.505Z" },
+    { url = "https://files.pythonhosted.org/packages/23/68/a2e3f65f6b25d9ef7e5b9080198b268c8de36e12c0c06fdf5717bb6491e0/ddtrace-4.10.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d032f36cb8b92aca49a840d3c16fdf6da01d26431af3db361fc3b148f149977a", size = 9682496, upload-time = "2026-06-29T15:47:05.035Z" },
+    { url = "https://files.pythonhosted.org/packages/24/83/cbe28480206a85e0060a5ae9cf7e948b83543f71e876368389eb763633e0/ddtrace-4.10.6-cp313-cp313-win32.whl", hash = "sha256:09e963b4bb823855e7ac8729d81cfbadf20c88887b1a41fe2a4d60323bfc95d7", size = 5584250, upload-time = "2026-06-29T15:47:07.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/37/d149fc0f9c881e16a327fc0526d8385125d9262b2c2584b8446dc1011108/ddtrace-4.10.6-cp313-cp313-win_amd64.whl", hash = "sha256:be209b122b3d109beb06b2638c88005e51c67bf4ca5185341065b2b83b77202f", size = 6156992, upload-time = "2026-06-29T15:47:11.345Z" },
+    { url = "https://files.pythonhosted.org/packages/66/a8/3435ee577beab7a76ccf04572234d9c2c85ed1f7c758a7192e53920e2893/ddtrace-4.10.6-cp313-cp313-win_arm64.whl", hash = "sha256:9d6763dd7fcd3be2bb1af5a75c7ff1077ebc0178cccf059d8f152eda416c7ed4", size = 5837939, upload-time = "2026-06-29T15:47:14.445Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/e7fa5570a0fca203d81436d5d0260614876c3a0a72e38856340cd5764b16/ddtrace-4.10.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c59e74357df419db3b5d2ea2429ef38367c42e86f64e238b68dd5557ceeccfaf", size = 6978516, upload-time = "2026-06-29T15:47:17.019Z" },
+    { url = "https://files.pythonhosted.org/packages/34/96/4069b46232541e003e08939caf80704de747aae70fcba8aaef1aa3b6706c/ddtrace-4.10.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:d2f63a74cea172e781e4772b8d5389d9ed992566bba587e886fce50e63725cc6", size = 7302804, upload-time = "2026-06-29T15:47:19.824Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ab/ad5a4c82787e9795e9a2992b3c3c0c2f1657168f5381e54934a5808b4c30/ddtrace-4.10.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:65973689c313099d7ed8051aadc80977359a2c281ea879c34d874e0bcfc10c7b", size = 8415926, upload-time = "2026-06-29T15:47:22.598Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/22/72ab8920bb74eb27984f3dad62b1bfa218c9f185feb8b7a952b33b8c1773/ddtrace-4.10.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2cc7f73a5363a1ef55bb37634fc7924b966ea3cd6910c821b316276fd8a9b11b", size = 8630424, upload-time = "2026-06-29T15:47:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/0b/c067c5b878bcaa94166d5ee4333b8fa28d67b7d48c21d262de66c311422f/ddtrace-4.10.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:211a0bbc701b0b90dbec8592c4987bc8347fd1911d1ef3d2a22765837984ff04", size = 9426201, upload-time = "2026-06-29T15:47:29.111Z" },
+    { url = "https://files.pythonhosted.org/packages/25/16/4778aa38b57b25450a2bc324142adf9cb87a66b4976328c43af607fc325f/ddtrace-4.10.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4c4a07b52e3c3d9a095acc899ec59fb6d81e4f1cf373736b6c9f3fc844ae38cf", size = 9689078, upload-time = "2026-06-29T15:47:32.483Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c4/a1d862f437dc73b74174ba2d9a83d30b478f13195ca788e2b42ea89ec00c/ddtrace-4.10.6-cp314-cp314-win32.whl", hash = "sha256:2ae32626cd5bad9f38dc5b3e04fc5963e5a53c985cba313c5034be4451976b03", size = 5683008, upload-time = "2026-06-29T15:47:36.174Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c5/fd5e27176d9827c1e0807420066cf54ca418a474c1977f04e7b0053fc00c/ddtrace-4.10.6-cp314-cp314-win_amd64.whl", hash = "sha256:cd1d85d2e1867dbe04941cb4cb3eab616a6e69affd36bdfb31d2aba01eab15f2", size = 6298853, upload-time = "2026-06-29T15:47:39.082Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4d/9532f5c68b062798c462122726a8ea3d9743d1a8070a40a58625a00a5095/ddtrace-4.10.6-cp314-cp314-win_arm64.whl", hash = "sha256:525f2d61bf7a2b5a7faced7581a7a123fc533413d7a62398a0c2890a5bee3504", size = 5988797, upload-time = "2026-06-29T15:47:42.116Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "envier"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e7/4fe4d3f6e21213cea9bcddc36ba60e6ae4003035f9ce8055e6a9f0322ddb/envier-0.6.1.tar.gz", hash = "sha256:3309a01bb3d8850c9e7a31a5166d5a836846db2faecb79b9cb32654dd50ca9f9", size = 10063, upload-time = "2024-10-22T09:56:47.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/e9/30493b1cc967f7c07869de4b2ab3929151a58e6bb04495015554d24b61db/envier-0.6.1-py3-none-any.whl", hash = "sha256:73609040a76be48bbcb97074d9969666484aa0de706183a6e9ef773156a8a6a9", size = 10638, upload-time = "2024-10-22T09:56:45.968Z" },
 ]
 
 [[package]]
@@ -1845,4 +1908,68 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]

--- a/core-worker/Dockerfile
+++ b/core-worker/Dockerfile
@@ -2,6 +2,20 @@
 # Async-embed event consumer — subscribes to memclaw.memory.embed-requested
 # and PATCHes the resulting embedding back to core-storage-api.
 
+# Optional Datadog serverless-init source (CAURA-0000 observability POC).
+# SaaS builds pass --build-arg DD_APM_ENABLED=true to pull in Datadog's
+# serverless-init binary; OSS / on-prem / local builds leave it false so the
+# binary is never fetched (BuildKit prunes the unreferenced stage) and never
+# lands in the image. Runtime activation is further gated by
+# docker-entrypoint.sh on DD_API_KEY.
+ARG DD_APM_ENABLED=false
+FROM datadog/serverless-init:1@sha256:2f498f4b1165ac3551c34129b4f0c0c7bd99d82c55c4e95cf494b55dad8d05d0 AS dd-bin
+FROM python:3.12-slim AS dd-apm-true
+COPY --from=dd-bin /datadog-init /dd/datadog-init
+FROM python:3.12-slim AS dd-apm-false
+RUN mkdir -p /dd
+FROM dd-apm-${DD_APM_ENABLED} AS dd-apm-src
+
 FROM python:3.12-slim AS builder
 
 WORKDIR /app
@@ -14,7 +28,12 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.18 /uv /usr/local/bin/uv
 COPY core-worker/pyproject.toml core-worker/uv.lock core-worker/README.md* ./core-worker/
 # Dummy src so the project metadata resolves during export.
 RUN mkdir -p core-worker/src/core_worker && touch core-worker/src/core_worker/__init__.py
-RUN uv export --frozen --no-dev --extra pubsub --extra vertex --no-emit-project \
+# DD_APM_ENABLED pulls in the ddtrace tracer via the ``datadog`` extra; only the
+# SaaS build sets it, so OSS / on-prem images carry no Datadog Python code.
+ARG DD_APM_ENABLED=false
+RUN EXTRAS="--extra pubsub --extra vertex"; \
+    if [ "$DD_APM_ENABLED" = "true" ]; then EXTRAS="$EXTRAS --extra datadog"; fi; \
+    uv export --frozen --no-dev $EXTRAS --no-emit-project \
       --directory core-worker -o /tmp/reqs.txt \
     && uv pip install --system --no-cache -r /tmp/reqs.txt
 
@@ -38,8 +57,14 @@ COPY --from=builder --chown=appuser:appuser /app /app
 ENV PYTHONPATH="/app/core-worker/src:/app"
 ENV PYTHONUNBUFFERED=1
 
+# Datadog APM (opt-in; see top-of-file dd-apm stage + docker-entrypoint.sh).
+# /app/dd is empty unless built with DD_APM_ENABLED=true.
+COPY --from=dd-apm-src --chown=appuser:appuser /dd /app/dd
+COPY --chown=appuser:appuser core-worker/docker-entrypoint.sh /app/docker-entrypoint.sh
+
 USER appuser
 
 EXPOSE 8080
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["uvicorn", "core_worker.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/core-worker/docker-entrypoint.sh
+++ b/core-worker/docker-entrypoint.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
-# core-api container entrypoint.
+# Core service container entrypoint.
 #
 # Datadog APM (CAURA-0000 observability POC) is OPT-IN and activates only when a
 # Datadog API key is supplied at runtime — i.e. the Caura SaaS deploy, which
 # injects DD_API_KEY + DD_TRACE_ENABLED. OSS / on-prem / local runs supply no
 # key, so they see no Datadog at all: no serverless-init, no ddtrace, no log
 # mutation — just the app. The serverless-init binary is only present in images
-# built with --build-arg DD_APM_ENABLED=true (see core-api/Dockerfile); the
-# -x check below is belt-and-suspenders for any image built without it.
+# built with --build-arg DD_APM_ENABLED=true (see the Dockerfile); the -x check
+# below is belt-and-suspenders for any image built without it.
 set -e
 
 # DD_TRACE_ENABLED is an explicit kill-switch; honor the common falsy spellings

--- a/core-worker/pyproject.toml
+++ b/core-worker/pyproject.toml
@@ -40,6 +40,10 @@ dependencies = [
 pubsub = ["google-cloud-pubsub>=2.23,<3"]
 vertex = ["google-cloud-aiplatform>=1.80,<2"]
 local = ["sentence-transformers>=3.0,<4"]
+# Datadog APM tracer (CAURA-0000). Opt-in: installed only in SaaS builds via
+# --build-arg DD_APM_ENABLED=true (--extra datadog); OSS/on-prem carry no
+# Datadog code. Auto-instruments FastAPI/httpx/pubsub.
+datadog = ["ddtrace>=4.10.6"]
 dev = [
     "core-worker[test,pubsub]",
     "mypy>=1.13,<3.0",

--- a/core-worker/uv.lock
+++ b/core-worker/uv.lock
@@ -80,6 +80,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bytecode"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/8f/7d12c539869a5cbd801d550b86cc0f030ecaeb12f57f8b3ff19f2d2a184c/bytecode-0.18.1.tar.gz", hash = "sha256:d9564f1565fe1ae6a1173e544ef43a85f093e83997ef45af65d0d250eb48d7a1", size = 104631, upload-time = "2026-06-03T14:17:59.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/ef/6a629424ec08adc3819ddfd7ec0a710361eaa29d1e5fffb4e02f074be5c9/bytecode-0.18.1-py3-none-any.whl", hash = "sha256:9535bfdd665260b2888ec4121569e3ca5106965a7fedbb6de6ba1bafebc5c7d7", size = 42868, upload-time = "2026-06-03T14:17:57.654Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -250,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "core-worker"
-version = "2.15.0"
+version = "2.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
@@ -266,6 +275,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+datadog = [
+    { name = "ddtrace" },
+]
 dev = [
     { name = "google-cloud-pubsub" },
     { name = "httpx" },
@@ -295,6 +307,7 @@ vertex = [
 requires-dist = [
     { name = "cachetools", specifier = ">=5.3" },
     { name = "core-worker", extras = ["test", "pubsub"], marker = "extra == 'dev'" },
+    { name = "ddtrace", marker = "extra == 'datadog'", specifier = ">=4.10.6" },
     { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "google-cloud-aiplatform", marker = "extra == 'vertex'", specifier = ">=1.80,<2" },
     { name = "google-cloud-pubsub", marker = "extra == 'pubsub'", specifier = ">=2.23,<3" },
@@ -314,7 +327,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.4,<27" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1" },
 ]
-provides-extras = ["pubsub", "vertex", "local", "dev", "test"]
+provides-extras = ["pubsub", "vertex", "local", "datadog", "dev", "test"]
 
 [[package]]
 name = "coverage"
@@ -517,6 +530,47 @@ nvtx = [
 ]
 
 [[package]]
+name = "ddtrace"
+version = "4.10.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bytecode" },
+    { name = "envier" },
+    { name = "opentelemetry-api" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/22/2fd7af9bc4118d4223627e4a98b679d4111d058688798877427b4a2be6df/ddtrace-4.10.6.tar.gz", hash = "sha256:cd6c877c232bc82834cd068d454c31569e9ba68967ef9f15ef41711124b1fa66", size = 2343462, upload-time = "2026-06-29T15:48:13.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/ad/251cac89e99469c8a63ffc17703ad420d84df6ce35ad292620ed53011682/ddtrace-4.10.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8ad4eb33c30f03bd581ce675b9b49caafa946d30ba4d75bdfae8327961c8448a", size = 6980965, upload-time = "2026-06-29T15:46:24.085Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5f/fa5055fc5e4c08fff0a23a52d820c96037865493198a402afc3a89238f23/ddtrace-4.10.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:1524fc49eaa0b9bd08baea6e0249029c43e5d2971635f5b0341eedb694129b83", size = 7305894, upload-time = "2026-06-29T15:46:26.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c4/84d4b147fb3580515f7dc419719bc7be2fbcaea946e0aa671f1814caa9ee/ddtrace-4.10.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:99fa47d78bf0d5f3c053f28e406c488bf69019c2e7ce16f0efb621162dae34b0", size = 8412325, upload-time = "2026-06-29T15:46:29.362Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ae/4504a7db4e1b4bb4aef59c7012510c0b17ce7d95475a324f4e7e0f2a4bd9/ddtrace-4.10.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:764120dee8dde534154cd26229baa2fb812bb1157c39768c8410348453da3a2a", size = 8635843, upload-time = "2026-06-29T15:46:35.263Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/34/f369b7db72946ee95387e7f529d0413b41a1e27daa4cf28eb7e956651e50/ddtrace-4.10.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5ad0b4f7d50808fd210d6d52b78057308e39d336c078ecff10d0ea775881e6f8", size = 9418429, upload-time = "2026-06-29T15:46:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/16/9f199a55a2ea3affd053eb29728fcd5707b9966fb8bed2bcbbdfd65b3b24/ddtrace-4.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e1fe13af69cd34d897e7289fc56beb4b78cfd866b235304ddcc0b97050a5bd8f", size = 9688989, upload-time = "2026-06-29T15:46:40.841Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/fd0b549f1c19fd2e0bd69865db0113a1d1c741d8576adccc38f20ce0210e/ddtrace-4.10.6-cp312-cp312-win32.whl", hash = "sha256:e276cf348152a431d7348bdc1c69232d7a4ca71d6d6d504e01e4eb12a7e30bc9", size = 5587062, upload-time = "2026-06-29T15:46:43.387Z" },
+    { url = "https://files.pythonhosted.org/packages/73/2e/8a4fcfd8d53c46ec62eb02c5e5541f1c5fe073f2a3f3ed0ef6a2bd0f83b2/ddtrace-4.10.6-cp312-cp312-win_amd64.whl", hash = "sha256:e0674a637ee52e4396c47d15fadefa39f342741a289a912a6f90d1f3a00e0b00", size = 6159976, upload-time = "2026-06-29T15:46:45.566Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/c0bf3ae46c930d3d48252d57cd5640a5d40aba6e9f47bf1e57ea761c04da/ddtrace-4.10.6-cp312-cp312-win_arm64.whl", hash = "sha256:da83e10c7fec868b3c00db4dbb7f0d048fa048e4db14d8da558efbf1f8b4d285", size = 5840553, upload-time = "2026-06-29T15:46:48.163Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e5/7f5dbadf7dd21b64bd899b7bf07a49b6b09fc9ec2e865fa0835921c97d53/ddtrace-4.10.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:5bf629942ae7e691ce3f0e2565f0808717e03350bc6cf22f781873c26d65e121", size = 6974259, upload-time = "2026-06-29T15:46:50.648Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f3/dbdd6b59dc30dea877502b0613fb78d69f56afbb8c67bc562dd019f090c7/ddtrace-4.10.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:1870a0c36945f76ad6b7a9d8c57a7fbb247049a7b79c96d424b34fb3f24535c1", size = 7299104, upload-time = "2026-06-29T15:46:53.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7f/88a9670409049eda4004a42c32aa66884462099f64c27d9a6226dcc44bdd/ddtrace-4.10.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e5879341603df0bd3c9699abbd5da83ca5a38b638ac42b2b9355a3fd6ffca927", size = 8406135, upload-time = "2026-06-29T15:46:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f9/456981881162e9640b6e0105280ae55c1f2026c01a5c6b65876ebad94b53/ddtrace-4.10.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d05dc9a6449ad2cf3bcead2f757e509ec3d598dd83b39e3e884b52b49abffdce", size = 8627275, upload-time = "2026-06-29T15:46:58.73Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d8/8e8ab7370df76a43d55a09f72bd0592343185b67b5d4532c08571dbb33a3/ddtrace-4.10.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5a17da207152cb6eac06ad6e827bf74daa05eb6dff628f06b7d8e63b4abefe3e", size = 9414877, upload-time = "2026-06-29T15:47:01.505Z" },
+    { url = "https://files.pythonhosted.org/packages/23/68/a2e3f65f6b25d9ef7e5b9080198b268c8de36e12c0c06fdf5717bb6491e0/ddtrace-4.10.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d032f36cb8b92aca49a840d3c16fdf6da01d26431af3db361fc3b148f149977a", size = 9682496, upload-time = "2026-06-29T15:47:05.035Z" },
+    { url = "https://files.pythonhosted.org/packages/24/83/cbe28480206a85e0060a5ae9cf7e948b83543f71e876368389eb763633e0/ddtrace-4.10.6-cp313-cp313-win32.whl", hash = "sha256:09e963b4bb823855e7ac8729d81cfbadf20c88887b1a41fe2a4d60323bfc95d7", size = 5584250, upload-time = "2026-06-29T15:47:07.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/37/d149fc0f9c881e16a327fc0526d8385125d9262b2c2584b8446dc1011108/ddtrace-4.10.6-cp313-cp313-win_amd64.whl", hash = "sha256:be209b122b3d109beb06b2638c88005e51c67bf4ca5185341065b2b83b77202f", size = 6156992, upload-time = "2026-06-29T15:47:11.345Z" },
+    { url = "https://files.pythonhosted.org/packages/66/a8/3435ee577beab7a76ccf04572234d9c2c85ed1f7c758a7192e53920e2893/ddtrace-4.10.6-cp313-cp313-win_arm64.whl", hash = "sha256:9d6763dd7fcd3be2bb1af5a75c7ff1077ebc0178cccf059d8f152eda416c7ed4", size = 5837939, upload-time = "2026-06-29T15:47:14.445Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/e7fa5570a0fca203d81436d5d0260614876c3a0a72e38856340cd5764b16/ddtrace-4.10.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c59e74357df419db3b5d2ea2429ef38367c42e86f64e238b68dd5557ceeccfaf", size = 6978516, upload-time = "2026-06-29T15:47:17.019Z" },
+    { url = "https://files.pythonhosted.org/packages/34/96/4069b46232541e003e08939caf80704de747aae70fcba8aaef1aa3b6706c/ddtrace-4.10.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:d2f63a74cea172e781e4772b8d5389d9ed992566bba587e886fce50e63725cc6", size = 7302804, upload-time = "2026-06-29T15:47:19.824Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ab/ad5a4c82787e9795e9a2992b3c3c0c2f1657168f5381e54934a5808b4c30/ddtrace-4.10.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:65973689c313099d7ed8051aadc80977359a2c281ea879c34d874e0bcfc10c7b", size = 8415926, upload-time = "2026-06-29T15:47:22.598Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/22/72ab8920bb74eb27984f3dad62b1bfa218c9f185feb8b7a952b33b8c1773/ddtrace-4.10.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2cc7f73a5363a1ef55bb37634fc7924b966ea3cd6910c821b316276fd8a9b11b", size = 8630424, upload-time = "2026-06-29T15:47:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/0b/c067c5b878bcaa94166d5ee4333b8fa28d67b7d48c21d262de66c311422f/ddtrace-4.10.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:211a0bbc701b0b90dbec8592c4987bc8347fd1911d1ef3d2a22765837984ff04", size = 9426201, upload-time = "2026-06-29T15:47:29.111Z" },
+    { url = "https://files.pythonhosted.org/packages/25/16/4778aa38b57b25450a2bc324142adf9cb87a66b4976328c43af607fc325f/ddtrace-4.10.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4c4a07b52e3c3d9a095acc899ec59fb6d81e4f1cf373736b6c9f3fc844ae38cf", size = 9689078, upload-time = "2026-06-29T15:47:32.483Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c4/a1d862f437dc73b74174ba2d9a83d30b478f13195ca788e2b42ea89ec00c/ddtrace-4.10.6-cp314-cp314-win32.whl", hash = "sha256:2ae32626cd5bad9f38dc5b3e04fc5963e5a53c985cba313c5034be4451976b03", size = 5683008, upload-time = "2026-06-29T15:47:36.174Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c5/fd5e27176d9827c1e0807420066cf54ca418a474c1977f04e7b0053fc00c/ddtrace-4.10.6-cp314-cp314-win_amd64.whl", hash = "sha256:cd1d85d2e1867dbe04941cb4cb3eab616a6e69affd36bdfb31d2aba01eab15f2", size = 6298853, upload-time = "2026-06-29T15:47:39.082Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4d/9532f5c68b062798c462122726a8ea3d9743d1a8070a40a58625a00a5095/ddtrace-4.10.6-cp314-cp314-win_arm64.whl", hash = "sha256:525f2d61bf7a2b5a7faced7581a7a123fc533413d7a62398a0c2890a5bee3504", size = 5988797, upload-time = "2026-06-29T15:47:42.116Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -532,6 +586,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "envier"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e7/4fe4d3f6e21213cea9bcddc36ba60e6ae4003035f9ce8055e6a9f0322ddb/envier-0.6.1.tar.gz", hash = "sha256:3309a01bb3d8850c9e7a31a5166d5a836846db2faecb79b9cb32654dd50ca9f9", size = 10063, upload-time = "2024-10-22T09:56:47.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/e9/30493b1cc967f7c07869de4b2ab3929151a58e6bb04495015554d24b61db/envier-0.6.1-py3-none-any.whl", hash = "sha256:73609040a76be48bbcb97074d9969666484aa0de706183a6e9ef773156a8a6a9", size = 10638, upload-time = "2024-10-22T09:56:45.968Z" },
 ]
 
 [[package]]
@@ -2628,4 +2691,68 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]


### PR DESCRIPTION
Rollout Phase 1 (OSS images). Replicates the merged [core-api APM pattern](https://github.com/caura-ai/caura-memclaw/pull/508) across the three remaining OSS Cloud Run services.

## Per service
- `ddtrace` → optional `datadog` extra, installed only when built with `--build-arg DD_APM_ENABLED=true` (`--extra datadog`).
- Top-of-Dockerfile stage conditionally pulls Datadog's `serverless-init` (pinned by digest) behind the same build-arg — **OSS / on-prem / local images carry no Datadog code or binary**.
- New `docker-entrypoint.sh` runs the app under serverless-init + ddtrace-run **only when `DD_API_KEY` is set** (else plain uvicorn; `DD_TRACE_ENABLED` falsy kill-switch honored).
- `uv.lock` regenerated.

## Verified (local builds, both variants)
| | OSS build | `DD_APM_ENABLED=true` build |
|---|---|---|
| ddtrace | absent (ModuleNotFoundError) | 4.10.6 present |
| /app/dd | empty | serverless-init binary |
| runtime, no key | plain uvicorn, 0 spans | plain uvicorn, 0 spans |
| runtime, key set | plain uvicorn | serverless-init + ddtrace active |

Confirmed core-operations' `sh -c` CMD wraps correctly under the shim. Deploy-side wiring (build-args + DD_* env + `datadog-api-key` secret + label per service, staging) follows in a paired caura-memclaw-enterprise PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)