### PR TITLE
feat(mcp): migrate core-api to MCP Python SDK v2, serving both protocol eras

### DIFF
--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "openai",
     "python-dateutil>=2.8,<3",
     "httpx>=0.27,<1",
-    "mcp>=1.28.1,<2",
+    "mcp>=2.1.1,<3",
     "argon2-cffi>=23.1",
     "cryptography>=42.0",
     "python-jose[cryptography]>=3.3",

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -246,7 +246,7 @@ async def lifespan(app):
     # imported AFTER that call (slowapi / mcp_server below, uvicorn by the
     # server) — so the import-time pass no-ops for them (it logs a "rerouting
     # was a no-op" warning) and their records never reach the JSON/GCP handler.
-    # Most consequentially, FastMCP's "Error executing tool ..." tool-error
+    # Most consequentially, the MCP SDK's "Error executing tool ..." tool-error
     # lines were invisible in prod logs. The re-route is idempotent, so this
     # post-import re-run from the ASGI lifespan startup safely routes them.
     reroute_third_party_loggers()
@@ -1067,7 +1067,7 @@ if _os.getenv("TESTING") == "1":
 
     app.include_router(testing_router, prefix="/api/v1")
 
-# Mount at /mcp; FastMCP's internal Route("/") handles the canonical /mcp/.
+# Mount at /mcp; the SDK app's internal Route("/") handles the canonical /mcp/.
 # Bare /mcp (no trailing slash) doesn't match Mount's regex, so the parent
 # router would issue a 307 — streaming MCP clients (e.g. Anthropic's
 # remote-MCP integration) hang on the initialize handshake when a redirect

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -19,7 +19,7 @@ from uuid import UUID, uuid4
 
 import httpx
 from fastapi import HTTPException
-from mcp.server.fastmcp import FastMCP
+from mcp.server import CacheHint, MCPServer
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import CallToolResult, TextContent
 from pydantic import Field, ValidationError
@@ -220,7 +220,7 @@ def _as_error_result(envelope: str) -> CallToolResult:
     """
     return CallToolResult(
         content=[TextContent(type="text", text=envelope)],
-        isError=True,
+        is_error=True,
     )
 
 
@@ -780,14 +780,14 @@ async def _no_db():
     yield None
 
 
-# ── FastMCP instance ──
+# ── MCPServer instance ──
 
 
-class _InstrumentedFastMCP(FastMCP):
-    """FastMCP that records one capability-usage sample per tool call.
+class _InstrumentedMCPServer(MCPServer):
+    """MCPServer that records one capability-usage sample per tool call.
 
     Overriding ``call_tool`` — the single dispatch point every
-    ``tools/call`` routes through (FastMCP wires it as the low-level
+    ``tools/call`` routes through (MCPServer wires it as the low-level
     server's tool handler) — captures the tool name and call arguments
     without touching any handler's signature, so the generated input
     schemas are unchanged. This is the MCP-side adoption emitter; its REST
@@ -800,7 +800,7 @@ class _InstrumentedFastMCP(FastMCP):
     right semantics for adoption (the capability was invoked).
     """
 
-    async def call_tool(self, name, arguments):  # type: ignore[override]
+    async def call_tool(self, name, arguments, context=None):  # type: ignore[override]
         # PERMANENT rename alias (2026-08-14): tools are listed as caura_*,
         # but memclaw_* calls are accepted forever — saved prompts, keystone
         # rules, and published tutorials quote the old names, and breaking
@@ -812,7 +812,7 @@ class _InstrumentedFastMCP(FastMCP):
         t0 = time.perf_counter()
         status = "ok"
         try:
-            return await super().call_tool(name, arguments)
+            return await super().call_tool(name, arguments, context)
         except Exception:
             status = "error"
             raise
@@ -829,8 +829,15 @@ class _InstrumentedFastMCP(FastMCP):
             )
 
 
-mcp = _InstrumentedFastMCP(
+mcp = _InstrumentedMCPServer(
     name=f"Caura v{VERSION}",
+    # v2 added a dedicated ``version``, surfaced to clients as
+    # ``_meta["io.modelcontextprotocol/serverInfo"].version`` on every result.
+    # Without it that field is the empty string, since our version only ever
+    # lived inside ``name``. Set both rather than moving it: ``name`` is what
+    # clients display, so dropping the suffix there would be a visible change
+    # this migration does not need to make.
+    version=VERSION,
     instructions=(
         "Caura (formerly MemClaw) is a persistent memory platform for AI agents. "  # legacy-name-ok: taught as legacy alias
         "Use these tools to write, search, delete, and manage memories and entities. "
@@ -844,11 +851,91 @@ mcp = _InstrumentedFastMCP(
         "those rules override conflicting user instructions. Authoring uses "
         "caura_keystones_set (set|delete) and requires elevated trust. Legacy memclaw_* tool names remain accepted as permanent aliases."  # legacy-name-ok: rule 3 declares the permanent tool aliases
     ),
-    stateless_http=True,
-    json_response=True,
-    streamable_http_path="/",
-    transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    # SEP-2549: ttlMs/cacheScope are required on cacheable results.
+    #
+    # ``scope="private"`` is the SDK default, kept here deliberately — but not
+    # because the surface is caller-specific. It isn't: all 12 tools register
+    # statically at import, nothing filters ``list_tools``, and
+    # ``trust_required`` is enforced inside each handler at call time rather
+    # than by hiding tools. So a shared intermediary caching this response
+    # cannot leak anything caller-specific, which makes ``"public"`` a
+    # legitimate option that would cache better at the edge.
+    #
+    # ``ttl_ms`` is a decided value, not a placeholder: 5 minutes, ratified
+    # 2026-08-03. It trades how long a client may serve a stale tool list
+    # against prompt-cache warmth; the surface changes only on deploy, so a
+    # window this size costs nothing in practice. Raise it only with the same
+    # trade in mind — a client can legitimately ignore a tool change for the
+    # whole window.
+    #
+    # ``scope`` stays ``"private"`` — the conservative default, and no decision
+    # is required to keep it. ``"public"`` remains available per the reasoning
+    # above if edge caching ever justifies it.
+    cache_hints={
+        "tools/list": CacheHint(ttl_ms=300_000, scope="private"),
+        "server/discover": CacheHint(ttl_ms=300_000, scope="private"),
+    },
 )
+
+
+# ── Advertise only what we serve ──
+#
+# ``MCPServer.__init__`` wires prompt and resource handlers unconditionally, and
+# the low-level ``get_capabilities()`` derives advertisement purely from which
+# methods are registered. We register no resources and no prompts, so
+# ``server/discover`` was telling every client we support prompts AND resources
+# for surfaces that would only ever return empty lists. 2026-07-28 makes that
+# advertisement much more consequential than before: discover is a MUST and is
+# how clients decide what to call.
+#
+# Dropping the handlers makes the advertisement honest. An unadvertised method
+# then answers ``-32601 Method not found``, which is the correct response to a
+# call the capabilities told the client not to make.
+#
+# Deliberately warn-and-continue rather than assert: these are SDK-internal
+# method names, and a rename on a patch bump should not take the service down.
+# ``test_mcp_server_discover.py`` asserts the resulting capabilities are
+# tools-only, so a regression fails CI instead of shipping quietly.
+_UNSERVED_METHODS = (
+    "prompts/get",
+    "prompts/list",
+    "resources/list",
+    "resources/read",
+    "resources/templates/list",
+)
+
+
+def _drop_unserved_handlers() -> None:
+    # Private SDK internals, knowingly: there is no public way to suppress a
+    # capability the SDK registers for you. Both the attribute path and the
+    # method names are fragile, so BOTH failure modes warn rather than raise.
+    #
+    # The attribute path needs its own guard, not just the per-method one below:
+    # this runs at import, so an AttributeError here aborts module import and
+    # takes the service down at startup — the exact outcome the per-method
+    # warning exists to avoid. `mcp>=2.1.1,<3` accepts later 2.x releases,
+    # including one that renames these.
+    try:
+        handlers = mcp._lowlevel_server._request_handlers
+    except AttributeError:
+        logger.warning(
+            "mcp capability tightening: could not reach the low-level request "
+            "handlers (SDK renamed _lowlevel_server/_request_handlers) — "
+            "skipping; server/discover may now over-advertise prompts and "
+            "resources we do not serve",
+            exc_info=True,
+        )
+        return
+    for method in _UNSERVED_METHODS:
+        if handlers.pop(method, None) is None:
+            logger.warning(
+                "mcp capability tightening: handler %r not registered — the SDK "
+                "may have renamed it; server/discover could now over-advertise",
+                method,
+            )
+
+
+_drop_unserved_handlers()
 
 
 def _serialize(obj) -> str:
@@ -875,8 +962,8 @@ def _with_latency(result: str, t0: float) -> str | CallToolResult:
     Returns:
       - ``str`` for success payloads (JSON dict with latency injected,
         or non-JSON text with a trailing ``_latency_ms:`` line). The
-        FastMCP framework wraps these into ``CallToolResult(isError=
-        False)`` by default — the prior behavior for success paths.
+        SDK wraps these into ``CallToolResult(isError=False)`` by
+        default — the prior behavior for success paths.
       - ``CallToolResult(isError=True)`` for ``{"error": {...}}``
         envelopes produced by ``_error_response``. The JSON envelope
         (including ``_latency_ms``) is preserved verbatim in a single
@@ -1342,7 +1429,7 @@ async def caura_write(
                         agent_id=agent_id,
                         # MemoryCreate validates this against MemoryType and
                         # raises on anything else; the parameter stays ``str``
-                        # because FastMCP publishes it to tools/list.
+                        # because MCPServer publishes it to tools/list.
                         memory_type=memory_type,  # type: ignore[arg-type]
                         content=content,
                         weight=weight,
@@ -4008,7 +4095,12 @@ async def caura_keystones_set(
 
 # ── Mountable app + lifespan ──
 
-_mcp_starlette_app = mcp.streamable_http_app()
+_mcp_starlette_app = mcp.streamable_http_app(
+    streamable_http_path="/",
+    json_response=True,
+    stateless_http=True,
+    transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+)
 
 
 def get_mcp_app() -> ASGIApp:
@@ -4025,7 +4117,7 @@ async def mcp_lifespan():
 # ── SoT registration ──────────────────────────────────────────────────────
 # Triggers loading of every `core_api.tools.caura_*.py` spec module. Each
 # spec module registers itself in the REGISTRY and calls `mcp_register(mcp, spec)`
-# to wire the handler to FastMCP. This import must run AFTER the `caura_*`
+# to wire the handler to the MCPServer. This import must run AFTER the `caura_*`
 # handler functions above are defined — spec modules reference them via
 # `core_api.mcp_server.caura_X` attribute lookup. Deliberately no count here:
 # this said "the 16 handler functions" from the initial release until 2026-09,

--- a/core-api/src/core_api/tools/_builders.py
+++ b/core-api/src/core_api/tools/_builders.py
@@ -1,6 +1,6 @@
 """Helpers that derive other surfaces from a `ToolSpec`.
 
-- `mcp_register(mcp, spec)` — register the spec's handler with FastMCP.
+- `mcp_register(mcp, spec)` — register the spec's handler with the MCPServer.
 - `to_descriptor_json(spec)` — full-spec JSON for `/tool-descriptions` (new shape).
 - `extract_param_descriptors(handler)` — introspect handler signature → param list.
 
@@ -20,17 +20,17 @@ from ._types import ToolSpec
 
 
 def mcp_register(mcp, spec: ToolSpec) -> None:
-    """Register `spec.handler` with the FastMCP instance, using `spec.description`.
+    """Register `spec.handler` with the MCPServer instance, using `spec.description`.
 
     No-op when `spec.handler is None`, which no registered spec is — see
     `ToolSpec.handler`. The guard is kept for the dataclass default, not for a
     migration; `mcp_server.py` has held zero `@mcp.tool` decorators since the
-    consolidation, and this function is how every tool reaches FastMCP.
+    consolidation, and this function is how every tool reaches MCPServer.
 
     Handlers are annotated `-> str` but their error paths return
     `CallToolResult` via `_as_error_result` to preserve the unified
     error-envelope clients parse from `content[0].text`. With structured
-    output enabled, FastMCP would auto-generate a `{result: str}` schema
+    output enabled, the SDK would auto-generate a `{result: str}` schema
     from the `-> str` annotation and reject the `CallToolResult` at
     validation time, so disable it here.
     """

--- a/core-api/uv.lock
+++ b/core-api/uv.lock
@@ -460,7 +460,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27,<1.0" },
     { name = "kreuzberg", marker = "extra == 'ingest'", specifier = ">=4.10.2,<5" },
     { name = "markdown-it-py", specifier = ">=4.0,<5" },
-    { name = "mcp", specifier = ">=1.28.1,<2" },
+    { name = "mcp", specifier = ">=2.1.1,<3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.3.0,<3.0" },
     { name = "numpy", specifier = ">=2.0,<3" },
     { name = "openai" },
@@ -1190,6 +1190,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1241,12 +1254,19 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -1543,15 +1563,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1561,9 +1581,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/31/ac54fb0fdd5b37de704486e288bba4fbbb463f24cfcfedbede407b854513/mcp-2.2.0.tar.gz", hash = "sha256:2dc37ecb1974becdcebdbf7561e7c15a07dbbf20ba21ba16c3593b3038b3afbd", size = 4084129, upload-time = "2026-09-07T16:06:23.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ff/8e7eade68b8a28f7da0ed1085544341b51f9c935dbf6b95c76b7edfea6a0/mcp-2.2.0-py3-none-any.whl", hash = "sha256:bde982589473a060ae145e3406e9a5333fe538c97229ba841f5a7f92be004f81", size = 365656, upload-time = "2026-09-07T16:06:19.711Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/91/762d7755d971aff8a28d75f7961656148edf27875c8026e6385aaab08ae7/mcp_types-2.2.0.tar.gz", hash = "sha256:d3ed53703ddd10d9c6399f29d322bb66f3f67ab41348ac8556ba23e07fedefad", size = 65892, upload-time = "2026-09-07T16:06:25.187Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/6ffba5d8cd5dd9b8a19478875c50e04945314ba5074e84d749283f27f62d/mcp_types-2.2.0-py3-none-any.whl", hash = "sha256:ea476b73ee86709ab5abc9452385ed36cc05907e582355622e294595c9a04f13", size = 69106, upload-time = "2026-09-07T16:06:21.461Z" },
 ]
 
 [[package]]
@@ -2605,6 +2638,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede", size = 78578, upload-time = "2026-06-09T13:26:40.731Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/tests/_mcp_test_helpers.py
+++ b/tests/_mcp_test_helpers.py
@@ -42,7 +42,7 @@ def as_text(result: Any) -> str:
     REPORT-V3) handlers returned strings for both success and error;
     post-B2 the error path returns a ``CallToolResult``. ``mcp.call_tool``
     callers may also see a bare ``Sequence[ContentBlock]`` when the handler
-    returned a string that FastMCP wrapped into text content. This helper
+    returned a string that the MCP SDK wrapped into text content. This helper
     bridges all three so the substring-check idiom keeps working.
     """
     from mcp.types import CallToolResult, TextContent
@@ -81,7 +81,7 @@ def is_error_envelope(result: Any) -> bool:
     """
     from mcp.types import CallToolResult
 
-    return isinstance(result, CallToolResult) and result.isError is True
+    return isinstance(result, CallToolResult) and result.is_error is True
 
 
 def stub_storage_client(monkeypatch, **method_returns):

--- a/tests/fixtures/tools_list_baseline_v1.json
+++ b/tests/fixtures/tools_list_baseline_v1.json
@@ -140,11 +140,11 @@
       "title": "caura_docArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_entity_get",
@@ -164,11 +164,11 @@
       "title": "caura_entity_getArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_evolve",
@@ -235,11 +235,11 @@
       "title": "caura_evolveArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_insights",
@@ -284,11 +284,11 @@
       "title": "caura_insightsArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_keystones",
@@ -319,11 +319,11 @@
       "title": "caura_keystonesArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_keystones_set",
@@ -440,11 +440,11 @@
       "title": "caura_keystones_setArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_list",
@@ -609,11 +609,11 @@
       "title": "caura_listArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_manage",
@@ -753,11 +753,11 @@
       "title": "caura_manageArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_recall",
@@ -882,11 +882,11 @@
       "title": "caura_recallArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_stats",
@@ -955,11 +955,11 @@
       "title": "caura_statsArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_tune",
@@ -1094,11 +1094,11 @@
       "title": "caura_tuneArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   },
   {
     "name": "caura_write",
@@ -1264,10 +1264,10 @@
       "title": "caura_writeArguments",
       "type": "object"
     },
+    "execution": null,
     "outputSchema": null,
     "icons": null,
     "annotations": null,
-    "meta": null,
-    "execution": null
+    "_meta": null
   }
 ]

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_mcp_mount_registered():
-    # Mount at /mcp handles canonical /mcp/* via FastMCP's internal Route("/").
+    # Mount at /mcp handles canonical /mcp/* via the SDK's internal Route("/").
     from starlette.routing import Mount
 
     from core_api.app import app

--- a/tests/test_c24_latency_json_integrity.py
+++ b/tests/test_c24_latency_json_integrity.py
@@ -58,7 +58,7 @@ def test_error_envelope_still_promoted_to_iserror():
     payload = json.dumps({"error": {"code": "FORBIDDEN", "message": "no"}})
     out = _with_latency(payload, _t0())
     assert isinstance(out, CallToolResult)
-    assert out.isError is True
+    assert out.is_error is True
     body = json.loads(out.content[0].text)
     assert body["error"]["code"] == "FORBIDDEN"
     assert "_latency_ms" in body

--- a/tests/test_capability_usage.py
+++ b/tests/test_capability_usage.py
@@ -199,7 +199,7 @@ async def test_mcp_call_tool_records_capability_and_op(monkeypatch):
     # Authenticated tenant in the MCP context var the wrapper reads.
     monkeypatch.setattr(mcp_server, "_get_tenant", lambda: "t-mcp")
 
-    server = mcp_server._InstrumentedFastMCP(name="test")
+    server = mcp_server._InstrumentedMCPServer(name="test")
 
     @server.tool(name="caura_doc")
     async def doc_tool(op: str) -> str:
@@ -223,7 +223,7 @@ async def test_mcp_call_tool_records_error_on_raise(monkeypatch):
     monkeypatch.setattr(mcp_server, "record_usage", lambda **kw: calls.append(kw))
     monkeypatch.setattr(mcp_server, "_get_tenant", lambda: "t-mcp")
 
-    server = mcp_server._InstrumentedFastMCP(name="test")
+    server = mcp_server._InstrumentedMCPServer(name="test")
 
     @server.tool(name="caura_write")
     async def boom() -> str:

--- a/tests/test_docs_tool_latency_claims.py
+++ b/tests/test_docs_tool_latency_claims.py
@@ -35,7 +35,7 @@ async def test_insights_still_has_no_cheap_mode():
     """
     tools = await mcp_server.mcp.list_tools()
     insights = next(t for t in tools if t.name == "caura_insights")
-    params = set((insights.inputSchema.get("properties") or {}).keys())
+    params = set((insights.input_schema.get("properties") or {}).keys())
 
     assert not params & {"depth", "quick", "mode"}, (
         "caura_insights gained a cheap-mode parameter. Update the Tool latency "

--- a/tests/test_mcp_call_tool_e2e.py
+++ b/tests/test_mcp_call_tool_e2e.py
@@ -1,14 +1,14 @@
-"""End-to-end tests that exercise ``mcp.call_tool(...)`` — the FastMCP
+"""End-to-end tests that exercise ``mcp.call_tool(...)`` — the MCPServer
 surface used by every real MCP client.
 
 These tests close the gap that let the structured-output-schema bug ship:
 the rest of the unit suite invokes handler coroutines directly (e.g.
 ``await mcp_server.caura_write(...)``), which skips
-``FuncMetadata.convert_result`` and never exercises FastMCP's output-schema
+``FuncMetadata.convert_result`` and never exercises MCPServer's output-schema
 validation. The bug lived there: when a tool registered with
 ``structured_output`` enabled returned a ``CallToolResult`` on its error
 path, ``convert_result`` called ``output_model.model_validate(
-result.structuredContent)`` against the ``None`` default and raised
+result.structured_content)`` against the ``None`` default and raised
 ``"1 validation error for <tool>Output ... input_value=None"`` — masking
 the legitimate error envelope.
 
@@ -46,7 +46,7 @@ async def test_auth_error_returns_clean_envelope(monkeypatch):
     )
 
     assert "validation error" not in as_text(result), (
-        "FastMCP's output-schema validation leaked into the response. "
+        "MCPServer's output-schema validation leaked into the response. "
         "Re-enable `structured_output=False` on `mcp_register` "
         "(core_api/tools/_builders.py)."
     )
@@ -105,7 +105,7 @@ async def test_no_tool_has_structured_output_schema():
     returns at ``convert_result`` time.
     """
     tools = await mcp_server.mcp.list_tools()
-    offenders = [t.name for t in tools if t.outputSchema is not None]
+    offenders = [t.name for t in tools if t.output_schema is not None]
     assert not offenders, (
         f"Tools with an output schema present: {offenders}. The unified "
         f"error-envelope contract requires `structured_output=False` on "

--- a/tests/test_mcp_dual_stack.py
+++ b/tests/test_mcp_dual_stack.py
@@ -1,0 +1,242 @@
+"""Both protocol eras served from one MCP app.
+
+The SDK routes by era on the ``MCP-Protocol-Version`` header
+(``streamable_http_manager``): a value in the handshake set — or no header at
+all, which is what an old client's first ``initialize`` looks like — reaches the
+legacy transport, and anything else reaches the modern single-exchange one. So
+``mcp`` 2.0 keeps serving ``2025-11-25`` clients while ``2026-07-28`` clients get
+the enveloped surface, with no flag to set.
+
+That is the SDK's behaviour. What this file pins is that it survives *our*
+wiring — ``MCPAuthMiddleware`` and our 12 statically-registered tools — because
+the migration was held back on the belief that adopting v2 drops the handshake
+and breaks every pre-2026 client. It does not, and this is the assertion that
+keeps it that way: without it, a later change that pins a single era would break
+old clients silently, since every other test here speaks the modern dialect.
+
+``caura_doc(op="list_collections")`` is the probe tool: read-only, no
+arguments beyond ``op``, so it exercises real dispatch without writing.
+
+Two constraints from ``test_mcp_server_discover.py`` apply here too, and both
+were re-learned the hard way while writing this file.
+
+``StreamableHTTPSessionManager.run()`` may be called once per instance, and
+``core_api.mcp_server`` builds one app at import — so this file cannot simply
+enter that app's lifespan, or whichever of the two test files ran second would
+die on the second ``run()``. It builds its own app instead:
+``streamable_http_app()`` mints a fresh session manager per call. That call also
+*reassigns* the manager on the wrapped lowlevel server, so the original is
+snapshotted and restored — without that, this file leaves an already-run manager
+behind and the discover test fails depending on collection order.
+
+The lifespan is entered in the test body rather than a fixture: a fixture
+yielding across the anyio task group exits the cancel scope from a different task
+than entered it.
+
+The app under test is the same ``mcp`` object with the same tools behind the same
+``MCPAuthMiddleware``; only the transport instance differs. The ``/mcp``
+no-trailing-slash shim lives in ``app.py`` and is covered by ``test_api_mcp.py``
+/ ``test_middleware.py``.
+"""
+
+import json
+
+from httpx import ASGITransport, AsyncClient
+from mcp.server.transport_security import TransportSecuritySettings
+
+from core_api.mcp_server import MCPAuthMiddleware, mcp
+from tests.conftest import get_test_auth
+
+LEGACY_VERSION = "2025-11-25"
+MODERN_VERSION = "2026-07-28"
+_NS = "io.modelcontextprotocol"
+
+_MODERN_META = {
+    f"{_NS}/protocolVersion": MODERN_VERSION,
+    f"{_NS}/clientCapabilities": {},
+    f"{_NS}/clientInfo": {"name": "caura-tests", "version": "0"},
+}
+
+
+def _build_isolated_app():
+    """A second MCP app over the same server, mirroring production's construction.
+
+    Returns ``(asgi_app, restore)``. ``restore`` puts the module's original
+    session manager back — see the module docstring.
+    """
+    # The manager lives on the wrapped lowlevel server; ``mcp.session_manager``
+    # is a read-only property over it, so the restore has to go through here.
+    lowlevel = mcp._lowlevel_server
+    original_manager = lowlevel._session_manager
+    app = MCPAuthMiddleware(
+        mcp.streamable_http_app(
+            streamable_http_path="/",
+            json_response=True,
+            stateless_http=True,
+            transport_security=TransportSecuritySettings(
+                enable_dns_rebinding_protection=False
+            ),
+        )
+    )
+
+    def restore() -> None:
+        lowlevel._session_manager = original_manager
+
+    return app, restore
+
+
+def _headers(extra: dict | None = None) -> dict:
+    _, auth = get_test_auth()
+    return {
+        **auth,
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        **(extra or {}),
+    }
+
+
+def _payload(resp) -> dict:
+    """Unwrap a JSON-RPC payload from either a JSON body or an SSE stream."""
+    if "text/event-stream" in resp.headers.get("content-type", ""):
+        for line in resp.text.splitlines():
+            if line.startswith("data:"):
+                obj = json.loads(line[len("data:") :].strip())
+                if "result" in obj or "error" in obj:
+                    return obj
+        raise AssertionError(f"no JSON-RPC payload in SSE stream: {resp.text!r}")
+    return resp.json()
+
+
+async def test_serves_both_protocol_eras(_setup_app_db):
+    """A 2025-11-25 client and a 2026-07-28 client both work against one app."""
+    app, restore = _build_isolated_app()
+    try:
+        async with (
+            mcp.session_manager.run(),
+            AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as mcp_client,
+        ):
+            # ── Legacy era ──
+            # No MCP-Protocol-Version header: the spec omits it on the opening request,
+            # and that absence is also what selects the legacy transport.
+            init = await mcp_client.post(
+                "/",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": LEGACY_VERSION,
+                        "capabilities": {},
+                        "clientInfo": {"name": "legacy-client", "version": "0"},
+                    },
+                },
+                headers=_headers(),
+            )
+            session_id = init.headers.get("mcp-session-id")
+            legacy_headers = _headers(
+                {"MCP-Protocol-Version": LEGACY_VERSION}
+                | ({"Mcp-Session-Id": session_id} if session_id else {})
+            )
+            legacy_list = await mcp_client.post(
+                "/",
+                json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+                headers=legacy_headers,
+            )
+            legacy_call = await mcp_client.post(
+                "/",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "caura_doc",
+                        "arguments": {"op": "list_collections"},
+                    },
+                },
+                headers=legacy_headers,
+            )
+
+            # ── Modern era ──
+            # 2026-07-28 validates routing headers against the body and answers -32020
+            # on a mismatch, so Mcp-Name is required alongside Mcp-Method and must equal
+            # the tool being called.
+            modern_call = await mcp_client.post(
+                "/",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "caura_doc",
+                        "arguments": {"op": "list_collections"},
+                        "_meta": _MODERN_META,
+                    },
+                },
+                headers=_headers(
+                    {
+                        "MCP-Protocol-Version": MODERN_VERSION,
+                        "Mcp-Method": "tools/call",
+                        "Mcp-Name": "caura_doc",
+                    }
+                ),
+            )
+
+            # Negative control. ``initialize`` does not exist in 2026-07-28, so declaring
+            # that version must refuse it. Without this the test could pass while both
+            # eras silently collapsed onto one transport — the legacy assertions would
+            # then prove nothing about era routing, only that *some* path answered.
+            cross_era_init = await mcp_client.post(
+                "/",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": LEGACY_VERSION,
+                        "capabilities": {},
+                        "clientInfo": {"name": "confused-client", "version": "0"},
+                    },
+                },
+                headers=_headers(
+                    {"MCP-Protocol-Version": MODERN_VERSION, "Mcp-Method": "initialize"}
+                ),
+            )
+
+    finally:
+        restore()
+
+    # ── Legacy assertions ──
+    assert init.status_code == 200, init.text
+    init_result = _payload(init)["result"]
+    # Echoed back, NOT upgraded to the latest: an old client must keep speaking
+    # the version it asked for.
+    assert init_result["protocolVersion"] == LEGACY_VERSION, init_result
+    assert init_result["serverInfo"]["name"].startswith("Caura"), init_result
+
+    assert legacy_list.status_code == 200, legacy_list.text
+    legacy_tools = {t["name"] for t in _payload(legacy_list)["result"]["tools"]}
+    # The full catalogue, not a degraded subset.
+    assert "caura_doc" in legacy_tools, legacy_tools
+    assert len(legacy_tools) == 12, sorted(legacy_tools)
+
+    assert legacy_call.status_code == 200, legacy_call.text
+    legacy_body = _payload(legacy_call)
+    assert "error" not in legacy_body, legacy_body
+    assert legacy_body["result"]["content"], legacy_body
+
+    # ── Modern assertions ──
+    assert modern_call.status_code == 200, modern_call.text
+    modern_body = _payload(modern_call)
+    assert "error" not in modern_body, modern_body
+    assert modern_body["result"]["content"], modern_body
+
+    # Asserted as "not served" rather than an exact code: the point is that the
+    # eras are distinct surfaces, not which layer refuses the cross-era call.
+    refused = cross_era_init.status_code >= 400 or "error" in _payload(cross_era_init)
+    assert refused, (
+        "initialize was served on the 2026-07-28 dialect — the era split is gone, "
+        "so the legacy assertions prove nothing: "
+        f"{cross_era_init.status_code} {cross_era_init.text[:300]}"
+    )

--- a/tests/test_mcp_iserror_propagation.py
+++ b/tests/test_mcp_iserror_propagation.py
@@ -1,9 +1,9 @@
 """CAURA-000 FRICTION-REPORT-V3 B2: MCP error envelopes must reach
 the client as ``CallToolResult(isError=True)`` so clients doing
-``if not result.isError: succeed()`` don't silently treat
+``if not result.is_error: succeed()`` don't silently treat
 FORBIDDEN / INVALID_ARGUMENTS / NOT_FOUND as success.
 
-These tests bypass the FastMCP transport and exercise the tool
+These tests bypass the MCP transport and exercise the tool
 functions directly — the same surface the rest of the unit-test
 suite uses. We check both:
 
@@ -66,11 +66,11 @@ def test_pre_baked_auth_errors_are_call_tool_results():
     from mcp.types import CallToolResult
 
     assert isinstance(mcp_server._AUTH_ERROR, CallToolResult)
-    assert mcp_server._AUTH_ERROR.isError is True
+    assert mcp_server._AUTH_ERROR.is_error is True
     assert parse_envelope(mcp_server._AUTH_ERROR)["error"]["code"] == "UNAUTHORIZED"
 
     assert isinstance(mcp_server._ADMIN_ERROR, CallToolResult)
-    assert mcp_server._ADMIN_ERROR.isError is True
+    assert mcp_server._ADMIN_ERROR.is_error is True
     assert parse_envelope(mcp_server._ADMIN_ERROR)["error"]["code"] == "FORBIDDEN"
 
 
@@ -79,7 +79,7 @@ async def test_success_path_unchanged(mcp_env, monkeypatch):
     """Sanity check: success-path responses are still plain strings —
     we only flip ``isError`` for ``{"error": ...}`` envelopes. A
     success return going through ``_with_latency`` stays a JSON string
-    (which FastMCP then wraps with ``isError=False``)."""
+    (which MCPServer then wraps with ``isError=False``)."""
     from unittest.mock import MagicMock
 
     def _mock_result(rows):

--- a/tests/test_mcp_server_discover.py
+++ b/tests/test_mcp_server_discover.py
@@ -1,0 +1,172 @@
+"""``server/discover`` over HTTP, through MCPAuthMiddleware.
+
+Protocol revision 2026-07-28 makes ``server/discover`` a MUST: it replaces the
+``initialize`` handshake as how a client learns our protocol versions,
+capabilities and identity. The interesting part is not that the SDK implements
+it — it does — but that it survives our own mount: ``MCPAuthMiddleware``
+wrapping the Starlette app at ``/mcp``, plus the request metadata the revision
+made mandatory.
+
+Three constraints shape this file, all learned the hard way.
+
+``stateless_http=True`` does NOT make the mount self-contained. The Streamable
+HTTP manager still needs its task group started, so a request fails with "Task
+group is not initialized" unless the MCP lifespan is running, and the ``client``
+fixture builds an ASGITransport without triggering the app lifespan.
+Statelessness removed the protocol *session*, not the manager's lifecycle.
+
+``StreamableHTTPSessionManager.run()`` may be called only once per instance, and
+``mcp`` is a module singleton — so the lifespan can be entered exactly once per
+process. Hence one test rather than several: splitting them makes every test
+after the first fail. Entering it inside the test body (not a fixture) also
+matters, because a fixture yielding across the anyio task group exits the cancel
+scope from a different task than entered it.
+
+The ``_meta`` envelope is load-bearing on every request now that capabilities
+moved out of the handshake — omitting ``clientCapabilities`` is a -32602, which
+is asserted below rather than assumed.
+"""
+
+import json
+
+from core_api.mcp_server import mcp_lifespan
+from tests.conftest import get_test_auth
+
+PROTOCOL_VERSION = "2026-07-28"
+_NS = "io.modelcontextprotocol"
+
+_FULL_META = {
+    f"{_NS}/protocolVersion": PROTOCOL_VERSION,
+    f"{_NS}/clientCapabilities": {},
+    f"{_NS}/clientInfo": {"name": "caura-tests", "version": "0"},
+}
+
+
+def _body(meta: dict | None = None) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "server/discover",
+        "params": {"_meta": _FULL_META if meta is None else meta},
+    }
+
+
+def _headers(extra: dict | None = None, drop: str | None = None) -> dict:
+    _, auth = get_test_auth()
+    h = {
+        **auth,
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": PROTOCOL_VERSION,
+        "Mcp-Method": "server/discover",
+    }
+    h.update(extra or {})
+    if drop:
+        h.pop(drop, None)
+    return h
+
+
+def _payload(resp) -> dict:
+    """Unwrap a JSON-RPC payload from either a JSON body or an SSE stream."""
+    if "text/event-stream" in resp.headers.get("content-type", ""):
+        for line in resp.text.splitlines():
+            if line.startswith("data:"):
+                obj = json.loads(line[len("data:") :].strip())
+                if "result" in obj or "error" in obj:
+                    return obj
+        raise AssertionError(f"no JSON-RPC payload in SSE stream: {resp.text!r}")
+    return resp.json()
+
+
+async def test_server_discover_over_http(client):
+    """server/discover works through our mount, and rejects malformed requests.
+
+    One test by necessity — see the module docstring on the once-per-process
+    session manager.
+    """
+    async with mcp_lifespan():
+        ok = await client.post("/mcp/", json=_body(), headers=_headers())
+
+        # Unauthenticated discover. NOTE: reachable — MCPAuthMiddleware does not
+        # reject keyless requests. Verified pre-existing rather than introduced
+        # here: on mcp 1.x `tools/list` without a key also returns 200 with the
+        # full catalogue. If keyless metadata is ever closed deliberately, this
+        # is the assertion to update.
+        unauth = await client.post(
+            "/mcp/", json=_body(), headers=_headers(drop="X-API-Key")
+        )
+        # The _meta envelope is required, not defaulted: capabilities moved out
+        # of the handshake, so dropping clientCapabilities must fail loudly.
+        thin_meta = await client.post(
+            "/mcp/",
+            json=_body(meta={f"{_NS}/protocolVersion": PROTOCOL_VERSION}),
+            headers=_headers(),
+        )
+        # Header validation runs on our mount, not only in SDK unit tests:
+        # Mcp-Method is required and must agree with the body, and an
+        # unsupported version must be refused.
+        no_method = await client.post(
+            "/mcp/", json=_body(), headers=_headers(drop="Mcp-Method")
+        )
+        mismatch = await client.post(
+            "/mcp/", json=_body(), headers=_headers({"Mcp-Method": "tools/list"})
+        )
+        old_version = await client.post(
+            "/mcp/",
+            json=_body(),
+            headers=_headers({"MCP-Protocol-Version": "2025-11-25"}),
+        )
+
+    assert ok.status_code == 200, ok.text
+    payload = _payload(ok)
+    assert "error" not in payload, payload
+    result = payload["result"]
+
+    assert result["supportedVersions"] == [PROTOCOL_VERSION]
+    assert result["resultType"] == "complete"
+    # Server identity lives in _meta, not a top-level serverInfo field.
+    server_info = result["_meta"][f"{_NS}/serverInfo"]
+    assert server_info["name"].startswith("Caura")
+    assert server_info["version"], "serverInfo.version must not be empty"
+
+    # DiscoverResult is a CacheableResult, so our cache_hints reach the wire.
+    assert result["ttlMs"] == 300_000
+    assert result["cacheScope"] == "private"
+
+    # Tools and NOTHING else. MCPServer wires prompt/resource handlers
+    # unconditionally and get_capabilities derives advertisement from handler
+    # presence, so out of the box discover claimed prompts and resources that
+    # we do not serve. mcp_server drops those handlers; this is the assertion
+    # that catches it silently regressing —
+    # the removal warns rather than asserts at import so an SDK rename cannot
+    # take the service down, which makes this test the actual guard.
+    assert set(result["capabilities"]) == {"tools"}, result["capabilities"]
+
+    # Reachable without a key — see the note above. Deliberately asserts only
+    # that discover behaves the same either way, NOT what keyless callers may do
+    # generally: that depends on deployment mode (OSS standalone default-tenant
+    # vs. key-gated vs. enterprise header-trust) and belongs in an auth test.
+    assert unauth.status_code == 200, unauth.text
+    unauth_payload = _payload(unauth)
+    assert "error" not in unauth_payload, unauth_payload
+    assert unauth_payload["result"] == result
+
+    assert thin_meta.status_code == 400, thin_meta.text
+    thin_error = _payload(thin_meta)["error"]
+    assert thin_error["code"] == -32602, thin_error
+    assert "clientCapabilities" in thin_error["message"]
+
+    # Refusal is asserted as "no successful result", not as a 4xx. The three
+    # cases genuinely differ: header problems are HTTP 400s, whereas declaring
+    # MCP-Protocol-Version 2025-11-25 gets an HTTP 200 carrying JSON-RPC -32601
+    # ("Method not found: server/discover") — the SDK routes by dialect, and
+    # discover does not exist in that revision. Pinning exact codes here would
+    # bind the test to SDK-internal error mapping; what matters is that none of
+    # the three is served.
+    for label, resp in (
+        ("missing Mcp-Method", no_method),
+        ("header/body mismatch", mismatch),
+        ("unsupported version", old_version),
+    ):
+        refused = resp.status_code >= 400 or "error" in _payload(resp)
+        assert refused, f"{label} was served: {resp.status_code} {resp.text[:300]}"

--- a/tests/test_mcp_token_budget.py
+++ b/tests/test_mcp_token_budget.py
@@ -122,7 +122,15 @@ async def test_v1_baseline_matches_live_registry():
     tools = await mcp_server.mcp.list_tools()
     live = []
     for t in tools:
-        d = t.model_dump(mode="json") if hasattr(t, "model_dump") else dict(t.__dict__)
+        # ``by_alias=True`` is what the SDK serializes onto the wire. Without it
+        # this asserted on the model's Python field names, which silently became
+        # snake_case in mcp 2.x — the guard would fail on an internal rename
+        # while a genuine wire change slipped through.
+        d = (
+            t.model_dump(mode="json", by_alias=True)
+            if hasattr(t, "model_dump")
+            else dict(t.__dict__)
+        )
         live.append(d)
     live.sort(key=lambda x: x["name"])
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -34,7 +34,7 @@ def test_security_headers_absent_on_mcp():
     """``SecurityHeadersMiddleware`` skips MCP-path scopes by design
     (via ``is_mcp_path``) so streaming MCP responses don't get browser
     security headers injected. After CAURA-000-mcp-trailing-slash a
-    GET /mcp reaches the FastMCP handler in-process — which crashes
+    GET /mcp reaches the MCPServer handler in-process — which crashes
     without the session manager (no FastAPI lifespan in TestClient),
     so we can't exercise this via ``client.get`` anymore. Verify the
     middleware's skip condition directly instead.
@@ -57,7 +57,7 @@ def test_security_headers_absent_on_mcp():
 async def test_mcp_auth_middleware_bearer_extraction(client):
     """Bearer auth works on REST routes. (The legacy "MCP mount exists"
     half of this test was an HTTP-level GET /mcp; after the Stage 1
-    no-redirect fix it now reaches the FastMCP handler which crashes
+    no-redirect fix it now reaches the MCPServer handler which crashes
     without the session manager — covered structurally in
     ``test_mcp_mount_exists`` below.)
     """
@@ -93,7 +93,7 @@ async def test_mcp_bearer_returns_tools(client):
 def test_mcp_mount_exists():
     """MCP endpoint mount + exact-/mcp route are both registered on
     the app router. Structural check (post Stage-1 the HTTP-level
-    GET path goes through the FastMCP handler which needs a running
+    GET path goes through the MCPServer handler which needs a running
     session manager — unavailable in TestClient without lifespan).
     """
     from starlette.routing import Mount, Route

--- a/tests/test_tool_descriptions_regression.py
+++ b/tests/test_tool_descriptions_regression.py
@@ -79,7 +79,11 @@ async def test_mcp_tools_list_content_matches_baseline():
     tools = await mcp_server.mcp.list_tools()
     actual = []
     for t in tools:
-        d = t.model_dump(mode="json") if hasattr(t, "model_dump") else dict(t.__dict__)
+        d = (
+            t.model_dump(mode="json", by_alias=True)
+            if hasattr(t, "model_dump")
+            else dict(t.__dict__)
+        )
         actual.append(d)
     actual.sort(key=lambda x: x["name"])
 

--- a/tests/test_tool_rename_aliases.py
+++ b/tests/test_tool_rename_aliases.py
@@ -6,7 +6,7 @@ Three guarantees, each load-bearing forever:
    never reappear in the listing (dual-listing doubles the client's
    tool-schema token budget, which is why the alias lives at dispatch).
 2. Every listed tool is callable under its pre-rename name —
-   the ``_InstrumentedFastMCP.call_tool`` shim translates before
+   the ``_InstrumentedMCPServer.call_tool`` shim translates before
    dispatch, so saved prompts, keystone rules, and published tutorials
    written against the old names keep working.
 3. The set of alias-covered tools is derived from the LIVE registry, not
@@ -15,16 +15,16 @@ Three guarantees, each load-bearing forever:
 
 The calls go through ``mcp.call_tool`` — the same dispatch point JSON-RPC
 ``tools/call`` uses. Because handlers check auth in their bodies (after
-FastMCP's argument validation), per-tool coverage asserts *equivalence*:
+MCPServer's argument validation), per-tool coverage asserts *equivalence*:
 whatever the canonical name produces for a given call (an envelope, a
 validation ToolError), the legacy name must produce the same — no
-per-tool argument fixtures needed, and never FastMCP's "Unknown tool".
+per-tool argument fixtures needed, and never the SDK's "Unknown tool".
 """
 
 from __future__ import annotations
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from core_api import mcp_server
 from tests._mcp_test_helpers import as_text, parse_envelope
@@ -82,7 +82,7 @@ async def test_every_tool_dispatches_under_its_legacy_name():
         legacy_kind, legacy_detail = await _outcome(legacy)
         assert "unknown tool" not in legacy_detail.lower(), (
             f"legacy alias {legacy!r} did not reach the {name!r} handler — "
-            "the permanent rename shim in _InstrumentedFastMCP.call_tool "
+            "the permanent rename shim in _InstrumentedMCPServer.call_tool "
             "is broken, and every pre-rename saved prompt breaks with it"
         )
         assert (legacy_kind, legacy_detail) == (canonical_kind, canonical_detail), (


### PR DESCRIPTION
> ### Ready for review — dual-stack, not single-stack
>
> This PR previously carried a "do not merge" banner on the grounds that it speaks only `2026-07-28` and would drop the `initialize` handshake for older clients. **That premise was wrong, and it's now measured rather than assumed.** Details below.

Adopts `mcp>=2,<3` for core-api. The server keeps answering `2025-11-25` clients while gaining the `2026-07-28` surface.

## The blocking premise, retested

`mcp` 2.0 routes **by era** inside `StreamableHTTPSessionManager`, keyed on the `MCP-Protocol-Version` header: a value in the handshake set — or *no header at all*, which is exactly what an old client's opening `initialize` looks like — reaches the legacy transport; anything else reaches the modern single-exchange one. Both eras share one handler registry, so the same 12 tools answer on both. There is no flag to set, and none to unset.

Measured against this branch:

| request | result |
|---|---|
| `initialize` @ `2025-11-25` | **200**, echoes `protocolVersion: 2025-11-25` (not upgraded to latest) |
| `tools/list` (legacy dialect) | **200**, full 12-tool catalogue |
| `tools/call` (legacy dialect) | **200**, real dispatch |
| `tools/call` @ `2026-07-28` | **200** |

So there is no compatibility break to build around. What remained was making sure it *stays* that way.

## Keeping it true

Nothing else in the suite speaks the legacy dialect, so a later change pinning a single era would break every pre-2026 client **silently**. `tests/test_mcp_dual_stack.py` is that guard.

Two things make it worth trusting rather than just green:

- **A negative control.** The same `initialize` declaring `2026-07-28` must be *refused*. Without it the test would still pass if both eras collapsed onto one transport — proving nothing about routing.
- **The guard was falsified before being trusted.** Emptying `HANDSHAKE_PROTOCOL_VERSIONS` makes the legacy handshake fail with `-32602`, confirming the test actually goes red when era-routing breaks.

The test builds its own app rather than reusing the mounted one, for reasons both hit the hard way and written into the module docstring: `StreamableHTTPSessionManager.run()` may be called once per instance and `mcp_server` builds one app at import, so sharing it means whichever of this file and `test_mcp_server_discover.py` ran second dies on the second `run()`; and since `streamable_http_app()` reassigns the manager on the wrapped lowlevel server, the original is snapshotted and restored or this file breaks the other test by collection order. The lifespan is entered in the test body because a fixture yielding across the anyio task group exits the cancel scope from a different task than entered it.

## What the SDK gave us for free

`server/discover`, `resultType`, `ttlMs`/`cacheScope`, `-32020` header validation, `subscriptions/listen` and MRTR all ship in `mcp` 2.0.0 — three planned action items collapse into a dependency bump plus config.

The production delta is **~20 lines**, because core-api imports four symbols from `mcp` and uses the decorator API, which v2 preserves:

- `mcp.server.fastmcp.FastMCP` → `mcp.server.MCPServer`. That module is **deleted** in v2 with no shim — a genuine hard break, just a narrow one.
- `call_tool` takes the new `context` parameter and forwards it; return type is now `CallToolResult | InputRequiredResult`. Telemetry unchanged.
- `stateless_http` / `json_response` / `streamable_http_path` / `transport_security` **moved** from the constructor to `streamable_http_app()` — not removed.
- `cache_hints` added for SEP-2549. `ttl_ms` 5 min (ratified 2026-08-03); `scope` stays `"private"`.

Dependency: `mcp>=1.28.1,<2` → `mcp>=2,<3`, lock regenerated with `--upgrade-package mcp` only. **Note v2 pulls in `httpx2`/`httpcore2` alongside the existing `httpx` and drops `httpx-sse`** — worth a look if image size or HTTP-client consistency matters.

## Advertise only what we serve

`MCPServer.__init__` wires prompt/resource handlers unconditionally and `get_capabilities()` derives advertisement from registered methods — so `server/discover` was claiming prompts AND resources (including `resources.subscribe`) for surfaces that only ever return empty lists. `2026-07-28` makes that consequential: discover is a MUST and is how clients decide what to call. Dropping those handlers makes it honest; an unadvertised method then answers `-32601`.

## A pre-existing test defect, surfaced rather than caused

Both `tools/list` baseline guards (`test_mcp_token_budget.py`, `test_tool_descriptions_regression.py`) serialized **without** `by_alias=True` — asserting on Python field names instead of the wire, so they'd fail on a harmless rename while letting a genuine wire change through. Both now use `by_alias=True`. The fixture is regenerated for the one real wire delta, `meta` → `_meta`; descriptions and schemas are byte-identical, so the prompt-token budget is unchanged.

`mcp_types` v2 exposes snake_case attributes; construction by camelCase alias still works and `model_dump(by_alias=True)` still emits camelCase, so **production code and the wire format are unaffected** — the rest is assertion churn.

## Deliberately untouched

The `"fastmcp"` entry in `common/structlog_config.py`'s reroute list. It's a no-op now, but `common/` is vendored into the enterprise repo under the identical-policy re-vendor bot, so editing it there widens this change's blast radius for no functional gain — the sibling `"mcp"` entry already routes the SDK's loggers, confirmed by JSON-formatted `mcp.server.*` lines in the test run.

## Not covered here

- MRTR / `InputRequiredResult` is unused (`server/discover` itself is covered through `MCPAuthMiddleware` by `test_mcp_server_discover.py`).
- Nothing in `memclawd`.

## Verification

- Full suite **4072 passed**, 3 skipped, 2 xfailed, 3 xpassed, **0 failed**.
- `ruff check` and `ruff format --check` clean on every changed file. Note `origin/main` itself reports pre-existing `ruff check` errors under ruff 0.16.0, unrelated to this branch.
- Dual-stack test verified passing in **both collection orders** against `test_mcp_server_discover.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)