### PR TITLE
fix(fleet): dedup the outdated-plugin heartbeat warning

### DIFF
--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import time
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
@@ -20,6 +21,33 @@ from core_api.version_compat import (
     MIN_RECOMMENDED_PLUGIN_VERSION,
     is_plugin_outdated,
 )
+
+# Dedup for the outdated-plugin warning. ``heartbeat`` runs on every plugin
+# tick (~every 20-60s per node), so a node stuck on an old plugin emits this
+# WARNING thousands of times a day (prod 2026-07: 3 internal nodes produced
+# 6.3k lines/day, one node ~every 20s). Log at most once per (node, version)
+# per hour so the fleet-health signal survives without drowning real warnings.
+# Keyed on (node, version) so a version change re-logs promptly. Per-instance
+# (module-level, not shared across Cloud Run instances), so worst case is one
+# line per instance per node per hour — still orders of magnitude below one
+# per tick. Bounded + oldest-evicted so churn in node names can't grow it.
+_OUTDATED_PLUGIN_LOG_TTL = 3600.0
+_OUTDATED_PLUGIN_LOG_MAX = 5000
+_outdated_plugin_logged: dict[tuple[str, str], float] = {}
+
+
+def _should_log_outdated_plugin(node: str, version: str) -> bool:
+    """True at most once per (node, version) per ``_OUTDATED_PLUGIN_LOG_TTL``."""
+    now = time.monotonic()
+    key = (node, version)
+    last = _outdated_plugin_logged.get(key)
+    if last is not None and now - last < _OUTDATED_PLUGIN_LOG_TTL:
+        return False
+    if key not in _outdated_plugin_logged and len(_outdated_plugin_logged) >= _OUTDATED_PLUGIN_LOG_MAX:
+        _outdated_plugin_logged.pop(next(iter(_outdated_plugin_logged)))
+    _outdated_plugin_logged[key] = now
+    return True
+
 
 # How long an ``acked`` deploy command counts as "in flight" before the
 # auto-upgrade gate allows queueing another. CAURA-000: customer prod
@@ -594,7 +622,9 @@ async def heartbeat(
     """Plugin pushes status; receives pending commands in response."""
     auth.enforce_tenant(body.tenant_id)
 
-    if is_plugin_outdated(body.plugin_version):
+    if is_plugin_outdated(body.plugin_version) and _should_log_outdated_plugin(
+        body.node_name or "", body.plugin_version or ""
+    ):
         logger.warning(
             "outdated plugin heartbeat",
             extra={

--- a/tests/test_fleet_heartbeat_auto_upgrade.py
+++ b/tests/test_fleet_heartbeat_auto_upgrade.py
@@ -850,3 +850,49 @@ def test_attempt_budget_constants_are_sensible():
     assert fleet_mod.AUTO_UPGRADE_MAX_ATTEMPTS <= 20, (
         "must brake a true wedge well below the ~1,440/day un-budgeted rate"
     )
+
+
+# ---------------------------------------------------------------------------
+# _should_log_outdated_plugin — per-(node, version) dedup so a stuck node
+# doesn't emit the "outdated plugin heartbeat" WARNING on every tick
+# (prod 2026-07: 3 internal nodes produced 6.3k lines/day).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_outdated_log_cache():
+    fleet_mod._outdated_plugin_logged.clear()
+    yield
+    fleet_mod._outdated_plugin_logged.clear()
+
+
+def test_outdated_log_dedups_same_node_version():
+    assert fleet_mod._should_log_outdated_plugin("node-a", "1.0.1") is True
+    assert fleet_mod._should_log_outdated_plugin("node-a", "1.0.1") is False
+    assert fleet_mod._should_log_outdated_plugin("node-a", "1.0.1") is False
+
+
+def test_outdated_log_relogs_on_version_change():
+    assert fleet_mod._should_log_outdated_plugin("node-a", "1.0.1") is True
+    assert fleet_mod._should_log_outdated_plugin("node-a", "2.5.0") is True
+    assert fleet_mod._should_log_outdated_plugin("node-a", "2.5.0") is False
+
+
+def test_outdated_log_is_per_node():
+    assert fleet_mod._should_log_outdated_plugin("node-a", "1.0.1") is True
+    assert fleet_mod._should_log_outdated_plugin("node-b", "1.0.1") is True
+
+
+def test_outdated_log_window_expiry(monkeypatch):
+    t = {"now": 1000.0}
+    monkeypatch.setattr(fleet_mod.time, "monotonic", lambda: t["now"])
+    assert fleet_mod._should_log_outdated_plugin("node-a", "1.0.1") is True
+    t["now"] += fleet_mod._OUTDATED_PLUGIN_LOG_TTL + 1
+    assert fleet_mod._should_log_outdated_plugin("node-a", "1.0.1") is True
+
+
+def test_outdated_log_cache_is_bounded(monkeypatch):
+    monkeypatch.setattr(fleet_mod, "_OUTDATED_PLUGIN_LOG_MAX", 3)
+    for i in range(10):
+        fleet_mod._should_log_outdated_plugin(f"node-{i}", "1.0.1")
+    assert len(fleet_mod._outdated_plugin_logged) <= 3


### PR DESCRIPTION
## Why (finding #2 from the 2026-07-19 prod error review)
`POST /fleet/heartbeat` logs a WARNING every tick a plugin is below `MIN_RECOMMENDED_PLUGIN_VERSION`. A node stuck on an old plugin heartbeats ~every 20–60s forever, so it floods: prod produced **6,301 lines/day** from just **3 internal nodes** — `eyal-open-claw-1` on plugin `1.0.1` (~every 20s), a container on `2.8.0`, and `shushants-MacBook-Air` on `2.5.0`. That volume drowns real warnings now that log severity classifies correctly (#561).

## What
Gate the warning through a per-`(node, version)` dedup with a 1h window — a module-level TTL cache, bounded (5000) + oldest-evicted, mirroring the auth-api cache idiom. The fleet-health signal still surfaces (once/hour/stuck node) without the per-tick spam. Keyed on `(node, version)` so a version change re-logs promptly. Per-instance (not shared across Cloud Run instances), so worst case is one line per instance per node per hour — still orders of magnitude below one per tick.

**Behaviour otherwise unchanged** — the auto-upgrade queueing path is untouched; only the log is throttled.

## Tests
5 new unit tests (appended to `test_fleet_heartbeat_auto_upgrade.py`): dedup, version-change re-log, per-node isolation, window expiry, size cap. Full file 61 pass; `ruff`/`mypy` clean.

## Ops follow-up (not code)
The 3 stuck nodes are all internal (a teammate's box, a container, a laptop) — worth nudging them to upgrade or decommissioning, but not a customer-fleet problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)