### PR TITLE
feat(client): memclaw-interviewer — Claude Code disk-parser adapter (Interviewer Phase 2)

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -53,6 +53,45 @@ For credentials, scopes, and the full API surface, see the
 [MemClaw docs](https://memclaw.net/docs). Production fleets should use
 [per-agent keys](https://memclaw.net/docs/integrations/per-agent-keys).
 
+## memclaw-interviewer — Claude Code adapter (Interviewer Phase 2)
+
+Installing this package also provides the `memclaw-interviewer` CLI: the
+MemClaw Interviewer's disk-parser adapter for Claude Code workstations. It
+reads Claude Code session transcripts (`~/.claude/projects/…/*.jsonl`)
+**read-only**, tracks a per-file cursor via the server's forward-only
+watermark documents (no local state), and submits event windows to
+`POST /api/v1/interview/submit`, where MemClaw synthesizes them into typed
+memories. Requires the tenant to have `interviewer.enabled = true`.
+
+```bash
+export MEMCLAW_API_KEY=mc_xxx MEMCLAW_TENANT_ID=my-team
+export MEMCLAW_INTERVIEWER_PROJECTS="-Users-me-work-*"   # allowlist, default-deny
+
+memclaw-interviewer status --since-hours 24     # cursors vs. local line counts
+memclaw-interviewer run --dry-run -v            # parse + window, submit nothing
+memclaw-interviewer run --max-windows 8         # submit due windows
+```
+
+**Privacy:** default-deny — with no allowlist the CLI lists discovered
+project dirs and exits with guidance; `--all-projects` is the explicit
+opt-in. Credential-shaped strings are scrubbed locally before anything
+leaves the machine, and the server masks PII again on receipt.
+
+**Triggers:** run it from cron, or wire Claude Code's SessionEnd hook so a
+session is interviewed the moment it ends (a failed harvest never fails
+the session — the hook always exits 0):
+
+```json
+{ "hooks": { "SessionEnd": [ { "hooks": [
+  { "type": "command", "command": "memclaw-interviewer hook", "timeout": 300 }
+] } ] } }
+```
+
+Crash-safety is inherited from the Interviewer protocol: the watermark
+advances only after the server commits a window, and retries of the same
+window dedup server-side via a deterministic attempt id — never a gap,
+never a duplicate.
+
 ## License
 
 Apache-2.0

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memclaw-client"
-version = "0.1.0"
+version = "0.2.0"
 description = "Official Python client for MemClaw — governed shared memory for AI agent fleets (multi-agent, multi-tenant, MCP-native)."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -36,6 +36,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = ["httpx>=0.27"]
+
+[project.scripts]
+memclaw-interviewer = "memclaw_client.interviewer.cli:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=8", "ruff>=0.6"]

--- a/clients/python/src/memclaw_client/client.py
+++ b/clients/python/src/memclaw_client/client.py
@@ -6,6 +6,7 @@ A thin wrapper over the MemClaw REST API. Point it at a managed
 
 from __future__ import annotations
 
+import urllib.parse
 from typing import Any
 
 import httpx
@@ -113,6 +114,69 @@ class MemClaw:
         """Liveness probe (GET /api/v1/health)."""
         response = self._http.get("/api/v1/health")
         return response.json()
+
+    def get_document(
+        self,
+        doc_id: str,
+        *,
+        collection: str,
+        tenant_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Fetch one structured document (GET /api/v1/documents/{doc_id}).
+
+        Returns the full ``DocOut`` envelope — the stored record is under
+        the ``"data"`` key. Raises ``NotFoundError`` if absent.
+        """
+        # Percent-encode the path segment: httpx does not encode f-string
+        # paths, so a doc_id containing '/' would hit a different route and
+        # '?' would inject query params.
+        encoded = urllib.parse.quote(doc_id, safe="")
+        response = self._http.get(
+            f"/api/v1/documents/{encoded}",
+            params={"tenant_id": tenant_id or self.tenant_id, "collection": collection},
+        )
+        self._raise_for_status(response)
+        return response.json()
+
+    def submit_interview(
+        self,
+        *,
+        node_id: str,
+        agent_id: str,
+        cursor_from: int,
+        cursor_to: int,
+        events: list[dict[str, Any]],
+        tenant_id: str | None = None,
+        fleet_id: str | None = None,
+        command_id: str | None = None,
+        timeout: float = 120.0,
+    ) -> dict[str, Any]:
+        """Submit one Interviewer window (POST /api/v1/interview/submit).
+
+        The server interviews the window synchronously (its budget is 90s),
+        so ``timeout`` defaults well above the client-wide 30s. Returns the
+        response body plus ``"http_status"`` so callers can distinguish a
+        207 partial from a 200 committed. Raises on 4xx/5xx via the shared
+        error mapping (403 → ``AuthError``: tenant not enabled / bad key).
+        """
+        body: dict[str, Any] = {
+            "tenant_id": tenant_id or self.tenant_id,
+            "node_id": node_id,
+            "agent_id": agent_id,
+            "cursor_from": cursor_from,
+            "cursor_to": cursor_to,
+            "events": events,
+        }
+        if fleet_id:
+            body["fleet_id"] = fleet_id
+        if command_id:
+            body["command_id"] = command_id
+        response = self._http.post("/api/v1/interview/submit", json=body, timeout=timeout)
+        self._raise_for_status(response)
+        result = response.json()
+        if isinstance(result, dict):
+            result["http_status"] = response.status_code
+        return result
 
     # ------------------------------------------------------------- internals
     def _post(self, path: str, body: dict[str, Any]) -> Any:

--- a/clients/python/src/memclaw_client/interviewer/__init__.py
+++ b/clients/python/src/memclaw_client/interviewer/__init__.py
@@ -1,0 +1,10 @@
+"""memclaw-interviewer — the Claude Code disk-parser adapter (Interviewer Phase 2).
+
+Reads Claude Code session transcripts (``~/.claude/projects/<slug>/<uuid>.jsonl``)
+READ-ONLY, tracks per-file cursors via the server's forward-only watermark
+documents, and submits event windows to ``POST /api/v1/interview/submit``.
+No local state; no server changes; the trail belongs to Claude Code and is
+never modified.
+"""
+
+from __future__ import annotations

--- a/clients/python/src/memclaw_client/interviewer/cli.py
+++ b/clients/python/src/memclaw_client/interviewer/cli.py
@@ -1,0 +1,328 @@
+"""memclaw-interviewer CLI — run / status / hook.
+
+Config precedence: flags > env > defaults. Env vars:
+  MEMCLAW_API_KEY (required)      MEMCLAW_TENANT_ID (required)
+  MEMCLAW_BASE_URL                MEMCLAW_AGENT_ID (default user@host)
+  MEMCLAW_FLEET_ID                MEMCLAW_INTERVIEWER_PROJECTS (comma-sep globs)
+
+Exit codes: 0 success / nothing to do; 1 every attempted file failed;
+2 configuration or authorization error. ``hook`` ALWAYS exits 0 — a
+memory-harvest failure must never fail a Claude Code session hook.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import getpass
+import json
+import os
+import socket
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from ..client import MemClaw
+from ..exceptions import AuthError
+from .discovery import (
+    DEFAULT_PROJECTS_ROOT,
+    Transcript,
+    find_transcripts,
+    list_project_dirs,
+    project_allowed,
+)
+from .machine import machine_id_short
+from .parser import count_lines
+from .runner import RunConfig, node_id_for, read_watermark, run_all
+
+DEFAULT_BASE_URL = "https://memclaw.net"
+
+
+def _default_agent_id() -> str:
+    return f"cc-{getpass.getuser()}@{socket.gethostname()}"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="memclaw-interviewer",
+        description="MemClaw Interviewer adapter for Claude Code transcripts (read-only).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def common(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--base-url", default=os.environ.get("MEMCLAW_BASE_URL", DEFAULT_BASE_URL))
+        p.add_argument("--api-key", default=os.environ.get("MEMCLAW_API_KEY", ""))
+        p.add_argument("--tenant-id", default=os.environ.get("MEMCLAW_TENANT_ID", ""))
+        p.add_argument("--agent-id", default=os.environ.get("MEMCLAW_AGENT_ID", "") or _default_agent_id())
+        p.add_argument("--fleet-id", default=os.environ.get("MEMCLAW_FLEET_ID", "") or None)
+        p.add_argument(
+            "--projects",
+            nargs="+",
+            default=None,
+            help="project-dir globs to allow (default: MEMCLAW_INTERVIEWER_PROJECTS env; DEFAULT-DENY without either)",
+        )
+        p.add_argument("--all-projects", action="store_true", help="explicit opt-in: harvest every project dir")
+        p.add_argument("--projects-root", type=Path, default=DEFAULT_PROJECTS_ROOT)
+        p.add_argument("-v", "--verbose", action="store_true")
+
+    run_p = sub.add_parser("run", help="scan transcripts and submit due interview windows")
+    common(run_p)
+    run_p.add_argument("--transcript", type=Path, default=None, help="drain ONE transcript file (bypasses discovery)")
+    run_p.add_argument("--dry-run", action="store_true", help="parse + window, submit nothing")
+    run_p.add_argument("--max-windows", type=int, default=8)
+    run_p.add_argument("--since-hours", type=float, default=168.0, help="only files modified in this window (0 = all)")
+    run_p.add_argument("--min-events", type=int, default=10, help="dribble gate for the final window")
+    run_p.add_argument("--max-event-chars", type=int, default=4_000)
+    run_p.add_argument("--flush", action="store_true", help="submit even below the dribble gate")
+
+    status_p = sub.add_parser("status", help="show per-file cursor vs local line counts")
+    common(status_p)
+    status_p.add_argument("--since-hours", type=float, default=168.0)
+
+    hook_p = sub.add_parser("hook", help="Claude Code SessionEnd hook: drain the session transcript (stdin JSON)")
+    common(hook_p)
+    hook_p.add_argument("--max-windows", type=int, default=2)
+    hook_p.add_argument("--max-event-chars", type=int, default=4_000)
+    return parser
+
+
+def _resolve_allowlist(args: argparse.Namespace) -> list[str]:
+    if args.projects is not None:
+        return list(args.projects)
+    env = os.environ.get("MEMCLAW_INTERVIEWER_PROJECTS", "")
+    return [g.strip() for g in env.split(",") if g.strip()]
+
+
+def _require_config(args: argparse.Namespace) -> Optional[str]:
+    if not args.api_key:
+        return "MEMCLAW_API_KEY (or --api-key) is required"
+    if not args.tenant_id:
+        return "MEMCLAW_TENANT_ID (or --tenant-id) is required"
+    return None
+
+
+def _deny_guidance(args: argparse.Namespace) -> str:
+    projects = list_project_dirs(args.projects_root)
+    lines = [
+        "No project allowlist configured - refusing to harvest by default.",
+        "Claude Code transcripts can contain sensitive work across ALL projects;",
+        "opt in explicitly with --projects <glob...>, MEMCLAW_INTERVIEWER_PROJECTS,",
+        "or --all-projects.",
+        "",
+        "Discovered project dirs:",
+    ]
+    lines += [f"  {p}" for p in projects] or ["  (none)"]
+    return "\n".join(lines)
+
+
+def _acquire_lock() -> Optional[object]:
+    """Best-effort cross-invocation guard (cron + hook overlap).
+
+    The REAL safety is the server's deterministic attempt-id dedup; this
+    just avoids burning duplicate LLM windows. Never blocks. On platforms
+    without ``fcntl`` (Windows) the guard degrades to a no-op — dedup
+    still protects correctness.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        # No fcntl (Windows): PROCEED without a lock rather than treating
+        # it as "already locked" — returning None here would make every
+        # Windows run exit immediately. Dedup still protects correctness.
+        return object()
+    # Per-user filename: a shared /tmp lock owned by another user would
+    # fail our open() with EACCES forever, reading as "always locked".
+    lock_path = Path(tempfile.gettempdir()) / f"memclaw-interviewer-{getpass.getuser()}.lock"
+    handle = None
+    try:
+        handle = open(lock_path, "w")
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return handle
+    except OSError as exc:
+        if handle is not None:
+            handle.close()
+        if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+            return None  # genuine contention: another run holds the lock
+        # Unrecoverable environment error (EACCES on the lock file,
+        # read-only tmpdir, ...): warn and PROCEED lockless, like the
+        # no-fcntl path — treating it as contention would silently
+        # disable the CLI on that machine forever.
+        print(f"[interviewer] lock unavailable ({exc}); proceeding without it", file=sys.stderr)
+        return object()
+
+
+def _make_client(args: argparse.Namespace) -> MemClaw:
+    return MemClaw(
+        args.api_key,
+        tenant_id=args.tenant_id,
+        base_url=args.base_url,
+        agent_id=args.agent_id,
+    )
+
+
+def _make_config(args: argparse.Namespace, *, flush: bool = False, dry_run: bool = False) -> RunConfig:
+    return RunConfig(
+        agent_id=args.agent_id,
+        machine12=machine_id_short(),
+        fleet_id=args.fleet_id,
+        max_event_chars=getattr(args, "max_event_chars", 4_000),
+        max_windows=getattr(args, "max_windows", 8),
+        min_events=getattr(args, "min_events", 10),
+        flush=flush,
+        dry_run=dry_run,
+        verbose=args.verbose,
+    )
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    if error := _require_config(args):
+        print(f"[interviewer] {error}", file=sys.stderr)
+        return 2
+    allow = _resolve_allowlist(args)
+    if args.transcript is not None:
+        if not args.transcript.is_file():
+            print(f"[interviewer] no such transcript: {args.transcript}", file=sys.stderr)
+            return 2
+        # --transcript must not bypass the project allowlist — including
+        # the EMPTY-allowlist case (default-deny has no carve-outs; same
+        # pattern as _cmd_hook and the discovery path below).
+        project = args.transcript.parent.name
+        if not args.all_projects and not (allow and project_allowed(project, allow)):
+            print(
+                f"[interviewer] transcript project '{project}' not in allowlist; "
+                "pass --all-projects or --projects to opt in",
+                file=sys.stderr,
+            )
+            return 2
+        transcripts = [Transcript(path=args.transcript, project=project)]
+    else:
+        if not allow and not args.all_projects:
+            print(_deny_guidance(args), file=sys.stderr)
+            return 2
+        transcripts = find_transcripts(
+            root=args.projects_root,
+            allow_globs=allow,
+            since_hours=args.since_hours or None,
+            all_projects=args.all_projects,
+        )
+    if not transcripts:
+        print("[interviewer] nothing to do (no matching transcripts)")
+        return 0
+
+    lock = _acquire_lock()
+    if lock is None:
+        print("[interviewer] another run holds the lock; exiting", file=sys.stderr)
+        return 0
+    try:
+        cfg = _make_config(args, flush=args.flush, dry_run=args.dry_run)
+        with _make_client(args) as mc:
+            summary = run_all(mc, transcripts, cfg)
+    finally:
+        # Deterministic flock release: on non-CPython runtimes the ref-count
+        # drop is not prompt, and a lingering handle blocks the next
+        # cron/hook invocation until GC. (The Windows sentinel has no close.)
+        if hasattr(lock, "close"):
+            lock.close()
+
+    submitted = sum(f.windows_submitted for f in summary.files)
+    memories = sum(f.memories_written for f in summary.files)
+    print(
+        f"[interviewer] {len(summary.files)} file(s): {submitted} window(s) submitted, "
+        f"{memories} memories written"
+        + (" [dry-run]" if args.dry_run else "")
+    )
+    if summary.aborted:
+        return 2
+    if summary.failed_all:
+        return 1
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    if error := _require_config(args):
+        print(f"[interviewer] {error}", file=sys.stderr)
+        return 2
+    allow = _resolve_allowlist(args)
+    if not allow and not args.all_projects:
+        print(_deny_guidance(args), file=sys.stderr)
+        return 2
+    transcripts = find_transcripts(
+        root=args.projects_root,
+        allow_globs=allow,
+        since_hours=args.since_hours or None,
+        all_projects=args.all_projects,
+    )
+    machine12 = machine_id_short()
+    with _make_client(args) as mc:
+        for transcript in transcripts:
+            node_id = node_id_for(machine12, transcript.path)
+            try:
+                last_seq = read_watermark(mc, node_id)
+                # Inside the guard: the transcript can vanish between
+                # discovery and here (same TOCTOU as discovery's stat).
+                lines = count_lines(transcript.path)
+            except AuthError as exc:
+                print(f"[interviewer] ABORT: {exc}", file=sys.stderr)
+                return 2
+            except Exception as exc:  # noqa: BLE001 - one bad file must not kill status
+                print(
+                    f"{transcript.project}/{transcript.path.name}: status check failed: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            pending = max(0, lines - (last_seq + 1))
+            print(f"{transcript.project}/{transcript.path.name}: lines={lines} cursor={last_seq} pending={pending}")
+    return 0
+
+
+def _cmd_hook(args: argparse.Namespace) -> int:
+    """SessionEnd hook: read {transcript_path,...} JSON from stdin, drain
+    that one file. ALWAYS exit 0 — never fail the user's session."""
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+        transcript_path = Path(str(payload.get("transcript_path") or ""))
+        if not transcript_path.is_file():
+            return 0
+        allow = _resolve_allowlist(args)
+        project = transcript_path.parent.name
+        if not args.all_projects and not (allow and project_allowed(project, allow)):
+            # Warn so operators can tell a config gap from an empty
+            # session; exit code stays 0 (never fail the session hook).
+            print(
+                f"[interviewer] hook: project '{project}' not in allowlist; skipping "
+                "(set MEMCLAW_INTERVIEWER_PROJECTS or --all-projects)",
+                file=sys.stderr,
+            )
+            return 0
+        if error := _require_config(args):
+            print(f"[interviewer] hook: {error}; skipping", file=sys.stderr)
+            return 0
+        lock = _acquire_lock()
+        if lock is None:
+            return 0
+        try:
+            cfg = _make_config(args, flush=True)  # session over: drain the tail
+            with _make_client(args) as mc:
+                run_all(mc, [Transcript(path=transcript_path, project=project)], cfg)
+        finally:
+            if hasattr(lock, "close"):
+                lock.close()
+    except Exception as exc:  # noqa: BLE001 - hook must never fail the session
+        print(f"[interviewer] hook error (ignored): {exc}", file=sys.stderr)
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.command == "run":
+        return _cmd_run(args)
+    if args.command == "status":
+        return _cmd_status(args)
+    if args.command == "hook":
+        return _cmd_hook(args)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clients/python/src/memclaw_client/interviewer/discovery.py
+++ b/clients/python/src/memclaw_client/interviewer/discovery.py
@@ -1,0 +1,66 @@
+"""Transcript discovery under ~/.claude/projects with allowlist gating.
+
+Privacy posture (user-confirmed): DEFAULT-DENY. With no allowlist the CLI
+lists what it found and exits with guidance — transcripts can contain
+NDA/client work and pasted secrets across every project on the machine,
+and installing the tool is not consent to harvest all of them.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_PROJECTS_ROOT = Path.home() / ".claude" / "projects"
+
+
+@dataclass
+class Transcript:
+    path: Path
+    project: str  # project dir name (the slug)
+
+
+def list_project_dirs(root: Path = DEFAULT_PROJECTS_ROOT) -> list[str]:
+    if not root.is_dir():
+        return []
+    return sorted(p.name for p in root.iterdir() if p.is_dir())
+
+
+def project_allowed(project: str, allow_globs: list[str]) -> bool:
+    return any(fnmatch.fnmatch(project, glob) for glob in allow_globs)
+
+
+def find_transcripts(
+    *,
+    root: Path = DEFAULT_PROJECTS_ROOT,
+    allow_globs: list[str],
+    since_hours: Optional[float] = None,
+    all_projects: bool = False,
+) -> list[Transcript]:
+    """Enumerate top-level session ``.jsonl`` files in allowed projects.
+
+    Skips subagent transcripts (``<uuid>/subagents/``) and offloaded tool
+    results by construction — only files DIRECTLY under a project dir are
+    session transcripts. ``since_hours`` prefilters by mtime so steady-state
+    runs don't rescan months of history.
+    """
+    if not root.is_dir():
+        return []
+    cutoff = time.time() - since_hours * 3600 if since_hours else None
+    found: list[Transcript] = []
+    for project_dir in sorted(root.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        if not all_projects and not project_allowed(project_dir.name, allow_globs):
+            continue
+        for path in sorted(project_dir.glob("*.jsonl")):
+            try:
+                if cutoff is not None and path.stat().st_mtime < cutoff:
+                    continue
+            except OSError:
+                continue  # deleted/renamed between glob and stat (TOCTOU)
+            found.append(Transcript(path=path, project=project_dir.name))
+    return found

--- a/clients/python/src/memclaw_client/interviewer/machine.py
+++ b/clients/python/src/memclaw_client/interviewer/machine.py
@@ -1,0 +1,66 @@
+"""Stable short machine identity for per-file node ids.
+
+The node id must survive reboots and CLI reinstalls but distinguish two
+machines that sync the same transcript file (each then owns an independent
+watermark stream — clean, never corrupting).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import socket
+import subprocess
+import sys
+
+
+def _raw_machine_id() -> str:
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.run(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            ).stdout
+            for line in out.splitlines():
+                if "IOPlatformUUID" in line:
+                    parts = line.split('"')
+                    # >= 4 means at least two quote PAIRS, so parts[-2] is a
+                    # real quoted value — with >= 2 a single stray quote
+                    # would return the raw line as the "UUID".
+                    if len(parts) >= 4:
+                        return parts[-2]
+        except (OSError, subprocess.SubprocessError):
+            pass
+    try:
+        with open("/etc/machine-id", encoding="utf-8") as f:
+            mid = f.read().strip()
+            # Reject degenerate ids (e.g. the all-zeros /etc/machine-id
+            # many container images ship): two such containers would
+            # collide on the same watermark doc and corrupt each other's
+            # cursors. Fall through to the host-based fallback instead.
+            if mid and len(set(mid)) > 1:
+                return mid
+    except OSError:
+        pass
+    # Last resort: stable enough per user+host.
+    return f"{socket.gethostname()}:{os.path.expanduser('~')}"
+
+
+_MACHINE_ID_SHORT: str | None = None
+
+
+def machine_id_short() -> str:
+    """First 12 hex chars of sha1 over the platform machine identity.
+
+    Cached per process: the identity is immutable for the process
+    lifetime and the ioreg subprocess / file read shouldn't repeat.
+    """
+    global _MACHINE_ID_SHORT
+    if _MACHINE_ID_SHORT is None:
+        _MACHINE_ID_SHORT = hashlib.sha1(
+            _raw_machine_id().encode(), usedforsecurity=False
+        ).hexdigest()[:12]
+    return _MACHINE_ID_SHORT

--- a/clients/python/src/memclaw_client/interviewer/parser.py
+++ b/clients/python/src/memclaw_client/interviewer/parser.py
@@ -1,0 +1,175 @@
+"""Claude Code transcript parser → C2 interview events.
+
+Format facts this parser is built on (verified against real transcripts,
+2026-07; see the Phase-2 plan):
+
+- A session ``.jsonl`` is append-only but may contain MULTIPLE
+  ``sessionId`` values (resuming appends to the original file) and eight
+  non-conversation line types interleaved (some without timestamps).
+- Tool RESULTS are ``type:"user"`` lines whose ``message.content`` starts
+  with a ``tool_result`` block (and carry a top-level ``toolUseResult``).
+- Meta/injected lines are flagged ``isMeta`` / ``isCompactSummary`` /
+  ``isVisibleInTranscriptOnly``.
+- Assistant ``message.content`` is a list of ``thinking|text|tool_use``
+  blocks (or occasionally a plain string).
+
+v1 emit policy (pilot-proven quality): REAL user prompts + assistant TEXT
+only. Everything else — thinking, tool_use, tool_result, meta, compaction
+summaries — is consumed as noise (it still advances the cursor).
+
+``seq`` is the RAW LINE INDEX in the file: monotonic under append-only
+writes regardless of session interleave, which is exactly the server's C2
+seq contract (sparse seqs are legal; ``cursor_to`` may point past a
+filtered tail).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from .scrub import scrub
+
+MIN_EVENT_CHARS = 60
+
+
+@dataclass
+class ParsedEvent:
+    seq: int
+    ts: str
+    session_id: str
+    role: str
+    kind: str
+    content: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "seq": self.seq,
+            "ts": self.ts,
+            "session_id": self.session_id,
+            "role": self.role,
+            "kind": self.kind,
+            "content": self.content,
+        }
+
+
+@dataclass
+class ScanResult:
+    """Events plus the index of the last COMPLETE line scanned."""
+
+    events: list[ParsedEvent]
+    last_complete_line: int  # -1 when nothing scannable past start_line
+    total_lines: int
+
+
+def _text_of(content: Any) -> str:
+    """Join text blocks; plain strings pass through; everything else is ''."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text" and block.get("text"):
+                parts.append(str(block["text"]))
+        return "\n".join(parts)
+    return ""
+
+
+def _is_tool_result_user(row: dict[str, Any], message: dict[str, Any]) -> bool:
+    if row.get("toolUseResult") is not None:
+        return True
+    content = message.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_result":
+                return True
+    return False
+
+
+def _event_from_line(
+    row: dict[str, Any],
+    seq: int,
+    project: str,
+    max_event_chars: int,
+) -> Optional[ParsedEvent]:
+    line_type = row.get("type")
+    if line_type not in ("user", "assistant"):
+        return None
+    message = row.get("message")
+    session_id = row.get("sessionId")
+    ts = row.get("timestamp")
+    if not isinstance(message, dict) or not session_id or not ts:
+        return None
+    # Meta / injected / compaction lines are noise, not conversation.
+    if row.get("isMeta") or row.get("isCompactSummary") or row.get("isVisibleInTranscriptOnly"):
+        return None
+    if line_type == "user":
+        if _is_tool_result_user(row, message):
+            return None
+        kind = "prompt"
+    else:
+        kind = "reply"
+    text = scrub(_text_of(message.get("content")).strip())
+    if len(text) < MIN_EVENT_CHARS:
+        return None
+    return ParsedEvent(
+        seq=seq,
+        ts=str(ts),
+        session_id=f"{project}:{session_id}",
+        role=str(message.get("role") or line_type),
+        kind=kind,
+        content=text[:max_event_chars],
+    )
+
+
+def count_lines(path: Path) -> int:
+    """Cheap line count for the skip-unchanged check (no JSON parsing)."""
+    count = 0
+    with open(path, "rb") as f:
+        for _ in f:
+            count += 1
+    return count
+
+
+def scan_events(
+    path: Path,
+    *,
+    start_line: int,
+    project: str,
+    max_event_chars: int,
+) -> ScanResult:
+    """Scan complete lines from ``start_line`` (0-based) to EOF.
+
+    A final line without a trailing newline may be mid-append (Claude Code
+    is live) — it is NOT counted as complete and will be picked up next
+    run. Unparseable COMPLETE lines are consumed as noise (cursor still
+    advances past them).
+    """
+    events: list[ParsedEvent] = []
+    last_complete = -1
+    total = 0
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for index, raw in enumerate(f):
+            total = index + 1
+            if not raw.endswith("\n"):
+                # Torn/mid-append tail: stop before it; complete next run.
+                total = index
+                break
+            if index < start_line:
+                continue
+            last_complete = index
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue  # corrupt line: noise, cursor advances past it
+            if not isinstance(row, dict):
+                continue
+            event = _event_from_line(row, index, project, max_event_chars)
+            if event is not None:
+                events.append(event)
+    return ScanResult(events=events, last_complete_line=last_complete, total_lines=total)

--- a/clients/python/src/memclaw_client/interviewer/runner.py
+++ b/clients/python/src/memclaw_client/interviewer/runner.py
@@ -1,0 +1,232 @@
+"""The per-file interview loop: watermark → scan → windows → submit.
+
+Protocol (inherited from Phase 1, crash-safe by construction):
+- the cursor is the SERVER's forward-only watermark doc — no local state;
+- the watermark advances only after the server commits, and the attempt id
+  is deterministic per (node, window), so any retry dedups;
+- this adapter never modifies the transcript (Claude Code owns the trail).
+
+Failure matrix (per the approved plan):
+  403  → abort the whole run (tenant off / bad key)         exit 2
+  422  → our windowing bug: log + skip file, no retry
+  504  → retry the SAME window once (dedup-safe), then skip file
+  500  → window not consumed: skip file, next run resumes
+  207  → partial success: watermark advanced, keep draining
+  transport error → one retry, then skip file
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from ..client import MemClaw
+from ..exceptions import AuthError, MemClawAPIError, NotFoundError
+from .discovery import Transcript
+from .parser import count_lines, scan_events
+from .windows import Window, build_windows, window_is_worth_interviewing
+
+WATERMARK_COLLECTION = "interview_watermarks"
+
+
+def node_id_for(machine12: str, path: Path) -> str:
+    # The stem is the session UUID — globally unique, so the project dir
+    # is DELIBERATELY excluded: (a) renaming/moving a project dir (the
+    # slug is the cwd path) must not orphan every watermark under it,
+    # and (b) long path slugs could overflow the server's 200-char
+    # node_id cap. A moved transcript keeps its cursor, by design.
+    return f"cc:{machine12}:{path.stem}"
+
+
+def watermark_doc_id(node_id: str) -> str:
+    # Mirrors core_api.services.interview_service.watermark_doc_id.
+    # usedforsecurity=False: this is a stable identifier, not crypto —
+    # without it FIPS-140 Linux systems raise ValueError on sha1.
+    return f"wm_{hashlib.sha1(node_id.encode(), usedforsecurity=False).hexdigest()[:40]}"
+
+
+@dataclass
+class RunConfig:
+    agent_id: str
+    machine12: str
+    fleet_id: Optional[str] = None
+    max_event_chars: int = 4_000
+    max_windows: int = 8
+    min_events: int = 10
+    flush: bool = False
+    dry_run: bool = False
+    verbose: bool = False
+
+
+@dataclass
+class FileResult:
+    path: Path
+    windows_submitted: int = 0
+    events_submitted: int = 0
+    memories_written: int = 0
+    skipped_reason: Optional[str] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class RunSummary:
+    files: list[FileResult] = field(default_factory=list)
+    windows_budget_left: int = 0
+    aborted: bool = False
+
+    @property
+    def failed_all(self) -> bool:
+        attempted = [f for f in self.files if f.skipped_reason is None]
+        return bool(attempted) and all(f.error for f in attempted)
+
+
+def _log(cfg: RunConfig, msg: str) -> None:
+    if cfg.verbose:
+        print(f"[interviewer] {msg}", file=sys.stderr)
+
+
+def read_watermark(mc: MemClaw, node_id: str) -> int:
+    """Server-side cursor for this file; -1 when never interviewed."""
+    try:
+        doc = mc.get_document(watermark_doc_id(node_id), collection=WATERMARK_COLLECTION)
+    except NotFoundError:
+        return -1
+    data = doc.get("data") if isinstance(doc, dict) else None
+    try:
+        return int(data.get("last_seq", -1)) if isinstance(data, dict) else -1
+    except (TypeError, ValueError):
+        return -1
+
+
+def _submit_window(mc: MemClaw, cfg: RunConfig, node_id: str, window: Window) -> dict:
+    return mc.submit_interview(
+        node_id=node_id,
+        agent_id=cfg.agent_id,
+        fleet_id=cfg.fleet_id,
+        cursor_from=window.cursor_from,
+        cursor_to=window.cursor_to,
+        events=[e.to_payload() for e in window.events],
+    )
+
+
+def run_file(mc: MemClaw, transcript: Transcript, cfg: RunConfig, windows_budget: int) -> FileResult:
+    """Drain one transcript up to the shared windows budget."""
+    result = FileResult(path=transcript.path)
+    node_id = node_id_for(cfg.machine12, transcript.path)
+    # Dry-run is fully offline: no watermark read, no submit — parse and
+    # window from the start of the file as if never interviewed.
+    last_seq = -1 if cfg.dry_run else read_watermark(mc, node_id)
+    cursor_from = last_seq + 1
+
+    # Cheap skip: nothing appended since the last committed window.
+    total_lines = count_lines(transcript.path)
+    if total_lines < cursor_from:
+        # Append-only violated (rotation/rewrite). Never guess a cursor.
+        result.skipped_reason = (
+            f"file shrank below watermark ({total_lines} lines < cursor {cursor_from}); "
+            "append-only assumption violated - skipping"
+        )
+        print(f"[interviewer] WARNING {transcript.path.name}: {result.skipped_reason}", file=sys.stderr)
+        return result
+    if total_lines == cursor_from:
+        result.skipped_reason = "no new lines"
+        return result
+    # NOTE: count_lines counts a torn (newline-less) final fragment, so a
+    # file whose only "new" line is mid-append reaches scan_events, which
+    # then correctly reports "no complete new lines". That wasted scan is
+    # accepted: a REAL single new complete line yields the same
+    # total_lines == cursor_from + 1, and only the scan can tell them
+    # apart — short-circuiting here would skip real data.
+
+    scan = scan_events(
+        transcript.path,
+        start_line=cursor_from,
+        project=transcript.project,
+        max_event_chars=cfg.max_event_chars,
+    )
+    if scan.last_complete_line < cursor_from:
+        result.skipped_reason = "no complete new lines (mid-append tail)"
+        return result
+    if not scan.events:
+        # Pure-noise tail: nothing to interview, nothing to submit (server
+        # requires >= 1 event). Local-only rescan next run; bounded.
+        result.skipped_reason = f"no interview-worthy events in {scan.last_complete_line - cursor_from + 1} new lines"
+        return result
+
+    for window in build_windows(
+        scan.events, cursor_from=cursor_from, eof_line_index=scan.last_complete_line
+    ):
+        if windows_budget - result.windows_submitted <= 0:
+            _log(cfg, f"{transcript.path.name}: windows budget exhausted, resuming next run")
+            break
+        if not window_is_worth_interviewing(window, min_events=cfg.min_events, flush=cfg.flush):
+            _log(cfg, f"{transcript.path.name}: final window below dribble gate ({len(window.events)} events), deferred")
+            break
+        if cfg.dry_run:
+            print(
+                f"[dry-run] {transcript.path.name}: window [{window.cursor_from}..{window.cursor_to}] "
+                f"{len(window.events)} events, {window.chars} chars"
+            )
+            result.windows_submitted += 1
+            result.events_submitted += len(window.events)
+            continue
+        try:
+            response = _try_submit(mc, cfg, node_id, window)
+        except AuthError:
+            raise  # abort the whole run (403: tenant off / bad key)
+        except MemClawAPIError as exc:
+            result.error = f"window [{window.cursor_from}..{window.cursor_to}]: {exc}"
+            _log(cfg, f"{transcript.path.name}: {result.error} - skipping file")
+            break
+        except httpx.TransportError as exc:
+            result.error = f"transport: {exc}"
+            _log(cfg, f"{transcript.path.name}: {result.error} - skipping file")
+            break
+        result.windows_submitted += 1
+        result.events_submitted += len(window.events)
+        result.memories_written += int(response.get("memories_written") or 0)
+        _log(
+            cfg,
+            f"{transcript.path.name}: [{window.cursor_from}..{window.cursor_to}] "
+            f"{response.get('status')} watermark={response.get('watermark')} "
+            f"memories={response.get('memories_written')}",
+        )
+    return result
+
+
+def _try_submit(mc: MemClaw, cfg: RunConfig, node_id: str, window: Window) -> dict:
+    """One submit with a single retry on 504/transport (dedup-safe)."""
+    try:
+        return _submit_window(mc, cfg, node_id, window)
+    except MemClawAPIError as exc:
+        if exc.status_code == 504:
+            _log(cfg, f"504 on [{window.cursor_from}..{window.cursor_to}], one dedup-safe retry")
+            return _submit_window(mc, cfg, node_id, window)
+        raise
+    except httpx.TransportError:
+        _log(cfg, f"transport error on [{window.cursor_from}..{window.cursor_to}], one dedup-safe retry")
+        return _submit_window(mc, cfg, node_id, window)
+
+
+def run_all(mc: MemClaw, transcripts: list[Transcript], cfg: RunConfig) -> RunSummary:
+    summary = RunSummary(windows_budget_left=cfg.max_windows)
+    for transcript in transcripts:
+        if summary.windows_budget_left <= 0:
+            break
+        try:
+            result = run_file(mc, transcript, cfg, summary.windows_budget_left)
+        except AuthError as exc:
+            print(f"[interviewer] ABORT: {exc} (tenant not enabled, or bad credentials)", file=sys.stderr)
+            summary.aborted = True
+            break
+        except Exception as exc:  # per-file isolation: one bad file never stops the run
+            result = FileResult(path=transcript.path, error=f"unexpected: {exc}")
+            print(f"[interviewer] ERROR {transcript.path.name}: {exc}", file=sys.stderr)
+        summary.windows_budget_left -= result.windows_submitted
+        summary.files.append(result)
+    return summary

--- a/clients/python/src/memclaw_client/interviewer/scrub.py
+++ b/clients/python/src/memclaw_client/interviewer/scrub.py
@@ -1,0 +1,42 @@
+"""Local secret scrub — defense in depth before anything leaves the machine.
+
+The server deterministically masks PII/secrets again on receipt
+(``common.governance``); this pass exists so credential-shaped strings
+never even transit. Patterns favor precision (long, prefixed token
+shapes) over recall — the server's scanner is the broad net.
+"""
+
+from __future__ import annotations
+
+import re
+
+_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9_\-]{20,}"),  # OpenAI / Anthropic-style
+    re.compile(r"mc[ai]?_[A-Za-z0-9_\-]{16,}"),  # MemClaw credentials
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),  # GitHub tokens (classic)
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),  # GitHub fine-grained PAT
+    re.compile(
+        r"(?i)\baws[_-]?secret[_-]?access[_-]?key\s*[=:]\s*['\"]?[A-Za-z0-9/+]{39,41}"
+    ),  # AWS secret access key (AKIA covers only the key ID)
+    re.compile(r"xox[a-z]-[A-Za-z0-9\-]{10,}"),  # Slack tokens
+    re.compile(r"AKIA[0-9A-Z]{16}"),  # AWS access key id
+    # Bounded span: an unmatched BEGIN scans at most 8192 chars instead of
+    # to EOF, keeping K stray markers in a long transcript at O(K*8k) not
+    # O(K*N). RSA-4096 PEM is ~3400 chars, so real keys fit comfortably;
+    # a pathological >8k key falls through to the server-side mask.
+    re.compile(
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]{0,8192}?-----END [A-Z ]*PRIVATE KEY-----"
+    ),
+    re.compile(r"(?i)\bbearer\s+[A-Za-z0-9_\-\.=]{16,}"),
+    re.compile(r"(?i)\b(api[_-]?key|token|secret|password)\s*[=:]\s*['\"]?[A-Za-z0-9_\-\.]{20,}"),
+    re.compile(r"\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{5,}\b"),  # JWT
+]
+
+REDACTED = "[REDACTED_SECRET]"
+
+
+def scrub(text: str) -> str:
+    """Replace credential-shaped substrings with a redaction token."""
+    for pattern in _PATTERNS:
+        text = pattern.sub(REDACTED, text)
+    return text

--- a/clients/python/src/memclaw_client/interviewer/windows.py
+++ b/clients/python/src/memclaw_client/interviewer/windows.py
@@ -1,0 +1,91 @@
+"""Window formation — the cursor_to mechanics of the per-file protocol.
+
+Server contract (verified, routes/interview.py:89-96): seqs strictly
+ascending, ``seqs[0] >= cursor_from``, ``seqs[-1] <= cursor_to``. Events
+need NOT reach cursor_to, so:
+
+- a window that stops on a CAP sets ``cursor_to`` to the last INCLUDED
+  event's seq (lines after it head the next window);
+- the FINAL window of a scan sets ``cursor_to`` to the last complete line
+  index — even when the tail is pure filtered noise — so the watermark
+  advances past it and the cheap next-run skip can fire;
+- zero events in the whole range → NO window (server requires ≥1 event);
+  the noise tail is rescanned locally next run, at zero LLM/network cost.
+
+Caps are sized to the server's synchronous 90s interview budget: the
+real-LLM pilot measured ~63s for ~200k chars, so 150k chars ≈ 30%
+headroom; 400 events stays under the 500 hard cap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator
+
+from .parser import ParsedEvent
+
+MAX_EVENTS_PER_WINDOW = 400
+MAX_WINDOW_CHARS = 150_000
+MIN_WINDOW_EVENTS = 10
+MIN_WINDOW_CHARS = 2_000
+
+
+@dataclass
+class Window:
+    cursor_from: int
+    cursor_to: int
+    events: list[ParsedEvent]
+
+    @property
+    def chars(self) -> int:
+        return sum(len(e.content) for e in self.events)
+
+
+def build_windows(
+    events: list[ParsedEvent],
+    *,
+    cursor_from: int,
+    eof_line_index: int,
+    max_events: int = MAX_EVENTS_PER_WINDOW,
+    max_chars: int = MAX_WINDOW_CHARS,
+) -> Iterator[Window]:
+    """Split a scan's events into submit windows.
+
+    ``cursor_from`` is the first unconsumed line index (watermark + 1);
+    ``eof_line_index`` is the last complete line the scan covered. Yields
+    nothing when ``events`` is empty.
+    """
+    if not events:
+        return
+    start = cursor_from
+    batch: list[ParsedEvent] = []
+    chars = 0
+    for event in events:
+        event_len = len(event.content)
+        if batch and (len(batch) >= max_events or chars + event_len > max_chars):
+            # Cap-stop: cursor_to = last included event's seq.
+            yield Window(cursor_from=start, cursor_to=batch[-1].seq, events=batch)
+            start = batch[-1].seq + 1
+            batch = []
+            chars = 0
+        batch.append(event)
+        chars += event_len
+    # Final window: advance past any filtered noise tail to EOF.
+    yield Window(cursor_from=start, cursor_to=max(eof_line_index, batch[-1].seq), events=batch)
+
+
+def window_is_worth_interviewing(
+    window: Window,
+    *,
+    min_events: int = MIN_WINDOW_EVENTS,
+    min_chars: int = MIN_WINDOW_CHARS,
+    flush: bool = False,
+) -> bool:
+    """Gate dribbles: don't burn an LLM interview on a couple of lines.
+
+    Only meaningful for the FINAL (typically small) window; callers pass
+    ``flush=True`` to override (e.g. session-end hook draining a file).
+    """
+    if flush:
+        return True
+    return len(window.events) >= min_events or window.chars >= min_chars

--- a/clients/python/tests/test_interviewer_parser.py
+++ b/clients/python/tests/test_interviewer_parser.py
@@ -1,0 +1,152 @@
+"""Parser tests — every transcript quirk the on-disk survey found."""
+
+from __future__ import annotations
+
+import json
+
+from memclaw_client.interviewer.parser import (
+    MIN_EVENT_CHARS,
+    count_lines,
+    scan_events,
+)
+
+LONG = "This is a substantive conversational line that easily clears the minimum length filter."
+
+
+def _user(content, session="s1", **extra):
+    row = {
+        "type": "user",
+        "sessionId": session,
+        "timestamp": "2026-07-19T10:00:00.000Z",
+        "message": {"role": "user", "content": content},
+    }
+    row.update(extra)
+    return row
+
+
+def _assistant(blocks, session="s1", **extra):
+    row = {
+        "type": "assistant",
+        "sessionId": session,
+        "timestamp": "2026-07-19T10:00:01.000Z",
+        "message": {"role": "assistant", "content": blocks},
+    }
+    row.update(extra)
+    return row
+
+
+def _write(tmp_path, rows, torn_tail=None):
+    path = tmp_path / "session.jsonl"
+    body = "".join(json.dumps(r) + "\n" for r in rows)
+    if torn_tail is not None:
+        body += torn_tail  # no trailing newline
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_emits_prompts_and_replies_with_line_index_seq(tmp_path):
+    rows = [
+        _user(LONG),
+        _assistant([{"type": "text", "text": LONG}]),
+    ]
+    path = _write(tmp_path, rows)
+    scan = scan_events(path, start_line=0, project="proj", max_event_chars=4000)
+    assert [(e.seq, e.kind) for e in scan.events] == [(0, "prompt"), (1, "reply")]
+    assert scan.events[0].session_id == "proj:s1"
+    assert scan.last_complete_line == 1
+
+
+def test_multi_session_file_keeps_per_line_session_ids(tmp_path):
+    rows = [_user(LONG, session="s1"), _user(LONG, session="s2")]
+    path = _write(tmp_path, rows)
+    scan = scan_events(path, start_line=0, project="p", max_event_chars=4000)
+    assert [e.session_id for e in scan.events] == ["p:s1", "p:s2"]
+
+
+def test_tool_result_user_lines_are_noise(tmp_path):
+    rows = [
+        _user([{"type": "tool_result", "tool_use_id": "t1", "content": LONG}]),
+        _user(LONG, toolUseResult={"stdout": "x" * 500}),
+        _user(LONG),  # the only real prompt
+    ]
+    path = _write(tmp_path, rows)
+    scan = scan_events(path, start_line=0, project="p", max_event_chars=4000)
+    assert [e.seq for e in scan.events] == [2]
+    # ...but the cursor still covers the noise lines.
+    assert scan.last_complete_line == 2
+
+
+def test_meta_and_compact_summary_lines_are_noise(tmp_path):
+    rows = [
+        _user(LONG, isMeta=True),
+        _user(LONG, isCompactSummary=True, isVisibleInTranscriptOnly=True),
+        _user(LONG),
+    ]
+    path = _write(tmp_path, rows)
+    scan = scan_events(path, start_line=0, project="p", max_event_chars=4000)
+    assert [e.seq for e in scan.events] == [2]
+
+
+def test_assistant_thinking_and_tool_use_blocks_dropped(tmp_path):
+    rows = [
+        _assistant(
+            [
+                {"type": "thinking", "thinking": LONG},
+                {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": LONG}},
+                {"type": "text", "text": LONG},
+            ]
+        )
+    ]
+    path = _write(tmp_path, rows)
+    scan = scan_events(path, start_line=0, project="p", max_event_chars=4000)
+    assert len(scan.events) == 1
+    assert scan.events[0].content == LONG  # only the text block survived
+
+
+def test_timestampless_metadata_types_are_noise(tmp_path):
+    rows = [
+        {"type": "custom-title", "customTitle": "x", "sessionId": "s1"},
+        {"type": "mode", "mode": "plan", "sessionId": "s1"},
+        {"type": "ai-title", "aiTitle": "y", "sessionId": "s1"},
+        _user(LONG),
+    ]
+    path = _write(tmp_path, rows)
+    scan = scan_events(path, start_line=0, project="p", max_event_chars=4000)
+    assert [e.seq for e in scan.events] == [3]
+    assert scan.last_complete_line == 3
+
+
+def test_torn_final_line_is_not_consumed(tmp_path):
+    rows = [_user(LONG)]
+    path = _write(tmp_path, rows, torn_tail='{"type":"user","sessionId":"s1"')
+    scan = scan_events(path, start_line=0, project="p", max_event_chars=4000)
+    assert scan.last_complete_line == 0  # cursor stops before the torn tail
+    assert len(scan.events) == 1
+    assert count_lines(path) == 2  # raw line count still sees the fragment
+
+
+def test_short_prompts_filtered_and_content_capped(tmp_path):
+    rows = [
+        _user("ok"),  # < MIN_EVENT_CHARS
+        _user("x" * (MIN_EVENT_CHARS + 4000)),
+    ]
+    path = _write(tmp_path, rows)
+    scan = scan_events(path, start_line=0, project="p", max_event_chars=4000)
+    assert [e.seq for e in scan.events] == [1]
+    assert len(scan.events[0].content) == 4000
+
+
+def test_start_line_skips_consumed_range(tmp_path):
+    rows = [_user(LONG), _user(LONG), _user(LONG)]
+    path = _write(tmp_path, rows)
+    scan = scan_events(path, start_line=2, project="p", max_event_chars=4000)
+    assert [e.seq for e in scan.events] == [2]
+
+
+def test_secrets_scrubbed_before_emit(tmp_path):
+    secret = "sk-" + "a" * 40
+    rows = [_user(f"deploy with key {secret} and then verify the health endpoint responds")]
+    path = _write(tmp_path, rows)
+    scan = scan_events(path, start_line=0, project="p", max_event_chars=4000)
+    assert secret not in scan.events[0].content
+    assert "[REDACTED_SECRET]" in scan.events[0].content

--- a/clients/python/tests/test_interviewer_platform.py
+++ b/clients/python/tests/test_interviewer_platform.py
@@ -1,0 +1,273 @@
+"""Platform-edge tests: Windows lock degradation, malformed ioreg output."""
+
+from __future__ import annotations
+
+import builtins
+import subprocess
+
+from memclaw_client.interviewer import machine
+from memclaw_client.interviewer.cli import _acquire_lock
+
+
+def test_acquire_lock_proceeds_when_fcntl_unavailable(monkeypatch):
+    """No fcntl (Windows) must mean 'run without a lock', NOT 'locked'."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "fcntl":
+            raise ImportError("No module named 'fcntl'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert _acquire_lock() is not None  # proceed, don't fake "already locked"
+
+
+def test_acquire_lock_returns_handle_on_unix():
+    handle = _acquire_lock()
+    assert handle is not None
+
+
+def test_machine_id_survives_malformed_ioreg(monkeypatch):
+    """A quoteless IOPlatformUUID line must fall through, not IndexError."""
+
+    class FakeResult:
+        # Quoteless AND single-stray-quote variants: neither may crash,
+        # and the stray quote (2 split parts) must NOT return the raw
+        # line as a fake UUID — the >= 4 guard requires two quote pairs.
+        stdout = (
+            "  IOPlatformUUID = malformed-without-quotes\n"
+            '  IOPlatformUUID = "\n'
+        )
+
+    monkeypatch.setattr(machine, "_MACHINE_ID_SHORT", None)  # bust the per-process cache
+    monkeypatch.setattr(machine.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: FakeResult()
+    )
+    # Falls through ioreg → /etc/machine-id (absent on macOS test) → host fallback.
+    mid = machine.machine_id_short()
+    assert len(mid) == 12 and all(c in "0123456789abcdef" for c in mid)
+
+
+def test_get_document_percent_encodes_doc_id():
+    """A doc_id with '/' or '?' must stay ONE path segment."""
+    import httpx
+
+    from memclaw_client import MemClaw
+
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # url.path is the DECODED view; raw_path is what goes on the wire.
+        seen["raw_path"] = request.url.raw_path.decode()
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"doc_id": "x", "data": {}})
+
+    mc = MemClaw("mc_test", tenant_id="t", transport=httpx.MockTransport(handler))
+    mc.get_document("a/b?c=d", collection="col")
+    assert seen["raw_path"].startswith("/api/v1/documents/a%2Fb%3Fc%3Dd")
+    assert seen["params"] == {"tenant_id": "t", "collection": "col"}
+
+
+def test_pem_scrub_terminates_fast_on_begin_without_end():
+    """A large input with a BEGIN marker but no END must not blow up."""
+    import time
+
+    from memclaw_client.interviewer.scrub import scrub
+
+    text = "-----BEGIN RSA PRIVATE KEY-----\n" + ("A" * 200_000)
+    start = time.monotonic()
+    out = scrub(text)
+    assert time.monotonic() - start < 2.0
+    assert out.startswith("-----BEGIN")  # unmatched: left as-is, no hang
+
+
+def test_acquire_lock_closes_fd_when_flock_fails(monkeypatch):
+    """A flock failure must not leak the just-opened file handle."""
+    import fcntl as real_fcntl
+
+    from memclaw_client.interviewer import cli as cli_mod
+
+    import errno as errno_mod
+
+    def failing_flock(handle, flags):
+        raise OSError(errno_mod.EAGAIN, "locked by someone else")
+
+    monkeypatch.setattr(real_fcntl, "flock", failing_flock)
+    opened = []
+    real_open = open
+
+    def tracking_open(*args, **kwargs):
+        handle = real_open(*args, **kwargs)
+        opened.append(handle)
+        return handle
+
+    monkeypatch.setattr("builtins.open", tracking_open)
+    assert cli_mod._acquire_lock() is None
+    assert opened and all(h.closed for h in opened)
+
+
+def test_run_transcript_respects_allowlist(tmp_path):
+    """--transcript must not bypass the project allowlist."""
+    from memclaw_client.interviewer.cli import main
+
+    project_dir = tmp_path / "secret-project"
+    project_dir.mkdir()
+    transcript = project_dir / "abc.jsonl"
+    transcript.write_text("", encoding="utf-8")
+
+    rc = main(
+        [
+            "run",
+            "--transcript", str(transcript),
+            "--projects", "allowed-*",
+            "--api-key", "k",
+            "--tenant-id", "t",
+            "--dry-run",
+        ]
+    )
+    assert rc == 2  # gated: project not in allowlist
+
+    rc_ok = main(
+        [
+            "run",
+            "--transcript", str(transcript),
+            "--projects", "secret-*",
+            "--api-key", "k",
+            "--tenant-id", "t",
+            "--dry-run",
+        ]
+    )
+    assert rc_ok == 0  # allowlisted project passes
+
+    rc_empty = main(
+        [
+            "run",
+            "--transcript", str(transcript),
+            "--api-key", "k",
+            "--tenant-id", "t",
+            "--dry-run",
+        ]
+    )
+    assert rc_empty == 2  # EMPTY allowlist: default-deny has no carve-outs
+
+    rc_all = main(
+        [
+            "run",
+            "--transcript", str(transcript),
+            "--all-projects",
+            "--api-key", "k",
+            "--tenant-id", "t",
+            "--dry-run",
+        ]
+    )
+    assert rc_all == 0  # explicit --all-projects opt-in passes
+
+
+def test_run_closes_lock_handle_deterministically(tmp_path, monkeypatch):
+    """The lock handle must be closed by the caller, not left to GC."""
+    from memclaw_client.interviewer import cli as cli_mod
+
+    lock_file = tmp_path / "test.lock"
+    handle = open(lock_file, "w")
+    monkeypatch.setattr(cli_mod, "_acquire_lock", lambda: handle)
+
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    transcript = project_dir / "abc.jsonl"
+    transcript.write_text("", encoding="utf-8")
+
+    rc = cli_mod.main(
+        [
+            "run",
+            "--transcript", str(transcript),
+            "--all-projects",
+            "--api-key", "k",
+            "--tenant-id", "t",
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    assert handle.closed  # released in the finally, not by refcount luck
+
+
+def test_status_survives_vanished_transcript(tmp_path, monkeypatch):
+    """A transcript deleted between discovery and count_lines must not
+    crash status — per-file isolation covers the whole loop body."""
+    from memclaw_client.interviewer import cli as cli_mod
+
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    transcript = project_dir / "abc.jsonl"
+    transcript.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(cli_mod, "read_watermark", lambda mc, node_id: -1)
+
+    def vanishing_count(path):
+        raise FileNotFoundError(f"{path} deleted mid-status")
+
+    monkeypatch.setattr(cli_mod, "count_lines", vanishing_count)
+    rc = cli_mod.main(
+        [
+            "status",
+            "--projects-root", str(tmp_path),
+            "--all-projects",
+            "--since-hours", "0",
+            "--api-key", "k",
+            "--tenant-id", "t",
+        ]
+    )
+    assert rc == 0  # file skipped with a message, command completes
+
+
+def test_zeroed_machine_id_falls_through_to_host_fallback(tmp_path, monkeypatch):
+    """An all-zeros /etc/machine-id (common container default) must NOT
+    become the identity — two such containers would share a watermark."""
+    import builtins
+    import hashlib
+    import io
+
+    zeros = "0" * 32
+    real_open = builtins.open
+
+    def fake_open(path, *args, **kwargs):
+        if str(path) == "/etc/machine-id":
+            return io.StringIO(zeros + "\n")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(machine, "_MACHINE_ID_SHORT", None)
+    monkeypatch.setattr(machine.sys, "platform", "linux")
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    mid = machine.machine_id_short()
+    zeros_digest = hashlib.sha1(zeros.encode(), usedforsecurity=False).hexdigest()[:12]
+    assert mid != zeros_digest  # fell through to the host-based fallback
+
+
+def test_watermark_doc_id_digest_unchanged_by_fips_kwarg():
+    """usedforsecurity=False must not change the digest — the client and
+    server compute the SAME watermark doc id."""
+    import hashlib
+
+    from memclaw_client.interviewer.runner import watermark_doc_id
+
+    node = "cc:abcdef123456:some-file"
+    expected = f"wm_{hashlib.sha1(node.encode()).hexdigest()[:40]}"
+    assert watermark_doc_id(node) == expected
+
+
+def test_acquire_lock_proceeds_lockless_on_permission_error(monkeypatch, capsys):
+    """EACCES on the lock file is an environment problem, not contention:
+    the CLI must warn and proceed, never read it as 'already locked'."""
+    import errno as errno_mod
+    import fcntl as real_fcntl
+
+    from memclaw_client.interviewer import cli as cli_mod
+
+    def denied_flock(handle, flags):
+        raise OSError(errno_mod.EACCES, "permission denied")
+
+    monkeypatch.setattr(real_fcntl, "flock", denied_flock)
+    result = cli_mod._acquire_lock()
+    assert result is not None  # proceeds lockless
+    assert "proceeding without it" in capsys.readouterr().err

--- a/clients/python/tests/test_interviewer_runner.py
+++ b/clients/python/tests/test_interviewer_runner.py
@@ -1,0 +1,204 @@
+"""Runner tests against a fake server that re-implements the server's
+three seq-validation rules and the watermark protocol.
+
+The fake is deliberately strict: any window the runner produces that the
+REAL server would 422 fails here too, so protocol drift is caught in unit
+tests rather than in the field.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import httpx
+import pytest
+
+from memclaw_client import MemClaw
+from memclaw_client.interviewer.discovery import Transcript
+from memclaw_client.interviewer.runner import (
+    RunConfig,
+    node_id_for,
+    run_all,
+    watermark_doc_id,
+)
+
+LONG = "This is a substantive conversational line that easily clears the minimum length filter."
+
+
+class FakeServer:
+    """In-memory interview server: watermarks + scripted submit outcomes."""
+
+    def __init__(self):
+        self.watermarks: dict[str, int] = {}  # doc_id -> last_seq
+        self.submits: list[dict] = []
+        self.script: list = []  # queue of "ok" | int status to force
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.startswith("/api/v1/documents/"):
+            doc_id = path.rsplit("/", 1)[-1]
+            if doc_id in self.watermarks:
+                return httpx.Response(200, json={"doc_id": doc_id, "data": {"last_seq": self.watermarks[doc_id]}})
+            return httpx.Response(404, json={"detail": "Document not found"})
+        if path == "/api/v1/interview/submit":
+            body = json.loads(request.content)
+            self.submits.append(body)
+            # The real server's validation rules (interview.py:87-96).
+            seqs = [e["seq"] for e in body["events"]]
+            assert body["cursor_to"] >= body["cursor_from"], "reversed cursor"
+            assert all(a < b for a, b in zip(seqs, seqs[1:])), "seqs not strictly ascending"
+            assert seqs[0] >= body["cursor_from"] and seqs[-1] <= body["cursor_to"], "seq outside window"
+            outcome = self.script.pop(0) if self.script else "ok"
+            if outcome == "ok" or outcome == 207:
+                doc_id = watermark_doc_id(body["node_id"])
+                self.watermarks[doc_id] = max(self.watermarks.get(doc_id, -1), body["cursor_to"])
+                status = 207 if outcome == 207 else 200
+                return httpx.Response(
+                    status,
+                    json={
+                        "status": "partial" if status == 207 else "committed",
+                        "watermark": self.watermarks[doc_id],
+                        "memories_written": len(body["events"]),
+                        "errors": 1 if status == 207 else 0,
+                    },
+                )
+            return httpx.Response(outcome, json={"detail": f"scripted {outcome}"})
+        return httpx.Response(404, json={"detail": "unknown route"})
+
+
+@pytest.fixture
+def server():
+    return FakeServer()
+
+
+@pytest.fixture
+def mc(server):
+    return MemClaw(
+        "mc_test",
+        tenant_id="t-test",
+        transport=httpx.MockTransport(server.handler),
+    )
+
+
+def _transcript(tmp_path, n_events=12, name="abc123.jsonl"):
+    rows = [
+        {
+            "type": "user",
+            "sessionId": "s1",
+            "timestamp": "2026-07-19T10:00:00.000Z",
+            "message": {"role": "user", "content": f"{LONG} #{i}"},
+        }
+        for i in range(n_events)
+    ]
+    path = tmp_path / name
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+    return Transcript(path=path, project="proj")
+
+
+def _cfg(**kw):
+    defaults = dict(agent_id="cc-test@host", machine12="abcdef123456", min_events=1)
+    defaults.update(kw)
+    return RunConfig(**defaults)
+
+
+def test_happy_path_submits_and_next_run_skips(server, mc, tmp_path):
+    transcript = _transcript(tmp_path)
+    summary = run_all(mc, [transcript], _cfg())
+    assert summary.files[0].windows_submitted == 1
+    assert summary.files[0].events_submitted == 12
+    node_id = node_id_for("abcdef123456", transcript.path)
+    assert server.watermarks[watermark_doc_id(node_id)] == 11  # EOF line index
+
+    # Second run: watermark == EOF → cheap "no new lines" skip, no submit.
+    server.submits.clear()
+    summary2 = run_all(mc, [transcript], _cfg())
+    assert summary2.files[0].skipped_reason == "no new lines"
+    assert server.submits == []
+
+
+def test_resume_from_existing_watermark(server, mc, tmp_path):
+    transcript = _transcript(tmp_path, n_events=10)
+    node_id = node_id_for("abcdef123456", transcript.path)
+    server.watermarks[watermark_doc_id(node_id)] = 5  # lines 0..5 consumed
+    run_all(mc, [transcript], _cfg())
+    (submit,) = server.submits
+    assert submit["cursor_from"] == 6
+    assert [e["seq"] for e in submit["events"]] == [6, 7, 8, 9]
+
+
+def test_504_retries_once_then_succeeds(server, mc, tmp_path):
+    transcript = _transcript(tmp_path)
+    server.script = [504, "ok"]
+    summary = run_all(mc, [transcript], _cfg())
+    assert len(server.submits) == 2  # same window twice (dedup-safe)
+    assert server.submits[0]["cursor_from"] == server.submits[1]["cursor_from"]
+    assert summary.files[0].windows_submitted == 1
+    assert not summary.files[0].error
+
+
+def test_500_skips_file_without_retry(server, mc, tmp_path):
+    transcript = _transcript(tmp_path)
+    server.script = [500]
+    summary = run_all(mc, [transcript], _cfg())
+    assert len(server.submits) == 1  # no retry on 500
+    assert summary.files[0].error
+    assert summary.files[0].windows_submitted == 0
+
+
+def test_403_aborts_the_whole_run(server, mc, tmp_path):
+    first = _transcript(tmp_path, name="a.jsonl")
+    second = _transcript(tmp_path, name="b.jsonl")
+    server.script = [403]
+    summary = run_all(mc, [first, second], _cfg())
+    assert summary.aborted
+    assert len(summary.files) == 0  # nothing recorded past the abort
+    assert len(server.submits) == 1  # second file never attempted
+
+
+def test_207_partial_counts_as_progress(server, mc, tmp_path):
+    transcript = _transcript(tmp_path)
+    server.script = [207]
+    summary = run_all(mc, [transcript], _cfg())
+    assert summary.files[0].windows_submitted == 1
+    node_id = node_id_for("abcdef123456", transcript.path)
+    assert server.watermarks[watermark_doc_id(node_id)] == 11
+
+
+def test_per_file_isolation(server, mc, tmp_path):
+    bad = _transcript(tmp_path, name="bad.jsonl")
+    good = _transcript(tmp_path, name="good.jsonl")
+    server.script = [500, "ok"]
+    summary = run_all(mc, [bad, good], _cfg())
+    assert summary.files[0].error and summary.files[1].windows_submitted == 1
+    assert not summary.failed_all
+
+
+def test_shrink_guard_skips_file(server, mc, tmp_path):
+    transcript = _transcript(tmp_path, n_events=3)
+    node_id = node_id_for("abcdef123456", transcript.path)
+    server.watermarks[watermark_doc_id(node_id)] = 50  # cursor beyond the file
+    summary = run_all(mc, [transcript], _cfg())
+    assert "shrank" in (summary.files[0].skipped_reason or "")
+    assert server.submits == []
+
+
+def test_windows_budget_caps_the_run(server, mc, tmp_path):
+    transcripts = [_transcript(tmp_path, name=f"f{i}.jsonl") for i in range(4)]
+    summary = run_all(mc, transcripts, _cfg(max_windows=2))
+    assert sum(f.windows_submitted for f in summary.files) == 2
+
+
+def test_dry_run_submits_nothing(server, mc, tmp_path):
+    transcript = _transcript(tmp_path)
+    summary = run_all(mc, [transcript], _cfg(dry_run=True))
+    assert summary.files[0].windows_submitted == 1
+    assert server.submits == []
+
+
+def test_attempt_id_would_be_deterministic(tmp_path):
+    # Same (node, window) → same server-side attempt id (documented tie-in).
+    node = "cc:abcdef123456:abc123"
+    a = hashlib.sha1(f"{node}:0:11".encode()).hexdigest()
+    b = hashlib.sha1(f"{node}:0:11".encode()).hexdigest()
+    assert a == b

--- a/clients/python/tests/test_interviewer_scrub.py
+++ b/clients/python/tests/test_interviewer_scrub.py
@@ -1,0 +1,45 @@
+"""Secret-scrub tests — credential shapes must never leave the machine."""
+
+from __future__ import annotations
+
+from memclaw_client.interviewer.scrub import REDACTED, scrub
+
+
+def test_scrubs_common_token_shapes():
+    samples = [
+        "sk-" + "a" * 48,
+        "sk-proj-" + "b" * 60,
+        "mc_" + "c" * 20,
+        "mca_" + "d" * 20,
+        "ghp_" + "e" * 36,
+        "github_pat_" + "k" * 30,
+        "xoxb-1234567890-abcdefghij",
+        "AKIA" + "F" * 16,
+        "aws_secret_access_key = '" + "m" * 40 + "'",
+        "AWS-SECRET-ACCESS-KEY: " + "n/+" * 13 + "nn",
+        "Bearer " + "g" * 32,
+        "api_key = 'hijklmnopqrstuvwx1234'",
+        "eyJ" + "h" * 20 + "." + "i" * 20 + "." + "j" * 10,
+    ]
+    for sample in samples:
+        out = scrub(f"context {sample} more context")
+        assert REDACTED in out, sample
+        assert sample not in out, sample
+
+
+def test_scrubs_pem_block():
+    pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\n-----END RSA PRIVATE KEY-----"
+    out = scrub(f"here is the key\n{pem}\ndone")
+    assert "PRIVATE KEY" not in out
+
+
+def test_leaves_normal_prose_alone():
+    text = "We decided to use Postgres for the watermark store, keyed per file."
+    assert scrub(text) == text
+
+
+def test_short_assignment_values_are_not_false_positives():
+    """The broad assignment pattern requires >= 20 value chars — short
+    technical identifiers must survive untouched."""
+    text = "set token = 'abc123def456' in the config"  # 12 chars: below threshold
+    assert scrub(text) == text

--- a/clients/python/tests/test_interviewer_windows.py
+++ b/clients/python/tests/test_interviewer_windows.py
@@ -1,0 +1,71 @@
+"""Window-formation tests — the cursor_to mechanics the protocol rests on."""
+
+from __future__ import annotations
+
+from memclaw_client.interviewer.parser import ParsedEvent
+from memclaw_client.interviewer.windows import (
+    Window,
+    build_windows,
+    window_is_worth_interviewing,
+)
+
+
+def _event(seq: int, chars: int = 100) -> ParsedEvent:
+    return ParsedEvent(
+        seq=seq,
+        ts="2026-07-19T10:00:00.000Z",
+        session_id="p:s1",
+        role="user",
+        kind="prompt",
+        content="x" * chars,
+    )
+
+
+def test_single_window_eof_cursor_advances_past_noise_tail():
+    # Events at lines 5 and 7; lines 8..20 are filtered noise. cursor_to
+    # must reach EOF so the watermark clears the tail.
+    events = [_event(5), _event(7)]
+    windows = list(build_windows(events, cursor_from=0, eof_line_index=20))
+    assert len(windows) == 1
+    assert windows[0].cursor_from == 0
+    assert windows[0].cursor_to == 20
+    assert [e.seq for e in windows[0].events] == [5, 7]
+
+
+def test_event_cap_split_sets_cursor_to_last_included_seq():
+    events = [_event(i) for i in range(10)]
+    windows = list(build_windows(events, cursor_from=0, eof_line_index=9, max_events=4))
+    assert [(w.cursor_from, w.cursor_to) for w in windows] == [(0, 3), (4, 7), (8, 9)]
+    # Contiguous, no gap and no overlap.
+    for prev, cur in zip(windows, windows[1:]):
+        assert cur.cursor_from == prev.cursor_to + 1
+
+
+def test_char_cap_split():
+    events = [_event(i, chars=600) for i in range(5)]
+    windows = list(build_windows(events, cursor_from=0, eof_line_index=4, max_chars=1500))
+    # 600*2=1200 fits, third would be 1800 > 1500 → split after 2.
+    assert [len(w.events) for w in windows] == [2, 2, 1]
+
+
+def test_zero_events_yields_no_windows():
+    assert list(build_windows([], cursor_from=0, eof_line_index=50)) == []
+
+
+def test_sparse_seqs_stay_within_cursor_range():
+    events = [_event(3), _event(9), _event(11)]
+    (window,) = build_windows(events, cursor_from=2, eof_line_index=15)
+    seqs = [e.seq for e in window.events]
+    assert seqs == sorted(seqs)
+    assert seqs[0] >= window.cursor_from
+    assert seqs[-1] <= window.cursor_to  # the server's exact validation rules
+
+
+def test_dribble_gate_and_flush():
+    small = Window(cursor_from=0, cursor_to=3, events=[_event(1, chars=50)])
+    assert not window_is_worth_interviewing(small)
+    assert window_is_worth_interviewing(small, flush=True)
+    big_chars = Window(cursor_from=0, cursor_to=3, events=[_event(1, chars=5000)])
+    assert window_is_worth_interviewing(big_chars)  # min_chars path
+    many = Window(cursor_from=0, cursor_to=30, events=[_event(i, chars=30) for i in range(12)])
+    assert window_is_worth_interviewing(many)  # min_events path


### PR DESCRIPTION
## Summary

Phase 2 of the Interviewer (client-priority roadmap: OpenClaw ✅ #558/#564/#572 → **Claude Code/CLI** → Hermes): a new `memclaw-interviewer` console command in `memclaw-client` (0.2.0) for Claude Code workstations. It reads Claude Code session transcripts (`~/.claude/projects/*/*.jsonl`) **read-only** — Claude Code owns the trail; we never modify it — and submits event windows to the existing `POST /api/v1/interview/submit`. **Zero server changes.**

### Protocol
- **Cursor = the server's forward-only watermark doc** (`interview_watermarks`), read back via the documents GET — **no local state**. Crash-safety inherited from Phase 1: watermark advances only on commit; deterministic attempt ids dedup retries; never a gap, never a duplicate.
- **Per-file cursors, seq = raw line index.** Verified on real disk: one `.jsonl` can interleave MULTIPLE `sessionId`s (session resume appends to the original file), so per-session cursors would fragment; line index stays monotonic under append-only writes. Session identity travels per event (`session_id = "<project>:<sessionId>"`).
- **Advance-past-noise-tail:** the final window's `cursor_to` reaches EOF even when the tail is filtered noise (legal — server validation only requires `seqs[-1] <= cursor_to`), enabling the cheap next-run skip. Torn/mid-append tails are left for the next run; a shrunken file (append-only violated) is skipped loudly.

### Parser (v1, pilot-proven signal)
Emits real user prompts + assistant text; drops tool results (`type:"user"` lines with `tool_result` blocks / `toolUseResult`), meta/compaction lines (`isMeta`/`isCompactSummary`/`isVisibleInTranscriptOnly`), thinking/`tool_use` blocks, timestamp-less metadata line types, and subagent files. Local credential scrub (sk-/mc_/ghp_/xox/AWS/PEM/Bearer/JWT) before anything leaves the machine; the server masks PII again on receipt.

### Privacy: default-deny
No allowlist → the CLI lists discovered project dirs and exits 2 with guidance. `--projects <globs>` / `MEMCLAW_INTERVIEWER_PROJECTS` opt in per project; `--all-projects` is the explicit full opt-in. Hook mode silently ignores non-allowlisted transcripts.

### CLI
- `run` — cron-able; window caps 400 events / 150k chars (sized to the server's 90s synchronous interview budget: the real-LLM pilot measured ~63s at ~200k chars); dribble gate (`--flush` to override); `--dry-run` is fully offline.
- `status` — per-file server cursor vs local line count.
- `hook` — Claude Code **SessionEnd** hook: drains that session's transcript; **always exits 0** (a memory-harvest failure must never fail a session).

## Test plan
- **40 unit tests**: parser quirks from the on-disk survey (multi-session files, tool_result-user lines, meta/compaction, timestamp-less metadata, torn tails, block mixes, scrub), window mechanics (cap splits, EOF-past-noise, contiguity, sparse-seq validity), and a runner suite against a fake server that re-implements the server's seq-validation rules across 200/207/403/422/500/504 (watermark resume, single 504 dedup-safe retry, 403 abort, per-file isolation, budget caps, shrink guard).
- **Real-disk dry-run** on actual transcripts from this machine: 7,925-line file → 3 contiguous windows at ~150k chars, 1,004 events, **zero tool_result/meta leakage, zero unredacted credentials**.
- **Live dogfood** against the released `:latest` images: submit → `committed`, watermark == EOF, memories carry `source=interviewer` + `node_id=cc:<machine>:<file>`; rerun → cheap "no new lines" skip; live SessionEnd hook drained a second transcript end-to-end (exit 0).

PyPI publish (tag `memclaw-client-v0.2.0`) deferred until after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)