### PR TITLE
chore(fleet): bump plugin auto-upgrade floor to 2.16.0 (arm #658 task-trail capture)

### DIFF
--- a/core-api/src/core_api/version_compat.py
+++ b/core-api/src/core_api/version_compat.py
@@ -8,14 +8,15 @@ recommended version; no hard rejection — operators decide when to upgrade.
 
 # Auto-upgrade target / "outdated" floor. The fleet heartbeat queues a deploy
 # to this version for eligible nodes (>= MIN_AUTO_DEPLOY, auto-upgrade enabled).
-# Reconciled to the current shipped plugin release. 2.15.2 is a superset of
-# 2.14.0 (firehose de-collapse #507 + flag-gated recall-gating/cross-agent #530,
-# both preserved) plus the Interviewer plugin side (durable buffer +
-# interview_request handler, Phase 1 #564). The Interviewer handler stays dark
-# until MEMCLAW_INTERVIEWER=true per node AND the per-tenant interviewer.enabled
-# flag is on server-side, so auto-upgrading the fleet to 2.15.2 changes no
-# behavior until those are set. Bumping the floor pulls the fleet onto 2.15.2.
-MIN_RECOMMENDED_PLUGIN_VERSION = "2.15.2"
+# Reconciled to the current shipped plugin release. 2.16.0 is a superset of
+# 2.15.2 (firehose de-collapse #507, flag-gated recall #530, Interviewer plugin
+# side #564 — all preserved) plus Interviewer task-trail capture (#658, fix for
+# #654): OpenClaw task_runs are mirrored into the interview buffer so tool/
+# write-pipeline-driven agents produce non-empty interviews. Still gated by
+# MEMCLAW_INTERVIEWER (buffer) + MEMCLAW_INTERVIEWER_TASKS (default on) per node
+# AND per-tenant interviewer.enabled, so auto-upgrading the fleet to 2.16.0
+# changes no behavior until those are set. Bumping the floor pulls the fleet onto 2.16.0.
+MIN_RECOMMENDED_PLUGIN_VERSION = "2.16.0"
 
 # Server-side floor below which plugins must NOT auto-upgrade — the
 # heartbeat path in ``routes/fleet.py`` enforces this hard, and


### PR DESCRIPTION
Bump MIN_RECOMMENDED_PLUGIN_VERSION 2.15.2 -> 2.16.0 for onprem-v2.11.12 (backend-v2.25.0). Plugin 2.16.0 carries #658 (fix for #654): OpenClaw `task_runs` are mirrored into the interview buffer, so tool/write-pipeline-driven agents (e.g. webclaw) finally produce non-empty interviews — the capture gap we hit in prod. Superset of 2.15.2 (de-collapse #507 / recall #530 / interviewer #564 preserved). Task capture defaults on (`MEMCLAW_INTERVIEWER_TASKS`) but still gated by `MEMCLAW_INTERVIEWER` + per-tenant `interviewer.enabled`, so the floor bump alone activates nothing. Floor invariant holds (MIN_AUTO_DEPLOY 2.6.0 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)