### PR TITLE
feat(reports): weekly agent-digest cron tick [CAURA-222]

### DIFF
--- a/core-operations/src/core_operations/app.py
+++ b/core-operations/src/core_operations/app.py
@@ -49,9 +49,14 @@ configure_logging(
     log_file=settings.log_file or None,
 )
 
-from core_operations.scheduler import scheduler, seconds_until_next_utc_hour
+from core_operations.scheduler import (
+    scheduler,
+    seconds_until_next_utc_hour,
+    seconds_until_next_utc_weekday_hour,
+)
 from core_operations.tasks import (
     run_agent_digest_tick,
+    run_agent_digest_weekly_tick,
     run_archive_expired_tick,
     run_archive_stale_tick,
     run_crystallize_tick,
@@ -76,6 +81,11 @@ def _register_scheduled_tasks() -> None:
         # Bind the setting lookup lazily so an operator override applied
         # before start() is still picked up, and recompute each cycle.
         return lambda: seconds_until_next_utc_hour(getattr(settings, hour_attr))
+
+    def _weekly_at(weekday_attr: str, hour_attr: str):
+        return lambda: seconds_until_next_utc_weekday_hour(
+            getattr(settings, weekday_attr), getattr(settings, hour_attr)
+        )
 
     scheduler.register(
         "lifecycle-archive-expired",
@@ -118,6 +128,12 @@ def _register_scheduled_tasks() -> None:
         24 * 3600,
         run_agent_digest_tick,
         delay_provider=_daily_at("agent_digest_run_at_hour"),
+    )
+    scheduler.register(
+        "agent-digest-weekly",
+        7 * 24 * 3600,
+        run_agent_digest_weekly_tick,
+        delay_provider=_weekly_at("agent_digest_weekly_run_at_weekday", "agent_digest_weekly_run_at_hour"),
     )
 
 

--- a/core-operations/src/core_operations/config.py
+++ b/core-operations/src/core_operations/config.py
@@ -66,6 +66,12 @@ class Settings(BaseSettings):
     # (``agent_digest.enabled``, default off); a tenant that hasn't opted in
     # costs nothing, so a daily fire is safe.
     agent_digest_run_at_hour: int = 2
+    # Weekly digest (period=week) — a separate wall-clock-aligned tick so the UI's
+    # "week" toggle isn't dead. Fires once a week on ``weekday`` (0=Mon..6=Sun) at
+    # ``hour``; default Monday 03:00 UTC, just after the Monday daily tick, so the
+    # just-closed Mon-Mon window is covered.
+    agent_digest_weekly_run_at_weekday: int = 0
+    agent_digest_weekly_run_at_hour: int = 3
     # Generation runs INLINE in core-api (LLM per agent across opted-in orgs), so
     # its trigger POST can take minutes — a generous timeout, not the 30s default.
     agent_digest_http_timeout_s: float = 600.0
@@ -76,11 +82,19 @@ class Settings(BaseSettings):
         "lifecycle_pipeline_run_at_hour",
         "lifecycle_insights_run_at_hour",
         "agent_digest_run_at_hour",
+        "agent_digest_weekly_run_at_hour",
     )
     @classmethod
     def _validate_run_at_hour(cls, v: int, info: ValidationInfo) -> int:
         if not 0 <= v <= 23:
             raise ValueError(f"{info.field_name} must be in 0..23 (UTC hour)")
+        return v
+
+    @field_validator("agent_digest_weekly_run_at_weekday")
+    @classmethod
+    def _validate_weekday(cls, v: int, info: ValidationInfo) -> int:
+        if not 0 <= v <= 6:
+            raise ValueError(f"{info.field_name} must be in 0..6 (Mon..Sun)")
         return v
 
 

--- a/core-operations/src/core_operations/scheduler.py
+++ b/core-operations/src/core_operations/scheduler.py
@@ -53,6 +53,29 @@ def seconds_until_next_utc_hour(hour: int, *, now: datetime | None = None) -> fl
     return (target - current).total_seconds()
 
 
+def seconds_until_next_utc_weekday_hour(weekday: int, hour: int, *, now: datetime | None = None) -> float:
+    """Seconds from ``now`` until the next ``weekday``@``hour``:00 UTC.
+
+    ``weekday`` is Python's ``date.weekday()`` convention: 0=Monday … 6=Sunday.
+    Same strict-future guarantee as :func:`seconds_until_next_utc_hour` (always
+    positive, at most 7 days): when ``now`` is exactly at or past this week's
+    target slot, it rolls forward a full week — so an aligned weekly task can't
+    hot-loop after a fast failure.
+
+    ``now`` is injectable for tests; defaults to the current UTC time.
+    """
+    if not 0 <= weekday <= 6:
+        raise ValueError(f"weekday must be in 0..6 (Mon..Sun), got {weekday}")
+    if not 0 <= hour <= 23:
+        raise ValueError(f"hour must be in 0..23, got {hour}")
+    current = now or datetime.now(UTC)
+    target = current.replace(hour=hour, minute=0, second=0, microsecond=0)
+    target += timedelta(days=(weekday - current.weekday()) % 7)
+    if target <= current:  # today IS the weekday but the hour has passed
+        target += timedelta(days=7)
+    return (target - current).total_seconds()
+
+
 @dataclass(frozen=True)
 class ScheduledTask:
     name: str

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -156,3 +156,9 @@ async def run_agent_digest_tick() -> None:
     enumerates opted-in orgs and generates inline; a tenant that hasn't opted in
     pays zero cost. Safe to fire daily."""
     await _fire_agent_digest("day")
+
+
+async def run_agent_digest_weekly_tick() -> None:
+    """Weekly per-agent digest (period=week). Same trigger as the daily tick,
+    fired once a week so the previous full Mon-Mon window gets summarized."""
+    await _fire_agent_digest("week")

--- a/core-operations/tests/test_app.py
+++ b/core-operations/tests/test_app.py
@@ -24,6 +24,8 @@ _EXPECTED_JOBS = {
     "lifecycle-crystallize",
     "lifecycle-entity-link",
     "lifecycle-insights",
+    "agent-digest",
+    "agent-digest-weekly",
 }
 
 
@@ -39,7 +41,9 @@ def test_all_lifecycle_jobs_registered_and_wall_clock_aligned(monkeypatch):
         # Aligned => no immediate boot tick, no drift.
         assert t.delay_provider is not None, f"{t.name} is not wall-clock aligned"
         delay = t.delay_provider()
-        assert 0 < delay <= 24 * 3600, f"{t.name} delay out of range: {delay}"
+        # Weekly-aligned jobs are up to 7 days out; daily ones up to 24h.
+        max_delay = 7 * 24 * 3600 if t.name == "agent-digest-weekly" else 24 * 3600
+        assert 0 < delay <= max_delay, f"{t.name} delay out of range: {delay}"
 
 
 def test_run_at_hour_override_is_threaded_through(monkeypatch):

--- a/core-operations/tests/test_scheduler.py
+++ b/core-operations/tests/test_scheduler.py
@@ -7,7 +7,11 @@ from datetime import UTC, datetime
 
 import pytest
 
-from core_operations.scheduler import Scheduler, seconds_until_next_utc_hour
+from core_operations.scheduler import (
+    Scheduler,
+    seconds_until_next_utc_hour,
+    seconds_until_next_utc_weekday_hour,
+)
 
 
 @pytest.mark.asyncio
@@ -208,6 +212,36 @@ def test_seconds_until_next_utc_hour_always_positive_and_bounded():
     s = seconds_until_next_utc_hour(2, now=now)
     assert 0 < s <= 24 * 3600
     assert s == 1.0
+
+
+def test_seconds_until_next_weekday_hour_same_day_future():
+    now = datetime(2026, 6, 8, 0, 0, 0, tzinfo=UTC)  # a Monday
+    # Today is the target weekday and 03:00 hasn't passed → 3h out.
+    assert seconds_until_next_utc_weekday_hour(0, 3, now=now) == 3 * 3600
+
+
+def test_seconds_until_next_weekday_hour_rolls_a_week_when_past():
+    now = datetime(2026, 6, 8, 5, 0, 0, tzinfo=UTC)  # Monday, past 03:00
+    assert seconds_until_next_utc_weekday_hour(0, 3, now=now) == (7 * 24 - 5 + 3) * 3600
+
+
+def test_seconds_until_next_weekday_hour_future_weekday():
+    now = datetime(2026, 6, 3, 0, 0, 0, tzinfo=UTC)  # a Wednesday
+    # Next Monday (2026-06-08) 03:00 = 5 days + 3h.
+    assert seconds_until_next_utc_weekday_hour(0, 3, now=now) == (5 * 24 + 3) * 3600
+
+
+def test_seconds_until_next_weekday_hour_exact_boundary_rolls_forward():
+    now = datetime(2026, 6, 8, 3, 0, 0, tzinfo=UTC)  # exactly Monday 03:00
+    assert seconds_until_next_utc_weekday_hour(0, 3, now=now) == 7 * 24 * 3600
+
+
+def test_seconds_until_next_weekday_hour_validates_range():
+    now = datetime(2026, 6, 8, 0, 0, 0, tzinfo=UTC)
+    with pytest.raises(ValueError):
+        seconds_until_next_utc_weekday_hour(7, 3, now=now)
+    with pytest.raises(ValueError):
+        seconds_until_next_utc_weekday_hour(0, 24, now=now)
 
 
 def test_seconds_until_next_utc_hour_rejects_out_of_range():

--- a/core-operations/tests/test_tasks.py
+++ b/core-operations/tests/test_tasks.py
@@ -102,6 +102,20 @@ async def test_agent_digest_tick_posts_to_run_endpoint(monkeypatch: pytest.Monke
 
 
 @pytest.mark.asyncio
+async def test_agent_digest_weekly_tick_posts_period_week(monkeypatch: pytest.MonkeyPatch):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    response = _StubResponse(200, {"period": "week", "orgs": 1, "completed": 1, "digests": 3})
+    async with _patch_client(monkeypatch, response=response) as stub:
+        await tasks.run_agent_digest_weekly_tick()
+
+    assert len(stub.calls) == 1
+    url, _ = stub.calls[0]
+    assert url == "http://core-api/api/v1/admin/reports/agent-digest/run?period=week"
+
+
+@pytest.mark.asyncio
 async def test_archive_stale_tick_hits_correct_path(monkeypatch: pytest.MonkeyPatch):
     settings.core_api_url = "http://core-api"
     settings.core_api_admin_api_key = "admin-key-xyz"


### PR DESCRIPTION
## Weekly agent-digest generation

Phase 2c registered a nightly tick that only generates `period=day`, so the reports UI's **"week" toggle shows nothing**. This adds a weekly wall-clock-aligned tick that fires `period=week`.

- **scheduler**: `seconds_until_next_utc_weekday_hour(weekday, hour)` — Mon..Sun alignment with the same strict-future / no-hot-loop guarantee as the existing daily helper.
- **config**: `AGENT_DIGEST_WEEKLY_RUN_AT_WEEKDAY` (0=Mon, default) + `AGENT_DIGEST_WEEKLY_RUN_AT_HOUR` (default 03:00 UTC, just after Monday's daily tick so the just-closed Mon–Mon window is covered), both validated.
- **tasks**: `run_agent_digest_weekly_tick` → `POST /admin/reports/agent-digest/run?period=week`.
- **app**: registers `agent-digest-weekly` (7-day interval, weekly `delay_provider`).

### Also fixes a stale test
`test_app._EXPECTED_JOBS` never included the daily `agent-digest` job added in Phase 2c (core-operations tests aren't in the CI gate, so it slipped through). This adds both jobs and gives the weekly job a 7-day delay bound in the alignment assertion.

### Testing
Full core-operations suite green (41 tests), incl. 5 new scheduler cases for the weekday helper + the weekly-tick test. ruff + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)