### PR TITLE
chore(fleet): bump plugin auto-upgrade floor to 2.13.0 (firehose de-collapse)

### DIFF
--- a/core-api/src/core_api/version_compat.py
+++ b/core-api/src/core_api/version_compat.py
@@ -8,8 +8,12 @@ recommended version; no hard rejection — operators decide when to upgrade.
 
 # Auto-upgrade target / "outdated" floor. The fleet heartbeat queues a deploy
 # to this version for eligible nodes (>= MIN_AUTO_DEPLOY, auto-upgrade enabled).
-# Reconciled to the current shipped plugin release.
-MIN_RECOMMENDED_PLUGIN_VERSION = "2.12.0"
+# Reconciled to the current shipped plugin release. 2.13.0 carries the
+# reserved-"main" write self-identification (plugin half of the firehose
+# de-collapse, #507): unset MEMCLAW_AGENT_ID now writes as main-<install_id>
+# instead of collapsing onto the shared "main" identity. Bumping the floor
+# auto-upgrades eligible fleet nodes so the de-collapse actually takes effect.
+MIN_RECOMMENDED_PLUGIN_VERSION = "2.13.0"
 
 # Server-side floor below which plugins must NOT auto-upgrade — the
 # heartbeat path in ``routes/fleet.py`` enforces this hard, and


### PR DESCRIPTION
## What
Bump `MIN_RECOMMENDED_PLUGIN_VERSION` **2.12.0 → 2.13.0** in `core_api/version_compat.py`.

## Why
Plugin **2.13.0** carries the plugin half of #507 — reserved-`main` write self-identification: when `MEMCLAW_AGENT_ID` is unset, `memclaw_write` now sends `agent_id = main-<install_id>` instead of an empty id that collapses onto the shared reserved `"main"` identity (the eToro "firehose").

The **server** half (`effective_write_agent_id`, honor body id when the verified id is reserved `main`) already shipped in v2.11.4, but it is **inert** while the fleet runs 2.12.0 — the old plugin supplies no body id, so writes keep collapsing onto `main`. Raising the floor to 2.13.0 makes eligible nodes (≥ `MIN_AUTO_DEPLOY` 2.6.0, auto-upgrade enabled) auto-upgrade on their next heartbeat, at which point the firehose **de-collapses**: new writes land under distinct `main-<install_id>` identities.

Deliberate: this is the intended firehose solution for the v2.19.0 / onprem-v2.11.5 delivery.

## Scope / safety
- One constant. `MIN_AUTO_DEPLOY_PLUGIN_VERSION` unchanged (2.6.0).
- Floor invariant (`recommended >= auto-deploy`) still holds — `tests/test_plugin_floor_invariant.py` is value-agnostic and passes.
- Forward-going only: affects **new** writes; does not retro-split existing `"main"` rows.
- `reserved_agent_id_policy` stays `warn` (observe-only) and `bind_write_identity_to_auth` stays `false` on eToro — the `reserved_agent_write` warn-log rate is the success counter (should drop toward 0 as nodes upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)