### PR TITLE
fix(logging): correlate structlog output with Datadog APM traces

### DIFF
--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -38,6 +38,16 @@ from typing import Any
 
 import structlog
 
+# ddtrace is an optional dependency — only the `datadog` extra (SaaS + APM
+# builds) installs it. Import it guarded so OSS / on-prem / local, which never
+# install it, keep importing this module. `_add_dd_trace_context` no-ops when
+# this is None. Top-level (not a deferred import) so the name is patchable in
+# tests and the dependency is visible at module scope.
+try:
+    from ddtrace import tracer as _dd_tracer
+except ImportError:  # pragma: no cover - exercised only in non-datadog installs
+    _dd_tracer = None
+
 # structlog's log-level method names → GCP Cloud Logging's severity enum.
 # Severities beyond ERROR (CRITICAL/ALERT/EMERGENCY) aren't emitted by the
 # standard log-level methods; use `logger.critical(...)` for CRITICAL, or
@@ -275,6 +285,39 @@ def _drop_level_field(
     return event_dict
 
 
+def _add_dd_trace_context(
+    _logger: Any,
+    _method_name: str,
+    event_dict: dict[str, Any],
+) -> dict[str, Any]:
+    """Inject Datadog trace/span IDs so logs correlate to APM traces.
+
+    ddtrace's built-in injection (``DD_LOGS_INJECTION``) patches the stdlib
+    ``logging.LogRecord`` only; this pipeline uses ``PrintLoggerFactory`` and
+    bypasses stdlib entirely, so injection never fires and Datadog can't link a
+    log line to its trace. Read the active span directly via ddtrace's public
+    helper instead — its keys are already ``dd.trace_id`` / ``dd.span_id``.
+
+    No-op when ddtrace isn't installed (OSS / on-prem) or no span is active
+    (``dd.trace_id`` == "0"), so ambient logs stay clean. Lives in
+    ``_base_processors`` so it runs on both the native and stdlib-bridge chains.
+    """
+    if _dd_tracer is None:
+        return event_dict
+    ctx = _dd_tracer.get_log_correlation_context()
+    # "0" is ddtrace's sentinel for "no active span". Read both keys defensively
+    # (.get) and require both present and non-zero: never stamp a log with a
+    # trace ID but no span ID (Datadog can't correlate that), and never KeyError
+    # out of the processor if a future ddtrace — or a test double — returns a
+    # partial context.
+    trace_id = ctx.get("dd.trace_id", "0")
+    span_id = ctx.get("dd.span_id", "0")
+    if trace_id != "0" and span_id != "0":
+        event_dict["dd.trace_id"] = trace_id
+        event_dict["dd.span_id"] = span_id
+    return event_dict
+
+
 # Processors shared by both the structlog-native chain and the stdlib bridge —
 # extracted so adding a new cross-cutting processor (e.g. request-id injection)
 # only needs a single edit.
@@ -283,6 +326,10 @@ def _base_processors() -> list[Any]:
         # merge_contextvars first so a context-bound `level` can't clobber
         # the one add_log_level derives from the real call site.
         structlog.contextvars.merge_contextvars,
+        # Datadog trace/span IDs for log↔trace correlation. Placed right after
+        # contextvars so the IDs are present for every downstream renderer;
+        # no-ops without ddtrace installed or an active span.
+        _add_dd_trace_context,
         # add_log_level populates `level`, needed by stdlib records (which
         # don't have `method_name`) and kept on the native side for shape
         # consistency across the two pipelines.

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -7,9 +7,11 @@ import logging
 
 import pytest
 
+import common.structlog_config as structlog_config
 from common.structlog_config import (
     _THIRD_PARTY_LOGGERS_TO_REROUTE,
     _add_datadog_status,
+    _add_dd_trace_context,
     _map_to_gcp_severity,
     _rename_event_to_message,
     _reset_for_testing,
@@ -124,6 +126,72 @@ def test_add_datadog_status_falsy_severity_uses_method_level() -> None:
     for value in values:
         result = _add_datadog_status(None, "error", {"event": "x", "severity": value})
         assert result["status"] == "error"
+
+
+class _FakeTracer:
+    """Stand-in for ddtrace's tracer exposing get_log_correlation_context()."""
+
+    def __init__(self, ctx: dict[str, str]) -> None:
+        self._ctx = ctx
+
+    def get_log_correlation_context(self) -> dict[str, str]:
+        return self._ctx
+
+
+def test_add_dd_trace_context_noop_without_ddtrace(monkeypatch) -> None:
+    # OSS / on-prem: ddtrace isn't installed, so the guarded import left the
+    # module-level tracer None. The processor must pass the event dict through
+    # untouched — no dd.* keys, no crash.
+    monkeypatch.setattr(structlog_config, "_dd_tracer", None)
+    event_dict = {"event": "hello"}
+    result = _add_dd_trace_context(None, "info", event_dict)
+    assert result == {"event": "hello"}
+
+
+def test_add_dd_trace_context_injects_ids_for_active_span(monkeypatch) -> None:
+    monkeypatch.setattr(
+        structlog_config,
+        "_dd_tracer",
+        _FakeTracer(
+            {
+                "dd.trace_id": "6a5fc7b3000000006d13f630a5c9fb22",
+                "dd.span_id": "12914032455535133506",
+                "dd.service": "core-api",
+                "dd.version": "",
+                "dd.env": "production",
+            }
+        ),
+    )
+    result = _add_dd_trace_context(None, "info", {"event": "x"})
+    assert result["dd.trace_id"] == "6a5fc7b3000000006d13f630a5c9fb22"
+    assert result["dd.span_id"] == "12914032455535133506"
+
+
+def test_add_dd_trace_context_skips_when_no_active_span(monkeypatch) -> None:
+    # ddtrace returns trace_id "0" when no span is active; the processor must
+    # NOT stamp ambient (non-request) logs with a null trace.
+    monkeypatch.setattr(
+        structlog_config,
+        "_dd_tracer",
+        _FakeTracer({"dd.trace_id": "0", "dd.span_id": "0"}),
+    )
+    result = _add_dd_trace_context(None, "info", {"event": "x"})
+    assert "dd.trace_id" not in result
+    assert "dd.span_id" not in result
+
+
+def test_add_dd_trace_context_skips_partial_context(monkeypatch) -> None:
+    # Defensive: a partial context (trace_id present, span_id missing/zero — a
+    # future ddtrace shape or a test double) must not KeyError or emit an
+    # uncorrelatable trace-without-span.
+    monkeypatch.setattr(
+        structlog_config,
+        "_dd_tracer",
+        _FakeTracer({"dd.trace_id": "6a5fc7b3000000006d13f630a5c9fb22"}),
+    )
+    result = _add_dd_trace_context(None, "info", {"event": "x"})
+    assert "dd.trace_id" not in result
+    assert "dd.span_id" not in result
 
 
 def test_rename_event_to_message_moves_field() -> None:


### PR DESCRIPTION
## Problem

`DD_LOGS_INJECTION=true` is set on the deployed services, but ddtrace's log injection patches the **stdlib** `logging.LogRecord` only. Our structlog pipeline uses `PrintLoggerFactory` (writes straight to stdout, bypassing stdlib), so injection never fires — `dd.trace_id` / `dd.span_id` never reach the emitted JSON, and Datadog can't correlate a log line to its APM trace. Surfaced during the caura-test-automation APM review (caura-test-automation#208) and deferred there as a pre-existing, fleet-wide issue.

## Fix

Add a `_add_dd_trace_context` structlog processor that reads the active span directly via ddtrace's public `tracer.get_log_correlation_context()` helper (verified against ddtrace 4.11.1 — its keys are already `dd.trace_id`/`dd.span_id`) and injects the IDs into the event dict. Placed in `_base_processors()` right after `merge_contextvars`, so it runs on **both** the native structlog chain and the stdlib-bridge `foreign_pre_chain`.

- **Guarded import:** `ddtrace` is the optional `datadog` extra, so it's imported `try/except ImportError` at module top; the processor no-ops when absent (OSS / on-prem / local) — those imports and log calls are unaffected.
- **No-op without an active span** (`trace_id == "0"`), so ambient (non-request) logs aren't stamped with a null trace.
- `DD_LOGS_INJECTION` stays `true` — it still covers third-party libs that log via stdlib directly.

## Tests
Three new cases in `tests/test_logging.py` (no ddtrace → no-op; active span → IDs injected; no active span → skipped). Full file: **35 passed** locally. `ruff format --check --isolated` (the vendored-file gate) passes.

## Rollout
- This file is **vendored `policy=identical`** into `caura-memclaw-enterprise` — the re-vendor bot syncs it after merge (no manual enterprise PR).
- `caura-ops` and `caura-test-automation` carry their own copies of this config; they get the same fix in their own repos (separate PRs).
- **Verify after deploy:** a log line emitted inside a traced request should show `dd.trace_id` matching the trace in APM. If Datadog doesn't auto-link, the remaining step is a Trace ID Remapper on the log pipeline (DD-side config, not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)