### PR TITLE
fix(storage): green the core-storage-api integration suite and add it to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,11 +124,19 @@ jobs:
       - name: Run Ruff linter (core-storage-api)
         run: uv run ruff check core-storage-api/src/
 
+      - name: Run Ruff linter (core-storage-api tests)
+        # The test tree was unlinted for as long as it was un-run; both halves
+        # of that blind spot close together or it just drifts again.
+        run: uv run ruff check core-storage-api/tests/
+
       - name: Run Ruff formatter check (core-api)
         run: uv run ruff format --check core-api/src/
 
       - name: Run Ruff formatter check (core-storage-api)
         run: uv run ruff format --check core-storage-api/src/
+
+      - name: Run Ruff formatter check (core-storage-api tests)
+        run: uv run ruff format --check core-storage-api/tests/
 
       - name: Run Ruff formatter check (vendored common/ files at ruff defaults)
         # This list mirrors the policy=identical entries of caura-memclaw-enterprise's
@@ -195,6 +203,41 @@ jobs:
           POSTGRES_DB: memclaw
           POSTGRES_REQUIRE_SSL: "false"
           TEST_DATABASE_URL: "postgresql+asyncpg://memclaw:changeme@localhost:5432/memclaw"
+          EMBEDDING_PROVIDER: fake
+          ENTITY_EXTRACTION_PROVIDER: none
+          USE_LLM_FOR_MEMORY_CREATION: "false"
+
+      - name: Create the storage-suite database
+        # Its own database, NOT the one `tests/` uses. The two suites provision
+        # differently — `tests/` conftest calls Base.metadata.create_all, the
+        # storage conftest runs the real Alembic chain via init_database(). On a
+        # shared database whichever ran first would win: create_all going first
+        # leaves tables with no alembic_version, so init_database() stamps head
+        # and skips the migrations, and every migration-only table (e.g.
+        # tenant_suppression, which has no ORM model) stays missing. Isolating
+        # removes that ordering coupling instead of relying on step order.
+        #
+        # Idempotent: Postgres has no CREATE DATABASE IF NOT EXISTS, so this
+        # guards on pg_database and creates only when absent. Fed via stdin
+        # rather than -c because \gexec is a psql meta-command and -c sends
+        # its argument as a single SQL string (where \gexec is a syntax
+        # error). ON_ERROR_STOP=1 is kept deliberately over the simpler
+        # `|| true`, which would also swallow a genuine connection or auth
+        # failure and defer the confusion to the pytest step below.
+        run: |
+          PGPASSWORD=changeme psql -h localhost -U memclaw -d memclaw -v ON_ERROR_STOP=1 <<'SQL'
+          SELECT 'CREATE DATABASE memclaw_storage'
+          WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'memclaw_storage')\gexec
+          SQL
+
+      - name: Run core-storage-api integration tests
+        run: uv run pytest core-storage-api/tests/ -v --tb=short
+        env:
+          PYTHONPATH: core-api/src:core-storage-api/src:.
+          POSTGRES_REQUIRE_SSL: "false"
+          # This suite reads DATABASE_URL (not TEST_DATABASE_URL) — its conftest
+          # migrates whatever core_storage_api.config points at.
+          DATABASE_URL: "postgresql+asyncpg://memclaw:changeme@localhost:5432/memclaw_storage"
           EMBEDDING_PROVIDER: fake
           ENTITY_EXTRACTION_PROVIDER: none
           USE_LLM_FOR_MEMORY_CREATION: "false"

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -16,7 +16,7 @@ from common.events.lifecycle_purge_request import (
 from core_storage_api.observability import bind_timer, log_request
 from core_storage_api.routers._validation import _require
 from core_storage_api.schemas import MEMORY_FIELDS, MEMORY_LIST_FIELDS, orm_to_dict
-from core_storage_api.services.postgres_service import PostgresService
+from core_storage_api.services.postgres_service import BulkValidationError, PostgresService
 
 router = APIRouter(prefix="/memories", tags=["Memories"])
 _svc = PostgresService()
@@ -100,7 +100,22 @@ async def create_memories_bulk(request: Request) -> list[dict]:
     body: list[dict] = await request.json()
     for item in body:
         _parse_datetimes(item)
-    return await _svc.memory_add_all(body)
+    try:
+        return await _svc.memory_add_all(body)
+    except BulkValidationError as exc:
+        # Malformed batch (an item missing ``client_request_id``, or mixed
+        # ``tenant_id`` / ``fleet_id``). Unwrapped it escaped as a 500 — a
+        # server-fault code for what is squarely a bad request, which pages
+        # and lands in the DLQ instead of being fixed by the caller. Same
+        # 4xx-at-the-edge convention as ``_parse_datetimes`` above and
+        # ``dedup_review_enqueue`` below.
+        #
+        # Catches the dedicated subclass, NOT bare ``ValueError``: those three
+        # guards all run before ``memory_add_all`` opens its session, but the
+        # try block spans the whole call, so a plain ``except ValueError``
+        # would also swallow anything raised from inside the session and
+        # relabel a genuine server fault as a client error.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 # ------------------------------------------------------------------

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -420,6 +420,18 @@ def _attach_agent_display_names(rows: Any) -> list[Memory]:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
+class BulkValidationError(ValueError):
+    """A bulk batch violated its input contract before any DB work started.
+
+    Distinct from a bare ``ValueError`` so the bulk route can map exactly these
+    to 422 and let anything unexpected from inside the session keep surfacing
+    as a 500. Catching plain ``ValueError`` around the whole call would mean a
+    future in-session failure got mislabelled as a client error — the inverse
+    of the bug that motivated the 422 in the first place. Subclasses
+    ``ValueError`` so existing callers that catch it broadly still work.
+    """
+
+
 class PostgresService:
     """Single point of DB access for all core tables.
 
@@ -506,7 +518,7 @@ class PostgresService:
                 # than at the FastAPI route, also catches in-process
                 # callers (auto-chunk via ``sc.create_memories``) that
                 # forgot to mint an id.
-                raise ValueError("memory_add_all: every item must carry client_request_id")
+                raise BulkValidationError("memory_add_all: every item must carry client_request_id")
 
         # All callers send a single-tenant, single-fleet batch (the
         # bulk endpoint is tenant-and-fleet-scoped on the way in). Pin
@@ -520,9 +532,9 @@ class PostgresService:
         tenant_id = items[0]["tenant_id"]
         fleet_id = items[0].get("fleet_id")
         if any(d.get("tenant_id") != tenant_id for d in items):
-            raise ValueError("memory_add_all: all items must share the same tenant_id")
+            raise BulkValidationError("memory_add_all: all items must share the same tenant_id")
         if any(d.get("fleet_id") != fleet_id for d in items):
-            raise ValueError("memory_add_all: all items must share the same fleet_id")
+            raise BulkValidationError("memory_add_all: all items must share the same fleet_id")
 
         async with get_session() as session:
             rows = [self._filter_memory_fields(d) for d in items]

--- a/core-storage-api/tests/conftest.py
+++ b/core-storage-api/tests/conftest.py
@@ -24,7 +24,6 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from core_storage_api.config import settings
 
-
 # ---------------------------------------------------------------------------
 # Database schema setup (once per session)
 # ---------------------------------------------------------------------------

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -158,7 +158,7 @@ class TestMemories:
 
         resp = await client.patch(
             f"{PREFIX}/memories/{memory_id}",
-            json={"status": "archived"},
+            json={"tenant_id": tenant_id, "status": "archived"},
         )
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
@@ -203,12 +203,18 @@ class TestMemories:
 
         resp = await client.patch(
             f"{PREFIX}/memories/{memory_id}",
-            json={"metadata_patch": {"embedding_pending": False, "summary": "done"}},
+            json={
+                "tenant_id": tenant_id,
+                "metadata_patch": {"embedding_pending": False, "summary": "done"},
+            },
         )
         assert resp.status_code == 200, resp.text
 
         updated = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
-        md = updated["metadata"]
+        # Storage serialises the ORM attribute name verbatim, so the wire key
+        # is ``metadata_`` (as the seed payload above already uses) — not the
+        # ``metadata`` spelling core-api uses in its own internal field dicts.
+        md = updated["metadata_"]
         # Patched keys reflect the new values.
         assert md["embedding_pending"] is False
         assert md["summary"] == "done"
@@ -245,6 +251,7 @@ class TestMemories:
         resp = await client.patch(
             f"{PREFIX}/memories/{memory_id}",
             json={
+                "tenant_id": tenant_id,
                 "ts_valid_start": "2026-09-14T00:00:00+00:00",
                 "ts_valid_end": "2026-10-15T23:59:59+00:00",
             },
@@ -278,7 +285,10 @@ class TestMemories:
 
         resp = await client.patch(
             f"{PREFIX}/memories/{memory_id}",
-            json={"ts_valid_start": "tomorrow"},  # not a valid ISO string
+            json={
+                "tenant_id": tenant_id,
+                "ts_valid_start": "tomorrow",  # not a valid ISO string
+            },
         )
         assert resp.status_code == 422, resp.text
         body = resp.json()
@@ -296,16 +306,22 @@ class TestMemories:
         m1 = (await client.post(f"{PREFIX}/memories", json=p1)).json()
         m2 = (await client.post(f"{PREFIX}/memories", json=p2)).json()
 
-        resp = await client.patch(
-            f"{PREFIX}/memories/batch-status",
+        # POST /batch-update-status, with tenant_id carried at the batch level
+        # (the route's cross-tenant write guard). The old PATCH /batch-status
+        # spelling in this test matched no route at all — it fell through to
+        # PATCH /memories/{memory_id} and 422'd on UUID coercion of the
+        # literal "batch-status". core-api's storage_client uses this path.
+        resp = await client.post(
+            f"{PREFIX}/memories/batch-update-status",
             json={
+                "tenant_id": tenant_id,
                 "updates": [
                     {"memory_id": m1["id"], "status": "archived"},
                     {"memory_id": m2["id"], "status": "archived"},
                 ],
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 200, resp.text
         assert resp.json()["ok"] is True
 
     async def test_soft_delete(
@@ -359,7 +375,11 @@ class TestMemories:
         # route must surface 404.
         resp = await client.patch(
             f"{PREFIX}/memories/{memory_id}",
-            json={"status": "active", "metadata_patch": {"resurrect_attempt": True}},
+            json={
+                "tenant_id": tenant_id,
+                "status": "active",
+                "metadata_patch": {"resurrect_attempt": True},
+            },
         )
         assert resp.status_code == 404, resp.text
 
@@ -368,11 +388,15 @@ class TestMemories:
         after = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
         assert after["deleted_at"] is not None
         assert after["status"] == "deleted"
-        assert (after.get("metadata") or {}).get("resurrect_attempt") is None
+        # ``metadata_``, not ``metadata`` — with the wrong key this assertion
+        # was vacuous (always {} → always None) and could never have caught a
+        # resurrected metadata merge.
+        assert (after.get("metadata_") or {}).get("resurrect_attempt") is None
 
     async def test_patch_on_nonexistent_memory_returns_404(
         self,
         client: AsyncClient,
+        tenant_id: str,
     ) -> None:
         """PATCH on a memory_id that never existed must surface 404 too,
         not the legacy ``200 {"ok": True}`` silent success.
@@ -385,7 +409,7 @@ class TestMemories:
         fake_id = str(uuid.uuid4())
         resp = await client.patch(
             f"{PREFIX}/memories/{fake_id}",
-            json={"status": "active"},
+            json={"tenant_id": tenant_id, "status": "active"},
         )
         assert resp.status_code == 404, resp.text
 
@@ -448,10 +472,13 @@ class TestMemories:
         bypass it (CAURA-602)."""
         payload = _memory_payload(tenant_id, fleet_id)  # no client_request_id
         resp = await client.post(f"{PREFIX}/memories/bulk", json=[payload])
-        # Storage-writer surfaces the ValueError as 500; core-api would
-        # be the layer that returns a clean 4xx — but at this layer the
-        # important assertion is "no row was inserted."
-        assert resp.status_code >= 400
+        # 422, not 500: a batch missing client_request_id is a bad request,
+        # not a server fault. This used to let the service's ValueError escape
+        # unhandled — a 500 that pages and lands in the DLQ for something only
+        # the caller can fix. Asserting the exact code (the old assertion was
+        # a permissive >= 400) is what keeps it from regressing to a 5xx.
+        assert resp.status_code == 422, resp.text
+        assert "client_request_id" in resp.json()["detail"]
 
     async def test_find_by_content_hash(
         self,
@@ -477,10 +504,10 @@ class TestMemories:
                 "fleet_id": fleet_id,
             },
         )
-        assert resp.status_code == 200
-        body = resp.json()
-        assert body["memory"] is not None
-        assert body["memory"]["content_hash"] == content_hash
+        assert resp.status_code == 200, resp.text
+        # Flat ORM dict, not an {"memory": ...} envelope — core-api's
+        # check_exact_duplicate step reads dup["id"] straight off this.
+        assert resp.json()["content_hash"] == content_hash
 
     async def test_find_by_content_hash_not_found(
         self,
@@ -491,8 +518,10 @@ class TestMemories:
             f"{PREFIX}/memories/by-content-hash",
             params={"tenant_id": tenant_id, "content_hash": "nonexistent"},
         )
-        assert resp.status_code == 200
-        assert resp.json()["memory"] is None
+        # 404-on-miss, which core-api's shared _get maps back to None — a
+        # 200 with a null envelope would make the duplicate check treat every
+        # write as a duplicate.
+        assert resp.status_code == 404, resp.text
 
     async def test_get_stats(
         self,
@@ -966,7 +995,7 @@ class TestMemories:
 
         Regression for the count-inflation bug: prior to the fix these
         endpoints reported tombstoned rows alongside live ones, so the
-        marketing-site landing-page tiles were ~10× higher than the
+        marketing-site landing-page tiles were ~10x higher than the
         actually-queryable footprint.
         """
         # Use a fresh, dedicated agent_id so distinct-agent / distinct-tenant
@@ -1250,7 +1279,7 @@ class TestEntities:
         await client.post(f"{PREFIX}/entities", json=payload)
 
         resp = await client.get(
-            f"{PREFIX}/entities/by-name",
+            f"{PREFIX}/entities/exact",
             params={
                 "tenant_id": tenant_id,
                 "name": name,
@@ -1258,10 +1287,10 @@ class TestEntities:
                 "fleet_id": fleet_id,
             },
         )
-        assert resp.status_code == 200
-        body = resp.json()
-        assert body["entity"] is not None
-        assert body["entity"]["canonical_name"] == name
+        assert resp.status_code == 200, resp.text
+        # Flat entity dict (orm_to_dict), not an {"entity": ...} envelope —
+        # matches what core-api's find_exact_entity consumes.
+        assert resp.json()["canonical_name"] == name
 
     async def test_find_exact_entity_not_found(
         self,
@@ -1269,15 +1298,17 @@ class TestEntities:
         tenant_id: str,
     ) -> None:
         resp = await client.get(
-            f"{PREFIX}/entities/by-name",
+            f"{PREFIX}/entities/exact",
             params={
                 "tenant_id": tenant_id,
                 "name": "NoSuchEntity",
                 "entity_type": "person",
             },
         )
-        assert resp.status_code == 200
-        assert resp.json()["entity"] is None
+        # 404-on-miss is the contract, not 200-with-null: core-api's shared
+        # storage-client _get maps 404 → None, which is how find_exact_entity
+        # produces its `| None` return.
+        assert resp.status_code == 404, resp.text
 
     async def test_create_relation(
         self,
@@ -1421,21 +1452,21 @@ class TestEntities:
         memory_id = mem["id"]
 
         link_resp = await client.post(
-            f"{PREFIX}/entities/memory-links/create",
+            f"{PREFIX}/entities/links",
             json={
                 "memory_id": memory_id,
                 "entity_id": entity_id,
                 "role": "subject",
             },
         )
-        assert link_resp.status_code == 200
+        assert link_resp.status_code == 200, link_resp.text
 
         # Get entity with linked memories
         resp = await client.get(
-            f"{PREFIX}/entities/linked-memories/{entity_id}",
+            f"{PREFIX}/entities/{entity_id}/with-memories",
             params={"tenant_id": tenant_id},
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["entity"]["id"] == entity_id
         assert len(body["linked_memories"]) >= 1
@@ -1525,7 +1556,9 @@ class TestAgents:
         )
 
         resp = await client.patch(
-            f"{PREFIX}/agents/{agent_id}/trust",
+            # Storage spells this /trust-level; /trust is the PUBLIC core-api
+            # route (core_api/routes/agents.py). The two layers differ.
+            f"{PREFIX}/agents/{agent_id}/trust-level",
             json={
                 "tenant_id": tenant_id,
                 "trust_level": 3,
@@ -1583,12 +1616,15 @@ class TestDocuments:
         assert body["doc_id"] == doc_id
         assert body["data"]["title"] == "Test Document"
 
-        # GET by doc_id
+        # GET by doc_id. Collection is a path segment here, not a query param:
+        # the route is /{collection}/{doc_id:path} so that doc_ids containing
+        # slashes work. The single-segment form silently matched the
+        # list-documents route instead and returned 200 [].
         resp2 = await client.get(
-            f"{PREFIX}/documents/{doc_id}",
-            params={"tenant_id": tenant_id, "collection": collection},
+            f"{PREFIX}/documents/{collection}/{doc_id}",
+            params={"tenant_id": tenant_id},
         )
-        assert resp2.status_code == 200
+        assert resp2.status_code == 200, resp2.text
         assert resp2.json()["doc_id"] == doc_id
 
     async def test_upsert_updates_existing(
@@ -1670,18 +1706,18 @@ class TestDocuments:
         )
 
         resp = await client.delete(
-            f"{PREFIX}/documents/{doc_id}",
-            params={"tenant_id": tenant_id, "collection": collection},
+            f"{PREFIX}/documents/{collection}/{doc_id}",
+            params={"tenant_id": tenant_id},
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 200, resp.text
         assert "deleted_id" in resp.json()
 
         # Verify deleted
         resp2 = await client.get(
-            f"{PREFIX}/documents/{doc_id}",
-            params={"tenant_id": tenant_id, "collection": collection},
+            f"{PREFIX}/documents/{collection}/{doc_id}",
+            params={"tenant_id": tenant_id},
         )
-        assert resp2.status_code == 404
+        assert resp2.status_code == 404, resp2.text
 
     async def test_get_nonexistent_document_returns_404(
         self,
@@ -1689,10 +1725,10 @@ class TestDocuments:
         tenant_id: str,
     ) -> None:
         resp = await client.get(
-            f"{PREFIX}/documents/nonexistent-doc",
-            params={"tenant_id": tenant_id, "collection": "nope"},
+            f"{PREFIX}/documents/nope/nonexistent-doc",
+            params={"tenant_id": tenant_id},
         )
-        assert resp.status_code == 404
+        assert resp.status_code == 404, resp.text
 
 
 # =====================================================================
@@ -1823,11 +1859,12 @@ class TestFleet:
                 },
             )
 
+        # node_name is a query param on this route, not a path segment.
         resp = await client.get(
-            f"{PREFIX}/fleet/commands/pending/{node_name}",
-            params={"tenant_id": tenant_id},
+            f"{PREFIX}/fleet/commands/pending",
+            params={"tenant_id": tenant_id, "node_name": node_name},
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 200, resp.text
         pending = resp.json()
         assert isinstance(pending, list)
         assert len(pending) >= 2


### PR DESCRIPTION
The sweep flagged in #630. `core-storage-api/tests/` goes from **18 failures → 103 passing**, and into CI so it can't drift again.

## Why it drifted

`ci.yml` only ran `tests/`. This suite was neither run nor linted, so nothing caught it.

## 17 of 18: stale tests, one shared root cause

Nearly all of them addressed the **internal storage API using the public core-api URL grammar**. The two layers deliberately differ — and `core-api`'s `storage_client`, the only production consumer, matches the real routes in every single case. That's what settles which side was wrong.

| Test expected | Actual route | Symptom |
|---|---|---|
| `PATCH /memories/{id}` without `tenant_id` | body `tenant_id` required (cross-tenant write guard) | 422 ×6 |
| `PATCH /memories/batch-status` | `POST /memories/batch-update-status`, batch-level `tenant_id` | fell through to `/{memory_id}`, 422 on UUID coercion |
| `/entities/by-name` | `/entities/exact` | 422 |
| `/entities/memory-links/create` | `/entities/links` | 404 |
| `/entities/linked-memories/{id}` | `/entities/{id}/with-memories` | 404 |
| `/documents/{doc_id}?collection=` | `/documents/{collection}/{doc_id:path}` | matched list-documents → `200 []` → `TypeError` |
| `/agents/{id}/trust` | `/agents/{id}/trust-level` (`/trust` is the *public* route) | 404 |
| `/fleet/commands/pending/{node}` | `node_name` is a query param | 404 |
| `{"memory": {...}}` / `{"entity": {...}}` envelopes | flat ORM dict | `KeyError` |
| `200` + null on miss | `404` | assertion mismatch |
| `metadata` | `metadata_` | `KeyError` |

The 404-on-miss is worth calling out as deliberate rather than sloppy: `storage_client._get` maps 404 → `None`, which is precisely how those callers' optional returns work. A `200` with a null envelope would make `check_exact_duplicate` treat **every** write as a duplicate.

## The 18th: a real defect

`POST /memories/bulk` let `memory_add_all`'s `ValueError` escape unhandled, so a batch missing `client_request_id` — or mixing `tenant_id`/`fleet_id` — returned **500**. A server-fault code for something only the caller can fix: it pages, and it lands in the DLQ.

Now 422, matching the convention this same router already states three times (`_parse_datetimes`, `_validate_pg_regex`, `dedup_review_enqueue`).

**Not a retry-behaviour change** — I checked before touching it: core-api retries POSTs on connection-phase failures only ("request provably never sent, so a retry cannot double-insert"), never on status code. And the guard runs before any session opens, so nothing was written either way.

## Two assertions were vacuous

Both could never have failed, and now can:

- the resurrect check read a `metadata` key that **never exists**, so `(after.get("metadata") or {})` was always `{}`;
- the bulk test accepted any `>= 400`, including the 500 it was actually getting. Now pinned to `== 422`.

## CI wiring — separate database, deliberately

The suite gets its **own** database rather than sharing `memclaw`. The two suites provision differently: `tests/` uses `create_all`, this one runs the real Alembic chain. On a shared database, whichever ran first would win — and `create_all` first leaves tables with no `alembic_version`, so `init_database()` stamps head, skips the migrations, and every migration-only table (`tenant_suppression`, which has no ORM model) goes missing again. That's the exact bug #630 fixed, reintroduced through step ordering.

Separate databases remove the coupling instead of depending on step order holding forever.

The test tree is now ruff-linted too (2 pre-existing errors fixed) — it was unlinted for exactly as long as it was un-run, and leaving that half open just invites the same drift.

## Verification

- `core-storage-api/tests/`: **103 passed, 0 failed** — on a pristine DB, again on the reused one (no state leakage), and via the exact CI env (`DATABASE_URL` only, DB named `memclaw_storage`)
- `tests/` (existing CI suite): **3958 passed**, 3 skipped, 1 xfailed, 3 xpassed — the 422 change doesn't disturb core-api
- `ruff check` + `ruff format --check` clean across both `src/` trees **and** the storage test tree; `mypy` clean for both configs (188 + 73)
- `ci.yml` parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
