### PR TITLE
fix(reports): salvage empty-narrative digests + period-scaled activity floor

### DIFF
--- a/core-api/src/core_api/services/agent_digest.py
+++ b/core-api/src/core_api/services/agent_digest.py
@@ -57,6 +57,26 @@ DIGEST_SCHEMA: dict = {
 }
 
 _SECTION_KEYS = ("decisions", "shipped", "learned", "open_threads")
+_SECTION_LABELS = (
+    ("decisions", "decision"),
+    ("shipped", "shipped item"),
+    ("learned", "learning"),
+    ("open_threads", "open thread"),
+)
+
+
+def _narrative_from_sections(agent: dict, mems: list[dict], sections: dict) -> str:
+    """Terse prose salvaged from the structured sections when the model returned
+    them but omitted the narrative — a useful placeholder beats a blank row."""
+    name = agent.get("display_name") or agent.get("agent_id")
+    parts = []
+    for key, label in _SECTION_LABELS:
+        n = len(sections.get(key) or [])
+        if n:
+            parts.append(f"{n} {label}{'' if n == 1 else 's'}")
+    if parts:
+        return f"{name}: {', '.join(parts)} across {len(mems)} durable memories."
+    return f"{name} recorded {len(mems)} durable memories this period."
 
 
 def _build_prompt(agent: dict, mems: list[dict], period: str) -> str:
@@ -135,9 +155,12 @@ async def _summarize_agent(
         elif not narrative:
             # The provider uses strict=False (no server-side schema enforcement)
             # and there's no Pydantic guardrail here, so a real response can omit
-            # the narrative — treat that as an error, not a NULL "ok" row.
-            status = "error"
-            error = "LLM returned no narrative"
+            # the narrative. Salvage one from the structured sections and mark it
+            # fallback — a useful placeholder beats a blank error row (which is
+            # what agents like memclaw-insighter were producing in prod).
+            narrative = _narrative_from_sections(agent, mems, sections)
+            status = "fallback"
+            error = "LLM returned no narrative; synthesized from sections"
     except Exception as exc:  # storage/unexpected — real errors, not LLM fallback
         status, error = "error", repr(exc)
         logger.warning("agent_digest: summarize failed for %s/%s: %r", org_id, agent.get("agent_id"), exc)
@@ -195,7 +218,14 @@ async def generate_for_org(
     window_start = window_end - timedelta(days=days)
     top_n = int(config.get("top_n") or 25)
     max_mems = int(config.get("max_memories_per_agent") or 60)
-    min_activity = int(config.get("min_activity_threshold") or 3)
+    # Scale the activity floor to the window: a daily span is ~1/7 of a week, so
+    # applying the (week-tuned) threshold to a day starves the daily digest —
+    # in prod only ~3 agents/day clear it. Daily surfaces every active agent
+    # (floor 1); weekly keeps the configurable floor.
+    if period == "week":
+        min_activity = int(config.get("min_activity_threshold") or 3)
+    else:
+        min_activity = 1
     model = config.get("model") or "gpt-5.4-mini"
     provider = config.get("provider") or "openai"
     max_cost = float(config.get("max_cost_per_run_usd") or 0)

--- a/core-api/tests/test_agent_digest.py
+++ b/core-api/tests/test_agent_digest.py
@@ -72,17 +72,35 @@ def wire(monkeypatch):
 
 
 async def test_generates_only_for_agents_above_threshold(wire):
+    # period="week" so the configured min_activity_threshold=3 applies (daily is
+    # floored to 1 — see test_daily_threshold_is_one).
     storage = wire(
         FakeStorage(
             [{"agent_id": "a", "fleet_id": None}, {"agent_id": "b", "fleet_id": "f1"}],
             {"a": [_mem(agent="a")] * 4, "b": [_mem(agent="b")] * 2},  # b below min_activity=3
         )
     )
-    summary = await agent_digest.generate_for_org("org1", "day", CONFIG, now=NOW)
+    summary = await agent_digest.generate_for_org("org1", "week", CONFIG, now=NOW)
     assert summary["generated"] == 1
     assert [r["agent_id"] for r in storage.upserts] == ["a"]
     assert storage.upserts[0]["status"] == "ok"
     assert storage.upserts[0]["source_count"] == 4
+
+
+async def test_daily_threshold_is_one(wire):
+    """Daily windows floor the activity threshold to 1 regardless of config, so a
+    barely-active agent still gets a daily digest (weekly would exclude it)."""
+    seed = {"a": [_mem(agent="a")] * 2, "b": [_mem(agent="b")] * 1}
+    agents = [{"agent_id": "a", "fleet_id": None}, {"agent_id": "b", "fleet_id": None}]
+
+    day = wire(FakeStorage(agents, seed))
+    s_day = await agent_digest.generate_for_org("org1", "day", CONFIG, now=NOW)
+    assert s_day["generated"] == 2  # both included at floor 1
+    assert sorted(r["agent_id"] for r in day.upserts) == ["a", "b"]
+
+    week = wire(FakeStorage(agents, seed))
+    s_week = await agent_digest.generate_for_org("org1", "week", CONFIG, now=NOW)
+    assert s_week["generated"] == 0  # both below the week floor of 3
 
 
 async def test_cohesive_filter_drops_noise_and_episodes(wire):
@@ -208,22 +226,23 @@ async def test_weekly_window_aligns_to_monday(wire):
     assert row["window_start"] == "2026-06-29T00:00:00+00:00"  # previous Monday
 
 
-async def test_empty_narrative_from_real_llm_is_error(monkeypatch, wire):
-    """A real (non-fallback) response missing the narrative is an error row, not
-    a NULL 'ok' row."""
+async def test_empty_narrative_from_real_llm_is_fallback_with_synthesis(monkeypatch, wire):
+    """A real response missing the narrative is salvaged from sections and marked
+    fallback (a useful placeholder) — never a blank error row."""
     storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 3}))
 
     async def _empty_cwf(provider, call_fn, fake_fn, **kw):
-        return {"shipped": ["x"]}  # no narrative key
+        return {"shipped": ["x", "y"]}  # sections present, no narrative key
 
     monkeypatch.setattr(agent_digest, "call_with_fallback", _empty_cwf)
     summary = await agent_digest.generate_for_org("org1", "day", CONFIG, now=NOW)
     row = storage.upserts[0]
-    assert row["status"] == "error"
-    assert row["error_detail"] == "LLM returned no narrative"
-    assert row["narrative"] is None
-    assert summary["errored"] == 1
+    assert row["status"] == "fallback"
+    assert row["narrative"] and "2 shipped items" in row["narrative"]  # synthesized
+    assert row["error_detail"] == "LLM returned no narrative; synthesized from sections"
+    assert summary["fallback"] == 1
     assert summary["generated"] == 0
+    assert summary["errored"] == 0
 
 
 async def test_upsert_failure_counts_as_errored(wire):


### PR DESCRIPTION
## Why
Prod review of the merged daily agent-activity digest (both eToro fleets) showed near-empty output. The latest daily run produced **3 rows across two 300+-agent tenants**, and **2 of 3 were dead `error` rows** (`memclaw-insighter`, `"LLM returned no narrative"`) that render blank in the UI.

Grounded findings (read-only prod queries):
- **Sparse daily activity is the real bottleneck**, not the corpus: only ~3 distinct agents/tenant write durable memories per *day* (vs 8–13 per *week*). `episode` (32k/7d — the raw firehose) is the only excluded type and correctly so; the shared noise-title filter drops genuine heartbeat/health noise (34% of `action`, 61% of `outcome`). **Corpus left untouched** — loosening it mostly re-admits noise and is shared with the live report.
- `min_activity_threshold=3` over a 1-day window then trims the ~3 daily agents down to ~1.
- Empty-narrative responses became blank `error` rows (worse than a placeholder).

## What
1. **Salvage empty narratives** → `fallback` (not `error`). If a real response omits the narrative, synthesize a terse one from the structured `sections` (`"Agent: 2 decisions, 1 shipped item across N durable memories."`); `error_detail` records why. Actual exceptions still → `error`.
2. **Period-scaled activity floor**: daily floors to `1` (surface every active agent); weekly keeps the configurable `min_activity_threshold`.

Not included (separate, by design): making **weekly the primary UI surface** (data is 4–5× richer weekly) and verifying the weekly cron is live on-prem for Monday — tracked separately.

## Tests
`test_daily_threshold_is_one` (day floor 1 vs week floor 3), rewrote the empty-narrative test to assert `fallback` + synthesized narrative, updated the threshold test to `week`. ruff + format + mypy clean (186 files); 16 generator unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)