### PR TITLE
fix(interviewer): preserve exact figures in synthesis + document list-limit cap

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -200,7 +200,15 @@ async def list_memories(
     ),
     order: str = Query(default="desc", pattern=r"^(asc|desc)$"),
     offset: int = Query(default=0, ge=0),
-    limit: int = Query(default=DEFAULT_LIST_LIMIT, ge=1, le=MAX_LIST_LIMIT),
+    limit: int = Query(
+        default=DEFAULT_LIST_LIMIT,
+        ge=1,
+        le=MAX_LIST_LIMIT,
+        description=(
+            f"Items per page, 1-{MAX_LIST_LIMIT}. A value above {MAX_LIST_LIMIT} is rejected "
+            "with 422 (not silently clamped); page via `cursor`/`offset` for more."
+        ),
+    ),
     include_deleted: bool = Query(default=False),
     auth: AuthContext = Depends(get_auth_context),
 ):
@@ -1848,7 +1856,15 @@ async def admin_list_memories(
     ),
     order: str = Query(default="desc", pattern=r"^(asc|desc)$"),
     offset: int = Query(default=0, ge=0),
-    limit: int = Query(default=DEFAULT_LIST_LIMIT, ge=1, le=MAX_LIST_LIMIT),
+    limit: int = Query(
+        default=DEFAULT_LIST_LIMIT,
+        ge=1,
+        le=MAX_LIST_LIMIT,
+        description=(
+            f"Items per page, 1-{MAX_LIST_LIMIT}. A value above {MAX_LIST_LIMIT} is rejected "
+            "with 422 (not silently clamped); page via `cursor`/`offset` for more."
+        ),
+    ),
     include_deleted: bool = Query(default=False),
     auth: AuthContext = Depends(get_auth_context),
 ):

--- a/core-api/src/core_api/services/interview_service.py
+++ b/core-api/src/core_api/services/interview_service.py
@@ -167,8 +167,12 @@ _REPORT_SCHEMA_INSTRUCTION = """Respond with ONLY a JSON object of this exact sh
   "open_questions":      [{"summary": "...", "ts": "ISO8601 or null"}],
   "preferences_learned": [{"summary": "...", "ts": "ISO8601 or null"}]
 }
-Rules: every item must be standalone and concrete (names, paths, numbers). Take ts values from the
-event timestamps you actually used — never invent times. Do not restate the same fact in two sections.
+Rules: every item must be standalone and concrete. Preserve exact figures VERBATIM — metrics,
+benchmark scores, thresholds, counts, durations, version numbers, and file/table/branch names —
+never round or generalize them (write "recall@10 0.87 vs 0.83, index -33%", not "better recall").
+Keep each decision whole: capture its conditions, sequencing, and alternatives ("migrate to X after
+the Y fix ships; keep Z as fallback"), not just the headline choice. Take ts values from the event
+timestamps you actually used — never invent times. Do not restate the same fact in two sections.
 Skip routine/mechanical steps; report only what a teammate would need to know."""
 
 

--- a/tests/test_api_interview.py
+++ b/tests/test_api_interview.py
@@ -257,6 +257,33 @@ def test_attempt_id_is_deterministic_and_valid():
     assert re.match(r"^[A-Za-z0-9._:\-]{1,128}$", a)
 
 
+def test_build_prompt_demands_verbatim_figures_and_whole_decisions():
+    """Staging quality eval (Gemini flash-lite) showed the model dropped
+    exact numbers and flattened compound/conditional decisions; the prompt
+    must instruct otherwise."""
+    prompt = interview_service.build_prompt(
+        [
+            {
+                "seq": 0,
+                "ts": "2026-07-23T09:00:00Z",
+                "session_id": "s",
+                "role": "assistant",
+                "kind": "reply",
+                "content": "recall@10 0.87 vs 0.83; migrate after the chunking fix, keep 3-small as fallback",
+            }
+        ],
+        agent_id="a1",
+        keystone_lines=[],
+        chunk_index=0,
+        chunk_count=1,
+    )
+    low = prompt.lower()
+    # preserve exact figures verbatim
+    assert "verbatim" in low and "version numbers" in low
+    # keep compound/conditional decisions whole
+    assert "keep each decision whole" in low and "fallback" in low
+
+
 def test_mask_events_masks_pii_before_llm():
     events = [
         {"seq": 0, "content": "email me at ran@caura.ai, card 4111 1111 1111 1111"}


### PR DESCRIPTION
Two fixes surfaced by the Interviewer staging rollout rehearsal (OpenClaw push path, validated end-to-end on `memclaw.dev`).

## 1. Synthesis preserves exact figures + whole decisions (substantive)
The staging quality eval ran realistic work windows through the live **Gemini flash-lite** synthesis and scored the output against known ground truth. It was strong on type-mapping, faithfulness (0 hallucinations), and negative-outcome discipline — but had one consistent weakness:
- **dropped exact numbers** (`recall@10 0.87 vs 0.83, index -33%` → "better recall"), and
- **flattened compound/conditional decisions** (`migrate to X after the Y fix; keep Z as fallback` → "migrate to X").

Fix: strengthen `_REPORT_SCHEMA_INSTRUCTION` in `interview_service.py` to require preserving figures **verbatim** (metrics, thresholds, counts, durations, versions, names) and keeping each decision **whole** (conditions, sequencing, alternatives). **Prompt-only — no model change** (flash-lite stays; it's cheap, fast, and faithful, just needed steering). Adds a unit test pinning the new instructions.

## 2. Document the list-limit cap (minor)
`GET /api/v1/memories?limit=1000` returns **422** (cap is `MAX_LIST_LIMIT=500`), which is easy to mistake for an empty result if the error body isn't parsed. Document the cap + 422 behaviour in the OpenAPI `limit` param description on both list endpoints. **Behaviour unchanged** — the memories endpoint is deliberately strict (`le=`), unlike the clamp-style `skills_inbox` endpoint; I kept that choice and made it discoverable rather than silently changing it.

## Verification
`tests/test_api_interview.py` 22/22 pass (incl. the new `test_build_prompt_demands_verbatim_figures_and_whole_decisions`); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)