### PR TITLE
feat(interviewer): async submit — persist window, accept fast, synthesize in the scheduler sweep

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -139,6 +139,18 @@ class Settings(BaseSettings):
     # raise the platform timeout BEFORE raising this budget (the
     # startup validator enforces the ceiling).
     interview_request_timeout_seconds: float = 90.0
+    # Async interview submit (#665). When True (default), the submit route
+    # persists the masked window as a durable ``interview_jobs`` doc,
+    # advances the watermark, and returns 200 ``accepted`` immediately;
+    # synthesis runs off the request path (fire-and-forget task + the
+    # hourly scheduler sweep). False is the escape hatch back to the
+    # legacy inline path, whose 60-90s synthesis intermediate proxies
+    # (on-prem nginx default 60s) 504'd mid-flight while the server
+    # committed anyway.
+    interview_async_submit: bool = True
+    # Max synthesis attempts per persisted interview job before it is
+    # parked as ``failed_permanent`` instead of retried by the sweep (#665).
+    interview_job_max_attempts: int = 3
     # Per-phase cap on the storage roundtrip inside
     # ``create_memories_bulk`` (CAURA-599). Embedding and enrichment
     # already enforce their own 30s caps; storage was the only phase

--- a/core-api/src/core_api/routes/interview.py
+++ b/core-api/src/core_api/routes/interview.py
@@ -2,9 +2,16 @@
 
 ``POST /api/v1/interview/submit`` receives one node's buffered event
 window from the OpenClaw plugin (delivered in response to an
-``interview_request`` fleet command) and hands it to the interview worker
-(``services/interview_service.py``): mask → chunked interview → typed
-memories via the idempotent bulk path → forward-only watermark.
+``interview_request`` fleet command).
+
+Default path (``interview_async_submit``, #665): persist-and-accept — the
+window is masked and stored as a durable ``interview_jobs`` doc, the
+forward-only watermark advances, and the route replies 200 ``accepted``
+immediately; synthesis (chunked interview → typed memories via the
+idempotent bulk path) runs off the request in a fire-and-forget task plus
+the hourly scheduler sweep. The legacy inline path (flag off) runs the
+full worker on the request: mask → chunked interview → typed memories →
+forward-only watermark.
 
 Dark by default: the per-tenant ``interviewer.enabled`` flag gates the
 endpoint (the scheduler also never queues commands for disabled tenants —
@@ -14,6 +21,7 @@ this check is defense in depth, mirroring the skills_factory pattern).
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -23,10 +31,53 @@ from pydantic import BaseModel, Field
 from core_api.auth import AuthContext, get_auth_context
 from core_api.config import settings as app_settings
 from core_api.constants import INTERVIEW_EVENT_MAX_CHARS, INTERVIEW_MAX_EVENTS_PER_SUBMIT
-from core_api.services.interview_service import run_interview, run_interview_schedule
+from core_api.services.interview_service import (
+    InterviewJobPermanentlyFailedError,
+    advance_watermark,
+    enqueue_interview_job,
+    process_interview_job,
+    run_interview,
+    run_interview_schedule,
+    synthesis_sem,
+)
 from core_api.services.organization_settings import get_settings_for_display
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(tags=["Interview"])
+
+# Strong references to the fire-and-forget per-submit synthesis tasks —
+# asyncio only holds weak refs to tasks, so without this set the GC could
+# cancel one mid-synthesis (#665). The scheduler sweep remains the durable
+# retry path if the process dies anyway.
+_inflight_jobs: set[asyncio.Task] = set()
+
+
+# Bound the route's fire-and-forget synthesis like the scheduler sweep bounds
+# its own: without this, a burst of simultaneous submits spawns an unbounded
+# number of concurrent LLM map-reduce tasks (rate-quota + storage-pool
+# exhaustion). Queued tasks just wait — jobs are durable and the sweep is the
+# backstop either way.
+async def _bounded_process(tenant_id: str, doc_id: str) -> None:
+    # Shares interview_service.synthesis_sem with the scheduler sweep so the
+    # global synthesis cap holds even when both paths run concurrently.
+    async with synthesis_sem:
+        await process_interview_job(tenant_id, doc_id)
+
+
+def _log_task_exc(task: asyncio.Task) -> None:
+    """Surface fire-and-forget synthesis failures in the logs (#667):
+    without a done-callback retrieving the exception, asyncio defers the
+    'Task exception was never retrieved' report to GC time (and drops it
+    entirely on shutdown). ``process_interview_job`` never raises ordinary
+    exceptions, so anything landing here is a genuine bug — log loudly.
+    ``cancelled()`` is guarded first: calling ``exception()`` on a
+    cancelled task raises ``CancelledError``."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("interview submit: fire-and-forget synthesis task crashed", exc_info=exc)
 
 
 class InterviewEventIn(BaseModel):
@@ -58,7 +109,7 @@ class InterviewSubmitIn(BaseModel):
 
 
 class InterviewSubmitOut(BaseModel):
-    status: str  # committed | partial | failed
+    status: str  # accepted | committed | partial | failed
     watermark: int | None
     memories_written: int
     errors: int
@@ -71,10 +122,17 @@ async def submit_interview(
 ):
     """Interview one node's event window and persist the report as memories.
 
+    Default (``interview_async_submit``, #665): persist the masked window
+    durably, advance the watermark, and return 200 ``accepted`` fast —
+    synthesis runs off the request path. Flag off: legacy inline synthesis
+    returning ``committed``/``partial``/``failed``.
+
     Idempotent per (node, window): the worker derives the bulk attempt id
     from ``sha1(node_id:cursor_from:cursor_to)`` server-side, so any retry
     of the same window resolves to ``duplicate_attempt`` rows and a
-    forward-only watermark — never duplicates, never a gap.
+    forward-only watermark — never duplicates, never a gap (the async job
+    doc id is derived from the same identity, so duplicate submits upsert
+    one job).
     """
     auth.enforce_read_only()
     auth.enforce_usage_limits()
@@ -101,6 +159,50 @@ async def submit_interview(
         # Defense in depth: the scheduler shouldn't have queued a command
         # for a disabled tenant; refuse rather than silently ingest.
         raise HTTPException(status_code=403, detail="interviewer is not enabled for this tenant")
+
+    if app_settings.interview_async_submit:
+        # Persist-and-accept (#665). The 60-90s inline synthesis outlived
+        # intermediate proxy budgets (on-prem nginx defaults to 60s), so
+        # plugins saw a 504 while the server committed anyway — misreported
+        # failure, never pruned. Order matters: the masked window is durable
+        # server-side BEFORE the watermark advances and the 2xx goes out, so
+        # the node may safely prune its buffer on this response.
+        try:
+            doc_id = await enqueue_interview_job(
+                tenant_id=tenant_id,
+                fleet_id=body.fleet_id,
+                agent_id=body.agent_id,
+                node_id=body.node_id,
+                command_id=body.command_id,
+                cursor_from=body.cursor_from,
+                cursor_to=body.cursor_to,
+                events=[ev.model_dump(mode="json") for ev in body.events],
+            )
+        except InterviewJobPermanentlyFailedError:
+            # 409 (not 500): the window is parked after exhausting its retry
+            # budget — permanence deserves a distinct status in access logs
+            # and lets a future-smarter plugin stop resubmitting.
+            raise HTTPException(
+                status_code=409,
+                detail="interview job is permanently failed — operator intervention required",
+            )
+        watermark = await advance_watermark(
+            tenant_id,
+            node_id=body.node_id,
+            agent_id=body.agent_id,
+            cursor_to=body.cursor_to,
+            command_id=body.command_id,
+        )
+        # Best-effort immediate synthesis WITHOUT holding the request; the
+        # scheduler sweep (process_pending_interview_jobs) is the durable
+        # retry path if this task dies with the process.
+        task = asyncio.create_task(_bounded_process(tenant_id, doc_id))
+        _inflight_jobs.add(task)
+        task.add_done_callback(_inflight_jobs.discard)
+        task.add_done_callback(_log_task_exc)
+        # Plain 200: deployed plugins advance/prune on any 2xx with a
+        # numeric watermark and do not gate on ``status`` — wire-compatible.
+        return InterviewSubmitOut(status="accepted", watermark=watermark, memories_written=0, errors=0)
 
     # Route-enforced deadline (the path opts out of the blanket 45s
     # middleware, which 504'd every realistic window — the synchronous

--- a/core-api/src/core_api/services/interview_service.py
+++ b/core-api/src/core_api/services/interview_service.py
@@ -23,6 +23,7 @@ Design notes (see ``docs/plans/interviewer-phase1-decisions.md``):
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 from datetime import UTC, datetime
@@ -30,6 +31,7 @@ from typing import Any
 
 from common.governance import mask, scan
 from core_api.clients.storage_client import get_storage_client
+from core_api.config import settings as app_settings
 from core_api.constants import (
     INTERVIEW_CHUNK_MAX_CHARS,
     INTERVIEW_EVENT_MAX_CHARS,
@@ -47,6 +49,36 @@ from core_api.services.tenants import list_tenants_with_interviewer_enabled
 logger = logging.getLogger(__name__)
 
 WATERMARK_COLLECTION = "interview_watermarks"
+# Durable async-submit job queue (#665): one doc per (node, window),
+# holding the MASKED event window until synthesis commits.
+JOBS_COLLECTION = "interview_jobs"
+
+
+class InterviewJobPermanentlyFailedError(RuntimeError):
+    """Raised when enqueue_interview_job is called for a job already parked
+    as failed_permanent — the route maps it to 409 so permanence is visible
+    as a distinct status instead of blending into transient 500s."""
+
+
+# A job stuck in "processing" longer than this is presumed dead (the
+# fire-and-forget task hard-crashed with the process between the
+# "processing" write and any terminal write) and is re-swept like a
+# pending job. Generous vs. the worst-case synthesis (multi-chunk
+# map-reduce with LLM fallback chains) so a slow-but-alive run is not
+# double-processed — and even if it were, re-processing is idempotent via
+# the deterministic bulk attempt id.
+INTERVIEW_JOB_STALE_PROCESSING_SECONDS = 600
+# Bounded fan-out for the scheduler sweep's job drain (#667): jobs
+# synthesize concurrently (each is an LLM map-reduce plus storage writes,
+# so a strictly sequential drain of a large backlog could outlive the
+# tick), capped so a backlog can't stampede the LLM provider or exhaust
+# the storage connection pool.
+INTERVIEW_SWEEP_CONCURRENCY = 5
+# ONE shared gate for every synthesis entry point (route fire-and-forget AND
+# the scheduler sweep): two independent Semaphore(N) instances would allow
+# 2N concurrent LLM map-reduces whenever the sweep overlaps in-flight route
+# tasks — exactly the quota/pool exhaustion the cap exists to prevent.
+synthesis_sem = asyncio.Semaphore(INTERVIEW_SWEEP_CONCURRENCY)
 
 # Report section → memory_type. The section label is preserved in
 # ``metadata.category`` so the original interview framing survives the
@@ -71,6 +103,16 @@ def interview_attempt_id(node_id: str, cursor_from: int, cursor_to: int) -> str:
     """
     digest = hashlib.sha1(f"{node_id}:{cursor_from}:{cursor_to}".encode()).hexdigest()
     return f"interview:{digest[:40]}"
+
+
+def interview_job_doc_id(node_id: str, cursor_from: int, cursor_to: int) -> str:
+    """Deterministic job-doc id for one (node, window) async submit (#665).
+
+    Derived from the same identity as the bulk attempt id, so a duplicate
+    submit of the same window upserts the SAME job doc instead of queueing
+    a second synthesis.
+    """
+    return f"job_{interview_attempt_id(node_id, cursor_from, cursor_to)}"
 
 
 def watermark_doc_id(node_id: str) -> str:
@@ -455,7 +497,7 @@ async def advance_watermark(
 # ── Orchestrator ──
 
 
-async def run_interview(
+async def _synthesize_and_write(
     *,
     tenant_id: str,
     fleet_id: str | None,
@@ -464,25 +506,21 @@ async def run_interview(
     command_id: str | None,
     cursor_from: int,
     cursor_to: int,
-    events: list[dict],
+    masked_events: list[dict],
+    advance_watermark_after: bool,
 ) -> dict:
-    """The full window interview: mask → map → reduce → bulk → watermark."""
-    started = datetime.now(UTC)
+    """Synthesis half of the interview: map → reduce → bulk (→ watermark).
 
-    masked, finding_count = mask_events(events)
-    if finding_count:
-        logger.info(
-            "%s interview: masked %d PII/secret findings pre-LLM (tenant=%s node=%s)",
-            started.isoformat(),
-            finding_count,
-            tenant_id,
-            node_id,
-        )
-
+    Shared by the legacy inline path (``run_interview``, which advances the
+    watermark here, after the bulk write) and the async job processor
+    (#665), which passes ``advance_watermark_after=False`` because the
+    watermark already advanced at accept time — then the returned status
+    dicts carry ``watermark: None``. Events MUST already be masked.
+    """
     config = await resolve_config(tenant_id)
     keystones = await _keystone_lines(tenant_id, fleet_id, agent_id)
 
-    chunks = chunk_events(masked)
+    chunks = chunk_events(masked_events)
     mini_reports = []
     for index, chunk in enumerate(chunks):
         prompt = build_prompt(
@@ -501,13 +539,15 @@ async def run_interview(
     if not items:
         # Nothing report-worthy in the window (e.g. pure noise). Still
         # advance the cursor: the window was consumed, not lost.
-        watermark = await advance_watermark(
-            tenant_id,
-            node_id=node_id,
-            agent_id=agent_id,
-            cursor_to=cursor_to,
-            command_id=command_id,
-        )
+        watermark = None
+        if advance_watermark_after:
+            watermark = await advance_watermark(
+                tenant_id,
+                node_id=node_id,
+                agent_id=agent_id,
+                cursor_to=cursor_to,
+                command_id=command_id,
+            )
         return {"status": "committed", "watermark": watermark, "memories_written": 0, "errors": 0}
 
     bulk: BulkMemoryResponse = await create_memories_bulk(
@@ -529,19 +569,616 @@ async def run_interview(
         # that did land dedup as duplicate_attempt).
         return {"status": "failed", "watermark": None, "memories_written": 0, "errors": errors}
 
-    watermark = await advance_watermark(
-        tenant_id,
-        node_id=node_id,
-        agent_id=agent_id,
-        cursor_to=cursor_to,
-        command_id=command_id,
-    )
+    watermark = None
+    if advance_watermark_after:
+        watermark = await advance_watermark(
+            tenant_id,
+            node_id=node_id,
+            agent_id=agent_id,
+            cursor_to=cursor_to,
+            command_id=command_id,
+        )
     return {
         "status": "partial" if errors else "committed",
         "watermark": watermark,
         "memories_written": written,
         "errors": errors,
     }
+
+
+async def run_interview(
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    agent_id: str,
+    node_id: str,
+    command_id: str | None,
+    cursor_from: int,
+    cursor_to: int,
+    events: list[dict],
+) -> dict:
+    """The full window interview: mask → map → reduce → bulk → watermark.
+
+    Legacy inline path (``interview_async_submit=False``): synthesis runs on
+    the request and the watermark advances only after the bulk write.
+    """
+    started = datetime.now(UTC)
+
+    masked, finding_count = mask_events(events)
+    if finding_count:
+        logger.info(
+            "%s interview: masked %d PII/secret findings pre-LLM (tenant=%s node=%s)",
+            started.isoformat(),
+            finding_count,
+            tenant_id,
+            node_id,
+        )
+
+    return await _synthesize_and_write(
+        tenant_id=tenant_id,
+        fleet_id=fleet_id,
+        agent_id=agent_id,
+        node_id=node_id,
+        command_id=command_id,
+        cursor_from=cursor_from,
+        cursor_to=cursor_to,
+        masked_events=masked,
+        advance_watermark_after=True,
+    )
+
+
+# ── Async submit job queue (#665) ──
+
+
+async def enqueue_interview_job(
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    agent_id: str,
+    node_id: str,
+    command_id: str | None,
+    cursor_from: int,
+    cursor_to: int,
+    events: list[dict],
+) -> str:
+    """Persist one (node, window) as a durable ``interview_jobs`` doc.
+
+    Masks FIRST — the job doc must never store unmasked PII/secrets (it
+    outlives the request and is read back by the sweep). Idempotent: a
+    duplicate submit of the same window resolves to the SAME doc id; the
+    existing doc's status decides what happens (see the status ladder
+    below). Returns the job doc id.
+    """
+    now = datetime.now(UTC)
+    masked, finding_count = mask_events(events)
+    if finding_count:
+        logger.info(
+            "%s interview: masked %d PII/secret findings pre-enqueue (tenant=%s node=%s)",
+            now.isoformat(),
+            finding_count,
+            tenant_id,
+            node_id,
+        )
+    doc_id = interview_job_doc_id(node_id, cursor_from, cursor_to)
+    sc = get_storage_client()
+    # Status ladder for a duplicate submit of the same window:
+    #   - "done": the window was already synthesized — skip the upsert
+    #     entirely (rewriting it would re-open a consumed window).
+    #   - "processing": a concurrent processor owns the job — skip the
+    #     upsert; downgrading to "pending" would hand the same window to a
+    #     second processor (re-synthesis dedups via the deterministic bulk
+    #     attempt id, but the race is pure wasted LLM work).
+    #   - missing / "pending" / "failed_permanent": (re-)enqueue as
+    #     "pending", PRESERVING attempts — resetting the retry budget
+    #     would let a plugin resubmit cycle a failing job past
+    #     interview_job_max_attempts forever.
+    prior_attempts = 0
+    prior_status: str | None = None
+    try:
+        existing = await sc.get_document(tenant_id, JOBS_COLLECTION, doc_id, read=False)
+        if isinstance(existing, dict):
+            prior_data = existing.get("data") or {}
+            prior_status = prior_data.get("status")
+            try:
+                prior_attempts = int(prior_data.get("attempts", 0))
+            except (TypeError, ValueError):
+                prior_attempts = 0
+    except Exception as exc:
+        # Never silent: a reset attempts counter (or a missed "done")
+        # bypasses interview_job_max_attempts / re-opens a consumed window.
+        logger.warning(
+            "interview job: could not read prior job state (tenant=%s doc=%s): %s "
+            "— failing the request so the plugin retries the window",
+            tenant_id,
+            doc_id,
+            exc,
+        )
+        # The doc's status is UNKNOWN — upserting "pending" here could
+        # overwrite a "done"/"processing" job (re-opening a consumed window
+        # / double-processing it) and reset its retry budget. But returning
+        # success is worse: on a first-time submit no doc exists, so the
+        # route would advance the watermark and the plugin would prune the
+        # window — losing it permanently. Re-raise instead: the route 500s,
+        # the plugin keeps its buffer and resubmits next tick.
+        raise
+    if prior_status in ("processing", "done"):
+        logger.debug(
+            "interview job: skipping enqueue over %s job (tenant=%s doc=%s)",
+            prior_status,
+            tenant_id,
+            doc_id,
+        )
+        return doc_id
+    if prior_status == "failed_permanent":
+        # Returning doc_id here would let the route advance the watermark and
+        # answer 200 — the plugin would prune a window the server has PARKED
+        # and will never re-synthesize: silent, permanent loss. Raising makes
+        # the route 500, the plugin keeps its buffer, and the failure stays
+        # visible every tick until an operator intervenes (the masked events
+        # remain in the job doc for recovery). Re-opening the job here is NOT
+        # an option: this racy read-check-write path would hand the window a
+        # fresh attempts budget (see the non-atomicity note below).
+        logger.warning(
+            "interview job: job permanently failed, cannot re-enqueue "
+            "(tenant=%s doc=%s) — returning error so the plugin retries",
+            tenant_id,
+            doc_id,
+        )
+        raise InterviewJobPermanentlyFailedError(
+            f"interview job {doc_id} is permanently failed and cannot be re-enqueued"
+        )
+    # NOTE: this read-check-write is NOT atomic — core-storage's document
+    # upsert is a plain replace (``ON CONFLICT DO UPDATE SET data = :data``,
+    # no conditional variant), so a processor can flip the doc to
+    # "processing"/"done" between our read above and this write. Worst
+    # case: a plugin resubmit in a multi-worker deployment can write a stale
+    # prior_attempts over a higher value a concurrent processor committed,
+    # allowing the job to exceed interview_job_max_attempts by up to
+    # (number of workers - 1) attempts before every concurrent snapshot
+    # sees the high value; a just-consumed window can also briefly re-open
+    # as "pending". A conditional upsert (UPDATE ... WHERE attempts <=
+    # :prior_attempts) in core-storage would close this; for now the
+    # overshoot is bounded and re-synthesis is idempotent via the
+    # deterministic bulk attempt id (wasted LLM work, never duplicate rows).
+    # Double-check (not a CAS — see the non-atomicity NOTE above): re-read
+    # immediately before the write to narrow the window in which a concurrent
+    # processor's "processing"/"done" (or a park) gets overwritten. A failed
+    # re-check raises — same invariant as the initial read: enqueue may only
+    # return normally when the window is durably owned server-side.
+    try:
+        recheck = await sc.get_document(tenant_id, JOBS_COLLECTION, doc_id, read=False)
+        if isinstance(recheck, dict):
+            recheck_status = (recheck.get("data") or {}).get("status")
+            if recheck_status in ("processing", "done"):
+                logger.debug(
+                    "interview job: skipping enqueue, status changed to %s during check (tenant=%s doc=%s)",
+                    recheck_status,
+                    tenant_id,
+                    doc_id,
+                )
+                return doc_id
+            if recheck_status == "failed_permanent":
+                logger.warning(
+                    "interview job: job permanently failed on re-check, cannot re-enqueue (tenant=%s doc=%s)",
+                    tenant_id,
+                    doc_id,
+                )
+                raise InterviewJobPermanentlyFailedError(
+                    f"interview job {doc_id} is permanently failed and cannot be re-enqueued"
+                )
+            # Adopt the freshest attempts: a concurrent processor may have
+            # incremented between the two reads — writing the stale
+            # first-read value back would silently reset the retry budget
+            # (the exact overwrite the double-check exists to narrow).
+            try:
+                prior_attempts = int((recheck.get("data") or {}).get("attempts", prior_attempts))
+            except (TypeError, ValueError):
+                pass
+    except InterviewJobPermanentlyFailedError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "interview job: re-check read failed (tenant=%s doc=%s): %s — failing request",
+            tenant_id,
+            doc_id,
+            exc,
+        )
+        raise
+    await sc.upsert_document(
+        {
+            "tenant_id": tenant_id,
+            "collection": JOBS_COLLECTION,
+            "doc_id": doc_id,
+            "data": {
+                "status": "pending",
+                "attempts": prior_attempts,
+                "fleet_id": fleet_id,
+                "agent_id": agent_id,
+                "node_id": node_id,
+                "command_id": command_id,
+                "cursor_from": cursor_from,
+                "cursor_to": cursor_to,
+                "events": masked,
+                "enqueued_at": now.isoformat(),
+            },
+        }
+    )
+    return doc_id
+
+
+async def process_interview_job(
+    tenant_id: str, doc_id: str, *, allow_stale_processing: bool = False
+) -> dict | None:
+    """Synthesize one persisted interview job. NEVER raises (#665).
+
+    Lifecycle: ``pending`` → ``processing`` (attempts+1) → ``done`` on
+    success; back to ``pending`` on failure so the scheduler sweep retries
+    it (re-synthesis is idempotent via the deterministic bulk attempt id);
+    parked as ``failed_permanent`` once attempts reach
+    ``interview_job_max_attempts``. Returns the synthesis result dict, or
+    None when there was nothing to do (missing/done/owned doc, parked, or
+    the attempt raised).
+
+    A ``processing`` doc is OWNED by whichever run wrote that status (the
+    route's fire-and-forget task, or a prior sweep) — a second processor
+    entering anyway would double-synthesize the window and its
+    finally-reset could flip the owner's subsequent "done" back to
+    "pending" (#667). So "processing" is a skip by default; only the
+    scheduler sweep may reclaim one, by passing
+    ``allow_stale_processing=True`` for docs whose owner is presumed dead
+    (see ``_job_processing_is_stale`` — the guard re-checks staleness
+    itself so the flag can never reclaim a fresh run).
+    """
+    sc = get_storage_client()
+    try:
+        doc = await sc.get_document(tenant_id, JOBS_COLLECTION, doc_id, read=False)
+    except Exception:
+        logger.exception("interview job: fetch failed (tenant=%s doc=%s)", tenant_id, doc_id)
+        return None
+    data = doc.get("data") if isinstance(doc, dict) else None
+    if not isinstance(data, dict) or data.get("status") in ("done", "failed_permanent"):
+        # Terminal states are no-ops: re-processing a parked job would
+        # recount it as jobs_parked every sweep instead of jobs_skipped.
+        return None
+    if data.get("status") == "processing" and not (
+        allow_stale_processing and _job_processing_is_stale(doc, datetime.now(UTC))
+    ):
+        return None
+
+    # Fallback base for _set_state when its fresh re-fetch can't produce
+    # one: the last merged payload this run wrote. Starts as the fetched
+    # snapshot; after the "processing" transition it carries the
+    # INCREMENTED attempts, so the status-only writes below ("done", the
+    # finally pending-reset) can't regress the counter to the
+    # pre-increment closure value when they hit the fallback path.
+    last_written = data
+
+    async def _set_state(
+        state: dict, *, increment_attempts: bool = False, skip_if_terminal: bool = False
+    ) -> bool:
+        # Returns True when the write landed, False when skip_if_terminal
+        # suppressed it — callers that must NOT proceed after a suppressed
+        # transition (the "processing" claim) branch on this instead of
+        # inferring from last_written, which can't distinguish a skip on
+        # the stale-reclaim path (its initial status is already "processing").
+        # upsert_document REPLACES the whole ``data`` payload server-side
+        # (``ON CONFLICT DO UPDATE SET data = :data`` — see
+        # core-storage-api ``document_upsert``), it does NOT merge keys. So
+        # writing only the transitioned keys would destroy the events
+        # payload, and writing the stale closure ``data`` snapshot would
+        # resurrect keys a concurrent writer (e.g. a duplicate enqueue)
+        # changed since our fetch. Re-fetch the CURRENT doc and merge the
+        # transition keys onto that fresh snapshot instead.
+        nonlocal last_written
+        base = last_written
+        fresh = await sc.get_document(tenant_id, JOBS_COLLECTION, doc_id, read=False)
+        if isinstance(fresh, dict) and isinstance(fresh.get("data"), dict):
+            base = fresh["data"]
+        if skip_if_terminal and base.get("status") in ("done", "failed_permanent"):
+            # A CONCURRENT run finished (or parked) the same window while
+            # this one was in flight — overwriting "done" would re-open a
+            # consumed window, and overwriting "failed_permanent" would
+            # re-enter the retry loop past the attempts cap (#667). The
+            # check runs on the SAME snapshot the merge uses, collapsing
+            # the old pre-check-then-write shape's two fetch-write gaps
+            # into one (round 6). On the fallback path (fresh fetch
+            # unusable → base is this run's own last-written snapshot) the
+            # check is best-effort only: our own snapshot can't show a
+            # concurrent terminal write, so a "done" landing while storage
+            # reads are failing may still be overwritten — the irreducible
+            # plain-replace race; re-synthesis stays idempotent via the
+            # deterministic bulk attempt id.
+            return False
+        merged = {**base, **state}
+        if increment_attempts:
+            # Increment from the FRESH base, not the caller's stale local
+            # snapshot: two concurrent processors would otherwise both read
+            # attempts=N and both write N+1, undercounting attempts and
+            # letting a job exceed interview_job_max_attempts.
+            try:
+                merged["attempts"] = int(base.get("attempts", 0)) + 1
+            except (TypeError, ValueError):
+                merged["attempts"] = 1
+        await sc.upsert_document(
+            {
+                "tenant_id": tenant_id,
+                "collection": JOBS_COLLECTION,
+                "doc_id": doc_id,
+                "data": merged,
+            }
+        )
+        last_written = merged
+        return True
+
+    try:
+        attempts = int(data.get("attempts", 0))
+    except (TypeError, ValueError):
+        attempts = 0
+    try:
+        if attempts >= app_settings.interview_job_max_attempts:
+            logger.warning(
+                "interview job: attempts exhausted, parking as failed_permanent "
+                "(tenant=%s doc=%s attempts=%d)",
+                tenant_id,
+                doc_id,
+                attempts,
+            )
+            # skip_if_terminal: a stale-processing reclaim can race the
+            # original (slow-but-alive) run — if that run wrote "done" just
+            # before this park, overwriting it would falsely discard a
+            # completed synthesis. Same rationale as the finally reset.
+            parked = await _set_state({"status": "failed_permanent"}, skip_if_terminal=True)
+            if not parked:
+                # A concurrent run finished the job between our fetch and
+                # this park — it owns the outcome; reporting parked here
+                # would miscount a completed window as failed_permanent.
+                return None
+            return {"status": "failed_permanent"}
+        # Local mirror for logging and the park-check above; the WRITTEN
+        # counter comes from increment_attempts (fresh-base increment).
+        attempts += 1
+        # processing_started_at drives the sweep's stale-"processing"
+        # recovery (INTERVIEW_JOB_STALE_PROCESSING_SECONDS).
+        claimed = await _set_state(
+            {
+                "status": "processing",
+                "processing_started_at": datetime.now(UTC).isoformat(),
+            },
+            increment_attempts=True,
+            skip_if_terminal=True,
+        )
+        if not claimed:
+            # A concurrent run finished (or parked) the job between our
+            # initial fetch and this claim — let it own the result rather
+            # than overwriting "done" with "processing" and re-synthesizing
+            # (whose failure path could later park a correctly-completed
+            # window as failed_permanent).
+            return None
+        # Use the actually-stored count (last_written carries the fresh-base
+        # increment) rather than the stale initial snapshot for logging and
+        # the park check on later paths.
+        attempts = last_written.get("attempts", attempts)
+    except Exception:
+        logger.exception("interview job: state write failed (tenant=%s doc=%s)", tenant_id, doc_id)
+        return None
+
+    # Every exit below without a committed "done" write MUST converge the
+    # job back to "pending" — synthesis failure, done-write failure, and
+    # cancellation alike — else it strands in "processing" until the
+    # (slower) stale-processing sweep. The finally block owns that
+    # convergence; ``wrote_done`` records the one exit that must not.
+    result: dict | None = None
+    wrote_done = False
+    try:
+        try:
+            result = await _synthesize_and_write(
+                tenant_id=tenant_id,
+                fleet_id=data.get("fleet_id"),
+                agent_id=str(data.get("agent_id") or ""),
+                node_id=str(data.get("node_id") or ""),
+                command_id=data.get("command_id"),
+                cursor_from=int(data.get("cursor_from") or 0),
+                cursor_to=int(data.get("cursor_to") or 0),
+                masked_events=data.get("events") or [],
+                # The watermark already advanced at accept time (route).
+                advance_watermark_after=False,
+            )
+        except Exception:
+            logger.exception(
+                "interview job: synthesis failed (tenant=%s doc=%s attempt=%d)",
+                tenant_id,
+                doc_id,
+                attempts,
+            )
+            # Sentinel (not None): the job WAS claimed and attempts WAS
+            # incremented before this failure — the sweep must count it as
+            # retried, while None stays reserved for true no-ops (missing/
+            # done doc, concurrent-ownership skip) where nothing happened.
+            result = {"status": "failed_transient"}
+        # "partial" is deliberately NOT terminal here: in the async path the
+        # watermark advanced at accept and the plugin pruned — marking a
+        # partial bulk write "done" would permanently lose the failed rows.
+        # Falling through to the pending reset lets the sweep re-drive it;
+        # re-synthesis is idempotent (already-written rows dedup as
+        # duplicate_attempt, failed rows get a fresh attempt).
+        if result and result.get("status") not in ("failed", "failed_transient", "partial"):
+            try:
+                # No "attempts" key: the "processing" transition already
+                # stamped the fresh-base increment; re-writing the local
+                # mirror here could clobber a concurrent run's newer count
+                # (#667). _set_state's merge base carries the stored value.
+                await _set_state(
+                    {
+                        "status": "done",
+                        "memories_written": result.get("memories_written", 0),
+                        "completed_at": datetime.now(UTC).isoformat(),
+                    }
+                )
+                wrote_done = True
+            except Exception:
+                logger.exception(
+                    "interview job: done-state write failed (tenant=%s doc=%s)", tenant_id, doc_id
+                )
+    finally:
+        # Runs for plain returns, ordinary Exceptions (already swallowed
+        # above — this function never raises for them), AND CancelledError
+        # (which re-raises on its own once this block ends, so cancellation
+        # still propagates to the asyncio runtime). Back to pending: the
+        # next sweep retries; the deterministic bulk attempt id makes the
+        # re-synthesis idempotent. The reset write itself gets one extra
+        # best-effort attempt — a single transient storage blip must not
+        # strand the job in "processing".
+        if not wrote_done:
+            for reset_try in (1, 2):
+                try:
+                    # skip_if_terminal: between our failure and this reset a
+                    # CONCURRENT run may have finished the same window —
+                    # _set_state backs off from a terminal status using the
+                    # SAME fresh snapshot it merges onto (one fetch-write
+                    # gap; round 6 collapsed the old separate pre-check +
+                    # write shape). Still not atomic (plain-replace upsert),
+                    # but the residual race is one gap, not two. No
+                    # "attempts" key on the reset either: the fresh merge
+                    # base already carries the stored count.
+                    await _set_state({"status": "pending"}, skip_if_terminal=True)
+                    break
+                # BaseException: a CancelledError-mid-teardown reset attempt
+                # must not mask the ORIGINAL in-flight exception (which the
+                # finally re-raises on its own once this block ends).
+                except BaseException:
+                    logger.warning(
+                        "interview job: pending-reset write failed (tenant=%s doc=%s try=%d)",
+                        tenant_id,
+                        doc_id,
+                        reset_try,
+                        exc_info=True,
+                    )
+    return result
+
+
+def _job_processing_is_stale(row: dict, now: datetime) -> bool:
+    """True when a ``processing`` job doc's run is presumed dead.
+
+    Stale = ``processing_started_at`` older than
+    ``INTERVIEW_JOB_STALE_PROCESSING_SECONDS`` — the owning task hard-
+    crashed between the "processing" write and any terminal write. A
+    missing/unparseable timestamp (docs written before it existed) also
+    counts as stale, else those docs would strand in "processing" forever.
+    """
+    data = row.get("data") if isinstance(row, dict) else None
+    if not isinstance(data, dict):
+        return False
+    started = data.get("processing_started_at")
+    if not started or not isinstance(started, str):
+        return True
+    try:
+        started_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if started_dt.tzinfo is None:
+        started_dt = started_dt.replace(tzinfo=UTC)
+    return (now - started_dt).total_seconds() >= INTERVIEW_JOB_STALE_PROCESSING_SECONDS
+
+
+async def process_pending_interview_jobs(limit_per_tenant: int = 20) -> dict:
+    """Drain ``pending`` (and stale ``processing``) interview jobs across
+    opted-in tenants (#665).
+
+    The durable retry path behind the submit route's fire-and-forget task:
+    the scheduler sweep calls this, so a job whose immediate processing
+    died with the process (or failed transiently) still completes. Jobs
+    stranded in ``processing`` by a hard crash mid-run are recovered once
+    stale (see ``_job_processing_is_stale``); re-processing them is
+    idempotent via the deterministic bulk attempt id, so racing a
+    slow-but-alive run wastes work but never duplicates rows. Jobs run
+    concurrently, bounded by ``INTERVIEW_SWEEP_CONCURRENCY`` (round 6).
+    Returns a bounded counts summary.
+    """
+    sc = get_storage_client()
+    now = datetime.now(UTC)
+    tenants = await list_tenants_with_interviewer_enabled()
+    summary = {
+        "tenants": len(tenants),
+        "jobs_processed": 0,
+        "jobs_done": 0,
+        "jobs_retried": 0,
+        "jobs_parked": 0,
+        "jobs_skipped": 0,
+    }
+    # Pass 1: collect (tenant, doc, allow_stale) triples across tenants —
+    # per-tenant limits and stale filtering identical to the old
+    # sequential drain.
+    jobs: list[tuple[str, str, bool]] = []
+    for tenant_id in tenants:
+        try:
+            # Storage ``where`` is JSONB scalar equality on ``data->>key``
+            # (see skills_inbox), so pending-only filtering happens DB-side.
+            docs = await sc.query_documents(
+                {
+                    "tenant_id": tenant_id,
+                    "collection": JOBS_COLLECTION,
+                    "where": {"status": "pending"},
+                    "order_by": "created_at",
+                    "order": "asc",
+                    "limit": limit_per_tenant,
+                }
+            )
+            # ``where`` can't express "older than", so fetch processing
+            # docs by scalar equality and apply the staleness cutoff
+            # client-side.
+            processing = await sc.query_documents(
+                {
+                    "tenant_id": tenant_id,
+                    "collection": JOBS_COLLECTION,
+                    "where": {"status": "processing"},
+                    "order_by": "created_at",
+                    "order": "asc",
+                    # over-fetch; stale filter is client-side
+                    "limit": limit_per_tenant * 4,
+                }
+            )
+        except Exception:
+            logger.exception("interview jobs: pending query failed (tenant=%s)", tenant_id)
+            continue
+        stale = [row for row in processing or [] if _job_processing_is_stale(row, now)]
+        # allow_stale_processing only for the stale rows: the sweep is the
+        # ONE caller allowed to reclaim a stale "processing" doc (the
+        # fire-and-forget task owns fresh ones — see process_interview_job).
+        stale_ids = {str(row.get("doc_id") or "") for row in stale}
+        for row in list(docs or []) + stale:
+            doc_id = str(row.get("doc_id") or "")
+            if not doc_id:
+                continue
+            jobs.append((tenant_id, doc_id, doc_id in stale_ids))
+
+    # Pass 2: bounded fan-out.
+    semaphore = synthesis_sem  # shared with the route's fire-and-forget path
+
+    async def _run_one(tenant_id: str, doc_id: str, allow_stale: bool) -> dict | None:
+        async with semaphore:
+            return await process_interview_job(tenant_id, doc_id, allow_stale_processing=allow_stale)
+
+    # process_interview_job NEVER raises ordinary exceptions (every path
+    # inside it is wrapped — see its docstring), so a bare gather can only
+    # propagate BaseException (cancellation), which SHOULD abort the sweep.
+    results = await asyncio.gather(
+        *(_run_one(tenant_id, doc_id, allow_stale) for tenant_id, doc_id, allow_stale in jobs)
+    )
+    # Per-result counting is order-insensitive — summary semantics are
+    # identical to the old sequential loop.
+    for result in results:
+        summary["jobs_processed"] += 1
+        if result and result.get("status") == "committed":
+            summary["jobs_done"] += 1
+        elif result and result.get("status") == "failed_permanent":
+            summary["jobs_parked"] += 1
+        elif result is None:
+            # No-op: missing/done doc, or a concurrent run claimed the job
+            # between the sweep's fetch and our claim — nothing was retried.
+            summary["jobs_skipped"] += 1
+        else:
+            summary["jobs_retried"] += 1
+    return summary
 
 
 # ── Schedule (cron entry point) ──
@@ -677,4 +1314,18 @@ async def run_interview_schedule() -> dict:
                     tenant_id,
                     node_id,
                 )
+    # #665: drain persisted async-submit jobs in the same sweep — the
+    # durable retry path for jobs whose fire-and-forget processing at
+    # submit time died with the process or failed transiently.
+    # Zero-init unconditionally so the summary schema is identical whether
+    # the sweep succeeds or raises — callers index these keys directly.
+    for key in ("jobs_processed", "jobs_done", "jobs_retried", "jobs_parked", "jobs_skipped"):
+        summary[key] = 0
+    try:
+        jobs_summary = await process_pending_interview_jobs()
+    except Exception:
+        logger.exception("interview schedule: pending-jobs sweep failed")
+    else:
+        for key in ("jobs_processed", "jobs_done", "jobs_retried", "jobs_parked", "jobs_skipped"):
+            summary[key] = jobs_summary.get(key, 0)
     return summary

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,12 @@ _TEST_DEFAULTS = {
     # silently break tests; flag-off / deferred-path tests override
     # this to ``"deferred"``.
     "DEPLOYMENT_MODE": "inline",
+    # Interviewer async submit (#665) defaults ON in prod, but the legacy
+    # route tests (tests/test_api_interview.py) assert the inline path's
+    # response shape (committed/memories_written/504-on-timeout), so tests
+    # pin the flag OFF here; tests/test_interview_async_submit.py flips it
+    # on explicitly per-test to exercise the async path.
+    "INTERVIEW_ASYNC_SUBMIT": "false",
 }
 for _k, _v in _TEST_DEFAULTS.items():
     os.environ.setdefault(_k, _v)

--- a/tests/test_interview_async_submit.py
+++ b/tests/test_interview_async_submit.py
@@ -1,0 +1,806 @@
+"""Async interview submit (#665): persist-and-accept route + job processor.
+
+With ``interview_async_submit=True`` the submit route masks and persists
+the window as a durable ``interview_jobs`` doc, advances the watermark,
+and replies 200 ``accepted`` immediately; synthesis runs in
+``process_interview_job`` (fire-and-forget at submit + the scheduler
+sweep). The conftest env default pins the flag OFF so the legacy suite
+(``tests/test_api_interview.py``) keeps asserting the inline path; tests
+here flip it on explicitly. The LLM map call is stubbed like the legacy
+suite (``canned_llm``); everything else runs the real in-process stack.
+"""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import core_api.routes.interview as interview_route
+import core_api.services.interview_service as interview_service
+from core_api.services.interview_service import (
+    JOBS_COLLECTION,
+    enqueue_interview_job,
+    interview_job_doc_id,
+    process_interview_job,
+    process_pending_interview_jobs,
+)
+from tests.conftest import get_admin_headers, get_test_auth, uid
+from tests.test_api_interview import (
+    _CANNED_REPORT,
+    _enable_interviewer,
+    _events,
+    _payload,
+)
+
+
+# ── helpers ──
+
+
+@pytest.fixture
+def async_submit(monkeypatch):
+    """Flip the #665 flag on (the conftest test default pins it off)."""
+    monkeypatch.setattr(interview_route.app_settings, "interview_async_submit", True)
+
+
+@pytest.fixture
+def canned_llm(monkeypatch):
+    """Stub the map-phase LLM call with the legacy suite's canned report."""
+    calls: list[str] = []
+
+    async def _fake_chunk(prompt, config, events):
+        calls.append(prompt)
+        return _CANNED_REPORT
+
+    monkeypatch.setattr(interview_service, "_interview_chunk", _fake_chunk)
+    return calls
+
+
+async def _job_doc(tenant_id: str, doc_id: str) -> dict | None:
+    sc = interview_service.get_storage_client()
+    return await sc.get_document(tenant_id, JOBS_COLLECTION, doc_id, read=False)
+
+
+async def _overwrite_job_data(tenant_id: str, doc_id: str, **overrides) -> dict:
+    """Merge ``overrides`` onto the job doc's current data (test harness for
+    forcing lifecycle states the public API won't produce on demand)."""
+    sc = interview_service.get_storage_client()
+    doc = await _job_doc(tenant_id, doc_id)
+    assert doc is not None
+    data = {**doc["data"], **overrides}
+    await sc.upsert_document(
+        {
+            "tenant_id": tenant_id,
+            "collection": JOBS_COLLECTION,
+            "doc_id": doc_id,
+            "data": data,
+        }
+    )
+    return data
+
+
+async def _drain_inflight() -> None:
+    """Await the route's fire-and-forget synthesis tasks for determinism."""
+    tasks = list(interview_route._inflight_jobs)
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _interviewer_memories(client, tenant_id: str, agent_id: str, headers: dict) -> list[dict]:
+    listing = await client.get(
+        f"/api/v1/memories?tenant_id={tenant_id}&agent_id={agent_id}", headers=headers
+    )
+    assert listing.status_code == 200
+    rows = listing.json()["items"] if isinstance(listing.json(), dict) else listing.json()
+    return [r for r in rows if (r.get("metadata") or {}).get("source") == "interviewer"]
+
+
+def _enqueue_kwargs(tenant_id: str, node_id: str, agent_id: str, **kw) -> dict:
+    kwargs = {
+        "tenant_id": tenant_id,
+        "fleet_id": None,
+        "agent_id": agent_id,
+        "node_id": node_id,
+        "command_id": "cmd-1",
+        "cursor_from": 0,
+        "cursor_to": 10,
+        "events": _events(),
+    }
+    kwargs.update(kw)
+    return kwargs
+
+
+# ── (a) accept fast, persist masked job, advance watermark ──
+
+
+async def test_async_submit_accepts_with_watermark_and_masked_job(
+    client, canned_llm, async_submit
+):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    events = _events()
+    events[0]["content"] = "emailed ran@caura.ai about the ingest refactor"
+
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, node_id, agent_id, events=events),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "accepted"
+    assert body["watermark"] == 10  # == cursor_to: advanced at accept time
+    assert body["memories_written"] == 0
+    assert body["errors"] == 0
+
+    doc = await _job_doc(tenant_id, interview_job_doc_id(node_id, 0, 10))
+    assert doc is not None
+    data = doc["data"]
+    # The fire-and-forget task may already be running (or finished).
+    assert data["status"] in {"pending", "processing", "done"}
+    assert data["node_id"] == node_id
+    assert data["agent_id"] == agent_id
+    assert data["cursor_from"] == 0 and data["cursor_to"] == 10
+    # The job doc must never store unmasked PII (masked BEFORE persist).
+    assert "ran@caura.ai" not in data["events"][0]["content"]
+    await _drain_inflight()
+
+
+# ── (b) processor writes memories and marks the job done ──
+
+
+async def test_processing_writes_typed_memories_and_marks_done(client, canned_llm, async_submit):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, node_id, agent_id),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    await _drain_inflight()
+
+    # Drive the processor directly for determinism (no-op if the
+    # fire-and-forget task already completed the job).
+    doc_id = interview_job_doc_id(node_id, 0, 10)
+    await process_interview_job(tenant_id, doc_id)
+
+    doc = await _job_doc(tenant_id, doc_id)
+    assert doc["data"]["status"] == "done"
+    assert doc["data"]["memories_written"] == 3  # episode + decision + outcome
+    assert doc["data"]["completed_at"]
+
+    ours = await _interviewer_memories(client, tenant_id, agent_id, headers)
+    assert len(ours) == 3
+    assert sorted(r["memory_type"] for r in ours) == ["decision", "episode", "outcome"]
+    for row in ours:
+        assert (row.get("metadata") or {}).get("node_id") == node_id
+        assert (row.get("metadata") or {}).get("written_by") == "interviewer"
+
+
+# ── (c) duplicate submits upsert one job; re-synthesis dedups ──
+
+
+async def test_resubmit_same_window_is_idempotent(client, canned_llm, async_submit):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    payload = _payload(tenant_id, node_id, agent_id)
+
+    first = await client.post("/api/v1/interview/submit", json=payload, headers=headers)
+    assert first.status_code == 200
+    await _drain_inflight()
+    doc_id = interview_job_doc_id(node_id, 0, 10)
+    await process_interview_job(tenant_id, doc_id)
+    assert len(await _interviewer_memories(client, tenant_id, agent_id, headers)) == 3
+
+    # Re-enqueue the SAME window directly (deterministic — no route task
+    # racing the assertion): the deterministic doc id resolves to the same
+    # job, and a "done" job is NOT flipped back to pending (#667
+    # no-downgrade ladder) — the window was already synthesized.
+    doc_id2 = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+    assert doc_id2 == doc_id
+    assert (await _job_doc(tenant_id, doc_id))["data"]["status"] == "done"
+    assert await process_interview_job(tenant_id, doc_id) is None  # done → no-op
+
+    # Crash-recovery replay (the stale-processing sweep's shape): force
+    # the done job back through synthesis — the deterministic bulk attempt
+    # id dedups every row as duplicate_attempt, so 0 new memories land.
+    await _overwrite_job_data(tenant_id, doc_id, status="pending")
+    result = await process_interview_job(tenant_id, doc_id)
+    assert result is not None
+    assert result["status"] == "committed"
+    assert result["memories_written"] == 0
+    assert (await _job_doc(tenant_id, doc_id))["data"]["status"] == "done"
+    assert len(await _interviewer_memories(client, tenant_id, agent_id, headers)) == 3
+
+
+async def test_enqueue_over_processing_job_does_not_downgrade(client, canned_llm):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+
+    # Simulate a concurrent processor owning the job.
+    started_at = datetime.now(UTC).isoformat()
+    await _overwrite_job_data(
+        tenant_id, doc_id, status="processing", attempts=1, processing_started_at=started_at
+    )
+
+    doc_id2 = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+    assert doc_id2 == doc_id
+    after = (await _job_doc(tenant_id, doc_id))["data"]
+    assert after["status"] == "processing"
+    assert after["attempts"] == 1
+    # The enqueue skipped the upsert entirely — nothing was refreshed.
+    assert after["processing_started_at"] == started_at
+
+
+async def test_duplicate_enqueue_preserves_attempts(client, monkeypatch):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+
+    async def _always_boom(prompt, config, events):
+        raise RuntimeError("llm down")
+
+    monkeypatch.setattr(interview_service, "_interview_chunk", _always_boom)
+    assert await process_interview_job(tenant_id, doc_id) == {"status": "failed_transient"}
+    doc = await _job_doc(tenant_id, doc_id)
+    assert doc["data"]["status"] == "pending"
+    assert doc["data"]["attempts"] == 1
+
+    # A plugin resubmit of the same failing window must NOT reset the
+    # retry budget (it would cycle past interview_job_max_attempts forever).
+    assert await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id)) == doc_id
+    doc = await _job_doc(tenant_id, doc_id)
+    assert doc["data"]["status"] == "pending"
+    assert doc["data"]["attempts"] == 1
+
+
+async def test_enqueue_prior_read_failure_raises_and_leaves_done_job_untouched(
+    client, canned_llm, monkeypatch
+):
+    """When the prior-doc read fails during enqueue, the doc's status is
+    UNKNOWN — the enqueue must RAISE (the route 500s and the plugin
+    resubmits the window next tick; returning success on a first-time
+    submit would lose the window, see the round-5 test below) and must
+    NOT upsert (writing "pending" over a "done" job would re-open the
+    consumed window and reset the retry budget) (#667)."""
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+    result = await process_interview_job(tenant_id, doc_id)
+    assert result is not None and result["status"] == "committed"
+    before = (await _job_doc(tenant_id, doc_id))["data"]
+    assert before["status"] == "done"
+
+    sc = interview_service.get_storage_client()
+    real_get = sc.get_document
+    boom = {"on": True}
+
+    async def _flaky_get(tenant, collection, did, **kw):
+        if boom["on"] and collection == JOBS_COLLECTION and did == doc_id:
+            raise RuntimeError("storage read blip")
+        return await real_get(tenant, collection, did, **kw)
+
+    monkeypatch.setattr(sc, "get_document", _flaky_get)
+    with pytest.raises(RuntimeError, match="storage read blip"):
+        await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+    boom["on"] = False
+    after = (await _job_doc(tenant_id, doc_id))["data"]
+    assert after == before  # untouched — still done, attempts unchanged
+
+
+async def test_first_submit_prior_read_failure_500s_without_advancing_watermark(
+    client, canned_llm, async_submit, monkeypatch
+):
+    """Round 5 (#667): FIRST-TIME submit with a transient storage blip on
+    the prior-doc read. No job doc exists yet, so swallowing the error and
+    returning success would let the route advance the watermark and 200 —
+    the plugin prunes its buffer and the window is permanently lost. The
+    enqueue must raise → route 500s → the plugin keeps the window and
+    resubmits next tick."""
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = interview_job_doc_id(node_id, 0, 10)
+
+    sc = interview_service.get_storage_client()
+    real_get = sc.get_document
+    boom = {"on": True}
+
+    async def _flaky_get(tenant, collection, did, **kw):
+        if boom["on"] and collection == JOBS_COLLECTION and did == doc_id:
+            raise RuntimeError("storage read blip")
+        return await real_get(tenant, collection, did, **kw)
+
+    monkeypatch.setattr(sc, "get_document", _flaky_get)
+
+    # Service level: the transient error propagates out of the enqueue.
+    with pytest.raises(RuntimeError, match="storage read blip"):
+        await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+
+    # Route level: 500 out; watermark NOT advanced; nothing persisted.
+    # A dedicated non-raising client so the test observes the response the
+    # plugin would see (the shared ``client`` fixture's ASGI transport
+    # re-raises app exceptions — established pattern, see test_role_flag).
+    from httpx import ASGITransport, AsyncClient
+
+    from core_api.app import app
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as raw_client:
+        resp = await raw_client.post(
+            "/api/v1/interview/submit",
+            json=_payload(tenant_id, node_id, agent_id),
+            headers=headers,
+        )
+    assert resp.status_code == 500
+
+    boom["on"] = False
+    assert await _job_doc(tenant_id, doc_id) is None
+    watermark_doc = await sc.get_document(
+        tenant_id,
+        interview_service.WATERMARK_COLLECTION,
+        interview_service.watermark_doc_id(node_id),
+        read=False,
+    )
+    assert watermark_doc is None  # first-time: never created, no advance
+
+
+# ── (d) failure → pending w/ attempts; exhaustion → failed_permanent ──
+
+
+async def test_failed_synthesis_returns_to_pending_then_retry_succeeds(client, monkeypatch):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+
+    boom = {"on": True}
+
+    async def _flaky_chunk(prompt, config, events):
+        if boom["on"]:
+            raise RuntimeError("llm down")
+        return _CANNED_REPORT
+
+    monkeypatch.setattr(interview_service, "_interview_chunk", _flaky_chunk)
+
+    assert await process_interview_job(tenant_id, doc_id) == {"status": "failed_transient"}  # never raises
+    doc = await _job_doc(tenant_id, doc_id)
+    assert doc["data"]["status"] == "pending"
+    assert doc["data"]["attempts"] == 1
+
+    boom["on"] = False
+    result = await process_interview_job(tenant_id, doc_id)
+    assert result is not None and result["status"] == "committed"
+    doc = await _job_doc(tenant_id, doc_id)
+    assert doc["data"]["status"] == "done"
+    assert doc["data"]["attempts"] == 2
+    assert len(await _interviewer_memories(client, tenant_id, agent_id, headers)) == 3
+
+
+async def test_job_attempts_exhaustion_parks_as_failed_permanent(client, monkeypatch):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+
+    async def _always_boom(prompt, config, events):
+        raise RuntimeError("llm down")
+
+    monkeypatch.setattr(interview_service, "_interview_chunk", _always_boom)
+    max_attempts = interview_route.app_settings.interview_job_max_attempts
+    for expected_attempts in range(1, max_attempts + 1):
+        assert await process_interview_job(tenant_id, doc_id) == {"status": "failed_transient"}
+        doc = await _job_doc(tenant_id, doc_id)
+        assert doc["data"]["status"] == "pending"
+        assert doc["data"]["attempts"] == expected_attempts
+
+    # attempts == max → the next run parks the job instead of retrying,
+    # returning the sentinel so the sweep can count it as jobs_parked.
+    assert await process_interview_job(tenant_id, doc_id) == {"status": "failed_permanent"}
+    assert (await _job_doc(tenant_id, doc_id))["data"]["status"] == "failed_permanent"
+
+
+async def test_concurrent_processors_increment_attempts_from_fresh_base(client, monkeypatch):
+    """Two racing processors both read a stale ``attempts=N`` snapshot; the
+    processing-transition write must increment from the FRESH stored value
+    (N → N+1 → N+2), not both write the stale N+1 — undercounting would let
+    a job exceed interview_job_max_attempts (#667). Simulated by doctoring
+    the second run's top-level fetch to return the pre-increment snapshot
+    while _set_state's fresh re-fetch sees the real doc."""
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+
+    async def _always_boom(prompt, config, events):
+        raise RuntimeError("llm down")
+
+    monkeypatch.setattr(interview_service, "_interview_chunk", _always_boom)
+
+    sc = interview_service.get_storage_client()
+    real_get = sc.get_document
+    real_upsert = sc.upsert_document
+    stale = {"armed": False}
+    processing_attempts: list[int] = []
+
+    async def _stale_once_get(tenant, collection, did, **kw):
+        doc = await real_get(tenant, collection, did, **kw)
+        if stale["armed"] and collection == JOBS_COLLECTION and did == doc_id:
+            # Only the run's FIRST fetch (the processor's snapshot read) is
+            # stale; _set_state's fresh re-fetch passes through.
+            stale["armed"] = False
+            doc = {**doc, "data": {**doc["data"], "status": "pending", "attempts": 0}}
+        return doc
+
+    async def _spy_upsert(payload):
+        data = payload.get("data") or {}
+        if payload.get("collection") == JOBS_COLLECTION and data.get("status") == "processing":
+            processing_attempts.append(data.get("attempts"))
+        return await real_upsert(payload)
+
+    monkeypatch.setattr(sc, "get_document", _stale_once_get)
+    monkeypatch.setattr(sc, "upsert_document", _spy_upsert)
+
+    assert await process_interview_job(tenant_id, doc_id) == {"status": "failed_transient"}  # attempts 0 → 1
+    stale["armed"] = True  # second run reads the pre-increment snapshot
+    assert await process_interview_job(tenant_id, doc_id) == {"status": "failed_transient"}
+    # Strictly 1 → 2 — the stale-snapshot run must NOT re-write 1.
+    assert processing_attempts == [1, 2]
+
+
+async def test_pending_reset_retry_survives_one_write_failure(client, monkeypatch):
+    """Synthesis fails AND the first pending-reset upsert fails: the reset's
+    extra best-effort attempt must still land the job in "pending" — a job
+    left in "processing" waits on the (slower) stale sweep."""
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+
+    async def _boom_chunk(prompt, config, events):
+        raise RuntimeError("llm down")
+
+    monkeypatch.setattr(interview_service, "_interview_chunk", _boom_chunk)
+
+    sc = interview_service.get_storage_client()
+    real_upsert = sc.upsert_document
+    blips = {"remaining": 1}
+
+    async def _flaky_upsert(payload):
+        if (
+            payload.get("collection") == JOBS_COLLECTION
+            and (payload.get("data") or {}).get("status") == "pending"
+            and blips["remaining"]
+        ):
+            blips["remaining"] -= 1
+            raise RuntimeError("storage blip")
+        return await real_upsert(payload)
+
+    monkeypatch.setattr(sc, "upsert_document", _flaky_upsert)
+
+    assert await process_interview_job(tenant_id, doc_id) == {"status": "failed_transient"}  # never raises
+    assert blips["remaining"] == 0  # the first reset write did raise
+    doc = await _job_doc(tenant_id, doc_id)
+    assert doc["data"]["status"] == "pending"
+    assert doc["data"]["attempts"] == 1
+
+
+async def test_pending_reset_does_not_overwrite_concurrent_done(client, monkeypatch):
+    """Synthesis fails, but a CONCURRENT run finished the SAME window while
+    this run was in flight (flipping the doc to "done"): the finally
+    pending-reset must detect the terminal status and back off — writing
+    "pending" over it would re-open a consumed window (#667)."""
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+    completed_at = datetime.now(UTC).isoformat()
+
+    async def _concurrent_done_then_boom(prompt, config, events):
+        # Simulate the concurrent processor committing between this run's
+        # "processing" write and its finally reset, then fail this run.
+        await _overwrite_job_data(
+            tenant_id,
+            doc_id,
+            status="done",
+            attempts=7,
+            memories_written=3,
+            completed_at=completed_at,
+        )
+        raise RuntimeError("llm down")
+
+    monkeypatch.setattr(interview_service, "_interview_chunk", _concurrent_done_then_boom)
+    assert await process_interview_job(tenant_id, doc_id) == {"status": "failed_transient"}  # never raises
+    after = (await _job_doc(tenant_id, doc_id))["data"]
+    assert after["status"] == "done"  # the reset backed off
+    assert after["attempts"] == 7  # the winner's count survives untouched
+    assert after["completed_at"] == completed_at
+
+
+async def test_pending_reset_guard_uses_the_merge_base_fetch(client, monkeypatch):
+    """Round 6 (#667): the finally pending-reset no longer does a separate
+    pre-check fetch — _set_state(skip_if_terminal=True) backs off from a
+    terminal status using the SAME fresh snapshot it merges onto. A
+    concurrent "done" landing exactly at that fetch (i.e. AFTER any
+    would-be pre-check already ran) is respected, and exactly ONE job
+    fetch happens after the synthesis failure — pinning the collapsed
+    single fetch-write gap (a reintroduced pre-check would make it two,
+    re-opening the gap between check and merge base)."""
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+    completed_at = datetime.now(UTC).isoformat()
+
+    failed = {"synthesis": False}
+
+    async def _boom_chunk(prompt, config, events):
+        failed["synthesis"] = True
+        raise RuntimeError("llm down")
+
+    monkeypatch.setattr(interview_service, "_interview_chunk", _boom_chunk)
+
+    sc = interview_service.get_storage_client()
+    real_get = sc.get_document
+    real_upsert = sc.upsert_document
+    post_failure_fetches = {"count": 0}
+
+    async def _inject_done_get(tenant, collection, did, **kw):
+        if failed["synthesis"] and collection == JOBS_COLLECTION and did == doc_id:
+            post_failure_fetches["count"] += 1
+            if post_failure_fetches["count"] == 1:
+                # The concurrent winner commits "done" right at the reset's
+                # merge-base fetch — after any would-be pre-check.
+                doc = await real_get(tenant, collection, did, **kw)
+                await real_upsert(
+                    {
+                        "tenant_id": tenant,
+                        "collection": JOBS_COLLECTION,
+                        "doc_id": did,
+                        "data": {
+                            **doc["data"],
+                            "status": "done",
+                            "attempts": 7,
+                            "memories_written": 3,
+                            "completed_at": completed_at,
+                        },
+                    }
+                )
+        return await real_get(tenant, collection, did, **kw)
+
+    monkeypatch.setattr(sc, "get_document", _inject_done_get)
+    assert await process_interview_job(tenant_id, doc_id) == {"status": "failed_transient"}  # never raises
+    monkeypatch.setattr(sc, "get_document", real_get)
+
+    after = (await _job_doc(tenant_id, doc_id))["data"]
+    assert after["status"] == "done"  # the guard skipped the pending write
+    assert after["attempts"] == 7
+    assert after["completed_at"] == completed_at
+    # Exactly one post-failure fetch: the reset went straight to
+    # _set_state's fresh merge-base snapshot — no separate pre-check.
+    assert post_failure_fetches["count"] == 1
+
+
+async def test_direct_processor_skips_processing_unless_stale_and_allowed(client, canned_llm):
+    """A "processing" doc is owned by the run that wrote it: a direct
+    process_interview_job call skips it, flag or not, while it is FRESH;
+    only allow_stale_processing=True on a STALE doc (the sweep's reclaim
+    path) reprocesses it (#667)."""
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+    fresh_started = datetime.now(UTC).isoformat()
+    await _overwrite_job_data(
+        tenant_id, doc_id, status="processing", attempts=1, processing_started_at=fresh_started
+    )
+
+    # Fresh + no flag: owned by the fire-and-forget task → skip.
+    assert await process_interview_job(tenant_id, doc_id) is None
+    # Fresh + flag: the flag alone can't reclaim a live run → still skip.
+    assert await process_interview_job(tenant_id, doc_id, allow_stale_processing=True) is None
+    after = (await _job_doc(tenant_id, doc_id))["data"]
+    assert after["status"] == "processing"
+    assert after["processing_started_at"] == fresh_started
+    assert len(await _interviewer_memories(client, tenant_id, agent_id, headers)) == 0
+
+    # Stale + flag (the sweep's shape): reclaimed and completed.
+    await _overwrite_job_data(
+        tenant_id,
+        doc_id,
+        processing_started_at=(datetime.now(UTC) - timedelta(minutes=11)).isoformat(),
+    )
+    result = await process_interview_job(tenant_id, doc_id, allow_stale_processing=True)
+    assert result is not None and result["status"] == "committed"
+    assert (await _job_doc(tenant_id, doc_id))["data"]["status"] == "done"
+    assert len(await _interviewer_memories(client, tenant_id, agent_id, headers)) == 3
+
+
+async def test_done_job_is_a_noop_for_the_processor(client, canned_llm):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+
+    first = await process_interview_job(tenant_id, doc_id)
+    assert first is not None and first["status"] == "committed"
+    assert await process_interview_job(tenant_id, doc_id) is None  # done → no-op
+    assert await process_interview_job(tenant_id, f"job_missing-{uid()}") is None
+
+
+# ── scheduler sweep drains pending jobs ──
+
+
+async def test_schedule_sweep_processes_pending_jobs(client, canned_llm, async_submit, monkeypatch):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+
+    # Suppress the route's immediate processing so the job stays pending
+    # for the sweep — simulates the fire-and-forget task dying with the
+    # process.
+    async def _noop(tenant, doc):
+        return None
+
+    monkeypatch.setattr(interview_route, "process_interview_job", _noop)
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, node_id, agent_id),
+        headers=headers,
+    )
+    assert resp.status_code == 200 and resp.json()["status"] == "accepted"
+    doc_id = interview_job_doc_id(node_id, 0, 10)
+    assert (await _job_doc(tenant_id, doc_id))["data"]["status"] == "pending"
+
+    run = await client.post("/api/v1/admin/interview/schedule/run", headers=get_admin_headers())
+    assert run.status_code == 200, run.text
+    summary = run.json()
+    assert summary["jobs_processed"] >= 1
+    assert summary["jobs_done"] >= 1
+    assert "jobs_retried" in summary
+    assert (await _job_doc(tenant_id, doc_id))["data"]["status"] == "done"
+    assert len(await _interviewer_memories(client, tenant_id, agent_id, headers)) == 3
+
+
+async def test_sweep_recovers_stale_processing_but_not_fresh(client, canned_llm):
+    """A job stranded in "processing" past the staleness cutoff (its task
+    hard-crashed mid-run) is re-swept and completed; a fresh "processing"
+    job (a live concurrent run) is left alone."""
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    now = datetime.now(UTC)
+
+    stale_node, stale_agent = f"node-{uid()}", f"agent-{uid()}"
+    stale_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, stale_node, stale_agent))
+    await _overwrite_job_data(
+        tenant_id,
+        stale_id,
+        status="processing",
+        attempts=1,
+        processing_started_at=(now - timedelta(minutes=11)).isoformat(),
+    )
+
+    fresh_node, fresh_agent = f"node-{uid()}", f"agent-{uid()}"
+    fresh_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, fresh_node, fresh_agent))
+    fresh_started = now.isoformat()
+    await _overwrite_job_data(
+        tenant_id, fresh_id, status="processing", attempts=1, processing_started_at=fresh_started
+    )
+
+    await process_pending_interview_jobs()
+
+    stale_after = (await _job_doc(tenant_id, stale_id))["data"]
+    assert stale_after["status"] == "done"
+    assert stale_after["attempts"] == 2  # the recovery run counted
+    assert len(await _interviewer_memories(client, tenant_id, stale_agent, headers)) == 3
+
+    fresh_after = (await _job_doc(tenant_id, fresh_id))["data"]
+    assert fresh_after["status"] == "processing"
+    assert fresh_after["processing_started_at"] == fresh_started
+    assert len(await _interviewer_memories(client, tenant_id, fresh_agent, headers)) == 0
+
+
+async def test_sweep_bounded_concurrency_completes_all_jobs(client, canned_llm, monkeypatch):
+    """Fix 2 (#667 round 6): a sweep over MORE jobs than the fan-out bound
+    (7 pending jobs across 2 tenants > INTERVIEW_SWEEP_CONCURRENCY=5)
+    completes every job with the same summary semantics as the old
+    sequential drain, while never exceeding the bound in flight."""
+    tenant_a, headers_a = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_a, headers_a)
+    tenant_b, headers_b = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_b, headers_b)
+
+    seeded: list[tuple[str, str]] = []
+    for tenant_id, count in ((tenant_a, 4), (tenant_b, 3)):
+        for _ in range(count):
+            node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+            doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+            seeded.append((tenant_id, doc_id))
+    assert len(seeded) == 7 > interview_service.INTERVIEW_SWEEP_CONCURRENCY
+
+    real_process = interview_service.process_interview_job
+    gauge = {"now": 0, "max": 0}
+
+    async def _tracking_process(tenant_id, doc_id, **kw):
+        gauge["now"] += 1
+        gauge["max"] = max(gauge["max"], gauge["now"])
+        try:
+            # Hold every task in flight long enough for the whole gathered
+            # batch to start — an unbounded gather would peak at 7 here.
+            await asyncio.sleep(0.01)
+            return await real_process(tenant_id, doc_id, **kw)
+        finally:
+            gauge["now"] -= 1
+
+    monkeypatch.setattr(interview_service, "process_interview_job", _tracking_process)
+    summary = await process_pending_interview_jobs()
+
+    # >= not ==: the sweep is global, so leftover jobs from other tests'
+    # tenants may ride along (same as the other sweep tests here).
+    assert summary["jobs_processed"] >= 7
+    assert summary["jobs_done"] >= 7
+    assert gauge["max"] <= interview_service.INTERVIEW_SWEEP_CONCURRENCY
+    for tenant_id, doc_id in seeded:
+        assert (await _job_doc(tenant_id, doc_id))["data"]["status"] == "done"
+
+
+async def test_process_pending_jobs_returns_counts_summary(client, canned_llm):
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+    await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
+
+    summary = await process_pending_interview_jobs()
+    assert set(summary) == {
+        "tenants",
+        "jobs_processed",
+        "jobs_done",
+        "jobs_retried",
+        "jobs_parked",
+        "jobs_skipped",
+    }
+    assert summary["tenants"] >= 1
+    assert summary["jobs_processed"] >= 1
+    assert summary["jobs_done"] >= 1
+
+
+# ── (e) escape hatch: legacy inline path behind the flag ──
+
+
+async def test_flag_off_runs_legacy_inline_path(client, canned_llm, monkeypatch):
+    monkeypatch.setattr(interview_route.app_settings, "interview_async_submit", False)
+    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    await _enable_interviewer(client, tenant_id, headers)
+    node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
+
+    resp = await client.post(
+        "/api/v1/interview/submit",
+        json=_payload(tenant_id, node_id, agent_id),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "committed"
+    assert body["watermark"] == 10
+    assert body["memories_written"] == 3
+    # Inline path never persists a job doc.
+    assert await _job_doc(tenant_id, interview_job_doc_id(node_id, 0, 10)) is None
+
+
+# ── unit ──
+
+
+def test_job_doc_id_is_deterministic_per_window():
+    a = interview_job_doc_id("node-1", 0, 10)
+    b = interview_job_doc_id("node-1", 0, 10)
+    c = interview_job_doc_id("node-1", 0, 11)
+    assert a == b != c
+    assert a.startswith("job_interview:")


### PR DESCRIPTION
Fixes #665 (durable track; the immediate on-prem gateway timeout bump is already live on eToro).

## Problem
`POST /interview/submit` ran 60–90s of inline LLM synthesis on the request. Intermediate proxies (on-prem nginx default `proxy_read_timeout` 60s) 504'd the plugin mid-flight **while the server completed and committed anyway** — ticks misreported `failed`, buffers never pruned, and the busiest agents' reports appeared "missing" (see the corrected diagnosis on #665: webclaw's 63 memories had committed at 08:01:45 under the install-default agent).

## Design
Default path (`interview_async_submit: bool = True`, escape hatch back to inline):
1. Validate exactly as before → **mask** → persist the window as a durable `interview_jobs` doc (doc id = `job_<sha1(node:from:to)>` — duplicate submits upsert one job).
2. **Advance the forward-only watermark and return 200 `accepted` immediately** — the events are durable server-side, so the node may safely prune on this response.
3. Synthesis runs off-request: a fire-and-forget task per submit (strong-ref'd) plus the hourly scheduler sweep (`process_pending_interview_jobs`, merged into `run_interview_schedule`) as the durable retry path — attempts capped (`interview_job_max_attempts=3` → `failed_permanent`), and the deterministic bulk attempt id keeps every retry idempotent.

**Wire-compatible with deployed plugins**: they advance/prune on any 2xx with a numeric watermark and don't gate on `status`. Legacy inline path preserved verbatim behind the flag (`run_interview` refactored into mask + `_synthesize_and_write(advance_watermark_after=…)`, byte-identical behavior).

## Tests
- New `tests/test_interview_async_submit.py` (10 tests): accepted+watermark+job-doc, processor→memories→done, idempotent re-submit (duplicate_attempt dedup), failure→pending→retry→`failed_permanent` at cap, flag-off legacy behavior, sweep summary.
- `tests/test_api_interview.py`: 22/22 unchanged (conftest pins `INTERVIEW_ASYNC_SUBMIT=false` for legacy tests; the new file opts in per-test).
- Full root suite: 3985 passed; 12 failures verified pre-existing (identical with this diff stashed).
- Ruff clean.

## Review pointers
- `query_documents` uses `where: {"status": "pending"}` (same JSONB pattern as `skills_inbox.py`).
- Done job docs retain their **masked** events (no cleanup yet — a future prune could shrink the collection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)