### PR TITLE
fix(client-ci): pin ruff to the 0.15 line so client CI stops floating into 0.16

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -41,7 +41,11 @@ dependencies = ["httpx>=0.27"]
 memclaw-interviewer = "memclaw_client.interviewer.cli:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "ruff>=0.6"]
+# ruff pinned to the 0.15 line (matches .pre-commit-config.yaml's v0.15.4): the
+# client CI installs ruff from this extra and `ruff>=0.6` floated to 0.16, whose
+# new default rules (RUF022, C408, …) fail on existing code. Adopting 0.16 is a
+# deliberate follow-up (fix the 18 findings), not a silent CI-breaking float.
+dev = ["pytest>=8", "ruff>=0.15.4,<0.16"]
 
 [project.urls]
 Homepage = "https://memclaw.net"


### PR DESCRIPTION
## What
Pins the `memclaw_client` dev extra to `ruff>=0.15.4,<0.16` (from `ruff>=0.6`).

## Why
`client-python-ci.yml` installs ruff via `pip install -e ".[dev]"`. With `ruff>=0.6` it floated to **0.16**, whose new default rules fire on existing code — **18 findings** (RUF022 `__all__`-not-sorted, C408, …). That silently red-lined the *Lint (ruff)* step on every `clients/python` PR, including the Dependabot `setup-python` bump #640 (which has nothing to do with ruff). Note the pre-commit ruff hook is scoped to `core-api`/`core-storage-api`, so it never covered the client package.

## Fix
Pin to the **0.15 line**, matching `.pre-commit-config.yaml`'s `rev: v0.15.4`. Verified locally:
- ruff **0.15.4** → `All checks passed!`
- ruff **0.16.0** → `Found 18 errors`

Adopting ruff 0.16 for the client (fixing the 18 findings) is a deliberate follow-up — same reasoning as the enterprise frozen-lint work — not a silent CI-breaking float. This unblocks #640 and other client PRs.