### PR TITLE
ci(core-api): freeze v1 broker OpenAPI baseline + oasdiff gate (Gate C Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,51 @@ jobs:
           uv pip install -e core-storage-api/[dev] -e core-api/[dev]
           echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
 
+      # --- Broker↔cloud API-versioning gate (Gate C / Phase 1, deliverables A+B) ---
+      # core-api/openapi.broker.json is the FROZEN v1 contract for the four
+      # broker-facing gateway endpoints (POST /api/v1/memories/bulk,
+      # POST /api/v1/search, GET /api/v1/health, GET /api/v1/version) that
+      # memclawd calls against Caura cloud. It is a subset of the full ~91-path
+      # OpenAPI surface, with info normalized to the frozen contract version so
+      # it changes ONLY when a broker endpoint's shape changes. Regenerate with
+      # `python core-api/scripts/gen_broker_openapi.py` and commit the result;
+      # breaking changes require a deliberate contract bump per the RFC
+      # (see core-api/scripts/README.md).
+      - name: Broker OpenAPI baseline is current (freeze v1)
+        # Regenerates the broker-contract subset from the live app and fails if
+        # the committed baseline is stale vs the code on this branch.
+        run: uv run python core-api/scripts/gen_broker_openapi.py --check
+        env:
+          # core_api is installed editable above; `.` puts the repo root on the
+          # path for the `common` package (mirrors the test/migration steps).
+          PYTHONPATH: core-api/src:core-storage-api/src:.
+
+      - name: Broker OpenAPI has no breaking change vs main
+        # oasdiff compares main's committed baseline (base) against this branch's
+        # baseline (revision) and fails on any BREAKING change (removed path or
+        # param, new required request field, narrowed type, ...). oasdiff is
+        # pinned to the tufin/oasdiff Docker image by tag; `--fail-on ERR` is
+        # required for a non-zero exit on breaking changes. On the very first
+        # merge main has no baseline yet — the gate detects that and skips.
+        run: |
+          set -euo pipefail
+          # caura-memclaw is public, so anonymous fetch works even though
+          # actions/checkout ran with persist-credentials: false.
+          git fetch --no-tags --depth=1 origin main
+          if git cat-file -e origin/main:core-api/openapi.broker.json 2>/dev/null; then
+            work="$RUNNER_TEMP/oasdiff"
+            mkdir -p "$work"
+            git show origin/main:core-api/openapi.broker.json > "$work/base.json"
+            cp core-api/openapi.broker.json "$work/revision.json"
+            # Pinned by digest (not just the mutable :v1.26.0 tag) so a retagged
+            # image can't silently exit 0 and hollow out the gate.
+            docker run --rm -v "$work:/specs:ro" \
+              tufin/oasdiff:v1.26.0@sha256:95a3f551ebecb6fd0fed3ff0f078bba3d51b66b379c4ca811370652d7e4d0cef \
+              breaking /specs/base.json /specs/revision.json --fail-on ERR
+          else
+            echo "No broker baseline on main yet (first-merge bootstrap) — skipping breaking-change gate."
+          fi
+
       - name: Run Ruff linter (core-api)
         run: uv run ruff check core-api/src/
 

--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -1,0 +1,1101 @@
+{
+  "components": {
+    "schemas": {
+      "BulkItemResult": {
+        "description": "Per-item outcome of a bulk write (CAURA-602).\n\nStatus semantics:\n\n- ``\"created\"``: this attempt newly inserted the row; ``id`` is the\n  new row's id.\n- ``\"duplicate_attempt\"``: same ``X-Bulk-Attempt-Id``+index already\n  committed in a prior call. ``id`` is the canonical row from that\n  first attempt. Returned when a retry hits the per-item unique\n  constraint — what eliminates the silent-create class.\n- ``\"duplicate_content\"``: a different attempt's row with the same\n  ``content_hash`` already exists. ``id`` and ``duplicate_of`` both\n  point at the existing row; emitted in place of an insert.\n- ``\"error\"``: the row could not be processed (validation,\n  enrichment timeout, missing storage id). ``error`` describes.\n\nThe legacy ``\"duplicate\"`` status is gone — callers must read\n``duplicate_attempt`` vs ``duplicate_content`` because they imply\ndifferent client-side actions (an idempotent retry succeeded vs\n\"you already wrote this content earlier\").",
+        "properties": {
+          "client_request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Request Id"
+          },
+          "duplicate_of": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duplicate Of"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "index": {
+            "title": "Index",
+            "type": "integer"
+          },
+          "status": {
+            "enum": [
+              "created",
+              "duplicate_attempt",
+              "duplicate_content",
+              "error"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "index",
+          "status"
+        ],
+        "title": "BulkItemResult",
+        "type": "object"
+      },
+      "BulkMemoryCreate": {
+        "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "fleet_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fleet Id"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/BulkMemoryItem"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "title": "Items",
+            "type": "array"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "pattern": "^(scope_agent|scope_team|scope_org)$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Visibility"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "items"
+        ],
+        "title": "BulkMemoryCreate",
+        "type": "object"
+      },
+      "BulkMemoryItem": {
+        "description": "Single item in a bulk write request. tenant_id/fleet_id/agent_id inherited from parent.",
+        "properties": {
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "entity_links": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/EntityLinkIn"
+            },
+            "title": "Entity Links",
+            "type": "array"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "memory_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Memory type. Auto-classified by LLM if omitted. Valid values: fact, episode, decision, preference, task, intention, plan, commitment, action, cancellation.",
+            "title": "Memory Type"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "object_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Value"
+          },
+          "predicate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predicate"
+          },
+          "reference_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Datetime"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Id"
+          },
+          "source_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Uri"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "subject_entity_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject Entity Id"
+          },
+          "ts_valid_end": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ts Valid End"
+          },
+          "ts_valid_start": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ts Valid Start"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "title": "BulkMemoryItem",
+        "type": "object"
+      },
+      "BulkMemoryResponse": {
+        "description": "Aggregate response from the bulk-write endpoint.\n\n``duplicates`` rolls up both ``duplicate_attempt`` and\n``duplicate_content`` for top-level metric continuity; per-item\ndetail lives in ``results``. The route returns 200 when everything\nsucceeded and 207 Multi-Status when at least one item is in error —\ncallers must read per-item ``status`` and never infer success from\na 2xx alone.",
+        "properties": {
+          "bulk_ms": {
+            "title": "Bulk Ms",
+            "type": "integer"
+          },
+          "created": {
+            "title": "Created",
+            "type": "integer"
+          },
+          "duplicates": {
+            "title": "Duplicates",
+            "type": "integer"
+          },
+          "errors": {
+            "title": "Errors",
+            "type": "integer"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/BulkItemResult"
+            },
+            "title": "Results",
+            "type": "array"
+          }
+        },
+        "required": [
+          "created",
+          "duplicates",
+          "errors",
+          "results",
+          "bulk_ms"
+        ],
+        "title": "BulkMemoryResponse",
+        "type": "object"
+      },
+      "ContradictionInfo": {
+        "description": "Summary of a contradiction detected on write.\n\n``old_memory_id`` always refers to the **pre-existing candidate**\n(never to ``new_memory``), regardless of which row ended up being\nthe older one in the supersession chain. The ``direction`` field\ndisambiguates the two cases:\n\n  - ``\"canonical\"`` — the candidate is older than ``new_memory``;\n    the candidate became outdated/conflicted, ``new_memory``\n    carries ``supersedes_id`` pointing at it. (Historical behaviour.)\n  - ``\"flipped\"`` — the candidate is newer than ``new_memory``;\n    ``new_memory`` is the row that became outdated/conflicted, and\n    the candidate now carries ``supersedes_id`` pointing back at\n    ``new_memory``. This branch was previously unreachable\n    (CAURA-125; gap A6) and is now exercised by deferred-embedding\n    races and ``created_at`` ties.",
+        "properties": {
+          "direction": {
+            "default": "canonical",
+            "enum": [
+              "canonical",
+              "flipped"
+            ],
+            "title": "Direction",
+            "type": "string"
+          },
+          "old_content_preview": {
+            "title": "Old Content Preview",
+            "type": "string"
+          },
+          "old_memory_id": {
+            "format": "uuid",
+            "title": "Old Memory Id",
+            "type": "string"
+          },
+          "old_status": {
+            "title": "Old Status",
+            "type": "string"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "old_memory_id",
+          "old_status",
+          "reason",
+          "old_content_preview"
+        ],
+        "title": "ContradictionInfo",
+        "type": "object"
+      },
+      "EntityLinkIn": {
+        "properties": {
+          "entity_id": {
+            "format": "uuid",
+            "title": "Entity Id",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "entity_id",
+          "role"
+        ],
+        "title": "EntityLinkIn",
+        "type": "object"
+      },
+      "EntityLinkOut": {
+        "properties": {
+          "entity_id": {
+            "format": "uuid",
+            "title": "Entity Id",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "entity_id",
+          "role"
+        ],
+        "title": "EntityLinkOut",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "MemoryOut": {
+        "properties": {
+          "agent_display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Display Name"
+          },
+          "agent_id": {
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "entity_links": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/EntityLinkOut"
+            },
+            "title": "Entity Links",
+            "type": "array"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "fleet_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fleet Id"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "last_recalled_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Recalled At"
+          },
+          "memory_type": {
+            "title": "Memory Type",
+            "type": "string"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "object_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Value"
+          },
+          "predicate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predicate"
+          },
+          "recall_count": {
+            "default": 0,
+            "title": "Recall Count",
+            "type": "integer"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Id"
+          },
+          "similarity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Similarity"
+          },
+          "source_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Uri"
+          },
+          "status": {
+            "default": "active",
+            "title": "Status",
+            "type": "string"
+          },
+          "subject_entity_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject Entity Id"
+          },
+          "superseded_by": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ContradictionInfo"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Superseded By"
+          },
+          "supersedes_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supersedes Id"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "ts_valid_end": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ts Valid End"
+          },
+          "ts_valid_start": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ts Valid Start"
+          },
+          "usage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UsageSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "visibility": {
+            "default": "scope_team",
+            "title": "Visibility",
+            "type": "string"
+          },
+          "weight": {
+            "title": "Weight",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "tenant_id",
+          "agent_id",
+          "memory_type",
+          "content",
+          "weight",
+          "source_uri",
+          "run_id",
+          "metadata",
+          "created_at",
+          "expires_at"
+        ],
+        "title": "MemoryOut",
+        "type": "object"
+      },
+      "MemoryType": {
+        "description": "Typed enum for the memory-type vocabulary.\n\nInheriting from ``str`` keeps full backward compatibility with the\nstring-based call sites: ``MemoryType.FACT == \"fact\"`` is True,\ndict lookup with the enum hashes the same as the literal, JSON\nserialisation emits the bare string, and SQLAlchemy reads of a\n``Text`` column coerce cleanly via Pydantic.",
+        "enum": [
+          "fact",
+          "episode",
+          "decision",
+          "preference",
+          "task",
+          "semantic",
+          "intention",
+          "plan",
+          "commitment",
+          "action",
+          "outcome",
+          "cancellation",
+          "rule",
+          "insight"
+        ],
+        "title": "MemoryType",
+        "type": "string"
+      },
+      "SearchRequest": {
+        "properties": {
+          "diagnostic": {
+            "default": false,
+            "title": "Diagnostic",
+            "type": "boolean"
+          },
+          "filter_agent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filter Agent Id"
+          },
+          "fleet_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fleet Ids"
+          },
+          "memory_type_filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MemoryType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Filter results to a single memory type. Valid values: fact, episode, decision, preference, task, semantic, intention, plan, commitment, action, outcome, cancellation, rule, insight."
+          },
+          "query": {
+            "maxLength": 5000,
+            "minLength": 1,
+            "title": "Query",
+            "type": "string"
+          },
+          "status_filter": {
+            "anyOf": [
+              {
+                "pattern": "^(active|pending|confirmed|cancelled|outdated|conflicted|archived|deleted)$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Filter"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "top_k": {
+            "default": 5,
+            "description": "Maximum results to return (1-20, default 5).",
+            "maximum": 20.0,
+            "minimum": 1.0,
+            "title": "Top K",
+            "type": "integer"
+          },
+          "valid_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Valid At"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "query"
+        ],
+        "title": "SearchRequest",
+        "type": "object"
+      },
+      "SearchResponse": {
+        "description": "Envelope for search results — matches PaginatedMemoryResponse shape.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/MemoryOut"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "SearchResponse",
+        "type": "object"
+      },
+      "UsageSummary": {
+        "properties": {
+          "memories_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memories Limit"
+          },
+          "memories_stored": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memories Stored"
+          },
+          "writes_remaining": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Writes Remaining"
+          }
+        },
+        "title": "UsageSummary",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "APIKeyHeader": {
+        "in": "header",
+        "name": "X-API-Key",
+        "type": "apiKey"
+      }
+    }
+  },
+  "info": {
+    "title": "MemClaw core-api broker contract",
+    "version": "v1"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/v1/health": {
+      "get": {
+        "description": "Liveness + readiness probe.\n\nReturns 503 when any required dependency is unavailable so deploy\ngates and Cloud Run health checks can fail-fast on status code alone.\nRequired deps:\n  - storage (core-storage-api): always\n  - redis:                      only when ``settings.redis_url`` is set\n                                (empty url = in-memory fallback, OSS default)\n  - event_bus:                  ``InProcessEventBus`` always reports ok;\n                                ``PubSubEventBus`` reports ``unhealthy``\n                                when a pull loop has halted on a permanent\n                                subscription / IAM error.\n\nNon-critical issues (platform provider init errors) flip status to\n``\"degraded\"`` but keep a 200 — the app can still serve requests.",
+        "operationId": "health_api_v1_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health",
+        "tags": [
+          "System"
+        ]
+      }
+    },
+    "/api/v1/memories/bulk": {
+      "post": {
+        "description": "Write up to 100 memories with per-attempt idempotency (CAURA-602).\n\nRequired header ``X-Bulk-Attempt-Id`` identifies the *attempt*. A\nretry of the same logical batch reuses the same value; storage's\nper-item unique constraint then converts each row into either\n``created`` or ``duplicate_attempt`` deterministically. The route\nreturns:\n\n- ``200`` when every item resolved as ``created``,\n  ``duplicate_attempt``, or ``duplicate_content``.\n- ``207 Multi-Status`` when at least one item has ``status=\"error\"``\n  (validation, enrichment timeout, missing storage id) AND at least\n  one item succeeded — partial outcomes are explicit, never inferred\n  from a 5xx with side effects.\n- ``200`` when every item is an error too — the request was processed\n  successfully; per-item ``status`` carries the rejection. We\n  deliberately don't reuse 422 here because FastAPI already emits\n  422 for request-body Pydantic validation, and clients that branch\n  on status code alone shouldn't have to disambiguate \"request was\n  malformed\" from \"request parsed and every item was rejected on\n  merit.\"\n- ``504`` when the bulk-only budget burns before storage commits;\n  the response carries no per-item state, so a retry with the same\n  attempt id is the recovery path.\n\nThe pre-existing ``Idempotency-Key`` header still controls\n*response*-level replay; ``X-Bulk-Attempt-Id`` is a separate\ncontract operating one layer down. Both are honoured: the header\ncache short-circuits when the receipt is final, the per-row\nconstraint resolves the slow path when the receipt is missing or\npending.",
+        "operationId": "write_memories_bulk_api_v1_memories_bulk_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Bulk-Attempt-Id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Bulk-Attempt-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkMemoryCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkMemoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "207": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkMemoryResponse"
+                }
+              }
+            },
+            "description": "Multi-Status"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Write Memories Bulk",
+        "tags": [
+          "Memory"
+        ]
+      }
+    },
+    "/api/v1/search": {
+      "post": {
+        "operationId": "search_api_v1_search_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Search",
+        "tags": [
+          "Memory"
+        ]
+      }
+    },
+    "/api/v1/version": {
+      "get": {
+        "operationId": "version_api_v1_version_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Version",
+        "tags": [
+          "System"
+        ]
+      }
+    }
+  }
+}

--- a/core-api/scripts/README.md
+++ b/core-api/scripts/README.md
@@ -1,0 +1,49 @@
+# core-api scripts
+
+## `gen_broker_openapi.py` — frozen v1 broker OpenAPI contract
+
+`../openapi.broker.json` is the **frozen v1 contract** for the four
+broker-facing gateway endpoints that memclawd (the on-prem broker) calls
+against Caura cloud:
+
+| Method | Path                     |
+| ------ | ------------------------ |
+| POST   | `/api/v1/memories/bulk`  |
+| POST   | `/api/v1/search`         |
+| GET    | `/api/v1/health`         |
+| GET    | `/api/v1/version`        |
+
+The baseline is a **subset** of core-api's full (~91-path) OpenAPI surface:
+only these four paths plus the schema / security components they reach. Its
+`info` is normalized to a fixed contract identity (`CONTRACT_VERSION = "v1"`,
+not core-api's rolling package version), so it changes **only when a broker
+endpoint's shape changes** — not on every release.
+
+### Regenerate
+
+Run from the `core-api/` directory (the repo root must be on `PYTHONPATH` for
+the `common` package):
+
+```bash
+cd core-api
+PYTHONPATH=.. uv run python scripts/gen_broker_openapi.py   # rewrite the baseline
+```
+
+Then commit `core-api/openapi.broker.json`.
+
+`--check` regenerates in memory and fails (exit 1) if the committed baseline is
+stale; `--out PATH` writes elsewhere instead of the committed file.
+
+### CI gate (see `.github/workflows/ci.yml`)
+
+1. **Freshness** — `gen_broker_openapi.py --check` fails if the committed
+   baseline drifts from the code on the branch.
+2. **Breaking change** — `oasdiff breaking` (pinned `tufin/oasdiff` Docker
+   image) compares **main's** baseline against **this branch's** baseline and
+   fails the PR on any breaking change. On the first merge (no baseline on main
+   yet) the gate skips gracefully.
+
+**A breaking change to this contract is not allowed to merge as-is.** Breaking
+the broker↔cloud API requires a deliberate contract version bump
+(`CONTRACT_VERSION`) per the broker↔cloud API-versioning RFC — not a silent
+edit to a v1 endpoint.

--- a/core-api/scripts/gen_broker_openapi.py
+++ b/core-api/scripts/gen_broker_openapi.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Generate / verify the frozen v1 broker OpenAPI contract for core-api.
+
+The baseline (``core-api/openapi.broker.json``) is the FROZEN v1 contract for
+the four broker-facing gateway endpoints that memclawd (the on-prem broker)
+calls against Caura cloud. It is a *subset* of core-api's full ~91-path
+OpenAPI surface: only the four broker paths plus the schema / security
+components those operations reach (transitively).
+
+Broker endpoints (gateway paths):
+
+    POST /api/v1/memories/bulk
+    POST /api/v1/search
+    GET  /api/v1/health
+    GET  /api/v1/version
+
+``info`` is normalized to a fixed contract identity (``CONTRACT_VERSION``)
+rather than core-api's rolling package version, so the baseline only changes
+when the broker API *shape* changes -- not on every release. Bump
+``CONTRACT_VERSION`` only when intentionally shipping a new broker contract
+major per the broker<->cloud API-versioning RFC.
+
+Breaking changes to this contract are gated in CI (see .github/workflows/ci.yml):
+    1. ``--check`` fails if the committed baseline is stale vs the current code.
+    2. ``oasdiff breaking`` fails the PR if this branch's baseline introduces a
+       BREAKING change vs main's baseline.
+
+Usage:
+    python scripts/gen_broker_openapi.py            # (re)write the baseline
+    python scripts/gen_broker_openapi.py --check     # verify; exit 1 if stale
+    python scripts/gen_broker_openapi.py --out PATH  # write elsewhere (e.g. tmp)
+
+Import note: ``core_api.app`` needs the repo root on PYTHONPATH for the
+``common`` package (e.g. ``PYTHONPATH=<repo-root>`` when run from core-api/).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# The four broker-facing gateway paths that make up the frozen v1 contract.
+# Adding or removing an entry is itself a contract change -- keep in sync with
+# the broker<->cloud API-versioning RFC.
+BROKER_PATHS: tuple[str, ...] = (
+    "/api/v1/memories/bulk",
+    "/api/v1/search",
+    "/api/v1/health",
+    "/api/v1/version",
+)
+
+# Frozen broker-contract version, deliberately decoupled from core-api's
+# package version. Bump ONLY for an intentional contract major per the RFC.
+CONTRACT_VERSION = "v1"
+CONTRACT_TITLE = "MemClaw core-api broker contract"
+
+BASELINE_PATH = Path(__file__).resolve().parent.parent / "openapi.broker.json"
+
+
+def _collect_refs(node: object) -> set[str]:
+    """Recursively collect every local ``$ref`` target string in ``node``."""
+    found: set[str] = set()
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$ref" and isinstance(value, str):
+                found.add(value)
+            else:
+                found |= _collect_refs(value)
+    elif isinstance(node, list):
+        for item in node:
+            found |= _collect_refs(item)
+    return found
+
+
+def _security_scheme_names(paths: dict, default_security: object) -> set[str]:
+    """Names of the security schemes the broker OPERATIONS actually require.
+
+    An operation's effective security is its own ``security`` if declared, else
+    the spec-level default. Collecting the EFFECTIVE requirement per operation —
+    rather than unconditionally unioning the global block — keeps schemes that
+    no broker endpoint uses out of the contract, so the baseline stays accurate
+    and future oasdiff runs don't flag spurious breaking changes if the full
+    spec's global security later changes.
+    """
+
+    def scheme_names(security: object) -> set[str]:
+        out: set[str] = set()
+        for requirement in security or []:  # type: ignore[union-attr]
+            if isinstance(requirement, dict):
+                out |= set(requirement.keys())
+        return out
+
+    names: set[str] = set()
+    for path_item in paths.values():
+        for operation in path_item.values():
+            if not isinstance(operation, dict):
+                continue
+            # Operation-level ``security`` OVERRIDES the global default (an
+            # explicit ``[]`` means "no auth"); when absent the default applies.
+            names |= scheme_names(operation.get("security", default_security))
+    return names
+
+
+def build_broker_spec() -> dict:
+    """Build the filtered, deterministic broker-contract OpenAPI document."""
+    # Imported lazily so ``--help`` stays cheap and import errors surface here.
+    from core_api.app import app
+
+    full = app.openapi()
+    all_paths = full.get("paths", {})
+
+    missing = [p for p in BROKER_PATHS if p not in all_paths]
+    if missing:
+        raise SystemExit(
+            "gen_broker_openapi: broker path(s) missing from core-api OpenAPI: "
+            + ", ".join(missing)
+            + "\nA broker endpoint was renamed or removed -- that is itself a "
+            "breaking contract change. Update BROKER_PATHS and the RFC."
+        )
+
+    paths = {p: all_paths[p] for p in BROKER_PATHS}
+
+    # Transitive closure of components (any type) reachable from the broker
+    # paths via ``$ref``, so every reference in the baseline resolves.
+    all_components = full.get("components", {})
+    reachable: dict[str, set[str]] = {}
+    frontier = _collect_refs(paths)
+    visited: set[str] = set()
+    while frontier:
+        ref = frontier.pop()
+        if ref in visited:
+            continue
+        visited.add(ref)
+        parts = ref.lstrip("#/").split("/")  # ["components", <type>, <name>]
+        if len(parts) != 3 or parts[0] != "components":
+            continue
+        ctype, name = parts[1], parts[2]
+        node = all_components.get(ctype, {}).get(name)
+        if node is None:
+            raise SystemExit(f"gen_broker_openapi: dangling $ref in spec: {ref}")
+        reachable.setdefault(ctype, set()).add(name)
+        frontier |= _collect_refs(node)
+
+    # Security schemes are referenced by name via ``security``, not ``$ref``.
+    scheme_names = _security_scheme_names(paths, full.get("security"))
+    declared_schemes = all_components.get("securitySchemes", {})
+    used_schemes = {n for n in scheme_names if n in declared_schemes}
+    if used_schemes:
+        reachable.setdefault("securitySchemes", set()).update(used_schemes)
+
+    components = {
+        ctype: {name: all_components[ctype][name] for name in sorted(names)}
+        for ctype, names in reachable.items()
+    }
+
+    # Explicit ALLOWLIST of top-level keys (not a denylist): only the keys the
+    # broker contract deliberately carries. A denylist would let any future
+    # top-level key app.openapi() gains (``servers``, ``tags``, ``externalDocs``,
+    # …) leak silently into the frozen baseline, causing spurious oasdiff noise
+    # or stale-baseline CI failures with no broker-endpoint change. A new key
+    # must be added here consciously. ``info`` is normalized to the frozen
+    # contract identity.
+    spec = {"openapi": full["openapi"]}
+    spec["info"] = {"title": CONTRACT_TITLE, "version": CONTRACT_VERSION}
+    spec["paths"] = paths
+    if components:
+        spec["components"] = components
+    return spec
+
+
+def _serialize(spec: dict) -> str:
+    """Deterministic JSON: sorted keys, 2-space indent, trailing newline."""
+    return json.dumps(spec, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate or verify the frozen v1 broker OpenAPI baseline.")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify the committed baseline matches current code; exit 1 if stale.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write the spec to this path instead of the committed baseline.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check and args.out:
+        print("--out is ignored with --check; pass one or the other", file=sys.stderr)
+        return 1
+
+    rendered = _serialize(build_broker_spec())
+
+    if args.check:
+        if not BASELINE_PATH.exists():
+            print(
+                f"broker OpenAPI baseline missing: {BASELINE_PATH}\n"
+                "Run: python core-api/scripts/gen_broker_openapi.py",
+                file=sys.stderr,
+            )
+            return 1
+        if BASELINE_PATH.read_text(encoding="utf-8") != rendered:
+            print(
+                "broker OpenAPI baseline stale -- run "
+                "gen_broker_openapi.py and commit core-api/openapi.broker.json",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"broker OpenAPI baseline up to date ({len(BROKER_PATHS)} paths).")
+        return 0
+
+    out = args.out or BASELINE_PATH
+    out.write_text(rendered, encoding="utf-8")
+    print(f"wrote {out} ({len(BROKER_PATHS)} broker paths)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
**Freeze the v1 broker↔cloud OpenAPI contract for core-api** and enforce it on every PR with an `oasdiff` breaking-change gate. Phase 1 (Deliverables A+B) of the broker API-versioning RFC (`docs/design/broker-cloud-api-versioning.md`, enterprise repo).

## Why
v1 was a *label*, not an enforced contract — breaking changes shipped inside `/v1` and silently broke installed brokers (the Phase-0 incident). This commits the broker-facing contract as an artifact and fails CI on any breaking change to it, so a break must ship a new `/vN`.

## Contents
- **`core-api/scripts/gen_broker_openapi.py`** — imports `core_api.app` offline, filters `paths` to the 4 broker endpoints (`POST /api/v1/memories/bulk`, `POST /api/v1/search`, `GET /api/v1/health`, `GET /api/v1/version`; a missing path is a hard error), keeps only the transitively-reachable schemas + referenced security schemes, **normalizes `info` to a frozen contract version (`v1`)** decoupled from the rolling package semver (so releases don't churn the baseline), and emits deterministic JSON. `--check` fails if the committed baseline is stale.
- **`core-api/openapi.broker.json`** — the frozen v1 baseline (4 paths, 14 schemas, `APIKeyHeader`).
- **`ci.yml`** — stale-baseline guard + `oasdiff breaking --fail-on ERR` vs `main`'s baseline (pinned `tufin/oasdiff:v1.26.0`; `--fail-on ERR` required — plain `oasdiff breaking` exits 0 even on breaks). First-merge bootstrap skips the diff when main has no baseline yet.
- **`core-api/scripts/README.md`** — regeneration + contract-bump rules.

## Validation
`--check` clean and deterministic (byte-identical across runs); **proof the gate bites**: a synthetic required field on `BulkMemoryCreate` → `oasdiff` reports `new-required-request-property`, exit 1 — then reverted. `ruff` clean on the script.

Regenerate after an intentional broker contract change: `python core-api/scripts/gen_broker_openapi.py`.

Gate C / Phase 1. Companion to the enterprise auth/audit gate (#889) and the Phase-0 fixes.
