### PR TITLE
fix(core-operations): configure logging at import so uvicorn startup lines aren't tagged ERROR

### DIFF
--- a/core-operations/src/core_operations/app.py
+++ b/core-operations/src/core_operations/app.py
@@ -4,8 +4,12 @@ Hosts cron/scheduled background jobs that operate on OSS data
 (memories, organizations, tenants). No business HTTP surface — only
 ``/healthz`` for Cloud Run probes.
 
+Logging is configured at MODULE IMPORT (see below) so uvicorn's own startup
+lines route through the JSON/GCP handler; the lifespan only re-routes
+third-party loggers once they're all imported.
+
 Lifespan ordering:
-1. ``configure_logging`` reads env BEFORE any module that emits log records.
+1. Re-route third-party loggers (uvicorn / scheduler) onto the JSON handler.
 2. If ``settings.standalone``: skip scheduler entirely. The service runs
    as a no-op; OSS standalone deployments should not deploy this image
    at all, but the flag is a defensive short-circuit.
@@ -24,8 +28,27 @@ from collections.abc import AsyncIterator
 
 from fastapi import FastAPI, HTTPException
 
-from common.structlog_config import configure_logging
+from common.structlog_config import configure_logging, reroute_third_party_loggers
 from core_operations.config import settings
+
+# Configure logging at import — before the scheduler/tasks imports below AND
+# before uvicorn emits its startup lines. uvicorn imports this module during
+# config load, so an import-time configure_logging() reroutes uvicorn's own
+# loggers onto the JSON/GCP handler before "Started server process" / "Waiting
+# for application startup" are logged. Configuring in the lifespan instead left
+# those two lines to fall through uvicorn's default stderr handler, where Cloud
+# Logging tagged them ERROR (false errors). E402 on the imports below is ignored
+# for app.py — the config call must precede any module that emits log records.
+# Test-safe: pytest caplog captures via stdlib root propagation, so the scheduler
+# /task caplog assertions still work (verified: full suite green) — this mirrors
+# core-api, which also configures at import with no special reset fixture.
+configure_logging(
+    settings.environment,
+    settings.log_level,
+    json_logs=settings.log_format_json,
+    log_file=settings.log_file or None,
+)
+
 from core_operations.scheduler import scheduler, seconds_until_next_utc_hour
 from core_operations.tasks import (
     run_archive_expired_tick,
@@ -93,15 +116,11 @@ def _register_scheduled_tasks() -> None:
 
 @contextlib.asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    # Logging is configured here rather than at module import so test
-    # runners that import this module (for `app` collection) don't
-    # reconfigure structlog before pytest's caplog activates.
-    configure_logging(
-        settings.environment,
-        settings.log_level,
-        json_logs=settings.log_format_json,
-        log_file=settings.log_file or None,
-    )
+    # Re-route third-party loggers (uvicorn / scheduler libs) onto the root JSON
+    # handler now that they're all imported — the import-time configure_logging()
+    # pass above no-ops for libraries imported after it (uvicorn is loaded by the
+    # server). Idempotent; mirrors core-api's lifespan.
+    reroute_third_party_loggers()
 
     logger.info(
         "Starting core-operations",


### PR DESCRIPTION
## What
Move `configure_logging()` from the lifespan startup hook to **module import** in `core-operations/app.py`, and call `reroute_third_party_loggers()` in the lifespan — mirroring core-api.

## Why
The 36h error sweep flagged `core-operations` (and `platform-operations`) emitting `status:error` logs that are actually uvicorn **INFO** startup lines:

```
INFO:     Started server process [8]
INFO:     Waiting for application startup.
```

uvicorn logs these via `uvicorn.error` **before** the ASGI lifespan runs. core-operations configured logging *inside* the lifespan, so at that moment the logger reroute wasn't active yet — the two lines fell through uvicorn's default plain-text stderr handler, and Cloud Logging tagged them `ERROR`. They're benign INFO (and pre-caura-ops#192 could even page).

core-api doesn't have this because it calls `configure_logging()` at import (uvicorn imports the app module during config load, so the reroute is in effect before the startup lines) and only `reroute_third_party_loggers()` in the lifespan. This change brings core-operations in line.

## Test
Full `core-operations` suite green (**34 passed**), including `test_app.py` (imports the module) and `test_scheduler.py` (uses caplog) — the deferral was originally to protect pytest caplog, and this proves import-time config doesn't break it (the repo's per-test reset handles it, same as core-api). ruff clean.

## Note
`platform-operations` (enterprise repo) has the same lifespan-deferred pattern and needs the identical one-line move — happy to follow up with that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)