### PR TITLE
feat(search): org flag to disable query-time entity/graph retrieval

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -90,6 +90,12 @@ class Settings(BaseSettings):
     gemini_api_key: str | None = None
     entity_extraction_provider: str = "openai"  # none | fake | openai | anthropic | openrouter | gemini
     entity_extraction_model: str = "gpt-5.4-nano"
+    # Default for the ``search.entity_retrieval`` org setting: query-time entity
+    # lookup + graph search. A tenant override wins; this is the fleet-wide
+    # fallback so an operator can disable entity/graph reads on a whole box
+    # (env / compose override) without editing every tenant's settings.
+    # Read-side only — the write path keeps building the entity graph.
+    entity_retrieval_enabled: bool = True
     use_llm_for_memory_creation: bool = True
     sentry_dsn: str = ""  # Set to enable Sentry error tracking
     redis_url: str = ""  # e.g. redis://localhost:6379/0. Empty = in-memory fallback.

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -699,6 +699,7 @@ async def memclaw_recall(
             top_k=capped_top_k,
             recall_boost=config.recall_boost,
             graph_expand=config.graph_expand,
+            entity_retrieval=config.entity_retrieval,
             tenant_config=config,
             search_profile=agent_profile,
             readable_tenant_ids=_get_readable_tenants() or None,

--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -72,7 +72,22 @@ class ClassifyQuery:
         graph_max_hops: int = search_params["graph_max_hops"]
         top_k: int = search_params["top_k"]
 
-        tokens = extract_entity_tokens(query)
+        # ``search.entity_retrieval`` org setting (default True — absent key on
+        # any internal caller means "enabled", so behaviour is unchanged). When
+        # off, skip the entity block entirely: no entity FTS, no graph
+        # expansion, and no ENTITY_LOOKUP short-circuit, so the query falls
+        # through to the temporal / recent-context / keyword / semantic cascade
+        # below. ``ParallelEmbedAndEntityBoost`` reads the same flag and skips
+        # hop-boosting, making this the single switch for query-time entity and
+        # graph retrieval. Deliberately independent of ``graph_expand``
+        # (``search.graph_retrieval``), which only bounds expansion depth once
+        # an entity has already matched.
+        entity_retrieval: bool = ctx.data.get("entity_retrieval", True)
+
+        tokens = extract_entity_tokens(query) if entity_retrieval else []
+
+        if not entity_retrieval:
+            logger.info("classify_query: entity retrieval disabled by org setting (tenant=%s)", tenant_id)
 
         if tokens:
             try:

--- a/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
+++ b/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
@@ -177,13 +177,29 @@ class ParallelEmbedAndEntityBoost:
         emb_task = asyncio.ensure_future(
             _get_or_cache_embedding(data["query"], data["tenant_id"], data["tenant_config"])
         )
-        # ClassifyQuery already ran the same tokenizer + entity FTS and
-        # declined the match as over-broad (CAURA-698). Re-deriving it here
-        # would hand GRAPH_HOP_BOOST to an arbitrary GRAPH_MAX_BOOSTED_MEMORIES
-        # subset of the sibling pool, outranking rows the scorer puts first.
+        # Two independent reasons to skip the entity boost entirely:
+        #
+        # 1. ``search.entity_retrieval`` is off for the tenant — the org-level
+        #    switch for query-time entity/graph retrieval. ClassifyQuery already
+        #    skipped its own entity block, so this leaves the read on pure
+        #    keyword/semantic scoring. Default True: an absent key means enabled.
+        # 2. ClassifyQuery ran the same tokenizer + entity FTS and declined the
+        #    match as over-broad (CAURA-698). Re-deriving it here would hand
+        #    GRAPH_HOP_BOOST to an arbitrary GRAPH_MAX_BOOSTED_MEMORIES subset of
+        #    the sibling pool, outranking rows the scorer puts first.
+        #
+        # Kept as distinct log reasons so ops can tell a deliberate org-level
+        # disable from the precision heuristic firing.
+        if not data.get("entity_retrieval", True):
+            ent_skip_reason = "disabled by org setting search.entity_retrieval"
+        elif data.get("entity_match_declined"):
+            ent_skip_reason = "entity match declined as over-broad in classify_query"
+        else:
+            ent_skip_reason = None
+
         ent_task = (
             None
-            if data.get("entity_match_declined")
+            if ent_skip_reason
             else asyncio.ensure_future(
                 _entity_boost_via_storage(
                     data["query"],
@@ -227,8 +243,8 @@ class ParallelEmbedAndEntityBoost:
         try:
             if ent_task is None:
                 logger.info(
-                    "parallel_embed_entity_boost: entity boost skipped "
-                    "(entity match declined as over-broad in classify_query)"
+                    "parallel_embed_entity_boost: entity boost skipped (%s)",
+                    ent_skip_reason,
                 )
                 boosted_memory_ids, memory_boost_factor = set(), {}
             else:

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1466,6 +1466,7 @@ async def _search_inner(
             top_k=body.top_k,
             recall_boost=config.recall_boost,
             graph_expand=config.graph_expand,
+            entity_retrieval=config.entity_retrieval,
             tenant_config=config,
             search_profile=_agent.get("search_profile") if _agent else None,
             readable_tenant_ids=auth.readable_tenant_ids if auth.is_cross_tenant_read else None,
@@ -1699,6 +1700,7 @@ async def recall_endpoint(
         valid_at=body.valid_at,
         recall_boost=config.recall_boost,
         graph_expand=config.graph_expand,
+        entity_retrieval=config.entity_retrieval,
         tenant_config=config,
         readable_tenant_ids=auth.readable_tenant_ids if auth.is_cross_tenant_read else None,
     )

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -3205,6 +3205,7 @@ async def search_memories(
     top_k: int = DEFAULT_SEARCH_TOP_K,
     recall_boost: bool = True,
     graph_expand: bool = True,
+    entity_retrieval: bool = True,
     tenant_config=None,
     search_profile: dict | None = None,
     diagnostic: bool = False,
@@ -3226,6 +3227,7 @@ async def search_memories(
             top_k=top_k,
             recall_boost=recall_boost,
             graph_expand=graph_expand,
+            entity_retrieval=entity_retrieval,
             tenant_config=tenant_config,
             search_profile=search_profile,
             diagnostic=diagnostic,
@@ -3246,6 +3248,7 @@ async def search_memories(
         top_k=top_k,
         recall_boost=recall_boost,
         graph_expand=graph_expand,
+        entity_retrieval=entity_retrieval,
         tenant_config=tenant_config,
         search_profile=search_profile,
     )
@@ -3263,6 +3266,7 @@ async def _search_memories_pipeline(
     top_k: int = DEFAULT_SEARCH_TOP_K,
     recall_boost: bool = True,
     graph_expand: bool = True,
+    entity_retrieval: bool = True,
     tenant_config=None,
     search_profile: dict | None = None,
     diagnostic: bool = False,
@@ -3287,6 +3291,10 @@ async def _search_memories_pipeline(
             "top_k": top_k,
             "recall_boost_enabled": recall_boost,
             "graph_expand": graph_expand,
+            # ``search.entity_retrieval`` — read by ClassifyQuery (skips the
+            # ENTITY_LOOKUP short-circuit) and ParallelEmbedAndEntityBoost
+            # (skips hop-boosting). False ⇒ keyword/semantic reads only.
+            "entity_retrieval": entity_retrieval,
             "tenant_config": tenant_config,
             "search_profile": search_profile,
             "diagnostic": diagnostic,
@@ -3322,6 +3330,15 @@ async def _search_memories_pipeline(
     return ctx.data["results"]
 
 
+async def _no_entity_boost() -> tuple[set[UUID], dict[UUID, float]]:
+    """Neutral stand-in for ``_entity_boost_pipeline`` when entity retrieval is off.
+
+    Returned as a coroutine (rather than short-circuiting the caller) so the
+    legacy path's ``gather`` + cancel-on-error structure stays byte-identical.
+    """
+    return set(), {}
+
+
 async def _search_memories_legacy(
     tenant_id: str,
     query: str,
@@ -3334,6 +3351,7 @@ async def _search_memories_legacy(
     top_k: int = DEFAULT_SEARCH_TOP_K,
     recall_boost: bool = True,
     graph_expand: bool = True,
+    entity_retrieval: bool = True,
     tenant_config=None,
     search_profile: dict | None = None,
 ) -> list[MemoryOut]:
@@ -3357,10 +3375,14 @@ async def _search_memories_legacy(
     # Temporal hint
     temporal_window = _extract_temporal_hint(query)
 
-    # Parallel: embedding + entity pipeline
+    # Parallel: embedding + entity pipeline. ``search.entity_retrieval`` off ⇒
+    # no entity FTS / graph expansion / hop-boost on this path either, so the
+    # deprecated legacy search honours the org switch exactly like the pipeline.
     emb_task = asyncio.ensure_future(_get_or_cache_embedding(query, tenant_id, tenant_config))
     ent_task = asyncio.ensure_future(
         _entity_boost_pipeline(query, tenant_id, fleet_ids, graph_expand, _graph_max_hops)
+        if entity_retrieval
+        else _no_entity_boost()
     )
     try:
         embedding, (boosted_memory_ids, memory_boost_factor) = await asyncio.gather(emb_task, ent_task)

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -93,6 +93,21 @@ DEFAULT_SETTINGS: dict = {
     "search": {
         "recall_boost": None,
         "graph_retrieval": None,
+        # Master switch for query-time entity/graph retrieval. ``False`` blocks
+        # BOTH read entry points: the ``ENTITY_LOOKUP`` short-circuit in
+        # ``ClassifyQuery`` (which skips embedding + scored search entirely) and
+        # the hop-boost in ``ParallelEmbedAndEntityBoost``. Every read then
+        # resolves through the keyword/semantic cascade alone, and no entity FTS
+        # or graph-expansion call is issued at all.
+        #
+        # Supersedes ``graph_retrieval`` and the ``graph_max_hops`` profile knob
+        # — those only bound expansion depth AFTER an entity match, so they
+        # cannot switch entity retrieval off on their own.
+        #
+        # Read-side only: entity extraction, entity linking (see
+        # ``entity_linking.auto_entity_linking_enabled``) and relation inference
+        # keep populating the graph, so flipping this back on needs no backfill.
+        "entity_retrieval": None,
         # Tenant-wide default search profile (A47). Any search_profile knob set
         # here (min_similarity, top_k, freshness_floor, ...) becomes the fallback
         # for EVERY agent in the tenant, filling the gap between a per-agent tuned
@@ -549,6 +564,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "security_audit.alert_score_drop_delta": (int, float),
     "search.recall_boost": bool,
     "search.graph_retrieval": bool,
+    "search.entity_retrieval": bool,
     "crystallizer.auto_crystallize": bool,
     "dedup.semantic_dedup_enabled": bool,
     "lifecycle.lifecycle_automation_enabled": bool,
@@ -871,6 +887,18 @@ class ResolvedConfig:
     def graph_expand(self) -> bool:
         val = self._ts.get("search", {}).get("graph_retrieval")
         return val if val is not None else True
+
+    @property
+    def entity_retrieval(self) -> bool:
+        """Query-time entity lookup + graph search (default ON).
+
+        ``False`` routes every read through keyword/semantic search alone. Falls
+        back to the ``ENTITY_RETRIEVAL_ENABLED`` env default (also ``True``) when
+        the tenant has no override, so the switch can be thrown fleet-wide on an
+        on-prem box without touching per-tenant settings.
+        """
+        val = self._ts.get("search", {}).get("entity_retrieval")
+        return val if val is not None else global_settings.entity_retrieval_enabled
 
     @property
     def default_search_profile(self) -> dict:

--- a/core-api/src/core_api/services/recall_service.py
+++ b/core-api/src/core_api/services/recall_service.py
@@ -276,6 +276,7 @@ async def recall(
         valid_at=valid_at,
         recall_boost=config.recall_boost,
         graph_expand=config.graph_expand,
+        entity_retrieval=config.entity_retrieval,
         tenant_config=config,
         diagnostic=diagnostic,
         diagnostic_ctx=diagnostic_ctx if diagnostic else None,

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -130,6 +130,7 @@ class SmokeTest:
             self.test_min_similarity_filtering,
             self.test_recall,
             self.test_graph_retrieval,
+            self.test_entity_retrieval_flag,
             self.test_list_memories,
             # ── Update paths ──
             self.test_memory_update,
@@ -673,6 +674,157 @@ class SmokeTest:
             found,
             f"got {len(result_ids)} results: {result_ids}, looking for {mem_id}",
         )
+
+    def test_entity_retrieval_flag(self):
+        """search.entity_retrieval=false blocks entity/graph reads; reads still work.
+
+        The inverse of test_graph_retrieval. The fixture memory is reachable ONLY
+        through the entity graph — its content shares no wording with the query and
+        it is linked to a *related* entity, not the queried one — so:
+
+          flag ON  → found (ENTITY_LOOKUP short-circuits, and that path is not
+                     subject to the min_similarity floor)
+          flag OFF → not found by keyword/semantic search alone
+
+        The setting is always restored, including on early return.
+        """
+        # 1. Two entities + a relation between them: query one, link the memory to
+        #    the other, so only graph expansion can bridge the two.
+        queried = f"orbital widget foundry {uuid.uuid4().hex[:6]}"
+        linked = f"zelda pemberton {uuid.uuid4().hex[:6]}"
+        r_q = self.client.post(
+            f"{self.api}/entities/upsert",
+            json={
+                "tenant_id": TENANT,
+                "entity_type": "project",
+                "canonical_name": queried,
+            },
+        )
+        r_l = self.client.post(
+            f"{self.api}/entities/upsert",
+            json={
+                "tenant_id": TENANT,
+                "entity_type": "person",
+                "canonical_name": linked,
+            },
+        )
+        if r_q.status_code != 200 or r_l.status_code != 200:
+            self.check(
+                "Entity flag: create entities",
+                False,
+                f"queried={r_q.status_code} linked={r_l.status_code}",
+            )
+            return
+        queried_id, linked_id = r_q.json()["id"], r_l.json()["id"]
+        self.entity_ids.extend([queried_id, linked_id])
+
+        r_rel = self.client.post(
+            f"{self.api}/relations/upsert",
+            json={
+                "tenant_id": TENANT,
+                "from_entity_id": linked_id,
+                "relation_type": "works_on",
+                "to_entity_id": queried_id,
+            },
+        )
+        self.check(
+            "Entity flag: relation created",
+            r_rel.status_code == 200,
+            f"status={r_rel.status_code}",
+        )
+
+        # 2. Memory linked only to the related entity, worded so nothing in it
+        #    overlaps the query — no lexical or semantic route to this row.
+        flag_fleet = f"entity-flag-{uuid.uuid4().hex[:6]}"
+        tag = uuid.uuid4().hex[:8]
+        r_mem = self.client.post(
+            f"{self.api}/memories",
+            json={
+                "tenant_id": TENANT,
+                "agent_id": AGENT,
+                "fleet_id": flag_fleet,
+                "content": f"Sourdough starter {tag} needs feeding every twelve hours.",
+                "entity_links": [{"entity_id": linked_id, "role": "subject"}],
+            },
+        )
+        if r_mem.status_code not in (200, 201) or not r_mem.json().get("id"):
+            self.check(
+                "Entity flag: write linked memory", False, f"status={r_mem.status_code}"
+            )
+            return
+        mem_id = r_mem.json()["id"]
+        self.memory_ids.append(mem_id)
+
+        def search_queried_entity():
+            return self.client.post(
+                f"{self.api}/search",
+                json={"tenant_id": TENANT, "fleet_ids": [flag_fleet], "query": queried},
+            )
+
+        def set_entity_retrieval(enabled: bool):
+            return self.client.put(
+                f"{self.api}/settings",
+                params={"tenant_id": TENANT},
+                json={"search": {"entity_retrieval": enabled}},
+            )
+
+        try:
+            # 3. Baseline (flag defaults ON): reachable via the graph only.
+            r_on = _retry_until(
+                search_queried_entity,
+                predicate=lambda resp: (
+                    resp.status_code == 200
+                    and isinstance(resp.json(), list)
+                    and mem_id in [m.get("id") for m in resp.json()]
+                ),
+                max_wait=12.0,
+            )
+            on_ids = (
+                [m.get("id") for m in r_on.json()] if r_on.status_code == 200 else []
+            )
+            self.check(
+                "Entity flag ON: graph-only memory found",
+                mem_id in on_ids,
+                f"got {len(on_ids)} results: {on_ids}, looking for {mem_id}",
+            )
+
+            # 4. Flip the flag off and re-run the identical query.
+            r_put = set_entity_retrieval(False)
+            self.check(
+                "Entity flag: PUT search.entity_retrieval=false",
+                r_put.status_code == 200,
+                f"status={r_put.status_code} body={r_put.text[:200]}",
+            )
+            if r_put.status_code != 200:
+                return
+            self.check(
+                "Entity flag: setting reads back as false",
+                r_put.json().get("search", {}).get("entity_retrieval") is False,
+                f"search={r_put.json().get('search')}",
+            )
+
+            # The settings cache is invalidated on write, so no wait is needed.
+            r_off = search_queried_entity()
+            self.check(
+                "Entity flag OFF: search still succeeds",
+                r_off.status_code == 200 and isinstance(r_off.json(), list),
+                f"status={r_off.status_code} body={r_off.text[:200]}",
+            )
+            if r_off.status_code == 200 and isinstance(r_off.json(), list):
+                off_ids = [m.get("id") for m in r_off.json()]
+                self.check(
+                    "Entity flag OFF: graph-only memory NOT returned",
+                    mem_id not in off_ids,
+                    f"got {len(off_ids)} results: {off_ids}, {mem_id} should be absent",
+                )
+        finally:
+            # Restore the default so later tests (and the tenant) are unaffected.
+            r_restore = set_entity_retrieval(True)
+            self.check(
+                "Entity flag: restored to enabled",
+                r_restore.status_code == 200,
+                f"status={r_restore.status_code}",
+            )
 
     def test_memory_update(self):
         """Test PATCH /api/memories/{id}: update content, weight, and verify re-embedding."""

--- a/tests/_mcp_test_helpers.py
+++ b/tests/_mcp_test_helpers.py
@@ -211,7 +211,10 @@ def mcp_env(monkeypatch):
     # monkeypatch.
     async def _stub_resolve_config(tenant_id):
         return SimpleNamespace(
-            require_agent_approval=False, recall_boost=False, graph_expand=False
+            require_agent_approval=False,
+            recall_boost=False,
+            graph_expand=False,
+            entity_retrieval=True,
         )
 
     monkeypatch.setattr(mcp_server, "resolve_config", _stub_resolve_config)

--- a/tests/test_c4_recall_items_alias.py
+++ b/tests/test_c4_recall_items_alias.py
@@ -80,6 +80,7 @@ def _minimal_config(recall_enabled: bool = True) -> SimpleNamespace:
         recall_model="fake-model",
         recall_boost=False,
         graph_expand=False,
+        entity_retrieval=True,
     )
 
 

--- a/tests/test_cross_tenant_audit_surfaces.py
+++ b/tests/test_cross_tenant_audit_surfaces.py
@@ -163,7 +163,7 @@ async def test_memclaw_recall_emits_cross_tenant_audit(
     monkeypatch.setattr(
         mcp_server,
         "resolve_config",
-        AsyncMock(return_value=SimpleNamespace(recall_boost=False, graph_expand=False)),
+        AsyncMock(return_value=SimpleNamespace(recall_boost=False, graph_expand=False, entity_retrieval=True)),
     )
     stub_storage_client(monkeypatch, get_agent=None)
 

--- a/tests/test_entity_retrieval_flag.py
+++ b/tests/test_entity_retrieval_flag.py
@@ -1,0 +1,389 @@
+"""``search.entity_retrieval`` — org switch that blocks query-time entity/graph reads.
+
+Entity retrieval enters the read path at TWO independent points, so a single
+gate is not enough:
+
+1. ``ClassifyQuery`` — entity FTS hit short-circuits to ``ENTITY_LOOKUP`` with
+   ``skip_embedding`` + ``skip_scored_search``, so semantic/keyword scoring
+   never runs at all.
+2. ``ParallelEmbedAndEntityBoost`` — applies ``GRAPH_HOP_BOOST`` on top of the
+   scored-search ranking.
+
+With the flag off, both are bypassed and every read resolves through the
+temporal / recent-context / keyword / semantic cascade alone — with no entity
+FTS or graph-expansion roundtrip issued.
+
+The flag is read-side only: entity extraction and linking keep populating the
+graph, so it is reversible without a backfill. Default is ON (unblocked) at
+every layer — tenant unset ⇒ env default ⇒ ``True`` — and an absent
+``ctx.data`` key means enabled, so internal callers are unaffected.
+
+Pure unit tests, no DB.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from core_api.constants import FTS_WEIGHT_BOOSTED
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search.classify_query import ClassifyQuery
+from core_api.pipeline.steps.search.parallel_embed_entity_boost import (
+    ParallelEmbedAndEntityBoost,
+)
+from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
+from core_api.services.organization_settings import (
+    DEFAULT_SETTINGS,
+    ResolvedConfig,
+    _check_keys,
+    _validate_leaf_types,
+)
+
+# ``asyncio_mode = auto`` (pytest.ini) runs the async tests below; the file also
+# holds sync settings-resolution tests, so the asyncio mark stays off pytestmark.
+pytestmark = [pytest.mark.unit]
+
+_EMBED_PATH = (
+    "core_api.pipeline.steps.search.parallel_embed_entity_boost._get_or_cache_embedding"
+)
+_BOOST_PATH = "core_api.pipeline.steps.search.parallel_embed_entity_boost._entity_boost_via_storage"
+_CLASSIFY_SC_PATH = "core_api.pipeline.steps.search.classify_query.get_storage_client"
+
+_BOOST_LOGGER = "core_api.pipeline.steps.search.parallel_embed_entity_boost"
+_CLASSIFY_LOGGER = "core_api.pipeline.steps.search.classify_query"
+
+_DUMMY_EMBED = [0.1] * 1536
+
+# A query whose tokens WOULD hit the entity index — every classify test below
+# uses it so a passing assertion means the flag suppressed entity retrieval,
+# not that the tokenizer found nothing to look up.
+_ENTITY_QUERY = "What is Comet 0002's launch_date?"
+
+
+def _classify_ctx(*, fts_weight: float = 0.3, **extra) -> PipelineContext:
+    data = {
+        "query": _ENTITY_QUERY,
+        "tenant_id": "t1",
+        "fleet_ids": ["fleet-1"],
+        "search_params": {"graph_max_hops": 2, "top_k": 10, "fts_weight": fts_weight},
+        **extra,
+    }
+    return PipelineContext(data=data)
+
+
+def _boost_ctx(extra: dict | None = None) -> PipelineContext:
+    data = {
+        "query": _ENTITY_QUERY,
+        "tenant_id": "t1",
+        "tenant_config": None,
+        "search_params": {"graph_max_hops": 2},
+        "graph_expand": True,
+        "fleet_ids": ["fleet-1"],
+    }
+    if extra:
+        data.update(extra)
+    return PipelineContext(data=data)
+
+
+def _entity_match_sc() -> AsyncMock:
+    """Storage client whose entity index WOULD short-circuit to ENTITY_LOOKUP."""
+    eid, mid = str(uuid4()), str(uuid4())
+    sc = AsyncMock()
+    sc.fts_search_entities = AsyncMock(return_value=[eid])
+    sc.expand_graph = AsyncMock(return_value={eid: {"hop": 0, "weight": 1.0}})
+    sc.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[{"memory_id": mid, "entity_id": eid, "role": "subject"}]
+    )
+    sc.load_memories_by_ids = AsyncMock(
+        return_value=[
+            {
+                "id": mid,
+                "tenant_id": "t1",
+                "content": "Comet 0002 launch_date is 2026-01-01",
+                "memory_type": "fact",
+            }
+        ]
+    )
+    return sc
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — ClassifyQuery skips the entity block
+# ---------------------------------------------------------------------------
+
+
+async def test_flag_off_routes_entity_query_to_semantic(caplog):
+    """Entity-token query with the flag off → SEMANTIC_SEARCH, zero entity roundtrips."""
+    caplog.set_level(logging.INFO, logger=_CLASSIFY_LOGGER)
+    sc = _entity_match_sc()
+
+    ctx = _classify_ctx(entity_retrieval=False)
+    with patch(_CLASSIFY_SC_PATH, return_value=sc):
+        await ClassifyQuery().execute(ctx)
+
+    plan = ctx.data["retrieval_plan"]
+    assert plan.strategy is RetrievalStrategy.SEMANTIC_SEARCH
+    # The whole point: scoring is NOT skipped, so semantic search actually runs.
+    assert plan.skip_embedding is False
+    assert plan.skip_scored_search is False
+    # No entity/graph work was issued at all.
+    sc.fts_search_entities.assert_not_called()
+    sc.expand_graph.assert_not_called()
+    sc.get_memory_ids_by_entity_ids.assert_not_called()
+    sc.load_memories_by_ids.assert_not_called()
+    # Neither fallthrough marker is left behind for the boost step to consume.
+    assert "filtered_rows" not in ctx.data
+    assert "entity_match_declined" not in ctx.data
+    assert "_classified_entity_hops" not in ctx.data
+    assert any(
+        "entity retrieval disabled by org setting" in r.message for r in caplog.records
+    )
+
+
+async def test_flag_off_routes_specific_query_to_keyword():
+    """Boosted fts_weight with the flag off → KEYWORD_SEARCH, not ENTITY_LOOKUP."""
+    sc = _entity_match_sc()
+
+    ctx = _classify_ctx(fts_weight=FTS_WEIGHT_BOOSTED, entity_retrieval=False)
+    with patch(_CLASSIFY_SC_PATH, return_value=sc):
+        await ClassifyQuery().execute(ctx)
+
+    assert ctx.data["retrieval_plan"].strategy is RetrievalStrategy.KEYWORD_SEARCH
+    sc.fts_search_entities.assert_not_called()
+
+
+async def test_flag_off_preserves_temporal_strategy():
+    """TEMPORAL still wins over the keyword/semantic tail when the flag is off."""
+    sc = _entity_match_sc()
+
+    ctx = _classify_ctx(entity_retrieval=False, temporal_window=timedelta(days=30))
+    with patch(_CLASSIFY_SC_PATH, return_value=sc):
+        await ClassifyQuery().execute(ctx)
+
+    plan = ctx.data["retrieval_plan"]
+    assert plan.strategy is RetrievalStrategy.TEMPORAL
+    assert plan.search_param_overrides["freshness_decay_days"] == 30
+    sc.fts_search_entities.assert_not_called()
+
+
+async def test_flag_off_preserves_recent_context_strategy():
+    """Recency-intent phrasing still routes to RECENT_CONTEXT when the flag is off."""
+    sc = _entity_match_sc()
+
+    ctx = _classify_ctx(entity_retrieval=False)
+    ctx.data["query"] = "what did i decide about Comet 0002 recently"
+    with patch(_CLASSIFY_SC_PATH, return_value=sc):
+        await ClassifyQuery().execute(ctx)
+
+    assert ctx.data["retrieval_plan"].strategy is RetrievalStrategy.RECENT_CONTEXT
+    sc.fts_search_entities.assert_not_called()
+
+
+async def test_flag_on_still_short_circuits_to_entity_lookup():
+    """Explicit True keeps the ENTITY_LOOKUP short-circuit intact."""
+    sc = _entity_match_sc()
+
+    ctx = _classify_ctx(entity_retrieval=True)
+    with patch(_CLASSIFY_SC_PATH, return_value=sc):
+        await ClassifyQuery().execute(ctx)
+
+    plan = ctx.data["retrieval_plan"]
+    assert plan.strategy is RetrievalStrategy.ENTITY_LOOKUP
+    assert plan.skip_embedding is True
+    assert plan.skip_scored_search is True
+    assert len(ctx.data["filtered_rows"]) > 0
+
+
+async def test_absent_key_defaults_to_enabled():
+    """No ``entity_retrieval`` in ctx.data ⇒ enabled (internal callers unaffected)."""
+    sc = _entity_match_sc()
+
+    ctx = _classify_ctx()
+    with patch(_CLASSIFY_SC_PATH, return_value=sc):
+        await ClassifyQuery().execute(ctx)
+
+    assert ctx.data["retrieval_plan"].strategy is RetrievalStrategy.ENTITY_LOOKUP
+    sc.fts_search_entities.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Gate 2 — ParallelEmbedAndEntityBoost skips hop-boosting
+# ---------------------------------------------------------------------------
+
+
+async def test_flag_off_skips_entity_boost(caplog):
+    """Flag off → boost helper never invoked; embedding still on the critical path."""
+    caplog.set_level(logging.INFO, logger=_BOOST_LOGGER)
+
+    async def fast_embed(*args, **kwargs):
+        return _DUMMY_EMBED
+
+    boost_mock = AsyncMock(return_value=({uuid4()}, {uuid4(): 1.3}))
+
+    ctx = _boost_ctx({"entity_retrieval": False})
+    with patch(_EMBED_PATH, side_effect=fast_embed), patch(_BOOST_PATH, boost_mock):
+        await ParallelEmbedAndEntityBoost().execute(ctx)
+
+    boost_mock.assert_not_called()
+    assert ctx.data["embedding"] == _DUMMY_EMBED
+    assert ctx.data["boosted_memory_ids"] == set()
+    assert ctx.data["memory_boost_factor"] == {}
+    assert any(
+        "disabled by org setting search.entity_retrieval" in r.message
+        for r in caplog.records
+    )
+
+
+async def test_flag_off_log_reason_wins_over_decline(caplog):
+    """Flag off + CAURA-698 decline → skipped, and logged as the org disable.
+
+    Both reasons suppress the boost; the log must name the deliberate switch so
+    ops don't misread a configured disable as the precision heuristic firing.
+    """
+    caplog.set_level(logging.INFO, logger=_BOOST_LOGGER)
+
+    async def fast_embed(*args, **kwargs):
+        return _DUMMY_EMBED
+
+    boost_mock = AsyncMock(return_value=(set(), {}))
+
+    ctx = _boost_ctx({"entity_retrieval": False, "entity_match_declined": True})
+    with patch(_EMBED_PATH, side_effect=fast_embed), patch(_BOOST_PATH, boost_mock):
+        await ParallelEmbedAndEntityBoost().execute(ctx)
+
+    boost_mock.assert_not_called()
+    assert any(
+        "disabled by org setting search.entity_retrieval" in r.message
+        for r in caplog.records
+    )
+    assert not any("declined as over-broad" in r.message for r in caplog.records)
+
+
+async def test_flag_on_still_boosts():
+    """Explicit True → prior behaviour intact: boost results flow into ctx.data."""
+    boosted = {uuid4()}
+    factors = {next(iter(boosted)): 1.3}
+
+    async def fast_embed(*args, **kwargs):
+        return _DUMMY_EMBED
+
+    boost_mock = AsyncMock(return_value=(boosted, factors))
+
+    ctx = _boost_ctx({"entity_retrieval": True})
+    with patch(_EMBED_PATH, side_effect=fast_embed), patch(_BOOST_PATH, boost_mock):
+        await ParallelEmbedAndEntityBoost().execute(ctx)
+
+    boost_mock.assert_called_once()
+    assert ctx.data["boosted_memory_ids"] == boosted
+    assert ctx.data["memory_boost_factor"] == factors
+
+
+# ---------------------------------------------------------------------------
+# Gate 3 — the deprecated legacy search path honours the flag too
+# ---------------------------------------------------------------------------
+
+
+async def test_legacy_path_flag_off_skips_entity_boost():
+    """``_search_memories_legacy`` with the flag off never runs the entity pipeline."""
+    from core_api.services import memory_service
+
+    sc = AsyncMock()
+    sc.scored_search = AsyncMock(return_value=[])
+    sc.get_entity_links_for_memories = AsyncMock(return_value={})
+
+    boost_mock = AsyncMock(return_value=({uuid4()}, {uuid4(): 1.3}))
+
+    async def fast_embed(*args, **kwargs):
+        return _DUMMY_EMBED
+
+    with (
+        patch.object(memory_service, "get_storage_client", return_value=sc),
+        patch.object(memory_service, "_get_or_cache_embedding", side_effect=fast_embed),
+        patch.object(memory_service, "_entity_boost_pipeline", boost_mock),
+    ):
+        results = await memory_service._search_memories_legacy(
+            "t1", _ENTITY_QUERY, entity_retrieval=False
+        )
+
+    assert results == []
+    boost_mock.assert_not_called()
+    # No hop-boost payload reaches storage on the disabled path.
+    assert sc.scored_search.call_args[0][0]["boosted_memory_ids"] is None
+
+
+async def test_legacy_path_flag_on_runs_entity_boost():
+    """Default/True on the legacy path keeps the entity boost wired up."""
+    from core_api.services import memory_service
+
+    sc = AsyncMock()
+    sc.scored_search = AsyncMock(return_value=[])
+    sc.get_entity_links_for_memories = AsyncMock(return_value={})
+
+    mid = uuid4()
+    boost_mock = AsyncMock(return_value=({mid}, {mid: 1.3}))
+
+    async def fast_embed(*args, **kwargs):
+        return _DUMMY_EMBED
+
+    with (
+        patch.object(memory_service, "get_storage_client", return_value=sc),
+        patch.object(memory_service, "_get_or_cache_embedding", side_effect=fast_embed),
+        patch.object(memory_service, "_entity_boost_pipeline", boost_mock),
+    ):
+        await memory_service._search_memories_legacy("t1", _ENTITY_QUERY)
+
+    boost_mock.assert_called_once()
+    assert sc.scored_search.call_args[0][0]["boosted_memory_ids"] == {str(mid): 1.3}
+
+
+# ---------------------------------------------------------------------------
+# Org setting — resolution, defaults, validation
+# ---------------------------------------------------------------------------
+
+
+def test_default_is_unblocked():
+    """No tenant override ⇒ entity retrieval stays ON."""
+    assert ResolvedConfig({}).entity_retrieval is True
+    assert ResolvedConfig({"search": {}}).entity_retrieval is True
+    assert DEFAULT_SETTINGS["search"]["entity_retrieval"] is None
+
+
+def test_tenant_override_blocks():
+    assert (
+        ResolvedConfig({"search": {"entity_retrieval": False}}).entity_retrieval
+        is False
+    )
+    assert (
+        ResolvedConfig({"search": {"entity_retrieval": True}}).entity_retrieval is True
+    )
+
+
+def test_env_default_is_the_fallback():
+    """Unset tenant key falls back to ``ENTITY_RETRIEVAL_ENABLED`` (fleet-wide switch)."""
+    with patch(
+        "core_api.services.organization_settings.global_settings.entity_retrieval_enabled",
+        False,
+    ):
+        assert ResolvedConfig({}).entity_retrieval is False
+        # An explicit tenant override still wins over the env default.
+        assert (
+            ResolvedConfig({"search": {"entity_retrieval": True}}).entity_retrieval
+            is True
+        )
+
+
+def test_settings_key_accepted_and_type_checked():
+    payload = {"search": {"entity_retrieval": False}}
+    _check_keys(payload, DEFAULT_SETTINGS)
+    _validate_leaf_types(payload)
+
+    with pytest.raises(ValueError, match="entity_retrieval"):
+        _validate_leaf_types({"search": {"entity_retrieval": "false"}})
+
+    with pytest.raises(ValueError, match="Unknown settings key"):
+        _check_keys({"search": {"entity_retreival": False}}, DEFAULT_SETTINGS)

--- a/tests/test_mcp_recall.py
+++ b/tests/test_mcp_recall.py
@@ -206,6 +206,7 @@ async def test_recall_brief_skipped_when_include_brief_false(mcp_env, monkeypatc
 class _FakeConfig:
     recall_boost = False
     graph_expand = False
+    entity_retrieval = True
 
 
 async def _fake_resolve_config(tenant_id):  # noqa: ARG001

--- a/tests/test_mcp_write.py
+++ b/tests/test_mcp_write.py
@@ -300,7 +300,10 @@ async def test_write_unapproved_agent_blocked(mcp_env, monkeypatch):
     # require_agent_approval a new agent resolves at trust_level 0, so MCP refuses
     # the write with AGENT_NOT_APPROVED and never persists.
     mcp_env["service"]("resolve_config").return_value = SimpleNamespace(
-        require_agent_approval=True, recall_boost=False, graph_expand=False
+        require_agent_approval=True,
+        recall_boost=False,
+        graph_expand=False,
+        entity_retrieval=True,
     )
 
     async def _resolve(
@@ -327,7 +330,10 @@ async def test_write_threads_require_approval_to_resolver(mcp_env, monkeypatch):
     # The tenant's require_agent_approval reaches resolve_write_agent, so a new
     # agent is created at trust 0 when required (the creation half of the gate).
     mcp_env["service"]("resolve_config").return_value = SimpleNamespace(
-        require_agent_approval=True, recall_boost=False, graph_expand=False
+        require_agent_approval=True,
+        recall_boost=False,
+        graph_expand=False,
+        entity_retrieval=True,
     )
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary

Adds **`search.entity_retrieval`** (bool, default `true`) — one org setting that blocks entity lookup and graph search on the read path, so every read resolves through keyword/semantic search alone.

There was no way to turn entity retrieval off. `search.graph_retrieval` only gates graph *expansion* inside `ParallelEmbedAndEntityBoost`, and `ClassifyQuery` never consults it — so the `ENTITY_LOOKUP` short-circuit (which sets `skip_embedding` + `skip_scored_search` and bypasses vector scoring entirely) fired regardless. `graph_max_hops: 0` doesn't help either: the classifier still runs entity FTS, takes hop-0 seeds and short-circuits.

```bash
curl -X PUT "$API/api/v1/settings?tenant_id=$TENANT" -H "X-API-Key: $KEY" \
  -d '{"search": {"entity_retrieval": false}}'
```

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## What changed

Entity retrieval enters the read path at **two independent points**, so a single gate isn't enough. Both are now gated on the same flag:

| File | Gate |
|---|---|
| `pipeline/steps/search/classify_query.py` | **1** — entity block skipped: no entity FTS, no graph expansion, no `ENTITY_LOOKUP` short-circuit. Query falls through to temporal → recent-context → keyword/semantic |
| `pipeline/steps/search/parallel_embed_entity_boost.py` | **2** — no `GRAPH_HOP_BOOST`, with a log reason distinct from the CAURA-698 over-broad decline so ops can tell a deliberate disable from the precision heuristic |
| `services/memory_service.py` | **3** — the deprecated `_search_memories_legacy` path honours it too, so the switch can't be silently a no-op if `_USE_PIPELINE_SEARCH` is ever flipped |
| `services/organization_settings.py` | `DEFAULT_SETTINGS` + `_LEAF_TYPES` + `ResolvedConfig.entity_retrieval` |
| `config.py` | `ENTITY_RETRIEVAL_ENABLED` env default — fleet-wide switch for on-prem without editing every tenant |
| `mcp_server.py`, `routes/memories.py` (×2), `services/recall_service.py` | `entity_retrieval=config.entity_retrieval`, alongside the existing `graph_expand` |

**Defaults are unblocked at every layer** — tenant unset → env default (`true`) → an absent `ctx.data` key means enabled, so internal callers and existing tests are unaffected.

**Read-side only.** Entity extraction, linking (`entity_linking.auto_entity_linking_enabled` is the write-side switch) and relation inference keep building the graph, so re-enabling needs no backfill. Precedence: `entity_retrieval=false` supersedes `graph_retrieval` and `graph_max_hops`, which only bound expansion depth *after* a match.

Gate 3 uses a `_no_entity_boost()` coroutine rather than branching around the `gather`, keeping the legacy path's cancel-on-error structure byte-identical.

## How Has This Been Tested?

```bash
python -m pytest tests -m unit -q          # 2181 passed
python -m pytest tests -m "not integration and not benchmark" -q
ruff check core-api/src/ && ruff format --check core-api/src/
cd core-api && uv run mypy src/            # 189 files, clean
```

- **2181 unit tests pass**; 3665 pass across all non-DB tests. The 5 remaining failures (`tests/test_events/test_factory.py` ×4, `tests/test_no_direct_db_outside_storage.py`) **pre-exist on `main`** — verified by stashing this change and re-running.
- 15 new tests in `tests/test_entity_retrieval_flag.py`: both gates, the legacy path, `TEMPORAL` / `RECENT_CONTEXT` / `KEYWORD` / `SEMANTIC` routing with the flag off, flag-on regression, absent-key default, and settings resolution + env fallback + type validation.
- Six MCP config stubs gained the new attribute (they construct `_FakeConfig` / `SimpleNamespace` configs by hand).
- Smoke: new `test_entity_retrieval_flag` in `scripts/smoke_test.py` — a memory reachable *only* through the graph (content shares no wording with the query; linked to a *related* entity) must be found with the flag on and absent with it off. The setting is restored in a `finally`.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally (pre-existing failures noted above)
- [x] No docs to update — org settings aren't enumerated in `docs/` or `README.md`; the flag is documented inline at its definition
- [x] `CHANGELOG.md` is generated by release-please from the Conventional Commit (`feat(search):`), so no manual entry

## Additional Notes

**Result sets legitimately change for entity queries when the flag is off.** `ENTITY_LOOKUP` bypasses the `min_similarity` floor (`vec_sim` is `None`, so `PostFilterResults` skips). With the flag off those rows pass through the cosine gate like everything else — intended semantics, and what makes the smoke assertion sound.

**Explicit entity APIs are deliberately untouched** — `GET /entities`, `GET /graph`, `memclaw_entity_get`. Those are direct entity fetches, not query-time retrieval. Happy to add a strict mode that closes them too if reviewers want it.

**Unrelated pre-existing bug spotted nearby:** `scripts/smoke_test.py` `test_settings` PUTs `{"graph_expand": False}`, which isn't a valid settings key — `_check_keys` 422s it, so that "Settings PUT: 200" check is failing on every smoke run. Left alone to keep this PR scoped; the fix is the nested `{"search": {"graph_retrieval": false}}` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
