### PR TITLE
fix(reports): count agent-private durable writes in report aggregates

### DIFF
--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -268,6 +268,16 @@ async def get_report(
         "exclude_memory_types": list(NON_DURABLE_TYPES),
         "exclude_agent_ids": list(RESERVED_FIREHOSE_AGENTS),
         "exclude_title_regex": NON_COHESIVE_TITLE_REGEX,
+        # Count agent-private (scope_agent) durable writes in the AGGREGATES
+        # (totals/by_type/by_agent/quality/trend). These are real, decision-
+        # bearing memories an agent kept private — excluding them made
+        # durable_memories_written measure "team-visible" rather than "written",
+        # and disproportionately undercounted privacy-heavy tenants. This is a
+        # pure count; the content sections (value_highlights/learning/spotlight/
+        # working_on) still exclude scope_agent — see list_query below — so no
+        # private content is surfaced to the group. Ignored on the self path
+        # (agent_id set), which already scopes visibility to the caller.
+        "include_scope_agent": True,
     }
     if org_mode:
         # Org-wide: aggregate across every tenant the credential may read.
@@ -375,6 +385,9 @@ async def get_report(
                 "exclude_memory_types": list(NON_DURABLE_TYPES),
                 "exclude_agent_ids": list(RESERVED_FIREHOSE_AGENTS),
                 "exclude_title_regex": NON_COHESIVE_TITLE_REGEX,
+                # Match the breakdown: the trend must count private durable rows
+                # too, or the daily line won't sum to durable_memories_written.
+                "include_scope_agent": True,
             }
             if org_mode:
                 trend_query["readable_tenant_ids"] = readable
@@ -491,9 +504,13 @@ async def get_report(
         # reuse-rate by type, never-recalled %, recall concentration (top-6
         # share), insight freshness, and the write→durable→reused funnel.
         # Scope keys shared by the three (independent) quality calls below.
+        # ``include_scope_agent`` rides along so the funnel's "written" (full) and
+        # the insight-freshness corpus (ins) count private rows too — otherwise
+        # ``durable`` (which now includes them) could exceed ``written`` and break
+        # the write→durable→reused funnel invariant.
         scope_keys = {
             k: breakdown_query[k]
-            for k in ("tenant_id", "agent_id", "fleet_id", "readable_tenant_ids")
+            for k in ("tenant_id", "agent_id", "fleet_id", "readable_tenant_ids", "include_scope_agent")
             if k in breakdown_query
         }
         # ── Phase 2: quality metrics + the two supporting breakdown calls run

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1123,6 +1123,7 @@ async def stats_breakdown(request: Request) -> dict:
         exclude_agent_ids=body.get("exclude_agent_ids"),
         exclude_title_regex=body.get("exclude_title_regex"),
         include_deleted=bool(body.get("include_deleted", False)),
+        include_scope_agent=bool(body.get("include_scope_agent", False)),
         readable_tenant_ids=body.get("readable_tenant_ids"),
     )
 
@@ -1132,8 +1133,10 @@ async def daily_durable_counts(request: Request) -> list[dict]:
     """Per-day durable-write counts since ``since`` (report activity trend).
 
     Body: ``{tenant_id, since (ISO), fleet_id?, exclude_memory_types?,
-    exclude_agent_ids?, exclude_title_regex?, readable_tenant_ids?}``. Team/org-scoped
-    (excludes ``scope_agent``); mirrors the durable/firehose exclusions of ``/stats-breakdown``.
+    exclude_agent_ids?, exclude_title_regex?, include_scope_agent?,
+    readable_tenant_ids?}``. Team/org-scoped; excludes ``scope_agent`` unless
+    ``include_scope_agent`` is set. Mirrors the durable/firehose exclusions of
+    ``/stats-breakdown``.
     """
     body: dict = await request.json()
     tenant_id = body.get("tenant_id")
@@ -1154,6 +1157,7 @@ async def daily_durable_counts(request: Request) -> list[dict]:
         exclude_memory_types=body.get("exclude_memory_types"),
         exclude_agent_ids=body.get("exclude_agent_ids"),
         exclude_title_regex=body.get("exclude_title_regex"),
+        include_scope_agent=bool(body.get("include_scope_agent", False)),
         readable_tenant_ids=body.get("readable_tenant_ids"),
     )
 
@@ -1186,6 +1190,7 @@ async def quality_metrics(request: Request) -> dict:
         exclude_memory_types=body.get("exclude_memory_types"),
         exclude_agent_ids=body.get("exclude_agent_ids"),
         exclude_title_regex=body.get("exclude_title_regex"),
+        include_scope_agent=bool(body.get("include_scope_agent", False)),
         readable_tenant_ids=body.get("readable_tenant_ids"),
     )
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -3434,6 +3434,7 @@ class PostgresService:
         exclude_agent_ids: list[str] | None = None,
         exclude_title_regex: str | None = None,
         include_deleted: bool = False,
+        include_scope_agent: bool = False,
         readable_tenant_ids: list[str] | None = None,
     ) -> dict:
         """Return ``{total, by_type, by_agent, by_status}`` (+ optional
@@ -3451,6 +3452,15 @@ class PostgresService:
         match what a non-semantic list would return), same single-pass GROUPING
         SETS aggregation, same cross-tenant widening + ``by_tenant`` breakdown,
         and same ``include_deleted`` CTE. Read-only (reader replica).
+
+        ``include_scope_agent`` (default False keeps the historical MCP
+        ``memclaw_stats`` behaviour) opts into counting agent-private
+        (``scope_agent``) rows in the no-``agent_id`` team/org aggregate. This is
+        a pure COUNT — no memory content is returned — so private rows can be
+        tallied without leaking their contents; the report uses it so
+        ``durable_memories_written`` reflects everything an agent wrote, not just
+        what it shared. Ignored when ``agent_id`` is set (that path already
+        scopes visibility to the named agent).
         """
         scope_filters = []
         if readable_tenant_ids:
@@ -3474,7 +3484,7 @@ class PostgresService:
                     ),
                 )
             )
-        else:
+        elif not include_scope_agent:
             scope_filters.append(Memory.visibility != "scope_agent")
         if memory_type:
             scope_filters.append(Memory.memory_type == memory_type)
@@ -3647,20 +3657,25 @@ class PostgresService:
         exclude_memory_types: list[str] | None = None,
         exclude_agent_ids: list[str] | None = None,
         exclude_title_regex: str | None = None,
+        include_scope_agent: bool = False,
         readable_tenant_ids: list[str] | None = None,
     ) -> list[dict]:
         """Per-day durable-write counts since ``since`` — the report's
         activity-over-time trend. Same durable/firehose exclusions and
-        team/org visibility scope as ``memory_stats_breakdown`` (no agent_id ⇒
-        excludes ``scope_agent``). Runs as a plain ORM ``GROUP BY`` executed
-        directly (no compile→text round-trip, so ``NOT IN`` expands natively).
-        Read-only (reader replica).
+        team/org visibility scope as ``memory_stats_breakdown``. Runs as a plain
+        ORM ``GROUP BY`` executed directly (no compile→text round-trip, so
+        ``NOT IN`` expands natively). Read-only (reader replica).
+
+        ``include_scope_agent`` (default False) mirrors ``memory_stats_breakdown``:
+        opt in to counting agent-private rows so the trend line matches the
+        report's ``durable_memories_written`` total. Pure count, no content.
         """
         conds = [
             Memory.deleted_at.is_(None),
             Memory.created_at >= since,
-            Memory.visibility != "scope_agent",
         ]
+        if not include_scope_agent:
+            conds.append(Memory.visibility != "scope_agent")
         if readable_tenant_ids:
             conds.append(Memory.tenant_id.in_(readable_tenant_ids))
         else:
@@ -3694,6 +3709,7 @@ class PostgresService:
         exclude_memory_types: list[str] | None = None,
         exclude_agent_ids: list[str] | None = None,
         exclude_title_regex: str | None = None,
+        include_scope_agent: bool = False,
         readable_tenant_ids: list[str] | None = None,
     ) -> dict:
         """Reuse / recall quality aggregates over the SAME scoped corpus as
@@ -3726,7 +3742,7 @@ class PostgresService:
                     and_(Memory.visibility == "scope_agent", Memory.agent_id == agent_id),
                 )
             )
-        else:
+        elif not include_scope_agent:
             scope_filters.append(Memory.visibility != "scope_agent")
         if created_after:
             scope_filters.append(Memory.created_at >= created_after)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -206,6 +206,57 @@ async def test_report_no_agent_caller_is_group_view(client):
     assert body["summary"]["durable_memories_written"] == 3, body
 
 
+async def test_report_group_counts_private_writes_but_hides_content(client):
+    """Agent-private (``scope_agent``) durable writes are COUNTED in the group
+    aggregates — durable_memories_written / by_type / per_agent / trend — but
+    their CONTENT is never surfaced (value_highlights). Visibility is an audience
+    attribute, not a measure of whether a memory is knowledge produced."""
+    tag = _uid()
+    tenant_id, headers = get_test_auth(f"rep-tenant-{tag}")
+    fleet, a1 = f"rep-fleet-{tag}", f"rep-a1-{tag}"
+    await _register(tenant_id, fleet, a1)
+    # 2 team-visible durable + 1 agent-private durable, all authored by a1.
+    await _seed(client, headers, tenant_id, fleet, a1, "decision", 2)
+    r = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": a1,
+            "fleet_id": fleet,
+            "memory_type": "fact",
+            "visibility": "scope_agent",
+            "content": f"private fact by {a1} {_uid()}",
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "internal_group",  # group view: no agent_id
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # COUNTS include the private durable write: 2 team decisions + 1 private fact.
+    assert body["summary"]["durable_memories_written"] == 3, body
+    assert body["summary"]["by_type"].get("fact") == 1, body["summary"]["by_type"]
+    agents = {p["agent_id"]: p["durable_writes"] for p in body["per_agent"]}
+    assert agents.get(a1) == 3, agents
+    # Trend line reconciles with the total (counts private too).
+    assert sum(pt["count"] for pt in body["trend"]) == 3, body["trend"]
+    # CONTENT stays audience-scoped: only the 2 team decisions surface; the
+    # private fact is counted above but never appears in value_highlights.
+    assert len(body["value_highlights"]) == 2, body["value_highlights"]
+    assert all(h["type"] == "decision" for h in body["value_highlights"]), body[
+        "value_highlights"
+    ]
+
+
 async def test_report_org_scope_aggregates_across_tenants(client):
     """scope=org with a cross-tenant read credential aggregates across the
     readable tenant set and returns a per-tenant breakdown."""


### PR DESCRIPTION
## Problem

The report's `durable_memories_written` (and `by_type` / `per_agent` / `trend` / `quality`) excluded `scope_agent` (agent-private) rows. So the top-line metric silently measured **team-visible** durable writes, not what was actually **written**.

Visibility is an *audience* attribute — an agent keeping a decision/fact private doesn't make it less durable or less decision-bearing. The exclusion also disproportionately undercounts privacy-heavy tenants. Verified against prod:

| tenant | current report | with private counted | delta |
|---|---|---|---|
| etoro0 (noisy/private-heavy) | 98 | **161** | +63 (+64%) |
| etoro-core (lean) | 254 | **275** | +21 (+8%) |

The recovered rows are real knowledge (rule/outcome/fact), not noise — the cohesive/episode/`main` filters already ran. The correction is self-targeting: it fixes the undercount where it was wrong and barely moves the already-clean tenant.

## Change

- Add an opt-in **`include_scope_agent`** flag (default `False`, so MCP `memclaw_stats` behavior is unchanged) to `memory_stats_breakdown`, `memory_daily_durable_counts`, and `memory_quality_metrics`.
- The report sets it `True` on its count/trend/quality queries; it rides `scope_keys` too, so the funnel's `written` and the insight-freshness corpus stay consistent (`written >= durable` holds).

This is a **pure count** change — no memory content is exposed. The content-bearing sections (`value_highlights` / `learning` / `spotlight` / `working_on`) still exclude `scope_agent`, so no agent's private memory is surfaced to the group.

## Test

`test_report_group_counts_private_writes_but_hides_content`: a private-scope durable write is counted in `durable_memories_written` / `by_type` / `per_agent` / `trend`, but never appears in `value_highlights`. Full `tests/test_reports.py` green locally (12 passed); the 11 pre-existing tests are unchanged (they seed only `scope_team`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)