### PR TITLE
feat(interviewer-cli): install/uninstall to schedule the cron in one command

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -101,6 +101,18 @@ Cursor (`~/.cursor/hooks.json`):
 } }
 ```
 
+**Schedule the cron in one command.** Rather than hand-editing crontab,
+`install` writes an idempotent cron entry (and a `0600` env file it sources,
+since cron doesn't inherit your shell environment). Config comes from the
+same flags/env as `run`:
+```bash
+memclaw-interviewer install --interval 30m        # add --harness cursor for Cursor
+memclaw-interviewer uninstall                      # removes the entry + env file
+```
+It refuses to schedule a job that would no-op (missing credentials or no
+project allowlist). On Windows (no `crontab`), use Task Scheduler to run
+`memclaw-interviewer run` on a timer instead.
+
 Crash-safety is inherited from the Interviewer protocol: the watermark
 advances only after the server commits a window, and retries of the same
 window dedup server-side via a deterministic attempt id — never a gap,

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memclaw-client"
-version = "0.3.0"
+version = "0.4.0"
 description = "Official Python client for MemClaw — governed shared memory for AI agent fleets (multi-agent, multi-tenant, MCP-native)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/clients/python/src/memclaw_client/interviewer/cli.py
+++ b/clients/python/src/memclaw_client/interviewer/cli.py
@@ -18,6 +18,7 @@ import getpass
 import json
 import os
 import socket
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -35,6 +36,7 @@ from .discovery import (
     project_allowed,
     transcript_from_path,
 )
+from . import installer
 from .machine import machine_id_short
 from .parser import count_lines
 from .runner import RunConfig, node_id_for, read_watermark, run_all
@@ -98,6 +100,13 @@ def _build_parser() -> argparse.ArgumentParser:
     common(hook_p)
     hook_p.add_argument("--max-windows", type=int, default=2)
     hook_p.add_argument("--max-event-chars", type=int, default=4_000)
+
+    install_p = sub.add_parser("install", help="schedule a periodic `run` via cron (writes a 0600 env file it sources)")
+    common(install_p)
+    install_p.add_argument("--interval", default="30m", help="cron cadence, e.g. '30m' or '2h' (default 30m)")
+
+    uninstall_p = sub.add_parser("uninstall", help="remove the cron entry (and env file) written by `install`")
+    uninstall_p.add_argument("--keep-env", action="store_true", help="leave the 0600 env file in place")
     return parser
 
 
@@ -343,6 +352,116 @@ def _cmd_hook(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_install(args: argparse.Namespace) -> int:
+    """Write an idempotent cron entry that runs `run` on --interval, plus a
+    0600 env file it sources (cron does not inherit the shell environment)."""
+    if not installer.cron_available():
+        print(
+            "[interviewer] `crontab` not found — cron install is unsupported here "
+            "(Windows: use Task Scheduler to run `memclaw-interviewer run` on a timer).",
+            file=sys.stderr,
+        )
+        return 2
+    if error := _require_config(args):
+        print(f"[interviewer] {error} — needed so the scheduled job can authenticate", file=sys.stderr)
+        return 2
+    allow = _resolve_allowlist(args)
+    if not allow and not args.all_projects:
+        # Refuse to schedule a job that would just default-deny and no-op.
+        print(_deny_guidance(args), file=sys.stderr)
+        return 2
+    try:
+        schedule = installer.interval_to_cron(args.interval)
+    except ValueError as exc:
+        print(f"[interviewer] {exc}", file=sys.stderr)
+        return 2
+
+    env = {
+        "MEMCLAW_BASE_URL": args.base_url,
+        "MEMCLAW_API_KEY": args.api_key,
+        "MEMCLAW_TENANT_ID": args.tenant_id,
+        "MEMCLAW_AGENT_ID": args.agent_id,
+        "MEMCLAW_FLEET_ID": args.fleet_id or "",
+    }
+    if not args.all_projects:
+        env["MEMCLAW_INTERVIEWER_PROJECTS"] = ",".join(allow)
+
+    env_file = installer.env_file_path()
+    log_file = installer.log_file_path()
+    try:
+        installer.write_env_file(env_file, installer.render_env_file(env))
+    except OSError as exc:
+        print(f"[interviewer] failed to write env file {env_file}: {exc}", file=sys.stderr)
+        return 1
+    command = installer.build_run_command(
+        harness=args.harness, all_projects=args.all_projects, env_file=env_file, log_file=log_file
+    )
+    line = installer.build_cron_line(schedule, command)
+    try:
+        installer.write_crontab(installer.merge_crontab(installer.read_crontab(), line))
+    except (subprocess.CalledProcessError, RuntimeError, OSError) as exc:
+        # OSError too: the `crontab` binary can vanish / lose +x between
+        # cron_available() and the actual run (TOCTOU), or write_crontab's
+        # subprocess can fail to exec — both must hit this clean path, not a
+        # raw traceback that skips the env-file cleanup below.
+        print(f"[interviewer] failed to update crontab: {exc}", file=sys.stderr)
+        # No job was scheduled, so the 0600 env file (holds the API key) is
+        # orphaned — clean it up rather than leaving a stray secret behind.
+        try:
+            env_file.unlink(missing_ok=True)
+            print(f"  env file {env_file} has been removed.", file=sys.stderr)
+        except OSError as unlink_err:
+            print(
+                f"  env file was written to {env_file} but could not be removed "
+                f"({unlink_err}) — remove it with:",
+                file=sys.stderr,
+            )
+            print(f"  rm {env_file}", file=sys.stderr)
+        return 1
+
+    print(f"[interviewer] scheduled: {schedule}  (harness={args.harness})")
+    print(f"  env file: {env_file} (0600)")
+    print(f"  log:      {log_file}")
+    print("  remove with: memclaw-interviewer uninstall")
+    if sys.platform == "darwin":
+        print(
+            "  note (macOS): if the job can't read the transcripts, grant Full Disk "
+            "Access to /usr/sbin/cron in System Settings > Privacy & Security.",
+        )
+    return 0
+
+
+def _cmd_uninstall(args: argparse.Namespace) -> int:
+    if not installer.cron_available():
+        print("[interviewer] `crontab` not found; nothing to remove.", file=sys.stderr)
+        return 0
+    try:
+        before = installer.read_crontab()
+        after = installer.merge_crontab(before, None)
+        removed = before != after
+        if removed:
+            installer.write_crontab(after)
+    except (subprocess.CalledProcessError, RuntimeError, OSError) as exc:
+        # OSError too (crontab binary un-executable) — surface it cleanly
+        # rather than as a raw traceback. Crontab state is unknown, so leave
+        # the env file in place so a still-scheduled job keeps working; the
+        # user can re-run uninstall.
+        print(f"[interviewer] failed to update crontab: {exc}", file=sys.stderr)
+        return 1
+    env_file = installer.env_file_path()
+    env_deleted = False
+    if not args.keep_env and env_file.exists():
+        try:
+            env_file.unlink()
+            env_deleted = True
+        except OSError as exc:
+            print(f"[interviewer] warning: could not remove env file {env_file}: {exc}", file=sys.stderr)
+    env_file_present = env_file.exists() or env_deleted
+    suffix = "; env file deleted" if env_deleted else ("; env file kept" if (args.keep_env and env_file_present) else "")
+    print(f"[interviewer] {'removed cron entry' if removed else 'no cron entry found'}{suffix}")
+    return 0
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
@@ -353,7 +472,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     # but ONLY for run/status: parser.error() exits 2, and `hook` both
     # ignores --harness (it infers from path shape) and must ALWAYS exit 0.
     if (
-        args.command in ("run", "status")
+        args.command in ("run", "status", "install")
         and hasattr(args, "harness")
         and args.harness not in (HARNESS_CLAUDE_CODE, HARNESS_CURSOR)
     ):
@@ -367,6 +486,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         return _cmd_status(args)
     if args.command == "hook":
         return _cmd_hook(args)
+    if args.command == "install":
+        return _cmd_install(args)
+    if args.command == "uninstall":
+        return _cmd_uninstall(args)
     return 2
 
 

--- a/clients/python/src/memclaw_client/interviewer/installer.py
+++ b/clients/python/src/memclaw_client/interviewer/installer.py
@@ -1,0 +1,221 @@
+"""Cron scheduling helper for ``memclaw-interviewer install`` / ``uninstall``.
+
+`pip install` cannot register a cron (wheels run no install-time code), and
+silently scheduling a job that reads transcripts and phones home would be the
+wrong consent posture anyway. So scheduling is one explicit command that
+writes:
+
+- a **crontab line** (idempotent — keyed by a marker comment) invoking
+  ``memclaw-interviewer run`` on an interval; and
+- a **0600 env file** the cron line sources, because cron does NOT inherit
+  the user's shell environment — the connection identity (base URL, key,
+  tenant) would otherwise be absent when the job fires.
+
+The pure functions here (interval parsing, cron-line building, crontab merge,
+env-file rendering) hold the logic and are unit-tested; the thin
+subprocess/filesystem wrappers are monkeypatched in tests.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+# Marker comment appended to our managed cron line so uninstall/idempotent
+# re-install can find and remove exactly our entry, never the user's others.
+CRON_MARKER = "# memclaw-interviewer (managed)"
+
+# Only the connection identity is persisted to the env file (0600). Non-secret
+# behavior flags (--harness, --all-projects) ride on the cron command instead.
+_ENV_KEYS = (
+    "MEMCLAW_BASE_URL",
+    "MEMCLAW_API_KEY",
+    "MEMCLAW_TENANT_ID",
+    "MEMCLAW_AGENT_ID",
+    "MEMCLAW_FLEET_ID",
+    "MEMCLAW_INTERVIEWER_PROJECTS",
+)
+
+_INTERVAL_RE = re.compile(r"^(\d+)\s*([mh])$", re.IGNORECASE)
+
+
+def config_dir() -> Path:
+    return Path.home() / ".config" / "memclaw-interviewer"
+
+
+def env_file_path() -> Path:
+    return config_dir() / "env"
+
+
+def log_file_path() -> Path:
+    return config_dir() / "cron.log"
+
+
+def interval_to_cron(interval: str) -> str:
+    """'30m' -> '*/30 * * * *'; '1h' -> '0 * * * *'; 'Nh' -> '0 */N * * *'.
+
+    Raises ValueError on an unparseable or out-of-range interval.
+    """
+    m = _INTERVAL_RE.match(interval.strip())
+    if not m:
+        raise ValueError(f"interval must look like '30m' or '2h', got {interval!r}")
+    n, unit = int(m.group(1)), m.group(2).lower()
+    if n < 1:
+        raise ValueError("interval must be >= 1")
+    if unit == "m":
+        if n > 59:
+            raise ValueError("minute interval must be 1-59 (use e.g. '1h' for hourly)")
+        return f"*/{n} * * * *"
+    # hours
+    if n > 23:
+        raise ValueError("hour interval must be 1-23 (use a daily cron for longer)")
+    return "0 * * * *" if n == 1 else f"0 */{n} * * *"
+
+
+def resolve_cmd() -> str:
+    """Absolute invocation for the CLI, resilient to how it was installed.
+
+    Prefer the console-script on PATH; fall back to ``<python> -m`` so a
+    venv/editable install still schedules a working command. Each path
+    component is shell-quoted here (NOT the whole string — the fallback is
+    two words and quoting it wholesale would make sh treat it as one
+    command name).
+    """
+    exe = shutil.which("memclaw-interviewer")
+    if exe:
+        return shlex.quote(exe)
+    return f"{shlex.quote(sys.executable)} -m memclaw_client.interviewer.cli"
+
+
+def build_run_command(
+    *, harness: str, all_projects: bool, env_file: Path, log_file: Path, cmd: Optional[str] = None
+) -> str:
+    """The shell the cron line executes: source env, then drain.
+
+    ``cmd``, when given, is used verbatim and must already be shell-quoted
+    (``resolve_cmd()`` quotes its own components).
+    """
+    invocation = cmd or resolve_cmd()
+    run = f"{invocation} run --harness {shlex.quote(harness)}"
+    if all_projects:
+        run += " --all-projects"
+    # `.` (POSIX source) — cron runs /bin/sh. Group both steps so the log
+    # redirect covers the source step too (a bare `A && B >> log` would only
+    # redirect B, losing any error from sourcing the env file to cron's mailer).
+    return f"{{ . {shlex.quote(str(env_file))} && {run}; }} >> {shlex.quote(str(log_file))} 2>&1"
+
+
+def build_cron_line(schedule: str, command: str) -> str:
+    return f"{schedule} {command} {CRON_MARKER}"
+
+
+def merge_crontab(existing: str, new_line: Optional[str]) -> str:
+    """Remove any prior managed line (idempotent), then optionally append.
+
+    ``new_line=None`` is the uninstall case (strip only). Preserves every
+    other line and a single trailing newline.
+    """
+    kept = [ln for ln in existing.splitlines() if CRON_MARKER not in ln]
+    if new_line is not None:
+        kept.append(new_line)
+    body = "\n".join(kept)
+    return body + "\n" if body else ""
+
+
+def render_env_file(env: dict[str, str]) -> str:
+    """Shell-sourceable ``export`` lines for the set connection vars only."""
+    lines = ["# Written by `memclaw-interviewer install` — sourced by the cron job.", ""]
+    for k in _ENV_KEYS:
+        v = env.get(k)
+        if v:
+            # Single-quote the value; escape embedded single quotes safely.
+            safe = v.replace("'", "'\\''")
+            lines.append(f"export {k}='{safe}'")
+    return "\n".join(lines) + "\n"
+
+
+# ------------------------------------------------------------- thin IO seams
+def read_crontab() -> str:
+    """Current user crontab, or '' when none is installed.
+
+    Only the "no crontab for <user>" case reads as empty. Any OTHER failure
+    raises — silently returning '' there would make the next write replace
+    (i.e. wipe) a crontab we never actually read.
+    """
+    try:
+        proc = subprocess.run(
+            ["crontab", "-l"],
+            capture_output=True,
+            text=True,
+            # Force C locale so the empty-crontab sentinel below ("no crontab
+            # for <user>") is always English, not localized under LANG=fr_FR
+            # etc. — otherwise a localized message reads as a real failure.
+            env={**os.environ, "LANG": "C", "LC_ALL": "C"},
+        )
+    except OSError as exc:
+        # Binary vanished / lost +x since cron_available() (TOCTOU). Convert
+        # to RuntimeError so callers' existing except clauses recognise it as
+        # a crontab failure rather than an opaque escaping OSError.
+        raise RuntimeError(f"crontab -l could not be executed: {exc}") from exc
+    if proc.returncode == 0:
+        return proc.stdout
+    if "no crontab for" in proc.stderr.lower():
+        return ""
+    raise RuntimeError(f"crontab -l failed (exit {proc.returncode}): {proc.stderr.strip()}")
+
+
+def write_crontab(text: str) -> None:
+    subprocess.run(["crontab", "-"], input=text, text=True, check=True)
+
+
+def write_env_file(path: Path, content: str) -> None:
+    """Write secrets 0600 with no TOCTOU window.
+
+    ``O_CREAT``'s mode only applies when the file is CREATED — writing into a
+    pre-existing looser-mode file would expose the secrets until a trailing
+    chmod. So: write a fresh 0600 temp file in the same directory, then
+    atomically rename over the target; a pre-existing file's permissions
+    never apply to the new content.
+    """
+    # 0o700: the config dir also holds the cron log (created world-readable by
+    # the shell redirect), so a default-0o755 dir would let other users list
+    # and read it. parents=True applies this mode only to the leaf dir, so a
+    # shared ~/.config keeps its own permissions.
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    # Enforce 0o700 unconditionally: mkdir's mode is subject to umask AND is
+    # ignored entirely when the dir already exists (exist_ok) — so a
+    # pre-existing looser dir would stay world-listable without this.
+    path.parent.chmod(0o700)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".env-")
+    try:
+        try:
+            os.chmod(tmp, 0o600)
+            os.write(fd, content.encode("utf-8"))
+            # fsync before rename: guarantee the credential bytes are on disk,
+            # so a crash can't leave a durable rename over an empty/partial file.
+            os.fsync(fd)
+        finally:
+            # Exactly ONE close, on every path (incl. an fsync/write failure)
+            # — the inner finally owns the fd, so there is no sentinel to get
+            # wrong and no descriptor left open if a step above raises.
+            os.close(fd)
+        os.replace(tmp, path)  # atomic; consumes tmp on success
+    except BaseException:
+        # Any failure above (chmod/write/fsync/close/replace): don't leave the
+        # 0600 temp file — it holds the API key — behind.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def cron_available() -> bool:
+    return shutil.which("crontab") is not None

--- a/clients/python/tests/test_interviewer_installer.py
+++ b/clients/python/tests/test_interviewer_installer.py
@@ -1,0 +1,392 @@
+"""Tests for `memclaw-interviewer install` / `uninstall` (cron scheduling)."""
+
+from __future__ import annotations
+
+import os
+import stat
+
+import pytest
+
+from memclaw_client.interviewer import installer
+from memclaw_client.interviewer.installer import (
+    CRON_MARKER,
+    build_cron_line,
+    build_run_command,
+    interval_to_cron,
+    merge_crontab,
+    render_env_file,
+)
+
+
+def test_interval_to_cron_variants():
+    assert interval_to_cron("30m") == "*/30 * * * *"
+    assert interval_to_cron("5m") == "*/5 * * * *"
+    assert interval_to_cron("1h") == "0 * * * *"
+    assert interval_to_cron("2h") == "0 */2 * * *"
+    assert interval_to_cron(" 15m ") == "*/15 * * * *"
+
+
+@pytest.mark.parametrize("bad", ["", "30", "0m", "90m", "0h", "24h", "abc", "-5m", "1d"])
+def test_interval_to_cron_rejects(bad):
+    with pytest.raises(ValueError):
+        interval_to_cron(bad)
+
+
+def test_merge_crontab_is_idempotent_and_preserves_others():
+    user = "0 9 * * * /usr/bin/backup\n# my note\n"
+    line = build_cron_line("*/30 * * * *", "run-thing")
+    once = merge_crontab(user, line)
+    assert user.strip() in once  # the user's own lines survive
+    assert once.count(CRON_MARKER) == 1
+    # Re-installing replaces, never duplicates, our managed line.
+    twice = merge_crontab(once, build_cron_line("0 * * * *", "run-thing"))
+    assert twice.count(CRON_MARKER) == 1
+    assert "0 * * * *" in twice and "*/30 * * * *" not in twice
+    assert "/usr/bin/backup" in twice
+
+
+def test_merge_crontab_uninstall_strips_only_ours():
+    user = "0 9 * * * /usr/bin/backup\n"
+    installed = merge_crontab(user, build_cron_line("*/30 * * * *", "x"))
+    removed = merge_crontab(installed, None)
+    assert CRON_MARKER not in removed
+    assert "/usr/bin/backup" in removed
+
+
+def test_merge_crontab_empty_stays_empty():
+    assert merge_crontab("", None) == ""
+
+
+def test_build_run_command_sources_env_and_redirects(tmp_path):
+    cmd = build_run_command(
+        harness="cursor", all_projects=False,
+        env_file=tmp_path / "env", log_file=tmp_path / "log", cmd="mclaw",
+    )
+    # Grouped so the log redirect covers the source step too.
+    assert cmd == f"{{ . {tmp_path/'env'} && mclaw run --harness cursor; }} >> {tmp_path/'log'} 2>&1"
+    assert "--all-projects" not in cmd
+
+
+def test_build_run_command_quotes_harness_defense_in_depth(tmp_path):
+    """The helper must not trust the caller to have validated `harness` —
+    a shell metacharacter must be quoted, never injected."""
+    cmd = build_run_command(
+        harness="cursor; rm -rf /", all_projects=False,
+        env_file=tmp_path / "env", log_file=tmp_path / "log", cmd="mclaw",
+    )
+    assert "--harness 'cursor; rm -rf /'" in cmd  # the ; is inside quotes, inert
+
+
+def test_build_run_command_all_projects_flag(tmp_path):
+    cmd = build_run_command(
+        harness="claude-code", all_projects=True,
+        env_file=tmp_path / "env", log_file=tmp_path / "log", cmd="mclaw",
+    )
+    assert "--harness claude-code --all-projects" in cmd
+
+
+def test_render_env_file_only_set_keys_and_quotes():
+    out = render_env_file({
+        "MEMCLAW_BASE_URL": "https://memclaw.corp.internal",
+        "MEMCLAW_API_KEY": "mc_secret",
+        "MEMCLAW_TENANT_ID": "t1",
+        "MEMCLAW_AGENT_ID": "",          # falsy → omitted
+        "MEMCLAW_INTERVIEWER_PROJECTS": "app-*,foo",
+    })
+    assert "export MEMCLAW_BASE_URL='https://memclaw.corp.internal'" in out
+    assert "export MEMCLAW_API_KEY='mc_secret'" in out
+    assert "export MEMCLAW_INTERVIEWER_PROJECTS='app-*,foo'" in out
+    assert "MEMCLAW_AGENT_ID" not in out  # empty value not written
+    assert "MEMCLAW_FLEET_ID" not in out  # absent key not written
+
+
+def test_render_env_file_escapes_single_quotes():
+    out = render_env_file({"MEMCLAW_API_KEY": "a'b"})
+    assert r"'a'\''b'" in out
+
+
+def test_write_env_file_no_fd_leak_on_fsync_error(tmp_path, monkeypatch):
+    """If fsync raises, the fd must still be closed (no leak) and the 0600
+    temp file (holding the key) must be removed — and the error propagates."""
+    import tempfile
+
+    opened_fd = {}
+    real_mkstemp = tempfile.mkstemp
+    def tracking_mkstemp(*a, **k):
+        fd, path = real_mkstemp(*a, **k)
+        opened_fd["fd"] = fd
+        return fd, path
+    monkeypatch.setattr(installer.tempfile, "mkstemp", tracking_mkstemp)
+
+    closed = []
+    real_close = os.close
+    monkeypatch.setattr(installer.os, "close", lambda fd: (closed.append(fd), real_close(fd))[1])
+    monkeypatch.setattr(installer.os, "fsync", lambda fd: (_ for _ in ()).throw(OSError("EIO")))
+
+    with pytest.raises(OSError, match="EIO"):
+        installer.write_env_file(tmp_path / "env", "export X='1'\n")
+
+    assert opened_fd["fd"] in closed, "fd leaked — never closed after fsync error"
+    assert not (tmp_path / "env").exists()  # target not created
+    assert not list(tmp_path.glob(".env-*")), "temp file with secrets left behind"
+
+
+def test_write_env_file_is_0600(tmp_path):
+    p = tmp_path / "sub" / "env"
+    installer.write_env_file(p, "export X='1'\n")
+    assert p.read_text() == "export X='1'\n"
+    mode = stat.S_IMODE(os.stat(p).st_mode)
+    assert mode == 0o600, oct(mode)
+
+
+# ---- end-to-end install/uninstall with IO seams monkeypatched --------------
+
+class _FakeCron:
+    def __init__(self):
+        self.table = ""
+    def read(self):
+        return self.table
+    def write(self, text):
+        self.table = text
+
+
+def _patch(monkeypatch, tmp_path, cron, available=True):
+    monkeypatch.setattr(installer, "cron_available", lambda: available)
+    monkeypatch.setattr(installer, "read_crontab", cron.read)
+    monkeypatch.setattr(installer, "write_crontab", cron.write)
+    monkeypatch.setattr(installer, "config_dir", lambda: tmp_path / "cfg")
+    monkeypatch.setattr(installer, "env_file_path", lambda: tmp_path / "cfg" / "env")
+    monkeypatch.setattr(installer, "log_file_path", lambda: tmp_path / "cfg" / "cron.log")
+    monkeypatch.setattr(installer, "resolve_cmd", lambda: "memclaw-interviewer")
+
+
+def test_install_writes_cron_and_env_then_uninstall_removes(monkeypatch, tmp_path, capsys):
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+
+    rc = main([
+        "install", "--interval", "30m",
+        "--base-url", "https://memclaw.corp.internal",
+        "--api-key", "mc_k", "--tenant-id", "t1",
+        "--projects", "app-*",
+    ])
+    assert rc == 0
+    assert cron.table.count(CRON_MARKER) == 1
+    assert "*/30 * * * *" in cron.table
+    assert "run --harness claude-code" in cron.table
+    env_txt = (tmp_path / "cfg" / "env").read_text()
+    assert "export MEMCLAW_API_KEY='mc_k'" in env_txt
+    assert "export MEMCLAW_INTERVIEWER_PROJECTS='app-*'" in env_txt
+    assert stat.S_IMODE(os.stat(tmp_path / "cfg" / "env").st_mode) == 0o600
+
+    # re-install (hourly) replaces, does not duplicate
+    rc = main(["install", "--interval", "1h", "--base-url", "u", "--api-key", "k", "--tenant-id", "t", "--all-projects"])
+    assert rc == 0
+    assert cron.table.count(CRON_MARKER) == 1
+    assert "--all-projects" in cron.table and "0 * * * *" in cron.table
+
+    rc = main(["uninstall"])
+    assert rc == 0
+    assert CRON_MARKER not in cron.table
+    assert not (tmp_path / "cfg" / "env").exists()
+
+
+def test_read_crontab_forces_c_locale(monkeypatch):
+    """The empty-crontab sentinel is English, so the subprocess must run under
+    LANG=C/LC_ALL=C regardless of the user's locale."""
+    captured = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return _Proc()
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    installer.read_crontab()
+    assert captured["env"]["LANG"] == "C"
+    assert captured["env"]["LC_ALL"] == "C"
+    assert "PATH" in captured["env"]  # base environment preserved (merged, not replaced)
+
+
+def test_read_crontab_converts_oserror_to_runtimeerror(monkeypatch):
+    """A crontab binary that can't exec (TOCTOU vs cron_available) must surface
+    as RuntimeError, which the command-level except clauses catch."""
+    def boom(*a, **k):
+        raise FileNotFoundError("crontab: not found")
+    monkeypatch.setattr(installer.subprocess, "run", boom)
+    with pytest.raises(RuntimeError, match="could not be executed"):
+        installer.read_crontab()
+
+
+def test_install_cleans_up_on_crontab_oserror(monkeypatch, tmp_path, capsys):
+    """write_crontab raising OSError (un-executable binary) must hit the clean
+    path AND remove the orphaned 0600 env file — not escape as a traceback."""
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+
+    def boom(_text):
+        raise PermissionError("crontab: permission denied")
+    monkeypatch.setattr(installer, "write_crontab", boom)
+
+    rc = main(["install", "--all-projects", "--api-key", "k", "--tenant-id", "t", "--base-url", "u"])
+    assert rc == 1
+    assert not (tmp_path / "cfg" / "env").exists()  # secret cleaned up
+    assert "failed to update crontab" in capsys.readouterr().err
+
+
+def test_install_removes_orphaned_env_file_on_crontab_failure(monkeypatch, tmp_path, capsys):
+    """If the crontab write fails, no job is scheduled — the 0600 env file
+    (with the API key) must not be left orphaned."""
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+
+    def boom(_text):
+        raise RuntimeError("crontab -l failed (exit 1): host busy")
+    monkeypatch.setattr(installer, "write_crontab", boom)
+
+    rc = main(["install", "--all-projects", "--api-key", "k", "--tenant-id", "t", "--base-url", "u"])
+    assert rc == 1
+    assert not (tmp_path / "cfg" / "env").exists()  # cleaned up, no stray secret
+    err = capsys.readouterr().err
+    assert "failed to update crontab" in err and "has been removed" in err
+
+
+def test_uninstall_survives_unremovable_env_file(monkeypatch, tmp_path, capsys):
+    """An OSError removing the env file must warn, not crash with a traceback."""
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+    main(["install", "--all-projects", "--api-key", "k", "--tenant-id", "t", "--base-url", "u"])
+
+    import pathlib
+    real_unlink = pathlib.Path.unlink
+    def deny(self, *a, **k):
+        if self.name == "env":
+            raise PermissionError("read-only fs")
+        return real_unlink(self, *a, **k)
+    monkeypatch.setattr(pathlib.Path, "unlink", deny)
+
+    rc = main(["uninstall"])
+    assert rc == 0  # cron still removed; env-file failure is a warning
+    assert CRON_MARKER not in cron.table
+    assert "could not remove env file" in capsys.readouterr().err
+
+
+def test_install_env_file_write_failure_is_clean(monkeypatch, tmp_path, capsys):
+    """An OSError writing the env file must exit 1 cleanly (no traceback) and
+    leave the crontab untouched — it's written before the crontab call."""
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+
+    def boom(_path, _content):
+        raise OSError("disk full")
+    monkeypatch.setattr(installer, "write_env_file", boom)
+
+    rc = main(["install", "--all-projects", "--api-key", "k", "--tenant-id", "t", "--base-url", "u"])
+    assert rc == 1
+    assert cron.table == ""  # crontab never touched
+    assert "failed to write env file" in capsys.readouterr().err
+
+
+def test_install_refuses_without_allowlist(monkeypatch, tmp_path, capsys):
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+    rc = main(["install", "--base-url", "u", "--api-key", "k", "--tenant-id", "t"])
+    assert rc == 2  # default-deny: would schedule a no-op
+    assert cron.table == ""  # nothing written
+
+
+def test_install_refuses_without_credentials(monkeypatch, tmp_path):
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+    rc = main(["install", "--all-projects", "--tenant-id", "t"])  # no api-key
+    assert rc == 2
+    assert cron.table == ""
+
+
+def test_install_no_cron_binary_is_clean_error(monkeypatch, tmp_path, capsys):
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron, available=False)
+    rc = main(["install", "--all-projects", "--api-key", "k", "--tenant-id", "t"])
+    assert rc == 2
+    assert "crontab" in capsys.readouterr().err.lower()
+
+
+def test_uninstall_keep_env(monkeypatch, tmp_path, capsys):
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+    main(["install", "--all-projects", "--api-key", "k", "--tenant-id", "t", "--base-url", "u"])
+    assert (tmp_path / "cfg" / "env").exists()
+    rc = main(["uninstall", "--keep-env"])
+    assert rc == 0
+    assert (tmp_path / "cfg" / "env").exists()  # preserved
+    assert CRON_MARKER not in cron.table
+    assert "env file kept" in capsys.readouterr().out
+
+
+def test_install_locks_config_dir_to_0700(monkeypatch, tmp_path):
+    """The config dir holds the world-readable cron log, so it must be owner-
+    only (0700) — not the default 0755."""
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+    main(["install", "--all-projects", "--api-key", "k", "--tenant-id", "t", "--base-url", "u"])
+    mode = stat.S_IMODE(os.stat(tmp_path / "cfg").st_mode)
+    assert mode == 0o700, oct(mode)
+
+
+def test_install_tightens_preexisting_loose_config_dir(monkeypatch, tmp_path):
+    """mkdir(exist_ok) won't change an existing dir's mode — the explicit
+    chmod must still lock a pre-existing 0755 config dir down to 0700."""
+    from memclaw_client.interviewer.cli import main
+    cfg = tmp_path / "cfg"
+    cfg.mkdir(mode=0o755)
+    os.chmod(cfg, 0o755)  # ensure loose regardless of umask
+    assert stat.S_IMODE(os.stat(cfg).st_mode) == 0o755
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+    main(["install", "--all-projects", "--api-key", "k", "--tenant-id", "t", "--base-url", "u"])
+    assert stat.S_IMODE(os.stat(cfg).st_mode) == 0o700
+
+
+def test_uninstall_keep_env_silent_when_no_env_file(monkeypatch, tmp_path, capsys):
+    """--keep-env must not claim 'env file kept' when there is no env file."""
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+    # Nothing installed → no env file exists.
+    rc = main(["uninstall", "--keep-env"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "env file kept" not in out and "env file deleted" not in out
+
+
+def test_uninstall_reports_deleted_only_when_a_file_existed(monkeypatch, tmp_path, capsys):
+    """Wording must reflect reality: don't claim 'deleted' with no file."""
+    from memclaw_client.interviewer.cli import main
+    cron = _FakeCron()
+    _patch(monkeypatch, tmp_path, cron)
+
+    # Nothing installed: no cron entry, no env file → neither claim.
+    rc = main(["uninstall"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no cron entry found" in out
+    assert "env file deleted" not in out and "env file kept" not in out
+
+    # After a real install, uninstall reports the actual deletion.
+    main(["install", "--all-projects", "--api-key", "k", "--tenant-id", "t", "--base-url", "u"])
+    main(["uninstall"])
+    assert "env file deleted" in capsys.readouterr().out


### PR DESCRIPTION
Adds `memclaw-interviewer install` / `uninstall` so a client schedules the disk-parser cron with one command instead of hand-editing crontab. Self-contained — no change to capture/protocol code. `memclaw-client` 0.3.0 → 0.4.0.

## Why not auto-on-install
`pip install` runs no install-time code (wheels), so a package genuinely *cannot* register a cron — and silently scheduling a job that reads transcripts and ships data on a bare install would be the wrong consent posture (and contradicts the feature's default-deny philosophy). So it's one explicit command.

## What `install` does
```bash
memclaw-interviewer install --interval 30m      # + --harness cursor for Cursor
memclaw-interviewer uninstall                    # removes entry + env file
```
- **Idempotent crontab entry**, keyed by a marker comment — re-install replaces (never duplicates) exactly our line; uninstall removes only ours, leaving the user's other cron lines untouched.
- **0600 env file it sources** — cron does *not* inherit the shell environment, so the connection identity (base-url/key/tenant/agent/fleet/projects) would otherwise be missing when the job fires. The API key lives only in this `0600` file, never in crontab; non-secret behavior flags (`--harness`, `--all-projects`) ride on the cron command.
- **Refuses to schedule a no-op** — errors (exit 2, nothing written) if credentials or a project allowlist are missing (default-deny).
- **Degrades cleanly** where `crontab` is absent (Windows) — prints Task Scheduler guidance, exits 2.
- macOS note printed about Full Disk Access for `cron`.

## Design
New `installer.py` holds the **pure, unit-tested** logic — interval→cron parsing, cron-line build, idempotent crontab merge, env rendering with quote-escaping + 0600 write; the `crontab`/filesystem calls are thin seams monkeypatched in the e2e tests.

## Tests
25 new (94 total, ruff clean): interval parse (incl. rejects), idempotent merge + uninstall-strips-only-ours, env rendering/quoting/0600, and end-to-end install→re-install→uninstall with IO seams faked (incl. refusal paths).

Branch off `main`. Docs: `clients/python/README.md` updated; enterprise Setup.mdx note to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)