### PR TITLE
fix(lifecycle): pin the crystallize spend gate to literal status='active'

### DIFF
--- a/core-api/src/core_api/services/lifecycle_audit.py
+++ b/core-api/src/core_api/services/lifecycle_audit.py
@@ -85,7 +85,15 @@ class _CoreApiLifecycleAdapter:
         config = await resolve_config(org_id)
         if not config.auto_crystallize_enabled:
             return 0
-        active = await self._storage.count_active(org_id, fleet_id)
+        # Explicit ``status="active"``: this gate gets the literal active count,
+        # NOT the wider live set (active/confirmed/pending) that ``count_active``
+        # returns by default since #626. #626 fixed a read-path under-count, but
+        # this call site is a *spend* gate — widening it would silently open
+        # auto-crystallization (LLM work) for orgs that sit under the threshold
+        # on active rows alone. Keep the two decisions decoupled; revisit the
+        # threshold deliberately if the live set is the better measure of "big
+        # enough corpus to be worth crystallizing".
+        active = await self._storage.count_active(org_id, fleet_id, status="active")
         if active <= _CRYSTALLIZE_MIN_ACTIVE_MEMORIES:
             return 0
         # Lazy import: the crystallizer service has heavy transitive

--- a/tests/test_lifecycle_audit.py
+++ b/tests/test_lifecycle_audit.py
@@ -25,11 +25,20 @@ from core_api.services.lifecycle_audit import (
 )
 
 
+_UNSET = object()  # "count_active was never called" sentinel
+
+
 class _FakeStorage:
     def __init__(self, active: int) -> None:
         self._active = active
+        # Records the status the gate asked for, so a refactor can't silently
+        # widen this spend gate to the live set (see the status= test below).
+        self.status_arg: str | None | object = _UNSET
 
-    async def count_active(self, org_id: str, fleet_id: str | None) -> int:
+    async def count_active(
+        self, org_id: str, fleet_id: str | None, status: str | None = None
+    ) -> int:
+        self.status_arg = status
         return self._active
 
 
@@ -76,6 +85,35 @@ async def test_crystallize_skips_when_auto_disabled() -> None:
         new=AsyncMock(return_value=_Off()),
     ):
         assert await adapter.crystallize(org_id="t1", fleet_id=None) == 0
+
+
+@pytest.mark.asyncio
+async def test_crystallize_gate_counts_only_literal_active_status() -> None:
+    """The spend gate asks for ``status="active"``, not the wider live set.
+
+    ``count_active`` defaults to the live set (active/confirmed/pending) since
+    #626, which fixed a read-path under-count. This call site gates LLM work,
+    so it stays pinned to the literal active count — widening it would open
+    auto-crystallization for orgs that sit under the threshold on active rows
+    alone. Asserting the argument (not just the outcome) is the point: without
+    it the gate could be widened by a one-word change and nothing would fail.
+    """
+    storage = _FakeStorage(active=_CRYSTALLIZE_MIN_ACTIVE_MEMORIES + 1)
+    adapter = _CoreApiLifecycleAdapter(storage)
+    with (
+        patch(
+            "core_api.services.lifecycle_audit.resolve_config",
+            new=AsyncMock(return_value=_Cfg()),
+        ),
+        patch(
+            "core_api.services.crystallizer_service.run_crystallization",
+            autospec=True,
+        ) as mock_run,
+    ):
+        mock_run.return_value = uuid4()
+        await adapter.crystallize(org_id="t1", fleet_id="f1")
+
+    assert storage.status_arg == "active"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #626 (merged).

## Why

#626 widened `count_active`'s default from literal `status="active"` to the live set (`active`, `confirmed`, `pending`). Correct for the read path — that was the whole bug.

But a blast-radius audit across `memclaw`, `memclawd`, `caura-ops`, and `memclaw-enterprise` found that `count_active` has exactly **one** internal consumer that isn't a read:

`core-api/src/core_api/services/lifecycle_audit.py:88`

```python
active = await self._storage.count_active(org_id, fleet_id)
if active <= _CRYSTALLIZE_MIN_ACTIVE_MEMORIES:  # 1000
    return 0
```

This gates **auto-crystallization** — LLM work — so that small corpora don't pay for a report row plus hygiene/health checks. Widening the count silently lowers that bar: an org under 1000 on active rows alone, but over it once `confirmed`/`pending` count, starts running crystallization it wasn't running before.

That's a **spend** decision. It shouldn't be inherited as a side effect of a read-path bug fix.

## What

Pass `status="active"` explicitly at that one call site, holding the pre-#626 behaviour, with a comment recording why it's pinned so it doesn't get "fixed" back.

Whether the live set is actually the better measure of "corpus big enough to be worth crystallizing" is a real question — but it's a separate one, and should be decided on its own merits (and probably alongside the 1000 threshold itself), not silently.

## Everything else was clean

For the record, the same audit found no other exposure:

- **Broker (memclawd)** — its cloud surface is `/api/v1/memories`, `/memories/bulk`, `/memories/{id}`, `/memories/{id}/links`, `/search`, plus auth/installs/health/audit-log. Never calls a count endpoint.
- **MCP (`memclaw_stats`)** — routes to `compute_memory_stats` → storage `memory_stats_breakdown` (GROUPING SETS), which already filtered on `deleted_at IS NULL` only. It was already liveness-correct; #626 brought `/memories/count` *into* agreement with it.
- **caura-ops** — reads the MemClaw replica directly via SQLAlchemy models; no calls to these endpoints.
- **memclaw-enterprise** — its `count_active_*` symbols are `count_active_api_credentials`, unrelated.

## Testing

`_FakeStorage.count_active` now records the `status` argument, and `test_crystallize_gate_counts_only_literal_active_status` asserts it is `"active"`.

Asserting the **argument** rather than just the outcome is deliberate: the threshold behaviour looks identical in both cases for most fixtures, so without this the gate could be widened by a one-word change and nothing would fail. Verified the test has teeth by reverting the source change — it fails with `assert None == 'active'`.

- `tests/`: **3958 passed**, 3 skipped, 1 xfailed, 3 xpassed — zero failures
- `ruff check` + `ruff format --check` clean; `mypy` clean for both configs (188 + 73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
