### PR TITLE
feat(plugin): opt-in recall-gating + cross-agent recall (F2/A44)

### DIFF
--- a/plugin/src/context-engine.test.ts
+++ b/plugin/src/context-engine.test.ts
@@ -45,6 +45,7 @@ function input(overrides: Partial<ShouldRecallInput> = {}): ShouldRecallInput {
     triggerKeywords: DEFAULT_KEYWORDS,
     sessionKey: "tenant:agent:default",
     denySessions: [],
+    applyNoiseRules: true,
     ...overrides,
   };
 }
@@ -356,5 +357,65 @@ describe("isDuplicateMemoryError — afterTurn 409 swallow gate", () => {
     // prefix is always present at the start.
     const e = new Error('MemClaw API 409: ...truncated...');
     assert.equal(isDuplicateMemoryError(e), true);
+  });
+});
+
+describe("shouldRecall — noise-skip gate (auto)", () => {
+  const MP = [/heartbeat/i, /health ?check/i, /\bcron\b/i];
+  test("skips a bare agent-name self-match", () => {
+    const r = shouldRecall(input({ prompt: "brandclaw", agentId: "brandclaw" }));
+    assert.equal(r.recall, false);
+    assert.equal(r.reason, "agent-name-self");
+  });
+  test("skips @mention / number-only turns", () => {
+    const r = shouldRecall(input({ prompt: "@50934788919473" }));
+    assert.equal(r.recall, false);
+    assert.equal(r.reason, "mention-only");
+  });
+  test("skips [Subagent Context] blobs", () => {
+    const r = shouldRecall(
+      input({ prompt: "[Subagent Context] you are running as a subagent (depth 1/1)" }),
+    );
+    assert.equal(r.recall, false);
+    assert.equal(r.reason, "subagent-context");
+  });
+  test("skips machine/automation turns via patterns", () => {
+    for (const p of [
+      "heartbeat check: all services healthy",
+      "cron run 08:00 UTC sync completed",
+      "AgentX health check exited 1",
+    ]) {
+      const r = shouldRecall(input({ prompt: p, machinePatterns: MP }));
+      assert.equal(r.recall, false, p);
+      assert.equal(r.reason, "machine-pattern", p);
+    }
+  });
+  test("skips instruction-to-third-party", () => {
+    const r = shouldRecall(input({ prompt: "tell Codex to add this MCP server for me" }));
+    assert.equal(r.recall, false);
+    assert.equal(r.reason, "instruction-3rd-party");
+  });
+  test("still recalls a genuine question", () => {
+    const r = shouldRecall(
+      input({
+        prompt: "what are the compliance rules for prediction markets?",
+        agentId: "complianceclaw",
+        machinePatterns: MP,
+      }),
+    );
+    assert.equal(r.recall, true);
+    assert.equal(r.reason, "default-substantive");
+  });
+  test("explicit recall keyword still wins over noise rules", () => {
+    const r = shouldRecall(
+      input({ prompt: "remember the deadline (heartbeat)", machinePatterns: MP }),
+    );
+    assert.equal(r.recall, true);
+    assert.equal(r.reason, "explicit-recall-trigger");
+  });
+  test("no machinePatterns supplied → machine rule inert", () => {
+    const r = shouldRecall(input({ prompt: "heartbeat check all healthy and nothing else here" }));
+    // falls through to default-substantive (length >= 14, not a ping)
+    assert.equal(r.reason, "default-substantive");
   });
 });

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -27,6 +27,9 @@ import {
   RECALL_MIN_PROMPT_CHARS,
   RECALL_TRIGGER_KEYWORDS,
   RECALL_DENY_SESSIONS,
+  RECALL_MACHINE_PATTERNS,
+  RECALL_GATE_MODE,
+  RECALL_CROSS_AGENT,
   type RecallPolicy,
 } from "./env.js";
 import { memclawPromptSectionText } from "./prompt-section.js";
@@ -186,7 +189,22 @@ export type ShouldRecallReason =
   | "trivial-ping"
   | "slash-command"
   | "session-denied"
+  | "agent-name-self"
+  | "mention-only"
+  | "subagent-context"
+  | "machine-pattern"
+  | "instruction-3rd-party"
   | "default-substantive";
+
+// Reasons introduced by the noise-skip gate. In shadow mode these are logged
+// as "would-skip" but do NOT suppress recall (see RECALL_GATE_SHADOW).
+export const NOISE_SKIP_REASONS: ReadonlySet<ShouldRecallReason> = new Set([
+  "agent-name-self",
+  "mention-only",
+  "subagent-context",
+  "machine-pattern",
+  "instruction-3rd-party",
+]);
 
 export interface ShouldRecallInput {
   policy: RecallPolicy;
@@ -196,7 +214,15 @@ export interface ShouldRecallInput {
   triggerKeywords: readonly string[];
   sessionKey?: string;
   denySessions: readonly string[];
+  agentId?: string;
+  machinePatterns?: readonly RegExp[];
+  // When false/undefined the noise-skip rules are not applied (gate "off").
+  applyNoiseRules?: boolean;
 }
+
+const _MENTION_ONLY_RE = /^\s*@?\+?[\d\s@]+$/;
+const _INSTR_3RD_RE =
+  /^\s*(tell|ask|have|get)\s+(codex|claude|cursor|\w*claw|him|her|them)\b/i;
 
 export interface ShouldRecallResult {
   recall: boolean;
@@ -331,6 +357,29 @@ export function shouldRecall(input: ShouldRecallInput): ShouldRecallResult {
       // "/help" should report `slash-command`, not `below-threshold`).
       if (_isTrivialPing(eff)) {
         return { recall: false, reason: "trivial-ping" };
+      }
+      // Noise-skip gate (opt-in via RECALL_GATE_MODE): automation / non-question
+      // turns that should not trigger recall. Ordered before slash/length so
+      // metrics show the precise reason. (Explicit keywords above still win.)
+      // Caller passes applyNoiseRules=false when the gate is "off", so this is
+      // behavior-neutral by default.
+      if (input.applyNoiseRules) {
+        const _lc = eff.trim().toLowerCase();
+        if (input.agentId && _lc === input.agentId.trim().toLowerCase()) {
+          return { recall: false, reason: "agent-name-self" };
+        }
+        if (_MENTION_ONLY_RE.test(eff)) {
+          return { recall: false, reason: "mention-only" };
+        }
+        if (_lc.startsWith("[subagent context]")) {
+          return { recall: false, reason: "subagent-context" };
+        }
+        if (input.machinePatterns && input.machinePatterns.some((re) => re.test(eff))) {
+          return { recall: false, reason: "machine-pattern" };
+        }
+        if (_INSTR_3RD_RE.test(eff)) {
+          return { recall: false, reason: "instruction-3rd-party" };
+        }
       }
       if (eff.startsWith("/") && eff.length < 60) {
         return { recall: false, reason: "slash-command" };
@@ -800,7 +849,7 @@ export class MemClawContextEngine {
     const sessionHash = createHashShort(sessionKey);
 
     // --- Recall gate ---
-    const decision = shouldRecall({
+    const rawDecision = shouldRecall({
       policy: RECALL_POLICY,
       prompt,
       messages: incomingMessages,
@@ -808,8 +857,19 @@ export class MemClawContextEngine {
       triggerKeywords: RECALL_TRIGGER_KEYWORDS,
       sessionKey,
       denySessions: RECALL_DENY_SESSIONS,
+      agentId,
+      machinePatterns: RECALL_MACHINE_PATTERNS,
+      applyNoiseRules: RECALL_GATE_MODE !== "off",
     });
-    _recordDecision(decision, sessionHash);
+    // Record the TRUE gate outcome for metrics (so shadow-mode would-skips are
+    // counted). In shadow mode, a noise-skip is logged but not enforced.
+    _recordDecision(rawDecision, sessionHash);
+    const decision: ShouldRecallResult =
+      RECALL_GATE_MODE === "shadow" &&
+      !rawDecision.recall &&
+      NOISE_SKIP_REASONS.has(rawDecision.reason)
+        ? { recall: true, reason: rawDecision.reason }
+        : rawDecision;
 
     // Block on keystones now that the gate decision is in. In the skip
     // path below we return immediately; in the recall path further down
@@ -879,10 +939,16 @@ export class MemClawContextEngine {
         const tid = await ensureTenantId();
         const searchBody: Record<string, unknown> = {
           tenant_id: tid,
-          filter_agent_id: agentId,
           query: searchQuery,
           top_k: 5,
         };
+        // Self-filter (agent silo) unless cross-agent recall is enabled. When
+        // enabled, omit filter_agent_id so the agent can retrieve sibling
+        // agents' knowledge — still bounded by the server-side fleet/trust
+        // scope. Opt-in (RECALL_CROSS_AGENT); pairs with the A43 freshness cap.
+        if (!RECALL_CROSS_AGENT) {
+          searchBody.filter_agent_id = agentId;
+        }
         const sr = (await apiCall(
           "POST",
           "/search",

--- a/plugin/src/env.ts
+++ b/plugin/src/env.ts
@@ -392,7 +392,70 @@ function _readDenySessions(): readonly string[] {
     .filter((s) => s.length > 0);
 }
 
+// Automation / machine-turn patterns. When a turn matches one of these it is
+// an agent's own heartbeat/cron/health-check/status line, not an
+// information-seeking question — recalling on it just injects noise. The set
+// is DEPLOYMENT-TUNABLE (a term that's noise here may be real business content
+// elsewhere, e.g. "health check" for an ops product), so operators can
+// override the whole list via MEMCLAW_RECALL_MACHINE_PATTERNS (comma-separated
+// regex sources). Defaults are seeded from observed eToro automation traffic.
+const DEFAULT_MACHINE_PATTERNS = [
+  "heartbeat",
+  "\\bcron\\b",
+  "health ?check",
+  "checkpoint",
+  "\\bpm2\\b",
+  "disk \\d",
+  "rpc ok",
+  "watchdog",
+  "status\\.md",
+  "no commits",
+  "quiet.?hours",
+  "no active",
+  "sync block",
+  "cache refresh",
+] as const;
+
+function _readMachinePatterns(): readonly RegExp[] {
+  const raw = process.env.MEMCLAW_RECALL_MACHINE_PATTERNS;
+  const sources = raw
+    ? raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0)
+    : [...DEFAULT_MACHINE_PATTERNS];
+  const out: RegExp[] = [];
+  for (const s of sources) {
+    try {
+      out.push(new RegExp(s, "i"));
+    } catch {
+      // Skip an invalid operator-supplied pattern rather than crash the plugin.
+    }
+  }
+  return out;
+}
+
 export const RECALL_POLICY: RecallPolicy = _readPolicy();
 export const RECALL_MIN_PROMPT_CHARS: number = _readMinPromptChars();
 export const RECALL_TRIGGER_KEYWORDS: readonly string[] = _readTriggerKeywords();
 export const RECALL_DENY_SESSIONS: readonly string[] = _readDenySessions();
+export const RECALL_MACHINE_PATTERNS: readonly RegExp[] = _readMachinePatterns();
+
+// Noise-skip gate rollout mode (MEMCLAW_RECALL_GATE):
+//   "off"    (default) — new noise-skip rules (machine / agent-name /
+//              mention-only / subagent-context / 3rd-party-instruction) are
+//              NOT applied. Merge is behavior-neutral; opt-in required.
+//   "shadow" — rules are evaluated and LOGGED as "would-skip" but do NOT
+//              suppress recall. Lets operators measure impact first.
+//   "on"     — rules are enforced (recall suppressed on a match).
+// Default "off" so shipping this change does not alter recall behavior for any
+// deployment until an operator opts in (cross-customer safety not yet validated).
+export type RecallGateMode = "off" | "shadow" | "on";
+function _readGateMode(): RecallGateMode {
+  const raw = (process.env.MEMCLAW_RECALL_GATE || "off").toLowerCase();
+  return raw === "shadow" || raw === "on" ? raw : "off";
+}
+export const RECALL_GATE_MODE: RecallGateMode = _readGateMode();
+// Cross-agent recall: when true, auto-recall omits filter_agent_id so the
+// agent can retrieve knowledge authored by SIBLING agents (still bounded by
+// the server-side fleet/trust scope). Default false — this changes read
+// isolation and must ship alongside the freshness cap (A43), else a
+// future-dated hub memory dominates cross-agent results. Opt-in.
+export const RECALL_CROSS_AGENT: boolean = _readBoolEnv("MEMCLAW_RECALL_CROSS_AGENT", false);


### PR DESCRIPTION
## What
Two **plugin-side**, **flag-gated (default off)** recall changes. Merging is behavior-neutral until opted in.

### F2 — recall-gating (`shouldRecall`)
Stops auto `/search` from firing on non-question turns. 5 new noise-skip reasons: machine/automation patterns, agent-name self-match, `@mention`/number-only, `[Subagent Context]` blobs, instruction-to-3rd-party.
- **`MEMCLAW_RECALL_GATE`** = `off` (default) · `shadow` (log would-skip, don't enforce) · `on`.
- **`MEMCLAW_RECALL_MACHINE_PATTERNS`** — machine regex list is per-deployment configurable (a term that's noise here may be real content elsewhere, e.g. "health check"), seeded from observed eToro automation traffic.
- Explicit recall keywords still win.

### A44 — cross-agent recall (silo removal)
- **`MEMCLAW_RECALL_CROSS_AGENT`** (default `false`): auto-recall omits `filter_agent_id` so an agent can retrieve **sibling agents' knowledge**, still bounded by the server-side fleet/trust scope. The silo was the plugin sending `filter_agent_id: agentId` on every recall.
- **Enable alongside the A43 freshness cap (#529)** — otherwise a future-dated hub memory dominates cross-agent results.

## Evidence
Held-out on `etoro-core` (rules built on `etoro0`): the noise gate skips **~76% of recall calls with 0/29 genuine questions lost**. Only 5–35% of `/search` calls are genuine questions; the rest are machine/probe/chatter.

## Tests
8 new unit tests for the noise-skip rules — **38/38 context-engine tests pass**, typecheck clean.

## Rollout
Default off → recommended path: `shadow` first (measure), then `on`; enable cross-agent only after #529 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
