### PR TITLE
feat(agent-digest): stop over-filtering agents — floor, episode-fallback, subagent rollup

### DIFF
--- a/common/models/agent_activity_digest.py
+++ b/common/models/agent_activity_digest.py
@@ -41,6 +41,11 @@ class AgentActivityDigest(Base):
     # ({decisions[], shipped[], learned[], open_threads[]}).
     narrative: Mapped[str | None] = mapped_column(Text, nullable=True)
     sections: Mapped[dict] = mapped_column(JSONB, server_default=text("'{}'::jsonb"))
+    # Rolled-up subagents that contributed to this (parent) family row —
+    # list of {agent_id, fleet_id, source_count}. Empty for standalone agents.
+    subagents: Mapped[list] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
     # Provenance / quality signals surfaced in the UI.
     source_count: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("0")

--- a/core-api/src/core_api/services/agent_digest.py
+++ b/core-api/src/core_api/services/agent_digest.py
@@ -25,6 +25,8 @@ from core_api.services.organization_settings import get_settings_for_display
 from core_api.services.report_corpus import (
     NON_COHESIVE_TITLE_REGEX,
     is_cohesive,
+    passes_noise_filter,
+    resolve_parent,
 )
 from core_api.services.report_corpus import (
     PERIOD_DAYS as _PERIOD_DAYS,
@@ -41,6 +43,14 @@ _FETCH_LIMIT = 400
 # Rough gpt-5.4-mini cost per digest call (~2k in + ~400 out). Only used to turn
 # ``max_cost_per_run_usd`` into a call budget — an estimate, not billing-grade.
 _PER_CALL_COST_USD = 0.005
+# Min non-noise EPISODE events to summarize an agent that has no durable rows
+# (its work IS episodic). Below this it still appears via the count-only tail.
+_EVENT_FLOOR_DEFAULT = 1
+# Cap on count-only ("listed") family rows past top_n, so an active-but-not-
+# summarized agent is never invisible without flooding the report.
+_LISTED_MAX_DEFAULT = 25
+# Cap on the stored per-family subagent list (bounds row size; UI shows top-N).
+_MAX_SUBAGENTS_STORED = 30
 
 # JSON schema the model must return.
 DIGEST_SCHEMA: dict = {
@@ -59,20 +69,28 @@ DIGEST_SCHEMA: dict = {
 _SECTION_KEYS = ("decisions", "shipped", "learned", "open_threads")
 
 
-def _build_prompt(agent: dict, mems: list[dict], period: str) -> str:
+def _build_prompt(agent: dict, mems: list[dict], period: str, mode: str = "durable") -> str:
     name = agent.get("display_name") or agent.get("agent_id")
     lines = []
+    parent_id = agent.get("agent_id")
     for m in mems:
         title = m.get("title") or (m.get("metadata") or {}).get("summary") or "(untitled)"
+        # In a rolled-up family, tag rows written by a subagent so the model can
+        # attribute the work to the right child.
+        src = m.get("agent_id", "")
+        agent_tag = f" [from {src}]" if src and src != parent_id else ""
         lines.append(
-            f"- [{m.get('memory_type', '?')}] {title}"
+            f"- [{m.get('memory_type', '?')}] {title}{agent_tag}"
             f" (recalled {m.get('recall_count') or 0}x, {str(m.get('created_at'))[:10]})"
         )
     corpus = "\n".join(lines)
     period_label = "day" if period == "day" else "week"
+    # "activity" mode: the agent has no durable decisions/facts — its work is its
+    # event log. Summarize the events as concrete activity rather than decisions.
+    source_desc = "durable memories" if mode == "durable" else "activity-log events"
     return (
         f"You are writing a factual activity digest for the AI agent '{name}' over "
-        f"the past {period_label}, grounded ONLY in its durable memories below.\n\n"
+        f"the past {period_label}, grounded ONLY in its {source_desc} below.\n\n"
         f"Write a 2-4 sentence narrative of the concrete work the agent did — "
         f"decisions made, work shipped, things learned, open threads — quantifying "
         f"where natural (e.g. 'made 3 decisions'). Do not invent anything that is "
@@ -102,20 +120,27 @@ async def _summarize_agent(
     model: str,
     provider: str,
     truncated: bool,
+    mode: str = "durable",
+    subagents: list[dict] | None = None,
+    source_count: int | None = None,
 ) -> str:
-    """Summarize one agent via the LLM and persist a row ONLY when we got a real
-    narrative. Returns a status:
+    """Summarize one agent family via the LLM and persist a row ONLY when we got
+    a real narrative. Returns a status:
 
-      ok / truncated — row written with a genuine LLM summary
+      ok / truncated — durable-corpus summary (row written)
+      activity       — episode/event-log summary (agent had no durable rows)
       skipped        — LLM unavailable or returned no narrative; logged, NO row
       errored        — the LLM call raised; logged, NO row
 
     We deliberately do NOT persist a generic placeholder ("<agent> recorded N
     durable memories") when the model is unavailable — a template row is noise in
     the report, so the agent is dropped and the gap is logged instead.
+
+    ``source_count`` is the family's total meaningful writes (the bar value);
+    ``subagents`` is the rolled-up child list stored for the collapsed UI.
     """
     agent_id = agent.get("agent_id")
-    prompt = _build_prompt(agent, mems, period)
+    prompt = _build_prompt(agent, mems, period, mode=mode)
 
     async def _call(llm: Any) -> dict:
         return await llm.complete_json(prompt, response_schema=DIGEST_SCHEMA)
@@ -155,7 +180,9 @@ async def _summarize_agent(
         return "skipped"
 
     sections = {k: raw.get(k) or [] for k in _SECTION_KEYS}
-    status = "truncated" if truncated else "ok"
+    # activity-mode (event-log) summaries are tagged distinctly; truncation only
+    # relabels a durable summary.
+    status = "activity" if mode == "activity" else ("truncated" if truncated else "ok")
     row = {
         "run_id": run_id,
         "tenant_id": org_id,
@@ -166,7 +193,8 @@ async def _summarize_agent(
         "window_end": window_end.isoformat(),
         "narrative": narrative,
         "sections": sections,
-        "source_count": len(mems),
+        "subagents": subagents or [],
+        "source_count": source_count if source_count is not None else len(mems),
         "recall_count": sum(m.get("recall_count") or 0 for m in mems),
         "model": model,
         "status": status,
@@ -204,24 +232,27 @@ async def generate_for_org(
     window_start = window_end - timedelta(days=days)
     top_n = int(config.get("top_n") or 25)
     max_mems = int(config.get("max_memories_per_agent") or 60)
-    # Scale the activity floor to the window: a daily span is ~1/7 of a week, so
-    # applying the (week-tuned) threshold to a day starves the daily digest —
-    # in prod only ~3 agents/day clear it. Daily surfaces every active agent
-    # (floor 1); weekly keeps the configurable floor.
-    if period == "week":
-        min_activity = int(config.get("min_activity_threshold") or 3)
-    else:
-        min_activity = 1
+    # Durable floor: 1 by default — a single decision/fact is worth surfacing;
+    # configurable to cut noise. Applies to day and week alike now.
+    min_activity = int(config.get("min_activity_threshold") or 1)
+    # Episode-fallback floor: min non-noise events to summarize an agent with no
+    # durable rows (its work IS episodic). Below it the agent still lists.
+    event_floor = int(config.get("event_floor") or _EVENT_FLOOR_DEFAULT)
+    listed_max = int(config.get("listed_max") or _LISTED_MAX_DEFAULT)
     model = config.get("model") or "gpt-5.4-mini"
     provider = config.get("provider") or "openai"
     max_cost = float(config.get("max_cost_per_run_usd") or 0)
 
     agents = await sc.list_agents(org_id)
+    known_ids = frozenset(a["agent_id"] for a in agents if a.get("agent_id"))
 
-    # Fetch each agent's cohesive window memories (cheap; bounded concurrency).
+    # Fetch each agent's window memories (cheap; bounded concurrency). We already
+    # pull ALL rows, so split them in-memory: durable (decision-bearing) vs.
+    # non-noise events (episodes) — the latter is the fallback corpus for agents
+    # whose real work is logged as episodes.
     fetch_sem = asyncio.Semaphore(_FETCH_CONCURRENCY)
 
-    async def _fetch(agent: dict) -> tuple[dict, list[dict]]:
+    async def _fetch(agent: dict) -> tuple[dict, list[dict], list[dict]]:
         async with fetch_sem:
             rows = await sc.list_memories_by_filters(
                 {
@@ -234,37 +265,103 @@ async def generate_for_org(
                     "limit": _FETCH_LIMIT,
                 }
             )
-            cohesive = [m for m in (rows or []) if is_cohesive(m)]
-            return agent, cohesive
+            rows = rows or []
+            durable = [m for m in rows if is_cohesive(m)]
+            events = [m for m in rows if passes_noise_filter(m) and not is_cohesive(m)]
+            return agent, durable, events
 
     fetched = await asyncio.gather(*(_fetch(a) for a in agents), return_exceptions=True)
-    candidates: list[tuple[dict, list[dict]]] = []
+
+    # Roll subagents up under their resolved parent (family) so a thin subagent
+    # isn't invisible and dozens of them don't flood top_n. No extra query —
+    # grouping + resolution are in-memory over the already-fetched rows.
+    families: dict[str, dict] = {}
     for res in fetched:
         if isinstance(res, BaseException):
             logger.warning("agent_digest: fetch failed for an agent in %s: %r", org_id, res)
             continue
-        agent, cohesive = res
-        if len(cohesive) >= min_activity:
-            candidates.append((agent, cohesive))
-    candidates.sort(key=lambda ac: len(ac[1]), reverse=True)
+        agent, durable, events = res
+        aid = agent["agent_id"]
+        parent = resolve_parent(aid, known_ids)
+        fam = families.setdefault(parent, {"durable": [], "events": [], "members": {}, "parent_agent": None})
+        fam["durable"].extend(durable)
+        fam["events"].extend(events)
+        fam["members"][aid] = {
+            "agent_id": aid,
+            "fleet_id": agent.get("fleet_id"),
+            "source_count": len(durable) + len(events),
+        }
+        if aid == parent:
+            fam["parent_agent"] = agent
 
-    selected = candidates[:top_n]
-    # Turn the USD cap into a call budget (rough per-call estimate).
-    if max_cost:
-        budget = max(1, int(max_cost / _PER_CALL_COST_USD))
-        if len(selected) > budget:
-            logger.warning("agent_digest: org %s cost cap trims %d→%d agents", org_id, len(selected), budget)
-            selected = selected[:budget]
+    def _family_agent(parent: str, fam: dict) -> dict:
+        if fam["parent_agent"]:
+            return fam["parent_agent"]
+        # Only subagents exist (no standalone parent row) — synthesize one,
+        # borrowing the busiest member's fleet.
+        busiest = max(fam["members"].values(), key=lambda m: m["source_count"], default=None)
+        return {"agent_id": parent, "fleet_id": busiest["fleet_id"] if busiest else None}
+
+    def _subagents(parent: str, fam: dict) -> list[dict]:
+        subs = [m for aid, m in fam["members"].items() if aid != parent and m["source_count"] > 0]
+        subs.sort(key=lambda m: m["source_count"], reverse=True)
+        return subs[:_MAX_SUBAGENTS_STORED]
+
+    # Active families, ranked by total meaningful writes.
+    active = [
+        {
+            "parent": p,
+            "agent": _family_agent(p, fam),
+            "durable": fam["durable"],
+            "events": fam["events"],
+            "total": len(fam["durable"]) + len(fam["events"]),
+            "subagents": _subagents(p, fam),
+        }
+        for p, fam in families.items()
+        if (len(fam["durable"]) + len(fam["events"])) > 0
+    ]
+    active.sort(key=lambda f: f["total"], reverse=True)
+
+    def _corpus(f: dict) -> tuple[list[dict], str] | None:
+        """Durable-first; else the episode/event fallback (ranked by recall)."""
+        if len(f["durable"]) >= min_activity:
+            return f["durable"], "durable"
+        if len(f["events"]) >= event_floor:
+            ranked = sorted(
+                f["events"],
+                key=lambda m: (
+                    m.get("recall_count") or 0,
+                    m.get("weight") or 0,
+                    str(m.get("created_at") or ""),
+                ),
+                reverse=True,
+            )
+            # Prepend any durable rows (below the floor) so decisions aren't
+            # silently dropped when we fall back to the event corpus.
+            return f["durable"] + ranked, "activity"
+        return None
+
+    # Split ranked families: top_n (cost-capped) get an LLM summary; the rest of
+    # the active families become count-only "listed" rows so none go invisible.
+    budget = max(1, int(max_cost / _PER_CALL_COST_USD)) if max_cost else None
+    to_summarize: list[tuple[dict, list[dict], str]] = []
+    to_list: list[dict] = []
+    for f in active:
+        c = _corpus(f)
+        if c and len(to_summarize) < top_n and (budget is None or len(to_summarize) < budget):
+            to_summarize.append((f, c[0], c[1]))
+        elif len(to_list) < listed_max:
+            to_list.append(f)
 
     llm_sem = asyncio.Semaphore(_LLM_CONCURRENCY)
 
-    async def _one(agent: dict, mems: list[dict]) -> str:
+    async def _one(f: dict, corpus: list[dict], mode: str) -> str:
         async with llm_sem:
-            truncated = len(mems) > max_mems
+            truncated = len(corpus) > max_mems
             return await _summarize_agent(
                 org_id=org_id,
-                agent=agent,
-                mems=mems[:max_mems],
+                agent=f["agent"],
+                mems=corpus[:max_mems],
                 period=period,
                 run_id=run_id,
                 window_start=window_start,
@@ -272,12 +369,44 @@ async def generate_for_org(
                 model=model,
                 provider=provider,
                 truncated=truncated,
+                mode=mode,
+                subagents=f["subagents"],
+                source_count=f["total"],
             )
 
-    statuses = await asyncio.gather(*(_one(a, m) for a, m in selected), return_exceptions=True)
-    generated = sum(1 for s in statuses if s in ("ok", "truncated"))
+    statuses = await asyncio.gather(*(_one(f, c, m) for f, c, m in to_summarize), return_exceptions=True)
+    generated = sum(1 for s in statuses if s in ("ok", "truncated", "activity"))
     skipped = sum(1 for s in statuses if s == "skipped")
     errored = sum(1 for s in statuses if isinstance(s, BaseException) or s == "errored")
+
+    # Count-only tail: active families we didn't LLM-summarize get a listed row
+    # (no narrative, no LLM) so an active agent is never fully invisible.
+    listed = 0
+    for f in to_list:
+        try:
+            await sc.upsert_agent_activity_digest(
+                {
+                    "run_id": run_id,
+                    "tenant_id": org_id,
+                    "fleet_id": f["agent"].get("fleet_id"),
+                    "agent_id": f["parent"],
+                    "period": period,
+                    "window_start": window_start.isoformat(),
+                    "window_end": window_end.isoformat(),
+                    "narrative": None,
+                    "sections": {},
+                    "subagents": f["subagents"],
+                    "source_count": f["total"],
+                    "recall_count": None,
+                    "model": None,
+                    "status": "listed",
+                    "error_detail": None,
+                }
+            )
+            listed += 1
+        except Exception as exc:
+            errored += 1
+            logger.warning("agent_digest: listed upsert failed for %s/%s: %r", org_id, f["parent"], exc)
 
     # Retention sweep, folded into the run (this org's latest run is always
     # fresh, so old runs age out). NOTE: an org that later DISABLES the digest
@@ -296,8 +425,9 @@ async def generate_for_org(
         "org_id": org_id,
         "run_id": run_id,
         "agents": len(agents),
-        "candidates": len(candidates),
+        "families": len(active),
         "generated": generated,
+        "listed": listed,
         "skipped": skipped,
         "errored": errored,
         "pruned": pruned,
@@ -333,6 +463,7 @@ async def run_agent_digest(period: str = "day") -> dict:
     completed = 0
     failed = 0
     digests = 0
+    agent_listed = 0
     agent_skipped = 0
     agent_errors = 0
     for org_id, res in zip(org_ids, results, strict=True):
@@ -342,16 +473,18 @@ async def run_agent_digest(period: str = "day") -> dict:
         elif res:
             completed += 1
             digests += res.get("generated", 0)
+            agent_listed += res.get("listed", 0)
             agent_skipped += res.get("skipped", 0)
             agent_errors += res.get("errored", 0)
     logger.info(
         "agent_digest run: period=%s orgs=%d completed=%d failed=%d "
-        "digests=%d agent_skipped=%d agent_errors=%d",
+        "digests=%d agent_listed=%d agent_skipped=%d agent_errors=%d",
         period,
         len(org_ids),
         completed,
         failed,
         digests,
+        agent_listed,
         agent_skipped,
         agent_errors,
     )
@@ -361,6 +494,7 @@ async def run_agent_digest(period: str = "day") -> dict:
         "completed": completed,
         "failed": failed,
         "digests": digests,
+        "agent_listed": agent_listed,
         "agent_skipped": agent_skipped,
         "agent_errors": agent_errors,
     }

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -80,7 +80,13 @@ DEFAULT_SETTINGS: dict = {
         "model": "gpt-5.4-mini",
         "top_n": 25,
         "max_memories_per_agent": 60,
-        "min_activity_threshold": 3,
+        # Durable floor (a single decision/fact is worth surfacing).
+        "min_activity_threshold": 1,
+        # Min non-noise events to summarize an agent whose work is episodic;
+        # below it the agent still appears as a count-only listed row.
+        "event_floor": 1,
+        # Cap on count-only rows past top_n (active-but-not-summarized agents).
+        "listed_max": 25,
         "max_cost_per_run_usd": 2.0,
         "retention_days": 90,
     },

--- a/core-api/src/core_api/services/report_corpus.py
+++ b/core-api/src/core_api/services/report_corpus.py
@@ -38,12 +38,55 @@ NON_COHESIVE_TITLE_REGEX = (
 _NON_COHESIVE_TITLE_RE = re.compile(NON_COHESIVE_TITLE_REGEX, re.IGNORECASE)
 
 
-def is_cohesive(m: dict) -> bool:
-    """True if a memory row belongs in the durable report corpus: not episodic,
-    not from a firehose agent, and not heartbeat/health/status-poll noise
-    (title-only match, mirroring the ``exclude_title_regex`` predicate)."""
-    return (
-        m.get("memory_type") not in NON_DURABLE_TYPES
-        and m.get("agent_id") not in RESERVED_FIREHOSE_AGENTS
-        and not _NON_COHESIVE_TITLE_RE.search(m.get("title") or "")
+def passes_noise_filter(m: dict) -> bool:
+    """True if a row is real signal — not a firehose agent and not
+    heartbeat/health/status-poll noise (title-only match). Includes episodes:
+    this is the base filter the digest's episode-fallback uses when an agent has
+    no durable rows (its activity IS episodic)."""
+    return m.get("agent_id") not in RESERVED_FIREHOSE_AGENTS and not _NON_COHESIVE_TITLE_RE.search(
+        m.get("title") or ""
     )
+
+
+def is_cohesive(m: dict) -> bool:
+    """True if a memory row belongs in the durable report corpus: passes the
+    noise filter AND is not an episodic activity-log type."""
+    return passes_noise_filter(m) and m.get("memory_type") not in NON_DURABLE_TYPES
+
+
+_SUBAGENT_RE = re.compile(r"^agent:(?P<parent>[^:]+):subagent:")
+
+
+def resolve_parent(agent_id: str, known_ids: frozenset[str] | set[str]) -> str:
+    """Resolve a subagent's top-level parent agent_id, for family rollup.
+
+    The structured ``agents.owner_ref`` pointer is unpopulated in production, so
+    the parent is derived from id conventions and resolved transitively to the
+    root:
+      1. ``agent:<parent>:subagent:<uuid>``            -> <parent>
+      2. ``<parent>-<task>`` where <parent> is itself a known agent id
+         (longest such prefix, boundary '-')           -> <parent>
+      3. otherwise the agent is already top-level       -> itself
+
+    ``known_ids`` is the tenant's agent-id set (already fetched by list_agents),
+    so this needs no extra query. Prefer ``owner_ref`` upstream once populated.
+    """
+    seen: set[str] = set()
+    cur = agent_id
+    while cur not in seen:
+        seen.add(cur)
+        m = _SUBAGENT_RE.match(cur)
+        if m:
+            nxt = m.group("parent")
+        else:
+            # longest known-agent prefix on a '-' boundary (avoids matching an
+            # unrelated agent that merely shares a leading substring)
+            best = ""
+            for pid in known_ids:
+                if pid != cur and cur.startswith(pid + "-") and len(pid) > len(best):
+                    best = pid
+            nxt = best
+        if not nxt or nxt == cur:
+            return cur
+        cur = nxt
+    return cur

--- a/core-api/tests/test_agent_digest.py
+++ b/core-api/tests/test_agent_digest.py
@@ -71,39 +71,39 @@ def wire(monkeypatch):
     return _install
 
 
-async def test_generates_only_for_agents_above_threshold(wire):
-    # period="week" so the configured min_activity_threshold=3 applies (daily is
-    # floored to 1 — see test_daily_threshold_is_one).
+async def test_above_threshold_summarized_below_is_listed(wire):
+    # CONFIG sets min_activity_threshold=3. 'a' clears it (summarized). 'b' is
+    # below it AND has no events, so it's a count-only "listed" row — not dropped.
     storage = wire(
         FakeStorage(
             [{"agent_id": "a", "fleet_id": None}, {"agent_id": "b", "fleet_id": "f1"}],
-            {"a": [_mem(agent="a")] * 4, "b": [_mem(agent="b")] * 2},  # b below min_activity=3
+            {"a": [_mem(agent="a")] * 4, "b": [_mem(agent="b")] * 2},
         )
     )
     summary = await agent_digest.generate_for_org("org1", "week", CONFIG, now=NOW)
     assert summary["generated"] == 1
-    assert [r["agent_id"] for r in storage.upserts] == ["a"]
+    assert summary["listed"] == 1
+    by_status = {r["agent_id"]: r["status"] for r in storage.upserts}
+    assert by_status == {"a": "ok", "b": "listed"}
+    a_row = next(r for r in storage.upserts if r["agent_id"] == "a")
+    assert a_row["source_count"] == 4
+    b_row = next(r for r in storage.upserts if r["agent_id"] == "b")
+    assert b_row["narrative"] is None and b_row["source_count"] == 2
+
+
+async def test_default_floor_is_one(wire):
+    """With no configured threshold the durable floor defaults to 1, so a
+    single-durable agent is summarized rather than dropped."""
+    storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")]}))
+    # No min_activity_threshold in config -> default 1.
+    summary = await agent_digest.generate_for_org("org1", "week", {"model": "gpt-5.4-mini"}, now=NOW)
+    assert summary["generated"] == 1
     assert storage.upserts[0]["status"] == "ok"
-    assert storage.upserts[0]["source_count"] == 4
 
 
-async def test_daily_threshold_is_one(wire):
-    """Daily windows floor the activity threshold to 1 regardless of config, so a
-    barely-active agent still gets a daily digest (weekly would exclude it)."""
-    seed = {"a": [_mem(agent="a")] * 2, "b": [_mem(agent="b")] * 1}
-    agents = [{"agent_id": "a", "fleet_id": None}, {"agent_id": "b", "fleet_id": None}]
-
-    day = wire(FakeStorage(agents, seed))
-    s_day = await agent_digest.generate_for_org("org1", "day", CONFIG, now=NOW)
-    assert s_day["generated"] == 2  # both included at floor 1
-    assert sorted(r["agent_id"] for r in day.upserts) == ["a", "b"]
-
-    week = wire(FakeStorage(agents, seed))
-    s_week = await agent_digest.generate_for_org("org1", "week", CONFIG, now=NOW)
-    assert s_week["generated"] == 0  # both below the week floor of 3
-
-
-async def test_cohesive_filter_drops_noise_and_episodes(wire):
+async def test_noise_dropped_episodes_become_events(wire):
+    """Heartbeat/noise titles are dropped entirely; episodes are retained as
+    events (not dropped) and counted toward the family total."""
     storage = wire(
         FakeStorage(
             [{"agent_id": "a", "fleet_id": None}],
@@ -111,8 +111,11 @@ async def test_cohesive_filter_drops_noise_and_episodes(wire):
         )
     )
     await agent_digest.generate_for_org("org1", "day", CONFIG, now=NOW)
-    # Only the 3 real decision rows survive the cohesive filter.
-    assert storage.upserts[0]["source_count"] == 3
+    row = storage.upserts[0]
+    # 3 durable (decisions) + 5 non-noise episodes (events); the 5 heartbeat rows
+    # are dropped. Durable path used (3 >= floor); source_count = family total.
+    assert row["source_count"] == 8
+    assert row["status"] == "ok"
 
 
 async def test_top_n_limits_llm_calls_to_busiest(wire):
@@ -141,11 +144,12 @@ async def test_cost_cap_trims_agents(wire):
     assert summary["generated"] == 2
 
 
-async def test_truncation_status_and_capped_source_count(wire):
+async def test_truncation_status_and_family_total_source_count(wire):
     storage = wire(FakeStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 5}))
     await agent_digest.generate_for_org("org1", "day", {**CONFIG, "max_memories_per_agent": 2}, now=NOW)
-    assert storage.upserts[0]["status"] == "truncated"
-    assert storage.upserts[0]["source_count"] == 2
+    assert storage.upserts[0]["status"] == "truncated"  # 5 durable > cap of 2
+    # source_count is the family total (meaningful writes), not the capped corpus.
+    assert storage.upserts[0]["source_count"] == 5
 
 
 async def test_fleet_id_passthrough_and_window(wire):
@@ -248,6 +252,113 @@ async def test_retention_prune_runs_with_cutoff(wire):
     summary = await agent_digest.generate_for_org("org1", "day", {**CONFIG, "retention_days": 30}, now=NOW)
     assert summary["pruned"] == 3
     assert storage.pruned == ("org1", "2026-06-06T00:00:00+00:00")  # NOW - 30d
+
+
+async def test_subagent_rollup_under_parent(wire):
+    """cmoclaw + its subagents (both id conventions) roll into ONE parent family
+    row; source_count is the family total and subagents lists the children."""
+    agents = [
+        {"agent_id": "cmoclaw", "fleet_id": "f1"},
+        {"agent_id": "cmoclaw-affiliate-fix", "fleet_id": "f1"},
+        {"agent_id": "agent:cmoclaw:subagent:abc", "fleet_id": "f1"},
+        {"agent_id": "other", "fleet_id": None},
+    ]
+    seed = {
+        "cmoclaw": [_mem(agent="cmoclaw")] * 2,
+        "cmoclaw-affiliate-fix": [_mem(agent="cmoclaw-affiliate-fix")] * 3,
+        "agent:cmoclaw:subagent:abc": [_mem(agent="agent:cmoclaw:subagent:abc")] * 1,
+        "other": [_mem(agent="other")] * 4,
+    }
+    storage = wire(FakeStorage(agents, seed))
+    await agent_digest.generate_for_org("org1", "week", CONFIG, now=NOW)
+    rows = {r["agent_id"]: r for r in storage.upserts}
+    assert set(rows) == {"cmoclaw", "other"}  # no standalone subagent rows
+    fam = rows["cmoclaw"]
+    assert fam["source_count"] == 6  # 2 + 3 + 1 rolled up
+    assert {s["agent_id"] for s in fam["subagents"]} == {
+        "cmoclaw-affiliate-fix",
+        "agent:cmoclaw:subagent:abc",
+    }
+
+
+async def test_episode_only_agent_summarized_as_activity(wire):
+    """An agent with only episodes (no durable rows) is summarized from its
+    events with status 'activity' — it is no longer invisible."""
+    storage = wire(
+        FakeStorage(
+            [{"agent_id": "tradingclaw", "fleet_id": "f1"}],
+            {"tradingclaw": [_mem(agent="tradingclaw", mtype="episode")] * 5},
+        )
+    )
+    summary = await agent_digest.generate_for_org("org1", "week", CONFIG, now=NOW)
+    assert summary["generated"] == 1
+    row = storage.upserts[0]
+    assert row["status"] == "activity"
+    assert row["source_count"] == 5
+
+
+async def test_active_beyond_top_n_are_listed(wire):
+    """Active families past top_n aren't dropped — they become count-only rows."""
+    agents = [{"agent_id": f"a{i}", "fleet_id": None} for i in range(3)]
+    seed = {f"a{i}": [_mem(agent=f"a{i}")] * (5 - i) for i in range(3)}  # 5,4,3
+    storage = wire(FakeStorage(agents, seed))
+    summary = await agent_digest.generate_for_org("org1", "week", {**CONFIG, "top_n": 1}, now=NOW)
+    assert summary["generated"] == 1
+    assert summary["listed"] == 2
+    statuses = {r["agent_id"]: r["status"] for r in storage.upserts}
+    assert statuses == {"a0": "ok", "a1": "listed", "a2": "listed"}
+
+
+async def test_events_fallback_keeps_durable_rows(monkeypatch, wire):
+    """When falling back to the event corpus, below-floor durable rows are still
+    included (prepended) so decisions aren't silently dropped."""
+    captured: dict = {}
+    orig = agent_digest._build_prompt
+
+    def _cap(agent, mems, period, mode="durable"):
+        captured["mems"] = mems
+        captured["mode"] = mode
+        return orig(agent, mems, period, mode)
+
+    monkeypatch.setattr(agent_digest, "_build_prompt", _cap)
+    # floor 3 (CONFIG): 2 durable < 3 -> event fallback (5 events >= event_floor 1)
+    wire(
+        FakeStorage(
+            [{"agent_id": "a", "fleet_id": None}],
+            {"a": [_mem(agent="a", title="key decision")] * 2 + [_mem(agent="a", mtype="episode")] * 5},
+        )
+    )
+    await agent_digest.generate_for_org("org1", "week", CONFIG, now=NOW)
+    assert captured["mode"] == "activity"
+    types = [m["memory_type"] for m in captured["mems"]]
+    assert types[:2] == ["decision", "decision"]  # durable prepended
+    assert "episode" in types
+
+
+async def test_listed_upsert_failure_counts_as_errored(wire):
+    """A storage failure on a count-only ('listed') row is surfaced in errored."""
+
+    class FailingStorage(FakeStorage):
+        async def upsert_agent_activity_digest(self, row: dict) -> dict:
+            raise RuntimeError("db down")
+
+    # 2 durable < floor 3, no events -> listed path; the upsert then fails.
+    wire(FailingStorage([{"agent_id": "a", "fleet_id": None}], {"a": [_mem(agent="a")] * 2}))
+    summary = await agent_digest.generate_for_org("org1", "week", CONFIG, now=NOW)
+    assert summary["listed"] == 0
+    assert summary["errored"] == 1
+
+
+async def test_build_prompt_tags_subagent_rows():
+    """Rolled-up rows from a subagent are attributed; the parent's own are not."""
+    agent = {"agent_id": "cmoclaw"}
+    mems = [
+        {"memory_type": "decision", "title": "x", "agent_id": "cmoclaw"},
+        {"memory_type": "decision", "title": "y", "agent_id": "cmoclaw-affiliate-fix"},
+    ]
+    prompt = agent_digest._build_prompt(agent, mems, "week")
+    assert "[from cmoclaw-affiliate-fix]" in prompt
+    assert "[from cmoclaw]" not in prompt
 
 
 async def test_run_agent_digest_rejects_bad_period(wire):

--- a/core-api/tests/test_report_corpus.py
+++ b/core-api/tests/test_report_corpus.py
@@ -1,0 +1,49 @@
+"""Unit tests for the shared report-corpus helpers (CAURA-222)."""
+
+from __future__ import annotations
+
+from core_api.services.report_corpus import is_cohesive, passes_noise_filter, resolve_parent
+
+
+def test_resolve_parent_explicit_subagent_convention():
+    known = frozenset({"quantclaw"})
+    assert resolve_parent("agent:quantclaw:subagent:4ce6c6c9", known) == "quantclaw"
+    # parent need not be a registered agent — still resolves to the derived name
+    assert resolve_parent("agent:devclaw:subagent:x", frozenset()) == "devclaw"
+
+
+def test_resolve_parent_prefix_convention_longest_and_transitive():
+    known = frozenset({"cmoclaw", "cmoclaw-affiliate", "other"})
+    # longest known prefix, then resolved transitively to the root
+    assert resolve_parent("cmoclaw-affiliate-ai-fix", known) == "cmoclaw"
+    assert resolve_parent("cmoclaw-a11y-audit", known) == "cmoclaw"
+
+
+def test_resolve_parent_boundary_guard():
+    # 'cmo' must not swallow 'cmoclaw' — the boundary is a '-'
+    assert resolve_parent("cmoclaw", frozenset({"cmo"})) == "cmoclaw"
+
+
+def test_resolve_parent_top_level_is_itself():
+    known = frozenset({"standalone", "other"})
+    assert resolve_parent("standalone", known) == "standalone"
+
+
+def _m(mtype="decision", title="did a thing", agent="a"):
+    return {"memory_type": mtype, "title": title, "agent_id": agent}
+
+
+def test_filter_split_durable_vs_events_vs_noise():
+    durable = _m()
+    episode = _m(mtype="episode")
+    heartbeat = _m(title="heartbeat check")
+    firehose = _m(agent="main")
+
+    # durable: passes noise AND not episode
+    assert is_cohesive(durable) and passes_noise_filter(durable)
+    # episode: real signal (passes noise) but NOT cohesive -> the events fallback
+    assert passes_noise_filter(episode) and not is_cohesive(episode)
+    # heartbeat title: dropped by both
+    assert not passes_noise_filter(heartbeat) and not is_cohesive(heartbeat)
+    # firehose agent: dropped by both
+    assert not passes_noise_filter(firehose) and not is_cohesive(firehose)

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/032_agent_digest_subagents.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/032_agent_digest_subagents.py
@@ -1,0 +1,36 @@
+"""Add ``subagents`` column to ``agent_activity_digests``.
+
+Subagent rollup (CAURA-222): a digest row now represents an agent *family* — the
+parent plus any subagents whose work rolled up into it. ``subagents`` holds the
+contributing children as ``[{agent_id, fleet_id, source_count}]`` so the report
+can render them collapsed under the parent (and deep-link each into Prism).
+
+NOT NULL default ``'[]'`` — existing rows and standalone agents carry an empty
+list.
+
+Revision ID: 032
+Revises: 031
+Create Date: 2026-07-20
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "032"
+down_revision: str | None = "031"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_activity_digests",
+        sa.Column("subagents", JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_activity_digests", "subagents")

--- a/core-storage-api/src/core_storage_api/schemas.py
+++ b/core-storage-api/src/core_storage_api/schemas.py
@@ -242,6 +242,7 @@ AGENT_DIGEST_FIELDS: list[str] = [
     "window_end",
     "narrative",
     "sections",
+    "subagents",
     "source_count",
     "recall_count",
     "model",

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -8438,6 +8438,7 @@ class PostgresService:
                 "window_end": insert_stmt.excluded.window_end,
                 "narrative": insert_stmt.excluded.narrative,
                 "sections": insert_stmt.excluded.sections,
+                "subagents": insert_stmt.excluded.subagents,
                 "source_count": insert_stmt.excluded.source_count,
                 "recall_count": insert_stmt.excluded.recall_count,
                 "model": insert_stmt.excluded.model,

--- a/core-storage-api/tests/test_agent_digest.py
+++ b/core-storage-api/tests/test_agent_digest.py
@@ -149,3 +149,24 @@ async def test_upsert_validation(client: AsyncClient, mutate: dict, detail_needl
     resp = await _post(client, body)
     assert resp.status_code == 422, resp.text
     assert detail_needle in resp.text
+
+
+async def test_upsert_roundtrips_subagents(client: AsyncClient):
+    """The rolled-up subagents list persists and is returned by the read path."""
+    tenant = f"dig-{_uid()}"
+    subs = [
+        {"agent_id": "cmoclaw-affiliate-fix", "fleet_id": "etoro0", "source_count": 3},
+        {"agent_id": "cmoclaw-a11y-audit", "fleet_id": None, "source_count": 1},
+    ]
+    r = await _post(client, _row(tenant, "cmoclaw", subagents=subs))
+    assert r.status_code == 200, r.text
+    rows = await _latest(client, tenant)
+    assert rows[0]["subagents"] == subs
+
+
+async def test_upsert_subagents_defaults_to_empty_list(client: AsyncClient):
+    """A row written without subagents comes back with an empty list, not null."""
+    tenant = f"dig-{_uid()}"
+    await _post(client, _row(tenant, "solo"))
+    rows = await _latest(client, tenant)
+    assert rows[0]["subagents"] == []

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"031"}, f"Expected single head '031', got {sorted(heads)}"
+        assert heads == {"032"}, f"Expected single head '032', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -688,6 +688,8 @@ class TestMigrationChain:
         assert chain.get("030") == "029", "030 must follow 029"
         # 031: broker-write agent ownership column (owner_install_uuid)
         assert chain.get("031") == "030", "031 must follow 030"
+        # 032: agent-digest subagents rollup column (CAURA-222)
+        assert chain.get("032") == "031", "032 must follow 031"
 
     def test_no_plain_create_index_on_large_tables(self):
         """Indexes on large, pre-existing tables MUST be built ``CONCURRENTLY``


### PR DESCRIPTION
Grounded in the eToro over-filtering finding: active agents were invisible in the digest because their work is **enrichment-classified as `episode`** (which we excluded wholesale) and/or **split across many subagents** (e.g. `cmoclaw` + ~40 `cmoclaw-*`). Core-api side (PR 1 of 2; UI PR follows).

## Fixes
1. **Durable floor 3→1** (default; removed the day/week special-case) — a single decision/fact is worth surfacing. Configurable via `min_activity_threshold`.
2. **Durable-first, episode-fallback** (`report_corpus` split into `passes_noise_filter` + `is_cohesive`). `generate_for_org` **reuses the already-fetched rows** (no extra query): an agent with `< floor` durable rows is summarized from its non-noise **episodes** (ranked by recall) with status `activity`. Same LLM budget; in-memory partition.
3. **Count-only "listed" tail** — active families past `top_n` (or below the summarize floors) get a no-LLM row, so no active agent is invisible.
4. **Subagent rollup** — `resolve_parent` derives the parent from id conventions (`agent:<p>:subagent:<uuid>` and `<parent>-<task>`, longest-prefix, transitive; `owner_ref` is unpopulated in prod). Subagents roll into the parent family; the parent row carries `source_count` = family total + a `subagents[]` list (`{agent_id, fleet_id, source_count}`) for the collapsed UI + child deeplinks. **Migration 032** adds the `subagents` JSONB column.

`source_count` now means the family's **meaningful-writes total** (the bar value). New statuses: `activity`, `listed`.

## Config (`agent_digest`)
`min_activity_threshold=1`, `event_floor=1`, `listed_max=25`.

## Tests
- `report_corpus`: `resolve_parent` (both conventions, boundary guard, transitive) + filter split.
- generator: floor→summarize/list, episode-only→`activity`, cmoclaw rollup (both id forms), active-beyond-top_n→`listed`.
- storage: `subagents` round-trip + empty default; migration head→032.
- 23 core-api + 13 storage tests green; ruff + mypy clean (both packages).

Cost: no new queries; LLM spend unchanged/lower (one call per family, `top_n`-bounded). Depends on nothing; the enterprise UI PR (collapsed subagent group + `activity`/`listed` rendering + child deeplinks) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)