### PR TITLE
fix(storage): provision test DB via migrations; accept omitted tenant_id on /count

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -784,17 +784,22 @@ async def get_lifecycle_candidates(tenant_id: str) -> dict:
 
 @router.get("/count")
 async def count_memories(
-    tenant_id: str,
+    tenant_id: str | None = None,
     fleet_id: str | None = None,
     status: str | None = None,
 ) -> dict:
     """Count live memories for a tenant. ``status`` narrows to one exact status.
 
-    An empty ``tenant_id`` (``?tenant_id=`` — an omitted param is a 422, since
-    the annotation is non-optional) falls through to the whole-corpus counter,
-    which takes no filters: ``fleet_id`` and ``status`` do NOT apply there. That
-    branch predates this endpoint's filters; it stays as-is rather than growing
-    a second filtered code path.
+    Omitting ``tenant_id`` (or passing it empty) returns the whole-corpus
+    counter, which takes no filters: ``fleet_id`` and ``status`` do NOT apply
+    on that path. It stays filterless rather than growing a second filtered
+    code path.
+
+    The annotation is optional so both forms reach that branch. It used to be
+    a bare ``str``, i.e. required, so only the empty-string form worked and an
+    omitted param 422'd — even though ``core-api``'s public-stats caller
+    (``routes/stats.py``, ``count_all(tenant_id="")``) and the whole-corpus
+    branch were both written for "no tenant".
     """
     if not tenant_id:
         count = await _svc.memory_count_all()

--- a/core-storage-api/tests/conftest.py
+++ b/core-storage-api/tests/conftest.py
@@ -34,30 +34,40 @@ _schema_ready = False
 
 @pytest.fixture(scope="session")
 async def _ensure_schema():
-    """Create extensions + tables for the test database once per session."""
+    """Provision the test database once per session, the way the app does.
+
+    Runs the Alembic migrations via ``init_database()`` — the same call the
+    FastAPI lifespan hook makes — rather than ``Base.metadata.create_all``
+    over a hand-maintained model import list.
+
+    ``create_all`` diverged from the real schema in two directions that both
+    produced failures unrelated to the code under test:
+
+    * Tables with no SQLAlchemy model were never created at all. Migration
+      ``019_tenant_suppression`` owns ``tenant_suppression``, which has no
+      model, so every suppression test failed on a pristine database.
+    * ``create_all`` only CREATEs; it never ALTERs. A database carried over
+      from an earlier revision kept its old columns, so a migration that
+      added one (e.g. ``agent_activity_digests.subagents``) left the suite
+      failing until the database was rebuilt by hand.
+
+    Migrating instead makes the suite depend on the migration chain that
+    production uses, so a fresh database and a reused one provision
+    identically.
+    """
     global _schema_ready
     if _schema_ready:
         return
 
+    from core_storage_api.database.init import init_database
+
     engine = create_async_engine(settings.database_url, echo=False)
-
-    # Import all models so metadata is populated
-    import common.models.memory  # noqa: F401
-    import common.models.entity  # noqa: F401
-    import common.models.agent  # noqa: F401
-    import common.models.audit  # noqa: F401
-    import common.models.fleet  # noqa: F401
-    import common.models.document  # noqa: F401
-    import common.models.background_task  # noqa: F401
-    import common.models.analysis_report  # noqa: F401
-    import common.models.agent_activity_digest  # noqa: F401
-    from common.models.base import Base
-
     async with engine.begin() as conn:
+        # pgvector must exist before the migrations that declare vector columns.
         await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-        await conn.run_sync(Base.metadata.create_all)
-
     await engine.dispose()
+
+    await init_database()
     _schema_ready = True
 
 

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -1002,6 +1002,32 @@ class TestMemories:
         assert post_total == before_total
         assert post_agents == before_agents
 
+    async def test_count_whole_corpus_accepts_omitted_and_empty_tenant(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """Both "no tenant" spellings reach the whole-corpus counter.
+
+        ``core-api``'s public-stats caller uses the empty-string form
+        (``routes/stats.py`` → ``count_all(tenant_id="")``), so that one is
+        load-bearing; the omitted form used to 422 because the annotation was
+        a bare ``str``. Pin both so neither regresses, and confirm the
+        whole-corpus number really is tenant-independent.
+        """
+        omitted = await client.get(f"{PREFIX}/memories/count")
+        empty = await client.get(f"{PREFIX}/memories/count", params={"tenant_id": ""})
+        assert omitted.status_code == 200, omitted.text
+        assert empty.status_code == 200, empty.text
+        assert omitted.json()["count"] == empty.json()["count"]
+
+        # Scoping to a tenant is a different (smaller-or-equal) number, so the
+        # global path isn't silently returning the tenant count.
+        scoped = await client.get(f"{PREFIX}/memories/count", params={"tenant_id": tenant_id})
+        assert scoped.status_code == 200, scoped.text
+        assert scoped.json()["count"] <= omitted.json()["count"]
+
     async def test_embedding_coverage_spans_the_live_status_set(
         self,
         client: AsyncClient,


### PR DESCRIPTION
Follow-up to #626 / #628. Fixes the two issues found there, plus the root cause behind most of the `core-storage-api/tests/` failures.

## 1. Test DB provisioning — the big one

`core-storage-api/tests/conftest.py` built the schema with `Base.metadata.create_all` over a **hand-maintained list of model imports**. Production provisions by running the Alembic chain (`init_database()`, called from the FastAPI lifespan hook). The two had drifted in both directions:

- **Tables with no SQLAlchemy model were never created.** Migration `019_tenant_suppression` owns `tenant_suppression`, which has no model — so every suppression test failed on a pristine database, on any machine.
- **`create_all` only CREATEs, never ALTERs.** A database carried over from an earlier revision keeps its old columns, so a migration that adds one (e.g. `agent_activity_digests.subagents`, added recently by #624) leaves the suite red until someone rebuilds the DB by hand.

Those two pull in opposite directions, which is why the failure count depended on *which* stale database you happened to have — and why "is this real rot or just my local DB?" had no stable answer.

Calling `init_database()` makes fresh and reused databases provision identically. Measured on this tree:

| Provisioning | Result |
|---|---|
| Pristine DB, `create_all` (before) | 35 failed / 65 passed |
| Carried-over dev DB, `create_all` (before) | 31 failed / 69 passed |
| **Any DB, migrations (after)** | **19 failed / 81 passed** |

All 12–16 schema-related failures are gone, and the number is now deterministic.

## 2. `/count` rejected an omitted `tenant_id`

`tenant_id` was annotated as a bare `str` — required — so `?tenant_id=` (empty) reached the whole-corpus branch but omitting the param entirely returned 422.

**The branch is not dead code**, which is worth stating clearly: `core-api`'s public-stats caller reaches it via `count_all(tenant_id="")` (`core-api/src/core_api/routes/stats.py`). Deleting it would have broken `/stats`. What didn't work was the *omitted* spelling the branch and its test were both written for.

Widening the annotation to `str | None = None` accepts both. The empty-string form is byte-for-byte unchanged, so the stats caller is unaffected.

This also un-breaks `test_public_counters_exclude_soft_deleted`, which had been failing with `KeyError: 'count'` (reading `["count"]` off a 422 body).

## Testing

New `test_count_whole_corpus_accepts_omitted_and_empty_tenant` pins **both** spellings — the empty-string one because it is load-bearing in production, the omitted one because it is what just got fixed — and asserts the tenant-scoped count is `<=` the global one, so the global path can't silently degrade into a tenant count.

- `tests/` (the CI suite): **3957 passed**, 3 skipped, 1 xfailed, 3 xpassed — zero failures
- `core-storage-api/tests/` on a pristine DB: **18 failed / 84 passed** (from 35/65)
- `ruff check` + `ruff format --check` clean on both `src/` trees; `mypy` clean for both configs (188 + 73)

## What's left, and why CI adoption isn't in this PR

18 failures remain. I triaged all of them — every one is **stale-test drift against tightened API contracts**, and I found no product bugs:

| Class | Count |
|---|---|
| Endpoint now requires `tenant_id` (explicit 400/422) | ~5 |
| Route moved / method changed (404, 405) | ~6 |
| Response shape changed (`KeyError`, `TypeError: list indices`) | ~3 |
| Bulk write now requires `client_request_id` | 1 |
| Other assorted contract drift | ~3 |

They need a separate sweep, since fixing them means deciding per-test whether the test or the contract is the intended behaviour — not something to bundle behind a provisioning fix.

**Recommendation:** land this first so the suite is deterministic, do the 18-test sweep next, then add `core-storage-api/tests/` to `ci.yml` in the same PR that gets it to green. Adding it to CI before then would just pin main red. Right now `ci.yml` only runs `uv run pytest tests/`, which is how this drifted for so long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
