### PR TITLE
fix(memories): /memories/count returns 0 for enriched tenants — count the live status set

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -1,5 +1,17 @@
 """DB-query constants shared between core-api and core-storage-api."""
 
+# ── Memory liveness ──
+# The statuses that mean "this memory is live". Broader than the literal
+# ``active`` value: enrichment promotes writes past ``active`` on the normal
+# path (the classifier assigns ``confirmed`` to outcome-shaped content and
+# ``pending`` to task/plan/commitment content, and the crystallizer writes
+# ``confirmed`` directly), so a liveness check that tests ``status ==
+# "active"`` silently drops enriched rows. Excludes the terminal/shelved
+# states (``cancelled``, ``outdated``, ``conflicted``, ``archived``,
+# ``deleted``). Callers that genuinely want one exact status filter on it
+# explicitly instead.
+LIVE_MEMORY_STATUSES = ("active", "confirmed", "pending")
+
 # ── Embeddings ──
 # Native dim of the default embedder (BAAI/bge-m3, see local-embedder docs).
 # Schema upgrade lives in alembic migration 012_vector_dim_1024.py — keep

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -727,10 +727,18 @@ class CoreStorageClient:
         result = await self._post("/preview/tenant-counts", {"tenant_id": tenant_id})
         return result.get("counts", {})  # type: ignore[union-attr,return-value]
 
-    async def count_active(self, tenant_id: str, fleet_id: str | None = None) -> int:
+    async def count_active(
+        self,
+        tenant_id: str,
+        fleet_id: str | None = None,
+        status: str | None = None,
+    ) -> int:
+        """Live-memory count; ``status`` narrows to one exact status."""
         params: dict[str, Any] = {"tenant_id": tenant_id}
         if fleet_id is not None:
             params["fleet_id"] = fleet_id
+        if status is not None:
+            params["status"] = status
         result = await self._get("/memories/count-active", **params)
         return (result or {}).get("count", 0)
 

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -30,6 +30,7 @@ from core_api.config import settings as app_settings
 from core_api.constants import (
     DEFAULT_LIST_LIMIT,
     MAX_LIST_LIMIT,
+    MEMORY_STATUSES_PATTERN,
 )
 from core_api.middleware.idempotency import (
     IDEMPOTENCY_HEADER,
@@ -361,9 +362,16 @@ async def memory_stats(
 async def memory_count(
     tenant_id: str | None = Query(default=None),
     fleet_id: str | None = Query(default=None),
+    status: str | None = Query(default=None, pattern=MEMORY_STATUSES_PATTERN),
     auth: AuthContext = Depends(get_auth_context),
 ):
-    """Count active (non-deleted) memories for a tenant, optionally a fleet.
+    """Count live (non-deleted) memories for a tenant, optionally a fleet.
+
+    "Live" is the whole ``LIVE_MEMORY_STATUSES`` set (``active``,
+    ``confirmed``, ``pending``) — NOT just the literal ``active`` value, which
+    is what this counted before and why tenants whose rows enrichment had
+    promoted to ``confirmed``/``pending`` saw 0 while ``GET /memories`` listed
+    them. Pass ``status`` to count exactly one status instead.
 
     A lightweight operational primitive — for type/agent/status breakdowns use
     ``GET /memories/stats``. Declared BEFORE ``/memories/{memory_id}`` so the
@@ -384,7 +392,7 @@ async def memory_count(
         tenant_id = auth.tenant_id
     if not tenant_id:
         raise HTTPException(status_code=400, detail="tenant_id is required")
-    count = await get_storage_client().count_active(tenant_id, fleet_id)
+    count = await get_storage_client().count_active(tenant_id, fleet_id, status=status)
     return {"count": count}
 
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -719,6 +719,13 @@ async def get_embedding_coverage(
     tenant_id: str,
     fleet_id: str | None = None,
 ) -> dict:
+    """Share of live memories that have an embedding.
+
+    Numerator and denominator both scope to ``LIVE_MEMORY_STATUSES`` — they
+    used to disagree (missing spanned every status, total only ``active``),
+    which let coverage_pct exceed 100% or go negative. ``missing_embeddings``
+    is still capped by the finder's batch_size, so treat it as a floor.
+    """
     missing = await _svc.memory_find_missing_embeddings(tenant_id, fleet_id)
     total = await _svc.memory_count_active(tenant_id, fleet_id)
     return {
@@ -779,17 +786,34 @@ async def get_lifecycle_candidates(tenant_id: str) -> dict:
 async def count_memories(
     tenant_id: str,
     fleet_id: str | None = None,
+    status: str | None = None,
 ) -> dict:
+    """Count live memories for a tenant. ``status`` narrows to one exact status.
+
+    An empty ``tenant_id`` (``?tenant_id=`` — an omitted param is a 422, since
+    the annotation is non-optional) falls through to the whole-corpus counter,
+    which takes no filters: ``fleet_id`` and ``status`` do NOT apply there. That
+    branch predates this endpoint's filters; it stays as-is rather than growing
+    a second filtered code path.
+    """
     if not tenant_id:
         count = await _svc.memory_count_all()
     else:
-        count = await _svc.memory_count_active(tenant_id, fleet_id)
+        count = await _svc.memory_count_active(tenant_id, fleet_id, status=status)
     return {"count": count}
 
 
 @router.get("/count-active")
-async def count_active_memories(tenant_id: str, fleet_id: str | None = None) -> dict:
-    count = await _svc.memory_count_active(tenant_id, fleet_id)
+async def count_active_memories(
+    tenant_id: str,
+    fleet_id: str | None = None,
+    status: str | None = None,
+) -> dict:
+    """Count live memories (``LIVE_MEMORY_STATUSES``), not just literal ``active``.
+
+    Pass ``status=active`` for the old narrow behaviour.
+    """
+    count = await _svc.memory_count_active(tenant_id, fleet_id, status=status)
     return {"count": count}
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -49,6 +49,7 @@ from common.constants import (
     ENTITY_RESOLUTION_CANDIDATE_LIMIT,
     GRAPH_MAX_EXPANDED_ENTITIES,
     GRAPH_MAX_HOPS,
+    LIVE_MEMORY_STATUSES,
     RECALL_BOOST_SCALE,
     RELATION_TYPE_WEIGHTS,
     SEMANTIC_DEDUP_CANDIDATE_LIMIT,
@@ -2216,14 +2217,26 @@ class PostgresService:
         self,
         tenant_id: str,
         fleet_id: str | None = None,
+        status: str | None = None,
     ) -> int:
+        """Count live (non-deleted) memories for a tenant, optionally a fleet.
+
+        ``status=None`` counts the whole live set (``LIVE_MEMORY_STATUSES``),
+        matching what the sibling dedup/successor queries treat as live. It
+        used to test ``status == "active"`` literally, which silently returned
+        0 for tenants whose rows enrichment had promoted to ``confirmed`` /
+        ``pending``. Pass an explicit ``status`` to count exactly that one.
+        """
+        status_filter = (
+            Memory.status == status if status is not None else Memory.status.in_(LIVE_MEMORY_STATUSES)
+        )
         async with get_read_session() as session:
             stmt = (
                 select(func.count())
                 .select_from(Memory)
                 .where(
                     Memory.tenant_id == tenant_id,
-                    Memory.status == "active",
+                    status_filter,
                     Memory.deleted_at.is_(None),
                 )
             )
@@ -2445,6 +2458,13 @@ class PostgresService:
         fleet_id: str | None,
         batch_size: int = 100,
     ) -> list[tuple]:
+        """Live memories with no embedding (drives /embedding-coverage).
+
+        Scoped to ``LIVE_MEMORY_STATUSES`` so it counts the same population as
+        ``memory_count_active``, which is the coverage denominator. Without the
+        status filter the numerator spanned every status while the denominator
+        did not, so coverage_pct could exceed 100% or go negative.
+        """
         async with get_session() as session:
             scope, params = _scope_sql(tenant_id, fleet_id)
             result = await session.execute(
@@ -2454,9 +2474,14 @@ class PostgresService:
                 WHERE {scope}
                   AND m.embedding IS NULL
                   AND m.deleted_at IS NULL
+                  AND m.status = ANY(CAST(:live_statuses AS text[]))
                 LIMIT :batch_size
             """),
-                {**params, "batch_size": batch_size},
+                {
+                    **params,
+                    "batch_size": batch_size,
+                    "live_statuses": list(LIVE_MEMORY_STATUSES),
+                },
             )
             return result.all()  # type: ignore[return-value]
 

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -1002,6 +1002,48 @@ class TestMemories:
         assert post_total == before_total
         assert post_agents == before_agents
 
+    async def test_embedding_coverage_spans_the_live_status_set(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+    ) -> None:
+        """``/embedding-coverage`` numerator and denominator cover the same rows.
+
+        Regression: ``missing_embeddings`` spanned every status while
+        ``total_active`` counted only literal ``status='active'``, so an
+        enriched tenant's coverage_pct was computed against a denominator that
+        excluded most of the numerator (it could exceed 100% or go negative).
+
+        Own fleet so the counts are exact rather than baseline-relative.
+        """
+        fleet = f"embcov-{_uid()}"
+
+        # Promoted past 'active' by enrichment, and still awaiting its embedding.
+        promoted = _memory_payload(tenant_id, fleet, content=f"promoted {_uid()}")
+        promoted["status"] = "confirmed"
+        promoted["embedding"] = None
+        assert (await client.post(f"{PREFIX}/memories", json=promoted)).status_code in (200, 201)
+
+        # Plain active row that already has its embedding.
+        embedded = _memory_payload(tenant_id, fleet, content=f"embedded {_uid()}")
+        assert (await client.post(f"{PREFIX}/memories", json=embedded)).status_code in (200, 201)
+
+        resp = await client.get(
+            f"{PREFIX}/memories/embedding-coverage",
+            params={"tenant_id": tenant_id, "fleet_id": fleet},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        # Denominator counts the confirmed row too (it was 1, not 2, pre-fix).
+        assert body["total_active"] == 2
+        assert body["missing_embeddings"] == 1
+        assert body["coverage_pct"] == 50.0
+        # The invariant that made this a bug: numerator can never exceed
+        # denominator, so the percentage can never go negative.
+        assert body["missing_embeddings"] <= body["total_active"]
+        assert body["coverage_pct"] >= 0.0
+
     async def test_patch_entities_is_bulk_and_idempotent(
         self,
         client: AsyncClient,

--- a/tests/test_api_memories.py
+++ b/tests/test_api_memories.py
@@ -71,6 +71,111 @@ async def test_memory_count(client):
     assert resp.json() == {"count": 2}
 
 
+async def _set_status(
+    client, tenant_id: str, headers: dict, memory_id: str, status: str
+) -> None:
+    """Promote a memory past ``active``, the way enrichment does on write."""
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}/status?tenant_id={tenant_id}",
+        json={"status": status},
+        headers=headers,
+    )
+    assert resp.status_code == 200, f"status transition failed: {resp.text}"
+
+
+async def test_memory_count_includes_enriched_statuses(client):
+    """/memories/count counts the LIVE set, not just literal status='active'.
+
+    Regression: the count filtered ``status == "active"`` while the list
+    endpoint left status unfiltered, so a tenant whose rows enrichment had
+    promoted to ``confirmed``/``pending`` read count=0 with a full list.
+    """
+    tenant_id, headers = get_test_auth()
+    fleet = f"count-live-{_uid()}"
+
+    await _write_memory(client, tenant_id, headers, "a", fleet_id=fleet)
+    becomes_confirmed = await _write_memory(
+        client, tenant_id, headers, "b", fleet_id=fleet
+    )
+    becomes_pending = await _write_memory(
+        client, tenant_id, headers, "c", fleet_id=fleet
+    )
+    await _set_status(client, tenant_id, headers, becomes_confirmed["id"], "confirmed")
+    await _set_status(client, tenant_id, headers, becomes_pending["id"], "pending")
+
+    resp = await client.get(
+        f"/api/v1/memories/count?tenant_id={tenant_id}&fleet_id={fleet}",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    # Would have been 1 (only ``stays_active``) before the fix.
+    assert resp.json() == {"count": 3}
+
+    # …and the count now agrees with what the list returns — the exact
+    # discrepancy that surfaced this bug.
+    listed = await client.get(
+        f"/api/v1/memories?tenant_id={tenant_id}&fleet_id={fleet}&limit=50",
+        headers=headers,
+    )
+    assert listed.status_code == 200, listed.text
+    data = listed.json()
+    memories = data.get("items", data) if isinstance(data, dict) else data
+    assert len(memories) == 3
+
+
+async def test_memory_count_status_param_narrows(client):
+    """``?status=`` counts exactly one status (the old narrow behaviour)."""
+    tenant_id, headers = get_test_auth()
+    fleet = f"count-narrow-{_uid()}"
+
+    await _write_memory(client, tenant_id, headers, "stays active", fleet_id=fleet)
+    promoted = await _write_memory(
+        client, tenant_id, headers, "promoted", fleet_id=fleet
+    )
+    await _set_status(client, tenant_id, headers, promoted["id"], "confirmed")
+
+    async def count(**params) -> int:
+        qs = "".join(f"&{k}={v}" for k, v in params.items())
+        resp = await client.get(
+            f"/api/v1/memories/count?tenant_id={tenant_id}&fleet_id={fleet}{qs}",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["count"]
+
+    assert await count() == 2  # live set
+    assert await count(status="active") == 1
+    assert await count(status="confirmed") == 1
+    assert await count(status="archived") == 0
+
+
+async def test_memory_count_excludes_shelved_statuses(client):
+    """Live means live: ``archived`` and friends drop out of the default count."""
+    tenant_id, headers = get_test_auth()
+    fleet = f"count-shelved-{_uid()}"
+
+    await _write_memory(client, tenant_id, headers, "live one", fleet_id=fleet)
+    shelved = await _write_memory(
+        client, tenant_id, headers, "shelved one", fleet_id=fleet
+    )
+    await _set_status(client, tenant_id, headers, shelved["id"], "archived")
+
+    resp = await client.get(
+        f"/api/v1/memories/count?tenant_id={tenant_id}&fleet_id={fleet}",
+        headers=headers,
+    )
+    assert resp.json() == {"count": 1}
+
+
+async def test_memory_count_rejects_invalid_status(client):
+    """``status`` is pattern-validated, so typos 422 instead of counting 0."""
+    tenant_id, headers = get_test_auth()
+    resp = await client.get(
+        f"/api/v1/memories/count?tenant_id={tenant_id}&status=bogus", headers=headers
+    )
+    assert resp.status_code == 422
+
+
 async def test_list_memories(client):
     """Write 3 memories, GET /api/memories?tenant_id=X → list includes them."""
     tenant_id, headers = get_test_auth()


### PR DESCRIPTION
## The bug

`GET /memories/count` returns **0** for tenants that have live memories, while `GET /memories` lists them normally. Reported against tenant `beacon-4c8fca` (7 rows listed, count 0).

`memory_count_active` filtered on the literal status value:

```python
Memory.status == "active"
```

…but "active" is being used in two different senses. The public endpoint's docstring promises *liveness* ("Count **active (non-deleted)** memories"), while the SQL tests one enum value. `confirmed` is a **stronger** liveness state than `active`, yet it was excluded.

## Why this is the count query's bug, not the caller's

Every sibling query in the same service already defines live as a **set**:

```python
Memory.status.in_(("active", "confirmed", "pending"))
```

— `memory_find_semantic_duplicate`, `memory_find_entity_overlap_candidates`, `memory_find_rdf_conflicts`, `memory_find_similar_candidates`. `memory_count_active` was the lone outlier. `/memories/stats` is also already liveness-based (`deleted_at IS NULL` only), so `/count` and `/stats` contradicted each other on the same tenant.

And `confirmed`/`pending` are reachable on the **normal** write path, not just by explicit transition:

- the enrichment classifier assigns `confirmed` to outcome-shaped content and `pending` to task/plan/commitment content (`common/enrichment/service.py`)
- the crystallizer writes `status="confirmed"` directly (`crystallizer_service.py`)
- the enrichment prompt explicitly offers all three (`_prompts.py`)

So any tenant whose writes get enriched drifts toward `count=0` while its list fills up.

## The fix

Adds `LIVE_MEMORY_STATUSES = ("active", "confirmed", "pending")` to `common/constants.py` — the module that already exists for "DB-query constants shared between core-api and core-storage-api" — as the single definition of liveness.

`memory_count_active(status=None)` counts that set; an explicit `status` counts exactly one. Threaded through:

| Layer | Change |
|---|---|
| `memory_count_active` | `status` param; default = live set |
| storage `/count`, `/count-active` | `status` query param, passed through |
| `storage_client.count_active` | forwards `status` |
| public `/memories/count` | `status` query param, **pattern-validated** so a typo 422s instead of silently counting 0 |

### Also: `/embedding-coverage` could report a negative percentage

Same mechanism, second-order. `memory_find_missing_embeddings` (its numerator) filtered `deleted_at IS NULL` with **no** status filter, while `memory_count_active` (its denominator) counted only `active`:

```
coverage_pct = (total - len(missing)) / total * 100
```

1 `active` + 6 `confirmed` rows all missing embeddings → `(1 - 7) / 1 * 100` = **−600%**. The reporting tenant only dodged it because `total=0` tripped the zero-guard. The numerator is now scoped to the same live set, so `missing ≤ total` holds by construction.

## Behaviour change

`/memories/count` and `/memories/count-active` now report the **live set** by default. Callers who want the old narrow number pass `status=active`. `/count-active` keeps its name but its default widens — flagging explicitly since the name now reads narrower than it behaves.

## Testing

Five new tests. The key one **fails on pre-fix code with exactly the reported symptom** — verified by reverting the filter and re-running (`assert {'count': 1} == {'count': 3}`):

- `test_memory_count_includes_enriched_statuses` — 1 active + 1 confirmed + 1 pending → count 3, and the count now **agrees with the list length**, the exact discrepancy that surfaced this
- `test_memory_count_status_param_narrows` — `?status=active` → 1, `?status=confirmed` → 1
- `test_memory_count_excludes_shelved_statuses` — `archived` drops out (liveness, not just non-deleted)
- `test_memory_count_rejects_invalid_status` — 422 on a bad status
- `test_embedding_coverage_spans_the_live_status_set` — denominator counts the confirmed row; asserts `missing ≤ total` and `coverage_pct ≥ 0`. This endpoint previously had **no** tests.

Gates:

- CI suite (`tests/`): **3954 passed**, 3 skipped, 1 xfailed, 3 xpassed — zero failures
- `ruff check` + `ruff format --check` (core-api, core-storage-api) clean
- `mypy` clean for both configs (188 + 73 files)

> `core-storage-api/tests/` is not run by CI and has 31 failures on `origin/main` in a local environment. Verified my branch is identical: **31 failed / 69 passed** clean vs **31 failed / 70 passed** here — the +1 is the new test. No regressions introduced; the pre-existing rot is untouched and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
