### PR TITLE
fix(clients): raise on unexpected search() response shape (#510)

### DIFF
--- a/clients/python/src/memclaw_client/client.py
+++ b/clients/python/src/memclaw_client/client.py
@@ -94,7 +94,13 @@ class MemClaw:
             body["filter_agent_id"] = filter_agent_id
         body.update(extra)
         data = self._post("/api/v1/search", body)
-        items = data.get("items", []) if isinstance(data, dict) else []
+        if not isinstance(data, dict):
+            raise MemClawAPIError(200, "search response must be a JSON object")
+        if "items" not in data:
+            raise MemClawAPIError(200, 'search response missing "items" list')
+        items = data["items"]
+        if not isinstance(items, list):
+            raise MemClawAPIError(200, 'search response "items" must be a list')
         return [Memory.from_dict(m) for m in items]
 
     def recall(self, query: str, *, top_k: int = 5, **extra: Any) -> RecallResult:

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -63,6 +63,36 @@ def test_search_returns_list():
     assert [m.id for m in results] == ["m1", "m2"]
 
 
+def test_search_raises_on_missing_items_key():
+    def handler(request):
+        return httpx.Response(200, json={"error": "quota exceeded"})
+
+    with pytest.raises(MemClawAPIError) as exc:
+        make_client(handler).search("q")
+    assert exc.value.status_code == 200
+    assert str(exc.value) == '[200] search response missing "items" list'
+
+
+def test_search_raises_on_items_not_a_list():
+    def handler(request):
+        return httpx.Response(200, json={"items": "not-a-list"})
+
+    with pytest.raises(MemClawAPIError) as exc:
+        make_client(handler).search("q")
+    assert exc.value.status_code == 200
+    assert str(exc.value) == '[200] search response "items" must be a list'
+
+
+def test_search_raises_on_non_dict_body():
+    def handler(request):
+        return httpx.Response(200, json=["not", "a", "dict"])
+
+    with pytest.raises(MemClawAPIError) as exc:
+        make_client(handler).search("q")
+    assert exc.value.status_code == 200
+    assert str(exc.value) == "[200] search response must be a JSON object"
+
+
 def test_recall_returns_summary():
     def handler(request):
         assert request.url.path == "/api/v1/recall"

--- a/clients/typescript/src/index.test.ts
+++ b/clients/typescript/src/index.test.ts
@@ -59,6 +59,26 @@ test("search posts to /search and returns a list", async () => {
   assert.deepEqual(results.map((m) => m.id), ["m1", "m2"]);
 });
 
+test("search throws when 200 body lacks items", async () => {
+  const client = makeClient(() => jsonResponse(200, { error: "quota exceeded" }));
+  await assert.rejects(client.search("q"), (err: unknown) => {
+    assert.ok(err instanceof MemClawApiError);
+    assert.equal((err as MemClawApiError).statusCode, 200);
+    assert.equal((err as MemClawApiError).message, '[200] search response missing "items" list');
+    return true;
+  });
+});
+
+test("search throws when 200 items is not a list", async () => {
+  const client = makeClient(() => jsonResponse(200, { items: "not-a-list" }));
+  await assert.rejects(client.search("q"), (err: unknown) => {
+    assert.ok(err instanceof MemClawApiError);
+    assert.equal((err as MemClawApiError).statusCode, 200);
+    assert.equal((err as MemClawApiError).message, '[200] search response "items" must be a list');
+    return true;
+  });
+});
+
 test("recall returns the summary and supporting memories", async () => {
   const client = makeClient((url) => {
     assert.equal(new URL(url).pathname, "/api/v1/recall");

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -128,8 +128,17 @@ export class MemClaw {
     if (filterAgentId) body.filter_agent_id = filterAgentId;
     Object.assign(body, extra);
     const data = await this.request("POST", "/api/v1/search", body);
-    const items: unknown = data?.items;
-    return Array.isArray(items) ? items.map((m) => toMemory(m as Record<string, any>)) : [];
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      throw new MemClawApiError(200, "search response must be a JSON object");
+    }
+    if (!("items" in data)) {
+      throw new MemClawApiError(200, 'search response missing "items" list');
+    }
+    const items = (data as Record<string, unknown>).items;
+    if (!Array.isArray(items)) {
+      throw new MemClawApiError(200, 'search response "items" must be a list');
+    }
+    return items.map((m) => toMemory(m as Record<string, any>));
   }
 
   /** Search + LLM-synthesized context brief. POST /api/v1/recall */


### PR DESCRIPTION
## Problem

On HTTP 200,  silently returned  when the JSON body was not a dict with an `items` list (e.g. `{ "error": "quota exceeded" }`), so callers could not distinguish zero hits from a malformed response.

Refs: caura-ai/caura-memclaw#510

## Proposed change

Validate the search response shape in both Python and TypeScript clients and raise `MemClawAPIError` / `MemClawApiError` with status 200 when the body is unexpected.

## Test results

- clients/python: 12 passed
- clients/typescript: 10 passed