### PR TITLE
feat(auth): read gateway-plumbed X-Org-Role into AuthContext (Skills Inbox A2, reader side)

### DIFF
--- a/core-api/src/core_api/auth.py
+++ b/core-api/src/core_api/auth.py
@@ -451,6 +451,24 @@ async def get_auth_context(
         credential_kind = (request.headers.get("x-caura-credential-kind") or "").lower()
         is_install_credential = credential_kind == "install_credential"
         install_uuid = request.headers.get("x-install-uuid") or None
+        # Org-level role of the human principal behind the request
+        # (``org_members``: "admin" | "member"), plumbed by the
+        # gateway's /_auth subrequest from the session row / JWT
+        # claim. Drives the admin gates on operator surfaces (e.g.
+        # the Skills Inbox actions). Read on THIS branch only: the
+        # header is trustworthy exactly when the request came through
+        # the gateway — enforced by the X-Gateway-Secret check above
+        # when configured, and the gateway overwrites any
+        # client-supplied X-Org-Role via proxy_set_header. (Without a
+        # secret, this path already trusts X-Tenant-ID itself, so
+        # X-Org-Role adds no new spoofing surface.) Values outside
+        # the org-membership model are dropped, not forwarded —
+        # downstream ``== "admin"`` gates must never see a smuggled
+        # third role. Agent-credential requests carry no org
+        # membership, so the auth service never emits the header for
+        # them and API keys stay unable to act on admin-only routes.
+        org_role_raw = (request.headers.get("x-org-role") or "").strip().lower()
+        org_role = org_role_raw if org_role_raw in ("admin", "member") else None
         set_current_tenant(tenant_id)
         _stash_request_tenant(request, tenant_id)
         # When the gateway plumbs a multi-tenant read set, expose it to the
@@ -466,6 +484,7 @@ async def get_auth_context(
             set_readable_tenants(None)
         return AuthContext(
             tenant_id=tenant_id,
+            org_role=org_role,
             agent_id=agent_id,
             is_read_only=is_read_only,
             is_install_credential=is_install_credential,

--- a/tests/test_org_role_plumb.py
+++ b/tests/test_org_role_plumb.py
@@ -1,0 +1,164 @@
+"""X-Org-Role plumbing on the gateway auth path (Skills Inbox A2).
+
+The enterprise gateway's /_auth subrequest resolves the signed-in
+user's org-membership role (``org_members``: admin | member) and
+forwards it as ``X-Org-Role``; Path 4 of ``get_auth_context`` reads it
+into ``AuthContext.org_role`` so admin gates on operator surfaces
+(Skills Inbox actions) work for session/JWT principals.
+
+Pins:
+- admin / member parse (with case + whitespace normalization),
+- the allowlist — values outside the org-membership model are dropped
+  (a smuggled third role must never reach ``== "admin"`` gates),
+- absent header → ``org_role is None`` (pre-rollout gateways),
+- the MEMCLAW_API_KEY path (Path 2) ignores the header — API-key
+  callers must NOT gain inbox-action rights from a spoofable header,
+- end-to-end: a gateway-shaped request opens the Skills Inbox admin
+  gate with the role and is 403'd without it.
+"""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from core_api import auth as auth_mod
+from core_api.routes import skills_inbox as si
+
+pytestmark = pytest.mark.unit
+
+
+class _Req:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+async def _path4_ctx(monkeypatch, headers):
+    """Resolve get_auth_context down Path 4 (gateway header trust)."""
+    monkeypatch.setattr(auth_mod.settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(auth_mod.settings, "is_standalone", False)
+    monkeypatch.setattr(auth_mod.settings, "memclaw_api_key", None)
+    monkeypatch.setattr(auth_mod, "get_admin_key", lambda: None)
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(auth_mod, "_block_if_suppressed", _noop)
+    monkeypatch.setattr(auth_mod, "_block_if_any_readable_suppressed", _noop)
+    return await auth_mod.get_auth_context(_Req(headers), key=None)
+
+
+async def test_path4_reads_admin_and_member(monkeypatch):
+    ctx = await _path4_ctx(monkeypatch, {"x-tenant-id": "t", "x-org-role": "admin"})
+    assert ctx.org_role == "admin"
+    ctx = await _path4_ctx(monkeypatch, {"x-tenant-id": "t", "x-org-role": "member"})
+    assert ctx.org_role == "member"
+
+
+async def test_path4_normalizes_case_and_whitespace(monkeypatch):
+    ctx = await _path4_ctx(monkeypatch, {"x-tenant-id": "t", "x-org-role": " Admin "})
+    assert ctx.org_role == "admin"
+
+
+@pytest.mark.parametrize("smuggled", ["owner", "superadmin", "admin,member", "1", ""])
+async def test_path4_drops_unknown_roles(monkeypatch, smuggled):
+    ctx = await _path4_ctx(monkeypatch, {"x-tenant-id": "t", "x-org-role": smuggled})
+    assert ctx.org_role is None
+
+
+async def test_path4_absent_header_is_none(monkeypatch):
+    """Pre-rollout gateways don't send the header — behavior unchanged."""
+    ctx = await _path4_ctx(monkeypatch, {"x-tenant-id": "t"})
+    assert ctx.org_role is None
+
+
+async def test_memclaw_key_path_ignores_org_role_header(monkeypatch):
+    """Path 2 (API-key callers) must not gain a role from the header —
+    approving skills stays a human decision; agent keys can't act on
+    admin-only routes by self-asserting X-Org-Role."""
+    monkeypatch.setattr(auth_mod.settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(auth_mod.settings, "is_standalone", False)
+    monkeypatch.setattr(auth_mod.settings, "memclaw_api_key", "sekrit")
+    monkeypatch.setattr(auth_mod, "get_admin_key", lambda: None)
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(auth_mod, "_block_if_suppressed", _noop)
+    monkeypatch.setattr(auth_mod, "_block_if_any_readable_suppressed", _noop)
+    ctx = await auth_mod.get_auth_context(
+        _Req({"x-tenant-id": "t", "x-org-role": "admin"}), key="sekrit"
+    )
+    assert ctx.tenant_id == "t"
+    assert ctx.org_role is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: gateway-shaped request → Skills Inbox admin gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def inbox_app(monkeypatch):
+    """Skills Inbox router behind the REAL get_auth_context, resolved
+    down Path 4, with the route's service seams stubbed."""
+    monkeypatch.setattr(auth_mod.settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(auth_mod.settings, "is_standalone", False)
+    monkeypatch.setattr(auth_mod.settings, "memclaw_api_key", None)
+    monkeypatch.setattr(auth_mod, "get_admin_key", lambda: None)
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(auth_mod, "_block_if_suppressed", _noop)
+    monkeypatch.setattr(auth_mod, "_block_if_any_readable_suppressed", _noop)
+
+    async def raw_settings(tenant_id):
+        return {"skills_factory": {"enabled": True}}
+
+    async def display_settings(tenant_id):
+        return {"skills_factory": {"enabled": True}}
+
+    monkeypatch.setattr(si, "get_raw_settings", raw_settings)
+    monkeypatch.setattr(si, "get_settings_for_display", display_settings)
+    monkeypatch.setattr(si, "log_action", _noop)
+
+    staged_doc = {
+        "doc_id": "forge/s1",
+        "fleet_id": None,
+        "data": {"status": "staged", "content_hash": "sha256:x"},
+    }
+
+    class _Storage:
+        async def get_document(self, *, tenant_id, collection, doc_id):
+            return staged_doc
+
+        async def upsert_document(self, payload):
+            return None
+
+    monkeypatch.setattr(si, "get_storage_client", lambda: _Storage())
+
+    app = FastAPI()
+    app.include_router(si.router, prefix="/api/v1")
+    return app
+
+
+async def test_gateway_admin_header_opens_inbox_actions(inbox_app):
+    transport = ASGITransport(app=inbox_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        r = await client.post(
+            "/api/v1/skills-inbox/forge/s1/defer",
+            headers={"x-tenant-id": "t", "x-org-role": "admin"},
+        )
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.parametrize("role_headers", [{}, {"x-org-role": "member"}])
+async def test_gateway_non_admin_still_403(inbox_app, role_headers):
+    transport = ASGITransport(app=inbox_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        r = await client.post(
+            "/api/v1/skills-inbox/forge/s1/defer",
+            headers={"x-tenant-id": "t", **role_headers},
+        )
+    assert r.status_code == 403, r.text
+    assert r.json()["detail"].startswith("SKILLS_INBOX_FORBIDDEN")


### PR DESCRIPTION
## Summary

Part 1 of 2 of the Skills Inbox admin-identity fix (A2). Today every inbox action (`approve`/`edit`/`defer`/`quarantine`/`reject`) returns **403 for everyone on the SaaS gateway path** — `_require_inbox_admin` checks `org_role == 'admin'`, but Path 4 of `get_auth_context` builds the `AuthContext` from gateway headers that never carried the org role. Only standalone mode (hardcoded `org_role='admin'`) works.

This PR is the **reader side**: Path 4 now reads `X-Org-Role` into `AuthContext.org_role`.

- **Allowlisted** to the org-membership model (`admin` | `member`, normalized); unknown values are dropped so `== 'admin'` gates never see a smuggled third role.
- **Trust boundary unchanged**: read only on the branch already gated by `X-Gateway-Secret` (when configured); the gateway overwrites any client-supplied `X-Org-Role` via `proxy_set_header`.
- **Deliberate non-goal**: the `MEMCLAW_API_KEY` path (Path 2) does NOT read the header — API-key/agent callers must not gain inbox-action rights from a self-asserted header.
- **Safe to deploy first**: absent header → `org_role=None` → behavior identical to today.

Part 2 (enterprise repo, follows): platform-auth-api `/validate` emits `X-Org-Role` from the session row / JWT claim; nginx captures + forwards it on the `/api/v1/` and legacy `/api/` blocks.

## Testing

- `tests/test_org_role_plumb.py`: admin/member parse + normalization, unknown-role allowlist drop, absent-header no-op, Path 2 ignores the header, and an end-to-end check that a gateway-shaped request opens the Skills Inbox admin gate (and 403s without the role / with `member`).
- Neighboring suites green: `test_gateway_secret_gate`, `test_skills_inbox_routes`, `test_install_credential_auth`, `test_cross_tenant_auth` (89 tests).
- `cd core-api && uv run mypy src/` (CI's invocation) clean for `auth.py`; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)