### PR TITLE
fix(docs): remove stale MCP tool count

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -38,7 +38,7 @@ body:
       label: Affected surface
       description: Which surface from the Public API list does this touch? (Pick the closest; reviewers will retag if needed.)
       options:
-        - MCP tool (one of the 9)
+        - MCP tool
         - REST endpoint (under /api/v1)
         - Plugin env var or behavior
         - Server configuration / env var


### PR DESCRIPTION
## Summary

Remove the hardcoded MCP tool count from the feature-request template so it cannot become stale as the server evolves.

## Related Issue

Closes #554

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

- Parsed `.github/ISSUE_TEMPLATE/feature_request.yml` with `yaml.safe_load`
- Verified the stale `MCP tool (one of the 9)` text is absent
- `git diff --check`

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] No tests are needed for this one-line issue-template copy correction
- [x] Python lint, mypy, and pytest are not applicable to this YAML-only change
- [x] Relevant documentation is updated
- [x] CHANGELOG update is not needed for issue-template copy

## Additional Notes

The commit includes the required DCO sign-off.