### PR TITLE
fix(embedding): cap in-flight embed calls to stop pool-exhaustion cascade

### DIFF
--- a/common/embedding/_service.py
+++ b/common/embedding/_service.py
@@ -14,7 +14,12 @@ import time
 from collections.abc import Awaitable, Callable
 
 from common.embedding._registry import get_embedding_provider
-from common.embedding.constants import EMBEDDING_RETRY_ATTEMPTS, EMBEDDING_RETRY_DELAY_S
+from common.embedding.constants import (
+    EMBEDDING_GATE_TIMEOUT_SECONDS,
+    EMBEDDING_MAX_CONCURRENCY,
+    EMBEDDING_RETRY_ATTEMPTS,
+    EMBEDDING_RETRY_DELAY_S,
+)
 from common.embedding.protocols import InstructionAwareEmbedder
 
 logger = logging.getLogger(__name__)
@@ -74,6 +79,71 @@ _stats = _EmbeddingStats()
 # Module-level (process-scoped); restart resets the set, which is
 # the right cadence for "operator forgot a flag" errors.
 _misconfiguration_logged: set[str] = set()
+
+
+# Per-event-loop so a test that spins a fresh loop (or an app that
+# restarts one) doesn't reuse a semaphore bound to a dead loop — waiters
+# on the stale object would never be woken. Keyed on identity rather than
+# reset explicitly because there is no shutdown hook this deep in the
+# stack.
+_gate: asyncio.Semaphore | None = None
+_gate_loop: asyncio.AbstractEventLoop | None = None
+
+
+def _concurrency_gate() -> asyncio.Semaphore:
+    """The process-wide cap on concurrent provider calls.
+
+    See ``EMBEDDING_MAX_CONCURRENCY`` for why the cap exists.
+    """
+    global _gate, _gate_loop
+    loop = asyncio.get_running_loop()
+    if _gate is None or _gate_loop is not loop:
+        _gate = asyncio.Semaphore(EMBEDDING_MAX_CONCURRENCY)
+        _gate_loop = loop
+    return _gate
+
+
+async def _call_gated[T](make_call: Callable[[], Awaitable[T]]) -> T:
+    """Run *make_call* holding a concurrency slot.
+
+    The slot is acquired per ATTEMPT, not per retry sequence, so a
+    backing-off retry never squats on a slot another caller could use.
+
+    A slot that doesn't free within ``EMBEDDING_GATE_TIMEOUT_SECONDS``
+    raises ``TimeoutError``, which callers already treat as a provider
+    failure — the pre-existing degradation path — rather than letting
+    waiters accumulate unboundedly and stall the write path.
+    """
+    gate = _concurrency_gate()
+    # Log saturation explicitly. During the 2026-07-27 incident the backend
+    # reported 3.5 ms inference while callers timed out, and nothing said
+    # where the time went. These two messages separate "queued behind our
+    # own cap" from "backend slow" for the next one.
+    if gate.locked():
+        logger.debug(
+            "Embedding concurrency gate saturated (cap=%d); queueing",
+            EMBEDDING_MAX_CONCURRENCY,
+        )
+    # ``asyncio.timeout`` rather than ``wait_for``: it matches the sibling
+    # gates (``per_tenant_concurrency``), and ``wait_for`` is reached via the
+    # shared ``asyncio`` module object, so tests that patch
+    # ``<their_module>.asyncio.wait_for`` to spy on their OWN ceiling would
+    # instead capture this gate's timeout and assert against the wrong value.
+    try:
+        async with asyncio.timeout(EMBEDDING_GATE_TIMEOUT_SECONDS):
+            await gate.acquire()
+    except TimeoutError:
+        logger.warning(
+            "Embedding concurrency gate timeout after %.1fs (cap=%d) — "
+            "degrading as provider failure; backend may be undersized",
+            EMBEDDING_GATE_TIMEOUT_SECONDS,
+            EMBEDDING_MAX_CONCURRENCY,
+        )
+        raise
+    try:
+        return await make_call()
+    finally:
+        gate.release()
 
 
 def _resolve_provider_name(tenant_config: object | None) -> str:
@@ -138,7 +208,7 @@ async def get_embeddings_batch(
         await _stats.record_failure()
         raise
     try:
-        result = await provider.embed_batch(texts)
+        result = await _call_gated(lambda: provider.embed_batch(texts))
     except Exception:
         await _stats.record_failure()
         raise
@@ -165,7 +235,7 @@ async def _run_with_retry(
     last_exc: BaseException | None = None
     for attempt in range(1, EMBEDDING_RETRY_ATTEMPTS + 1):
         try:
-            result = await make_call()
+            result = await _call_gated(make_call)
             await _stats.record_success()
             return result
         # Intentionally broad: must catch all provider-specific errors during retry.

--- a/common/embedding/constants.py
+++ b/common/embedding/constants.py
@@ -56,10 +56,89 @@ EMBEDDING_RETRY_DELAY_S: float = float(os.environ.get("EMBEDDING_RETRY_DELAY_S",
 # concurrent writes × 10 enrichment calls = 160 concurrent LLM
 # requests per process, well over the keepalive budget). See
 # ``common/llm/constants.py`` for full rationale.
-from common.env_utils import clamp_keepalive, read_int_env  # noqa: E402
+from common.env_utils import (  # noqa: E402
+    clamp_keepalive,
+    read_float_env,
+    read_int_env,
+)
 
 OPENAI_HTTPX_MAX_CONNECTIONS: int = read_int_env("OPENAI_HTTPX_MAX_CONNECTIONS", 200)
 OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS: int = clamp_keepalive(
     OPENAI_HTTPX_MAX_CONNECTIONS,
     read_int_env("OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS", 50),
+)
+
+# Dedicated embedding-pool knobs, defaulting to the shared
+# ``OPENAI_HTTPX_*`` values above for backward compatibility.
+#
+# Why these exist: the embedding backend is frequently NOT OpenAI. Prod
+# points ``OPENAI_EMBEDDING_BASE_URL`` at a self-hosted TEI service whose
+# total capacity is a couple of GPU instances, while the LLM path talks
+# to a hyperscaler API that happily absorbs a 200-connection pool. Before
+# this split both paths read the same env var, so sizing the embedding
+# pool down to match a small self-hosted backend would also throttle
+# every LLM call — making the one knob you need during an embedding
+# incident unusable.
+EMBEDDING_HTTPX_MAX_CONNECTIONS: int = read_int_env(
+    "EMBEDDING_HTTPX_MAX_CONNECTIONS", OPENAI_HTTPX_MAX_CONNECTIONS
+)
+# The inherited default is pre-clamped: sizing ONLY
+# EMBEDDING_HTTPX_MAX_CONNECTIONS below the LLM keepalive would otherwise
+# trip clamp_keepalive's warning naming a var the operator never set.
+# An explicit over-large keepalive still warns, which is the point.
+EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS: int = clamp_keepalive(
+    EMBEDDING_HTTPX_MAX_CONNECTIONS,
+    read_int_env(
+        "EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS",
+        min(OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS, EMBEDDING_HTTPX_MAX_CONNECTIONS),
+    ),
+    max_connections_var="EMBEDDING_HTTPX_MAX_CONNECTIONS",
+    max_keepalive_var="EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS",
+)
+
+
+# ── Client-side concurrency cap (backpressure) ───────────────────────
+#
+# The embedding backend is finite and can be much smaller than the
+# fleet calling it: prod's TEI service serves
+# ``maxScale × containerConcurrency`` requests at once, while core-api
+# scales to many instances that each hold a large httpx pool. Aggregate
+# demand can therefore oversubscribe the backend by orders of magnitude.
+#
+# When that happens the backend itself stays healthy (it just queues) but
+# every caller waits at the HTTP pool and dies on ``httpx.PoolTimeout``
+# -> ``APITimeoutError`` — and the per-item fallback for a failed batch
+# re-jams the same slots, so the failure sustains itself. That is exactly
+# the 2026-07-27 prod incident: ~77% of embeds failing for ~1h45m with
+# TEI reporting 3.5 ms inference throughout, leaving ~430 memories
+# permanently unembedded.
+#
+# Capping in-flight provider calls per process makes surplus work wait on
+# a cheap in-process semaphore instead of holding a connection until it
+# times out.
+#
+# Be honest about the bound: this is PER PROCESS, so the fleet-wide total
+# is this value x instance count. At the default 16 x minScale 10 that is
+# still ~8x TEI's capacity, and far more at maxScale — so this reduces
+# thrash AMPLITUDE, it does not restore a capacity invariant. Raising TEI
+# maxScale/containerConcurrency is the actual capacity fix; set this
+# explicitly per deployment with the arithmetic written down.
+EMBEDDING_MAX_CONCURRENCY: int = read_int_env("EMBEDDING_MAX_CONCURRENCY", 16)
+
+# Bound the wait for a slot. Queueing is the point, but an unbounded wait
+# would let waiters pile up and stall the write path well past its own
+# budget. On timeout the caller degrades exactly as a provider failure
+# does (persist ``embedding=NULL``, leave it to re-embed) instead of
+# hanging — same outcome as before this cap existed, minus the
+# connection thrash that produced it.
+#
+# Deliberately BELOW the callers' own deadlines: the bulk paths already
+# arm 30 s budgets (``BULK_EMBEDDING_TIMEOUT_SECONDS`` and the
+# ``asyncio.wait_for`` around ``get_embeddings_batch``). At 30 s here the
+# outer timer would always fire first, so the gate could never attribute
+# the failure to backpressure — it would surface as the caller's generic
+# timeout instead. 5 s leaves the queue useful while keeping the
+# attribution (and the degradation) on the gate.
+EMBEDDING_GATE_TIMEOUT_SECONDS: float = read_float_env(
+    "EMBEDDING_GATE_TIMEOUT_SECONDS", 5.0
 )

--- a/common/embedding/providers/openai.py
+++ b/common/embedding/providers/openai.py
@@ -9,9 +9,9 @@ import openai
 
 from common.constants import VECTOR_DIM
 from common.embedding.constants import (
+    EMBEDDING_HTTPX_MAX_CONNECTIONS,
+    EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
     OPENAI_EMBEDDING_MODEL,
-    OPENAI_HTTPX_MAX_CONNECTIONS,
-    OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
     OPENAI_REQUEST_TIMEOUT_SECONDS,
 )
 
@@ -71,8 +71,8 @@ class OpenAIEmbeddingProvider:
             "timeout": OPENAI_REQUEST_TIMEOUT_SECONDS,
             "http_client": httpx.AsyncClient(
                 limits=httpx.Limits(
-                    max_connections=OPENAI_HTTPX_MAX_CONNECTIONS,
-                    max_keepalive_connections=OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+                    max_connections=EMBEDDING_HTTPX_MAX_CONNECTIONS,
+                    max_keepalive_connections=EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
                 ),
             ),
         }

--- a/common/env_utils.py
+++ b/common/env_utils.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import sys
+from typing import overload
 
 
 def read_int_env(name: str, default: int) -> int:
@@ -53,6 +54,42 @@ def read_int_env(name: str, default: int) -> int:
         )
         return default
     return value
+
+
+@overload
+def read_float_env(name: str, default: float) -> float: ...
+
+
+@overload
+def read_float_env(name: str, default: None) -> float | None: ...
+
+
+def read_float_env(name: str, default: float | None) -> float | None:
+    """Read ``name`` from the environment, parse as float, fall back on bad input.
+
+    Same rationale as ``read_int_env``: a bare
+    ``float(os.environ.get(...))`` raises ``ValueError`` at module import
+    on a misconfigured value (e.g. ``"30s"`` instead of ``"30"``),
+    crashing core-api / the worker before structured logging exists to
+    report it.
+
+    Unlike ``read_int_env`` this permits 0 and negatives — callers use
+    them meaningfully (an explicit ``0.0`` timeout means "don't wait") —
+    and ``None`` is a valid default meaning "unset, track another
+    budget". The overloads keep ``float``-in / ``float``-out so callers
+    with a concrete default don't inherit an ``Optional``.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        print(
+            f"WARN: {name}={raw!r} is not a valid float; falling back to {default}",
+            file=sys.stderr,
+        )
+        return default
 
 
 def clamp_keepalive(

--- a/common/llm/constants.py
+++ b/common/llm/constants.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import os
 
+from common.env_utils import read_float_env as _read_float_env
+
 # ── Provider model defaults ──────────────────────────────────────────
 
 VERTEX_LLM_DEFAULT_MODEL = "gemini-2.0-flash-lite"
@@ -53,33 +55,6 @@ LLM_FALLBACK_MODEL_OPENAI = os.environ.get("LLM_FALLBACK_MODEL_OPENAI", "gpt-5.4
 # enough that a single hung upstream call eats the whole enrichment
 # budget silently. 25s gives the provider room to respond while still
 # leaving budget for one retry under the inline ceiling.
-def _read_float_env(name: str, default: float | None) -> float | None:
-    """Parse a float env var defensively.
-
-    Bare ``float(os.environ.get(...))`` would raise ``ValueError`` at
-    module import on a misconfigured value (e.g. ``"25s"`` instead of
-    ``"25"``), crashing the entire worker / core-api startup before any
-    structured-logging is wired. Catch it here, write a warning to
-    stderr, and fall back to the documented default.
-    """
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    try:
-        return float(raw)
-    except (TypeError, ValueError):
-        # Module-level import has no logger configured yet — print to
-        # stderr with the key name so the bad value is visible in the
-        # crash log even before structlog wires up.
-        import sys
-
-        print(
-            f"WARN: {name}={raw!r} is not a valid float; falling back to {default}",
-            file=sys.stderr,
-        )
-        return default
-
-
 OPENAI_REQUEST_TIMEOUT_SECONDS = _read_float_env("OPENAI_REQUEST_TIMEOUT_SECONDS", 25.0)
 
 

--- a/tests/test_embedding_concurrency_gate.py
+++ b/tests/test_embedding_concurrency_gate.py
@@ -1,0 +1,116 @@
+"""Embedding client-side concurrency cap (backpressure) tests.
+
+Regression cover for the 2026-07-27 prod incident: the embedding backend
+(a self-hosted TEI service) serves a fixed number of concurrent requests,
+while core-api scales to many instances each holding a large httpx pool.
+Unthrottled, aggregate demand oversubscribes the backend, every caller
+queues at the HTTP pool and dies on ``PoolTimeout`` while the backend
+itself stays healthy — and the per-item fallback for a failed batch
+re-jams the same slots, sustaining the failure.
+
+Unit tests validate:
+  - In-flight provider calls never exceed ``EMBEDDING_MAX_CONCURRENCY``
+  - A slot is held per ATTEMPT, so a backing-off retry doesn't squat
+  - A waiter that can't get a slot in time degrades (raises) rather than
+    hanging forever, and the raised type is one the retry path treats as
+    a provider failure
+"""
+
+import asyncio
+
+import pytest
+
+from common.embedding import _service as svc
+
+
+@pytest.fixture
+def reset_gate():
+    """Isolate each test from the module-level lazy semaphore."""
+    original_cap = svc.EMBEDDING_MAX_CONCURRENCY
+    original_timeout = svc.EMBEDDING_GATE_TIMEOUT_SECONDS
+    svc._gate = None
+    svc._gate_loop = None
+    yield
+    svc.EMBEDDING_MAX_CONCURRENCY = original_cap
+    svc.EMBEDDING_GATE_TIMEOUT_SECONDS = original_timeout
+    svc._gate = None
+    svc._gate_loop = None
+
+
+@pytest.mark.unit
+class TestEmbeddingConcurrencyGate:
+    """The gate is what keeps surplus work off the HTTP connection pool."""
+
+    @pytest.mark.asyncio
+    async def test_caps_in_flight_calls(self, reset_gate):
+        """30 callers against a cap of 3 never exceed 3 concurrent calls."""
+        svc.EMBEDDING_MAX_CONCURRENCY = 3
+
+        in_flight = 0
+        peak = 0
+
+        async def fake_call():
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            # Yield so every gathered task gets a chance to pile up —
+            # without an await the calls would serialise and the test
+            # would pass even with a broken gate.
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return [0.1]
+
+        await asyncio.gather(*(svc._call_gated(fake_call) for _ in range(30)))
+
+        assert peak <= 3, f"gate leaked: {peak} concurrent calls with cap 3"
+        assert in_flight == 0, "slot not released"
+
+    @pytest.mark.asyncio
+    async def test_releases_slot_on_exception(self, reset_gate):
+        """A failing call must not leak its slot, or the cap drains to zero."""
+        svc.EMBEDDING_MAX_CONCURRENCY = 1
+
+        async def boom():
+            raise RuntimeError("provider exploded")
+
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                await svc._call_gated(boom)
+
+        # If the slot leaked, this would block until the gate timeout.
+        async def ok():
+            return [0.2]
+
+        assert await svc._call_gated(ok) == [0.2]
+
+    @pytest.mark.asyncio
+    async def test_blocked_waiter_degrades_instead_of_hanging(self, reset_gate):
+        """Exhausted gate raises rather than accumulating waiters forever.
+
+        ``TimeoutError`` is deliberately a subclass of ``Exception`` (not
+        ``BaseException``), so ``_run_with_retry``'s broad handler treats
+        it as a provider failure and the caller degrades down the
+        pre-existing path (persist ``embedding=NULL``, leave it to
+        re-embed) instead of stalling the write.
+        """
+        svc.EMBEDDING_MAX_CONCURRENCY = 1
+        svc.EMBEDDING_GATE_TIMEOUT_SECONDS = 0.05
+
+        gate = svc._concurrency_gate()
+        await gate.acquire()  # occupy the only slot
+
+        async def never_runs():  # pragma: no cover - gate blocks first
+            return [0.3]
+
+        with pytest.raises(TimeoutError):
+            await svc._call_gated(never_runs)
+
+    @pytest.mark.asyncio
+    async def test_gate_rebinds_per_event_loop(self, reset_gate):
+        """A gate bound to a dead loop would never wake its waiters."""
+        first = svc._concurrency_gate()
+        assert svc._concurrency_gate() is first, "same loop should reuse the gate"
+
+        # Simulate a previously-used loop by faking the recorded identity.
+        svc._gate_loop = None
+        assert svc._concurrency_gate() is not first, "stale loop should rebind"


### PR DESCRIPTION
## Incident

**2026-07-27 07:26–09:10Z.** ~77% of embeds failed for ~1h45m; **~430 memories were left permanently unembedded** — stored fine, all HTTP 200s, but not semantically recallable. Silent data-quality loss.

## Root cause: oversubscription of our OWN backend, not a provider outage

Prod points `OPENAI_EMBEDDING_BASE_URL` at a **self-hosted TEI service** (`BAAI/bge-m3`, L4 GPU), not OpenAI:

| side | capacity |
|---|---|
| TEI backend | `maxScale 2` × `containerConcurrency 10` = **20 concurrent** |
| core-api demand | `minScale 10` (max 200) instances × **200-connection** pool = **≥2,000** |

When bulk volume spiked ~18× (181/hr → 3,274/hr), TEI's 20 slots saturated. Callers queued at the HTTP pool and died on `httpx.PoolTimeout` → `openai.APITimeoutError` — **while TEI itself stayed healthy, reporting 3.5 ms inference throughout.**

The self-sustaining part: a failed 50-item batch falls back to 50 per-item calls, re-jamming the same 20 slots → more failures → more fallback.

## Changes

- **`EMBEDDING_MAX_CONCURRENCY`** (default 16) caps in-flight provider calls per process — surplus work waits on a cheap semaphore instead of holding a connection until the pool times out. Applied at both provider chokepoints, acquired **per attempt** so a backing-off retry never squats on a slot.
- **`EMBEDDING_GATE_TIMEOUT_SECONDS`** (default 5.0) bounds the wait. Deliberately **below** the tightest caller cap (the search path's 10 s) — at or above it the outer timer always fires first and the gate could never attribute the failure to backpressure. On timeout the caller degrades down the *pre-existing* provider-failure path.
- **Gate logs saturation and timeout distinctly.** During the incident the backend reported 3.5 ms while callers timed out and nothing said where the time went.
- **`EMBEDDING_HTTPX_MAX_CONNECTIONS` / `_KEEPALIVE`** split the embedding pool from the LLM pool. Both previously read `OPENAI_HTTPX_MAX_CONNECTIONS`, so shrinking the embedding pool to match a small self-hosted backend would also throttle every LLM call — making the one knob you need during an embedding incident unusable.
- **`read_float_env` promoted to `common/env_utils`** (beside `read_int_env`, which that module exists to share); `common/llm/constants` delegates to it. The new gate timeout would otherwise have used a bare `float(os.environ.get(...))` that raises at module import on a bad value.

## Honest limits of this PR

**This reduces thrash amplitude; it does not restore a capacity invariant.** The cap is *per process*, so 16 × instance count is still well above TEI's capacity. Called out in the constant's comment rather than papered over.

**Two structural follow-ups I deliberately did not fold in** (both surfaced by review, both deserve their own focused change):

1. **The request-count amplifier survives.** The gate removes *connection* amplification, but one failed 50-item batch still spawns 50 × 3 re-embed retries × 2 attempts ≈ 300 gated acquisitions against 16 slots. Most time out → row stays NULL → same terminal outcome as the incident, with no automatic recovery (backfill is a manual CLI). The right fix is one function away: swap the in-process `track_task(_reembed_memory(..., is_failure_fallback=True))` fallbacks for a durable `EMBED_REQUESTED` publish, whose consumer already has Pub/Sub redelivery + DLQ + per-tenant slots. That would make the permanently-unembedded class structurally impossible — but it changes retry semantics and contradicts a deliberate existing comment, so it needs its own review.
2. **The gate is a single unkeyed global**, while the constraint is per-backend. The registry supports simultaneous distinct backends, so a saturated TEI tenant currently throttles an OpenAI tenant. Keying the gate on the same backend identity the provider cache already uses is the deeper form.

## Related (already live, not in this PR)

TEI `maxScale` raised **2 → 3** (20 → 30 concurrent). Capped there by GPU quota — `NvidiaL4GpuAllocNoZonalRedundancy` allows 3; a quota increase is needed to go further.

## Validation

- 4 new tests in `tests/test_embedding_concurrency_gate.py`: cap enforced (30 callers → 3 in-flight), slot released on exception, blocked waiter degrades instead of hanging, gate rebinds per event loop.
- `ruff check` / `ruff format` clean on changed files (the 3 remaining `G201`/`RUF100` hits are pre-existing on `main`, verified by linting the pristine tree).
- Defensive parsing verified: a misconfigured `EMBEDDING_GATE_TIMEOUT_SECONDS=30s` warns and falls back instead of crashing import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
