### PR TITLE
fix(search): keep FTS-only rows past the legacy cosine gate (#687)

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -3437,13 +3437,26 @@ async def _search_memories_legacy(
     async with per_tenant_storage_slot("storage_search", tenant_id):
         rows = await sc.scored_search(search_data)
 
-    # Post-filter by min_similarity, then trim to top_k. The `vec_sim is None`
-    # branch is defensive: the scored_search SQL currently enforces
-    # `Memory.embedding IS NOT NULL` and the storage layer coerces None → 0.0,
-    # so this branch is never taken today. Left in place — mirrored in the
-    # pipeline post_filter step — so that FTS-only rows aren't silently gated
-    # out by the cosine threshold if either invariant ever changes.
-    rows = [r for r in rows if r.get("vec_sim") is None or float(r["vec_sim"]) >= _min_similarity]
+    # Post-filter by min_similarity, then trim to top_k.
+    #
+    # `has_embedding is False` is the clause that matters, and it was missing:
+    # the invariant the old comment here relied on ("the scored_search SQL
+    # enforces `Memory.embedding IS NOT NULL`") stopped holding at CAURA-594,
+    # which admits NULL-embedding rows that FTS-match via
+    # `or_(embedding IS NOT NULL, fts_guard)`. The storage layer coerces those
+    # rows' cosine to 0.0 rather than NULL — as that comment itself noted — so
+    # the `vec_sim is None` branch never fires for them and `0.0 >= threshold`
+    # gated out exactly the FTS-only rows CAURA-679 exists to keep discoverable
+    # during the deferred-embed window. `has_embedding` is the authoritative
+    # NULL signal for precisely this reason. Now genuinely mirrors the
+    # pipeline's post_filter step, which has carried this clause since CAURA-679.
+    rows = [
+        r
+        for r in rows
+        if r.get("has_embedding") is False
+        or r.get("vec_sim") is None
+        or float(r["vec_sim"]) >= _min_similarity
+    ]
     rows = rows[:_top_k]
 
     # Build results from storage API response

--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -7,6 +7,7 @@ They exercise both paths with identical inputs and compare the MemoryOut results
 import uuid
 
 import pytest
+from sqlalchemy import text
 
 from core_api.schemas import MemoryCreate, MemoryOut
 
@@ -567,3 +568,100 @@ async def test_search_pipeline_empty_results(db):
         assert results == []
     finally:
         memory_service._USE_PIPELINE_SEARCH = original
+
+
+# ---------------------------------------------------------------------------
+# Recall of a memory whose embedding backfill has not landed yet
+# (caura-memclaw#687)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_pipeline", [True, False], ids=["pipeline", "legacy"])
+async def test_recall_returns_memory_with_pending_embedding(db, monkeypatch, use_pipeline):
+    """A memory must be recallable before its embedding backfill lands.
+
+    Production defers the embedding: under ``deployment_mode=deferred`` the row
+    is stored with ``embedding IS NULL`` and ``metadata.embedding_pending=True``,
+    and a worker back-fills it seconds (prod) to minutes (staging) later. Three
+    pieces of machinery exist so the row stays discoverable in that window —
+    CAURA-594's admission predicate ``or_(embedding IS NOT NULL, fts_guard)``,
+    CAURA-679's FTS-only ``similarity`` for NULL-embedding rows, and
+    PostFilterResults exempting them from the ``vec_sim`` gate.
+
+    Nothing asserted that end to end, which is the gap #687 shipped through:
+    against the live control plane a row that is present and whose content is
+    byte-identical to the query is not returned until it has been embedded.
+    core-storage-api's own integration test covers the storage layer but POSTs
+    ``embedding=None`` straight to core-storage-api, bypassing core-api, and no
+    test anywhere pairs a pending embedding with a recall.
+
+    Both search implementations are exercised: ``search_memories`` dispatches on
+    ``_USE_PIPELINE_SEARCH``, so covering only the default would leave the other
+    path unpinned — and a divergence between them localises the defect.
+    """
+    from core_api.config import settings
+    from core_api.services import memory_service
+    from core_api.services.memory_service import create_memory, search_memories
+
+    monkeypatch.setattr(memory_service, "_USE_PIPELINE_SEARCH", use_pipeline)
+    # Faithful to production's deferred write rather than hand-inserting a NULL:
+    # this is what makes core-api store the row without an embedding.
+    monkeypatch.setattr(settings, "deployment_mode", "deferred")
+
+    tid = f"test-tenant-pending-embed-{uuid.uuid4().hex[:8]}"
+    token = f"zqxjvbn{uuid.uuid4().hex[:10]}"
+    content = (
+        "The quarterly irrigation schedule for the northern greenhouse was revised "
+        f"to alternate drip cycles on alternate mornings. Reference code {token}."
+    )
+
+    created = await create_memory(
+        MemoryCreate(
+            tenant_id=tid,
+            fleet_id=FLEET_ID,
+            agent_id=AGENT_ID,
+            content=content,
+            persist=True,
+            entity_links=[],
+        )
+    )
+
+    # Preconditions. Without these the test could pass vacuously (an embedded
+    # row proves nothing about the deferred window) or fail for a fixture
+    # reason rather than the behaviour under test: `search_vector` is populated
+    # by a trigger created in migration 001, so a metadata-only schema
+    # (``Base.metadata.create_all`` with no ``alembic upgrade head``) leaves it
+    # NULL and no NULL-embedding row can ever be admitted.
+    row = (
+        await db.execute(
+            text(
+                "SELECT embedding IS NULL AS embedding_null, "
+                "       search_vector IS NOT NULL AS sv_populated, "
+                "       search_vector @@ plainto_tsquery('english', :q) AS fts_matches "
+                "FROM memories WHERE id = :mid"
+            ),
+            {"mid": str(created.id), "q": token},
+        )
+    ).one()
+    assert row.embedding_null, (
+        "precondition: deployment_mode=deferred must store the row without an "
+        "embedding, otherwise this test says nothing about the deferred window"
+    )
+    assert row.sv_populated, (
+        "precondition: search_vector must be populated — if this fails the schema "
+        "was built without migration 001's trigger (run `alembic upgrade head`)"
+    )
+    assert row.fts_matches, (
+        "precondition: the query token must FTS-match the stored content, "
+        "otherwise the FTS fallback has nothing to match on"
+    )
+
+    results = await search_memories(tenant_id=tid, query=token, top_k=10)
+
+    assert str(created.id) in {str(r.id) for r in results}, (
+        f"a memory whose embedding backfill has not landed was not returned by "
+        f"recall (caura-memclaw#687). query={token!r} matched the row's content "
+        f"exactly and search_vector @@ plainto_tsquery is true, yet search "
+        f"returned {len(results)} other row(s): "
+        f"{[str(r.id) for r in results]}"
+    )


### PR DESCRIPTION
Closes the coverage gap behind #687, and fixes a real bug the new test found on its first run.

## The contract

Under `deployment_mode=deferred` a memory is stored with `embedding IS NULL` and `metadata.embedding_pending=True`; a worker fills the vector seconds (prod) to minutes (staging) later. Three mechanisms exist so the row stays discoverable in that window:

1. CAURA-594's admission predicate — `or_(embedding IS NOT NULL, fts_guard)`
2. CAURA-679's FTS-only `similarity` for NULL-embedding rows
3. the pipeline post-filter exempting them from the cosine gate

**The legacy search path never got #3.**

## The bug

```python
rows = [r for r in rows
        if r.get("vec_sim") is None or float(r["vec_sim"]) >= _min_similarity]
```

The comment above it justified the `is None` branch as defensive, because "the scored_search SQL currently enforces `Memory.embedding IS NOT NULL`". **CAURA-594 ended that invariant.** And as the same comment conceded, the storage layer coerces a NULL-embedding row's cosine to `0.0` rather than NULL — so the defensive branch never fires for those rows and `0.0 >= threshold` drops them.

The guard documented its own defeat. It says it is there *"so that FTS-only rows aren't silently gated out by the cosine threshold if either invariant ever changes"* — and that is exactly what happened.

Fix: add the `has_embedding is False` exemption so the legacy path genuinely mirrors the pipeline post-filter it claims to mirror. `has_embedding` is the authoritative NULL signal precisely because `vec_sim == 0.0` is ambiguous with a genuinely orthogonal embedding.

## The missing test

Coverage of this contract stopped at the storage layer. `core-storage-api/tests/test_integration.py` pins it well — but it POSTs `embedding=None` **straight to core-storage-api, bypassing core-api**. And `grep -l embedding_pending` across the suites hits only write-pipeline tests: **nothing paired a pending embedding with a recall.** That is the hole #687 shipped through.

The new test writes through the real core-api path with the embedding deferred, then asserts recall returns the row. It is parameterised over both search implementations because `search_memories` dispatches on `_USE_PIPELINE_SEARCH` — covering only the default would have left the other path unpinned. **That parameterisation is what found the bug:** `[pipeline]` passed and `[legacy]` failed on the very first run, with the log showing `path=scored-search row_count: 1` — the SQL returned the row and the legacy path threw it away.

Its preconditions assert the row really has a NULL embedding and a populated `search_vector` that FTS-matches the query, so it cannot pass vacuously against an embedded row, and cannot fail misleadingly on a schema built by `Base.metadata.create_all` without migration 001's `search_vector` trigger (the fixtures do exactly that; CI's `alembic upgrade head` is what supplies it).

## Verification

| Check | Result |
|---|---|
| `tests/pipeline/` + `tests/test_integration_search.py` | **120 passed** |
| Inverting the new clause | `[legacy]` fails again, nothing else — the test earns its keep |
| `mypy src/` (core-api) | no issues in 189 files |
| `ruff check` (both files) | clean |
| `ruff format --check` | source clean; the test file's pre-existing drift is at lines 67–290, untouched by this change |

Run against a local pgvector 0.8.6 with `alembic upgrade head`, mirroring CI.

## What this does not fix

**#687's production symptom is on the pipeline path** (`_USE_PIPELINE_SEARCH = True`), and that path *passes* the new test under every shape I could reproduce locally: bare, the full MCP-recall argument set (`caller_agent_id`, `fleet_ids`, `recall_boost`, `graph_expand`, `entity_retrieval`), and against 25 competing embedded rows — the crowding scenario CAURA-679's own comment warns about, verified non-vacuous by asserting the competitors really embedded.

So the remaining divergence there is environmental — `tenant_config`, `search_profile`, or the rank provider — not pipeline logic. That narrowing is itself a result, and it stays tracked in #687. This PR fixes the defect that *is* in code and installs the test that will catch the next one.