### PR TITLE
fix(logging): emit Datadog `status` field so log levels survive intake

### DIFF
--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -6,7 +6,17 @@ this, log lines written through `structlog` end up as severity `DEFAULT`
 (unlabeled) in Cloud Logging, which breaks severity filtering and distorts
 severity-based histograms.
 
-This module wires those two fields in via processors, and is safe to call
+Datadog derives a log's official status from the JSON `status` field (the
+first attribute its JSON preprocessing checks). Observed intake behavior for
+our org: `severity` is NOT consulted, and the serverless-init sidecar that
+ships Cloud Run stdout stamps every line with the stream-derived status
+`info` — so without an explicit `status` field every log, ERRORs included,
+lands in Datadog as status:info, leaving `status:error` queries and log
+monitors blind (verified 2026-07-17 against prod/staging logs, all 1.6M/3d
+status:info). `_add_datadog_status` emits the field so both backends see
+the real level.
+
+This module wires those fields in via processors, and is safe to call
 from multiple service entry points because it's idempotent. Callers pass
 their own `environment` and `log_level` so this module stays agnostic of
 per-service settings schemas.
@@ -33,6 +43,19 @@ _LEVEL_TO_SEVERITY = {
     "info": "INFO",
     "debug": "DEBUG",
 }
+
+# GCP severity enum values beyond what the standard log-level methods emit —
+# reachable only via an explicit `severity=` override (see _LEVEL_TO_SEVERITY's
+# comment). Each lowercases to a status Datadog's syslog-style vocabulary
+# recognizes (notice/alert/emergency), so overrides carry through to both
+# backends instead of being demoted.
+_OVERRIDE_ONLY_SEVERITIES = frozenset({"NOTICE", "ALERT", "EMERGENCY"})
+
+# Every GCP severity that maps 1:1 onto a Datadog status via `.lower()`.
+# Derived from _LEVEL_TO_SEVERITY so the two can't drift; GCP's DEFAULT is
+# deliberately absent (Datadog has no equivalent — the processor falls back
+# to the method-derived level instead).
+_DATADOG_STATUS_SEVERITIES = frozenset(_LEVEL_TO_SEVERITY.values()) | _OVERRIDE_ONLY_SEVERITIES
 
 # Allowlist for log_level validation. `isinstance(min_level, int)` would
 # admit `logging.NOTSET` (== 0), which silently disables both the level
@@ -109,6 +132,14 @@ _LOG_RECORD_STANDARD_ATTRS: frozenset[str] = frozenset(
 #     log-level-derived value, producing an invalid GCP severity, and
 #     potentially misrouting log-based alerts.
 #
+#   * ``status`` — ``_add_datadog_status`` derives it from the final
+#     severity / method level, and Datadog's JSON preprocessing remaps
+#     it into the log's official status. An ``extra={"status": 200}``
+#     (an application-domain value, e.g. an HTTP status code) would be
+#     unrecognized at intake and degrade the whole line to `info` —
+#     re-opening the every-log-is-info blindness the processor exists
+#     to fix.
+#
 #   * ``stack`` — set by ``StackInfoRenderer`` ONLY when the caller
 #     passes ``stack_info=True``. Without that flag, the renderer is
 #     a no-op and an ``extra={"stack": "noise"}`` would propagate
@@ -120,7 +151,7 @@ _LOG_RECORD_STANDARD_ATTRS: frozenset[str] = frozenset(
 #     ``extra={"exception": "fake"}`` persists in the JSON payload,
 #     fabricating exception data on a non-exception log line.
 _RESERVED_OUTPUT_KEYS: frozenset[str] = frozenset(
-    {"event", "message", "severity", "stack", "exception"}
+    {"event", "message", "severity", "status", "stack", "exception"}
 )
 
 
@@ -176,6 +207,33 @@ def _map_to_gcp_severity(
     severity = event_dict.get("severity")
     if severity is None or severity == "":
         event_dict["severity"] = _LEVEL_TO_SEVERITY.get(method_name, "DEFAULT")
+    return event_dict
+
+
+def _add_datadog_status(
+    _logger: Any,
+    method_name: str,
+    event_dict: dict[str, Any],
+) -> dict[str, Any]:
+    """Emit the Datadog `status` field alongside GCP's `severity`.
+
+    Any recognized GCP severity — method-derived or an explicit
+    `severity=` override, NOTICE/ALERT/EMERGENCY included — lowercases to
+    a status Datadog's syslog-style vocabulary understands, keeping both
+    backends' views of the line in agreement. GCP's DEFAULT and garbage /
+    non-string severities (the falsy-but-intentional values
+    `_map_to_gcp_severity` preserves) fall back to the method-derived
+    level so the status at least stays truthful to the call site rather
+    than leak a value Datadog would degrade to `info`. Always overwrites:
+    a caller- or contextvar-supplied `status` would otherwise remap the
+    line to an arbitrary value at Datadog intake. The `isinstance` guard
+    is load-bearing — unhashable overrides like `[]` would raise on set
+    membership.
+    """
+    severity = event_dict.get("severity")
+    if not (isinstance(severity, str) and severity in _DATADOG_STATUS_SEVERITIES):
+        severity = _LEVEL_TO_SEVERITY.get(method_name, "INFO")
+    event_dict["status"] = severity.lower()
     return event_dict
 
 
@@ -255,6 +313,9 @@ def _json_processors() -> list[Any]:
         structlog.processors.format_exc_info,
         _drop_level_field,
         _map_to_gcp_severity,
+        # After _map_to_gcp_severity so the status derives from the final
+        # (possibly caller-overridden) severity.
+        _add_datadog_status,
         _rename_event_to_message,
     ]
 
@@ -554,10 +615,10 @@ def _configure_logging_impl(
         processors.append(structlog.dev.ConsoleRenderer(colors=sys.stdout.isatty()))
     else:
         # JSON for Cloud Run. The JSON chain (`format_exc_info` → drop
-        # `level` → GCP severity → `event` → `message`) is centralised in
-        # `_json_processors()` because the stdlib bridge below needs the
-        # same sequence. ConsoleRenderer handles `exc_info` directly, so
-        # `format_exc_info` MUST NOT run in the dev branch.
+        # `level` → GCP severity → Datadog status → `event` → `message`)
+        # is centralised in `_json_processors()` because the stdlib bridge
+        # below needs the same sequence. ConsoleRenderer handles `exc_info`
+        # directly, so `format_exc_info` MUST NOT run in the dev branch.
         processors.extend(_json_processors())
         processors.append(structlog.processors.JSONRenderer(default=str))
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -9,6 +9,7 @@ import pytest
 
 from common.structlog_config import (
     _THIRD_PARTY_LOGGERS_TO_REROUTE,
+    _add_datadog_status,
     _map_to_gcp_severity,
     _rename_event_to_message,
     _reset_for_testing,
@@ -66,6 +67,63 @@ def test_map_to_gcp_severity_preserves_falsy_non_none_non_empty() -> None:
     for value in values:
         result = _map_to_gcp_severity(None, "info", {"event": "x", "severity": value})
         assert result["severity"] == value
+
+
+def test_add_datadog_status_maps_each_level() -> None:
+    # Run after _map_to_gcp_severity, exactly as ordered in
+    # _json_processors(), so the status derives from the final severity.
+    for method, expected in [
+        ("info", "info"),
+        ("warning", "warning"),
+        ("warn", "warning"),
+        ("error", "error"),
+        ("critical", "critical"),
+        ("debug", "debug"),
+    ]:
+        event_dict = _map_to_gcp_severity(None, method, {"event": "hello"})
+        result = _add_datadog_status(None, method, event_dict)
+        assert result["status"] == expected
+
+
+def test_add_datadog_status_unknown_method_falls_back_to_info() -> None:
+    # "notice" isn't a structlog level method: severity lands DEFAULT and
+    # status degrades to "info" (Datadog's own default for unrecognized
+    # values) rather than leaking "default".
+    event_dict = _map_to_gcp_severity(None, "notice", {"event": "hi"})
+    result = _add_datadog_status(None, "notice", event_dict)
+    assert result["status"] == "info"
+
+
+def test_add_datadog_status_severity_override_carries_through() -> None:
+    # Explicit severity= overrides — the module-documented route to levels
+    # the standard methods can't emit — must agree across both backends.
+    # NOTICE/ALERT/EMERGENCY are valid syslog-style Datadog statuses.
+    for override, expected in [
+        ("ERROR", "error"),
+        ("NOTICE", "notice"),
+        ("ALERT", "alert"),
+        ("EMERGENCY", "emergency"),
+    ]:
+        result = _add_datadog_status(None, "info", {"event": "x", "severity": override})
+        assert result["status"] == expected
+
+
+def test_add_datadog_status_unrecognized_severity_uses_method_level() -> None:
+    # A severity outside the GCP enum (e.g. an app-domain label that slipped
+    # through) has no Datadog meaning; status falls back to the real
+    # call-site level instead of a value intake would degrade to info.
+    result = _add_datadog_status(None, "warning", {"event": "x", "severity": "P1"})
+    assert result["status"] == "warning"
+
+
+def test_add_datadog_status_falsy_severity_uses_method_level() -> None:
+    # 0/False/[] severities are preserved for GCP (see
+    # test_map_to_gcp_severity_preserves_falsy_non_none_non_empty); status
+    # must derive from the method rather than crash or emit garbage.
+    values: list[object] = [0, False, []]
+    for value in values:
+        result = _add_datadog_status(None, "error", {"event": "x", "severity": value})
+        assert result["status"] == "error"
 
 
 def test_rename_event_to_message_moves_field() -> None:
@@ -423,6 +481,10 @@ def test_extra_message_key_is_rejected_by_stdlib_then_blocked_in_depth(
         # None/""; a non-empty extra value would survive and produce
         # an invalid GCP severity or misroute alerts.
         ("severity", "P1", "INFO"),
+        # ``status`` — an application-domain value (e.g. an HTTP status
+        # code) would reach Datadog's JSON preprocessing as the log's
+        # official status and degrade the line to `info`.
+        ("status", "200", "info"),
         # ``stack`` — StackInfoRenderer only sets this when
         # stack_info=True; an extra would propagate untouched.
         ("stack", "fake-traceback", None),
@@ -435,8 +497,8 @@ def test_extra_message_key_is_rejected_by_stdlib_then_blocked_in_depth(
 def test_extra_pipeline_reserved_keys_are_dropped(
     _json_log_buffer, extra_key: str, extra_value: str, expected_value
 ) -> None:
-    """Reserved-output-key extras (``severity``, ``stack``, ``exception``)
-    must be dropped by ``_add_logrecord_extras`` so a caller can't
+    """Reserved-output-key extras (``severity``, ``status``, ``stack``,
+    ``exception``) must be dropped by ``_add_logrecord_extras`` so a caller can't
     silently inject pipeline-managed fields via ``extra={...}``. Each
     one corresponds to a real corruption vector documented on
     ``_RESERVED_OUTPUT_KEYS``."""
@@ -462,3 +524,25 @@ def test_extra_pipeline_reserved_keys_are_dropped(
     # break the happy path.
     assert record["ok"] is True
     assert record["message"] == "real-message"
+
+
+def test_stdlib_logger_emits_datadog_status_alongside_severity(
+    _json_log_buffer,
+) -> None:
+    """The JSON payload must carry ``status`` (Datadog) next to
+    ``severity`` (GCP). Pre-fix, the serverless-init envelope's
+    stream-derived status (``info`` for stdout) won at Datadog intake and
+    every log — ERRORs included — landed as status:info, making
+    ``status:error`` queries and log monitors blind."""
+    logger = logging.getLogger("test_dd_status_e2e")
+    logger.warning("warn-level message")
+    logger.error("error-level message")
+    lines = _json_log_buffer.getvalue().strip().splitlines()
+    for needle, severity, status in [
+        ('"warn-level message"', "WARNING", "warning"),
+        ('"error-level message"', "ERROR", "error"),
+    ]:
+        records = [json.loads(line) for line in lines if needle in line]
+        assert len(records) == 1, f"expected one record for {needle}, got: {lines}"
+        assert records[0]["severity"] == severity
+        assert records[0]["status"] == status


### PR DESCRIPTION
## Problem

Every log the fleet ships to Datadog arrives as `status:info` — verified 2026-07-17: ~1.6M logs over 3 days across prod+staging (core-api, platform-storage-api, platform-auth-api, core-storage-reader/writer, core-worker, platform-admin-api, platform-audit-api, platform/core-operations), **zero** logs of any other status. `status:error` queries and any log-based alerting are blind — the July 5–12 staging Pub/Sub dead-letter storm (thousands of consumer failures) produced no error-status logs.

## Root cause

`common/structlog_config.py` deliberately emits GCP-style `severity` (uppercase; Cloud Logging promotes it) and drops structlog's lowercase `level`. But Datadog's JSON preprocessing derives the official log status from the **`status`** attribute — and the only `status` on the wire comes from the serverless-init envelope, which stamps the stream default (`info` for stdout) onto every line. Observed on live logs: `@severity:WARNING` sitting next to `@status:info` and official status `info`.

## Fix

New `_add_datadog_status` processor in the JSON chain (both the native structlog path and the stdlib bridge, via `_json_processors()`):

- Any recognized GCP severity — method-derived or an explicit `severity=` override, NOTICE/ALERT/EMERGENCY included — lowercases to a syslog-style status Datadog's vocabulary understands, so both backends see the same level.
- GCP's `DEFAULT` and garbage/non-string severities fall back to the method-derived level rather than leak a value intake would degrade to `info`.
- The membership set is derived from `_LEVEL_TO_SEVERITY` so the two can't drift.
- `status` joins `_RESERVED_OUTPUT_KEYS`: an `extra={"status": 200}` (app-domain value) can no longer hijack the official status at intake.

`common/` is vendored OSS→enterprise, so the re-vendor bot propagates this to the enterprise fleet after merge.

## Verification

- 32/32 tests in `tests/test_logging.py` (5 new unit tests + reserved-key param case + an end-to-end stdlib-bridge test asserting `status`+`severity` pairs).
- `ruff check` clean; `ruff format --diff` produces no hunks touching the new code (the files carry pre-existing formatter drift that CI doesn't police on these paths — left untouched to keep the diff focused).
- `mypy` clean for both core-api (188 files) and core-storage-api (71 files).
- Post-merge check once staging picks it up: `env:staging status:(warn OR error)` in Datadog Logs should start returning rows (e.g. the recurring "Contradiction check failed" WARNINGs).

## Fallback if intake still pins info

If the serverless-init envelope status somehow still wins over the in-payload field, the 2-minute Datadog-side alternative is a pipeline **status remapper** on `@severity` (Logs → Pipelines). Not included here since the emit-side field is the canonical mechanism and works for any future log consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)