### PR TITLE
fix(core-api): reserved-id guard as a storage-boundary chokepoint + episode-path regression test

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -20,6 +20,30 @@ from core_api.config import settings
 logger = logging.getLogger(__name__)
 
 
+def _reject_reserved_write_id(agent_id: str | None) -> None:
+    """Storage-boundary reserved-id backstop. No-op under ``allow``/``warn``;
+    only under ``reject`` does it raise ``ReservedAgentIdError`` for a reserved
+    id (the service maps it to HTTP 409).
+
+    Gated on ``reject`` on purpose: this runs on the normal service→storage
+    path, and the service layer has *already* called ``enforce_reserved_write_id``
+    (which logs one ``reserved_agent_write`` event under warn/reject). Calling it
+    again here would emit a duplicate log on every write, inflating the counter
+    ops uses to decide when to flip warn→reject. Under ``reject`` the service
+    path 409s before reaching storage, so this only fires for a *direct-storage*
+    caller that skipped the service guard — exactly the bypass we defend against,
+    and the single log/raise there is correct. ``main-<install_id>`` and named
+    ids are never reserved, so they pass.
+    """
+    from core_api.config import settings
+
+    if settings.reserved_agent_id_policy != "reject":
+        return
+    from core_api.services.agent_identity import enforce_reserved_write_id
+
+    enforce_reserved_write_id(agent_id)
+
+
 # Retry policy (F5 + the 2026-06-11 connect-timeout incident) lives in
 # ``common/http_retry.py``, shared with core-worker's storage client:
 # GET/PATCH/DELETE retry the full transient set + retryable 5xx;
@@ -408,6 +432,16 @@ class CoreStorageClient:
     # =====================================================================
 
     async def create_memory(self, data: dict) -> dict:
+        # Defense-in-depth reserved-id chokepoint. The service layer
+        # (memory_service.create_memory / create_memories_bulk) already rejects
+        # bare reserved "main" under policy=reject and is the path every current
+        # caller takes. Re-asserting it here — the single boundary EVERY memory
+        # insert funnels through — guarantees no present or future caller can
+        # persist a bare-"main" firehose row by reaching storage directly,
+        # skipping the service guard. Only exact ALWAYS_RESERVED_AGENT_IDS
+        # ({"main"}) reject; the de-collapsed main-<install_id> form (#507) and
+        # every named id pass untouched.
+        _reject_reserved_write_id(data.get("agent_id"))
         return await self._post("/memories", data)
 
     async def create_memories(self, data: list[dict]) -> list[dict]:
@@ -428,6 +462,9 @@ class CoreStorageClient:
         (concurrent soft-delete or a torn write); the upstream caller
         treats it as a per-item error.
         """
+        # Defense-in-depth reserved-id chokepoint (see create_memory).
+        for item in data:
+            _reject_reserved_write_id(item.get("agent_id"))
         return await self._post("/memories/bulk", data)
 
     async def get_memory(self, memory_id: str) -> dict | None:

--- a/tests/test_api_memories.py
+++ b/tests/test_api_memories.py
@@ -55,6 +55,50 @@ async def test_write_memory(client):
     assert data["memory_type"] == "fact"
 
 
+async def test_reserved_main_episode_rejected_under_reject(client, monkeypatch):
+    """Regression: the episode auto-persist path (POST /memories,
+    memory_type=episode — how the plugin persists user turns) is covered by the
+    reserved-id guard. Under policy=reject a bare-"main" episode is 409'd, while
+    the de-collapsed main-<install_id> form (#507) still writes.
+
+    Guards the eToro "firehose": 353 bare-"main" episodes leaked ONLY during a
+    window when reject was transiently unset (deploy churn) — never a guard
+    bypass. This locks the episode path to the guard so a future refactor can't
+    quietly reopen it.
+    """
+    from core_api.config import settings
+
+    monkeypatch.setattr(settings, "reserved_agent_id_policy", "reject")
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+
+    rejected = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "content": f"firehose episode [{tag}]",
+            "agent_id": "main",
+            "memory_type": "episode",
+        },
+        headers=headers,
+    )
+    assert rejected.status_code == 409, rejected.text
+    assert "reserved" in rejected.text.lower()
+
+    allowed = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "content": f"install-scoped episode [{tag}]",
+            "agent_id": f"main-inst{tag}",
+            "memory_type": "episode",
+        },
+        headers=headers,
+    )
+    assert allowed.status_code == 201, allowed.text
+    assert allowed.json()["agent_id"] == f"main-inst{tag}"
+
+
 async def test_memory_count(client):
     """GET /memories/count returns the active count (F-16). 'count' must resolve
     as a literal route, not be parsed as a {memory_id} UUID (which 422'd)."""

--- a/tests/test_reserved_write_storage_chokepoint.py
+++ b/tests/test_reserved_write_storage_chokepoint.py
@@ -1,0 +1,86 @@
+"""Storage-boundary reserved-id chokepoint — defense-in-depth for the bare-"main"
+firehose guard.
+
+The service layer (``memory_service.create_memory`` / ``create_memories_bulk``)
+already rejects bare reserved ``"main"`` under ``policy=reject``. These tests
+prove the SAME rejection now also holds at ``storage_client.create_memory`` /
+``create_memories`` — the single boundary every memory insert funnels through —
+so no present or future caller can persist a bare-"main" row by reaching storage
+directly and skipping the service guard. The de-collapsed ``main-<install_id>``
+form (#507) and every named id pass untouched.
+
+Hermetic: ``_post`` is stubbed, so nothing touches the network or a DB.
+"""
+
+import pytest
+
+from core_api.clients.storage_client import CoreStorageClient
+from core_api.config import settings
+from core_api.services.agent_identity import ReservedAgentIdError
+
+
+@pytest.fixture
+def policy(monkeypatch):
+    def _set(value: str) -> None:
+        monkeypatch.setattr(settings, "reserved_agent_id_policy", value)
+
+    return _set
+
+
+@pytest.fixture
+def client_no_post(monkeypatch):
+    """Client whose ``_post`` explodes if reached — a rejection test then proves
+    the guard fired BEFORE any storage round-trip."""
+    c = CoreStorageClient()
+
+    async def _boom(*_a, **_k):
+        raise AssertionError("storage _post reached — reserved-id guard did not block")
+
+    monkeypatch.setattr(c, "_post", _boom)
+    return c
+
+
+@pytest.fixture
+def client_ok(monkeypatch):
+    c = CoreStorageClient()
+
+    async def _post(_path, data, *_a, **_k):
+        return {"id": "ok"} if isinstance(data, dict) else [{"id": "ok"} for _ in data]
+
+    monkeypatch.setattr(c, "_post", _post)
+    return c
+
+
+async def test_bare_main_rejected_at_create_memory(policy, client_no_post):
+    policy("reject")
+    with pytest.raises(ReservedAgentIdError):
+        await client_no_post.create_memory(
+            {"agent_id": "main", "content": "x", "memory_type": "episode"}
+        )
+
+
+async def test_bare_main_rejected_at_create_memories_bulk(policy, client_no_post):
+    policy("reject")
+    with pytest.raises(ReservedAgentIdError):
+        await client_no_post.create_memories(
+            [
+                {"agent_id": "brandclaw", "content": "ok"},
+                {"agent_id": "main", "content": "firehose"},  # one bad item blocks the batch
+            ]
+        )
+
+
+@pytest.mark.parametrize("aid", ["main-abc123def456", "brandclaw", "mcp-agent"])
+async def test_decollapsed_and_named_pass_under_reject(policy, client_ok, aid):
+    policy("reject")
+    out = await client_ok.create_memory(
+        {"agent_id": aid, "content": "x", "memory_type": "episode"}
+    )
+    assert out == {"id": "ok"}
+
+
+async def test_warn_does_not_block_at_storage(policy, client_ok):
+    # Matches service semantics: warn logs + proceeds; only reject blocks.
+    policy("warn")
+    out = await client_ok.create_memory({"agent_id": "main", "content": "x"})
+    assert out == {"id": "ok"}


### PR DESCRIPTION
## Context
On eToro on-prem, bare-\`agent_id=\"main\"\` (the reserved firehose identity) episode writes were observed landing **despite \`RESERVED_AGENT_ID_POLICY=reject\`**, suggesting the reserved-id guard (#505) was bypassed by the episode-persist path.

## Investigation — no bypass
Traced **every** persist path at the deployed version: REST \`/memories\` (incl. the plugin's episode auto-persist, \`context-engine.ts\` → \`POST /memories memory_type=episode\`), \`/ingest\`, STM, crystallizer, interviewer — **all funnel through \`memory_service.create_memory\` / \`create_memories_bulk\`, both guarded.** No unguarded writer exists.

The 353 bare-\`main\` episodes leaked **only during a window when \`reject\` was transiently unset** (deploy/cutover churn). They **stopped the moment stable \`reject\` came up** (0 in the following 8h while the guard fired 350–560×/hr). Reproduced on erni: bare-\`main\` episode → **409 under reject**, **201 under warn**; \`main-<install_id>\` → **201** either way. So the guard already covers the episode path — the defect was reject **durability**, not a code bypass (handled separately, on-prem installer).

## This PR — defense-in-depth
Assert the same guard at **\`storage_client.create_memory\` / \`create_memories\`** — the single boundary **every** memory insert crosses — so no present or future caller can persist a bare-\`main\` row by reaching storage directly and skipping the service guard.
- Only exact \`ALWAYS_RESERVED_AGENT_IDS\` (\`{\"main\"}\`) reject.
- De-collapsed \`main-<install_id>\` (#507) and named ids pass untouched.
- Reuses \`enforce_reserved_write_id\` (lazy import; no new log path, no import cycle).

## Tests
- **\`tests/test_reserved_write_storage_chokepoint.py\`** (hermetic, \`_post\` stubbed): bare-\`main\` rejected at \`create_memory\` + \`create_memories\` under reject; \`main-<install_id>\`/named/\`mcp-agent\` pass; \`warn\` does not block.
- **\`tests/test_api_memories.py::test_reserved_main_episode_rejected_under_reject\`** (integration): \`POST /memories memory_type=episode agent_id=\"main\"\` → **409** under reject; \`main-<install_id>\` episode → **201**. Locks the plugin episode path to the guard so a refactor can't quietly reopen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)