### PR TITLE
style(serve): keep common/serve.py <=88 cols for the enterprise vendoring gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         # docstring). ``--isolated`` pins default behavior even if a root ruff
         # config is ever added; deliberately NOT all of common/ — non-vendored
         # files there are not held to the 88-col contract.
-        run: uv run ruff format --check --isolated common/__init__.py common/structlog_config.py
+        run: uv run ruff format --check --isolated common/__init__.py common/structlog_config.py common/serve.py
 
       - name: Guard against raw-string MCP error returns (audit B4 / CAURA-000 #147)
         # MCP tool handlers must build error envelopes via ``_error_response(...)``

--- a/common/serve.py
+++ b/common/serve.py
@@ -28,6 +28,13 @@ to uvicorn as a string so the workers can re-import it. ``<settings_import>`` is
 ``module:attr`` for the service's settings singleton, imported here only to read
 ``environment`` / ``log_level`` / ``log_format_json`` / ``log_file`` — matching
 the app's own ``configure_logging()`` call exactly.
+
+Vendoring constraint: this file is vendored byte-for-byte into
+caura-memclaw-enterprise as an ``identical``-policy ``common/`` file, whose CI
+runs ``ruff format --check`` with no resolved config (ruff's 88-col default).
+Keep every line <= 88 cols so the vendored copy stays format-stable there — a
+wider line passes OSS CI (which does not format-check ``common/``) but wedges
+the enterprise re-vendor (the 2026-06 structlog_config drift incident).
 """
 
 from __future__ import annotations
@@ -60,7 +67,9 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--host", default="0.0.0.0")
     p.add_argument("--port", type=int, required=True)
     p.add_argument("--workers", type=int, default=1)
-    p.add_argument("--timeout-keep-alive", type=int, default=65, dest="timeout_keep_alive")
+    p.add_argument(
+        "--timeout-keep-alive", type=int, default=65, dest="timeout_keep_alive"
+    )
     return p
 
 


### PR DESCRIPTION
## Why

`common/serve.py` (added in #661) has a 91-col line. OSS CI doesn't format-check `common/`, so it merged clean — but that file is a prerequisite for launching the **enterprise** `platform-*` services the same way, which means vendoring it byte-for-byte into `caura-memclaw-enterprise` as an `identical`-policy `common/` file.

Enterprise CI runs `ruff format --check common/` with **no resolved config** → ruff's **88-col default**. A >88-col vendored line fails that gate, while the byte-identical drift check simultaneously forbids reformatting *only* the enterprise copy. That's the exact wedge from the 2026-06 `structlog_config` drift incident (fixed by #563). Fixing it here on the OSS source keeps both copies byte-identical **and** 88-col-clean.

## What

- Reflow the one offending line (`--timeout-keep-alive` arg) to the 88-col form via `ruff format --isolated` — the width both repos' `common/` gates use.
- Document the ≤88-col vendoring constraint in the module docstring so it isn't reintroduced.

No behaviour change. `tests/test_serve.py` unchanged and green; `ruff check` clean; still valid at the repo's 110-col config too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)