### PR TITLE
feat(memories): attribute broker bulk writes to the originating agent

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -42,6 +42,7 @@ from core_api.middleware.rate_limit import search_limit, write_bulk_limit, write
 from core_api.pagination import decode_cursor, encode_cursor
 from core_api.schemas import (
     BulkMemoryCreate,
+    BulkMemoryItem,
     BulkMemoryResponse,
     IngestCommitRequest,
     IngestRequest,
@@ -931,7 +932,9 @@ async def write_memories_bulk(
     # — the broker's own per-
     # session ``client_hash`` de-dup is the design contract per
     # cloud-data-plane.md §2.4 (gap G3). Server-derive a per-request
-    # attempt id and attribute writes to the install. Non-broker
+    # attempt id and attribute the write to the agent the batch's per-item
+    # metadata names (memclawd Layer 1 stamps ``metadata.agent_id``); a mixed
+    # or pre-Layer-1 batch falls back to the install. Non-broker
     # callers (dashboard, SDK) keep the CAURA-602 invariants in full.
     if auth.is_install_credential:
         if not bulk_attempt_id:
@@ -939,7 +942,7 @@ async def write_memories_bulk(
 
             bulk_attempt_id = f"broker-{auth.install_uuid or 'unknown'}-{_uuid.uuid4()}"
         if not body.agent_id:
-            body.agent_id = f"broker:{auth.install_uuid or 'unknown'}"
+            body.agent_id = _broker_write_agent_id(body.items, auth.install_uuid)
     # Resolve a missing agent_id (mirrors write_memory). Install-credential
     # callers were already attributed above; everyone else either gets the
     # reserved standalone identity or must name a real agent. Defaulting
@@ -976,6 +979,29 @@ async def write_memories_bulk(
         return JSONResponse(content=_body, status_code=_status)
     async with per_tenant_slot("write", body.tenant_id):
         return await _write_memories_bulk_inner(body, response, auth, _idem, bulk_attempt_id)
+
+
+def _broker_write_agent_id(items: list[BulkMemoryItem], install_uuid: str | None) -> str:
+    """Attribute a broker (install-credential) bulk write to the agent that
+    produced it, when the batch unambiguously names one.
+
+    Each item's ``metadata.agent_id`` is stamped by the broker from the
+    capturing agent (memclawd Layer 1). When every item that carries an
+    agent_id agrees on a single value, the write is attributed to that agent —
+    so the memory view names the agent, not the bare install. Items with no
+    agent_id abstain rather than veto, so a mixed pre-Layer-1/Layer-1 batch that
+    still names a single agent attributes to it. A batch where named items
+    disagree, or where no item carries an agent_id at all, falls back to the
+    install identity; a write is never mis-attributed to the wrong agent.
+    """
+    agent_ids: set[str] = set()
+    for item in items:
+        aid = (item.metadata or {}).get("agent_id")
+        if isinstance(aid, str) and aid:
+            agent_ids.add(aid)
+    if len(agent_ids) == 1:
+        return next(iter(agent_ids))
+    return f"broker:{install_uuid or 'unknown'}"
 
 
 def _bulk_response(result: BulkMemoryResponse) -> JSONResponse:

--- a/core-api/tests/test_broker_write_attribution.py
+++ b/core-api/tests/test_broker_write_attribution.py
@@ -1,0 +1,54 @@
+"""Unit tests for broker (install-credential) bulk-write agent attribution.
+
+memclawd Layer 1 stamps each capture's ``metadata.agent_id`` with the agent that
+produced it. Layer 2 (``_broker_write_agent_id``) attributes a broker bulk write
+to that agent when the batch unambiguously names one — so the memory view shows
+the agent instead of the bare install. A mixed batch, or a pre-Layer-1 broker
+that sends no per-item agent_id, falls back to the install identity so a write
+is never mis-attributed.
+"""
+
+from __future__ import annotations
+
+from core_api.routes.memories import _broker_write_agent_id
+from core_api.schemas import BulkMemoryItem
+
+_INSTALL = "8fd60b3e-7369-4938-bee9-c55d07be3c67"
+_AGENT = "ea41b380-fdf6-5f08-acc2-420c45acb670"
+_AGENT2 = "93ca3edd-1219-518a-9360-2d1c00b22532"
+
+
+def _item(agent_id: str | None) -> BulkMemoryItem:
+    meta = {"agent_id": agent_id} if agent_id is not None else None
+    return BulkMemoryItem(content="x", metadata=meta)
+
+
+def test_unanimous_agent_is_used():
+    items = [_item(_AGENT), _item(_AGENT)]
+    assert _broker_write_agent_id(items, _INSTALL) == _AGENT
+
+
+def test_mixed_agents_fall_back_to_install():
+    items = [_item(_AGENT), _item(_AGENT2)]
+    assert _broker_write_agent_id(items, _INSTALL) == f"broker:{_INSTALL}"
+
+
+def test_no_metadata_falls_back_to_install():
+    items = [_item(None), _item(None)]
+    assert _broker_write_agent_id(items, _INSTALL) == f"broker:{_INSTALL}"
+
+
+def test_empty_agent_id_is_ignored():
+    items = [_item(""), _item("")]
+    assert _broker_write_agent_id(items, _INSTALL) == f"broker:{_INSTALL}"
+
+
+def test_single_named_agent_among_unnamed_items_wins():
+    # A pre-Layer-1 item (no agent_id) mixed with Layer-1 items that all name
+    # the same agent: the one distinct agent still attributes the write.
+    items = [_item(None), _item(_AGENT), _item(_AGENT)]
+    assert _broker_write_agent_id(items, _INSTALL) == _AGENT
+
+
+def test_missing_install_uuid_falls_back_to_unknown():
+    assert _broker_write_agent_id([_item(None)], None) == "broker:unknown"


### PR DESCRIPTION
## What

A broker (install-credential) bulk write carries no request-level `agent_id`, so the cloud attributed every such write to a synthetic `broker:<install_uuid>` identity — the memory view (Prism) shows `broker-<id>`, with no way to tell **which agent** produced a memory (feedback from the broker walkthrough).

## How

memclawd **Layer 1** (already merged, `caura-ai/memclawd#82`) now stamps each capture's `metadata.agent_id` with the capturing agent. **Layer 2** (this PR): when a broker batch's per-item metadata **unanimously** names one agent, attribute the write to that agent — so the memory view names it. A **mixed batch**, or a **pre-Layer-1 broker** (v0.8.3, no per-item `agent_id`), falls back to `broker:<install_uuid>` — the exact prior behavior, so a write is **never mis-attributed**.

New pure helper `_broker_write_agent_id(items, install_uuid)` in `routes/memories.py`, wired into the install-credential branch of the bulk-write handler.

## Scope

Attribution stays **request-level** (one `agent_id` per batch — `get_or_create_agent` / fleet-enforcement / quota / idempotency all assume this). Per-item attribution (each memory to its own agent) would require re-scoping all of those and is a larger multi-layer change, out of scope for this cut. In practice memclawd flushes one agent's captures per batch, so the unanimous case is the common one; mixed batches simply degrade to today's behavior.

## Tests

`core-api/tests/test_broker_write_attribution.py` — unit tests for the helper: unanimous → agent, mixed → install, no-metadata → install, empty-id ignored, single-named-among-unnamed → agent, missing install → `broker:unknown`. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
