### PR TITLE
ci: gate vendored common/ files with ruff format at enterprise defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,17 @@ jobs:
       - name: Run Ruff formatter check (core-storage-api)
         run: uv run ruff format --check core-storage-api/src/
 
+      - name: Run Ruff formatter check (vendored common/ files at ruff defaults)
+        # This list mirrors the policy=identical entries of caura-memclaw-enterprise's
+        # scripts/vendored_files_manifest.json — the source of truth; keep in sync.
+        # Enterprise CI format-checks the vendored copies at ruff DEFAULTS (88 cols),
+        # so gate them here too or a merge turns enterprise CI red until a reflow
+        # lands (full story: the vendoring note in common/structlog_config.py's
+        # docstring). ``--isolated`` pins default behavior even if a root ruff
+        # config is ever added; deliberately NOT all of common/ — non-vendored
+        # files there are not held to the 88-col contract.
+        run: uv run ruff format --check --isolated common/__init__.py common/structlog_config.py
+
       - name: Guard against raw-string MCP error returns (audit B4 / CAURA-000 #147)
         # MCP tool handlers must build error envelopes via ``_error_response(...)``
         # so ``_with_latency`` can flip ``CallToolResult.isError = True``. Raw


### PR DESCRIPTION
Closes the loop on the 2026-07-17 incident chain (#561 merged clean here → every enterprise PR's Backend CI turned red on the vendored-drift/format gates → #563 reflow): OSS CI now format-checks exactly the two identical-policy vendored files (`common/__init__.py`, `common/structlog_config.py`) at ruff defaults (88 cols) — the same contract enterprise CI enforces on the vendored copies — so the breakage is caught pre-merge here instead of post-merge there.

- List mirrors the `policy=identical` entries of enterprise's `scripts/vendored_files_manifest.json` (source of truth, noted in the step comment). Cross-repo fetch was rejected: the manifest lives in a private repo and this is a public-repo `pull_request` workflow (fork PRs get no secrets).
- `--isolated` pins ruff-default behavior even if a root-level ruff config is ever added.
- Deliberately not gating all of `common/` — 7 non-vendored files exceed 88 today and aren't held to that contract.
- Verified: the exact gated command passes on both files locally (`2 files already formatted`); YAML/actionlint clean (one pre-existing info finding untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)