### PR TITLE
feat(memories): enforce broker-write ownership boundary on the MCP write path

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -54,6 +54,7 @@ from core_api.services.agent_service import (
     enforce_fleet_read,
     enforce_fleet_write,
     get_or_create_agent,
+    resolve_write_agent,
 )
 from core_api.services.audit_service import log_action, log_cross_tenant_read
 from core_api.services.capability_usage import record_usage
@@ -105,6 +106,16 @@ _readable_tenant_ids_var: contextvars.ContextVar[list[str] | None] = contextvars
     "mcp_readable_tenant_ids", default=None
 )
 _scopes_var: contextvars.ContextVar[set[str] | None] = contextvars.ContextVar("mcp_scopes", default=None)
+# memclawd (broker) identity, plumbed from the gateway on the verified path.
+# X-Caura-Credential-Kind distinguishes ``install_credential`` (broker) from
+# ``user_api_key`` (dashboard/SDK); X-Install-UUID is the broker's install id.
+# Drives the agent-ownership boundary on MCP writes (parity with REST auth).
+_credential_kind_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "mcp_credential_kind", default=None
+)
+_install_uuid_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "mcp_install_uuid", default=None
+)
 
 _UNAUTH = "__unauthenticated__"
 _ADMIN = "__admin__"
@@ -276,6 +287,18 @@ class MCPAuthMiddleware:
                 else ""
             )
             _scopes_var.set({s.strip() for s in caps_header.split(",") if s.strip()} if caps_header else None)
+            # Credential provenance for the write-ownership boundary. Only
+            # honored on the gateway-verified path — a direct client must not
+            # be able to self-assert an install identity and write under a
+            # broker's ownership namespace.
+            _credential_kind_var.set(
+                (headers.get(b"x-caura-credential-kind", b"").decode().lower() or None)
+                if via_gateway
+                else None
+            )
+            _install_uuid_var.set(
+                (headers.get(b"x-install-uuid", b"").decode() or None) if via_gateway else None
+            )
 
         await self.app(scope, receive, send)
 
@@ -297,6 +320,17 @@ def _get_readable_tenants() -> list[str]:
 def _get_scopes() -> set[str] | None:
     """Return the credential's scope set, or None for full-scope (legacy) keys."""
     return _scopes_var.get(None)
+
+
+def _is_install_credential() -> bool:
+    """True when the gateway authenticated this call with a memclawd install
+    credential (kind=install_credential) — mirrors ``AuthContext.is_install_credential``."""
+    return _credential_kind_var.get(None) == "install_credential"
+
+
+def _get_install_uuid() -> str | None:
+    """The broker's install UUID (X-Install-UUID), or None for non-broker calls."""
+    return _install_uuid_var.get(None)
 
 
 def _is_write_allowed() -> bool:
@@ -766,6 +800,20 @@ async def memclaw_write(
     # ``db``-first signatures satisfied.
     async with _no_db():
         try:
+            # Broker (install-credential) agent-ownership boundary — the same
+            # gate + owner-stamp + post-create re-check the REST write paths use
+            # (``resolve_write_agent``), so an install can't attribute a memory
+            # to an agent owned by a different install via MCP. Non-broker
+            # (interactive) callers pass straight through. Runs before
+            # ``enforce_fleet_write`` so the trust gate applies to the resolved
+            # (possibly degraded ``broker:<install>``) id.
+            _agent, agent_id = await resolve_write_agent(
+                agent_id,
+                tenant_id,
+                fleet_id,
+                is_install_credential=_is_install_credential(),
+                install_uuid=_get_install_uuid(),
+            )
             # Register the calling agent (auto-create row on first write) and
             # enforce trust gating for cross-fleet writes — same surface the
             # REST write path uses. Without this, MCP writes succeed without

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -59,11 +59,13 @@ from core_api.schemas import (
 )
 from core_api.services.agent_service import (
     authorize_memory_access,
+    broker_label,
     enforce_delete,
     enforce_fleet_read,
     enforce_fleet_write,
     get_or_create_agent,
     lookup_agent,
+    resolve_write_agent,
 )
 from core_api.services.audit_service import log_action, log_cross_tenant_read
 from core_api.services.ingest_service import (
@@ -822,9 +824,10 @@ async def _write_memory_inner(
     # an agent owned by a different install.
     agent, body.agent_id = await resolve_write_agent(
         body.agent_id,
-        auth,
         body.tenant_id,
         body.fleet_id,
+        is_install_credential=auth.is_install_credential,
+        install_uuid=auth.install_uuid,
         require_approval=write_config.require_agent_approval,
     )
     if agent.get("trust_level", 0) == 0:
@@ -1012,119 +1015,7 @@ def _broker_write_agent_id(items: list[BulkMemoryItem], install_uuid: str | None
             agent_ids.add(aid)
     if len(agent_ids) == 1:
         return next(iter(agent_ids))
-    return _broker_label(install_uuid)
-
-
-_BROKER_LABEL_PREFIX = "broker:"
-
-
-def _broker_label(install_uuid: str | None) -> str:
-    """The bare-install fallback identity for a broker write."""
-    return f"{_BROKER_LABEL_PREFIX}{install_uuid or 'unknown'}"
-
-
-def _owned_by_other_install(owner_install_uuid: str | None, install_uuid: str | None) -> bool:
-    """True when an agent row is first-touch owned by a DIFFERENT install than
-    ``install_uuid`` — the single condition under which a broker write is
-    degraded to its own ``broker:<install>`` identity. A NULL owner (unclaimed
-    or grandfathered) is not "another install", so it never triggers a degrade.
-    """
-    return owner_install_uuid is not None and owner_install_uuid != install_uuid
-
-
-async def _broker_owned_agent_id(chosen: str, install_uuid: str | None, tenant_id: str) -> str:
-    """Lenient ownership gate over ``_broker_write_agent_id``'s choice.
-
-    A broker write may be attributed to an agent named in the batch metadata.
-    Before trusting that name, verify this install owns it: ``owner_install_uuid``
-    is stamped (first-touch) with the install that first wrote as the agent.
-    Degrade to the bare-install identity ONLY when the named agent is owned by a
-    *different* install (``owner_install_uuid`` non-NULL AND != this install),
-    so one install can't write under another install's agent id.
-
-    Lenient — never blocks a legitimate first write:
-      - already the install fallback   -> no lookup, return as-is
-      - another install's broker:<x>   -> degrade (reserved namespace; no lookup)
-      - agent doesn't exist yet         -> keep (this write first-touches it)
-      - ``owner_install_uuid`` is NULL  -> keep (unclaimed; this write claims it)
-      - owned by THIS install           -> keep
-      - owned by a DIFFERENT install    -> degrade to ``broker:<install>``
-    """
-    fallback = _broker_label(install_uuid)
-    if chosen == fallback:
-        return chosen
-    # The ``broker:<install>`` namespace is RESERVED — an install may only ever
-    # write as its OWN bare-install identity. A chosen id in that namespace that
-    # isn't this install's own fallback (handled above) is *another* install's
-    # reserved identity (a broker that named ``broker:<other-uuid>`` in
-    # body.agent_id or item metadata). Degrade to this install's own fallback,
-    # with NO lookup: the fallback id is deterministic and guessable, so without
-    # this guard an attacker could first-touch ``broker:<victim>`` (stamping
-    # itself as owner) and thereby capture the victim's later degraded writes.
-    if chosen.startswith(_BROKER_LABEL_PREFIX):
-        return fallback
-    owner = await lookup_agent(tenant_id, chosen)
-    if owner is None:
-        return chosen
-    if _owned_by_other_install(owner.get("owner_install_uuid"), install_uuid):
-        return fallback
-    return chosen
-
-
-async def resolve_write_agent(
-    chosen_agent_id: str,
-    auth: AuthContext,
-    tenant_id: str,
-    fleet_id: str | None,
-    *,
-    require_approval: bool = False,
-) -> tuple[dict, str]:
-    """Resolve the agent a write is attributed to, enforcing the broker
-    ownership boundary, and return ``(agent_row, safe_agent_id)``.
-
-    Shared by the single- (``_write_memory_inner``) and bulk-write
-    (``_write_memories_bulk_inner``) paths so the boundary can't be bypassed
-    by an install's choice of endpoint. For a broker (install-credential)
-    caller it:
-
-      1. Gates ``chosen_agent_id`` through :func:`_broker_owned_agent_id`
-         (degrade to ``broker:<install>`` when it names an agent owned by a
-         different install, or another install's reserved ``broker:`` id).
-      2. Stamps ``owner_install_uuid`` first-touch via ``get_or_create_agent``.
-      3. Re-checks the committed row and degrades the loser of a first-touch
-         race to its own ``broker:<install>`` identity — the row is now
-         authoritative (storage re-selects FOR UPDATE and never overwrites a
-         set owner), so this closes the gate's optimistic ``owner is None``
-         window.
-
-    Non-broker callers (dashboard / SDK) pass straight through
-    ``get_or_create_agent`` unchanged — the stamp and the gate are broker-only.
-    """
-    if auth.is_install_credential:
-        chosen_agent_id = await _broker_owned_agent_id(chosen_agent_id, auth.install_uuid, tenant_id)
-    agent = await get_or_create_agent(
-        tenant_id,
-        chosen_agent_id,
-        fleet_id,
-        require_approval=require_approval,
-        # Stamp ownership only for broker writes — never rely on the gateway
-        # happening to omit x-install-uuid for non-broker callers.
-        owner_install_uuid=auth.install_uuid if auth.is_install_credential else None,
-    )
-    if (
-        auth.is_install_credential
-        and auth.install_uuid
-        and _owned_by_other_install(agent.get("owner_install_uuid"), auth.install_uuid)
-    ):
-        chosen_agent_id = _broker_label(auth.install_uuid)
-        agent = await get_or_create_agent(
-            tenant_id,
-            chosen_agent_id,
-            fleet_id,
-            require_approval=require_approval,
-            owner_install_uuid=auth.install_uuid,
-        )
-    return agent, chosen_agent_id
+    return broker_label(install_uuid)
 
 
 def _bulk_response(result: BulkMemoryResponse) -> JSONResponse:
@@ -1168,7 +1059,13 @@ async def _write_memories_bulk_inner(
         body.agent_id = auth.agent_id
     # Ownership boundary (gate + owner stamp + post-create re-check), shared
     # with the single-write path.
-    agent, body.agent_id = await resolve_write_agent(body.agent_id, auth, body.tenant_id, body.fleet_id)
+    agent, body.agent_id = await resolve_write_agent(
+        body.agent_id,
+        body.tenant_id,
+        body.fleet_id,
+        is_install_credential=auth.is_install_credential,
+        install_uuid=auth.install_uuid,
+    )
     if not body.fleet_id and agent.get("fleet_id"):
         body.fleet_id = agent["fleet_id"]
     usage = None

--- a/core-api/src/core_api/services/agent_service.py
+++ b/core-api/src/core_api/services/agent_service.py
@@ -125,6 +125,119 @@ async def lookup_agent(tenant_id: str, agent_id: str) -> dict | None:
     return await sc.get_agent(agent_id, tenant_id)
 
 
+_BROKER_LABEL_PREFIX = "broker:"
+
+
+def broker_label(install_uuid: str | None) -> str:
+    """The bare-install fallback identity for a broker write."""
+    return f"{_BROKER_LABEL_PREFIX}{install_uuid or 'unknown'}"
+
+
+def _owned_by_other_install(owner_install_uuid: str | None, install_uuid: str | None) -> bool:
+    """True when an agent row is first-touch owned by a DIFFERENT install than
+    ``install_uuid`` — the single condition under which a broker write is
+    degraded to its own ``broker:<install>`` identity. A NULL owner (unclaimed
+    or grandfathered) is not "another install", so it never triggers a degrade.
+    """
+    return owner_install_uuid is not None and owner_install_uuid != install_uuid
+
+
+async def _broker_owned_agent_id(chosen: str, install_uuid: str | None, tenant_id: str) -> str:
+    """Lenient ownership gate over a broker write's chosen agent id.
+
+    A broker write may be attributed to an agent named by the caller (REST item
+    metadata / body.agent_id, or the MCP agent id). Before trusting that name,
+    verify this install owns it: ``owner_install_uuid`` is stamped (first-touch)
+    with the install that first wrote as the agent. Degrade to the bare-install
+    identity ONLY when the named agent is owned by a *different* install, so one
+    install can't write under another install's agent id.
+
+    Lenient — never blocks a legitimate first write:
+      - already the install fallback   -> no lookup, return as-is
+      - another install's broker:<x>   -> degrade (reserved namespace; no lookup)
+      - agent doesn't exist yet         -> keep (this write first-touches it)
+      - ``owner_install_uuid`` is NULL  -> keep (unclaimed; this write claims it)
+      - owned by THIS install           -> keep
+      - owned by a DIFFERENT install    -> degrade to ``broker:<install>``
+    """
+    fallback = broker_label(install_uuid)
+    if chosen == fallback:
+        return chosen
+    # The ``broker:<install>`` namespace is RESERVED — an install may only ever
+    # write as its OWN bare-install identity. A chosen id in that namespace that
+    # isn't this install's own fallback (handled above) is *another* install's
+    # reserved identity. Degrade to this install's own fallback, with NO lookup:
+    # the fallback id is deterministic and guessable, so without this guard an
+    # attacker could first-touch ``broker:<victim>`` (stamping itself as owner)
+    # and thereby capture the victim's later degraded writes.
+    if chosen.startswith(_BROKER_LABEL_PREFIX):
+        return fallback
+    owner = await lookup_agent(tenant_id, chosen)
+    if owner is None:
+        return chosen
+    if _owned_by_other_install(owner.get("owner_install_uuid"), install_uuid):
+        return fallback
+    return chosen
+
+
+async def resolve_write_agent(
+    chosen_agent_id: str,
+    tenant_id: str,
+    fleet_id: str | None,
+    *,
+    is_install_credential: bool,
+    install_uuid: str | None,
+    require_approval: bool = False,
+) -> tuple[dict, str]:
+    """Resolve the agent a write is attributed to, enforcing the broker
+    ownership boundary, and return ``(agent_row, safe_agent_id)``.
+
+    Shared by every write entry point — the REST single- and bulk-write paths
+    and the MCP write tool — so the boundary can't be bypassed by a caller's
+    choice of endpoint. For a broker (install-credential) caller it:
+
+      1. Gates ``chosen_agent_id`` through :func:`_broker_owned_agent_id`
+         (degrade to ``broker:<install>`` when it names an agent owned by a
+         different install, or another install's reserved ``broker:`` id).
+      2. Stamps ``owner_install_uuid`` first-touch via ``get_or_create_agent``.
+      3. Re-checks the committed row and degrades the loser of a first-touch
+         race to its own ``broker:<install>`` identity — the row is now
+         authoritative (storage re-selects FOR UPDATE and never overwrites a
+         set owner), so this closes the gate's optimistic ``owner is None``
+         window.
+
+    Non-broker callers (dashboard / SDK / interactive MCP) pass straight through
+    ``get_or_create_agent`` unchanged — the stamp and gate are broker-only, keyed
+    on ``is_install_credential`` (a stray ``install_uuid`` without the credential
+    kind is ignored).
+    """
+    if is_install_credential:
+        chosen_agent_id = await _broker_owned_agent_id(chosen_agent_id, install_uuid, tenant_id)
+    agent = await get_or_create_agent(
+        tenant_id,
+        chosen_agent_id,
+        fleet_id,
+        require_approval=require_approval,
+        # Stamp ownership only for broker writes — never rely on the gateway
+        # happening to omit x-install-uuid for non-broker callers.
+        owner_install_uuid=install_uuid if is_install_credential else None,
+    )
+    if (
+        is_install_credential
+        and install_uuid
+        and _owned_by_other_install(agent.get("owner_install_uuid"), install_uuid)
+    ):
+        chosen_agent_id = broker_label(install_uuid)
+        agent = await get_or_create_agent(
+            tenant_id,
+            chosen_agent_id,
+            fleet_id,
+            require_approval=require_approval,
+            owner_install_uuid=install_uuid,
+        )
+    return agent, chosen_agent_id
+
+
 async def enforce_fleet_write(
     tenant_id: str,
     agent_id: str,

--- a/tests/_mcp_test_helpers.py
+++ b/tests/_mcp_test_helpers.py
@@ -177,6 +177,32 @@ def mcp_env(monkeypatch):
 
     monkeypatch.setattr(mcp_server, "enforce_fleet_write", _stub_enforce_fleet_write)
 
+    # Write tools route attribution through ``resolve_write_agent`` (the broker
+    # ownership boundary, shared with the REST write paths). There's no DB in
+    # unit tests, so stub it as a passthrough returning the caller's identity
+    # unchanged. Tests exercising the boundary itself replace this (or restore
+    # the real function and mock ``agent_service`` get/lookup).
+    async def _stub_resolve_write_agent(
+        chosen_agent_id,
+        tenant_id,
+        fleet_id,
+        *,
+        is_install_credential,
+        install_uuid,
+        require_approval=False,
+    ):
+        return (
+            {
+                "agent_id": chosen_agent_id,
+                "tenant_id": tenant_id,
+                "fleet_id": fleet_id,
+                "trust_level": 3,
+            },
+            chosen_agent_id,
+        )
+
+    monkeypatch.setattr(mcp_server, "resolve_write_agent", _stub_resolve_write_agent)
+
     service_mocks: dict[str, AsyncMock] = {}
 
     def service(name: str) -> AsyncMock:

--- a/tests/test_broker_owned_agent_id.py
+++ b/tests/test_broker_owned_agent_id.py
@@ -1,43 +1,46 @@
 """Unit tests for the broker-attribution ownership gate (_broker_owned_agent_id).
 
-A broker (install-credential) bulk write may name an agent in its batch
-metadata; the gate keeps that attribution only when this install may claim the
-agent, and otherwise degrades to the bare ``broker:<install>`` identity so one
-install can't write under another install's agent id. Lenient — never raises.
+A broker (install-credential) write may name an agent (REST item metadata /
+body.agent_id, or the MCP agent id); the gate keeps that attribution only when
+this install may claim the agent, and otherwise degrades to the bare
+``broker:<install>`` identity so one install can't write under another install's
+agent id. Lenient — never raises. Lives in ``agent_service`` so every write
+entry point (REST + MCP) shares it via ``resolve_write_agent``.
 """
 
 from unittest.mock import AsyncMock
 
 import pytest
 
-from core_api.routes import memories
+from core_api.services import agent_service
 
 pytestmark = pytest.mark.unit
 
 
 async def test_owned_by_this_install_kept(monkeypatch):
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "lookup_agent",
         AsyncMock(
             return_value={"agent_id": "agent-a", "owner_install_uuid": "install-1"}
         ),
     )
     assert (
-        await memories._broker_owned_agent_id("agent-a", "install-1", "t") == "agent-a"
+        await agent_service._broker_owned_agent_id("agent-a", "install-1", "t")
+        == "agent-a"
     )
 
 
 async def test_owned_by_different_install_degraded(monkeypatch):
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "lookup_agent",
         AsyncMock(
             return_value={"agent_id": "agent-a", "owner_install_uuid": "install-2"}
         ),
     )
     assert (
-        await memories._broker_owned_agent_id("agent-a", "install-1", "t")
+        await agent_service._broker_owned_agent_id("agent-a", "install-1", "t")
         == "broker:install-1"
     )
 
@@ -45,28 +48,32 @@ async def test_owned_by_different_install_degraded(monkeypatch):
 async def test_null_owner_kept(monkeypatch):
     # Grandfathered / unclaimed agent — this write first-touches it.
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "lookup_agent",
         AsyncMock(return_value={"agent_id": "agent-a", "owner_install_uuid": None}),
     )
     assert (
-        await memories._broker_owned_agent_id("agent-a", "install-1", "t") == "agent-a"
+        await agent_service._broker_owned_agent_id("agent-a", "install-1", "t")
+        == "agent-a"
     )
 
 
 async def test_nonexistent_agent_kept(monkeypatch):
     # No row yet — this write creates + owns it via get_or_create_agent.
-    monkeypatch.setattr(memories, "lookup_agent", AsyncMock(return_value=None))
+    monkeypatch.setattr(agent_service, "lookup_agent", AsyncMock(return_value=None))
     assert (
-        await memories._broker_owned_agent_id("agent-a", "install-1", "t") == "agent-a"
+        await agent_service._broker_owned_agent_id("agent-a", "install-1", "t")
+        == "agent-a"
     )
 
 
 async def test_already_fallback_short_circuits(monkeypatch):
     # The chosen id is already the install fallback — no lookup needed.
     spy = AsyncMock(return_value=None)
-    monkeypatch.setattr(memories, "lookup_agent", spy)
-    result = await memories._broker_owned_agent_id("broker:install-1", "install-1", "t")
+    monkeypatch.setattr(agent_service, "lookup_agent", spy)
+    result = await agent_service._broker_owned_agent_id(
+        "broker:install-1", "install-1", "t"
+    )
     assert result == "broker:install-1"
     spy.assert_not_awaited()
 
@@ -76,7 +83,9 @@ async def test_foreign_broker_label_degraded_without_lookup(monkeypatch):
     # to THIS install's own fallback with NO lookup, so the deterministic
     # (guessable) fallback id can't be pre-claimed to capture a victim's writes.
     spy = AsyncMock(return_value=None)
-    monkeypatch.setattr(memories, "lookup_agent", spy)
-    result = await memories._broker_owned_agent_id("broker:install-1", "install-3", "t")
+    monkeypatch.setattr(agent_service, "lookup_agent", spy)
+    result = await agent_service._broker_owned_agent_id(
+        "broker:install-1", "install-3", "t"
+    )
     assert result == "broker:install-3"
     spy.assert_not_awaited()

--- a/tests/test_broker_write_ownership.py
+++ b/tests/test_broker_write_ownership.py
@@ -1,36 +1,39 @@
 """Broker-write agent-ownership boundary — the shared ``resolve_write_agent``
-helper and its wiring into BOTH write routes.
+helper (in ``agent_service``) and its wiring into every write entry point.
 
-The ownership boundary (a broker/install-credential caller may only attribute a
-memory to an agent it owns) lives in one place — ``resolve_write_agent`` — so an
-install can't bypass it by choosing the single- vs bulk-write endpoint. This
-module tests:
+The boundary (a broker/install-credential caller may only attribute a memory to
+an agent it owns) lives in ONE place — ``agent_service.resolve_write_agent`` — so
+an install can't bypass it by choosing the REST single-, REST bulk-, or MCP
+write surface. This module tests:
 
-- ``resolve_write_agent`` directly: the gate (degrade a foreign / reserved
-  ``broker:`` id), the first-touch owner stamp, the post-create TOCTOU
-  re-check, non-broker passthrough, and ``require_approval`` passthrough.
-- End-to-end that BOTH ``_write_memory_inner`` (single) and
-  ``_write_memories_bulk_inner`` (bulk) route attribution through the helper, so
-  a broker naming another install's agent is degraded to ``broker:<install>``
-  before the memory is written.
+- ``resolve_write_agent`` directly: gate (degrade a foreign / reserved
+  ``broker:`` id), first-touch owner stamp, post-create TOCTOU re-check,
+  non-broker passthrough, ``require_approval`` passthrough.
+- End-to-end that ``_write_memory_inner`` (REST single), ``_write_memories_bulk_inner``
+  (REST bulk), and ``memclaw_write`` (MCP) all route attribution through it, so a
+  broker naming another install's agent is degraded to ``broker:<install>`` before
+  the memory is written.
 
 The pure gate branches are additionally unit-tested in
-``test_broker_owned_agent_id.py``. Storage/metering are mocked here; only the
-agent id that ends up attributed to the write is asserted.
+``test_broker_owned_agent_id.py``. Storage/metering are mocked; only the agent id
+that ends up attributed to the write is asserted.
 """
 
 from __future__ import annotations
 
+import contextlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import Response
 
+from core_api import mcp_server
 from core_api.auth import AuthContext
 from core_api.config import settings as app_settings
 from core_api.routes import memories
 from core_api.schemas import BulkMemoryCreate, BulkMemoryItem, MemoryCreate
+from core_api.services import agent_service
 
 pytestmark = pytest.mark.unit
 
@@ -49,6 +52,13 @@ class _Sentinel(Exception):
     """Raised by the mocked create_* to short-circuit after attribution is set."""
 
 
+class _OutStub:
+    """Minimal stand-in for the object returned by create_memory (MCP path)."""
+
+    def model_dump(self, mode: str = "python"):  # noqa: ARG002
+        return {"id": "m-1", "status": "created"}
+
+
 # ── resolve_write_agent (shared helper) ─────────────────────────────────
 
 
@@ -56,10 +66,10 @@ async def test_resolve_non_broker_passthrough(monkeypatch):
     # Non-broker caller: no gate lookup, no owner stamp, id unchanged.
     lookup = AsyncMock()
     goc = AsyncMock(return_value={"owner_install_uuid": None, "fleet_id": None})
-    monkeypatch.setattr(memories, "lookup_agent", lookup)
-    monkeypatch.setattr(memories, "get_or_create_agent", goc)
-    agent, agent_id = await memories.resolve_write_agent(
-        "dash-agent", _broker_auth(None, is_install=False), "tenant-1", None
+    monkeypatch.setattr(agent_service, "lookup_agent", lookup)
+    monkeypatch.setattr(agent_service, "get_or_create_agent", goc)
+    _agent, agent_id = await agent_service.resolve_write_agent(
+        "dash-agent", "tenant-1", None, is_install_credential=False, install_uuid=None
     )
     assert agent_id == "dash-agent"
     lookup.assert_not_awaited()
@@ -69,14 +79,14 @@ async def test_resolve_non_broker_passthrough(monkeypatch):
 async def test_resolve_broker_foreign_agent_degraded(monkeypatch):
     # Gate: named agent owned by a different install -> degrade to own fallback.
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "lookup_agent",
         AsyncMock(return_value={"owner_install_uuid": "install-2"}),
     )
     goc = AsyncMock(return_value={"owner_install_uuid": "install-1", "fleet_id": None})
-    monkeypatch.setattr(memories, "get_or_create_agent", goc)
-    _agent, agent_id = await memories.resolve_write_agent(
-        "victim", _broker_auth("install-1"), "tenant-1", None
+    monkeypatch.setattr(agent_service, "get_or_create_agent", goc)
+    _agent, agent_id = await agent_service.resolve_write_agent(
+        "victim", "tenant-1", None, is_install_credential=True, install_uuid="install-1"
     )
     assert agent_id == "broker:install-1"
     assert goc.await_args_list[0].args[1] == "broker:install-1"
@@ -85,14 +95,18 @@ async def test_resolve_broker_foreign_agent_degraded(monkeypatch):
 async def test_resolve_reserved_namespace_degraded_without_lookup(monkeypatch):
     # Gate: another install's reserved broker:<x> id -> degrade, no lookup.
     lookup = AsyncMock()
-    monkeypatch.setattr(memories, "lookup_agent", lookup)
+    monkeypatch.setattr(agent_service, "lookup_agent", lookup)
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "get_or_create_agent",
         AsyncMock(return_value={"owner_install_uuid": "install-1", "fleet_id": None}),
     )
-    _agent, agent_id = await memories.resolve_write_agent(
-        "broker:install-9", _broker_auth("install-1"), "tenant-1", None
+    _agent, agent_id = await agent_service.resolve_write_agent(
+        "broker:install-9",
+        "tenant-1",
+        None,
+        is_install_credential=True,
+        install_uuid="install-1",
     )
     assert agent_id == "broker:install-1"
     lookup.assert_not_awaited()
@@ -100,25 +114,29 @@ async def test_resolve_reserved_namespace_degraded_without_lookup(monkeypatch):
 
 async def test_resolve_self_owned_kept(monkeypatch):
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "lookup_agent",
         AsyncMock(return_value={"owner_install_uuid": "install-1"}),
     )
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "get_or_create_agent",
         AsyncMock(return_value={"owner_install_uuid": "install-1", "fleet_id": None}),
     )
-    _agent, agent_id = await memories.resolve_write_agent(
-        "my-agent", _broker_auth("install-1"), "tenant-1", None
+    _agent, agent_id = await agent_service.resolve_write_agent(
+        "my-agent",
+        "tenant-1",
+        None,
+        is_install_credential=True,
+        install_uuid="install-1",
     )
     assert agent_id == "my-agent"
 
 
 async def test_resolve_post_create_race_lost_degrades(monkeypatch):
-    # Gate passes (row absent), but the committed row is owned by another
-    # install (lost first-touch race) -> post-create re-check degrades + recreates.
-    monkeypatch.setattr(memories, "lookup_agent", AsyncMock(return_value=None))
+    # Gate passes (row absent), but the committed row is owned by another install
+    # (lost first-touch race) -> post-create re-check degrades + recreates.
+    monkeypatch.setattr(agent_service, "lookup_agent", AsyncMock(return_value=None))
     goc = AsyncMock(
         side_effect=[
             {
@@ -131,9 +149,13 @@ async def test_resolve_post_create_race_lost_degrades(monkeypatch):
             },  # recreate under broker id
         ]
     )
-    monkeypatch.setattr(memories, "get_or_create_agent", goc)
-    _agent, agent_id = await memories.resolve_write_agent(
-        "contested", _broker_auth("install-1"), "tenant-1", None
+    monkeypatch.setattr(agent_service, "get_or_create_agent", goc)
+    _agent, agent_id = await agent_service.resolve_write_agent(
+        "contested",
+        "tenant-1",
+        None,
+        is_install_credential=True,
+        install_uuid="install-1",
     )
     assert agent_id == "broker:install-1"
     assert goc.await_count == 2
@@ -142,19 +164,20 @@ async def test_resolve_post_create_race_lost_degrades(monkeypatch):
 
 async def test_resolve_passes_require_approval(monkeypatch):
     goc = AsyncMock(return_value={"owner_install_uuid": None, "fleet_id": None})
-    monkeypatch.setattr(memories, "get_or_create_agent", goc)
-    monkeypatch.setattr(memories, "lookup_agent", AsyncMock())
-    await memories.resolve_write_agent(
+    monkeypatch.setattr(agent_service, "get_or_create_agent", goc)
+    monkeypatch.setattr(agent_service, "lookup_agent", AsyncMock())
+    await agent_service.resolve_write_agent(
         "a",
-        _broker_auth(None, is_install=False),
         "tenant-1",
         None,
+        is_install_credential=False,
+        install_uuid=None,
         require_approval=True,
     )
     assert goc.await_args.kwargs["require_approval"] is True
 
 
-# ── End-to-end: both routes attribute through resolve_write_agent ────────
+# ── REST end-to-end: both routes attribute through resolve_write_agent ───
 
 
 async def _drive_single(monkeypatch, *, agent_id, auth, gate_owner, created_owner):
@@ -165,8 +188,9 @@ async def _drive_single(monkeypatch, *, agent_id, auth, gate_owner, created_owne
         "core_api.services.organization_settings.resolve_config",
         AsyncMock(return_value=SimpleNamespace(require_agent_approval=False)),
     )
+    # resolve_write_agent lives in agent_service; mock its storage deps there.
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "lookup_agent",
         AsyncMock(
             return_value=None
@@ -175,7 +199,7 @@ async def _drive_single(monkeypatch, *, agent_id, auth, gate_owner, created_owne
         ),
     )
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "get_or_create_agent",
         AsyncMock(
             return_value={
@@ -205,7 +229,7 @@ async def _drive_bulk(monkeypatch, *, agent_id, auth, gate_owner, created_owner)
     the agent id that reaches ``create_memories_bulk``."""
     monkeypatch.setattr(app_settings, "bind_write_identity_to_auth", False)
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "lookup_agent",
         AsyncMock(
             return_value=None
@@ -214,7 +238,7 @@ async def _drive_bulk(monkeypatch, *, agent_id, auth, gate_owner, created_owner)
         ),
     )
     monkeypatch.setattr(
-        memories,
+        agent_service,
         "get_or_create_agent",
         AsyncMock(return_value={"owner_install_uuid": created_owner, "fleet_id": None}),
     )
@@ -242,8 +266,8 @@ async def _drive_bulk(monkeypatch, *, agent_id, auth, gate_owner, created_owner)
 
 
 async def test_single_write_broker_foreign_agent_degraded(monkeypatch):
-    # The gap this PR closes: a broker single-write naming an agent owned by a
-    # different install is degraded to broker:<install>, not mis-attributed.
+    # A broker single-write naming an agent owned by a different install is
+    # degraded to broker:<install>, not mis-attributed.
     agent_id = await _drive_single(
         monkeypatch,
         agent_id="victim-agent",
@@ -266,7 +290,6 @@ async def test_single_write_non_broker_passthrough(monkeypatch):
 
 
 async def test_bulk_write_broker_foreign_agent_degraded(monkeypatch):
-    # Same boundary still holds on the bulk path via the shared helper.
     agent_id = await _drive_bulk(
         monkeypatch,
         agent_id="victim-agent",
@@ -275,3 +298,104 @@ async def test_bulk_write_broker_foreign_agent_degraded(monkeypatch):
         created_owner="install-1",
     )
     assert agent_id == "broker:install-1"
+
+
+# ── MCP end-to-end: memclaw_write attributes through resolve_write_agent ─
+
+
+@contextlib.contextmanager
+def _mcp_credential(kind: str | None, install_uuid: str | None):
+    """Set the MCP credential context vars (as the gateway middleware would),
+    then reset — exercises the real ``_is_install_credential`` / ``_get_install_uuid``
+    read path that feeds ``resolve_write_agent``."""
+    tok_k = mcp_server._credential_kind_var.set(kind)
+    tok_u = mcp_server._install_uuid_var.set(install_uuid)
+    try:
+        yield
+    finally:
+        mcp_server._credential_kind_var.reset(tok_k)
+        mcp_server._install_uuid_var.reset(tok_u)
+
+
+async def test_mcp_write_broker_foreign_agent_degraded(mcp_env, monkeypatch):
+    # The gap this closes: a broker MCP write naming a foreign agent is degraded.
+    # Restore the REAL resolve_write_agent (mcp_env stubs it) and mock its deps.
+    monkeypatch.setattr(
+        mcp_server, "resolve_write_agent", agent_service.resolve_write_agent
+    )
+    monkeypatch.setattr(
+        agent_service,
+        "lookup_agent",
+        AsyncMock(return_value={"owner_install_uuid": "install-2"}),
+    )
+    monkeypatch.setattr(
+        agent_service,
+        "get_or_create_agent",
+        AsyncMock(
+            return_value={
+                "owner_install_uuid": "install-1",
+                "trust_level": 3,
+                "fleet_id": None,
+            }
+        ),
+    )
+    cm = mcp_env["service"]("create_memory")
+    cm.return_value = _OutStub()
+
+    with _mcp_credential("install_credential", "install-1"):
+        await mcp_server.memclaw_write(content="x", agent_id="victim-agent")
+    assert cm.await_args.args[0].agent_id == "broker:install-1"
+
+
+async def test_mcp_write_non_broker_passthrough(mcp_env, monkeypatch):
+    monkeypatch.setattr(
+        mcp_server, "resolve_write_agent", agent_service.resolve_write_agent
+    )
+    monkeypatch.setattr(agent_service, "lookup_agent", AsyncMock())
+    monkeypatch.setattr(
+        agent_service,
+        "get_or_create_agent",
+        AsyncMock(
+            return_value={
+                "owner_install_uuid": None,
+                "trust_level": 3,
+                "fleet_id": None,
+            }
+        ),
+    )
+    cm = mcp_env["service"]("create_memory")
+    cm.return_value = _OutStub()
+
+    with _mcp_credential(None, None):  # not a broker
+        await mcp_server.memclaw_write(content="x", agent_id="dash-agent")
+    assert cm.await_args.args[0].agent_id == "dash-agent"
+
+
+async def test_mcp_write_passes_credential_identity(mcp_env, monkeypatch):
+    # The MCP middleware's plumbed credential identity reaches resolve_write_agent.
+    captured: dict[str, object] = {}
+
+    async def _spy(
+        chosen_agent_id,
+        tenant_id,
+        fleet_id,
+        *,
+        is_install_credential,
+        install_uuid,
+        require_approval=False,
+    ):
+        captured["is_install"] = is_install_credential
+        captured["install_uuid"] = install_uuid
+        return {
+            "agent_id": chosen_agent_id,
+            "trust_level": 3,
+            "fleet_id": fleet_id,
+        }, chosen_agent_id
+
+    monkeypatch.setattr(mcp_server, "resolve_write_agent", _spy)
+    mcp_env["service"]("create_memory").return_value = _OutStub()
+
+    with _mcp_credential("install_credential", "install-7"):
+        await mcp_server.memclaw_write(content="x", agent_id="a1")
+    assert captured["is_install"] is True
+    assert captured["install_uuid"] == "install-7"


### PR DESCRIPTION
## What

Follow-up to #560 / #562. The broker (install-credential) agent-ownership boundary — *an install may only attribute a memory to an agent it owns* — was enforced on the REST write paths (`/memories`, `/memories/bulk`) but **not on the MCP write tool** (`memclaw_write`): it resolved its agent id via `effective_write_agent_id` and went straight to `enforce_fleet_write` → `create_memory`, with no gate, no `owner_install_uuid` stamp, and no post-create re-check. The MCP ASGI middleware also never plumbed the credential kind, so the MCP surface couldn't even *identify* a broker.

Not broker-reachable in today's deployment (memclawd writes via REST), so this is defense-in-depth — but the boundary shouldn't depend on the caller's choice of transport.

## How

Chosen approach (per discussion): **enforce uniformly** — make the MCP path apply the same boundary as REST rather than refusing broker credentials.

- **Lift `resolve_write_agent` + the broker helpers** (`_broker_owned_agent_id`, `_broker_label`, `_owned_by_other_install`, `_BROKER_LABEL_PREFIX`) from `routes/memories.py` into `services/agent_service.py` — the shared home next to `get_or_create_agent` / `lookup_agent` — so all three write entry points use one definition. The signature now takes `is_install_credential` + `install_uuid` instead of an `AuthContext`, keeping `agent_service` free of the web-auth type and letting the MCP path (which has no `AuthContext`) call it from its context vars.
- **Plumb `X-Caura-Credential-Kind` + `X-Install-UUID`** through the MCP ASGI middleware into context vars (gateway-verified path only, mirroring the existing `x-agent-id` / `x-capabilities` plumbing), with `_is_install_credential` / `_get_install_uuid` helpers.
- **`memclaw_write` routes attribution through `resolve_write_agent`** before `enforce_fleet_write`, so a broker MCP write degrades a foreign agent to `broker:<install>` exactly like REST. Non-broker (interactive) writes pass straight through, keyed on `is_install_credential`.

No storage/schema change (`owner_install_uuid` + migration 031 landed with #560).

## Testing

- `resolve_write_agent` unit coverage (gate degrade, reserved-namespace degrade, self-owned keep, post-create race, non-broker passthrough, `require_approval` passthrough) + the gate unit tests, now against `agent_service`.
- End-to-end that **all three write surfaces** — REST single (`_write_memory_inner`), REST bulk (`_write_memories_bulk_inner`), and MCP (`memclaw_write`) — attribute through the shared helper, including the MCP context-var → credential-identity plumbing.
- The `mcp_env` fixture gains a `resolve_write_agent` passthrough stub (write tools now hit it); the boundary tests restore the real function and mock `agent_service` storage.
- Local: `ruff check` + `ruff format --check`, `mypy` (core-api + core-storage-api), and the broker / MCP-write / REST-write unit suites all green.

## Scope note / follow-up (out of scope here)

The altitude review surfaced that the broker-reachable **`/evolve/report` and `/insights/generate`** paths resolve identity via a *separate* helper (`resolve_caller_and_gate`) and still attribute memories under a caller-named `agent_id` with only a trust gate — no ownership check. That's a distinct mechanism from `resolve_write_agent`; **tracked as a follow-up**, not folded in here to keep this PR to the MCP write path. (`/ingest/commit` + `/stm/promote` are the same latent class but not exercised by the current plugin client.)

There's also a pre-existing minor redundancy — `resolve_write_agent` and `enforce_fleet_write` each call `get_or_create_agent` (one extra read on every write, REST and MCP) — left as a separate optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
