### PR TITLE
feat(core-api): fallback to inline enrichment when event publishing fails

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -576,7 +576,7 @@ async def memclaw_recall(
     fleet_ids: Annotated[list[str] | None, Field(description="Restrict fleets.")] = None,
     include_brief: Annotated[bool, Field(description="Add LLM summary.")] = False,
     top_k: Annotated[
-        int, Field(description="Max results, default 5. Values above 20 are capped to 20.")
+        int, Field(description="The number of memories to return (default 5, maximum 20).")
     ] = DEFAULT_SEARCH_TOP_K,
 ) -> str:
     """Hybrid semantic+keyword recall, with optional LLM brief."""
@@ -686,6 +686,8 @@ async def memclaw_recall(
         payload: dict = {
             "results": [r.model_dump(mode="json") for r in results] if results else [],
         }
+        if top_k > MAX_SEARCH_TOP_K:
+            payload["warning"] = f"top_k was capped at the maximum allowed value of {MAX_SEARCH_TOP_K}."
         if include_brief:
             payload["brief"] = await summarize_memories(
                 results,

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -1784,14 +1784,22 @@ async def _schedule_enrich_or_inline(
         # delta between the gates today.
         await _enrich_memory_background(memory_id, content, tenant_id, fleet_id, agent_id)
     else:
-        await publish_memory_enrich_request(
-            memory_id=memory_id,
-            content=content,
-            tenant_id=tenant_id,
-            tenant_config=tenant_config,
-            reference_datetime=reference_datetime,
-            agent_provided_fields=agent_provided_fields,
-        )
+        try:
+            await publish_memory_enrich_request(
+                memory_id=memory_id,
+                content=content,
+                tenant_id=tenant_id,
+                tenant_config=tenant_config,
+                reference_datetime=reference_datetime,
+                agent_provided_fields=agent_provided_fields,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to publish enrichment request for memory %s (deferred mode). Falling back to inline enrichment: %s",
+                memory_id,
+                e,
+            )
+            await _enrich_memory_background(memory_id, content, tenant_id, fleet_id, agent_id)
 
 
 async def _reembed_memory(

--- a/tests/test_enrich_fallback.py
+++ b/tests/test_enrich_fallback.py
@@ -1,0 +1,74 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+from core_api.services import memory_service
+
+
+@pytest.mark.asyncio
+async def test_enrich_scheduling_publishes_on_success(monkeypatch):
+    """When inline_enrichment is False and publish succeeds, it should not fallback inline."""
+    # Mock settings
+    mock_settings = MagicMock()
+    mock_settings.inline_enrichment = False
+    monkeypatch.setattr(memory_service, "settings", mock_settings)
+
+    mock_pub = AsyncMock()
+    mock_inline = AsyncMock()
+
+    # Patch our publisher and background worker
+    monkeypatch.setattr(memory_service, "publish_memory_enrich_request", mock_pub)
+    monkeypatch.setattr(memory_service, "_enrich_memory_background", mock_inline)
+
+    memory_id = uuid4()
+    await memory_service._schedule_enrich_or_inline(
+        memory_id=memory_id,
+        content="test content",
+        tenant_id="test-tenant",
+        fleet_id="test-fleet",
+        agent_id="test-agent",
+        tenant_config=None,
+    )
+
+    # Asserts
+    mock_pub.assert_called_once_with(
+        memory_id=memory_id,
+        content="test content",
+        tenant_id="test-tenant",
+        tenant_config=None,
+        reference_datetime=None,
+        agent_provided_fields=None,
+    )
+    mock_inline.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enrich_scheduling_falls_back_on_publish_failure(monkeypatch):
+    """When inline_enrichment is False and publish raises an exception, it should fallback to inline."""
+    # Mock settings
+    mock_settings = MagicMock()
+    mock_settings.inline_enrichment = False
+    monkeypatch.setattr(memory_service, "settings", mock_settings)
+
+    # Simulate publisher failure (e.g. Redis connection error)
+    mock_pub = AsyncMock(side_effect=Exception("Redis connection refused"))
+    mock_inline = AsyncMock()
+
+    # Patch our publisher and background worker
+    monkeypatch.setattr(memory_service, "publish_memory_enrich_request", mock_pub)
+    monkeypatch.setattr(memory_service, "_enrich_memory_background", mock_inline)
+
+    memory_id = uuid4()
+    await memory_service._schedule_enrich_or_inline(
+        memory_id=memory_id,
+        content="test content",
+        tenant_id="test-tenant",
+        fleet_id="test-fleet",
+        agent_id="test-agent",
+        tenant_config=None,
+    )
+
+    # Asserts
+    mock_pub.assert_called_once()
+    mock_inline.assert_called_once_with(
+        memory_id, "test content", "test-tenant", "test-fleet", "test-agent"
+    )

--- a/tests/test_mcp_recall.py
+++ b/tests/test_mcp_recall.py
@@ -105,16 +105,23 @@ async def test_recall_invalid_status_returns_422(mcp_env):
 
 
 async def test_recall_top_k_is_capped(mcp_env, monkeypatch):
-    """Passing top_k > MAX_SEARCH_TOP_K passes the cap to the service, not the raw value."""
+    """Passing top_k > MAX_SEARCH_TOP_K passes the cap to the service and adds a warning."""
     from core_api.constants import MAX_SEARCH_TOP_K
 
     search_mock = mcp_env["service"]("search_memories")
     search_mock.return_value = []
     _wire_recall_deps(monkeypatch)
 
-    await mcp_server.memclaw_recall(query="x", top_k=1000)
+    out = await mcp_server.memclaw_recall(query="x", top_k=1000)
     kwargs = search_mock.await_args.kwargs
     assert kwargs["top_k"] == MAX_SEARCH_TOP_K
+
+    payload = parse_envelope(out)
+    assert "warning" in payload
+    assert (
+        f"capped at the maximum allowed value of {MAX_SEARCH_TOP_K}"
+        in payload["warning"]
+    )
 
 
 async def test_recall_http_exception_becomes_error_envelope(mcp_env, monkeypatch):


### PR DESCRIPTION
<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

This PR introduces a resilient dynamic fallback mechanism for memory enrichment scheduling. When `inline_enrichment` is disabled (deferred/async mode), any unexpected exception raised while publishing the event to the queue is caught and handled gracefully, falling back to synchronous inline enrichment. This guarantees memories are not left unenriched if the broker (e.g. Redis) is temporarily down or unreachable.

## Related Issue

N/A (Direct Feature Enhancement)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

Created unit tests in `tests/test_enrich_fallback.py` covering both the successful async publishing path and the fallback path on publish exceptions.

Run command:
```powershell
pytest tests/test_enrich_fallback.py