### PR TITLE
feat(search): cosine-dominant candidate pool selection (A49), off by default

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -153,6 +153,15 @@ MAX_QUERY_LENGTH = 5000
 DEFAULT_SEARCH_TOP_K = 5
 MAX_SEARCH_TOP_K = 20
 MIN_SEARCH_SIMILARITY = 0.3
+# A49: cosine-dominant candidate selection. 0 = OFF (the first-stage candidate pool
+# is selected by the boost-distorted ``score`` — current behaviour). >0 = select the
+# candidate pool by semantic relevance (``similarity``, boost-free) at this size, so
+# boost-demoted-but-strong matches survive the LIMIT into the ranking/rerank (A50)
+# stage instead of being evicted by the boost stack. Enable per-tenant via
+# ``default_search_profile.candidate_pool_size``; keep 0 globally until the A49/A50
+# A/B validates it. Offline ceiling (LongMemEval): pool=50 recovers 95% of the gold
+# production dropped from top-20; >70 adds nothing. See benchmark/a49_ceiling_check.py.
+CANDIDATE_POOL_SIZE = 0
 FRESHNESS_DECAY_DAYS = 90
 FRESHNESS_FLOOR = 0.7
 ENTITY_BOOST_FACTOR = 1.3

--- a/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
+++ b/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from core_api.constants import (
+    CANDIDATE_POOL_SIZE,
     FRESHNESS_DECAY_DAYS,
     FRESHNESS_FLOOR,
     GRAPH_MAX_HOPS,
@@ -52,5 +53,7 @@ class ResolveSearchProfile:
             "recall_decay_window_days": sp.get("recall_decay_window_days", RECALL_DECAY_WINDOW_DAYS),
             "graph_max_hops": sp.get("graph_max_hops", GRAPH_MAX_HOPS),
             "similarity_blend": sp.get("similarity_blend", SIMILARITY_BLEND),
+            # A49: 0 = off; >0 = storage selects a cosine-dominant candidate pool of this size.
+            "candidate_pool_size": sp.get("candidate_pool_size", CANDIDATE_POOL_SIZE),
         }
         return None

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -1059,6 +1059,8 @@ _SEARCH_PROFILE_RULES: dict[str, tuple[type, tuple, object]] = {
     "recall_decay_window_days": (int, (7, 365), None),
     "graph_max_hops": (int, (0, 5), None),
     "similarity_blend": (float, (0.0, 1.0), None),
+    # A49: 0 = off (candidate pool by boosted score); >0 = cosine-dominant pool of this size.
+    "candidate_pool_size": (int, (0, 200), None),
 }
 
 

--- a/core-api/tests/test_a49_candidate_pool.py
+++ b/core-api/tests/test_a49_candidate_pool.py
@@ -1,0 +1,52 @@
+"""A49 — cosine-dominant candidate pool: core-api plumbing.
+
+Covers the two core-api touch points:
+  * ``validate_search_profile`` accepts / clamps the new ``candidate_pool_size`` knob.
+  * ``ResolveSearchProfile`` threads it into ``search_params`` (default 0 = off).
+
+The storage-side behaviour (pool selected by similarity) is covered by
+core-storage-api/tests/test_integration.py::test_scored_search_candidate_pool_selects_by_similarity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_api.constants import CANDIDATE_POOL_SIZE
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search.resolve_search_profile import ResolveSearchProfile
+from core_api.services.organization_settings import validate_search_profile
+
+
+def test_default_off() -> None:
+    assert CANDIDATE_POOL_SIZE == 0, "A49 must ship OFF by default (no behaviour change)"
+
+
+def test_validate_search_profile_accepts_valid_pool_size() -> None:
+    assert validate_search_profile({"candidate_pool_size": 50}) == {"candidate_pool_size": 50}
+
+
+def test_validate_search_profile_clamps_out_of_range() -> None:
+    assert validate_search_profile({"candidate_pool_size": 500})["candidate_pool_size"] == 200
+    assert validate_search_profile({"candidate_pool_size": -5})["candidate_pool_size"] == 0
+
+
+def test_validate_search_profile_drops_wrong_type() -> None:
+    # rule default is None -> a wrong-typed value is dropped, not defaulted
+    assert "candidate_pool_size" not in validate_search_profile({"candidate_pool_size": "big"})
+
+
+@pytest.mark.asyncio
+async def test_resolve_defaults_pool_size_off() -> None:
+    ctx = PipelineContext(data={"query": "what is my role", "top_k": 5})
+    await ResolveSearchProfile().execute(ctx)
+    assert ctx.data["search_params"]["candidate_pool_size"] == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_honours_profile_pool_size() -> None:
+    ctx = PipelineContext(
+        data={"query": "what is my role", "top_k": 5, "search_profile": {"candidate_pool_size": 50}}
+    )
+    await ResolveSearchProfile().execute(ctx)
+    assert ctx.data["search_params"]["candidate_pool_size"] == 50

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1103,6 +1103,10 @@ class PostgresService:
         _recall_decay_window_days = sp["recall_decay_window_days"]
         _similarity_blend = sp["similarity_blend"]
         _top_k = sp.get("top_k", top_k)
+        # A49: 0 = off (candidate pool by boosted score, below); >0 = select the pool by
+        # semantic relevance (``similarity``) at this size so boost-demoted-but-strong
+        # matches survive the LIMIT into ranking/rerank. Arrives via search_params.
+        _candidate_pool_size = int(sp.get("candidate_pool_size", 0) or 0)
 
         # -- Scoring expressions --
         # CAURA-594: pgvector's `<=>` is strict — NULL in → NULL out. A
@@ -1450,7 +1454,19 @@ class PostgresService:
         # NOTE: date_range_start/end no longer produces a hard WHERE filter;
         # the multiplier ``date_range_boost`` above handles it softly.
 
-        scored_stmt = scored_stmt.order_by(score.desc(), Memory.created_at.desc()).limit(_top_k)
+        if _candidate_pool_size > 0:
+            # A49: select the candidate POOL by semantic relevance (``similarity``)
+            # rather than the boost-distorted ``score``, so boost-demoted-but-strong
+            # matches survive the LIMIT and reach the ranking/rerank (A50) stage. The
+            # outer query below still orders the surfaced pool by ``score`` and
+            # PostFilterResults trims to the caller's top_k — so with A49 alone this
+            # only *widens/relevance-selects the pool*, it does not reorder the final
+            # result; the reorder is A50. Off (0) by default → unchanged behaviour.
+            scored_stmt = scored_stmt.order_by(similarity.desc(), Memory.created_at.desc()).limit(
+                _candidate_pool_size
+            )
+        else:
+            scored_stmt = scored_stmt.order_by(score.desc(), Memory.created_at.desc()).limit(_top_k)
 
         scored_cte = scored_stmt.cte("scored")
 

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -790,6 +790,96 @@ class TestMemories:
             f"b_score={b_score} must not exceed a_score={a_score}"
         )
 
+    async def test_scored_search_candidate_pool_selects_by_similarity(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """A49: ``candidate_pool_size`` > 0 selects the candidate pool by semantic
+        similarity, so a boost-demoted-but-strong match is retained where the default
+        score-order drops it.
+
+        H: high similarity (0.70), no boost.  L: lower similarity (0.35) but a
+        ``date_range_boost`` (2x) that pushes its *score* above H's.  With the pool
+        OFF (score-order) L outranks H; with the pool ON (size 1, similarity-order)
+        the single surviving row is H. Also asserts pool=0 is a no-op vs the default.
+        """
+        import math
+
+        seed = f"a49_{_uid()}"
+        q = fake_embedding(seed + "_q")
+
+        def _unit(v: list[float]) -> list[float]:
+            n = math.sqrt(sum(x * x for x in v)) or 1.0
+            return [x / n for x in v]
+
+        def _emb_cos(target: float, rseed: str) -> list[float]:
+            # exact cosine=target vs q, via a Gram-Schmidt orthonormal basis {q, r_orth}
+            r = fake_embedding(rseed)
+            dot = sum(a * b for a, b in zip(r, q, strict=False))
+            r_orth = _unit([ri - dot * qi for ri, qi in zip(r, q, strict=False)])
+            a, b = target, math.sqrt(max(0.0, 1.0 - target * target))
+            return _unit([a * qi + b * ri for qi, ri in zip(q, r_orth, strict=False)])
+
+        # H: sim 0.70, weight 0.0, anchor = today (outside the queried date range).
+        ph = _memory_payload(tenant_id, fleet_id, content=f"H {seed}")
+        ph["embedding"] = _emb_cos(0.70, seed + "_h")
+        ph["weight"] = 0.0
+        rh = await client.post(f"{PREFIX}/memories", json=ph)
+        assert rh.status_code == 200, rh.text
+        h_id = rh.json()["id"]
+
+        # L: sim 0.35, weight 1.0, ts_valid_start inside the queried date range -> 2x boost.
+        pl = _memory_payload(tenant_id, fleet_id, content=f"L {seed}")
+        pl["embedding"] = _emb_cos(0.35, seed + "_l")
+        pl["weight"] = 1.0
+        pl["ts_valid_start"] = "2020-01-15T00:00:00+00:00"
+        rl = await client.post(f"{PREFIX}/memories", json=pl)
+        assert rl.status_code == 200, rl.text
+        l_id = rl.json()["id"]
+
+        base_params = {
+            "fts_weight": 0.0,  # similarity == pure vec_sim -> deterministic on constructed cosines
+            "freshness_floor": 0.7,
+            "freshness_decay_days": 90.0,
+            "recall_boost_cap": 1.1,
+            "recall_decay_window_days": 14.0,
+            "similarity_blend": 0.85,
+        }
+        base_body = {
+            "tenant_id": tenant_id,
+            "embedding": q,
+            "query": seed,
+            "fleet_ids": [fleet_id],
+            "date_range_start": "2020-01-01",
+            "date_range_end": "2020-01-31",
+            "top_k": 10,
+        }
+
+        # Pool OFF (default score-order): boosted L outranks H.
+        off = {**base_body, "search_params": base_params}
+        r_off = await client.post(f"{PREFIX}/memories/scored-search", json=off)
+        assert r_off.status_code == 200, r_off.text
+        off_ids = [r["id"] for r in r_off.json()]
+        assert h_id in off_ids and l_id in off_ids
+        assert off_ids.index(l_id) < off_ids.index(h_id), (
+            f"score-order should rank boosted L above H; got {off_ids}"
+        )
+
+        # Pool ON (size 1, similarity-order): the single surviving row is high-similarity H.
+        on = {**base_body, "search_params": {**base_params, "candidate_pool_size": 1}}
+        r_on = await client.post(f"{PREFIX}/memories/scored-search", json=on)
+        assert r_on.status_code == 200, r_on.text
+        on_ids = [r["id"] for r in r_on.json()]
+        assert on_ids == [h_id], f"cosine pool (size 1) should keep high-similarity H; got {on_ids}"
+
+        # Safety: candidate_pool_size=0 is a no-op vs. omitting the key entirely.
+        zero = {**base_body, "search_params": {**base_params, "candidate_pool_size": 0}}
+        r_zero = await client.post(f"{PREFIX}/memories/scored-search", json=zero)
+        assert r_zero.status_code == 200, r_zero.text
+        assert [r["id"] for r in r_zero.json()] == off_ids, "pool_size=0 must equal default behaviour"
+
     async def test_public_counters_exclude_soft_deleted(
         self,
         client: AsyncClient,


### PR DESCRIPTION
## What

Adds an opt-in **per-tenant** knob `candidate_pool_size` (default **0 = off**). When `>0`, the first-stage candidate pool is selected by semantic relevance (`similarity`) instead of the boost-distorted `score`, so **boost-demoted-but-strong matches survive the LIMIT** into the ranking/rerank stage (A50) rather than being evicted by the boost stack.

Resolution: agent profile → tenant `default_search_profile` → global constant (0). Validator caps it to 0–200.

## Why

LongMemEval 500-case failure analysis: **64%** of the gold memories production dropped from its top-20 rank **≤20 by pure cosine** — i.e. the ranking demoted strong semantic matches, it didn't fail to find them. A cross-encoder reranker (A50) only re-scores the candidate pool it's handed, so those demoted matches must first be *in* the pool. Offline ceiling: a cosine-selected pool of **50 recovers 95%** of the dropped gold; >70 adds nothing.

## Scope / behavior

- **Off by default → zero behavior change.** A49 alone widens/relevance-selects the candidate pool; the outer query still orders by `score` and `PostFilterResults` still trims to the caller's `top_k`, so the **final reorder is A50's job**. This is dark-launch infrastructure for A50.
- Enable per tenant via `default_search_profile.candidate_pool_size` for the A49+A50 A/B.

## Changes

- **core-api**: `CANDIDATE_POOL_SIZE` constant, `_SEARCH_PROFILE_RULES` entry (int 0–200), thread `candidate_pool_size` into `search_params`.
- **core-storage-api**: order the LIMIT pool by `similarity` when `candidate_pool_size > 0` (else unchanged `score` order).

## Tests

- core-api plumbing unit tests (6, passing): default-off, validate/clamp, resolve threading.
- storage integration test (real pgvector, passing): a boost-demoted high-similarity row is dropped by score-order but retained by the cosine pool; `candidate_pool_size=0` is byte-identical to default.
- Existing `/scored-search` tests: no regression (4/4).

## Not yet validated

End-to-end accuracy — that requires the **A49+A50 A/B** (re-seed + full-500), since A49 alone is pool infrastructure. Merging is safe because the flag is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)