### PR TITLE
fix(mcp): add warning when top_k is capped and document search limit

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -719,6 +719,8 @@ async def memclaw_recall(
         payload: dict = {
             "results": [r.model_dump(mode="json") for r in results] if results else [],
         }
+        if top_k > MAX_SEARCH_TOP_K:
+            payload["warning"] = f"top_k was capped at the maximum allowed value of {MAX_SEARCH_TOP_K}."
         if include_brief:
             payload["brief"] = await summarize_memories(
                 results,

--- a/tests/test_mcp_recall.py
+++ b/tests/test_mcp_recall.py
@@ -105,16 +105,23 @@ async def test_recall_invalid_status_returns_422(mcp_env):
 
 
 async def test_recall_top_k_is_capped(mcp_env, monkeypatch):
-    """Passing top_k > MAX_SEARCH_TOP_K passes the cap to the service, not the raw value."""
+    """Passing top_k > MAX_SEARCH_TOP_K passes the cap to the service and adds a warning."""
     from core_api.constants import MAX_SEARCH_TOP_K
 
     search_mock = mcp_env["service"]("search_memories")
     search_mock.return_value = []
     _wire_recall_deps(monkeypatch)
 
-    await mcp_server.memclaw_recall(query="x", top_k=1000)
+    out = await mcp_server.memclaw_recall(query="x", top_k=1000)
     kwargs = search_mock.await_args.kwargs
     assert kwargs["top_k"] == MAX_SEARCH_TOP_K
+
+    payload = parse_envelope(out)
+    assert "warning" in payload
+    assert (
+        f"capped at the maximum allowed value of {MAX_SEARCH_TOP_K}"
+        in payload["warning"]
+    )
 
 
 async def test_recall_http_exception_becomes_error_envelope(mcp_env, monkeypatch):


### PR DESCRIPTION
<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

This PR addresses the silent truncation of `top_k` results in the MCP server. It updates the parameter schema description to explicitly mention the limit of 20, and adds a `"warning"` field in the JSON response payload whenever the requested `top_k` exceeds the maximum allowed value (`MAX_SEARCH_TOP_K`).

## Related Issue

Closes #512

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

Ran the updated unit test to assert both the capped `top_k` value and the warning payload:
```powershell
pytest tests/test_mcp_recall.py -k test_recall_top_k_is_capped