### PR TITLE
fix(storage): count missing embeddings instead of len()-ing a LIMITed fetch

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -721,17 +721,20 @@ async def get_embedding_coverage(
 ) -> dict:
     """Share of live memories that have an embedding.
 
-    Numerator and denominator both scope to ``LIVE_MEMORY_STATUSES`` — they
-    used to disagree (missing spanned every status, total only ``active``),
-    which let coverage_pct exceed 100% or go negative. ``missing_embeddings``
-    is still capped by the finder's batch_size, so treat it as a floor.
+    Numerator and denominator scope to the same population
+    (``LIVE_MEMORY_STATUSES``, not soft-deleted, same tenant/fleet), so
+    ``missing_embeddings <= total_active`` holds and ``coverage_pct`` stays
+    within 0-100. Both are exact COUNTs; the numerator used to be
+    ``len(rows)`` off a ``LIMIT``-ed query, which capped it at the batch size
+    and made coverage read high on any tenant with more missing rows than
+    that.
     """
-    missing = await _svc.memory_find_missing_embeddings(tenant_id, fleet_id)
+    missing = await _svc.memory_count_missing_embeddings(tenant_id, fleet_id)
     total = await _svc.memory_count_active(tenant_id, fleet_id)
     return {
         "total_active": total,
-        "missing_embeddings": len(missing),
-        "coverage_pct": round((total - len(missing)) / total * 100, 1) if total > 0 else 0.0,
+        "missing_embeddings": missing,
+        "coverage_pct": round((total - missing) / total * 100, 1) if total > 0 else 0.0,
     }
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2245,6 +2245,40 @@ class PostgresService:
             result = await session.execute(stmt)
             return result.scalar() or 0
 
+    async def memory_count_missing_embeddings(
+        self,
+        tenant_id: str,
+        fleet_id: str | None = None,
+    ) -> int:
+        """Count live memories with no embedding — /embedding-coverage's numerator.
+
+        Deliberately adjacent to ``memory_count_active``: that one is the
+        denominator of the same ratio, and the two only produce a meaningful
+        percentage while their population predicates stay identical (live
+        statuses, not soft-deleted, same tenant/fleet scope). Keep them in
+        sync — a mismatch here is what previously let coverage_pct exceed
+        100% or go negative.
+
+        A COUNT rather than ``len(rows)``: the caller needs a number, and the
+        row-returning version it replaced was ``LIMIT``-ed, so it silently
+        capped the numerator (and fetched ``content`` it never read).
+        """
+        async with get_read_session() as session:
+            stmt = (
+                select(func.count())
+                .select_from(Memory)
+                .where(
+                    Memory.tenant_id == tenant_id,
+                    Memory.status.in_(LIVE_MEMORY_STATUSES),
+                    Memory.deleted_at.is_(None),
+                    Memory.embedding.is_(None),
+                )
+            )
+            if fleet_id:
+                stmt = stmt.where(Memory.fleet_id == fleet_id)
+            result = await session.execute(stmt)
+            return result.scalar() or 0
+
     async def memory_entity_coverage_count(
         self,
         tenant_id: str,
@@ -2451,39 +2485,6 @@ class PostgresService:
                 [(r[0], r[1]) for r in rows],
                 int(total_remaining),
             )
-
-    async def memory_find_missing_embeddings(
-        self,
-        tenant_id: str,
-        fleet_id: str | None,
-        batch_size: int = 100,
-    ) -> list[tuple]:
-        """Live memories with no embedding (drives /embedding-coverage).
-
-        Scoped to ``LIVE_MEMORY_STATUSES`` so it counts the same population as
-        ``memory_count_active``, which is the coverage denominator. Without the
-        status filter the numerator spanned every status while the denominator
-        did not, so coverage_pct could exceed 100% or go negative.
-        """
-        async with get_session() as session:
-            scope, params = _scope_sql(tenant_id, fleet_id)
-            result = await session.execute(
-                text(f"""
-                SELECT m.id, m.content
-                FROM memories m
-                WHERE {scope}
-                  AND m.embedding IS NULL
-                  AND m.deleted_at IS NULL
-                  AND m.status = ANY(CAST(:live_statuses AS text[]))
-                LIMIT :batch_size
-            """),
-                {
-                    **params,
-                    "batch_size": batch_size,
-                    "live_statuses": list(LIVE_MEMORY_STATUSES),
-                },
-            )
-            return result.all()  # type: ignore[return-value]
 
     async def memory_find_near_duplicate_candidates(
         self,

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -1028,6 +1028,43 @@ class TestMemories:
         assert scoped.status_code == 200, scoped.text
         assert scoped.json()["count"] <= omitted.json()["count"]
 
+    async def test_embedding_coverage_is_not_capped_by_a_batch_size(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+    ) -> None:
+        """``missing_embeddings`` is an exact COUNT, not a capped row fetch.
+
+        The numerator used to be ``len(rows)`` off a query with
+        ``LIMIT :batch_size`` (default 100), so any tenant with more than 100
+        un-embedded memories under-reported the number missing and therefore
+        over-reported coverage. Seeding past that boundary is the whole point
+        of this test — at 100 rows or fewer it passes either way.
+        """
+        fleet = f"embcov-cap-{_uid()}"
+        missing_count = 105  # > the old batch_size of 100
+        embedded_count = 3
+
+        for i in range(missing_count):
+            payload = _memory_payload(tenant_id, fleet, content=f"unembedded {i} {_uid()}")
+            payload["embedding"] = None
+            assert (await client.post(f"{PREFIX}/memories", json=payload)).status_code in (200, 201)
+        for i in range(embedded_count):
+            payload = _memory_payload(tenant_id, fleet, content=f"embedded {i} {_uid()}")
+            assert (await client.post(f"{PREFIX}/memories", json=payload)).status_code in (200, 201)
+
+        resp = await client.get(
+            f"{PREFIX}/memories/embedding-coverage",
+            params={"tenant_id": tenant_id, "fleet_id": fleet},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        # Pre-fix this read 100 (the cap), making coverage look like 5.4%.
+        assert body["missing_embeddings"] == missing_count
+        assert body["total_active"] == missing_count + embedded_count
+        assert body["coverage_pct"] == 2.8  # 3/108
+
     async def test_embedding_coverage_spans_the_live_status_set(
         self,
         client: AsyncClient,


### PR DESCRIPTION
Closes the last wrong number from the #626 → #628 → #630 chain.

## The bug

`/embedding-coverage` built its numerator by fetching rows and calling `len()` on them:

```python
missing = await memory_find_missing_embeddings(tenant_id, fleet_id)   # LIMIT :batch_size
...
"missing_embeddings": len(missing),
"coverage_pct": round((total - len(missing)) / total * 100, 1)
```

That query carries `LIMIT :batch_size` (default **100**). So any tenant with more than 100 un-embedded memories under-reports how many are missing, and therefore **over-reports coverage**:

| Actual | Reported before | Reported now |
|---|---|---|
| 105 missing of 108 → 2.8% covered | `missing=100` → **5.4%** | `missing=105` → **2.8%** |

The failure mode is the bad direction: the number looks *better* the worse the real backlog is, and it silently saturates. A tenant with 10,000 un-embedded rows and a tenant with 100 report identically.

#630 fixed this endpoint's *population* mismatch (numerator and denominator disagreeing on status), which is what made `coverage_pct` able to go negative. This is the remaining half — the numerator was also **capped**.

## The fix

New `memory_count_missing_embeddings` — an exact `COUNT` over the same population the denominator uses (`LIVE_MEMORY_STATUSES`, not soft-deleted, same tenant/fleet scope).

It sits **directly next to `memory_count_active`** on purpose: those two are the numerator and denominator of one ratio, and they only produce a meaningful percentage while their predicates stay identical. Splitting them across the file is what allowed them to drift apart in the first place.

## Removing `memory_find_missing_embeddings`

The coverage endpoint was its **only** caller, so it's now dead. Removed rather than left behind:

- the backfill path that genuinely needs rows already has `memory_list_null_embedding_rows`, which pages on a cursor and returns its own exact `total_remaining` — the same COUNT-not-`len()` pattern this PR applies;
- it selected `m.content` for every row and never read it, so the replacement is cheaper as well as correct.

## Testing

`test_embedding_coverage_is_not_capped_by_a_batch_size` seeds **105** un-embedded rows plus 3 embedded ones. The 105 is the point — at 100 or fewer the test passes with or without the fix, which is exactly why the existing coverage test never caught this.

Verified the test has teeth by simulating the old cap: it fails with `assert 100 == 105`. Worth noting the pre-existing `test_embedding_coverage_spans_the_live_status_set` **passed** under that simulated cap — so the new test isn't redundant with it.

- `tests/` (CI suite): **3958 passed**, 3 skipped, 1 xfailed, 3 xpassed — zero failures
- `core-storage-api/tests/`: **18 failed / 85 passed** — same 18 known-drift failures as `main`'s post-#630 baseline, +1 new pass
- No dangling references to the removed method (`grep` → 0)
- `ruff check` + `ruff format --check` clean on both `src/` trees; `mypy` clean for both configs (188 + 73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
