### PR TITLE
feat(insights): clarity contract — findings about the work, not the machinery

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -2621,6 +2621,7 @@ async def memclaw_insights(
     #   3. ``_no_db`` — persist findings (storage-routed; no commit)
     from core_api.services.insights_service import (
         _QUERY_DISPATCH,
+        _build_method,
         _DiscoverResult,
         _persist_findings,
         synthesize_insights,
@@ -2671,6 +2672,7 @@ async def memclaw_insights(
                             "findings": [],
                             "summary": "No relevant memories found for this analysis.",
                             "insight_memory_ids": [],
+                            "gate_rejected": 0,
                             "insights_ms": int((time.perf_counter() - t0) * 1000),
                         },
                         indent=2,
@@ -2696,7 +2698,15 @@ async def memclaw_insights(
         # ``_persist_findings`` are each storage-committed independently, so
         # there's no session to open or commit here (``_no_db()`` ⇒ db=None).
         async with _no_db():
-            insight_ids = await _persist_findings(tenant_id, agent_id, fleet_id, focus, scope, findings)
+            insight_ids = await _persist_findings(
+                tenant_id,
+                agent_id,
+                fleet_id,
+                focus,
+                scope,
+                findings,
+                method=_build_method(focus, scope, is_clustered, synth),
+            )
 
         result = {
             "focus": focus,
@@ -2705,6 +2715,7 @@ async def memclaw_insights(
             "findings": [{**f, "insight_memory_id": mid} for f, mid in zip(findings, insight_ids)],
             "summary": synth["summary"],
             "insight_memory_ids": [mid for mid in insight_ids if mid],
+            "gate_rejected": synth.get("gate_rejected", 0),
             "insights_ms": int((time.perf_counter() - t0) * 1000),
         }
         return _with_latency(json.dumps(result, indent=2, default=str), t0)

--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -6,6 +6,7 @@ vector-space clusters. Findings are persisted as insight-type memories.
 """
 
 import logging
+import re
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -46,194 +47,239 @@ _SCOPE_TO_VISIBILITY = {
 
 
 # -- Prompts -------------------------------------------------------------------
+#
+# Clarity contract ("the front-page test"): a persisted finding must read like
+# a line a human would put in a status report. Measured on the eToro fleet
+# BEFORE this contract, 80% of discover findings discussed the clustering
+# machinery itself ("Cluster 5 shows std=0.22 ... re-cluster with a finer
+# label set") and 67% of their recommendations targeted the memory system
+# rather than the work the memories describe — the old "memory analyst"
+# persona answered exactly what it was asked. The prompts below flip the
+# persona to an operations analyst, make the retrieval mechanics a LENS
+# rather than a SUBJECT, and require a structured finding (headline /
+# what_happened / why_it_matters / recommended_action). A deterministic
+# post-LLM gate (``_gate_findings``) enforces the contract with one
+# self-repair retry.
 
-_PROMPT_CONTRADICTIONS = """\
-You are a memory analyst specializing in contradiction detection.
-
-Analyze these {count} memories for contradiction clusters. Identify what is \
-contradicted, which memories conflict, which version is likely correct \
-(consider recency, weight, and agent trust), and what should be done to \
-resolve the conflict.
-
-Look for:
-- Direct factual contradictions (same entity, different values)
-- Superseded memories that may still be recalled
-- Status conflicts (e.g. "active" vs "conflicted")
-- Temporal contradictions (events placed at incompatible times)
-
-Memories:
-{memories}
-
+# Shared JSON response contract. Legacy keys (title/description/
+# recommendation) are still accepted at sanitize time for models that answer
+# old-style, and are mirrored back onto every finding for downstream
+# consumers.
+_FINDING_JSON_BLOCK = """\
 Respond with JSON:
 {{
   "findings": [
     {{
-      "type": "contradictions",
-      "title": "short headline (max 80 chars)",
-      "description": "2-3 sentence explanation",
+      "headline": "one declarative sentence about the work itself (max 80 chars)",
+      "what_happened": "2-3 concrete sentences naming the real systems, people, dates and values involved",
+      "why_it_matters": "one sentence: the impact or risk if nothing changes",
+      "recommended_action": "one imperative sentence starting with a verb, naming who or what should act",
       "confidence": 0.0 to 1.0,
-      "related_memory_ids": ["uuid1", "uuid2"],
-      "recommendation": "actionable next step"
+      "related_memory_ids": ["uuid1", "uuid2"]
     }}
   ],
-  "summary": "one paragraph overview"
+  "summary": "one short paragraph overview"
 }}"""
 
-_PROMPT_FAILURES = """\
-You are a memory analyst specializing in failure pattern detection.
+# World modes (discover / patterns): the subject must be the WORK, never the
+# records or the analysis machinery.
+_RULES_WORLD = """\
+RULES — your reader is a busy operator who never sees these records:
+- Report on the WORK the records describe (systems, incidents, deals, \
+decisions) — never on the records themselves, their grouping, this sample, \
+or this analysis. If a group of records reveals nothing about the work \
+itself, produce no finding for it.
+- Name things by their real names. Never reference numbering from this \
+prompt ("record 5", "group 3").
+- recommended_action must be something an operator or agent can do in their \
+systems or process. Suggestions to write, tag, merge, store or restructure \
+records are FORBIDDEN.
+- Fewer, sharper findings beat coverage. An empty findings list is a valid \
+answer.
 
-These {count} memories have low importance but were recalled by agents -- \
-meaning agents may have acted on weak or unreliable information. Identify \
-recurring failure patterns, common root causes, and memories that should be \
-deprecated or flagged.
+BAD finding (never produce): headline "Cluster 5 has high weight variance \
+(std=0.22)", action "Re-cluster with a finer label set".
+GOOD finding: headline "Health monitoring runs as two disconnected loops", \
+what_happened "Heartbeat checks and cleanup escalation fire independently \
+across 6 agents; a disk-full event on Jul 28 alerted twice with no shared \
+cooldown.", action "Unify triggers and cooldowns in the monitoring workflow \
+config."""
+
+# Hygiene modes (contradictions / failures / stale / divergence): the records
+# ARE the legitimate subject, but findings must name the disputed fact in
+# real-world terms and resolve it concretely.
+_RULES_HYGIENE = """\
+RULES — your reader is a busy operator deciding what to trust:
+- Name the disputed, weak or stale FACT in real-world terms ("gateway \
+endpoint: old.example vs new.example"), with the real names, dates and \
+values involved.
+- Never reference numbering from this prompt ("record 5"); when pointing at \
+a specific record, use its (id:...) value in related_memory_ids.
+- recommended_action must state the concrete resolution: which version to \
+trust and why, what to re-verify, or what to stop relying on — not generic \
+bookkeeping.
+- Fewer, sharper findings beat coverage. An empty findings list is a valid \
+answer."""
+
+_PROMPT_CONTRADICTIONS = (
+    """\
+You are an operations analyst reviewing the team's work records for \
+conflicting claims.
+
+Analyze these {count} records for contradictions. Identify what fact is \
+contradicted, which version is likely correct (consider recency and how \
+each record was produced), and how to resolve it.
 
 Look for:
-- Memories with very low weight that were recalled frequently
-- Patterns in the types of unreliable information
-- Agents that consistently rely on weak memories
-- Information that should have been superseded but wasn't
+- Direct factual contradictions (same thing, different values)
+- Corrected facts whose old version may still be trusted somewhere
+- Workflow states that cannot both be true (e.g. "sent" vs "blocked")
+- Events placed at incompatible times
 
-Memories:
+"""
+    + _RULES_HYGIENE
+    + """
+
+Records:
 {memories}
 
-Respond with JSON:
-{{
-  "findings": [
-    {{
-      "type": "failures",
-      "title": "short headline (max 80 chars)",
-      "description": "2-3 sentence explanation",
-      "confidence": 0.0 to 1.0,
-      "related_memory_ids": ["uuid1", "uuid2"],
-      "recommendation": "actionable next step"
-    }}
-  ],
-  "summary": "one paragraph overview"
-}}"""
+"""
+    + _FINDING_JSON_BLOCK
+)
 
-_PROMPT_STALE = """\
-You are a memory analyst specializing in knowledge freshness.
+_PROMPT_FAILURES = (
+    """\
+You are an operations analyst investigating where the team acted on weak or \
+unreliable information.
 
-These {count} memories are likely outdated -- they haven't been recalled \
-recently or have very low weight. Identify which are genuinely stale vs. \
-rarely needed, and flag ones that could cause harm if recalled.
+These {count} records carry low reliability yet were used by agents -- \
+meaning decisions may rest on shaky ground. Identify what unreliable \
+information was acted on, what could go wrong because of it, and what should \
+be trusted instead.
 
 Look for:
-- Memories about time-sensitive topics (deadlines, prices, versions)
-- Knowledge that likely changed since creation
-- Memories that were never recalled (possibly irrelevant from the start)
-- Low-weight memories that could mislead if surfaced
+- Weak information that was used repeatedly
+- Recurring kinds of unreliable information and their root causes
+- Actions taken on evidence that never confirmed success
+- Corrected facts that are still being relied on in their old form
 
-Memories:
+"""
+    + _RULES_HYGIENE
+    + """
+
+Records:
 {memories}
 
-Respond with JSON:
-{{
-  "findings": [
-    {{
-      "type": "stale",
-      "title": "short headline (max 80 chars)",
-      "description": "2-3 sentence explanation",
-      "confidence": 0.0 to 1.0,
-      "related_memory_ids": ["uuid1", "uuid2"],
-      "recommendation": "actionable next step"
-    }}
-  ],
-  "summary": "one paragraph overview"
-}}"""
+"""
+    + _FINDING_JSON_BLOCK
+)
 
-_PROMPT_DIVERGENCE = """\
-You are a memory analyst specializing in cross-agent knowledge consistency.
+_PROMPT_STALE = (
+    """\
+You are an operations analyst reviewing aging work records for information \
+that has likely gone stale.
 
-These {count} memories come from different agents about the same entities. \
-Identify where agents disagree, which agent's perspective is more credible, \
-and whether the divergence indicates a real disagreement or different contexts.
+These {count} records are old or rarely used. Identify which describe facts \
+that have probably changed since (versions, endpoints, prices, deadlines, \
+owners), what the team might still wrongly assume, and what should be \
+re-verified.
 
 Look for:
-- Same entity described differently by different agents
-- Conflicting conclusions or assessments
-- Different levels of detail or confidence
-- Cases where divergence reveals complementary rather than conflicting views
+- Time-sensitive facts recorded once and never revisited
+- States ("running", "blocked", "pending") frozen from a past moment
+- Old symptoms or incidents that likely no longer describe the system
+- Anything that would mislead an operator who trusted it today
 
-Memories:
+"""
+    + _RULES_HYGIENE
+    + """
+
+Records:
 {memories}
 
-Respond with JSON:
-{{
-  "findings": [
-    {{
-      "type": "divergence",
-      "title": "short headline (max 80 chars)",
-      "description": "2-3 sentence explanation",
-      "confidence": 0.0 to 1.0,
-      "related_memory_ids": ["uuid1", "uuid2"],
-      "recommendation": "actionable next step"
-    }}
-  ],
-  "summary": "one paragraph overview"
-}}"""
+"""
+    + _FINDING_JSON_BLOCK
+)
 
-_PROMPT_PATTERNS = """\
-You are a memory analyst specializing in trend and pattern recognition.
+_PROMPT_DIVERGENCE = (
+    """\
+You are an operations analyst reviewing where teammates disagree about the \
+same things.
 
-Analyze these {count} recent memories for emerging themes, trends, and \
-patterns. What topics are getting more attention? What decisions are being \
-made? Are there any concerning patterns?
+These {count} records come from different agents about the same entities. \
+Identify where agents hold different beliefs about the same fact, which \
+belief is likely correct, and whether the disagreement is real or just \
+different contexts.
 
 Look for:
-- Recurring topics or entities across multiple memories
-- Shifts in focus or priority over time
-- Decision patterns and their outcomes
-- Gaps in knowledge coverage
+- The same system/entity described with different values or states
+- Conflicting conclusions or assessments between agents
+- One agent acting on information another agent has already corrected
+- Divergence that is actually complementary detail, not conflict
 
-Memories:
+"""
+    + _RULES_HYGIENE
+    + """
+
+Records:
 {memories}
 
-Respond with JSON:
-{{
-  "findings": [
-    {{
-      "type": "patterns",
-      "title": "short headline (max 80 chars)",
-      "description": "2-3 sentence explanation",
-      "confidence": 0.0 to 1.0,
-      "related_memory_ids": ["uuid1", "uuid2"],
-      "recommendation": "actionable next step"
-    }}
-  ],
-  "summary": "one paragraph overview"
-}}"""
+"""
+    + _FINDING_JSON_BLOCK
+)
 
-_PROMPT_DISCOVER = """\
-You are a memory analyst specializing in knowledge topology.
+_PROMPT_PATTERNS = (
+    """\
+You are an operations analyst briefing the team on what their recent work \
+records show.
 
-These are {count} memories organized into natural clusters discovered in the \
-embedding vector space. For each cluster, what is the underlying theme? Are \
-any clusters surprising? Are there gaps in knowledge between clusters?
+Analyze these {count} recent records for what is actually going on in the \
+work: emerging themes, repeated struggles, decisions being made, risks \
+building up.
 
 Look for:
-- Unexpected groupings that reveal hidden connections
-- Clusters with high weight variance (inconsistent confidence)
-- Cross-agent clusters (same topic, multiple agents)
-- Missing clusters (topics you'd expect but don't see)
+- The same problem being fought repeatedly instead of fixed
+- Shifts in what the team spends its time on
+- Decisions and whether their outcomes ever materialized
+- Risks or frictions (auth, deploys, data quality) building up quietly
 
-Clusters:
+"""
+    + _RULES_WORLD
+    + """
+
+Records ("[repeats: Nx]" marks a record whose exact operation recurred N \
+times in the window — treat the repetition itself as signal about the work):
 {memories}
 
-Respond with JSON:
-{{
-  "findings": [
-    {{
-      "type": "discover",
-      "title": "short headline (max 80 chars)",
-      "description": "2-3 sentence explanation",
-      "confidence": 0.0 to 1.0,
-      "related_memory_ids": ["uuid1", "uuid2"],
-      "recommendation": "actionable next step"
-    }}
-  ],
-  "summary": "one paragraph overview"
-}}"""
+"""
+    + _FINDING_JSON_BLOCK
+)
+
+_PROMPT_DISCOVER = (
+    """\
+You are an operations analyst briefing the team on what their work records \
+reveal.
+
+These are {count} records grouped by similarity. THE GROUPS ARE A READING \
+AID, NOT THE SUBJECT — use them to scan efficiently, then report what the \
+records reveal about the work itself.
+
+Look for:
+- Recurring operational themes (and whether they represent progress or churn)
+- The same real-world problem showing up across several agents
+- Work that starts but never visibly completes or gets verified
+- Risks or dependencies the team may not have noticed
+
+"""
+    + _RULES_WORLD
+    + """
+
+Record groups:
+{memories}
+
+"""
+    + _FINDING_JSON_BLOCK
+)
 
 
 # -- Scope helpers -------------------------------------------------------------
@@ -555,16 +601,28 @@ def _format_clusters_for_analysis(clusters: list[dict]) -> tuple[str, set[str]]:
 
     Returns (text, shown_ids) — only representative IDs actually rendered
     into the prompt are included, keeping hallucination-filter accurate.
+
+    Scaffolding vocabulary is deliberately gate-neutral: an earlier revision
+    rendered "Cluster {id}" headers and "std=" stats — the exact tokens
+    ``_GATE_PROMPT_REF_RE`` / ``_GATE_META_RE`` reject in findings — priming
+    the model into violations and burning the repair round on the nightly
+    discover run (pre-contract, 80% of discover findings echoed this
+    vocabulary when shown it). Numeric cluster ids carry no value to the
+    model anyway (findings must reference records by their real ids), so
+    headers are anonymous groups, stats are worded, and the record noun
+    matches the prompts ("records", never "memories").
+    ``test_cluster_scaffolding_is_gate_neutral`` pins this invariant.
     """
     lines = []
     shown_ids: set[str] = set()
     for c in clusters:
-        lines.append(f"--- Cluster {c['cluster_id']} ({c['size']} memories) ---")
-        lines.append(f"  Weight: mean={c['weight_mean']:.2f}, std={c['weight_std']:.2f}")
+        lines.append(f"--- A group of {c['size']} related records ---")
+        lines.append(f"  Typical reliability {c['weight_mean']:.2f} (variability {c['weight_std']:.2f})")
         safe_agents = [_sanitize_content(a, max_len=100) for a in c["agents"]]
         lines.append(f"  Agents: {', '.join(safe_agents)} ({c['agent_count']} unique)")
-        lines.append(f"  Types: {c['type_distribution']}")
-        lines.append("  Representative memories:")
+        types = ", ".join(f"{t} x{n}" for t, n in c.get("type_distribution", {}).items())
+        lines.append(f"  Record types: {types}")
+        lines.append("  Representative records:")
         for r in c.get("representatives", []):
             title = _sanitize_content(r.get("title", "untitled"), max_len=120)
             content = _sanitize_content(r.get("content", ""), max_len=200)
@@ -601,16 +659,162 @@ def _fake_insights() -> dict:
     return {
         "findings": [
             {
-                "type": "patterns",
-                "title": "Fake insight for testing",
-                "description": "This is a placeholder finding generated by the fake provider.",
+                "headline": "Fake insight for testing",
+                "what_happened": "This is a placeholder finding generated by the fake provider.",
+                "why_it_matters": "It only exists so tests have a stable shape to assert on.",
+                "recommended_action": "Proceed; no action needed (fake provider).",
                 "confidence": 0.5,
                 "related_memory_ids": [],
-                "recommendation": "No action needed (fake provider).",
             }
         ],
         "summary": "Fake analysis complete.",
     }
+
+
+# -- Sharpness gate --------------------------------------------------------------
+#
+# Deterministic post-LLM enforcement of the clarity contract. The prompts
+# already forbid machinery-subject findings; the gate catches what slips
+# through, with one self-repair retry (the violations are quoted back to the
+# LLM). Rejected findings are dropped and counted — a rejected non-finding is
+# better than a persisted one.
+
+# World modes must never have the memory/clustering machinery as subject.
+_GATE_WORLD_MODES = frozenset({"discover", "patterns"})
+
+# Max violation bullets carried into the repair prompt (the finding count is
+# LLM-controlled, so the violation list is unbounded without this).
+_REPAIR_MAX_VIOLATIONS = 10
+
+# Machinery-subject markers (world modes: headline or action).
+# The memory-noun alternative must not false-positive on legitimate
+# operational findings about RAM/heap ("Memory usage spiked on the batch
+# worker"): fixed-width lookbehinds exclude hardware qualifiers and a
+# lookahead excludes resource-usage nouns, so only STORED-memory talk
+# ("multiple memories show...") counts as machinery-subject.
+# Two alternatives carry false-positive guards because the machinery words
+# double as legitimate infrastructure vocabulary:
+# - "memory": RAM/heap findings ("Memory usage spiked") are real operations
+#   subject matter — hardware qualifiers and resource nouns are excluded, so
+#   only STORED-memory talk ("multiple memories show...") counts.
+# - "cluster": compute clusters (Spark/Databricks/Kafka...) are real systems
+#   — named-technology qualifiers and capacity nouns are excluded, so only
+#   similarity-grouping talk ("Cluster 5", "re-cluster...") counts.
+# "cluster" detection is POSITIVE-SIGNAL, not an allowlist: an earlier
+# revision excluded a fixed set of technologies via lookbehinds
+# (spark/kafka/databricks/...), but legitimate infra phrasings are unbounded
+# ("application cluster", "staging cluster", "EKS cluster"...) and every miss
+# silently drops a valid finding. Instead, bare "cluster" only counts as
+# machinery when it co-occurs with clustering-analysis vocabulary; the
+# numbered ("Cluster 3" — _GATE_PROMPT_REF_RE), "re-cluster", "std=" and
+# "weight variance" cases are caught by their own checks. Trade-off: an
+# un-numbered, un-signalled machinery sentence ("this cluster is coherent")
+# relies on the prompt rules + repair loop rather than this regex.
+_GATE_META_RE = re.compile(
+    r"\bembeddings?\b|\bknowledge (base|graph|coverage|topolog)"
+    r"|\btaxonom|\bdedup|\bstd\s*=|weight variance|\bre-?cluster|\bthis (sample|analysis)\b"
+    r"|\b(similarity|embedding|semantic|record|memory) clusters?\b"
+    r"|\bclusters? of (records?|memor(y|ies)|episodes?|findings?|similar)\b"
+    r"|\b(singleton|bridge|missing|high.variance) clusters?\b"
+    r"|\bclusters? (formation|boundar|separation|overlap|topolog)"
+    # Hardware-memory exclusions: qualifier before the word (incl. capacity
+    # qualifiers: peak/available/free/used/total) OR resource noun/verb after
+    # it (incl. capacity movements: dropped/exceeded/critical/high). Residual
+    # known gap: a bare unqualified "Memory hit 90%" still flags — covered by
+    # the repair loop rather than growing this list unboundedly.
+    r"|(?<!out of )(?<!gpu )(?<!ram )(?<!heap )(?<!swap )(?<!system )(?<!shared )(?<!virtual )(?<!physical )"
+    r"(?<!peak )(?<!available )(?<!free )(?<!used )(?<!total )"
+    r"\bmemor(y|ies)\b(?!\s+(usage|leak|pressure|consumption|footprint|limit|spike|error|exhaust"
+    r"|utili[sz]ation|alloc|dropped|exceed|critical|high))",
+    re.IGNORECASE,
+)
+
+# Bookkeeping actions (world modes: the action must act on the world).
+# Two precision constraints, each pinned by tests:
+# - The verb may sit after a short hedge/subject prefix ("Analysts should
+#   record...", "Consider merging..."), so allow up to three FILLER words
+#   before it — a whitelist, not arbitrary words, lest real actions whose
+#   later words overlap these verbs get caught ("Fix the config writing
+#   logic" must pass).
+# - The verb alone is NOT enough: "Store the API credentials in the secrets
+#   manager", "Tag the PagerDuty incident as P1", "Merge the duplicate CRM
+#   vendor entries" are real operator actions. The verb must take a
+#   record-machinery OBJECT within a few words ("Record a postmortem
+#   memory...", "Consolidate these records..."). Exceptions: "re-cluster"
+#   (inherently machinery) and the "add a memory/metadata/tag/cluster" form,
+#   which already carries its object.
+_GATE_BOOKKEEPING_RE = re.compile(
+    r"^\s*((please|consider|agents?|analysts?|operators?|teams?|we|you|should|must|could|can|then|also)\s+){0,3}"
+    r"(?:(?:record(ing)?|tag(ging)?|stor(e|ing)|captur(e|ing)|annotat(e|ing)|merg(e|ing)|consolidat(e|ing)"
+    r"|writ(e|ing)|link(ing)?|supersed(e|ing)|deprecat(e|ing))\b"
+    r"(?:\s+[\w-]+){0,3}?\s+(memor(y|ies)|records?|findings?|insights?|clusters?|groups?)\b"
+    r"|re-?cluster(ing)?\b"
+    # "memor" needs its suffixes spelled out (as in _GATE_META_RE): the
+    # group-closing \b can never fire after the bare stem — "memory"/"memories"
+    # continue with word characters — so "Add a memory..." went uncaught.
+    r"|add (a |an )?(memor(y|ies)?|metadata|tag|cluster)\b)",
+    re.IGNORECASE,
+)
+
+# Prompt-local numbering (all modes): meaningless once persisted.
+# Deliberately narrow ("memory 5" / "cluster 3" only): "record"/"group"
+# false-positive on legitimate operational ids ("task group 4", "record #123"),
+# and the repair loop plus the prompt rules cover the residual phrasings.
+_GATE_PROMPT_REF_RE = re.compile(r"\b(memor(y|ies)|cluster(s|ing|ed)?)\s+#?\d", re.IGNORECASE)
+
+
+def _gate_findings(findings: list[dict], focus: str) -> tuple[list[dict], list[str]]:
+    """Split sanitized findings into (passed, violation_messages).
+
+    Hygiene modes (contradictions/failures/stale/divergence) legitimately have
+    the records as subject — only the prompt-local-numbering check applies.
+    World modes additionally reject machinery subjects and bookkeeping
+    actions.
+    """
+    passed: list[dict] = []
+    violations: list[str] = []
+    for f in findings:
+        headline = f.get("headline", "")
+        action = f.get("recommended_action", "")
+        text_fields = " | ".join(
+            str(f.get(k, "")) for k in ("headline", "what_happened", "why_it_matters", "recommended_action")
+        )
+        problems = []
+        if _GATE_PROMPT_REF_RE.search(text_fields):
+            problems.append(
+                "references prompt-local numbering (e.g. 'record 5') — name things by their real names"
+            )
+        if focus in _GATE_WORLD_MODES:
+            # All four fields, not just headline/action: machinery talk that
+            # hides in what_happened/why_it_matters ("the embedding separated
+            # them by workflow type") is the same defect.
+            if _GATE_META_RE.search(text_fields):
+                problems.append(
+                    "subject is the records/clustering machinery — report on the work the records describe"
+                )
+            if _GATE_BOOKKEEPING_RE.search(action):
+                problems.append(
+                    "recommended_action is record bookkeeping — it must act on systems or process"
+                )
+        if problems:
+            violations.append(f'"{headline[:80]}": ' + "; ".join(problems))
+        else:
+            passed.append(f)
+    return passed, violations
+
+
+_REPAIR_SUFFIX = """
+
+YOUR PREVIOUS ATTEMPT violated the rules for these findings:
+{violations}
+
+Return findings JSON containing ONLY corrected versions of the violating
+findings listed above — fix each so it complies with the RULES, or omit it
+entirely if no compliant version exists. Do NOT repeat findings that already
+complied, and do NOT introduce new findings. Same JSON shape, plus one extra
+field on each corrected finding: "repairs" — the ORIGINAL violating headline
+copied verbatim from the list above (this is a correlation key; corrected
+findings without a matching "repairs" value are discarded)."""
 
 
 # -- Persist -------------------------------------------------------------------
@@ -623,6 +827,7 @@ async def _persist_findings(
     focus: str,
     scope: str,
     findings: list[dict],
+    method: dict | None = None,
 ) -> list[str | None]:
     """Create insight-type memories for each finding.
 
@@ -732,19 +937,28 @@ async def _persist_findings(
     titles: list[str] = []
     items: list[BulkMemoryItem] = []
     for finding in findings:
-        title = str(finding.get("title", "Untitled insight"))[:80]
-        titles.append(title)
-        description = str(finding.get("description", ""))[:1000]
-        recommendation = str(finding.get("recommendation", ""))[:500]
+        headline = str(finding.get("headline") or finding.get("title") or "Untitled insight")[:80]
+        titles.append(headline)
+        what_happened = str(finding.get("what_happened") or finding.get("description") or "")[:1000]
+        why_it_matters = str(finding.get("why_it_matters") or "")[:300]
+        action = str(finding.get("recommended_action") or finding.get("recommendation") or "")[:500]
         confidence = max(0.0, min(1.0, float(finding.get("confidence", 0.5))))
         related_ids = finding.get("related_memory_ids", [])
 
-        content = f"[Insight/{finding.get('type', focus)}] {title}: {description}"
-        if recommendation:
-            content += f" Recommendation: {recommendation}"
+        # Clarity contract renderer: the headline leads (enrichment derives
+        # the memory ``title`` from it — ``BulkMemoryItem`` has no title
+        # field), followed by short labeled lines instead of the old run-on
+        # "[Insight/{type}] {title}: {description} Recommendation: ..."
+        # paragraph. Method/provenance lives in metadata, NOT in the text.
+        lines = [headline]
+        if what_happened:
+            lines.append(f"What happened: {what_happened}")
+        if why_it_matters:
+            lines.append(f"Why it matters: {why_it_matters}")
+        if action:
+            lines.append(f"Action: {action}")
+        content = "\n".join(lines)
 
-        # ``BulkMemoryItem`` has no ``title`` field — the title is encoded
-        # in ``content`` as "[Insight/{type}] {title}: {description}".
         items.append(
             BulkMemoryItem(
                 memory_type="insight",
@@ -755,8 +969,12 @@ async def _persist_findings(
                     "insight_scope": scope,
                     "insight_type": finding.get("type", focus),
                     "related_memory_ids": [str(rid) for rid in related_ids],
-                    "recommendation": recommendation,
+                    "headline": headline,
+                    "recommendation": action,
                     "confidence": confidence,
+                    # Method transparency: how this finding was produced —
+                    # kept out of the finding text, auditable here.
+                    "method": method or {"focus": focus, "scope": scope},
                 },
             )
         )
@@ -830,6 +1048,20 @@ def _to_float(val, default: float = 0.5) -> float:
         return default
 
 
+def _build_method(focus: str, scope: str, is_clustered: bool, synth: dict) -> dict:
+    """Run-level provenance stamped into each finding's ``metadata.method``.
+
+    Method transparency lives HERE (and in logs), never in the finding text —
+    the clarity contract keeps the insight sharp and the method auditable."""
+    return {
+        "focus": focus,
+        "scope": scope,
+        "memories_analyzed": synth.get("memories_analyzed", 0),
+        "clustered": is_clustered,
+        "gate_rejected": synth.get("gate_rejected", 0),
+    }
+
+
 # -- Public API ----------------------------------------------------------------
 
 
@@ -875,11 +1107,136 @@ async def synthesize_insights(
     prompt = prompt_template.format(memories=memories_text, count=count)
 
     analysis = await _run_llm_analysis(prompt, config)
+    sanitized, summary = _sanitize_findings(analysis, shown_ids, focus=focus, scope=scope)
 
+    # Sharpness gate + one self-repair retry: quote the violations back to
+    # the LLM once; findings that still violate after the retry are dropped.
+    passed, violations = _gate_findings(sanitized, focus)
+    gate_rejected = 0
+    if violations:
+        # Identity-based rescue tracking: violators are the sanitized
+        # findings that did NOT pass (same dict objects, so identity
+        # comparison is exact), and each violation message in ``violations``
+        # was appended in the same iteration order — zip-aligned below.
+        passed_ids = {id(f) for f in passed}
+        violators = [f for f in sanitized if id(f) not in passed_ids]
+        # FIFO queue per casefolded headline, NOT a flat dict: near-duplicate
+        # LLM headlines within one batch are likely, and a dict comprehension
+        # would silently collapse same-headline violators onto the last one —
+        # breaking echo correlation and the rescue accounting for exactly
+        # that case. With queues, each rescue echoing a shared headline
+        # consumes the next unfixed violator carrying it.
+        violators_by_headline: dict[str, list[dict]] = {}
+        for v in violators:
+            violators_by_headline.setdefault(v.get("headline", "").casefold(), []).append(v)
+        violation_msg_by_id = {id(v): msg for v, msg in zip(violators, violations, strict=True)}
+
+        # Repair-round trigger rate is the health metric for the clarity
+        # contract: the nightly lifecycle job runs discover for every tenant,
+        # so a high rate here means the prompts are priming violations (and
+        # every trigger is a second LLM call). One greppable line per
+        # invocation — watch its frequency after deploy.
+        logger.info(
+            "insights: gate flagged %d of %d findings; invoking repair round (focus=%s, scope=%s)",
+            len(violations),
+            len(sanitized),
+            focus,
+            scope,
+        )
+        # The LLM controls the finding count, so the violation list is
+        # unbounded — cap what the repair prompt carries. Violators beyond
+        # the cap simply can't be rescued (their headlines aren't in the
+        # prompt) and the identity-based accounting counts them rejected.
+        shown_violations = violations[:_REPAIR_MAX_VIOLATIONS]
+        if len(violations) > len(shown_violations):
+            logger.info(
+                "insights: repair prompt capped to %d of %d violations (focus=%s, scope=%s)",
+                len(shown_violations),
+                len(violations),
+                focus,
+                scope,
+            )
+        repair_prompt = prompt + _REPAIR_SUFFIX.format(
+            violations="\n".join(f"- {v}" for v in shown_violations)
+        )
+        try:
+            repaired = await _run_llm_analysis(repair_prompt, config)
+        except Exception:
+            logger.warning(
+                "insights: repair pass failed; keeping first-pass compliant findings", exc_info=True
+            )
+        else:
+            re_sanitized, re_summary = _sanitize_findings(repaired, shown_ids, focus=focus, scope=scope)
+            re_passed, _still_violating = _gate_findings(re_sanitized, focus)
+            # MERGE, never replace: findings that already passed the
+            # first-pass gate are kept unconditionally — an incomplete or
+            # malformed repair response can only fail to rescue violators,
+            # never lose compliant work. A repair-pass finding counts as a
+            # rescue ONLY if it ties back to a flagged violator: via its
+            # "repairs" echo key (the repair prompt requires the original
+            # violating headline verbatim) or, fallback, by keeping the
+            # violator's own headline while fixing the body. Anything else
+            # — inventions, echoes of kept findings — is dropped, so the
+            # repair cannot smuggle in findings the first pass never
+            # produced, and an invention can't mask an unrescued violator
+            # in the accounting.
+            kept_headlines = {f.get("headline", "").casefold() for f in passed}
+            rescued: list[dict] = []
+            fixed_violator_ids: set[int] = set()
+            for f in re_passed:
+                echo = str(f.pop("repairs", "") or "").casefold()
+                own = f.get("headline", "").casefold()
+                queue = violators_by_headline.get(echo) or violators_by_headline.get(own) or []
+                violator = next((v for v in queue if id(v) not in fixed_violator_ids), None)
+                if violator is None or own in kept_headlines:
+                    continue
+                fixed_violator_ids.add(id(violator))
+                rescued.append(f)
+                # Rescued findings join the dedup set so two rescues can't
+                # merge under one identical new headline.
+                kept_headlines.add(own)
+            passed = passed + rescued
+            # gate_rejected = original violators minus confirmed-fixed ones;
+            # the surviving messages are exactly the unfixed violators'.
+            violations = [violation_msg_by_id[id(v)] for v in violators if id(v) not in fixed_violator_ids]
+            summary = re_summary or summary
+        gate_rejected = len(violations)
+        if gate_rejected:
+            logger.info(
+                "insights: gate dropped %d findings after repair (focus=%s, scope=%s): %s",
+                gate_rejected,
+                focus,
+                scope,
+                " | ".join(violations)[:500],
+            )
+
+    return {
+        # A first-pass model that hallucinates the repair-only "repairs" key
+        # must not leak it to consumers/persist (rescued findings had theirs
+        # popped during correlation).
+        "findings": [{k: v for k, v in f.items() if k != "repairs"} for f in passed],
+        "summary": summary,
+        "memories_analyzed": count,
+        "gate_rejected": gate_rejected,
+    }
+
+
+def _sanitize_findings(
+    analysis: dict, shown_ids: set[str], *, focus: str, scope: str
+) -> tuple[list[dict], str]:
+    """Normalize an LLM response into finding dicts.
+
+    New schema (headline / what_happened / why_it_matters /
+    recommended_action) with fallbacks from the legacy keys (title /
+    description / recommendation), so a model that answers old-style still
+    works. Every finding also carries the legacy keys MIRRORED from the new
+    fields — downstream consumers (digest agents, dashboards) that read
+    ``title``/``description``/``recommendation`` keep working unchanged.
+    """
     findings = analysis.get("findings", [])
     if not isinstance(findings, list):
         findings = []
-    sanitized = []
+    sanitized: list[dict] = []
     total_dropped = 0
     findings_with_drops = 0
     for f in findings:
@@ -891,16 +1248,33 @@ async def synthesize_insights(
         if dropped > 0:
             total_dropped += dropped
             findings_with_drops += 1
-        sanitized.append(
-            {
-                "type": str(f.get("type", focus))[:50],
-                "title": str(f.get("title", "Untitled"))[:80],
-                "description": str(f.get("description", "")),
-                "confidence": max(0.0, min(1.0, _to_float(f.get("confidence", 0.5)))),
-                "related_memory_ids": kept_related,
-                "recommendation": str(f.get("recommendation", "")),
-            }
-        )
+        # Same length caps the persist path applies — the gate and the
+        # repair prompt must operate on the exact bounded text that
+        # ultimately gets persisted, not on a longer variant.
+        headline = str(f.get("headline") or f.get("title") or "Untitled")[:80]
+        what_happened = str(f.get("what_happened") or f.get("description") or "")[:1000]
+        why_it_matters = str(f.get("why_it_matters") or "")[:300]
+        action = str(f.get("recommended_action") or f.get("recommendation") or "")[:500]
+        item = {
+            "type": str(f.get("type", focus))[:50],
+            "headline": headline,
+            "what_happened": what_happened,
+            "why_it_matters": why_it_matters,
+            "recommended_action": action,
+            "confidence": max(0.0, min(1.0, _to_float(f.get("confidence", 0.5)))),
+            "related_memory_ids": kept_related,
+            # Legacy mirrors — see docstring.
+            "title": headline,
+            "description": " ".join(p for p in (what_happened, why_it_matters) if p),
+            "recommendation": action,
+        }
+        # Repair-pass correlation key: the repair prompt asks each corrected
+        # finding to echo the ORIGINAL violating headline verbatim so the
+        # merge can tie the rescue back to a flagged violator. Carried only
+        # when present; the merge block consumes (pops) it.
+        if f.get("repairs"):
+            item["repairs"] = str(f.get("repairs"))[:80]
+        sanitized.append(item)
     if total_dropped > 0:
         logger.info(
             "insights: dropped %d hallucinated related_memory_ids across %d findings (focus=%s, scope=%s)",
@@ -909,12 +1283,7 @@ async def synthesize_insights(
             focus,
             scope,
         )
-
-    return {
-        "findings": sanitized,
-        "summary": analysis.get("summary", ""),
-        "memories_analyzed": count,
-    }
+    return sanitized, analysis.get("summary", "")
 
 
 async def generate_insights(
@@ -987,6 +1356,7 @@ async def generate_insights(
             "findings": [],
             "summary": "No relevant memories found for this analysis.",
             "insight_memory_ids": [],
+            "gate_rejected": 0,
             "insights_ms": int((time.perf_counter() - t0) * 1000),
         }
 
@@ -1011,7 +1381,10 @@ async def generate_insights(
     # bulk-create and restore are each storage-committed independently — there
     # is no caller-side transaction to commit (``db`` is now None on the
     # storage-routed paths).
-    insight_ids = await _persist_findings(tenant_id, agent_id, fleet_id, focus, scope, findings)
+    method = _build_method(focus, scope, is_clustered, synth)
+    insight_ids = await _persist_findings(
+        tenant_id, agent_id, fleet_id, focus, scope, findings, method=method
+    )
 
     return {
         "focus": focus,
@@ -1020,5 +1393,6 @@ async def generate_insights(
         "findings": [{**f, "insight_memory_id": mid} for f, mid in zip(findings, insight_ids)],
         "summary": synth["summary"],
         "insight_memory_ids": [mid for mid in insight_ids if mid],
+        "gate_rejected": synth.get("gate_rejected", 0),
         "insights_ms": int((time.perf_counter() - t0) * 1000),
     }

--- a/tests/test_insights_service.py
+++ b/tests/test_insights_service.py
@@ -258,8 +258,7 @@ class TestFormatClusters:
             },
         ]
         result, shown_ids = _format_clusters_for_analysis(clusters)
-        assert "Cluster 0" in result
-        assert "10 memories" in result
+        assert "A group of 10 related records" in result
         assert "agent-a" in result
         assert shown_ids == {"rep1"}
 
@@ -276,12 +275,344 @@ class TestFakeInsights:
         assert isinstance(result["findings"], list)
         assert len(result["findings"]) >= 1
         finding = result["findings"][0]
-        assert "type" in finding
-        assert "title" in finding
-        assert "description" in finding
+        # Clarity-contract schema (legacy title/description/recommendation
+        # mirrors are added by _sanitize_findings, not by the raw provider).
+        assert "headline" in finding
+        assert "what_happened" in finding
+        assert "why_it_matters" in finding
+        assert "recommended_action" in finding
         assert "confidence" in finding
         assert "related_memory_ids" in finding
-        assert "recommendation" in finding
+
+
+class TestSanitizeFindings:
+    """_sanitize_findings: new schema, legacy fallbacks, legacy mirrors."""
+
+    def test_new_schema_with_legacy_mirrors(self):
+        from core_api.services.insights_service import _sanitize_findings
+
+        findings, summary = _sanitize_findings(
+            {
+                "findings": [
+                    {
+                        "headline": "Backups fail on repo drift",
+                        "what_happened": "Backup exits 4 whenever main is ahead of origin.",
+                        "why_it_matters": "No workspace backup exists during drift windows.",
+                        "recommended_action": "Auto-push pending commits before the backup job runs.",
+                        "confidence": 0.9,
+                        "related_memory_ids": ["m1", "hallucinated"],
+                    }
+                ],
+                "summary": "s",
+            },
+            shown_ids={"m1"},
+            focus="patterns",
+            scope="all",
+        )
+        assert summary == "s"
+        f = findings[0]
+        assert f["headline"] == "Backups fail on repo drift"
+        assert f["related_memory_ids"] == ["m1"]  # hallucinated id dropped
+        # Legacy mirrors for downstream consumers.
+        assert f["title"] == f["headline"]
+        assert f["recommendation"] == f["recommended_action"]
+        assert (
+            "exits 4" in f["description"] and "No workspace backup" in f["description"]
+        )
+
+    def test_legacy_answer_accepted(self):
+        """A model that ignores the new schema and answers old-style still works."""
+        from core_api.services.insights_service import _sanitize_findings
+
+        findings, _ = _sanitize_findings(
+            {
+                "findings": [
+                    {
+                        "title": "Old-style title",
+                        "description": "Old-style description.",
+                        "recommendation": "Old-style action.",
+                        "confidence": 0.4,
+                        "related_memory_ids": [],
+                    }
+                ]
+            },
+            shown_ids=set(),
+            focus="patterns",
+            scope="all",
+        )
+        f = findings[0]
+        assert f["headline"] == "Old-style title"
+        assert f["what_happened"] == "Old-style description."
+        assert f["recommended_action"] == "Old-style action."
+
+
+class TestSharpnessGate:
+    """_gate_findings: machinery-subject and bookkeeping findings rejected."""
+
+    @staticmethod
+    def _finding(**kw):
+        base = {
+            "headline": "Health monitoring runs as two disconnected loops",
+            "what_happened": "Heartbeat and cleanup fire independently across 6 agents.",
+            "why_it_matters": "A disk-full event alerts twice with no shared cooldown.",
+            "recommended_action": "Unify triggers and cooldowns in the monitoring workflow.",
+        }
+        base.update(kw)
+        return base
+
+    def test_world_mode_rejects_machinery_subject(self):
+        from core_api.services.insights_service import _gate_findings
+
+        passed, violations = _gate_findings(
+            [self._finding(headline="Cluster 5 has high weight variance (std=0.22)")],
+            "discover",
+        )
+        assert passed == []
+        assert len(violations) == 1 and "machinery" in violations[0]
+
+    def test_world_mode_rejects_non_imperative_bookkeeping_action(self):
+        """The bookkeeping verb may hide behind a hedge/subject prefix —
+        'Analysts should record...', 'Consider merging...' — and must still
+        be caught; but real actions whose LATER words overlap the verbs
+        ('Fix the config writing logic') must pass."""
+        from core_api.services.insights_service import _gate_findings
+
+        for action in (
+            "Analysts should record a postmortem memory for each incident.",
+            "Consider merging these near-duplicate records into one.",
+            "We should tag every incident record going forward.",
+        ):
+            passed, violations = _gate_findings(
+                [self._finding(recommended_action=action)], "patterns"
+            )
+            assert passed == [], f"not caught: {action!r}"
+            assert "bookkeeping" in violations[0]
+
+        for action in (
+            "Fix the config writing logic in the deploy script.",
+            "Restart the service and record the outcome in the runbook.",
+        ):
+            passed, violations = _gate_findings(
+                [self._finding(recommended_action=action)], "patterns"
+            )
+            assert passed != [], f"false positive: {action!r} — {violations}"
+
+    def test_bookkeeping_verbs_require_machinery_object(self):
+        """A bookkeeping verb alone is not enough — 'Store the API
+        credentials...' is a real operator action. The verb must take a
+        record-machinery object within a few words."""
+        from core_api.services.insights_service import _gate_findings
+
+        for action in (
+            "Store the API credentials in the secrets manager.",
+            "Tag the PagerDuty incident as P1.",
+            "Merge the duplicate CRM vendor entries.",
+            "Write a runbook update for the on-call rotation.",
+            "Link the outage to the incident tracker.",
+            "Deprecate the legacy v1 endpoint.",
+        ):
+            passed, violations = _gate_findings(
+                [self._finding(recommended_action=action)], "patterns"
+            )
+            assert passed != [], f"false positive: {action!r} — {violations}"
+
+        for action in (
+            "Store these findings in a shared index.",
+            "Consolidate the duplicate records into one.",
+            "Merge overlapping insights across agents.",
+        ):
+            passed, violations = _gate_findings(
+                [self._finding(recommended_action=action)], "patterns"
+            )
+            assert passed == [], f"not caught: {action!r}"
+            assert "bookkeeping" in violations[0]
+
+    def test_infra_cluster_phrasings_are_not_meta(self):
+        """'cluster' is machinery only with clustering-analysis co-occurrence
+        — arbitrary infra clusters (not just an allowlist of technologies)
+        must pass."""
+        from core_api.services.insights_service import _gate_findings
+
+        for headline, body in (
+            (
+                "Application cluster restarts loop during deploys",
+                "The staging cluster restarted 9 times.",
+            ),
+            (
+                "EKS cluster autoscaling exhausted the node quota",
+                "The web cluster hit its pod limit.",
+            ),
+        ):
+            f = self._finding(headline=headline, what_happened=body)
+            passed, violations = _gate_findings([f], "discover")
+            assert passed == [f], f"false positive: {headline!r} — {violations}"
+
+        for machinery_headline in (
+            "The similarity clusters overlap heavily",
+            "Singleton cluster fragmentation persists",
+            "Clusters of records with no verification steps",
+        ):
+            f = self._finding(headline=machinery_headline)
+            passed, violations = _gate_findings([f], "discover")
+            assert passed == [], f"not caught: {machinery_headline!r}"
+
+    def test_world_mode_rejects_add_memory_actions(self):
+        """The 'add a memory' phrasing must be caught — the bare 'memor' stem
+        followed by \\b could never match it (regression pin)."""
+        from core_api.services.insights_service import _gate_findings
+
+        for action in (
+            "Add a memory for the follow-up.",
+            "Add a memory tag for this.",
+            "Add memories for each verification step.",
+        ):
+            passed, violations = _gate_findings(
+                [self._finding(recommended_action=action)], "patterns"
+            )
+            assert passed == [], f"not caught: {action!r}"
+            assert "bookkeeping" in violations[0]
+
+        # Legitimate world actions starting with "Add" must keep passing.
+        passed, violations = _gate_findings(
+            [
+                self._finding(
+                    recommended_action="Add an alert threshold for disk usage."
+                )
+            ],
+            "patterns",
+        )
+        assert passed != [], violations
+
+    def test_world_mode_rejects_bookkeeping_action(self):
+        from core_api.services.insights_service import _gate_findings
+
+        passed, violations = _gate_findings(
+            [
+                self._finding(
+                    recommended_action="Record a postmortem memory for each incident."
+                )
+            ],
+            "patterns",
+        )
+        assert passed == []
+        assert "bookkeeping" in violations[0]
+
+    def test_all_modes_reject_prompt_local_numbering(self):
+        from core_api.services.insights_service import _gate_findings
+
+        bad = self._finding(
+            what_happened="Memory 5 explicitly states the report was blocked."
+        )
+        for focus in ("discover", "contradictions"):
+            passed, violations = _gate_findings([bad], focus)
+            assert passed == []
+            assert "numbering" in violations[0]
+
+    def test_hygiene_mode_allows_memory_subject(self):
+        from core_api.services.insights_service import _gate_findings
+
+        f = self._finding(
+            headline="Gateway endpoint: old.example superseded by new.example",
+            what_happened="An older record still claims old.example; the corrected value is new.example.",
+            recommended_action="Trust new.example; stop relying on the April endpoint value.",
+        )
+        passed, violations = _gate_findings([f], "contradictions")
+        assert passed == [f]
+        assert violations == []
+
+    def test_world_mode_passes_clean_finding(self):
+        from core_api.services.insights_service import _gate_findings
+
+        f = self._finding()
+        passed, violations = _gate_findings([f], "discover")
+        assert passed == [f]
+        assert violations == []
+
+    def test_hardware_memory_findings_are_not_meta(self):
+        """RAM/heap talk is legitimate operations subject matter — only
+        STORED-memory talk counts as machinery-subject."""
+        from core_api.services.insights_service import _gate_findings
+
+        for headline, action in [
+            (
+                "Memory usage spiked on the batch worker",
+                "Raise the worker's memory limit to 4GB.",
+            ),
+            (
+                "Batch worker killed: out of memory during Spark merge",
+                "Cap partition size in the merge job.",
+            ),
+            (
+                "GPU memory exhaustion blocks the nightly training run",
+                "Reduce batch size on the trainer.",
+            ),
+            (
+                "Peak memory hit 90% during the nightly batch",
+                "Split the batch into two runs.",
+            ),
+            (
+                "Available memory dropped below threshold on ingest",
+                "Add headroom alerts on the ingest node.",
+            ),
+            (
+                "Worker memory exceeded the cgroup ceiling",
+                "Raise the cgroup ceiling to 8GB.",
+            ),
+        ]:
+            f = self._finding(headline=headline, recommended_action=action)
+            passed, violations = _gate_findings([f], "discover")
+            assert passed == [f], f"false positive on: {headline!r} — {violations}"
+
+    def test_stored_memory_talk_still_rejected(self):
+        from core_api.services.insights_service import _gate_findings
+
+        f = self._finding(headline="Several memories lack verification of outcomes")
+        passed, violations = _gate_findings([f], "discover")
+        assert passed == []
+        assert "machinery" in violations[0]
+
+    def test_machinery_talk_in_body_fields_rejected(self):
+        """A clean headline must not smuggle machinery talk through
+        what_happened/why_it_matters — the gate scans all four fields."""
+        from core_api.services.insights_service import _gate_findings
+
+        f = self._finding(
+            what_happened="The embedding separated these workflows by type rather than by team."
+        )
+        passed, violations = _gate_findings([f], "discover")
+        assert passed == []
+        assert "machinery" in violations[0]
+
+    def test_compute_cluster_findings_are_not_meta(self):
+        """Spark/Databricks/Kafka clusters are real systems — only
+        similarity-grouping talk counts as machinery."""
+        from core_api.services.insights_service import _gate_findings
+
+        f = self._finding(
+            headline="Spark cluster jobs failing on the nightly merge stage",
+            what_happened="The Databricks cluster ran out of capacity during the AppsFlyer merge on Jul 30.",
+            recommended_action="Raise the cluster capacity or split the merge job.",
+        )
+        passed, violations = _gate_findings([f], "discover")
+        assert passed == [f], violations
+
+    def test_operational_group_ids_are_not_prompt_refs(self):
+        """'task group 4' is a legitimate operational id — only 'memory N' /
+        'cluster N' count as prompt-local numbering."""
+        from core_api.services.insights_service import _gate_findings
+
+        f = self._finding(
+            what_happened="Task group 4 failed twice; record #123 was reprocessed."
+        )
+        passed, violations = _gate_findings([f], "discover")
+        assert passed == [f], violations
+
+    def test_cluster_numbering_still_rejected(self):
+        from core_api.services.insights_service import _gate_findings
+
+        f = self._finding(what_happened="Cluster 3 groups the incident-response work.")
+        passed, violations = _gate_findings([f], "discover")
+        assert passed == []
 
 
 class TestNumpyKmeans:
@@ -403,6 +734,45 @@ class TestFormatterDedupAnnotation:
         )
         assert "[repeats: 7x]" in text
         assert shown == {"r1", "r2"}
+
+    def test_cluster_scaffolding_is_gate_neutral(self):
+        """The rendered cluster scaffolding must not hand the model the very
+        tokens the sharpness gate rejects ("Cluster N", "std=", "memories") —
+        that primes violations and burns the repair round on every nightly
+        discover run. Representative titles/content are user data and exempt;
+        this fixture keeps them neutral so the check isolates OUR scaffolding."""
+        from core_api.services.insights_service import (
+            _GATE_META_RE,
+            _GATE_PROMPT_REF_RE,
+            _format_clusters_for_analysis,
+        )
+
+        text, _ = _format_clusters_for_analysis(
+            [
+                {
+                    "cluster_id": 3,
+                    "size": 41,
+                    "weight_mean": 0.62,
+                    "weight_std": 0.22,
+                    "agent_count": 2,
+                    "agents": ["a1", "a2"],
+                    "type_distribution": {"episode": 40, "fact": 1},
+                    "representatives": [
+                        {
+                            "id": "r1",
+                            "memory_type": "episode",
+                            "title": "Bastion tunnel opened",
+                            "content": "ssh session established",
+                            "dup_count": 12,
+                        }
+                    ],
+                }
+            ]
+        )
+        assert not _GATE_PROMPT_REF_RE.search(text), text
+        assert not _GATE_META_RE.search(text), text
+        assert "std=" not in text
+        assert "memories" not in text.casefold()
 
 
 class TestScopeFilters:
@@ -1068,5 +1438,496 @@ class TestHallucinatedIds:
             findings = result["findings"]
             assert len(findings) == 1
             assert findings[0]["related_memory_ids"] == [a_id]
+        finally:
+            await _cleanup_tenant(tenant_id)
+
+
+# ---------------------------------------------------------------------------
+# Clarity contract: content renderer, method metadata, gate + repair loop
+# ---------------------------------------------------------------------------
+
+
+def _clean_finding(**kw):
+    base = {
+        "headline": "Backups fail whenever main drifts ahead of origin",
+        "what_happened": "The workspace backup exits 4 while main is ~90 commits ahead.",
+        "why_it_matters": "No backup exists during drift windows.",
+        "recommended_action": "Auto-push pending commits before the backup job runs.",
+        "confidence": 0.8,
+        "related_memory_ids": [],
+    }
+    base.update(kw)
+    return base
+
+
+class TestClarityPersist:
+    @pytest.mark.asyncio
+    async def test_content_rendered_as_labeled_lines_with_method(self, monkeypatch):
+        """Persisted content = headline + labeled lines; no '[Insight/' scaffold;
+        method provenance in metadata, not in the text."""
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=f"a-{tag}",
+                content=f"work happened [{tag}]",
+            )
+            await _stub_llm(monkeypatch, findings=[_clean_finding()])
+
+            from core_api.services.insights_service import generate_insights
+
+            result = await generate_insights(
+                tenant_id=tenant_id,
+                focus="patterns",
+                scope="agent",
+                agent_id=f"a-{tag}",
+            )
+            assert result["gate_rejected"] == 0
+            rows = await _insight_rows(tenant_id)
+            assert len(rows) == 1
+            async with get_session() as session:
+                content = (
+                    await session.execute(
+                        text(
+                            "SELECT content FROM memories WHERE id = CAST(:id AS uuid)"
+                        ),
+                        {"id": rows[0].id},
+                    )
+                ).scalar_one()
+            lines = content.split("\n")
+            assert lines[0] == "Backups fail whenever main drifts ahead of origin"
+            assert lines[1].startswith("What happened: ")
+            assert lines[2].startswith("Why it matters: ")
+            assert lines[3].startswith("Action: ")
+            assert "[Insight/" not in content
+            meta = rows[0].metadata
+            if isinstance(meta, str):
+                meta = _json.loads(meta)
+            assert meta["headline"] == lines[0]
+            assert meta["method"]["focus"] == "patterns"
+            assert meta["method"]["clustered"] is False
+            assert meta["method"]["memories_analyzed"] == 1
+        finally:
+            await _cleanup_tenant(tenant_id)
+
+    @pytest.mark.asyncio
+    async def test_result_findings_carry_legacy_mirrors(self, monkeypatch):
+        """REST/MCP consumers reading title/description/recommendation keep working."""
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=f"a-{tag}",
+                content=f"work happened [{tag}]",
+            )
+            await _stub_llm(monkeypatch, findings=[_clean_finding()])
+
+            from core_api.services.insights_service import generate_insights
+
+            result = await generate_insights(
+                tenant_id=tenant_id,
+                focus="patterns",
+                scope="agent",
+                agent_id=f"a-{tag}",
+            )
+            f = result["findings"][0]
+            assert f["title"] == f["headline"]
+            assert f["recommendation"] == f["recommended_action"]
+            assert f["what_happened"] in f["description"]
+        finally:
+            await _cleanup_tenant(tenant_id)
+
+
+class TestGateRepairLoop:
+    @pytest.mark.asyncio
+    async def test_violating_finding_triggers_repair_and_uses_second_pass(
+        self, monkeypatch
+    ):
+        """First pass violates the contract → one repair call; its compliant
+        output is what gets persisted; gate_rejected counts what still failed."""
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        calls = []
+        from core_api.services import insights_service
+
+        async def fake_run(prompt, config):
+            calls.append(prompt)
+            if len(calls) == 1:
+                return {
+                    "findings": [
+                        _clean_finding(
+                            headline="Cluster 5 has high weight variance (std=0.22)",
+                            recommended_action="Re-cluster with a finer label set.",
+                        )
+                    ],
+                    "summary": "first",
+                }
+            return {
+                "findings": [
+                    {
+                        **_clean_finding(),
+                        # Correlation key required by the repair contract:
+                        # the original violating headline, verbatim.
+                        "repairs": "Cluster 5 has high weight variance (std=0.22)",
+                    }
+                ],
+                "summary": "repaired",
+            }
+
+        monkeypatch.setattr(insights_service, "_run_llm_analysis", fake_run)
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=f"a-{tag}",
+                content=f"work happened [{tag}]",
+            )
+            from core_api.services.insights_service import generate_insights
+
+            result = await generate_insights(
+                tenant_id=tenant_id,
+                focus="patterns",
+                scope="agent",
+                agent_id=f"a-{tag}",
+            )
+            assert len(calls) == 2, (
+                "gate violation must trigger exactly one repair call"
+            )
+            assert "YOUR PREVIOUS ATTEMPT" in calls[1]
+            assert "Cluster 5 has high weight variance" in calls[1]
+            assert result["gate_rejected"] == 0
+            assert result["summary"] == "repaired"
+            assert [f["headline"] for f in result["findings"]] == [
+                "Backups fail whenever main drifts ahead of origin"
+            ]
+        finally:
+            await _cleanup_tenant(tenant_id)
+
+    @pytest.mark.asyncio
+    async def test_still_violating_after_repair_is_dropped_and_counted(
+        self, monkeypatch
+    ):
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        from core_api.services import insights_service
+
+        bad = _clean_finding(
+            headline="Cluster 5 has high weight variance (std=0.22)",
+            recommended_action="Re-cluster with a finer label set.",
+        )
+
+        async def fake_run(prompt, config):
+            return {"findings": [bad, _clean_finding()], "summary": "s"}
+
+        monkeypatch.setattr(insights_service, "_run_llm_analysis", fake_run)
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=f"a-{tag}",
+                content=f"work happened [{tag}]",
+            )
+            from core_api.services.insights_service import generate_insights
+
+            result = await generate_insights(
+                tenant_id=tenant_id,
+                focus="patterns",
+                scope="agent",
+                agent_id=f"a-{tag}",
+            )
+            assert result["gate_rejected"] == 1
+            assert [f["headline"] for f in result["findings"]] == [
+                "Backups fail whenever main drifts ahead of origin"
+            ]
+        finally:
+            await _cleanup_tenant(tenant_id)
+
+    @pytest.mark.asyncio
+    async def test_compliant_findings_survive_sloppy_repair(self, monkeypatch):
+        """The repair merges, never replaces: findings that already passed the
+        first-pass gate are kept unconditionally, so an incomplete or empty
+        repair response can only fail to rescue violators — it can never lose
+        compliant work."""
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        from core_api.services import insights_service
+
+        bad = _clean_finding(
+            headline="Cluster 5 has high weight variance (std=0.22)",
+            recommended_action="Re-cluster with a finer label set.",
+        )
+
+        async def fake_run(prompt, config):
+            if "YOUR PREVIOUS ATTEMPT" in prompt:
+                # Sloppy repair: returns NOTHING instead of a corrected
+                # version of the violating finding.
+                return {"findings": [], "summary": "repaired"}
+            return {
+                "findings": [
+                    _clean_finding(),
+                    _clean_finding(
+                        headline="Portfolio brief missed its window twice this week"
+                    ),
+                    bad,
+                ],
+                "summary": "first",
+            }
+
+        monkeypatch.setattr(insights_service, "_run_llm_analysis", fake_run)
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=f"a-{tag}",
+                content=f"work happened [{tag}]",
+            )
+            from core_api.services.insights_service import generate_insights
+
+            result = await generate_insights(
+                tenant_id=tenant_id,
+                focus="patterns",
+                scope="agent",
+                agent_id=f"a-{tag}",
+            )
+            # Both first-pass-compliant findings survive; only the violator
+            # is gone (and counted).
+            assert [f["headline"] for f in result["findings"]] == [
+                "Backups fail whenever main drifts ahead of origin",
+                "Portfolio brief missed its window twice this week",
+            ]
+            assert result["gate_rejected"] == 1
+        finally:
+            await _cleanup_tenant(tenant_id)
+
+    @pytest.mark.asyncio
+    async def test_repair_prompt_caps_violations(self, monkeypatch, caplog):
+        """The finding count is LLM-controlled — the repair prompt must carry
+        at most _REPAIR_MAX_VIOLATIONS violation bullets, and the overflow
+        must be logged. Uncapped violators simply aren't rescued and count
+        as rejected."""
+        import logging as _logging
+
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        from core_api.services import insights_service
+
+        bads = [
+            _clean_finding(
+                headline=f"Cluster {i} has high weight variance (std=0.2{i})",
+                recommended_action="Re-cluster with a finer label set.",
+            )
+            for i in range(12)
+        ]
+        captured: list[str] = []
+
+        async def fake_run(prompt, config):
+            if "YOUR PREVIOUS ATTEMPT" in prompt:
+                captured.append(prompt)
+                return {"findings": [], "summary": "repaired"}
+            return {"findings": bads, "summary": "first"}
+
+        monkeypatch.setattr(insights_service, "_run_llm_analysis", fake_run)
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=f"a-{tag}",
+                content=f"work happened [{tag}]",
+            )
+            from core_api.services.insights_service import generate_insights
+
+            with caplog.at_level(
+                _logging.INFO, logger="core_api.services.insights_service"
+            ):
+                result = await generate_insights(
+                    tenant_id=tenant_id,
+                    focus="patterns",
+                    scope="agent",
+                    agent_id=f"a-{tag}",
+                )
+            assert len(captured) == 1
+            suffix = captured[0].split("YOUR PREVIOUS ATTEMPT", 1)[1]
+            bullet_count = sum(
+                1 for line in suffix.splitlines() if line.startswith("- ")
+            )
+            assert bullet_count == insights_service._REPAIR_MAX_VIOLATIONS
+            assert any(
+                "repair prompt capped to 10 of 12" in r.message for r in caplog.records
+            )
+            # Every violator dies (repair returned nothing) — all 12 counted.
+            assert result["gate_rejected"] == 12
+            assert result["findings"] == []
+        finally:
+            await _cleanup_tenant(tenant_id)
+
+    @pytest.mark.asyncio
+    async def test_duplicate_headline_violators_rescued_independently(
+        self, monkeypatch
+    ):
+        """Two violators sharing a casefold-equal headline must each get
+        their own rescue slot — a headline-keyed dict would silently collapse
+        them onto one, breaking the echo correlation and the accounting."""
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        from core_api.services import insights_service
+
+        shared = "Cluster 5 has high weight variance (std=0.22)"
+        bad1 = _clean_finding(
+            headline=shared, recommended_action="Re-cluster with a finer label set."
+        )
+        bad2 = _clean_finding(
+            headline=shared, recommended_action="Re-cluster with coarser labels."
+        )
+
+        async def fake_run(prompt, config):
+            if "YOUR PREVIOUS ATTEMPT" in prompt:
+                return {
+                    "findings": [
+                        {
+                            **_clean_finding(
+                                headline="Nightly merge stalls on unverified handoffs"
+                            ),
+                            "repairs": shared,
+                        },
+                        {
+                            **_clean_finding(
+                                headline="Portfolio brief missed its window twice this week"
+                            ),
+                            "repairs": shared,
+                        },
+                    ],
+                    "summary": "repaired",
+                }
+            return {"findings": [bad1, bad2], "summary": "first"}
+
+        monkeypatch.setattr(insights_service, "_run_llm_analysis", fake_run)
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=f"a-{tag}",
+                content=f"work happened [{tag}]",
+            )
+            from core_api.services.insights_service import generate_insights
+
+            result = await generate_insights(
+                tenant_id=tenant_id,
+                focus="patterns",
+                scope="agent",
+                agent_id=f"a-{tag}",
+            )
+            # BOTH violators independently rescued: two distinct corrected
+            # findings, zero rejected.
+            assert sorted(f["headline"] for f in result["findings"]) == [
+                "Nightly merge stalls on unverified handoffs",
+                "Portfolio brief missed its window twice this week",
+            ]
+            assert result["gate_rejected"] == 0
+        finally:
+            await _cleanup_tenant(tenant_id)
+
+    @pytest.mark.asyncio
+    async def test_repair_inventions_are_dropped_not_merged(self, monkeypatch):
+        """A repair-pass finding that can't be tied back to a flagged
+        violator (no valid "repairs" echo, new headline) is an invention —
+        it must be dropped, and the unrescued violator still counts as
+        rejected instead of being masked by the invention."""
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        from core_api.services import insights_service
+
+        bad = _clean_finding(
+            headline="Cluster 5 has high weight variance (std=0.22)",
+            recommended_action="Re-cluster with a finer label set.",
+        )
+
+        async def fake_run(prompt, config):
+            if "YOUR PREVIOUS ATTEMPT" in prompt:
+                # Compliant but unrelated to any flagged violator, and no
+                # "repairs" correlation key.
+                return {
+                    "findings": [
+                        _clean_finding(
+                            headline="Invented: onboarding flow drops half the signups"
+                        )
+                    ],
+                    "summary": "repaired",
+                }
+            return {"findings": [_clean_finding(), bad], "summary": "first"}
+
+        monkeypatch.setattr(insights_service, "_run_llm_analysis", fake_run)
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=f"a-{tag}",
+                content=f"work happened [{tag}]",
+            )
+            from core_api.services.insights_service import generate_insights
+
+            result = await generate_insights(
+                tenant_id=tenant_id,
+                focus="patterns",
+                scope="agent",
+                agent_id=f"a-{tag}",
+            )
+            assert [f["headline"] for f in result["findings"]] == [
+                "Backups fail whenever main drifts ahead of origin"
+            ]
+            assert result["gate_rejected"] == 1
+        finally:
+            await _cleanup_tenant(tenant_id)
+
+    @pytest.mark.asyncio
+    async def test_repair_repeating_kept_findings_is_deduped(self, monkeypatch):
+        """A model that ignores the ONLY-the-violators instruction and echoes
+        a kept finding back must not produce duplicates."""
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        from core_api.services import insights_service
+
+        bad = _clean_finding(
+            headline="Cluster 5 has high weight variance (std=0.22)",
+            recommended_action="Re-cluster with a finer label set.",
+        )
+
+        async def fake_run(prompt, config):
+            if "YOUR PREVIOUS ATTEMPT" in prompt:
+                # Echoes the kept finding (headline case differs) alongside
+                # the genuinely rescued one (tied back via the "repairs" key).
+                return {
+                    "findings": [
+                        {
+                            **_clean_finding(
+                                headline="BACKUPS FAIL WHENEVER MAIN DRIFTS AHEAD OF ORIGIN"
+                            ),
+                            "repairs": "Cluster 5 has high weight variance (std=0.22)",
+                        },
+                        {
+                            **_clean_finding(
+                                headline="Nightly merge stalls on unverified handoffs"
+                            ),
+                            "repairs": "Cluster 5 has high weight variance (std=0.22)",
+                        },
+                    ],
+                    "summary": "repaired",
+                }
+            return {"findings": [_clean_finding(), bad], "summary": "first"}
+
+        monkeypatch.setattr(insights_service, "_run_llm_analysis", fake_run)
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=f"a-{tag}",
+                content=f"work happened [{tag}]",
+            )
+            from core_api.services.insights_service import generate_insights
+
+            result = await generate_insights(
+                tenant_id=tenant_id,
+                focus="patterns",
+                scope="agent",
+                agent_id=f"a-{tag}",
+            )
+            assert [f["headline"] for f in result["findings"]] == [
+                "Backups fail whenever main drifts ahead of origin",
+                "Nightly merge stalls on unverified handoffs",
+            ]
         finally:
             await _cleanup_tenant(tenant_id)


### PR DESCRIPTION
## Problem

Follow-up to the eToro insights quality analysis (#679, #681 fixed the input side; this fixes the **output** side). Persisted insights are frequently unreadable or meta — they discuss the methodology of producing insights rather than any insight:

- **80% of nightly discover findings** contain clustering-machinery language, e.g. a real persisted "insight": *"Cluster 5 shows inconsistent confidence (std=0.22)… Recommendation: Re-cluster Cluster 5 using a finer label set."* That is k-means QA, not intelligence.
- **67% of discover recommendations target the memory system** ("merge Cluster 0", "add verification memories") rather than anything an operator can act on.
- Content is a single run-on paragraph — `[Insight/discover] Cluster 5: {title-truncated-mid-wor}: {description} Recommendation: …` — with prompt-local references ("Memory 5", "memories 1, 8, 18") that mean nothing after the run.

Root cause is the prompts: the persona was a *"memory analyst specializing in knowledge topology"* asked *"are any clusters surprising?"*. The LLM answered exactly what it was asked.

## The clarity contract ("front-page test")

A persisted finding must read like a line a human would put in a status report.

| Piece | What it does |
|---|---|
| **Prompts re-aimed** (6 modes) | Persona → *operations analyst reading the team's work records*. Clusters/weights/repeat-counts are a **lens, never the subject**. World modes (discover/patterns) forbid machinery subjects and bookkeeping actions, with a bad→good example pair; hygiene modes (contradictions/failures/stale/divergence) keep records as legitimate subject but must name the disputed fact in world terms and resolve it concretely. *"An empty findings list is a valid answer."* |
| **Structured schema** | `headline` / `what_happened` / `why_it_matters` / `recommended_action`. Legacy answers (title/description/recommendation) accepted as fallbacks; legacy keys **mirrored** onto every finding so existing consumers keep working unchanged. |
| **Clean renderer** | Headline first (enrichment derives the memory title from it), then short labeled lines. Method/provenance (`focus, scope, memories_analyzed, clustered, gate_rejected`) moves to `metadata.method` — transparent and auditable, out of the text. |
| **Sharpness gate + self-repair** | Deterministic post-LLM regex checks (no extra LLM call on the happy path): machinery subjects & bookkeeping actions rejected in world modes, prompt-local numbering rejected everywhere. Violations are quoted back to the LLM in **one** repair retry; still-violating findings are dropped and counted as `gate_rejected` in the result — the ongoing per-run quality metric. |

**Before → after (real finding):**
> ❌ `[Insight/discover] Cluster 3: Periodic self-health checks & heartbeat monitoring: … Low std (≈0.08) suggests a stable monitoring routine… Recommendation: Merge with Cluster 0 into a unified workflow.`

> ✅ `Health monitoring runs as two disconnected loops`
> `What happened: Heartbeat checks and cleanup escalation fire independently across 6 agents; a disk-full event on Jul 28 alerted twice with no shared cooldown.`
> `Why it matters: Duplicate alerts and no shared cooldown.`
> `Action: Unify triggers and cooldowns in the monitoring workflow config.`

## Compatibility

- No storage/API-shape changes: findings carry strictly more fields; `gate_rejected` is additive; metadata keeps `recommendation`/`confidence` (plus new `headline`, `method`).
- Old-style LLM answers still sanitize correctly (legacy fallback), proven by the pre-existing stub tests passing unmodified.
- Nothing parses the old `[Insight/` content prefix (verified across repo).

## Tests

12 new: sanitize (new schema, legacy fallback, mirrors), gate (machinery subject, bookkeeping action, prompt-numbering, hygiene-mode allowance, clean pass), persist renderer + `metadata.method`, repair loop (violation → exactly one repair call quoting the offender; still-violating → dropped + counted). All six prompt templates smoke-tested for `.format()` safety against brace-containing content. **47/47** in the service suite, **87/87** across the three insights suites; `ruff` format+lint clean.

## Out of scope (deliberate)

- Machine-actionable resolutions for hygiene modes (`{action: transition, target_id, …}`) — second PR as planned.
- Offline A/B against a real night's prod input — validation step before the eToro cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
