### PR TITLE
fix(lifecycle): correct run_crystallization args in crystallize adapter

### DIFF
--- a/core-api/src/core_api/services/lifecycle_audit.py
+++ b/core-api/src/core_api/services/lifecycle_audit.py
@@ -92,7 +92,7 @@ class _CoreApiLifecycleAdapter:
         # core-api startup just for the lifecycle adapter wiring.
         from core_api.services.crystallizer_service import run_crystallization
 
-        report_id = await run_crystallization(None, org_id, fleet_id, trigger="lifecycle")
+        report_id = await run_crystallization(tenant_id=org_id, fleet_id=fleet_id, trigger="lifecycle")
         return 1 if report_id is not None else 0
 
     async def insights(self, *, org_id: str, fleet_id: str | None) -> int:

--- a/tests/test_lifecycle_audit.py
+++ b/tests/test_lifecycle_audit.py
@@ -1,0 +1,90 @@
+"""Regression tests for _CoreApiLifecycleAdapter.crystallize (CAURA-657).
+
+The lifecycle crystallize adapter previously called run_crystallization as
+``run_crystallization(None, org_id, fleet_id, trigger="lifecycle")`` — a stray
+leading positional that shifted every arg and passed ``trigger`` both
+positionally and by keyword, so every lifecycle-triggered crystallization raised
+``TypeError: got multiple values for argument 'trigger'`` and the pubsub handler
+nacked + redelivered forever in prod (observed ~20x/day). The existing
+lifecycle-handler tests use a fully-faked adapter, so the real call site was
+never exercised. These tests hit the real adapter method with an ``autospec``'d
+run_crystallization, so the enforced signature makes a regression fail here
+rather than in a live pubsub handler.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from core_api.services.lifecycle_audit import (
+    _CRYSTALLIZE_MIN_ACTIVE_MEMORIES,
+    _CoreApiLifecycleAdapter,
+)
+
+
+class _FakeStorage:
+    def __init__(self, active: int) -> None:
+        self._active = active
+
+    async def count_active(self, org_id: str, fleet_id: str | None) -> int:
+        return self._active
+
+
+class _Cfg:
+    auto_crystallize_enabled = True
+
+
+@pytest.mark.asyncio
+async def test_crystallize_calls_run_crystallization_with_correct_args() -> None:
+    adapter = _CoreApiLifecycleAdapter(
+        _FakeStorage(active=_CRYSTALLIZE_MIN_ACTIVE_MEMORIES + 1)
+    )
+    report_id = uuid4()
+    with (
+        patch(
+            "core_api.services.lifecycle_audit.resolve_config",
+            new=AsyncMock(return_value=_Cfg()),
+        ),
+        patch(
+            "core_api.services.crystallizer_service.run_crystallization",
+            autospec=True,
+        ) as mock_run,
+    ):
+        mock_run.return_value = report_id
+        result = await adapter.crystallize(org_id="t1", fleet_id="f1")
+
+    assert result == 1
+    # org_id maps to run_crystallization's tenant_id (translated at the boundary);
+    # trigger is passed exactly once. Under autospec the old buggy positional call
+    # (None, org_id, fleet_id, trigger=...) would raise TypeError here.
+    mock_run.assert_awaited_once_with(
+        tenant_id="t1", fleet_id="f1", trigger="lifecycle"
+    )
+
+
+@pytest.mark.asyncio
+async def test_crystallize_skips_when_auto_disabled() -> None:
+    class _Off:
+        auto_crystallize_enabled = False
+
+    adapter = _CoreApiLifecycleAdapter(_FakeStorage(active=10_000))
+    with patch(
+        "core_api.services.lifecycle_audit.resolve_config",
+        new=AsyncMock(return_value=_Off()),
+    ):
+        assert await adapter.crystallize(org_id="t1", fleet_id=None) == 0
+
+
+@pytest.mark.asyncio
+async def test_crystallize_skips_below_active_threshold() -> None:
+    adapter = _CoreApiLifecycleAdapter(
+        _FakeStorage(active=_CRYSTALLIZE_MIN_ACTIVE_MEMORIES)
+    )
+    with patch(
+        "core_api.services.lifecycle_audit.resolve_config",
+        new=AsyncMock(return_value=_Cfg()),
+    ):
+        assert await adapter.crystallize(org_id="t1", fleet_id=None) == 0


### PR DESCRIPTION
## What
One-line fix at `core-api/src/core_api/services/lifecycle_audit.py` — the lifecycle `crystallize` adapter called `run_crystallization` with a stray leading `None` and a colliding `trigger`:

```python
# before
run_crystallization(None, org_id, fleet_id, trigger="lifecycle")
# after
run_crystallization(tenant_id=org_id, fleet_id=fleet_id, trigger="lifecycle")
```

## Why
`run_crystallization(tenant_id, fleet_id=None, trigger="manual", auto_crystallize=True)`. The stray `None` shifted every positional — `tenant_id=None`, `fleet_id=org_id`, `trigger=fleet_id` — and then `trigger="lifecycle"` was *also* passed by keyword, so **every** lifecycle-triggered crystallization raised:

```
TypeError: run_crystallization() got multiple values for argument 'trigger'
```

The pubsub lifecycle handler (`common/events/lifecycle_handlers.py` → `crystallize_op` → `adapter.crystallize`) then nacked + redelivered — **~20 occurrences/day on prod core-api**, and lifecycle-driven crystallization never actually ran.

`org_id` is the tenant scope at this boundary — the adapter's own docstring says *"the storage client's primitives still call the column `tenant_id`; translate at the boundary"*, and `resolve_config(org_id)` here is the same call the HTTP routes make as `resolve_config(tenant_id)` before `run_crystallization(tenant_id, …)`. So `tenant_id=org_id`. Keyword args are used so this positional class of bug can't recur.

## Tests
Adds `tests/test_lifecycle_audit.py` (3 tests): the happy path asserts the exact call `run_crystallization(tenant_id="t1", fleet_id="f1", trigger="lifecycle")` via an **`autospec`'d** mock (which enforces the real signature — the old buggy call would raise `TypeError` in the test), plus the two skip gates (auto-crystallize disabled, below active-memory threshold). The existing `test_lifecycle_handlers.py` fully fakes the adapter, which is why this call site was uncovered. Full run green; ruff clean.

## Note
Auto-review will skip on open (public OSS repo, non-public-member author) — `@claude` if you want a review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)