### PR TITLE
docs(ci): document that the two claude-review entry points don't share gates

### DIFF
--- a/.github/workflows/claude_code_review.yml
+++ b/.github/workflows/claude_code_review.yml
@@ -1,14 +1,54 @@
 # Claude Code Review
 #
 # Runs automatically when a PR is opened/reopened by a public member of
-# the ``caura-ai`` organization. Re-trigger after pushing changes by
-# commenting "@claude" on the PR (also restricted to org members).
+# the ``caura-ai`` organization. Commenting "@claude" on the PR triggers a
+# review too (also restricted to org members) — that is how you re-review
+# after a push, AND the only way to review a draft. See "TWO ENTRY POINTS"
+# below, because the two paths do not enforce the same conditions.
 #
 # Why org-only: this workflow consumes ``ANTHROPIC_API_KEY`` and burns
 # real budget per review. ``pull_request`` events from forks don't
 # receive secrets anyway (GitHub strips them); restricting to org
 # members makes the policy explicit and stops fork PRs from triggering
 # silent-failure runs.
+#
+# TWO ENTRY POINTS, AND THEY DO NOT SHARE GATES. This is the single most
+# surprising thing about this workflow, so read it before adding a check.
+#
+#   ``pull_request``  -> pre-checks -> claude-review
+#   ``issue_comment`` -> claude-retrigger          (pre-checks never runs)
+#
+# ``pre-checks`` is gated on ``if: github.event_name == 'pull_request'``,
+# and ``claude-retrigger`` has no ``needs: pre-checks``. So on a comment
+# event ``pre-checks`` does not run at all, and EVERY condition it owns is
+# absent from that path. Today that is all six of them: org membership of
+# the PR author, synchronize-event skip, draft skip, bot skip, the
+# ``MAX_FILES`` cap, and the tests/docs/config-only skip.
+#
+# Consequences worth knowing:
+#
+#   * A DRAFT PR GETS NO REVIEW ON OPEN. ``pre-checks`` reports
+#     ``reason=draft PR`` and ``claude-review`` is skipped. Commenting
+#     "@claude" on that same draft DOES produce a full review, because the
+#     retrigger path never consults the draft check. So the effective
+#     policy is "drafts get opt-in review, not automatic review" — which is
+#     deliberate (drafts are unfinished; each review costs real budget), and
+#     is the intended way to request one. It is not discoverable from the
+#     skip message, which is why it is written down here.
+#   * The ``MAX_FILES`` cap is likewise bypassed on the comment path, so an
+#     "@claude" comment can review a PR of any size. Left as-is on purpose:
+#     it is a useful escape hatch for a large but genuinely reviewable PR.
+#     If that ever needs to change, change it deliberately — a member may
+#     be relying on it.
+#   * Membership IS still enforced on the comment path, but it validates the
+#     COMMENTER (``claude-retrigger``'s job-level ``author_association``
+#     gate plus its step-level re-check), not the PR author. A member
+#     vouching for someone else's PR is therefore a supported flow.
+#
+# MAINTAINER NOTE: adding a condition to ``pre-checks`` applies it to the
+# ``pull_request`` path ONLY. If a new gate should hold universally, it has
+# to be duplicated into ``claude-retrigger`` or lifted somewhere both jobs
+# consult. See issue #683 for the history.
 #
 # OPERATIONAL REQUIREMENT: every member who wants their pull requests
 # reviewed must set their caura-ai org membership to **Public**


### PR DESCRIPTION
Fixes #683. **Comment-only change — no behaviour change.** The diff touches nothing but comment lines in `claude_code_review.yml`.

## The gap

`pre-checks` is gated on `if: github.event_name == 'pull_request'`, and `claude-retrigger` has no `needs: pre-checks`. So on an `issue_comment` event `pre-checks` never runs, and **every condition it owns is absent from that path** — all six of them:

| # | condition in `pre-checks` | on `@claude` comment path |
|---|---|---|
| 1 | PR-author org membership | not applied (commenter is checked instead) |
| 2 | synchronize-event skip | not applied |
| 3 | **draft skip** | **not applied** |
| 4 | bot skip | not applied |
| 5 | **`MAX_FILES: 30` cap** | **not applied** |
| 6 | tests/docs/config-only skip | not applied |

The user-visible consequence: a draft PR gets **no review on open**, yet commenting `@claude` on that same draft produces a full review. The effective policy is "drafts get opt-in review, not automatic review" — sensible, but discoverable only by reading the job conditions. The skip message says `reason=draft PR` and stops there.

## Why document rather than unify

Deliberate, and it was the explicit decision:

- Making the paths agree would remove the **only** way to review a draft.
- The `MAX_FILES` bypass is a useful escape hatch for a large but genuinely reviewable PR.

A member may be relying on either, so both are now recorded as intentional rather than quietly changed. Added a maintainer note that a condition added to `pre-checks` covers one path only — if a future gate must hold universally it has to be duplicated into `claude-retrigger` or lifted somewhere both jobs consult.

## This is the second instance of one root cause

The header already documents, at length, that `author_association` differs between the two event types — *"which is why an `@claude` retrigger worked for private members while the on-open review did not."*

Same shape both times: **the entry points do not share gates, so they drift.** That instance was found and written up; the draft and `MAX_FILES` ones were not. The new block names the pattern so the next one is easier to spot.

## Also

Clarified the opening paragraph, which framed `@claude` purely as the way to re-review after a push — so it read as though that were its only use, when it is also the only route to a draft review.

One nuance worth flagging for the reviewer: membership *is* still enforced on the comment path, but it validates the **commenter**, not the PR author. A member vouching for someone else's PR is a supported flow — consistent with the fork-retrigger checkout fix in `d5f60ca`. Documented as such rather than treated as a hole.

## How this surfaced

PR #682 is a deliberately-draft migration branch that must not merge yet but did need reviewing. The review was obtained by commenting `@claude`, after reading the workflow to confirm the retrigger path had no draft gate. Without reading the source there was no way to know that was possible.

## Verification

- Diff contains no non-comment lines (verified mechanically).
- `actionlint` reports the same single pre-existing finding as `origin/main`; YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
