### PR TITLE
feat(insights): give the nightly insights run a dedicated registered identity

### DIFF
--- a/core-api/src/core_api/agent_ids.py
+++ b/core-api/src/core_api/agent_ids.py
@@ -12,6 +12,22 @@ otherwise couple the route module to the whole MCP tool surface.
 # anonymous writes are never silently attributed to one shared identity.
 DEFAULT_AGENT_ID = "mcp-agent"
 
+# Dedicated system identity for the automated nightly insights run
+# (``lifecycle_audit._CoreApiLifecycleAdapter.insights`` → ``generate_insights``).
+# Distinct from ``DEFAULT_AGENT_ID`` above: that is the generic "caller specified
+# nothing" fallback, whereas the scheduled insights pass has no human/agent
+# caller and must write under a stable, registerable identity rather than
+# collapsing onto the anonymous default (which is unregistered, so its writes
+# never surface in Prism or the per-agent report). Registered per-tenant with
+# ``belonging_type='service'`` the first time the job runs for that tenant.
+INSIGHTER_AGENT_ID = "memclaw-insighter"
+
+# Trust tier the insighter self-registers at: service level, granting cross-fleet
+# read (>=2, needed for scope='all') and write (>=3, it persists scope_org
+# insights). The automated path calls the service directly and bypasses the
+# route trust gate, so this is future-proofing for any gated re-route.
+INSIGHTER_TRUST_LEVEL = 3
+
 # Bare ``"main"`` is the OpenClaw plugin's *unset* default agent_id: when an
 # operator never sets ``MEMCLAW_AGENT_ID`` every install collapses onto this one
 # shared identity (the eToro "firehose"). Unlike ``DEFAULT_AGENT_ID``

--- a/core-api/src/core_api/services/lifecycle_audit.py
+++ b/core-api/src/core_api/services/lifecycle_audit.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 
+from core_api.agent_ids import INSIGHTER_AGENT_ID, INSIGHTER_TRUST_LEVEL
 from core_api.clients.storage_client import CoreStorageClient
 from core_api.constants import LIFECYCLE_STALE_ARCHIVE_WEIGHT
 from core_api.services.organization_settings import resolve_config
@@ -144,11 +145,47 @@ class _CoreApiLifecycleAdapter:
             if latest_non_insight <= latest_insight:
                 return 0
 
+        # Register the dedicated system identity for this org BEFORE persisting,
+        # so the insights are attributed to a real, Prism-visible service agent
+        # instead of the anonymous ``mcp-agent`` fallback. This is the "registered
+        # at any new tenant" hook: the first nightly run for a tenant registers it.
+        #
+        # One-time setup, guarded by an existence check rather than a bare upsert:
+        # create_or_update_agent's conflict path *updates* trust_level /
+        # display_name (etc.) when the supplied value differs, so re-registering
+        # every night would silently overwrite an operator's later customisation
+        # of this agent. Only create it when absent.
+        #
+        # Best-effort: a transient storage error here must not abort the whole
+        # insights run. The write below works even without the agent row (writes
+        # don't require the agent to be registered), and the next nightly run
+        # retries registration.
+        try:
+            existing = await self._storage.get_agent(INSIGHTER_AGENT_ID, org_id)
+            if existing is None:
+                await self._storage.create_or_update_agent(
+                    {
+                        "tenant_id": org_id,
+                        "agent_id": INSIGHTER_AGENT_ID,
+                        "fleet_id": None,
+                        "display_name": "MemClaw Insighter",
+                        "belonging_type": "service",
+                        "trust_level": INSIGHTER_TRUST_LEVEL,
+                    }
+                )
+        except Exception:
+            logger.warning(
+                "Failed to register insighter agent for org %s; proceeding without registration",
+                org_id,
+                exc_info=True,
+            )
+
         result = await generate_insights(
             org_id,
             focus="discover",
             scope="fleet" if fleet_id else "all",
             fleet_id=fleet_id,
+            agent_id=INSIGHTER_AGENT_ID,
         )
 
         return len(result.get("insight_memory_ids", []))

--- a/core-api/uv.lock
+++ b/core-api/uv.lock
@@ -374,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "core-api"
-version = "2.18.0"
+version = "2.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/030_register_memclaw_insighter.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/030_register_memclaw_insighter.py
@@ -1,0 +1,47 @@
+"""Register the ``memclaw-insighter`` service agent for existing tenants.
+
+The automated nightly insights run (core-api
+``lifecycle_audit._CoreApiLifecycleAdapter.insights``) now attributes its
+writes to a dedicated ``memclaw-insighter`` identity and self-registers that
+agent the first time it runs for a tenant. This migration backfills the same
+registration for tenants that ALREADY hold ``memclaw-insighter`` memories (e.g.
+those renamed from the historical ``mcp-agent`` fallback), so the agent surfaces
+in Prism and the per-agent report immediately — without waiting for the next
+nightly run.
+
+Data-driven and idempotent: one ``service`` agent per distinct tenant that has
+an insighter memory, ``ON CONFLICT (tenant_id, agent_id) DO NOTHING``. trust
+level 3 mirrors ``core_api.agent_ids.INSIGHTER_TRUST_LEVEL`` (hardcoded here —
+migrations are frozen snapshots and must not import app code).
+
+Revision ID: 030
+Revises: 029
+Create Date: 2026-07-08
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "030"
+down_revision: str | None = "029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO agents (tenant_id, agent_id, fleet_id, display_name, belonging_type, trust_level)
+        SELECT DISTINCT m.tenant_id, 'memclaw-insighter', NULL, 'MemClaw Insighter', 'service', 3
+        FROM memories m
+        WHERE m.agent_id = 'memclaw-insighter'
+        ON CONFLICT (tenant_id, agent_id) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    # Reverts the feature: removes every insighter registration, including any
+    # the running job self-registered after this migration.
+    op.execute("DELETE FROM agents WHERE agent_id = 'memclaw-insighter'")

--- a/tests/test_lifecycle_audit.py
+++ b/tests/test_lifecycle_audit.py
@@ -88,3 +88,147 @@ async def test_crystallize_skips_below_active_threshold() -> None:
         new=AsyncMock(return_value=_Cfg()),
     ):
         assert await adapter.crystallize(org_id="t1", fleet_id=None) == 0
+
+
+@pytest.mark.asyncio
+async def test_insights_attributes_and_registers_dedicated_agent() -> None:
+    """The automated insights run writes under the dedicated ``memclaw-insighter``
+    identity — never the anonymous ``mcp-agent`` fallback — and self-registers it
+    as a service agent (trust 3) for the org before persisting."""
+    registered: list[dict] = []
+
+    class _InsightsStorage:
+        async def insights_activity_gate(self, *, tenant_id: str, fleet_id):
+            # Corpus has grown since the last insight → run proceeds.
+            return {"latest_non_insight": "2026-07-08T00:00:00+00:00", "latest_insight": None}
+
+        async def get_agent(self, agent_id: str, tenant_id: str) -> dict | None:
+            return None  # not yet registered → should create
+
+        async def create_or_update_agent(self, payload: dict) -> dict:
+            registered.append(payload)
+            return {"id": str(uuid4())}
+
+    class _On:
+        auto_insights_enabled = True
+
+    adapter = _CoreApiLifecycleAdapter(_InsightsStorage())
+    with (
+        patch(
+            "core_api.services.lifecycle_audit.resolve_config",
+            new=AsyncMock(return_value=_On()),
+        ),
+        patch(
+            "core_api.services.insights_service.generate_insights",
+            new=AsyncMock(return_value={"insight_memory_ids": ["a", "b"]}),
+        ) as mock_gen,
+    ):
+        produced = await adapter.insights(org_id="t1", fleet_id=None)
+
+    assert produced == 2
+    # Attributed to the dedicated identity, tenant-wide (no fleet → scope='all').
+    mock_gen.assert_awaited_once()
+    assert mock_gen.await_args.kwargs["agent_id"] == "memclaw-insighter"
+    assert mock_gen.await_args.kwargs["scope"] == "all"
+    # Self-registered exactly once as a service agent with cross-fleet trust.
+    assert len(registered) == 1
+    reg = registered[0]
+    assert reg["tenant_id"] == "t1"
+    assert reg["agent_id"] == "memclaw-insighter"
+    assert reg["belonging_type"] == "service"
+    assert reg["trust_level"] == 3
+
+
+@pytest.mark.asyncio
+async def test_insights_does_not_reregister_existing_agent() -> None:
+    """Registration is one-time setup: when the insighter already exists, the run
+    must NOT re-upsert it — create_or_update_agent's conflict path updates
+    trust_level/display_name and would clobber operator customisation nightly."""
+
+    class _InsightsStorage:
+        async def insights_activity_gate(self, *, tenant_id: str, fleet_id):
+            return {"latest_non_insight": "2026-07-08T00:00:00+00:00", "latest_insight": None}
+
+        async def get_agent(self, agent_id: str, tenant_id: str) -> dict | None:
+            # Already registered (operator may have since customised it).
+            return {"agent_id": agent_id, "tenant_id": tenant_id, "trust_level": 2}
+
+        async def create_or_update_agent(self, payload: dict) -> dict:  # pragma: no cover
+            raise AssertionError("must not re-register an existing insighter agent")
+
+    class _On:
+        auto_insights_enabled = True
+
+    adapter = _CoreApiLifecycleAdapter(_InsightsStorage())
+    with (
+        patch(
+            "core_api.services.lifecycle_audit.resolve_config",
+            new=AsyncMock(return_value=_On()),
+        ),
+        patch(
+            "core_api.services.insights_service.generate_insights",
+            new=AsyncMock(return_value={"insight_memory_ids": ["a"]}),
+        ) as mock_gen,
+    ):
+        produced = await adapter.insights(org_id="t1", fleet_id=None)
+
+    assert produced == 1
+    # Still attributed to the dedicated identity even though it was pre-existing.
+    assert mock_gen.await_args.kwargs["agent_id"] == "memclaw-insighter"
+
+
+@pytest.mark.asyncio
+async def test_insights_registration_failure_does_not_abort_run() -> None:
+    """A transient storage error while registering the insighter must NOT abort
+    the run: the insight write works without the agent row, so the run completes
+    and the next nightly pass retries registration."""
+
+    class _InsightsStorage:
+        async def insights_activity_gate(self, *, tenant_id: str, fleet_id):
+            return {"latest_non_insight": "2026-07-08T00:00:00+00:00", "latest_insight": None}
+
+        async def get_agent(self, agent_id: str, tenant_id: str) -> dict | None:
+            raise RuntimeError("storage down")
+
+        async def create_or_update_agent(self, payload: dict) -> dict:  # pragma: no cover
+            raise AssertionError("unreachable — get_agent raised first")
+
+    class _On:
+        auto_insights_enabled = True
+
+    adapter = _CoreApiLifecycleAdapter(_InsightsStorage())
+    with (
+        patch(
+            "core_api.services.lifecycle_audit.resolve_config",
+            new=AsyncMock(return_value=_On()),
+        ),
+        patch(
+            "core_api.services.insights_service.generate_insights",
+            new=AsyncMock(return_value={"insight_memory_ids": ["a", "b", "c"]}),
+        ) as mock_gen,
+    ):
+        produced = await adapter.insights(org_id="t1", fleet_id=None)
+
+    # Run completed despite the registration failure, still under the dedicated id.
+    assert produced == 3
+    assert mock_gen.await_args.kwargs["agent_id"] == "memclaw-insighter"
+
+
+@pytest.mark.asyncio
+async def test_insights_skips_registration_when_auto_disabled() -> None:
+    """Insights opt-out short-circuits before any registration or generation —
+    a tenant that never runs insights gets no phantom agent row."""
+
+    class _Off:
+        auto_insights_enabled = False
+
+    class _Storage:
+        async def create_or_update_agent(self, payload: dict) -> dict:  # pragma: no cover
+            raise AssertionError("must not register when auto_insights disabled")
+
+    adapter = _CoreApiLifecycleAdapter(_Storage())
+    with patch(
+        "core_api.services.lifecycle_audit.resolve_config",
+        new=AsyncMock(return_value=_Off()),
+    ):
+        assert await adapter.insights(org_id="t1", fleet_id=None) == 0

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"029"}, f"Expected single head '029', got {sorted(heads)}"
+        assert heads == {"030"}, f"Expected single head '030', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -684,6 +684,8 @@ class TestMigrationChain:
         assert chain.get("028") == "027", "028 must follow 027"
         # 029: agent activity digest (cached per-agent summaries, CAURA-222)
         assert chain.get("029") == "028", "029 must follow 028"
+        # 030: register the memclaw-insighter service agent for existing tenants
+        assert chain.get("030") == "029", "030 must follow 029"
 
     def test_no_plain_create_index_on_large_tables(self):
         """Indexes on large, pre-existing tables MUST be built ``CONCURRENTLY``


### PR DESCRIPTION
## Problem

The scheduled nightly insights pass had **no caller identity**, so it fell through to the generic `DEFAULT_AGENT_ID = "mcp-agent"` — an *unregistered*, anonymous id that also catches any caller who specifies nothing. Consequences:

- Its writes never surfaced in **Prism** or the **per-agent report** — there's no matching `agents` row to join against.
- It was conflated with unrelated anonymous traffic under one shared `mcp-agent` bucket.

(On prod, `mcp-agent` was the top "agent" on etoro0/etoro-core purely because of this — 100% of those writes were `client_request_id='insights:%'`.)

## Change

Give the automated run its own registerable identity, `memclaw-insighter`:

| File | Change |
|---|---|
| `agent_ids.py` | Add `INSIGHTER_AGENT_ID = "memclaw-insighter"` + `INSIGHTER_TRUST_LEVEL = 3`, distinct from the generic `mcp-agent` fallback |
| `services/lifecycle_audit.py` | `insights()` attributes `generate_insights(agent_id=INSIGHTER_AGENT_ID)` and **self-registers** the agent (idempotent `create_or_update_agent`, `ON CONFLICT DO NOTHING`) as `belonging_type='service'`, trust 3, before persisting |
| `migrations/030` | Backfill the same registration for tenants that already hold `memclaw-insighter` memories, so Prism/reports show it immediately |

**Registration timing** = lazy, on first run: the first nightly insights run for any tenant (new or existing) registers the agent; a tenant with `auto_insights_enabled` off registers nothing (no phantom agent). No cross-repo tenant-provisioning hook needed.

**Privileges:** `service`/trust 3 grants cross-fleet read (≥2, needed for `scope='all'`) and write (≥3, it persists `scope_org`). The automated path calls the service directly and bypasses the route trust gate, so this is future-proofing for any gated re-route.

**Scope guard:** interactive MCP/REST callers are unaffected — they pass their real `agent_id` via `resolve_caller_and_gate`. Only the identity-less automated path changes. The generic `mcp-agent` fallback is intentionally left in place.

## Testing

- `test_lifecycle_audit.py`: automated run attributes to `memclaw-insighter` + registers the service agent (trust 3); opt-out short-circuits with no registration. 5/5 + 14 handler tests pass locally.
- Migration 030 validated against the live ORM schema: upgrade registers only tenants with insighter memories, re-run is a no-op, downgrade removes them.

> Note: this is the persistence follow-up to the manual prod DB rename of `mcp-agent → memclaw-insighter` on etoro0/etoro-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)