### PR TITLE
feat(reports): agent-activity digest — Phase 1 (inert read slice) [CAURA-222]

### DIFF
--- a/common/models/__init__.py
+++ b/common/models/__init__.py
@@ -1,5 +1,6 @@
 # Shared SQLAlchemy models — used by core-api and core-storage-api.
 from common.models.agent import Agent
+from common.models.agent_activity_digest import AgentActivityDigest
 from common.models.analysis_report import CrystallizationReport
 from common.models.audit import AuditChainHead, AuditLog
 from common.models.background_task import BackgroundTaskLog
@@ -16,6 +17,7 @@ from common.models.skill_factory import ForgeRejectedFingerprint, SessionTrace
 
 __all__ = [
     "Agent",
+    "AgentActivityDigest",
     "AuditChainHead",
     "AuditLog",
     "BackgroundTaskLog",

--- a/common/models/agent_activity_digest.py
+++ b/common/models/agent_activity_digest.py
@@ -80,6 +80,6 @@ class AgentActivityDigest(Base):
             "ix_agent_digest_latest",
             "tenant_id",
             "period",
-            window_start.desc(),
+            text("window_start DESC"),
         ),
     )

--- a/common/models/agent_activity_digest.py
+++ b/common/models/agent_activity_digest.py
@@ -1,0 +1,85 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Integer, Text, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from common.models.base import Base
+
+
+class AgentActivityDigest(Base):
+    """One LLM-generated "what did this agent do" summary, per agent per window.
+
+    Rows are grouped by ``run_id`` — a single scheduled pass over a tenant/fleet
+    produces one row per agent. Unlike the live report (GET /api/v1/reports),
+    these are PRECOMPUTED on a schedule (default nightly, see core-operations)
+    and served read-only, because an LLM pass per agent is too slow/costly to
+    run on every page view.
+
+    ``status`` values:
+      ok        — narrative generated from the agent's window memories
+      quiet     — below the activity threshold; no LLM call made
+      truncated — window exceeded the per-agent cap; summary is partial
+      skipped   — run-level cost/token cap hit before this agent
+      error     — the LLM call (or fetch) failed; ``error_detail`` explains
+    """
+
+    __tablename__ = "agent_activity_digests"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, server_default=text("gen_random_uuid()"))
+    # Groups every agent's row from one scheduled pass.
+    run_id: Mapped[uuid.UUID] = mapped_column(nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    fleet_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
+    period: Mapped[str] = mapped_column(Text, nullable=False)  # 'day' | 'week'
+    window_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    window_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # The prose summary + its structured breakdown
+    # ({decisions[], shipped[], learned[], open_threads[]}).
+    narrative: Mapped[str | None] = mapped_column(Text, nullable=True)
+    sections: Mapped[dict] = mapped_column(JSONB, server_default=text("'{}'::jsonb"))
+    # Provenance / quality signals surfaced in the UI.
+    source_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )  # durable memories fed to the model
+    recall_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    model: Mapped[str | None] = mapped_column(Text, nullable=True)  # LLM registry id
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    error_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    generated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=text("now()"))
+
+    __table_args__ = (
+        # Idempotent re-runs: one row per (tenant, fleet, agent, period, window).
+        # TWO partial unique indexes rather than a single UniqueConstraint because
+        # Postgres treats NULLs as distinct — a plain UNIQUE(... fleet_id ...) would
+        # let duplicate no-fleet digests through whenever fleet_id IS NULL. Split on
+        # the NULL-ness of fleet_id so uniqueness holds in both cases.
+        Index(
+            "uq_agent_digest_window_fleet",
+            "tenant_id",
+            "fleet_id",
+            "agent_id",
+            "period",
+            "window_start",
+            unique=True,
+            postgresql_where=text("fleet_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_agent_digest_window_no_fleet",
+            "tenant_id",
+            "agent_id",
+            "period",
+            "window_start",
+            unique=True,
+            postgresql_where=text("fleet_id IS NULL"),
+        ),
+        # "latest run for this tenant/period" — the hot read path.
+        Index(
+            "ix_agent_digest_latest",
+            "tenant_id",
+            "period",
+            window_start.desc(),
+        ),
+    )

--- a/core-api/src/core_api/auth.py
+++ b/core-api/src/core_api/auth.py
@@ -240,6 +240,27 @@ class AuthContext:
                 detail=f"API key is not authorized to read tenant '{requested_tenant}'",
             )
 
+    def enforce_cross_tenant_read(self) -> None:
+        """Raise 403 unless this credential may read beyond its home tenant.
+
+        The gate for admin-plane, cross-tenant read artifacts (e.g. the cached
+        agent-activity digest at GET /api/v1/reports/agent-activity). Strict by
+        design: a single-tenant key never qualifies — those callers reach the
+        report through the enterprise org-report proxy, which is org-admin-gated
+        and itself holds a cross-tenant read credential. ``is_admin`` (the
+        internal super-admin key) always passes.
+
+        Bounding *which* tenants remains ``enforce_readable_tenant`` per target;
+        this only asserts the credential has cross-tenant read at all.
+        """
+        if self.is_admin:
+            return
+        if not self.is_cross_tenant_read:
+            raise HTTPException(
+                status_code=403,
+                detail="Cross-tenant read privileges are required for this report.",
+            )
+
     def enforce_write_scope(self) -> None:
         """Raise 403 if this credential's capabilities exclude ``write``.
 

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2450,6 +2450,22 @@ class CoreStorageClient:
     async def list_reports(self, tenant_id: str) -> list[dict]:
         return await self._get_list("/reports", tenant_id=tenant_id)
 
+    async def get_agent_activity_digest(
+        self,
+        tenant_id: str,
+        period: str,
+        *,
+        agent_id: str | None = None,
+        as_of: str | None = None,
+    ) -> list[dict]:
+        """Latest run's per-agent digest rows for a tenant/period ([] if none)."""
+        params: dict[str, Any] = {"tenant_id": tenant_id, "period": period}
+        if agent_id is not None:
+            params["agent_id"] = agent_id
+        if as_of is not None:
+            params["as_of"] = as_of
+        return await self._get_list("/reports/agent-activity", **params)
+
     # =====================================================================
     # Tasks
     # =====================================================================

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -612,7 +612,10 @@ async def get_report(
 
 @router.get("/reports/agent-activity")
 async def get_agent_activity_digest(
-    tenant_id: str = Query(..., description="Home tenant scope."),
+    tenant_id: str | None = Query(
+        None,
+        description="Home tenant scope. Required and used for scope='own'; ignored for scope='org'.",
+    ),
     period: str = Query("day", description="Digest window: 'day' or 'week'."),
     scope: str = Query(
         "own",
@@ -664,16 +667,23 @@ async def get_agent_activity_digest(
         else:
             tenants = list(auth.readable_tenant_ids)
     else:
+        if tenant_id is None:
+            raise HTTPException(status_code=422, detail="'tenant_id' is required for scope='own'.")
         tenants = [tenant_id]
     # Bound which tenants: every target must be in the credential's readable set.
     for t in tenants:
         auth.enforce_readable_tenant(t)
 
     sc = get_storage_client()
+    # return_exceptions: one tenant's storage failure must not sink the whole
+    # org report — skip the failed tenant and return what did resolve.
     per_tenant = await asyncio.gather(
-        *(sc.get_agent_activity_digest(t, period, agent_id=agent_id, as_of=as_of) for t in tenants)
+        *(sc.get_agent_activity_digest(t, period, agent_id=agent_id, as_of=as_of) for t in tenants),
+        return_exceptions=True,
     )
-    digests: list[dict] = [row for rows in per_tenant for row in (rows or [])]
+    digests: list[dict] = [
+        row for rows in per_tenant if not isinstance(rows, BaseException) for row in (rows or [])
+    ]
 
     # Meta reflects the freshest run represented in the result set. Under
     # scope='org' the digests can span tenants whose scheduled passes ran over

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -668,16 +668,24 @@ async def get_agent_activity_digest(
     )
     digests: list[dict] = [row for rows in per_tenant for row in (rows or [])]
 
-    # Meta reflects the freshest run represented in the result set.
+    # Meta reflects the freshest run represented in the result set. Under
+    # scope='org' the digests can span tenants whose scheduled passes ran over
+    # different windows / with different models (per-tenant cadence + model
+    # config), so the scalar window_start/window_end/model are "from the freshest
+    # run" only — ``windows`` lists every distinct window actually present, so a
+    # caller can tell when the result set is not a single coherent window.
     latest = max(digests, key=lambda d: d["generated_at"]) if digests else None
+    windows = sorted({(d["window_start"], d["window_end"]) for d in digests}, reverse=True)
     meta = {
         "period": period,
         "scope": scope,
         "tenants": len(tenants),
         "agents": len({d["agent_id"] for d in digests}),
         "generated_at": latest["generated_at"] if latest else None,
+        # From the freshest run; see ``windows`` for the full set under scope='org'.
         "window_start": latest["window_start"] if latest else None,
         "window_end": latest["window_end"] if latest else None,
         "model": latest["model"] if latest else None,
+        "windows": [{"window_start": s, "window_end": e} for s, e in windows],
     }
     return {"meta": meta, "digests": digests}

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -27,6 +27,7 @@ the report reflects durable per-agent work rather than the raw activity stream.
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from collections.abc import Awaitable
 from datetime import UTC, datetime, timedelta
@@ -40,6 +41,7 @@ from core_api.services.audit_service import log_action
 from core_api.services.caller_identity import resolve_caller_and_gate
 
 router = APIRouter(tags=["Reports"])
+logger = logging.getLogger(__name__)
 
 # Episodic activity-log type(s) + the unattributed firehose agent excluded so the
 # report reflects durable, decision-bearing per-agent work.
@@ -681,9 +683,12 @@ async def get_agent_activity_digest(
         *(sc.get_agent_activity_digest(t, period, agent_id=agent_id, as_of=as_of) for t in tenants),
         return_exceptions=True,
     )
-    digests: list[dict] = [
-        row for rows in per_tenant if not isinstance(rows, BaseException) for row in (rows or [])
-    ]
+    digests: list[dict] = []
+    for t, rows in zip(tenants, per_tenant):
+        if isinstance(rows, BaseException):
+            logger.warning("agent_activity_digest: storage call failed for tenant %s: %r", t, rows)
+        else:
+            digests.extend(rows or [])
 
     # Meta reflects the freshest run represented in the result set. Under
     # scope='org' the digests can span tenants whose scheduled passes ran over

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -608,3 +608,76 @@ async def get_report(
         "learning": learning,
         "quality": quality,
     }
+
+
+@router.get("/reports/agent-activity")
+async def get_agent_activity_digest(
+    tenant_id: str = Query(..., description="Home tenant scope."),
+    period: str = Query("day", description="Digest window: 'day' or 'week'."),
+    scope: str = Query(
+        "own",
+        description=(
+            "Breadth: 'own' (just ``tenant_id``) or 'org' (every tenant the "
+            "credential may read). Both require a cross-tenant read credential."
+        ),
+    ),
+    agent_id: str | None = Query(None, description="Filter the digest to a single agent."),
+    as_of: str | None = Query(
+        None, description="ISO date/datetime to view a past snapshot; absent ⇒ latest."
+    ),
+    readable_tenant_ids: str | None = Query(
+        None,
+        description=(
+            "CSV of tenant ids for scope='org'. Honored ONLY for the internal "
+            "admin credential (the org-report proxy); ignored otherwise."
+        ),
+    ),
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict:
+    """Cached, LLM-generated per-agent activity digest (read-only).
+
+    Precomputed on a schedule (default nightly; see core-operations) and served
+    from storage — never computed live. Gated on **cross-tenant read
+    privileges** (``enforce_cross_tenant_read``): single-tenant callers reach it
+    through the enterprise org-report proxy instead. Returns ``digests: []`` with
+    ``meta.generated_at: null`` when no run exists yet, not a 404.
+    """
+    auth.enforce_cross_tenant_read()
+    if period not in _PERIOD_DAYS:
+        raise HTTPException(status_code=422, detail=f"Invalid period '{period}'. Use 'day' or 'week'.")
+    if scope not in ("own", "org"):
+        raise HTTPException(status_code=422, detail="Invalid scope. Use 'own' or 'org'.")
+
+    # Resolve the target tenant set. The internal admin proxy may pass an
+    # explicit set; every other caller is pinned to its own readable set so a
+    # cross-tenant agent cannot widen past its grant.
+    if scope == "org":
+        if auth.is_admin and readable_tenant_ids:
+            tenants = [t.strip() for t in readable_tenant_ids.split(",") if t.strip()]
+        else:
+            tenants = list(auth.readable_tenant_ids)
+    else:
+        tenants = [tenant_id]
+    # Bound which tenants: every target must be in the credential's readable set.
+    for t in tenants:
+        auth.enforce_readable_tenant(t)
+
+    sc = get_storage_client()
+    per_tenant = await asyncio.gather(
+        *(sc.get_agent_activity_digest(t, period, agent_id=agent_id, as_of=as_of) for t in tenants)
+    )
+    digests: list[dict] = [row for rows in per_tenant for row in (rows or [])]
+
+    # Meta reflects the freshest run represented in the result set.
+    latest = max(digests, key=lambda d: d["generated_at"]) if digests else None
+    meta = {
+        "period": period,
+        "scope": scope,
+        "tenants": len(tenants),
+        "agents": len({d["agent_id"] for d in digests}),
+        "generated_at": latest["generated_at"] if latest else None,
+        "window_start": latest["window_start"] if latest else None,
+        "window_end": latest["window_end"] if latest else None,
+        "model": latest["model"] if latest else None,
+    }
+    return {"meta": meta, "digests": digests}

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -647,6 +647,13 @@ async def get_agent_activity_digest(
         raise HTTPException(status_code=422, detail=f"Invalid period '{period}'. Use 'day' or 'week'.")
     if scope not in ("own", "org"):
         raise HTTPException(status_code=422, detail="Invalid scope. Use 'own' or 'org'.")
+    if as_of is not None:
+        # Fail fast with a clean 422 before any storage round-trip (N calls under
+        # scope='org'); the storage router validates too, as a backstop.
+        try:
+            datetime.fromisoformat(as_of)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="'as_of' must be a valid ISO date/datetime.")
 
     # Resolve the target tenant set. The internal admin proxy may pass an
     # explicit set; every other caller is pinned to its own readable set so a

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -674,8 +674,17 @@ async def get_agent_activity_digest(
     # config), so the scalar window_start/window_end/model are "from the freshest
     # run" only — ``windows`` lists every distinct window actually present, so a
     # caller can tell when the result set is not a single coherent window.
-    latest = max(digests, key=lambda d: d["generated_at"]) if digests else None
-    windows = sorted({(d["window_start"], d["window_end"]) for d in digests}, reverse=True)
+    # Order on parsed datetimes, not raw ISO strings: lexical comparison is wrong
+    # when offsets are formatted differently across rows ("Z" vs "+00:00").
+    def _parse_dt(s: str) -> datetime:
+        return datetime.fromisoformat(s)
+
+    latest = max(digests, key=lambda d: _parse_dt(d["generated_at"])) if digests else None
+    windows = sorted(
+        {(d["window_start"], d["window_end"]) for d in digests},
+        key=lambda t: _parse_dt(t[0]),
+        reverse=True,
+    )
     meta = {
         "period": period,
         "scope": scope,

--- a/core-storage-api/src/core_storage_api/database/migrations/env.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/env.py
@@ -21,6 +21,7 @@ from common.models.memory import Memory  # noqa: F401
 from common.models.entity import Entity, MemoryEntityLink, Relation  # noqa: F401
 from common.models.audit import AuditLog  # noqa: F401
 from common.models.agent import Agent  # noqa: F401
+from common.models.agent_activity_digest import AgentActivityDigest  # noqa: F401
 from common.models.analysis_report import CrystallizationReport  # noqa: F401
 from common.models.fleet import FleetNode, FleetCommand  # noqa: F401
 from common.models.document import Document  # noqa: F401
@@ -56,8 +57,7 @@ async def run_migrations_cli():
 
 if context.is_offline_mode():
     raise RuntimeError(
-        "Offline mode (alembic --sql) is not supported. "
-        "Run 'alembic upgrade head' without --sql."
+        "Offline mode (alembic --sql) is not supported. Run 'alembic upgrade head' without --sql."
     )
 else:
     connection = context.config.attributes.get("connection")

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/029_agent_activity_digest.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/029_agent_activity_digest.py
@@ -1,0 +1,96 @@
+"""Agent activity digest: cached per-agent LLM summaries.
+
+Backs the precomputed "what did this agent do this day/week" report
+(GET /api/v1/reports/agent-activity). Rows are grouped by ``run_id`` — one
+scheduled pass (default nightly, core-operations) writes one row per agent.
+
+Distinct from ``analysis_reports`` (the crystallization report): that stores a
+single JSONB blob per run; this stores one queryable row per agent so the UI
+can render/deep-link a per-agent narrative and the read path can filter by
+``agent_id``. The UNIQUE constraint makes re-runs of the same window idempotent
+(upsert), and the ``(tenant_id, period, window_start DESC)`` index serves the
+"latest run" hot read.
+
+No DB CHECK on ``period``/``status``: the value sets are validated at the app
+layer, mirroring ``memories.visibility`` and ``agents.belonging_type``.
+
+Revision ID: 029
+Revises: 028
+Create Date: 2026-07-06
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "029"
+down_revision: str | None = "028"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_activity_digests",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("run_id", sa.Uuid(), nullable=False),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("fleet_id", sa.Text(), nullable=True),
+        sa.Column("agent_id", sa.Text(), nullable=False),
+        sa.Column("period", sa.Text(), nullable=False),
+        sa.Column("window_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("window_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("narrative", sa.Text(), nullable=True),
+        sa.Column("sections", JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("source_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("recall_count", sa.Integer(), nullable=True),
+        sa.Column("model", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("error_detail", sa.Text(), nullable=True),
+        sa.Column(
+            "generated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_agent_activity_digests_run_id", "agent_activity_digests", ["run_id"])
+    op.create_index("ix_agent_activity_digests_tenant_id", "agent_activity_digests", ["tenant_id"])
+    op.create_index(
+        "ix_agent_digest_latest",
+        "agent_activity_digests",
+        ["tenant_id", "period", sa.text("window_start DESC")],
+    )
+    # Idempotency guard. Two PARTIAL unique indexes instead of a plain UNIQUE
+    # constraint: Postgres treats NULLs as distinct, so UNIQUE(... fleet_id ...)
+    # would let duplicate no-fleet digests through when fleet_id IS NULL.
+    op.create_index(
+        "uq_agent_digest_window_fleet",
+        "agent_activity_digests",
+        ["tenant_id", "fleet_id", "agent_id", "period", "window_start"],
+        unique=True,
+        postgresql_where=sa.text("fleet_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_agent_digest_window_no_fleet",
+        "agent_activity_digests",
+        ["tenant_id", "agent_id", "period", "window_start"],
+        unique=True,
+        postgresql_where=sa.text("fleet_id IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_agent_digest_window_no_fleet", table_name="agent_activity_digests")
+    op.drop_index("uq_agent_digest_window_fleet", table_name="agent_activity_digests")
+    op.drop_index("ix_agent_digest_latest", table_name="agent_activity_digests")
+    op.drop_index("ix_agent_activity_digests_tenant_id", table_name="agent_activity_digests")
+    op.drop_index("ix_agent_activity_digests_run_id", table_name="agent_activity_digests")
+    op.drop_table("agent_activity_digests")

--- a/core-storage-api/src/core_storage_api/routers/reports.py
+++ b/core-storage-api/src/core_storage_api/routers/reports.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
 
-from core_storage_api.schemas import REPORT_FIELDS, orm_to_dict
+from core_storage_api.schemas import AGENT_DIGEST_FIELDS, REPORT_FIELDS, orm_to_dict
 from core_storage_api.services.postgres_service import PostgresService
 
 router = APIRouter(prefix="/reports", tags=["Reports"])
@@ -51,6 +52,32 @@ async def get_latest_report(
 async def list_reports(tenant_id: str) -> list[dict]:
     reports = await _svc.report_list_by_tenant(tenant_id)
     return [orm_to_dict(r, REPORT_FIELDS) for r in reports]
+
+
+@router.get("/agent-activity")
+async def get_agent_activity_digest(
+    tenant_id: str,
+    period: str = "day",
+    agent_id: str | None = None,
+    as_of: str | None = None,
+) -> list[dict]:
+    """Latest run's per-agent digest rows for a tenant/period.
+
+    Read-only; returns ``[]`` when no run has been generated yet. Cross-tenant
+    authorization is enforced upstream in core-api (this internal endpoint is
+    reached only via the storage client). ``as_of`` (ISO date/datetime) views a
+    past snapshot; absent ⇒ latest.
+    """
+    if period not in ("day", "week"):
+        raise HTTPException(status_code=422, detail="'period' must be 'day' or 'week'")
+    as_of_dt: datetime | None = None
+    if as_of is not None:
+        try:
+            as_of_dt = datetime.fromisoformat(as_of)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="'as_of' must be a valid ISO date/datetime")
+    rows = await _svc.agent_activity_digest_get_latest(tenant_id, period, agent_id=agent_id, as_of=as_of_dt)
+    return [orm_to_dict(r, AGENT_DIGEST_FIELDS) for r in rows]
 
 
 @router.get("/{report_id}")

--- a/core-storage-api/src/core_storage_api/routers/reports.py
+++ b/core-storage-api/src/core_storage_api/routers/reports.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
@@ -76,6 +76,10 @@ async def get_agent_activity_digest(
             as_of_dt = datetime.fromisoformat(as_of)
         except ValueError:
             raise HTTPException(status_code=422, detail="'as_of' must be a valid ISO date/datetime")
+        # A date-only / tz-less ISO string parses naive; window_start is
+        # timestamptz, so assume UTC to avoid a naive-vs-aware asyncpg error.
+        if as_of_dt.tzinfo is None:
+            as_of_dt = as_of_dt.replace(tzinfo=UTC)
     rows = await _svc.agent_activity_digest_get_latest(tenant_id, period, agent_id=agent_id, as_of=as_of_dt)
     return [orm_to_dict(r, AGENT_DIGEST_FIELDS) for r in rows]
 

--- a/core-storage-api/src/core_storage_api/schemas.py
+++ b/core-storage-api/src/core_storage_api/schemas.py
@@ -225,6 +225,25 @@ BACKGROUND_TASK_FIELDS: list[str] = [
     "created_at",
 ]
 
+AGENT_DIGEST_FIELDS: list[str] = [
+    "id",
+    "run_id",
+    "tenant_id",
+    "fleet_id",
+    "agent_id",
+    "period",
+    "window_start",
+    "window_end",
+    "narrative",
+    "sections",
+    "source_count",
+    "recall_count",
+    "model",
+    "status",
+    "error_detail",
+    "generated_at",
+]
+
 
 # ---------------------------------------------------------------------------
 # Pydantic request schemas for complex query endpoints

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -8287,8 +8287,11 @@ class PostgresService:
             if latest_run_id is None:
                 return []
 
+            # Scope to tenant_id as well: a fleet-wide pass shares one run_id
+            # across tenants, so run_id alone would return other tenants' rows.
             rows_stmt = select(AgentActivityDigest).where(
                 AgentActivityDigest.run_id == latest_run_id,
+                AgentActivityDigest.tenant_id == tenant_id,
             )
             if agent_id is not None:
                 rows_stmt = rows_stmt.where(AgentActivityDigest.agent_id == agent_id)

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -8269,22 +8269,26 @@ class PostgresService:
         exists yet — the caller renders "not generated yet", never an error.
         """
         async with get_session() as session:
-            # Resolve the latest run's window_start for this tenant/period.
-            window_stmt = select(AgentActivityDigest.window_start).where(
+            # Resolve the latest run_id for this tenant/period. Keying the row
+            # fetch on run_id (not window_start) keeps the result to a single
+            # coherent run: a same-window re-run mints a new run_id, and the
+            # generated_at tie-break makes the newest such run win.
+            run_stmt = select(AgentActivityDigest.run_id).where(
                 AgentActivityDigest.tenant_id == tenant_id,
                 AgentActivityDigest.period == period,
             )
             if as_of is not None:
-                window_stmt = window_stmt.where(AgentActivityDigest.window_start <= as_of)
-            window_stmt = window_stmt.order_by(AgentActivityDigest.window_start.desc()).limit(1)
-            latest_window = (await session.execute(window_stmt)).scalar_one_or_none()
-            if latest_window is None:
+                run_stmt = run_stmt.where(AgentActivityDigest.window_start <= as_of)
+            run_stmt = run_stmt.order_by(
+                AgentActivityDigest.window_start.desc(),
+                AgentActivityDigest.generated_at.desc(),
+            ).limit(1)
+            latest_run_id = (await session.execute(run_stmt)).scalar_one_or_none()
+            if latest_run_id is None:
                 return []
 
             rows_stmt = select(AgentActivityDigest).where(
-                AgentActivityDigest.tenant_id == tenant_id,
-                AgentActivityDigest.period == period,
-                AgentActivityDigest.window_start == latest_window,
+                AgentActivityDigest.run_id == latest_run_id,
             )
             if agent_id is not None:
                 rows_stmt = rows_stmt.where(AgentActivityDigest.agent_id == agent_id)

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -58,6 +58,7 @@ from common.constants import (
 from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
 from common.models import (
     Agent,
+    AgentActivityDigest,
     AuditChainHead,
     AuditLog,
     BackgroundTaskLog,
@@ -8246,6 +8247,50 @@ class PostgresService:
                 .limit(1)
             )
             return result.scalar_one_or_none()
+
+    # ══════════════════════════════════════════════════════════════════════
+    #  AGENT ACTIVITY DIGEST (AgentActivityDigest) — cached per-agent summaries
+    # ══════════════════════════════════════════════════════════════════════
+
+    async def agent_activity_digest_get_latest(
+        self,
+        tenant_id: str,
+        period: str,
+        *,
+        agent_id: str | None = None,
+        as_of: datetime | None = None,
+    ) -> list[AgentActivityDigest]:
+        """Return every agent row from the most recent run for a tenant/period.
+
+        A "run" is identified by ``run_id``; all its rows share one
+        ``window_start``. We pick the latest run (``window_start`` at or before
+        ``as_of`` when given — for viewing past snapshots) and return its rows.
+        ``agent_id`` narrows to a single agent. Returns ``[]`` when no run
+        exists yet — the caller renders "not generated yet", never an error.
+        """
+        async with get_session() as session:
+            # Resolve the latest run's window_start for this tenant/period.
+            window_stmt = select(AgentActivityDigest.window_start).where(
+                AgentActivityDigest.tenant_id == tenant_id,
+                AgentActivityDigest.period == period,
+            )
+            if as_of is not None:
+                window_stmt = window_stmt.where(AgentActivityDigest.window_start <= as_of)
+            window_stmt = window_stmt.order_by(AgentActivityDigest.window_start.desc()).limit(1)
+            latest_window = (await session.execute(window_stmt)).scalar_one_or_none()
+            if latest_window is None:
+                return []
+
+            rows_stmt = select(AgentActivityDigest).where(
+                AgentActivityDigest.tenant_id == tenant_id,
+                AgentActivityDigest.period == period,
+                AgentActivityDigest.window_start == latest_window,
+            )
+            if agent_id is not None:
+                rows_stmt = rows_stmt.where(AgentActivityDigest.agent_id == agent_id)
+            rows_stmt = rows_stmt.order_by(AgentActivityDigest.source_count.desc())
+            result = await session.execute(rows_stmt)
+            return list(result.scalars().all())
 
     # ══════════════════════════════════════════════════════════════════════
     #  TASKS (BackgroundTaskLog)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,7 @@ def _import_all_models():
     import common.models.memory  # noqa: F401
     import common.models.entity  # noqa: F401
     import common.models.agent  # noqa: F401
+    import common.models.agent_activity_digest  # noqa: F401
     import common.models.audit  # noqa: F401
     import common.models.analysis_report  # noqa: F401
     import common.models.fleet  # noqa: F401
@@ -139,6 +140,7 @@ async def _setup_schema(_engine):
             "entities",
             "memories",
             "audit_log",
+            "agent_activity_digests",
         ):
             try:
                 await conn.execute(

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -564,3 +564,78 @@ async def test_report_org_scope_requires_cross_tenant_key(client):
         assert resp.status_code == 403, resp.text
     finally:
         app.dependency_overrides.pop(get_auth_context, None)
+
+
+# ── Agent-activity digest (CAURA-222): cached per-agent summaries ──
+# Phase 1 is the inert read slice — the generation worker lands in Phase 2, so
+# these cover the gate + the "no run yet" contract. Non-empty read coverage
+# arrives with the writer.
+
+
+async def test_agent_activity_requires_cross_tenant_read(client):
+    """A single-tenant (non-admin) credential is refused: the digest is a
+    cross-tenant admin-plane artifact (``enforce_cross_tenant_read``)."""
+    tag = _uid()
+    t1 = f"rep-dig-solo-{tag}"
+    ctx = AuthContext(tenant_id=t1)  # single-tenant, non-admin
+    app.dependency_overrides[get_auth_context] = lambda: ctx
+    try:
+        resp = await client.get(
+            "/api/v1/reports/agent-activity",
+            params={"tenant_id": t1, "period": "day"},
+        )
+        assert resp.status_code == 403, resp.text
+    finally:
+        app.dependency_overrides.pop(get_auth_context, None)
+
+
+async def test_agent_activity_cross_tenant_empty_until_generated(client):
+    """A cross-tenant reader is allowed; with no run yet the endpoint returns an
+    empty digest list + null ``generated_at`` (never a 404)."""
+    tag = _uid()
+    t1, t2 = f"rep-dig1-{tag}", f"rep-dig2-{tag}"
+    ctx = AuthContext(tenant_id=t1, readable_tenant_ids=[t1, t2])
+    app.dependency_overrides[get_auth_context] = lambda: ctx
+    try:
+        resp = await client.get(
+            "/api/v1/reports/agent-activity",
+            params={"tenant_id": t1, "period": "day", "scope": "org"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["digests"] == [], body
+        assert body["meta"]["generated_at"] is None, body["meta"]
+        assert body["meta"]["scope"] == "org"
+        assert body["meta"]["tenants"] == 2, body["meta"]
+    finally:
+        app.dependency_overrides.pop(get_auth_context, None)
+
+
+async def test_agent_activity_admin_allowed(client):
+    """The internal admin key bypasses the cross-tenant gate."""
+    tag = _uid()
+    t1 = f"rep-dig-adm-{tag}"
+    _, headers = get_test_auth(t1)  # admin key (is_admin=True)
+    resp = await client.get(
+        "/api/v1/reports/agent-activity",
+        params={"tenant_id": t1, "period": "day"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["digests"] == []
+
+
+async def test_agent_activity_invalid_period(client):
+    """Period is validated to 'day'|'week' → 422 otherwise."""
+    tag = _uid()
+    t1, t2 = f"rep-dig-per1-{tag}", f"rep-dig-per2-{tag}"
+    ctx = AuthContext(tenant_id=t1, readable_tenant_ids=[t1, t2])
+    app.dependency_overrides[get_auth_context] = lambda: ctx
+    try:
+        resp = await client.get(
+            "/api/v1/reports/agent-activity",
+            params={"tenant_id": t1, "period": "month"},
+        )
+        assert resp.status_code == 422, resp.text
+    finally:
+        app.dependency_overrides.pop(get_auth_context, None)

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"028"}, f"Expected single head '028', got {sorted(heads)}"
+        assert heads == {"029"}, f"Expected single head '029', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -682,6 +682,8 @@ class TestMigrationChain:
         assert chain.get("027") == "026", "027 must follow 026"
         # 028: agent belonging model (belonging_type + owner_ref)
         assert chain.get("028") == "027", "028 must follow 027"
+        # 029: agent activity digest (cached per-agent summaries, CAURA-222)
+        assert chain.get("029") == "028", "029 must follow 028"
 
     def test_no_plain_create_index_on_large_tables(self):
         """Indexes on large, pre-existing tables MUST be built ``CONCURRENTLY``


### PR DESCRIPTION
## What

Phase 1 of the **cached per-agent activity digest** — an LLM-generated "what did this agent do this day/week" report, distinct from the live `GET /api/v1/reports` (quantitative, computed per request). This phase is the **inert read scaffold**: schema + a read endpoint that returns empty until the generation worker lands. **No worker, no LLM, no UI — safe to merge.**

## Changes
- **Migration 029 + `AgentActivityDigest` model** — one queryable row per agent per run (`run_id` groups a scheduled pass). `UNIQUE(tenant, fleet, agent, period, window_start)` makes re-runs idempotent; `(tenant, period, window_start DESC)` index serves the "latest run" read. Deliberately separate from `analysis_reports` (the single-blob crystallization report) so the UI can deep-link a per-agent narrative.
- **core-storage** — `agent_activity_digest_get_latest` + `GET /reports/agent-activity` (latest run's rows, optional `agent_id`/`as_of`; `[]` when none).
- **core-api** — `GET /api/v1/reports/agent-activity`, gated by the new `AuthContext.enforce_cross_tenant_read()` (**strict**: `is_admin or is_cross_tenant_read`) + per-tenant `enforce_readable_tenant`. Returns `{meta, digests: []}` with `meta.generated_at: null` until generated (never a 404).
- **tests** — gate (403 single-tenant), empty-until-generated, admin bypass, 422 period. `conftest` registers the new model + cleanup.

## Verification
- `ruff format`/`check` + `mypy` clean on both packages.
- Migration `029` applies with the exact 16 columns + all indexes/constraints; `alembic history` linear, single head.
- 8/8 report tests pass (4 new + 4 regression) against the pgvector test DB.

## Design / next phases
Gate = **cross-tenant read privileges** (single-tenant orgs consume via the org-admin-gated proxy). Cadence = **nightly daily digest** primary + weekly add-on, scheduled in **core-operations**, generated with **gpt-5.4-mini**.
- **Phase 2** — generation worker (LLM pass per agent, reusing the live report's corpus filters), config surface, upsert writer.
- **Phase 3** — UI tab on the Reports page + deep-link from the leaderboard; org-report proxy passes a dedicated cross-tenant read key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)