### PR TITLE
fix(core-api): bulk write reports oversized items per-item (207), not whole-batch 422

### DIFF
--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -69,8 +69,22 @@ class BulkMemoryItem(BaseModel):
     """Single item in a bulk write request. tenant_id/fleet_id/agent_id inherited from parent."""
 
     memory_type: MemoryType | None = Field(default=None, description=MEMORY_TYPES_WRITE_DESCRIPTION)
-    content: str = Field(min_length=1, max_length=MAX_CONTENT_LENGTH)
-    weight: float | None = Field(default=None, ge=0.0, le=1.0)
+    # Additive-tolerance policy (broker↔cloud API-versioning RFC): a bulk write
+    # must NOT 422 the whole batch because one item has a bad field — the valid
+    # items must still be written. So schema-level constraints that would reject
+    # the ENTIRE request are deliberately dropped here (unlike single-write
+    # ``MemoryCreate`` / ``MemoryUpdate``, which keep them) and re-enforced PER
+    # ITEM in ``create_memories_bulk`` as a ``status="error"`` 207 row:
+    #   - content length → short_content_errors
+    #     (``< CRYSTALLIZER_SHORT_CONTENT_CHARS`` = 10, subsumes the old
+    #     ``min_length=1``) + oversized_content_errors (``> MAX_CONTENT_LENGTH``).
+    #   - weight range [0.0, 1.0] → weight_errors.
+    #   - status enum → status_errors.
+    # ``memory_type`` still uses its typed enum below (an invalid value 422s the
+    # whole batch); making it per-item needs an enum→str change with downstream
+    # impact, tracked as a follow-up.
+    content: str
+    weight: float | None = Field(default=None)
     source_uri: str | None = None
     run_id: str | None = None
     metadata: dict | None = None
@@ -82,7 +96,7 @@ class BulkMemoryItem(BaseModel):
     ts_valid_start: datetime | None = None
     ts_valid_end: datetime | None = None
     reference_datetime: datetime | None = None
-    status: str | None = Field(default=None, pattern=MEMORY_STATUSES_PATTERN)
+    status: str | None = Field(default=None)  # validated per-item (status_errors); see note above
 
 
 class BulkMemoryCreate(BaseModel):

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -58,6 +58,8 @@ from core_api.constants import (
     GRAPH_HOP_BOOST,
     GRAPH_MAX_BOOSTED_MEMORIES,
     GRAPH_MAX_HOPS,
+    MAX_CONTENT_LENGTH,
+    MEMORY_STATUSES,
     MIN_SEARCH_SIMILARITY,
     OPENAI_EMBEDDING_MODEL,
     RECALL_BOOST_CAP,
@@ -1083,15 +1085,51 @@ async def create_memories_bulk(
         if len(item.content.strip()) < CRYSTALLIZER_SHORT_CONTENT_CHARS
     }
 
+    # -- Per-item validation. Oversized content (over ``MAX_CONTENT_LENGTH``)
+    # used to 422 the whole batch via ``BulkMemoryItem.content``'s schema
+    # ``max_length``; that constraint was removed (see schemas.py) so a single
+    # oversized item no longer rejects its valid siblings. Enforce the cap here
+    # as a per-item "error" instead — additive-tolerant, matching the
+    # short-content path exactly. Length is measured on the raw string (not
+    # ``.strip()``d), preserving the old schema-``max_length`` semantics.
+    oversized_content_errors: dict[int, str] = {
+        i: f"content exceeds maximum length of {MAX_CONTENT_LENGTH} characters"
+        for i, item in enumerate(items)
+        if i not in short_content_errors and len(item.content) > MAX_CONTENT_LENGTH
+    }
+
+    # weight out of [0.0, 1.0] and unknown status used to 422 the whole batch via
+    # BulkMemoryItem's schema Field constraints (ge/le, pattern); those were
+    # removed (see schemas.py) so one bad field no longer rejects valid siblings.
+    # Enforce per-item here, preserving the old bounds exactly. (memory_type is
+    # still a typed enum on the schema — a follow-up.)
+    weight_errors: dict[int, str] = {
+        i: "weight must be between 0.0 and 1.0"
+        for i, item in enumerate(items)
+        if item.weight is not None and not (0.0 <= item.weight <= 1.0)
+    }
+    status_errors: dict[int, str] = {
+        i: f"status must be one of: {', '.join(sorted(MEMORY_STATUSES))}"
+        for i, item in enumerate(items)
+        if item.status is not None and item.status not in MEMORY_STATUSES
+    }
+
     # -- Resolve per-tenant config once --
     from core_api.services.organization_settings import resolve_config
 
     tenant_config = await resolve_config(data.tenant_id)
 
     # -- Batch embeddings + parallel enrichment (valid items only). Short
-    # items are skipped so we don't spend provider budget on content
-    # that will surface as an error anyway.
-    valid_indices = [i for i in range(n) if i not in short_content_errors]
+    # and oversized items are skipped so we don't spend provider budget on
+    # content that will surface as an error anyway.
+    valid_indices = [
+        i
+        for i in range(n)
+        if i not in short_content_errors
+        and i not in oversized_content_errors
+        and i not in weight_errors
+        and i not in status_errors
+    ]
 
     # -- Deterministic governance gate (eToro). Runs BEFORE embeddings +
     # content-hash so masked content flows through dedup + storage, and dropped
@@ -1227,14 +1265,28 @@ async def create_memories_bulk(
         # request body — same body + same attempt id ⇒ same per-item id.
         item_request_id = f"{bulk_attempt_id}:{i}"
 
-        # Short-content items surface as per-item errors; never embedded,
-        # enriched, deduped, or written.
-        if i in short_content_errors:
+        # Input-validation errors surface as per-item error rows (never embedded,
+        # enriched, deduped, or written — they're excluded from valid_indices):
+        # content length (short/oversized), weight range, status enum. These were
+        # all whole-batch 422s at the schema before the additive-tolerance work.
+        # ALL applicable messages for the item are aggregated into one row so a
+        # caller sees every problem at once rather than one per round-trip.
+        item_errors = [
+            errs[i]
+            for errs in (
+                short_content_errors,
+                oversized_content_errors,
+                weight_errors,
+                status_errors,
+            )
+            if i in errs
+        ]
+        if item_errors:
             results[i] = BulkItemResult(
                 index=i,
                 client_request_id=item_request_id,
                 status="error",
-                error=short_content_errors[i],
+                error="; ".join(item_errors),
             )
             error_count += 1
             continue

--- a/tests/test_bulk_atomicity.py
+++ b/tests/test_bulk_atomicity.py
@@ -23,6 +23,7 @@ import time
 
 import pytest
 
+from core_api.constants import MAX_CONTENT_LENGTH
 from tests.conftest import get_test_auth, uid
 
 pytestmark = pytest.mark.asyncio
@@ -93,6 +94,184 @@ async def test_all_short_content_batch_returns_200(client):
     assert data["errors"] == 3
     assert data["duplicates"] == 0
     assert all(r["status"] == "error" for r in data["results"])
+
+
+async def test_oversized_content_in_mixed_batch_returns_207(client):
+    """One item whose ``content`` exceeds ``MAX_CONTENT_LENGTH`` must NOT
+    422 the whole batch (the pre-fix behaviour, caused by the schema-level
+    ``max_length`` on ``BulkMemoryItem.content``). Instead the valid items
+    are written and the oversized item surfaces as a per-item
+    ``status="error"`` — same additive-tolerant contract as short-content.
+    """
+    tenant_id, headers = get_test_auth()
+    oversized = "x" * (MAX_CONTENT_LENGTH + 1)
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"oversized-{uid()}",
+        "items": [
+            {"content": f"well-formed content one {uid()}"},
+            {"content": oversized},  # over MAX_CONTENT_LENGTH
+            {"content": f"well-formed content two {uid()}"},
+        ],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("oversized")},
+    )
+    # 207 Multi-Status: two created + one error — NOT a whole-batch 422.
+    assert resp.status_code == 207
+    data = resp.json()
+    assert data["created"] == 2
+    assert data["errors"] == 1
+    assert data["duplicates"] == 0
+
+    by_index = {r["index"]: r for r in data["results"]}
+    assert by_index[0]["status"] == "created"
+    assert by_index[0]["id"]
+    assert by_index[1]["status"] == "error"
+    assert "exceeds" in by_index[1]["error"]
+    assert str(MAX_CONTENT_LENGTH) in by_index[1]["error"]
+    # The oversized item was never written — no id on the error row.
+    assert by_index[1]["id"] is None
+    assert by_index[2]["status"] == "created"
+    assert by_index[2]["id"]
+    # Server-derived per-item attempt id is present on every row.
+    for r in data["results"]:
+        assert r["client_request_id"]
+        assert r["client_request_id"].endswith(f":{r['index']}")
+
+
+async def test_all_valid_batch_returns_200(client):
+    """An all-valid batch (including an item at exactly ``MAX_CONTENT_LENGTH``,
+    the boundary) still returns 200 with every item ``created`` — the fix
+    doesn't perturb the happy path."""
+    tenant_id, headers = get_test_auth()
+    # Exactly MAX_CONTENT_LENGTH chars: (MAX-9) filler + "-" + 8-char uid.
+    at_cap = ("y" * (MAX_CONTENT_LENGTH - 9)) + f"-{uid()}"
+    assert len(at_cap) == MAX_CONTENT_LENGTH
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"all-valid-{uid()}",
+        "items": [
+            {"content": f"valid alpha {uid()}"},
+            {"content": at_cap},
+            {"content": f"valid gamma {uid()}"},
+        ],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("all-valid")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["created"] == 3
+    assert data["errors"] == 0
+    assert data["duplicates"] == 0
+    assert all(r["status"] == "created" and r["id"] for r in data["results"])
+
+
+async def test_empty_content_in_mixed_batch_returns_207(client):
+    """An empty-content item must NOT 422 the whole batch either. Dropping the
+    schema-level ``min_length=1`` from ``BulkMemoryItem.content`` lets an empty
+    item reach the per-item short-content check (``< CRYSTALLIZER_SHORT_CONTENT_CHARS``
+    = 10, which subsumes empty), so it surfaces as a per-item ``status="error"``
+    while valid siblings are written — the same additive-tolerant contract as
+    oversized content, closing the empty-vs-oversized asymmetry."""
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"empty-{uid()}",
+        "items": [
+            {"content": f"well-formed content one {uid()}"},
+            {"content": ""},  # empty — previously 422'd the entire batch
+            {"content": f"well-formed content two {uid()}"},
+        ],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("empty")},
+    )
+    # 207 Multi-Status: two created + one error — NOT a whole-batch 422.
+    assert resp.status_code == 207
+    data = resp.json()
+    assert data["created"] == 2
+    assert data["errors"] == 1
+    assert data["duplicates"] == 0
+
+    by_index = {r["index"]: r for r in data["results"]}
+    assert by_index[0]["status"] == "created" and by_index[0]["id"]
+    assert by_index[1]["status"] == "error"
+    # The empty item was never written — no id on the error row.
+    assert by_index[1]["id"] is None
+    assert by_index[2]["status"] == "created" and by_index[2]["id"]
+
+
+async def test_bad_weight_and_status_in_mixed_batch_return_207(client):
+    """Out-of-range ``weight`` and an unknown ``status`` must each surface as a
+    per-item error, not a whole-batch 422: those schema-level ``Field``
+    constraints (``ge``/``le``, ``pattern``) were moved to per-item checks in
+    ``create_memories_bulk`` for additive-tolerance, like content. Valid
+    siblings are still written. (``memory_type`` is deferred — still a typed
+    enum on the schema.)"""
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"badfields-{uid()}",
+        "items": [
+            {"content": f"valid one {uid()}"},
+            {"content": f"bad weight {uid()}", "weight": 1.5},  # > 1.0
+            {"content": f"bad status {uid()}", "status": "nonsense"},  # not a lifecycle status
+            {"content": f"valid two {uid()}"},
+        ],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("badfields")},
+    )
+    assert resp.status_code == 207
+    data = resp.json()
+    assert data["created"] == 2
+    assert data["errors"] == 2
+    by_index = {r["index"]: r for r in data["results"]}
+    assert by_index[0]["status"] == "created" and by_index[0]["id"]
+    assert by_index[1]["status"] == "error" and by_index[1]["id"] is None
+    assert "weight" in by_index[1]["error"]
+    assert by_index[2]["status"] == "error" and by_index[2]["id"] is None
+    assert "status" in by_index[2]["error"]
+    assert by_index[3]["status"] == "created" and by_index[3]["id"]
+
+
+async def test_item_failing_multiple_validations_aggregates_errors(client):
+    """An item violating several constraints at once surfaces ONE per-item error
+    row listing all of them (not just the first), so a caller can fix everything
+    in a single round-trip rather than discovering problems one at a time."""
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"multi-{uid()}",
+        "items": [
+            {"content": f"valid {uid()}"},
+            {"content": f"both bad {uid()}", "weight": 1.5, "status": "nonsense"},
+        ],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("multi")},
+    )
+    assert resp.status_code == 207
+    data = resp.json()
+    assert data["created"] == 1
+    assert data["errors"] == 1
+    err = {r["index"]: r for r in data["results"]}[1]
+    assert err["status"] == "error" and err["id"] is None
+    # Both problems reported in the single aggregated message.
+    assert "weight" in err["error"]
+    assert "status" in err["error"]
 
 
 # ── X-Bulk-Attempt-Id contract ──

--- a/tests/test_bulk_write.py
+++ b/tests/test_bulk_write.py
@@ -16,12 +16,18 @@ from uuid import uuid4
 
 import pytest
 
-from core_api.constants import BULK_MAX_ITEMS, DEFAULT_MEMORY_WEIGHT, VECTOR_DIM
+from core_api.constants import (
+    BULK_MAX_ITEMS,
+    DEFAULT_MEMORY_WEIGHT,
+    MAX_CONTENT_LENGTH,
+    VECTOR_DIM,
+)
 from core_api.schemas import (
     BulkItemResult,
     BulkMemoryCreate,
     BulkMemoryItem,
     BulkMemoryResponse,
+    MemoryCreate,
 )
 from common.embedding import fake_embedding
 
@@ -81,10 +87,46 @@ class TestBulkSchemaValidation:
         req = _make_bulk_request(1)
         assert len(req.items) == 1
 
-    def test_item_content_validation(self):
-        """Empty content should be rejected."""
+    def test_empty_content_accepted_at_schema(self):
+        """Empty bulk-item content must parse WITHOUT raising: ``min_length``
+        was removed from ``BulkMemoryItem.content`` (alongside ``max_length``)
+        so an empty item no longer 422s the whole batch. Empty/whitespace/short
+        content is enforced per-item in ``create_memories_bulk`` via the
+        short-content check (< ``CRYSTALLIZER_SHORT_CONTENT_CHARS`` = 10, which
+        subsumes empty), surfaced as a 207 per-item error — consistent with the
+        oversized path below."""
+        item = BulkMemoryItem(content="")
+        assert item.content == ""
+
+    def test_oversized_content_accepted_at_schema(self):
+        """Oversized bulk-item content must parse WITHOUT raising: the
+        ``max_length`` constraint was removed from ``BulkMemoryItem.content``
+        so one oversized item no longer 422s the whole batch. The
+        ``MAX_CONTENT_LENGTH`` cap is enforced per-item in
+        ``create_memories_bulk`` (surfaced as a 207 per-item error), not at
+        the schema layer."""
+        item = BulkMemoryItem(content="x" * (MAX_CONTENT_LENGTH + 1))
+        assert len(item.content) == MAX_CONTENT_LENGTH + 1
+
+    def test_single_write_schema_still_caps_content(self):
+        """Scope guard: the per-item relaxation is bulk-only. ``MemoryCreate``
+        (single-write) must still reject oversized content at the schema
+        layer — this fix must not have touched it."""
         with pytest.raises(Exception):
-            BulkMemoryItem(content="")
+            MemoryCreate(
+                tenant_id="t",
+                agent_id="a",
+                content="x" * (MAX_CONTENT_LENGTH + 1),
+            )
+
+    def test_out_of_range_weight_and_bad_status_accepted_at_schema(self):
+        """weight (ge/le) and status (pattern) Field constraints were removed
+        from ``BulkMemoryItem`` so a single bad value no longer 422s the batch;
+        they are enforced per-item in ``create_memories_bulk`` (207 error rows).
+        The schema must therefore parse them without raising."""
+        item = BulkMemoryItem(content="ok", weight=1.5, status="nonsense")
+        assert item.weight == 1.5
+        assert item.status == "nonsense"
 
     def test_item_inherits_no_tenant(self):
         """BulkMemoryItem should not have tenant_id field."""
@@ -110,16 +152,18 @@ class TestBulkSchemaValidation:
         assert item.weight == 0.8
 
     def test_invalid_memory_type_rejected(self):
+        # memory_type is deliberately still a typed enum on BulkMemoryItem — the
+        # per-item relaxation (content/weight/status) did NOT extend to it, since
+        # making it per-item needs an enum→str change with downstream impact
+        # (tracked as a follow-up). So an invalid value still raises at the schema.
         with pytest.raises(Exception):
             BulkMemoryItem(content="test", memory_type="invalid_type")
 
-    def test_invalid_status_rejected(self):
-        with pytest.raises(Exception):
-            BulkMemoryItem(content="test", status="invalid_status")
-
-    def test_weight_out_of_range_rejected(self):
-        with pytest.raises(Exception):
-            BulkMemoryItem(content="test", weight=1.5)
+    # Bad ``status`` and out-of-range ``weight`` are intentionally NOT rejected
+    # at the schema anymore — those constraints moved to per-item 207 errors in
+    # create_memories_bulk. Covered by
+    # test_out_of_range_weight_and_bad_status_accepted_at_schema (above) and, for
+    # the batch behavior, test_bad_weight_and_status_in_mixed_batch_return_207.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Make the core-api bulk memory-write endpoint (`POST /api/v1/memories/bulk`) report an oversized item as a **per-item `status="error"` (207 multi-status)** instead of rejecting the **entire batch with 422**.

## Why
`BulkMemoryItem.content` carried a schema-level `max_length=MAX_CONTENT_LENGTH` (10 000), so FastAPI validated the whole body before the handler ran and **one** oversized item 422'd **all** items. The broker↔cloud API-versioning RFC (`docs/design/broker-cloud-api-versioning.md`, enterprise repo) requires this to be additive-tolerant: valid items must still be written, the oversized one surfaced as a typed per-item error.

## Change
- Remove `max_length` from `BulkMemoryItem.content` **only** (`MemoryCreate.content` and `MemoryUpdate.content` keep it — single-write still hard-rejects). `min_length=1` stays (an empty item is a malformed request, not a per-item business error).
- Enforce the cap per-item in `create_memories_bulk`: an oversized item is excluded from embed/enrich/dedup/write and recorded as `BulkItemResult(status="error", error="content exceeds maximum length of 10000 characters")` — the **same shape** as the existing short-content and governance-drop paths. `_bulk_response` then yields 207 for a mix, 200 for all-valid (unchanged). Length is measured on the raw string, matching the old `max_length` semantics.

## Tests
- Mixed batch (1 oversized + 2 valid) → `created=2, errors=1`, HTTP **207**, oversized row `status="error"` with `id=null`.
- All-valid batch (incl. one at exactly 10 000 chars) → HTTP **200**.
- Schema now accepts oversized bulk content; `MemoryCreate` still rejects it (scope guard).

`ruff check`, `ruff format --check`, `mypy` clean; bulk test modules + a regression sweep of every `create_memories_bulk` caller pass locally.

Gate C / Phase 0; **T0.2 core-api side** — complements the broker content cap ([memclawd #92](https://github.com/caura-ai/memclawd/pull/92)) and the gateway body limit (enterprise #888).
