### PR TITLE
feat(search): pluggable reranking component (MiniLM cross-encoder), ships dark

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,30 @@ OPENAI_API_KEY=
 # Default model. Change requires a re-embed when changing dim or pooling.
 # TEI_MODEL_ID=BAAI/bge-m3
 
+# -- Reranking (opt-in second-stage cross-encoder) --------------------------
+# Off by default. When enabled, a cross-encoder re-orders the candidate pool
+# that scored-search returns (it does NOT change which memories are
+# retrieved). Turning it on takes TWO flags: RANK_ENABLED=true AND a non-noop
+# RANK_PROVIDER. Any failure/timeout degrades to first-stage order — recall
+# never blocks on rerank.
+#
+# Master kill-switch. false (default) = the rerank step is skipped entirely
+# (zero cost — no candidates built, no model call). Set false to disable
+# reranking in an incident without touching provider config.
+# RANK_ENABLED=false
+# Which ranker runs when enabled. Options: noop | local | fake
+#   local = in-process sentence-transformers CrossEncoder (MiniLM). NOTE:
+#   requires torch + sentence-transformers in the core-api image (~+1-2GB)
+#   and loads the model in-process — the first few searches after start
+#   fall back to first-stage order while the model warms.
+# RANK_PROVIDER=noop
+# Cross-encoder model for RANK_PROVIDER=local (MiniLM ~= bge quality, CPU-viable).
+# RANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+# Per-call scoring deadline (seconds); over this, degrade to first-stage order.
+# RANK_TIMEOUT_SECONDS=0.5
+# Max candidates re-scored per search; rows past the cap keep first-stage order.
+# RANK_CANDIDATE_LIMIT=50
+
 # -- LLM enrichment ---------------------------------------------------------
 USE_LLM_FOR_MEMORY_CREATION=true
 # Options: openai | anthropic | openrouter | gemini | fake | none

--- a/common/ranking/__init__.py
+++ b/common/ranking/__init__.py
@@ -1,0 +1,17 @@
+"""Pluggable second-stage ranking (reranking) component.
+
+Mirrors ``common/embedding/`` one-for-one: one provider Protocol, one
+registry that dispatches on a config name, one service wrapper that owns
+retries + degrade-to-first-stage. The backend — a no-op, an in-process
+cross-encoder, or an HTTP call to a separate ranking service — is chosen
+by ``RANK_PROVIDER`` exactly like ``EMBEDDING_PROVIDER`` selects an embedder.
+
+Public entrypoint: :func:`common.ranking.get_ranking`.
+"""
+
+from __future__ import annotations
+
+from common.ranking._service import get_ranking
+from common.ranking.protocols import RankCandidate, RankProvider
+
+__all__ = ["RankCandidate", "RankProvider", "get_ranking"]

--- a/common/ranking/_registry.py
+++ b/common/ranking/_registry.py
@@ -1,0 +1,68 @@
+"""Rank-provider factory. Resolves a concrete provider from a name.
+
+Env-driven (no service-config dependency), mirroring
+``common/embedding/_registry.py``. Unlike embeddings there is no
+platform-tier singleton — ranking runs only on the core-api search path.
+
+The ``local`` cross-encoder is cached per model name: the provider holds
+a lazily-loaded model (hundreds of MB), so reconstructing it per request
+would reload the model every call. ``noop`` / ``fake`` are stateless and
+built fresh.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from common.provider_names import ProviderName
+from common.ranking.constants import RANK_MODEL
+from common.ranking.protocols import RankProvider
+from common.ranking.providers.fake import FakeRanker
+from common.ranking.providers.local import LocalCrossEncoderRanker
+from common.ranking.providers.noop import NoopRanker
+
+logger = logging.getLogger(__name__)
+
+# Cache the in-process cross-encoder per model name so the (large) model
+# loads once per process rather than on every search. Keyed on model name
+# so a per-tenant ``rank_model`` override gets its own cached instance.
+_local_ranker_cache: dict[str, LocalCrossEncoderRanker] = {}
+
+
+def get_rank_provider(name: str, tenant_config: object | None = None) -> RankProvider:
+    """Construct a rank provider by name.
+
+    Parameters
+    ----------
+    name:
+        ``"noop"`` (default), ``"local"`` (in-process MiniLM), or
+        ``"fake"`` (tests). ``"remote"`` is reserved for a future HTTP
+        sidecar provider.
+    tenant_config:
+        Optional ``ResolvedConfig``-shaped object for per-tenant overrides
+        (``rank_model``). Duck-typed via ``getattr`` — may be ``None``.
+
+    Raises
+    ------
+    ValueError
+        If the provider name is unknown.
+    """
+    if name == ProviderName.NONE or name == "noop":
+        return NoopRanker()
+
+    if name == ProviderName.FAKE:
+        return FakeRanker()
+
+    if name == ProviderName.LOCAL:
+        model = (
+            getattr(tenant_config, "rank_model", None)
+            if tenant_config is not None
+            else None
+        ) or RANK_MODEL
+        cached = _local_ranker_cache.get(model)
+        if cached is None:
+            cached = LocalCrossEncoderRanker(model_name=model)
+            _local_ranker_cache[model] = cached
+        return cached
+
+    raise ValueError(f"Unknown rank provider: {name}")

--- a/common/ranking/_service.py
+++ b/common/ranking/_service.py
@@ -1,0 +1,158 @@
+"""Service-level ranking entrypoint with retry, timeout, and degrade-to-first-stage.
+
+Mirrors ``common/embedding/_service.py``. Reads provider selection from a
+tenant override (``tenant_config.rank_provider``) or the ``RANK_PROVIDER``
+env, defaulting to ``noop``. The contract every caller relies on:
+
+    get_ranking(...) -> list[float] | None
+
+``None`` means "keep first-stage order" — returned on misconfig, timeout,
+empty input, or exhausted retries. Recall must NEVER fail because rerank
+did, so every failure path degrades rather than raises. This is the
+embedding module's "persist NULL / fall back" posture applied to ranking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from common.ranking._registry import get_rank_provider
+from common.ranking.constants import (
+    RANK_RETRY_ATTEMPTS,
+    RANK_RETRY_DELAY_S,
+    RANK_TIMEOUT_SECONDS,
+)
+from common.ranking.protocols import RankCandidate
+
+logger = logging.getLogger(__name__)
+
+
+class _RankStats:
+    """Fire a single ERROR after N consecutive failures (degraded trip-wire).
+
+    Mirrors ``_EmbeddingStats``: loud on a fresh outage, quiet during a
+    sustained one, reset on the next success.
+    """
+
+    def __init__(self) -> None:
+        self.failures = 0
+        self.successes = 0
+        self.consecutive_failures = 0
+        self._lock = asyncio.Lock()
+
+    async def record_success(self) -> None:
+        async with self._lock:
+            self.successes += 1
+            self.consecutive_failures = 0
+
+    async def record_failure(self) -> None:
+        async with self._lock:
+            self.failures += 1
+            self.consecutive_failures += 1
+            if (
+                self.consecutive_failures >= 3
+                and (self.consecutive_failures - 3) % 10 == 0
+            ):
+                logger.error(
+                    "Ranking service degraded: %d consecutive failures (total: %d/%d)",
+                    self.consecutive_failures,
+                    self.failures,
+                    self.failures + self.successes,
+                )
+
+
+_stats = _RankStats()
+
+# One-shot misconfiguration log dedup, keyed on provider name — a bad
+# ``RANK_PROVIDER`` would otherwise log once per search.
+_misconfiguration_logged: set[str] = set()
+
+
+def _resolve_provider_name(tenant_config: object | None) -> str:
+    """Tenant override first, else ``RANK_PROVIDER`` env, else ``"noop"``."""
+    if tenant_config is not None:
+        name = getattr(tenant_config, "rank_provider", None)
+        if name:
+            return name
+    return os.environ.get("RANK_PROVIDER") or "noop"
+
+
+def _resolve_provider_or_degrade(tenant_config: object | None):
+    """Resolve the provider, mapping an unknown-name ``ValueError`` to ``None``.
+
+    Returns ``None`` on misconfiguration (logged once per provider name),
+    so the caller keeps first-stage order instead of crashing the search.
+    """
+    provider_name = _resolve_provider_name(tenant_config)
+    try:
+        return get_rank_provider(provider_name, tenant_config)
+    except ValueError:
+        if provider_name not in _misconfiguration_logged:
+            _misconfiguration_logged.add(provider_name)
+            logger.error(
+                "Ranking: provider misconfiguration %r (will not repeat); "
+                "keeping first-stage order",
+                provider_name,
+                exc_info=True,
+            )
+        return None
+
+
+async def get_ranking(
+    query: str,
+    candidates: list[RankCandidate],
+    tenant_config: object | None = None,
+) -> list[float] | None:
+    """Score ``candidates`` for ``query``; return one score each, input order.
+
+    Returns ``None`` (caller keeps first-stage order) when the provider is
+    misconfigured, there are no candidates, or the call times out / errors
+    past the retry budget. Enforces a hard ``RANK_TIMEOUT_SECONDS`` deadline
+    per attempt — recall is latency-critical, a slow rerank must not extend
+    the turn.
+    """
+    if not candidates:
+        return None
+    provider = _resolve_provider_or_degrade(tenant_config)
+    if provider is None:
+        return None
+
+    for attempt in range(1, RANK_RETRY_ATTEMPTS + 1):
+        try:
+            scores = await asyncio.wait_for(
+                provider.rank(query, candidates), timeout=RANK_TIMEOUT_SECONDS
+            )
+            if len(scores) != len(candidates):
+                # Contract violation — treat as a failure, degrade rather
+                # than return a misaligned scores<->candidates mapping.
+                raise ValueError(
+                    f"ranker returned {len(scores)} scores for {len(candidates)} candidates"
+                )
+            await _stats.record_success()
+            return scores
+        except TimeoutError:
+            logger.warning(
+                "Ranking attempt %d/%d timed out after %.3fs",
+                attempt,
+                RANK_RETRY_ATTEMPTS,
+                RANK_TIMEOUT_SECONDS,
+            )
+        # Intentionally broad: any provider error degrades to first-stage.
+        except Exception:
+            logger.warning(
+                "Ranking attempt %d/%d failed",
+                attempt,
+                RANK_RETRY_ATTEMPTS,
+                exc_info=True,
+            )
+        if attempt < RANK_RETRY_ATTEMPTS:
+            await asyncio.sleep(RANK_RETRY_DELAY_S * attempt)
+
+    await _stats.record_failure()
+    logger.error(
+        "Ranking failed after %d attempt(s); keeping first-stage order",
+        RANK_RETRY_ATTEMPTS,
+    )
+    return None

--- a/common/ranking/constants.py
+++ b/common/ranking/constants.py
@@ -15,9 +15,22 @@ from __future__ import annotations
 
 import os
 
-# Provider selection default. ``noop`` = identity (keep first-stage
-# order) so the component ships dark: zero behaviour change until a
-# deployment or tenant opts in. Mirrors ``EMBEDDING_PROVIDER``.
+# Master on/off for the rerank step. When false (the default) the
+# RerankResults step is skipped entirely — a zero-cost kill-switch
+# (no candidates built, no service call) independent of RANK_PROVIDER,
+# which selects *which* ranker runs when enabled. Keeps the component
+# dark by default; flip to true (plus a non-noop RANK_PROVIDER) to turn
+# reranking on. Per-tenant override: tenant_config.rank_enabled.
+RANK_ENABLED: bool = os.environ.get("RANK_ENABLED", "").strip().lower() in (
+    "true",
+    "1",
+    "yes",
+    "on",
+)
+
+# Provider selection when reranking is enabled. ``noop`` = identity (keep
+# first-stage order); ``local`` = in-process MiniLM cross-encoder; ``fake``
+# = tests. Mirrors ``EMBEDDING_PROVIDER``.
 RANK_PROVIDER: str = os.environ.get("RANK_PROVIDER") or "noop"
 
 # Cross-encoder model for the in-process ``local`` provider. MiniLM-L6

--- a/common/ranking/constants.py
+++ b/common/ranking/constants.py
@@ -1,0 +1,53 @@
+"""Ranking-side default constants — env-overridable.
+
+Kept env-driven so this module has no dependency on any service's
+``config`` module, mirroring ``common/embedding/constants.py``. Ranking
+runs only on the core-api search path (never the async write worker), so
+there is no worker-tier variant to mirror.
+
+NOTE: every constant below is evaluated ONCE at module-import time. Tests
+that need a different value must patch the module-level binding directly
+(``monkeypatch.setattr("common.ranking.constants.RANK_CANDIDATE_LIMIT", 5)``)
+— ``monkeypatch.setenv`` after import is too late.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Provider selection default. ``noop`` = identity (keep first-stage
+# order) so the component ships dark: zero behaviour change until a
+# deployment or tenant opts in. Mirrors ``EMBEDDING_PROVIDER``.
+RANK_PROVIDER: str = os.environ.get("RANK_PROVIDER") or "noop"
+
+# Cross-encoder model for the in-process ``local`` provider. MiniLM-L6
+# (22M) was measured ~= bge-reranker-base (278M) on our data (A50 quality
+# spike) while being CPU-viable (~50-150ms at pool<=20); bge in-process is
+# not (1-5s). So ``local`` is MiniLM-class only.
+RANK_MODEL: str = os.environ.get("RANK_MODEL") or "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+# Max sequence length fed to the cross-encoder. Caps per-pair compute so
+# long memory content can't blow the latency budget (the A50 latency
+# numbers were taken at maxlen 256).
+RANK_MAX_LENGTH: int = int(os.environ.get("RANK_MAX_LENGTH", "256"))
+
+# Base URL for the ``remote`` provider (a self-hosted TEI/Cohere-shaped
+# reranker sidecar, typically GPU bge). Unset -> in-process only.
+RANK_BASE_URL: str | None = os.environ.get("RANK_BASE_URL") or None
+RANK_API_KEY: str = os.environ.get("RANK_API_KEY", "")
+
+# Hard per-call deadline. Recall is latency-critical: a slow rerank must
+# degrade to first-stage order, not extend the turn. Default 150ms matches
+# the small-pool MiniLM budget from the latency spike.
+RANK_TIMEOUT_SECONDS: float = float(os.environ.get("RANK_TIMEOUT_SECONDS", "0.15"))
+
+# Retry budget. Default 1 (no retry) — a reranker miss degrades, it does
+# not warrant spending more of the turn's latency budget.
+RANK_RETRY_ATTEMPTS: int = int(os.environ.get("RANK_RETRY_ATTEMPTS", "1"))
+RANK_RETRY_DELAY_S: float = float(os.environ.get("RANK_RETRY_DELAY_S", "0.5"))
+
+# Max candidates re-scored in one call. Bounds cross-encoder compute (the
+# MiniLM CPU budget holds only at small pools) and remote payload size.
+# Rows beyond this cap keep their first-stage order, appended after the
+# re-ranked head.
+RANK_CANDIDATE_LIMIT: int = int(os.environ.get("RANK_CANDIDATE_LIMIT", "50"))

--- a/common/ranking/constants.py
+++ b/common/ranking/constants.py
@@ -36,10 +36,13 @@ RANK_MAX_LENGTH: int = int(os.environ.get("RANK_MAX_LENGTH", "256"))
 RANK_BASE_URL: str | None = os.environ.get("RANK_BASE_URL") or None
 RANK_API_KEY: str = os.environ.get("RANK_API_KEY", "")
 
-# Hard per-call deadline. Recall is latency-critical: a slow rerank must
-# degrade to first-stage order, not extend the turn. Default 150ms matches
-# the small-pool MiniLM budget from the latency spike.
-RANK_TIMEOUT_SECONDS: float = float(os.environ.get("RANK_TIMEOUT_SECONDS", "0.15"))
+# Hard per-call deadline for SCORING (the one-time model load is shielded
+# from it — see LocalCrossEncoderRanker.rank). A slow rerank degrades to
+# first-stage order rather than extending the turn. Default 0.5s: wet-tested
+# warm MiniLM predict was ~112-201ms at pool<=20 on fast CPU (slower on prod
+# x86), so 0.15s would time out even when warm. 0.5s gives headroom while
+# staying far under the turn's multi-second LLM cost. Tune per deployment.
+RANK_TIMEOUT_SECONDS: float = float(os.environ.get("RANK_TIMEOUT_SECONDS", "0.5"))
 
 # Retry budget. Default 1 (no retry) — a reranker miss degrades, it does
 # not warrant spending more of the turn's latency budget.

--- a/common/ranking/protocols.py
+++ b/common/ranking/protocols.py
@@ -1,0 +1,53 @@
+"""Rank-provider protocol shared across the search path.
+
+Mirrors ``common/embedding/protocols.py``: one ``@runtime_checkable``
+Protocol every backend implements. A provider is *pure* — it turns a
+query + candidate pool into one relevance score per candidate and has no
+DB access, no writes, and no side effects. The pipeline step owns the
+sort + trim, exactly as the embedding caller owns what it does with the
+returned vector.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class RankCandidate:
+    """One first-stage result handed to a ranker for re-scoring.
+
+    ``content`` is the text a cross-encoder / remote service scores
+    against the query. ``similarity`` is the first-stage relevance so a
+    provider *can* blend rather than replace (the ``noop`` provider just
+    returns it). ``features`` carries the other scored-search signals
+    (freshness, recall_count, memory_type, status, ts_valid_*) so a future
+    blending/learned ranker has them without a contract change — today's
+    providers ignore it (design decision: start with ``content`` only).
+    """
+
+    id: str
+    content: str
+    similarity: float
+    features: dict = field(default_factory=dict)
+
+
+@runtime_checkable
+class RankProvider(Protocol):
+    """Async reranker: query + candidates → one score per candidate.
+
+    Implementations must return scores in the SAME order as the input
+    candidates (``len(scores) == len(candidates)``). Pure: no DB, no
+    writes, no side effects — the caller sorts and trims.
+    """
+
+    @property
+    def provider_name(self) -> str: ...
+
+    @property
+    def model(self) -> str: ...
+
+    async def rank(self, query: str, candidates: list[RankCandidate]) -> list[float]:
+        """Return one relevance score per candidate, input order preserved."""
+        ...

--- a/common/ranking/providers/fake.py
+++ b/common/ranking/providers/fake.py
@@ -1,0 +1,40 @@
+"""Deterministic fake ranker for tests/dev.
+
+Hash-based scores with word-level overlap signal — candidates sharing
+words with the query score higher — so tests can assert a meaningful
+reorder without loading a model or hitting a service. Always succeeds,
+no external deps. Mirrors ``FakeEmbeddingProvider``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from common.ranking.protocols import RankCandidate
+
+
+def _fake_score(query: str, content: str) -> float:
+    """Deterministic query x content score in [0, 1).
+
+    Rewards word overlap (so relevance is not random), with a small
+    hash-derived jitter to break ties deterministically.
+    """
+    q_words = set(query.lower().split())
+    c_words = set(content.lower().split())
+    overlap = len(q_words & c_words) / len(q_words) if q_words else 0.0
+    h = hashlib.sha256(f"{query}\x00{content}".encode()).digest()
+    jitter = h[0] / 255.0 * 0.01  # < overlap granularity, just a tiebreak
+    return overlap + jitter
+
+
+class FakeRanker:
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+    @property
+    def model(self) -> str:
+        return "fake"
+
+    async def rank(self, query: str, candidates: list[RankCandidate]) -> list[float]:
+        return [_fake_score(query, c.content) for c in candidates]

--- a/common/ranking/providers/local.py
+++ b/common/ranking/providers/local.py
@@ -66,7 +66,16 @@ class LocalCrossEncoderRanker:
     async def rank(self, query: str, candidates: list[RankCandidate]) -> list[float]:
         if not candidates:
             return []
-        await self._ensure_model()
+        # Shield the one-time model load from the caller's per-call deadline.
+        # The service wraps ``rank`` in ``asyncio.wait_for(RANK_TIMEOUT_SECONDS)``;
+        # a cold load takes seconds, so without the shield the first call's
+        # timeout cancels the load mid-flight and DISCARDS it (``self._model``
+        # stays None) — every subsequent call restarts the load and the
+        # provider never warms up, permanently falling back to first-stage
+        # order (verified by wet test). ``shield`` lets the load run to
+        # completion + cache even when this call is cancelled; the caller
+        # still degrades for the cold call(s), then warm calls score normally.
+        await asyncio.shield(self._ensure_model())
         pairs = [(query, c.content) for c in candidates]
         loop = asyncio.get_running_loop()
         # ``predict`` is synchronous, CPU-bound batched inference — run it

--- a/common/ranking/providers/local.py
+++ b/common/ranking/providers/local.py
@@ -1,0 +1,75 @@
+"""Local in-process cross-encoder ranker (MiniLM), mirrors ``LocalEmbedding``.
+
+Lazy-loads a sentence-transformers ``CrossEncoder`` under an
+``asyncio.Lock`` and scores (query, content) pairs in a thread executor
+(``predict`` is sync CPU work). ``sentence-transformers`` is lazy-imported
+so it stays an optional dependency — if it is absent the load raises
+``ImportError``, which the service layer treats as a provider failure and
+degrades to first-stage order.
+
+Viable only at small pools: MiniLM-L6 (22M) is ~50-150ms CPU at pool<=20
+(A50 latency spike); a large model (bge-base, 278M) is NOT CPU-viable
+in-process (1-5s) and belongs behind the ``remote`` provider.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from common.ranking.constants import RANK_MAX_LENGTH, RANK_MODEL
+from common.ranking.protocols import RankCandidate
+
+logger = logging.getLogger(__name__)
+
+
+class LocalCrossEncoderRanker:
+    """Reranker backed by a local sentence-transformers CrossEncoder."""
+
+    def __init__(
+        self, model_name: str = RANK_MODEL, max_length: int = RANK_MAX_LENGTH
+    ) -> None:
+        self._model_name = model_name
+        self._max_length = max_length
+        self._model = None
+        self._load_lock = asyncio.Lock()
+
+    @property
+    def provider_name(self) -> str:
+        return "local"
+
+    @property
+    def model(self) -> str:
+        return self._model_name
+
+    async def _ensure_model(self) -> None:
+        if self._model is not None:
+            return
+        async with self._load_lock:
+            if self._model is not None:
+                return
+            try:
+                from sentence_transformers import CrossEncoder
+            except ImportError:
+                raise ImportError(
+                    "sentence-transformers is required for the local reranker "
+                    "(RANK_PROVIDER=local). Install it with: "
+                    "pip install sentence-transformers"
+                ) from None
+            logger.info("Loading local cross-encoder model: %s", self._model_name)
+            loop = asyncio.get_running_loop()
+            self._model = await loop.run_in_executor(
+                None,
+                lambda: CrossEncoder(self._model_name, max_length=self._max_length),
+            )
+
+    async def rank(self, query: str, candidates: list[RankCandidate]) -> list[float]:
+        if not candidates:
+            return []
+        await self._ensure_model()
+        pairs = [(query, c.content) for c in candidates]
+        loop = asyncio.get_running_loop()
+        # ``predict`` is synchronous, CPU-bound batched inference — run it
+        # off the event loop so a rerank never blocks other requests.
+        scores = await loop.run_in_executor(None, lambda: self._model.predict(pairs))
+        return [float(s) for s in scores]

--- a/common/ranking/providers/noop.py
+++ b/common/ranking/providers/noop.py
@@ -1,0 +1,33 @@
+"""No-op ranker — the default, a TRUE identity on first-stage order.
+
+Ships the component dark: ``RANK_PROVIDER=noop`` (the default) must leave
+the result order byte-for-byte identical to what scored-search produced.
+
+Subtlety: the caller sorts candidates by the returned scores (descending).
+First-stage rows arrive ordered by the composite ``score`` (SQL ORDER BY
+score), which is NOT the same as ``similarity`` order once boosts diverge.
+So returning ``[c.similarity]`` would silently re-order the pool by cosine
+— a behaviour change, not a no-op. Instead we return a strictly
+descending score by input position, so the caller's sort reproduces the
+exact input order regardless of similarity/score.
+"""
+
+from __future__ import annotations
+
+from common.ranking.protocols import RankCandidate
+
+
+class NoopRanker:
+    @property
+    def provider_name(self) -> str:
+        return "noop"
+
+    @property
+    def model(self) -> str:
+        return "noop"
+
+    async def rank(self, query: str, candidates: list[RankCandidate]) -> list[float]:
+        # Descending by position → caller's ``sort(reverse=True)`` keeps the
+        # input order exactly. A true identity, independent of similarity.
+        n = len(candidates)
+        return [float(n - i) for i in range(n)]

--- a/core-api/src/core_api/pipeline/compositions/search.py
+++ b/core-api/src/core_api/pipeline/compositions/search.py
@@ -10,6 +10,7 @@ from core_api.pipeline.steps.search import (
     LogRecallEvent,
     ParallelEmbedAndEntityBoost,
     PostFilterResults,
+    RerankResults,
     ResolveSearchProfile,
     TrackRecalls,
 )
@@ -24,6 +25,7 @@ def build_search_pipeline() -> Pipeline:
             ClassifyQuery(),
             ParallelEmbedAndEntityBoost(),
             ExecuteScoredSearch(),
+            RerankResults(),
             PostFilterResults(),
             LoadAndSerialize(),
             InjectSTMContext(),

--- a/core-api/src/core_api/pipeline/steps/search/__init__.py
+++ b/core-api/src/core_api/pipeline/steps/search/__init__.py
@@ -10,6 +10,7 @@ from core_api.pipeline.steps.search.parallel_embed_entity_boost import (
     ParallelEmbedAndEntityBoost,
 )
 from core_api.pipeline.steps.search.post_filter_results import PostFilterResults
+from core_api.pipeline.steps.search.rerank_results import RerankResults
 from core_api.pipeline.steps.search.resolve_search_profile import ResolveSearchProfile
 from core_api.pipeline.steps.search.retrieval_types import (
     RetrievalPlan,
@@ -26,6 +27,7 @@ __all__ = [
     "LogRecallEvent",
     "ParallelEmbedAndEntityBoost",
     "PostFilterResults",
+    "RerankResults",
     "ResolveSearchProfile",
     "RetrievalPlan",
     "RetrievalStrategy",

--- a/core-api/src/core_api/pipeline/steps/search/rerank_results.py
+++ b/core-api/src/core_api/pipeline/steps/search/rerank_results.py
@@ -5,17 +5,22 @@ Sits between ``ExecuteScoredSearch`` (which produces ``raw_rows``) and
 configured ranker (``RANK_PROVIDER``) and reorders ``raw_rows`` by the new
 scores. This is the ``rerank seam`` from the ranking-component design.
 
-Ships dark: with ``RANK_PROVIDER=noop`` (the default) the ranker returns
-first-stage similarity and the reorder is a stable no-op — zero behaviour
-change until a deployment/tenant opts in. Any failure (misconfig, timeout,
-provider down) returns ``None`` from ``get_ranking`` and this step keeps
-the first-stage order. Recall never fails because rerank did.
+Ships dark two ways: (1) a master kill-switch ``RANK_ENABLED`` (default
+false) skips this step entirely — zero cost, no candidates built, no
+service call — independent of which provider is configured; (2) even when
+enabled, ``RANK_PROVIDER=noop`` (the default provider) is a true identity
+on first-stage order. Turning reranking ON therefore takes both
+``RANK_ENABLED=true`` and a non-noop ``RANK_PROVIDER`` (e.g. ``local``).
+
+Any failure (misconfig, timeout, provider down) returns ``None`` from
+``get_ranking`` and this step keeps the first-stage order. Recall never
+fails because rerank did.
 """
 
 from __future__ import annotations
 
 from common.ranking import RankCandidate, get_ranking
-from common.ranking.constants import RANK_CANDIDATE_LIMIT
+from common.ranking.constants import RANK_CANDIDATE_LIMIT, RANK_ENABLED
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepOutcome, StepResult
 
@@ -26,6 +31,18 @@ class RerankResults:
         return "rerank_results"
 
     async def execute(self, ctx: PipelineContext) -> StepResult | None:
+        # Master kill-switch. Tenant override (``rank_enabled``) wins over the
+        # ``RANK_ENABLED`` env default. Skipping here — rather than relying on
+        # ``RANK_PROVIDER=noop`` — is a true zero-cost bypass: no candidates
+        # built, no service call, no sort. This is the switch to flip reranking
+        # off in an incident without touching provider config.
+        tenant_config = ctx.data.get("tenant_config")
+        enabled = getattr(tenant_config, "rank_enabled", None)
+        if enabled is None:
+            enabled = RANK_ENABLED
+        if not enabled:
+            return StepResult(outcome=StepOutcome.SKIPPED)
+
         plan = ctx.data.get("retrieval_plan")
         # ENTITY_LOOKUP skipped scored-search and populated filtered_rows
         # directly (no raw_rows / no vector scores) — nothing to rerank.
@@ -56,7 +73,7 @@ class RerankResults:
             for r in head
         ]
 
-        scores = await get_ranking(ctx.data["query"], candidates, ctx.data.get("tenant_config"))
+        scores = await get_ranking(ctx.data["query"], candidates, tenant_config)
         if scores is None:
             # Degraded / noop-with-nothing-to-do: keep first-stage order.
             return None

--- a/core-api/src/core_api/pipeline/steps/search/rerank_results.py
+++ b/core-api/src/core_api/pipeline/steps/search/rerank_results.py
@@ -1,0 +1,66 @@
+"""RerankResults — optional second-stage reranking of the candidate pool.
+
+Sits between ``ExecuteScoredSearch`` (which produces ``raw_rows``) and
+``PostFilterResults`` (which floors + trims). Re-scores the pool with the
+configured ranker (``RANK_PROVIDER``) and reorders ``raw_rows`` by the new
+scores. This is the ``rerank seam`` from the ranking-component design.
+
+Ships dark: with ``RANK_PROVIDER=noop`` (the default) the ranker returns
+first-stage similarity and the reorder is a stable no-op — zero behaviour
+change until a deployment/tenant opts in. Any failure (misconfig, timeout,
+provider down) returns ``None`` from ``get_ranking`` and this step keeps
+the first-stage order. Recall never fails because rerank did.
+"""
+
+from __future__ import annotations
+
+from common.ranking import RankCandidate, get_ranking
+from common.ranking.constants import RANK_CANDIDATE_LIMIT
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.step import StepOutcome, StepResult
+
+
+class RerankResults:
+    @property
+    def name(self) -> str:
+        return "rerank_results"
+
+    async def execute(self, ctx: PipelineContext) -> StepResult | None:
+        plan = ctx.data.get("retrieval_plan")
+        # ENTITY_LOOKUP skipped scored-search and populated filtered_rows
+        # directly (no raw_rows / no vector scores) — nothing to rerank.
+        if plan and plan.skip_scored_search:
+            return StepResult(outcome=StepOutcome.SKIPPED)
+
+        rows = ctx.data.get("raw_rows")
+        if not rows:
+            return StepResult(outcome=StepOutcome.SKIPPED)
+
+        # Bound cross-encoder compute / remote payload: re-rank the top
+        # RANK_CANDIDATE_LIMIT by first-stage order; rows past the cap keep
+        # their order, appended after the re-ranked head.
+        head = rows[:RANK_CANDIDATE_LIMIT]
+        tail = rows[RANK_CANDIDATE_LIMIT:]
+
+        candidates = [
+            RankCandidate(
+                id=str(r.Memory.id),
+                content=(getattr(r.Memory, "content", "") or ""),
+                similarity=float(r.similarity) if r.similarity is not None else 0.0,
+                features={
+                    "vec_sim": getattr(r, "vec_sim", None),
+                    "freshness": getattr(r, "freshness", None),
+                    "memory_type": getattr(r.Memory, "memory_type", None),
+                },
+            )
+            for r in head
+        ]
+
+        scores = await get_ranking(ctx.data["query"], candidates, ctx.data.get("tenant_config"))
+        if scores is None:
+            # Degraded / noop-with-nothing-to-do: keep first-stage order.
+            return None
+
+        order = sorted(range(len(head)), key=lambda i: scores[i], reverse=True)
+        ctx.data["raw_rows"] = [head[i] for i in order] + tail
+        return None

--- a/tests/pipeline/test_rerank_results.py
+++ b/tests/pipeline/test_rerank_results.py
@@ -38,7 +38,7 @@ async def test_rerank_reorders_by_ranker_score():
         data={
             "raw_rows": [r_unrelated, r_match],
             "query": "alpha",
-            "tenant_config": SimpleNamespace(rank_provider="fake"),
+            "tenant_config": SimpleNamespace(rank_enabled=True, rank_provider="fake"),
         },
     )
     await RerankResults().execute(ctx)
@@ -47,14 +47,29 @@ async def test_rerank_reorders_by_ranker_score():
 
 
 @pytest.mark.asyncio
+async def test_disabled_by_default_skips():
+    # RANK_ENABLED defaults false → the step is a zero-cost skip even with a
+    # full pool present. This is the ship-dark / kill-switch guarantee.
+    ctx = PipelineContext(data={"raw_rows": [_row("x", 0.5)], "query": "q"})
+    result = await RerankResults().execute(ctx)
+    assert result is not None and result.outcome.name == "SKIPPED"
+
+
+@pytest.mark.asyncio
 async def test_noop_keeps_first_stage_order():
-    # Default provider (noop). Similarity is NOT descending in input order;
-    # a correct noop must still keep the exact first-stage order (ship dark).
+    # Enabled + default provider (noop). Similarity is NOT descending in input
+    # order; a correct noop must still keep the exact first-stage order.
     r0 = _row("x", 0.2)
     r1 = _row("y", 0.9)
     r2 = _row("z", 0.5)
     ctx = PipelineContext(
-        data={"raw_rows": [r0, r1, r2], "query": "q"},  # no tenant_config → noop
+        data={
+            "raw_rows": [r0, r1, r2],
+            "query": "q",
+            "tenant_config": SimpleNamespace(
+                rank_enabled=True
+            ),  # provider defaults noop
+        },
     )
     await RerankResults().execute(ctx)
     assert ctx.data["raw_rows"] == [r0, r1, r2]
@@ -63,13 +78,22 @@ async def test_noop_keeps_first_stage_order():
 @pytest.mark.asyncio
 async def test_skips_on_entity_lookup_plan():
     plan = SimpleNamespace(skip_scored_search=True)
-    ctx = PipelineContext(data={"retrieval_plan": plan, "query": "q"})
+    ctx = PipelineContext(
+        data={
+            "retrieval_plan": plan,
+            "query": "q",
+            "tenant_config": SimpleNamespace(rank_enabled=True),
+        },
+    )
     result = await RerankResults().execute(ctx)
     assert result is not None and result.outcome.name == "SKIPPED"
 
 
 @pytest.mark.asyncio
 async def test_no_raw_rows_is_skipped():
-    ctx = PipelineContext(data={"query": "q"})
+    # Enabled, but no candidate pool (e.g. upstream produced nothing) → skip.
+    ctx = PipelineContext(
+        data={"query": "q", "tenant_config": SimpleNamespace(rank_enabled=True)}
+    )
     result = await RerankResults().execute(ctx)
     assert result is not None and result.outcome.name == "SKIPPED"

--- a/tests/pipeline/test_rerank_results.py
+++ b/tests/pipeline/test_rerank_results.py
@@ -1,0 +1,75 @@
+"""RerankResults pipeline step tests.
+
+Guards the three behaviours that matter: (1) it reorders raw_rows by the
+ranker's scores, (2) the default noop keeps first-stage order exactly
+(ship-dark), and (3) it degrades to first-stage order on the entity-lookup
+skip path / empty pool.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search.rerank_results import RerankResults
+
+
+def _row(content: str, similarity: float):
+    return SimpleNamespace(
+        Memory=SimpleNamespace(id=uuid.uuid4(), content=content, memory_type="fact"),
+        similarity=similarity,
+        vec_sim=similarity,
+        freshness=1.0,
+        score=similarity,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rerank_reorders_by_ranker_score():
+    # First-stage order: unrelated first, "alpha" match last. The fake
+    # ranker scores word overlap with the query, so it must promote the
+    # "alpha" row to the front.
+    r_unrelated = _row("totally unrelated", 0.9)
+    r_match = _row("alpha alpha alpha", 0.1)
+    ctx = PipelineContext(
+        data={
+            "raw_rows": [r_unrelated, r_match],
+            "query": "alpha",
+            "tenant_config": SimpleNamespace(rank_provider="fake"),
+        },
+    )
+    await RerankResults().execute(ctx)
+    assert ctx.data["raw_rows"][0] is r_match
+    assert ctx.data["raw_rows"][1] is r_unrelated
+
+
+@pytest.mark.asyncio
+async def test_noop_keeps_first_stage_order():
+    # Default provider (noop). Similarity is NOT descending in input order;
+    # a correct noop must still keep the exact first-stage order (ship dark).
+    r0 = _row("x", 0.2)
+    r1 = _row("y", 0.9)
+    r2 = _row("z", 0.5)
+    ctx = PipelineContext(
+        data={"raw_rows": [r0, r1, r2], "query": "q"},  # no tenant_config → noop
+    )
+    await RerankResults().execute(ctx)
+    assert ctx.data["raw_rows"] == [r0, r1, r2]
+
+
+@pytest.mark.asyncio
+async def test_skips_on_entity_lookup_plan():
+    plan = SimpleNamespace(skip_scored_search=True)
+    ctx = PipelineContext(data={"retrieval_plan": plan, "query": "q"})
+    result = await RerankResults().execute(ctx)
+    assert result is not None and result.outcome.name == "SKIPPED"
+
+
+@pytest.mark.asyncio
+async def test_no_raw_rows_is_skipped():
+    ctx = PipelineContext(data={"query": "q"})
+    result = await RerankResults().execute(ctx)
+    assert result is not None and result.outcome.name == "SKIPPED"

--- a/tests/test_ranking_component.py
+++ b/tests/test_ranking_component.py
@@ -1,0 +1,94 @@
+"""Unit tests for the pluggable ranking component (common/ranking).
+
+Covers the provider Protocol conformance, the noop true-identity
+contract, the fake provider's overlap signal, and the service's
+degrade-to-first-stage (None) behaviour on empty input, misconfig, and a
+provider that violates the length contract.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from common.ranking import RankCandidate, get_ranking
+from common.ranking.protocols import RankProvider
+from common.ranking.providers.fake import FakeRanker
+from common.ranking.providers.noop import NoopRanker
+
+
+def _cand(cid: str, content: str, similarity: float) -> RankCandidate:
+    return RankCandidate(id=cid, content=content, similarity=similarity)
+
+
+def test_providers_conform_to_protocol():
+    assert isinstance(NoopRanker(), RankProvider)
+    assert isinstance(FakeRanker(), RankProvider)
+
+
+@pytest.mark.asyncio
+async def test_noop_is_true_identity_regardless_of_similarity():
+    # similarity is NOT descending in input order — a naive "return
+    # similarity" noop would reorder these; the true-identity noop must not.
+    cands = [_cand("a", "x", 0.2), _cand("b", "y", 0.9), _cand("c", "z", 0.5)]
+    scores = await NoopRanker().rank("q", cands)
+    # scores strictly decreasing by position → sort(reverse) keeps order
+    assert scores == sorted(scores, reverse=True)
+    assert len(scores) == 3
+
+
+@pytest.mark.asyncio
+async def test_fake_rewards_word_overlap():
+    cands = [
+        _cand("a", "totally unrelated text", 0.5),
+        _cand("b", "alpha matches the query", 0.5),
+    ]
+    scores = await FakeRanker().rank("alpha", cands)
+    assert scores[1] > scores[0]  # overlap with "alpha" scores higher
+
+
+@pytest.mark.asyncio
+async def test_get_ranking_empty_returns_none():
+    assert await get_ranking("q", []) is None
+
+
+@pytest.mark.asyncio
+async def test_get_ranking_defaults_to_noop_identity():
+    # No tenant_config, no RANK_PROVIDER env → noop → strictly descending.
+    cands = [_cand("a", "x", 0.1), _cand("b", "y", 0.9)]
+    scores = await get_ranking("q", cands)
+    assert scores is not None
+    assert scores[0] > scores[1]  # position 0 ranked first (identity)
+
+
+@pytest.mark.asyncio
+async def test_get_ranking_fake_via_tenant_config():
+    tenant = SimpleNamespace(rank_provider="fake")
+    cands = [_cand("a", "nope", 0.5), _cand("b", "alpha", 0.5)]
+    scores = await get_ranking("alpha", cands, tenant)
+    assert scores is not None
+    assert scores[1] > scores[0]
+
+
+@pytest.mark.asyncio
+async def test_get_ranking_unknown_provider_degrades_to_none():
+    tenant = SimpleNamespace(rank_provider="does-not-exist")
+    cands = [_cand("a", "x", 0.5)]
+    assert await get_ranking("q", cands, tenant) is None
+
+
+@pytest.mark.asyncio
+async def test_get_ranking_length_contract_violation_degrades(monkeypatch):
+    class BadRanker:
+        provider_name = "bad"
+        model = "bad"
+
+        async def rank(self, query, candidates):
+            return [0.1]  # wrong length vs 2 candidates
+
+    monkeypatch.setattr(
+        "common.ranking._service.get_rank_provider", lambda name, tc=None: BadRanker()
+    )
+    cands = [_cand("a", "x", 0.5), _cand("b", "y", 0.5)]
+    assert await get_ranking("q", cands, SimpleNamespace(rank_provider="bad")) is None


### PR DESCRIPTION
## What
Adds a **second-stage reranking component** — `common/ranking/` — mirroring the embedding component one-for-one (Protocol / registry / service / providers), selected by `RANK_PROVIDER` exactly like `EMBEDDING_PROVIDER`. A new `RerankResults` pipeline step sits at the **rerank seam** (between `ExecuteScoredSearch` and `PostFilterResults`) and reorders the candidate pool by the ranker's scores.

## Providers
| `RANK_PROVIDER` | backend | notes |
|---|---|---|
| `noop` (default) | identity | true no-op on first-stage order → **ships dark** |
| `local` | in-process `sentence-transformers` CrossEncoder | **MiniLM-L6 (22M)** |
| `fake` | deterministic overlap | tests |
| `remote` | *(reserved)* | future TEI/Cohere-shaped GPU sidecar via `RANK_BASE_URL` |

## Why MiniLM-L6
Grounded in the A50 quality/latency spike (`benchmark/a50_rerank_latency/RESULTS.md`):
- **Quality:** MiniLM-L6 (22M) reranked **≈ bge-reranker-base (278M)** on our data — within 1–4pp hit@k, even beating bge @1.
- **Latency:** MiniLM at small pools ≈ **50–150ms CPU**; bge in-process is **1–5s** (not viable) → the big model belongs behind a future `remote` GPU provider.

## Ships dark
`RANK_PROVIDER=noop` is the default and a **true identity** on first-stage order, so behaviour is unchanged until a deployment/tenant opts in (same guarantee as A49/`score_formula`). Every failure path — misconfig, timeout past `RANK_TIMEOUT_SECONDS`, provider down, length-contract violation — **degrades to first-stage order**. Recall never fails because rerank did. `sentence-transformers` stays lazy-imported (already an optional dep of the local embedder) → **no new hard dependency**.

## Note on `noop`
Unlike the design sketch, `noop` returns position-descending scores (a true identity) rather than `similarity`: first-stage rows are ordered by the composite `score`, not `similarity`, so returning similarity would silently reorder the pool when boosts diverge — not ship-dark.

## Tests
- `tests/test_ranking_component.py` — protocol conformance, noop true-identity, fake overlap, service degrade (empty / misconfig / length-contract violation).
- `tests/pipeline/test_rerank_results.py` — step reorders by ranker score, noop keeps first-stage order, skips on entity-lookup / empty pool.

All logic verified locally (pytest suite's DB fixture runs in CI).

## Follow-ups (not in this PR)
- `remote` provider (GPU bge sidecar).
- A/B `local` MiniLM vs `noop` on the benchmark; validate quality on eToro's corpus/embedder (LongMemEval numbers may not transfer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)