### PR TITLE
feat(plugin): interviewer task-trail capture — mirror OpenClaw task_runs into the interview buffer

### DIFF
--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -50,6 +50,7 @@ _plugin_files = [
     "keystones.ts",
     "openclaw-sdk-bridge.ts",
     "interview-buffer.ts",
+    "task-trail.ts",
 ]
 
 
@@ -406,7 +407,7 @@ fi
 
 if [ -z "$SRC_FILES" ] || [ -z "$ROOT_FILES" ]; then
   echo "WARNING: Could not fetch/parse /api/v1/plugin-manifest (python3 missing or endpoint unreachable). Falling back to hardcoded file list."
-  SRC_FILES="index.ts prompt-section.ts tools.ts tool-specs.ts version.ts env.ts transport.ts validation.ts config.ts paths.ts logger.ts resolve-agent.ts tool-definitions.ts deploy.ts heartbeat.ts educate.ts context-engine.ts context-engine.internal.ts agent-auth.ts health.ts install-id.ts identity.ts reconcile-skills.ts keystones.ts openclaw-sdk-bridge.ts interview-buffer.ts"
+  SRC_FILES="index.ts prompt-section.ts tools.ts tool-specs.ts version.ts env.ts transport.ts validation.ts config.ts paths.ts logger.ts resolve-agent.ts tool-definitions.ts deploy.ts heartbeat.ts educate.ts context-engine.ts context-engine.internal.ts agent-auth.ts health.ts install-id.ts identity.ts reconcile-skills.ts keystones.ts openclaw-sdk-bridge.ts interview-buffer.ts task-trail.ts"
   ROOT_FILES="openclaw.plugin.json tools.json skills/memclaw/SKILL.md"
 fi
 

--- a/plugin/e2e/interviewer-wet-capture.sh
+++ b/plugin/e2e/interviewer-wet-capture.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Interviewer Phase 1.5 — capture-layer wet test (#654 / PR #658).
+#
+# The Phase-1 suite (interviewer-wet.sh) hand-feeds the buffer and is
+# therefore a PIPELINE regression. This suite exercises the CAPTURE
+# layer: events must originate from OpenClaw's real task_runs SQLite
+# (created by a real `openclaw` gateway; rows from real system-event
+# cron runs where possible, schema-introspecting inserts for edge
+# shapes). No appendInterviewEvent calls anywhere in this file.
+#
+# Expects: plugin/ cwd with dist/ built; backend up on MEMCLAW_API_URL;
+# a real ~/.openclaw created by the installed OpenClaw (legacy layout
+# phase A; run again post-upgrade for phase B). TASK_DB points at the
+# discovered task DB for insert helpers.
+set -u
+set -o pipefail
+
+: "${MEMCLAW_API_URL:=http://localhost:8000}"
+: "${MEMCLAW_API_KEY:?set MEMCLAW_API_KEY (admin key)}"
+: "${MEMCLAW_TENANT_ID:=t-wet-capture}"
+: "${MEMCLAW_FLEET_ID:=wet-fleet}"
+: "${MEMCLAW_NODE_NAME:=wet-node-capture}"
+: "${TASK_DB:=$HOME/.openclaw/tasks/runs.sqlite}"
+export MEMCLAW_API_URL MEMCLAW_API_KEY MEMCLAW_TENANT_ID MEMCLAW_FLEET_ID MEMCLAW_NODE_NAME
+export MEMCLAW_INTERVIEWER=true
+unset MEMCLAW_INTERVIEWER_TASKS MEMCLAW_TASK_DB_PATH || true
+
+H() { node e2e/interviewer-wet.mjs "$@" | tail -1; }
+PASS=0; FAIL=0
+say()  { echo ">>> $*"; }
+ok()   { PASS=$((PASS+1)); echo "  PASS: $*"; }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL: $*"; }
+need() { # need <jq-expr> <expected> <json> <label>
+  local got
+  got=$(echo "$3" | jq -r "$1")
+  if [ "$got" = "$2" ]; then ok "$4 ($1=$got)"; else bad "$4 — expected $1=$2, got $got  [$3]"; fi
+}
+
+say "A0 setup: enable tenant + register node; task DB = $TASK_DB"
+H set-enabled true >/dev/null || { echo "setup failed"; exit 1; }
+H heartbeat >/dev/null || { echo "heartbeat failed"; exit 1; }
+R=$(H task-db-schema "$TASK_DB"); need '.ok' true "$R" "real task DB readable"
+echo "  real columns: $(echo "$R" | jq -c .columns)"
+
+say "A1 discovery: sync sees the real DB, no hand-fed events anywhere"
+R=$(H sync)
+need '.db_paths | length >= 1' true "$R" "discovery found >=1 task DB"
+echo "  discovered: $(echo "$R" | jq -c .db_paths)"
+A1_SYNCED=$(echo "$R" | jq -r .synced)
+say "A1 synced $A1_SYNCED pre-existing real task events"
+
+say "A2 real capture -> interview: fresh terminal tasks -> tick -> memories"
+R=$(H task-insert "$TASK_DB" 3 phaseA terminal); need '.inserted' 3 "$R" "3 terminal tasks in the REAL DB"
+R=$(H tick 0)
+need '.status' done "$R" "tick done"
+need '.result.submitted' true "$R" "window submitted"
+need '.result.synced_tasks >= 3' true "$R" "synced_tasks counted the new tasks"
+W=$(echo "$R" | jq -r '.result.watermark // empty'); [ -n "$W" ] || { echo "ABORT: no watermark"; exit 1; }
+R=$(H memories); need '.interviewer_memories >= 1' true "$R" "interviewer memories written from task events"
+
+say "A3 delta: second tick is a genuine no-op"
+R=$(H tick $((W + 1)))
+need '.result.submitted' false "$R" "nothing new submitted"
+need '.result.synced_tasks' 0 "$R" "no re-emission (sidecar delta)"
+need '.result.reason' "no new events since cursor" "$R" "idle reason"
+
+say "A4 terminal transition: running -> completed emits the result half"
+R=$(H task-insert "$TASK_DB" 1 phaseA4); TID=$(echo "$R" | jq -r .first_id)
+R=$(H tick $((W + 1)))
+need '.result.synced_tasks' 1 "$R" "discovered event synced"
+W=$(echo "$R" | jq -r '.result.watermark // empty')
+H task-finish "$TASK_DB" "$TID" "phaseA4 finished: verified terminal transition capture" ok >/dev/null
+R=$(H tick $((W + 1)))
+need '.result.synced_tasks' 1 "$R" "terminal event synced on transition"
+W=$(echo "$R" | jq -r '.result.watermark // empty')
+
+say "D1 observability: task capture disabled is a distinct note"
+R=$(MEMCLAW_INTERVIEWER_TASKS=false H tick $((W + 1)))
+need '.result.synced_tasks' 0 "$R" "no sync when disabled"
+need '.result.task_trail' "task capture disabled (MEMCLAW_INTERVIEWER_TASKS=false)" "$R" "disabled note"
+
+say "D2 observability: broken MEMCLAW_TASK_DB_PATH names the path"
+R=$(MEMCLAW_TASK_DB_PATH=/nonexistent/tasks.sqlite H tick $((W + 1)))
+need '.result.synced_tasks' 0 "$R" "no sync on broken override"
+need '.result.task_trail | contains("/nonexistent/tasks.sqlite")' true "$R" "note names the misconfigured path"
+
+say "D3 cap: 220-task burst -> capped tick -> remainder drains"
+R=$(H task-insert "$TASK_DB" 220 phaseD3); need '.inserted' 220 "$R" "220 tasks inserted"
+R=$(H tick $((W + 1)))
+need '.result.synced_tasks' 200 "$R" "first tick capped at 200"
+need '.result.task_trail | contains("capped")' true "$R" "capped note present"
+W=$(echo "$R" | jq -r '.result.watermark // empty')
+R=$(H tick $((W + 1)))
+need '.result.synced_tasks' 20 "$R" "remainder drained next tick"
+W=$(echo "$R" | jq -r '.result.watermark // empty')
+
+echo
+echo "capture-suite: PASS=$PASS FAIL=$FAIL (watermark=$W)"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/plugin/e2e/interviewer-wet.mjs
+++ b/plugin/e2e/interviewer-wet.mjs
@@ -51,6 +51,7 @@ async function nodeUuid() {
 const cmd = process.argv[2];
 const arg1 = process.argv[3];
 const arg2 = process.argv[4];
+const arg3 = process.argv[5];
 
 try {
   if (cmd === "set-enabled") {
@@ -145,6 +146,126 @@ try {
     out({ enabled: !!(s.interviewer || {}).enabled });
   } else if (cmd === "node-uuid") {
     out({ node_uuid: await nodeUuid() });
+
+    // ------------------------------------------------------------------
+    // Phase 1.5 (task-trail, #654) — capture-layer subcommands. Unlike
+    // "append" (which hand-feeds the buffer and therefore validates only
+    // the pipeline), these operate on the OpenClaw task_runs DB so the
+    // REAL capture path (discovery -> probe -> delta -> buffer) is what
+    // gets exercised.
+    // ------------------------------------------------------------------
+  } else if (cmd === "sync") {
+    // Run the real task-trail sync directly; print its result AND the
+    // sidecar (db_paths records which DBs discovery actually found — on
+    // >= 2026.6 this documents the consolidated DB's real filename).
+    const { syncTaskTrail } = await import("../dist/task-trail.js");
+    const res = await syncTaskTrail();
+    let sidecar = null;
+    try {
+      const { readFileSync } = await import("fs");
+      const { join } = await import("path");
+      const { homedir } = await import("os");
+      sidecar = JSON.parse(
+        readFileSync(
+          join(homedir(), ".openclaw", "plugins", "memclaw", "interview-task-sync.json"),
+          "utf-8",
+        ),
+      );
+    } catch {
+      // sidecar may not exist yet
+    }
+    out({ ...res, db_paths: sidecar?.db_paths ?? null, tracked_tasks: sidecar ? Object.keys(sidecar.tasks).length : 0 });
+  } else if (cmd === "task-insert") {
+    // arg1: db path, arg2: count, arg3: label, argv[6]: "terminal" to
+    // insert already-finished rows. Schema-INTROSPECTING: reads the real
+    // table's columns via PRAGMA and only fills what exists, so the same
+    // command works against whatever schema the installed OpenClaw
+    // version created — rows are as real as the schema is.
+    const { DatabaseSync } = await import("node:sqlite");
+    const db = new DatabaseSync(arg1);
+    const cols = db.prepare("PRAGMA table_info(task_runs)").all();
+    const names = new Set(cols.map((c) => c.name));
+    const notNull = cols.filter((c) => c.notnull && c.dflt_value === null && c.name !== "task_id");
+    const n = parseInt(arg2 || "1", 10);
+    const label = arg3 || "wet";
+    const terminal = process.argv[6] === "terminal";
+    const now = Date.now();
+    const ids = [];
+    for (let i = 0; i < n; i++) {
+      const id = `wet-${label}-${now}-${i}`;
+      const row = { task_id: id };
+      // Known semantic columns first.
+      if (names.has("task")) row.task = `[${label}] investigate wet-test workload item ${i}`;
+      if (names.has("status")) row.status = terminal ? "completed" : "running";
+      if (names.has("runtime")) row.runtime = "subagent";
+      if (names.has("label")) row.label = label;
+      if (names.has("created_at")) row.created_at = now - 10_000 + i;
+      if (names.has("last_event_at")) row.last_event_at = now - 5_000 + i;
+      if (terminal) {
+        if (names.has("ended_at")) row.ended_at = now - 1_000 + i;
+        if (names.has("terminal_summary"))
+          row.terminal_summary = `completed wet workload ${i}: validated the ${label} path end-to-end`;
+        if (names.has("terminal_outcome")) row.terminal_outcome = "ok";
+      }
+      // Any remaining NOT-NULL-without-default column gets a type-shaped
+      // filler so the insert works on schema variants we haven't seen.
+      for (const c of notNull) {
+        if (row[c.name] !== undefined) continue;
+        row[c.name] = /INT|REAL|NUM/i.test(c.type || "") ? 0 : "wet";
+      }
+      const keys = Object.keys(row);
+      db.prepare(
+        `INSERT OR REPLACE INTO task_runs (${keys.join(",")}) VALUES (${keys.map(() => "?").join(",")})`,
+      ).run(...keys.map((k) => row[k]));
+      ids.push(id);
+    }
+    db.close();
+    out({ ok: true, inserted: n, terminal, first_id: ids[0], db: arg1 });
+  } else if (cmd === "task-finish") {
+    // arg1: db path, arg2: task_id, arg3: summary, argv[6]: outcome
+    const { DatabaseSync } = await import("node:sqlite");
+    const db = new DatabaseSync(arg1);
+    const names = new Set(db.prepare("PRAGMA table_info(task_runs)").all().map((c) => c.name));
+    const sets = ["status = 'completed'"];
+    const vals = [];
+    if (names.has("ended_at")) sets.push(`ended_at = ${Date.now()}`);
+    if (names.has("last_event_at")) sets.push(`last_event_at = ${Date.now()}`);
+    if (names.has("terminal_summary")) {
+      sets.push("terminal_summary = ?");
+      vals.push(arg3 || "finished");
+    }
+    if (names.has("terminal_outcome")) {
+      sets.push("terminal_outcome = ?");
+      vals.push(process.argv[6] || "ok");
+    }
+    db.prepare(`UPDATE task_runs SET ${sets.join(", ")} WHERE task_id = ?`).run(...vals, arg2);
+    db.close();
+    out({ ok: true, task_id: arg2 });
+  } else if (cmd === "task-db-schema") {
+    // arg1: db path — print the REAL table columns (documents what the
+    // installed OpenClaw version actually ships; phase-B evidence).
+    const { DatabaseSync } = await import("node:sqlite");
+    const db = new DatabaseSync(arg1, { readOnly: true });
+    const cols = db.prepare("PRAGMA table_info(task_runs)").all().map((c) => c.name);
+    const count = db.prepare("SELECT COUNT(*) AS c FROM task_runs").get().c;
+    db.close();
+    out({ ok: true, db: arg1, columns: cols, rows: count });
+  } else if (cmd === "tick") {
+    // arg1: since_seq — one full interview tick: queue command on the
+    // rail, heartbeat to process it, return the latest command result
+    // (incl. synced_tasks / task_trail — the phase-1.5 observability).
+    const uuid = await nodeUuid();
+    await api("POST", "/fleet/commands", {
+      tenant_id: TENANT,
+      node_id: uuid,
+      command: "interview_request",
+      payload: { node_id: uuid, since_seq: parseInt(arg1 || "0", 10), template_id: "default-v1", period_hours: 12 },
+    });
+    const { sendHeartbeat } = await import("../dist/heartbeat.js");
+    await sendHeartbeat();
+    const rows = await api("GET", "/fleet/commands", undefined, { tenant_id: TENANT });
+    const ours = rows.filter((c) => c.command === "interview_request");
+    out({ ok: true, status: ours[0]?.status, result: ours[0]?.result ?? null });
   } else {
     throw new Error(`unknown subcommand: ${cmd}`);
   }

--- a/plugin/e2e/interviewer-wet.sh
+++ b/plugin/e2e/interviewer-wet.sh
@@ -80,6 +80,14 @@ for i in $(seq 1 10); do
   sleep 1
 done
 [ "$EN" = "false" ] || { echo "ABORT: tenant still enabled after disable"; exit 1; }
+# get-enabled=false only proves ONE worker sees the flip: core-api runs 2
+# uvicorn workers with independent 5-min settings caches, and the submit
+# may hit the other one (observed 2026-07-28: a stale-cache worker accepted
+# the submit, pruned the buffer, and broke this invariant's assertions).
+# Wait out the TTL so BOTH workers are guaranteed to enforce the disable.
+: "${SETTINGS_CACHE_TTL_WAIT:=310}"
+say "waiting ${SETTINGS_CACHE_TTL_WAIT}s for the per-worker settings-cache TTL"
+sleep "$SETTINGS_CACHE_TTL_WAIT"
 SINCE=$((W2 + 1))
 H queue-cmd "$SINCE" >/dev/null
 R=$(H heartbeat)          # command fails server-side (403)
@@ -96,11 +104,18 @@ for i in $(seq 1 8); do
   H heartbeat >/dev/null
   SUBMITTED=$(H commands | jq -r '.latest.result.submitted // false')
   [ "$SUBMITTED" = "true" ] && break
-  sleep 2
+  # 45s between retries: 8 tries must span the 5-min per-worker cache
+  # TTL, or a stale-cache worker can refuse all 8 quick attempts.
+  sleep 45
 done
 R=$(H commands);           need '.latest.result.submitted' true "$R" "retry submitted after re-enable (eventual, per-worker cache)"
 W3=$(echo "$R" | jq -r '.latest.result.watermark // empty'); [ -n "$W3" ] || { echo "ABORT: no watermark after P3"; exit 1; }
 R=$(H count);              need '.count' 0 "$R" "buffer pruned after recovery"
+# The retry loop exits as soon as ONE worker accepts; the other worker's
+# cache may still say "disabled" for up to the TTL and 403 the next
+# phase's submit (observed 2026-07-28 in P5). Wait for convergence.
+say "waiting ${SETTINGS_CACHE_TTL_WAIT}s for both workers to see the re-enable"
+sleep "$SETTINGS_CACHE_TTL_WAIT"
 
 say "P4 kill -9 durability: hard-kill mid-append, then verify + continue"
 node e2e/interviewer-wet.mjs append-loop > /tmp/killer.log 2>&1 &

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -16,7 +16,7 @@
     "pretest": "bash ../scripts/gen-version.sh",
     "build": "tsc",
     "dev": "bash ../scripts/gen-version.sh && tsc --watch",
-    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/interview-buffer.test.js dist/interview-command.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js",
+    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/interview-buffer.test.js dist/interview-command.test.js dist/task-trail.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js",
     "check:version": "bash -c 'V=$(node -p \"require(\\\"./package.json\\\").version\"); grep -qF \"PLUGIN_VERSION = \\\"$V\\\"\" src/version.ts || (echo \"version.ts out of sync with package.json ($V): run bash ../scripts/gen-version.sh\" >&2 && exit 1) && echo \"check:version ok: $V\"'"
   },
   "devDependencies": {

--- a/plugin/src/env.ts
+++ b/plugin/src/env.ts
@@ -85,6 +85,20 @@ export const MEMCLAW_REQUIRE_SIGNED_COMMANDS =
 // feature to function end-to-end.
 export const MEMCLAW_INTERVIEWER = process.env.MEMCLAW_INTERVIEWER === "true";
 
+// Interviewer Phase 1.5 (issue #654): mirror OpenClaw's ``task_runs``
+// SQLite trail into the interview buffer at interview time, so task /
+// sub-agent-driven work is interviewed, not just the host chat stream.
+// Default ON whenever the interviewer itself is on — this is the fix
+// for the empty-interview gap, not a separate feature. ``"false"`` is
+// the escape hatch if a node's task DB misbehaves.
+export const MEMCLAW_INTERVIEWER_TASKS = process.env.MEMCLAW_INTERVIEWER_TASKS !== "false";
+
+// Operator override for the task_runs database location. Normally
+// discovered (legacy <base>/tasks/runs.sqlite, else a shallow scan for
+// a task_runs table — the >= 2026.6 consolidated state DB has no stable
+// filename); set this when a deployment relocates OpenClaw state.
+export const MEMCLAW_TASK_DB_PATH = process.env.MEMCLAW_TASK_DB_PATH || "";
+
 // Warn at import time if API key is set but URL is HTTP
 warnIfInsecureUrl(MEMCLAW_API_URL, MEMCLAW_API_KEY);
 
@@ -281,6 +295,15 @@ export const INTERVIEW_BUFFER_MAX_BYTES = 50_000_000;
 // the default timeout aborted every full-window submit). Generous
 // like BUILD_TIMEOUT_MS; a timeout still fails safe (no prune).
 export const INTERVIEW_SUBMIT_TIMEOUT_MS = 300_000;
+// Task-trail sync (Phase 1.5): at most this many task events are
+// appended per interview tick — bounds the first-sync burst on a busy
+// node; the sidecar only advances for emitted rows, so the remainder
+// drains on later ticks.
+export const INTERVIEW_TASK_SYNC_MAX_PER_TICK = 200;
+// Sidecar entries older than this are pruned. One day past OpenClaw's
+// 7-day terminal-task retention (task-retention.ts) — anything older
+// can never resurface from the DB, so tracking it is waste.
+export const INTERVIEW_TASK_SIDECAR_RETENTION_MS = 8 * 24 * 60 * 60_000;
 
 // --- Keystones (CAURA-000): mandatory governance rules auto-injected ---
 //

--- a/plugin/src/heartbeat.ts
+++ b/plugin/src/heartbeat.ts
@@ -32,6 +32,7 @@ import {
   MEMCLAW_FLEET_ID,
   MEMCLAW_REQUIRE_SIGNED_COMMANDS,
   MEMCLAW_INTERVIEWER,
+  MEMCLAW_INTERVIEWER_TASKS,
   INTERVIEW_SUBMIT_MAX_EVENTS,
   INTERVIEW_SUBMIT_TIMEOUT_MS,
   BUILD_TIMEOUT_MS,
@@ -39,6 +40,7 @@ import {
   ensureTenantId,
 } from "./env.js";
 import { readInterviewEvents, pruneInterviewBuffer } from "./interview-buffer.js";
+import { syncTaskTrail } from "./task-trail.js";
 import { resolveAgentIdQuiet } from "./resolve-agent.js";
 import { PLUGIN_VERSION } from "./version.js";
 import { MEMCLAW_TOOLS } from "./tools.js";
@@ -1127,12 +1129,27 @@ async function processCommand(cmd: {
         status = "failed";
         result = { error: "interview_request payload missing node_id" };
       } else {
+        // Phase 1.5 (#654): mirror the OpenClaw task-trail delta into the
+        // buffer BEFORE reading the window, so task/sub-agent-driven work
+        // is interviewed too — the chat stream alone misses it entirely.
+        // syncTaskTrail never throws; a degraded sync (db missing/locked)
+        // is reported via ``task_trail`` so operators can tell "idle"
+        // from "not captured" instead of a silent no-op.
+        const taskSync = MEMCLAW_INTERVIEWER_TASKS
+          ? await syncTaskTrail()
+          : { synced: 0, note: "task capture disabled (MEMCLAW_INTERVIEWER_TASKS=false)" };
         const events = await readInterviewEvents(sinceSeq, INTERVIEW_SUBMIT_MAX_EVENTS);
         if (events.length === 0) {
           // Nothing new since the cursor: done, nothing submitted. The
           // server watermark is untouched, so the node stays "due" and
           // will simply be asked again next period.
-          result = { ok: true, submitted: false, reason: "no new events since cursor" };
+          result = {
+            ok: true,
+            submitted: false,
+            reason: "no new events since cursor",
+            synced_tasks: taskSync.synced,
+            ...(taskSync.note ? { task_trail: taskSync.note } : {}),
+          };
         } else {
           const tenantId = await ensureTenantId();
           // Phase-1 grain is per-node (matches the server watermark):
@@ -1173,6 +1190,8 @@ async function processCommand(cmd: {
             ok: true,
             submitted: true,
             events: events.length,
+            synced_tasks: taskSync.synced,
+            ...(taskSync.note ? { task_trail: taskSync.note } : {}),
             watermark: resp.watermark,
             server_status: resp.status,
             memories_written: resp.memories_written,

--- a/plugin/src/interview-command.test.ts
+++ b/plugin/src/interview-command.test.ts
@@ -25,6 +25,7 @@ process.env.MEMCLAW_API_URL = "http://localhost:8000";
 process.env.MEMCLAW_TENANT_ID = "t-test";
 
 const { __DEPLOY_INTERNALS__ } = await import("./heartbeat.js");
+const { __TASK_TRAIL_INTERNALS__ } = await import("./task-trail.js");
 const { appendInterviewEvent, readInterviewEvents, __INTERVIEW_BUFFER_INTERNALS__ } =
   await import("./interview-buffer.js");
 
@@ -51,6 +52,11 @@ describe("interview_request command handler", () => {
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), "memclaw-interview-cmd-"));
     __INTERVIEW_BUFFER_INTERNALS__.setPathForTests(join(tmp, "buf.jsonl"));
+    // Point the Phase-1.5 task-trail at the empty tmp dir so the handler's
+    // pre-read sync can never discover a REAL ~/.openclaw task DB on the
+    // machine running the tests (which would append nondeterministic events).
+    __TASK_TRAIL_INTERNALS__.setBaseDirForTests(tmp);
+    __TASK_TRAIL_INTERNALS__.setSidecarPathForTests(join(tmp, "task-sidecar.json"));
     __DEPLOY_INTERNALS__.setInterviewerEnabledForTests(true);
     captured = [];
     submitResponse = {
@@ -79,6 +85,8 @@ describe("interview_request command handler", () => {
     globalThis.fetch = originalFetch;
     __DEPLOY_INTERNALS__.setInterviewerEnabledForTests(undefined);
     __INTERVIEW_BUFFER_INTERNALS__.setPathForTests(undefined);
+    __TASK_TRAIL_INTERNALS__.setBaseDirForTests(undefined);
+    __TASK_TRAIL_INTERNALS__.setSidecarPathForTests(undefined);
     rmSync(tmp, { recursive: true, force: true });
   });
 

--- a/plugin/src/task-trail.test.ts
+++ b/plugin/src/task-trail.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Tests for the Interviewer's OpenClaw task-trail capture (#654).
+ *
+ * Pins the properties the fix rests on:
+ * - DB discovery across BOTH OpenClaw layouts (2026.4/5 standalone
+ *   ``tasks/runs.sqlite``; >= 2026.6 consolidated state DB with an
+ *   unstable filename) plus the operator env override;
+ * - column probing: an old schema missing the optional summary columns
+ *   still syncs (falls back to task/status), a schema missing REQUIRED
+ *   columns degrades to task-db-unavailable instead of throwing;
+ * - the delta contract: at most two events per task (discovered +
+ *   terminal), progress-only bumps emit nothing, re-syncs are no-ops;
+ * - fail-soft: no DB present is a note, never a throw;
+ * - the per-tick cap with natural resume on the next sync;
+ * - sidecar pruning past the retention horizon.
+ */
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { DatabaseSync } from "node:sqlite";
+
+const { syncTaskTrail, __TASK_TRAIL_INTERNALS__ } = await import("./task-trail.js");
+const { readInterviewEvents, __INTERVIEW_BUFFER_INTERNALS__ } = await import(
+  "./interview-buffer.js"
+);
+const { INTERVIEW_TASK_SYNC_MAX_PER_TICK } = await import("./env.js");
+
+/** The real task_runs schema (captured from an OpenClaw 2026.4/5 install). */
+const FULL_SCHEMA = `
+  CREATE TABLE task_runs (
+    task_id TEXT PRIMARY KEY,
+    runtime TEXT NOT NULL,
+    task_kind TEXT,
+    source_id TEXT,
+    requester_session_key TEXT,
+    owner_key TEXT NOT NULL,
+    scope_kind TEXT NOT NULL,
+    child_session_key TEXT,
+    parent_flow_id TEXT,
+    parent_task_id TEXT,
+    agent_id TEXT,
+    run_id TEXT,
+    label TEXT,
+    task TEXT NOT NULL,
+    status TEXT NOT NULL,
+    delivery_status TEXT NOT NULL,
+    notify_policy TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    started_at INTEGER,
+    ended_at INTEGER,
+    last_event_at INTEGER,
+    cleanup_after INTEGER,
+    error TEXT,
+    progress_summary TEXT,
+    terminal_summary TEXT,
+    terminal_outcome TEXT
+  );
+`;
+
+interface RowSpec {
+  task_id: string;
+  task?: string;
+  status?: string;
+  runtime?: string;
+  label?: string | null;
+  created_at?: number;
+  last_event_at?: number | null;
+  ended_at?: number | null;
+  terminal_summary?: string | null;
+  progress_summary?: string | null;
+  terminal_outcome?: string | null;
+  error?: string | null;
+  child_session_key?: string | null;
+}
+
+function makeDb(path: string, schema: string = FULL_SCHEMA): void {
+  const db = new DatabaseSync(path);
+  db.exec(schema);
+  db.close();
+}
+
+function insertRow(path: string, spec: RowSpec): void {
+  const db = new DatabaseSync(path);
+  const now = Date.now();
+  db.prepare(
+    `INSERT OR REPLACE INTO task_runs
+     (task_id, runtime, owner_key, scope_kind, task, status, delivery_status,
+      notify_policy, created_at, last_event_at, ended_at, label,
+      terminal_summary, progress_summary, terminal_outcome, error, child_session_key)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    spec.task_id,
+    spec.runtime ?? "subagent",
+    "owner",
+    "session",
+    spec.task ?? "investigate the flaky deploy",
+    spec.status ?? "running",
+    "none",
+    "auto",
+    spec.created_at ?? now,
+    spec.last_event_at === undefined ? now : spec.last_event_at,
+    spec.ended_at ?? null,
+    spec.label ?? null,
+    spec.terminal_summary ?? null,
+    spec.progress_summary ?? null,
+    spec.terminal_outcome ?? null,
+    spec.error ?? null,
+    spec.child_session_key ?? null,
+  );
+  db.close();
+}
+
+describe("task-trail sync", () => {
+  let tmp: string;
+  let legacyDbPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "memclaw-task-trail-"));
+    __TASK_TRAIL_INTERNALS__.setBaseDirForTests(tmp);
+    __TASK_TRAIL_INTERNALS__.setSidecarPathForTests(join(tmp, "sidecar.json"));
+    __INTERVIEW_BUFFER_INTERNALS__.setPathForTests(join(tmp, "buf.jsonl"));
+    legacyDbPath = join(tmp, "tasks", "runs.sqlite");
+    mkdirSync(join(tmp, "tasks"), { recursive: true });
+  });
+
+  afterEach(() => {
+    __TASK_TRAIL_INTERNALS__.setBaseDirForTests(undefined);
+    __TASK_TRAIL_INTERNALS__.setSidecarPathForTests(undefined);
+    __INTERVIEW_BUFFER_INTERNALS__.setPathForTests(undefined);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("no task DB anywhere degrades to a note, never a throw", async () => {
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 0);
+    assert.match(res.note ?? "", /task-db-unavailable/);
+    const events = await readInterviewEvents(0, 100);
+    assert.equal(events.length, 0);
+  });
+
+  test("MEMCLAW_TASK_DB_PATH override: valid path is exclusive, broken path is named in the note", async () => {
+    // Valid override: used exclusively, even though a legacy DB also exists.
+    makeDb(legacyDbPath);
+    insertRow(legacyDbPath, { task_id: "t-legacy" });
+    const overridePath = join(tmp, "custom-tasks.sqlite");
+    makeDb(overridePath);
+    insertRow(overridePath, { task_id: "t-override", task: "work in the override DB" });
+    __TASK_TRAIL_INTERNALS__.setTaskDbPathForTests(overridePath);
+    try {
+      const res = await syncTaskTrail();
+      assert.equal(res.synced, 1);
+      assert.match((await readInterviewEvents(0, 100))[0].content, /override DB/);
+
+      // Broken override: the note must NAME the misconfigured path instead
+      // of the generic "not found" (which reads as an idle node).
+      __TASK_TRAIL_INTERNALS__.setTaskDbPathForTests(join(tmp, "does-not-exist.sqlite"));
+      const broken = await syncTaskTrail();
+      assert.equal(broken.synced, 0);
+      assert.match(broken.note ?? "", /MEMCLAW_TASK_DB_PATH=.*does-not-exist\.sqlite/);
+    } finally {
+      __TASK_TRAIL_INTERNALS__.setTaskDbPathForTests(undefined);
+    }
+  });
+
+  test("legacy layout: new running task emits ONE discovered event", async () => {
+    makeDb(legacyDbPath);
+    insertRow(legacyDbPath, {
+      task_id: "t1",
+      task: "compile the weekly revenue digest",
+      runtime: "subagent",
+      label: "digest",
+      child_session_key: "agent:main:sub:42",
+    });
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 1);
+    assert.equal(res.note, undefined);
+    const events = await readInterviewEvents(0, 100);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].kind, "task");
+    assert.equal(events[0].role, "agent");
+    assert.equal(events[0].session_id, "agent:main:sub:42");
+    assert.equal(events[0].tool, "subagent");
+    assert.match(events[0].content, /\[task subagent\/digest\] compile the weekly/);
+  });
+
+  test("terminal transition emits task_result with summary + outcome", async () => {
+    makeDb(legacyDbPath);
+    insertRow(legacyDbPath, { task_id: "t1", status: "running" });
+    await syncTaskTrail(); // discovers t1
+    insertRow(legacyDbPath, {
+      task_id: "t1",
+      status: "completed",
+      ended_at: Date.now(),
+      terminal_summary: "digest built and posted to #revenue",
+      terminal_outcome: "ok",
+    });
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 1);
+    const events = await readInterviewEvents(0, 100);
+    assert.equal(events.length, 2);
+    assert.equal(events[1].kind, "task_result");
+    assert.match(events[1].content, /digest built and posted/);
+    assert.equal(events[1].outcome, "ok");
+  });
+
+  test("progress-only bumps emit nothing; re-sync is a no-op", async () => {
+    makeDb(legacyDbPath);
+    insertRow(legacyDbPath, { task_id: "t1", status: "running" });
+    await syncTaskTrail();
+    insertRow(legacyDbPath, {
+      task_id: "t1",
+      status: "running",
+      last_event_at: Date.now() + 1000,
+      progress_summary: "half done",
+    });
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 0);
+    const res2 = await syncTaskTrail();
+    assert.equal(res2.synced, 0);
+    assert.equal((await readInterviewEvents(0, 100)).length, 1);
+  });
+
+  test("task that appears already-terminal emits both halves in one sync", async () => {
+    makeDb(legacyDbPath);
+    insertRow(legacyDbPath, {
+      task_id: "t1",
+      status: "failed",
+      ended_at: Date.now(),
+      error: "npm install exploded",
+    });
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 2);
+    const events = await readInterviewEvents(0, 100);
+    assert.equal(events[0].kind, "task");
+    assert.equal(events[1].kind, "task_result");
+    assert.match(events[1].content, /npm install exploded/);
+    assert.equal(events[1].outcome, "failed"); // no terminal_outcome -> status
+  });
+
+  test("old schema without summary/label columns still syncs (fallback)", async () => {
+    makeDb(
+      legacyDbPath,
+      `CREATE TABLE task_runs (
+        task_id TEXT PRIMARY KEY,
+        task TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        ended_at INTEGER
+      );`,
+    );
+    const db = new DatabaseSync(legacyDbPath);
+    db.prepare(
+      "INSERT INTO task_runs (task_id, task, status, created_at, ended_at) VALUES (?, ?, ?, ?, ?)",
+    ).run("t-old", "ancient work", "completed", Date.now(), Date.now());
+    db.close();
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 2);
+    const events = await readInterviewEvents(0, 100);
+    assert.match(events[0].content, /\[task\] ancient work/);
+    assert.match(events[1].content, /task ended: completed/); // summary fallback
+    assert.equal(events[1].outcome, "completed");
+  });
+
+  test("schema missing REQUIRED columns degrades, never throws", async () => {
+    makeDb(legacyDbPath, "CREATE TABLE task_runs (task_id TEXT PRIMARY KEY);");
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 0);
+    assert.match(res.note ?? "", /task-db-unavailable: no readable task_runs schema/);
+  });
+
+  test("consolidated layout: scan finds task_runs DB, skips decoys", async () => {
+    // Decoy: a memory-index sqlite WITHOUT task_runs (real OpenClaw layout).
+    mkdirSync(join(tmp, "memory"), { recursive: true });
+    const decoy = new DatabaseSync(join(tmp, "memory", "agent.sqlite"));
+    decoy.exec("CREATE TABLE chunks (id TEXT PRIMARY KEY);");
+    decoy.close();
+    // The consolidated DB, deliberately NOT at the legacy path/name.
+    const statePath = join(tmp, "openclaw-state.sqlite");
+    makeDb(statePath);
+    insertRow(statePath, { task_id: "t-consolidated" });
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 1);
+    // Synced paths are recorded in the sidecar (informational, not a cache).
+    const sidecar = JSON.parse(readFileSync(join(tmp, "sidecar.json"), "utf-8"));
+    assert.deepEqual(sidecar.db_paths, [statePath]);
+  });
+
+  test("stale post-upgrade legacy DB cannot shadow the live consolidated DB", async () => {
+    // The 2026.5 -> 2026.6 upgrade scenario: the old tasks/runs.sqlite
+    // survives with a valid-but-frozen task_runs table (and was even the
+    // previously-synced source), while all NEW tasks land in the
+    // consolidated state DB. Both must be read — single-winner discovery
+    // would return the frozen file forever and report synced:0,
+    // indistinguishable from an idle node.
+    makeDb(legacyDbPath);
+    insertRow(legacyDbPath, { task_id: "t-pre-upgrade" });
+    const first = await syncTaskTrail(); // sidecar now knows the legacy path
+    assert.equal(first.synced, 1);
+
+    const statePath = join(tmp, "openclaw-state.sqlite");
+    makeDb(statePath);
+    insertRow(statePath, {
+      task_id: "t-post-upgrade",
+      task: "work recorded only in the consolidated DB",
+    });
+    const second = await syncTaskTrail();
+    assert.equal(second.synced, 1); // the new task IS captured
+    const events = await readInterviewEvents(0, 100);
+    assert.match(events[1].content, /consolidated DB/);
+    // Migrated duplicate of the old task in the new DB de-dups via sidecar.
+    insertRow(statePath, { task_id: "t-pre-upgrade" });
+    const third = await syncTaskTrail();
+    assert.equal(third.synced, 0);
+  });
+
+  test("per-tick cap: remainder drains on the next sync", async () => {
+    makeDb(legacyDbPath);
+    const total = INTERVIEW_TASK_SYNC_MAX_PER_TICK + 25;
+    const base = Date.now() - 60_000;
+    for (let i = 0; i < total; i++) {
+      insertRow(legacyDbPath, {
+        task_id: `t${String(i).padStart(4, "0")}`,
+        last_event_at: base + i, // stable ordering
+      });
+    }
+    const first = await syncTaskTrail();
+    assert.equal(first.synced, INTERVIEW_TASK_SYNC_MAX_PER_TICK);
+    assert.match(first.note ?? "", /capped/);
+    const second = await syncTaskTrail();
+    assert.equal(second.synced, 25);
+    assert.equal(second.note, undefined);
+    assert.equal((await readInterviewEvents(0, 1000)).length, total);
+  });
+
+  test("terminal event deferred by the cap is emitted on the NEXT tick, not lost", async () => {
+    makeDb(legacyDbPath);
+    const base = Date.now() - 60_000;
+    // Fill the tick to exactly one slot below the cap...
+    for (let i = 0; i < INTERVIEW_TASK_SYNC_MAX_PER_TICK - 1; i++) {
+      insertRow(legacyDbPath, {
+        task_id: `t${String(i).padStart(4, "0")}`,
+        last_event_at: base + i,
+      });
+    }
+    // ...so this already-terminal task gets its discovered event as the
+    // cap-th emission and its terminal half deferred.
+    insertRow(legacyDbPath, {
+      task_id: "t-boundary",
+      status: "completed",
+      last_event_at: base + 100_000,
+      ended_at: Date.now(),
+      terminal_summary: "finished at the cap boundary",
+      terminal_outcome: "ok",
+    });
+    const first = await syncTaskTrail();
+    assert.equal(first.synced, INTERVIEW_TASK_SYNC_MAX_PER_TICK);
+    assert.match(first.note ?? "", /capped/);
+    // The sidecar must NOT have recorded the terminal half as emitted.
+    const second = await syncTaskTrail();
+    assert.equal(second.synced, 1);
+    const events = await readInterviewEvents(0, 1000);
+    const last = events[events.length - 1];
+    assert.equal(last.kind, "task_result");
+    assert.match(last.content, /finished at the cap boundary/);
+    assert.equal(last.outcome, "ok");
+  });
+
+  test("sidecar prunes entries past the retention horizon", async () => {
+    makeDb(legacyDbPath);
+    const stale = Date.now() - 9 * 24 * 60 * 60_000; // > 8d retention
+    writeFileSync(
+      join(tmp, "sidecar.json"),
+      JSON.stringify({
+        tasks: { "t-ancient": { status: "completed", last_event_at: stale, terminal_emitted: true } },
+      }),
+      "utf-8",
+    );
+    insertRow(legacyDbPath, { task_id: "t-fresh" });
+    await syncTaskTrail();
+    const sidecar = JSON.parse(readFileSync(join(tmp, "sidecar.json"), "utf-8"));
+    assert.equal(sidecar.tasks["t-ancient"], undefined);
+    assert.ok(sidecar.tasks["t-fresh"]);
+  });
+
+  test("merged multi-DB rows are appended in global chronological order", async () => {
+    // Interleaved timestamps across two DBs: legacy holds t=1000 and
+    // t=3000, consolidated holds t=2000. Without the global re-sort the
+    // buffer (and any cap deferral) would follow DB-discovery order.
+    const base = Date.now() - 60_000;
+    makeDb(legacyDbPath);
+    insertRow(legacyDbPath, { task_id: "t-a", task: "first", last_event_at: base + 1000 });
+    insertRow(legacyDbPath, { task_id: "t-c", task: "third", last_event_at: base + 3000 });
+    const statePath = join(tmp, "openclaw-state.sqlite");
+    makeDb(statePath);
+    insertRow(statePath, { task_id: "t-b", task: "second", last_event_at: base + 2000 });
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 3);
+    const events = await readInterviewEvents(0, 100);
+    assert.match(events[0].content, /first/);
+    assert.match(events[1].content, /second/);
+    assert.match(events[2].content, /third/);
+  });
+
+  test("buffer failure BEFORE the first append reports task-trail-error, not db-unavailable", async () => {
+    makeDb(legacyDbPath);
+    insertRow(legacyDbPath, { task_id: "t1" });
+    // Break the BUFFER (not the DB): its parent path is a file, so the very
+    // first appendInterviewEvent throws — appended stays 0, but the DB read
+    // succeeded, so blaming the task DB would send operators the wrong way.
+    writeFileSync(join(tmp, "bufblocker"), "not a directory", "utf-8");
+    __INTERVIEW_BUFFER_INTERNALS__.setPathForTests(join(tmp, "bufblocker", "buf.jsonl"));
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 0);
+    assert.match(res.note ?? "", /task-trail-error/);
+    assert.doesNotMatch(res.note ?? "", /task-db-unavailable/);
+  });
+
+  test("failure AFTER appends reports partial-sync-error with the real count", async () => {
+    makeDb(legacyDbPath);
+    insertRow(legacyDbPath, { task_id: "t1" });
+    // Make saveSidecar fail deterministically: its parent path is a FILE,
+    // so mkdir -p throws (ENOTDIR) — but only after the appends succeeded.
+    writeFileSync(join(tmp, "blocker"), "not a directory", "utf-8");
+    __TASK_TRAIL_INTERNALS__.setSidecarPathForTests(join(tmp, "blocker", "sidecar.json"));
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 1); // the appended event is real and reported
+    assert.match(res.note ?? "", /partial-sync-error/); // NOT task-db-unavailable
+    assert.equal((await readInterviewEvents(0, 100)).length, 1);
+  });
+
+  test("crash-torn sidecar starts fresh instead of throwing", async () => {
+    makeDb(legacyDbPath);
+    insertRow(legacyDbPath, { task_id: "t1" });
+    writeFileSync(join(tmp, "sidecar.json"), '{"tasks": {"t1"', "utf-8"); // torn JSON
+    const res = await syncTaskTrail();
+    assert.equal(res.synced, 1); // treated as unseen; re-emission is the accepted cost
+    assert.ok(existsSync(join(tmp, "sidecar.json")));
+  });
+});

--- a/plugin/src/task-trail.ts
+++ b/plugin/src/task-trail.ts
@@ -1,0 +1,547 @@
+/**
+ * Interviewer Phase 1.5 — OpenClaw task-trail capture (issue #654).
+ *
+ * The Phase-1 buffer captured only the host message stream
+ * (``context-engine.ingest()``), so agents whose work runs through
+ * spawned tasks / sub-agents — recorded in OpenClaw's ``task_runs``
+ * SQLite, never in the chat stream — produced empty interviews forever.
+ *
+ * This module mirrors the agent's durable task trail into the SAME
+ * interview buffer at interview time (no background poller): the
+ * ``interview_request`` handler calls ``syncTaskTrail()`` before it
+ * reads the window, so "buffer empty after sync" genuinely means idle.
+ * The buffer's seq / prune / watermark machinery and the frozen server
+ * contract are untouched — task rows just become C2 events.
+ *
+ * Version tolerance (OpenClaw >= 2026.4, verified against source):
+ * - 2026.4–2026.5: standalone ``<base>/tasks/runs.sqlite``
+ *   (``resolveTaskRegistrySqlitePath``);
+ * - >= 2026.6: store refactor — ``task_runs`` lives in a consolidated
+ *   state DB whose filename is not stable across versions.
+ * So the DBs are DISCOVERED (env override, else legacy path + shallow
+ * scan for ``task_runs`` tables) and ALL of them are synced — a frozen
+ * post-upgrade leftover can't shadow the live DB when there is no
+ * single winner. Columns are PROBED via PRAGMA — the
+ * reader degrades to the minimum column set instead of breaking on
+ * schema drift. ``node:sqlite`` ships with every Node able to run
+ * OpenClaw >= 2026.4 (OpenClaw itself uses ``DatabaseSync``), read-only
+ * over WAL, so we never contend with the gateway's own writes.
+ *
+ * Everything here is fail-soft: any error degrades to
+ * ``{synced: 0, note: "task-db-unavailable: ..."}`` — a tick must never
+ * fail because the task DB is missing, locked, or reshaped.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { writeFile, mkdir, rename } from "fs/promises";
+import { dirname, join } from "path";
+
+import { appendInterviewEvent } from "./interview-buffer.js";
+import { getOpenClawBaseDir, getPluginDir } from "./paths.js";
+import {
+  INTERVIEW_TASK_SYNC_MAX_PER_TICK,
+  INTERVIEW_TASK_SIDECAR_RETENTION_MS,
+  MEMCLAW_TASK_DB_PATH,
+} from "./env.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TaskSyncResult {
+  /** Events appended to the interview buffer this sync. */
+  synced: number;
+  /** Present when the sync degraded (db unavailable, cap hit, ...). */
+  note?: string;
+}
+
+interface SidecarTaskState {
+  /** Last status we saw for the task (informational). */
+  status: string;
+  /** Row's last_event_at at last emission — drives sidecar pruning. */
+  last_event_at: number;
+  /** Whether the terminal task_result event was already emitted. */
+  terminal_emitted: boolean;
+}
+
+interface SidecarState {
+  /**
+   * Paths synced on the last tick — informational/debug only. NOT a
+   * discovery cache: caching a winner is what made a stale post-upgrade
+   * DB shadow the live one (see discoverTaskDbs).
+   */
+  db_paths?: string[];
+  tasks: Record<string, SidecarTaskState>;
+}
+
+interface TaskRow {
+  task_id: string;
+  status: string;
+  created_at: number;
+  last_event_at: number | null;
+  ended_at: number | null;
+  task: string;
+  label: string | null;
+  runtime: string | null;
+  agent_id: string | null;
+  progress_summary: string | null;
+  terminal_summary: string | null;
+  terminal_outcome: string | null;
+  error: string | null;
+  child_session_key: string | null;
+  requester_session_key: string | null;
+}
+
+// Minimum columns the reader needs; everything else is optional and
+// probed. ``last_event_at`` is technically optional too (falls back to
+// created_at) so a very old schema still syncs.
+const REQUIRED_COLUMNS = ["task_id", "status", "created_at", "task"] as const;
+const OPTIONAL_COLUMNS = [
+  "last_event_at",
+  "ended_at",
+  "label",
+  "runtime",
+  "agent_id",
+  "progress_summary",
+  "terminal_summary",
+  "terminal_outcome",
+  "error",
+  "child_session_key",
+  "requester_session_key",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Test overrides
+// ---------------------------------------------------------------------------
+
+let _baseDirOverride: string | undefined;
+let _sidecarPathOverride: string | undefined;
+let _taskDbPathOverride: string | undefined;
+
+export const __TASK_TRAIL_INTERNALS__ = {
+  setBaseDirForTests(dir: string | undefined): void {
+    _baseDirOverride = dir;
+  },
+  setSidecarPathForTests(path: string | undefined): void {
+    _sidecarPathOverride = path;
+  },
+  setTaskDbPathForTests(path: string | undefined): void {
+    _taskDbPathOverride = path;
+  },
+};
+
+function taskDbPathOverride(): string {
+  return _taskDbPathOverride ?? MEMCLAW_TASK_DB_PATH;
+}
+
+function baseDir(): string {
+  return _baseDirOverride ?? getOpenClawBaseDir();
+}
+
+/**
+ * ~/.openclaw/plugins/memclaw/interview-task-sync.json
+ *
+ * Deliberately a shared singleton for the whole install: if two gateway
+ * processes ever sync concurrently, both load the same sidecar and the
+ * later ``saveSidecar`` wins — the loser re-emits already-seen events on
+ * its next tick. That duplicate narrative is acceptable (the interview
+ * LLM absorbs it; the seq/watermark contract is unaffected), so do NOT
+ * "fix" this with file locking — a lock adds a blocking failure mode to
+ * a path that must stay fail-soft, for a race whose cost is only dupes.
+ */
+function sidecarPath(): string {
+  return _sidecarPathOverride ?? join(getPluginDir(), "interview-task-sync.json");
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar state
+// ---------------------------------------------------------------------------
+
+function loadSidecar(): SidecarState {
+  try {
+    const raw = readFileSync(sidecarPath(), "utf-8");
+    const parsed = JSON.parse(raw) as SidecarState;
+    if (parsed && typeof parsed === "object" && parsed.tasks && typeof parsed.tasks === "object") {
+      return parsed;
+    }
+  } catch {
+    // Missing or corrupt sidecar: start fresh. Worst case we re-emit
+    // events for tasks still inside the DB's 7-day retention — duplicate
+    // narrative the interview LLM absorbs, never data loss.
+  }
+  return { tasks: {} };
+}
+
+async function saveSidecar(state: SidecarState): Promise<void> {
+  const path = sidecarPath();
+  await mkdir(dirname(path), { recursive: true });
+  // Write-then-rename so a crash mid-write can't leave a torn JSON that
+  // would reset the delta state (and re-emit the whole window).
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, JSON.stringify(state), "utf-8");
+  await rename(tmp, path);
+}
+
+// ---------------------------------------------------------------------------
+// DB discovery
+// ---------------------------------------------------------------------------
+
+type SqliteModule = typeof import("node:sqlite");
+type SqliteDb = InstanceType<SqliteModule["DatabaseSync"]>;
+
+async function loadSqlite(): Promise<SqliteModule | null> {
+  try {
+    return await import("node:sqlite");
+  } catch {
+    return null; // Node < 22.5 — degrade to message-capture-only.
+  }
+}
+
+function openReadOnly(sqlite: SqliteModule, path: string): SqliteDb | null {
+  try {
+    return new sqlite.DatabaseSync(path, { readOnly: true });
+  } catch {
+    return null;
+  }
+}
+
+function hasTaskRunsTable(db: SqliteDb): boolean {
+  try {
+    const row = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'")
+      .get();
+    return !!row;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Locate EVERY SQLite file holding ``task_runs`` — not a single winner.
+ *
+ * First-match discovery cannot distinguish a valid-but-DEAD DB from the
+ * live one: an OpenClaw 2026.5 -> 2026.6 upgrade can leave the old
+ * ``tasks/runs.sqlite`` on disk with a valid (but frozen) task_runs
+ * table while all new rows land in the consolidated state DB — any
+ * single-winner precedence keeps returning the stale file and the sync
+ * reports synced:0 forever, indistinguishable from "node idle". So the
+ * sync reads ALL candidates: the sidecar's task_id-keyed delta makes
+ * multi-source safe (rows migrated into the new DB de-dup as already
+ * seen), and the shallow scan is a trivial hourly readdir.
+ *
+ * ``MEMCLAW_TASK_DB_PATH`` remains an exclusive operator override.
+ */
+function discoverTaskDbs(sqlite: SqliteModule): string[] {
+  const tryPath = (p: string): boolean => {
+    if (!existsSync(p)) return false;
+    const db = openReadOnly(sqlite, p);
+    if (!db) return false;
+    try {
+      return hasTaskRunsTable(db);
+    } finally {
+      // Same pattern as the read loop: a throwing close() must neither
+      // leak the handle nor surface as a bogus task-db-unavailable.
+      try {
+        db.close();
+      } catch {
+        // best-effort close; the handle is read-only
+      }
+    }
+  };
+
+  const overridePath = taskDbPathOverride();
+  if (overridePath) {
+    return tryPath(overridePath) ? [overridePath] : [];
+  }
+
+  // Legacy path first for deterministic ordering; the scan re-finds it,
+  // so results are deduped by path string (identical join construction).
+  const candidates: string[] = [join(baseDir(), "tasks", "runs.sqlite")];
+  const scanDir = (dir: string, depth: number): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      if (name.endsWith("-wal") || name.endsWith("-shm") || name.startsWith(".")) continue;
+      const full = join(dir, name);
+      let st;
+      try {
+        st = statSync(full);
+      } catch {
+        continue; // TOCTOU: vanished between readdir and stat
+      }
+      if (st.isFile() && name.endsWith(".sqlite")) candidates.push(full);
+      else if (st.isDirectory() && depth > 0 && name !== "plugins") scanDir(full, depth - 1);
+    }
+  };
+  scanDir(baseDir(), 1);
+  return [...new Set(candidates)].filter(tryPath);
+}
+
+// ---------------------------------------------------------------------------
+// Column probe + row reading
+// ---------------------------------------------------------------------------
+
+function probeColumns(db: SqliteDb): Set<string> | null {
+  try {
+    const rows = db.prepare("PRAGMA table_info(task_runs)").all() as Array<{ name: string }>;
+    const cols = new Set(rows.map((r) => r.name));
+    for (const required of REQUIRED_COLUMNS) {
+      if (!cols.has(required)) return null;
+    }
+    return cols;
+  } catch {
+    return null;
+  }
+}
+
+function readRecentRows(db: SqliteDb, cols: Set<string>, cutoffMs: number): TaskRow[] {
+  const available = [
+    ...REQUIRED_COLUMNS,
+    ...OPTIONAL_COLUMNS.filter((c) => cols.has(c)),
+  ];
+  // Window on last_event_at when present (indexed in every schema we've
+  // seen), else created_at. Retention already bounds the table to ~7d.
+  const timeCol = cols.has("last_event_at") ? "last_event_at" : "created_at";
+  const sql =
+    `SELECT ${available.join(", ")} FROM task_runs ` +
+    `WHERE COALESCE(${timeCol}, created_at) >= ? ` +
+    `ORDER BY COALESCE(${timeCol}, created_at) ASC, task_id ASC`;
+  const raw = db.prepare(sql).all(cutoffMs) as Array<Record<string, unknown>>;
+  return raw.map((r) => ({
+    task_id: String(r.task_id),
+    status: String(r.status ?? ""),
+    created_at: Number(r.created_at ?? 0),
+    last_event_at: r.last_event_at == null ? null : Number(r.last_event_at),
+    ended_at: r.ended_at == null ? null : Number(r.ended_at),
+    task: String(r.task ?? ""),
+    label: r.label == null ? null : String(r.label),
+    runtime: r.runtime == null ? null : String(r.runtime),
+    agent_id: r.agent_id == null ? null : String(r.agent_id),
+    progress_summary: r.progress_summary == null ? null : String(r.progress_summary),
+    terminal_summary: r.terminal_summary == null ? null : String(r.terminal_summary),
+    terminal_outcome: r.terminal_outcome == null ? null : String(r.terminal_outcome),
+    error: r.error == null ? null : String(r.error),
+    child_session_key: r.child_session_key == null ? null : String(r.child_session_key),
+    requester_session_key:
+      r.requester_session_key == null ? null : String(r.requester_session_key),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Row -> C2 event mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * A row is terminal when the runtime stamped ``ended_at``. Deliberately
+ * NOT an enum check on ``status`` — status vocabularies drift across
+ * OpenClaw versions, ``ended_at`` semantics don't.
+ */
+function isTerminal(row: TaskRow): boolean {
+  return row.ended_at != null;
+}
+
+function taskHeader(row: TaskRow): string {
+  const scope = [row.runtime, row.label].filter(Boolean).join("/");
+  return scope ? `[task ${scope}] ` : "[task] ";
+}
+
+function discoveredEvent(row: TaskRow) {
+  return {
+    session_id: row.child_session_key ?? row.requester_session_key ?? null,
+    role: "agent",
+    kind: "task",
+    content: taskHeader(row) + row.task,
+    ...(row.runtime ? { tool: row.runtime } : {}),
+  };
+}
+
+function terminalEvent(row: TaskRow) {
+  const summary =
+    row.terminal_summary ?? row.progress_summary ?? row.error ?? `task ended: ${row.status}`;
+  return {
+    session_id: row.child_session_key ?? row.requester_session_key ?? null,
+    role: "agent",
+    kind: "task_result",
+    content: taskHeader(row) + summary,
+    ...(row.runtime ? { tool: row.runtime } : {}),
+    outcome: row.terminal_outcome ?? row.status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The sync
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirror the task-trail delta into the interview buffer. Emits at most
+ * TWO events per task — one when it first appears, one when it reaches
+ * a terminal state — so long-running tasks don't spam the buffer on
+ * every progress bump. Bounded by ``INTERVIEW_TASK_SYNC_MAX_PER_TICK``
+ * per call; the sidecar is only advanced for emitted rows, so the
+ * remainder drains naturally on later ticks.
+ *
+ * Never throws.
+ */
+export async function syncTaskTrail(): Promise<TaskSyncResult> {
+  // Hoisted past the outer catch: events appended to the buffer BEFORE a
+  // mid-loop failure are real (the buffer is append-only and the sidecar
+  // hasn't advanced), so a partial sync must report them — not synced:0.
+  let appended = 0;
+  // Flipped once the task DB(s) have been read successfully: from that
+  // point on, any failure is in the buffer/sidecar layer, not the DB.
+  let dbReadStarted = false;
+  try {
+    const sqlite = await loadSqlite();
+    if (!sqlite) {
+      return { synced: 0, note: "task-db-unavailable: node:sqlite not present in this runtime" };
+    }
+    const sidecar = loadSidecar();
+    const dbPaths = discoverTaskDbs(sqlite);
+    if (dbPaths.length === 0) {
+      // A configured-but-broken override deserves a pointed diagnostic —
+      // the generic "not found" reads as an idle/undiscovered node and
+      // sends the operator hunting in the wrong place.
+      const overridePath = taskDbPathOverride();
+      const note = overridePath
+        ? `task-db-unavailable: MEMCLAW_TASK_DB_PATH=${overridePath} has no task_runs table`
+        : "task-db-unavailable: no task_runs database found";
+      return { synced: 0, note };
+    }
+    const cutoff = Date.now() - INTERVIEW_TASK_SIDECAR_RETENTION_MS;
+    // Rows from EVERY valid DB, merged: after a 2026.5 -> 2026.6 upgrade
+    // both the frozen legacy file and the live consolidated DB may hold a
+    // task_runs table — reading all of them makes "which one is live" a
+    // non-question. Same task_id in two DBs (installer-migrated rows)
+    // de-dups through the sidecar like any already-seen task. A DB that
+    // fails to open/probe here is skipped, not fatal: the others still sync.
+    const rows: TaskRow[] = [];
+    const unreadable: string[] = [];
+    for (const dbPath of dbPaths) {
+      const db = openReadOnly(sqlite, dbPath);
+      if (!db) {
+        unreadable.push(dbPath);
+        continue;
+      }
+      try {
+        const cols = probeColumns(db);
+        if (!cols) {
+          unreadable.push(dbPath);
+          continue;
+        }
+        // Plain loop, not rows.push(...arr): spread maps elements to call
+        // ARGUMENTS, and V8 caps those (~65k) — a busy node's 8-day window
+        // could exceed it and RangeError into the outer catch, masquerading
+        // as task-db-unavailable and dropping the whole sync.
+        const newRows = readRecentRows(db, cols, cutoff);
+        for (const r of newRows) rows.push(r);
+      } finally {
+        try {
+          db.close();
+        } catch {
+          // best-effort close; the handle is read-only
+        }
+      }
+    }
+    if (rows.length === 0 && unreadable.length === dbPaths.length) {
+      return {
+        synced: 0,
+        note: `task-db-unavailable: no readable task_runs schema among ${dbPaths.join(", ")}`,
+      };
+    }
+    // Each DB's rows arrive internally ordered, but the multi-DB merge is
+    // in DB-discovery order — re-sort globally so buffer narrative and,
+    // more importantly, cap DEFERRAL are chronological: without this, the
+    // cap would defer whichever DB happened to be scanned last, not the
+    // newest work.
+    rows.sort((a, b) => {
+      const ta = a.last_event_at ?? a.created_at;
+      const tb = b.last_event_at ?? b.created_at;
+      return ta !== tb ? ta - tb : a.task_id < b.task_id ? -1 : 1;
+    });
+
+    {
+      dbReadStarted = true;
+      let capped = false;
+      for (const row of rows) {
+        if (appended >= INTERVIEW_TASK_SYNC_MAX_PER_TICK) {
+          capped = true;
+          break;
+        }
+        const known = sidecar.tasks[row.task_id];
+        const eventTs = row.last_event_at ?? row.created_at;
+        if (!known) {
+          await appendInterviewEvent(discoveredEvent(row));
+          appended += 1;
+          // ``terminal_emitted`` must reflect what was ACTUALLY appended:
+          // when the cap fires right after the discovered event, the
+          // terminal half is deferred — recording it as emitted here would
+          // suppress it forever (the next tick's terminal-transition check
+          // would see terminal_emitted:true and skip).
+          const nowTerminal = isTerminal(row);
+          const terminalEmitted = nowTerminal && appended < INTERVIEW_TASK_SYNC_MAX_PER_TICK;
+          if (terminalEmitted) {
+            // Task appeared AND finished between ticks: emit both halves.
+            await appendInterviewEvent(terminalEvent(row));
+            appended += 1;
+          } else if (nowTerminal) {
+            // Terminal half deferred by the cap: surface it in the note —
+            // the row-level guard at the top of the loop never fires when
+            // the LAST row's second half is what got deferred.
+            capped = true;
+          }
+          sidecar.tasks[row.task_id] = {
+            status: row.status,
+            last_event_at: eventTs,
+            terminal_emitted: terminalEmitted,
+          };
+        } else if (isTerminal(row) && !known.terminal_emitted) {
+          await appendInterviewEvent(terminalEvent(row));
+          appended += 1;
+          known.status = row.status;
+          known.last_event_at = eventTs;
+          known.terminal_emitted = true;
+        } else {
+          // Progress-only change: track freshness, emit nothing.
+          known.status = row.status;
+          known.last_event_at = Math.max(known.last_event_at, eventTs);
+        }
+      }
+
+      // Prune sidecar entries older than the retention horizon — the DB
+      // itself prunes at ~7d, so anything older can never resurface.
+      for (const [id, st] of Object.entries(sidecar.tasks)) {
+        if (st.last_event_at < cutoff) delete sidecar.tasks[id];
+      }
+      sidecar.db_paths = dbPaths;
+      // Sidecar advances AFTER the appends: a crash between the two
+      // re-emits (duplicate narrative, harmless) rather than drops.
+      await saveSidecar(sidecar);
+
+      const notes: string[] = [];
+      if (capped) notes.push(`capped at ${INTERVIEW_TASK_SYNC_MAX_PER_TICK} events; remainder next tick`);
+      if (unreadable.length > 0) notes.push(`skipped unreadable: ${unreadable.join(", ")}`);
+      return notes.length > 0 ? { synced: appended, note: notes.join("; ") } : { synced: appended };
+    }
+  } catch (e: unknown) {
+    // Distinguish the failure domain for operators (events already written
+    // are always reported — the sidecar didn't advance, so the next tick
+    // re-emits the tail: duplicates, never loss):
+    //   appended > 0   -> appends succeeded, a later step failed;
+    //   dbReadStarted  -> DB was readable, the buffer/sidecar layer failed
+    //                     before the first append landed;
+    //   otherwise      -> never got to reading rows: genuinely a DB problem.
+    return {
+      synced: appended,
+      note:
+        appended > 0
+          ? `partial-sync-error: ${String(e)}`
+          : dbReadStarted
+            ? `task-trail-error: ${String(e)}`
+            : `task-db-unavailable: ${String(e)}`,
+    };
+  }
+}


### PR DESCRIPTION
Fixes #654.

## Problem

Armed, highly-active agents produced **empty interviews indefinitely** (`"no new events since cursor"`). The Phase-1 buffer captures only the host message stream (`context-engine.ingest()`); task/sub-agent-driven work — the dominant mode on the eToro fleet (`oc-webclaw-prod`: 363 memories in 3h, zero interviews) — is recorded in OpenClaw's **`task_runs` SQLite** and never enters the chat stream. Wrong source, not wrong plumbing: no configuration could fix it.

## Approach

**The buffer stays; a second source feeds it.** The two sources cover disjoint work types (chat-driven agents → existing `ingest()` capture, proven correct; task/sub-agent work → this PR). At interview time — no background poller — the `interview_request` handler mirrors the task-trail **delta** into the same durable buffer, then reads the window as before. The buffer's seq/prune/watermark machinery and the frozen server contract (#558) are untouched; the server needs **zero changes** (`kind` is free-form ≤64 chars, verified at `routes/interview.py:39`).

**Event mapping — at most two events per task:**
- first seen → `kind:"task"` (`[task <runtime>/<label>] <task>`, session from `child_session_key`)
- terminal transition (`ended_at` set — deliberately not a status-enum check; enums drift across OpenClaw versions) → `kind:"task_result"` with `terminal_summary`/`error` and `outcome`
- progress-only bumps emit nothing

## Version tolerance (OpenClaw ≥ 2026.4, verified against openclaw source)

| OpenClaw | task_runs location |
|---|---|
| 2026.4–2026.5 | standalone `<base>/tasks/runs.sqlite` (`resolveTaskRegistrySqlitePath`) |
| ≥ 2026.6 | consolidated state DB, **unstable filename** (store refactor; `task-registry.paths.ts` removed) |

So the DB is **discovered**, not hardcoded (env override → sidecar cache → legacy path → shallow `sqlite_master` scan), and columns are **probed** via PRAGMA with graceful degradation to the minimum set. `node:sqlite` `DatabaseSync` read-only over WAL — no new dependency (OpenClaw ≥2026.4 hosts already run Node ≥22.5, since OpenClaw itself uses `DatabaseSync`), and WAL readers never block the gateway's writes.

## Fail-soft + observability (issue remedy #3)

Any failure (DB missing / locked / reshaped / no `node:sqlite`) degrades to `{synced: 0, note: "task-db-unavailable: …"}`, surfaced as `task_trail` + `synced_tasks` in the command result — operators can now tell **"idle"** from **"not captured"**. A tick can never fail on the task DB. Bounded: ≤200 events/tick (sidecar advances only for emitted rows → remainder drains next tick); sidecar pruned past OpenClaw's 7-day task retention.

Flags: `MEMCLAW_INTERVIEWER_TASKS` — **default ON** with the interviewer (this is the fix for #654, not an optional feature; `"false"` is the escape hatch). `MEMCLAW_TASK_DB_PATH` — operator override for relocated state.

## Verification

- **11-case task-trail suite**: both layouts (+ decoy non-task DBs), old-schema fallback, required-column degradation, delta/no-op/cap/resume, sidecar prune, torn sidecar, already-terminal double-emit.
- `interview-command` tests pinned to a tmp base dir so the handler's pre-read sync can never scan the real `~/.openclaw` of a dev machine.
- **Full plugin suite: 389/389.**
- **Real-disk check**: discovery against a genuine OpenClaw install's WAL `runs.sqlite` resolves, opens read-only, and syncs cleanly.
- Node-service-level impact: none on the hot path — sync runs only inside the hourly handler, read-only WAL, ms-scale, fail-soft.

## Versioning / rollout

Version deliberately **left to release-please** (plugin component → 2.16.0 on merge; package.json/manifest/version.ts are its managed files). Rollout: plugin floor 2.16.0 on the armed eToro nodes; acceptance = the #654 repro inverted (webclaw returns `submitted:true, synced_tasks>0` within 2 ticks; idle agents keep returning "no new events" with `synced_tasks:0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)