### PR TITLE
fix(recall): don't inflate recall_count on agentless recalls (A26)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/track_recalls.py
+++ b/core-api/src/core_api/pipeline/steps/search/track_recalls.py
@@ -42,6 +42,19 @@ class TrackRecalls:
         return "track_recalls"
 
     async def execute(self, ctx: PipelineContext) -> StepResult | None:
+        # ``recall_count`` is a per-memory "an agent found this useful" signal,
+        # and it feeds ``recall_boost`` in scoring. Only bump it for recalls
+        # that carry a caller agent identity. Agentless ``/search`` traffic —
+        # liveness/health probes, monitoring pollers, dashboard/admin queries
+        # that hit the endpoint with no agent — is not an agent using memory;
+        # counting it inflates ``recall_count`` (and thus ``recall_boost``) with
+        # non-agent noise and can pin a single memory under a repeating probe.
+        # ``caller_agent_id`` is the authenticated identity (``filter_agent_id``
+        # or ``auth.agent_id``), so genuine agent recalls — including cross-agent
+        # ones that omit ``filter_agent_id`` — still count. Results are returned
+        # unchanged either way; only the counter bump is skipped. (Gap A26.)
+        if not ctx.data.get("caller_agent_id"):
+            return None
         memory_ids = [row.Memory.id for row in ctx.data["filtered_rows"]]
         if memory_ids:
             track_task(_track_recalls_background(memory_ids))

--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -283,7 +283,9 @@ async def test_track_recalls_fire_and_forget():
 
     mock_db = AsyncMock()
     ctx = PipelineContext(
-                data={"filtered_rows": rows},
+                # caller_agent_id present → genuine agent recall, so recall_count
+                # is bumped (agentless recalls are skipped; see track_recalls).
+                data={"filtered_rows": rows, "caller_agent_id": "test-agent"},
     )
 
     with patch("core_api.pipeline.steps.search.track_recalls.track_task") as mock_track:

--- a/tests/test_track_recalls_agentless.py
+++ b/tests/test_track_recalls_agentless.py
@@ -1,0 +1,55 @@
+"""TrackRecalls should bump recall_count only for recalls with a caller agent
+identity — agentless /search (health probes, monitoring, dashboard/admin) must
+not inflate recall_count / recall_boost (gap A26).
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search import track_recalls as tr
+
+
+def _row():
+    return SimpleNamespace(Memory=SimpleNamespace(id=uuid4()))
+
+
+def _ctx(caller_agent_id):
+    return PipelineContext(
+        data={"caller_agent_id": caller_agent_id, "filtered_rows": [_row(), _row()]}
+    )
+
+
+async def _run(monkeypatch, caller_agent_id):
+    calls = []
+
+    def fake_track_task(coro):
+        calls.append(coro)
+        coro.close()  # never actually run the background bump; avoid "never awaited"
+
+    monkeypatch.setattr(tr, "track_task", fake_track_task)
+    await tr.TrackRecalls().execute(_ctx(caller_agent_id))
+    return calls
+
+
+async def test_counts_for_real_agent(monkeypatch):
+    calls = await _run(monkeypatch, "brandclaw")
+    assert len(calls) == 1  # genuine agent recall → recall_count bumped
+
+
+async def test_skips_when_agent_id_none(monkeypatch):
+    calls = await _run(monkeypatch, None)
+    assert calls == []  # agentless (probe/monitoring) → no bump
+
+
+async def test_skips_when_agent_id_empty(monkeypatch):
+    calls = await _run(monkeypatch, "")
+    assert calls == []  # empty identity → no bump
+
+
+async def test_no_rows_no_bump(monkeypatch):
+    calls = []
+    monkeypatch.setattr(tr, "track_task", lambda c: (calls.append(c), c.close()))
+    ctx = PipelineContext(data={"caller_agent_id": "brandclaw", "filtered_rows": []})
+    await tr.TrackRecalls().execute(ctx)
+    assert calls == []


### PR DESCRIPTION
## Problem

`recall_count` is a per-memory *"an agent found this useful"* signal, and it feeds `recall_boost` in scoring. `TrackRecalls` bumps it for **every** `/search` return — including **agentless** traffic: liveness/health probes, monitoring pollers, and dashboard/admin queries that hit `/search` with no agent identity.

None of those are an agent using memory, yet they:
- inflate `recall_count` (and the `recall_boost` that rides on it) with non-agent noise, and
- let a repeating automated caller **pin a single memory's counter** — e.g. a health check calling `/search` thousands of times a day at `top_k=1` hammers one memory's `recall_count`, which then gets boosted for everyone.

## Fix

Skip the `recall_count` bump when there's no caller agent identity:

```python
if not ctx.data.get("caller_agent_id"):
    return None
```

`caller_agent_id` is the authenticated identity (`filter_agent_id` or `auth.agent_id`), so **genuine agent recalls still count** — including cross-agent recalls that omit `filter_agent_id` and fall back to `auth.agent_id`. Search **results are returned unchanged**; only the counter increment is skipped.

## Why it generalizes

This isn't specific to one deployment — any environment with automated `/search` callers (health checks, monitoring, pipelines, dashboards) currently skews the usefulness signal and the `recall_boost` derived from it. Restricting the counter to identified-agent recalls makes `recall_count` mean what it's supposed to mean everywhere. (Addresses gap **A26** — self-reinforcing `recall_boost` with no usefulness signal.)

## Tests

`tests/test_track_recalls_agentless.py` — bump fires for a real agent, is skipped for `None`/empty caller identity, and is a no-op when there are no rows. Guard logic also verified standalone against the real `TrackRecalls.execute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)