### PR TITLE
feat(memories): enforce per-agent approval gate on MCP writes

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -800,6 +800,12 @@ async def memclaw_write(
     # ``db``-first signatures satisfied.
     async with _no_db():
         try:
+            # Per-agent approval gate (require_agent_approval): resolve the
+            # tenant config so a new agent is created at trust_level 0 and the
+            # check below can refuse it — parity with the REST single-write path
+            # (routes/memories.py). REST bulk deliberately does NOT gate approval
+            # (broker fan-in path — see _write_memories_bulk_inner).
+            config = await resolve_config(tenant_id)
             # Broker (install-credential) agent-ownership boundary — the same
             # gate + owner-stamp + post-create re-check the REST write paths use
             # (``resolve_write_agent``), so an install can't attribute a memory
@@ -807,13 +813,26 @@ async def memclaw_write(
             # (interactive) callers pass straight through. Runs before
             # ``enforce_fleet_write`` so the trust gate applies to the resolved
             # (possibly degraded ``broker:<install>``) id.
-            _agent, agent_id = await resolve_write_agent(
+            agent, agent_id = await resolve_write_agent(
                 agent_id,
                 tenant_id,
                 fleet_id,
                 is_install_credential=_is_install_credential(),
                 install_uuid=_get_install_uuid(),
+                require_approval=config.require_agent_approval,
             )
+            # Per-agent approval gate: a new agent under require_agent_approval
+            # starts at trust_level 0 and can't write until an admin approves it
+            # (mirrors _write_memory_inner's 403).
+            if agent.get("trust_level", 0) == 0:
+                return _with_latency(
+                    _error_response(
+                        "AGENT_NOT_APPROVED",
+                        f"Agent '{agent_id}' is not approved. Contact the tenant "
+                        "admin to set trust_level >= 1.",
+                    ),
+                    t0,
+                )
             # Register the calling agent (auto-create row on first write) and
             # enforce trust gating for cross-fleet writes — same surface the
             # REST write path uses. Without this, MCP writes succeed without

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1059,6 +1059,14 @@ async def _write_memories_bulk_inner(
         body.agent_id = auth.agent_id
     # Ownership boundary (gate + owner stamp + post-create re-check), shared
     # with the single-write path.
+    #
+    # NOTE: unlike single-write (_write_memory_inner) and the MCP write tool,
+    # bulk deliberately does NOT enforce the per-agent approval gate
+    # (require_agent_approval / trust_level==0): it passes no require_approval and
+    # has no trust==0 check. Bulk is the broker (memclawd) fan-in path that
+    # auto-registers many agents from item metadata; gating each on admin
+    # approval would create trust-0 rows and 403 whole batches, breaking capture.
+    # Per-agent approval is an interactive / single-agent concern.
     agent, body.agent_id = await resolve_write_agent(
         body.agent_id,
         body.tenant_id,

--- a/tests/_mcp_test_helpers.py
+++ b/tests/_mcp_test_helpers.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import contextlib
 import json
 import re
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -202,6 +203,18 @@ def mcp_env(monkeypatch):
         )
 
     monkeypatch.setattr(mcp_server, "resolve_write_agent", _stub_resolve_write_agent)
+
+    # Write tools resolve the tenant config for the per-agent approval gate
+    # (require_agent_approval); search resolves it for recall knobs. Stub a
+    # permissive default (approval off) so handlers don't hit storage. Tests that
+    # assert on config replace this via ``service("resolve_config")`` or a local
+    # monkeypatch.
+    async def _stub_resolve_config(tenant_id):
+        return SimpleNamespace(
+            require_agent_approval=False, recall_boost=False, graph_expand=False
+        )
+
+    monkeypatch.setattr(mcp_server, "resolve_config", _stub_resolve_config)
 
     service_mocks: dict[str, AsyncMock] = {}
 

--- a/tests/test_mcp_write.py
+++ b/tests/test_mcp_write.py
@@ -13,6 +13,8 @@ Covers:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from fastapi import HTTPException
 
@@ -291,3 +293,59 @@ async def test_write_batch_omitted_fleet_resolves_home_fleet(mcp_env):
     )
 
     assert cmb.await_args.args[0].fleet_id == "home-f"
+
+
+async def test_write_unapproved_agent_blocked(mcp_env, monkeypatch):
+    # Per-agent approval gate (parity with REST single-write): under
+    # require_agent_approval a new agent resolves at trust_level 0, so MCP refuses
+    # the write with AGENT_NOT_APPROVED and never persists.
+    mcp_env["service"]("resolve_config").return_value = SimpleNamespace(
+        require_agent_approval=True, recall_boost=False, graph_expand=False
+    )
+
+    async def _resolve(
+        agent_id,
+        tenant_id,
+        fleet_id,
+        *,
+        is_install_credential,
+        install_uuid,
+        require_approval=False,
+    ):
+        return {"agent_id": agent_id, "trust_level": 0, "fleet_id": fleet_id}, agent_id
+
+    monkeypatch.setattr(mcp_server, "resolve_write_agent", _resolve)
+    cm = mcp_env["service"]("create_memory")
+
+    out = await mcp_server.memclaw_write(content="x", agent_id="new-agent")
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "AGENT_NOT_APPROVED"
+    cm.assert_not_awaited()
+
+
+async def test_write_threads_require_approval_to_resolver(mcp_env, monkeypatch):
+    # The tenant's require_agent_approval reaches resolve_write_agent, so a new
+    # agent is created at trust 0 when required (the creation half of the gate).
+    mcp_env["service"]("resolve_config").return_value = SimpleNamespace(
+        require_agent_approval=True, recall_boost=False, graph_expand=False
+    )
+    captured: dict[str, object] = {}
+
+    async def _resolve(
+        agent_id,
+        tenant_id,
+        fleet_id,
+        *,
+        is_install_credential,
+        install_uuid,
+        require_approval=False,
+    ):
+        captured["require_approval"] = require_approval
+        return {"agent_id": agent_id, "trust_level": 3, "fleet_id": fleet_id}, agent_id
+
+    monkeypatch.setattr(mcp_server, "resolve_write_agent", _resolve)
+    mcp_env["service"]("create_memory").return_value = _OutStub("m-1")
+
+    out = await mcp_server.memclaw_write(content="x", agent_id="a1")
+    assert parse_envelope(out)["id"] == "m-1"
+    assert captured["require_approval"] is True


### PR DESCRIPTION
## What

Follow-up flagged in the #565 review. The per-agent **approval** gate (`require_agent_approval` → new agents start at `trust_level 0`, blocked until an admin sets trust ≥ 1) was enforced only on the REST **single-write** path. The MCP write tool (`memclaw_write`) bypassed it entirely — it neither threaded `require_approval` into agent creation nor checked `trust_level == 0`, so a brand-new agent could write via MCP without approval.

This is distinct from the broker **ownership** boundary (#560/#562/#565/#566) — it's the agent-**approval** feature.

**Decision (confirmed):** enforce on **MCP** (interactive / single-agent, analogous to REST single-write); leave REST **bulk** unchanged — it's the broker (memclawd) fan-in path where per-agent approval would create trust-0 rows and 403 whole capture batches.

## How

- `memclaw_write` resolves the tenant config and threads `require_approval=config.require_agent_approval` into `resolve_write_agent` (so a new agent is created at `trust_level 0` when required), then refuses a trust-0 agent with an `AGENT_NOT_APPROVED` error envelope **before** the write — mirroring `_write_memory_inner`'s 403.
- Documented in `_write_memories_bulk_inner` **why** bulk deliberately does NOT gate approval (broker fan-in path; gating would create trust-0 rows and 403 whole batches, breaking capture).

## Testing

- `memclaw_write` refuses an unapproved (trust-0) agent (`AGENT_NOT_APPROVED`, no persist); `require_approval` threads through to the resolver.
- The `mcp_env` fixture gains a default `resolve_config` stub (approval off) so write tools that now resolve config don't hit storage.
- Local: `ruff check` + `ruff format --check`, `mypy` (both packages), and the MCP write + recall suites green.

## Note

Independent of #566 (evolve/insights). Rebased onto `main` after #565 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
