### PR TITLE
fix(ci): pin common/'s ruff contract and lint-gate it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,15 @@ jobs:
         # of that blind spot close together or it just drifts again.
         run: uv run ruff check core-storage-api/tests/
 
+      - name: Run Ruff linter (common)
+        # ``--config`` is explicit on purpose. common/ had NO ruff config above it
+        # (no ruff.toml, no root pyproject.toml), so ruff fell back to built-in
+        # DEFAULTS here — meaning the rule set was "whatever the installed ruff
+        # version ships," and it changed under us on the 0.16.0 bump. common/ruff.toml
+        # pins it; naming the config keeps this step immune to future config
+        # discovery changes, the same reasoning as ``--isolated`` below. See #684.
+        run: uv run ruff check common/ --config common/ruff.toml
+
       - name: Run Ruff formatter check (core-api)
         run: uv run ruff format --check core-api/src/
 
@@ -144,9 +153,12 @@ jobs:
         # Enterprise CI format-checks the vendored copies at ruff DEFAULTS (88 cols),
         # so gate them here too or a merge turns enterprise CI red until a reflow
         # lands (full story: the vendoring note in common/structlog_config.py's
-        # docstring). ``--isolated`` pins default behavior even if a root ruff
-        # config is ever added; deliberately NOT all of common/ — non-vendored
-        # files there are not held to the 88-col contract.
+        # docstring). ``--isolated`` pins default behavior regardless of any ruff
+        # config in scope — which now includes common/ruff.toml (added in #684),
+        # so this step is deliberately unaffected by it. Still NOT all of common/:
+        # only the policy=identical files owe byte-parity to enterprise. Note
+        # common/ruff.toml also sets line-length = 88, so the two agree today;
+        # ``--isolated`` is what guarantees they cannot silently diverge.
         run: uv run ruff format --check --isolated common/__init__.py common/structlog_config.py common/serve.py
 
       - name: Guard against raw-string MCP error returns (audit B4 / CAURA-000 #147)

--- a/common/embedding/constants.py
+++ b/common/embedding/constants.py
@@ -53,10 +53,10 @@ EMBEDDING_RETRY_DELAY_S: float = float(os.environ.get("EMBEDDING_RETRY_DELAY_S",
 # tunable controls both the LLM and the embedding pools. Without an
 # explicit limits arg the SDK rides httpx's default (100 max / 20
 # keepalive) which saturates under bulk-write storm fan-out (16
-# concurrent writes × 10 enrichment calls = 160 concurrent LLM
+# concurrent writes x 10 enrichment calls = 160 concurrent LLM
 # requests per process, well over the keepalive budget). See
 # ``common/llm/constants.py`` for full rationale.
-from common.env_utils import (  # noqa: E402
+from common.env_utils import (
     clamp_keepalive,
     read_float_env,
     read_int_env,
@@ -101,7 +101,7 @@ EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS: int = clamp_keepalive(
 #
 # The embedding backend is finite and can be much smaller than the
 # fleet calling it: prod's TEI service serves
-# ``maxScale × containerConcurrency`` requests at once, while core-api
+# ``maxScale x containerConcurrency`` requests at once, while core-api
 # scales to many instances that each hold a large httpx pool. Aggregate
 # demand can therefore oversubscribe the backend by orders of magnitude.
 #

--- a/common/enrichment/schema.py
+++ b/common/enrichment/schema.py
@@ -21,7 +21,6 @@ from pydantic import BaseModel, field_validator
 
 from common.enrichment.constants import MemoryType
 
-
 # A8 — number of tags retained after normalisation. Mirrors the cap
 # the prompt asks the LLM to respect; the validator enforces it
 # regardless of LLM output.

--- a/common/events/base.py
+++ b/common/events/base.py
@@ -89,13 +89,13 @@ class EventBus(ABC):
         per-process subscription.
         """
 
-    async def start(self) -> None:
+    async def start(self) -> None:  # noqa: B027 — optional hook, not abstract
         """Start any background machinery (subscription listeners, etc.).
         In-process buses treat this as a no-op. Pub/Sub buses spin up
         subscriber pull-tasks here so they can receive messages.
         """
 
-    async def stop(self) -> None:
+    async def stop(self) -> None:  # noqa: B027 — optional hook, not abstract
         """Drain + shut down. Called on graceful shutdown."""
 
     @property

--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -104,7 +104,7 @@ class PubSubEventBus(EventBus):
         # filtering) — preserves the pre-guard behaviour for single-env
         # deployments and in-process tests.
         env: str | None = None,
-        # Batch size per pull. Caps ``workers × max_messages``
+        # Batch size per pull. Caps ``workers x max_messages``
         # concurrent embed calls across the deployed pool, so 25
         # balances drain throughput against the OpenAI per-org
         # rate limit and the blast radius of a single wedged

--- a/common/governance/pii_patterns.py
+++ b/common/governance/pii_patterns.py
@@ -4,7 +4,7 @@ Seeded from the 4 high-frequency patterns in the Skill-Factory Sentinel scanner
 (``core_api.services.forge.sentinel_scan``) and extended to 60+ patterns across
 emails, phones, payment cards (Luhn-validated), IBANs (mod-97-validated),
 national IDs, and provider API keys / secrets (high-entropy-validated). The
-validators are the whole point — a bare "13–19 digits" regex flags every order
+validators are the whole point — a bare "13-19 digits" regex flags every order
 number; gating it on the Luhn checksum cuts the false-positive rate hard.
 
 ``scan`` returns :class:`Finding` objects that carry only category + offsets +

--- a/common/llm/constants.py
+++ b/common/llm/constants.py
@@ -76,7 +76,7 @@ PREGATE_CLASSIFIER_TIMEOUT_SECONDS = _read_float_env(
 #
 # CAURA-627: the SDK rides httpx's default (100 max_connections / 20
 # keepalive). Under bulk-write storms — 100-item batches with
-# ``BULK_ENRICHMENT_CONCURRENCY=10`` × ``per_tenant_write_concurrency=16``
+# ``BULK_ENRICHMENT_CONCURRENCY=10`` x ``per_tenant_write_concurrency=16``
 # in flight per worker — the pool saturates and queues subsequent
 # requests, including other tenants'. The defaults were sized for
 # request/response patterns where one user's bursty fan-out doesn't
@@ -86,7 +86,7 @@ PREGATE_CLASSIFIER_TIMEOUT_SECONDS = _read_float_env(
 # Sized for headroom over the worst-case fan-out per process. Env-
 # tunable so an operator can adjust during an incident (e.g. if the
 # upstream provider's per-IP cap is hit) without a redeploy.
-from common.env_utils import clamp_keepalive, read_int_env  # noqa: E402
+from common.env_utils import clamp_keepalive, read_int_env
 
 OPENAI_HTTPX_MAX_CONNECTIONS = read_int_env("OPENAI_HTTPX_MAX_CONNECTIONS", 200)
 OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS = clamp_keepalive(

--- a/common/llm/providers/openai.py
+++ b/common/llm/providers/openai.py
@@ -87,7 +87,7 @@ class OpenAILLMProvider:
         # Explicit ``http_client`` with ``httpx.Limits`` sized for our
         # bulk-write fan-out (CAURA-627). The SDK's default httpx pool
         # (100 max / 20 keepalive) saturates under storm load — 16
-        # concurrent writes × 10 enrichment calls per request = 160
+        # concurrent writes x 10 enrichment calls per request = 160
         # concurrent LLM calls per worker process, with the next
         # tenant's traffic queueing at the pool layer. Sizing the pool
         # 2x the worst-case fan-out keeps headroom; values are env-

--- a/common/llm/registry.py
+++ b/common/llm/registry.py
@@ -6,7 +6,7 @@ Constructs LLM providers by name with three-tier credential resolution:
     Tenant key  →  Platform singleton  →  FakeLLMProvider
 
 Infrastructure backend factories (storage, job queue, identity, conflict,
-STM) stay in ``core_api.providers._registry`` — those are core-api–only
+STM) stay in ``core_api.providers._registry`` — those are core-api-only
 concerns. core-worker only needs LLM construction, so this module is the
 narrow public surface both processes share.
 """

--- a/common/models/dedup_review.py
+++ b/common/models/dedup_review.py
@@ -20,7 +20,6 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from common.models.base import Base
 
-
 # Status lifecycle:
 #   pending → confirmed_duplicate (reviewer agreed; no-op as the
 #             reject already happened OR the user accepts the

--- a/common/models/fleet.py
+++ b/common/models/fleet.py
@@ -49,7 +49,7 @@ class FleetCommand(Base):
         # is a tiny fraction of all fleet commands) and lets Postgres
         # seek straight to a node's deploy rows; the JSONB
         # ``payload->>'target_version'`` predicate is then applied on the
-        # O(1)–O(10) rows that survive, so it doesn't need to be in the
+        # O(1)-O(10) rows that survive, so it doesn't need to be in the
         # index. Bare column names (not ``.desc()``) so Alembic autogen
         # can reflect/compare — matches the style in ``memory.py``.
         Index(

--- a/common/models/memory.py
+++ b/common/models/memory.py
@@ -3,7 +3,8 @@ from datetime import datetime
 
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, Text, func, text
-from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID as PG_UUID
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from common.constants import VECTOR_DIM

--- a/common/models/skill_factory.py
+++ b/common/models/skill_factory.py
@@ -14,7 +14,15 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, DateTime, Index, Integer, Text, UniqueConstraint, text
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column

--- a/common/ruff.toml
+++ b/common/ruff.toml
@@ -1,0 +1,55 @@
+# Ruff contract for common/ — pinned deliberately.
+#
+# WHY THIS FILE EXISTS: before it, no ruff config governed common/. There is no
+# ruff.toml and no pyproject.toml at the repo root or in common/, so ruff walked
+# up from each file, found nothing, and fell back to its BUILT-IN DEFAULTS. That
+# made the effective rule set for this directory "whatever the installed ruff
+# version ships as default" — which grows on every upgrade. Under ruff 0.16.0
+# that default set (YTT, ASYNC, BLE, TRY, S, DTZ, G, ...) reported 21 findings
+# here that no one had chosen to enable, including two dead ``noqa: E402``
+# directives that were meaningful under an older default set. See issue #684.
+#
+# ``line-length`` is 88, NOT the 110 used by core-api and core-storage-api, and
+# that difference is load-bearing. Three files here are vendored into
+# caura-memclaw-enterprise under ``policy=identical`` (see its
+# ``scripts/vendored_files_manifest.json``) and are format-checked in CI at ruff
+# DEFAULTS via ``--isolated`` for byte-parity. This tree has been maintained to
+# 88 columns throughout: at 88 only 7 of 88 files would reflow, at 110 it would
+# be 49. Raising it would churn most of the directory and break that parity.
+#
+# Lint rules mirror ``core-api/pyproject.toml`` exactly, so shared code is held
+# to the same standard as the services importing it. ``E501`` is ignored there
+# and here, so ``line-length`` affects only ``ruff format`` — the 88/110 split
+# costs nothing on the lint side. Keep the two lists in sync when either moves.
+
+target-version = "py312"
+line-length = 88
+
+exclude = [
+    ".git", ".mypy_cache", ".pytest_cache", ".ruff_cache",
+    ".venv", "__pycache__", "build", "dist",
+]
+
+[lint]
+select = [
+    "E", "W", "F", "I", "B", "C4", "UP", "ARG",
+    "SIM", "TCH", "PTH", "RUF", "ASYNC",
+]
+ignore = [
+    "E501", "TC001", "TC002", "TC003", "ARG001", "ARG002",
+    "B008", "B904", "RUF022", "PTH123", "RUF006", "SIM117",
+    "RUF012", "RUF009",
+    "SIM108", "SIM105", "SIM103", "E701", "E402",
+    "B905", "B007", "B023",
+    "UP042", "UP047",
+    "PTH103", "PTH111", "PTH120",
+    "RUF005", "RUF034", "RUF059",
+    "ASYNC109",
+]
+fixable = ["ALL"]
+
+[lint.per-file-ignores]
+"__init__.py" = ["F401", "E402"]
+
+[lint.isort]
+known-first-party = ["common"]


### PR DESCRIPTION
Fixes #684.

## The problem

`common/` had **no ruff config above it** — no `ruff.toml`, no root `pyproject.toml`, nothing in `common/`. So ruff walked up from each file, found nothing, and fell back to its **built-in defaults**. The rule set governing shared code that every service imports was therefore "whatever the installed ruff version ships as default," and it changes on upgrade.

Confirmed with `--show-settings`: it reported `linter.line_length = 88` (ruff's default) for `common/structlog_config.py` rather than the 110 configured for core-api, and a bare `ruff check common/` was byte-identical to `--isolated`.

Ruff 0.16.0's default set (YTT, ASYNC, BLE, TRY, S, DTZ, G, …) reported 21 findings here that nobody had enabled — including two dead `noqa: E402` directives, meaningful under an older default set and silently dead under the new one. **That drift is the defect.** The specific findings were only its current symptom, and would have been a different set after the next bump.

## The fix

`common/ruff.toml` mirrors core-api'"'"'s lint rules, so shared code is held to the same standard as its consumers — but sets `line-length = 88` rather than 110.

That difference is deliberate and load-bearing. Three files here are vendored into `caura-memclaw-enterprise` under `policy=identical` and are format-checked at ruff defaults via `--isolated` for byte-parity. This tree has been maintained at 88 throughout: **at 88 only 7 of 88 files would reflow; at 110 it would be 49.** Raising it would churn most of the directory and break that parity for no benefit — `E501` is ignored in both configs, so `line-length` affects only `ruff format` and the 88/110 split costs nothing on the lint side.

CI gains one step, `ruff check common/ --config common/ruff.toml`. The config is named explicitly rather than relying on discovery, for the same reason the neighbouring vendored step uses `--isolated`: the gate should not change meaning if config resolution ever does.

## Clearing the 16 findings the pinned rules report

- **6 auto-fixed** — 4 `I001` import order, 2 `RUF100` dead `noqa`.
- **8 `RUF002`/`RUF003` ambiguous unicode** in comments and docstrings. I replaced **only** U+00D7 (`×`→`x`) and U+2013 (en dash→hyphen). **U+2014 (em dash) is not flagged by ruff and is this codebase'"'"'s prose style, so it is untouched** — a blanket dash replacement would have mangled it. Worth noting `core-api/src` has zero `RUF002`/`RUF003` hits, so `common/` was the outlier here, not the rule being unreasonable.
- **2 `B027`** on `EventBus.start`/`stop` — marked `noqa` rather than decorated. Their docstrings define them as optional hooks ("In-process buses treat this as a no-op"), so adding `@abstractmethod` would force every subclass to implement them. That is a contract change, not a lint fix.

## Reviewer notes

- `common/events/{base,pubsub}.py` are `policy=manual` in the enterprise vendoring manifest, so those two edits create reconciliation work there — not a CI break. **None of the three `policy=identical` files are touched.**
- I also updated the neighbouring vendored-format step'"'"'s comment, which said `--isolated` pins defaults "even if a root ruff config is ever added." One now exists nearby, so the comment would have read as stale.
- The import reordering touches four `common/models` files, which is why the full suite matters here rather than just the lint gate.

## Verification

- `ruff check common/ --config common/ruff.toml` — clean.
- All pre-existing ruff scopes still clean; the vendored `--isolated` gate still passes (3 files already formatted).
- **4051 passed, 3 skipped, 1 xfailed, 3 xpassed, 0 failed.**
- `actionlint` reports the same single pre-existing finding as `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
