### PR TITLE
feat(reports): agent-activity digest generation — Phase 2 [CAURA-222]

### DIFF
--- a/common/models/agent_activity_digest.py
+++ b/common/models/agent_activity_digest.py
@@ -21,6 +21,7 @@ class AgentActivityDigest(Base):
       ok        — narrative generated from the agent's window memories
       quiet     — below the activity threshold; no LLM call made
       truncated — window exceeded the per-agent cap; summary is partial
+      fallback  — LLM unavailable; narrative is a template placeholder
       skipped   — run-level cost/token cap hit before this agent
       error     — the LLM call (or fetch) failed; ``error_detail`` explains
     """

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2466,6 +2466,10 @@ class CoreStorageClient:
             params["as_of"] = as_of
         return await self._get_list("/reports/agent-activity", **params)
 
+    async def upsert_agent_activity_digest(self, data: dict) -> dict:
+        """Insert/replace one agent-activity digest row (digest generator writes)."""
+        return await self._post("/reports/agent-activity", data)  # type: ignore[return-value]
+
     # =====================================================================
     # Tasks
     # =====================================================================

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2408,6 +2408,13 @@ class CoreStorageClient:
             raise RuntimeError("core-storage-api /tenants/skills-factory-enabled returned 404")
         return result.get("org_ids", [])
 
+    async def list_agent_digest_enabled_orgs(self) -> list[str]:
+        """Orgs whose ``agent_digest.enabled`` setting is True."""
+        result = await self._get("/tenants/agent-digest-enabled")
+        if result is None:
+            raise RuntimeError("core-storage-api /tenants/agent-digest-enabled returned 404")
+        return result.get("org_ids", [])
+
     # =====================================================================
     # Reports
     # =====================================================================

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2477,6 +2477,13 @@ class CoreStorageClient:
         """Insert/replace one agent-activity digest row (digest generator writes)."""
         return await self._post("/reports/agent-activity", data)  # type: ignore[return-value]
 
+    async def prune_agent_activity_digests(self, tenant_id: str, older_than: str) -> int:
+        """Delete a tenant's digest rows older than ``older_than`` (ISO); count."""
+        result = await self._post(
+            "/reports/agent-activity/prune", {"tenant_id": tenant_id, "older_than": older_than}
+        )
+        return result.get("deleted", 0) if isinstance(result, dict) else 0
+
     # =====================================================================
     # Tasks
     # =====================================================================

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -45,6 +45,9 @@ from core_api.services.report_corpus import (
     RESERVED_FIREHOSE_AGENTS,
 )
 from core_api.services.report_corpus import (
+    PERIOD_DAYS as _PERIOD_DAYS,
+)
+from core_api.services.report_corpus import (
     is_cohesive as _cohesive,
 )
 
@@ -68,7 +71,6 @@ _DETAIL_AUDIENCES = {AUDIENCE_OWNER_1TO1, AUDIENCE_GROUP, AUDIENCE_PRIVATE}
 # "self" audiences scope to the caller's OWN contributions (narrowest).
 _SELF_AUDIENCES = {AUDIENCE_OWNER_1TO1, AUDIENCE_PRIVATE}
 
-_PERIOD_DAYS = {"day": 1, "week": 7}
 _LEARNING_LIMIT = 5
 _HIGHLIGHTS_LIMIT = 5
 _TOP_AGENTS_LIMIT = 25

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from collections.abc import Awaitable
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -37,33 +36,24 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
+from core_api.services.agent_digest import run_agent_digest
 from core_api.services.audit_service import log_action
 from core_api.services.caller_identity import resolve_caller_and_gate
+from core_api.services.report_corpus import (
+    NON_COHESIVE_TITLE_REGEX,
+    NON_DURABLE_TYPES,
+    RESERVED_FIREHOSE_AGENTS,
+)
+from core_api.services.report_corpus import (
+    is_cohesive as _cohesive,
+)
 
 router = APIRouter(tags=["Reports"])
 logger = logging.getLogger(__name__)
 
-# Episodic activity-log type(s) + the unattributed firehose agent excluded so the
-# report reflects durable, decision-bearing per-agent work.
-NON_DURABLE_TYPES = ("episode",)
-RESERVED_FIREHOSE_AGENTS = ("main",)
-
-# "Cohesive" filter: heartbeat / health-check / status-poll noise leaks in as
-# NON-episode rows (e.g. action/outcome "heartbeat" or "Checked HEARTBEAT.md"
-# writes), so the type+firehose exclusion above is not enough — a per-agent
-# leaderboard built on it still counts monitoring pings as "what the agent did".
-# This case-insensitive title regex drops that noise across ALL types so the
-# report reflects real work; genuine rules/decisions/insights never match it, so
-# the value/quality surfaces are unaffected. Applied report-wide (breakdown,
-# durable rows, trend) for a single reconcilable corpus. Pure-monitor agents
-# fall off the leaderboard naturally once their pings are excluded.
-NON_COHESIVE_TITLE_REGEX = (
-    r"(heartbeat|health[- ]?check|healthz|healthy|watchdog|gpu.?health|no.?change|"
-    r"auth error|zero auth|0 auth|encrypted|unreadable|no readable|no actionable|"
-    r"no usable|no_reply|polled|quickcheck|app-fleet|discovery script|"
-    r"gateway (active|reachable)|cache refresh)"
-)
-_NON_COHESIVE_TITLE_RE = re.compile(NON_COHESIVE_TITLE_REGEX, re.IGNORECASE)
+# Corpus rules (NON_DURABLE_TYPES / RESERVED_FIREHOSE_AGENTS /
+# NON_COHESIVE_TITLE_REGEX / _cohesive) are shared with the digest generator —
+# see core_api.services.report_corpus.
 
 # Delivery audience classes — an abstraction over messaging platforms
 # (WhatsApp / Teams / Slack / Claude-Code map to one of these at the edge).
@@ -321,23 +311,11 @@ async def get_report(
         def _rank(m: dict) -> tuple:
             return (m.get("recall_count") or 0, m.get("created_at") or "")
 
-        def _cohesive(m: dict) -> bool:
-            # WARNING: the /memories/list API cannot push exclude_memory_types /
-            # exclude_agent_ids / exclude_title_regex server-side, so the row
-            # fetches (list_query, highlights_query) come back raw and this
-            # predicate drops the noise client-side — AFTER the fetch limit has
-            # already been consumed. That is why _DURABLE_FETCH_LIMIT /
-            # _HIGHLIGHTS_FETCH_LIMIT over-fetch: the surviving pool must still
-            # exceed the downstream _LEARNING_LIMIT / _HIGHLIGHTS_LIMIT slices.
-            #
-            # Mirror the server-side report corpus in Python for the row fetches:
-            # durable (non-episodic, non-firehose) AND not heartbeat/status noise.
-            # Title-only match mirrors the ``exclude_title_regex`` predicate.
-            return (
-                m.get("memory_type") not in NON_DURABLE_TYPES
-                and m.get("agent_id") not in RESERVED_FIREHOSE_AGENTS
-                and not _NON_COHESIVE_TITLE_RE.search(m.get("title") or "")
-            )
+        # ``_cohesive`` (imported from report_corpus) drops the noise the
+        # /memories/list API can't exclude server-side — AFTER the fetch limit is
+        # consumed, which is why _DURABLE_FETCH_LIMIT / _HIGHLIGHTS_FETCH_LIMIT
+        # over-fetch: the surviving pool must still exceed the downstream
+        # _LEARNING_LIMIT / _HIGHLIGHTS_LIMIT slices.
 
         # Recent-ordered fetch → LEARNING (recent insights) + working-on LANES.
         list_query: dict = {
@@ -720,3 +698,22 @@ async def get_agent_activity_digest(
         "windows": [{"window_start": s, "window_end": e} for s, e in windows],
     }
     return {"meta": meta, "digests": digests}
+
+
+@router.post("/admin/reports/agent-digest/run")
+async def run_agent_digest_endpoint(
+    period: str = Query("day", description="Digest window to generate: 'day' or 'week'."),
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict:
+    """Generate agent-activity digests for all opted-in orgs (admin/cron only).
+
+    The core-operations nightly cron POSTs this. Enumerates orgs with
+    ``agent_digest.enabled`` and generates inline with bounded concurrency
+    (see ``services.agent_digest``); returns a bounded counts summary. This is
+    the WRITE/generation path — the read path (GET /reports/agent-activity)
+    never computes.
+    """
+    auth.enforce_admin()
+    if period not in _PERIOD_DAYS:
+        raise HTTPException(status_code=422, detail=f"Invalid period '{period}'. Use 'day' or 'week'.")
+    return await run_agent_digest(period)

--- a/core-api/src/core_api/services/agent_digest.py
+++ b/core-api/src/core_api/services/agent_digest.py
@@ -22,11 +22,15 @@ from typing import Any
 from common.llm import call_with_fallback
 from core_api.clients.storage_client import get_storage_client
 from core_api.services.organization_settings import get_settings_for_display
-from core_api.services.report_corpus import NON_COHESIVE_TITLE_REGEX, is_cohesive
+from core_api.services.report_corpus import (
+    NON_COHESIVE_TITLE_REGEX,
+    is_cohesive,
+)
+from core_api.services.report_corpus import (
+    PERIOD_DAYS as _PERIOD_DAYS,
+)
 
 logger = logging.getLogger(__name__)
-
-_PERIOD_DAYS = {"day": 1, "week": 7}
 
 # Bounded concurrency: cheap per-agent memory fetches vs. the expensive LLM pass.
 _FETCH_CONCURRENCY = 8
@@ -90,17 +94,26 @@ async def _summarize_agent(
     model: str,
     provider: str,
     truncated: bool,
-) -> dict:
+) -> str:
     """Build (via LLM) and persist one agent's digest row. Returns its status."""
     prompt = _build_prompt(agent, mems, period)
 
     async def _call(llm: Any) -> dict:
         return await llm.complete_json(prompt, response_schema=DIGEST_SCHEMA)
 
+    # call_with_fallback silently drops to _fake() when the real (and fallback)
+    # provider both fail. This flag lets us mark the row so a placeholder
+    # narrative is never mistaken for a real LLM summary.
+    used_fallback = False
+
     def _fake() -> dict:
+        nonlocal used_fallback
+        used_fallback = True
         return {"narrative": f"{agent.get('agent_id')} recorded {len(mems)} durable memories."}
 
-    status = "truncated" if truncated else "ok"
+    status = "ok"
+    if truncated:
+        status = "truncated"
     narrative: str | None = None
     sections: dict = {}
     error: str | None = None
@@ -113,9 +126,19 @@ async def _summarize_agent(
             service_label="agent-digest",
             model_override=model,
         )
-        narrative = raw.get("narrative")
+        narrative = raw.get("narrative") or None
         sections = {k: raw.get(k) or [] for k in _SECTION_KEYS}
-    except Exception as exc:  # storage/unexpected — LLM failures degrade via _fake
+        if used_fallback:
+            # Template narrative — overrides truncated so the caller can tell
+            # it's a placeholder, not a real (if partial) summary.
+            status = "fallback"
+        elif not narrative:
+            # The provider uses strict=False (no server-side schema enforcement)
+            # and there's no Pydantic guardrail here, so a real response can omit
+            # the narrative — treat that as an error, not a NULL "ok" row.
+            status = "error"
+            error = "LLM returned no narrative"
+    except Exception as exc:  # storage/unexpected — real errors, not LLM fallback
         status, error = "error", repr(exc)
         logger.warning("agent_digest: summarize failed for %s/%s: %r", org_id, agent.get("agent_id"), exc)
 
@@ -135,7 +158,17 @@ async def _summarize_agent(
         "status": status,
         "error_detail": error,
     }
-    await get_storage_client().upsert_agent_activity_digest(row)
+    try:
+        await get_storage_client().upsert_agent_activity_digest(row)
+    except Exception as exc:
+        # Re-raise so gather still counts this agent as errored; log for traceability.
+        logger.warning(
+            "agent_digest: upsert failed for %s/%s: %r",
+            org_id,
+            agent.get("agent_id"),
+            exc,
+        )
+        raise
     return status
 
 
@@ -151,8 +184,15 @@ async def generate_for_org(
     sc = get_storage_client()
     run_id = run_id or str(uuid.uuid4())
     days = _PERIOD_DAYS.get(period, 1)
-    window_end = now
-    window_start = now - timedelta(days=days)
+    # Normalize to clean UTC boundaries so a run covers the full previous
+    # day/week and re-runs on the same date reproduce the same window. Retention
+    # (below) stays wall-clock on the raw ``now``.
+    if period == "week":
+        window_end = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        window_end -= timedelta(days=window_end.weekday())  # Monday 00:00 UTC
+    else:
+        window_end = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    window_start = window_end - timedelta(days=days)
     top_n = int(config.get("top_n") or 25)
     max_mems = int(config.get("max_memories_per_agent") or 60)
     min_activity = int(config.get("min_activity_threshold") or 3)
@@ -172,6 +212,7 @@ async def generate_for_org(
                     "tenant_id": org_id,
                     "written_by": agent["agent_id"],
                     "created_after": window_start.isoformat(),
+                    "created_before": window_end.isoformat(),
                     "sort": "created_at",
                     "order": "desc",
                     "limit": _FETCH_LIMIT,
@@ -218,15 +259,32 @@ async def generate_for_org(
             )
 
     statuses = await asyncio.gather(*(_one(a, m) for a, m in selected), return_exceptions=True)
-    generated = sum(1 for s in statuses if not isinstance(s, BaseException))
+    generated = sum(1 for s in statuses if s in ("ok", "truncated"))
+    fallback = sum(1 for s in statuses if s == "fallback")
     errored = sum(1 for s in statuses if isinstance(s, BaseException) or s == "error")
+
+    # Retention sweep, folded into the run (this org's latest run is always
+    # fresh, so old runs age out). NOTE: an org that later DISABLES the digest
+    # stops running and won't self-prune — acceptable for v1; a global sweep can
+    # reclaim those later. A prune failure must not fail the generation.
+    pruned = 0
+    retention_days = int(config.get("retention_days") or 0)
+    if retention_days > 0:
+        cutoff = now - timedelta(days=retention_days)
+        try:
+            pruned = await sc.prune_agent_activity_digests(org_id, cutoff.isoformat())
+        except Exception as exc:
+            logger.warning("agent_digest: prune failed for %s: %r", org_id, exc)
+
     return {
         "org_id": org_id,
         "run_id": run_id,
         "agents": len(agents),
         "candidates": len(candidates),
         "generated": generated,
+        "fallback": fallback,
         "errored": errored,
+        "pruned": pruned,
         "window_start": window_start.isoformat(),
         "window_end": window_end.isoformat(),
     }
@@ -259,6 +317,8 @@ async def run_agent_digest(period: str = "day") -> dict:
     completed = 0
     failed = 0
     digests = 0
+    agent_fallbacks = 0
+    agent_errors = 0
     for org_id, res in zip(org_ids, results, strict=True):
         if isinstance(res, BaseException):
             failed += 1
@@ -266,13 +326,18 @@ async def run_agent_digest(period: str = "day") -> dict:
         elif res:
             completed += 1
             digests += res.get("generated", 0)
+            agent_fallbacks += res.get("fallback", 0)
+            agent_errors += res.get("errored", 0)
     logger.info(
-        "agent_digest run: period=%s orgs=%d completed=%d failed=%d digests=%d",
+        "agent_digest run: period=%s orgs=%d completed=%d failed=%d "
+        "digests=%d agent_fallbacks=%d agent_errors=%d",
         period,
         len(org_ids),
         completed,
         failed,
         digests,
+        agent_fallbacks,
+        agent_errors,
     )
     return {
         "period": period,
@@ -280,6 +345,8 @@ async def run_agent_digest(period: str = "day") -> dict:
         "completed": completed,
         "failed": failed,
         "digests": digests,
+        "agent_fallbacks": agent_fallbacks,
+        "agent_errors": agent_errors,
     }
 
 

--- a/core-api/src/core_api/services/agent_digest.py
+++ b/core-api/src/core_api/services/agent_digest.py
@@ -1,0 +1,288 @@
+"""Nightly per-agent activity digest generation (Phase 2b).
+
+Precomputes the prose "what did this agent do this day/week" summaries that
+``GET /api/v1/reports/agent-activity`` serves read-only. Runs OFF the request
+path — a core-operations cron POSTs the admin fanout endpoint (see
+``routes/reports.py``), which calls :func:`run_agent_digest`. An LLM pass per
+agent is too slow/costly to run on demand, so results are cached in
+``agent_activity_digests``.
+
+v1 fans out INLINE with bounded concurrency (fine at on-prem/eToro tenant
+counts); a per-tenant Pub/Sub fanout is the scale path if org counts grow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from common.llm import call_with_fallback
+from core_api.clients.storage_client import get_storage_client
+from core_api.services.organization_settings import get_settings_for_display
+from core_api.services.report_corpus import NON_COHESIVE_TITLE_REGEX, is_cohesive
+
+logger = logging.getLogger(__name__)
+
+_PERIOD_DAYS = {"day": 1, "week": 7}
+
+# Bounded concurrency: cheap per-agent memory fetches vs. the expensive LLM pass.
+_FETCH_CONCURRENCY = 8
+_LLM_CONCURRENCY = 4
+_ORG_CONCURRENCY = 4
+# Pre-filter fetch size (cohesive filter runs client-side after the fetch).
+_FETCH_LIMIT = 400
+# Rough gpt-5.4-mini cost per digest call (~2k in + ~400 out). Only used to turn
+# ``max_cost_per_run_usd`` into a call budget — an estimate, not billing-grade.
+_PER_CALL_COST_USD = 0.005
+
+# JSON schema the model must return.
+DIGEST_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "narrative": {"type": "string"},
+        "decisions": {"type": "array", "items": {"type": "string"}},
+        "shipped": {"type": "array", "items": {"type": "string"}},
+        "learned": {"type": "array", "items": {"type": "string"}},
+        "open_threads": {"type": "array", "items": {"type": "string"}},
+        "confidence": {"type": "number"},
+    },
+    "required": ["narrative"],
+}
+
+_SECTION_KEYS = ("decisions", "shipped", "learned", "open_threads")
+
+
+def _build_prompt(agent: dict, mems: list[dict], period: str) -> str:
+    name = agent.get("display_name") or agent.get("agent_id")
+    lines = []
+    for m in mems:
+        title = m.get("title") or (m.get("metadata") or {}).get("summary") or "(untitled)"
+        lines.append(
+            f"- [{m.get('memory_type', '?')}] {title}"
+            f" (recalled {m.get('recall_count') or 0}x, {str(m.get('created_at'))[:10]})"
+        )
+    corpus = "\n".join(lines)
+    return (
+        f"You are summarizing what the AI agent '{name}' did over the past "
+        f"{'day' if period == 'day' else 'week'}, based ONLY on its durable "
+        f"memories below. Do not invent anything not grounded in them. Quantify "
+        f"where natural (e.g. 'made 3 decisions'). If the memories are thin, say "
+        f"so briefly.\n\n"
+        f"Memories ({len(mems)}):\n{corpus}\n\n"
+        f"Return JSON: narrative (2-4 sentence prose recap), decisions, shipped, "
+        f"learned, open_threads (short bullet strings; omit or empty if none), "
+        f"and confidence (0-1)."
+    )
+
+
+async def _summarize_agent(
+    *,
+    org_id: str,
+    agent: dict,
+    mems: list[dict],
+    period: str,
+    run_id: str,
+    window_start: datetime,
+    window_end: datetime,
+    model: str,
+    provider: str,
+    truncated: bool,
+) -> dict:
+    """Build (via LLM) and persist one agent's digest row. Returns its status."""
+    prompt = _build_prompt(agent, mems, period)
+
+    async def _call(llm: Any) -> dict:
+        return await llm.complete_json(prompt, response_schema=DIGEST_SCHEMA)
+
+    def _fake() -> dict:
+        return {"narrative": f"{agent.get('agent_id')} recorded {len(mems)} durable memories."}
+
+    status = "truncated" if truncated else "ok"
+    narrative: str | None = None
+    sections: dict = {}
+    error: str | None = None
+    try:
+        raw = await call_with_fallback(
+            provider,
+            _call,
+            _fake,
+            tenant_config=None,
+            service_label="agent-digest",
+            model_override=model,
+        )
+        narrative = raw.get("narrative")
+        sections = {k: raw.get(k) or [] for k in _SECTION_KEYS}
+    except Exception as exc:  # storage/unexpected — LLM failures degrade via _fake
+        status, error = "error", repr(exc)
+        logger.warning("agent_digest: summarize failed for %s/%s: %r", org_id, agent.get("agent_id"), exc)
+
+    row = {
+        "run_id": run_id,
+        "tenant_id": org_id,
+        "fleet_id": agent.get("fleet_id"),
+        "agent_id": agent["agent_id"],
+        "period": period,
+        "window_start": window_start.isoformat(),
+        "window_end": window_end.isoformat(),
+        "narrative": narrative,
+        "sections": sections,
+        "source_count": len(mems),
+        "recall_count": sum(m.get("recall_count") or 0 for m in mems),
+        "model": model,
+        "status": status,
+        "error_detail": error,
+    }
+    await get_storage_client().upsert_agent_activity_digest(row)
+    return status
+
+
+async def generate_for_org(
+    org_id: str, period: str, config: dict, *, now: datetime, run_id: str | None = None
+) -> dict:
+    """Generate + persist digests for one org's most-active agents in the window.
+
+    Fetches each agent's cohesive durable memories, ranks by volume, and
+    LLM-summarizes the top ``top_n`` above ``min_activity_threshold``. Returns a
+    per-org counts summary.
+    """
+    sc = get_storage_client()
+    run_id = run_id or str(uuid.uuid4())
+    days = _PERIOD_DAYS.get(period, 1)
+    window_end = now
+    window_start = now - timedelta(days=days)
+    top_n = int(config.get("top_n") or 25)
+    max_mems = int(config.get("max_memories_per_agent") or 60)
+    min_activity = int(config.get("min_activity_threshold") or 3)
+    model = config.get("model") or "gpt-5.4-mini"
+    provider = config.get("provider") or "openai"
+    max_cost = float(config.get("max_cost_per_run_usd") or 0)
+
+    agents = await sc.list_agents(org_id)
+
+    # Fetch each agent's cohesive window memories (cheap; bounded concurrency).
+    fetch_sem = asyncio.Semaphore(_FETCH_CONCURRENCY)
+
+    async def _fetch(agent: dict) -> tuple[dict, list[dict]]:
+        async with fetch_sem:
+            rows = await sc.list_memories_by_filters(
+                {
+                    "tenant_id": org_id,
+                    "written_by": agent["agent_id"],
+                    "created_after": window_start.isoformat(),
+                    "sort": "created_at",
+                    "order": "desc",
+                    "limit": _FETCH_LIMIT,
+                }
+            )
+            cohesive = [m for m in (rows or []) if is_cohesive(m)]
+            return agent, cohesive
+
+    fetched = await asyncio.gather(*(_fetch(a) for a in agents), return_exceptions=True)
+    candidates: list[tuple[dict, list[dict]]] = []
+    for res in fetched:
+        if isinstance(res, BaseException):
+            logger.warning("agent_digest: fetch failed for an agent in %s: %r", org_id, res)
+            continue
+        agent, cohesive = res
+        if len(cohesive) >= min_activity:
+            candidates.append((agent, cohesive))
+    candidates.sort(key=lambda ac: len(ac[1]), reverse=True)
+
+    selected = candidates[:top_n]
+    # Turn the USD cap into a call budget (rough per-call estimate).
+    if max_cost:
+        budget = max(1, int(max_cost / _PER_CALL_COST_USD))
+        if len(selected) > budget:
+            logger.warning("agent_digest: org %s cost cap trims %d→%d agents", org_id, len(selected), budget)
+            selected = selected[:budget]
+
+    llm_sem = asyncio.Semaphore(_LLM_CONCURRENCY)
+
+    async def _one(agent: dict, mems: list[dict]) -> str:
+        async with llm_sem:
+            truncated = len(mems) > max_mems
+            return await _summarize_agent(
+                org_id=org_id,
+                agent=agent,
+                mems=mems[:max_mems],
+                period=period,
+                run_id=run_id,
+                window_start=window_start,
+                window_end=window_end,
+                model=model,
+                provider=provider,
+                truncated=truncated,
+            )
+
+    statuses = await asyncio.gather(*(_one(a, m) for a, m in selected), return_exceptions=True)
+    generated = sum(1 for s in statuses if not isinstance(s, BaseException))
+    errored = sum(1 for s in statuses if isinstance(s, BaseException) or s == "error")
+    return {
+        "org_id": org_id,
+        "run_id": run_id,
+        "agents": len(agents),
+        "candidates": len(candidates),
+        "generated": generated,
+        "errored": errored,
+        "window_start": window_start.isoformat(),
+        "window_end": window_end.isoformat(),
+    }
+
+
+async def run_agent_digest(period: str = "day") -> dict:
+    """Enumerate opted-in orgs and generate their digests (inline fanout).
+
+    Called by the admin fanout endpoint (core-operations cron trigger). One org's
+    failure never sinks the rest. Returns a bounded counts summary.
+    """
+    if period not in _PERIOD_DAYS:
+        raise ValueError(f"invalid period {period!r}; use 'day' or 'week'")
+    # Local import breaks a tenants ↔ storage_client import cycle at module load.
+    from core_api.services.tenants import list_tenants_with_agent_digest_enabled
+
+    org_ids = await list_tenants_with_agent_digest_enabled()
+    now = datetime.now(UTC)
+    org_sem = asyncio.Semaphore(_ORG_CONCURRENCY)
+
+    async def _one(org_id: str) -> dict | None:
+        async with org_sem:
+            settings = await get_settings_for_display(org_id)
+            config = settings.get("agent_digest") or {}
+            if not config.get("enabled"):  # enumeration already filters; re-check
+                return None
+            return await generate_for_org(org_id, period, config, now=now)
+
+    results = await asyncio.gather(*(_one(o) for o in org_ids), return_exceptions=True)
+    completed = 0
+    failed = 0
+    digests = 0
+    for org_id, res in zip(org_ids, results, strict=True):
+        if isinstance(res, BaseException):
+            failed += 1
+            logger.warning("agent_digest: org %s generation failed: %r", org_id, res)
+        elif res:
+            completed += 1
+            digests += res.get("generated", 0)
+    logger.info(
+        "agent_digest run: period=%s orgs=%d completed=%d failed=%d digests=%d",
+        period,
+        len(org_ids),
+        completed,
+        failed,
+        digests,
+    )
+    return {
+        "period": period,
+        "orgs": len(org_ids),
+        "completed": completed,
+        "failed": failed,
+        "digests": digests,
+    }
+
+
+# NON_COHESIVE_TITLE_REGEX is re-exported for callers/tests that want the exact
+# server-side exclusion string alongside the client-side is_cohesive filter.
+__all__ = ["run_agent_digest", "generate_for_org", "DIGEST_SCHEMA", "NON_COHESIVE_TITLE_REGEX"]

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -70,6 +70,20 @@ DEFAULT_SETTINGS: dict = {
         "provider": None,
         "model": None,
     },
+    # Cached per-agent activity digest (nightly generation; served read-only by
+    # GET /api/v1/reports/agent-activity). Opt-in — disabled by default because
+    # generation spends LLM tokens. See core_api.services.agent_digest.
+    "agent_digest": {
+        "enabled": False,
+        "cadence": "daily",  # daily | weekly | both
+        "provider": "openai",
+        "model": "gpt-5.4-mini",
+        "top_n": 25,
+        "max_memories_per_agent": 60,
+        "min_activity_threshold": 3,
+        "max_cost_per_run_usd": 2.0,
+        "retention_days": 90,
+    },
     "search": {
         "recall_boost": None,
         "graph_retrieval": None,

--- a/core-api/src/core_api/services/report_corpus.py
+++ b/core-api/src/core_api/services/report_corpus.py
@@ -1,0 +1,45 @@
+"""Shared "durable, decision-bearing" corpus rules for the report surfaces.
+
+Both the live report (``routes/reports.py``) and the cached agent-activity
+digest generator (``services/agent_digest.py``) must describe the SAME corpus,
+so the exclusion rules live here as a single source of truth.
+
+The ``/memories/list`` storage API cannot push these excludes server-side, so
+callers fetch raw rows and drop the noise client-side via :func:`is_cohesive`.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Episodic activity-log type(s) + the unattributed firehose agent excluded so the
+# report reflects durable, decision-bearing per-agent work.
+NON_DURABLE_TYPES = ("episode",)
+RESERVED_FIREHOSE_AGENTS = ("main",)
+
+# "Cohesive" filter: heartbeat / health-check / status-poll noise leaks in as
+# NON-episode rows (e.g. action/outcome "heartbeat" or "Checked HEARTBEAT.md"
+# writes), so the type+firehose exclusion above is not enough — a per-agent
+# leaderboard built on it still counts monitoring pings as "what the agent did".
+# This case-insensitive title regex drops that noise across ALL types so the
+# report reflects real work; genuine rules/decisions/insights never match it, so
+# the value/quality surfaces are unaffected. Pure-monitor agents fall off the
+# leaderboard naturally once their pings are excluded.
+NON_COHESIVE_TITLE_REGEX = (
+    r"(heartbeat|health[- ]?check|healthz|healthy|watchdog|gpu.?health|no.?change|"
+    r"auth error|zero auth|0 auth|encrypted|unreadable|no readable|no actionable|"
+    r"no usable|no_reply|polled|quickcheck|app-fleet|discovery script|"
+    r"gateway (active|reachable)|cache refresh)"
+)
+_NON_COHESIVE_TITLE_RE = re.compile(NON_COHESIVE_TITLE_REGEX, re.IGNORECASE)
+
+
+def is_cohesive(m: dict) -> bool:
+    """True if a memory row belongs in the durable report corpus: not episodic,
+    not from a firehose agent, and not heartbeat/health/status-poll noise
+    (title-only match, mirroring the ``exclude_title_regex`` predicate)."""
+    return (
+        m.get("memory_type") not in NON_DURABLE_TYPES
+        and m.get("agent_id") not in RESERVED_FIREHOSE_AGENTS
+        and not _NON_COHESIVE_TITLE_RE.search(m.get("title") or "")
+    )

--- a/core-api/src/core_api/services/report_corpus.py
+++ b/core-api/src/core_api/services/report_corpus.py
@@ -12,6 +12,10 @@ from __future__ import annotations
 
 import re
 
+# Reporting window lengths in days, shared by the live report and the digest
+# generator so "day"/"week" mean the same thing on both surfaces.
+PERIOD_DAYS: dict[str, int] = {"day": 1, "week": 7}
+
 # Episodic activity-log type(s) + the unattributed firehose agent excluded so the
 # report reflects durable, decision-bearing per-agent work.
 NON_DURABLE_TYPES = ("episode",)

--- a/core-api/src/core_api/services/tenants.py
+++ b/core-api/src/core_api/services/tenants.py
@@ -45,3 +45,12 @@ async def list_tenants_with_skills_factory_enabled(db: AsyncSession | None = Non
     (default ``enabled=False``). ``db`` is ignored (reads via core-storage-api).
     """
     return await get_storage_client().list_skills_factory_enabled_orgs()
+
+
+async def list_tenants_with_agent_digest_enabled(db: AsyncSession | None = None) -> list[str]:
+    """Return ``org_id`` values whose ``agent_digest.enabled`` is True, sorted.
+
+    Used by the nightly agent-digest fanout so a tenant that hasn't opted in pays
+    zero cost. Orgs without a settings row are excluded (default off). ``db`` is
+    ignored (reads via core-storage-api)."""
+    return await get_storage_client().list_agent_digest_enabled_orgs()

--- a/core-api/tests/test_agent_digest.py
+++ b/core-api/tests/test_agent_digest.py
@@ -35,6 +35,10 @@ class FakeStorage:
         self.upserts.append(row)
         return row
 
+    async def prune_agent_activity_digests(self, tenant_id: str, older_than: str) -> int:
+        self.pruned: tuple[str, str] = (tenant_id, older_than)
+        return 3
+
 
 def _mem(*, mtype: str = "decision", title: str = "did a thing", recall: int = 1, agent: str = "a") -> dict:
     return {
@@ -48,12 +52,17 @@ def _mem(*, mtype: str = "decision", title: str = "did a thing", recall: int = 1
 
 @pytest.fixture
 def wire(monkeypatch):
-    """Return a helper that wires a FakeStorage + a deterministic LLM (fake tier)."""
+    """Return a helper that wires a FakeStorage + a deterministic LLM.
 
-    async def _fake_cwf(provider, call_fn, fake_fn, **kw):
-        return fake_fn()
+    The default LLM mock simulates the REAL provider succeeding (returns a dict
+    directly, without touching the fake tier) so ``used_fallback`` stays False
+    and status is ``ok``/``truncated``. The fallback path is exercised
+    separately in ``test_llm_fallback_marks_status``."""
 
-    monkeypatch.setattr(agent_digest, "call_with_fallback", _fake_cwf)
+    async def _real_cwf(provider, call_fn, fake_fn, **kw):
+        return {"narrative": "real summary", "shipped": ["shipped a thing"]}
+
+    monkeypatch.setattr(agent_digest, "call_with_fallback", _real_cwf)
 
     def _install(storage: FakeStorage) -> FakeStorage:
         monkeypatch.setattr(agent_digest, "get_storage_client", lambda: storage)
@@ -115,9 +124,7 @@ async def test_cost_cap_trims_agents(wire):
 
 
 async def test_truncation_status_and_capped_source_count(wire):
-    storage = wire(
-        FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 5})
-    )
+    storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 5}))
     await agent_digest.generate_for_org("org1", "day", {**CONFIG, "max_memories_per_agent": 2}, now=NOW)
     assert storage.upserts[0]["status"] == "truncated"
     assert storage.upserts[0]["source_count"] == 2
@@ -150,6 +157,93 @@ async def test_run_agent_digest_enumerates_opted_in_orgs(monkeypatch, wire):
     assert summary["orgs"] == 2
     assert summary["completed"] == 2
     assert summary["digests"] == 2
+
+
+async def test_llm_fallback_marks_status(monkeypatch, wire):
+    """When call_with_fallback drops to the template tier, the row is marked
+    'fallback' (not 'ok') and counts as neither generated nor errored."""
+    storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 4}))
+
+    async def _fallback_cwf(provider, call_fn, fake_fn, **kw):
+        return fake_fn()  # real + fallback providers failed → template narrative
+
+    monkeypatch.setattr(agent_digest, "call_with_fallback", _fallback_cwf)
+    summary = await agent_digest.generate_for_org("org1", "day", CONFIG, now=NOW)
+    assert storage.upserts[0]["status"] == "fallback"
+    assert summary["fallback"] == 1
+    assert summary["generated"] == 0
+    assert summary["errored"] == 0
+
+
+async def test_fallback_overrides_truncated(monkeypatch, wire):
+    """A template (fallback) narrative wins over 'truncated' so the caller can
+    tell the narrative is fake, not merely partial."""
+    storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 5}))
+
+    async def _fallback_cwf(provider, call_fn, fake_fn, **kw):
+        return fake_fn()
+
+    monkeypatch.setattr(agent_digest, "call_with_fallback", _fallback_cwf)
+    await agent_digest.generate_for_org("org1", "day", {**CONFIG, "max_memories_per_agent": 2}, now=NOW)
+    assert storage.upserts[0]["status"] == "fallback"
+
+
+async def test_daily_window_is_previous_utc_day(wire):
+    """A mid-day run normalizes to the full previous UTC calendar day."""
+    now = datetime(2026, 7, 6, 15, 30, tzinfo=UTC)
+    storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 3}))
+    await agent_digest.generate_for_org("org1", "day", CONFIG, now=now)
+    row = storage.upserts[0]
+    assert row["window_end"] == "2026-07-06T00:00:00+00:00"  # today 00:00
+    assert row["window_start"] == "2026-07-05T00:00:00+00:00"  # yesterday 00:00
+
+
+async def test_weekly_window_aligns_to_monday(wire):
+    """A mid-week run normalizes to the previous full Mon-Mon week."""
+    now = datetime(2026, 7, 8, 12, 0, tzinfo=UTC)  # a Wednesday
+    storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 3}))
+    await agent_digest.generate_for_org("org1", "week", CONFIG, now=now)
+    row = storage.upserts[0]
+    assert row["window_end"] == "2026-07-06T00:00:00+00:00"  # Monday of that week
+    assert row["window_start"] == "2026-06-29T00:00:00+00:00"  # previous Monday
+
+
+async def test_empty_narrative_from_real_llm_is_error(monkeypatch, wire):
+    """A real (non-fallback) response missing the narrative is an error row, not
+    a NULL 'ok' row."""
+    storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 3}))
+
+    async def _empty_cwf(provider, call_fn, fake_fn, **kw):
+        return {"shipped": ["x"]}  # no narrative key
+
+    monkeypatch.setattr(agent_digest, "call_with_fallback", _empty_cwf)
+    summary = await agent_digest.generate_for_org("org1", "day", CONFIG, now=NOW)
+    row = storage.upserts[0]
+    assert row["status"] == "error"
+    assert row["error_detail"] == "LLM returned no narrative"
+    assert row["narrative"] is None
+    assert summary["errored"] == 1
+    assert summary["generated"] == 0
+
+
+async def test_upsert_failure_counts_as_errored(wire):
+    """An upsert failure re-raises and is counted as errored, not generated."""
+
+    class FailingStorage(FakeStorage):
+        async def upsert_agent_activity_digest(self, row: dict) -> dict:
+            raise RuntimeError("db down")
+
+    wire(FailingStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 3}))
+    summary = await agent_digest.generate_for_org("org1", "day", CONFIG, now=NOW)
+    assert summary["errored"] == 1
+    assert summary["generated"] == 0
+
+
+async def test_retention_prune_runs_with_cutoff(wire):
+    storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 3}))
+    summary = await agent_digest.generate_for_org("org1", "day", {**CONFIG, "retention_days": 30}, now=NOW)
+    assert summary["pruned"] == 3
+    assert storage.pruned == ("org1", "2026-06-06T00:00:00+00:00")  # NOW - 30d
 
 
 async def test_run_agent_digest_rejects_bad_period(wire):

--- a/core-api/tests/test_agent_digest.py
+++ b/core-api/tests/test_agent_digest.py
@@ -1,0 +1,157 @@
+"""Unit tests for the agent-digest generator (Phase 2b).
+
+Storage + LLM are mocked, so these run without a DB or API key and assert the
+generation LOGIC: cohesive filtering, activity threshold, top-N + cost budget,
+truncation, fleet passthrough, and the enumerate→generate fanout.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from core_api.services import agent_digest
+
+pytestmark = pytest.mark.asyncio
+
+NOW = datetime(2026, 7, 6, 0, 0, tzinfo=UTC)
+CONFIG = {"top_n": 25, "max_memories_per_agent": 60, "min_activity_threshold": 3, "model": "gpt-5.4-mini"}
+
+
+class FakeStorage:
+    def __init__(self, agents: list[dict], mems_by_agent: dict[str, list[dict]]):
+        self._agents = agents
+        self._mems = mems_by_agent
+        self.upserts: list[dict] = []
+
+    async def list_agents(self, org_id: str, fleet_id: str | None = None) -> list[dict]:
+        return self._agents
+
+    async def list_memories_by_filters(self, query: dict) -> list[dict]:
+        return self._mems.get(query["written_by"], [])
+
+    async def upsert_agent_activity_digest(self, row: dict) -> dict:
+        self.upserts.append(row)
+        return row
+
+
+def _mem(*, mtype: str = "decision", title: str = "did a thing", recall: int = 1, agent: str = "a") -> dict:
+    return {
+        "memory_type": mtype,
+        "title": title,
+        "recall_count": recall,
+        "created_at": "2026-07-05T10:00:00+00:00",
+        "agent_id": agent,
+    }
+
+
+@pytest.fixture
+def wire(monkeypatch):
+    """Return a helper that wires a FakeStorage + a deterministic LLM (fake tier)."""
+
+    async def _fake_cwf(provider, call_fn, fake_fn, **kw):
+        return fake_fn()
+
+    monkeypatch.setattr(agent_digest, "call_with_fallback", _fake_cwf)
+
+    def _install(storage: FakeStorage) -> FakeStorage:
+        monkeypatch.setattr(agent_digest, "get_storage_client", lambda: storage)
+        return storage
+
+    return _install
+
+
+async def test_generates_only_for_agents_above_threshold(wire):
+    storage = wire(
+        FakeStorage(
+            [{"agent_id": "a", "fleet_id": None}, {"agent_id": "b", "fleet_id": "f1"}],
+            {"a": [_mem(agent="a")] * 4, "b": [_mem(agent="b")] * 2},  # b below min_activity=3
+        )
+    )
+    summary = await agent_digest.generate_for_org("org1", "day", CONFIG, now=NOW)
+    assert summary["generated"] == 1
+    assert [r["agent_id"] for r in storage.upserts] == ["a"]
+    assert storage.upserts[0]["status"] == "ok"
+    assert storage.upserts[0]["source_count"] == 4
+
+
+async def test_cohesive_filter_drops_noise_and_episodes(wire):
+    storage = wire(
+        FakeStorage(
+            [{"agent_id": "a", "fleet_id": None}],
+            {"a": [_mem(title="heartbeat check")] * 5 + [_mem(mtype="episode")] * 5 + [_mem()] * 3},
+        )
+    )
+    await agent_digest.generate_for_org("org1", "day", CONFIG, now=NOW)
+    # Only the 3 real decision rows survive the cohesive filter.
+    assert storage.upserts[0]["source_count"] == 3
+
+
+async def test_top_n_limits_llm_calls_to_busiest(wire):
+    storage = wire(
+        FakeStorage(
+            [{"agent_id": "busy", "fleet_id": None}, {"agent_id": "quieter", "fleet_id": None}],
+            {"busy": [_mem(agent="busy")] * 10, "quieter": [_mem(agent="quieter")] * 4},
+        )
+    )
+    summary = await agent_digest.generate_for_org("org1", "day", {**CONFIG, "top_n": 1}, now=NOW)
+    assert summary["generated"] == 1
+    assert storage.upserts[0]["agent_id"] == "busy"  # ranked by volume
+
+
+async def test_cost_cap_trims_agents(wire):
+    storage = wire(
+        FakeStorage(
+            [{"agent_id": f"a{i}", "fleet_id": None} for i in range(5)],
+            {f"a{i}": [_mem(agent=f"a{i}")] * 4 for i in range(5)},
+        )
+    )
+    # budget = max(1, 0.01 / 0.005) = 2 calls
+    summary = await agent_digest.generate_for_org(
+        "org1", "day", {**CONFIG, "max_cost_per_run_usd": 0.01}, now=NOW
+    )
+    assert summary["generated"] == 2
+
+
+async def test_truncation_status_and_capped_source_count(wire):
+    storage = wire(
+        FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 5})
+    )
+    await agent_digest.generate_for_org("org1", "day", {**CONFIG, "max_memories_per_agent": 2}, now=NOW)
+    assert storage.upserts[0]["status"] == "truncated"
+    assert storage.upserts[0]["source_count"] == 2
+
+
+async def test_fleet_id_passthrough_and_window(wire):
+    storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": "etoro0"}], {"a": [_mem(agent="a")] * 3}))
+    await agent_digest.generate_for_org("org1", "week", CONFIG, now=NOW)
+    row = storage.upserts[0]
+    assert row["fleet_id"] == "etoro0"
+    assert row["window_end"] == NOW.isoformat()
+    assert row["window_start"] == "2026-06-29T00:00:00+00:00"  # 7 days back
+    assert row["period"] == "week"
+
+
+async def test_run_agent_digest_enumerates_opted_in_orgs(monkeypatch, wire):
+    import core_api.services.tenants as tenants_mod
+
+    async def _list_orgs() -> list[str]:
+        return ["org1", "org2"]
+
+    async def _settings(org_id: str) -> dict:
+        return {"agent_digest": {"enabled": True, **CONFIG}}
+
+    monkeypatch.setattr(tenants_mod, "list_tenants_with_agent_digest_enabled", _list_orgs)
+    monkeypatch.setattr(agent_digest, "get_settings_for_display", _settings)
+    wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 4}))
+
+    summary = await agent_digest.run_agent_digest("day")
+    assert summary["orgs"] == 2
+    assert summary["completed"] == 2
+    assert summary["digests"] == 2
+
+
+async def test_run_agent_digest_rejects_bad_period(wire):
+    with pytest.raises(ValueError):
+        await agent_digest.run_agent_digest("month")

--- a/core-operations/src/core_operations/app.py
+++ b/core-operations/src/core_operations/app.py
@@ -51,6 +51,7 @@ configure_logging(
 
 from core_operations.scheduler import scheduler, seconds_until_next_utc_hour
 from core_operations.tasks import (
+    run_agent_digest_tick,
     run_archive_expired_tick,
     run_archive_stale_tick,
     run_crystallize_tick,
@@ -111,6 +112,12 @@ def _register_scheduled_tasks() -> None:
         24 * 3600,
         run_insights_tick,
         delay_provider=_daily_at("lifecycle_insights_run_at_hour"),
+    )
+    scheduler.register(
+        "agent-digest",
+        24 * 3600,
+        run_agent_digest_tick,
+        delay_provider=_daily_at("agent_digest_run_at_hour"),
     )
 
 

--- a/core-operations/src/core_operations/config.py
+++ b/core-operations/src/core_operations/config.py
@@ -62,12 +62,20 @@ class Settings(BaseSettings):
     # gate further no-ops ticks where no non-insight memories landed since
     # the last run, so a once-a-day fire is plenty.
     lifecycle_insights_run_at_hour: int = 2
+    # Per-agent activity digest generation (CAURA-222 Phase 2). Opt-in per-org
+    # (``agent_digest.enabled``, default off); a tenant that hasn't opted in
+    # costs nothing, so a daily fire is safe.
+    agent_digest_run_at_hour: int = 2
+    # Generation runs INLINE in core-api (LLM per agent across opted-in orgs), so
+    # its trigger POST can take minutes — a generous timeout, not the 30s default.
+    agent_digest_http_timeout_s: float = 600.0
 
     @field_validator(
         "lifecycle_archive_run_at_hour",
         "lifecycle_purge_run_at_hour",
         "lifecycle_pipeline_run_at_hour",
         "lifecycle_insights_run_at_hour",
+        "agent_digest_run_at_hour",
     )
     @classmethod
     def _validate_run_at_hour(cls, v: int, info: ValidationInfo) -> int:

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -111,3 +111,44 @@ async def run_insights_tick() -> None:
     quiet tenants.
     """
     await _fire_fanout("insights")
+
+
+async def _fire_agent_digest(period: str) -> None:
+    """POST ``/admin/reports/agent-digest/run?period=<period>``. Unlike the
+    lifecycle fanout, digest generation runs INLINE in core-api (no Pub/Sub), so
+    this trigger has its own endpoint. Non-2xx logs and returns — the scheduler
+    retries next tick.
+    """
+    url = f"{settings.core_api_url.rstrip('/')}/api/v1/admin/reports/agent-digest/run?period={period}"
+    headers: dict[str, str] = {}
+    if settings.core_api_admin_api_key:
+        headers["X-API-Key"] = settings.core_api_admin_api_key
+    else:
+        logger.warning(
+            "core-operations: CORE_API_ADMIN_API_KEY unset; agent-digest run will be unauthorised",
+            extra={"period": period},
+        )
+
+    # Generation is a long inline job (LLM per agent across opted-in orgs), so
+    # give it a generous timeout rather than the short storage default.
+    timeout = httpx.Timeout(settings.agent_digest_http_timeout_s)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            resp = await client.post(url, headers=headers)
+        except httpx.HTTPError:
+            logger.exception("agent-digest POST failed", extra={"period": period, "url": url})
+            return
+    if resp.status_code >= 400:
+        logger.error(
+            "agent-digest run returned non-2xx; will retry next tick",
+            extra={"period": period, "status_code": resp.status_code, "body": resp.text[:500]},
+        )
+        return
+    logger.info("agent-digest run fired", extra={"period": period, "summary": resp.json()})
+
+
+async def run_agent_digest_tick() -> None:
+    """Nightly per-agent activity digest generation (daily window). core-api
+    enumerates opted-in orgs and generates inline; a tenant that hasn't opted in
+    pays zero cost. Safe to fire daily."""
+    await _fire_agent_digest("day")

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -144,7 +144,11 @@ async def _fire_agent_digest(period: str) -> None:
             extra={"period": period, "status_code": resp.status_code, "body": resp.text[:500]},
         )
         return
-    logger.info("agent-digest run fired", extra={"period": period, "summary": resp.json()})
+    try:
+        summary = resp.json()
+    except Exception:
+        summary = resp.text[:200]
+    logger.info("agent-digest run fired", extra={"period": period, "summary": summary})
 
 
 async def run_agent_digest_tick() -> None:

--- a/core-operations/tests/test_tasks.py
+++ b/core-operations/tests/test_tasks.py
@@ -87,6 +87,21 @@ async def test_archive_expired_tick_posts_to_fanout(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
+async def test_agent_digest_tick_posts_to_run_endpoint(monkeypatch: pytest.MonkeyPatch):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    response = _StubResponse(200, {"period": "day", "orgs": 2, "completed": 2, "digests": 5})
+    async with _patch_client(monkeypatch, response=response) as stub:
+        await tasks.run_agent_digest_tick()
+
+    assert len(stub.calls) == 1
+    url, headers = stub.calls[0]
+    assert url == "http://core-api/api/v1/admin/reports/agent-digest/run?period=day"
+    assert headers == {"X-API-Key": "admin-key-xyz"}
+
+
+@pytest.mark.asyncio
 async def test_archive_stale_tick_hits_correct_path(monkeypatch: pytest.MonkeyPatch):
     settings.core_api_url = "http://core-api"
     settings.core_api_admin_api_key = "admin-key-xyz"

--- a/core-storage-api/src/core_storage_api/routers/reports.py
+++ b/core-storage-api/src/core_storage_api/routers/reports.py
@@ -84,6 +84,30 @@ async def get_agent_activity_digest(
     return [orm_to_dict(r, AGENT_DIGEST_FIELDS) for r in rows]
 
 
+@router.post("/agent-activity")
+async def upsert_agent_activity_digest(request: Request) -> dict:
+    """Insert or replace one agent-activity digest row (internal; written by the
+    digest generator in core-api). Idempotent on the run window — see
+    ``agent_activity_digest_upsert``. Body is the full row; ISO datetime strings
+    are parsed to datetimes.
+    """
+    body: dict = await request.json()
+    for field in ("tenant_id", "run_id", "agent_id", "period", "window_start", "window_end", "status"):
+        if not body.get(field):
+            raise HTTPException(status_code=422, detail=f"'{field}' is required")
+    if body["period"] not in ("day", "week"):
+        raise HTTPException(status_code=422, detail="'period' must be 'day' or 'week'")
+    for k in ("window_start", "window_end", "generated_at"):
+        v = body.get(k)
+        if isinstance(v, str):
+            try:
+                body[k] = datetime.fromisoformat(v)
+            except ValueError:
+                raise HTTPException(status_code=422, detail=f"'{k}' must be a valid ISO datetime")
+    row = await _svc.agent_activity_digest_upsert(body)
+    return orm_to_dict(row, AGENT_DIGEST_FIELDS)
+
+
 @router.get("/{report_id}")
 async def get_report(report_id: UUID) -> dict:
     report = await _svc.report_get_by_id(report_id)

--- a/core-storage-api/src/core_storage_api/routers/reports.py
+++ b/core-storage-api/src/core_storage_api/routers/reports.py
@@ -108,6 +108,25 @@ async def upsert_agent_activity_digest(request: Request) -> dict:
     return orm_to_dict(row, AGENT_DIGEST_FIELDS)
 
 
+@router.post("/agent-activity/prune")
+async def prune_agent_activity_digests(request: Request) -> dict:
+    """Delete a tenant's digest rows older than ``older_than`` (retention sweep;
+    internal). Body: ``{tenant_id, older_than (ISO)}``. Returns ``{deleted}``."""
+    body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    older_than = body.get("older_than")
+    if not tenant_id:
+        raise HTTPException(status_code=422, detail="'tenant_id' is required")
+    if not older_than:
+        raise HTTPException(status_code=422, detail="'older_than' is required")
+    if isinstance(older_than, str):
+        try:
+            older_than = datetime.fromisoformat(older_than)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="'older_than' must be a valid ISO datetime")
+    return {"deleted": await _svc.agent_activity_digest_prune(tenant_id, older_than)}
+
+
 @router.get("/{report_id}")
 async def get_report(report_id: UUID) -> dict:
     report = await _svc.report_get_by_id(report_id)

--- a/core-storage-api/src/core_storage_api/routers/tenants.py
+++ b/core-storage-api/src/core_storage_api/routers/tenants.py
@@ -49,3 +49,10 @@ async def list_skills_factory_enabled_orgs() -> OrgIdsResponse:
     """Orgs whose ``skills_factory.enabled`` setting is True (forge-distill
     fanout target)."""
     return OrgIdsResponse(org_ids=await _svc.tenants_list_skills_factory_enabled())
+
+
+@router.get("/agent-digest-enabled")
+async def list_agent_digest_enabled_orgs() -> OrgIdsResponse:
+    """Orgs whose ``agent_digest.enabled`` setting is True (nightly digest
+    fanout target)."""
+    return OrgIdsResponse(org_ids=await _svc.tenants_list_agent_digest_enabled())

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -8150,6 +8150,18 @@ class PostgresService:
             )
             return sorted(row[0] for row in result.all())
 
+    async def tenants_list_agent_digest_enabled(self) -> list[str]:
+        """``org_id`` values whose ``agent_digest.enabled`` JSONB flag is True,
+        sorted. The nightly digest fanout uses this so a tenant that hasn't opted
+        in pays zero cost. Orgs with no settings row are excluded (default off)."""
+        async with get_read_session() as session:
+            result = await session.execute(
+                select(OrganizationSettings.org_id).where(
+                    OrganizationSettings.settings["agent_digest"]["enabled"].as_boolean().is_(True)
+                )
+            )
+            return sorted(row[0] for row in result.all())
+
     # ══════════════════════════════════════════════════════════════════════
     #  REPORTS (CrystallizationReport)
     # ══════════════════════════════════════════════════════════════════════

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -8299,6 +8299,60 @@ class PostgresService:
             result = await session.execute(rows_stmt)
             return list(result.scalars().all())
 
+    async def agent_activity_digest_upsert(self, data: dict) -> AgentActivityDigest:
+        """Insert or replace one digest row; idempotent on the run window.
+
+        Re-running the same (tenant_id, [fleet_id], agent_id, period,
+        window_start) overwrites the prior content — a re-run mints a fresh
+        ``run_id`` and refreshes ``generated_at``. Uniqueness is enforced by two
+        PARTIAL unique indexes (fleet / no-fleet), and ``ON CONFLICT`` can infer
+        only one, so we target the index matching this row's fleet_id NULL-ness.
+        """
+        async with get_session() as session:
+            insert_stmt = pg_insert(AgentActivityDigest).values(**data)
+            set_ = {
+                "run_id": insert_stmt.excluded.run_id,
+                "window_end": insert_stmt.excluded.window_end,
+                "narrative": insert_stmt.excluded.narrative,
+                "sections": insert_stmt.excluded.sections,
+                "source_count": insert_stmt.excluded.source_count,
+                "recall_count": insert_stmt.excluded.recall_count,
+                "model": insert_stmt.excluded.model,
+                "status": insert_stmt.excluded.status,
+                "error_detail": insert_stmt.excluded.error_detail,
+                # A re-run's row is freshly generated — stamp update time.
+                "generated_at": func.now(),
+            }
+            if data.get("fleet_id") is None:
+                upsert_stmt = insert_stmt.on_conflict_do_update(
+                    index_elements=["tenant_id", "agent_id", "period", "window_start"],
+                    index_where=text("fleet_id IS NULL"),
+                    set_=set_,
+                )
+            else:
+                upsert_stmt = insert_stmt.on_conflict_do_update(
+                    index_elements=["tenant_id", "fleet_id", "agent_id", "period", "window_start"],
+                    index_where=text("fleet_id IS NOT NULL"),
+                    set_=set_,
+                )
+            await session.execute(upsert_stmt)
+
+            # Re-fetch for a tracked ORM instance: RETURNING on a
+            # pg_insert+on_conflict yields a Row, not the ORM object orm_to_dict
+            # expects (mirrors relation_upsert). The natural key + fleet_id
+            # NULL-ness pins exactly one row.
+            select_stmt = select(AgentActivityDigest).where(
+                AgentActivityDigest.tenant_id == data["tenant_id"],
+                AgentActivityDigest.agent_id == data["agent_id"],
+                AgentActivityDigest.period == data["period"],
+                AgentActivityDigest.window_start == data["window_start"],
+            )
+            if data.get("fleet_id") is None:
+                select_stmt = select_stmt.where(AgentActivityDigest.fleet_id.is_(None))
+            else:
+                select_stmt = select_stmt.where(AgentActivityDigest.fleet_id == data["fleet_id"])
+            return (await session.execute(select_stmt)).scalar_one()
+
     # ══════════════════════════════════════════════════════════════════════
     #  TASKS (BackgroundTaskLog)
     # ══════════════════════════════════════════════════════════════════════

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -8365,6 +8365,18 @@ class PostgresService:
                 select_stmt = select_stmt.where(AgentActivityDigest.fleet_id == data["fleet_id"])
             return (await session.execute(select_stmt)).scalar_one()
 
+    async def agent_activity_digest_prune(self, tenant_id: str, older_than: datetime) -> int:
+        """Delete this tenant's digest rows generated before ``older_than``
+        (retention sweep). Returns the number of rows deleted."""
+        async with get_session() as session:
+            result = await session.execute(
+                delete(AgentActivityDigest).where(
+                    AgentActivityDigest.tenant_id == tenant_id,
+                    AgentActivityDigest.generated_at < older_than,
+                )
+            )
+            return result.rowcount or 0  # type: ignore[attr-defined]
+
     # ══════════════════════════════════════════════════════════════════════
     #  TASKS (BackgroundTaskLog)
     # ══════════════════════════════════════════════════════════════════════

--- a/core-storage-api/tests/conftest.py
+++ b/core-storage-api/tests/conftest.py
@@ -50,6 +50,7 @@ async def _ensure_schema():
     import common.models.document  # noqa: F401
     import common.models.background_task  # noqa: F401
     import common.models.analysis_report  # noqa: F401
+    import common.models.agent_activity_digest  # noqa: F401
     from common.models.base import Base
 
     async with engine.begin() as conn:

--- a/core-storage-api/tests/test_agent_digest.py
+++ b/core-storage-api/tests/test_agent_digest.py
@@ -113,6 +113,27 @@ async def test_agent_id_filter(client: AsyncClient):
     assert len(rows) == 1 and rows[0]["agent_id"] == "a"
 
 
+async def test_prune_deletes_rows_older_than_cutoff(client: AsyncClient):
+    tenant = f"dig-{_uid()}"
+    await _post(client, _row(tenant, "old", generated_at="2020-01-01T00:00:00+00:00"))
+    await _post(client, _row(tenant, "new", generated_at="2026-07-06T00:00:00+00:00"))
+    resp = await client.post(
+        f"{PREFIX}/reports/agent-activity/prune",
+        json={"tenant_id": tenant, "older_than": "2021-01-01T00:00:00+00:00"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["deleted"] == 1
+    rows = await _latest(client, tenant)
+    assert [r["agent_id"] for r in rows] == ["new"]
+
+
+async def test_prune_validation(client: AsyncClient):
+    resp = await client.post(
+        f"{PREFIX}/reports/agent-activity/prune", json={"older_than": "2021-01-01T00:00:00+00:00"}
+    )
+    assert resp.status_code == 422 and "tenant_id" in resp.text
+
+
 @pytest.mark.parametrize(
     "mutate,detail_needle",
     [

--- a/core-storage-api/tests/test_agent_digest.py
+++ b/core-storage-api/tests/test_agent_digest.py
@@ -1,0 +1,130 @@
+"""Integration tests for the agent-activity digest write/read path (Phase 2a).
+
+Exercises ``POST/GET /reports/agent-activity`` against a live PostgreSQL,
+focusing on the idempotent upsert over the two PARTIAL unique indexes
+(fleet / no-fleet).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+PREFIX = "/api/v1/storage"
+WIN_START = "2026-07-05T00:00:00+00:00"
+WIN_END = "2026-07-06T00:00:00+00:00"
+
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _row(tenant: str, agent: str, *, fleet: str | None = None, **over) -> dict:
+    body = {
+        "run_id": str(uuid.uuid4()),
+        "tenant_id": tenant,
+        "fleet_id": fleet,
+        "agent_id": agent,
+        "period": "day",
+        "window_start": WIN_START,
+        "window_end": WIN_END,
+        "narrative": "did some work",
+        "sections": {"shipped": ["a thing"]},
+        "source_count": 5,
+        "recall_count": 2,
+        "model": "gpt-5.4-mini",
+        "status": "ok",
+    }
+    body.update(over)
+    return body
+
+
+async def _post(client: AsyncClient, body: dict):
+    return await client.post(f"{PREFIX}/reports/agent-activity", json=body)
+
+
+async def _latest(client: AsyncClient, tenant: str, **params) -> list[dict]:
+    resp = await client.get(
+        f"{PREFIX}/reports/agent-activity", params={"tenant_id": tenant, "period": "day", **params}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def test_upsert_is_idempotent_on_window_no_fleet(client: AsyncClient):
+    """Re-running the same (tenant, agent, period, window) with fleet_id NULL
+    replaces the row rather than duplicating it (no-fleet partial index)."""
+    tenant, agent = f"dig-{_uid()}", "DevopsClaw"
+    r1 = await _post(client, _row(tenant, agent, narrative="v1", source_count=3))
+    assert r1.status_code == 200, r1.text
+
+    r2 = await _post(client, _row(tenant, agent, narrative="v2", source_count=9))
+    assert r2.status_code == 200, r2.text
+
+    rows = await _latest(client, tenant)
+    assert len(rows) == 1, rows
+    assert rows[0]["narrative"] == "v2"
+    assert rows[0]["source_count"] == 9
+
+
+async def test_upsert_idempotent_with_fleet(client: AsyncClient):
+    """Same natural key WITH a fleet_id upserts on the fleet partial index."""
+    tenant, agent, fleet = f"dig-{_uid()}", "SecurityClaw", "etoro0"
+    assert (await _post(client, _row(tenant, agent, fleet=fleet, narrative="a"))).status_code == 200
+    assert (await _post(client, _row(tenant, agent, fleet=fleet, narrative="b"))).status_code == 200
+
+    rows = await _latest(client, tenant)
+    assert len(rows) == 1, rows
+    assert rows[0]["narrative"] == "b"
+    assert rows[0]["fleet_id"] == fleet
+
+
+async def test_fleet_and_no_fleet_are_distinct_rows(client: AsyncClient):
+    """A fleeted and a fleetless digest for the same agent/window are distinct —
+    the two partial indexes don't collide."""
+    tenant, agent = f"dig-{_uid()}", "BankingClaw"
+    run = str(uuid.uuid4())
+    await _post(client, _row(tenant, agent, fleet=None, run_id=run))
+    await _post(client, _row(tenant, agent, fleet="etoro0", run_id=run))
+    rows = await _latest(client, tenant)
+    assert len(rows) == 2, rows
+
+
+async def test_latest_run_returns_all_agents_sorted(client: AsyncClient):
+    """One run's rows come back for all agents, ordered by source_count desc."""
+    tenant = f"dig-{_uid()}"
+    run = str(uuid.uuid4())
+    await _post(client, _row(tenant, "low", run_id=run, source_count=1))
+    await _post(client, _row(tenant, "high", run_id=run, source_count=42))
+    rows = await _latest(client, tenant)
+    assert [r["agent_id"] for r in rows] == ["high", "low"]
+
+
+async def test_agent_id_filter(client: AsyncClient):
+    tenant = f"dig-{_uid()}"
+    run = str(uuid.uuid4())
+    await _post(client, _row(tenant, "a", run_id=run))
+    await _post(client, _row(tenant, "b", run_id=run))
+    rows = await _latest(client, tenant, agent_id="a")
+    assert len(rows) == 1 and rows[0]["agent_id"] == "a"
+
+
+@pytest.mark.parametrize(
+    "mutate,detail_needle",
+    [
+        ({"tenant_id": ""}, "tenant_id"),
+        ({"status": None}, "status"),
+        ({"period": "month"}, "day' or 'week"),
+        ({"window_start": "not-a-date"}, "window_start"),
+    ],
+)
+async def test_upsert_validation(client: AsyncClient, mutate: dict, detail_needle: str):
+    body = _row(f"dig-{_uid()}", "a")
+    body.update(mutate)
+    resp = await _post(client, body)
+    assert resp.status_code == 422, resp.text
+    assert detail_needle in resp.text


### PR DESCRIPTION
## Phase 2 — nightly per-agent activity digest generation

Builds on Phase 1 (#533, the inert read slice). Generates the cached, LLM-written "what did this agent do this day/week" prose that `GET /api/v1/reports/agent-activity` already serves. Generation runs **off the request path** (an LLM pass per agent is too slow/costly on demand).

### Architecture
core-operations nightly cron → POST core-api admin endpoint → enumerate opted-in orgs → **inline bounded-concurrency** generation → upsert digest rows. core-operations stays a dumb trigger (no LLM/DB); generation lives in core-api (LLM + config + storage access).

**Fanout choice:** inline bounded-concurrency (v1), not per-tenant Pub/Sub. Far less shared-infra surface, adequate at on-prem/eToro tenant counts; a per-tenant Pub/Sub fanout is the documented scale path if org counts grow. (Approved fallback from the design.)

### Sub-phases (one commit each)
- **2a — storage write path:** `agent_activity_digest_upsert` (idempotent; branches on `fleet_id` to hit the correct partial unique index), `POST /reports/agent-activity`, storage client. Integration tests.
- **2b — generation:** `services/agent_digest.py` — fetch each agent's cohesive durable memories, rank by volume, LLM-summarize the top-N above the activity threshold (`call_with_fallback` + `complete_json`, JSON schema), upsert per-agent rows with `ok`/`truncated`/`error` status; USD cost cap trims the call budget. `run_agent_digest` enumerates opted-in orgs, fans out inline (one org's failure never sinks the rest). Shared corpus rules extracted to `services/report_corpus.py` (one source of truth with the live report). `POST /admin/reports/agent-digest/run` (admin-gated). Opt-in `agent_digest` config in `DEFAULT_SETTINGS` (model `gpt-5.4-mini`). Unit tests (mocked storage + LLM).
- **2c — cron:** wall-clock-aligned daily tick in core-operations (`agent_digest_run_at_hour`, default 02:00 UTC) → the admin endpoint, generous timeout. Test.
- **2d — retention:** per-run prune of rows older than `retention_days` (default 90). Unit + storage integration tests.

### Config (org settings, opt-in — disabled by default)
`agent_digest`: `enabled`, `cadence`, `provider`/`model`, `top_n`, `max_memories_per_agent`, `min_activity_threshold`, `max_cost_per_run_usd`, `retention_days`.

### Testing
- core-api unit (generator, mocked storage+LLM): 9 tests — threshold, cohesive/episode filtering, top-N, cost cap, truncation, fleet passthrough, window, enumerate→generate, retention.
- core-storage integration (upsert + prune): 11 tests — idempotency on both partial indexes, fleet/no-fleet distinctness, latest-run ordering, prune.
- core-operations: cron tick test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)