### PR TITLE
perf(recall): cap summary max_tokens and fail fast on slow provider

### DIFF
--- a/common/llm/retry.py
+++ b/common/llm/retry.py
@@ -88,6 +88,7 @@ async def call_with_fallback(
     model_override: str | None = None,
     model_attr: str = "enrichment_model",
     timeout: float | None = None,
+    max_attempts: int = LLM_RETRY_ATTEMPTS,
     provider_factory: Callable[..., Any] | None = None,
 ) -> T:
     """3-tier fallback chain for LLM calls.
@@ -117,6 +118,11 @@ async def call_with_fallback(
         Attribute name forwarded to the provider factory for resolving the
         default Vertex model. Defaults to ``"enrichment_model"``; entity
         extraction should pass ``"entity_extraction_model"``.
+    max_attempts:
+        Per-provider attempt count, forwarded to ``call_with_retry`` for both the
+        primary and fallback provider. Defaults to ``LLM_RETRY_ATTEMPTS``. Pass
+        ``1`` on latency-sensitive read paths (e.g. recall) to fail fast to the
+        fallback provider instead of retrying a slow/hung primary.
     provider_factory:
         Callable ``(name, tenant_config) -> LLMProvider``. Defaults to
         ``common.llm.registry.get_llm_provider`` (imported lazily to avoid
@@ -150,6 +156,7 @@ async def call_with_fallback(
             return await call_with_retry(
                 lambda: call_fn(provider),
                 label=f"{label}-primary",
+                max_attempts=max_attempts,
                 timeout=timeout,
             )
         logger.warning(
@@ -192,6 +199,7 @@ async def call_with_fallback(
                     return await call_with_retry(
                         lambda: call_fn(fb_provider),
                         label=f"{label}-fallback-{fb_provider_name}",
+                        max_attempts=max_attempts,
                         timeout=timeout,
                     )
     except Exception:

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -512,7 +512,14 @@ RECALL_DECAY_WINDOW_DAYS = 14  # only recalls within this window contribute to b
 
 # ── Recall summary ──
 MEMORY_RECALL_SUMMARY_TEMPERATURE = 0.3
-MEMORY_RECALL_SUMMARY_MAX_TOKENS = 1000
+# Hard cap on recall-summary generation. The recall LLM call is non-streaming and
+# output-bound, so the full generation time is exposed to the caller; this ceiling
+# bounds the worst-case p95+ tail (prod /recall was routinely 5-15s, traced to long
+# summary generations on the recall model). Halved from 1000 to 500: kept at 500
+# rather than lower because RECALL_PROMPT still emits step-by-step reasoning BEFORE
+# the answer, so too tight a cap would truncate the answer itself. If that
+# chain-of-thought is later trimmed from the prompt, this can drop toward ~400.
+MEMORY_RECALL_SUMMARY_MAX_TOKENS = 500
 
 # ── Insights ──
 INSIGHTS_MAX_MEMORIES = 50  # max memories per analysis pass (token budget ~10k)

--- a/core-api/src/core_api/services/recall_service.py
+++ b/core-api/src/core_api/services/recall_service.py
@@ -189,7 +189,14 @@ async def summarize_memories(
         tenant_config=config,
         service_label="recall",
         model_override=recall_model,
-        timeout=30.0,
+        # Recall is a latency-sensitive read path. Cap the per-attempt LLM timeout AND
+        # don't retry the same provider: with the default 2 attempts across primary +
+        # fallback, a slow provider stacks past the 45s request-timeout budget and
+        # surfaces as a Cloud Run "malformed response / connection error" 503. One
+        # primary attempt (15s), then one fallback attempt (15s), then _fake_recall
+        # keeps the worst case ~30s and fails fast instead of hanging.
+        timeout=15.0,
+        max_attempts=1,
     )
 
     recall_ms = int((time.perf_counter() - t0) * 1000)

--- a/tests/test_p4_1_llm_fallback.py
+++ b/tests/test_p4_1_llm_fallback.py
@@ -594,3 +594,70 @@ class TestFakeExtract:
 
         result = _fake_extract("John Smith manages the Auth Team")
         assert result.relations == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: call_with_fallback max_attempts (recall latency lever)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCallWithFallbackMaxAttempts:
+    """``call_with_fallback(max_attempts=...)`` bounds per-provider retries. Recall
+    passes ``max_attempts=1`` so a slow/hung primary fails fast to the fallback
+    provider instead of stacking retries past the request-timeout budget (which
+    surfaces as Cloud Run "malformed response / connection error" 503s)."""
+
+    @staticmethod
+    def _factory(name, tenant_config, **_kwargs):
+        # Non-fake provider so call_with_fallback actually invokes call_fn.
+        return SimpleNamespace(is_fake=False, name=name)
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_1_does_not_retry_primary(self):
+        from common.llm.retry import call_with_fallback
+
+        calls = 0
+
+        async def call_fn(_provider):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("slow/hung")
+
+        with patch("common.llm.retry.asyncio.sleep", new_callable=AsyncMock):
+            result = await call_with_fallback(
+                primary_provider_name="openai",
+                call_fn=call_fn,
+                fake_fn=lambda: "fake",
+                tenant_config=None,  # no fallback configured → straight to fake_fn
+                service_label="recall",
+                max_attempts=1,
+                provider_factory=self._factory,
+            )
+
+        assert result == "fake"
+        assert calls == 1  # one primary attempt, no retry
+
+    @pytest.mark.asyncio
+    async def test_default_max_attempts_retries_primary(self):
+        from common.llm.retry import call_with_fallback
+
+        calls = 0
+
+        async def call_fn(_provider):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("transient")
+
+        with patch("common.llm.retry.asyncio.sleep", new_callable=AsyncMock):
+            result = await call_with_fallback(
+                primary_provider_name="openai",
+                call_fn=call_fn,
+                fake_fn=lambda: "fake",
+                tenant_config=None,
+                service_label="recall",
+                provider_factory=self._factory,
+            )
+
+        assert result == "fake"
+        assert calls == LLM_RETRY_ATTEMPTS  # default retries the primary provider


### PR DESCRIPTION
## What

Two latency levers on the `POST /api/v1/recall` hot path, from the investigation into the prod recall tail (and its link to the Cloud Run 503 alert).

1. **Cap `MEMORY_RECALL_SUMMARY_MAX_TOKENS` 1000 → 500** (`core-api/constants.py`). The recall summary is generated non-streaming, so the full generation time is exposed to the caller and long completions dominate the tail. 500 halves the worst-case output-bound generation.
2. **Recall calls `call_with_fallback(timeout=15.0, max_attempts=1)`** (`recall_service.py`). Adds a backward-compatible `max_attempts` kwarg to `call_with_fallback` (default `LLM_RETRY_ATTEMPTS`, threaded to both the primary and fallback `call_with_retry` — no change for any other caller).

## Why

Prod `POST /api/v1/recall` p95+ was routinely **5–15s** — all HTTP 200, just slow. Traced to the LLM summarization step (`summarize_memories` → `llm.complete_text`, non-streaming); search/embed is not the bottleneck (`DEFAULT_SEARCH_TOP_K=5`, small input).

The retry path is also a **503 amplifier**: `call_with_fallback` ran `LLM_RETRY_ATTEMPTS=2` per-attempt-timeout retries across **both** primary and fallback at a **30s** per-attempt timeout — worst case ~122s, capped only by the 45s request-timeout middleware / 60s Cloud Run, at which point it becomes one of the *"malformed response / connection to the instance had an error"* 503s. Capping the timeout **and** dropping to a single attempt per provider bounds recall at ~30s worst case (15s primary → 15s fallback → `_fake_recall`) and fails fast instead of hanging.

## Trade-offs

- **max_tokens=500, not lower:** `RECALL_PROMPT` still emits step-by-step chain-of-thought *before* the answer, so a tighter cap risks truncating the answer. If we later trim the CoT from the prompt (the separate prompt lever), this can drop toward ~400.
- **max_attempts=1 for recall only:** removes *same-provider* retries on this read path. Cross-provider resilience (primary → fallback → fake) is unchanged; a same-provider retry after a timeout rarely succeeds and doubles user-facing latency. Write-path enrichment/extraction keep the default 2 attempts.

## Tests

`tests/test_p4_1_llm_fallback.py`: added `TestCallWithFallbackMaxAttempts` — `max_attempts=1` invokes the primary once (no retry) then falls through; default still retries `LLM_RETRY_ATTEMPTS` times. Full fallback suite (40) + recall suites (43) green; ruff clean.

## Follow-up / verification

Now that DD APM + LLMObs are live in prod, the `POST /api/v1/recall` APM span waterfall + `ml_obs.span.llm.duration` for the recall model will show the before/after split directly (these are the traces the `--no-cpu-throttling` fix stopped dropping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)