### PR TITLE
fix(common): converge common/ruff.toml with enterprise's stricter config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,13 +130,21 @@ jobs:
         run: uv run ruff check core-storage-api/tests/
 
       - name: Run Ruff linter (common)
-        # ``--config`` is explicit on purpose. common/ had NO ruff config above it
-        # (no ruff.toml, no root pyproject.toml), so ruff fell back to built-in
-        # DEFAULTS here — meaning the rule set was "whatever the installed ruff
-        # version ships," and it changed under us on the 0.16.0 bump. common/ruff.toml
-        # pins it; naming the config keeps this step immune to future config
-        # discovery changes, the same reasoning as ``--isolated`` below. See #684.
-        run: uv run ruff check common/ --config common/ruff.toml
+        # common/ had NO ruff config above it (no ruff.toml, no root
+        # pyproject.toml), so ruff fell back to built-in DEFAULTS here — the rule
+        # set was "whatever the installed ruff version ships," and it changed
+        # under us on the 0.16.0 bump. common/ruff.toml pins it (#684).
+        #
+        # DO NOT add ``--config common/ruff.toml``. #685 did, reasoning that
+        # naming the config made the step immune to discovery changes; it instead
+        # broke every per-file-ignore silently. Those patterns are relative to the
+        # config's own directory under discovery (so ``llm/retry.py`` means
+        # ``common/llm/retry.py``), but ``--config`` resolves them against the CWD
+        # instead — from the repo root nothing matches, all per-file-ignores
+        # become inert, and the step fails on exactly the findings they exempt.
+        # Discovery is also what enterprise's equivalent step uses, which matters
+        # because the config is byte-identical across both repos (#696).
+        run: uv run ruff check common/
 
       - name: Run Ruff formatter check (core-api)
         run: uv run ruff format --check core-api/src/

--- a/common/embedding/constants.py
+++ b/common/embedding/constants.py
@@ -56,7 +56,7 @@ EMBEDDING_RETRY_DELAY_S: float = float(os.environ.get("EMBEDDING_RETRY_DELAY_S",
 # concurrent writes x 10 enrichment calls = 160 concurrent LLM
 # requests per process, well over the keepalive budget). See
 # ``common/llm/constants.py`` for full rationale.
-from common.env_utils import (
+from common.env_utils import (  # noqa: E402 — intentional late import, see module docstring
     clamp_keepalive,
     read_float_env,
     read_int_env,

--- a/common/enrichment/service.py
+++ b/common/enrichment/service.py
@@ -44,10 +44,7 @@ def _parse_temporal(val: str) -> datetime | None:
     """Parse a temporal string to UTC datetime, returning None on failure."""
     try:
         dt = dateutil_parser.parse(val, fuzzy=False)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=UTC)
-        else:
-            dt = dt.astimezone(UTC)
+        dt = dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)
         # Sanity check: not before 1970, not after 2100
         if dt.year < 1970 or dt.year > 2100:
             logger.warning("Temporal value out of range: %s", val)

--- a/common/events/base.py
+++ b/common/events/base.py
@@ -89,13 +89,13 @@ class EventBus(ABC):
         per-process subscription.
         """
 
-    async def start(self) -> None:  # noqa: B027 — optional hook, not abstract
+    async def start(self) -> None:
         """Start any background machinery (subscription listeners, etc.).
         In-process buses treat this as a no-op. Pub/Sub buses spin up
         subscriber pull-tasks here so they can receive messages.
         """
 
-    async def stop(self) -> None:  # noqa: B027 — optional hook, not abstract
+    async def stop(self) -> None:
         """Drain + shut down. Called on graceful shutdown."""
 
     @property

--- a/common/llm/constants.py
+++ b/common/llm/constants.py
@@ -86,7 +86,10 @@ PREGATE_CLASSIFIER_TIMEOUT_SECONDS = _read_float_env(
 # Sized for headroom over the worst-case fan-out per process. Env-
 # tunable so an operator can adjust during an incident (e.g. if the
 # upstream provider's per-IP cap is hit) without a redeploy.
-from common.env_utils import clamp_keepalive, read_int_env
+from common.env_utils import (  # noqa: E402 — intentional late import, see module docstring
+    clamp_keepalive,
+    read_int_env,
+)
 
 OPENAI_HTTPX_MAX_CONNECTIONS = read_int_env("OPENAI_HTTPX_MAX_CONNECTIONS", 200)
 OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS = clamp_keepalive(

--- a/common/ruff.toml
+++ b/common/ruff.toml
@@ -1,30 +1,36 @@
-# Ruff contract for common/ — pinned deliberately.
+# Ruff contract for common/ — pinned deliberately, and SHARED VERBATIM between
+# caura-memclaw (OSS) and caura-memclaw-enterprise.
 #
-# WHY THIS FILE EXISTS: before it, no ruff config governed common/. There is no
-# ruff.toml and no pyproject.toml at the repo root or in common/, so ruff walked
-# up from each file, found nothing, and fell back to its BUILT-IN DEFAULTS. That
-# made the effective rule set for this directory "whatever the installed ruff
-# version ships as default" — which grows on every upgrade. Under ruff 0.16.0
-# that default set (YTT, ASYNC, BLE, TRY, S, DTZ, G, ...) reported 21 findings
-# here that no one had chosen to enable, including two dead ``noqa: E402``
-# directives that were meaningful under an older default set. See issue #684.
+# WHY THIS FILE EXISTS: common/ has no pyproject.toml of its own (it is
+# PYTHONPATH-mounted, not pip-installed), and neither repo has a root
+# [tool.ruff]. So `ruff check common/` had no ancestor config and fell back to
+# ruff's bare CLI defaults — meaning the effective rule set was "whatever the
+# installed ruff version ships," which silently expanded from 59 to 413 rules in
+# ruff 0.16 (enterprise #879/#898; OSS #684). Scoped to common/ ONLY (a ruff.toml
+# here, not a root-level [tool.ruff]) so other loose scripts keep their existing
+# behaviour rather than being pulled under stricter enforcement.
 #
-# ``line-length`` is 88, NOT the 110 used by core-api and core-storage-api, and
-# that difference is load-bearing. Three files here are vendored into
-# caura-memclaw-enterprise under ``policy=identical`` (see its
-# ``scripts/vendored_files_manifest.json``) and are format-checked in CI at ruff
-# DEFAULTS via ``--isolated`` for byte-parity. This tree has been maintained to
-# 88 columns throughout: at 88 only 7 of 88 files would reflow, at 110 it would
-# be 49. Raising it would churn most of the directory and break that parity.
+# WHY IT IS BYTE-IDENTICAL ACROSS REPOS: enterprise vendors common/ and its
+# scripts/vendored_files_manifest.json classifies this file `identical`, so
+# check_vendored_drift.py fails on any divergence. Edit it in OSS; the re-vendor
+# bot mirrors it downstream. Two consequences worth knowing:
 #
-# Lint rules mirror ``core-api/pyproject.toml`` exactly, so shared code is held
-# to the same standard as the services importing it. ``E501`` is ignored there
-# and here, so ``line-length`` affects only ``ruff format`` — the 88/110 split
-# costs nothing on the lint side. Keep the two lists in sync when either moves.
+#   * ``target-version`` is py312, NOT py313. common/ runs on py312 in OSS and
+#     py313 in enterprise, so the shared target must be the LOWER bound —
+#     otherwise pyupgrade rules suggest rewrites that break OSS.
+#   * The per-file-ignores below span BOTH trees, which are not the same file
+#     set (enterprise's common/ additionally has email_service.py, license/*).
+#     An entry with no matching file is inert, so each repo carries a few
+#     patterns that only matter in the other. That is the cost of one shared
+#     file, and is preferred over two configs drifting apart.
+#
+# ``line-length`` is 88, not the 110 used by core-api and core-storage-api. Three
+# files here are vendored `identical` and are format-checked at ruff DEFAULTS via
+# ``--isolated`` in OSS ci.yml for byte-parity; this tree has been maintained at
+# 88 throughout. E501 is ignored, so line-length affects only ``ruff format``.
 
 target-version = "py312"
 line-length = 88
-
 exclude = [
     ".git", ".mypy_cache", ".pytest_cache", ".ruff_cache",
     ".venv", "__pycache__", "build", "dist",
@@ -37,19 +43,37 @@ select = [
 ]
 ignore = [
     "E501", "TC001", "TC002", "TC003", "ARG001", "ARG002",
-    "B008", "B904", "RUF022", "PTH123", "RUF006", "SIM117",
+    "B008", "B904", "RUF022", "PTH123", "SIM117",
     "RUF012", "RUF009",
-    "SIM108", "SIM105", "SIM103", "E701", "E402",
-    "B905", "B007", "B023",
-    "UP042", "UP047",
-    "PTH103", "PTH111", "PTH120",
-    "RUF005", "RUF034", "RUF059",
-    "ASYNC109",
 ]
 fixable = ["ALL"]
 
 [lint.per-file-ignores]
-"__init__.py" = ["F401", "E402"]
+# structlog_config.py is a BYTE-IDENTICAL vendored copy — its content can't
+# diverge between repos without failing check_vendored_drift.py. These are real,
+# minor findings (contextlib.suppress / pathlib style); fixing them upstream in
+# OSS and re-vendoring would let this entry go away.
+"structlog_config.py" = ["SIM105", "PTH120", "PTH103"]
+# EventBus.start/stop are DELIBERATELY non-abstract no-ops (see their
+# docstrings) — every bus implementation relies on that default; adding
+# @abstractmethod would force each to override it for no behavioural benefit.
+"events/base.py" = ["B027"]
+# ``(str, Enum)`` -> ``StrEnum`` is a real suggestion that ruff itself marks as
+# an unsafe/manual fix. These are all widely-imported shared types, so changing
+# a base class is its own deliberate decision, not something to bundle into a
+# tooling change. Applies in both trees.
+"enrichment/constants.py" = ["UP042"]
+"governance/pii_patterns.py" = ["UP042"]
+"license/claims.py" = ["UP042"]
+# ``timeout`` here configures an owned client's request timeout, not a manual
+# cancellation deadline — asyncio.timeout() does not apply to this pattern.
+# UP047 (PEP 695 type parameters) would rewrite public generic signatures in
+# shared retry code; same reasoning as UP042 above.
+"llm/retry.py" = ["ASYNC109", "UP047"]
+"license/phone_home.py" = ["ASYNC109"]
+# Customer-facing email copy — the en dash is intentional typography.
+"email_service.py" = ["RUF001"]
 
-[lint.isort]
-known-first-party = ["common"]
+[format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
Follow-up to #685. **Land this before caura-memclaw-enterprise's companion PR** — that repo's drift checker compares against OSS `main`, so its PR stays red until this merges.

## Why

#685 pinned `common/`'s ruff contract by mirroring core-api's rules. It then emerged that **enterprise had already solved the same problem independently and earlier**, in `e6d12110` ("deps: take the ruff 0.15.22 → 0.16.0 bump", #898) — same root cause, same fix shape. Its config even quantifies the expansion: **59 → 413 default rules**.

The two configs disagreed, and enterprise's is stricter. It keeps a short global `ignore` and uses targeted per-file-ignores *with a written reason for each*, where OSS globally ignored 18 more rules:

`ASYNC109, B007, B023, B905, E402, E701, PTH103/111/120, RUF005/006/034/059, SIM103/105/108, UP042, UP047`

`select` was already identical on both sides.

## What this does

Adopts enterprise's shape as the shared config, so **one file governs `common/` in both repos** and enterprise can classify it `identical` in its vendoring manifest — after which the drift checker guarantees they cannot diverge again.

Two deliberate details:

- **`target-version = "py312"`, not enterprise's `py313`.** `common/` runs on py312 here and py313 there, so the shared target must be the **lower** bound, or pyupgrade suggests rewrites that break this repo.
- **The per-file-ignores are the union across both trees**, which are *not* the same file set — enterprise's `common/` also contains `email_service.py` and `license/*`. An entry with no matching file is inert, so each repo carries a few patterns that only matter in the other. That is the price of a single shared file, and beats two configs drifting apart. Called out here because it will look odd in review.

## Consequences under the newly-enforced rules

- **Restored the two `noqa: E402` that #685 removed** as `RUF100` "unused". They were unused only relative to OSS's looser ignore list — `E402` is enforced under the shared config, so both late imports need them back. Removing them was right for the config at the time and wrong for this one.
- **Dropped the two `# noqa: B027`** #685 added to `EventBus.start`/`stop`. The shared config per-file-ignores `events/base.py` with the same reasoning, which is the cleaner expression of it — and enterprise had already written that entry.
- **`SIM108` in `_parse_temporal`: applied the ternary.** Both branches are simple assignments to the same name with no interleaved comments, so it is behaviour-identical. Ruff marks `SIM108` unsafe in general, so I applied and read this by hand rather than trusting `--fix`. OSS previously ignored `SIM108` globally; fixing it is the honest way to meet the stricter rule instead of re-adding the ignore and partially undoing the convergence.
- **`UP042`/`UP047`/`ASYNC109` are per-file-ignored with reasons, not fixed.** They would rewrite base classes and public generic signatures on widely imported shared types — its own deliberate decision, not something to bundle into a tooling change. That is the call enterprise already made, in the same words.

## Follow-up left deliberately

Enterprise's `structlog_config.py` entry notes that `SIM105`/`PTH120`/`PTH103` are real findings whose fix belongs upstream *here*. Doing that would let the entry disappear, but it is a code change rather than a tooling one, so it is out of scope.

## Verification

- `ruff check common/` clean; all pre-existing ruff scopes clean; vendored `--isolated` gate still passes.
- `common/ruff.toml` verified **byte-identical** to the enterprise copy via `cmp`.
- **4068 passed, 3 skipped, 1 xfailed, 3 xpassed, 0 failed** — including 176 targeted temporal/enrichment tests, since `_parse_temporal` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
