### PR TITLE
feat(memories): verify broker-write agent ownership (lenient)

### DIFF
--- a/common/models/agent.py
+++ b/common/models/agent.py
@@ -29,6 +29,13 @@ class Agent(Base):
     # heartbeat and persists it to ``install.json`` in the plugin data dir;
     # never rotates. Indexed because the admin UI groups agents by install.
     install_id: Mapped[str | None] = mapped_column(String(32), index=True)
+    # ``owner_install_uuid``: the credential-install (``x-install-uuid``, the
+    # 36-char value) that FIRST wrote memories as this agent. First-touch,
+    # never overwritten (mirrors ``install_id``'s stability). SEPARATE from
+    # ``install_id`` — this is the write-credential's install, used only for
+    # the broker lenient ownership gate; ``install_id`` stays the plugin's
+    # admin-grouping suffix. No index: read per-agent, never a query predicate.
+    owner_install_uuid: Mapped[str | None] = mapped_column(String(36))
     trust_level: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default=text("1"))
     search_profile: Mapped[dict | None] = mapped_column(JSONB)
     # ``belonging_type`` / ``owner_ref``: the typed agent→owner relationship the

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -944,6 +944,13 @@ async def write_memories_bulk(
             bulk_attempt_id = f"broker-{auth.install_uuid or 'unknown'}-{_uuid.uuid4()}"
         if not body.agent_id:
             body.agent_id = _broker_write_agent_id(body.items, auth.install_uuid)
+        # Ownership gate runs on EVERY broker write, not just the
+        # auto-derived case: a broker caller that pre-populates ``agent_id``
+        # in the request body must not bypass the check and write under an
+        # agent owned by a different install. The gate short-circuits
+        # (chosen == fallback, or owner NULL / this install) so the common
+        # paths stay lookup-free.
+        body.agent_id = await _broker_owned_agent_id(body.agent_id, auth.install_uuid, body.tenant_id)
     # Resolve a missing agent_id (mirrors write_memory). Install-credential
     # callers were already attributed above; everyone else either gets the
     # reserved standalone identity or must name a real agent. Defaulting
@@ -1002,7 +1009,63 @@ def _broker_write_agent_id(items: list[BulkMemoryItem], install_uuid: str | None
             agent_ids.add(aid)
     if len(agent_ids) == 1:
         return next(iter(agent_ids))
-    return f"broker:{install_uuid or 'unknown'}"
+    return _broker_label(install_uuid)
+
+
+_BROKER_LABEL_PREFIX = "broker:"
+
+
+def _broker_label(install_uuid: str | None) -> str:
+    """The bare-install fallback identity for a broker write."""
+    return f"{_BROKER_LABEL_PREFIX}{install_uuid or 'unknown'}"
+
+
+def _owned_by_other_install(owner_install_uuid: str | None, install_uuid: str | None) -> bool:
+    """True when an agent row is first-touch owned by a DIFFERENT install than
+    ``install_uuid`` — the single condition under which a broker write is
+    degraded to its own ``broker:<install>`` identity. A NULL owner (unclaimed
+    or grandfathered) is not "another install", so it never triggers a degrade.
+    """
+    return owner_install_uuid is not None and owner_install_uuid != install_uuid
+
+
+async def _broker_owned_agent_id(chosen: str, install_uuid: str | None, tenant_id: str) -> str:
+    """Lenient ownership gate over ``_broker_write_agent_id``'s choice.
+
+    A broker write may be attributed to an agent named in the batch metadata.
+    Before trusting that name, verify this install owns it: ``owner_install_uuid``
+    is stamped (first-touch) with the install that first wrote as the agent.
+    Degrade to the bare-install identity ONLY when the named agent is owned by a
+    *different* install (``owner_install_uuid`` non-NULL AND != this install),
+    so one install can't write under another install's agent id.
+
+    Lenient — never blocks a legitimate first write:
+      - already the install fallback   -> no lookup, return as-is
+      - another install's broker:<x>   -> degrade (reserved namespace; no lookup)
+      - agent doesn't exist yet         -> keep (this write first-touches it)
+      - ``owner_install_uuid`` is NULL  -> keep (unclaimed; this write claims it)
+      - owned by THIS install           -> keep
+      - owned by a DIFFERENT install    -> degrade to ``broker:<install>``
+    """
+    fallback = _broker_label(install_uuid)
+    if chosen == fallback:
+        return chosen
+    # The ``broker:<install>`` namespace is RESERVED — an install may only ever
+    # write as its OWN bare-install identity. A chosen id in that namespace that
+    # isn't this install's own fallback (handled above) is *another* install's
+    # reserved identity (a broker that named ``broker:<other-uuid>`` in
+    # body.agent_id or item metadata). Degrade to this install's own fallback,
+    # with NO lookup: the fallback id is deterministic and guessable, so without
+    # this guard an attacker could first-touch ``broker:<victim>`` (stamping
+    # itself as owner) and thereby capture the victim's later degraded writes.
+    if chosen.startswith(_BROKER_LABEL_PREFIX):
+        return fallback
+    owner = await lookup_agent(tenant_id, chosen)
+    if owner is None:
+        return chosen
+    if _owned_by_other_install(owner.get("owner_install_uuid"), install_uuid):
+        return fallback
+    return chosen
 
 
 def _bulk_response(result: BulkMemoryResponse) -> JSONResponse:
@@ -1040,10 +1103,43 @@ async def _write_memories_bulk_inner(
     bulk_attempt_id: str,
 ):
     # Phase 2 (dark, default off): bind to the verified credential identity
-    # (see _write_memory_inner). Enabled only post-re-identification.
+    # (see _write_memory_inner). Enabled only post-re-identification. When this
+    # overrides body.agent_id, the outer ``_broker_owned_agent_id`` gate's work
+    # is discarded — harmless, because the post-create re-check below is the
+    # authoritative ownership guard; the outer gate is only a lookup-free fast
+    # path that spares this stricter check on the common broker flow.
     if app_settings.bind_write_identity_to_auth and auth.agent_id:
         body.agent_id = auth.agent_id
-    agent = await get_or_create_agent(body.tenant_id, body.agent_id, body.fleet_id)
+    agent = await get_or_create_agent(
+        body.tenant_id,
+        body.agent_id,
+        body.fleet_id,
+        # Stamp ownership only for broker (install-credential) writes, symmetric
+        # with the attribution gate above — never rely on the gateway happening
+        # to omit x-install-uuid for non-broker callers.
+        owner_install_uuid=auth.install_uuid if auth.is_install_credential else None,
+    )
+    # Post-create ownership re-check — closes the first-touch TOCTOU window in
+    # ``_broker_owned_agent_id``. That gate optimistically keeps the chosen
+    # agent id when no row exists yet (``owner is None`` -> pass), so two
+    # brokers racing the same new agent id both pass, but only one wins the
+    # create + ownership stamp. ``get_or_create_agent`` returns the
+    # authoritative committed row (storage re-selects FOR UPDATE and never
+    # overwrites a set ``owner_install_uuid``); if the winner is a different
+    # install, degrade this loser's write to its own ``broker:<install>``
+    # identity rather than mis-attribute it to the winner's agent.
+    if (
+        auth.is_install_credential
+        and auth.install_uuid
+        and _owned_by_other_install(agent.get("owner_install_uuid"), auth.install_uuid)
+    ):
+        body.agent_id = _broker_label(auth.install_uuid)
+        agent = await get_or_create_agent(
+            body.tenant_id,
+            body.agent_id,
+            body.fleet_id,
+            owner_install_uuid=auth.install_uuid,
+        )
     if not body.fleet_id and agent.get("fleet_id"):
         body.fleet_id = agent["fleet_id"]
     usage = None

--- a/core-api/src/core_api/services/agent_service.py
+++ b/core-api/src/core_api/services/agent_service.py
@@ -21,6 +21,7 @@ async def get_or_create_agent(
     require_approval: bool = False,
     display_name: str | None = None,
     install_id: str | None = None,
+    owner_install_uuid: str | None = None,
 ) -> dict:
     """Return the agent dict, creating it on first encounter.
 
@@ -46,6 +47,8 @@ async def get_or_create_agent(
             backfill["display_name"] = display_name
         if install_id is not None and agent.get("install_id") is None:
             backfill["install_id"] = install_id
+        if owner_install_uuid is not None and agent.get("owner_install_uuid") is None:
+            backfill["owner_install_uuid"] = owner_install_uuid
         if backfill:
             agent.update(backfill)
             agent["updated_at"] = datetime.now(UTC)
@@ -93,6 +96,7 @@ async def get_or_create_agent(
         "fleet_id": fleet_id,
         "display_name": display_name,
         "install_id": install_id,
+        "owner_install_uuid": owner_install_uuid,
         "trust_level": initial_trust,
     }
     if inherited_search_profile is not None:
@@ -109,6 +113,7 @@ async def get_or_create_agent(
             "trust_level": initial_trust,
             "display_name": display_name,
             "install_id": install_id,
+            "owner_install_uuid": owner_install_uuid,
             "carried_from_legacy_main": inherited_trust is not None,
         },
     )

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/031_agent_owner_install_uuid.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/031_agent_owner_install_uuid.py
@@ -1,0 +1,41 @@
+"""Add ``owner_install_uuid`` column to ``agents``.
+
+Hardening broker-write attribution: records the credential-install
+(``auth.install_uuid`` — the 36-char ``x-install-uuid``) that FIRST wrote
+memories as this agent. First-touch and never overwritten, mirroring
+``install_id``'s stability guarantee — but a SEPARATE field. ``install_id``
+stays the plugin's admin-grouping suffix (``String(32)``); this holds a full
+credential-install UUID (``String(36)``).
+
+The broker bulk-write route stamps it on first contact and uses it for a
+lenient ownership check: a broker write naming an agent whose
+``owner_install_uuid`` is non-NULL and belongs to a *different* install is
+degraded to the ``broker:<install>`` identity, so one install can't write
+under another install's agent id.
+
+Nullable, no default — existing rows and non-broker callers are unaffected.
+No index: read per-agent via the ``(tenant_id, agent_id)`` lookup, never a
+query predicate.
+
+Revision ID: 031
+Revises: 030
+Create Date: 2026-07-17
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "031"
+down_revision: str | None = "030"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("agents", sa.Column("owner_install_uuid", sa.String(length=36), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "owner_install_uuid")

--- a/core-storage-api/src/core_storage_api/schemas.py
+++ b/core-storage-api/src/core_storage_api/schemas.py
@@ -121,6 +121,7 @@ AGENT_FIELDS: list[str] = [
     "agent_id",
     "display_name",
     "install_id",
+    "owner_install_uuid",
     "trust_level",
     "search_profile",
     "belonging_type",

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -5684,21 +5684,20 @@ class PostgresService:
             # plain idempotent re-register that just wants the
             # existing row back.
             changed = False
-            for key in ("fleet_id", "trust_level", "display_name", "install_id"):
+            for key in ("fleet_id", "trust_level", "display_name", "install_id", "owner_install_uuid"):
                 if key in data and data[key] is not None and getattr(agent, key) != data[key]:
-                    if key == "install_id" and getattr(agent, key) is not None:
-                        # ``install_id`` is the per-OpenClaw-install opaque
-                        # identity that disambiguates the default
-                        # ``agent_id="main"`` across fleet machines. Once
-                        # persisted it must be stable for the agent row's
-                        # lifetime: backfill when previously NULL but never
-                        # overwrite. ``agent_service.get_or_create_agent``
-                        # already enforces this at the application layer;
-                        # the guard is duplicated here so any future direct
-                        # caller of ``agent_add`` (REST endpoint, admin
-                        # tool) can't silently rewrite a stable identity.
-                        # ``display_name`` and ``fleet_id`` intentionally
-                        # overwrite on change (rename / reassignment).
+                    if key in ("install_id", "owner_install_uuid") and getattr(agent, key) is not None:
+                        # ``install_id`` / ``owner_install_uuid`` are stable
+                        # per-install identities: backfill when previously NULL
+                        # but never overwrite. ``install_id`` disambiguates the
+                        # default ``agent_id="main"`` across fleet machines;
+                        # ``owner_install_uuid`` records the credential-install
+                        # that first wrote as this agent (broker ownership gate).
+                        # ``get_or_create_agent`` enforces this at the app layer;
+                        # duplicated here so any direct ``agent_add`` caller
+                        # (REST endpoint, admin tool) can't silently rewrite a
+                        # stable identity. ``display_name`` / ``fleet_id``
+                        # intentionally overwrite on change (rename / reassign).
                         continue
                     setattr(agent, key, data[key])
                     changed = True

--- a/tests/test_broker_bulk_write_ownership.py
+++ b/tests/test_broker_bulk_write_ownership.py
@@ -1,0 +1,245 @@
+"""Route-level regression tests for the broker-write ownership boundary.
+
+These complement the pure-helper unit tests in
+``test_broker_owned_agent_id.py`` by exercising how the bulk-write route
+*wires in* that gate — the two places a naive implementation leaks:
+
+- **Finding 1 (High):** the ownership gate must run on EVERY broker write,
+  including one where the caller pre-populates ``agent_id`` in the request
+  body. A gate that only fires on the auto-derived path lets a broker write
+  under an agent owned by a different install just by naming it explicitly.
+- **Finding 2 (Medium):** ``_broker_owned_agent_id`` optimistically keeps a
+  not-yet-existing agent id (first-touch). Two installs racing the same new
+  id both pass the gate; only one wins the ownership stamp. The post-create
+  re-check in ``_write_memories_bulk_inner`` reads the now-authoritative
+  ``owner_install_uuid`` and degrades the loser to ``broker:<install>``.
+
+The route's happy-path runtime is otherwise integration-tested on the docker
+compose stack; here we mock storage/metering and assert only the attribution
+that ends up on ``body.agent_id``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import Response
+
+from core_api.auth import AuthContext
+from core_api.config import settings as app_settings
+from core_api.routes import memories
+from core_api.schemas import (
+    BulkItemResult,
+    BulkMemoryCreate,
+    BulkMemoryItem,
+    BulkMemoryResponse,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _broker_auth(
+    install_uuid: str | None = "install-1", *, is_install: bool = True
+) -> AuthContext:
+    return AuthContext(
+        tenant_id="tenant-1",
+        is_install_credential=is_install,
+        install_uuid=install_uuid,
+    )
+
+
+def _bulk_body(agent_id: str | None) -> BulkMemoryCreate:
+    return BulkMemoryCreate(
+        tenant_id="tenant-1",
+        agent_id=agent_id,
+        items=[BulkMemoryItem(content="hello world")],
+    )
+
+
+def _ok_response() -> BulkMemoryResponse:
+    return BulkMemoryResponse(
+        created=1,
+        duplicates=0,
+        errors=0,
+        results=[BulkItemResult(index=0, status="created", id=uuid4())],
+        bulk_ms=1,
+    )
+
+
+# ── Finding 1: gate applies to an explicitly-supplied agent_id ──────────
+
+
+async def _run_outer(
+    monkeypatch, *, body: BulkMemoryCreate, auth: AuthContext, owner: str | None
+) -> str:
+    """Drive ``write_memories_bulk`` with the gate's storage lookup mocked;
+    return the ``agent_id`` the route hands to the inner writer."""
+    monkeypatch.setattr(
+        memories,
+        "lookup_agent",
+        AsyncMock(
+            return_value=None
+            if owner is None
+            else {"agent_id": body.agent_id, "owner_install_uuid": owner}
+        ),
+    )
+    monkeypatch.setattr(memories, "idempotency_for", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        memories, "per_tenant_slot", lambda *a, **k: contextlib.nullcontext()
+    )
+
+    captured: dict[str, str | None] = {}
+
+    async def _inner(body_, response_, auth_, idem_, bulk_attempt_id_):
+        captured["agent_id"] = body_.agent_id
+        return "SENTINEL"
+
+    monkeypatch.setattr(memories, "_write_memories_bulk_inner", _inner)
+
+    result = await memories.write_memories_bulk(
+        request=SimpleNamespace(),
+        body=body,
+        response=Response(),
+        auth=auth,
+        idempotency_key=None,
+        bulk_attempt_id="attempt-1",
+    )
+    assert result == "SENTINEL"
+    return captured["agent_id"]
+
+
+async def test_explicit_agent_id_owned_by_other_install_is_degraded(monkeypatch):
+    # Finding 1: broker names an agent it does NOT own -> must NOT bypass the gate.
+    agent_id = await _run_outer(
+        monkeypatch,
+        body=_bulk_body("victim-agent"),
+        auth=_broker_auth("install-1"),
+        owner="install-2",
+    )
+    assert agent_id == "broker:install-1"
+
+
+async def test_explicit_agent_id_owned_by_self_is_kept(monkeypatch):
+    agent_id = await _run_outer(
+        monkeypatch,
+        body=_bulk_body("my-agent"),
+        auth=_broker_auth("install-1"),
+        owner="install-1",
+    )
+    assert agent_id == "my-agent"
+
+
+async def test_explicit_agent_id_unclaimed_is_kept(monkeypatch):
+    # Owner NULL (grandfathered/unclaimed) -> lenient: this write claims it.
+    agent_id = await _run_outer(
+        monkeypatch,
+        body=_bulk_body("fresh-agent"),
+        auth=_broker_auth("install-1"),
+        owner=None,
+    )
+    assert agent_id == "fresh-agent"
+
+
+# ── Finding 2: post-create re-check closes the first-touch race ──────────
+
+
+async def _run_inner(
+    monkeypatch, *, body: BulkMemoryCreate, auth: AuthContext, get_or_create: AsyncMock
+) -> str:
+    """Drive ``_write_memories_bulk_inner`` with storage/metering mocked;
+    return the ``agent_id`` that reaches ``create_memories_bulk``."""
+    monkeypatch.setattr(app_settings, "bind_write_identity_to_auth", False)
+    monkeypatch.setattr(memories, "get_or_create_agent", get_or_create)
+    monkeypatch.setattr(memories, "enforce_fleet_write", AsyncMock(return_value={}))
+    monkeypatch.setattr(
+        memories, "bulk_check_and_increment", AsyncMock(return_value=None)
+    )
+
+    captured: dict[str, str | None] = {}
+
+    async def _create(body_, *, bulk_attempt_id=None):
+        captured["agent_id"] = body_.agent_id
+        return _ok_response()
+
+    monkeypatch.setattr(memories, "create_memories_bulk", _create)
+
+    await memories._write_memories_bulk_inner(body, Response(), auth, None, "attempt-1")
+    return captured["agent_id"]
+
+
+async def test_post_create_recheck_degrades_when_race_lost(monkeypatch):
+    # Gate passed (agent didn't exist at read time); the create returns the
+    # committed row owned by a DIFFERENT install -> loser degrades to broker id.
+    get_or_create = AsyncMock(
+        side_effect=[
+            {
+                "owner_install_uuid": "install-2",
+                "fleet_id": None,
+            },  # winner is install-2
+            {
+                "owner_install_uuid": "install-1",
+                "fleet_id": None,
+            },  # re-create under broker id
+        ]
+    )
+    agent_id = await _run_inner(
+        monkeypatch,
+        body=_bulk_body("contested-agent"),
+        auth=_broker_auth("install-1"),
+        get_or_create=get_or_create,
+    )
+    assert agent_id == "broker:install-1"
+    assert get_or_create.await_count == 2
+    # Second create is under the degraded identity.
+    assert get_or_create.await_args_list[1].args[1] == "broker:install-1"
+
+
+async def test_post_create_no_recheck_when_owner_matches(monkeypatch):
+    get_or_create = AsyncMock(
+        return_value={"owner_install_uuid": "install-1", "fleet_id": None}
+    )
+    agent_id = await _run_inner(
+        monkeypatch,
+        body=_bulk_body("my-agent"),
+        auth=_broker_auth("install-1"),
+        get_or_create=get_or_create,
+    )
+    assert agent_id == "my-agent"
+    assert get_or_create.await_count == 1
+
+
+async def test_post_create_recheck_skipped_for_non_broker(monkeypatch):
+    # A non-install (dashboard/SDK) caller is NOT subject to the broker gate
+    # even if the agent row happens to carry an owner_install_uuid.
+    get_or_create = AsyncMock(
+        return_value={"owner_install_uuid": "install-2", "fleet_id": None}
+    )
+    agent_id = await _run_inner(
+        monkeypatch,
+        body=_bulk_body("dash-agent"),
+        auth=_broker_auth(None, is_install=False),
+        get_or_create=get_or_create,
+    )
+    assert agent_id == "dash-agent"
+    assert get_or_create.await_count == 1
+
+
+# ── Reserved broker:<install> namespace can't be pre-claimed ─────────────
+
+
+async def test_cannot_preclaim_another_installs_fallback(monkeypatch):
+    # Attacker (install-3) explicitly names victim install-1's reserved fallback.
+    # It must degrade to the attacker's OWN fallback so install-3 never creates
+    # or owns "broker:install-1" — otherwise it could capture install-1's later
+    # degraded writes.
+    agent_id = await _run_outer(
+        monkeypatch,
+        body=_bulk_body("broker:install-1"),
+        auth=_broker_auth("install-3"),
+        owner=None,
+    )
+    assert agent_id == "broker:install-3"

--- a/tests/test_broker_owned_agent_id.py
+++ b/tests/test_broker_owned_agent_id.py
@@ -1,0 +1,82 @@
+"""Unit tests for the broker-attribution ownership gate (_broker_owned_agent_id).
+
+A broker (install-credential) bulk write may name an agent in its batch
+metadata; the gate keeps that attribution only when this install may claim the
+agent, and otherwise degrades to the bare ``broker:<install>`` identity so one
+install can't write under another install's agent id. Lenient — never raises.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core_api.routes import memories
+
+pytestmark = pytest.mark.unit
+
+
+async def test_owned_by_this_install_kept(monkeypatch):
+    monkeypatch.setattr(
+        memories,
+        "lookup_agent",
+        AsyncMock(
+            return_value={"agent_id": "agent-a", "owner_install_uuid": "install-1"}
+        ),
+    )
+    assert (
+        await memories._broker_owned_agent_id("agent-a", "install-1", "t") == "agent-a"
+    )
+
+
+async def test_owned_by_different_install_degraded(monkeypatch):
+    monkeypatch.setattr(
+        memories,
+        "lookup_agent",
+        AsyncMock(
+            return_value={"agent_id": "agent-a", "owner_install_uuid": "install-2"}
+        ),
+    )
+    assert (
+        await memories._broker_owned_agent_id("agent-a", "install-1", "t")
+        == "broker:install-1"
+    )
+
+
+async def test_null_owner_kept(monkeypatch):
+    # Grandfathered / unclaimed agent — this write first-touches it.
+    monkeypatch.setattr(
+        memories,
+        "lookup_agent",
+        AsyncMock(return_value={"agent_id": "agent-a", "owner_install_uuid": None}),
+    )
+    assert (
+        await memories._broker_owned_agent_id("agent-a", "install-1", "t") == "agent-a"
+    )
+
+
+async def test_nonexistent_agent_kept(monkeypatch):
+    # No row yet — this write creates + owns it via get_or_create_agent.
+    monkeypatch.setattr(memories, "lookup_agent", AsyncMock(return_value=None))
+    assert (
+        await memories._broker_owned_agent_id("agent-a", "install-1", "t") == "agent-a"
+    )
+
+
+async def test_already_fallback_short_circuits(monkeypatch):
+    # The chosen id is already the install fallback — no lookup needed.
+    spy = AsyncMock(return_value=None)
+    monkeypatch.setattr(memories, "lookup_agent", spy)
+    result = await memories._broker_owned_agent_id("broker:install-1", "install-1", "t")
+    assert result == "broker:install-1"
+    spy.assert_not_awaited()
+
+
+async def test_foreign_broker_label_degraded_without_lookup(monkeypatch):
+    # Reserved ``broker:`` namespace: naming ANOTHER install's fallback degrades
+    # to THIS install's own fallback with NO lookup, so the deterministic
+    # (guessable) fallback id can't be pre-claimed to capture a victim's writes.
+    spy = AsyncMock(return_value=None)
+    monkeypatch.setattr(memories, "lookup_agent", spy)
+    result = await memories._broker_owned_agent_id("broker:install-1", "install-3", "t")
+    assert result == "broker:install-3"
+    spy.assert_not_awaited()

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"030"}, f"Expected single head '030', got {sorted(heads)}"
+        assert heads == {"031"}, f"Expected single head '031', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -686,6 +686,8 @@ class TestMigrationChain:
         assert chain.get("029") == "028", "029 must follow 028"
         # 030: register the memclaw-insighter service agent for existing tenants
         assert chain.get("030") == "029", "030 must follow 029"
+        # 031: broker-write agent ownership column (owner_install_uuid)
+        assert chain.get("031") == "030", "031 must follow 030"
 
     def test_no_plain_create_index_on_large_tables(self):
         """Indexes on large, pre-existing tables MUST be built ``CONCURRENTLY``


### PR DESCRIPTION
## What

Hardens broker-write attribution (the **lenient** variant of backlog #2). Broker (install-credential) bulk writes trusted the client-supplied `metadata.agent_id` verbatim (#556), so an install could attribute a memory to **any** agent in its tenant — within-tenant and label-only, but the "which agent" attribution wasn't trustworthy.

## Approach: lenient ownership check

- **New `agents.owner_install_uuid`** (migration 031) — the credential-install (`auth.install_uuid`) that *first* wrote memories as the agent. First-touch, never overwritten (mirrors `install_id`'s stability), but a **separate** field from `install_id` (which stays the plugin's admin-grouping suffix — a different id namespace, so a dedicated column rather than overloading it).
- `get_or_create_agent` threads `owner_install_uuid`; the broker bulk-write path stamps it first-touch, **only for install credentials** (symmetric with the attribution gate).
- **Lenient gate** `_broker_owned_agent_id`: degrade the chosen `agent_id` to `broker:<install>` **only** when the named agent's `owner_install_uuid` is non-NULL and belongs to a *different* install. Never rejects a write; unclaimed / nonexistent / same-install agents keep their attribution.

## Behavior / safety

- No change for legitimate single-install use; a degrade happens only on genuine cross-install attribution.
- `install_id` (plugin admin grouping) is untouched; `owner_install_uuid` is nullable (no default, no index — read per-agent, never a query predicate).
- Migration 031 is a non-destructive `add_column`, applied via the storage-service alembic lifespan flow.

## Tests

`tests/test_broker_owned_agent_id.py` covers all gate branches (owned-by-this / owned-by-different → degraded / null-owner / nonexistent / already-fallback short-circuit). Locally: gate + memory/reports suites pass against Postgres; ruff + mypy clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)