### PR TITLE
chore(fleet): bump plugin auto-upgrade floor to 2.14.0

### DIFF
--- a/core-api/src/core_api/version_compat.py
+++ b/core-api/src/core_api/version_compat.py
@@ -8,12 +8,13 @@ recommended version; no hard rejection — operators decide when to upgrade.
 
 # Auto-upgrade target / "outdated" floor. The fleet heartbeat queues a deploy
 # to this version for eligible nodes (>= MIN_AUTO_DEPLOY, auto-upgrade enabled).
-# Reconciled to the current shipped plugin release. 2.13.0 carries the
-# reserved-"main" write self-identification (plugin half of the firehose
-# de-collapse, #507): unset MEMCLAW_AGENT_ID now writes as main-<install_id>
-# instead of collapsing onto the shared "main" identity. Bumping the floor
-# auto-upgrades eligible fleet nodes so the de-collapse actually takes effect.
-MIN_RECOMMENDED_PLUGIN_VERSION = "2.13.0"
+# Reconciled to the current shipped plugin release. 2.14.0 is a superset of
+# 2.13.0 (which carries the reserved-"main" write self-identification / firehose
+# de-collapse, #507 — preserved) plus opt-in recall-gating + cross-agent recall
+# (#530), both flag-gated OFF by default (MEMCLAW_RECALL_GATE / _CROSS_AGENT), so
+# auto-upgrading the fleet to 2.14.0 changes no recall behavior until those env
+# flags are set. Bumping the floor pulls the fleet onto 2.14.0.
+MIN_RECOMMENDED_PLUGIN_VERSION = "2.14.0"
 
 # Server-side floor below which plugins must NOT auto-upgrade — the
 # heartbeat path in ``routes/fleet.py`` enforces this hard, and


### PR DESCRIPTION
## What
Bump `MIN_RECOMMENDED_PLUGIN_VERSION` **2.13.0 → 2.14.0** in `core_api/version_compat.py`, so eligible fleet nodes auto-upgrade to plugin 2.14.0.

## Why
Intended part of the v2.20.0 / onprem-v2.11.6 delivery: get plugin 2.14.0 onto the fleet.

**2.14.0 is a superset of 2.13.0** — verified `plugin-v2.13.0..plugin-v2.14.0` is only #530 + the version bump:
- **Preserves** the reserved-`main` write self-identification (#507 firehose de-collapse) — `main-${getInstallId()}` write default still present.
- **Adds** opt-in recall-gating + cross-agent recall (#530), both **flag-gated OFF by default** (`MEMCLAW_RECALL_GATE`=`off`, `MEMCLAW_RECALL_CROSS_AGENT`=`false`).

So the auto-upgrade **changes no recall behavior** until those env flags are deliberately set on a node — it just moves the fleet from 2.13.0 to 2.14.0.

## Scope / safety
- One constant. `MIN_AUTO_DEPLOY_PLUGIN_VERSION` unchanged (2.6.0); floor invariant (`recommended >= auto-deploy`) holds — `tests/test_plugin_floor_invariant.py` is value-agnostic.
- De-collapse behavior from 2.13.0 is carried forward unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)