### PR TITLE
fix(logging): make dd trace-context processor resilient to tracer errors

### DIFF
--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -304,7 +304,15 @@ def _add_dd_trace_context(
     """
     if _dd_tracer is None:
         return event_dict
-    ctx = _dd_tracer.get_log_correlation_context()
+    # This processor runs on EVERY log call. ddtrace's helper is safe in normal
+    # operation, but a tracer-side raise (shutdown, forked-process re-init, an
+    # internal ddtrace bug) must never propagate out of the logging chain — it
+    # would drop the log line (or surface as a 500 in FastAPI), masking the very
+    # error worth seeing. Fail open to an un-annotated log.
+    try:
+        ctx = _dd_tracer.get_log_correlation_context()
+    except Exception:
+        return event_dict
     # "0" is ddtrace's sentinel for "no active span". Read both keys defensively
     # (.get) and require both present and non-zero: never stamp a log with a
     # trace ID but no span ID (Datadog can't correlate that), and never KeyError

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -194,6 +194,19 @@ def test_add_dd_trace_context_skips_partial_context(monkeypatch) -> None:
     assert "dd.span_id" not in result
 
 
+def test_add_dd_trace_context_fails_open_when_tracer_raises(monkeypatch) -> None:
+    # This processor runs on every log call; a tracer-side raise (shutdown,
+    # forked process, ddtrace bug) must never break the logging chain — the
+    # event dict passes through untouched rather than dropping the log line.
+    class _RaisingTracer:
+        def get_log_correlation_context(self) -> dict[str, str]:
+            raise RuntimeError("tracer unavailable")
+
+    monkeypatch.setattr(structlog_config, "_dd_tracer", _RaisingTracer())
+    result = _add_dd_trace_context(None, "info", {"event": "x"})
+    assert result == {"event": "x"}
+
+
 def test_rename_event_to_message_moves_field() -> None:
     result = _rename_event_to_message(
         None, "info", {"event": "hello world", "extra": 1}


### PR DESCRIPTION
Follow-up hardening to #614 (flagged on the enterprise re-vendor #843 review).

**What:** wrap `_dd_tracer.get_log_correlation_context()` in `try/except` inside `_add_dd_trace_context`, failing open to an un-annotated log.

**Why:** this processor runs on **every** log call via `_base_processors()`. ddtrace's helper is safe in normal operation, but a tracer-side raise (shutdown, forked-process re-init, internal ddtrace bug) would otherwise propagate out of the structlog chain — dropping the log line (or surfacing as a 500 in FastAPI), masking the very error worth seeing. Logging infra must be resilient.

Adds a test with a raising-tracer double. `ruff format --check --isolated` + 37 tests green. Re-vendors to enterprise on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)