### PR TITLE
chore(search): rename raw_fts -> raw_keyword_rank for clarity

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1129,8 +1129,8 @@ class PostgresService:
         has_embedding = Memory.embedding.is_not(None).label("has_embedding")
 
         ts_query = func.plainto_tsquery("english", query)
-        raw_fts = func.ts_rank_cd(Memory.search_vector, ts_query)
-        fts_score = (raw_fts / (1.0 + raw_fts)).label("fts_score")
+        raw_keyword_rank = func.ts_rank_cd(Memory.search_vector, ts_query)
+        fts_score = (raw_keyword_rank / (1.0 + raw_keyword_rank)).label("fts_score")
 
         # CAURA-679: NULL-embedding rows fall back to `fts_score` alone
         # rather than the `(1 - w) * 0 + w * fts_score` haircut that


### PR DESCRIPTION
## What
Rename the local variable `raw_fts` → `raw_keyword_rank` in `memory_scored_search` (core-storage-api `postgres_service.py`).

## Why
`raw_fts` is the raw, unbounded `ts_rank_cd` cover-density keyword rank *before* it's squashed to `[0,1)` as `fts_score`. The new name says what it is.

## Scope
- Local variable only (2 lines); the built-in `ts_rank_cd(...)` call is untouched.
- **No behaviour change**, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)