### PR TITLE
fix(logging): floor ddtrace trace/LLMObs writer loggers at CRITICAL

### DIFF
--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -494,6 +494,11 @@ def _reset_for_testing() -> None:
         # silent divergence from production behavior.
         for dep in ("httpx", "httpcore", "google.auth", "google.auth.transport"):
             logging.getLogger(dep).setLevel(logging.NOTSET)
+        # Clear the ddtrace-writer CRITICAL floor installed by
+        # _configure_logging_impl so a test reconfiguring at DEBUG doesn't see
+        # these stuck at CRITICAL — same rationale as the overrides above.
+        for dep in ("ddtrace.internal.writer.writer", "ddtrace.llmobs._writer"):
+            logging.getLogger(dep).setLevel(logging.NOTSET)
         # Restore third-party loggers to pre-config state from the snapshot
         # captured by ``_route_third_party_to_root``. Best-effort: any
         # FileHandler / SocketHandler that was closed during stripping won't
@@ -683,5 +688,19 @@ def _configure_logging_impl(
     if logging.DEBUG < min_level < logging.WARNING:
         for dep in ("httpx", "httpcore", "google.auth", "google.auth.transport"):
             logging.getLogger(dep).setLevel(logging.WARNING)
+
+    # ddtrace's trace + LLMObs writers emit a benign ERROR every time a flush to
+    # the local agent (localhost:8126) times out or the agent resets the
+    # connection ("failed to send, dropping N traces …" / "failed to send N
+    # LLMObs span events …"). These are telemetry-plumbing failures — dropped
+    # spans, send_to_telemetry:false — not app errors, but at ERROR they surface
+    # as errors in every sink (Datadog Logs, GCP, the caura-ops error alerter)
+    # and drive alert flapping. Floor them at CRITICAL so the ERROR/WARNING noise
+    # is dropped while a genuine writer CRITICAL still comes through. Unlike the
+    # httpx floor above (INFO-only), this must also apply at WARNING — the ERROR
+    # clears root's WARNING filter otherwise. Skip only at DEBUG (opt-in verbose).
+    if min_level > logging.DEBUG:
+        for dep in ("ddtrace.internal.writer.writer", "ddtrace.llmobs._writer"):
+            logging.getLogger(dep).setLevel(logging.CRITICAL)
 
     _route_third_party_to_root()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -253,6 +253,53 @@ def _json_log_buffer():
         _reset_for_testing()
 
 
+_DDTRACE_WRITER_LOGGERS = ("ddtrace.internal.writer.writer", "ddtrace.llmobs._writer")
+
+
+def test_ddtrace_writer_loggers_floored_at_critical_when_not_debug() -> None:
+    """The ddtrace trace + LLMObs writer loggers emit benign flush-failure
+    ERRORs ("failed to send, dropping N traces …"). configure_logging must
+    floor them at CRITICAL at both INFO and WARNING so that ERROR noise is
+    dropped from every sink (Datadog / GCP / the caura-ops error alerter) —
+    the ERROR clears root's WARNING filter otherwise and drives alert flap."""
+    for level in ("INFO", "WARNING"):
+        _reset_for_testing()
+        try:
+            configure_logging(environment="test", log_level=level, json_logs=True)
+            for name in _DDTRACE_WRITER_LOGGERS:
+                assert logging.getLogger(name).level == logging.CRITICAL, (
+                    f"{name} must be floored at CRITICAL when configured at {level}"
+                )
+        finally:
+            _reset_for_testing()
+
+
+def test_ddtrace_writer_loggers_not_floored_at_debug() -> None:
+    """At DEBUG (explicit opt-in to verbose output) the writer loggers must NOT
+    be floored, so ddtrace's own diagnostics stay visible."""
+    _reset_for_testing()
+    try:
+        configure_logging(environment="test", log_level="DEBUG", json_logs=True)
+        for name in _DDTRACE_WRITER_LOGGERS:
+            assert logging.getLogger(name).level != logging.CRITICAL, (
+                f"{name} must not be floored at CRITICAL when configured at DEBUG"
+            )
+    finally:
+        _reset_for_testing()
+
+
+def test_reset_clears_ddtrace_writer_floor() -> None:
+    """_reset_for_testing must clear the CRITICAL floor back to NOTSET so a
+    later DEBUG reconfigure isn't left with these stuck at CRITICAL."""
+    _reset_for_testing()
+    configure_logging(environment="test", log_level="INFO", json_logs=True)
+    _reset_for_testing()
+    for name in _DDTRACE_WRITER_LOGGERS:
+        assert logging.getLogger(name).level == logging.NOTSET, (
+            f"{name} must be reset to NOTSET after _reset_for_testing"
+        )
+
+
 def test_stdlib_logger_extras_reach_json_payload(_json_log_buffer) -> None:
     """``logger.info(msg, extra={...})`` from stdlib must surface its
     ``extra`` keys as top-level JSON fields, not be silently dropped.


### PR DESCRIPTION
## What
Floor the `ddtrace.internal.writer.writer` and `ddtrace.llmobs._writer` loggers at CRITICAL in the shared `configure_logging` (when the root level is INFO/WARNING; skipped at DEBUG). `_reset_for_testing` clears the floor back to NOTSET.

## Why
Over the last 36h these two loggers produced **~95% of all `status:error` log volume** across prod+staging — every failed flush to the in-container agent at `localhost:8126` logs at ERROR:

```
failed to send, dropping N traces to intake at http://localhost:8126/v0.5/traces: timed out
failed to send N LLMObs span events to http://localhost:8126 … TimeoutError / 502 / 429 / ConnectionReset
```

These are **dropped-telemetry events** (`send_to_telemetry:false`), not application errors — the app is unaffected. But because they emit at ERROR they surface as errors in Datadog Logs, GCP Logging, and the **caura-ops error alerter**, where they drive alert flapping in both envs. CPU-throttling fixes (ent#701/#717) reduce the CPU-starvation timeouts but the agent-side variants (502/429/RemoteDisconnected) persist, so silencing at the source is the durable fix.

Flooring at CRITICAL drops the ERROR/WARNING noise while still surfacing a genuine writer CRITICAL. Lives in the shared structlog config, so it applies to every service (core-api, core-worker, core-operations, platform-*) at once.

## Test
Added `tests/test_logging.py` coverage: floored at CRITICAL at INFO **and** WARNING, not floored at DEBUG, and reset restores NOTSET. `uv run pytest tests/test_logging.py` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)