### PR TITLE
fix(core-api): bulk unknown memory_type → per-item 207 (stacked on #619)

### DIFF
--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -68,21 +68,22 @@ class MemoryCreate(BaseModel):
 class BulkMemoryItem(BaseModel):
     """Single item in a bulk write request. tenant_id/fleet_id/agent_id inherited from parent."""
 
-    memory_type: MemoryType | None = Field(default=None, description=MEMORY_TYPES_WRITE_DESCRIPTION)
     # Additive-tolerance policy (broker↔cloud API-versioning RFC): a bulk write
     # must NOT 422 the whole batch because one item has a bad field — the valid
     # items must still be written. So schema-level constraints that would reject
     # the ENTIRE request are deliberately dropped here (unlike single-write
     # ``MemoryCreate`` / ``MemoryUpdate``, which keep them) and re-enforced PER
-    # ITEM in ``create_memories_bulk`` as a ``status="error"`` 207 row:
+    # ITEM in ``create_memories_bulk``, aggregated into one ``status="error"``
+    # 207 row per item:
+    #   - memory_type ∉ MEMORY_TYPES → memory_type_errors. The field is ``str``
+    #     here (not the typed ``MemoryType`` enum used on single-write), so an
+    #     unknown type is a per-item error, not a whole-batch 422.
     #   - content length → short_content_errors
     #     (``< CRYSTALLIZER_SHORT_CONTENT_CHARS`` = 10, subsumes the old
     #     ``min_length=1``) + oversized_content_errors (``> MAX_CONTENT_LENGTH``).
     #   - weight range [0.0, 1.0] → weight_errors.
     #   - status enum → status_errors.
-    # ``memory_type`` still uses its typed enum below (an invalid value 422s the
-    # whole batch); making it per-item needs an enum→str change with downstream
-    # impact, tracked as a follow-up.
+    memory_type: str | None = Field(default=None, description=MEMORY_TYPES_WRITE_DESCRIPTION)
     content: str
     weight: float | None = Field(default=None)
     source_uri: str | None = None

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -60,6 +60,7 @@ from core_api.constants import (
     GRAPH_MAX_HOPS,
     MAX_CONTENT_LENGTH,
     MEMORY_STATUSES,
+    MEMORY_TYPES,
     MIN_SEARCH_SIMILARITY,
     OPENAI_EMBEDDING_MODEL,
     RECALL_BOOST_CAP,
@@ -1113,6 +1114,16 @@ async def create_memories_bulk(
         for i, item in enumerate(items)
         if item.status is not None and item.status not in MEMORY_STATUSES
     }
+    # memory_type is a plain str on BulkMemoryItem (not the typed MemoryType
+    # enum used on single-write), so an unknown value reaches here instead of
+    # 422-ing the whole batch at the schema. Validate against the same full
+    # vocabulary the enum accepted (MEMORY_TYPES); reserved/deprecated-but-known
+    # types stay valid here and are handled downstream exactly as before.
+    memory_type_errors: dict[int, str] = {
+        i: f"memory_type must be one of: {', '.join(MEMORY_TYPES)}"
+        for i, item in enumerate(items)
+        if item.memory_type is not None and item.memory_type not in MEMORY_TYPES
+    }
 
     # -- Resolve per-tenant config once --
     from core_api.services.organization_settings import resolve_config
@@ -1129,6 +1140,7 @@ async def create_memories_bulk(
         and i not in oversized_content_errors
         and i not in weight_errors
         and i not in status_errors
+        and i not in memory_type_errors
     ]
 
     # -- Deterministic governance gate (eToro). Runs BEFORE embeddings +
@@ -1274,6 +1286,7 @@ async def create_memories_bulk(
         item_errors = [
             errs[i]
             for errs in (
+                memory_type_errors,
                 short_content_errors,
                 oversized_content_errors,
                 weight_errors,

--- a/tests/test_bulk_atomicity.py
+++ b/tests/test_bulk_atomicity.py
@@ -274,6 +274,37 @@ async def test_item_failing_multiple_validations_aggregates_errors(client):
     assert "status" in err["error"]
 
 
+async def test_bad_memory_type_in_mixed_batch_returns_207(client):
+    """An unknown memory_type on one item is a per-item 207 error (memory_type is
+    now a plain str on BulkMemoryItem, validated against MEMORY_TYPES in the
+    service) rather than a whole-batch 422. A VALID explicit memory_type still
+    flows through and is written, and valid siblings are unaffected."""
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"badtype-{uid()}",
+        "items": [
+            {"content": f"valid explicit type {uid()}", "memory_type": "decision"},
+            {"content": f"bad type {uid()}", "memory_type": "not_a_type"},
+            {"content": f"valid default type {uid()}"},
+        ],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("badtype")},
+    )
+    assert resp.status_code == 207
+    data = resp.json()
+    assert data["created"] == 2
+    assert data["errors"] == 1
+    by_index = {r["index"]: r for r in data["results"]}
+    assert by_index[0]["status"] == "created" and by_index[0]["id"]
+    assert by_index[1]["status"] == "error" and by_index[1]["id"] is None
+    assert "memory_type" in by_index[1]["error"]
+    assert by_index[2]["status"] == "created" and by_index[2]["id"]
+
+
 # ── X-Bulk-Attempt-Id contract ──
 
 

--- a/tests/test_bulk_write.py
+++ b/tests/test_bulk_write.py
@@ -151,19 +151,19 @@ class TestBulkSchemaValidation:
         assert item.memory_type == "decision"
         assert item.weight == 0.8
 
-    def test_invalid_memory_type_rejected(self):
-        # memory_type is deliberately still a typed enum on BulkMemoryItem — the
-        # per-item relaxation (content/weight/status) did NOT extend to it, since
-        # making it per-item needs an enum→str change with downstream impact
-        # (tracked as a follow-up). So an invalid value still raises at the schema.
-        with pytest.raises(Exception):
-            BulkMemoryItem(content="test", memory_type="invalid_type")
+    def test_invalid_memory_type_accepted_at_schema(self):
+        """memory_type is now a plain ``str`` on BulkMemoryItem (not the typed
+        MemoryType enum), so an unknown value parses WITHOUT raising and is
+        enforced per-item in create_memories_bulk (207 error row) — matching
+        content/weight/status. (Single-write MemoryCreate keeps the typed enum,
+        so it still rejects at the schema — see test_single_write_* above.)"""
+        item = BulkMemoryItem(content="test", memory_type="invalid_type")
+        assert item.memory_type == "invalid_type"
 
-    # Bad ``status`` and out-of-range ``weight`` are intentionally NOT rejected
-    # at the schema anymore — those constraints moved to per-item 207 errors in
-    # create_memories_bulk. Covered by
-    # test_out_of_range_weight_and_bad_status_accepted_at_schema (above) and, for
-    # the batch behavior, test_bad_weight_and_status_in_mixed_batch_return_207.
+    # Bad memory_type / status / out-of-range weight are intentionally NOT
+    # rejected at the schema anymore — those constraints moved to per-item 207
+    # errors in create_memories_bulk. Covered by the *_accepted_at_schema tests
+    # here and the batch-behavior tests in test_bulk_atomicity.py.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Completes bulk **additive-tolerance** for `BulkMemoryItem`: an unknown `memory_type` on one item now surfaces as a per-item `status="error"` (207) row instead of 422-ing the whole batch. Follow-up to #619 (content/weight/status), which deferred `memory_type` because it required an enum→str change.

> **Stacked on #619** (`CAURA-000-coreapi-bulk-oversized-207`) — base is that branch so the diff shows only the memory_type delta. **Merge after #619.**

## Change
- `BulkMemoryItem.memory_type`: `MemoryType | None` → `str | None` (single-write `MemoryCreate`/`MemoryUpdate` keep the typed enum — they still hard-reject).
- `create_memories_bulk`: new `memory_type_errors` validating against the **full `MEMORY_TYPES`** vocabulary the enum accepted; it joins the aggregated per-item error row and is excluded from `valid_indices`.
- Valid types — including reserved/deprecated-but-known ones — flow downstream **unchanged** (deprecated folding, defaulting, storage): `MemoryType` is a `str`-Enum, so valid values compare and persist identically to before.

## Tests
- Integration: mixed batch with a bad `memory_type` **and a valid explicit one** → 207, bad row errored, valid items (explicit + default type) created.
- Schema: `BulkMemoryItem` now accepts an unknown `memory_type`; `MemoryCreate` still rejects it (scope guard).
- Full `test_bulk_write.py` + `test_bulk_atomicity.py` pass (47), plus the deprecated-type (`test_caura702_*`) and bulk-caller (ingest/mcp/broker-write) regression modules (65). `ruff`/`mypy` clean on `core-api/src`.

Gate C / Phase 0; T0.2 core-api. Closes the `memory_type` follow-up from #619.
