### PR TITLE
feat(search): tenant-wide default search profile (agent > tenant > constant)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
+++ b/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
@@ -27,6 +27,18 @@ class ResolveSearchProfile:
         search_profile = ctx.data.get("search_profile")
         sp = validate_search_profile(search_profile) if search_profile else {}
 
+        # Tenant-wide default profile (A47) sits BELOW the agent profile and
+        # ABOVE the global constants: a per-agent tuned knob wins, the tenant
+        # default fills the gaps, and the constant is the final fallback.
+        # ``tenant_config`` is a ResolvedConfig on the primary search/recall
+        # paths (routes resolve it before calling); guard for callers that
+        # don't pass one so behaviour is unchanged when it's absent.
+        tenant_config = ctx.tenant_config
+        if tenant_config is not None:
+            tenant_default = getattr(tenant_config, "default_search_profile", {}) or {}
+            if tenant_default:
+                sp = {**tenant_default, **sp}
+
         query = ctx.data["query"]
         top_k = ctx.data["top_k"]
 

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -73,6 +73,13 @@ DEFAULT_SETTINGS: dict = {
     "search": {
         "recall_boost": None,
         "graph_retrieval": None,
+        # Tenant-wide default search profile (A47). Any search_profile knob set
+        # here (min_similarity, top_k, freshness_floor, ...) becomes the fallback
+        # for EVERY agent in the tenant, filling the gap between a per-agent tuned
+        # profile and the global constants. Empty by default → global constants
+        # apply, unchanged. Validated by ``_validate_default_search_profile`` on
+        # write (strict, raises) and ``validate_search_profile`` on read (clamps).
+        "default_profile": {},
     },
     "crystallizer": {
         "auto_crystallize": None,
@@ -445,6 +452,39 @@ def _validate_governance_enums(payload: dict) -> None:
         )
 
 
+def _validate_default_search_profile(payload: dict) -> None:
+    """Strictly validate the tenant-wide ``search.default_profile`` on write.
+
+    Unlike ``validate_search_profile`` (which silently clamps/drops for the
+    agent-tune path), an org-wide setting write should fail loudly so an
+    operator gets a 422 rather than a value that was quietly clamped. Unknown
+    keys, wrong types, and out-of-range values all raise. Keys and ranges are
+    the same source of truth as agent profiles (``_SEARCH_PROFILE_RULES``).
+    """
+    dp = payload.get("search", {}).get("default_profile")
+    if dp is None:
+        return
+    if not isinstance(dp, dict):
+        raise ValueError("search.default_profile must be an object")
+    for key, value in dp.items():
+        if key not in _SEARCH_PROFILE_RULES:
+            raise ValueError(
+                f"search.default_profile: unknown key {key!r} (allowed: {sorted(_SEARCH_PROFILE_RULES)})"
+            )
+        expected_type, (lo, hi), _ = _SEARCH_PROFILE_RULES[key]
+        # Accept an int where a float is expected (e.g. min_similarity=0 → 0.0),
+        # but never a bool (bool is an int subclass and would slip through).
+        if expected_type is float and isinstance(value, int) and not isinstance(value, bool):
+            value = float(value)
+        wrong_bool = isinstance(value, bool) and expected_type is not bool
+        if wrong_bool or not isinstance(value, expected_type):
+            raise ValueError(
+                f"search.default_profile.{key} must be {expected_type.__name__}, got {type(value).__name__}"
+            )
+        if value < lo or value > hi:
+            raise ValueError(f"search.default_profile.{key} must be in [{lo}, {hi}], got {value}")
+
+
 def _check_keys(payload: dict, schema: dict, path: str = "") -> None:
     """Raise ``ValueError`` for any key in *payload* not present in *schema*.
 
@@ -793,6 +833,17 @@ class ResolvedConfig:
         val = self._ts.get("search", {}).get("graph_retrieval")
         return val if val is not None else True
 
+    @property
+    def default_search_profile(self) -> dict:
+        """Tenant-wide default search profile (A47).
+
+        Sits below a per-agent tuned profile and above the global constants in
+        ``resolve_search_profile``. Sanitised via ``validate_search_profile`` on
+        read so a malformed stored value can never crash the search pipeline —
+        unknown/out-of-range knobs are clamped or dropped. Empty ⇒ constants.
+        """
+        return validate_search_profile(self._ts.get("search", {}).get("default_profile", {}) or {})
+
     # Crystallizer
     @property
     def auto_crystallize_enabled(self) -> bool:
@@ -1087,6 +1138,7 @@ async def update_settings(
     _check_keys(new_settings, DEFAULT_SETTINGS)
     _validate_leaf_types(new_settings)
     _validate_governance_enums(new_settings)
+    _validate_default_search_profile(new_settings)
     cron_override = new_settings.get("security_audit", {}).get("schedule_cron")
     if cron_override is not None:
         _validate_cron(cron_override)

--- a/tests/test_search_default_profile.py
+++ b/tests/test_search_default_profile.py
@@ -1,0 +1,137 @@
+"""Unit tests for the tenant-wide default search profile (A47).
+
+Covers the three pieces of the change:
+  * ``ResolvedConfig.default_search_profile`` accessor (read + sanitise)
+  * ``_check_keys`` / ``_validate_default_search_profile`` (write validation)
+  * ``ResolveSearchProfile`` precedence: agent > tenant default > constant
+
+Pure logic — no DB.
+"""
+
+import pytest
+
+from core_api.constants import MIN_SEARCH_SIMILARITY
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search.resolve_search_profile import ResolveSearchProfile
+from core_api.services.organization_settings import (
+    DEFAULT_SETTINGS,
+    ResolvedConfig,
+    _check_keys,
+    _validate_default_search_profile,
+)
+
+
+# ── ResolvedConfig.default_search_profile ──
+
+
+def test_default_profile_empty_by_default():
+    rc = ResolvedConfig({})
+    assert rc.default_search_profile == {}
+
+
+def test_default_profile_reads_override():
+    rc = ResolvedConfig({"search": {"default_profile": {"min_similarity": 0.42}}})
+    assert rc.default_search_profile == {"min_similarity": 0.42}
+
+
+def test_default_profile_sanitises_out_of_range_on_read():
+    # 0.99 is above the validate_search_profile ceiling (0.9) → clamped, never crashes.
+    rc = ResolvedConfig({"search": {"default_profile": {"min_similarity": 0.99}}})
+    assert rc.default_search_profile["min_similarity"] == 0.9
+
+
+# ── write-path validation ──
+
+
+def test_check_keys_allows_default_profile():
+    # Must not raise: default_profile is a declared (open) sub-object.
+    _check_keys(
+        {"search": {"default_profile": {"min_similarity": 0.4, "top_k": 10}}},
+        DEFAULT_SETTINGS,
+    )
+
+
+def test_validate_default_profile_accepts_valid():
+    _validate_default_search_profile(
+        {"search": {"default_profile": {"min_similarity": 0.4, "top_k": 8}}}
+    )
+
+
+def test_validate_default_profile_accepts_int_for_float():
+    # min_similarity is float-typed; a bare int (0) must be accepted (→ 0.0-ish),
+    # but 0 is below the 0.1 floor so it should raise on range, not on type.
+    with pytest.raises(ValueError, match="in \\[0.1, 0.9\\]"):
+        _validate_default_search_profile(
+            {"search": {"default_profile": {"min_similarity": 0}}}
+        )
+
+
+def test_validate_default_profile_rejects_unknown_key():
+    with pytest.raises(ValueError, match="unknown key"):
+        _validate_default_search_profile({"search": {"default_profile": {"bogus": 1}}})
+
+
+def test_validate_default_profile_rejects_wrong_type():
+    with pytest.raises(ValueError, match="must be float"):
+        _validate_default_search_profile(
+            {"search": {"default_profile": {"min_similarity": "hi"}}}
+        )
+
+
+def test_validate_default_profile_rejects_bool_for_float():
+    with pytest.raises(ValueError, match="must be float"):
+        _validate_default_search_profile(
+            {"search": {"default_profile": {"min_similarity": True}}}
+        )
+
+
+def test_validate_default_profile_rejects_out_of_range():
+    with pytest.raises(ValueError, match="in \\[0.1, 0.9\\]"):
+        _validate_default_search_profile(
+            {"search": {"default_profile": {"min_similarity": 0.95}}}
+        )
+
+
+def test_validate_default_profile_noop_when_absent():
+    _validate_default_search_profile({"search": {"recall_boost": True}})
+    _validate_default_search_profile({})
+
+
+# ── ResolveSearchProfile precedence: agent > tenant default > constant ──
+
+
+async def _resolve(tenant_config, agent_profile):
+    step = ResolveSearchProfile()
+    ctx = PipelineContext(
+        data={
+            "query": "what is the compliance deadline",
+            "top_k": 5,
+            "search_profile": agent_profile,
+        },
+        tenant_config=tenant_config,
+    )
+    await step.execute(ctx)
+    return ctx.data["search_params"]
+
+
+async def test_precedence_no_tenant_config_uses_constant():
+    params = await _resolve(tenant_config=None, agent_profile=None)
+    assert params["min_similarity"] == MIN_SEARCH_SIMILARITY
+
+
+async def test_precedence_tenant_default_fills_gap():
+    tc = ResolvedConfig({"search": {"default_profile": {"min_similarity": 0.42}}})
+    params = await _resolve(tenant_config=tc, agent_profile=None)
+    assert params["min_similarity"] == 0.42
+
+
+async def test_precedence_agent_profile_overrides_tenant_default():
+    tc = ResolvedConfig({"search": {"default_profile": {"min_similarity": 0.42}}})
+    params = await _resolve(tenant_config=tc, agent_profile={"min_similarity": 0.55})
+    assert params["min_similarity"] == 0.55
+
+
+async def test_precedence_empty_tenant_default_is_neutral():
+    tc = ResolvedConfig({})  # no default_profile
+    params = await _resolve(tenant_config=tc, agent_profile=None)
+    assert params["min_similarity"] == MIN_SEARCH_SIMILARITY


### PR DESCRIPTION
## What

Adds a **tenant/org-level default search profile** so a single setting sets the similarity floor (and any other search knob) for **every agent** in a tenant. Resolution order in `resolve_search_profile` is now:

```
per-agent search_profile  →  tenant default_profile  →  global constant
```

## Why

Today only a per-agent `search_profile` can override the global `MIN_SEARCH_SIMILARITY = 0.3` — there's no tenant layer. Setting a per-customer floor (e.g. for eToro) meant tuning every agent individually: drift-prone, and new agents fall back to the global default. This is the groundwork for a **per-tenant, data-calibrated similarity floor (A47)** — after this, it's one setting per tenant.

## Changes

- **`organization_settings.py`**
  - `DEFAULT_SETTINGS.search.default_profile` — empty by default → neutral (global constants unchanged)
  - `ResolvedConfig.default_search_profile` — read accessor, sanitised via `validate_search_profile` on read (clamps out-of-range; can never crash the search path)
  - `_validate_default_search_profile` — strict **write** validator: raises → **422** on unknown key / wrong type / out-of-range, reusing `_SEARCH_PROFILE_RULES`; wired into `update_settings`
- **`resolve_search_profile.py`** — merge `{**tenant_default, **agent_profile}` (agent wins, tenant default fills gaps, constant last). Guarded on a missing `tenant_config` so behaviour is unchanged when absent.

Default-off / neutral: with no `default_profile` set, every knob resolves exactly as before.

## Usage (once merged)

```
PUT /api/v1/settings   {"search": {"default_profile": {"min_similarity": 0.40}}}
```

## Tests

- Unit (`tests/test_search_default_profile.py`, 15 cases): accessor read + sanitise-on-read, write-validator rejects unknown-key/wrong-type/out-of-range/bool, and the **real `ResolveSearchProfile` step** precedence (agent > tenant > constant).
- `ruff check` + `ruff format --check` clean; `cd core-api && mypy src/` → no issues.
- **Wet-tested on the local enterprise stack**: `PUT /settings` valid multi-key → 200 + GET round-trip; invalid → 422; and the real `resolve_config` (fresh DB read) → `ResolveSearchProfile` produced `min_similarity=0.42`/`top_k=9` from the tenant default (overriding global 0.3 / the request), with an agent profile correctly overriding to 0.55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)