### PR TITLE
CAURA-703 feat(write): record memory_type provenance in metadata

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/merge_enrichment_fields.py
+++ b/core-api/src/core_api/pipeline/steps/write/merge_enrichment_fields.py
@@ -26,6 +26,15 @@ class MergeEnrichmentFields:
         ts_valid_start = data.ts_valid_start
         ts_valid_end = data.ts_valid_end
 
+        # CAURA-703: record whether the CALLER chose the type, vs the enrichment
+        # classifier / default fallback filling it. Captured from the raw agent
+        # value BEFORE the deprecation demotion below, so an agent who supplied a
+        # now-deprecated type (e.g. "semantic", coerced to fact) still counts as
+        # agent-set. Fully determined at write time — the async enrichment worker
+        # never overrides memory_type when the agent set it (``agent_provided_fields``
+        # skip), so this flag needs no worker-side finalisation.
+        memory_type_agent_set = memory_type is not None
+
         # CAURA-701: caller-supplied deprecated types (currently ``semantic``)
         # bypass the enrichment-LLM demotion in ``_validate_enrichment`` because
         # a non-``None`` ``data.memory_type`` short-circuits the fill-gaps branch
@@ -81,6 +90,8 @@ class MergeEnrichmentFields:
             metadata["write_mode"] = resolved_write_mode
         if resolved_write_mode == "fast" and enrichment is None:
             metadata["enrichment_pending"] = True
+
+        metadata["memory_type_agent_set"] = memory_type_agent_set
 
         ctx.data["memory_fields"] = {
             "memory_type": memory_type,

--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -1037,6 +1037,9 @@ async def ingest_commit(request: IngestCommitRequest) -> dict:
             metadata: dict = {
                 "source": "ingest",
                 "ingest_url": request_url_override or fact.source_uri or None,
+                # CAURA-703: ingest types come from the extraction LLM's
+                # suggested_type, not the calling agent — mark as not agent-set.
+                "memory_type_agent_set": False,
             }
             if request.doc_hash:
                 metadata["doc_hash"] = request.doc_hash

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -1319,6 +1319,12 @@ async def create_memories_bulk(
         ts_valid_start = item.ts_valid_start
         ts_valid_end = item.ts_valid_end
 
+        # CAURA-703: provenance of memory_type. Ingest pre-stamps this False on
+        # its items (the type comes from the extraction LLM, not the caller), so
+        # honour an existing value; otherwise the type is agent-set iff the item
+        # carried one.
+        metadata.setdefault("memory_type_agent_set", item.memory_type is not None)
+
         if enrichment:
             if memory_type is None:
                 memory_type = enrichment.memory_type

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -61,6 +61,87 @@ async def test_validate_step_rejects_short_content():
 
 
 @pytest.mark.asyncio
+async def test_merge_flags_memory_type_agent_set_when_caller_supplies_type():
+    """CAURA-703: an agent-supplied type sets metadata.memory_type_agent_set=True
+    and wins over the enrichment classifier's suggestion."""
+    from common.enrichment.schema import EnrichmentResult
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.write.merge_enrichment_fields import (
+        MergeEnrichmentFields,
+    )
+
+    ctx = PipelineContext(
+        data={
+            "input": _make_input(memory_type="decision"),
+            "enrichment": EnrichmentResult(memory_type="fact"),
+        }
+    )
+    await MergeEnrichmentFields().execute(ctx)
+    fields = ctx.data["memory_fields"]
+    assert fields["memory_type"] == "decision"
+    assert fields["metadata"]["memory_type_agent_set"] is True
+
+
+@pytest.mark.asyncio
+async def test_merge_flags_not_agent_set_when_classifier_fills_type():
+    """CAURA-703: when the caller omits the type, the classifier fills it and
+    the flag is False."""
+    from common.enrichment.schema import EnrichmentResult
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.write.merge_enrichment_fields import (
+        MergeEnrichmentFields,
+    )
+
+    ctx = PipelineContext(
+        data={
+            "input": _make_input(),  # no memory_type
+            "enrichment": EnrichmentResult(memory_type="decision"),
+        }
+    )
+    await MergeEnrichmentFields().execute(ctx)
+    fields = ctx.data["memory_fields"]
+    assert fields["memory_type"] == "decision"
+    assert fields["metadata"]["memory_type_agent_set"] is False
+
+
+@pytest.mark.asyncio
+async def test_merge_agent_set_true_even_when_deprecated_type_demoted():
+    """CAURA-703: an agent who supplied a deprecated type (semantic → demoted to
+    fact) still counts as agent-set — the flag is captured before demotion."""
+    from common.enrichment.schema import EnrichmentResult
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.write.merge_enrichment_fields import (
+        MergeEnrichmentFields,
+    )
+
+    ctx = PipelineContext(
+        data={
+            "input": _make_input(memory_type="semantic"),
+            "enrichment": EnrichmentResult(memory_type="episode"),
+        }
+    )
+    await MergeEnrichmentFields().execute(ctx)
+    fields = ctx.data["memory_fields"]
+    assert fields["memory_type"] == "fact"  # deprecated → demoted
+    assert fields["metadata"]["memory_type_agent_set"] is True  # agent still chose it
+
+
+@pytest.mark.asyncio
+async def test_merge_flags_not_agent_set_on_default_fallback():
+    """CAURA-703: no caller type and no enrichment → default fact, not agent-set."""
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.write.merge_enrichment_fields import (
+        MergeEnrichmentFields,
+    )
+
+    ctx = PipelineContext(data={"input": _make_input()})  # no enrichment
+    await MergeEnrichmentFields().execute(ctx)
+    fields = ctx.data["memory_fields"]
+    assert fields["memory_type"] == "fact"
+    assert fields["metadata"]["memory_type_agent_set"] is False
+
+
+@pytest.mark.asyncio
 async def test_compute_content_hash_skips_cache_lookup_when_embedding_deferred(
     monkeypatch,
 ):

--- a/tests/test_ingest_commit.py
+++ b/tests/test_ingest_commit.py
@@ -247,6 +247,22 @@ async def test_run_id_on_column_and_source_in_metadata(captured):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_ingest_marks_memory_type_not_agent_set(captured):
+    """CAURA-703: an ingested fact's type comes from the extraction LLM's
+    ``suggested_type``, not the calling agent, so each write is stamped
+    ``metadata.memory_type_agent_set = False``. ``create_memories_bulk``
+    honours this pre-stamped value instead of inferring ``True`` from the
+    (LLM-supplied) ``memory_type`` on the item."""
+    req = _request("t1", "fact one", "fact two")
+    await ingest_service.ingest_commit(request=req)
+
+    assert len(captured.writes) == 2
+    for mc in captured.writes:
+        assert mc.metadata["memory_type_agent_set"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_parent_document_written_once_per_batch(captured):
     """One ingest_commit produces exactly one ``documents`` row with
     ``collection='ingest-sources'`` and ``doc_id == run_id``. The


### PR DESCRIPTION
## What

Adds a `metadata.memory_type_agent_set` boolean recording **who chose a memory's type**:
- `true` — the calling agent supplied `memory_type` explicitly.
- `false` — the enrichment classifier, the default fallback, or the ingest extractor chose it.

This was previously unrecoverable: nothing persisted the distinction (the `agent_provided_fields` snapshot lives only in the transient enrich event and is discarded). It's set **synchronously at write time** — **no worker change, no DB migration** (plain JSONB key).

## Why

We needed to answer, per memory, "did the agent hand-pick this type or did the system?" — e.g. to audit classification quality and to tell agent-authored types apart from auto-classified ones. Binary was chosen over a multi-value source because it's fully known at write time (never changes), so it avoids any async/worker coupling; the finer classifier-vs-heuristic-vs-default split remains derivable from `metadata.llm_ms`.

## Changes

- **`merge_enrichment_fields`** (single write, fast + strong): capture the flag from the raw agent value **before** the CAURA-701 deprecation demotion, so an agent who supplied a now-deprecated type (`semantic` → coerced to `fact`) still counts as agent-set.
- **`create_memories_bulk`**: `metadata.setdefault("memory_type_agent_set", item.memory_type is not None)` — honours an ingest pre-stamp, else infers from the item.
- **`ingest_service`**: pre-stamp `False` — ingested types come from the extraction LLM's `suggested_type`, not the calling agent.

## Not in scope
- Historical backfill (unrecoverable; absent key = legacy/unknown).
- The bulk/ingest `semantic → fact` demotion gap (separate PR, CAURA-702).

## Tests
- Merge-step unit tests: agent-set wins & flagged `true`; classifier-fill → `false`; deprecated-demote still `true`; default fallback → `false`.
- Ingest: each committed fact is stamped `memory_type_agent_set = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)