### PR TITLE
feat(search): unified relevance-dominant ranking formula behind score_formula flag

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -182,6 +182,15 @@ MIN_SEARCH_SIMILARITY = 0.3
 # A/B validates it. Offline ceiling (LongMemEval): pool=50 recovers 95% of the gold
 # production dropped from top-20; >70 adds nothing. See benchmark/a49_ceiling_check.py.
 CANDIDATE_POOL_SIZE = 0
+# Ranking formula selector (A50 unified). 0 = LEGACY multiplicative boost stack
+# (score = base_score x freshness x recall x temporal x date x currency x status --
+# current behaviour). 1 = UNIFIED relevance-dominant formula: score = similarity plus
+# BOUNDED, query-gated ADDITIVE nudges (freshness gated to temporal queries, date/entity
+# gated to their triggers), minus a staleness penalty, times status_penalty; drops the
+# 0.15·weight floor (A46) and popularity recall_boost (A41). Off by default; flip per
+# tenant via default_search_profile.score_formula to A/B old vs new on the benchmark.
+# Rationale + offline calibration: docs/ranking/unified-ranking-formula.md.
+SCORE_FORMULA = 0
 FRESHNESS_DECAY_DAYS = 90
 FRESHNESS_FLOOR = 0.7
 ENTITY_BOOST_FACTOR = 1.3

--- a/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
+++ b/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
@@ -10,6 +10,7 @@ from core_api.constants import (
     MIN_SEARCH_SIMILARITY,
     RECALL_BOOST_CAP,
     RECALL_DECAY_WINDOW_DAYS,
+    SCORE_FORMULA,
     SIMILARITY_BLEND,
 )
 from core_api.pipeline.context import PipelineContext
@@ -55,5 +56,7 @@ class ResolveSearchProfile:
             "similarity_blend": sp.get("similarity_blend", SIMILARITY_BLEND),
             # A49: 0 = off; >0 = storage selects a cosine-dominant candidate pool of this size.
             "candidate_pool_size": sp.get("candidate_pool_size", CANDIDATE_POOL_SIZE),
+            # A50 unified: 0 = legacy multiplicative score; 1 = unified relevance-dominant formula.
+            "score_formula": sp.get("score_formula", SCORE_FORMULA),
         }
         return None

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -1061,6 +1061,8 @@ _SEARCH_PROFILE_RULES: dict[str, tuple[type, tuple, object]] = {
     "similarity_blend": (float, (0.0, 1.0), None),
     # A49: 0 = off (candidate pool by boosted score); >0 = cosine-dominant pool of this size.
     "candidate_pool_size": (int, (0, 200), None),
+    # A50 unified: 0 = legacy multiplicative score; 1 = unified relevance-dominant formula.
+    "score_formula": (int, (0, 1), None),
 }
 
 

--- a/core-api/tests/test_a50_score_formula.py
+++ b/core-api/tests/test_a50_score_formula.py
@@ -1,0 +1,40 @@
+"""A50 unified — score_formula flag: core-api plumbing.
+
+Storage behaviour (the unified formula actually re-orders results) is covered by
+core-storage-api/tests/test_integration.py::test_scored_search_unified_formula.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_api.constants import SCORE_FORMULA
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search.resolve_search_profile import ResolveSearchProfile
+from core_api.services.organization_settings import validate_search_profile
+
+
+def test_default_legacy() -> None:
+    assert SCORE_FORMULA == 0, "must default to the legacy formula (no behaviour change)"
+
+
+def test_validate_search_profile_score_formula() -> None:
+    assert validate_search_profile({"score_formula": 1}) == {"score_formula": 1}
+    assert validate_search_profile({"score_formula": 9})["score_formula"] == 1  # clamped
+    assert validate_search_profile({"score_formula": -3})["score_formula"] == 0  # clamped
+
+
+@pytest.mark.asyncio
+async def test_resolve_defaults_legacy() -> None:
+    ctx = PipelineContext(data={"query": "what is my role", "top_k": 5})
+    await ResolveSearchProfile().execute(ctx)
+    assert ctx.data["search_params"]["score_formula"] == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_honours_profile() -> None:
+    ctx = PipelineContext(
+        data={"query": "what is my role", "top_k": 5, "search_profile": {"score_formula": 1}}
+    )
+    await ResolveSearchProfile().execute(ctx)
+    assert ctx.data["search_params"]["score_formula"] == 1

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1107,6 +1107,9 @@ class PostgresService:
         # semantic relevance (``similarity``) at this size so boost-demoted-but-strong
         # matches survive the LIMIT into ranking/rerank. Arrives via search_params.
         _candidate_pool_size = int(sp.get("candidate_pool_size", 0) or 0)
+        # A50 unified: which ranking formula computes `score`. 0 = legacy multiplicative
+        # boost stack; 1 = unified relevance-dominant additive formula (see below).
+        _score_formula = int(sp.get("score_formula", 0) or 0)
 
         # -- Scoring expressions --
         # CAURA-594: pgvector's `<=>` is strict — NULL in → NULL out. A
@@ -1291,6 +1294,8 @@ class PostgresService:
         else:
             currency_factor = literal_column("1.0").label("currency_factor")
 
+        # Entity/graph boost — always defined (1.0 when no boosted ids) so both
+        # scoring formulas below can reference it uniformly.
         if boosted_memory_ids and memory_boost_factor:
             boost_tiers: dict[float, list[UUID]] = {}
             for mid, factor in memory_boost_factor.items():
@@ -1299,20 +1304,39 @@ class PostgresService:
                 (Memory.id.in_(mids), factor) for factor, mids in sorted(boost_tiers.items(), reverse=True)
             ]
             entity_boost = case(*whens, else_=1.0).label("entity_boost")
+        else:
+            entity_boost = literal_column("1.0").label("entity_boost")
+
+        if _score_formula == 1:
+            # -- A50 UNIFIED formula: relevance-dominant, bounded additive, query-gated --
+            # score = similarity (dominant) + small ADDITIVE, GATED nudges, then x status.
+            # A nudge can reorder within a relevance band but never override a real
+            # relevance gap. Drops the 0.15·weight floor (A46) and popularity
+            # recall_boost (A41). Weights are small so |Σ nudges| stays well below the
+            # similarity spread; tune via the offline calibration harness before default-on.
+            # Freshness is GATED to temporal queries (temporal_window set) — an always-on
+            # recency term is what hurt non-temporal recall in the legacy stack.
+            _V2_W_FRESH = 0.10  # recency nudge (gated to temporal queries)
+            _V2_W_DATE = 0.10  # date-window nudge (date_range_boost is 1.0 off-query -> term 0)
+            _V2_W_ENTITY = 0.10  # entity/graph nudge (entity_boost is 1.0 when absent -> term 0)
+            _V2_W_STALE = 0.20  # staleness penalty (currency_factor is 1.0 when current -> term 0)
+            _recency_gate = 1.0 if temporal_window is not None else 0.0
+            score = (
+                (
+                    similarity
+                    + _V2_W_FRESH * _recency_gate * (freshness - _freshness_floor)
+                    + _V2_W_DATE * (date_range_boost - 1.0)
+                    + _V2_W_ENTITY * (entity_boost - 1.0)
+                    - _V2_W_STALE * (1.0 - currency_factor)
+                )
+                * status_penalty
+            ).label("score")
+        else:
+            # -- LEGACY formula: multiplicative boost stack (unchanged) --
             score = (
                 base_score
                 * freshness
                 * entity_boost
-                * recall_boost_expr
-                * temporal_boost
-                * date_range_boost
-                * currency_factor
-                * status_penalty
-            ).label("score")
-        else:
-            score = (
-                base_score
-                * freshness
                 * recall_boost_expr
                 * temporal_boost
                 * date_range_boost

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -880,6 +880,81 @@ class TestMemories:
         assert r_zero.status_code == 200, r_zero.text
         assert [r["id"] for r in r_zero.json()] == off_ids, "pool_size=0 must equal default behaviour"
 
+    async def test_scored_search_unified_formula(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """A50 unified: score_formula=1 makes `score` relevance-dominant, so a
+        boost-inflated low-similarity row no longer outranks a strong match.
+
+        H: similarity 0.70, weight 0.0, no boosts.
+        L: similarity 0.35, weight 1.0, ts_valid_start inside the queried date range
+           (legacy date_range_boost 2x pushes its multiplicative score above H).
+        Legacy (0): boosted L outranks H. Unified (1): H (0.70) > L (0.35 + 0.10·date) = 0.45.
+        """
+        import math
+
+        seed = f"a50u_{_uid()}"
+        q = fake_embedding(seed + "_q")
+
+        def _unit(v: list[float]) -> list[float]:
+            n = math.sqrt(sum(x * x for x in v)) or 1.0
+            return [x / n for x in v]
+
+        def _emb_cos(target: float, rseed: str) -> list[float]:
+            r = fake_embedding(rseed)
+            dot = sum(a * b for a, b in zip(r, q, strict=False))
+            r_orth = _unit([ri - dot * qi for ri, qi in zip(r, q, strict=False)])
+            a, b = target, math.sqrt(max(0.0, 1.0 - target * target))
+            return _unit([a * qi + b * ri for qi, ri in zip(q, r_orth, strict=False)])
+
+        ph = _memory_payload(tenant_id, fleet_id, content=f"H {seed}")
+        ph["embedding"] = _emb_cos(0.70, seed + "_h")
+        ph["weight"] = 0.0
+        h_id = (await client.post(f"{PREFIX}/memories", json=ph)).json()["id"]
+
+        pl = _memory_payload(tenant_id, fleet_id, content=f"L {seed}")
+        pl["embedding"] = _emb_cos(0.35, seed + "_l")
+        pl["weight"] = 1.0
+        pl["ts_valid_start"] = "2020-01-15T00:00:00+00:00"
+        l_id = (await client.post(f"{PREFIX}/memories", json=pl)).json()["id"]
+
+        base = {
+            "tenant_id": tenant_id,
+            "embedding": q,
+            "query": seed,
+            "fleet_ids": [fleet_id],
+            "date_range_start": "2020-01-01",
+            "date_range_end": "2020-01-31",
+            "top_k": 10,
+            "search_params": {
+                "fts_weight": 0.0,
+                "freshness_floor": 0.7,
+                "freshness_decay_days": 90.0,
+                "recall_boost_cap": 1.1,
+                "recall_decay_window_days": 14.0,
+                "similarity_blend": 0.85,
+            },
+        }
+
+        legacy = {**base, "search_params": {**base["search_params"], "score_formula": 0}}
+        legacy_ids = [
+            r["id"] for r in (await client.post(f"{PREFIX}/memories/scored-search", json=legacy)).json()
+        ]
+        assert legacy_ids.index(l_id) < legacy_ids.index(h_id), (
+            f"legacy formula should rank boosted L above H; got {legacy_ids}"
+        )
+
+        unified = {**base, "search_params": {**base["search_params"], "score_formula": 1}}
+        unified_ids = [
+            r["id"] for r in (await client.post(f"{PREFIX}/memories/scored-search", json=unified)).json()
+        ]
+        assert unified_ids.index(h_id) < unified_ids.index(l_id), (
+            f"unified formula should rank high-similarity H above L; got {unified_ids}"
+        )
+
     async def test_public_counters_exclude_soft_deleted(
         self,
         client: AsyncClient,


### PR DESCRIPTION
## What
A per-tenant **`score_formula`** flag (default **0 = legacy**, no behaviour change). When **1**, `memory_scored_search` computes a **unified, relevance-dominant** score instead of the legacy multiplicative boost stack.

## The unified formula (`score_formula = 1`)
```
score = ( similarity                                        # relevance, dominant ∈ [0,1]
        + 0.10 · recency_gate · (freshness − freshness_floor)   # recency, GATED to temporal queries
        + 0.10 · (date_range_boost − 1.0)                        # date-window nudge (0 off-query)
        + 0.10 · (entity_boost − 1.0)                            # entity/graph nudge (0 when absent)
        − 0.20 · (1.0 − currency_factor) )                       # staleness penalty (0 when current)
        × status_penalty                                         # hard conflicted/outdated demotion
```
`recency_gate = 1` iff the query is temporal (`temporal_window` set), else 0.

Vs legacy: **similarity dominates**; boosts are **additive + bounded** (reorder within a relevance band, never override a real gap); **freshness gated to temporal queries**; drops the `0.15·weight` floor (A46) and popularity `recall_boost` (A41).

## Why
LongMemEval failure analysis + offline calibration: relevance-dominant ordering beats the boost stack on every category (incl. temporal), because the multiplicative boosts demote strong matches. Full rationale: `docs/ranking/unified-ranking-formula.md`.

## Scope / safety
- **Off by default → zero behaviour change.** Flip per tenant via `default_search_profile.score_formula`.
- Weights are a **first cut, uncalibrated** — tune via the offline harness before considering default-on.
- Enables an A/B on the benchmark by flipping the flag between runs (no runner change).

## Tests
- core-api plumbing (default legacy, validate/clamp, resolve threading).
- storage integration (real pgvector): the unified formula ranks a strong match above a boost-inflated low-similarity row; legacy does the opposite. No regression on existing `/scored-search` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)