### PR TITLE
feat(client): memclaw-interviewer --harness cursor — Cursor adapter (Interviewer Phase 3)

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -53,15 +53,17 @@ For credentials, scopes, and the full API surface, see the
 [MemClaw docs](https://memclaw.net/docs). Production fleets should use
 [per-agent keys](https://memclaw.net/docs/integrations/per-agent-keys).
 
-## memclaw-interviewer — Claude Code adapter (Interviewer Phase 2)
+## memclaw-interviewer — Claude Code + Cursor adapter
 
 Installing this package also provides the `memclaw-interviewer` CLI: the
-MemClaw Interviewer's disk-parser adapter for Claude Code workstations. It
-reads Claude Code session transcripts (`~/.claude/projects/…/*.jsonl`)
-**read-only**, tracks a per-file cursor via the server's forward-only
-watermark documents (no local state), and submits event windows to
-`POST /api/v1/interview/submit`, where MemClaw synthesizes them into typed
-memories. Requires the tenant to have `interviewer.enabled = true`.
+MemClaw Interviewer's disk-parser adapter for Claude Code and Cursor
+workstations. It reads agent session transcripts **read-only** — Claude
+Code's `~/.claude/projects/…/*.jsonl` or Cursor's
+`~/.cursor/projects/…/agent-transcripts/…/*.jsonl` — tracks a per-file
+cursor via the server's forward-only watermark documents (no local state),
+and submits event windows to `POST /api/v1/interview/submit`, where MemClaw
+synthesizes them into typed memories. Requires the tenant to have
+`interviewer.enabled = true`.
 
 ```bash
 export MEMCLAW_API_KEY=mc_xxx MEMCLAW_TENANT_ID=my-team
@@ -70,6 +72,8 @@ export MEMCLAW_INTERVIEWER_PROJECTS="-Users-me-work-*"   # allowlist, default-de
 memclaw-interviewer status --since-hours 24     # cursors vs. local line counts
 memclaw-interviewer run --dry-run -v            # parse + window, submit nothing
 memclaw-interviewer run --max-windows 8         # submit due windows
+memclaw-interviewer run --harness cursor        # harvest Cursor instead (or
+                                                # MEMCLAW_INTERVIEWER_HARNESS=cursor)
 ```
 
 **Privacy:** default-deny — with no allowlist the CLI lists discovered
@@ -77,14 +81,24 @@ project dirs and exits with guidance; `--all-projects` is the explicit
 opt-in. Credential-shaped strings are scrubbed locally before anything
 leaves the machine, and the server masks PII again on receipt.
 
-**Triggers:** run it from cron, or wire Claude Code's SessionEnd hook so a
+**Triggers:** run it from cron, or wire the harness's session-end hook so a
 session is interviewed the moment it ends (a failed harvest never fails
-the session — the hook always exits 0):
+the session — the hook always exits 0). The SAME hook command serves both
+harnesses: each sends `transcript_path` on stdin, and the harness is
+inferred from the path shape.
 
+Claude Code (`~/.claude/settings.json`):
 ```json
 { "hooks": { "SessionEnd": [ { "hooks": [
   { "type": "command", "command": "memclaw-interviewer hook", "timeout": 300 }
 ] } ] } }
+```
+
+Cursor (`~/.cursor/hooks.json`):
+```json
+{ "version": 1, "hooks": {
+  "sessionEnd": [ { "command": "memclaw-interviewer hook" } ]
+} }
 ```
 
 Crash-safety is inherited from the Interviewer protocol: the watermark

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memclaw-client"
-version = "0.2.0"
+version = "0.3.0"
 description = "Official Python client for MemClaw — governed shared memory for AI agent fleets (multi-agent, multi-tenant, MCP-native)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/clients/python/src/memclaw_client/interviewer/cli.py
+++ b/clients/python/src/memclaw_client/interviewer/cli.py
@@ -26,11 +26,14 @@ from typing import Optional
 from ..client import MemClaw
 from ..exceptions import AuthError
 from .discovery import (
+    DEFAULT_CURSOR_PROJECTS_ROOT,
     DEFAULT_PROJECTS_ROOT,
-    Transcript,
+    HARNESS_CLAUDE_CODE,
+    HARNESS_CURSOR,
     find_transcripts,
     list_project_dirs,
     project_allowed,
+    transcript_from_path,
 )
 from .machine import machine_id_short
 from .parser import count_lines
@@ -63,7 +66,18 @@ def _build_parser() -> argparse.ArgumentParser:
             help="project-dir globs to allow (default: MEMCLAW_INTERVIEWER_PROJECTS env; DEFAULT-DENY without either)",
         )
         p.add_argument("--all-projects", action="store_true", help="explicit opt-in: harvest every project dir")
-        p.add_argument("--projects-root", type=Path, default=DEFAULT_PROJECTS_ROOT)
+        p.add_argument(
+            "--harness",
+            choices=(HARNESS_CLAUDE_CODE, HARNESS_CURSOR),
+            default=os.environ.get("MEMCLAW_INTERVIEWER_HARNESS", HARNESS_CLAUDE_CODE),
+            help="which agent's transcripts to harvest (default: claude-code; env MEMCLAW_INTERVIEWER_HARNESS)",
+        )
+        p.add_argument(
+            "--projects-root",
+            type=Path,
+            default=None,
+            help="override the harness's default projects root (~/.claude/projects or ~/.cursor/projects)",
+        )
         p.add_argument("-v", "--verbose", action="store_true")
 
     run_p = sub.add_parser("run", help="scan transcripts and submit due interview windows")
@@ -87,6 +101,14 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _projects_root(args: argparse.Namespace) -> Path:
+    if args.projects_root is not None:
+        return args.projects_root
+    if args.harness == HARNESS_CURSOR:
+        return DEFAULT_CURSOR_PROJECTS_ROOT
+    return DEFAULT_PROJECTS_ROOT
+
+
 def _resolve_allowlist(args: argparse.Namespace) -> list[str]:
     if args.projects is not None:
         return list(args.projects)
@@ -103,10 +125,10 @@ def _require_config(args: argparse.Namespace) -> Optional[str]:
 
 
 def _deny_guidance(args: argparse.Namespace) -> str:
-    projects = list_project_dirs(args.projects_root)
+    projects = list_project_dirs(_projects_root(args))
     lines = [
         "No project allowlist configured - refusing to harvest by default.",
-        "Claude Code transcripts can contain sensitive work across ALL projects;",
+        "Agent transcripts can contain sensitive work across ALL projects;",
         "opt in explicitly with --projects <glob...>, MEMCLAW_INTERVIEWER_PROJECTS,",
         "or --all-projects.",
         "",
@@ -186,25 +208,28 @@ def _cmd_run(args: argparse.Namespace) -> int:
             return 2
         # --transcript must not bypass the project allowlist — including
         # the EMPTY-allowlist case (default-deny has no carve-outs; same
-        # pattern as _cmd_hook and the discovery path below).
-        project = args.transcript.parent.name
-        if not args.all_projects and not (allow and project_allowed(project, allow)):
+        # pattern as _cmd_hook and the discovery path below). Harness is
+        # inferred from the path shape, not --harness: the file IS the
+        # ground truth.
+        transcript = transcript_from_path(args.transcript)
+        if not args.all_projects and not (allow and project_allowed(transcript.project, allow)):
             print(
-                f"[interviewer] transcript project '{project}' not in allowlist; "
+                f"[interviewer] transcript project '{transcript.project}' not in allowlist; "
                 "pass --all-projects or --projects to opt in",
                 file=sys.stderr,
             )
             return 2
-        transcripts = [Transcript(path=args.transcript, project=project)]
+        transcripts = [transcript]
     else:
         if not allow and not args.all_projects:
             print(_deny_guidance(args), file=sys.stderr)
             return 2
         transcripts = find_transcripts(
-            root=args.projects_root,
+            root=_projects_root(args),
             allow_globs=allow,
             since_hours=args.since_hours or None,
             all_projects=args.all_projects,
+            harness=args.harness,
         )
     if not transcripts:
         print("[interviewer] nothing to do (no matching transcripts)")
@@ -248,15 +273,16 @@ def _cmd_status(args: argparse.Namespace) -> int:
         print(_deny_guidance(args), file=sys.stderr)
         return 2
     transcripts = find_transcripts(
-        root=args.projects_root,
+        root=_projects_root(args),
         allow_globs=allow,
         since_hours=args.since_hours or None,
         all_projects=args.all_projects,
+        harness=args.harness,
     )
     machine12 = machine_id_short()
     with _make_client(args) as mc:
         for transcript in transcripts:
-            node_id = node_id_for(machine12, transcript.path)
+            node_id = node_id_for(machine12, transcript.path, transcript.dialect)
             try:
                 last_seq = read_watermark(mc, node_id)
                 # Inside the guard: the transcript can vanish between
@@ -277,20 +303,24 @@ def _cmd_status(args: argparse.Namespace) -> int:
 
 
 def _cmd_hook(args: argparse.Namespace) -> int:
-    """SessionEnd hook: read {transcript_path,...} JSON from stdin, drain
-    that one file. ALWAYS exit 0 — never fail the user's session."""
+    """Session-end hook: read {transcript_path,...} JSON from stdin, drain
+    that one file. ALWAYS exit 0 — never fail the user's session.
+
+    Both Claude Code (SessionEnd) and Cursor (sessionEnd/stop) hooks send
+    ``transcript_path`` in their stdin payload; the harness is inferred
+    from the path shape, so ONE hook command serves both."""
     try:
         payload = json.loads(sys.stdin.read() or "{}")
         transcript_path = Path(str(payload.get("transcript_path") or ""))
         if not transcript_path.is_file():
             return 0
         allow = _resolve_allowlist(args)
-        project = transcript_path.parent.name
-        if not args.all_projects and not (allow and project_allowed(project, allow)):
+        transcript = transcript_from_path(transcript_path)
+        if not args.all_projects and not (allow and project_allowed(transcript.project, allow)):
             # Warn so operators can tell a config gap from an empty
             # session; exit code stays 0 (never fail the session hook).
             print(
-                f"[interviewer] hook: project '{project}' not in allowlist; skipping "
+                f"[interviewer] hook: project '{transcript.project}' not in allowlist; skipping "
                 "(set MEMCLAW_INTERVIEWER_PROJECTS or --all-projects)",
                 file=sys.stderr,
             )
@@ -304,7 +334,7 @@ def _cmd_hook(args: argparse.Namespace) -> int:
         try:
             cfg = _make_config(args, flush=True)  # session over: drain the tail
             with _make_client(args) as mc:
-                run_all(mc, [Transcript(path=transcript_path, project=project)], cfg)
+                run_all(mc, [transcript], cfg)
         finally:
             if hasattr(lock, "close"):
                 lock.close()
@@ -314,7 +344,23 @@ def _cmd_hook(args: argparse.Namespace) -> int:
 
 
 def main(argv: Optional[list[str]] = None) -> int:
-    args = _build_parser().parse_args(argv)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    # argparse's choices= only validates values passed on the command line,
+    # NOT a default sourced from os.environ — so a bad
+    # MEMCLAW_INTERVIEWER_HARNESS (wrong case "Cursor", a typo) would slip
+    # through and silently fall back to Claude Code behavior. Fail loudly —
+    # but ONLY for run/status: parser.error() exits 2, and `hook` both
+    # ignores --harness (it infers from path shape) and must ALWAYS exit 0.
+    if (
+        args.command in ("run", "status")
+        and hasattr(args, "harness")
+        and args.harness not in (HARNESS_CLAUDE_CODE, HARNESS_CURSOR)
+    ):
+        parser.error(
+            f"Invalid harness '{args.harness}' — set MEMCLAW_INTERVIEWER_HARNESS to "
+            f"'{HARNESS_CLAUDE_CODE}' or '{HARNESS_CURSOR}'"
+        )
     if args.command == "run":
         return _cmd_run(args)
     if args.command == "status":

--- a/clients/python/src/memclaw_client/interviewer/discovery.py
+++ b/clients/python/src/memclaw_client/interviewer/discovery.py
@@ -9,18 +9,58 @@ and installing the tool is not consent to harvest all of them.
 from __future__ import annotations
 
 import fnmatch
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+# Cursor session dirs are UUIDs; a prefix match (8-4-4) is enough to
+# distinguish them from an arbitrarily-named dir that merely happens to
+# sit under a folder called "agent-transcripts".
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}", re.IGNORECASE)
+
 DEFAULT_PROJECTS_ROOT = Path.home() / ".claude" / "projects"
+DEFAULT_CURSOR_PROJECTS_ROOT = Path.home() / ".cursor" / "projects"
+
+HARNESS_CLAUDE_CODE = "claude-code"
+HARNESS_CURSOR = "cursor"
+
+# Where session transcripts live RELATIVE to a project dir, per harness.
+# Claude Code: <project>/<uuid>.jsonl (subagents live one level deeper).
+# Cursor:      <project>/agent-transcripts/<uuid>/<uuid>.jsonl (subagents
+#              live under the session dir, one level deeper again).
+# Both globs exclude subagent transcripts BY CONSTRUCTION — they sit at a
+# depth the glob never reaches.
+_SESSION_GLOB = {
+    HARNESS_CLAUDE_CODE: "*.jsonl",
+    HARNESS_CURSOR: "agent-transcripts/*/*.jsonl",
+}
 
 
 @dataclass
 class Transcript:
     path: Path
     project: str  # project dir name (the slug)
+    dialect: str = HARNESS_CLAUDE_CODE
+
+
+def transcript_from_path(path: Path) -> Transcript:
+    """Infer harness + project from a transcript's path shape.
+
+    Used where the file arrives without discovery context (--transcript,
+    hook stdin). A Cursor transcript always sits inside a session dir under
+    ``agent-transcripts``; anything else is treated as Claude Code, whose
+    project dir is the immediate parent.
+    """
+    session_dir = path.parent
+    if session_dir.parent.name == "agent-transcripts" and _UUID_RE.match(session_dir.name):
+        return Transcript(
+            path=path,
+            project=session_dir.parent.parent.name,
+            dialect=HARNESS_CURSOR,
+        )
+    return Transcript(path=path, project=path.parent.name)
 
 
 def list_project_dirs(root: Path = DEFAULT_PROJECTS_ROOT) -> list[str]:
@@ -39,16 +79,18 @@ def find_transcripts(
     allow_globs: list[str],
     since_hours: Optional[float] = None,
     all_projects: bool = False,
+    harness: str = HARNESS_CLAUDE_CODE,
 ) -> list[Transcript]:
-    """Enumerate top-level session ``.jsonl`` files in allowed projects.
+    """Enumerate session ``.jsonl`` files in allowed projects.
 
-    Skips subagent transcripts (``<uuid>/subagents/``) and offloaded tool
-    results by construction — only files DIRECTLY under a project dir are
-    session transcripts. ``since_hours`` prefilters by mtime so steady-state
+    Skips subagent transcripts and offloaded tool results by construction —
+    the per-harness glob only reaches session-transcript depth (see
+    ``_SESSION_GLOB``). ``since_hours`` prefilters by mtime so steady-state
     runs don't rescan months of history.
     """
     if not root.is_dir():
         return []
+    glob = _SESSION_GLOB.get(harness, _SESSION_GLOB[HARNESS_CLAUDE_CODE])
     cutoff = time.time() - since_hours * 3600 if since_hours else None
     found: list[Transcript] = []
     for project_dir in sorted(root.iterdir()):
@@ -56,11 +98,11 @@ def find_transcripts(
             continue
         if not all_projects and not project_allowed(project_dir.name, allow_globs):
             continue
-        for path in sorted(project_dir.glob("*.jsonl")):
+        for path in sorted(project_dir.glob(glob)):
             try:
                 if cutoff is not None and path.stat().st_mtime < cutoff:
                     continue
             except OSError:
                 continue  # deleted/renamed between glob and stat (TOCTOU)
-            found.append(Transcript(path=path, project=project_dir.name))
+            found.append(Transcript(path=path, project=project_dir.name, dialect=harness))
     return found

--- a/clients/python/src/memclaw_client/interviewer/parser.py
+++ b/clients/python/src/memclaw_client/interviewer/parser.py
@@ -1,7 +1,7 @@
-"""Claude Code transcript parser → C2 interview events.
+"""Transcript parsers (Claude Code + Cursor dialects) → C2 interview events.
 
-Format facts this parser is built on (verified against real transcripts,
-2026-07; see the Phase-2 plan):
+Claude Code format facts (verified against real transcripts, 2026-07; see
+the Phase-2 plan):
 
 - A session ``.jsonl`` is append-only but may contain MULTIPLE
   ``sessionId`` values (resuming appends to the original file) and eight
@@ -13,9 +13,25 @@ Format facts this parser is built on (verified against real transcripts,
 - Assistant ``message.content`` is a list of ``thinking|text|tool_use``
   blocks (or occasionally a plain string).
 
+Cursor agent-transcript facts (verified against real
+``~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl`` files,
+2026-07; Cursor calls the format "Claude Code-compatible JSONL"):
+
+- Lines are ``{"role": "user"|"assistant", "message": {"content": [...]}}``
+  with no meta/sidechain envelope, plus roleless status lines such as
+  ``{"type": "turn_ended", "status": "success"}``.
+- There are NO tool_result lines (tool outputs are excluded upstream) and
+  no per-line sessionId/timestamp fields.
+- USER text arrives wrapped in ``<timestamp>...</timestamp>`` and
+  ``<user_query>...</user_query>`` tags; the timestamp is human-formatted
+  ("Tuesday, Jul 21, 2026, 1:11 PM (UTC+3)").
+- Every assistant text block ends with a trailing ``[REDACTED]`` marker
+  (redacted thinking); thinking-only turns are ONLY that marker.
+
 v1 emit policy (pilot-proven quality): REAL user prompts + assistant TEXT
 only. Everything else — thinking, tool_use, tool_result, meta, compaction
-summaries — is consumed as noise (it still advances the cursor).
+summaries, status lines — is consumed as noise (it still advances the
+cursor).
 
 ``seq`` is the RAW LINE INDEX in the file: monotonic under append-only
 writes regardless of session interleave, which is exactly the server's C2
@@ -26,10 +42,13 @@ filtered tail).
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from .discovery import HARNESS_CLAUDE_CODE, HARNESS_CURSOR
 from .scrub import scrub
 
 MIN_EVENT_CHARS = 60
@@ -124,6 +143,143 @@ def _event_from_line(
     )
 
 
+# --------------------------------------------------------------- cursor
+_REDACTED_MARKER = "[REDACTED]"
+# [\s\S] instead of DOTALL: same convention as scrub.py, and these tags
+# appear at most once per message so a single non-greedy pass is cheap.
+_CURSOR_TS_TAG = re.compile(r"<timestamp>([^<]{0,80})</timestamp>")
+_CURSOR_QUERY_TAG = re.compile(r"<user_query>\s*([\s\S]*?)\s*</user_query>")
+# "Tuesday, Jul 21, 2026, 1:11 PM (UTC+3)" — day name skipped (redundant),
+# offset may be +H / -H / +H:MM. Sub-fields captured directly:
+# 1=month 2=day 3=year 4=hour12 5=minute 6=AM/PM 7=sign 8=tz-hour 9=tz-min.
+_CURSOR_TS_FMT = re.compile(
+    r"^[A-Za-z]+, ([A-Za-z]{3}) (\d{1,2}), (\d{4}), (\d{1,2}):(\d{2}) ([AP])M "
+    r"\(UTC([+-])(\d{1,2})(?::(\d{2}))?\)$"
+)
+# Hard-coded, not strptime("%b"): %b is locale-sensitive, so a user with
+# LANG=fr_FR / de_DE etc. would fail to parse Cursor's English month names
+# and silently fall back to file mtime for every event's timestamp.
+_MONTH_ABBR = {
+    "Jan": 1, "Feb": 2, "Mar": 3, "Apr": 4, "May": 5, "Jun": 6,
+    "Jul": 7, "Aug": 8, "Sep": 9, "Oct": 10, "Nov": 11, "Dec": 12,
+}
+
+
+def _parse_cursor_timestamp(raw: str) -> Optional[str]:
+    """Cursor's human-formatted tag → ISO 8601, or None if unparseable.
+
+    Locale-independent, and defensive about the out-of-range fields the
+    permissive ``\\d{1,2}`` groups admit (day/hour/tz-offset up to 99):
+    ``datetime()`` rejects an impossible day and ``timezone()`` rejects an
+    offset >= 24 h, and either ValueError is swallowed here — otherwise it
+    would propagate through event_from_line and crash the whole scan.
+    """
+    match = _CURSOR_TS_FMT.match(raw.strip())
+    if not match:
+        return None
+    month = _MONTH_ABBR.get(match.group(1))
+    if month is None:
+        return None
+    hour12 = int(match.group(4))
+    if not 1 <= hour12 <= 12:
+        return None
+    hour = hour12 % 12 + (12 if match.group(6) == "P" else 0)
+    sign = -1 if match.group(7) == "-" else 1
+    try:
+        offset = timezone(sign * timedelta(hours=int(match.group(8)), minutes=int(match.group(9) or 0)))
+        return datetime(
+            int(match.group(3)), month, int(match.group(2)),
+            hour, int(match.group(5)), tzinfo=offset,
+        ).isoformat()
+    except ValueError:
+        return None
+
+
+def _strip_redacted(text: str) -> str:
+    """Drop the trailing ``[REDACTED]`` thinking marker(s) Cursor appends
+    to every assistant text block. Trailing-only by design: a literal
+    ``[REDACTED]`` in the MIDDLE of prose is content, not a marker."""
+    text = text.strip()
+    while text.endswith(_REDACTED_MARKER):
+        text = text[: -len(_REDACTED_MARKER)].rstrip()
+    return text
+
+
+class _CursorDialect:
+    """Per-file line decoder for Cursor agent-transcripts.
+
+    Stateful on purpose: assistant lines carry no timestamp, so each reply
+    inherits the most recent user ``<timestamp>`` tag; before any tag is
+    seen (or if parsing fails) events fall back to the file's mtime.
+    """
+
+    def __init__(self, path: Path, project: str) -> None:
+        self.session_id = f"{project}:{path.stem}"
+        try:
+            mtime = path.stat().st_mtime
+            self.last_ts = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+        except OSError:
+            self.last_ts = ""
+        # Roleless status lines ({"type": "turn_ended", ...}) fall out via
+        # the role check below — no explicit type list to chase.
+
+    def update_ts(self, row: dict[str, Any]) -> None:
+        """Advance ``last_ts`` from a user turn's ``<timestamp>`` tag.
+
+        Called for EVERY user line, including those BEFORE ``start_line``
+        on an incremental run: assistant lines carry no timestamp and
+        inherit the last user tag, so a window that opens on replies must
+        still have seen the earlier tag or every event in it falls back to
+        the file's mtime. Idempotent and side-effect-free beyond
+        ``last_ts``.
+        """
+        if row.get("role") != "user":
+            return
+        message = row.get("message")
+        if not isinstance(message, dict):
+            return
+        ts_match = _CURSOR_TS_TAG.search(_text_of(message.get("content")))
+        if ts_match:
+            parsed = _parse_cursor_timestamp(ts_match.group(1))
+            if parsed:
+                self.last_ts = parsed
+
+    def event_from_line(
+        self, row: dict[str, Any], seq: int, max_event_chars: int
+    ) -> Optional[ParsedEvent]:
+        role = row.get("role")
+        if role not in ("user", "assistant"):
+            return None
+        message = row.get("message")
+        if not isinstance(message, dict):
+            return None
+        text = _text_of(message.get("content"))
+        if role == "user":
+            kind = "prompt"
+            self.update_ts(row)
+            query_match = _CURSOR_QUERY_TAG.search(text)
+            if query_match:
+                text = query_match.group(1)
+            elif _CURSOR_TS_TAG.search(text):
+                # Tagged timestamp but no query wrapper: drop the tag, keep
+                # the rest (unknown wrapper variants stay ingestable).
+                text = _CURSOR_TS_TAG.sub("", text)
+        else:
+            kind = "reply"
+            text = _strip_redacted(text)
+        text = scrub(text.strip())
+        if len(text) < MIN_EVENT_CHARS:
+            return None
+        return ParsedEvent(
+            seq=seq,
+            ts=self.last_ts,
+            session_id=self.session_id,
+            role=role,
+            kind=kind,
+            content=text[:max_event_chars],
+        )
+
+
 def count_lines(path: Path) -> int:
     """Cheap line count for the skip-unchanged check (no JSON parsing)."""
     count = 0
@@ -139,14 +295,17 @@ def scan_events(
     start_line: int,
     project: str,
     max_event_chars: int,
+    dialect: str = HARNESS_CLAUDE_CODE,
 ) -> ScanResult:
     """Scan complete lines from ``start_line`` (0-based) to EOF.
 
-    A final line without a trailing newline may be mid-append (Claude Code
+    A final line without a trailing newline may be mid-append (the agent
     is live) — it is NOT counted as complete and will be picked up next
     run. Unparseable COMPLETE lines are consumed as noise (cursor still
-    advances past them).
+    advances past them). ``dialect`` selects the per-line decoder
+    ("claude-code" or "cursor"); the scan mechanics are shared.
     """
+    cursor_dialect = _CursorDialect(path, project) if dialect == HARNESS_CURSOR else None
     events: list[ParsedEvent] = []
     last_complete = -1
     total = 0
@@ -158,6 +317,18 @@ def scan_events(
                 total = index
                 break
             if index < start_line:
+                # Cursor timestamps live only on user turns and are
+                # inherited forward, so rebuild that state from lines
+                # before the cursor. The "<timestamp>" substring
+                # pre-filter keeps this proportional to user turns, not
+                # every skipped line (assistant/status lines never match).
+                if cursor_dialect is not None and "<timestamp>" in raw:
+                    try:
+                        skipped = json.loads(raw.strip())
+                    except ValueError:
+                        skipped = None
+                    if isinstance(skipped, dict):
+                        cursor_dialect.update_ts(skipped)
                 continue
             last_complete = index
             line = raw.strip()
@@ -169,7 +340,10 @@ def scan_events(
                 continue  # corrupt line: noise, cursor advances past it
             if not isinstance(row, dict):
                 continue
-            event = _event_from_line(row, index, project, max_event_chars)
+            if cursor_dialect is not None:
+                event = cursor_dialect.event_from_line(row, index, max_event_chars)
+            else:
+                event = _event_from_line(row, index, project, max_event_chars)
             if event is not None:
                 events.append(event)
     return ScanResult(events=events, last_complete_line=last_complete, total_lines=total)

--- a/clients/python/src/memclaw_client/interviewer/runner.py
+++ b/clients/python/src/memclaw_client/interviewer/runner.py
@@ -27,20 +27,27 @@ import httpx
 
 from ..client import MemClaw
 from ..exceptions import AuthError, MemClawAPIError, NotFoundError
-from .discovery import Transcript
+from .discovery import HARNESS_CLAUDE_CODE, HARNESS_CURSOR, Transcript
 from .parser import count_lines, scan_events
 from .windows import Window, build_windows, window_is_worth_interviewing
 
 WATERMARK_COLLECTION = "interview_watermarks"
 
 
-def node_id_for(machine12: str, path: Path) -> str:
+# Harness → node-id namespace. Distinct prefixes keep a Claude Code and a
+# Cursor session with a colliding stem (both UUID4 — effectively never)
+# on separate watermark streams, and make node provenance greppable
+# server-side.
+_NODE_PREFIX = {HARNESS_CLAUDE_CODE: "cc", HARNESS_CURSOR: "cursor"}
+
+
+def node_id_for(machine12: str, path: Path, dialect: str = HARNESS_CLAUDE_CODE) -> str:
     # The stem is the session UUID — globally unique, so the project dir
     # is DELIBERATELY excluded: (a) renaming/moving a project dir (the
     # slug is the cwd path) must not orphan every watermark under it,
     # and (b) long path slugs could overflow the server's 200-char
     # node_id cap. A moved transcript keeps its cursor, by design.
-    return f"cc:{machine12}:{path.stem}"
+    return f"{_NODE_PREFIX.get(dialect, 'cc')}:{machine12}:{path.stem}"
 
 
 def watermark_doc_id(node_id: str) -> str:
@@ -117,7 +124,7 @@ def _submit_window(mc: MemClaw, cfg: RunConfig, node_id: str, window: Window) ->
 def run_file(mc: MemClaw, transcript: Transcript, cfg: RunConfig, windows_budget: int) -> FileResult:
     """Drain one transcript up to the shared windows budget."""
     result = FileResult(path=transcript.path)
-    node_id = node_id_for(cfg.machine12, transcript.path)
+    node_id = node_id_for(cfg.machine12, transcript.path, transcript.dialect)
     # Dry-run is fully offline: no watermark read, no submit — parse and
     # window from the start of the file as if never interviewed.
     last_seq = -1 if cfg.dry_run else read_watermark(mc, node_id)
@@ -148,6 +155,7 @@ def run_file(mc: MemClaw, transcript: Transcript, cfg: RunConfig, windows_budget
         start_line=cursor_from,
         project=transcript.project,
         max_event_chars=cfg.max_event_chars,
+        dialect=transcript.dialect,
     )
     if scan.last_complete_line < cursor_from:
         result.skipped_reason = "no complete new lines (mid-append tail)"

--- a/clients/python/tests/test_interviewer_cursor.py
+++ b/clients/python/tests/test_interviewer_cursor.py
@@ -1,0 +1,260 @@
+"""Cursor-dialect tests: agent-transcript parsing, discovery layout,
+node-id namespacing, hook auto-detection.
+
+Fixture lines mirror a REAL ~/.cursor/projects/<slug>/agent-transcripts
+file captured 2026-07-21 (content anonymized, structure verbatim).
+"""
+
+from __future__ import annotations
+
+import json
+
+from memclaw_client.interviewer.discovery import (
+    HARNESS_CURSOR,
+    find_transcripts,
+    transcript_from_path,
+)
+from memclaw_client.interviewer.parser import (
+    _parse_cursor_timestamp,
+    _strip_redacted,
+    scan_events,
+)
+from memclaw_client.interviewer.runner import node_id_for
+
+LONG = "x" * 80  # comfortably past MIN_EVENT_CHARS
+
+USER_LINE = {
+    "role": "user",
+    "message": {
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    "<timestamp>Tuesday, Jul 21, 2026, 1:11 PM (UTC+3)</timestamp>\n"
+                    f"<user_query>\nPlease review the widget module. {LONG}\n</user_query>"
+                ),
+            }
+        ]
+    },
+}
+# Thinking-only intermediate turn: text is ONLY the redaction marker.
+THINKING_ONLY_LINE = {
+    "role": "assistant",
+    "message": {
+        "content": [
+            {"type": "text", "text": "[REDACTED]"},
+            {"type": "tool_use", "name": "Read", "input": {"path": "/tmp/x"}},
+        ]
+    },
+}
+REPLY_LINE = {
+    "role": "assistant",
+    "message": {
+        "content": [
+            {"type": "text", "text": f"Here is the review you asked for. {LONG}\n\n[REDACTED]"}
+        ]
+    },
+}
+STATUS_LINE = {"type": "turn_ended", "status": "success"}
+
+
+def _write_session(tmp_path, project="Users-alice-work-app", stem="fad15427-9db8-4e39"):
+    session_dir = tmp_path / project / "agent-transcripts" / stem
+    session_dir.mkdir(parents=True)
+    path = session_dir / f"{stem}.jsonl"
+    lines = [USER_LINE, THINKING_ONLY_LINE, REPLY_LINE, STATUS_LINE]
+    path.write_text("".join(json.dumps(line) + "\n" for line in lines), encoding="utf-8")
+    return path
+
+
+def test_cursor_scan_emits_prompt_and_reply_only(tmp_path):
+    path = _write_session(tmp_path)
+    scan = scan_events(path, start_line=0, project="Users-alice-work-app", max_event_chars=4000, dialect="cursor")
+    assert [e.kind for e in scan.events] == ["prompt", "reply"]
+    assert scan.last_complete_line == 3  # status line consumed as noise
+    prompt, reply = scan.events
+    # Wrapper tags stripped from the prompt; nothing leaks.
+    assert prompt.content.startswith("Please review the widget module.")
+    assert "<user_query>" not in prompt.content and "<timestamp>" not in prompt.content
+    # Trailing [REDACTED] stripped from the reply.
+    assert reply.content.startswith("Here is the review")
+    assert not reply.content.endswith("[REDACTED]")
+    # seq = raw line index (thinking-only line 1 filtered, sparse seqs legal).
+    assert [e.seq for e in scan.events] == [0, 2]
+
+
+def test_cursor_timestamps_parse_and_propagate(tmp_path):
+    path = _write_session(tmp_path)
+    scan = scan_events(path, start_line=0, project="p", max_event_chars=4000, dialect="cursor")
+    prompt, reply = scan.events
+    assert prompt.ts == "2026-07-21T13:11:00+03:00"
+    # Assistant lines carry no timestamp: they inherit the last user tag.
+    assert reply.ts == prompt.ts
+    # Session id = project:file-stem (no per-line sessionId in this dialect).
+    assert prompt.session_id == "p:fad15427-9db8-4e39"
+
+
+def test_parse_cursor_timestamp_variants():
+    assert _parse_cursor_timestamp("Tuesday, Jul 21, 2026, 1:11 PM (UTC+3)") == "2026-07-21T13:11:00+03:00"
+    assert _parse_cursor_timestamp("Friday, Dec 5, 2025, 12:07 AM (UTC-5:30)") == "2025-12-05T00:07:00-05:30"
+    assert _parse_cursor_timestamp("Sunday, Jan 1, 2026, 12:00 PM (UTC+0)") == "2026-01-01T12:00:00+00:00"
+    assert _parse_cursor_timestamp("not a timestamp") is None
+    assert _parse_cursor_timestamp("Tuesday, Foo 21, 2026, 1:11 PM (UTC+3)") is None
+
+
+def test_parse_cursor_timestamp_rejects_out_of_range_without_raising():
+    """The permissive \\d{1,2} groups admit values datetime()/timezone()
+    reject — those ValueErrors must be swallowed, never crash the scan."""
+    # tz offset >= 24 h (timezone() raises)
+    assert _parse_cursor_timestamp("Monday, Jul 21, 2026, 1:11 PM (UTC+99)") is None
+    # impossible day (datetime() raises)
+    assert _parse_cursor_timestamp("Monday, Feb 30, 2026, 1:11 PM (UTC+3)") is None
+    # 12-hour clock overflow (guarded before conversion)
+    assert _parse_cursor_timestamp("Monday, Jul 21, 2026, 13:11 PM (UTC+3)") is None
+
+
+def test_scan_survives_malformed_timestamp(tmp_path):
+    """A bad <timestamp> must degrade to mtime fallback, not crash scan."""
+    session_dir = tmp_path / "proj" / "agent-transcripts" / "abc"
+    session_dir.mkdir(parents=True)
+    path = session_dir / "abc.jsonl"
+    bad_user = {
+        "role": "user",
+        "message": {"content": [{"type": "text",
+            "text": f"<timestamp>Monday, Jul 21, 2026, 1:11 PM (UTC+99)</timestamp>\n<user_query>\n{LONG}\n</user_query>"}]},
+    }
+    path.write_text(json.dumps(bad_user) + "\n", encoding="utf-8")
+    scan = scan_events(path, start_line=0, project="proj", max_event_chars=4000, dialect="cursor")
+    assert len(scan.events) == 1
+    assert scan.events[0].ts and "T" in scan.events[0].ts  # mtime fallback, no crash
+
+
+def test_strip_redacted_trailing_only():
+    assert _strip_redacted("Real answer.\n\n[REDACTED]") == "Real answer."
+    assert _strip_redacted("[REDACTED]") == ""
+    # A literal [REDACTED] mid-prose is content, not a marker.
+    kept = "The log printed [REDACTED] where the key was masked."
+    assert _strip_redacted(kept) == kept
+
+
+def test_cursor_reply_before_any_user_tag_falls_back_to_mtime(tmp_path):
+    session_dir = tmp_path / "proj" / "agent-transcripts" / "abc"
+    session_dir.mkdir(parents=True)
+    path = session_dir / "abc.jsonl"
+    path.write_text(json.dumps(REPLY_LINE) + "\n", encoding="utf-8")
+    scan = scan_events(path, start_line=0, project="proj", max_event_chars=4000, dialect="cursor")
+    assert len(scan.events) == 1
+    # ISO string derived from file mtime — parseable, non-empty.
+    assert scan.events[0].ts and "T" in scan.events[0].ts
+
+
+def test_cursor_discovery_layout_and_subagent_exclusion(tmp_path):
+    path = _write_session(tmp_path)
+    # A subagent transcript one level deeper must NOT be discovered.
+    sub = path.parent / "subagents"
+    sub.mkdir()
+    (sub / "helper.jsonl").write_text("{}\n", encoding="utf-8")
+    # A Claude Code-shaped file at project top level must not match either.
+    (tmp_path / "Users-alice-work-app" / "stray.jsonl").write_text("{}\n", encoding="utf-8")
+    found = find_transcripts(
+        root=tmp_path, allow_globs=["Users-alice-*"], harness=HARNESS_CURSOR
+    )
+    assert [t.path for t in found] == [path]
+    assert found[0].dialect == HARNESS_CURSOR
+    assert found[0].project == "Users-alice-work-app"
+
+
+def test_cursor_incremental_reply_inherits_earlier_timestamp(tmp_path):
+    """The load-bearing incremental case: a window that opens AFTER the
+    user turn (cursor already past it) must still stamp replies with the
+    earlier <timestamp>, not fall back to file mtime."""
+    session_dir = tmp_path / "proj" / "agent-transcripts" / "abcd1234-9db8-4e39"
+    session_dir.mkdir(parents=True)
+    path = session_dir / "abcd1234-9db8-4e39.jsonl"
+    lines = [USER_LINE, REPLY_LINE, REPLY_LINE]  # user@0, replies@1,2
+    path.write_text("".join(json.dumps(line) + "\n" for line in lines), encoding="utf-8")
+    # Resume from cursor=2: L0 (the only timestamp-bearing line) is skipped
+    # for emission but must still update timestamp state.
+    scan = scan_events(path, start_line=2, project="proj", max_event_chars=4000, dialect="cursor")
+    assert len(scan.events) == 1
+    assert scan.events[0].kind == "reply"
+    assert scan.events[0].ts == "2026-07-21T13:11:00+03:00"  # inherited, NOT mtime
+
+
+def test_transcript_from_path_requires_uuid_session_dir(tmp_path):
+    """A non-UUID dir under 'agent-transcripts' must NOT be classified as
+    Cursor — the layout coincidence alone is not enough."""
+    d = tmp_path / "proj" / "agent-transcripts" / "not-a-uuid"
+    d.mkdir(parents=True)
+    p = d / "file.jsonl"
+    p.write_text("", encoding="utf-8")
+    inferred = transcript_from_path(p)
+    assert inferred.dialect == "claude-code"
+
+
+def test_transcript_from_path_infers_harness(tmp_path):
+    cursor_path = _write_session(tmp_path)
+    inferred = transcript_from_path(cursor_path)
+    assert inferred.dialect == HARNESS_CURSOR
+    assert inferred.project == "Users-alice-work-app"
+
+    cc_dir = tmp_path / "-Users-alice-work-app"
+    cc_dir.mkdir()
+    cc_path = cc_dir / "0000.jsonl"
+    cc_path.write_text("", encoding="utf-8")
+    inferred_cc = transcript_from_path(cc_path)
+    assert inferred_cc.dialect == "claude-code"
+    assert inferred_cc.project == "-Users-alice-work-app"
+
+
+def test_node_id_namespaced_per_harness(tmp_path):
+    path = _write_session(tmp_path)
+    assert node_id_for("abc123def456", path, "cursor") == "cursor:abc123def456:fad15427-9db8-4e39"
+    assert node_id_for("abc123def456", path) == "cc:abc123def456:fad15427-9db8-4e39"
+
+
+def test_invalid_harness_env_fails_loudly(monkeypatch, capsys):
+    """A bad MEMCLAW_INTERVIEWER_HARNESS (choices= doesn't validate env
+    defaults) must exit 2 with guidance, not silently run as claude-code."""
+    import pytest
+
+    from memclaw_client.interviewer.cli import main
+
+    monkeypatch.setenv("MEMCLAW_INTERVIEWER_HARNESS", "Cursor")  # wrong case
+    with pytest.raises(SystemExit) as exc:
+        main(["run", "--all-projects", "--api-key", "k", "--tenant-id", "t"])
+    assert exc.value.code == 2
+    assert "Invalid harness 'Cursor'" in capsys.readouterr().err
+
+
+def test_invalid_harness_env_never_breaks_hook(tmp_path, monkeypatch):
+    """The harness guard must NOT fire for `hook`: it exits 2, and hook has
+    an ALWAYS-exit-0 contract (and ignores --harness, inferring from path)."""
+    import io
+
+    from memclaw_client.interviewer.cli import main
+
+    path = _write_session(tmp_path)
+    payload = json.dumps({"transcript_path": str(path), "hook_event_name": "sessionEnd"})
+    monkeypatch.setenv("MEMCLAW_INTERVIEWER_HARNESS", "GARBAGE")
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    rc = main(["hook", "--projects", "Users-alice-*", "--api-key", "k", "--tenant-id", "t"])
+    assert rc == 0  # bad env or not, the hook never fails the session
+
+
+def test_cursor_hook_autodetects_and_respects_allowlist(tmp_path, monkeypatch, capsys):
+    """The hook must resolve a Cursor transcript's PROJECT (three levels
+    up), not its session dir — and still gate on the allowlist."""
+    import io
+
+    from memclaw_client.interviewer.cli import main
+
+    path = _write_session(tmp_path)
+    payload = json.dumps({"transcript_path": str(path), "hook_event_name": "sessionEnd"})
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    rc = main(["hook", "--projects", "other-*", "--api-key", "k", "--tenant-id", "t"])
+    assert rc == 0  # hook never fails the session
+    err = capsys.readouterr().err
+    # Correct project name in the warning proves cursor-shape inference.
+    assert "Users-alice-work-app" in err and "not in allowlist" in err


### PR DESCRIPTION
## What

Extends the `memclaw-interviewer` disk-parser adapter (#581) to **Cursor** workstations. Client-only; zero server changes; version → 0.3.0.

## Substrate choice (grounded 2026-07-21)

Cursor has three conversation stores; this adapter rides the **JSONL agent-transcripts** (`~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl`) — the layer Cursor's changelog persists *"for tooling and hooks"* and calls *"Claude Code-compatible JSONL"*. The IDE `state.vscdb` (undocumented, has broken community parsers ~2×/year) and the CLI `store.db` (drifting to opaque protobuf) are deliberately out of scope.

## Dialect (verified against real transcripts on disk)

- `{role, message}` lines, no meta envelope; roleless `turn_ended` status lines consumed as noise
- user text unwrapped from `<timestamp>`/`<user_query>` tags; timestamp parsed to ISO 8601 and inherited by replies (assistant lines carry none; mtime fallback)
- trailing `[REDACTED]` thinking markers stripped; thinking-only turns fall under the 60-char floor
- **no tool_result lines exist** — tool outputs excluded upstream by Cursor

## Reuse

Scan mechanics, windowing, watermark protocol, scrub, machine identity, and the failure matrix are shared unchanged. New: `--harness {claude-code,cursor}` (env `MEMCLAW_INTERVIEWER_HARNESS`), Cursor discovery layout (subagents excluded by construction), `cursor:`-namespaced node ids, and harness auto-inference from `transcript_path` shape so **one hook command serves both** Claude Code `SessionEnd` and Cursor `sessionEnd`.

## Verification

- 65 unit tests (9 new, fixtures mirror a real transcript), ruff clean
- Real-disk dry-run: correct window `[0..10]`, zero tag/redaction/tool leakage
- Live dogfood vs local stack: window committed, watermark `cursor:<machine12>:<stem>` at `last_seq=10`, typed memory written, idempotent rerun skips via cheap line-count
- Hook wet test: Cursor-shaped stdin payload drains the file, exit 0 on every path, allowlist warn names the correct project (3 levels up)

## Known accepted risks

- Transcripts are append-only only since the 2026-06-29 Cursor CLI release; `--resume` can rewrite a file. The existing shrink guard skips-with-warning; same-length rewrites past the watermark are accepted (as with CC torn-tails).
- Transcripts can be disabled in Cursor (`transcript_path: null`) — the hook exits 0 silently; docs to note enabling them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)