### PR TITLE
fix(core-api): map unhandled upstream 5xx/429 to a retryable 503

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -4,6 +4,7 @@ import os as _os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+import httpx
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -626,6 +627,44 @@ async def global_exception_handler(request: Request, exc: Exception):
     if app_settings.environment != "production":
         content["error_type"] = type(exc).__name__
     return JSONResponse(status_code=500, content=content)
+
+
+@app.exception_handler(httpx.HTTPStatusError)
+async def upstream_http_error_handler(request: Request, exc: httpx.HTTPStatusError) -> JSONResponse:
+    """Map an unhandled upstream (storage-api etc.) 5xx/429 to a retryable
+    503 instead of letting it reach the catch-all as an ``INTERNAL_ERROR``
+    500 "unhandled exception".
+
+    A dependency returning 5xx/429 is a transient infrastructure blip, not a
+    bug in this request — surfacing it as 503 lets the caller back off and
+    retry. Prod 2026-07: a single storage-writer 503 on POST /fleet/heartbeat
+    bubbled through ``_post``'s ``raise_for_status`` as an unhandled 500 and
+    opened an Error-Tracking issue; the plugin should have just retried the
+    next tick.
+
+    A 4xx from an upstream is a bug in OUR request shape (genuinely
+    unexpected), so it must surface exactly as before this handler existed —
+    re-raise it unchanged rather than swallowing it into a response, so it
+    reaches the catch-all as a 500 (and callers that deliberately let a
+    storage 4xx propagate, e.g. the bulk-write atomicity path, keep seeing the
+    raw ``HTTPStatusError``). ``response`` is a required, non-Optional field
+    on ``HTTPStatusError``, so it's always present.
+    """
+    from core_api.errors import code_for_status, make_error_payload
+
+    status = exc.response.status_code
+    if status < 500 and status != 429:
+        raise exc
+
+    logger.warning(
+        "upstream %s on %s %s → 503 (retryable)",
+        status,
+        request.method,
+        request.url.path,
+    )
+    message = "Upstream dependency unavailable; retry."
+    body = {"detail": message, **make_error_payload(code_for_status(503), message)}
+    return JSONResponse(status_code=503, content=body)
 
 
 app.include_router(health_router, prefix="/api/v1")

--- a/tests/test_upstream_error_handler.py
+++ b/tests/test_upstream_error_handler.py
@@ -1,0 +1,63 @@
+"""Upstream 5xx/429 → retryable 503 mapping (2026-07-19 error review #3).
+
+A transient dependency failure (storage-api 5xx/429) must surface to the
+caller as a retryable 503, not an unhandled INTERNAL_ERROR 500. Prod
+2026-07: a single storage-writer 503 on POST /fleet/heartbeat bubbled
+through ``_post``'s ``raise_for_status`` as an unhandled 500 and opened an
+Error-Tracking issue; the plugin should have just retried next tick.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from starlette.requests import Request
+
+from core_api.app import app, upstream_http_error_handler
+
+pytestmark = pytest.mark.asyncio
+
+
+def _request(path: str = "/api/v1/fleet/heartbeat", method: str = "POST") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": [],
+            "query_string": b"",
+        }
+    )
+
+
+def _status_error(status: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "http://storage-writer/api/v1/storage/fleet/nodes")
+    resp = httpx.Response(status, request=req)
+    return httpx.HTTPStatusError(str(status), request=req, response=resp)
+
+
+async def test_handler_is_registered_for_httpx_status_error():
+    assert httpx.HTTPStatusError in app.exception_handlers
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504, 429])
+async def test_upstream_5xx_and_429_map_to_retryable_503(status: int):
+    resp = await upstream_http_error_handler(_request(), _status_error(status))
+    assert resp.status_code == 503
+    body = json.loads(bytes(resp.body))
+    assert body["error"]["code"] == "UNAVAILABLE"
+
+
+@pytest.mark.parametrize("status", [400, 404, 409, 422])
+async def test_upstream_4xx_is_reraised_unchanged(status: int):
+    # A 4xx from an upstream means OUR request was malformed — a genuine bug,
+    # not a transient blip. The handler must re-raise it unchanged so it
+    # surfaces exactly as before (catch-all 500), and callers that deliberately
+    # let a storage 4xx propagate (bulk-write atomicity) keep seeing the raw
+    # HTTPStatusError rather than a swallowed response.
+    err = _status_error(status)
+    with pytest.raises(httpx.HTTPStatusError) as caught:
+        await upstream_http_error_handler(_request(), err)
+    assert caught.value is err


### PR DESCRIPTION
## Why (finding #3 from the 2026-07-19 prod error review — option a)
The one prod 500 in 3 days was `POST /fleet/heartbeat` → `upsert_node()` → core-storage-writer returned a transient **503**, and the storage client's `raise_for_status()` let it bubble as an **unhandled** exception → the catch-all returned 500 (`INTERNAL_ERROR`) and opened an Error-Tracking issue. A transient dependency blip on an idempotent, frequently-retried endpoint shouldn't read as a hard server bug — the plugin should just retry next tick.

## What
App-level `@app.exception_handler(httpx.HTTPStatusError)` that maps an **upstream 5xx/429** to a retryable **503** (canonical `UNAVAILABLE` envelope) instead of the 500 catch-all. Fixing it at the exception mechanism covers every endpoint uniformly rather than bolting a try/except onto the heartbeat handler (the "fix the mechanism, not the symptom" altitude).

A **4xx** from an upstream means *our* request was malformed — a genuine bug, not a blip — so it still flows to the 500 catch-all unchanged.

## Tests (`tests/test_upstream_error_handler.py`)
- 500/502/503/504/429 → 503 `UNAVAILABLE`;
- 400/404/409/422 → 500 `INTERNAL_ERROR`;
- handler is registered for `httpx.HTTPStatusError`.
`ruff`/`mypy` clean.

Companion to #574 (which dedups the heartbeat's outdated-plugin log). Together they close the fleet-heartbeat findings from the error review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)