### PR TITLE
docs: fix agent install reference

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@
 - [ ] `ruff check` and `ruff format --check` pass
 - [ ] `mypy` passes
 - [ ] `pytest` passes locally
-- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
+- [ ] I have updated relevant documentation (README, docs, etc.)
 - [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)
 
 ## Additional Notes

--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -246,4 +246,7 @@ If you see search latency materially above ~50 ms p50 after warm-up, the pgvecto
 
 ## Full Reference
 
-For complete tool documentation with parameters, examples, memory types, status lifecycle, and best practices, see the [README](README.md) and [ARCHITECTURE_REVIEW.md](ARCHITECTURE_REVIEW.md). For benchmark methodology and competitive context, see [`docs/performance.md`](docs/performance.md).
+For complete tool documentation with parameters, examples, memory types, status lifecycle, best practices, and
+project structure, see the [README API reference](README.md#api-reference) and
+[README project structure](README.md#project-structure). For benchmark methodology and competitive context, see
+[`docs/performance.md`](docs/performance.md).

--- a/README.md
+++ b/README.md
@@ -931,6 +931,7 @@ All configuration is via environment variables or `.env`. See `.env.example` for
 
 </details>
 
+<a id="project-structure"></a>
 <details>
 <summary>Project structure</summary>
 


### PR DESCRIPTION
Closes #513

## Summary
- replace the dead ARCHITECTURE_REVIEW.md reference in AGENT-INSTALL.md with existing README anchors
- add a stable README project-structure anchor for the docs link target
- remove the stale ARCHITECTURE_REVIEW.md mention from the PR template

## Verification
- git grep -n "ARCHITECTURE_REVIEW" returned no matches
- git grep -n "project-structure" -- AGENT-INSTALL.md README.md
- git diff --check