### PR TITLE
chore(search): log temporal_hint at DEBUG, not INFO

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/extract_temporal_hint.py
+++ b/core-api/src/core_api/pipeline/steps/search/extract_temporal_hint.py
@@ -31,7 +31,12 @@ class ExtractTemporalHint:
 
         reference_dt = ctx.data.get("valid_at") or datetime.now(UTC)
         ctx.data["date_range_filter"] = _extract_temporal_date_range(query, reference_dt)
-        logger.info(
+        # DEBUG, not INFO: this fires once per search and echoes the raw query
+        # text — mild PII (customer query content), and it surfaces verbatim in
+        # prod logs whenever ops searches memclaw with an error-alert signature
+        # (the "temporal_hint: query='<error text>'" echo). The extracted
+        # window/date_range are carried on ctx.data for any downstream logging.
+        logger.debug(
             "temporal_hint: query=%r ref=%s window=%s date_range=%s",
             query[:80],
             reference_dt,


### PR DESCRIPTION
## What
`extract_temporal_hint` logged the raw search query at `INFO` on every search:
```
temporal_hint: query='<the query>' ref=… window=… date_range=…
```
Dropped to `DEBUG`.

## Why
1. **PII / noise:** it emits verbatim customer query content to prod logs, once per search.
2. **The "phantom error" echo:** caura-ops's error-investigator semantically searches memclaw using each error-alert **signature** as the query. So an error string like `failed to send, dropping 1 traces to intake at http://localhost:8126/v0.5/traces` comes back through *this* log as `temporal_hint: query='failed to send, dropping 1 traces…'` — which looks like a recurring tracer error in prod logs but is just the search echo. Dropping to DEBUG removes the echo (and the PII) from prod regardless of what triggers the search.

`extract_temporal_hint` is the only search step that logs the raw query at INFO (the others log classifications). `temporal_window` / `date_range_filter` remain on `ctx.data` for downstream logging. Tests green (41), ruff clean.

## Note
OSS repo — auto-review skips for non-public-member authors; `@claude` for a review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)