### PR TITLE
chore(fleet): bump plugin auto-upgrade floor to 2.15.2 (arm Interviewer plugin)

### DIFF
--- a/core-api/src/core_api/version_compat.py
+++ b/core-api/src/core_api/version_compat.py
@@ -8,13 +8,14 @@ recommended version; no hard rejection — operators decide when to upgrade.
 
 # Auto-upgrade target / "outdated" floor. The fleet heartbeat queues a deploy
 # to this version for eligible nodes (>= MIN_AUTO_DEPLOY, auto-upgrade enabled).
-# Reconciled to the current shipped plugin release. 2.14.0 is a superset of
-# 2.13.0 (which carries the reserved-"main" write self-identification / firehose
-# de-collapse, #507 — preserved) plus opt-in recall-gating + cross-agent recall
-# (#530), both flag-gated OFF by default (MEMCLAW_RECALL_GATE / _CROSS_AGENT), so
-# auto-upgrading the fleet to 2.14.0 changes no recall behavior until those env
-# flags are set. Bumping the floor pulls the fleet onto 2.14.0.
-MIN_RECOMMENDED_PLUGIN_VERSION = "2.14.0"
+# Reconciled to the current shipped plugin release. 2.15.2 is a superset of
+# 2.14.0 (firehose de-collapse #507 + flag-gated recall-gating/cross-agent #530,
+# both preserved) plus the Interviewer plugin side (durable buffer +
+# interview_request handler, Phase 1 #564). The Interviewer handler stays dark
+# until MEMCLAW_INTERVIEWER=true per node AND the per-tenant interviewer.enabled
+# flag is on server-side, so auto-upgrading the fleet to 2.15.2 changes no
+# behavior until those are set. Bumping the floor pulls the fleet onto 2.15.2.
+MIN_RECOMMENDED_PLUGIN_VERSION = "2.15.2"
 
 # Server-side floor below which plugins must NOT auto-upgrade — the
 # heartbeat path in ``routes/fleet.py`` enforces this hard, and


### PR DESCRIPTION
Bump MIN_RECOMMENDED_PLUGIN_VERSION 2.14.0 -> 2.15.2 for onprem-v2.11.11 (backend-v2.24.0). Plugin 2.15.2 carries the Interviewer plugin side (#564). Superset of 2.14.0 (de-collapse #507 + flag-gated #530 preserved). Interviewer stays dark until MEMCLAW_INTERVIEWER per node AND per-tenant interviewer.enabled — floor bump alone activates nothing. Floor invariant holds (MIN_AUTO_DEPLOY 2.6.0 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)