### PR TITLE
feat(insights): filter input noise — opaque payloads, title-dedup, discover window

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1849,8 +1849,18 @@ class CoreStorageClient:
         )
 
     async def insights_query_failures(
-        self, *, tenant_id: str, fleet_id: str | None, agent_id: str, scope: str, max_memories: int
+        self,
+        *,
+        tenant_id: str,
+        fleet_id: str | None,
+        agent_id: str,
+        scope: str,
+        max_memories: int,
+        window_start: datetime | None = None,
     ) -> list[dict]:
+        """``window_start`` bounds the title-dedup scan (see
+        ``INSIGHTS_FAILURES_WINDOW_DAYS``); ``None`` keeps the legacy
+        unbounded read."""
         return await self._post(  # type: ignore[return-value]
             "/insights/failures",
             {
@@ -1859,6 +1869,7 @@ class CoreStorageClient:
                 "agent_id": agent_id,
                 "scope": scope,
                 "max_memories": max_memories,
+                "window_start": window_start.isoformat() if window_start else None,
             },
             read=True,
         )
@@ -1873,7 +1884,12 @@ class CoreStorageClient:
         thirty_days_ago: datetime,
         fourteen_days_ago: datetime,
         max_memories: int,
+        window_start: datetime | None = None,
     ) -> list[dict]:
+        """``window_start`` bounds the title-dedup scan (see
+        ``INSIGHTS_STALE_WINDOW_DAYS`` — wider than the 30-day age threshold
+        rows must exceed to qualify); ``None`` keeps the legacy unbounded
+        read."""
         return await self._post(  # type: ignore[return-value]
             "/insights/stale",
             {
@@ -1884,6 +1900,7 @@ class CoreStorageClient:
                 "thirty_days_ago": thirty_days_ago.isoformat(),
                 "fourteen_days_ago": fourteen_days_ago.isoformat(),
                 "max_memories": max_memories,
+                "window_start": window_start.isoformat() if window_start else None,
             },
             read=True,
         )
@@ -1904,8 +1921,18 @@ class CoreStorageClient:
         )
 
     async def insights_query_patterns(
-        self, *, tenant_id: str, fleet_id: str | None, agent_id: str, scope: str, max_memories: int
+        self,
+        *,
+        tenant_id: str,
+        fleet_id: str | None,
+        agent_id: str,
+        scope: str,
+        max_memories: int,
+        window_start: datetime | None = None,
     ) -> list[dict]:
+        """``window_start`` bounds the title-dedup scan to a trailing window
+        (see ``INSIGHTS_PATTERNS_WINDOW_DAYS``); ``None`` keeps the legacy
+        unbounded read."""
         return await self._post(  # type: ignore[return-value]
             "/insights/patterns",
             {
@@ -1914,14 +1941,25 @@ class CoreStorageClient:
                 "agent_id": agent_id,
                 "scope": scope,
                 "max_memories": max_memories,
+                "window_start": window_start.isoformat() if window_start else None,
             },
             read=True,
         )
 
     async def insights_discover_sample(
-        self, *, tenant_id: str, fleet_id: str | None, agent_id: str, scope: str, sample_size: int
+        self,
+        *,
+        tenant_id: str,
+        fleet_id: str | None,
+        agent_id: str,
+        scope: str,
+        sample_size: int,
+        window_start: datetime | None = None,
     ) -> list[dict]:
-        """Sample active memories WITH embeddings for client-side k-means."""
+        """Sample active memories WITH embeddings for client-side k-means.
+
+        ``window_start`` bounds + spreads the draw over a trailing window
+        (see the storage router); ``None`` keeps the legacy newest-first."""
         return await self._post(  # type: ignore[return-value]
             "/insights/discover-sample",
             {
@@ -1930,6 +1968,7 @@ class CoreStorageClient:
                 "agent_id": agent_id,
                 "scope": scope,
                 "sample_size": sample_size,
+                "window_start": window_start.isoformat() if window_start else None,
             },
             read=True,
         )

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -563,7 +563,29 @@ MEMORY_RECALL_SUMMARY_MAX_TOKENS = 500
 INSIGHTS_MAX_MEMORIES = 50  # max memories per analysis pass (token budget ~10k)
 INSIGHTS_TEMPERATURE = 0.3  # analytical, not creative
 INSIGHTS_DISCOVER_SAMPLE_SIZE = 200  # memories to sample for vector clustering
+# Trailing window the discover sample is spread over. Without it the sample is
+# "newest N", which on a busy tenant spans hours — discover then clusters
+# yesterday's activity instead of the corpus, and consecutive nightly runs
+# re-find the same shapes in near-identical slices.
+INSIGHTS_DISCOVER_WINDOW_DAYS = 30
 INSIGHTS_DISCOVER_CLUSTERS = 6  # k-means cluster count for discover mode
+# Trailing window for the patterns read. Semantically aligned with the mode
+# (the prompt analyzes "recent" memories) — but primarily a cost bound: the
+# title-dedup subquery computes window functions over every row matching the
+# filters, so an unbounded patterns read would scan the tenant's whole active
+# history to return 50 deduped rows (pre-dedup it early-terminated on the
+# (tenant_id, created_at DESC) index). Separate from the discover window so
+# the two modes stay independently tunable.
+INSIGHTS_PATTERNS_WINDOW_DAYS = 30
+# Same cost bound for the failures and stale reads (their weight/recall
+# predicates prune less and less as the corpus grows; the dedup subquery has
+# no inner LIMIT). 90 days — deliberately wider than the stale mode's own
+# 30/14-day age thresholds, which rows must EXCEED to qualify: stale now
+# surfaces the 30-90-day "recently became stale" band instead of perpetually
+# re-reporting the same ancient tail (which is the archive-stale lifecycle
+# job's business, not nightly reporting's).
+INSIGHTS_FAILURES_WINDOW_DAYS = 90
+INSIGHTS_STALE_WINDOW_DAYS = 90
 INSIGHTS_FOCUS_MODES = ("contradictions", "failures", "stale", "divergence", "patterns", "discover")
 
 # Shared scope enum used by memclaw_list, memclaw_insights, memclaw_evolve and

--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -17,8 +17,12 @@ from core_api.clients.storage_client import get_storage_client
 from core_api.constants import (
     INSIGHTS_DISCOVER_CLUSTERS,
     INSIGHTS_DISCOVER_SAMPLE_SIZE,
+    INSIGHTS_DISCOVER_WINDOW_DAYS,
+    INSIGHTS_FAILURES_WINDOW_DAYS,
     INSIGHTS_FOCUS_MODES,
     INSIGHTS_MAX_MEMORIES,
+    INSIGHTS_PATTERNS_WINDOW_DAYS,
+    INSIGHTS_STALE_WINDOW_DAYS,
     INSIGHTS_TEMPERATURE,
 )
 from core_api.utils.sanitize import sanitize_content as _sanitize_content
@@ -286,7 +290,11 @@ async def _query_contradictions(tenant_id, fleet_id, agent_id, scope) -> list[di
 
 
 async def _query_failures(tenant_id, fleet_id, agent_id, scope) -> list[dict]:
-    """Fetch low-weight memories that were recalled (agents acted on weak info)."""
+    """Fetch low-weight memories that were recalled (agents acted on weak info).
+
+    ``window_start`` bounds the title-dedup scan — see
+    ``INSIGHTS_FAILURES_WINDOW_DAYS``.
+    """
     _scope_filters(tenant_id, fleet_id, agent_id, scope)
     sc = get_storage_client()
     return await sc.insights_query_failures(
@@ -295,6 +303,7 @@ async def _query_failures(tenant_id, fleet_id, agent_id, scope) -> list[dict]:
         agent_id=agent_id,
         scope=scope,
         max_memories=INSIGHTS_MAX_MEMORIES,
+        window_start=datetime.now(UTC) - timedelta(days=INSIGHTS_FAILURES_WINDOW_DAYS),
     )
 
 
@@ -302,6 +311,9 @@ async def _query_stale(tenant_id, fleet_id, agent_id, scope) -> list[dict]:
     """Fetch memories that are likely outdated based on age and recall activity."""
     _scope_filters(tenant_id, fleet_id, agent_id, scope)
     # Age thresholds computed on the caller's clock and bound server-side.
+    # The window (INSIGHTS_STALE_WINDOW_DAYS) is deliberately wider than the
+    # 30-day age threshold rows must exceed to qualify — stale reports the
+    # 30-to-window-days "recently became stale" band.
     now = datetime.now(UTC)
     thirty_days_ago = now - timedelta(days=30)
     fourteen_days_ago = now - timedelta(days=14)
@@ -314,6 +326,7 @@ async def _query_stale(tenant_id, fleet_id, agent_id, scope) -> list[dict]:
         thirty_days_ago=thirty_days_ago,
         fourteen_days_ago=fourteen_days_ago,
         max_memories=INSIGHTS_MAX_MEMORIES,
+        window_start=now - timedelta(days=INSIGHTS_STALE_WINDOW_DAYS),
     )
 
 
@@ -331,7 +344,11 @@ async def _query_divergence(tenant_id, fleet_id, agent_id, scope) -> list[dict]:
 
 
 async def _query_patterns(tenant_id, fleet_id, agent_id, scope) -> list[dict]:
-    """Fetch recent active memories for trend/pattern analysis."""
+    """Fetch recent active memories for trend/pattern analysis.
+
+    ``window_start`` (caller's clock, like the stale thresholds) bounds the
+    title-dedup scan — see ``INSIGHTS_PATTERNS_WINDOW_DAYS``.
+    """
     _scope_filters(tenant_id, fleet_id, agent_id, scope)
     sc = get_storage_client()
     return await sc.insights_query_patterns(
@@ -340,6 +357,7 @@ async def _query_patterns(tenant_id, fleet_id, agent_id, scope) -> list[dict]:
         agent_id=agent_id,
         scope=scope,
         max_memories=INSIGHTS_MAX_MEMORIES,
+        window_start=datetime.now(UTC) - timedelta(days=INSIGHTS_PATTERNS_WINDOW_DAYS),
     )
 
 
@@ -390,13 +408,16 @@ async def _query_discover(tenant_id, fleet_id, agent_id, scope) -> _DiscoverResu
     sc = get_storage_client()
     # ``rows`` are plain dicts (``_insights_rows_to_dicts(..., include_embedding=True)``)
     # — already the ``_rows_to_dicts`` shape the formatter consumes, with the
-    # raw embedding vector for clustering.
+    # raw embedding vector for clustering. ``window_start`` (caller's clock,
+    # mirroring the stale thresholds) spreads the draw over the trailing
+    # window instead of "newest N" — see ``INSIGHTS_DISCOVER_WINDOW_DAYS``.
     rows = await sc.insights_discover_sample(
         tenant_id=tenant_id,
         fleet_id=fleet_id,
         agent_id=agent_id,
         scope=scope,
         sample_size=INSIGHTS_DISCOVER_SAMPLE_SIZE,
+        window_start=datetime.now(UTC) - timedelta(days=INSIGHTS_DISCOVER_WINDOW_DAYS),
     )
 
     def _strip_embeddings(dicts: list[dict]) -> list[dict]:
@@ -506,6 +527,19 @@ def _format_memories_for_analysis(memories: list[dict]) -> tuple[str, set[str]]:
         meta_parts.append(f"[agent: {_sanitize_content(m.get('agent_id', '?'), max_len=100)}]")
         if m.get("recall_count", 0) > 0:
             meta_parts.append(f"[recalls: {m['recall_count']}]")
+        # Title-dedup annotation (storage collapses repeated exact titles to
+        # one exemplar): keep the frequency-and-duration signal the dropped
+        # copies carried, at 1/Nth of the token cost. ``first_seen`` is the
+        # oldest occurrence among the rows the QUERY considered (windowed for
+        # some modes, unbounded legacy for others) — the label is kept
+        # neutral so it doesn't overclaim either global history or a window.
+        if m.get("dup_count", 1) > 1:
+            first_seen = (m.get("first_seen") or "")[:10]
+            meta_parts.append(
+                f"[repeats: {m['dup_count']}x, first seen: {first_seen}]"
+                if first_seen
+                else f"[repeats: {m['dup_count']}x]"
+            )
         if m.get("supersedes_id"):
             meta_parts.append(f"[supersedes: {m['supersedes_id']}]")
         meta = " ".join(meta_parts)
@@ -534,7 +568,8 @@ def _format_clusters_for_analysis(clusters: list[dict]) -> tuple[str, set[str]]:
         for r in c.get("representatives", []):
             title = _sanitize_content(r.get("title", "untitled"), max_len=120)
             content = _sanitize_content(r.get("content", ""), max_len=200)
-            lines.append(f"    - (id:{r['id']}) [{r.get('memory_type', 'fact')}] {title}: {content}")
+            repeats = f" [repeats: {r['dup_count']}x]" if r.get("dup_count", 1) > 1 else ""
+            lines.append(f"    - (id:{r['id']}) [{r.get('memory_type', 'fact')}]{repeats} {title}: {content}")
             if r.get("id"):
                 shown_ids.add(str(r["id"]))
         lines.append("")

--- a/core-storage-api/src/core_storage_api/routers/insights.py
+++ b/core-storage-api/src/core_storage_api/routers/insights.py
@@ -48,6 +48,29 @@ def _max_memories(body: dict) -> int:
     return val
 
 
+def _window_start(body: dict) -> datetime | None:
+    """Parse the optional ``window_start`` ISO datetime (the windowed
+    insight reads). ``created_at`` is timestamptz; asyncpg interprets a
+    NAIVE bound through local-time semantics instead of erroring, silently
+    shifting the window by the server's UTC offset — reject rather than
+    guess. Absent/null → the mode's legacy unbounded behaviour, keeping
+    older core-api callers working. Only None gets that fallback: an
+    explicit ``""`` (or any other non-ISO value) is a caller bug and 422s
+    like every other invalid value."""
+    raw = body.get("window_start")
+    if raw is None:
+        return None
+    try:
+        window_start = datetime.fromisoformat(raw)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=422, detail="Invalid ISO datetime for window_start")
+    if window_start.tzinfo is None:
+        raise HTTPException(
+            status_code=422, detail="window_start must be timezone-aware (e.g. include +00:00)"
+        )
+    return window_start
+
+
 # ──────────────────────────────────────────────────────────────────────
 #  Analytic reads (one per focus)
 # ──────────────────────────────────────────────────────────────────────
@@ -76,6 +99,7 @@ async def insights_failures(request: Request) -> list[dict]:
         agent_id=agent_id,
         scope=scope,
         max_memories=_max_memories(body),
+        window_start=_window_start(body),
     )
 
 
@@ -101,6 +125,7 @@ async def insights_stale(request: Request) -> list[dict]:
         thirty_days_ago=thirty,
         fourteen_days_ago=fourteen,
         max_memories=_max_memories(body),
+        window_start=_window_start(body),
     )
 
 
@@ -127,12 +152,19 @@ async def insights_patterns(request: Request) -> list[dict]:
         agent_id=agent_id,
         scope=scope,
         max_memories=_max_memories(body),
+        window_start=_window_start(body),
     )
 
 
 @router.post("/insights/discover-sample")
 async def insights_discover_sample(request: Request) -> list[dict]:
-    """Rows (INCLUDING ``embedding``) for client-side k-means clustering."""
+    """Rows (INCLUDING ``embedding``) for client-side k-means clustering.
+
+    ``window_start`` (optional ISO datetime, computed on the core-api clock
+    from ``INSIGHTS_DISCOVER_WINDOW_DAYS`` — same pattern as the stale-age
+    thresholds) switches the draw from newest-first to a spread sample over
+    the window. Absent → legacy newest-first, keeping older core-api
+    callers working."""
     body: dict = await request.json()
     tenant_id, fleet_id, agent_id, scope = _scope_args(body)
     sample_size = body.get("sample_size")
@@ -144,6 +176,7 @@ async def insights_discover_sample(request: Request) -> list[dict]:
         agent_id=agent_id,
         scope=scope,
         sample_size=sample_size,
+        window_start=_window_start(body),
     )
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -22,9 +22,11 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import (
+    String,
     and_,
     bindparam,
     case,
+    cast,
     delete,
     distinct,
     false,
@@ -6803,10 +6805,29 @@ class PostgresService:
     # expects (NO embedding) except for discover-sample, which includes the
     # embedding (client-side k-means).
 
+    # Content-free reasoning artifact: an episode whose content is an empty
+    # thinking block carrying only an encrypted signature —
+    # ``[{"type":"thinking","thinking":"","thinkingSignature":"..."}]``.
+    # There is nothing for the insights LLM to analyze in these rows, yet they
+    # embed near-identically and so form the tightest clusters discover can
+    # find (measured on the eToro fleet: 4.3% of 30-day episodes but 23.9% of
+    # all insight citations). Excluded from EVERY insights read via
+    # ``_insights_scope_filters``; the rows themselves are untouched and stay
+    # recallable — this is an insights-input filter, not a lifecycle change.
+    _INSIGHTS_OPAQUE_CONTENT_PREFIX = '[{"type":"thinking","thinking":""%'
+
     @staticmethod
     def _insights_scope_filters(tenant_id: str, fleet_id: str | None, agent_id: str, scope: str) -> list:
-        """Reconstruct ``insights_service._scope_filters`` ORM WHERE clauses."""
-        base = [Memory.tenant_id == tenant_id, Memory.deleted_at.is_(None)]
+        """Reconstruct ``insights_service._scope_filters`` ORM WHERE clauses,
+        plus the opaque-payload noise guard (see
+        ``_INSIGHTS_OPAQUE_CONTENT_PREFIX``) that applies to all 6 analytic
+        reads — including contradictions/divergence, since a row with no
+        readable content can't evidence anything."""
+        base = [
+            Memory.tenant_id == tenant_id,
+            Memory.deleted_at.is_(None),
+            Memory.content.notlike(PostgresService._INSIGHTS_OPAQUE_CONTENT_PREFIX),
+        ]
         if scope == "agent":
             base.append(Memory.agent_id == agent_id)
             if fleet_id:
@@ -6849,6 +6870,71 @@ class PostgresService:
                 emb = r.embedding
                 d["embedding"] = [float(x) for x in emb] if emb is not None else None
             out.append(d)
+        return out
+
+    @staticmethod
+    def _insights_dedup_stmt(filters: list, order_by, limit: int):
+        """Build a one-exemplar-per-exact-title select for the theme-finding
+        insight reads (patterns / stale / failures / discover-sample).
+
+        Routine operations on a busy fleet repeat the same episode title
+        hundreds of times per window (heartbeats, polling loops, bastion
+        sessions...). Feeding every instance to the insights LLM makes the
+        sample one giant echo — measured on the eToro fleet, "newest 200"
+        spanned under a day and ~1/3 of insight citations were repetition
+        noise. Collapsing to the NEWEST row per title keeps every distinct
+        activity discoverable while the ``dup_count`` / ``first_seen`` window
+        annotations preserve the frequency-and-duration signal the dropped
+        copies carried (rendered by the core-api prompt formatter as
+        "[repeats: Nx, first seen: date]").
+
+        Deliberately NOT used by contradictions/divergence: same-titled rows
+        that disagree are precisely the evidence those modes exist to find.
+
+        Correctness notes:
+        - NULL/empty titles must not collapse into one exemplar — the dedup
+          key falls back to the row id, so untitled rows all survive.
+        - ``dup_count``/``first_seen`` are computed over the FILTERED set
+          (the window functions run after ``filters``), so the annotation
+          means "N matching rows in this window", not "N rows ever".
+        - Exemplar choice is newest-by-created_at (id-desc tiebreak for
+          determinism); the caller's ``order_by`` is applied AFTER the join,
+          so each mode keeps its own result ordering. ``order_by`` may be a
+          callable receiving the inner subquery, for modes whose ordering
+          needs the window annotations themselves (failures sorts by
+          ``inner.c.dup_count`` so high-frequency patterns aren't cut by
+          LIMIT below one-off rows).
+        """
+        dedup_key = func.coalesce(func.nullif(Memory.title, ""), cast(Memory.id, String))
+        inner = (
+            select(
+                Memory.id.label("mid"),
+                func.row_number()
+                .over(partition_by=dedup_key, order_by=(Memory.created_at.desc(), Memory.id.desc()))
+                .label("rn"),
+                func.count().over(partition_by=dedup_key).label("dup_count"),
+                func.min(Memory.created_at).over(partition_by=dedup_key).label("first_seen"),
+            )
+            .where(*filters)
+            .subquery()
+        )
+        order_cols = order_by(inner) if callable(order_by) else order_by
+        return (
+            select(Memory, inner.c.dup_count, inner.c.first_seen)
+            .join(inner, Memory.id == inner.c.mid)
+            .where(inner.c.rn == 1)
+            .order_by(*order_cols)
+            .limit(limit)
+        )
+
+    def _insights_annotated_rows_to_dicts(self, rows, *, include_embedding: bool = False) -> list[dict]:
+        """Dictify ``(Memory, dup_count, first_seen)`` tuples from
+        ``_insights_dedup_stmt`` — the ``_rows_to_dicts`` shape plus the two
+        window annotations."""
+        out = self._insights_rows_to_dicts([r[0] for r in rows], include_embedding=include_embedding)
+        for d, r in zip(out, rows, strict=True):
+            d["dup_count"] = int(r[1] or 1)
+            d["first_seen"] = r[2].isoformat() if r[2] else None
         return out
 
     async def insights_query_contradictions(
@@ -6937,26 +7023,62 @@ class PostgresService:
         return self._insights_rows_to_dicts(rows[:max_memories])
 
     async def insights_query_failures(
-        self, *, tenant_id: str, fleet_id: str | None, agent_id: str, scope: str, max_memories: int
+        self,
+        *,
+        tenant_id: str,
+        fleet_id: str | None,
+        agent_id: str,
+        scope: str,
+        max_memories: int,
+        window_start: datetime | None = None,
     ) -> list[dict]:
         """Low-weight memories that were recalled (agents acted on weak info).
-        Ports ``_query_failures`` verbatim."""
+        Ports ``_query_failures``, deduped to one exemplar per exact title
+        (see ``_insights_dedup_stmt``) — repeated weak-recall rows show up
+        once with a ``dup_count`` instead of crowding out distinct failures.
+
+        ``window_start`` (core-api clock, ``INSIGHTS_FAILURES_WINDOW_DAYS``)
+        bounds the dedup scan — the weight/recall predicates prune less as
+        the corpus grows, and the window-function subquery has no inner
+        LIMIT. Omitted (None) → the ORIGINAL pre-dedup query (identical
+        results AND cost for older core-api callers; no full-corpus window
+        scan for annotations they don't read).
+
+        Dedup ordering: ``dup_count`` is the secondary key — the exemplar is
+        the NEWEST row per title, whose individual ``recall_count`` may be
+        low even when the pattern repeats constantly, so without it a
+        40-instance pattern (newest rc=2) would be cut by LIMIT below a
+        one-off rc=5 row."""
         base = self._insights_scope_filters(tenant_id, fleet_id, agent_id, scope)
+        filters = [
+            *base,
+            Memory.memory_type != "insight",
+            Memory.weight < 0.3,
+            Memory.recall_count > 0,
+            Memory.status == "active",
+        ]
         async with get_read_session() as session:
-            stmt = (
-                select(Memory)
-                .where(
-                    *base,
-                    Memory.memory_type != "insight",
-                    Memory.weight < 0.3,
-                    Memory.recall_count > 0,
-                    Memory.status == "active",
+            if window_start is None:
+                stmt = (
+                    select(Memory)
+                    .where(*filters)
+                    .order_by(Memory.recall_count.desc(), Memory.weight.asc())
+                    .limit(max_memories)
                 )
-                .order_by(Memory.recall_count.desc(), Memory.weight.asc())
-                .limit(max_memories)
+                result = await session.execute(stmt)
+                return self._insights_rows_to_dicts(result.scalars().all())
+            filters.append(Memory.created_at > window_start)
+            stmt = self._insights_dedup_stmt(
+                filters,
+                lambda inner: (
+                    Memory.recall_count.desc(),
+                    inner.c.dup_count.desc(),
+                    Memory.weight.asc(),
+                ),
+                max_memories,
             )
             result = await session.execute(stmt)
-            return self._insights_rows_to_dicts(result.scalars().all())
+            return self._insights_annotated_rows_to_dicts(result.all())
 
     async def insights_query_stale(
         self,
@@ -6968,34 +7090,48 @@ class PostgresService:
         thirty_days_ago: datetime,
         fourteen_days_ago: datetime,
         max_memories: int,
+        window_start: datetime | None = None,
     ) -> list[dict]:
         """Memories likely outdated based on age + recall activity. Ports
-        ``_query_stale`` verbatim. The two age thresholds are passed from the
-        caller's clock (core-api) and bound as datetimes server-side."""
+        ``_query_stale``, deduped to one exemplar per exact title (see
+        ``_insights_dedup_stmt``). The two age thresholds are passed from the
+        caller's clock (core-api) and bound as datetimes server-side.
+
+        ``window_start`` (core-api clock, ``INSIGHTS_STALE_WINDOW_DAYS`` —
+        deliberately WIDER than the 30-day age threshold rows must exceed to
+        qualify) bounds the dedup scan AND changes what the mode reports:
+        the ordered-oldest-first unbounded read perpetually re-reported the
+        same ancient tail; windowed, it surfaces the "recently became stale"
+        band instead (the ancient tail is the archive-stale lifecycle job's
+        business). Omitted (None) → the ORIGINAL pre-dedup query (identical
+        results AND cost for older core-api callers)."""
         base = self._insights_scope_filters(tenant_id, fleet_id, agent_id, scope)
+        filters = [
+            *base,
+            Memory.memory_type != "insight",
+            Memory.status == "active",
+            ((Memory.recall_count == 0) & (Memory.created_at < thirty_days_ago))
+            | (
+                (Memory.weight < 0.3)
+                & or_(
+                    Memory.last_recalled_at.is_(None),
+                    Memory.last_recalled_at < fourteen_days_ago,
+                )
+            ),
+        ]
         async with get_read_session() as session:
-            stmt = (
-                select(Memory)
-                .where(
-                    *base,
-                    Memory.memory_type != "insight",
-                    Memory.status == "active",
-                )
-                .where(
-                    ((Memory.recall_count == 0) & (Memory.created_at < thirty_days_ago))
-                    | (
-                        (Memory.weight < 0.3)
-                        & or_(
-                            Memory.last_recalled_at.is_(None),
-                            Memory.last_recalled_at < fourteen_days_ago,
-                        )
-                    )
-                )
-                .order_by(Memory.created_at.asc())
-                .limit(max_memories)
+            if window_start is None:
+                stmt = select(Memory).where(*filters).order_by(Memory.created_at.asc()).limit(max_memories)
+                result = await session.execute(stmt)
+                return self._insights_rows_to_dicts(result.scalars().all())
+            filters.append(Memory.created_at > window_start)
+            stmt = self._insights_dedup_stmt(
+                filters,
+                (Memory.created_at.asc(),),
+                max_memories,
             )
             result = await session.execute(stmt)
-            return self._insights_rows_to_dicts(result.scalars().all())
+            return self._insights_annotated_rows_to_dicts(result.all())
 
     async def insights_query_divergence(
         self, *, tenant_id: str, fleet_id: str | None, agent_id: str, scope: str, max_memories: int
@@ -7038,48 +7174,94 @@ class PostgresService:
             return self._insights_rows_to_dicts(result.scalars().all())
 
     async def insights_query_patterns(
-        self, *, tenant_id: str, fleet_id: str | None, agent_id: str, scope: str, max_memories: int
+        self,
+        *,
+        tenant_id: str,
+        fleet_id: str | None,
+        agent_id: str,
+        scope: str,
+        max_memories: int,
+        window_start: datetime | None = None,
     ) -> list[dict]:
         """Recent active memories for trend/pattern analysis. Ports
-        ``_query_patterns`` verbatim."""
+        ``_query_patterns``, deduped to one exemplar per exact title (see
+        ``_insights_dedup_stmt``).
+
+        ``window_start`` (core-api clock, ``INSIGHTS_PATTERNS_WINDOW_DAYS``)
+        bounds the dedup scan: the window-function subquery has no LIMIT, so
+        without it this read scans the tenant's ENTIRE active history to
+        return ``max_memories`` deduped rows — the pre-dedup query
+        early-terminated on the (tenant_id, created_at DESC) index instead.
+        A trailing window is also what the mode means ("recent memories").
+        Omitted (None) → the ORIGINAL pre-dedup query (identical results AND
+        cost for older core-api callers; no full-corpus window scan)."""
         base = self._insights_scope_filters(tenant_id, fleet_id, agent_id, scope)
+        filters = [
+            *base,
+            Memory.memory_type != "insight",
+            Memory.status == "active",
+        ]
         async with get_read_session() as session:
-            stmt = (
-                select(Memory)
-                .where(
-                    *base,
-                    Memory.memory_type != "insight",
-                    Memory.status == "active",
-                )
-                .order_by(Memory.created_at.desc())
-                .limit(max_memories)
+            if window_start is None:
+                stmt = select(Memory).where(*filters).order_by(Memory.created_at.desc()).limit(max_memories)
+                result = await session.execute(stmt)
+                return self._insights_rows_to_dicts(result.scalars().all())
+            filters.append(Memory.created_at > window_start)
+            stmt = self._insights_dedup_stmt(
+                filters,
+                (Memory.created_at.desc(),),
+                max_memories,
             )
             result = await session.execute(stmt)
-            return self._insights_rows_to_dicts(result.scalars().all())
+            return self._insights_annotated_rows_to_dicts(result.all())
 
     async def insights_discover_sample(
-        self, *, tenant_id: str, fleet_id: str | None, agent_id: str, scope: str, sample_size: int
+        self,
+        *,
+        tenant_id: str,
+        fleet_id: str | None,
+        agent_id: str,
+        scope: str,
+        sample_size: int,
+        window_start: datetime | None = None,
     ) -> list[dict]:
         """Sample active memories WITH embeddings for client-side k-means.
         Ports ``_query_discover``'s row-fetch (the numpy clustering + cluster
         build stay on the core-api side). Returns rows INCLUDING ``embedding``,
         capped at ``sample_size`` (``INSIGHTS_DISCOVER_SAMPLE_SIZE`` forwarded
-        from core-api)."""
+        from core-api).
+
+        Two sampling changes vs the original newest-first fetch:
+
+        - Deduped to one exemplar per exact title (``_insights_dedup_stmt``).
+        - When ``window_start`` is given (computed on the core-api clock from
+          ``INSIGHTS_DISCOVER_WINDOW_DAYS``, mirroring the stale thresholds),
+          the draw is restricted to that window and SPREAD across it by
+          ordering on ``random()`` instead of recency. On a busy tenant
+          "newest N" spans hours — clustering yesterday's firehose rather
+          than the corpus — and a genuinely run-varying uniform draw both
+          widens coverage and de-correlates consecutive runs' samples (a
+          deterministic hash order like ``md5(id)`` would NOT: it's a fixed
+          permutation per corpus state, so low-hash rows re-enter the sample
+          every night). Omitted (None) → the ORIGINAL pre-dedup newest-first
+          query (identical results AND cost for older core-api callers; no
+          full-corpus window scan)."""
         base = self._insights_scope_filters(tenant_id, fleet_id, agent_id, scope)
+        filters = [
+            *base,
+            Memory.status == "active",
+            Memory.memory_type != "insight",
+            Memory.embedding.isnot(None),
+        ]
         async with get_read_session() as session:
-            stmt = (
-                select(Memory)
-                .where(
-                    *base,
-                    Memory.status == "active",
-                    Memory.memory_type != "insight",
-                    Memory.embedding.isnot(None),
-                )
-                .order_by(Memory.created_at.desc())
-                .limit(sample_size)
-            )
+            if window_start is None:
+                stmt = select(Memory).where(*filters).order_by(Memory.created_at.desc()).limit(sample_size)
+                result = await session.execute(stmt)
+                return self._insights_rows_to_dicts(result.scalars().all(), include_embedding=True)
+            filters.append(Memory.created_at > window_start)
+            stmt = self._insights_dedup_stmt(filters, (func.random(),), sample_size)
             result = await session.execute(stmt)
-            return self._insights_rows_to_dicts(result.scalars().all(), include_embedding=True)
+            return self._insights_annotated_rows_to_dicts(result.all(), include_embedding=True)
 
     async def insights_supersede_priors(
         self,

--- a/tests/test_insights_service.py
+++ b/tests/test_insights_service.py
@@ -49,7 +49,11 @@ async def _seed_memory(
     """
     created = created_at or datetime.now(UTC)
     mem_id = str(uuid4())
-    emb_literal = "[" + ",".join(str(float(x)) for x in embedding) + "]" if embedding is not None else None
+    emb_literal = (
+        "[" + ",".join(str(float(x)) for x in embedding) + "]"
+        if embedding is not None
+        else None
+    )
     async with get_session() as session:
         await session.execute(
             text(
@@ -90,7 +94,8 @@ async def _status_of(mem_id: str) -> str:
     async with get_session() as session:
         row = (
             await session.execute(
-                text("SELECT status FROM memories WHERE id = CAST(:id AS uuid)"), {"id": mem_id}
+                text("SELECT status FROM memories WHERE id = CAST(:id AS uuid)"),
+                {"id": mem_id},
             )
         ).fetchone()
     return row.status
@@ -321,6 +326,85 @@ class TestNumpyKmeans:
         assert labels[0] != labels[20]
 
 
+class TestFormatterDedupAnnotation:
+    """The title-dedup exemplars carry dup_count/first_seen — the formatter
+    must render the frequency signal the dropped copies carried."""
+
+    def test_repeats_annotation_rendered(self):
+        from core_api.services.insights_service import _format_memories_for_analysis
+
+        text, shown = _format_memories_for_analysis(
+            [
+                {
+                    "id": "m1",
+                    "memory_type": "episode",
+                    "title": "Heartbeat OK",
+                    "content": "routine check",
+                    "weight": 0.5,
+                    "agent_id": "a1",
+                    "dup_count": 42,
+                    "first_seen": "2026-07-01T02:00:00+00:00",
+                }
+            ]
+        )
+        assert "[repeats: 42x, first seen: 2026-07-01]" in text
+        assert shown == {"m1"}
+
+    def test_no_annotation_for_singletons_or_undecorated_rows(self):
+        from core_api.services.insights_service import _format_memories_for_analysis
+
+        # dup_count == 1 and legacy rows without the field render identically.
+        for extra in ({"dup_count": 1, "first_seen": None}, {}):
+            text, _ = _format_memories_for_analysis(
+                [
+                    {
+                        "id": "m1",
+                        "memory_type": "fact",
+                        "title": "t",
+                        "content": "c",
+                        "weight": 0.5,
+                        "agent_id": "a1",
+                        **extra,
+                    }
+                ]
+            )
+            assert "repeats" not in text
+
+    def test_cluster_representatives_annotated(self):
+        from core_api.services.insights_service import _format_clusters_for_analysis
+
+        text, shown = _format_clusters_for_analysis(
+            [
+                {
+                    "cluster_id": 0,
+                    "size": 5,
+                    "weight_mean": 0.5,
+                    "weight_std": 0.1,
+                    "agent_count": 1,
+                    "agents": ["a1"],
+                    "type_distribution": {"episode": 5},
+                    "representatives": [
+                        {
+                            "id": "r1",
+                            "memory_type": "episode",
+                            "title": "Heartbeat OK",
+                            "content": "x",
+                            "dup_count": 7,
+                        },
+                        {
+                            "id": "r2",
+                            "memory_type": "episode",
+                            "title": "One-off fix",
+                            "content": "y",
+                        },
+                    ],
+                }
+            ]
+        )
+        assert "[repeats: 7x]" in text
+        assert shown == {"r1", "r2"}
+
+
 class TestScopeFilters:
     """Test _scope_filters returns correct conditions."""
 
@@ -338,7 +422,8 @@ class TestScopeFilters:
         from fastapi import HTTPException
 
         with pytest.raises(HTTPException) as exc_info:
-            await generate_insights("t1", focus="patterns", scope="fleet", fleet_id=None
+            await generate_insights(
+                "t1", focus="patterns", scope="fleet", fleet_id=None
             )
         assert exc_info.value.status_code == 422
         assert "fleet_id" in exc_info.value.detail.lower()
@@ -492,7 +577,8 @@ async def test_generate_insights_with_fake_provider():
 
         from core_api.services.insights_service import generate_insights
 
-        result = await generate_insights(tenant_id=tenant_id,
+        result = await generate_insights(
+            tenant_id=tenant_id,
             focus="patterns",
             scope="agent",
             fleet_id=None,
@@ -525,7 +611,8 @@ async def test_insights_persists_as_memory():
 
         from core_api.services.insights_service import generate_insights
 
-        result = await generate_insights(tenant_id=tenant_id,
+        result = await generate_insights(
+            tenant_id=tenant_id,
             focus="patterns",
             scope="agent",
             agent_id="persist-agent",
@@ -613,15 +700,20 @@ class TestSupersedeScope:
 
             from core_api.services.insights_service import generate_insights
 
-            await generate_insights(tenant_id=tenant_id,
+            await generate_insights(
+                tenant_id=tenant_id,
                 focus="patterns",
                 scope="fleet",
                 fleet_id=f"fleet-A-{tag}",
                 agent_id=agent_id,
             )
 
-            assert await _status_of(prior_a_id) == "outdated", "fleet-A prior should be outdated"
-            assert await _status_of(prior_b_id) == "active", "fleet-B prior must stay active"
+            assert await _status_of(prior_a_id) == "outdated", (
+                "fleet-A prior should be outdated"
+            )
+            assert await _status_of(prior_b_id) == "active", (
+                "fleet-B prior must stay active"
+            )
         finally:
             await _cleanup_tenant(tenant_id)
 
@@ -675,7 +767,8 @@ class TestSupersedeScope:
 
             from core_api.services.insights_service import generate_insights
 
-            await generate_insights(tenant_id=tenant_id,
+            await generate_insights(
+                tenant_id=tenant_id,
                 focus="patterns",
                 scope="agent",
                 fleet_id=None,
@@ -683,7 +776,9 @@ class TestSupersedeScope:
             )
 
             assert await _status_of(ap_id) == "outdated"
-            assert await _status_of(all_id) == "active", "insight_scope='all' prior must stay active"
+            assert await _status_of(all_id) == "active", (
+                "insight_scope='all' prior must stay active"
+            )
         finally:
             await _cleanup_tenant(tenant_id)
 
@@ -692,7 +787,9 @@ class TestSupersedeOrdering:
     """P0: supersede must run BEFORE create, with a rollback safety net."""
 
     @pytest.mark.asyncio
-    async def test_new_finding_persists_despite_similar_prior_insight(self, monkeypatch):
+    async def test_new_finding_persists_despite_similar_prior_insight(
+        self, monkeypatch
+    ):
         """A prior similar insight is outdated first, so the new finding persists.
 
         Because the reorder moves the prior to 'outdated' before create_memory
@@ -737,7 +834,8 @@ class TestSupersedeOrdering:
 
             from core_api.services.insights_service import generate_insights
 
-            result = await generate_insights(tenant_id=tenant_id,
+            result = await generate_insights(
+                tenant_id=tenant_id,
                 focus="patterns",
                 scope="agent",
                 fleet_id=None,
@@ -803,7 +901,8 @@ class TestSupersedeOrdering:
 
             monkeypatch.setattr(ms_mod, "create_memories_bulk", failing_create_bulk)
 
-            result = await insights_service.generate_insights(tenant_id=tenant_id,
+            result = await insights_service.generate_insights(
+                tenant_id=tenant_id,
                 focus="patterns",
                 scope="agent",
                 fleet_id=None,
@@ -846,7 +945,8 @@ class TestSupersedeOrdering:
 
             from core_api.services.insights_service import generate_insights
 
-            await generate_insights(tenant_id=tenant_id,
+            await generate_insights(
+                tenant_id=tenant_id,
                 focus="patterns",
                 scope="agent",
                 fleet_id=None,
@@ -870,12 +970,18 @@ class TestHallucinatedIds:
         agent_id = f"agent-{tag}"
         try:
             a_id = await _seed_memory(
-                tenant_id=tenant_id, agent_id=agent_id, fleet_id=None,
-                content=f"Fact A [{tag}]", visibility="scope_agent",
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                fleet_id=None,
+                content=f"Fact A [{tag}]",
+                visibility="scope_agent",
             )
             b_id = await _seed_memory(
-                tenant_id=tenant_id, agent_id=agent_id, fleet_id=None,
-                content=f"Fact B [{tag}]", visibility="scope_agent",
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                fleet_id=None,
+                content=f"Fact B [{tag}]",
+                visibility="scope_agent",
             )
             hallucinated = "00000000-0000-0000-0000-deadbeef1234"
 
@@ -895,7 +1001,8 @@ class TestHallucinatedIds:
 
             from core_api.services.insights_service import generate_insights
 
-            result = await generate_insights(tenant_id=tenant_id,
+            result = await generate_insights(
+                tenant_id=tenant_id,
                 focus="patterns",
                 scope="agent",
                 fleet_id=None,
@@ -920,12 +1027,18 @@ class TestHallucinatedIds:
         agent_id = f"agent-{tag}"
         try:
             a_id = await _seed_memory(
-                tenant_id=tenant_id, agent_id=agent_id, fleet_id=None,
-                content=f"Fact A [{tag}]", visibility="scope_agent",
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                fleet_id=None,
+                content=f"Fact A [{tag}]",
+                visibility="scope_agent",
             )
             await _seed_memory(
-                tenant_id=tenant_id, agent_id=agent_id, fleet_id=None,
-                content=f"Fact B [{tag}]", visibility="scope_agent",
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                fleet_id=None,
+                content=f"Fact B [{tag}]",
+                visibility="scope_agent",
             )
 
             await _stub_llm(
@@ -944,7 +1057,8 @@ class TestHallucinatedIds:
 
             from core_api.services.insights_service import generate_insights
 
-            result = await generate_insights(tenant_id=tenant_id,
+            result = await generate_insights(
+                tenant_id=tenant_id,
                 focus="patterns",
                 scope="agent",
                 fleet_id=None,

--- a/tests/test_ph5b_insights_storage.py
+++ b/tests/test_ph5b_insights_storage.py
@@ -44,6 +44,7 @@ async def _seed_memory(
     *,
     tenant_id: str,
     content: str = "x",
+    title: str | None = None,
     agent_id: str = "agent-1",
     fleet_id: str | None = None,
     memory_type: str = "fact",
@@ -70,12 +71,12 @@ async def _seed_memory(
             text(
                 """
                 INSERT INTO memories
-                    (id, tenant_id, fleet_id, agent_id, content, memory_type,
+                    (id, tenant_id, fleet_id, agent_id, content, title, memory_type,
                      status, weight, recall_count, created_at, last_recalled_at,
                      supersedes_id, subject_entity_id, object_value, embedding,
                      metadata, visibility)
                 VALUES
-                    (CAST(:id AS uuid), :tenant_id, :fleet_id, :agent_id, :content, :memory_type,
+                    (CAST(:id AS uuid), :tenant_id, :fleet_id, :agent_id, :content, :title, :memory_type,
                      :status, :weight, :recall_count, :created_at, :last_recalled_at,
                      CAST(:supersedes_id AS uuid), CAST(:subject_entity_id AS uuid), :object_value,
                      CAST(:embedding AS vector), CAST(:metadata AS jsonb), :visibility)
@@ -87,6 +88,7 @@ async def _seed_memory(
                 "fleet_id": fleet_id,
                 "agent_id": agent_id,
                 "content": content,
+                "title": title,
                 "memory_type": memory_type,
                 "status": status,
                 "weight": weight,
@@ -108,7 +110,8 @@ async def _status(mem_id: str) -> str:
     async with get_session() as session:
         row = (
             await session.execute(
-                text("SELECT status FROM memories WHERE id = CAST(:id AS uuid)"), {"id": mem_id}
+                text("SELECT status FROM memories WHERE id = CAST(:id AS uuid)"),
+                {"id": mem_id},
             )
         ).fetchone()
     return row.status
@@ -124,9 +127,15 @@ async def test_patterns_returns_recent_active(sc):
     for i in range(3):
         await _seed_memory(tenant_id=tenant, agent_id="a1", content=f"p{i}")
     # An insight-type memory must be excluded (feedback-loop guard).
-    await _seed_memory(tenant_id=tenant, agent_id="a1", memory_type="insight", content="ins")
+    await _seed_memory(
+        tenant_id=tenant, agent_id="a1", memory_type="insight", content="ins"
+    )
     rows = await sc.insights_query_patterns(
-        tenant_id=tenant, fleet_id=None, agent_id="a1", scope="agent", max_memories=INSIGHTS_MAX_MEMORIES
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
     )
     assert len(rows) == 3
     assert all(r["memory_type"] == "fact" for r in rows)
@@ -139,7 +148,11 @@ async def test_patterns_tenant_isolation(sc):
     await _seed_memory(tenant_id=t_a, agent_id="a1", content="a")
     await _seed_memory(tenant_id=t_b, agent_id="a1", content="b")
     rows = await sc.insights_query_patterns(
-        tenant_id=t_a, fleet_id=None, agent_id="a1", scope="agent", max_memories=INSIGHTS_MAX_MEMORIES
+        tenant_id=t_a,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
     )
     assert {r["content"] for r in rows} == {"a"}
 
@@ -150,12 +163,20 @@ async def test_patterns_scope_agent_filters_by_agent(sc):
     await _seed_memory(tenant_id=tenant, agent_id="a2", content="theirs")
     # scope='agent' → only a1's row.
     rows = await sc.insights_query_patterns(
-        tenant_id=tenant, fleet_id=None, agent_id="a1", scope="agent", max_memories=INSIGHTS_MAX_MEMORIES
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
     )
     assert {r["content"] for r in rows} == {"mine"}
     # scope='all' → both, regardless of agent_id.
     rows_all = await sc.insights_query_patterns(
-        tenant_id=tenant, fleet_id=None, agent_id="a1", scope="all", max_memories=INSIGHTS_MAX_MEMORIES
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="all",
+        max_memories=INSIGHTS_MAX_MEMORIES,
     )
     assert {r["content"] for r in rows_all} == {"mine", "theirs"}
 
@@ -165,7 +186,11 @@ async def test_patterns_scope_fleet_filters_by_fleet(sc):
     await _seed_memory(tenant_id=tenant, agent_id="a1", fleet_id="f1", content="f1mem")
     await _seed_memory(tenant_id=tenant, agent_id="a2", fleet_id="f2", content="f2mem")
     rows = await sc.insights_query_patterns(
-        tenant_id=tenant, fleet_id="f1", agent_id="a1", scope="fleet", max_memories=INSIGHTS_MAX_MEMORIES
+        tenant_id=tenant,
+        fleet_id="f1",
+        agent_id="a1",
+        scope="fleet",
+        max_memories=INSIGHTS_MAX_MEMORIES,
     )
     assert {r["content"] for r in rows} == {"f1mem"}
 
@@ -173,13 +198,23 @@ async def test_patterns_scope_fleet_filters_by_fleet(sc):
 async def test_failures_low_weight_recalled(sc):
     tenant = _t()
     # weight<0.3, recall_count>0, active → returned.
-    await _seed_memory(tenant_id=tenant, agent_id="a1", content="weak", weight=0.1, recall_count=5)
+    await _seed_memory(
+        tenant_id=tenant, agent_id="a1", content="weak", weight=0.1, recall_count=5
+    )
     # high weight → excluded.
-    await _seed_memory(tenant_id=tenant, agent_id="a1", content="strong", weight=0.9, recall_count=5)
+    await _seed_memory(
+        tenant_id=tenant, agent_id="a1", content="strong", weight=0.9, recall_count=5
+    )
     # never recalled → excluded.
-    await _seed_memory(tenant_id=tenant, agent_id="a1", content="unread", weight=0.1, recall_count=0)
+    await _seed_memory(
+        tenant_id=tenant, agent_id="a1", content="unread", weight=0.1, recall_count=0
+    )
     rows = await sc.insights_query_failures(
-        tenant_id=tenant, fleet_id=None, agent_id="a1", scope="agent", max_memories=INSIGHTS_MAX_MEMORIES
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
     )
     assert {r["content"] for r in rows} == {"weak"}
 
@@ -189,11 +224,16 @@ async def test_stale_old_unrecalled(sc):
     now = datetime.now(UTC)
     # zero recalls + >30d old → stale.
     old = await _seed_memory(
-        tenant_id=tenant, agent_id="a1", content="old", recall_count=0,
+        tenant_id=tenant,
+        agent_id="a1",
+        content="old",
+        recall_count=0,
         created_at=now - timedelta(days=60),
     )
     # recent → not stale.
-    await _seed_memory(tenant_id=tenant, agent_id="a1", content="fresh", recall_count=0, created_at=now)
+    await _seed_memory(
+        tenant_id=tenant, agent_id="a1", content="fresh", recall_count=0, created_at=now
+    )
     rows = await sc.insights_query_stale(
         tenant_id=tenant,
         fleet_id=None,
@@ -212,14 +252,24 @@ async def test_contradictions_supersedes_and_superseded(sc):
     tenant = _t()
     now = datetime.now(UTC)
     old = await _seed_memory(
-        tenant_id=tenant, agent_id="a1", content="old value", created_at=now - timedelta(days=2)
+        tenant_id=tenant,
+        agent_id="a1",
+        content="old value",
+        created_at=now - timedelta(days=2),
     )
     new = await _seed_memory(
-        tenant_id=tenant, agent_id="a1", content="new value", created_at=now - timedelta(hours=1),
+        tenant_id=tenant,
+        agent_id="a1",
+        content="new value",
+        created_at=now - timedelta(hours=1),
         supersedes_id=old,
     )
     rows = await sc.insights_query_contradictions(
-        tenant_id=tenant, fleet_id=None, agent_id="a1", scope="agent", max_memories=INSIGHTS_MAX_MEMORIES
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
     )
     ids = {r["id"] for r in rows}
     # Both the supersedor and the superseded row are pulled in (the LLM needs
@@ -234,18 +284,34 @@ async def test_contradictions_entity_divergence_group_by_having(sc):
     # Same subject_entity_id, two different object_values → HAVING COUNT(DISTINCT
     # object_value) > 1 selects the entity, then both rows are fetched.
     await _seed_memory(
-        tenant_id=tenant, agent_id="a1", content="x is 1", subject_entity_id=ent, object_value="1"
+        tenant_id=tenant,
+        agent_id="a1",
+        content="x is 1",
+        subject_entity_id=ent,
+        object_value="1",
     )
     await _seed_memory(
-        tenant_id=tenant, agent_id="a1", content="x is 2", subject_entity_id=ent, object_value="2"
+        tenant_id=tenant,
+        agent_id="a1",
+        content="x is 2",
+        subject_entity_id=ent,
+        object_value="2",
     )
     # A different entity with a single object_value must NOT qualify.
     ent2 = str(uuid4())
     await _seed_memory(
-        tenant_id=tenant, agent_id="a1", content="y is 9", subject_entity_id=ent2, object_value="9"
+        tenant_id=tenant,
+        agent_id="a1",
+        content="y is 9",
+        subject_entity_id=ent2,
+        object_value="9",
     )
     rows = await sc.insights_query_contradictions(
-        tenant_id=tenant, fleet_id=None, agent_id="a1", scope="agent", max_memories=INSIGHTS_MAX_MEMORIES
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
     )
     contents = {r["content"] for r in rows}
     assert "x is 1" in contents and "x is 2" in contents
@@ -258,13 +324,25 @@ async def test_divergence_group_by_having_count_agents(sc):
     # Same entity referenced by 2 distinct agents → HAVING COUNT(DISTINCT
     # agent_id) >= 2 selects it.
     await _seed_memory(
-        tenant_id=tenant, agent_id="a1", content="agent1 view", subject_entity_id=ent, object_value="v1"
+        tenant_id=tenant,
+        agent_id="a1",
+        content="agent1 view",
+        subject_entity_id=ent,
+        object_value="v1",
     )
     await _seed_memory(
-        tenant_id=tenant, agent_id="a2", content="agent2 view", subject_entity_id=ent, object_value="v2"
+        tenant_id=tenant,
+        agent_id="a2",
+        content="agent2 view",
+        subject_entity_id=ent,
+        object_value="v2",
     )
     rows = await sc.insights_query_divergence(
-        tenant_id=tenant, fleet_id=None, agent_id="a1", scope="all", max_memories=INSIGHTS_MAX_MEMORIES
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="all",
+        max_memories=INSIGHTS_MAX_MEMORIES,
     )
     assert {r["content"] for r in rows} == {"agent1 view", "agent2 view"}
 
@@ -274,10 +352,18 @@ async def test_divergence_empty_when_single_agent(sc):
     ent = str(uuid4())
     # Only one agent references the entity → no divergence → [].
     await _seed_memory(
-        tenant_id=tenant, agent_id="a1", content="only one", subject_entity_id=ent, object_value="v"
+        tenant_id=tenant,
+        agent_id="a1",
+        content="only one",
+        subject_entity_id=ent,
+        object_value="v",
     )
     rows = await sc.insights_query_divergence(
-        tenant_id=tenant, fleet_id=None, agent_id="a1", scope="all", max_memories=INSIGHTS_MAX_MEMORIES
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="all",
+        max_memories=INSIGHTS_MAX_MEMORIES,
     )
     assert rows == []
 
@@ -285,9 +371,13 @@ async def test_divergence_empty_when_single_agent(sc):
 async def test_discover_sample_includes_embedding(sc):
     tenant = _t()
     emb = [0.1] * VECTOR_DIM
-    await _seed_memory(tenant_id=tenant, agent_id="a1", content="with-emb", embedding=emb)
+    await _seed_memory(
+        tenant_id=tenant, agent_id="a1", content="with-emb", embedding=emb
+    )
     # No embedding → excluded.
-    await _seed_memory(tenant_id=tenant, agent_id="a1", content="no-emb", embedding=None)
+    await _seed_memory(
+        tenant_id=tenant, agent_id="a1", content="no-emb", embedding=None
+    )
     rows = await sc.insights_discover_sample(
         tenant_id=tenant,
         fleet_id=None,
@@ -311,12 +401,18 @@ async def test_supersede_priors_selects_by_jsonb_metadata(sc):
     tenant = _t()
     agent = "a1"
     match = await _seed_memory(
-        tenant_id=tenant, agent_id=agent, memory_type="insight", content="prior match",
+        tenant_id=tenant,
+        agent_id=agent,
+        memory_type="insight",
+        content="prior match",
         metadata={"insight_focus": "patterns", "insight_scope": "agent"},
     )
     # Different focus → must NOT be outdated.
     other_focus = await _seed_memory(
-        tenant_id=tenant, agent_id=agent, memory_type="insight", content="other focus",
+        tenant_id=tenant,
+        agent_id=agent,
+        memory_type="insight",
+        content="other focus",
         metadata={"insight_focus": "stale", "insight_scope": "agent"},
     )
     result = await sc.insights_supersede_priors(
@@ -334,11 +430,19 @@ async def test_supersede_priors_fleet_arm(sc):
     agent = "a1"
     # fleet_id=None prior, selected only when the request also has fleet_id=None.
     fleetless = await _seed_memory(
-        tenant_id=tenant, agent_id=agent, fleet_id=None, memory_type="insight", content="fleetless",
+        tenant_id=tenant,
+        agent_id=agent,
+        fleet_id=None,
+        memory_type="insight",
+        content="fleetless",
         metadata={"insight_focus": "patterns", "insight_scope": "all"},
     )
     fleeted = await _seed_memory(
-        tenant_id=tenant, agent_id=agent, fleet_id="f1", memory_type="insight", content="fleeted",
+        tenant_id=tenant,
+        agent_id=agent,
+        fleet_id="f1",
+        memory_type="insight",
+        content="fleeted",
         metadata={"insight_focus": "patterns", "insight_scope": "fleet"},
     )
     # Request fleet_id=None, scope='all' → only the fleetless prior.
@@ -356,7 +460,10 @@ async def test_supersede_priors_fleet_arm(sc):
 async def test_supersede_priors_tenant_isolation(sc):
     t_a, t_b = _t(), _t()
     prior_a = await _seed_memory(
-        tenant_id=t_a, agent_id="a1", memory_type="insight", content="A",
+        tenant_id=t_a,
+        agent_id="a1",
+        memory_type="insight",
+        content="A",
         metadata={"insight_focus": "patterns", "insight_scope": "agent"},
     )
     # Tenant B's supersede must not touch tenant A's prior.
@@ -379,7 +486,11 @@ async def test_restore_priors(sc):
     tenant = _t()
     agent = "a1"
     prior = await _seed_memory(
-        tenant_id=tenant, agent_id=agent, memory_type="insight", content="p", status="outdated",
+        tenant_id=tenant,
+        agent_id=agent,
+        memory_type="insight",
+        content="p",
+        status="outdated",
         metadata={"insight_focus": "patterns", "insight_scope": "agent"},
     )
     res = await sc.insights_restore_priors(tenant_id=tenant, prior_ids=[prior])
@@ -390,7 +501,11 @@ async def test_restore_priors(sc):
 async def test_restore_priors_tenant_isolation(sc):
     t_a, t_b = _t(), _t()
     prior = await _seed_memory(
-        tenant_id=t_a, agent_id="a1", memory_type="insight", content="p", status="outdated",
+        tenant_id=t_a,
+        agent_id="a1",
+        memory_type="insight",
+        content="p",
+        status="outdated",
     )
     # Tenant B can't restore tenant A's row.
     res = await sc.insights_restore_priors(tenant_id=t_b, prior_ids=[prior])
@@ -412,11 +527,17 @@ async def test_activity_gate_reports_max_created_at(sc):
     tenant = _t()
     now = datetime.now(UTC)
     await _seed_memory(
-        tenant_id=tenant, agent_id="a1", memory_type="fact", content="f",
+        tenant_id=tenant,
+        agent_id="a1",
+        memory_type="fact",
+        content="f",
         created_at=now - timedelta(hours=2),
     )
     await _seed_memory(
-        tenant_id=tenant, agent_id="a1", memory_type="insight", content="i",
+        tenant_id=tenant,
+        agent_id="a1",
+        memory_type="insight",
+        content="i",
         created_at=now - timedelta(hours=3),
     )
     gate = await sc.insights_activity_gate(tenant_id=tenant, fleet_id=None)
@@ -454,6 +575,71 @@ async def test_missing_agent_422(storage_http):
     assert resp.status_code == 422
 
 
+async def test_discover_naive_window_start_422(storage_http):
+    # created_at is timestamptz — a naive bound would silently shift the
+    # window by the server's UTC offset, so the router rejects it.
+    resp = await storage_http.post(
+        "/api/v1/storage/insights/discover-sample",
+        json={
+            "tenant_id": "t",
+            "agent_id": "a1",
+            "scope": "agent",
+            "sample_size": 200,
+            "window_start": "2026-07-01T02:00:00",
+        },
+    )
+    assert resp.status_code == 422
+    assert "timezone-aware" in resp.json()["detail"]
+
+
+async def test_discover_invalid_window_start_422(storage_http):
+    resp = await storage_http.post(
+        "/api/v1/storage/insights/discover-sample",
+        json={
+            "tenant_id": "t",
+            "agent_id": "a1",
+            "scope": "agent",
+            "sample_size": 200,
+            "window_start": "not-a-date",
+        },
+    )
+    assert resp.status_code == 422
+
+
+async def test_empty_string_window_start_422(storage_http):
+    # Only None/absent means "no window" (legacy fallback); an explicit ""
+    # is a caller bug and must 422 like any other invalid value, not
+    # silently run the unbounded read.
+    resp = await storage_http.post(
+        "/api/v1/storage/insights/patterns",
+        json={
+            "tenant_id": "t",
+            "agent_id": "a1",
+            "scope": "agent",
+            "max_memories": 50,
+            "window_start": "",
+        },
+    )
+    assert resp.status_code == 422
+    assert "Invalid ISO datetime" in resp.json()["detail"]
+
+
+async def test_patterns_naive_window_start_422(storage_http):
+    # patterns shares the _window_start guard with discover-sample.
+    resp = await storage_http.post(
+        "/api/v1/storage/insights/patterns",
+        json={
+            "tenant_id": "t",
+            "agent_id": "a1",
+            "scope": "agent",
+            "max_memories": 50,
+            "window_start": "2026-07-01T02:00:00",
+        },
+    )
+    assert resp.status_code == 422
+    assert "timezone-aware" in resp.json()["detail"]
+
+
 async def test_supersede_missing_focus_422(storage_http):
     resp = await storage_http.post(
         "/api/v1/storage/insights/supersede-priors",
@@ -465,3 +651,456 @@ async def test_supersede_missing_focus_422(storage_http):
 async def test_activity_gate_missing_tenant_422(storage_http):
     resp = await storage_http.post("/api/v1/storage/insights/activity-gate", json={})
     assert resp.status_code == 422
+
+
+# ===========================================================================
+# E. Input noise filter — opaque-payload exclusion, title-dedup, discover window
+# ===========================================================================
+
+# Content-free reasoning artifact (empty thinking block + encrypted signature):
+# matches PostgresService._INSIGHTS_OPAQUE_CONTENT_PREFIX and must be invisible
+# to every insights read, while staying untouched in storage.
+_OPAQUE = '[{"type":"thinking","thinking":"","thinkingSignature":"rs_abc123"}]'
+
+_EMB = [0.0] * VECTOR_DIM
+
+
+async def test_opaque_payload_excluded_from_all_reads(sc):
+    tenant = _t()
+    now = datetime.now(UTC)
+    old = now - timedelta(days=40)
+    # One opaque row shaped to qualify for EVERY read: active, low weight,
+    # recalled, old, embedded. Plus a second conflicted opaque row for the
+    # contradictions candidate set.
+    await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content=_OPAQUE,
+        title="Encrypted reasoning payload stored",
+        memory_type="episode",
+        weight=0.1,
+        recall_count=3,
+        created_at=old,
+        embedding=_EMB,
+    )
+    await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content=_OPAQUE,
+        title="Encrypted reasoning payload stored",
+        memory_type="episode",
+        status="conflicted",
+        weight=0.1,
+        created_at=old,
+    )
+    keep_id = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="real work happened",
+        title="Deployed rate-limit fix",
+        memory_type="episode",
+        weight=0.1,
+        recall_count=3,
+        created_at=old,
+        embedding=_EMB,
+    )
+
+    patterns = await sc.insights_query_patterns(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+    )
+    assert {r["id"] for r in patterns} == {keep_id}
+
+    failures = await sc.insights_query_failures(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+    )
+    assert {r["id"] for r in failures} == {keep_id}
+
+    stale = await sc.insights_query_stale(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        thirty_days_ago=now - timedelta(days=30),
+        fourteen_days_ago=now - timedelta(days=14),
+        max_memories=INSIGHTS_MAX_MEMORIES,
+    )
+    assert {r["id"] for r in stale} == {keep_id}
+
+    discover = await sc.insights_discover_sample(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        sample_size=INSIGHTS_DISCOVER_SAMPLE_SIZE,
+    )
+    assert {r["id"] for r in discover} == {keep_id}
+
+    contradictions = await sc.insights_query_contradictions(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+    )
+    assert all(r["content"] != _OPAQUE for r in contradictions)
+
+
+async def test_patterns_dedup_one_exemplar_per_title_with_annotations(sc):
+    tenant = _t()
+    now = datetime.now(UTC)
+    oldest = now - timedelta(days=5)
+    # 4 same-titled routine rows (newest wins) + 1 distinct row.
+    dup_ids = []
+    for i in range(4):
+        dup_ids.append(
+            await _seed_memory(
+                tenant_id=tenant,
+                agent_id="a1",
+                content=f"heartbeat run {i}",
+                title="Heartbeat OK",
+                memory_type="episode",
+                created_at=oldest + timedelta(days=i),
+            )
+        )
+    solo_id = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="fixed the flaky test",
+        title="Fixed flaky auth test",
+        created_at=now - timedelta(days=1),
+    )
+
+    # Dedup runs on the windowed path (window_start=None is the legacy
+    # pre-dedup query).
+    rows = await sc.insights_query_patterns(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+        window_start=now - timedelta(days=30),
+    )
+    by_id = {r["id"]: r for r in rows}
+    # One exemplar per title: the NEWEST of the dup group + the solo row.
+    assert set(by_id) == {dup_ids[-1], solo_id}
+    exemplar = by_id[dup_ids[-1]]
+    assert exemplar["dup_count"] == 4
+    assert datetime.fromisoformat(exemplar["first_seen"]) == oldest
+    assert by_id[solo_id]["dup_count"] == 1
+
+
+async def test_dedup_null_and_empty_titles_not_collapsed(sc):
+    tenant = _t()
+    ids = set()
+    for i, title in enumerate([None, None, "", ""]):
+        ids.add(
+            await _seed_memory(
+                tenant_id=tenant,
+                agent_id="a1",
+                content=f"untitled {i}",
+                title=title,
+                created_at=datetime.now(UTC) - timedelta(minutes=i),
+            )
+        )
+    rows = await sc.insights_query_patterns(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+        window_start=datetime.now(UTC) - timedelta(days=30),
+    )
+    # NULL/'' titles fall back to the row id as dedup key — all rows survive.
+    assert {r["id"] for r in rows} == ids
+    assert all(r["dup_count"] == 1 for r in rows)
+
+
+async def test_contradictions_not_deduped_same_title_pair_survives(sc):
+    tenant = _t()
+    # A supersede pair sharing a title: same-titled disagreement is exactly
+    # what contradictions mode must see — dedup must NOT apply here.
+    old_id = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="endpoint is https://old.example",
+        title="Gateway endpoint",
+        created_at=datetime.now(UTC) - timedelta(days=2),
+    )
+    new_id = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="endpoint is https://new.example",
+        title="Gateway endpoint",
+        supersedes_id=old_id,
+        created_at=datetime.now(UTC) - timedelta(days=1),
+    )
+    rows = await sc.insights_query_contradictions(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+    )
+    assert {old_id, new_id} <= {r["id"] for r in rows}
+
+
+async def test_discover_window_bounds_and_legacy_fallback(sc):
+    tenant = _t()
+    now = datetime.now(UTC)
+    in_window = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="recent embedded",
+        title="Recent work",
+        created_at=now - timedelta(days=3),
+        embedding=_EMB,
+    )
+    out_of_window = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="ancient embedded",
+        title="Ancient work",
+        created_at=now - timedelta(days=90),
+        embedding=_EMB,
+    )
+
+    windowed = await sc.insights_discover_sample(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        sample_size=INSIGHTS_DISCOVER_SAMPLE_SIZE,
+        window_start=now - timedelta(days=30),
+    )
+    assert {r["id"] for r in windowed} == {in_window}
+    assert windowed[0]["embedding"] is not None
+
+    # window_start omitted → legacy newest-first behaviour, both rows visible
+    # (back-compat for an older core-api against a newer storage).
+    legacy = await sc.insights_discover_sample(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        sample_size=INSIGHTS_DISCOVER_SAMPLE_SIZE,
+    )
+    assert {r["id"] for r in legacy} == {in_window, out_of_window}
+
+
+async def test_patterns_window_bounds_and_legacy_fallback(sc):
+    tenant = _t()
+    now = datetime.now(UTC)
+    in_window = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="recent pattern",
+        title="Recent work",
+        created_at=now - timedelta(days=3),
+    )
+    out_of_window = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="ancient pattern",
+        title="Ancient work",
+        created_at=now - timedelta(days=90),
+    )
+
+    windowed = await sc.insights_query_patterns(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+        window_start=now - timedelta(days=30),
+    )
+    assert {r["id"] for r in windowed} == {in_window}
+
+    # window_start omitted → the ORIGINAL pre-dedup query (back-compat for
+    # an older core-api against a newer storage): unbounded, un-annotated,
+    # no window-function scan.
+    legacy = await sc.insights_query_patterns(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+    )
+    assert {r["id"] for r in legacy} == {in_window, out_of_window}
+    assert all("dup_count" not in r for r in legacy)
+
+
+async def test_failures_window_bounds_and_legacy_fallback(sc):
+    tenant = _t()
+    now = datetime.now(UTC)
+    in_window = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="recent weak recall",
+        title="Recent weak",
+        weight=0.1,
+        recall_count=2,
+        created_at=now - timedelta(days=10),
+    )
+    out_of_window = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="ancient weak recall",
+        title="Ancient weak",
+        weight=0.1,
+        recall_count=2,
+        created_at=now - timedelta(days=120),
+    )
+
+    windowed = await sc.insights_query_failures(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+        window_start=now - timedelta(days=90),
+    )
+    assert {r["id"] for r in windowed} == {in_window}
+
+    legacy = await sc.insights_query_failures(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+    )
+    assert {r["id"] for r in legacy} == {in_window, out_of_window}
+
+
+async def test_stale_window_bounds_and_legacy_fallback(sc):
+    tenant = _t()
+    now = datetime.now(UTC)
+    # Stale rows must be OLDER than the 30-day threshold to qualify, so the
+    # window (90d) is deliberately wider: the windowed read reports the
+    # 30-90-day "recently became stale" band.
+    in_band = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="became stale recently",
+        title="Recently stale",
+        recall_count=0,
+        created_at=now - timedelta(days=40),
+    )
+    ancient = await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="ancient never recalled",
+        title="Ancient stale",
+        recall_count=0,
+        created_at=now - timedelta(days=200),
+    )
+
+    windowed = await sc.insights_query_stale(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        thirty_days_ago=now - timedelta(days=30),
+        fourteen_days_ago=now - timedelta(days=14),
+        max_memories=INSIGHTS_MAX_MEMORIES,
+        window_start=now - timedelta(days=90),
+    )
+    assert {r["id"] for r in windowed} == {in_band}
+
+    legacy = await sc.insights_query_stale(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        thirty_days_ago=now - timedelta(days=30),
+        fourteen_days_ago=now - timedelta(days=14),
+        max_memories=INSIGHTS_MAX_MEMORIES,
+    )
+    assert {r["id"] for r in legacy} == {in_band, ancient}
+
+
+async def test_failures_dedup_keeps_mode_ordering(sc):
+    tenant = _t()
+    now = datetime.now(UTC)
+    # Two dup groups with different recall_count; failures orders by
+    # recall_count DESC — the ordering applies to the deduped exemplars.
+    for i in range(3):
+        await _seed_memory(
+            tenant_id=tenant,
+            agent_id="a1",
+            content=f"blob {i}",
+            title="Opaque-ish recalled blob",
+            weight=0.1,
+            recall_count=9,
+            created_at=now - timedelta(hours=i + 1),
+        )
+    for i in range(2):
+        await _seed_memory(
+            tenant_id=tenant,
+            agent_id="a1",
+            content=f"weak {i}",
+            title="Weak evidence row",
+            weight=0.2,
+            recall_count=2,
+            created_at=now - timedelta(hours=i + 1),
+        )
+    rows = await sc.insights_query_failures(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+        window_start=now - timedelta(days=90),
+    )
+    assert [r["title"] for r in rows] == [
+        "Opaque-ish recalled blob",
+        "Weak evidence row",
+    ]
+    assert [r["dup_count"] for r in rows] == [3, 2]
+
+
+async def test_failures_dupcount_breaks_recall_ties(sc):
+    tenant = _t()
+    now = datetime.now(UTC)
+    # The exemplar is the NEWEST row per title, whose individual
+    # recall_count may understate a frequent pattern — dup_count is the
+    # secondary sort key so, at equal exemplar recall_count, the
+    # 3-instance pattern outranks the one-off and isn't cut by LIMIT.
+    for i in range(3):
+        await _seed_memory(
+            tenant_id=tenant,
+            agent_id="a1",
+            content=f"frequent {i}",
+            title="Frequent weak pattern",
+            weight=0.1,
+            recall_count=5,
+            created_at=now - timedelta(hours=i + 1),
+        )
+    await _seed_memory(
+        tenant_id=tenant,
+        agent_id="a1",
+        content="one-off",
+        title="One-off weak row",
+        weight=0.1,
+        recall_count=5,
+        created_at=now - timedelta(hours=1),
+    )
+    rows = await sc.insights_query_failures(
+        tenant_id=tenant,
+        fleet_id=None,
+        agent_id="a1",
+        scope="agent",
+        max_memories=INSIGHTS_MAX_MEMORIES,
+        window_start=now - timedelta(days=90),
+    )
+    assert [r["title"] for r in rows] == [
+        "Frequent weak pattern",
+        "One-off weak row",
+    ]


### PR DESCRIPTION
## Problem

Follow-up to the eToro insights quality analysis (and #679). The insights engine's input is the raw memory firehose, and on a busy fleet that means:

- **~1/3 of all insight citations point at repetition noise** (measured over 4.6K citations from every post-Jun-16 insight on the eToro deployment).
- One family alone — **content-free reasoning artifacts** (`[{"type":"thinking","thinking":"","thinkingSignature":"…"}]`, an empty thinking block with an encrypted blob) — is 4.3% of 30-day episodes but drew **23.9% of citations**: nothing to analyze, but near-identical embeddings form the tightest clusters discover can find. The engine has been correctly reporting this about its own input nightly for weeks.
- The discover sample ("newest 200") **spans under a day** on a busy tenant (~700 distinct titles/day) — nightly runs cluster yesterday's activity and re-discover the same shapes.

Notably, **excluding episodes by type would be wrong**: measured across 141K 30-day episodes, 63% are substantive work, and the noise is defined by *repetition and opacity*, not by memory type.

## Changes (input-side only; nothing in storage is deleted or modified)

| Change | Where | Modes |
|---|---|---|
| Opaque-payload guard: structural content-prefix predicate (no title regexes) | `_insights_scope_filters` | all 6 — an unreadable row can't evidence anything |
| Title-dedup: one exemplar per exact title (newest), annotated `dup_count`/`first_seen`, rendered by the prompt formatter as `[repeats: Nx, first seen: date]` | `_insights_dedup_stmt` + formatter | patterns, stale, failures, discover — **deliberately not** contradictions/divergence, where same-titled disagreement is the evidence |
| Discover window: sample spread (`ORDER BY random()` — genuinely run-varying; a deterministic hash order would be a fixed permutation per corpus state) over trailing  `INSIGHTS_DISCOVER_WINDOW_DAYS = 30` instead of newest-first; patterns/failures/stale get their own scan bounds (`INSIGHTS_PATTERNS_WINDOW_DAYS = 30`, `INSIGHTS_FAILURES_WINDOW_DAYS = 90`, `INSIGHTS_STALE_WINDOW_DAYS = 90` — stale's deliberately wider than its 30-day age threshold, so it reports the 30-90d "recently became stale" band instead of perpetually re-reporting the ancient tail) — the dedup subquery has no inner LIMIT, so unbounded patterns would scan the tenant's whole active history for 50 deduped rows (prod: 21K rows/167ms windowed vs 44K/243ms and growing) | discover only | window start computed on the core-api clock (same pattern as the stale thresholds) |

Correctness details: NULL/empty titles fall back to row-id as dedup key (no collapse); `dup_count` is computed over the *filtered* set so it means "N matching rows in this window"; each mode keeps its own result ordering; `window_start` omitted → the ORIGINAL pre-dedup query shape (identical results and cost — no dedup, no annotations, no full-corpus window scan), so an older core-api works against a newer storage and vice versa; failures sorts with `dup_count` as secondary key so frequent patterns aren't cut by LIMIT below one-off rows.

## Validation

- **Wet tests** (6 new in `test_ph5b_insights_storage.py`, against real Postgres): opaque exclusion across all reads incl. contradictions; dedup exemplar choice + annotations; NULL/empty-title survival; same-title supersede pair still visible to contradictions; window bounding + naive-datetime 422 guard (created_at is timestamptz) + legacy fallback; mode ordering preserved under dedup. 30/30 pass.
- **Formatter unit tests** (3 new): annotation rendering, singleton/legacy rows unchanged, cluster representatives annotated. 38/38 pass in the two core-api insights files.
- **Against production data (read-only)**: predicate catches 97.6% of the opaque family; the new discover shape spans **31 distinct days instead of 1**, residual noise titles drop to ~10% of the sample; ~130ms on the busiest tenant. `ruff` clean.

## Explicitly out of scope

- Upstream write suppression (why agents persist empty encrypted thinking blocks at all) — separate track.
- The pending-status leak, novelty guard, and fallback observability from the same analysis — separate PRs.
- eToro deploy: the box needs a release cutover (which would also pick up #679's numpy fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)





