### PR TITLE
ci(review): cap review spend with --max-budget-usd

### DIFF
--- a/.github/scripts/claude_pr_review.sh
+++ b/.github/scripts/claude_pr_review.sh
@@ -20,9 +20,34 @@
 #   REVIEW_PROMPT     review instructions + output format
 # Optional env:
 #   MODEL             model id (default: claude-sonnet-4-6)
+#   MAX_BUDGET_USD    per-review spend ceiling, passed to --max-budget-usd (default 10.00)
 set -euo pipefail
 
 MODEL="${MODEL:-claude-sonnet-4-6}"
+
+# A ceiling so one runaway review cannot bill without bound. The reviewer reads the repo
+# across turns to judge a diff, which is what makes it useful and also what makes an
+# unbounded run possible; sibling repos on the org's shared pipeline have billed $6.11 on a
+# two-file diff. The org-membership gate above stops a fork pull request from triggering a
+# review at all, but it does not bound what a member's large pull request costs.
+#
+# A runaway guard, not a budget target. The CLI checks the ceiling BETWEEN turns, so a run
+# can overshoot it by roughly one turn, and on a single hung turn it never fires at all —
+# the job timeout is the only bound there. Sized above observed spend on purpose: the
+# expensive reviews are the ones that find real defects, so capping near the average would
+# truncate exactly the runs worth paying for.
+MAX_BUDGET_USD="${MAX_BUDGET_USD:-10.00}"
+# Shape, then value. Shape does not require a leading digit, so `.50` is accepted the way the
+# CLI accepts it, while `.`, `1.`, `10,00`, `$10`, `-1` and `1e3` are rejected. Value is
+# checked arithmetically rather than with a second pattern: a zero ceiling is accepted by the
+# CLI and makes every review fail on its first turn — which reads as a broken pipeline rather
+# than a bad setting — and spelling "zero" as a regex means enumerating 0, 00, 0.0, .0, 0.00
+# and .00, where the no-leading-digit forms are the easy ones to miss.
+if ! [[ "$MAX_BUDGET_USD" =~ ^[0-9]*\.?[0-9]+$ ]] \
+   || ! awk -v v="$MAX_BUDGET_USD" 'BEGIN { exit !(v + 0 > 0) }'; then
+  echo "::error::MAX_BUDGET_USD must be a positive decimal number, got '${MAX_BUDGET_USD}'" >&2
+  exit 1
+fi
 
 post() { gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$1" >/dev/null; }
 
@@ -41,8 +66,27 @@ Review the PR diff provided on stdin. Review ONLY the changed lines. If after a 
 # No 2>&1: claude's stderr (warnings/progress) must not contaminate the JSON on
 # stdout, or jq would parse garbage and yield an empty review. A non-zero exit is
 # still caught below; stderr goes to the workflow log for debugging.
-RESULT=$(printf '%s' "$DIFF" | claude --print --model "$MODEL" --output-format json "$PROMPT") || {
-  post "⚠️ Claude Code review failed (check workflow logs)."
+RESULT=$(printf '%s' "$DIFF" | claude --print --model "$MODEL" --output-format json \
+  --max-budget-usd "$MAX_BUDGET_USD" \
+  "$PROMPT") || {
+  CLAUDE_EXIT=$?
+  # `VAR=$(cmd)` keeps cmd's stdout even when cmd fails, and claude reports several failures
+  # (auth, quota, and budget exhaustion) there rather than on stderr. This branch used to
+  # discard it and post "check workflow logs" above a log that held nothing — which would have
+  # made a ceiling hit the least diagnosable outcome in the script.
+  echo "Claude exited ${CLAUDE_EXIT}. First 2000 chars of its stdout:" >&2
+  printf '%s\n' "${RESULT:0:2000}" >&2
+  # Budget exhaustion is an EXPECTED outcome carrying a machine-readable marker, and it exits
+  # 1 exactly like a crash, so without this branch the ceiling would surface as a bare exit
+  # code and read as a broken pipeline. `jq -e` rather than `grep -q`: grep stops reading on
+  # match, the upstream printf takes SIGPIPE, and pipefail then turns a MATCH into a non-zero
+  # pipeline. jq drains stdin.
+  if printf '%s' "$RESULT" | jq -e '.subtype == "error_max_budget_usd"' >/dev/null 2>&1; then
+    SPENT=$(printf '%s' "$RESULT" | jq -r '.total_cost_usd // "unknown"' 2>/dev/null || echo unknown)
+    post "⚠️ Claude Code review reached the \$${MAX_BUDGET_USD} spend ceiling after \$${SPENT} without finishing. Split the PR, or raise \`MAX_BUDGET_USD\` on the workflow step."
+    exit 1
+  fi
+  post "⚠️ Claude Code review failed: exit ${CLAUDE_EXIT} (see workflow logs)."
   exit 1
 }
 


### PR DESCRIPTION
This repo's review pipeline ran the CLI with **no spend ceiling**, so one runaway exploration could
bill without bound — and this is the org's one **public** repo, which is where that matters most.
Default is `$10.00` per review.

### Why the membership gate wasn't already enough

It stops a fork pull request from triggering a review at all, which is the right control for *who*
can spend. It does nothing about *how much* a legitimate member's large pull request costs. Sibling
repos on the org's shared pipeline have billed **$6.11 on a two-file diff**. The ceiling is the
missing half of that control, not a replacement for it.

It's a **runaway guard, not a budget target**: the CLI checks it between turns, so a run can overshoot
by about one turn, and on a single hung turn it never fires at all — the job timeout is the only bound
there. Sized above observed spend on purpose, because the expensive reviews are the ones that find
real defects; capping near the average would truncate exactly the runs worth paying for.

### The failure branch had to change with it

Otherwise the ceiling would have been the *least* diagnosable outcome in the script. It discarded the
CLI's stdout and posted "check workflow logs" above a log that held nothing — and budget exhaustion
exits `1` exactly like a crash, so hitting the ceiling would have looked like a broken pipeline.

It now logs the first 2000 chars of stdout (`VAR=$(cmd)` keeps it even when cmd fails, and claude
reports auth, quota and budget failures there rather than on stderr) and branches on the
machine-readable marker to name the ceiling and the spend.

### Verified, not assumed

**Flag support** — `--max-budget-usd` is in `claude --help` on `2.1.159`, the version this workflow
pins in both install steps.

**Validator**, driven through the real script under bash 5.2.21 (what `ubuntu-latest` runs):

```
accept:  10.00  10  .5  2.50
reject:  0  00  0.0  .0  0.00  .00  .  abc  10,00  $10  1.  -1  1e3
```

An empty value takes the `10.00` default — bash `:-` treats unset and empty alike, so that's intended,
not a hole.

**All three runtime paths**, with a stubbed CLI and `gh`:

| scenario | result |
|---|---|
| budget exhausted | posts *"reached the $7.50 spend ceiling after $7.61 without finishing"*, exit 1 |
| ordinary crash | posts the exit code, logs the payload to the job log |
| success | posts the review unchanged — happy path untouched |

(The $7.61-against-$7.50 in that first row is the documented between-turns overshoot, not a bug.)

### Two deliberate non-changes

`jq -e` rather than `grep -q` for the marker: grep stops reading on a match, the upstream `printf`
takes SIGPIPE, and `pipefail` then turns a **match** into a non-zero pipeline.

**No `RESULT=""` declaration**, unlike `caura-ai/.github`. That guard exists there because a CLI smoke
test calls the failure helper before `RESULT` is assigned, and under bash 5.2 `${RESULT:0:2000}` on an
unset variable aborts. Every `$RESULT` reference in this script follows the assignment, so there is
nothing for `nounset` to trip on — I checked rather than copying the fix across.

No workflow change: both invocation sites pass env explicitly, so the script-side default applies.

### What this does not do

It doesn't bring over the rest of the shared pipeline's hardening — `--bare`, the `--tools`
allow-list, the zero-exit `is_error` guard, or the docs-only skip. Those are a separate change, and
this repo can't consume the shared pipeline at all while it is public and `caura-ai/.github` is
private (see #668). This is the one gap worth closing independently of that.
