### PR TITLE
feat(skills-inbox): scan findings on the card + truncated page flag (Phase B backend)

### DIFF
--- a/core-api/src/core_api/routes/skills_inbox.py
+++ b/core-api/src/core_api/routes/skills_inbox.py
@@ -121,18 +121,40 @@ def _require_inbox_admin(auth: AuthContext) -> None:
 # ── Pydantic shapes ────────────────────────────────────────────────
 
 
+# Cap on findings surfaced per card. A pathological doc can carry an
+# unbounded findings list; the card only needs enough for an operator
+# to see WHY a scan tripped — the full list stays on ``data.scan``.
+_MAX_CARD_FINDINGS = 20
+
+
+class ScanFindingOut(BaseModel):
+    """One Sentinel finding, shaped for the card UI: enough to render
+    '<severity> <code>: <message>' under the scan badge. Mirrors the
+    ``data.scan.findings[]`` entries written by ``ScanResult.as_doc_field``.
+    """
+
+    code: str = ""
+    severity: str = ""
+    message: str = ""
+    fatal: bool = False
+    locator: str | None = None
+
+
 class SentinelScanSummary(BaseModel):
     """Nested scan verdict, shaped for the dashboard card UI.
 
     ``status`` mirrors ``data.scan.state`` (``clean`` / ``quarantined``
     / ``failed``); the counts mirror ``critical`` / ``warn``. The flat
     ``scan_state`` / ``scan_critical`` / ``scan_warn`` card fields carry
-    the same values for pre-existing consumers.
+    the same values for pre-existing consumers. ``findings`` carries up
+    to ``_MAX_CARD_FINDINGS`` entries so the UI can say WHY a scan
+    tripped instead of just showing counts.
     """
 
     status: str | None = None
     critical_count: int = 0
     warning_count: int = 0
+    findings: list[ScanFindingOut] = Field(default_factory=list)
 
 
 class ForgeEvidence(BaseModel):
@@ -201,6 +223,13 @@ class InboxListResponse(BaseModel):
     tenant_id: str
     fleet_id: str | None
     count: int
+    # True when more staged cards exist than this page returned (the
+    # effective limit — min(limit, inbox_max_pending, 200) — cut the
+    # list, or the oversample window saturated). Lets the UI say
+    # "there's more" instead of guessing from page fullness: a page of
+    # exactly ``count`` items is indistinguishable from a capped one
+    # without this flag.
+    truncated: bool = False
     items: list[InboxCard]
 
 
@@ -259,10 +288,30 @@ def _card_from_doc(doc: dict) -> InboxCard:
 
     sentinel_scan: SentinelScanSummary | None = None
     if scan:
+        raw_findings = scan.get("findings")
+        findings: list[ScanFindingOut] = []
+        if isinstance(raw_findings, list):
+            for f in raw_findings:
+                if len(findings) >= _MAX_CARD_FINDINGS:
+                    break
+                # Skip malformed entries (don't 500 the page, and don't
+                # let junk consume one of the capped slots).
+                if not isinstance(f, dict):
+                    continue
+                findings.append(
+                    ScanFindingOut(
+                        code=str(f.get("code") or ""),
+                        severity=str(f.get("severity") or ""),
+                        message=str(f.get("message") or ""),
+                        fatal=bool(f.get("fatal", False)),
+                        locator=(str(f["locator"]) if f.get("locator") else None),
+                    )
+                )
         sentinel_scan = SentinelScanSummary(
             status=scan.get("state"),
             critical_count=scan.get("critical", 0),
             warning_count=scan.get("warn", 0),
+            findings=findings,
         )
 
     # Evidence counters ride in ``data.origin`` (Forge stamps them for
@@ -519,6 +568,12 @@ async def list_inbox(
     if remaining > 0:
         items.extend(deferred[:remaining])
 
+    # More staged cards exist than this page shows when either the
+    # effective limit cut the fetched set, or the oversample window
+    # itself saturated (in which case even ``all_cards`` is missing
+    # the tail — see the warning above).
+    truncated = len(all_cards) > len(items) or (oversample_limit > 0 and len(all_cards) >= oversample_limit)
+
     if not include_content:
         # Lean default: drop the SKILL.md bodies from the page. The edit
         # UI re-requests with ?include_content=true when it needs them.
@@ -529,6 +584,7 @@ async def list_inbox(
         tenant_id=tenant_id,
         fleet_id=fleet_id,
         count=len(items),
+        truncated=truncated,
         items=items,
     )
 

--- a/docs/skills-inbox-api.md
+++ b/docs/skills-inbox-api.md
@@ -87,6 +87,7 @@ Response shape (this example was requested with
   "tenant_id": "acme",
   "fleet_id": null,
   "count": 1,
+  "truncated": false,
   "items": [
     {
       "slug": "forge/summarize-oncall-handoff",
@@ -104,7 +105,14 @@ Response shape (this example was requested with
       "scan_state": "clean",
       "scan_critical": 0,
       "scan_warn": 1,
-      "sentinel_scan": { "status": "clean", "critical_count": 0, "warning_count": 1 },
+      "sentinel_scan": {
+        "status": "clean",
+        "critical_count": 0,
+        "warning_count": 1,
+        "findings": [
+          { "code": "S-STYLE-001", "severity": "warn", "message": "description exceeds recommended length", "fatal": false, "locator": "description" }
+        ]
+      },
       "forge_evidence": { "cluster_size": 5, "distinct_agents": 4 },
       "origin": {
         "agent_id": "forge",
@@ -136,10 +144,17 @@ Field notes:
   `GET`), so the edit UI opts in to pre-fill the Edit form; it's what an
   Edit must send back (see below).
 - `sentinel_scan` — the latest Sentinel verdict:
-  `{ status, critical_count, warning_count }` where `status` is
-  `clean` / `quarantined` / `failed`, or `null` when the doc was never
-  scanned. The flat `scan_state` / `scan_critical` / `scan_warn`
-  fields carry the same values (kept for older consumers).
+  `{ status, critical_count, warning_count, findings }` where `status`
+  is `clean` / `quarantined` / `failed`, or `null` when the doc was
+  never scanned. `findings` carries up to 20 entries
+  (`{ code, severity, message, fatal, locator? }`) so the UI can show
+  WHY a scan tripped; the full list stays on the doc. The flat
+  `scan_state` / `scan_critical` / `scan_warn` fields carry the same
+  counts (kept for older consumers).
+- `truncated` (top-level) — `true` when more staged cards exist than
+  this page returned (the effective limit —
+  `min(limit, inbox_max_pending, 200)` — cut the list). Narrow by
+  `fleet_id` or raise `skills_factory.inbox_max_pending` to see more.
 - `forge_evidence` — `{ cluster_size, distinct_agents }`: how many
   behavior traces the candidate was distilled from and how many
   distinct agents produced them. Only present on `source: "forge"`

--- a/tests/test_skills_inbox_routes.py
+++ b/tests/test_skills_inbox_routes.py
@@ -75,7 +75,15 @@ def forge_doc(**data_overrides) -> dict:
             "critical": 0,
             "warn": 1,
             "info": 0,
-            "findings": [],
+            "findings": [
+                {
+                    "code": "S-STYLE-001",
+                    "severity": "warn",
+                    "message": "description exceeds recommended length",
+                    "fatal": False,
+                    "locator": "description",
+                }
+            ],
         },
         "content_hash": "sha256:9b2e",
         "created_at": "2026-07-18T06:02:11+00:00",
@@ -268,6 +276,7 @@ async def test_list_returns_enriched_golden_card(storage, settings):
     body = r.json()
     assert body["tenant_id"] == TENANT
     assert body["count"] == 1
+    assert body["truncated"] is False
     card = body["items"][0]
 
     # The full doc_id (WITH the forge/ prefix) is the action handle.
@@ -281,6 +290,15 @@ async def test_list_returns_enriched_golden_card(storage, settings):
         "status": "clean",
         "critical_count": 0,
         "warning_count": 1,
+        "findings": [
+            {
+                "code": "S-STYLE-001",
+                "severity": "warn",
+                "message": "description exceeds recommended length",
+                "fatal": False,
+                "locator": "description",
+            }
+        ],
     }
     assert card["forge_evidence"] == {"cluster_size": 5, "distinct_agents": 4}
     assert card["cites"] == ["mem-1", "mem-2"]
@@ -775,3 +793,72 @@ async def test_edit_concurrent_approve_409(storage, settings, side_effects):
         r = await client.post(f"{BASE}/{SLUG}/edit", json={"summary": "x"})
     assert r.status_code == 409
     assert storage.upserts == []
+
+
+# ---------------------------------------------------------------------------
+# Phase B: scan findings on the card + the truncated flag
+# ---------------------------------------------------------------------------
+
+
+async def test_findings_capped_and_malformed_entries_skipped(storage, settings):
+    """A pathological doc can carry an unbounded/garbage findings list —
+    the card surfaces at most _MAX_CARD_FINDINGS well-formed entries."""
+    many = [
+        {"code": f"S-{i:03d}", "severity": "warn", "message": f"finding {i}", "fatal": False}
+        for i in range(30)
+    ]
+    many.insert(0, "not-a-dict")  # malformed entry must be skipped, not 500
+    storage.query_rows = [
+        forge_doc(scan={"state": "quarantined", "critical": 30, "warn": 0, "info": 0, "findings": many})
+    ]
+    async with make_client() as client:
+        r = await client.get(BASE)
+    assert r.status_code == 200, r.text
+    findings = r.json()["items"][0]["sentinel_scan"]["findings"]
+    assert len(findings) == 20  # capped, and the junk entry didn't count
+    assert findings[0]["code"] == "S-000"
+    assert all(f["message"] for f in findings)
+
+
+async def test_scan_without_findings_key_yields_empty_list(storage, settings):
+    """Legacy docs whose scan block predates findings persistence."""
+    storage.query_rows = [
+        forge_doc(scan={"state": "clean", "critical": 0, "warn": 0, "info": 0})
+    ]
+    async with make_client() as client:
+        r = await client.get(BASE)
+    assert r.json()["items"][0]["sentinel_scan"]["findings"] == []
+
+
+async def test_truncated_true_when_cap_cuts_the_page(storage, settings):
+    settings["skills_factory"]["inbox_max_pending"] = 2
+    storage.query_rows = [forge_doc(slug=f"s{i}") for i in range(4)]
+    async with make_client() as client:
+        r = await client.get(f"{BASE}?limit=50")
+    body = r.json()
+    assert body["count"] == 2
+    assert body["truncated"] is True
+
+
+async def test_truncated_true_when_oversample_saturates(storage, settings):
+    """The oversample window (2x effective limit) filled — even the
+    fetched set may be missing the tail."""
+    settings["skills_factory"]["inbox_max_pending"] = 2
+    # oversample = min(2*2, 400) = 4; return exactly 4 rows, but make
+    # them all deferred so the page itself isn't even full.
+    storage.query_rows = [
+        forge_doc(slug=f"s{i}", deferred_at="2026-07-19T00:00:00+00:00") for i in range(4)
+    ]
+    async with make_client() as client:
+        r = await client.get(f"{BASE}?limit=50")
+    body = r.json()
+    assert body["truncated"] is True
+
+
+async def test_truncated_false_on_partial_page(storage, settings):
+    storage.query_rows = [forge_doc(slug="only-one")]
+    async with make_client() as client:
+        r = await client.get(f"{BASE}?limit=50")
+    body = r.json()
+    assert body["count"] == 1
+    assert body["truncated"] is False


### PR DESCRIPTION
## Summary

Backend half of the Skills Inbox Phase B polish (pairs with an enterprise dashboard PR). Two **additive** list-contract changes:

- **`sentinel_scan.findings`** — up to 20 well-formed `{code, severity, message, fatal, locator?}` entries mapped from `data.scan.findings`, so the UI can show *why* a scan tripped (and disable Approve with a reason when `critical_count > 0`). Malformed entries are skipped without consuming a capped slot; the full list stays on the doc.
- **`truncated`** top-level response flag — `true` when more staged cards exist than the page returned (effective limit `min(limit, inbox_max_pending, 200)` cut the list, or the oversample window saturated). Without it, a page of exactly N items is indistinguishable from a capped one, so no client-side "showing first N" heuristic can be accurate.

Both changes are backward-compatible (new fields only); the dashboard feature-detects them, so deploy order doesn't matter.

## Testing

- Golden Forge-card contract updated (finding entry now rides the golden doc's `warn: 1`).
- New: findings cap at 20 with malformed-entry skip (the test caught a slice-before-filter bug where junk consumed a slot — fixed), legacy scan blocks without a `findings` key, and `truncated` across cap-cut / oversample-saturated / partial-page cases.
- 60 route tests green; ruff + format clean; CI-invocation mypy clean for the touched file.
- `docs/skills-inbox-api.md` updated (response example + field notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)