### PR TITLE
feat(core-api): governed daily/weekly agent activity report (GET /api/v1/reports)

### DIFF
--- a/common/models/agent.py
+++ b/common/models/agent.py
@@ -31,6 +31,21 @@ class Agent(Base):
     install_id: Mapped[str | None] = mapped_column(String(32), index=True)
     trust_level: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default=text("1"))
     search_profile: Mapped[dict | None] = mapped_column(JSONB)
+    # ``belonging_type`` / ``owner_ref``: the typed agent→owner relationship the
+    # report API (GET /api/v1/reports) uses to resolve where an agent's report
+    # goes. Two kinds:
+    #   ``personal`` — belongs to a human user (``owner_ref`` = that user id);
+    #                  the agent reports 1:1 to its owner.
+    #   ``service``  — belongs to a group/fleet (the group IS ``fleet_id``;
+    #                  ``owner_ref`` is NULL); the agent reports into the group.
+    # Validated at the app layer (no DB enum, mirroring ``visibility``/``trust``).
+    # Existing rows backfill to ``service`` so today's fleet agents keep working;
+    # ``personal`` agents are set explicitly (interim ``owner_ref`` default =
+    # the agent credential's ``created_by``). Extensible to more types later.
+    belonging_type: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'service'")
+    )
+    owner_ref: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=text("now()")
     )

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -59,6 +59,7 @@ from core_api.routes.memories import router as memories_router
 from core_api.routes.org_deletion import router as org_deletion_router
 from core_api.routes.plugin import plugin_bootstrap_router
 from core_api.routes.plugin import router as plugin_router
+from core_api.routes.reports import router as reports_router
 from core_api.routes.settings import router as settings_router
 from core_api.routes.skills_inbox import router as skills_inbox_router
 from core_api.routes.stats import router as stats_router
@@ -635,6 +636,7 @@ app.include_router(settings_router, prefix="/api/v1")
 app.include_router(agents_router, prefix="/api/v1")
 app.include_router(fleet_router, prefix="/api/v1")
 app.include_router(documents_router, prefix="/api/v1")
+app.include_router(reports_router, prefix="/api/v1")
 # Skill Factory Phase 2 — HITL Skills Inbox. Routes flag-gated at
 # request time via ``org_settings.skills_factory.enabled``; non-opted-in
 # tenants receive 403 SKILLS_FACTORY_DISABLED, ensuring zero behavior

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1010,6 +1010,13 @@ class CoreStorageClient:
             raise RuntimeError("core-storage-api /memories/daily-durable-counts returned 404")
         return result  # type: ignore[return-value]
 
+    async def memory_quality_metrics(self, data: dict) -> dict:
+        """Reuse / recall quality aggregates over a scoped corpus (report Quality section)."""
+        result = await self._post("/memories/quality-metrics", data, read=True)
+        if result is None:
+            raise RuntimeError("core-storage-api /memories/quality-metrics returned 404")
+        return result  # type: ignore[return-value]
+
     async def soft_delete_by_run(
         self,
         tenant_id: str,

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1003,6 +1003,13 @@ class CoreStorageClient:
             raise RuntimeError("core-storage-api /memories/stats-breakdown returned 404")
         return result  # type: ignore[return-value]
 
+    async def memory_daily_durable_counts(self, data: dict) -> list[dict]:
+        """Per-day durable-write counts (report activity-over-time trend)."""
+        result = await self._post("/memories/daily-durable-counts", data, read=True)
+        if result is None:
+            raise RuntimeError("core-storage-api /memories/daily-durable-counts returned 404")
+        return result  # type: ignore[return-value]
+
     async def soft_delete_by_run(
         self,
         tenant_id: str,

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -80,15 +80,21 @@ _PERIOD_DAYS = {"day": 1, "week": 7}
 _LEARNING_LIMIT = 5
 _HIGHLIGHTS_LIMIT = 5
 _TOP_AGENTS_LIMIT = 25
+# PRE-FILTER fetch sizes, NOT final result sizes. The list API (see the warning
+# at _cohesive() below) cannot push exclude_memory_types/exclude_agent_ids/
+# exclude_title_regex server-side, so these rows are fetched raw and the noise
+# (episode/firehose/heartbeat) is dropped client-side by _cohesive(). Both must
+# stay large enough that the POST-_cohesive() pool still exceeds the downstream
+# limits (_LEARNING_LIMIT=5, _HIGHLIGHTS_LIMIT=5) even in noisy corpora — a
+# ~3-5x margin over the known exclusion rate.
+#
 # Recent in-window durable rows (created_at desc) feeding LEARNING (recent
-# insights) and the working-on LANES (keyword categorization). Capped for a
-# representative window sample without an unbounded fetch.
-_DURABLE_FETCH_LIMIT = 200
+# insights) and the working-on LANES (keyword categorization).
+_DURABLE_FETCH_LIMIT = 600  # was 200
 # Separate recall-sorted fetch backing VALUE HIGHLIGHTS + the spotlight headline,
 # so "most-reused" is the true top-by-recall in the window — not merely the
-# most-reused among the most-recent rows. Over-fetched so post-filtering
-# (episode/firehose/cohesive) still leaves enough to take _HIGHLIGHTS_LIMIT.
-_HIGHLIGHTS_FETCH_LIMIT = 40
+# most-reused among the most-recent rows.
+_HIGHLIGHTS_FETCH_LIMIT = 150  # was 40
 # Activity-over-time trend length (daily buckets), independent of the period toggle.
 _TREND_DAYS = 14
 # "What the org is working on" lanes — heuristic keyword match on title/content,
@@ -304,6 +310,14 @@ async def get_report(
             return (m.get("recall_count") or 0, m.get("created_at") or "")
 
         def _cohesive(m: dict) -> bool:
+            # WARNING: the /memories/list API cannot push exclude_memory_types /
+            # exclude_agent_ids / exclude_title_regex server-side, so the row
+            # fetches (list_query, highlights_query) come back raw and this
+            # predicate drops the noise client-side — AFTER the fetch limit has
+            # already been consumed. That is why _DURABLE_FETCH_LIMIT /
+            # _HIGHLIGHTS_FETCH_LIMIT over-fetch: the surviving pool must still
+            # exceed the downstream _LEARNING_LIMIT / _HIGHLIGHTS_LIMIT slices.
+            #
             # Mirror the server-side report corpus in Python for the row fetches:
             # durable (non-episodic, non-firehose) AND not heartbeat/status noise.
             # Title-only match mirrors the ``exclude_title_regex`` predicate.

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -1,0 +1,437 @@
+"""Report API — ``GET /api/v1/reports``.
+
+Daily/weekly governed activity report — "what each agent did" — backing the
+report → product-page → agent-self-report flow (an agent fetches its own report
+and surfaces it in its 1:1 with its owner, or in its group). MemClaw returns the
+governed data; the agent's runtime does the messaging.
+
+Two-check governed read (order matters):
+
+1. **Authorization (authoritative, server-verified).** ``resolve_caller_and_gate``
+   resolves the caller (gateway-verified ``X-Agent-ID`` > query > default) and
+   gates on trust (scope=agent → trust ≥ 1). The data is then scoped to the
+   caller's own tenant + own fleet (team/org-visible) + own agent rows — exactly
+   what the caller can already recall. Cross-fleet / tenant-wide reporting is
+   deliberately NOT exposed here (would need trust ≥ 2; future admin surface).
+
+2. **Destination down-filter (client-asserted, NARROW-ONLY).** The agent declares
+   the delivery *audience class* it will surface into. This can only ever
+   *narrow* the result from check 1 — never widen it. Absent/unknown destination
+   ⇒ fail closed to the most restrictive class.
+
+The corpus is restricted to **durable, decision-bearing** memories: episodic
+activity-log types and the unattributed ``main`` firehose agent are excluded so
+the report reflects durable per-agent work rather than the raw activity stream.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from core_api.auth import AuthContext, get_auth_context
+from core_api.clients.storage_client import get_storage_client
+from core_api.services.audit_service import log_action
+from core_api.services.caller_identity import resolve_caller_and_gate
+
+router = APIRouter(tags=["Reports"])
+
+# Episodic activity-log type(s) + the unattributed firehose agent excluded so the
+# report reflects durable, decision-bearing per-agent work.
+NON_DURABLE_TYPES = ("episode",)
+RESERVED_FIREHOSE_AGENTS = ("main",)
+
+# Delivery audience classes — an abstraction over messaging platforms
+# (WhatsApp / Teams / Slack / Claude-Code map to one of these at the edge).
+AUDIENCE_OWNER_1TO1 = "owner_1to1"
+AUDIENCE_GROUP = "internal_group"
+AUDIENCE_PRIVATE = "private_session"
+AUDIENCE_EXTERNAL = "external"
+_KNOWN_DESTINATIONS = {AUDIENCE_OWNER_1TO1, AUDIENCE_GROUP, AUDIENCE_PRIVATE, AUDIENCE_EXTERNAL}
+# Audiences that may see per-agent detail + learning titles. ``external`` (and any
+# unknown value, which we coerce to ``external``) is fail-closed to summary only.
+_DETAIL_AUDIENCES = {AUDIENCE_OWNER_1TO1, AUDIENCE_GROUP, AUDIENCE_PRIVATE}
+# "self" audiences scope to the caller's OWN contributions (narrowest).
+_SELF_AUDIENCES = {AUDIENCE_OWNER_1TO1, AUDIENCE_PRIVATE}
+
+_PERIOD_DAYS = {"day": 1, "week": 7}
+_LEARNING_LIMIT = 5
+_HIGHLIGHTS_LIMIT = 5
+_TOP_AGENTS_LIMIT = 25
+# Recent in-window durable rows fetched once to derive learning + highlights +
+# spotlight (top-by-recall is taken among these — avoids a recall_count sort dep).
+_DURABLE_FETCH_LIMIT = 60
+# Activity-over-time trend length (daily buckets), independent of the period toggle.
+_TREND_DAYS = 14
+# "What the org is working on" lanes — heuristic keyword match on title/content,
+# with a memory-type fallback so every durable memory lands in a lane.
+_LANE_KEYWORDS = {
+    "Governing": (
+        "rule",
+        "policy",
+        "keystone",
+        "governance",
+        "complian",
+        "trust",
+        "permission",
+        "access",
+        "audit",
+        "security",
+        "regulat",
+        "privacy",
+        "gdpr",
+        "pii",
+        "insider",
+    ),
+    "Building": (
+        "build",
+        "ship",
+        "feature",
+        "implement",
+        "deploy",
+        "product",
+        "integration",
+        "pipeline",
+        "engine",
+        "migration",
+        "release",
+        "launch",
+        "develop",
+        "signal",
+        "portfolio",
+    ),
+    "Operating": (
+        "monitor",
+        "incident",
+        "alert",
+        "outage",
+        "health",
+        "disk",
+        "dba",
+        "reliab",
+        "restart",
+        "latency",
+        "downtime",
+        "backup",
+        "on-call",
+        "stall",
+    ),
+}
+_TYPE_LANE = {
+    "rule": "Governing",
+    "decision": "Governing",
+    "preference": "Governing",
+    "commitment": "Governing",
+    "insight": "Governing",
+    "plan": "Building",
+    "task": "Building",
+    "action": "Building",
+    "intention": "Building",
+    "semantic": "Building",
+    "fact": "Building",
+    "outcome": "Operating",
+    "episode": "Operating",
+    "cancellation": "Operating",
+}
+
+
+@router.get("/reports")
+async def get_report(
+    tenant_id: str = Query(..., description="Tenant scope (validated against the calling credential)."),
+    period: str = Query("week", description="Reporting window: 'day' or 'week'."),
+    destination: str = Query(
+        AUDIENCE_EXTERNAL,
+        description=(
+            "Delivery audience class the agent will surface this into: "
+            "'owner_1to1', 'internal_group', 'private_session', or 'external'. "
+            "Narrows the result; never widens it. Unknown/absent ⇒ most restrictive."
+        ),
+    ),
+    agent_id: str | None = Query(
+        None, description="Caller agent id (gateway-verified X-Agent-ID wins when present)."
+    ),
+    scope: str = Query(
+        "own",
+        description=(
+            "Data breadth: 'own' (home tenant, default) or 'org' (aggregate across "
+            "every tenant the credential may read — requires a cross-tenant read key)."
+        ),
+    ),
+    readable_tenant_ids: str | None = Query(
+        None,
+        description=(
+            "CSV of tenant ids to aggregate under scope='org'. Honored ONLY for the "
+            "internal admin credential (the org-report proxy); every other caller is "
+            "pinned to its own credential's readable set and this value is ignored."
+        ),
+    ),
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict:
+    # Tenant scope is validated against the credential: agent creds can only
+    # report on their own tenant; admin keys may target any tenant.
+    auth.enforce_tenant(tenant_id)
+    if period not in _PERIOD_DAYS:
+        raise HTTPException(status_code=422, detail=f"Invalid period '{period}'. Use 'day' or 'week'.")
+    if scope not in ("own", "org"):
+        raise HTTPException(status_code=422, detail="Invalid scope. Use 'own' or 'org'.")
+
+    # ── Org breadth ("true org level" = a credential capability, not a
+    # memory scope). ``scope='org'`` aggregates across the caller's readable
+    # tenant set and REQUIRES a cross-tenant read credential — a home-only key
+    # cannot widen. Attribution still lives in each tenant's writes; the widened
+    # breakdown keeps Inv-Scope (no agent_id ⇒ excludes ``scope_agent``). ──
+    org_mode = scope == "org"
+    if org_mode and not (auth.is_admin or auth.is_cross_tenant_read):
+        raise HTTPException(
+            status_code=403,
+            detail="scope='org' requires a cross-tenant read credential.",
+        )
+    # The internal admin credential (the enterprise org-report proxy) may pass an
+    # explicit tenant set — the proxy has already org-admin-gated the caller and
+    # resolved the org's own tenants. Every other caller is pinned to its own
+    # credential's readable set; a client-supplied value is ignored so a
+    # cross-tenant agent cannot widen past its grant.
+    if org_mode and auth.is_admin and readable_tenant_ids:
+        readable: list[str] | None = [t.strip() for t in readable_tenant_ids.split(",") if t.strip()]
+    else:
+        readable = auth.readable_tenant_ids if org_mode else None
+
+    # ── Check 1: authorization. ──
+    # ``enforce_tenant`` (above) is the base authz: the caller is a member/admin
+    # of this tenant. An AGENT caller (gateway-verified ``X-Agent-ID`` or an
+    # explicit ``agent_id``) is additionally gated on trust ≥ 1 and resolved for
+    # the self view. A human/tenant dashboard caller has no agent identity — it
+    # gets the tenant GROUP view (never another agent's private rows; the
+    # breakdown's own visibility scoping excludes ``scope_agent`` when no agent
+    # is set). This avoids 403-ing a logged-in human on the unregistered default
+    # agent id.
+    asserted_agent = auth.agent_id or agent_id
+    caller_agent_id: str | None = None
+    if asserted_agent:
+        caller_agent_id = await resolve_caller_and_gate(
+            auth,
+            tenant_id=tenant_id,
+            body_agent_id=asserted_agent,
+            scope="agent",
+            action="reports",
+        )
+
+    # Caller's agent row → fleet (data scope) + belonging (audience target).
+    sc = get_storage_client()
+    caller = (await sc.get_agent(caller_agent_id, tenant_id) or {}) if caller_agent_id else {}
+    caller_fleet = caller.get("fleet_id")
+    belonging_type = caller.get("belonging_type") or "service"
+    owner_ref = caller.get("owner_ref")
+
+    # ── Check 2: destination → data scope (NARROW-ONLY; unknown ⇒ external). ──
+    dest = destination if destination in _KNOWN_DESTINATIONS else AUDIENCE_EXTERNAL
+    now = datetime.now(UTC)
+    window_start = now - timedelta(days=_PERIOD_DAYS[period])
+
+    breakdown_query: dict = {
+        "tenant_id": tenant_id,
+        "created_after": window_start.isoformat(),
+        "exclude_memory_types": list(NON_DURABLE_TYPES),
+        "exclude_agent_ids": list(RESERVED_FIREHOSE_AGENTS),
+    }
+    if org_mode:
+        # Org-wide: aggregate across every tenant the credential may read.
+        # Team/org-visible only (no agent_id ⇒ excludes scope_agent); the
+        # breakdown returns a per-tenant ``by_tenant`` when the set spans >1.
+        breakdown_query["readable_tenant_ids"] = readable
+        scope_label = "org"
+    elif dest in _SELF_AUDIENCES and caller_agent_id:
+        # Narrowest: only the caller's own contributions.
+        breakdown_query["agent_id"] = caller_agent_id
+        scope_label = "self"
+    else:
+        # internal_group / external: the caller's own fleet (team/org-visible).
+        # ``external`` shares the same query but its detail is stripped below.
+        if caller_fleet:
+            breakdown_query["fleet_id"] = caller_fleet
+        scope_label = "group"
+
+    breakdown = await sc.memory_stats_breakdown(breakdown_query)
+    by_agent = {
+        a: c for a, c in (breakdown.get("by_agent") or {}).items() if a not in RESERVED_FIREHOSE_AGENTS
+    }
+    by_type = breakdown.get("by_type") or {}
+    durable_total = int(breakdown.get("total", 0) or 0)
+    by_tenant = breakdown.get("by_tenant") or {}  # populated only in org scope (>1 tenant)
+
+    per_agent: list[dict] = []
+    learning: list[dict] = []
+    value_highlights: list[dict] = []
+    spotlight: dict | None = None
+    trend: list[dict] = []
+    working_on: dict = {}
+    if dest in _DETAIL_AUDIENCES or org_mode:
+        # Per-agent leaderboard, joined with belonging metadata (group view).
+        # Skip the belonging join in org scope — ``list_agents`` is per-tenant
+        # and can't cover the whole readable set (cross-tenant agents get null).
+        belong_by_id: dict[str, dict] = {}
+        if dest == AUDIENCE_GROUP and not org_mode:
+            for row in await sc.list_agents(tenant_id, caller_fleet) or []:
+                aid = row.get("agent_id")
+                if aid:
+                    belong_by_id[aid] = row
+        for aid, cnt in sorted(by_agent.items(), key=lambda kv: kv[1], reverse=True)[:_TOP_AGENTS_LIMIT]:
+            row = belong_by_id.get(aid, {})
+            per_agent.append(
+                {
+                    "agent_id": aid,
+                    "display_name": row.get("display_name"),
+                    "belonging_type": row.get("belonging_type"),
+                    "durable_writes": cnt,
+                }
+            )
+
+        # One fetch of recent in-window durable memories feeds learning,
+        # value_highlights, and the spotlight.
+        list_query: dict = {
+            "tenant_id": tenant_id,
+            "caller_agent_id": caller_agent_id,
+            "created_after": window_start.isoformat(),
+            "sort": "created_at",
+            "order": "desc",
+            "limit": _DURABLE_FETCH_LIMIT,
+        }
+        if org_mode:
+            list_query["readable_tenant_ids"] = readable
+        elif dest == AUDIENCE_GROUP and caller_fleet:
+            list_query["fleet_id"] = caller_fleet
+        rows = await sc.list_memories_by_filters(list_query) or []
+        durable = [
+            m
+            for m in rows
+            if m.get("memory_type") not in NON_DURABLE_TYPES
+            and m.get("agent_id") not in RESERVED_FIREHOSE_AGENTS
+        ]
+
+        def _title(m: dict) -> str:
+            return m.get("title") or (m.get("metadata") or {}).get("summary") or "(untitled)"
+
+        def _rank(m: dict) -> tuple:
+            return (m.get("recall_count") or 0, m.get("created_at") or "")
+
+        # Learning: most recent distilled insights in the window.
+        learning = [
+            {"title": _title(m), "created_at": m.get("created_at")}
+            for m in durable
+            if m.get("memory_type") == "insight"
+        ][:_LEARNING_LIMIT]
+
+        # Value highlights: the most-reused durable knowledge in the window.
+        value_highlights = [
+            {
+                "title": _title(m),
+                "type": m.get("memory_type"),
+                "recall_count": m.get("recall_count") or 0,
+                "agent_id": m.get("agent_id"),
+            }
+            for m in sorted(durable, key=_rank, reverse=True)[:_HIGHLIGHTS_LIMIT]
+        ]
+
+        # Spotlight: the top contributor + their headline durable memory.
+        if per_agent:
+            top = per_agent[0]
+            authored = sorted(
+                (m for m in durable if m.get("agent_id") == top["agent_id"]),
+                key=_rank,
+                reverse=True,
+            )
+            spotlight = {
+                "agent_id": top["agent_id"],
+                "durable_writes": top["durable_writes"],
+                "headline": (
+                    {"title": _title(authored[0]), "type": authored[0].get("memory_type")}
+                    if authored
+                    else None
+                ),
+            }
+
+        # Working-on lanes: heuristic categorization of the window's durable work
+        # (keyword match on title/content, else a memory-type fallback).
+        lanes: dict[str, dict] = {
+            name: {"count": 0, "items": []} for name in ("Governing", "Building", "Operating")
+        }
+        for m in durable:
+            text = (_title(m) + " " + (m.get("content") or "")).lower()
+            lane = next(
+                (name for name, kws in _LANE_KEYWORDS.items() if any(k in text for k in kws)),
+                None,
+            )
+            if lane is None:
+                lane = _TYPE_LANE.get(m.get("memory_type") or "", "Building")
+            lanes[lane]["count"] += 1
+            if len(lanes[lane]["items"]) < 3:
+                lanes[lane]["items"].append(_title(m))
+        working_on = lanes
+
+        # Activity-over-time trend (group/org view): daily durable counts, last _TREND_DAYS.
+        if dest == AUDIENCE_GROUP or org_mode:
+            trend_query: dict = {
+                "tenant_id": tenant_id,
+                "since": (now - timedelta(days=_TREND_DAYS)).isoformat(),
+                "exclude_memory_types": list(NON_DURABLE_TYPES),
+                "exclude_agent_ids": list(RESERVED_FIREHOSE_AGENTS),
+            }
+            if org_mode:
+                trend_query["readable_tenant_ids"] = readable
+            elif caller_fleet:
+                trend_query["fleet_id"] = caller_fleet
+            raw_counts = {
+                r["day"]: r["count"] for r in (await sc.memory_daily_durable_counts(trend_query) or [])
+            }
+            trend = [
+                {
+                    "day": (now.date() - timedelta(days=d)).isoformat(),
+                    "count": raw_counts.get((now.date() - timedelta(days=d)).isoformat(), 0),
+                }
+                for d in reversed(range(_TREND_DAYS))
+            ]
+
+    # ── Audit the read + the declared destination (provenance / no-leakage trail). ──
+    await log_action(
+        tenant_id=tenant_id,
+        action="report_read",
+        resource_type="report",
+        detail={
+            "period": period,
+            "destination": dest,
+            "scope": scope_label,
+            "agent_id": caller_agent_id,
+        },
+    )
+
+    return {
+        "meta": {
+            "period": period,
+            "window_start": window_start.isoformat(),
+            "window_end": now.isoformat(),
+            "tenant_id": tenant_id,
+            "fleet_id": None if org_mode else caller_fleet,
+            "tenants": len(readable) if org_mode and readable else 1,
+            "destination": dest,
+            "scope": scope_label,
+            "corpus": "durable, decision-bearing memories only (excl. episodic logs & 'main')",
+            "belonging": (
+                {"type": belonging_type, "owner_ref": owner_ref}
+                if dest in _SELF_AUDIENCES and not org_mode
+                else None
+            ),
+        },
+        "summary": {
+            "durable_memories_written": durable_total,
+            "active_agents": len(by_agent),
+            "by_type": by_type,
+            "by_tenant": by_tenant,
+        },
+        "per_agent": per_agent,
+        "value_highlights": value_highlights,
+        "spotlight": spotlight,
+        "trend": trend,
+        "working_on": working_on,
+        "learning": learning,
+    }

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -26,6 +26,7 @@ the report reflects durable per-agent work rather than the raw activity stream.
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -41,6 +42,23 @@ router = APIRouter(tags=["Reports"])
 # report reflects durable, decision-bearing per-agent work.
 NON_DURABLE_TYPES = ("episode",)
 RESERVED_FIREHOSE_AGENTS = ("main",)
+
+# "Cohesive" filter: heartbeat / health-check / status-poll noise leaks in as
+# NON-episode rows (e.g. action/outcome "heartbeat" or "Checked HEARTBEAT.md"
+# writes), so the type+firehose exclusion above is not enough — a per-agent
+# leaderboard built on it still counts monitoring pings as "what the agent did".
+# This case-insensitive title regex drops that noise across ALL types so the
+# report reflects real work; genuine rules/decisions/insights never match it, so
+# the value/quality surfaces are unaffected. Applied report-wide (breakdown,
+# durable rows, trend) for a single reconcilable corpus. Pure-monitor agents
+# fall off the leaderboard naturally once their pings are excluded.
+NON_COHESIVE_TITLE_REGEX = (
+    r"(heartbeat|health[- ]?check|healthz|healthy|watchdog|gpu.?health|no.?change|"
+    r"auth error|zero auth|0 auth|encrypted|unreadable|no readable|no actionable|"
+    r"no usable|no_reply|polled|quickcheck|app-fleet|discovery script|"
+    r"gateway (active|reachable)|cache refresh)"
+)
+_NON_COHESIVE_TITLE_RE = re.compile(NON_COHESIVE_TITLE_REGEX, re.IGNORECASE)
 
 # Delivery audience classes — an abstraction over messaging platforms
 # (WhatsApp / Teams / Slack / Claude-Code map to one of these at the edge).
@@ -59,9 +77,15 @@ _PERIOD_DAYS = {"day": 1, "week": 7}
 _LEARNING_LIMIT = 5
 _HIGHLIGHTS_LIMIT = 5
 _TOP_AGENTS_LIMIT = 25
-# Recent in-window durable rows fetched once to derive learning + highlights +
-# spotlight (top-by-recall is taken among these — avoids a recall_count sort dep).
-_DURABLE_FETCH_LIMIT = 60
+# Recent in-window durable rows (created_at desc) feeding LEARNING (recent
+# insights) and the working-on LANES (keyword categorization). Capped for a
+# representative window sample without an unbounded fetch.
+_DURABLE_FETCH_LIMIT = 200
+# Separate recall-sorted fetch backing VALUE HIGHLIGHTS + the spotlight headline,
+# so "most-reused" is the true top-by-recall in the window — not merely the
+# most-reused among the most-recent rows. Over-fetched so post-filtering
+# (episode/firehose/cohesive) still leaves enough to take _HIGHLIGHTS_LIMIT.
+_HIGHLIGHTS_FETCH_LIMIT = 40
 # Activity-over-time trend length (daily buckets), independent of the period toggle.
 _TREND_DAYS = 14
 # "What the org is working on" lanes — heuristic keyword match on title/content,
@@ -234,6 +258,7 @@ async def get_report(
         "created_after": window_start.isoformat(),
         "exclude_memory_types": list(NON_DURABLE_TYPES),
         "exclude_agent_ids": list(RESERVED_FIREHOSE_AGENTS),
+        "exclude_title_regex": NON_COHESIVE_TITLE_REGEX,
     }
     if org_mode:
         # Org-wide: aggregate across every tenant the credential may read.
@@ -287,8 +312,23 @@ async def get_report(
                 }
             )
 
-        # One fetch of recent in-window durable memories feeds learning,
-        # value_highlights, and the spotlight.
+        def _title(m: dict) -> str:
+            return m.get("title") or (m.get("metadata") or {}).get("summary") or "(untitled)"
+
+        def _rank(m: dict) -> tuple:
+            return (m.get("recall_count") or 0, m.get("created_at") or "")
+
+        def _cohesive(m: dict) -> bool:
+            # Mirror the server-side report corpus in Python for the row fetches:
+            # durable (non-episodic, non-firehose) AND not heartbeat/status noise.
+            # Title-only match mirrors the ``exclude_title_regex`` predicate.
+            return (
+                m.get("memory_type") not in NON_DURABLE_TYPES
+                and m.get("agent_id") not in RESERVED_FIREHOSE_AGENTS
+                and not _NON_COHESIVE_TITLE_RE.search(m.get("title") or "")
+            )
+
+        # Recent-ordered fetch → LEARNING (recent insights) + working-on LANES.
         list_query: dict = {
             "tenant_id": tenant_id,
             "caller_agent_id": caller_agent_id,
@@ -301,19 +341,13 @@ async def get_report(
             list_query["readable_tenant_ids"] = readable
         elif dest == AUDIENCE_GROUP and caller_fleet:
             list_query["fleet_id"] = caller_fleet
-        rows = await sc.list_memories_by_filters(list_query) or []
-        durable = [
-            m
-            for m in rows
-            if m.get("memory_type") not in NON_DURABLE_TYPES
-            and m.get("agent_id") not in RESERVED_FIREHOSE_AGENTS
-        ]
+        durable = [m for m in (await sc.list_memories_by_filters(list_query) or []) if _cohesive(m)]
 
-        def _title(m: dict) -> str:
-            return m.get("title") or (m.get("metadata") or {}).get("summary") or "(untitled)"
-
-        def _rank(m: dict) -> tuple:
-            return (m.get("recall_count") or 0, m.get("created_at") or "")
+        # Separate recall-sorted fetch → VALUE HIGHLIGHTS + spotlight headline, so
+        # "most-reused" is the true top-by-recall in the window, not just the
+        # most-reused among the most-recent rows. Over-fetch then post-filter.
+        highlights_query = dict(list_query, sort="recall_count", limit=_HIGHLIGHTS_FETCH_LIMIT)
+        top_durable = [m for m in (await sc.list_memories_by_filters(highlights_query) or []) if _cohesive(m)]
 
         # Learning: most recent distilled insights in the window.
         learning = [
@@ -322,7 +356,9 @@ async def get_report(
             if m.get("memory_type") == "insight"
         ][:_LEARNING_LIMIT]
 
-        # Value highlights: the most-reused durable knowledge in the window.
+        # Value highlights: the most-reused (all-time) durable knowledge authored
+        # in-window. NOTE: recall_count is a lifetime counter — MemClaw has no
+        # per-period recall log — so this is not "reused *this* period".
         value_highlights = [
             {
                 "title": _title(m),
@@ -330,14 +366,18 @@ async def get_report(
                 "recall_count": m.get("recall_count") or 0,
                 "agent_id": m.get("agent_id"),
             }
-            for m in sorted(durable, key=_rank, reverse=True)[:_HIGHLIGHTS_LIMIT]
+            for m in top_durable[:_HIGHLIGHTS_LIMIT]
         ]
 
-        # Spotlight: the top contributor + their headline durable memory.
+        # Spotlight: the top contributor + their headline (highest-recall) memory.
         if per_agent:
             top = per_agent[0]
+            # Search a deduped union of both fetches so the headline is the top
+            # agent's highest-recall in-window memory, whether it surfaced via the
+            # recall-sorted or the recent-ordered fetch.
+            pool = list({m.get("id"): m for m in (*top_durable, *durable)}.values())
             authored = sorted(
-                (m for m in durable if m.get("agent_id") == top["agent_id"]),
+                (m for m in pool if m.get("agent_id") == top["agent_id"]),
                 key=_rank,
                 reverse=True,
             )
@@ -376,6 +416,7 @@ async def get_report(
                 "since": (now - timedelta(days=_TREND_DAYS)).isoformat(),
                 "exclude_memory_types": list(NON_DURABLE_TYPES),
                 "exclude_agent_ids": list(RESERVED_FIREHOSE_AGENTS),
+                "exclude_title_regex": NON_COHESIVE_TITLE_REGEX,
             }
             if org_mode:
                 trend_query["readable_tenant_ids"] = readable
@@ -415,7 +456,10 @@ async def get_report(
             "tenants": len(readable) if org_mode and readable else 1,
             "destination": dest,
             "scope": scope_label,
-            "corpus": "durable, decision-bearing memories only (excl. episodic logs & 'main')",
+            "corpus": (
+                "durable, decision-bearing memories (excl. episodic logs, the "
+                "'main' firehose, and heartbeat/health/status noise)"
+            ),
             "belonging": (
                 {"type": belonging_type, "owner_ref": owner_ref}
                 if dest in _SELF_AUDIENCES and not org_mode

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -26,6 +26,7 @@ the report reflects durable per-agent work rather than the raw activity stream.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from datetime import UTC, datetime, timedelta
 
@@ -293,32 +294,6 @@ async def get_report(
     working_on: dict = {}
     quality: dict = {}
     if dest in _DETAIL_AUDIENCES or org_mode:
-        # Per-agent leaderboard, joined with belonging metadata (group view).
-        # Skip the belonging join in org scope — ``list_agents`` is per-tenant
-        # and can't cover the whole readable set (cross-tenant agents get null).
-        belong_by_id: dict[str, dict] = {}
-        if (dest == AUDIENCE_GROUP or dest in _SELF_AUDIENCES) and not org_mode:
-            # Group view enriches the whole fleet; the self view only needs the
-            # caller's own row (already fetched above) so its single per_agent
-            # entry carries display_name / belonging_type instead of nulls.
-            if dest == AUDIENCE_GROUP:
-                agent_rows = await sc.list_agents(tenant_id, caller_fleet) or []
-            else:
-                agent_rows = [caller] if caller else []
-            for row in agent_rows:
-                aid = row.get("agent_id")
-                if aid:
-                    belong_by_id[aid] = row
-        for aid, cnt in sorted(by_agent.items(), key=lambda kv: kv[1], reverse=True)[:_TOP_AGENTS_LIMIT]:
-            row = belong_by_id.get(aid, {})
-            per_agent.append(
-                {
-                    "agent_id": aid,
-                    "display_name": row.get("display_name"),
-                    "belonging_type": row.get("belonging_type"),
-                    "durable_writes": cnt,
-                }
-            )
 
         def _title(m: dict) -> str:
             return m.get("title") or (m.get("metadata") or {}).get("summary") or "(untitled)"
@@ -358,13 +333,71 @@ async def get_report(
             list_query["readable_tenant_ids"] = readable
         elif dest == AUDIENCE_GROUP and caller_fleet:
             list_query["fleet_id"] = caller_fleet
-        durable = [m for m in (await sc.list_memories_by_filters(list_query) or []) if _cohesive(m)]
-
-        # Separate recall-sorted fetch → VALUE HIGHLIGHTS + spotlight headline, so
-        # "most-reused" is the true top-by-recall in the window, not just the
-        # most-reused among the most-recent rows. Over-fetch then post-filter.
+        # Recall-sorted fetch → VALUE HIGHLIGHTS + spotlight headline (true
+        # top-by-recall, not merely the most-reused among the most-recent rows).
+        # Derived from list_query AFTER the written_by/fleet/readable conditionals.
         highlights_query = dict(list_query, sort="recall_count", limit=_HIGHLIGHTS_FETCH_LIMIT)
-        top_durable = [m for m in (await sc.list_memories_by_filters(highlights_query) or []) if _cohesive(m)]
+
+        # Activity-over-time trend query (group/org only) — built before the gather.
+        want_trend = dest == AUDIENCE_GROUP or org_mode
+        trend_query: dict | None = None
+        if want_trend:
+            trend_query = {
+                "tenant_id": tenant_id,
+                "since": (now - timedelta(days=_TREND_DAYS)).isoformat(),
+                "exclude_memory_types": list(NON_DURABLE_TYPES),
+                "exclude_agent_ids": list(RESERVED_FIREHOSE_AGENTS),
+                "exclude_title_regex": NON_COHESIVE_TITLE_REGEX,
+            }
+            if org_mode:
+                trend_query["readable_tenant_ids"] = readable
+            elif caller_fleet:
+                trend_query["fleet_id"] = caller_fleet
+
+        # ── Phase 1: independent storage reads, concurrently. The belong lookup
+        # (group only) and the trend fetch (group/org only) are conditional. ──
+        want_agents = dest == AUDIENCE_GROUP and not org_mode
+        phase1: dict[str, object] = {
+            "recent": sc.list_memories_by_filters(list_query),
+            "recall": sc.list_memories_by_filters(highlights_query),
+        }
+        if want_agents:
+            phase1["agents"] = sc.list_agents(tenant_id, caller_fleet)
+        if want_trend:
+            phase1["trend"] = sc.memory_daily_durable_counts(trend_query)
+        p1_keys = list(phase1)
+        p1_vals = await asyncio.gather(*(phase1[k] for k in p1_keys))
+        p1 = dict(zip(p1_keys, p1_vals))
+
+        durable = [m for m in (p1["recent"] or []) if _cohesive(m)]
+        top_durable = [m for m in (p1["recall"] or []) if _cohesive(m)]
+
+        # Per-agent leaderboard, joined with belonging metadata. Group = the whole
+        # fleet (list_agents); self = just the caller's own row (already fetched);
+        # org scope skips the join (list_agents is per-tenant, can't cover the
+        # readable set — cross-tenant agents get null).
+        belong_by_id: dict[str, dict] = {}
+        if not org_mode:
+            if dest == AUDIENCE_GROUP:
+                agent_rows = p1.get("agents") or []
+            elif dest in _SELF_AUDIENCES:
+                agent_rows = [caller] if caller else []
+            else:
+                agent_rows = []
+            for row in agent_rows:
+                aid = row.get("agent_id")
+                if aid:
+                    belong_by_id[aid] = row
+        for aid, cnt in sorted(by_agent.items(), key=lambda kv: kv[1], reverse=True)[:_TOP_AGENTS_LIMIT]:
+            row = belong_by_id.get(aid, {})
+            per_agent.append(
+                {
+                    "agent_id": aid,
+                    "display_name": row.get("display_name"),
+                    "belonging_type": row.get("belonging_type"),
+                    "durable_writes": cnt,
+                }
+            )
 
         # Learning: most recent distilled insights in the window.
         learning = [
@@ -426,22 +459,10 @@ async def get_report(
                 lanes[lane]["items"].append(_title(m))
         working_on = lanes
 
-        # Activity-over-time trend (group/org view): daily durable counts, last _TREND_DAYS.
-        if dest == AUDIENCE_GROUP or org_mode:
-            trend_query: dict = {
-                "tenant_id": tenant_id,
-                "since": (now - timedelta(days=_TREND_DAYS)).isoformat(),
-                "exclude_memory_types": list(NON_DURABLE_TYPES),
-                "exclude_agent_ids": list(RESERVED_FIREHOSE_AGENTS),
-                "exclude_title_regex": NON_COHESIVE_TITLE_REGEX,
-            }
-            if org_mode:
-                trend_query["readable_tenant_ids"] = readable
-            elif caller_fleet:
-                trend_query["fleet_id"] = caller_fleet
-            raw_counts = {
-                r["day"]: r["count"] for r in (await sc.memory_daily_durable_counts(trend_query) or [])
-            }
+        # Activity-over-time trend (group/org view): assembled from the Phase-1
+        # daily-durable-counts fetch, bucketed into the last _TREND_DAYS days.
+        if want_trend:
+            raw_counts = {r["day"]: r["count"] for r in (p1.get("trend") or [])}
             trend = [
                 {
                     "day": (now.date() - timedelta(days=d)).isoformat(),
@@ -453,7 +474,23 @@ async def get_report(
         # ── Quality: how good is the durable corpus (not just how much). ──
         # reuse-rate by type, never-recalled %, recall concentration (top-6
         # share), insight freshness, and the write→durable→reused funnel.
-        qm = await sc.memory_quality_metrics(breakdown_query)
+        # Scope keys shared by the three (independent) quality calls below.
+        scope_keys = {
+            k: breakdown_query[k]
+            for k in ("tenant_id", "agent_id", "fleet_id", "readable_tenant_ids")
+            if k in breakdown_query
+        }
+        # ── Phase 2: quality metrics + the two supporting breakdown calls run
+        # concurrently — all independent, and derived only from breakdown_query
+        # (already resolved), not from the main breakdown's results.
+        #   - memory_quality_metrics: reuse-rate/never/concentration over the corpus
+        #   - insight breakdown: lifetime insight corpus by status (freshness)
+        #   - funnel breakdown: full-corpus writes in the window (no excludes)
+        qm, ins, full = await asyncio.gather(
+            sc.memory_quality_metrics(breakdown_query),
+            sc.memory_stats_breakdown({**scope_keys, "memory_type": "insight"}),
+            sc.memory_stats_breakdown({**scope_keys, "created_after": window_start.isoformat()}),
+        )
         q_total = int(qm.get("total", 0) or 0)
         q_reused = int(qm.get("reused", 0) or 0)
         q_recalls = int(qm.get("total_recalls", 0) or 0)
@@ -471,21 +508,10 @@ async def get_report(
             key=lambda r: r["reuse_pct"],
             reverse=True,
         )
-        # Scope keys shared with the two supporting breakdown calls below.
-        scope_keys = {
-            k: breakdown_query[k]
-            for k in ("tenant_id", "agent_id", "fleet_id", "readable_tenant_ids")
-            if k in breakdown_query
-        }
-        # Insight freshness — the lifetime insight corpus (same scope; no window
-        # or excludes) by status. "outdated"/"archived" = gone stale.
-        ins = await sc.memory_stats_breakdown({**scope_keys, "memory_type": "insight"})
+        # Insight freshness — "outdated"/"archived" = gone stale.
         ins_status = ins.get("by_status") or {}
         ins_total = int(ins.get("total", 0) or 0)
         ins_stale = int(ins_status.get("outdated", 0) or 0) + int(ins_status.get("archived", 0) or 0)
-        # Funnel: full-corpus writes in the window (NO durable/cohesive excludes)
-        # → the durable corpus → ever-reused.
-        full = await sc.memory_stats_breakdown({**scope_keys, "created_after": window_start.isoformat()})
         written = int(full.get("total", 0) or 0)
         quality = {
             "never_recalled_pct": round(100.0 * (q_total - q_reused) / q_total, 1) if q_total else 0.0,

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -338,6 +338,15 @@ async def get_report(
             "order": "desc",
             "limit": _DURABLE_FETCH_LIMIT,
         }
+        # Self audiences scope to the caller's OWN authored rows, mirroring the
+        # ``agent_id`` filter applied to breakdown_query on this path — so the
+        # list-derived sections (learning, value_highlights, working_on) stay
+        # consistent with the breakdown-derived counts (durable_total, per_agent).
+        # NOTE: /memories/list filters authorship via ``written_by`` (``agent_id``
+        # is not read on that path); ``caller_agent_id`` above is the visibility
+        # identity, not an author filter.
+        if dest in _SELF_AUDIENCES and caller_agent_id:
+            list_query["written_by"] = caller_agent_id
         if org_mode:
             list_query["readable_tenant_ids"] = readable
         elif dest == AUDIENCE_GROUP and caller_fleet:

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -28,7 +28,9 @@ from __future__ import annotations
 
 import asyncio
 import re
+from collections.abc import Awaitable
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -326,8 +328,9 @@ async def get_report(
         # consistent with the breakdown-derived counts (durable_total, per_agent).
         # NOTE: /memories/list filters authorship via ``written_by`` (``agent_id``
         # is not read on that path); ``caller_agent_id`` above is the visibility
-        # identity, not an author filter.
-        if dest in _SELF_AUDIENCES and caller_agent_id:
+        # identity, not an author filter. Skipped in org_mode: an org-scope report
+        # aggregates the whole readable set, so it must not narrow to one author.
+        if dest in _SELF_AUDIENCES and caller_agent_id and not org_mode:
             list_query["written_by"] = caller_agent_id
         if org_mode:
             list_query["readable_tenant_ids"] = readable
@@ -338,11 +341,21 @@ async def get_report(
         # Derived from list_query AFTER the written_by/fleet/readable conditionals.
         highlights_query = dict(list_query, sort="recall_count", limit=_HIGHLIGHTS_FETCH_LIMIT)
 
-        # Activity-over-time trend query (group/org only) — built before the gather.
+        # ── Phase 1: independent storage reads, concurrently. The agent
+        # leaderboard (group only) and the trend fetch (group/org only) are
+        # conditional. ──
         want_trend = dest == AUDIENCE_GROUP or org_mode
-        trend_query: dict | None = None
+        want_agents = dest == AUDIENCE_GROUP and not org_mode
+        phase1: dict[str, Awaitable[Any]] = {
+            "recent": sc.list_memories_by_filters(list_query),
+            "recall": sc.list_memories_by_filters(highlights_query),
+        }
+        if want_agents:
+            phase1["agents"] = sc.list_agents(tenant_id, caller_fleet)
         if want_trend:
-            trend_query = {
+            # Activity-over-time trend (group/org only). Built here — inside the
+            # guard — so trend_query is a concrete dict, not dict | None.
+            trend_query: dict = {
                 "tenant_id": tenant_id,
                 "since": (now - timedelta(days=_TREND_DAYS)).isoformat(),
                 "exclude_memory_types": list(NON_DURABLE_TYPES),
@@ -353,17 +366,6 @@ async def get_report(
                 trend_query["readable_tenant_ids"] = readable
             elif caller_fleet:
                 trend_query["fleet_id"] = caller_fleet
-
-        # ── Phase 1: independent storage reads, concurrently. The belong lookup
-        # (group only) and the trend fetch (group/org only) are conditional. ──
-        want_agents = dest == AUDIENCE_GROUP and not org_mode
-        phase1: dict[str, object] = {
-            "recent": sc.list_memories_by_filters(list_query),
-            "recall": sc.list_memories_by_filters(highlights_query),
-        }
-        if want_agents:
-            phase1["agents"] = sc.list_agents(tenant_id, caller_fleet)
-        if want_trend:
             phase1["trend"] = sc.memory_daily_durable_counts(trend_query)
         p1_keys = list(phase1)
         p1_vals = await asyncio.gather(*(phase1[k] for k in p1_keys))

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -297,8 +297,15 @@ async def get_report(
         # Skip the belonging join in org scope — ``list_agents`` is per-tenant
         # and can't cover the whole readable set (cross-tenant agents get null).
         belong_by_id: dict[str, dict] = {}
-        if dest == AUDIENCE_GROUP and not org_mode:
-            for row in await sc.list_agents(tenant_id, caller_fleet) or []:
+        if (dest == AUDIENCE_GROUP or dest in _SELF_AUDIENCES) and not org_mode:
+            # Group view enriches the whole fleet; the self view only needs the
+            # caller's own row (already fetched above) so its single per_agent
+            # entry carries display_name / belonging_type instead of nulls.
+            if dest == AUDIENCE_GROUP:
+                agent_rows = await sc.list_agents(tenant_id, caller_fleet) or []
+            else:
+                agent_rows = [caller] if caller else []
+            for row in agent_rows:
                 aid = row.get("agent_id")
                 if aid:
                     belong_by_id[aid] = row

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -291,6 +291,7 @@ async def get_report(
     spotlight: dict | None = None
     trend: list[dict] = []
     working_on: dict = {}
+    quality: dict = {}
     if dest in _DETAIL_AUDIENCES or org_mode:
         # Per-agent leaderboard, joined with belonging metadata (group view).
         # Skip the belonging join in org scope — ``list_agents`` is per-tenant
@@ -433,6 +434,58 @@ async def get_report(
                 for d in reversed(range(_TREND_DAYS))
             ]
 
+        # ── Quality: how good is the durable corpus (not just how much). ──
+        # reuse-rate by type, never-recalled %, recall concentration (top-6
+        # share), insight freshness, and the write→durable→reused funnel.
+        qm = await sc.memory_quality_metrics(breakdown_query)
+        q_total = int(qm.get("total", 0) or 0)
+        q_reused = int(qm.get("reused", 0) or 0)
+        q_recalls = int(qm.get("total_recalls", 0) or 0)
+        top6 = sum(qm.get("top_recalls") or [])
+        reuse_by_type = sorted(
+            (
+                {
+                    "type": t,
+                    "total": int(v.get("total", 0) or 0),
+                    "reused": int(v.get("reused", 0) or 0),
+                    "reuse_pct": round(100.0 * v["reused"] / v["total"], 1) if v.get("total") else 0.0,
+                }
+                for t, v in (qm.get("by_type") or {}).items()
+            ),
+            key=lambda r: r["reuse_pct"],
+            reverse=True,
+        )
+        # Scope keys shared with the two supporting breakdown calls below.
+        scope_keys = {
+            k: breakdown_query[k]
+            for k in ("tenant_id", "agent_id", "fleet_id", "readable_tenant_ids")
+            if k in breakdown_query
+        }
+        # Insight freshness — the lifetime insight corpus (same scope; no window
+        # or excludes) by status. "outdated"/"archived" = gone stale.
+        ins = await sc.memory_stats_breakdown({**scope_keys, "memory_type": "insight"})
+        ins_status = ins.get("by_status") or {}
+        ins_total = int(ins.get("total", 0) or 0)
+        ins_stale = int(ins_status.get("outdated", 0) or 0) + int(ins_status.get("archived", 0) or 0)
+        # Funnel: full-corpus writes in the window (NO durable/cohesive excludes)
+        # → the durable corpus → ever-reused.
+        full = await sc.memory_stats_breakdown({**scope_keys, "created_after": window_start.isoformat()})
+        written = int(full.get("total", 0) or 0)
+        quality = {
+            "never_recalled_pct": round(100.0 * (q_total - q_reused) / q_total, 1) if q_total else 0.0,
+            "recall_concentration_pct": round(100.0 * top6 / q_recalls, 1) if q_recalls else 0.0,
+            "recall_concentration_top6": top6,
+            "total_recalls": q_recalls,
+            "reuse_by_type": reuse_by_type,
+            "insight_freshness": {
+                "total": ins_total,
+                "stale": ins_stale,
+                "stale_pct": round(100.0 * ins_stale / ins_total, 1) if ins_total else 0.0,
+                "by_status": ins_status,
+            },
+            "funnel": {"written": written, "durable": q_total, "reused": q_reused},
+        }
+
     # ── Audit the read + the declared destination (provenance / no-leakage trail). ──
     await log_action(
         tenant_id=tenant_id,
@@ -478,4 +531,5 @@ async def get_report(
         "trend": trend,
         "working_on": working_on,
         "learning": learning,
+        "quality": quality,
     }

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/028_agent_belonging.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/028_agent_belonging.py
@@ -1,0 +1,47 @@
+"""Agent belonging model: ``belonging_type`` + ``owner_ref`` on ``agents``.
+
+Adds the typed agent→owner relationship the report API (GET /api/v1/reports)
+uses to decide where an agent's report is delivered:
+
+  belonging_type='personal' → belongs to a human user (``owner_ref`` = user id);
+                              the agent reports 1:1 to its owner.
+  belonging_type='service'  → belongs to a group/fleet (the group IS ``fleet_id``;
+                              ``owner_ref`` NULL); the agent reports into the group.
+
+Existing rows backfill to ``service`` (server_default) with ``owner_ref`` NULL —
+today's fleet agents keep working unchanged; ``personal`` agents are set
+explicitly. No DB enum/CHECK: the value set is validated at the app layer,
+mirroring ``memories.visibility`` and ``agents.trust_level``.
+
+Revision ID: 028
+Revises: 027
+Create Date: 2026-06-28
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "028"
+down_revision: str | None = "027"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agents",
+        sa.Column(
+            "belonging_type",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'service'"),
+        ),
+    )
+    op.add_column("agents", sa.Column("owner_ref", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "owner_ref")
+    op.drop_column("agents", "belonging_type")

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1085,14 +1085,22 @@ async def stats_breakdown(request: Request) -> dict:
     # as the admin stats route above.
     ca = body.get("created_after")
     cb = body.get("created_before")
+    try:
+        created_after = datetime.fromisoformat(ca) if isinstance(ca, str) else ca
+        created_before = datetime.fromisoformat(cb) if isinstance(cb, str) else cb
+    except ValueError:
+        raise HTTPException(
+            status_code=422,
+            detail="'created_after'/'created_before' must be a valid ISO datetime string",
+        )
     return await _svc.memory_stats_breakdown(
         tenant_id=tenant_id,
         fleet_id=body.get("fleet_id"),
         agent_id=body.get("agent_id"),
         memory_type=body.get("memory_type"),
         status=body.get("status"),
-        created_after=datetime.fromisoformat(ca) if isinstance(ca, str) else ca,
-        created_before=datetime.fromisoformat(cb) if isinstance(cb, str) else cb,
+        created_after=created_after,
+        created_before=created_before,
         exclude_memory_types=body.get("exclude_memory_types"),
         exclude_agent_ids=body.get("exclude_agent_ids"),
         exclude_title_regex=body.get("exclude_title_regex"),
@@ -1114,7 +1122,10 @@ async def daily_durable_counts(request: Request) -> list[dict]:
     if not tenant_id:
         raise HTTPException(status_code=422, detail="tenant_id is required")
     since_raw = body.get("since")
-    since = datetime.fromisoformat(since_raw) if isinstance(since_raw, str) else since_raw
+    try:
+        since = datetime.fromisoformat(since_raw) if isinstance(since_raw, str) else since_raw
+    except ValueError:
+        raise HTTPException(status_code=422, detail="'since' must be a valid ISO datetime string")
     if since is None:
         raise HTTPException(status_code=422, detail="since is required")
     return await _svc.memory_daily_durable_counts(
@@ -1143,11 +1154,15 @@ async def quality_metrics(request: Request) -> dict:
     if not tenant_id and not body.get("readable_tenant_ids"):
         raise HTTPException(status_code=422, detail="tenant_id is required")
     ca = body.get("created_after")
+    try:
+        created_after = datetime.fromisoformat(ca) if isinstance(ca, str) else ca
+    except ValueError:
+        raise HTTPException(status_code=422, detail="'created_after' must be a valid ISO datetime string")
     return await _svc.memory_quality_metrics(
         tenant_id=tenant_id,
         fleet_id=body.get("fleet_id"),
         agent_id=body.get("agent_id"),
-        created_after=datetime.fromisoformat(ca) if isinstance(ca, str) else ca,
+        created_after=created_after,
         exclude_memory_types=body.get("exclude_memory_types"),
         exclude_agent_ids=body.get("exclude_agent_ids"),
         exclude_title_regex=body.get("exclude_title_regex"),

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1128,6 +1128,33 @@ async def daily_durable_counts(request: Request) -> list[dict]:
     )
 
 
+@router.post("/quality-metrics")
+async def quality_metrics(request: Request) -> dict:
+    """Reuse / recall quality aggregates over a scoped corpus (report Quality section).
+
+    Body: ``{tenant_id, fleet_id?, agent_id?, created_after? (ISO),
+    exclude_memory_types?, exclude_agent_ids?, exclude_title_regex?,
+    readable_tenant_ids?}``. Returns ``{total, reused, total_recalls,
+    top_recalls, by_type:{type:{total,reused}}}``. Same scope/visibility as
+    ``/stats-breakdown``; read-only.
+    """
+    body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    if not tenant_id and not body.get("readable_tenant_ids"):
+        raise HTTPException(status_code=422, detail="tenant_id is required")
+    ca = body.get("created_after")
+    return await _svc.memory_quality_metrics(
+        tenant_id=tenant_id,
+        fleet_id=body.get("fleet_id"),
+        agent_id=body.get("agent_id"),
+        created_after=datetime.fromisoformat(ca) if isinstance(ca, str) else ca,
+        exclude_memory_types=body.get("exclude_memory_types"),
+        exclude_agent_ids=body.get("exclude_agent_ids"),
+        exclude_title_regex=body.get("exclude_title_regex"),
+        readable_tenant_ids=body.get("readable_tenant_ids"),
+    )
+
+
 @router.post("/soft-delete-by-filter")
 async def soft_delete_by_filter(request: Request) -> dict:
     """Soft-delete every matching live memory for a tenant.

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1081,13 +1081,47 @@ async def stats_breakdown(request: Request) -> dict:
         # Mirror /list: a binding/home tenant is mandatory. Without it (and with no
         # readable set) the aggregation would run unscoped across all tenants.
         raise HTTPException(status_code=422, detail="tenant_id is required")
+    # Optional report time-window (ISO strings or datetimes) — same parse idiom
+    # as the admin stats route above.
+    ca = body.get("created_after")
+    cb = body.get("created_before")
     return await _svc.memory_stats_breakdown(
         tenant_id=tenant_id,
         fleet_id=body.get("fleet_id"),
         agent_id=body.get("agent_id"),
         memory_type=body.get("memory_type"),
         status=body.get("status"),
+        created_after=datetime.fromisoformat(ca) if isinstance(ca, str) else ca,
+        created_before=datetime.fromisoformat(cb) if isinstance(cb, str) else cb,
+        exclude_memory_types=body.get("exclude_memory_types"),
+        exclude_agent_ids=body.get("exclude_agent_ids"),
         include_deleted=bool(body.get("include_deleted", False)),
+        readable_tenant_ids=body.get("readable_tenant_ids"),
+    )
+
+
+@router.post("/daily-durable-counts")
+async def daily_durable_counts(request: Request) -> list[dict]:
+    """Per-day durable-write counts since ``since`` (report activity trend).
+
+    Body: ``{tenant_id, since (ISO), fleet_id?, exclude_memory_types?,
+    exclude_agent_ids?, readable_tenant_ids?}``. Team/org-scoped (excludes
+    ``scope_agent``); mirrors the durable/firehose exclusions of ``/stats-breakdown``.
+    """
+    body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    if not tenant_id:
+        raise HTTPException(status_code=422, detail="tenant_id is required")
+    since_raw = body.get("since")
+    since = datetime.fromisoformat(since_raw) if isinstance(since_raw, str) else since_raw
+    if since is None:
+        raise HTTPException(status_code=422, detail="since is required")
+    return await _svc.memory_daily_durable_counts(
+        tenant_id=tenant_id,
+        since=since,
+        fleet_id=body.get("fleet_id"),
+        exclude_memory_types=body.get("exclude_memory_types"),
+        exclude_agent_ids=body.get("exclude_agent_ids"),
         readable_tenant_ids=body.get("readable_tenant_ids"),
     )
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -73,9 +73,7 @@ def _validate_pg_regex(value: str | None, field: str) -> None:
     try:
         _re.compile(value)
     except _re.error as exc:
-        raise HTTPException(
-            status_code=422, detail=f"'{field}' is not a valid regex: {exc}"
-        )
+        raise HTTPException(status_code=422, detail=f"'{field}' is not a valid regex: {exc}")
 
 
 @router.post("")

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re as _re
 import time
 from datetime import datetime, timedelta
 from uuid import UUID
@@ -57,6 +58,24 @@ def _parse_datetimes(body: dict) -> dict:
                     detail=f"Invalid ISO datetime for field {key!r}: {val!r}",
                 )
     return body
+
+
+def _validate_pg_regex(value: str | None, field: str) -> None:
+    """Reject a malformed regex at the edge with 422, not a 500 from Postgres.
+
+    ``exclude_title_regex`` flows into a Postgres ``~*`` operator; an invalid
+    pattern would otherwise surface as a DataError deep in the query. Python's
+    ``re`` grammar is close enough to POSIX that compiling it here catches the
+    common client mistakes (unbalanced brackets/parens, dangling quantifiers).
+    """
+    if value is None:
+        return
+    try:
+        _re.compile(value)
+    except _re.error as exc:
+        raise HTTPException(
+            status_code=422, detail=f"'{field}' is not a valid regex: {exc}"
+        )
 
 
 @router.post("")
@@ -1093,6 +1112,7 @@ async def stats_breakdown(request: Request) -> dict:
             status_code=422,
             detail="'created_after'/'created_before' must be a valid ISO datetime string",
         )
+    _validate_pg_regex(body.get("exclude_title_regex"), "exclude_title_regex")
     return await _svc.memory_stats_breakdown(
         tenant_id=tenant_id,
         fleet_id=body.get("fleet_id"),
@@ -1128,6 +1148,7 @@ async def daily_durable_counts(request: Request) -> list[dict]:
         raise HTTPException(status_code=422, detail="'since' must be a valid ISO datetime string")
     if since is None:
         raise HTTPException(status_code=422, detail="since is required")
+    _validate_pg_regex(body.get("exclude_title_regex"), "exclude_title_regex")
     return await _svc.memory_daily_durable_counts(
         tenant_id=tenant_id,
         since=since,
@@ -1158,6 +1179,7 @@ async def quality_metrics(request: Request) -> dict:
         created_after = datetime.fromisoformat(ca) if isinstance(ca, str) else ca
     except ValueError:
         raise HTTPException(status_code=422, detail="'created_after' must be a valid ISO datetime string")
+    _validate_pg_regex(body.get("exclude_title_regex"), "exclude_title_regex")
     return await _svc.memory_quality_metrics(
         tenant_id=tenant_id,
         fleet_id=body.get("fleet_id"),

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1095,6 +1095,7 @@ async def stats_breakdown(request: Request) -> dict:
         created_before=datetime.fromisoformat(cb) if isinstance(cb, str) else cb,
         exclude_memory_types=body.get("exclude_memory_types"),
         exclude_agent_ids=body.get("exclude_agent_ids"),
+        exclude_title_regex=body.get("exclude_title_regex"),
         include_deleted=bool(body.get("include_deleted", False)),
         readable_tenant_ids=body.get("readable_tenant_ids"),
     )
@@ -1105,8 +1106,8 @@ async def daily_durable_counts(request: Request) -> list[dict]:
     """Per-day durable-write counts since ``since`` (report activity trend).
 
     Body: ``{tenant_id, since (ISO), fleet_id?, exclude_memory_types?,
-    exclude_agent_ids?, readable_tenant_ids?}``. Team/org-scoped (excludes
-    ``scope_agent``); mirrors the durable/firehose exclusions of ``/stats-breakdown``.
+    exclude_agent_ids?, exclude_title_regex?, readable_tenant_ids?}``. Team/org-scoped
+    (excludes ``scope_agent``); mirrors the durable/firehose exclusions of ``/stats-breakdown``.
     """
     body: dict = await request.json()
     tenant_id = body.get("tenant_id")
@@ -1122,6 +1123,7 @@ async def daily_durable_counts(request: Request) -> list[dict]:
         fleet_id=body.get("fleet_id"),
         exclude_memory_types=body.get("exclude_memory_types"),
         exclude_agent_ids=body.get("exclude_agent_ids"),
+        exclude_title_regex=body.get("exclude_title_regex"),
         readable_tenant_ids=body.get("readable_tenant_ids"),
     )
 

--- a/core-storage-api/src/core_storage_api/schemas.py
+++ b/core-storage-api/src/core_storage_api/schemas.py
@@ -118,6 +118,8 @@ AGENT_FIELDS: list[str] = [
     "install_id",
     "trust_level",
     "search_profile",
+    "belonging_type",
+    "owner_ref",
     "created_at",
     "updated_at",
 ]

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -3426,6 +3426,7 @@ class PostgresService:
         created_before: datetime | None = None,
         exclude_memory_types: list[str] | None = None,
         exclude_agent_ids: list[str] | None = None,
+        exclude_title_regex: str | None = None,
         include_deleted: bool = False,
         readable_tenant_ids: list[str] | None = None,
     ) -> dict:
@@ -3487,6 +3488,15 @@ class PostgresService:
             scope_filters.append(Memory.memory_type.notin_(exclude_memory_types))
         if exclude_agent_ids:
             scope_filters.append(Memory.agent_id.notin_(exclude_agent_ids))
+        # Report "cohesive" filter: drop heartbeat / health-check / status-poll
+        # noise that isn't type=episode (e.g. action/outcome "heartbeat" rows) so
+        # the per-agent leaderboard reflects real work, not monitoring pings.
+        # ``coalesce(title,'')`` keeps null-title rows instead of dropping them on
+        # the NULL-propagating negation. Case-insensitive POSIX regex (``~*``).
+        if exclude_title_regex:
+            scope_filters.append(
+                ~func.coalesce(Memory.title, "").op("~*")(exclude_title_regex)
+            )
 
         filters = [Memory.deleted_at.is_(None), *scope_filters]
 
@@ -3632,6 +3642,7 @@ class PostgresService:
         fleet_id: str | None = None,
         exclude_memory_types: list[str] | None = None,
         exclude_agent_ids: list[str] | None = None,
+        exclude_title_regex: str | None = None,
         readable_tenant_ids: list[str] | None = None,
     ) -> list[dict]:
         """Per-day durable-write counts since ``since`` — the report's
@@ -3656,6 +3667,8 @@ class PostgresService:
             conds.append(Memory.memory_type.notin_(exclude_memory_types))
         if exclude_agent_ids:
             conds.append(Memory.agent_id.notin_(exclude_agent_ids))
+        if exclude_title_regex:
+            conds.append(~func.coalesce(Memory.title, "").op("~*")(exclude_title_regex))
         day = func.date_trunc("day", Memory.created_at)
         stmt = select(day.label("d"), func.count().label("c")).where(*conds).group_by(day).order_by(day)
         async with get_read_session() as session:

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -3494,9 +3494,7 @@ class PostgresService:
         # ``coalesce(title,'')`` keeps null-title rows instead of dropping them on
         # the NULL-propagating negation. Case-insensitive POSIX regex (``~*``).
         if exclude_title_regex:
-            scope_filters.append(
-                ~func.coalesce(Memory.title, "").op("~*")(exclude_title_regex)
-            )
+            scope_filters.append(~func.coalesce(Memory.title, "").op("~*")(exclude_title_regex))
 
         filters = [Memory.deleted_at.is_(None), *scope_filters]
 
@@ -3674,6 +3672,88 @@ class PostgresService:
         async with get_read_session() as session:
             rows = (await session.execute(stmt)).all()
         return [{"day": r.d.date().isoformat(), "count": int(r.c)} for r in rows]
+
+    async def memory_quality_metrics(
+        self,
+        *,
+        tenant_id: str | None,
+        fleet_id: str | None = None,
+        agent_id: str | None = None,
+        created_after: datetime | None = None,
+        exclude_memory_types: list[str] | None = None,
+        exclude_agent_ids: list[str] | None = None,
+        exclude_title_regex: str | None = None,
+        readable_tenant_ids: list[str] | None = None,
+    ) -> dict:
+        """Reuse / recall quality aggregates over the SAME scoped corpus as
+        ``memory_stats_breakdown`` (durable+cohesive when the exclude_* filters are
+        passed). Backs the report Quality section:
+
+        - ``by_type`` = ``{type: {total, reused}}`` → reuse RATE per type,
+        - ``total`` / ``reused`` → never-recalled %,
+        - ``total_recalls`` + ``top_recalls`` (top 6 values) → recall concentration.
+
+        Kept separate from the GROUPING SETS breakdown so that shared (MCP stats)
+        path stays untouched. The scope/visibility block below MUST mirror
+        ``memory_stats_breakdown`` so the two report surfaces reconcile. Read-only
+        (reader replica).
+        """
+        # ── Scope/visibility — MUST mirror memory_stats_breakdown. ──
+        scope_filters = []
+        if readable_tenant_ids:
+            scope_filters.append(Memory.tenant_id.in_(readable_tenant_ids))
+        else:
+            scope_filters.append(Memory.tenant_id == tenant_id)
+        if fleet_id:
+            scope_filters.append(Memory.fleet_id == fleet_id)
+        if agent_id:
+            scope_filters.append(Memory.agent_id == agent_id)
+            scope_filters.append(
+                or_(
+                    Memory.visibility == "scope_org",
+                    Memory.visibility == "scope_team",
+                    and_(Memory.visibility == "scope_agent", Memory.agent_id == agent_id),
+                )
+            )
+        else:
+            scope_filters.append(Memory.visibility != "scope_agent")
+        if created_after:
+            scope_filters.append(Memory.created_at >= created_after)
+        if exclude_memory_types:
+            scope_filters.append(Memory.memory_type.notin_(exclude_memory_types))
+        if exclude_agent_ids:
+            scope_filters.append(Memory.agent_id.notin_(exclude_agent_ids))
+        if exclude_title_regex:
+            scope_filters.append(~func.coalesce(Memory.title, "").op("~*")(exclude_title_regex))
+        filters = [Memory.deleted_at.is_(None), *scope_filters]
+
+        reused = case((Memory.recall_count > 0, 1), else_=0)
+        per_type_stmt = (
+            select(
+                Memory.memory_type,
+                func.count().label("n"),
+                func.coalesce(func.sum(reused), 0).label("r"),
+            )
+            .where(*filters)
+            .group_by(Memory.memory_type)
+        )
+        overall_stmt = select(
+            func.count(),
+            func.coalesce(func.sum(reused), 0),
+            func.coalesce(func.sum(Memory.recall_count), 0),
+        ).where(*filters)
+        top_stmt = select(Memory.recall_count).where(*filters).order_by(Memory.recall_count.desc()).limit(6)
+        async with get_read_session() as session:
+            per_type = (await session.execute(per_type_stmt)).all()
+            total, total_reused, total_recalls = (await session.execute(overall_stmt)).one()
+            top_recalls = [int(x[0] or 0) for x in (await session.execute(top_stmt)).all()]
+        return {
+            "total": int(total or 0),
+            "reused": int(total_reused or 0),
+            "total_recalls": int(total_recalls or 0),
+            "top_recalls": top_recalls,
+            "by_type": {r.memory_type: {"total": int(r.n), "reused": int(r.r or 0)} for r in per_type},
+        }
 
     # ══════════════════════════════════════════════════════════════════════
     #  ENTITIES

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -3667,7 +3667,12 @@ class PostgresService:
             conds.append(Memory.agent_id.notin_(exclude_agent_ids))
         if exclude_title_regex:
             conds.append(~func.coalesce(Memory.title, "").op("~*")(exclude_title_regex))
-        day = func.date_trunc("day", Memory.created_at)
+        # Bucket by UTC day: the report caller builds its day-keys in UTC
+        # (datetime.now(UTC)), but bare date_trunc uses the PG session TimeZone —
+        # a non-UTC session TZ would shift the buckets so every raw_counts.get()
+        # misses and silently zeroes the whole trend. ``timezone('UTC', ...)``
+        # normalizes the timestamptz to UTC wall-clock before truncating.
+        day = func.date_trunc("day", func.timezone("UTC", Memory.created_at))
         stmt = select(day.label("d"), func.count().label("c")).where(*conds).group_by(day).order_by(day)
         async with get_read_session() as session:
             rows = (await session.execute(stmt)).all()

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -3422,11 +3422,21 @@ class PostgresService:
         agent_id: str | None = None,
         memory_type: str | None = None,
         status: str | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+        exclude_memory_types: list[str] | None = None,
+        exclude_agent_ids: list[str] | None = None,
         include_deleted: bool = False,
         readable_tenant_ids: list[str] | None = None,
     ) -> dict:
         """Return ``{total, by_type, by_agent, by_status}`` (+ optional
         ``by_tenant`` / ``deleted`` / ``total_including_deleted``).
+
+        ``created_after`` / ``created_before`` bound the aggregation to a
+        half-open ``[after, before)`` window — used by the daily/weekly report
+        (GET /api/v1/reports) for "what each agent did in the period". Both
+        optional; omitting them aggregates all-time (the MCP ``memclaw_stats``
+        behaviour, unchanged).
 
         Ports core-api ``services.memory_stats.compute_memory_stats`` verbatim —
         same visibility scoping (``agent_id`` doubles as visibility identity AND
@@ -3463,6 +3473,20 @@ class PostgresService:
             scope_filters.append(Memory.memory_type == memory_type)
         if status:
             scope_filters.append(Memory.status == status)
+        # Report time-window: half-open [created_after, created_before). Added to
+        # ``scope_filters`` so it flows through BOTH the live and include_deleted
+        # query paths below (each derives from this list).
+        if created_after:
+            scope_filters.append(Memory.created_at >= created_after)
+        if created_before:
+            scope_filters.append(Memory.created_at < created_before)
+        # Report "durable, decision-bearing" filter: drop episodic activity-log
+        # types and the unattributed firehose agent ("main") so the report
+        # reflects real per-agent work rather than the raw activity stream.
+        if exclude_memory_types:
+            scope_filters.append(Memory.memory_type.notin_(exclude_memory_types))
+        if exclude_agent_ids:
+            scope_filters.append(Memory.agent_id.notin_(exclude_agent_ids))
 
         filters = [Memory.deleted_at.is_(None), *scope_filters]
 
@@ -3495,7 +3519,17 @@ class PostgresService:
         # Returns (where_fragment, params) to thread into the ``text()`` execute.
         def _predicate_sql(filter_list) -> tuple[str, dict]:
             compiled = (
-                select(Memory.id).where(*filter_list).compile(dialect=postgresql.dialect(paramstyle="named"))
+                select(Memory.id)
+                .where(*filter_list)
+                # ``render_postcompile`` expands IN/NOT IN bind lists (e.g. the
+                # exclude_memory_types / exclude_agent_ids filters) into individual
+                # named params at compile time. Without it the compiled string
+                # carries an unexpanded ``[POSTCOMPILE_x]`` placeholder that the
+                # raw ``text()`` re-execution below cannot bind ("column __ ...").
+                .compile(
+                    dialect=postgresql.dialect(paramstyle="named"),
+                    compile_kwargs={"render_postcompile": True},
+                )
             )
             rendered = str(compiled)
             idx = rendered.upper().find("WHERE ")
@@ -3589,6 +3623,44 @@ class PostgresService:
             result["deleted"] = deleted
             result["total_including_deleted"] = total + deleted
         return result
+
+    async def memory_daily_durable_counts(
+        self,
+        *,
+        tenant_id: str,
+        since: datetime,
+        fleet_id: str | None = None,
+        exclude_memory_types: list[str] | None = None,
+        exclude_agent_ids: list[str] | None = None,
+        readable_tenant_ids: list[str] | None = None,
+    ) -> list[dict]:
+        """Per-day durable-write counts since ``since`` — the report's
+        activity-over-time trend. Same durable/firehose exclusions and
+        team/org visibility scope as ``memory_stats_breakdown`` (no agent_id ⇒
+        excludes ``scope_agent``). Runs as a plain ORM ``GROUP BY`` executed
+        directly (no compile→text round-trip, so ``NOT IN`` expands natively).
+        Read-only (reader replica).
+        """
+        conds = [
+            Memory.deleted_at.is_(None),
+            Memory.created_at >= since,
+            Memory.visibility != "scope_agent",
+        ]
+        if readable_tenant_ids:
+            conds.append(Memory.tenant_id.in_(readable_tenant_ids))
+        else:
+            conds.append(Memory.tenant_id == tenant_id)
+        if fleet_id:
+            conds.append(Memory.fleet_id == fleet_id)
+        if exclude_memory_types:
+            conds.append(Memory.memory_type.notin_(exclude_memory_types))
+        if exclude_agent_ids:
+            conds.append(Memory.agent_id.notin_(exclude_agent_ids))
+        day = func.date_trunc("day", Memory.created_at)
+        stmt = select(day.label("d"), func.count().label("c")).where(*conds).group_by(day).order_by(day)
+        async with get_read_session() as session:
+            rows = (await session.execute(stmt)).all()
+        return [{"day": r.d.date().isoformat(), "count": int(r.c)} for r in rows]
 
     # ══════════════════════════════════════════════════════════════════════
     #  ENTITIES

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -265,6 +265,138 @@ async def test_report_org_scope_admin_readable_param(client):
     assert body["summary"]["by_tenant"] == {t1: 2, t2: 3}, body["summary"]["by_tenant"]
 
 
+async def _seed_titled(client, headers, tenant_id, fleet, agent, mtype, title):
+    """Create a durable memory then set an exact title via the storage client.
+
+    Enrichment runs inline in tests and would auto-title, so we PATCH the title
+    directly to make the cohesive-filter assertions enrichment-independent.
+    Returns the memory id.
+    """
+    r = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": agent,
+            "fleet_id": fleet,
+            "memory_type": mtype,
+            "visibility": "scope_team",
+            "content": f"{title} {_uid()}",
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    mid = r.json()["id"]
+    await get_storage_client().update_memory(mid, tenant_id, {"title": title})
+    return mid
+
+
+async def test_report_excludes_noncohesive_titles(client):
+    """Non-episode heartbeat / health / status memories are excluded.
+
+    The durable filter (episode + ``main``) is not sufficient: monitoring pings
+    are written as NON-episode rows (a ``decision``/``outcome``/``action`` titled
+    "Heartbeat check…", "GPU health check…", "Gateway healthy…"). The cohesive
+    title filter drops them so the per-agent leaderboard and highlights reflect
+    real work, not pings.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet, a1 = f"rep-fleet-{tag}", f"rep-a1-{tag}"
+    await _register(tenant_id, fleet, a1)
+
+    # Genuine durable work — kept. (Only decision/fact/semantic are writable
+    # directly; outcome/rule/insight are server-reserved. The noise the filter
+    # targets is in the TITLE, not the type, so non-episode types suffice.)
+    await _seed_titled(
+        client, headers, tenant_id, fleet, a1, "decision",
+        "Chose Postgres over Mongo for the signal store",
+    )
+    await _seed_titled(
+        client, headers, tenant_id, fleet, a1, "semantic",
+        "Verify a project URL via the proxy before sharing it",
+    )
+    # Non-episode monitoring noise — excluded by the cohesive title filter.
+    await _seed_titled(
+        client, headers, tenant_id, fleet, a1, "decision",
+        "Heartbeat check for GoodDollar L2 builder status",
+    )
+    await _seed_titled(
+        client, headers, tenant_id, fleet, a1, "fact",
+        "GPU health check recorded no_change",
+    )
+    await _seed_titled(
+        client, headers, tenant_id, fleet, a1, "semantic",
+        "Gateway healthy: zero auth errors",
+    )
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "internal_group",
+            "agent_id": a1,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Only the 2 genuine memories survive the cohesive filter.
+    assert body["summary"]["durable_memories_written"] == 2, body["summary"]
+    assert {p["agent_id"]: p["durable_writes"] for p in body["per_agent"]} == {a1: 2}
+    titles = " ".join(h["title"].lower() for h in body["value_highlights"])
+    assert "heartbeat" not in titles and "health check" not in titles, body["value_highlights"]
+    assert "gateway healthy" not in titles, body["value_highlights"]
+    assert len(body["value_highlights"]) == 2, body["value_highlights"]
+    # Trend counts share the cohesive corpus (noise excluded there too).
+    assert sum(pt["count"] for pt in body["trend"]) == 2, body["trend"]
+
+
+async def test_report_value_highlights_ranked_by_recall(client):
+    """value_highlights is the true top-by-recall in the window (dedicated
+    recall-sorted fetch), not merely the most-reused among the most-recent rows —
+    it surfaces an older-but-heavily-reused memory above newer, unreused ones.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet, a1 = f"rep-fleet-{tag}", f"rep-a1-{tag}"
+    await _register(tenant_id, fleet, a1)
+    sc = get_storage_client()
+
+    older = await _seed_titled(
+        client, headers, tenant_id, fleet, a1, "decision",
+        "Older but heavily-reused architecture decision",
+    )
+    # Newer, unreused writes created AFTER the high-recall one.
+    for i in range(3):
+        await _seed_titled(
+            client, headers, tenant_id, fleet, a1, "fact", f"Newer reference fact {i}"
+        )
+    # Bump the older memory's lifetime recall so it is the top by recall.
+    for _ in range(3):
+        assert await sc.increment_recall([older]) == 1
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "internal_group",
+            "agent_id": a1,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["value_highlights"], body
+    top = body["value_highlights"][0]
+    assert top["title"] == "Older but heavily-reused architecture decision", body["value_highlights"]
+    assert top["recall_count"] == 3, top
+    # Spotlight headline is the top contributor's highest-recall memory.
+    assert body["spotlight"]["agent_id"] == a1
+    assert body["spotlight"]["headline"]["title"] == "Older but heavily-reused architecture decision", body["spotlight"]
+
+
 async def test_report_org_scope_requires_cross_tenant_key(client):
     """scope=org without a cross-tenant read credential → 403 (home-only key can't widen)."""
     tag = _uid()

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -114,6 +114,14 @@ async def test_report_owner_1to1_is_self(client):
     body = resp.json()
     assert body["meta"]["scope"] == "self", body["meta"]
     assert body["summary"]["durable_memories_written"] == 2, body  # only a1's own
+    # List-derived sections are author-scoped to the caller too (self path),
+    # consistent with the breakdown counts — a2's team-visible fact must NOT leak.
+    assert all(h["agent_id"] == a1 for h in body["value_highlights"]), body[
+        "value_highlights"
+    ]
+    assert body["spotlight"] is None or body["spotlight"]["agent_id"] == a1, body[
+        "spotlight"
+    ]
 
 
 async def test_report_external_is_fail_closed(client):
@@ -308,24 +316,49 @@ async def test_report_excludes_noncohesive_titles(client):
     # directly; outcome/rule/insight are server-reserved. The noise the filter
     # targets is in the TITLE, not the type, so non-episode types suffice.)
     await _seed_titled(
-        client, headers, tenant_id, fleet, a1, "decision",
+        client,
+        headers,
+        tenant_id,
+        fleet,
+        a1,
+        "decision",
         "Chose Postgres over Mongo for the signal store",
     )
     await _seed_titled(
-        client, headers, tenant_id, fleet, a1, "semantic",
+        client,
+        headers,
+        tenant_id,
+        fleet,
+        a1,
+        "semantic",
         "Verify a project URL via the proxy before sharing it",
     )
     # Non-episode monitoring noise — excluded by the cohesive title filter.
     await _seed_titled(
-        client, headers, tenant_id, fleet, a1, "decision",
+        client,
+        headers,
+        tenant_id,
+        fleet,
+        a1,
+        "decision",
         "Heartbeat check for GoodDollar L2 builder status",
     )
     await _seed_titled(
-        client, headers, tenant_id, fleet, a1, "fact",
+        client,
+        headers,
+        tenant_id,
+        fleet,
+        a1,
+        "fact",
         "GPU health check recorded no_change",
     )
     await _seed_titled(
-        client, headers, tenant_id, fleet, a1, "semantic",
+        client,
+        headers,
+        tenant_id,
+        fleet,
+        a1,
+        "semantic",
         "Gateway healthy: zero auth errors",
     )
 
@@ -345,7 +378,9 @@ async def test_report_excludes_noncohesive_titles(client):
     assert body["summary"]["durable_memories_written"] == 2, body["summary"]
     assert {p["agent_id"]: p["durable_writes"] for p in body["per_agent"]} == {a1: 2}
     titles = " ".join(h["title"].lower() for h in body["value_highlights"])
-    assert "heartbeat" not in titles and "health check" not in titles, body["value_highlights"]
+    assert "heartbeat" not in titles and "health check" not in titles, body[
+        "value_highlights"
+    ]
     assert "gateway healthy" not in titles, body["value_highlights"]
     assert len(body["value_highlights"]) == 2, body["value_highlights"]
     # Trend counts share the cohesive corpus (noise excluded there too).
@@ -364,7 +399,12 @@ async def test_report_value_highlights_ranked_by_recall(client):
     sc = get_storage_client()
 
     older = await _seed_titled(
-        client, headers, tenant_id, fleet, a1, "decision",
+        client,
+        headers,
+        tenant_id,
+        fleet,
+        a1,
+        "decision",
         "Older but heavily-reused architecture decision",
     )
     # Newer, unreused writes created AFTER the high-recall one.
@@ -390,11 +430,16 @@ async def test_report_value_highlights_ranked_by_recall(client):
     body = resp.json()
     assert body["value_highlights"], body
     top = body["value_highlights"][0]
-    assert top["title"] == "Older but heavily-reused architecture decision", body["value_highlights"]
+    assert top["title"] == "Older but heavily-reused architecture decision", body[
+        "value_highlights"
+    ]
     assert top["recall_count"] == 3, top
     # Spotlight headline is the top contributor's highest-recall memory.
     assert body["spotlight"]["agent_id"] == a1
-    assert body["spotlight"]["headline"]["title"] == "Older but heavily-reused architecture decision", body["spotlight"]
+    assert (
+        body["spotlight"]["headline"]["title"]
+        == "Older but heavily-reused architecture decision"
+    ), body["spotlight"]
 
 
 async def test_report_quality_metrics(client):
@@ -410,9 +455,15 @@ async def test_report_quality_metrics(client):
     await _register(tenant_id, fleet, a1)
     sc = get_storage_client()
 
-    d1 = await _seed_titled(client, headers, tenant_id, fleet, a1, "decision", f"Decision one {tag}")
-    await _seed_titled(client, headers, tenant_id, fleet, a1, "decision", f"Decision two {tag}")
-    f1 = await _seed_titled(client, headers, tenant_id, fleet, a1, "fact", f"Fact one {tag}")
+    d1 = await _seed_titled(
+        client, headers, tenant_id, fleet, a1, "decision", f"Decision one {tag}"
+    )
+    await _seed_titled(
+        client, headers, tenant_id, fleet, a1, "decision", f"Decision two {tag}"
+    )
+    f1 = await _seed_titled(
+        client, headers, tenant_id, fleet, a1, "fact", f"Fact one {tag}"
+    )
     await _seed_titled(client, headers, tenant_id, fleet, a1, "fact", f"Fact two {tag}")
     # One episode — counts toward the funnel's "written" but not the durable corpus.
     await _seed(client, headers, tenant_id, fleet, a1, "episode", 1)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,281 @@
+"""Integration tests for GET /api/v1/reports — the governed two-check read.
+
+Real FastAPI app + in-process storage (see conftest). Validates:
+- durable corpus filter (excludes the ``episode`` type and the ``main`` firehose),
+- destination narrowing (owner_1to1 = self, internal_group = fleet, external = fail-closed),
+- period validation.
+"""
+
+import pytest
+
+from core_api.app import app
+from core_api.auth import AuthContext, get_auth_context
+from core_api.clients.storage_client import get_storage_client
+from tests.conftest import get_test_auth, uid as _uid
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _register(tenant_id, fleet, *agents):
+    sc = get_storage_client()
+    for a in agents:
+        await sc.create_or_update_agent(
+            {"tenant_id": tenant_id, "agent_id": a, "fleet_id": fleet, "trust_level": 1}
+        )
+
+
+async def _seed(client, headers, tenant_id, fleet, agent, mtype, n=1):
+    for i in range(n):
+        r = await client.post(
+            "/api/v1/memories",
+            json={
+                "tenant_id": tenant_id,
+                "agent_id": agent,
+                "fleet_id": fleet,
+                "memory_type": mtype,
+                "visibility": "scope_team",
+                "content": f"{mtype} by {agent} #{i} {_uid()}",
+            },
+            headers=headers,
+        )
+        assert r.status_code == 201, r.text
+
+
+async def test_report_internal_group_durable_filter(client):
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet, a1, a2 = f"rep-fleet-{tag}", f"rep-a1-{tag}", f"rep-a2-{tag}"
+    await _register(tenant_id, fleet, a1, a2)
+    await _seed(client, headers, tenant_id, fleet, a1, "decision", 2)
+    await _seed(client, headers, tenant_id, fleet, a2, "fact", 1)
+    await _seed(
+        client, headers, tenant_id, fleet, a1, "episode", 1
+    )  # excluded: episodic
+    await _seed(
+        client, headers, tenant_id, fleet, "main", "fact", 1
+    )  # excluded: firehose
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "internal_group",
+            "agent_id": a1,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["summary"]["durable_memories_written"] == 3, body
+    assert body["summary"]["active_agents"] == 2, body
+    agents = {p["agent_id"]: p["durable_writes"] for p in body["per_agent"]}
+    assert agents == {a1: 2, a2: 1}, agents
+    assert "main" not in agents
+    assert "episode" not in body["summary"]["by_type"], body["summary"]["by_type"]
+    # weekly extras: value_highlights (top durable) + spotlight (top contributor)
+    assert len(body["value_highlights"]) == 3, body["value_highlights"]
+    assert all(
+        "episode" != h["type"] and h["agent_id"] != "main"
+        for h in body["value_highlights"]
+    )
+    assert body["spotlight"]["agent_id"] == a1, body["spotlight"]
+    assert body["spotlight"]["durable_writes"] == 2
+    assert body["spotlight"]["headline"] is not None
+    # activity-over-time trend (14 daily buckets) + working-on lanes
+    assert len(body["trend"]) == 14, body["trend"]
+    assert sum(pt["count"] for pt in body["trend"]) == 3, body["trend"]
+    assert set(body["working_on"]) == {"Governing", "Building", "Operating"}
+    assert body["working_on"]["Governing"]["count"] == 2, body[
+        "working_on"
+    ]  # 2 decisions
+    assert body["working_on"]["Building"]["count"] == 1, body["working_on"]  # 1 fact
+
+
+async def test_report_owner_1to1_is_self(client):
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet, a1, a2 = f"rep-fleet-{tag}", f"rep-a1-{tag}", f"rep-a2-{tag}"
+    await _register(tenant_id, fleet, a1, a2)
+    await _seed(client, headers, tenant_id, fleet, a1, "decision", 2)
+    await _seed(client, headers, tenant_id, fleet, a2, "fact", 1)
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "owner_1to1",
+            "agent_id": a1,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["meta"]["scope"] == "self", body["meta"]
+    assert body["summary"]["durable_memories_written"] == 2, body  # only a1's own
+
+
+async def test_report_external_is_fail_closed(client):
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet, a1 = f"rep-fleet-{tag}", f"rep-a1-{tag}"
+    await _register(tenant_id, fleet, a1)
+    await _seed(client, headers, tenant_id, fleet, a1, "decision", 2)
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "external",
+            "agent_id": a1,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["meta"]["destination"] == "external"
+    assert body["per_agent"] == [], body  # fail-closed: no per-agent detail
+    assert body["learning"] == [], body
+
+
+async def test_report_unknown_destination_and_invalid_period(client):
+    tenant_id, headers = get_test_auth()
+    a1 = f"rep-a1-{_uid()}"
+    # Unknown destination → coerced to most-restrictive ``external`` (still 200).
+    r1 = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "bogus",
+            "agent_id": a1,
+        },
+        headers=headers,
+    )
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["meta"]["destination"] == "external"
+    # Invalid period → 422.
+    r2 = await client.get(
+        "/api/v1/reports",
+        params={"tenant_id": tenant_id, "period": "month", "agent_id": a1},
+        headers=headers,
+    )
+    assert r2.status_code == 422, r2.text
+
+
+async def test_report_no_agent_caller_is_group_view(client):
+    """Human/tenant caller (no agent_id) → tenant group view, NOT a 403.
+
+    Regression guard for the auth fix: the trust gate only runs for agent
+    callers; a tenant member/admin with no agent identity is authorized for the
+    group view by enforce_tenant. Uses a dedicated tenant so the tenant-wide
+    (no-fleet) group view is isolated from other tests.
+    """
+    tag = _uid()
+    tenant_id, headers = get_test_auth(f"rep-tenant-{tag}")
+    fleet, a1, a2 = f"rep-fleet-{tag}", f"rep-a1-{tag}", f"rep-a2-{tag}"
+    await _register(tenant_id, fleet, a1, a2)
+    await _seed(client, headers, tenant_id, fleet, a1, "decision", 2)
+    await _seed(client, headers, tenant_id, fleet, a2, "fact", 1)
+    await _seed(client, headers, tenant_id, fleet, "main", "fact", 2)  # excluded
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "internal_group",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text  # the fix: not 403
+    body = resp.json()
+    assert body["meta"]["scope"] == "group"
+    agents = {p["agent_id"]: p["durable_writes"] for p in body["per_agent"]}
+    assert agents == {a1: 2, a2: 1}, agents
+    assert body["summary"]["durable_memories_written"] == 3, body
+
+
+async def test_report_org_scope_aggregates_across_tenants(client):
+    """scope=org with a cross-tenant read credential aggregates across the
+    readable tenant set and returns a per-tenant breakdown."""
+    tag = _uid()
+    t1, t2 = f"rep-org1-{tag}", f"rep-org2-{tag}"
+    _, headers = get_test_auth(
+        t1
+    )  # admin key — used only to SEED (before the override)
+    await _register(t1, f"f1-{tag}", f"a1-{tag}")
+    await _register(t2, f"f2-{tag}", f"a2-{tag}")
+    await _seed(client, headers, t1, f"f1-{tag}", f"a1-{tag}", "decision", 2)
+    await _seed(client, headers, t2, f"f2-{tag}", f"a2-{tag}", "fact", 3)
+
+    ctx = AuthContext(tenant_id=t1, readable_tenant_ids=[t1, t2])  # cross-tenant reader
+    app.dependency_overrides[get_auth_context] = lambda: ctx
+    try:
+        resp = await client.get(
+            "/api/v1/reports",
+            params={
+                "tenant_id": t1,
+                "period": "week",
+                "destination": "internal_group",
+                "scope": "org",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["meta"]["scope"] == "org"
+        assert body["summary"]["durable_memories_written"] == 5, body["summary"]
+        assert body["summary"]["by_tenant"] == {t1: 2, t2: 3}, body["summary"][
+            "by_tenant"
+        ]
+    finally:
+        app.dependency_overrides.pop(get_auth_context, None)
+
+
+async def test_report_org_scope_admin_readable_param(client):
+    """The internal admin credential may pass an explicit ``readable_tenant_ids``
+    (the org-report proxy path). A non-admin caller's value is ignored — asserted
+    by the sibling override tests, which never pass the param.
+    """
+    tag = _uid()
+    t1, t2 = f"rep-adm1-{tag}", f"rep-adm2-{tag}"
+    _, headers = get_test_auth(t1)  # admin key (is_admin=True)
+    await _register(t1, f"f1-{tag}", f"a1-{tag}")
+    await _register(t2, f"f2-{tag}", f"a2-{tag}")
+    await _seed(client, headers, t1, f"f1-{tag}", f"a1-{tag}", "decision", 2)
+    await _seed(client, headers, t2, f"f2-{tag}", f"a2-{tag}", "fact", 3)
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": t1,
+            "period": "week",
+            "destination": "internal_group",
+            "scope": "org",
+            "readable_tenant_ids": f"{t1},{t2}",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["meta"]["scope"] == "org"
+    assert body["summary"]["durable_memories_written"] == 5, body["summary"]
+    assert body["summary"]["by_tenant"] == {t1: 2, t2: 3}, body["summary"]["by_tenant"]
+
+
+async def test_report_org_scope_requires_cross_tenant_key(client):
+    """scope=org without a cross-tenant read credential → 403 (home-only key can't widen)."""
+    tag = _uid()
+    t1 = f"rep-org-solo-{tag}"
+    ctx = AuthContext(tenant_id=t1)  # single-tenant, non-admin
+    app.dependency_overrides[get_auth_context] = lambda: ctx
+    try:
+        resp = await client.get(
+            "/api/v1/reports",
+            params={"tenant_id": t1, "period": "week", "scope": "org"},
+        )
+        assert resp.status_code == 403, resp.text
+    finally:
+        app.dependency_overrides.pop(get_auth_context, None)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -397,6 +397,57 @@ async def test_report_value_highlights_ranked_by_recall(client):
     assert body["spotlight"]["headline"]["title"] == "Older but heavily-reused architecture decision", body["spotlight"]
 
 
+async def test_report_quality_metrics(client):
+    """Quality block: reuse-rate by type, never-recalled %, recall concentration,
+    the write→durable→reused funnel, and insight-freshness structure.
+
+    Seeds 4 durable memories (2 decisions, 2 facts) with one of each reused, plus
+    one episode (full-corpus only), so every quality figure is deterministic.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet, a1 = f"rep-fleet-{tag}", f"rep-a1-{tag}"
+    await _register(tenant_id, fleet, a1)
+    sc = get_storage_client()
+
+    d1 = await _seed_titled(client, headers, tenant_id, fleet, a1, "decision", f"Decision one {tag}")
+    await _seed_titled(client, headers, tenant_id, fleet, a1, "decision", f"Decision two {tag}")
+    f1 = await _seed_titled(client, headers, tenant_id, fleet, a1, "fact", f"Fact one {tag}")
+    await _seed_titled(client, headers, tenant_id, fleet, a1, "fact", f"Fact two {tag}")
+    # One episode — counts toward the funnel's "written" but not the durable corpus.
+    await _seed(client, headers, tenant_id, fleet, a1, "episode", 1)
+    # Reuse: d1 twice, f1 once → 2 of 4 durable memories ever reused; 3 total recalls.
+    for _ in range(2):
+        assert await sc.increment_recall([d1]) == 1
+    assert await sc.increment_recall([f1]) == 1
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "internal_group",
+            "agent_id": a1,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    q = resp.json()["quality"]
+    # Funnel: 5 written (4 durable + 1 episode), 4 durable, 2 ever-reused.
+    assert q["funnel"] == {"written": 5, "durable": 4, "reused": 2}, q["funnel"]
+    # Never-recalled: 2 of 4 durable → 50%.
+    assert q["never_recalled_pct"] == 50.0, q
+    # Reuse rate by type: decision 1/2, fact 1/2 → 50% each.
+    rbt = {r["type"]: r["reuse_pct"] for r in q["reuse_by_type"]}
+    assert rbt.get("decision") == 50.0 and rbt.get("fact") == 50.0, q["reuse_by_type"]
+    # Concentration: total recalls 3 (=2+1); top-6 captures all → 100%.
+    assert q["total_recalls"] == 3, q
+    assert q["recall_concentration_pct"] == 100.0, q
+    # Insight freshness present and well-formed (no insights seeded here).
+    assert q["insight_freshness"]["total"] == 0, q["insight_freshness"]
+    assert q["insight_freshness"]["stale_pct"] == 0.0, q["insight_freshness"]
+
+
 async def test_report_org_scope_requires_cross_tenant_key(client):
     """scope=org without a cross-tenant read credential → 403 (home-only key can't widen)."""
     tag = _uid()

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"027"}, f"Expected single head '027', got {sorted(heads)}"
+        assert heads == {"028"}, f"Expected single head '028', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -680,6 +680,8 @@ class TestMigrationChain:
         assert chain.get("026") == "025", "026 must follow 025"
         # 027: opt-in recall logging (recall_event + recall_candidate)
         assert chain.get("027") == "026", "027 must follow 026"
+        # 028: agent belonging model (belonging_type + owner_ref)
+        assert chain.get("028") == "027", "028 must follow 027"
 
     def test_no_plain_create_index_on_large_tables(self):
         """Indexes on large, pre-existing tables MUST be built ``CONCURRENTLY``


### PR DESCRIPTION
## What
Adds `GET /api/v1/reports` — a governed, audience-scoped daily/weekly agent activity report: per-agent durable-write counts, a by-type breakdown, and recent distilled insights.

## Changes
- **Agent belonging model** — `belonging_type` + `owner_ref` on `agents` (migration `028`) to resolve report delivery audience; surfaced via `AGENT_FIELDS` so `get_agent`/`list_agents` return them.
- **Windowed + durable breakdown** — `memory_stats_breakdown` gains `created_after`/`created_before` + `exclude_memory_types`/`exclude_agent_ids`, flowing through both the live and `include_deleted` paths. Fixes the compile→`text()` POSTCOMPILE expansion so `NOT IN` filters bind.
- **Two-check governed read** — tenant authorization (`enforce_tenant`) + a **narrow-only** `destination` down-filter (`owner_1to1` / `internal_group` / `private_session` / `external`; unknown or absent fails closed). The trust gate applies to agent callers only; a tenant member gets the group view.
- Corpus = durable, decision-bearing memories (excludes episodic logs + the unattributed default identity).

## Tests
`tests/test_reports.py` — 5 DB-backed cases (durable filter, destination narrowing, fail-closed, period validation, no-agent group view). All green locally against pgvector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
