### PR TITLE
feat(memories): extend broker-write ownership boundary to evolve/insights

### DIFF
--- a/core-api/src/core_api/services/agent_service.py
+++ b/core-api/src/core_api/services/agent_service.py
@@ -142,7 +142,7 @@ def _owned_by_other_install(owner_install_uuid: str | None, install_uuid: str | 
     return owner_install_uuid is not None and owner_install_uuid != install_uuid
 
 
-async def _broker_owned_agent_id(chosen: str, install_uuid: str | None, tenant_id: str) -> str:
+async def broker_owned_agent_id(chosen: str, install_uuid: str | None, tenant_id: str) -> str:
     """Lenient ownership gate over a broker write's chosen agent id.
 
     A broker write may be attributed to an agent named by the caller (REST item
@@ -196,7 +196,7 @@ async def resolve_write_agent(
     and the MCP write tool — so the boundary can't be bypassed by a caller's
     choice of endpoint. For a broker (install-credential) caller it:
 
-      1. Gates ``chosen_agent_id`` through :func:`_broker_owned_agent_id`
+      1. Gates ``chosen_agent_id`` through :func:`broker_owned_agent_id`
          (degrade to ``broker:<install>`` when it names an agent owned by a
          different install, or another install's reserved ``broker:`` id).
       2. Stamps ``owner_install_uuid`` first-touch via ``get_or_create_agent``.
@@ -212,7 +212,7 @@ async def resolve_write_agent(
     kind is ignored).
     """
     if is_install_credential:
-        chosen_agent_id = await _broker_owned_agent_id(chosen_agent_id, install_uuid, tenant_id)
+        chosen_agent_id = await broker_owned_agent_id(chosen_agent_id, install_uuid, tenant_id)
     agent = await get_or_create_agent(
         tenant_id,
         chosen_agent_id,

--- a/core-api/src/core_api/services/caller_identity.py
+++ b/core-api/src/core_api/services/caller_identity.py
@@ -23,6 +23,7 @@ from fastapi import HTTPException
 from core_api.agent_ids import DEFAULT_AGENT_ID
 from core_api.auth import AuthContext
 from core_api.config import settings as app_settings
+from core_api.services.agent_service import broker_owned_agent_id
 from core_api.services.trust_service import parse_trust_error, require_trust
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,12 @@ async def resolve_caller_and_gate(
     Returns the resolved ``caller_agent_id``; raises 403 when the resolved agent
     isn't registered or lacks the required trust (``min_level`` is 1 for
     ``scope=agent``, else 2).
+
+    For an install-credential (broker) caller the resolved id first passes
+    through the broker ownership gate (``broker_owned_agent_id``): a foreign or
+    reserved ``broker:`` id degrades to the caller's own ``broker:<install>``
+    fallback BEFORE the trust check, so a broker can't attribute an outcome /
+    insight memory to an agent owned by another install.
 
     The gate is skipped for (a) admins — tenant-free system callers — and (b)
     the unidentified standalone operator: ``IS_STANDALONE`` with no asserted
@@ -65,6 +72,17 @@ async def resolve_caller_and_gate(
         return caller_agent_id
     if app_settings.is_standalone and not auth.agent_id and not body_agent_id:
         return caller_agent_id
+
+    # Broker ownership boundary: an install-credential caller may only attribute
+    # a write to an agent it owns. Degrade a foreign / reserved-namespace agent
+    # id to this install's own ``broker:<install>`` fallback BEFORE the trust
+    # gate, so trust is evaluated on the identity actually written (parity with
+    # the data-plane ``resolve_write_agent``). Non-broker callers are unaffected.
+    # No owner stamp here: evolve/insights never first-touch an agent (require_trust
+    # 403s an unregistered id), so this only redirects attribution, it doesn't
+    # create/claim rows.
+    if auth.is_install_credential:
+        caller_agent_id = await broker_owned_agent_id(caller_agent_id, auth.install_uuid, tenant_id)
 
     min_level = 1 if scope == "agent" else 2
     # Write paths must pin identity: outcome/insight memories + an audit-log row

--- a/tests/test_broker_owned_agent_id.py
+++ b/tests/test_broker_owned_agent_id.py
@@ -1,4 +1,4 @@
-"""Unit tests for the broker-attribution ownership gate (_broker_owned_agent_id).
+"""Unit tests for the broker-attribution ownership gate (broker_owned_agent_id).
 
 A broker (install-credential) write may name an agent (REST item metadata /
 body.agent_id, or the MCP agent id); the gate keeps that attribution only when
@@ -26,7 +26,7 @@ async def test_owned_by_this_install_kept(monkeypatch):
         ),
     )
     assert (
-        await agent_service._broker_owned_agent_id("agent-a", "install-1", "t")
+        await agent_service.broker_owned_agent_id("agent-a", "install-1", "t")
         == "agent-a"
     )
 
@@ -40,7 +40,7 @@ async def test_owned_by_different_install_degraded(monkeypatch):
         ),
     )
     assert (
-        await agent_service._broker_owned_agent_id("agent-a", "install-1", "t")
+        await agent_service.broker_owned_agent_id("agent-a", "install-1", "t")
         == "broker:install-1"
     )
 
@@ -53,7 +53,7 @@ async def test_null_owner_kept(monkeypatch):
         AsyncMock(return_value={"agent_id": "agent-a", "owner_install_uuid": None}),
     )
     assert (
-        await agent_service._broker_owned_agent_id("agent-a", "install-1", "t")
+        await agent_service.broker_owned_agent_id("agent-a", "install-1", "t")
         == "agent-a"
     )
 
@@ -62,7 +62,7 @@ async def test_nonexistent_agent_kept(monkeypatch):
     # No row yet — this write creates + owns it via get_or_create_agent.
     monkeypatch.setattr(agent_service, "lookup_agent", AsyncMock(return_value=None))
     assert (
-        await agent_service._broker_owned_agent_id("agent-a", "install-1", "t")
+        await agent_service.broker_owned_agent_id("agent-a", "install-1", "t")
         == "agent-a"
     )
 
@@ -71,7 +71,7 @@ async def test_already_fallback_short_circuits(monkeypatch):
     # The chosen id is already the install fallback — no lookup needed.
     spy = AsyncMock(return_value=None)
     monkeypatch.setattr(agent_service, "lookup_agent", spy)
-    result = await agent_service._broker_owned_agent_id(
+    result = await agent_service.broker_owned_agent_id(
         "broker:install-1", "install-1", "t"
     )
     assert result == "broker:install-1"
@@ -84,7 +84,7 @@ async def test_foreign_broker_label_degraded_without_lookup(monkeypatch):
     # (guessable) fallback id can't be pre-claimed to capture a victim's writes.
     spy = AsyncMock(return_value=None)
     monkeypatch.setattr(agent_service, "lookup_agent", spy)
-    result = await agent_service._broker_owned_agent_id(
+    result = await agent_service.broker_owned_agent_id(
         "broker:install-1", "install-3", "t"
     )
     assert result == "broker:install-3"

--- a/tests/test_caller_identity.py
+++ b/tests/test_caller_identity.py
@@ -13,8 +13,15 @@ from core_api.services.caller_identity import resolve_caller_and_gate
 pytestmark = pytest.mark.asyncio
 
 
-def _auth(*, agent_id=None, is_admin=False):
-    return SimpleNamespace(agent_id=agent_id, is_admin=is_admin)
+def _auth(
+    *, agent_id=None, is_admin=False, is_install_credential=False, install_uuid=None
+):
+    return SimpleNamespace(
+        agent_id=agent_id,
+        is_admin=is_admin,
+        is_install_credential=is_install_credential,
+        install_uuid=install_uuid,
+    )
 
 
 async def test_standalone_operator_bypasses_gate(monkeypatch):
@@ -23,7 +30,8 @@ async def test_standalone_operator_bypasses_gate(monkeypatch):
     evolve/insights (the test env runs IS_STANDALONE=true)."""
     gate = AsyncMock()
     monkeypatch.setattr(caller_identity, "require_trust", gate)
-    result = await resolve_caller_and_gate(        _auth(),
+    result = await resolve_caller_and_gate(
+        _auth(),
         tenant_id="default",
         body_agent_id=None,
         scope="agent",
@@ -38,7 +46,8 @@ async def test_admin_bypasses_gate(monkeypatch):
     standalone check even runs."""
     gate = AsyncMock()
     monkeypatch.setattr(caller_identity, "require_trust", gate)
-    result = await resolve_caller_and_gate(        _auth(is_admin=True),
+    result = await resolve_caller_and_gate(
+        _auth(is_admin=True),
         tenant_id="t",
         body_agent_id=None,
         scope="fleet",
@@ -51,9 +60,12 @@ async def test_admin_bypasses_gate(monkeypatch):
 async def test_asserted_unregistered_identity_403(monkeypatch):
     """An explicit (non-default) identity still goes through the gate — the
     bypass only applies when NO identity is asserted. Unregistered → 403."""
-    monkeypatch.setattr(caller_identity, "require_trust", AsyncMock(return_value=(1, True, None)))
+    monkeypatch.setattr(
+        caller_identity, "require_trust", AsyncMock(return_value=(1, True, None))
+    )
     with pytest.raises(HTTPException) as exc:
-        await resolve_caller_and_gate(            _auth(),
+        await resolve_caller_and_gate(
+            _auth(),
             tenant_id="t",
             body_agent_id="ghost",
             scope="agent",
@@ -65,11 +77,53 @@ async def test_asserted_unregistered_identity_403(monkeypatch):
 
 async def test_verified_registered_identity_passes(monkeypatch):
     """Gateway-verified identity is gated and, when registered at trust, wins."""
-    monkeypatch.setattr(caller_identity, "require_trust", AsyncMock(return_value=(2, False, None)))
-    result = await resolve_caller_and_gate(        _auth(agent_id="backend-dev"),
+    monkeypatch.setattr(
+        caller_identity, "require_trust", AsyncMock(return_value=(2, False, None))
+    )
+    result = await resolve_caller_and_gate(
+        _auth(agent_id="backend-dev"),
         tenant_id="t",
         body_agent_id=None,
         scope="fleet",
         action="evolve",
     )
     assert result == "backend-dev"
+
+
+async def test_broker_foreign_agent_degraded_before_trust_gate(monkeypatch):
+    """An install-credential caller naming an agent it doesn't own is degraded to
+    its own ``broker:<install>`` fallback, and the trust gate runs on the degraded
+    id (parity with the data-plane ownership boundary)."""
+    broker_gate = AsyncMock(return_value="broker:install-1")
+    monkeypatch.setattr(caller_identity, "broker_owned_agent_id", broker_gate)
+    trust = AsyncMock(return_value=(1, False, None))
+    monkeypatch.setattr(caller_identity, "require_trust", trust)
+    result = await resolve_caller_and_gate(
+        _auth(is_install_credential=True, install_uuid="install-1"),
+        tenant_id="t",
+        body_agent_id="victim-agent",
+        scope="agent",
+        action="evolve",
+    )
+    assert result == "broker:install-1"
+    # The gate saw the raw (foreign) id; the trust check saw the degraded id.
+    assert broker_gate.await_args.args == ("victim-agent", "install-1", "t")
+    assert trust.await_args.args[1] == "broker:install-1"
+
+
+async def test_non_broker_caller_not_degraded(monkeypatch):
+    """A non-broker (dashboard/SDK) caller skips the ownership gate entirely."""
+    broker_gate = AsyncMock()
+    monkeypatch.setattr(caller_identity, "broker_owned_agent_id", broker_gate)
+    monkeypatch.setattr(
+        caller_identity, "require_trust", AsyncMock(return_value=(2, False, None))
+    )
+    result = await resolve_caller_and_gate(
+        _auth(agent_id="backend-dev"),
+        tenant_id="t",
+        body_agent_id=None,
+        scope="fleet",
+        action="evolve",
+    )
+    assert result == "backend-dev"
+    broker_gate.assert_not_awaited()


### PR DESCRIPTION
## What

Follow-up to #560 / #562 / #565. Those closed the broker (install-credential) agent-ownership boundary on the **memory-write** paths (`/memories`, `/memories/bulk`, MCP `memclaw_write`). This closes the last broker-reachable gap: **`/evolve/report` and `/insights/generate`**, which the plugin/broker client also POSTs (`plugin/src/tool-definitions.ts:511,516`).

Those two endpoints resolve their write identity via a *separate* helper, `resolve_caller_and_gate`, which computed `caller_agent_id = auth.agent_id or body_agent_id or DEFAULT_AGENT_ID` and applied only a **trust** gate. For a broker (`auth.agent_id` is None) that's the caller-controlled `body.agent_id` — so a broker could attribute an **outcome / rule / insight** memory to an agent owned by a *different* install (as long as it's registered at default trust). No ownership check, no degrade.

## How

- Make `broker_owned_agent_id` public (was `_broker_owned_agent_id`) in `agent_service` — it's now imported by `caller_identity` (consistent with the earlier `_broker_label` → `broker_label` rename).
- In `resolve_caller_and_gate`, for an install-credential caller, degrade the resolved id through `broker_owned_agent_id` **before** the trust gate — so a foreign / reserved `broker:<x>` id becomes the caller's own `broker:<install>` fallback, and trust is evaluated on the identity actually written (parity with the data-plane `resolve_write_agent`). Non-broker callers are unaffected.
- **No `owner_install_uuid` stamp / no `get_or_create` here**, deliberately: evolve/insights never first-touch an agent (`require_trust` 403s an unregistered id), so this only *redirects* attribution — it doesn't create/claim rows, and it preserves the existing 403-on-unregistered contract.

`resolve_caller_and_gate` is also called by the `/reports` read path; the degrade is read-only there (a lookup), only fires for install credentials, and `/reports` isn't broker-reachable — so applying it uniformly is harmless and simpler than a write-only flag.

## Testing

- `resolve_caller_and_gate`: broker foreign-agent → degraded-before-trust-gate, and non-broker → passthrough. (The gate function itself is unit-tested in `test_broker_owned_agent_id.py`.)
- Local: `ruff check` + `ruff format --check`, `mypy` (both packages), and the caller-identity / evolve / insights / reports suites all green (267 passing across those suites).

With this, **all broker-reachable memory-write surfaces enforce the ownership boundary.** (Latent same-class paths `/ingest/commit` + `/stm/promote` aren't exercised by the current plugin client — noted, not in scope.)

## ⚠️ Stacked PR

Based on `broker-attribution-mcp` (#565), which isn't merged yet — so the base is that branch and the diff shows only the evolve/insights changes. **Once #565 merges I'll rebase this onto `main` and retarget the base to `main`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
