### PR TITLE
ci: type-check + build the plugin in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node.js (for plugin version-sync check)
+      - name: Set up Node.js (for plugin version-sync + type-check)
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
@@ -47,6 +47,15 @@ jobs:
         # edited version.ts. The drift-prevention guarantee documented
         # in scripts/gen-version.sh is enforced here.
         run: cd plugin && npm run check:version
+
+      - name: Type-check + build plugin (tsc)
+        # Compiles the plugin with its own tsconfig so a dependency bump that
+        # breaks the build (e.g. a TypeScript major that changes @types
+        # resolution) can't merge while looking green. The version-sync check
+        # above runs no compiler; `client-typescript-ci.yml` is path-scoped to
+        # the client SDK, not /plugin — so without this step the plugin has no
+        # type-check gate in CI.
+        run: cd plugin && npm ci && npm run build
 
       - name: Install uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5.4.2


### PR DESCRIPTION
## What
Adds a `cd plugin && npm ci && npm run build` (tsc) step to the CI job.

## Why
The plugin currently has **no type-check gate in CI**:
- The only plugin step is `npm run check:version` (version-sync — runs no compiler).
- The real TS `Build + test` job lives in `client-typescript-ci.yml`, which is **path-scoped to the client SDK, not `/plugin`**.

So a `/plugin`-only PR can be fully green while `tsc` would fail. This surfaced when Dependabot's **typescript 5→7** bump (#547) would have broken `main` with ~47 `TS2591` errors despite a green checkmark. This step closes that blind spot (and runs `npm ci` on Linux, giving us lockfile validation too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)