### PR TITLE
fix(logging): route uvicorn parent-supervisor lines through structlog

### DIFF
--- a/common/serve.py
+++ b/common/serve.py
@@ -1,0 +1,97 @@
+"""Uvicorn launcher that configures structlog logging in the *parent* process.
+
+With ``uvicorn --workers N`` the multiprocess supervisor (the parent process)
+never imports the ASGI app module, so the import-time ``configure_logging()``
+call in ``<service>/app.py`` runs only inside the workers. The parent's own
+lifecycle lines — ``Started parent process [N]``, ``Waiting for child process
+[N]``, ``Received SIGTERM, exiting.``, ``Uvicorn running on ...`` — are emitted
+via the ``uvicorn.error`` logger with uvicorn's *default* configuration, which
+writes plain ``INFO:`` text to stdout. Those lines bypass the structlog JSON
+pipeline and reach Datadog without a ``status`` field, where they are
+mis-classified as ``status:error`` (the dominant false-error source across the
+Cloud Run services in the 2026-07 error sweeps).
+
+This launcher fixes that by calling ``configure_logging()`` — from the *same*
+settings object the app uses — before starting the server, then running uvicorn
+with ``log_config=None``. With ``log_config=None`` uvicorn does not install its
+own stream handlers, so the ``uvicorn.*`` loggers keep ``propagate=True`` and
+their records reach the structlog root handler in both the parent and the
+workers. The supervisor lines then emit as structured JSON with ``status:info``.
+
+Usage (see each service's Dockerfile ``CMD``)::
+
+    python -m common.serve <app_import> --settings <settings_import> \
+        --port <port> [--host H] [--workers N] [--timeout-keep-alive S]
+
+``<app_import>`` is an ASGI import string (``core_api.app:app``); it is passed
+to uvicorn as a string so the workers can re-import it. ``<settings_import>`` is
+``module:attr`` for the service's settings singleton, imported here only to read
+``environment`` / ``log_level`` / ``log_format_json`` / ``log_file`` — matching
+the app's own ``configure_logging()`` call exactly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+from typing import Any
+
+import uvicorn
+
+from common.structlog_config import configure_logging
+
+
+def _load(path: str) -> Any:
+    """Return the attribute named by a ``module:attr`` import path."""
+    module_name, sep, attr = path.partition(":")
+    if not sep or not attr:
+        raise ValueError(f"expected a 'module:attr' import path, got {path!r}")
+    return getattr(importlib.import_module(module_name), attr)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="common.serve")
+    p.add_argument("app", help="ASGI app import string, e.g. core_api.app:app")
+    p.add_argument(
+        "--settings",
+        required=True,
+        help="Import path of the settings singleton, e.g. core_api.config:settings",
+    )
+    p.add_argument("--host", default="0.0.0.0")
+    p.add_argument("--port", type=int, required=True)
+    p.add_argument("--workers", type=int, default=1)
+    p.add_argument("--timeout-keep-alive", type=int, default=65, dest="timeout_keep_alive")
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_parser().parse_args(argv)
+    settings = _load(args.settings)
+
+    # Parent-process logging: the workers re-run this via the app import, but
+    # the supervisor process must configure it here or its lifecycle lines
+    # bypass structlog. Mirrors the app's own configure_logging() arguments.
+    configure_logging(
+        settings.environment,
+        settings.log_level,
+        json_logs=settings.log_format_json,
+        log_file=settings.log_file or None,
+    )
+
+    # log_config=None: do NOT let uvicorn install its own stream handlers.
+    # That keeps uvicorn.{error,access} propagating to the structlog root
+    # handler configured above (in the parent AND the workers), so every
+    # uvicorn line — including the parent supervisor's — emits as JSON with a
+    # Datadog status. Installing uvicorn's config would re-plain-text them.
+    uvicorn.run(
+        args.app,
+        host=args.host,
+        port=args.port,
+        workers=args.workers,
+        timeout_keep_alive=args.timeout_keep_alive,
+        log_config=None,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/core-api/Dockerfile
+++ b/core-api/Dockerfile
@@ -112,4 +112,8 @@ USER appuser
 EXPOSE 8000
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
-CMD ["uvicorn", "core_api.app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--timeout-keep-alive", "65"]
+# Launch via common.serve (not the uvicorn CLI directly) so the multiprocess
+# supervisor/parent configures structlog before starting — otherwise its
+# lifecycle lines ("Started parent process", "Received SIGTERM", ...) bypass
+# the JSON pipeline and land in Datadog as status:error. See common/serve.py.
+CMD ["python", "-m", "common.serve", "core_api.app:app", "--settings", "core_api.config:settings", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--timeout-keep-alive", "65"]

--- a/core-storage-api/Dockerfile
+++ b/core-storage-api/Dockerfile
@@ -76,4 +76,8 @@ USER appuser
 EXPOSE 8002
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
-CMD ["uvicorn", "core_storage_api.app:app", "--host", "0.0.0.0", "--port", "8002", "--workers", "2", "--timeout-keep-alive", "65"]
+# Launch via common.serve (not the uvicorn CLI directly) so the multiprocess
+# supervisor/parent configures structlog before starting — otherwise its
+# lifecycle lines ("Started parent process", "Received SIGTERM", ...) bypass
+# the JSON pipeline and land in Datadog as status:error. See common/serve.py.
+CMD ["python", "-m", "common.serve", "core_storage_api.app:app", "--settings", "core_storage_api.config:settings", "--host", "0.0.0.0", "--port", "8002", "--workers", "2", "--timeout-keep-alive", "65"]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -614,3 +614,27 @@ def test_stdlib_logger_emits_datadog_status_alongside_severity(
         assert len(records) == 1, f"expected one record for {needle}, got: {lines}"
         assert records[0]["severity"] == severity
         assert records[0]["status"] == status
+
+
+def test_uvicorn_error_lifecycle_line_emits_info_status(_json_log_buffer) -> None:
+    """The uvicorn *parent supervisor* logs its lifecycle lines ("Started
+    parent process", "Received SIGTERM, exiting.", ...) via the
+    ``uvicorn.error`` logger at INFO. When the server is launched via
+    ``common.serve`` (which calls ``configure_logging()`` in the parent, then
+    ``uvicorn.run(log_config=None)`` so uvicorn installs no handlers of its
+    own), that logger stays pristine and propagates to the structlog root
+    handler — so the line emits as JSON with ``status:info``, not the plain
+    ``INFO:`` text that was reaching Datadog as ``status:error``.
+
+    This pins the classification: an INFO record on a pristine ``uvicorn.error``
+    logger renders through our pipeline as ``severity:INFO`` / ``status:info``.
+    """
+    logging.getLogger("uvicorn.error").info("Started parent process [8]")
+    lines = _json_log_buffer.getvalue().strip().splitlines()
+    # Filter on the quoted message so only the JSON handler's line matches — the
+    # buffer also holds pytest's plain-format capture-handler copies (same
+    # buffer, swapped by the fixture), which lack the surrounding quotes.
+    records = [json.loads(line) for line in lines if '"Started parent process [8]"' in line]
+    assert len(records) == 1, f"expected one uvicorn.error JSON record, got: {lines}"
+    assert records[0]["severity"] == "INFO"
+    assert records[0]["status"] == "info"

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,0 +1,72 @@
+"""Unit tests for common.serve — the uvicorn launcher wrapper.
+
+These pin the launcher's contract without starting a server: it must read the
+service's own settings object, configure structlog from those fields, and start
+uvicorn with ``log_config=None`` (so the uvicorn.* loggers propagate to the
+structlog root handler — see the module docstring in common/serve.py).
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from unittest import mock
+
+import pytest
+
+import common.serve as serve
+
+
+def test_load_returns_module_attribute() -> None:
+    assert serve._load("json:dumps") is json.dumps
+
+
+@pytest.mark.parametrize("bad", ["json", "json:", ""])
+def test_load_rejects_paths_missing_module_or_attr(bad: str) -> None:
+    with pytest.raises(ValueError):
+        serve._load(bad)
+
+
+def test_main_configures_logging_from_settings_and_disables_uvicorn_log_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_settings = types.SimpleNamespace(
+        environment="production",
+        log_level="INFO",
+        log_format_json=True,
+        log_file="",
+    )
+    monkeypatch.setattr(serve, "_load", lambda _path: fake_settings)
+    configure = mock.MagicMock()
+    run = mock.MagicMock()
+    monkeypatch.setattr(serve, "configure_logging", configure)
+    monkeypatch.setattr(serve.uvicorn, "run", run)
+
+    serve.main(
+        [
+            "core_api.app:app",
+            "--settings",
+            "core_api.config:settings",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8000",
+            "--workers",
+            "2",
+            "--timeout-keep-alive",
+            "65",
+        ]
+    )
+
+    # Logging configured from the settings object's fields; empty log_file -> None.
+    configure.assert_called_once_with("production", "INFO", json_logs=True, log_file=None)
+
+    # Server started with uvicorn's own logging config disabled.
+    run.assert_called_once()
+    args, kwargs = run.call_args
+    assert args == ("core_api.app:app",)
+    assert kwargs["log_config"] is None
+    assert kwargs["host"] == "0.0.0.0"
+    assert kwargs["port"] == 8000
+    assert kwargs["workers"] == 2
+    assert kwargs["timeout_keep_alive"] == 65


### PR DESCRIPTION
## What

Adds a `common/serve.py` launcher and points the **core-api** and **core-storage-api** Docker `CMD`s at it (`python -m common.serve <app> --settings <module:attr> ...`), so the uvicorn multiprocess **parent supervisor** configures structlog before starting.

## Why

With `uvicorn --workers 2`, the parent supervisor never imports the ASGI app module, so the import-time `configure_logging()` in `<service>/app.py` runs **only in the workers**. The parent's own lifecycle lines — emitted via the `uvicorn.error` logger — bypass the structlog JSON pipeline and reach Datadog with no `status` field, where they're mis-classified as `status:error`:

```
INFO:     Started parent process [8]
INFO:     Waiting for child process [22]
INFO:     Received SIGTERM, exiting.
INFO:     Uvicorn running on http://0.0.0.0:8000 ...
```

This was the **single biggest source of false `status:error`** across the Cloud Run services in the 2026-07 error sweeps. It's functionally harmless, but it pollutes `status:error` queries and log monitors (the alert added after the embedding incident keys off message content, not `status`, so nothing is broken — this is log-hygiene).

## How

- `common/serve.py`: calls `configure_logging(...)` from the **service's own settings object** (identical args to `app.py`), then `uvicorn.run(..., log_config=None)`.
- `log_config=None` is the key: uvicorn then installs **no** handlers of its own, so `uvicorn.{error,access}` keep `propagate=True` and reach the structlog root handler in **both** the parent and the workers. The parent's lifecycle lines emit as JSON with `status:info`. (Letting uvicorn apply its default `LOGGING_CONFIG` would re-plain-text them.)
- Reuses the existing `configure_logging()` / `_route_third_party_to_root()` machinery — no new formatter.

## Tests

- `tests/test_serve.py`: the launcher reads settings and calls `configure_logging` from those fields + `uvicorn.run(log_config=None)` (no server started).
- `tests/test_logging.py`: an INFO record on the `uvicorn.error` logger renders as `severity:INFO` / `status:info` through the pipeline.

## Verification gate ⚠️

The **end-to-end** parent-supervisor output can only be confirmed with a running multi-worker server. **Please verify in staging before merge** — `env:staging` is off in Datadog, so check via `gcloud logging read` on the staging revisions that the supervisor lines (`Started parent process`, `Received SIGTERM`) now emit as JSON with `status:info` and that nothing else regressed. This touches the shared logging path for both services, so the staging check is the real gate.

## Follow-up

The enterprise **platform-\*** services share this same pattern; they'll be wired in a follow-up once this `common/` change vendors over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)