### PR TITLE
feat(interview): Interviewer Phase 1 — server side (submit endpoint, worker, scheduler)

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -52,6 +52,7 @@ from core_api.routes.evolve import router as evolve_router
 from core_api.routes.fleet import router as fleet_router
 from core_api.routes.health import router as health_router
 from core_api.routes.insights import router as insights_router
+from core_api.routes.interview import router as interview_router
 from core_api.routes.keystones import router as keystones_router
 from core_api.routes.lifecycle import router as lifecycle_router
 from core_api.routes.memories import admin_memories_router
@@ -650,6 +651,7 @@ app.include_router(plugin_bootstrap_router, prefix="/api")
 app.include_router(stats_router, prefix="/api/v1")
 app.include_router(stm_router, prefix="/api/v1")
 app.include_router(insights_router, prefix="/api/v1")
+app.include_router(interview_router, prefix="/api/v1")
 app.include_router(evolve_router, prefix="/api/v1")
 app.include_router(lifecycle_router, prefix="/api/v1")
 app.include_router(org_deletion_router, prefix="/api/v1")

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2057,12 +2057,16 @@ class CoreStorageClient:
         tenant_id: str,
         node_name: str | None = None,
         status: str | None = None,
+        command: str | None = None,
+        limit: int = 50,
     ) -> list[dict]:
-        params: dict[str, Any] = {"tenant_id": tenant_id}
+        params: dict[str, Any] = {"tenant_id": tenant_id, "limit": limit}
         if node_name is not None:
             params["node_name"] = node_name
         if status is not None:
             params["status"] = status
+        if command is not None:
+            params["command"] = command
         return await self._get_list("/fleet/commands", **params)
 
     async def update_command_status(
@@ -2413,6 +2417,13 @@ class CoreStorageClient:
         result = await self._get("/tenants/agent-digest-enabled")
         if result is None:
             raise RuntimeError("core-storage-api /tenants/agent-digest-enabled returned 404")
+        return result.get("org_ids", [])
+
+    async def list_interviewer_enabled_orgs(self) -> list[str]:
+        """Orgs whose ``interviewer.enabled`` setting is True."""
+        result = await self._get("/tenants/interviewer-enabled")
+        if result is None:
+            raise RuntimeError("core-storage-api /tenants/interviewer-enabled returned 404")
         return result.get("org_ids", [])
 
     # =====================================================================

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -615,10 +615,12 @@ CRYSTALLIZER_MAX_DEDUP_PAIRS = 1000  # safety valve: cap total near-dup pairs pe
 
 # ── Interviewer (Phase 1) ──
 # Scheduled reflective work-reports (docs/plans/interviewer-phase1-decisions.md).
-INTERVIEW_MAX_EVENTS_PER_SUBMIT = 500  # plugin-side submit cap; the cursor-driven catch-up loop drains any backlog
+INTERVIEW_MAX_EVENTS_PER_SUBMIT = (
+    500  # plugin-side submit cap; the cursor-driven catch-up loop drains any backlog
+)
 INTERVIEW_EVENT_MAX_CHARS = 8_000  # per-event content truncation before masking/prompting
 INTERVIEW_CHUNK_MAX_CHARS = 96_000  # ~24k tokens per map-phase chunk
-INTERVIEW_MAX_ITEMS_PER_SECTION = 15  # 6 sections × 15 = 90, safely under BULK_MAX_ITEMS
+INTERVIEW_MAX_ITEMS_PER_SECTION = 15  # 6 sections x 15 = 90, safely under BULK_MAX_ITEMS
 INTERVIEW_MAX_KEYSTONES_IN_PROMPT = 8
 INTERVIEW_TEMPERATURE = 0.2
 

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -613,6 +613,15 @@ CRYSTALLIZER_DEDUP_BATCH_SIZE = 500  # memories per ANN batch during dedup scan
 CRYSTALLIZER_DEDUP_NEIGHBORS = 5  # top-K neighbors to check per memory
 CRYSTALLIZER_MAX_DEDUP_PAIRS = 1000  # safety valve: cap total near-dup pairs per run
 
+# ── Interviewer (Phase 1) ──
+# Scheduled reflective work-reports (docs/plans/interviewer-phase1-decisions.md).
+INTERVIEW_MAX_EVENTS_PER_SUBMIT = 500  # plugin-side submit cap; the cursor-driven catch-up loop drains any backlog
+INTERVIEW_EVENT_MAX_CHARS = 8_000  # per-event content truncation before masking/prompting
+INTERVIEW_CHUNK_MAX_CHARS = 96_000  # ~24k tokens per map-phase chunk
+INTERVIEW_MAX_ITEMS_PER_SECTION = 15  # 6 sections × 15 = 90, safely under BULK_MAX_ITEMS
+INTERVIEW_MAX_KEYSTONES_IN_PROMPT = 8
+INTERVIEW_TEMPERATURE = 0.2
+
 # ── Bulk write ──
 BULK_MAX_ITEMS = 100  # max memories per bulk request
 BULK_EMBEDDING_CONCURRENCY = 10  # max parallel embedding calls in bulk mode

--- a/core-api/src/core_api/routes/interview.py
+++ b/core-api/src/core_api/routes/interview.py
@@ -20,8 +20,8 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from core_api.auth import AuthContext, get_auth_context
-from core_api.constants import INTERVIEW_MAX_EVENTS_PER_SUBMIT
-from core_api.services.interview_service import run_interview
+from core_api.constants import INTERVIEW_EVENT_MAX_CHARS, INTERVIEW_MAX_EVENTS_PER_SUBMIT
+from core_api.services.interview_service import run_interview, run_interview_schedule
 from core_api.services.organization_settings import get_settings_for_display
 
 router = APIRouter(tags=["Interview"])
@@ -35,7 +35,10 @@ class InterviewEventIn(BaseModel):
     session_id: str | None = None
     role: str = Field(min_length=1, max_length=64)
     kind: str = Field(min_length=1, max_length=64)
-    content: str = Field(min_length=0, max_length=32_000)
+    # Matches the worker's processing limit (mask_events truncates to the
+    # same constant) — accepting more would silently drop the excess from
+    # the LLM prompt with no error to the plugin caller.
+    content: str = Field(min_length=0, max_length=INTERVIEW_EVENT_MAX_CHARS)
     tool: str | None = Field(default=None, max_length=200)
     outcome: str | None = Field(default=None, max_length=200)
 
@@ -82,8 +85,8 @@ async def submit_interview(
     if body.cursor_to < body.cursor_from:
         raise HTTPException(status_code=422, detail="cursor_to must be >= cursor_from")
     seqs = [ev.seq for ev in body.events]
-    if seqs != sorted(seqs):
-        raise HTTPException(status_code=422, detail="events must be seq-ascending")
+    if any(seqs[i] >= seqs[i + 1] for i in range(len(seqs) - 1)):
+        raise HTTPException(status_code=422, detail="events must be strictly seq-ascending (no duplicates)")
     if seqs[0] < body.cursor_from or seqs[-1] > body.cursor_to:
         raise HTTPException(
             status_code=422,
@@ -110,10 +113,27 @@ async def submit_interview(
 
     if result["status"] == "failed":
         # Whole window failed to persist: watermark NOT advanced; the
-        # plugin must NOT prune. 502 → the command retries next tick.
-        raise HTTPException(status_code=502, detail="interview ingest failed; window not consumed")
+        # plugin must NOT prune. 500 (origin error, not 502 — proxies/ALBs
+        # rewrite 502 and strip the JSON body) → the command retries next
+        # tick (caller checks >= 400).
+        raise HTTPException(status_code=500, detail="interview ingest failed; window not consumed")
     if result["status"] == "partial":
         # Mirror the bulk endpoint's 207 semantics: some rows landed, the
         # cursor advanced, caller reads per-field detail.
         return JSONResponse(status_code=207, content=InterviewSubmitOut(**result).model_dump())
     return InterviewSubmitOut(**result)
+
+
+@router.post("/admin/interview/schedule/run")
+async def run_interview_schedule_endpoint(
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict:
+    """Queue due ``interview_request`` fleet commands (admin/cron only).
+
+    The core-operations hourly tick POSTs this. Enumerates orgs with
+    ``interviewer.enabled``, and per live node queues at most one pending
+    command, gated by the watermark's ``last_interview_at`` against the
+    tenant's ``period_hours``. Returns a bounded counts summary.
+    """
+    auth.enforce_admin()
+    return await run_interview_schedule()

--- a/core-api/src/core_api/routes/interview.py
+++ b/core-api/src/core_api/routes/interview.py
@@ -1,0 +1,119 @@
+"""Interviewer Phase 1 — the submit endpoint.
+
+``POST /api/v1/interview/submit`` receives one node's buffered event
+window from the OpenClaw plugin (delivered in response to an
+``interview_request`` fleet command) and hands it to the interview worker
+(``services/interview_service.py``): mask → chunked interview → typed
+memories via the idempotent bulk path → forward-only watermark.
+
+Dark by default: the per-tenant ``interviewer.enabled`` flag gates the
+endpoint (the scheduler also never queues commands for disabled tenants —
+this check is defense in depth, mirroring the skills_factory pattern).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from core_api.auth import AuthContext, get_auth_context
+from core_api.constants import INTERVIEW_MAX_EVENTS_PER_SUBMIT
+from core_api.services.interview_service import run_interview
+from core_api.services.organization_settings import get_settings_for_display
+
+router = APIRouter(tags=["Interview"])
+
+
+class InterviewEventIn(BaseModel):
+    """One normalized trail event (contract C2)."""
+
+    seq: int = Field(ge=0)
+    ts: datetime
+    session_id: str | None = None
+    role: str = Field(min_length=1, max_length=64)
+    kind: str = Field(min_length=1, max_length=64)
+    content: str = Field(min_length=0, max_length=32_000)
+    tool: str | None = Field(default=None, max_length=200)
+    outcome: str | None = Field(default=None, max_length=200)
+
+
+class InterviewSubmitIn(BaseModel):
+    tenant_id: str | None = None
+    fleet_id: str | None = None
+    node_id: str = Field(min_length=1, max_length=200)
+    # The WORKER agent the window belongs to (memory subject).
+    agent_id: str = Field(min_length=1, max_length=200)
+    command_id: str | None = Field(default=None, max_length=200)
+    cursor_from: int = Field(ge=0)
+    cursor_to: int = Field(ge=0)
+    events: list[InterviewEventIn] = Field(min_length=1, max_length=INTERVIEW_MAX_EVENTS_PER_SUBMIT)
+
+
+class InterviewSubmitOut(BaseModel):
+    status: str  # committed | partial | failed
+    watermark: int | None
+    memories_written: int
+    errors: int
+
+
+@router.post("/interview/submit", response_model=InterviewSubmitOut)
+async def submit_interview(
+    body: InterviewSubmitIn,
+    auth: AuthContext = Depends(get_auth_context),
+):
+    """Interview one node's event window and persist the report as memories.
+
+    Idempotent per (node, window): the worker derives the bulk attempt id
+    from ``sha1(node_id:cursor_from:cursor_to)`` server-side, so any retry
+    of the same window resolves to ``duplicate_attempt`` rows and a
+    forward-only watermark — never duplicates, never a gap.
+    """
+    auth.enforce_read_only()
+    auth.enforce_usage_limits()
+
+    tenant_id = body.tenant_id or auth.tenant_id
+    if not tenant_id:
+        raise HTTPException(status_code=400, detail="tenant_id required")
+    auth.enforce_tenant(tenant_id)
+
+    if body.cursor_to < body.cursor_from:
+        raise HTTPException(status_code=422, detail="cursor_to must be >= cursor_from")
+    seqs = [ev.seq for ev in body.events]
+    if seqs != sorted(seqs):
+        raise HTTPException(status_code=422, detail="events must be seq-ascending")
+    if seqs[0] < body.cursor_from or seqs[-1] > body.cursor_to:
+        raise HTTPException(
+            status_code=422,
+            detail="event seq range must lie within [cursor_from, cursor_to]",
+        )
+
+    settings = await get_settings_for_display(tenant_id)
+    interviewer_cfg = settings.get("interviewer") or {}
+    if not interviewer_cfg.get("enabled"):
+        # Defense in depth: the scheduler shouldn't have queued a command
+        # for a disabled tenant; refuse rather than silently ingest.
+        raise HTTPException(status_code=403, detail="interviewer is not enabled for this tenant")
+
+    result = await run_interview(
+        tenant_id=tenant_id,
+        fleet_id=body.fleet_id,
+        agent_id=body.agent_id,
+        node_id=body.node_id,
+        command_id=body.command_id,
+        cursor_from=body.cursor_from,
+        cursor_to=body.cursor_to,
+        events=[ev.model_dump(mode="json") for ev in body.events],
+    )
+
+    if result["status"] == "failed":
+        # Whole window failed to persist: watermark NOT advanced; the
+        # plugin must NOT prune. 502 → the command retries next tick.
+        raise HTTPException(status_code=502, detail="interview ingest failed; window not consumed")
+    if result["status"] == "partial":
+        # Mirror the bulk endpoint's 207 semantics: some rows landed, the
+        # cursor advanced, caller reads per-field detail.
+        return JSONResponse(status_code=207, content=InterviewSubmitOut(**result).model_dump())
+    return InterviewSubmitOut(**result)

--- a/core-api/src/core_api/services/interview_service.py
+++ b/core-api/src/core_api/services/interview_service.py
@@ -37,10 +37,12 @@ from core_api.constants import (
     INTERVIEW_MAX_KEYSTONES_IN_PROMPT,
     INTERVIEW_TEMPERATURE,
     MAX_CONTENT_LENGTH,
+    NODE_OFFLINE_SECONDS,
 )
 from core_api.schemas import BulkMemoryCreate, BulkMemoryItem, BulkMemoryResponse
 from core_api.services.memory_service import create_memories_bulk
-from core_api.services.organization_settings import resolve_config
+from core_api.services.organization_settings import get_settings_for_display, resolve_config
+from core_api.services.tenants import list_tenants_with_interviewer_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -84,22 +86,34 @@ def watermark_doc_id(node_id: str) -> str:
 
 
 def mask_events(events: list[dict]) -> tuple[list[dict], int]:
-    """Deterministically mask PII/secrets in event content pre-LLM.
+    """Deterministically mask PII/secrets in event fields pre-LLM.
 
-    All categories are scanned unconditionally: this runs before the
-    tenant-configurable persistence gate, and a masked token in the
-    interview prompt is always acceptable while a leaked secret is not.
-    Returns the masked copies and the total finding count (audit/log).
+    Covers every field that reaches the prompt via ``_serialize_events``:
+    ``content``, ``tool``, and ``outcome``. All categories are scanned
+    unconditionally: this runs before the tenant-configurable persistence
+    gate, and a masked token in the interview prompt is always acceptable
+    while a leaked secret is not. Returns the masked copies and the total
+    finding count (audit/log).
     """
+
+    def _mask_field(text: str | None, max_len: int) -> tuple[str, int]:
+        val = (text or "")[:max_len]
+        findings = scan(val)
+        return (mask(val, findings) if findings else val), len(findings)
+
     masked: list[dict] = []
     total = 0
     for ev in events:
-        content = (ev.get("content") or "")[:INTERVIEW_EVENT_MAX_CHARS]
-        findings = scan(content)
-        if findings:
-            total += len(findings)
-            content = mask(content, findings)
-        masked.append({**ev, "content": content})
+        masked_content, n1 = _mask_field(ev.get("content"), INTERVIEW_EVENT_MAX_CHARS)
+        masked_tool, n2 = _mask_field(ev.get("tool"), 200)
+        masked_outcome, n3 = _mask_field(ev.get("outcome"), 200)
+        total += n1 + n2 + n3
+        update: dict = {"content": masked_content}
+        if ev.get("tool") is not None:
+            update["tool"] = masked_tool
+        if ev.get("outcome") is not None:
+            update["outcome"] = masked_outcome
+        masked.append({**ev, **update})
     return masked, total
 
 
@@ -112,7 +126,15 @@ def chunk_events(events: list[dict]) -> list[list[dict]]:
     current: list[dict] = []
     size = 0
     for ev in events:
-        ev_len = len(ev.get("content") or "") + 64  # + envelope overhead
+        # Budget every field _serialize_events puts on the prompt line:
+        # content, tool (" tool="), outcome (" outcome="), plus the
+        # seq/ts/session/role envelope.
+        ev_len = (
+            len(ev.get("content") or "")
+            + (len(ev.get("tool") or "") + 6 if ev.get("tool") else 0)
+            + (len(ev.get("outcome") or "") + 9 if ev.get("outcome") else 0)
+            + 80
+        )
         if current and size + ev_len > INTERVIEW_CHUNK_MAX_CHARS:
             chunks.append(current)
             current, size = [], 0
@@ -253,7 +275,13 @@ def _parse_ts(value: Any) -> datetime | None:
     if not value or not isinstance(value, str):
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        # LLM-emitted timestamps may omit the offset; treat naive as UTC so
+        # downstream aware/naive comparisons and timestamptz storage don't
+        # break.
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
     except ValueError:
         return None
 
@@ -327,6 +355,20 @@ async def _keystone_lines(tenant_id: str, fleet_id: str | None, agent_id: str) -
 # ── Watermark ──
 
 
+async def _read_watermark_seq(sc, tenant_id: str, doc_id: str) -> int:
+    doc = await sc.get_document(tenant_id, WATERMARK_COLLECTION, doc_id, read=False)
+    if doc and isinstance(doc.get("data"), dict):
+        try:
+            return int(doc["data"].get("last_seq", -1))
+        except (TypeError, ValueError):
+            return -1
+    return -1
+
+
+# Bounded verify-and-repair passes for the read-max-write loop below.
+_WATERMARK_WRITE_ATTEMPTS = 3
+
+
 async def advance_watermark(
     tenant_id: str,
     *,
@@ -340,34 +382,70 @@ async def advance_watermark(
     A stale retry (its ``cursor_to`` at or behind the stored cursor) is a
     no-op — the bulk write already deduplicated its rows, and regressing
     the cursor would re-open a consumed range.
+
+    Concurrency contract: the doc store has no compare-and-set, so a bare
+    read-check-write would be a TOCTOU race. Two mitigations, in order of
+    load-bearing-ness:
+
+    1. **Writers are serialized by design.** The scheduler keeps at most
+       ONE pending ``interview_request`` per node and the plugin processes
+       commands sequentially, so two in-flight submits for the same node
+       only arise from a pathological zombie retry (e.g. a network-delayed
+       resubmit of an old window landing after a newer window committed).
+    2. **Verify-and-repair.** The write is max-preserving (re-reads and
+       writes ``max(stored, cursor_to)``), then verifies the stored value
+       and re-runs the pass if a concurrent smaller write clobbered it
+       (bounded attempts).
+
+    And the invariant is self-healing even if both miss: a regressed
+    cursor only makes the next scheduler tick re-issue an already-consumed
+    window, whose rows dedup via the deterministic bulk attempt id and
+    whose completion re-advances the cursor — wasted work, never data
+    corruption. If the doc store ever grows a conditional upsert /
+    GREATEST semantics, this loop collapses to one call.
     """
     sc = get_storage_client()
     doc_id = watermark_doc_id(node_id)
-    existing = await sc.get_document(tenant_id, WATERMARK_COLLECTION, doc_id, read=False)
-    existing_seq = -1
-    if existing and isinstance(existing.get("data"), dict):
-        try:
-            existing_seq = int(existing["data"].get("last_seq", -1))
-        except (TypeError, ValueError):
-            existing_seq = -1
-    if cursor_to <= existing_seq:
-        return existing_seq
-    await sc.upsert_document(
-        {
-            "tenant_id": tenant_id,
-            "collection": WATERMARK_COLLECTION,
-            "doc_id": doc_id,
-            "data": {
-                "node_id": node_id,
-                "agent_id": agent_id,
+    effective = cursor_to
+    for _attempt in range(_WATERMARK_WRITE_ATTEMPTS):
+        existing_seq = await _read_watermark_seq(sc, tenant_id, doc_id)
+        if cursor_to <= existing_seq:
+            return existing_seq
+        await sc.upsert_document(
+            {
                 "tenant_id": tenant_id,
-                "last_seq": cursor_to,
-                "last_interview_at": datetime.now(UTC).isoformat(),
-                "last_command_id": command_id,
-            },
-        }
-    )
-    return cursor_to
+                "collection": WATERMARK_COLLECTION,
+                "doc_id": doc_id,
+                "data": {
+                    "node_id": node_id,
+                    "agent_id": agent_id,
+                    "tenant_id": tenant_id,
+                    "last_seq": cursor_to,
+                    "last_interview_at": datetime.now(UTC).isoformat(),
+                    "last_command_id": command_id,
+                },
+            }
+        )
+        # Verify: if a concurrent (smaller) writer landed between our write
+        # and this read, repair on the next pass.
+        stored = await _read_watermark_seq(sc, tenant_id, doc_id)
+        if stored >= cursor_to:
+            return stored
+        logger.warning(
+            "interview watermark: concurrent write regressed cursor (tenant=%s node=%s "
+            "stored=%d want=%d); repairing",
+            tenant_id,
+            node_id,
+            stored,
+            cursor_to,
+        )
+    # Verify-and-repair attempts exhausted: report what is actually stored
+    # rather than optimistically claiming ``cursor_to`` landed.
+    try:
+        final_stored = await _read_watermark_seq(sc, tenant_id, doc_id)
+        return final_stored if final_stored >= 0 else effective
+    except Exception:
+        return effective
 
 
 # ── Orchestrator ──
@@ -460,3 +538,139 @@ async def run_interview(
         "memories_written": written,
         "errors": errors,
     }
+
+
+# ── Schedule (cron entry point) ──
+
+
+def _is_due(watermark_data: dict | None, period_hours: int, now: datetime) -> bool:
+    """A node is due when it has never been interviewed, or its last
+    interview is at least one period old."""
+    if not watermark_data:
+        return True
+    last = watermark_data.get("last_interview_at")
+    if not last or not isinstance(last, str):
+        return True
+    try:
+        last_dt = datetime.fromisoformat(last.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    return (now - last_dt).total_seconds() >= period_hours * 3600
+
+
+def _node_is_eligible(node: dict, now: datetime) -> bool:
+    """Live, real nodes only: skip fleet-registration sentinels and nodes
+    whose heartbeat has gone dark (an offline node can't answer the
+    command anyway — it would just sit pending and block the next tick)."""
+    name = node.get("node_name") or ""
+    metadata = node.get("metadata") or {}
+    if metadata.get("sentinel") or name.startswith("_fleet_"):
+        return False
+    hb = node.get("last_heartbeat")
+    if not hb or not isinstance(hb, str):
+        return False
+    try:
+        hb_dt = datetime.fromisoformat(hb.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return (now - hb_dt).total_seconds() <= NODE_OFFLINE_SECONDS
+
+
+async def run_interview_schedule() -> dict:
+    """Queue ``interview_request`` fleet commands for every due node of every
+    opted-in tenant. The core-operations hourly tick calls this via
+    ``POST /admin/interview/schedule/run``.
+
+    Per node, at most ONE interview_request is in flight: an existing
+    pending command skips the node (no stacking while a node is slow or
+    briefly offline). Dueness is driven by the watermark doc's
+    ``last_interview_at`` vs the tenant's ``interviewer.period_hours``, so
+    the same tick cadence serves every tenant regardless of their period —
+    and a backlog (submit cap reached) naturally drains because the
+    watermark's ``last_seq`` advances while ``last_interview_at`` gates the
+    NEXT window. Commands are queued unsigned in OSS (the plugin default is
+    permissive; enterprise signing gateways sign in transit).
+    """
+    sc = get_storage_client()
+    now = datetime.now(UTC)
+    tenants = await list_tenants_with_interviewer_enabled()
+    summary = {
+        "tenants": len(tenants),
+        "nodes_considered": 0,
+        "commands_queued": 0,
+        "skipped_pending": 0,
+        "skipped_not_due": 0,
+    }
+    for tenant_id in tenants:
+        settings = await get_settings_for_display(tenant_id)
+        cfg = settings.get("interviewer") or {}
+        period_hours = int(cfg.get("period_hours") or 12)
+        template_id = cfg.get("template_id") or "default-v1"
+
+        try:
+            nodes = await sc.list_nodes(tenant_id)
+            # High limit so the pending-dedup set is complete for any
+            # realistic fleet size — a truncated set would re-queue nodes
+            # whose pending command fell outside the page.
+            pending = await sc.list_commands(
+                tenant_id, status="pending", command="interview_request", limit=10_000
+            )
+        except Exception:
+            logger.exception("interview schedule: tenant scan failed (tenant=%s)", tenant_id)
+            continue
+        pending_nodes = {str(c.get("node_id")) for c in pending}
+
+        for node in nodes:
+            if not _node_is_eligible(node, now):
+                continue
+            node_id = str(node.get("id") or "")
+            if not node_id:
+                continue
+            summary["nodes_considered"] += 1
+            if node_id in pending_nodes:
+                summary["skipped_pending"] += 1
+                continue
+            # Per-node isolation: one node's storage failure must not abort
+            # scheduling for the tenant's remaining nodes (or later tenants).
+            try:
+                # read=False → primary, matching the advance path: a stale
+                # replica cursor would re-issue a consumed window (dedup makes
+                # it harmless but wasted LLM work) or mis-time dueness.
+                watermark = await sc.get_document(
+                    tenant_id, WATERMARK_COLLECTION, watermark_doc_id(node_id), read=False
+                )
+                data = watermark.get("data") if isinstance(watermark, dict) else None
+                if not _is_due(data, period_hours, now):
+                    summary["skipped_not_due"] += 1
+                    continue
+                last_seq = -1
+                if isinstance(data, dict):
+                    try:
+                        last_seq = int(data.get("last_seq", -1))
+                    except (TypeError, ValueError):
+                        last_seq = -1
+                await sc.create_command(
+                    {
+                        "tenant_id": tenant_id,
+                        "node_id": node_id,
+                        "command": "interview_request",
+                        "payload": {
+                            # Echoed so the plugin submits with the SAME node key
+                            # the watermark is stored under (it only knows its
+                            # node_name locally; the watermark is keyed by the
+                            # fleet-node UUID).
+                            "node_id": node_id,
+                            "since_seq": last_seq + 1,
+                            "template_id": template_id,
+                            "period_hours": period_hours,
+                        },
+                    }
+                )
+                summary["commands_queued"] += 1
+            except Exception:
+                logger.exception(
+                    "interview schedule: node scan failed (tenant=%s node=%s)",
+                    tenant_id,
+                    node_id,
+                )
+    return summary

--- a/core-api/src/core_api/services/interview_service.py
+++ b/core-api/src/core_api/services/interview_service.py
@@ -1,0 +1,462 @@
+"""Interviewer Phase 1 — server-side interview worker.
+
+Consumes a node's buffered event window (submitted by the OpenClaw plugin
+via ``POST /api/v1/interview/submit``), synthesizes a structured reflective
+report with the tenant's LLM, and writes the report's sections as typed
+memories through the existing idempotent bulk-write path.
+
+Design notes (see ``docs/plans/interviewer-phase1-decisions.md``):
+
+- **Mask before the LLM.** Events are PII/secret-masked on receipt with the
+  shared deterministic library (``common.governance``) BEFORE any LLM sees
+  them — the write-pipeline ``GovernanceScanContent`` gate only protects
+  *persistence*, and this worker runs the LLM pre-persistence. The bulk
+  write then re-runs the gate on the report items (defense in depth).
+- **Chunked map-reduce.** Events are split into char-budgeted chunks; each
+  chunk yields a mini-report (map); mini-reports merge into the final
+  report (reduce). Single-chunk windows skip the reduce. The plugin-side
+  submit cap plus the cursor-driven catch-up loop bound total volume.
+- **Watermark is forward-only** and advances only AFTER the bulk write
+  commits (crash anywhere → retry with the same deterministic attempt id
+  → ``duplicate_attempt`` dedup → then the watermark advances).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from common.governance import mask, scan
+from core_api.clients.storage_client import get_storage_client
+from core_api.constants import (
+    INTERVIEW_CHUNK_MAX_CHARS,
+    INTERVIEW_EVENT_MAX_CHARS,
+    INTERVIEW_MAX_ITEMS_PER_SECTION,
+    INTERVIEW_MAX_KEYSTONES_IN_PROMPT,
+    INTERVIEW_TEMPERATURE,
+    MAX_CONTENT_LENGTH,
+)
+from core_api.schemas import BulkMemoryCreate, BulkMemoryItem, BulkMemoryResponse
+from core_api.services.memory_service import create_memories_bulk
+from core_api.services.organization_settings import resolve_config
+
+logger = logging.getLogger(__name__)
+
+WATERMARK_COLLECTION = "interview_watermarks"
+
+# Report section → memory_type. The section label is preserved in
+# ``metadata.category`` so the original interview framing survives the
+# mapping onto the fixed memory-type enum.
+REPORT_SECTIONS: dict[str, str] = {
+    "worked_on": "episode",
+    "decisions": "decision",
+    "outcomes": "outcome",
+    "blockers": "task",
+    "open_questions": "fact",
+    "preferences_learned": "preference",
+}
+
+
+def interview_attempt_id(node_id: str, cursor_from: int, cursor_to: int) -> str:
+    """Deterministic bulk-attempt id for one (node, window) interview.
+
+    Computed server-side — never trusted from the client — so any retry of
+    the same window (plugin resubmit, command re-delivery, worker crash
+    re-run) resolves to ``duplicate_attempt`` instead of duplicate rows.
+    Matches ``_BULK_ATTEMPT_ID_PATTERN`` (``^[A-Za-z0-9._:\\-]{1,128}$``).
+    """
+    digest = hashlib.sha1(f"{node_id}:{cursor_from}:{cursor_to}".encode()).hexdigest()
+    return f"interview:{digest[:40]}"
+
+
+def watermark_doc_id(node_id: str) -> str:
+    """Phase 1 keys the watermark per NODE (see decisions doc Q2):
+    OpenClaw session keys are not guaranteed stable (legacy-compat paths
+    mint synthetic per-instance ids), so per-session cursors would
+    fragment. Session ids still travel per-event for report grouping.
+    """
+    return f"wm_{hashlib.sha1(node_id.encode()).hexdigest()[:40]}"
+
+
+# ── Masking ──
+
+
+def mask_events(events: list[dict]) -> tuple[list[dict], int]:
+    """Deterministically mask PII/secrets in event content pre-LLM.
+
+    All categories are scanned unconditionally: this runs before the
+    tenant-configurable persistence gate, and a masked token in the
+    interview prompt is always acceptable while a leaked secret is not.
+    Returns the masked copies and the total finding count (audit/log).
+    """
+    masked: list[dict] = []
+    total = 0
+    for ev in events:
+        content = (ev.get("content") or "")[:INTERVIEW_EVENT_MAX_CHARS]
+        findings = scan(content)
+        if findings:
+            total += len(findings)
+            content = mask(content, findings)
+        masked.append({**ev, "content": content})
+    return masked, total
+
+
+# ── Chunking (map side) ──
+
+
+def chunk_events(events: list[dict]) -> list[list[dict]]:
+    """Split the window into char-budgeted chunks for the map phase."""
+    chunks: list[list[dict]] = []
+    current: list[dict] = []
+    size = 0
+    for ev in events:
+        ev_len = len(ev.get("content") or "") + 64  # + envelope overhead
+        if current and size + ev_len > INTERVIEW_CHUNK_MAX_CHARS:
+            chunks.append(current)
+            current, size = [], 0
+        current.append(ev)
+        size += ev_len
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _serialize_events(events: list[dict]) -> str:
+    lines = []
+    for ev in events:
+        session = ev.get("session_id") or "-"
+        tool = f" tool={ev['tool']}" if ev.get("tool") else ""
+        outcome = f" outcome={ev['outcome']}" if ev.get("outcome") else ""
+        lines.append(
+            f"[{ev.get('seq')}] {ev.get('ts')} (session {session}) "
+            f"{ev.get('role')}/{ev.get('kind')}{tool}{outcome}: {ev.get('content')}"
+        )
+    return "\n".join(lines)
+
+
+_REPORT_SCHEMA_INSTRUCTION = """Respond with ONLY a JSON object of this exact shape (empty arrays allowed):
+{
+  "worked_on":           [{"summary": "...", "ts_start": "ISO8601 or null", "ts_end": "ISO8601 or null", "session_id": "... or null"}],
+  "decisions":           [{"summary": "...", "rationale": "... or null", "ts": "ISO8601 or null"}],
+  "outcomes":            [{"summary": "...", "result": "success|failure|partial", "ts": "ISO8601 or null"}],
+  "blockers":            [{"summary": "...", "ts": "ISO8601 or null"}],
+  "open_questions":      [{"summary": "...", "ts": "ISO8601 or null"}],
+  "preferences_learned": [{"summary": "...", "ts": "ISO8601 or null"}]
+}
+Rules: every item must be standalone and concrete (names, paths, numbers). Take ts values from the
+event timestamps you actually used — never invent times. Do not restate the same fact in two sections.
+Skip routine/mechanical steps; report only what a teammate would need to know."""
+
+
+def build_prompt(
+    events: list[dict],
+    *,
+    agent_id: str,
+    keystone_lines: list[str],
+    chunk_index: int,
+    chunk_count: int,
+) -> str:
+    """Build the interview prompt for one chunk (the single shared prompt —
+    Phase 4 relocates its execution into the broker, it does not fork it)."""
+    part = f" (part {chunk_index + 1} of {chunk_count})" if chunk_count > 1 else ""
+    keystones = ""
+    if keystone_lines:
+        keystones = (
+            "\nMandatory governance rules for this scope — obey them in what you"
+            " include or exclude:\n" + "\n".join(keystone_lines) + "\n"
+        )
+    return (
+        f"You are the Interviewer: you turn an AI agent's raw activity trail into the team's"
+        f" durable memory. Below is the recent activity window{part} of agent `{agent_id}`."
+        f" Synthesize a structured reflective report of the key activities that kept it busy.\n"
+        f"{keystones}\n"
+        f"ACTIVITY TRAIL:\n{_serialize_events(events)}\n\n"
+        f"{_REPORT_SCHEMA_INSTRUCTION}"
+    )
+
+
+# ── LLM (map) ──
+
+
+def _empty_report() -> dict[str, list]:
+    return {section: [] for section in REPORT_SECTIONS}
+
+
+def _fake_report(events: list[dict]) -> dict:
+    """Deterministic no-LLM fallback (fake provider / total LLM outage):
+    a single episode summarizing the window so the cursor can still
+    advance — an empty report would silently drop the window's history."""
+    if not events:
+        return _empty_report()
+    report = _empty_report()
+    report["worked_on"] = [
+        {
+            "summary": f"Activity window of {len(events)} events (LLM unavailable; unsynthesized).",
+            "ts_start": events[0].get("ts"),
+            "ts_end": events[-1].get("ts"),
+            "session_id": None,
+        }
+    ]
+    return report
+
+
+async def _interview_chunk(prompt: str, config, events: list[dict]) -> dict:
+    """Run one map-phase LLM call through the tenant's fallback chain."""
+    from core_api.providers._retry import call_with_fallback
+
+    async def _do_interview(llm) -> dict:
+        return await llm.complete_json(prompt, temperature=INTERVIEW_TEMPERATURE)
+
+    return await call_with_fallback(
+        primary_provider_name=config.enrichment_provider,
+        call_fn=_do_interview,
+        fake_fn=lambda: _fake_report(events),
+        tenant_config=config,
+        service_label="interview",
+        model_override=config.enrichment_model,
+    )
+
+
+# ── Reduce ──
+
+
+def merge_reports(reports: list[dict]) -> dict:
+    """Merge mini-reports: concatenate sections, drop exact-duplicate
+    summaries, cap per section (keeps total under BULK_MAX_ITEMS)."""
+    merged = _empty_report()
+    seen: set[tuple[str, str]] = set()
+    for report in reports:
+        if not isinstance(report, dict):
+            continue
+        for section in REPORT_SECTIONS:
+            for item in report.get(section) or []:
+                if not isinstance(item, dict):
+                    continue
+                summary = (item.get("summary") or "").strip()
+                if not summary:
+                    continue
+                key = (section, summary.lower())
+                if key in seen:
+                    continue
+                seen.add(key)
+                if len(merged[section]) < INTERVIEW_MAX_ITEMS_PER_SECTION:
+                    merged[section].append(item)
+    return merged
+
+
+# ── Report → bulk items ──
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def report_to_items(report: dict, *, node_id: str, command_id: str | None) -> list[BulkMemoryItem]:
+    """Map report sections onto typed memories.
+
+    ``ts_valid_start`` carries the SOURCE event time (not report time) so
+    batching does not corrupt freshness ranking — decisions doc / C2/C3.
+    """
+    items: list[BulkMemoryItem] = []
+    for section, memory_type in REPORT_SECTIONS.items():
+        for entry in report.get(section) or []:
+            summary = (entry.get("summary") or "").strip()
+            if not summary:
+                continue
+            content = summary
+            if section == "decisions" and entry.get("rationale"):
+                content = f"{summary} — rationale: {entry['rationale']}"
+            elif section == "outcomes" and entry.get("result"):
+                content = f"[{entry['result']}] {summary}"
+            metadata: dict[str, Any] = {
+                "source": "interviewer",
+                "category": section,
+                "node_id": node_id,
+                "written_by": "interviewer",
+            }
+            if command_id:
+                metadata["command_id"] = command_id
+            if entry.get("session_id"):
+                metadata["session_id"] = entry["session_id"]
+            if section == "outcomes" and entry.get("result"):
+                metadata["outcome_result"] = entry["result"]
+            items.append(
+                BulkMemoryItem(
+                    memory_type=memory_type,
+                    content=content[:MAX_CONTENT_LENGTH],
+                    metadata=metadata,
+                    ts_valid_start=_parse_ts(entry.get("ts") or entry.get("ts_start")),
+                    ts_valid_end=_parse_ts(entry.get("ts_end")),
+                )
+            )
+    return items
+
+
+# ── Keystones ──
+
+
+async def _keystone_lines(tenant_id: str, fleet_id: str | None, agent_id: str) -> list[str]:
+    """Merged governance rules for the interview prompt (best-effort)."""
+    try:
+        sc = get_storage_client()
+        rows, _truncated = await sc.list_keystones(
+            tenant_id,
+            fleet_id=fleet_id,
+            # Mirror routes/keystones.py: agent scope only makes sense
+            # under a fleet scope.
+            agent_id=agent_id if fleet_id else None,
+        )
+    except Exception:
+        logger.warning("interview: keystone fetch failed; proceeding without", exc_info=True)
+        return []
+    lines = []
+    for row in rows[:INTERVIEW_MAX_KEYSTONES_IN_PROMPT]:
+        title = row.get("title") or row.get("doc_id") or ""
+        content = (row.get("content") or "")[:200]
+        lines.append(f"- {title}: {content}")
+    return lines
+
+
+# ── Watermark ──
+
+
+async def advance_watermark(
+    tenant_id: str,
+    *,
+    node_id: str,
+    agent_id: str,
+    cursor_to: int,
+    command_id: str | None,
+) -> int:
+    """Forward-only watermark advance. Returns the effective cursor.
+
+    A stale retry (its ``cursor_to`` at or behind the stored cursor) is a
+    no-op — the bulk write already deduplicated its rows, and regressing
+    the cursor would re-open a consumed range.
+    """
+    sc = get_storage_client()
+    doc_id = watermark_doc_id(node_id)
+    existing = await sc.get_document(tenant_id, WATERMARK_COLLECTION, doc_id, read=False)
+    existing_seq = -1
+    if existing and isinstance(existing.get("data"), dict):
+        try:
+            existing_seq = int(existing["data"].get("last_seq", -1))
+        except (TypeError, ValueError):
+            existing_seq = -1
+    if cursor_to <= existing_seq:
+        return existing_seq
+    await sc.upsert_document(
+        {
+            "tenant_id": tenant_id,
+            "collection": WATERMARK_COLLECTION,
+            "doc_id": doc_id,
+            "data": {
+                "node_id": node_id,
+                "agent_id": agent_id,
+                "tenant_id": tenant_id,
+                "last_seq": cursor_to,
+                "last_interview_at": datetime.now(UTC).isoformat(),
+                "last_command_id": command_id,
+            },
+        }
+    )
+    return cursor_to
+
+
+# ── Orchestrator ──
+
+
+async def run_interview(
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    agent_id: str,
+    node_id: str,
+    command_id: str | None,
+    cursor_from: int,
+    cursor_to: int,
+    events: list[dict],
+) -> dict:
+    """The full window interview: mask → map → reduce → bulk → watermark."""
+    started = datetime.now(UTC)
+
+    masked, finding_count = mask_events(events)
+    if finding_count:
+        logger.info(
+            "%s interview: masked %d PII/secret findings pre-LLM (tenant=%s node=%s)",
+            started.isoformat(),
+            finding_count,
+            tenant_id,
+            node_id,
+        )
+
+    config = await resolve_config(tenant_id)
+    keystones = await _keystone_lines(tenant_id, fleet_id, agent_id)
+
+    chunks = chunk_events(masked)
+    mini_reports = []
+    for index, chunk in enumerate(chunks):
+        prompt = build_prompt(
+            chunk,
+            agent_id=agent_id,
+            keystone_lines=keystones,
+            chunk_index=index,
+            chunk_count=len(chunks),
+        )
+        mini_reports.append(await _interview_chunk(prompt, config, chunk))
+    report = mini_reports[0] if len(mini_reports) == 1 else merge_reports(mini_reports)
+    # Single-chunk reports still need shape normalization + caps.
+    report = merge_reports([report])
+
+    items = report_to_items(report, node_id=node_id, command_id=command_id)
+    if not items:
+        # Nothing report-worthy in the window (e.g. pure noise). Still
+        # advance the cursor: the window was consumed, not lost.
+        watermark = await advance_watermark(
+            tenant_id,
+            node_id=node_id,
+            agent_id=agent_id,
+            cursor_to=cursor_to,
+            command_id=command_id,
+        )
+        return {"status": "committed", "watermark": watermark, "memories_written": 0, "errors": 0}
+
+    bulk: BulkMemoryResponse = await create_memories_bulk(
+        BulkMemoryCreate(
+            tenant_id=tenant_id,
+            fleet_id=fleet_id,
+            agent_id=agent_id,  # subject = the WORKER; interviewer is in metadata.written_by
+            items=items,
+            visibility="scope_team",
+        ),
+        bulk_attempt_id=interview_attempt_id(node_id, cursor_from, cursor_to),
+    )
+
+    errors = sum(1 for r in bulk.results if r.status == "error")
+    written = sum(1 for r in bulk.results if r.status == "created")
+    if errors and errors == len(bulk.results):
+        # Total failure: do NOT advance the watermark — the window must be
+        # re-interviewed (retry keeps the same attempt id, so any rows
+        # that did land dedup as duplicate_attempt).
+        return {"status": "failed", "watermark": None, "memories_written": 0, "errors": errors}
+
+    watermark = await advance_watermark(
+        tenant_id,
+        node_id=node_id,
+        agent_id=agent_id,
+        cursor_to=cursor_to,
+        command_id=command_id,
+    )
+    return {
+        "status": "partial" if errors else "committed",
+        "watermark": watermark,
+        "memories_written": written,
+        "errors": errors,
+    }

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -249,6 +249,19 @@ DEFAULT_SETTINGS: dict = {
             "enabled": False,
         },
     },
+    # Interviewer (Phase 1) — scheduled reflective work-reports ingested as
+    # typed memories (docs/plans/interviewer-phase1-decisions.md). Default
+    # OFF: the core-operations scheduler only queues ``interview_request``
+    # commands for tenants that flip this on, and the submit endpoint
+    # re-checks it (defense in depth, same posture as skills_factory).
+    "interviewer": {
+        "enabled": False,
+        # Cadence the scheduler uses when queuing interview_request
+        # commands (the client ask: "once or twice daily").
+        "period_hours": 12,
+        # Report template identifier; Phase 1 ships only the static default.
+        "template_id": "default-v1",
+    },
     "entity_blocklist": [
         "team",
         "meeting",
@@ -560,6 +573,10 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "skills_factory.forge.llm_tokens_per_run": int,
     "skills_factory.forge.max_writes_per_run": int,
     "skills_factory.openclaw_bridge.enabled": bool,
+    # Interviewer Phase 1.
+    "interviewer.enabled": bool,
+    "interviewer.period_hours": int,
+    "interviewer.template_id": str,
     # Governance content policy (eToro). Enum values (action / disposition) are
     # type-checked here as str; their allowed values are checked by
     # ``_validate_governance_enums`` in update_settings.
@@ -597,6 +614,8 @@ _LEAF_RANGES: dict[str, tuple[int, int]] = {
     # surfaces as 422. Capping at 365 prevents a tenant from
     # accidentally writing a near-permanent poison entry.
     "skills_factory.rejection_cooloff_days": (1, 365),
+    # Interviewer cadence: 1 hour .. weekly.
+    "interviewer.period_hours": (1, 168),
     # Size caps must be > 0: a tenant misconfiguring these to 0 or
     # negative would silently break ALL skills writes (every doc
     # would trip BODY_TOO_LARGE / DESCRIPTION_TOO_LARGE in Sentinel's

--- a/core-api/src/core_api/services/tenants.py
+++ b/core-api/src/core_api/services/tenants.py
@@ -54,3 +54,12 @@ async def list_tenants_with_agent_digest_enabled(db: AsyncSession | None = None)
     zero cost. Orgs without a settings row are excluded (default off). ``db`` is
     ignored (reads via core-storage-api)."""
     return await get_storage_client().list_agent_digest_enabled_orgs()
+
+
+async def list_tenants_with_interviewer_enabled(db: AsyncSession | None = None) -> list[str]:
+    """Return ``org_id`` values whose ``interviewer.enabled`` is True, sorted.
+
+    Used by the interviewer schedule tick so a tenant that hasn't opted in pays
+    zero cost. Orgs without a settings row are excluded (default off). ``db`` is
+    ignored (reads via core-storage-api)."""
+    return await get_storage_client().list_interviewer_enabled_orgs()

--- a/core-operations/src/core_operations/app.py
+++ b/core-operations/src/core_operations/app.py
@@ -52,6 +52,7 @@ configure_logging(
 from core_operations.scheduler import (
     scheduler,
     seconds_until_next_utc_hour,
+    seconds_until_next_utc_top_of_hour,
     seconds_until_next_utc_weekday_hour,
 )
 from core_operations.tasks import (
@@ -62,6 +63,7 @@ from core_operations.tasks import (
     run_crystallize_tick,
     run_entity_link_tick,
     run_insights_tick,
+    run_interviewer_schedule_tick,
     run_purge_soft_deleted_tick,
 )
 
@@ -134,6 +136,14 @@ def _register_scheduled_tasks() -> None:
         7 * 24 * 3600,
         run_agent_digest_weekly_tick,
         delay_provider=_weekly_at("agent_digest_weekly_run_at_weekday", "agent_digest_weekly_run_at_hour"),
+    )
+    # Interviewer Phase 1: hourly queue-only tick; per-tenant period_hours
+    # gates actual command creation, so opted-out tenants pay zero cost.
+    scheduler.register(
+        "interviewer-schedule",
+        3600,
+        run_interviewer_schedule_tick,
+        delay_provider=lambda: seconds_until_next_utc_top_of_hour(),
     )
 
 

--- a/core-operations/src/core_operations/scheduler.py
+++ b/core-operations/src/core_operations/scheduler.py
@@ -53,6 +53,19 @@ def seconds_until_next_utc_hour(hour: int, *, now: datetime | None = None) -> fl
     return (target - current).total_seconds()
 
 
+def seconds_until_next_utc_top_of_hour(*, now: datetime | None = None) -> float:
+    """Seconds from ``now`` until the next :00 UTC of any hour.
+
+    Same strict-future guarantee as :func:`seconds_until_next_utc_hour`
+    (always positive, at most 1h) for hourly-cadence jobs — keeps an
+    aligned task from hot-looping after a fast failure at the top of the
+    hour.
+    """
+    current = now or datetime.now(UTC)
+    target = current.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    return (target - current).total_seconds()
+
+
 def seconds_until_next_utc_weekday_hour(weekday: int, hour: int, *, now: datetime | None = None) -> float:
     """Seconds from ``now`` until the next ``weekday``@``hour``:00 UTC.
 

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -162,3 +162,43 @@ async def run_agent_digest_weekly_tick() -> None:
     """Weekly per-agent digest (period=week). Same trigger as the daily tick,
     fired once a week so the previous full Mon-Mon window gets summarized."""
     await _fire_agent_digest("week")
+
+
+async def run_interviewer_schedule_tick() -> None:
+    """Queue due ``interview_request`` fleet commands (Interviewer Phase 1).
+
+    POSTs ``/admin/interview/schedule/run`` on core-api, which enumerates
+    orgs with ``interviewer.enabled`` and queues at most one pending command
+    per live node, gated by each node's watermark vs the tenant's
+    ``period_hours``. Firing hourly is safe: a tenant that hasn't opted in
+    pays zero cost, and dueness gating makes the tick idempotent.
+    """
+    url = f"{settings.core_api_url.rstrip('/')}/api/v1/admin/interview/schedule/run"
+    headers: dict[str, str] = {}
+    if settings.core_api_admin_api_key:
+        headers["X-API-Key"] = settings.core_api_admin_api_key
+    else:
+        logger.warning(
+            "core-operations: CORE_API_ADMIN_API_KEY unset; interviewer schedule run will be unauthorised",
+        )
+
+    # Scheduling is queue-only (no LLM work inline) — the storage default
+    # timeout is plenty.
+    timeout = httpx.Timeout(settings.storage_http_timeout_s)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            resp = await client.post(url, headers=headers)
+        except httpx.HTTPError:
+            logger.exception("interviewer-schedule POST failed", extra={"url": url})
+            return
+    if resp.status_code >= 400:
+        logger.error(
+            "interviewer-schedule run returned non-2xx; will retry next tick",
+            extra={"status_code": resp.status_code, "body": resp.text[:500]},
+        )
+        return
+    try:
+        summary = resp.json()
+    except Exception:
+        summary = resp.text[:200]
+    logger.info("interviewer-schedule run fired", extra={"summary": summary})

--- a/core-operations/tests/test_app.py
+++ b/core-operations/tests/test_app.py
@@ -26,6 +26,7 @@ _EXPECTED_JOBS = {
     "lifecycle-insights",
     "agent-digest",
     "agent-digest-weekly",
+    "interviewer-schedule",
 }
 
 

--- a/core-storage-api/src/core_storage_api/routers/fleet.py
+++ b/core-storage-api/src/core_storage_api/routers/fleet.py
@@ -134,20 +134,23 @@ async def list_commands(
     tenant_id: str,
     node_name: str | None = None,
     status: str | None = None,
+    command: str | None = None,
     limit: int = 50,
 ) -> list[dict]:
     node_id: UUID | None = None
     if node_name:
         node_id = await _svc.fleet_get_node_id(tenant_id=tenant_id, node_name=node_name)
+    # status/command are filtered in SQL (pre-limit) — the previous
+    # post-limit status filter could silently hide matching rows older
+    # than the ``limit`` newest commands.
     commands = await _svc.fleet_list_commands(
         tenant_id=tenant_id,
         node_id=node_id,
+        status=status,
+        command=command,
         limit=limit,
     )
-    results = [orm_to_dict(c, FLEET_COMMAND_FIELDS) for c in commands]
-    if status:
-        results = [c for c in results if c.get("status") == status]
-    return results
+    return [orm_to_dict(c, FLEET_COMMAND_FIELDS) for c in commands]
 
 
 @router.get("/commands/pending")

--- a/core-storage-api/src/core_storage_api/routers/tenants.py
+++ b/core-storage-api/src/core_storage_api/routers/tenants.py
@@ -56,3 +56,10 @@ async def list_agent_digest_enabled_orgs() -> OrgIdsResponse:
     """Orgs whose ``agent_digest.enabled`` setting is True (nightly digest
     fanout target)."""
     return OrgIdsResponse(org_ids=await _svc.tenants_list_agent_digest_enabled())
+
+
+@router.get("/interviewer-enabled")
+async def list_interviewer_enabled_orgs() -> OrgIdsResponse:
+    """Orgs whose ``interviewer.enabled`` setting is True (interviewer
+    schedule-tick target)."""
+    return OrgIdsResponse(org_ids=await _svc.tenants_list_interviewer_enabled())

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -7687,8 +7687,14 @@ class PostgresService:
         *,
         tenant_id: str,
         node_id: UUID | None = None,
+        status: str | None = None,
+        command: str | None = None,
         limit: int = 50,
     ) -> Sequence[FleetCommand]:
+        # ``status``/``command`` filter in SQL, BEFORE the limit — a
+        # post-limit filter would silently drop matching rows older than
+        # the ``limit`` newest commands (e.g. a long-pending
+        # interview_request behind 50 newer deploys).
         async with get_session() as session:
             stmt = (
                 select(FleetCommand)
@@ -7698,6 +7704,10 @@ class PostgresService:
             )
             if node_id:
                 stmt = stmt.where(FleetCommand.node_id == node_id)
+            if status:
+                stmt = stmt.where(FleetCommand.status == status)
+            if command:
+                stmt = stmt.where(FleetCommand.command == command)
             result = await session.execute(stmt)
             return result.scalars().all()
 
@@ -8204,6 +8214,19 @@ class PostgresService:
             result = await session.execute(
                 select(OrganizationSettings.org_id).where(
                     OrganizationSettings.settings["agent_digest"]["enabled"].as_boolean().is_(True)
+                )
+            )
+            return sorted(row[0] for row in result.all())
+
+    async def tenants_list_interviewer_enabled(self) -> list[str]:
+        """``org_id`` values whose ``interviewer.enabled`` JSONB flag is True,
+        sorted. The interviewer schedule tick uses this so a tenant that hasn't
+        opted in pays zero cost. Orgs with no settings row are excluded
+        (default off)."""
+        async with get_read_session() as session:
+            result = await session.execute(
+                select(OrganizationSettings.org_id).where(
+                    OrganizationSettings.settings["interviewer"]["enabled"].as_boolean().is_(True)
                 )
             )
             return sorted(row[0] for row in result.all())

--- a/docs/plans/interviewer-phase1-decisions.md
+++ b/docs/plans/interviewer-phase1-decisions.md
@@ -1,0 +1,64 @@
+# Interviewer Phase 1 — Open-Question Resolutions
+
+**Branch:** `interviewer-phase1` · **Date:** 2026-07-16
+**Parent specs:** MemClaw doc store `design_docs/interviewer-feature-plan`, `design_docs/interviewer-phase1-spec`
+
+Task #1 of the Phase-1 prep: the four questions that gated the build, resolved against source.
+
+---
+
+## Q4 — Is there an existing OpenClaw gateway trail the plugin can read? → **NO. Build the on-disk buffer.**
+
+Grounding:
+- `plugin/src/openclaw-sdk-bridge.ts` exposes **no** transcript / session-persistence surface (grep: `transcript|history|sessionFile|persist|.jsonl|readSession` → zero hits).
+- `plugin/src/context-engine.ts:128` — today's buffer is an **in-memory LRU** capped at `SESSION_BUFFER_CAP`; old events are dropped even without a crash. Only user messages are persisted (as episodes, write-capped per session).
+- `static/docs/integration-guide.md` — no session-persistence mention.
+
+**Decision:** Fork 1 stands as spec'd — the plugin writes its own append-only `interview-buffer.jsonl` under the plugin state dir (`~/.openclaw`, per `paths.ts`). If OpenClaw later exposes a persisted transcript, only the buffer *writer* is swapped; the contract is untouched.
+
+---
+
+## Q2 — Watermark granularity: per-node or per-session? → **Per-node. Session id travels as event metadata.**
+
+Grounding (`plugin/src/context-engine.internal.ts:25`):
+- `getSessionKey` prefers the per-call `sessionId/sessionKey` OpenClaw ≥2026.5.4 passes, **but** falls back to a factory default (`"default:main-<installId>:default"`), and legacy-compat paths mint **synthetic per-instance ids** (`legacycompat-<ts>-<rand>`, `context-engine.ts:520`).
+
+Session boundaries are therefore **not guaranteed stable** — per-session watermarks would fragment across synthetic ids and defaults.
+
+**Decision:** Phase 1 keys the watermark **per node** (`wm_<sha1(node_id)>`, server-authoritative), and every buffered event carries its `sessionKey` in the C2 `session_id` field so the interview prompt can group by session. Revisit per-session cursors in Phase 2, where disk trails have real per-session files.
+
+---
+
+## Q3 — Is redaction sufficient pre-broker? → **YES, with one addition: mask events at `/interview/submit` ingestion, *before* the interview LLM.**
+
+Grounding (`core-api/src/core_api/pipeline/steps/write/governance_scan_content.py`):
+- `GovernanceScanContent` is a **deterministic PII/secret gate at the ingestion boundary** — regex / Luhn / IBAN / entropy detectors — running in **both** write modes, positioned **before** `ComputeContentHash`, so hash/dedup/embedding/stored-row all see the redacted form. Per-tenant action: mask-in-place / drop (422) / flag. Every action audit-logged. LLM free-form PII signal applied separately (`GovernanceDecision` strong-mode / post-write remediation fast-mode).
+
+The nuance the spec missed: that gate protects **persistence**. The interview worker runs the LLM **before** `/memories/bulk`, so raw window content would reach the platform LLM pre-governance.
+
+**Decision:** the `/interview/submit` handler runs the **same shared library** (`common.governance.scan/mask`) on `events[].content` immediately on receipt — before the interview prompt sees anything. Bulk-write governance then runs again on the Report (defense in depth, zero new code — it's always-on). Plugin-side regex stays a lightweight optional wire-privacy improvement, not a correctness requirement. Phase-1 redaction posture: **adequate for the opt-in tenant; full pre-wire redaction remains Path A's (broker) value.**
+
+---
+
+## Q1 — Window size vs. LLM context → **Cap per submit + worker-side map-reduce; the watermark loop is the catch-up mechanism.**
+
+Grounding: `core-api/constants.py:144` (`CHUNKING_THRESHOLD_CHARS = 2000`) establishes the chunking precedent; platform enrichment model is small-context-tier (`gpt-5.4-nano` class).
+
+**Decision — three stacked caps, no giant payloads, no lost data:**
+1. **Submit cap (plugin):** at most `INTERVIEW_MAX_EVENTS_PER_SUBMIT` (initial: 500) / ~2 MB per `/interview/submit`. The plugin submits `[since_seq, min(head, since_seq+cap)]`.
+2. **Catch-up via the cursor (free):** the watermark only advances to `cursor_to`. If the buffer head is beyond it, the next scheduler tick issues a new `interview_request` from the new cursor — the crash-safe loop doubles as the backlog-drain loop. No special backlog mode.
+3. **Worker map-reduce (server):** events chunked into token-budgeted windows (initial: ~24k tokens/chunk); map = per-chunk mini-report (same fixed JSON schema); reduce = merge mini-reports into the final Report (dedup episodes, union decisions/outcomes). Single-chunk windows skip the reduce.
+
+Initial numbers are config, not constants — tune on the opt-in tenant.
+
+---
+
+## Net effect on the build tasks
+
+| Task | Delta |
+|---|---|
+| #2 buffer | confirmed required; add `sessionKey` per event; add submit cap |
+| #3 handler | submit `[since_seq, head∧cap]`; no backlog special-casing |
+| #4 worker | **add**: `common.governance` mask on receipt; map-reduce with 24k-token chunks |
+| #5 scheduler/watermark | per-node key confirmed; cadence tick naturally drains backlog |
+| #6 e2e | add backlog-drain case (buffer > cap → multiple ticks converge) |

--- a/tests/test_api_interview.py
+++ b/tests/test_api_interview.py
@@ -71,7 +71,11 @@ _CANNED_REPORT = {
         }
     ],
     "outcomes": [
-        {"summary": "Refactor landed green.", "result": "success", "ts": "2026-07-16T08:02:00+00:00"}
+        {
+            "summary": "Refactor landed green.",
+            "result": "success",
+            "ts": "2026-07-16T08:02:00+00:00",
+        }
     ],
     "blockers": [],
     "open_questions": [],
@@ -111,7 +115,9 @@ async def test_submit_rejects_reversed_cursor(client):
     await _enable_interviewer(client, tenant_id, headers)
     resp = await client.post(
         "/api/v1/interview/submit",
-        json=_payload(tenant_id, f"node-{uid()}", f"agent-{uid()}", cursor_from=10, cursor_to=5),
+        json=_payload(
+            tenant_id, f"node-{uid()}", f"agent-{uid()}", cursor_from=10, cursor_to=5
+        ),
         headers=headers,
     )
     assert resp.status_code == 422
@@ -123,7 +129,12 @@ async def test_submit_rejects_events_outside_window(client):
     resp = await client.post(
         "/api/v1/interview/submit",
         json=_payload(
-            tenant_id, f"node-{uid()}", f"agent-{uid()}", cursor_from=0, cursor_to=2, events=_events(5)
+            tenant_id,
+            f"node-{uid()}",
+            f"agent-{uid()}",
+            cursor_from=0,
+            cursor_to=2,
+            events=_events(5),
         ),
         headers=headers,
     )
@@ -148,7 +159,9 @@ async def test_submit_rejects_unsorted_events(client):
 # ── happy path & idempotency ──
 
 
-async def test_submit_happy_path_writes_typed_memories_and_watermark(client, canned_llm):
+async def test_submit_happy_path_writes_typed_memories_and_watermark(
+    client, canned_llm
+):
     tenant_id, headers = get_test_auth(f"t-{uid()}")
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
@@ -172,7 +185,9 @@ async def test_submit_happy_path_writes_typed_memories_and_watermark(client, can
         f"/api/v1/memories?tenant_id={tenant_id}&agent_id={agent_id}", headers=headers
     )
     assert listing.status_code == 200
-    rows = listing.json()["items"] if isinstance(listing.json(), dict) else listing.json()
+    rows = (
+        listing.json()["items"] if isinstance(listing.json(), dict) else listing.json()
+    )
     ours = [r for r in rows if (r.get("metadata") or {}).get("source") == "interviewer"]
     assert len(ours) == 3
     types = sorted(r["memory_type"] for r in ours)
@@ -194,7 +209,9 @@ async def test_submit_retry_is_idempotent(client, canned_llm):
 
     # Same (node, window) → same server-derived attempt id → every row
     # resolves duplicate_attempt; watermark stays; no new memories.
-    second = await client.post("/api/v1/interview/submit", json=payload, headers=headers)
+    second = await client.post(
+        "/api/v1/interview/submit", json=payload, headers=headers
+    )
     assert second.status_code == 200, second.text
     body = second.json()
     assert body["status"] == "committed"
@@ -241,7 +258,9 @@ def test_attempt_id_is_deterministic_and_valid():
 
 
 def test_mask_events_masks_pii_before_llm():
-    events = [{"seq": 0, "content": "email me at ran@caura.ai, card 4111 1111 1111 1111"}]
+    events = [
+        {"seq": 0, "content": "email me at ran@caura.ai, card 4111 1111 1111 1111"}
+    ]
     masked, findings = interview_service.mask_events(events)
     assert findings >= 2
     assert "ran@caura.ai" not in masked[0]["content"]
@@ -265,11 +284,219 @@ def test_merge_reports_dedups_and_caps():
 
 
 def test_report_to_items_maps_types_and_event_time():
-    items = interview_service.report_to_items(_CANNED_REPORT, node_id="n1", command_id="c1")
+    items = interview_service.report_to_items(
+        _CANNED_REPORT, node_id="n1", command_id="c1"
+    )
     by_type = {i.memory_type: i for i in items}
     assert set(by_type) == {"episode", "decision", "outcome"}
-    assert by_type["decision"].content.endswith("In-memory buffer loses the window on crash.")
+    assert by_type["decision"].content.endswith(
+        "In-memory buffer loses the window on crash."
+    )
     assert by_type["outcome"].content.startswith("[success]")
     # Source event time, not report time.
     assert by_type["episode"].ts_valid_start is not None
     assert by_type["episode"].ts_valid_start.year == 2026
+
+
+# ── schedule (admin cron entry point) ──
+
+
+async def _seed_live_node(
+    client, tenant_id: str, headers: dict, node_name: str
+) -> None:
+    resp = await client.post(
+        "/api/v1/fleet/heartbeat",
+        json={"tenant_id": tenant_id, "node_name": node_name},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def _interview_commands(client, tenant_id: str, headers: dict) -> list[dict]:
+    resp = await client.get(
+        f"/api/v1/fleet/commands?tenant_id={tenant_id}", headers=headers
+    )
+    assert resp.status_code == 200
+    return [c for c in resp.json() if c["command"] == "interview_request"]
+
+
+async def test_schedule_queues_once_then_respects_pending_and_dueness(
+    client, canned_llm
+):
+    from tests.conftest import get_admin_headers
+
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    await _seed_live_node(client, tenant_id, headers, f"node-{uid()}")
+
+    # First run: one interview_request queued for the live node, cursor from 0.
+    run1 = await client.post(
+        "/api/v1/admin/interview/schedule/run", headers=get_admin_headers()
+    )
+    assert run1.status_code == 200, run1.text
+    assert run1.json()["commands_queued"] >= 1
+    cmds = await _interview_commands(client, tenant_id, headers)
+    assert len(cmds) == 1
+    payload = cmds[0]["payload"]
+    assert payload["since_seq"] == 0
+    assert payload["template_id"] == "default-v1"
+    node_uuid = payload["node_id"]
+    assert (
+        node_uuid == cmds[0]["node_id"]
+    )  # plugin submits with the watermark's node key
+
+    # Second run while the command is still pending: no stacking.
+    await client.post(
+        "/api/v1/admin/interview/schedule/run", headers=get_admin_headers()
+    )
+    assert len(await _interview_commands(client, tenant_id, headers)) == 1
+
+    # Plugin acks the command and submits the window → watermark advances
+    # and last_interview_at is stamped.
+    ack = await client.post(
+        f"/api/v1/fleet/commands/{cmds[0]['id']}/result",
+        json={"status": "done", "result": {"submitted": True}},
+        headers=headers,
+    )
+    assert ack.status_code == 200, ack.text
+    submit = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, node_uuid, f"agent-{uid()}", command_id=cmds[0]["id"]),
+        headers=headers,
+    )
+    assert submit.status_code == 200, submit.text
+
+    # Third run: command done + interview fresh → NOT due → nothing queued.
+    run3 = await client.post(
+        "/api/v1/admin/interview/schedule/run", headers=get_admin_headers()
+    )
+    assert run3.status_code == 200
+    assert len(await _interview_commands(client, tenant_id, headers)) == 1
+
+
+async def test_schedule_next_window_resumes_from_watermark(
+    client, canned_llm, monkeypatch
+):
+    from tests.conftest import get_admin_headers
+
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    await _seed_live_node(client, tenant_id, headers, f"node-{uid()}")
+
+    run1 = await client.post(
+        "/api/v1/admin/interview/schedule/run", headers=get_admin_headers()
+    )
+    assert run1.status_code == 200
+    cmds = await _interview_commands(client, tenant_id, headers)
+    node_uuid = cmds[0]["payload"]["node_id"]
+    await client.post(
+        f"/api/v1/fleet/commands/{cmds[0]['id']}/result",
+        json={"status": "done"},
+        headers=headers,
+    )
+    submit = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, node_uuid, f"agent-{uid()}"),
+        headers=headers,
+    )
+    assert submit.status_code == 200
+    assert submit.json()["watermark"] == 10
+
+    # Force dueness (period elapsed) without waiting: the next command must
+    # resume exactly after the committed cursor — never re-open the range.
+    monkeypatch.setattr(interview_service, "_is_due", lambda *a, **kw: True)
+    run2 = await client.post(
+        "/api/v1/admin/interview/schedule/run", headers=get_admin_headers()
+    )
+    assert run2.status_code == 200
+    cmds2 = await _interview_commands(client, tenant_id, headers)
+    assert len(cmds2) == 2
+    newest = max(cmds2, key=lambda c: c["created_at"])
+    assert newest["payload"]["since_seq"] == 11
+
+
+async def test_schedule_survives_per_node_storage_failure(client, monkeypatch):
+    """One node's storage failure must not abort the whole schedule run."""
+    from tests.conftest import get_admin_headers
+
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    await _seed_live_node(client, tenant_id, headers, f"node-{uid()}")
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("storage down")
+
+    monkeypatch.setattr(interview_service.get_storage_client(), "create_command", _boom)
+    run = await client.post(
+        "/api/v1/admin/interview/schedule/run", headers=get_admin_headers()
+    )
+    assert run.status_code == 200  # run completes; failure is logged + skipped
+    assert run.json()["commands_queued"] == 0
+
+
+def test_mask_events_masks_tool_and_outcome_fields():
+    events = [
+        {
+            "seq": 0,
+            "content": "ran the export",
+            "tool": "curl -H 'apikey' user@example.com",
+            "outcome": "sent to ran@caura.ai",
+        }
+    ]
+    masked, findings = interview_service.mask_events(events)
+    assert findings >= 2
+    assert "user@example.com" not in masked[0]["tool"]
+    assert "ran@caura.ai" not in masked[0]["outcome"]
+    assert masked[0]["content"] == "ran the export"
+
+
+def test_mask_events_preserves_absent_optional_fields():
+    masked, _ = interview_service.mask_events([{"seq": 0, "content": "plain"}])
+    assert "tool" not in masked[0]
+    assert "outcome" not in masked[0]
+
+
+async def test_submit_rejects_duplicate_seqs(client):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    events = _events(3)
+    events[1]["seq"] = events[0]["seq"]  # duplicate
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, f"node-{uid()}", f"agent-{uid()}", events=events),
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert "no duplicates" in resp.json()["detail"]
+
+
+async def test_submit_rejects_oversized_event_content(client):
+    """API cap == worker cap (INTERVIEW_EVENT_MAX_CHARS): oversized content
+    is a 422, never a silent truncation of the LLM prompt."""
+    from core_api.constants import INTERVIEW_EVENT_MAX_CHARS
+
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    events = _events(1)
+    events[0]["content"] = "x" * (INTERVIEW_EVENT_MAX_CHARS + 1)
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, f"node-{uid()}", f"agent-{uid()}", events=events),
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_parse_ts_coerces_naive_to_utc():
+    items = interview_service.report_to_items(
+        {
+            "decisions": [
+                {"summary": "Naive time decision.", "ts": "2026-07-16T08:00:00"}
+            ]
+        },
+        node_id="n1",
+        command_id=None,
+    )
+    assert items[0].ts_valid_start is not None
+    assert items[0].ts_valid_start.tzinfo is not None
+    assert items[0].ts_valid_start.utcoffset().total_seconds() == 0

--- a/tests/test_api_interview.py
+++ b/tests/test_api_interview.py
@@ -1,0 +1,275 @@
+"""Route tests for ``POST /api/v1/interview/submit`` (Interviewer Phase 1).
+
+The LLM map call (``_interview_chunk``) is stubbed with a canned report so
+assertions are deterministic; everything else — auth, settings gate, bulk
+write idempotency, watermark document — runs the real in-process stack.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import core_api.services.interview_service as interview_service
+from tests.conftest import get_test_auth, uid
+
+
+# ── helpers ──
+
+
+def _events(n: int = 3, start_seq: int = 0) -> list[dict]:
+    base = datetime(2026, 7, 16, 8, 0, tzinfo=UTC)
+    return [
+        {
+            "seq": start_seq + i,
+            "ts": (base + timedelta(minutes=i)).isoformat(),
+            "session_id": "sess-1",
+            "role": "assistant",
+            "kind": "message",
+            "content": f"Worked on step {i}: refactored the ingest pipeline module.",
+        }
+        for i in range(n)
+    ]
+
+
+def _payload(tenant_id: str, node_id: str, agent_id: str, **kw) -> dict:
+    payload = {
+        "tenant_id": tenant_id,
+        "node_id": node_id,
+        "agent_id": agent_id,
+        "command_id": "cmd-1",
+        "cursor_from": 0,
+        "cursor_to": 10,
+        "events": _events(),
+    }
+    payload.update(kw)
+    return payload
+
+
+async def _enable_interviewer(client, tenant_id: str, headers: dict) -> None:
+    resp = await client.put(
+        f"/api/v1/settings?tenant_id={tenant_id}",
+        json={"interviewer": {"enabled": True}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+_CANNED_REPORT = {
+    "worked_on": [
+        {
+            "summary": "Refactored the ingest pipeline module across three steps.",
+            "ts_start": "2026-07-16T08:00:00+00:00",
+            "ts_end": "2026-07-16T08:02:00+00:00",
+            "session_id": "sess-1",
+        }
+    ],
+    "decisions": [
+        {
+            "summary": "Adopted append-only buffer for the ingest path.",
+            "rationale": "In-memory buffer loses the window on crash.",
+            "ts": "2026-07-16T08:01:00+00:00",
+        }
+    ],
+    "outcomes": [
+        {"summary": "Refactor landed green.", "result": "success", "ts": "2026-07-16T08:02:00+00:00"}
+    ],
+    "blockers": [],
+    "open_questions": [],
+    "preferences_learned": [],
+}
+
+
+@pytest.fixture
+def canned_llm(monkeypatch):
+    """Stub the map-phase LLM call with a deterministic report."""
+    calls: list[str] = []
+
+    async def _fake_chunk(prompt, config, events):
+        calls.append(prompt)
+        return _CANNED_REPORT
+
+    monkeypatch.setattr(interview_service, "_interview_chunk", _fake_chunk)
+    return calls
+
+
+# ── gate & validation ──
+
+
+async def test_submit_rejected_when_interviewer_disabled(client):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, f"node-{uid()}", f"agent-{uid()}"),
+        headers=headers,
+    )
+    assert resp.status_code == 403
+    assert "not enabled" in resp.json()["detail"]
+
+
+async def test_submit_rejects_reversed_cursor(client):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, f"node-{uid()}", f"agent-{uid()}", cursor_from=10, cursor_to=5),
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+async def test_submit_rejects_events_outside_window(client):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(
+            tenant_id, f"node-{uid()}", f"agent-{uid()}", cursor_from=0, cursor_to=2, events=_events(5)
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert "within" in resp.json()["detail"]
+
+
+async def test_submit_rejects_unsorted_events(client):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    events = _events(3)
+    events[0], events[2] = events[2], events[0]
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, f"node-{uid()}", f"agent-{uid()}", events=events),
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert "ascending" in resp.json()["detail"]
+
+
+# ── happy path & idempotency ──
+
+
+async def test_submit_happy_path_writes_typed_memories_and_watermark(client, canned_llm):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, node_id, agent_id),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "committed"
+    assert body["watermark"] == 10
+    assert body["memories_written"] == 3  # episode + decision + outcome
+    assert body["errors"] == 0
+    assert len(canned_llm) == 1  # single chunk → single map call
+
+    # The memories are attributed to the WORKER agent, typed per section,
+    # and stamped with the interviewer provenance + real event time.
+    listing = await client.get(
+        f"/api/v1/memories?tenant_id={tenant_id}&agent_id={agent_id}", headers=headers
+    )
+    assert listing.status_code == 200
+    rows = listing.json()["items"] if isinstance(listing.json(), dict) else listing.json()
+    ours = [r for r in rows if (r.get("metadata") or {}).get("source") == "interviewer"]
+    assert len(ours) == 3
+    types = sorted(r["memory_type"] for r in ours)
+    assert types == ["decision", "episode", "outcome"]
+    for row in ours:
+        assert (row.get("metadata") or {}).get("node_id") == node_id
+        assert (row.get("metadata") or {}).get("written_by") == "interviewer"
+
+
+async def test_submit_retry_is_idempotent(client, canned_llm):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    payload = _payload(tenant_id, node_id, agent_id)
+
+    first = await client.post("/api/v1/interview/submit", json=payload, headers=headers)
+    assert first.status_code == 200
+    assert first.json()["memories_written"] == 3
+
+    # Same (node, window) → same server-derived attempt id → every row
+    # resolves duplicate_attempt; watermark stays; no new memories.
+    second = await client.post("/api/v1/interview/submit", json=payload, headers=headers)
+    assert second.status_code == 200, second.text
+    body = second.json()
+    assert body["status"] == "committed"
+    assert body["memories_written"] == 0
+    assert body["errors"] == 0
+    assert body["watermark"] == 10
+
+
+async def test_watermark_is_forward_only(client, canned_llm):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+
+    first = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, node_id, agent_id, cursor_from=0, cursor_to=10),
+        headers=headers,
+    )
+    assert first.json()["watermark"] == 10
+
+    # A stale window (older cursor range) must not regress the cursor.
+    stale = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(
+            tenant_id, node_id, agent_id, cursor_from=0, cursor_to=5, events=_events(3)
+        ),
+        headers=headers,
+    )
+    assert stale.status_code == 200
+    assert stale.json()["watermark"] == 10
+
+
+# ── service-layer unit tests (no DB) ──
+
+
+def test_attempt_id_is_deterministic_and_valid():
+    a = interview_service.interview_attempt_id("node-1", 0, 10)
+    b = interview_service.interview_attempt_id("node-1", 0, 10)
+    c = interview_service.interview_attempt_id("node-1", 0, 11)
+    assert a == b != c
+    import re
+
+    assert re.match(r"^[A-Za-z0-9._:\-]{1,128}$", a)
+
+
+def test_mask_events_masks_pii_before_llm():
+    events = [{"seq": 0, "content": "email me at ran@caura.ai, card 4111 1111 1111 1111"}]
+    masked, findings = interview_service.mask_events(events)
+    assert findings >= 2
+    assert "ran@caura.ai" not in masked[0]["content"]
+    assert "4111 1111 1111 1111" not in masked[0]["content"]
+
+
+def test_chunk_events_respects_char_budget(monkeypatch):
+    monkeypatch.setattr(interview_service, "INTERVIEW_CHUNK_MAX_CHARS", 500)
+    events = [{"seq": i, "content": "x" * 200} for i in range(10)]
+    chunks = interview_service.chunk_events(events)
+    assert len(chunks) > 1
+    assert sum(len(c) for c in chunks) == 10  # nothing dropped
+
+
+def test_merge_reports_dedups_and_caps():
+    r1 = {"decisions": [{"summary": "Use Postgres."}, {"summary": "use postgres."}]}
+    r2 = {"decisions": [{"summary": "Use Postgres."}, {"summary": "Ship Friday."}]}
+    merged = interview_service.merge_reports([r1, r2])
+    summaries = [d["summary"] for d in merged["decisions"]]
+    assert summaries == ["Use Postgres.", "Ship Friday."]
+
+
+def test_report_to_items_maps_types_and_event_time():
+    items = interview_service.report_to_items(_CANNED_REPORT, node_id="n1", command_id="c1")
+    by_type = {i.memory_type: i for i in items}
+    assert set(by_type) == {"episode", "decision", "outcome"}
+    assert by_type["decision"].content.endswith("In-memory buffer loses the window on crash.")
+    assert by_type["outcome"].content.startswith("[success]")
+    # Source event time, not report time.
+    assert by_type["episode"].ts_valid_start is not None
+    assert by_type["episode"].ts_valid_start.year == 2026


### PR DESCRIPTION
## Summary

Server half of **the Interviewer** — a third ingestion mode (pull/reflective): on a per-tenant cadence, a node's buffered activity window is synthesized into a structured report and ingested as typed memories. Full design + fork resolutions: `docs/plans/interviewer-phase1-decisions.md` (committed here); parent design docs live in the MemClaw doc store (`design_docs/interviewer-feature-plan`, `design_docs/interviewer-phase1-spec`).

**Dark by default** — everything is gated on the new per-tenant `interviewer.enabled` setting (default `false`, `skills_factory` posture): the scheduler queues nothing for disabled tenants and the endpoint refuses them (defense in depth). Merging this changes zero behavior for existing tenants.

### What's in

- **`POST /api/v1/interview/submit`** (`routes/interview.py`) — receives one node's event window (C2 shape, ≤500 events), validates cursors/seq ordering, 207 partial semantics, 502 on total failure (plugin must not prune).
- **Interview worker** (`services/interview_service.py`):
  - **Mask before the LLM** — deterministic `common.governance.scan/mask` on every event **on receipt**, because the write-pipeline governance gate only protects persistence and this worker runs the LLM pre-persistence (bulk re-runs the gate → defense in depth).
  - **Chunked map-reduce** (~24k-token chunks) → fixed-JSON report → mapped onto the 14-type enum (`worked_on→episode`, `decisions→decision`, `outcomes→outcome`, `blockers→task`, `open_questions→fact`, `preferences_learned→preference`), section label kept in `metadata.category`, **source event time → `ts_valid_start`** so batching doesn't corrupt freshness ranking.
  - **Effectively-once:** server-derived attempt id `sha1(node:cursor_from:cursor_to)` through the existing `/memories/bulk` idempotency; **forward-only per-node watermark** (`interview_watermarks` doc) advances only after the bulk commits.
  - Attribution: memory `agent_id` = the worker (subject); `metadata.written_by = "interviewer"`.
- **Scheduler** — hourly wall-clock-aligned core-operations tick → `POST /admin/interview/schedule/run` → per opted-in tenant, per **live non-sentinel** node: at most one pending `interview_request` on the existing `/fleet/commands` rail, dueness = watermark `last_interview_at` vs tenant `period_hours`, resumes at `last_seq + 1` (submit-cap backlog drains across ticks). Payload echoes the fleet-node UUID so the plugin submits under the watermark's key.
- **Settings** — `interviewer.{enabled, period_hours, template_id}` + leaf types + bounds; new zero-cost `tenants/interviewer-enabled` storage query (agent-digest pattern).
- Commands are queued **unsigned** in OSS — plugin default is permissive; enterprise signing gateways sign in transit (`MEMCLAW_REQUIRE_SIGNED_COMMANDS` opts into fail-closed).

### Not in this PR (PR-2, plugin side)

On-disk interview buffer + `interview_request` command handler in the OpenClaw plugin (tasks tracked; contract frozen by this PR: payload `{node_id, since_seq, template_id, period_hours}` → submit `{node_id, agent_id, cursor_from/to, events[]}`).

## Test plan

- `tests/test_api_interview.py` (14): settings gate, cursor/seq validation, happy path asserting typed memories + provenance via the real list endpoint, **idempotent retry** (resubmit → 0 written), **forward-only watermark**, full schedule loop (queue → no stacking while pending → ack+submit → not due), **window resume** (`since_seq == watermark+1`), plus unit tests for masking (email+card actually stripped), chunking (nothing dropped), report merge dedup/caps, type mapping.
- core-operations suite (41) green incl. the wall-clock-alignment invariant (new `seconds_until_next_utc_top_of_hour`); adjacent suites (settings/idempotency/keystones/forge-cron, 58) green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)