### PR TITLE
fix(embedding): make batch-failure re-embed fallback durable

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -1736,6 +1736,7 @@ async def _schedule_embed_or_reembed(
     tenant_id: str,
     *,
     content_hash: str | None = None,
+    is_failure_fallback: bool = False,
 ) -> None:
     """Backfill the embedding for a memory persisted with ``embedding=NULL``.
 
@@ -1746,9 +1747,14 @@ async def _schedule_embed_or_reembed(
     circuit the provider call when the same content was already
     embedded for this tenant — pass it whenever the caller has it in
     scope.
+
+    ``is_failure_fallback`` only affects the INLINE branch, where it adds
+    the thundering-herd backoff before retrying in-process. The deferred
+    branch needs no equivalent: Pub/Sub owns redelivery and backoff, so
+    the publish is a single cheap hand-off regardless.
     """
     if settings.inline_embedding:
-        await _reembed_memory(memory_id, content, tenant_id)
+        await _reembed_memory(memory_id, content, tenant_id, is_failure_fallback=is_failure_fallback)
     else:
         await publish_memory_embed_request(
             memory_id=memory_id,
@@ -2036,10 +2042,25 @@ async def _reembed_memories_bulk(
         for memory_id, content in items:
             track_task(
                 tracked_task(
-                    # is_failure_fallback=True: provider just failed for
-                    # the whole batch, so the per-item retries need the
-                    # 30s backoff to avoid a thundering herd.
-                    _reembed_memory(memory_id, content, tenant_id, is_failure_fallback=True),
+                    # Route through the inline/deferred router rather than
+                    # calling _reembed_memory directly. In deferred mode this
+                    # hands each item to EMBED_REQUESTED, so the retry lives on
+                    # Pub/Sub (redelivery + DLQ) instead of in this process.
+                    #
+                    # That is what makes the fallback DURABLE. Direct in-process
+                    # retry meant a failed 50-item batch fanned out to 50 x
+                    # _REEMBED_MAX_RETRIES x EMBEDDING_RETRY_ATTEMPTS provider
+                    # calls, all contending for the same saturated backend; when
+                    # they exhausted, the rows stayed embedding=NULL with no
+                    # further recovery — a manual CLI backfill was the only way
+                    # out. That is exactly how ~430 memories were stranded in
+                    # the 2026-07-27 incident.
+                    #
+                    # is_failure_fallback=True still gives the INLINE branch its
+                    # thundering-herd backoff (the provider just failed for the
+                    # whole batch); the deferred branch ignores it because
+                    # Pub/Sub owns backoff.
+                    _schedule_embed_or_reembed(memory_id, content, tenant_id, is_failure_fallback=True),
                     "reembed",
                     memory_id,
                     tenant_id,
@@ -2060,7 +2081,7 @@ async def _reembed_memories_bulk(
         for memory_id, content in items:
             track_task(
                 tracked_task(
-                    _reembed_memory(memory_id, content, tenant_id, is_failure_fallback=True),
+                    _schedule_embed_or_reembed(memory_id, content, tenant_id, is_failure_fallback=True),
                     "reembed",
                     memory_id,
                     tenant_id,
@@ -2085,7 +2106,7 @@ async def _reembed_memories_bulk(
                 tracked_task(
                     # Per-item None after a partial batch success is
                     # still a provider partial-failure — back off.
-                    _reembed_memory(memory_id, content, tenant_id, is_failure_fallback=True),
+                    _schedule_embed_or_reembed(memory_id, content, tenant_id, is_failure_fallback=True),
                     "reembed",
                     memory_id,
                     tenant_id,
@@ -2103,7 +2124,7 @@ async def _reembed_memories_bulk(
             )
             track_task(
                 tracked_task(
-                    _reembed_memory(memory_id, content, tenant_id, is_failure_fallback=True),
+                    _schedule_embed_or_reembed(memory_id, content, tenant_id, is_failure_fallback=True),
                     "reembed",
                     memory_id,
                     tenant_id,
@@ -2148,7 +2169,7 @@ async def _reembed_memories_bulk(
             )
             track_task(
                 tracked_task(
-                    _reembed_memory(memory_id, content, tenant_id, is_failure_fallback=True),
+                    _schedule_embed_or_reembed(memory_id, content, tenant_id, is_failure_fallback=True),
                     "reembed",
                     memory_id,
                     tenant_id,

--- a/tests/test_durable_reembed_fallback.py
+++ b/tests/test_durable_reembed_fallback.py
@@ -1,0 +1,95 @@
+"""Batch-failure re-embed fallback must be DURABLE in deferred mode.
+
+Regression cover for the 2026-07-27 incident tail. When a bulk re-embed
+batch call fails, the per-item fallback used to retry in-process:
+50 items x _REEMBED_MAX_RETRIES x EMBEDDING_RETRY_ATTEMPTS provider calls,
+all contending for the same already-saturated backend. When they
+exhausted, the rows stayed ``embedding=NULL`` with no further recovery —
+only a manual CLI backfill. That stranded ~430 memories.
+
+Routing the fallback through ``_schedule_embed_or_reembed`` moves the
+retry onto Pub/Sub (redelivery + DLQ) in deferred mode, while inline mode
+keeps in-process retry plus its thundering-herd backoff.
+
+Unit tests validate:
+  - Deferred mode publishes EMBED_REQUESTED instead of retrying in-process
+  - Inline mode still retries in-process, and still gets the backoff flag
+"""
+
+from unittest.mock import AsyncMock, PropertyMock, patch
+from uuid import uuid4
+
+import pytest
+
+from core_api.services import memory_service
+
+
+@pytest.mark.unit
+class TestDurableReembedFallback:
+    """The fallback's retry must outlive this process in deferred mode."""
+
+    @pytest.mark.asyncio
+    async def test_deferred_mode_publishes_instead_of_retrying_inline(self):
+        """Deferred mode hands off to Pub/Sub — no in-process embed retry."""
+        memory_id, content, tenant_id = uuid4(), "hello", "tenant-a"
+
+        with (
+            patch.object(
+                type(memory_service.settings),
+                "inline_embedding",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(memory_service, "publish_memory_embed_request", new=AsyncMock()) as publish,
+            patch.object(memory_service, "_reembed_memory", new=AsyncMock()) as reembed,
+        ):
+            await memory_service._schedule_embed_or_reembed(
+                memory_id, content, tenant_id, is_failure_fallback=True
+            )
+
+        publish.assert_awaited_once()
+        assert publish.await_args.kwargs["memory_id"] == memory_id
+        assert publish.await_args.kwargs["tenant_id"] == tenant_id
+        # The whole point: the retry does NOT stay in this process.
+        reembed.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_inline_mode_keeps_in_process_retry_with_backoff(self):
+        """Inline mode (OSS, no worker fleet) must not lose its backoff."""
+        memory_id, content, tenant_id = uuid4(), "hello", "tenant-b"
+
+        with (
+            patch.object(
+                type(memory_service.settings),
+                "inline_embedding",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
+            patch.object(memory_service, "publish_memory_embed_request", new=AsyncMock()) as publish,
+            patch.object(memory_service, "_reembed_memory", new=AsyncMock()) as reembed,
+        ):
+            await memory_service._schedule_embed_or_reembed(
+                memory_id, content, tenant_id, is_failure_fallback=True
+            )
+
+        reembed.assert_awaited_once()
+        # Without this flag the inline retries stampede an already-failing
+        # provider with zero delay.
+        assert reembed.await_args.kwargs["is_failure_fallback"] is True
+        publish.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_default_is_not_a_failure_fallback(self):
+        """The hot-path offload must NOT inherit the 30s backoff."""
+        with (
+            patch.object(
+                type(memory_service.settings),
+                "inline_embedding",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
+            patch.object(memory_service, "_reembed_memory", new=AsyncMock()) as reembed,
+        ):
+            await memory_service._schedule_embed_or_reembed(uuid4(), "hello", "tenant-c")
+
+        assert reembed.await_args.kwargs["is_failure_fallback"] is False

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -650,9 +650,15 @@ async def test_reembed_is_failure_fallback_triggers_backoff() -> None:
 
 
 async def test_bulk_reembed_fallback_passes_is_failure_fallback() -> None:
-    """Batch-call failure must fan out to per-item _reembed_memory with
-    is_failure_fallback=True, otherwise the per-items skip their sleep
-    and thunder onto the failing provider."""
+    """Batch-call failure must fan out per-item through
+    _schedule_embed_or_reembed with is_failure_fallback=True.
+
+    The fan-out goes through the inline/deferred router (not _reembed_memory
+    directly) so the retry is DURABLE in deferred mode — one EMBED_REQUESTED
+    publish per item, retried by Pub/Sub. The flag still matters: it is what
+    gives the INLINE branch its backoff, without which the per-items skip
+    their sleep and thunder onto the failing provider. See
+    tests/test_durable_reembed_fallback.py for the per-branch behaviour."""
     from core_api.services import memory_service
 
     called_with: list[dict] = []
@@ -677,7 +683,7 @@ async def test_bulk_reembed_fallback_passes_is_failure_fallback() -> None:
 
     with (
         patch.object(memory_service, "get_embeddings_batch", new=_failing_batch),
-        patch.object(memory_service, "_reembed_memory", new=_capture),
+        patch.object(memory_service, "_schedule_embed_or_reembed", new=_capture),
         patch.object(memory_service, "track_task"),
         patch.object(
             memory_service,
@@ -727,7 +733,7 @@ async def test_bulk_reembed_fallback_catches_unexpected_exception_types() -> Non
 
     with (
         patch.object(memory_service, "get_embeddings_batch", new=_failing_batch),
-        patch.object(memory_service, "_reembed_memory", new=_capture),
+        patch.object(memory_service, "_schedule_embed_or_reembed", new=_capture),
         patch.object(memory_service, "track_task"),
         patch.object(
             memory_service,


### PR DESCRIPTION
## Why

Closes the tail of the **2026-07-27 incident**. #652 capped concurrency so the backend stops being thrashed — but it did **not** remove the request-count amplification, nor the permanence.

A failed 50-item bulk re-embed batch fanned out to **50 in-process tasks × 3 re-embed retries × 2 embedding attempts ≈ 300 provider calls**, all contending for the same already-saturated backend. When they exhausted, the rows stayed `embedding=NULL` **with no further recovery** — a manual CLI backfill was the only way out. That is exactly how **~430 memories were stranded**: stored, HTTP 200, but not semantically recallable.

I originally claimed #652's gate subsumed this. It doesn't — the gate removes *connection* amplification only. This PR is the actual fix.

## What changed

The five batch-failure fallbacks now go through the **existing** `_schedule_embed_or_reembed` router instead of calling `_reembed_memory` directly:

| mode | behaviour |
|---|---|
| **deferred** (prod) | one cheap `EMBED_REQUESTED` publish per item → retry lives on **Pub/Sub with redelivery + DLQ**, and survives instance restart |
| **inline** (OSS, no worker fleet) | unchanged: in-process retry |

This makes the permanently-unembedded class **structurally impossible** rather than merely less likely.

`is_failure_fallback` is threaded through the router so the **inline** branch keeps its thundering-herd backoff (the provider just failed for the whole batch); the deferred branch ignores it because Pub/Sub owns backoff.

**No new mechanism** — this reuses the same router the hot-path offload already uses, which is why the diff is small. The deliberate comment that previously documented the in-process behaviour is updated to explain the durability rationale.

## Validation

- `ruff check` / `ruff format` clean; module compiles; all 5 sites routed, 0 direct calls remain.
- 3 new tests in `tests/test_durable_reembed_fallback.py`: deferred publishes and does **not** retry in-process; inline retries in-process **and** receives the backoff flag; the hot-path default does **not** inherit the backoff.
- ⚠️ **The new tests were not run locally** — `memory_service` pulls in the full app dependency graph that isn't installed in my sandbox (`cachetools`, `croniter`, …). CI runs them in the real environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
