### PR TITLE
feat(search): remote rerank provider (sidecar) + opt-in local build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,14 +122,27 @@ OPENAI_API_KEY=
 # (zero cost — no candidates built, no model call). Set false to disable
 # reranking in an incident without touching provider config.
 # RANK_ENABLED=false
-# Which ranker runs when enabled. Options: noop | local | fake
-#   local = in-process sentence-transformers CrossEncoder (MiniLM). NOTE:
-#   requires torch + sentence-transformers in the core-api image (~+1-2GB)
-#   and loads the model in-process — the first few searches after start
-#   fall back to first-stage order while the model warms.
+# Which ranker runs when enabled. Options: noop | local | remote | fake
+#   local  = in-process sentence-transformers CrossEncoder (MiniLM). Needs torch
+#            + sentence-transformers in the core-api image (~+2GB) — NOT in the
+#            default image; enable via the WITH_RERANK_LOCAL build-arg. For LOCAL
+#            dev just use the overlay (torch has no arm64 TEI image, so in-process
+#            is the only path on Apple Silicon):
+#              docker compose -f docker-compose.yml \
+#                -f docker-compose.rerank-local.yml up --build
+#   remote = HTTP /rerank sidecar (self-hosted TEI reranker, typically GPU bge, or
+#            a Cohere-style endpoint). Keeps torch OUT of core-api — the RECOMMENDED
+#            path for staging/prod, mirroring the TEI embedder sidecar. Set
+#            RANK_BASE_URL below.
 # RANK_PROVIDER=noop
 # Cross-encoder model for RANK_PROVIDER=local (MiniLM ~= bge quality, CPU-viable).
 # RANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+# -- remote provider only --
+# Base URL of the /rerank sidecar (TEI-native contract). Unset = in-process only.
+# RANK_BASE_URL=http://tei-rerank:80
+# Optional bearer token (Cohere / token-gated TEI). Open TEI needs none.
+# RANK_API_KEY=
+# -- tuning (all providers) --
 # Per-call scoring deadline (seconds); over this, degrade to first-stage order.
 # RANK_TIMEOUT_SECONDS=0.5
 # Max candidates re-scored per search; rows past the cap keep first-stage order.

--- a/common/ranking/_registry.py
+++ b/common/ranking/_registry.py
@@ -12,14 +12,18 @@ built fresh.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
+from collections import OrderedDict
 
 from common.provider_names import ProviderName
-from common.ranking.constants import RANK_MODEL
+from common.ranking.constants import RANK_API_KEY, RANK_BASE_URL, RANK_MODEL
 from common.ranking.protocols import RankProvider
 from common.ranking.providers.fake import FakeRanker
 from common.ranking.providers.local import LocalCrossEncoderRanker
 from common.ranking.providers.noop import NoopRanker
+from common.ranking.providers.remote import RemoteRanker
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +32,37 @@ logger = logging.getLogger(__name__)
 # so a per-tenant ``rank_model`` override gets its own cached instance.
 _local_ranker_cache: dict[str, LocalCrossEncoderRanker] = {}
 
+# LRU-bounded cache of RemoteRanker instances keyed on the full client config
+# tuple. Each holds a long-lived httpx pool, so without the cache every search
+# would build a fresh pool + pay a connect to the sidecar. Mirrors the OpenAI
+# embedding-provider cache: ``move_to_end`` on hit, evict-oldest + background
+# ``aclose()`` on overflow so a rotated URL/key doesn't leak its pool.
+_REMOTE_CACHE_MAX = 32
+_remote_ranker_cache: OrderedDict[tuple[str, str, str], RemoteRanker] = OrderedDict()
+_background_tasks: set[asyncio.Task[None]] = set()
+
+
+def _get_or_create_remote_ranker(
+    base_url: str, api_key: str, model: str
+) -> RemoteRanker:
+    key = (base_url, api_key, model)
+    cached = _remote_ranker_cache.get(key)
+    if cached is not None:
+        _remote_ranker_cache.move_to_end(key)
+        return cached
+    ranker = RemoteRanker(base_url=base_url, api_key=api_key, model=model)
+    _remote_ranker_cache[key] = ranker
+    if len(_remote_ranker_cache) > _REMOTE_CACHE_MAX:
+        _, evicted = _remote_ranker_cache.popitem(last=False)
+        try:
+            loop = asyncio.get_running_loop()
+            task = loop.create_task(evicted.aclose())
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
+        except RuntimeError:
+            pass
+    return ranker
+
 
 def get_rank_provider(name: str, tenant_config: object | None = None) -> RankProvider:
     """Construct a rank provider by name.
@@ -35,17 +70,18 @@ def get_rank_provider(name: str, tenant_config: object | None = None) -> RankPro
     Parameters
     ----------
     name:
-        ``"noop"`` (default), ``"local"`` (in-process MiniLM), or
-        ``"fake"`` (tests). ``"remote"`` is reserved for a future HTTP
-        sidecar provider.
+        ``"noop"`` (default), ``"local"`` (in-process MiniLM), ``"remote"``
+        (HTTP ``/rerank`` sidecar), or ``"fake"`` (tests).
     tenant_config:
         Optional ``ResolvedConfig``-shaped object for per-tenant overrides
-        (``rank_model``). Duck-typed via ``getattr`` — may be ``None``.
+        (``rank_model`` / ``rank_base_url`` / ``rank_api_key``). Duck-typed
+        via ``getattr`` — may be ``None``.
 
     Raises
     ------
     ValueError
-        If the provider name is unknown.
+        If the provider name is unknown, or ``remote`` is selected with no
+        base URL configured (RANK_BASE_URL / tenant ``rank_base_url``).
     """
     if name == ProviderName.NONE or name == "noop":
         return NoopRanker()
@@ -53,16 +89,28 @@ def get_rank_provider(name: str, tenant_config: object | None = None) -> RankPro
     if name == ProviderName.FAKE:
         return FakeRanker()
 
+    def _tc(attr: str):
+        return getattr(tenant_config, attr, None) if tenant_config is not None else None
+
     if name == ProviderName.LOCAL:
-        model = (
-            getattr(tenant_config, "rank_model", None)
-            if tenant_config is not None
-            else None
-        ) or RANK_MODEL
+        model = _tc("rank_model") or RANK_MODEL
         cached = _local_ranker_cache.get(model)
         if cached is None:
             cached = LocalCrossEncoderRanker(model_name=model)
             _local_ranker_cache[model] = cached
         return cached
+
+    if name == "remote":
+        base_url = _tc("rank_base_url") or RANK_BASE_URL
+        if not base_url:
+            raise ValueError(
+                "rank provider 'remote' requires a base URL "
+                "(set RANK_BASE_URL or tenant rank_base_url)"
+            )
+        api_key = (
+            _tc("rank_api_key") or RANK_API_KEY or os.environ.get("RANK_API_KEY", "")
+        )
+        model = _tc("rank_model") or RANK_MODEL
+        return _get_or_create_remote_ranker(base_url, api_key, model)
 
     raise ValueError(f"Unknown rank provider: {name}")

--- a/common/ranking/providers/remote.py
+++ b/common/ranking/providers/remote.py
@@ -1,0 +1,99 @@
+"""Remote reranker — HTTP call to a separate ranking service (sidecar).
+
+Mirrors ``OpenAIEmbeddingProvider`` + ``OPENAI_EMBEDDING_BASE_URL``: the model
+lives in its own service (a self-hosted TEI reranker, typically GPU bge, or a
+hosted Cohere-style ``/rerank``) and core-api sends it the query + candidate
+texts over HTTP. This keeps torch out of the core-api image — the deployment
+pattern the stack already uses for the TEI *embedder*.
+
+Contract (TEI-native ``/rerank``, the primary target since the infra runs TEI):
+
+    POST {RANK_BASE_URL}/rerank
+    { "query": "<query>", "texts": ["<candidate 0>", "<candidate 1>", ...] }
+    -> [ {"index": 1, "score": 0.91}, {"index": 0, "score": 0.42}, ... ]
+
+The response is a ranked list of ``{index, score}`` (index = position in the
+input ``texts``). We also accept a Cohere-style wrapper
+(``{"results": [{"index", "relevance_score"}]}``) so a Cohere-compatible
+endpoint drops in without an adapter. Scores are re-projected back to INPUT
+order — the caller (RerankResults) owns the sort.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from common.ranking.constants import RANK_TIMEOUT_SECONDS
+from common.ranking.protocols import RankCandidate
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteRanker:
+    """Reranker backed by a separate HTTP ``/rerank`` service."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str = "",
+        model: str = "",
+        timeout: float = RANK_TIMEOUT_SECONDS,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        headers = {}
+        if api_key:
+            # Bearer for Cohere / token-gated TEI; harmless for open TEI.
+            headers["Authorization"] = f"Bearer {api_key}"
+        # Long-lived pooled client (one rerank call per search). Explicit
+        # limits + timeout so a hung sidecar can't ride httpx's 600s default;
+        # the service layer's wait_for is the hard outer deadline, this is the
+        # transport-level guard.
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            headers=headers,
+            timeout=timeout,
+            limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "remote"
+
+    @property
+    def model(self) -> str:
+        return self._model or "remote"
+
+    async def aclose(self) -> None:
+        """Close the httpx pool cleanly (called on registry cache eviction)."""
+        await self._client.aclose()
+
+    async def rank(self, query: str, candidates: list[RankCandidate]) -> list[float]:
+        if not candidates:
+            return []
+        body: dict = {"query": query, "texts": [c.content for c in candidates]}
+        resp = await self._client.post("/rerank", json=body)
+        resp.raise_for_status()
+        data = resp.json()
+
+        # TEI returns a bare list; Cohere-style wraps it in {"results": [...]}.
+        results = data.get("results", data) if isinstance(data, dict) else data
+        if not isinstance(results, list):
+            raise ValueError(f"rerank response not a list: {type(results).__name__}")
+
+        # Re-project the ranked results back onto the INPUT order. Missing
+        # indices (a partial response) keep 0.0 — the sort then places them
+        # last, which is the safe degradation for a candidate the service
+        # dropped rather than crashing the search.
+        scores = [0.0] * len(candidates)
+        for item in results:
+            idx = item["index"]
+            if not (0 <= idx < len(candidates)):
+                continue
+            score = item.get("score")
+            if score is None:
+                score = item.get("relevance_score")
+            scores[idx] = float(score)
+        return scores

--- a/core-api/Dockerfile
+++ b/core-api/Dockerfile
@@ -53,6 +53,17 @@ RUN EXTRAS="--extra pubsub"; \
       --directory core-api -o /tmp/reqs.txt \
     && uv pip install --system --no-cache -r /tmp/reqs.txt
 
+# Opt-in in-process reranker (RANK_PROVIDER=local). torch + sentence-transformers
+# are ~2GB and deliberately NOT in the frozen lock — installed here only when a
+# build wants the local cross-encoder path (local dev, or a deployment that
+# reranks inside core-api), so the DEFAULT image stays lean and prod-unaffected.
+# Unpinned by design: a dev/opt-in convenience, not a prod-critical pinned dep.
+# Prod should prefer RANK_PROVIDER=remote (a /rerank sidecar) — no torch here.
+ARG WITH_RERANK_LOCAL=0
+RUN if [ "$WITH_RERANK_LOCAL" = "1" ]; then \
+      uv pip install --system --no-cache torch sentence-transformers; \
+    fi
+
 # Stamp the service version into a file the app reads at runtime. Source of
 # truth is pyproject.toml; an optional MEMCLAW_VERSION build-arg (e.g. the
 # release tag) overrides it. Deterministic and independent of installed-

--- a/docker-compose.rerank-local.yml
+++ b/docker-compose.rerank-local.yml
@@ -1,0 +1,27 @@
+# Local dev overlay: run the in-process MiniLM reranker (RANK_PROVIDER=local).
+#
+# The TEI rerank sidecar (the prod path, RANK_PROVIDER=remote) has no arm64
+# image and can't run on an Apple-Silicon Mac — so for LOCAL dev the reranker
+# runs in-process inside core-api instead. This overlay (a) builds core-api
+# with torch + sentence-transformers via the WITH_RERANK_LOCAL build-arg, and
+# (b) turns reranking on. It is the reranker analogue of `--profile embed-local`
+# for embeddings (which can't be a plain profile here because the model runs
+# in-process, not as a separate service, so it needs a build-arg, not a service).
+#
+# Usage (must --build so the build-arg takes effect):
+#   docker compose -f docker-compose.yml -f docker-compose.rerank-local.yml up --build
+#
+# The default `docker compose up` is completely unaffected — no torch, rerank
+# off. First build is slow + large (~2GB torch); the MiniLM weights download
+# from HuggingFace at first search (local machine has egress, unlike the VPC).
+services:
+  core-api:
+    build:
+      args:
+        WITH_RERANK_LOCAL: "1"
+    environment:
+      RANK_ENABLED: "true"
+      RANK_PROVIDER: "local"
+      # Optional overrides:
+      # RANK_MODEL: "cross-encoder/ms-marco-MiniLM-L-6-v2"
+      # RANK_TIMEOUT_SECONDS: "0.5"

--- a/tests/test_ranking_remote.py
+++ b/tests/test_ranking_remote.py
@@ -1,0 +1,125 @@
+"""RemoteRanker + registry tests — HTTP /rerank via httpx.MockTransport.
+
+No network: a MockTransport stands in for the sidecar so we verify the
+request body we send, the response parse (TEI bare-list AND Cohere-wrapped),
+re-projection onto INPUT order, and the registry's remote wiring / no-URL
+guard. This tests the provider CODE against the assumed contract — a real
+TEI wet test still happens at sidecar-deploy time (see PR notes).
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from common.ranking import RankCandidate, get_ranking
+from common.ranking.protocols import RankProvider
+from common.ranking.providers.remote import RemoteRanker
+
+
+def _cands(*contents):
+    return [
+        RankCandidate(id=str(i), content=c, similarity=0.5)
+        for i, c in enumerate(contents)
+    ]
+
+
+def _client_with(handler):
+    """Build a RemoteRanker whose httpx client uses a MockTransport handler."""
+    r = RemoteRanker(base_url="http://sidecar:80", model="test-model")
+    r._client = httpx.AsyncClient(
+        base_url="http://sidecar:80", transport=httpx.MockTransport(handler)
+    )
+    return r
+
+
+def test_remote_conforms_to_protocol():
+    assert isinstance(RemoteRanker(base_url="http://x"), RankProvider)
+
+
+@pytest.mark.asyncio
+async def test_tei_bare_list_response_reprojected_to_input_order():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["body"] = json.loads(request.content)
+        # TEI-native: bare list, ranked (best first), index into input texts.
+        return httpx.Response(
+            200, json=[{"index": 2, "score": 0.9}, {"index": 0, "score": 0.1}]
+        )
+
+    r = _client_with(handler)
+    scores = await r.rank("q", _cands("a", "b", "c"))
+    # request shape
+    assert captured["path"] == "/rerank"
+    assert captured["body"] == {"query": "q", "texts": ["a", "b", "c"]}
+    # scores re-projected to INPUT order: idx0=0.1, idx1=missing→0.0, idx2=0.9
+    assert scores == [0.1, 0.0, 0.9]
+
+
+@pytest.mark.asyncio
+async def test_cohere_wrapped_response_and_relevance_score():
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"index": 0, "relevance_score": 0.8},
+                    {"index": 1, "relevance_score": 0.3},
+                ]
+            },
+        )
+
+    r = _client_with(handler)
+    scores = await r.rank("q", _cands("x", "y"))
+    assert scores == [0.8, 0.3]
+
+
+@pytest.mark.asyncio
+async def test_empty_candidates_short_circuits():
+    r = _client_with(lambda req: httpx.Response(500))  # would error if called
+    assert await r.rank("q", []) == []
+
+
+@pytest.mark.asyncio
+async def test_get_ranking_remote_degrades_on_http_error():
+    # 503 from the sidecar → provider raises → service returns None (keep order).
+    def handler(request):
+        return httpx.Response(503, text="unavailable")
+
+    import common.ranking._service as svc
+
+    r = _client_with(handler)
+    # Force the service to use our mock-backed remote ranker.
+    orig = svc.get_rank_provider
+    svc.get_rank_provider = lambda name, tc=None: r
+    try:
+        out = await get_ranking(
+            "q", _cands("a", "b"), SimpleNamespace(rank_provider="remote")
+        )
+    finally:
+        svc.get_rank_provider = orig
+    assert out is None
+    await r._client.aclose()
+
+
+def test_registry_remote_requires_base_url():
+    from common.ranking._registry import get_rank_provider
+
+    # No RANK_BASE_URL and no tenant override → ValueError (→ service degrades).
+    with pytest.raises(ValueError, match="requires a base URL"):
+        get_rank_provider("remote", SimpleNamespace(rank_base_url=None))
+
+
+def test_registry_remote_builds_with_tenant_base_url():
+    from common.ranking._registry import get_rank_provider
+
+    p = get_rank_provider(
+        "remote", SimpleNamespace(rank_base_url="http://tei:80", rank_model="m")
+    )
+    assert isinstance(p, RemoteRanker)
+    assert p.model == "m"


### PR DESCRIPTION
Completes the reranking component (#669) so it fits **both** deployment shapes behind the same `RANK_PROVIDER` flag — the right tool per environment.

## `remote` provider (staging/prod) — recommended
`common/ranking/providers/remote.py`: HTTP `/rerank` to a **separate sidecar** (self-hosted TEI reranker / GPU bge, or a Cohere-style endpoint). Keeps **torch out of core-api**, mirroring how you already serve the TEI *embedder*.
- TEI-native contract `{query, texts} → [{index, score}]`; also parses the Cohere `{results:[{index, relevance_score}]}` wrapper. Scores re-projected to **input order** (caller sorts).
- Registry LRU-caches the httpx pool per `(base_url, api_key, model)` with background `aclose()` on eviction (mirrors the OpenAI embedding cache). `remote` with no base URL → `ValueError` → service **degrades to first-stage order**.

## `local` build opt-in (local dev)
- `core-api/Dockerfile` gains `WITH_RERANK_LOCAL` (default `0`) that installs `torch + sentence-transformers` **outside the frozen lock** — the **default image stays lean and prod-unaffected**.
- `docker-compose.rerank-local.yml` overlay builds core-api with it + flips `RANK_ENABLED`/`RANK_PROVIDER=local`. The reranker analogue of `--profile embed-local`, needed because **the TEI sidecar has no arm64 image** — so in-process is the only reranker path on Apple Silicon.
  ```
  docker compose -f docker-compose.yml -f docker-compose.rerank-local.yml up --build
  ```

## Net
| Environment | `RANK_PROVIDER` | Model runs |
|---|---|---|
| Local dev (arm64 Mac) | `local` (via overlay) | in-process in core-api |
| Staging / prod | `remote` | `/rerank` sidecar, core-api lean |

Same pipeline step, same `RANK_ENABLED` kill-switch — just the right backend per env. All still **dark by default**.

## Tests
`tests/test_ranking_remote.py` (httpx `MockTransport`): request shape, TEI + Cohere response parsing, input-order re-projection, empty short-circuit, HTTP-error degrade, registry no-URL guard. **Additionally wet-tested against a real stdlib `/rerank` server** (real httpx round-trip → correct reorder). `.env.example` documents both providers + the overlay.

## Follow-ups (not in this PR)
- Enterprise: stand up a TEI **rerank sidecar** on staging (mirror `staging-memclaw-tei`), set `RANK_BASE_URL`+`RANK_ENABLED`+`RANK_PROVIDER=remote` in core-api Helm — then the **real-TEI wet test** (the one thing MockTransport/stdlib can't cover) runs against live infra.
- A/B `remote`/`local` vs `noop` on the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)