### PR TITLE
docs: document TESTING=1 env var with production-danger warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,6 +179,12 @@ CRYSTALLIZER_DEDUP_THRESHOLD=0.95
 # -- CORS -------------------------------------------------------------------
 CORS_ORIGINS=http://localhost:3000
 
+# -- Test-only endpoints (NEVER set in production) ---------------------------
+# Setting TESTING=1 registers destructive time-warp and field-rewrite endpoints
+# at /api/v1/testing/*. These routes exist solely for E2E test suites.
+# Leaving this unset (the default) is correct for every non-test environment.
+# TESTING=1
+
 # -- Sentry (optional error tracking) ---------------------------------------
 SENTRY_DSN=
 


### PR DESCRIPTION
<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

Add a commented-out `TESTING=1` entry to `.env.example` with a clear
production-danger warning. The variable was checked in two places in the
codebase but entirely absent from the example config, leaving no hint of
its existence or risk for anyone bootstrapping from it.

## Related Issue

Closes #511 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

Documentation-only change — no code paths affected. Verified manually:
1. `TESTING` now appears in `.env.example` (previously absent).
2. The entry is fully commented out, so copying the file verbatim cannot
   accidentally activate the test endpoints.
3. `ruff`, `mypy`, and `pytest` are unaffected (no Python files changed).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes (or explained why none are needed)
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally
- [ ] I have updated relevant documentation (README, ARCHITECTURE_REVIEW, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

`TESTING=1` registers the `/api/v1/testing/time-warp` router, which can
directly overwrite timestamp columns in the database. It is set
automatically by `tests/conftest.py` and `.env.test` — developers running
`pytest` or the containerised test stack never need to set it manually.
The only scenario requiring a manual set is debugging temporal/crystallizer
E2E tests against a live local Docker stack.
