### PR TITLE
fix(search): reserve candidate and result slots for FTS-only rows (#687)

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -537,6 +537,7 @@ FTS_BOOST_MAX_TOKENS = 3  # queries with more meaningful tokens than this stay a
 FTS_BOOST_SPECIFICITY_RATIO = 0.4  # strict >; at N=2 this means >=1 specific token triggers boost
 SIMILARITY_BLEND = 0.85  # base_score = SIMILARITY_BLEND * similarity + (1 - SIMILARITY_BLEND) * weight (raised from 0.75 — LoCoMo sweep showed +13pp recall)
 SEARCH_OVERFETCH_FACTOR = 2  # fetch top_k * N candidates from storage, trim to top_k after min_similarity filter — gives post-filter headroom
+FTS_ONLY_RESERVED_RESULTS = 1  # #687: result slots held for rows that FTS-match but are not embedded yet (transient deferred-embed window); 0 restores the pre-#687 head-slice behaviour
 # A26: recall_count is bumped for every RETURNED row, used or not (see
 # TrackRecalls + memory_increment_recall), and feeds recall_boost back into the
 # rank score — a self-reinforcing "returned → boosted → returned" loop with no

--- a/core-api/src/core_api/pipeline/steps/search/post_filter_results.py
+++ b/core-api/src/core_api/pipeline/steps/search/post_filter_results.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepOutcome, StepResult
 from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
+from core_api.search_trim import trim_reserving_fts_only
 
 
 class PostFilterResults:
@@ -37,6 +38,24 @@ class PostFilterResults:
         # Trim to the user-requested top_k (storage returned top_k * overfetch_factor)
         final_top_k = ctx.data.get("final_top_k")
         if final_top_k is not None:
-            filtered = filtered[:final_top_k]
+            filtered = trim_reserving_fts_only(filtered, final_top_k, _is_fts_only)
         ctx.data["filtered_rows"] = filtered
         return None
+
+
+def _is_fts_only(row) -> bool:
+    """True for a row storage admitted on FTS alone, with no embedding yet.
+
+    Same test as the cosine-gate exemption above, which has used this form since
+    CAURA-679 — kept identical so the gate and the reservation cannot disagree
+    about what "FTS-only" means.
+
+    ``row`` is a ``SimpleNamespace``, hence ``getattr``; the legacy path in
+    ``memory_service`` holds dicts and reads the same field with ``.get``. The
+    value is always a real ``bool``, never ``None``: storage computes it as
+    ``Memory.embedding.is_not(None)`` — a non-nullable SQL boolean — and
+    ``execute_scored_search`` carries it onto the namespace with a ``True``
+    default. So truthiness and ``is False`` cannot diverge on any reachable
+    input here.
+    """
+    return not getattr(row, "has_embedding", True)

--- a/core-api/src/core_api/search_trim.py
+++ b/core-api/src/core_api/search_trim.py
@@ -1,0 +1,61 @@
+"""Head-slice trim that reserves result slots for FTS-only rows (#687).
+
+Lives at the package root, importing only :mod:`core_api.constants`, so both the
+pipeline post-filter step and the legacy search path can use it without an import
+cycle. One implementation on purpose: the two paths trim independently, and when
+this logic was duplicated a boundary bug had to be fixed in both copies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from core_api.constants import FTS_ONLY_RESERVED_RESULTS
+
+
+def trim_reserving_fts_only(
+    rows: list[Any],
+    top_k: int,
+    is_fts_only: Callable[[Any], bool],
+) -> list[Any]:
+    """Trim ``rows`` to ``top_k``, keeping one FTS-only row if any exist.
+
+    #687: exempting FTS-only rows from the cosine gate is not enough to make them
+    reachable. They score on ``fts_score`` alone — single digits of a percent for
+    one term — so with enough embedded rows above them a plain head slice drops
+    them, having already survived storage's candidate LIMIT only because that
+    reserves slots for them too.
+
+    The reservation is deliberately minimal: it promotes at most
+    ``FTS_ONLY_RESERVED_RESULTS`` rows, displacing the same number from the tail
+    of the head — the weakest results — and only when the head contains none
+    already. It never reorders anything. The population is transient: a row is
+    FTS-only just until the deferred embed backfill lands, after which it competes
+    on cosine normally.
+
+    ``is_fts_only`` is passed in because the two callers hold different row
+    shapes: the pipeline has objects (attribute access), the legacy path dicts.
+
+    Never consumes the whole head. A ``top_k=1`` caller (valid input —
+    ``schemas.py`` allows ``ge=1``) asked for their single best match, and
+    answering with only an FTS-pending stub in its place is worse than not
+    surfacing the stub at all. #687's contract is that such a row is
+    *discoverable*, which storage's candidate reservation still provides; it was
+    never that the row outranks the best result.
+    """
+    head = rows[:top_k]
+    if FTS_ONLY_RESERVED_RESULTS <= 0 or top_k <= 0:
+        return head
+    if any(is_fts_only(r) for r in head):
+        return head
+    # The ``- 1`` is what stops the promotion taking every slot: it keeps
+    # ``top_k - len(promoted)`` in the slice below at 1 or more, so at least one
+    # row that earned its place on score always survives.
+    budget = min(FTS_ONLY_RESERVED_RESULTS, top_k - 1)
+    if budget <= 0:
+        return head
+    promoted = [r for r in rows[top_k:] if is_fts_only(r)][:budget]
+    if not promoted:
+        return head
+    return head[: top_k - len(promoted)] + promoted

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -78,6 +78,7 @@ from core_api.schemas import (
     MemoryOut,
     MemoryUpdate,
 )
+from core_api.search_trim import trim_reserving_fts_only
 from core_api.services.entity_extraction_worker import process_entity_extraction
 from core_api.services.entity_tokens import extract_entity_tokens
 from core_api.services.governance_gate import (
@@ -3457,7 +3458,14 @@ async def _search_memories_legacy(
         or r.get("vec_sim") is None
         or float(r["vec_sim"]) >= _min_similarity
     ]
-    rows = rows[:_top_k]
+    # #687: the same reservation the pipeline post-filter applies — exempting
+    # FTS-only rows from the cosine gate above does not make them reachable,
+    # because they score on fts_score alone and a plain head slice drops them once
+    # enough embedded rows sit above. Shared with that path via
+    # `trim_reserving_fts_only` so the two cannot drift; rows here are dicts, so
+    # the predicate reads `has_embedding` with `.get` (matching the gate above)
+    # where the pipeline uses attribute access.
+    rows = trim_reserving_fts_only(rows, _top_k, lambda r: r.get("has_embedding") is False)
 
     # Build results from storage API response
     memory_ids = [row.get("id") for row in rows if row.get("id")]

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -235,6 +235,22 @@ def _entity_uf_union(parent: dict[UUID, UUID], rank: dict[UUID, int], a: UUID, b
         rank[ra] += 1
 
 
+# #687: how many candidate slots the scored search reserves for rows that
+# FTS-match but have no embedding yet. Deliberately small: the guarantee needed
+# is "discoverable", not "ranked highly", and the population is transient — rows
+# carry a NULL embedding only until the deferred backfill lands. Set to 0 to
+# restore the pre-#687 behaviour where such rows are cut by the candidate LIMIT.
+#
+# This also floors what the result layer can promote: core-api's
+# ``FTS_ONLY_RESERVED_RESULTS`` (currently 1) reserves result slots only among
+# rows that already reached it, and this branch is the only supply it is
+# guaranteed — the main branch carries FTS-only rows just when they earn a slot
+# on score. So keep this >= that constant; above it, the extra promotions are
+# satisfied only incidentally. core-storage-api must not import core-api, so the
+# coupling is documented here rather than enforced.
+_FTS_ONLY_RESERVED_CANDIDATES = 3
+
+
 # Cached at import time so the per-row column-name filter on the bulk
 # write hot path (100 items x ~25 columns) doesn't pay the cost of
 # walking ``Memory.__table__.columns`` and ``__mapper__.column_attrs``
@@ -1501,13 +1517,40 @@ class PostgresService:
             # PostFilterResults trims to the caller's top_k — so with A49 alone this
             # only *widens/relevance-selects the pool*, it does not reorder the final
             # result; the reorder is A50. Off (0) by default → unchanged behaviour.
-            scored_stmt = scored_stmt.order_by(similarity.desc(), Memory.created_at.desc()).limit(
+            main_stmt = scored_stmt.order_by(similarity.desc(), Memory.created_at.desc()).limit(
                 _candidate_pool_size
             )
         else:
-            scored_stmt = scored_stmt.order_by(score.desc(), Memory.created_at.desc()).limit(_top_k)
+            main_stmt = scored_stmt.order_by(score.desc(), Memory.created_at.desc()).limit(_top_k)
 
-        scored_cte = scored_stmt.cte("scored")
+        # #687: reserve candidate slots for FTS-only rows.
+        #
+        # CAURA-594 admits a NULL-embedding row when it FTS-matches, and CAURA-679
+        # scores it on ``fts_score`` alone so the blend's haircut can't bury it —
+        # both so a memory stays discoverable during the deferred-embed window.
+        # Neither helps it survive the LIMIT above: ``fts_score`` is
+        # ``ts_rank_cd/(1+ts_rank_cd)``, single digits of a percent for one term,
+        # while embedded rows near the query score far higher. Measured on prod
+        # (#687): embedded rows 0.35-0.39, the FTS-only row 0, a 10-row window —
+        # so the row was cut here, upstream of every exemption downstream of it.
+        #
+        # A small dedicated branch, ordered by FTS relevance and separately capped,
+        # guarantees such rows reach the caller without touching how anything else
+        # ranks: they enter the pool at their own true (low) score and the outer
+        # ORDER BY still places them last. Bounded twice over — the cap, and the
+        # fact that NULL-embedding rows exist only until the backfill lands.
+        if _FTS_ONLY_RESERVED_CANDIDATES > 0 and query and query.strip():
+            reserved_stmt = (
+                scored_stmt.where(and_(Memory.embedding.is_(None), _fts_guard))
+                .order_by(fts_score.desc(), Memory.created_at.desc())
+                .limit(_FTS_ONLY_RESERVED_CANDIDATES)
+            )
+            # Each operand is wrapped in its own subquery so its ORDER BY/LIMIT is
+            # applied BEFORE the union, not hoisted to the compound statement — the
+            # main branch must stay byte-identical to the un-reserved query.
+            scored_cte = select(main_stmt.subquery()).union(select(reserved_stmt.subquery())).cte("scored")
+        else:
+            scored_cte = main_stmt.cte("scored")
 
         # -- Outer query: JOIN Memory + LEFT JOIN entity links --
         stmt = (

--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -665,3 +665,93 @@ async def test_recall_returns_memory_with_pending_embedding(db, monkeypatch, use
         f"returned {len(results)} other row(s): "
         f"{[str(r.id) for r in results]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Bounds of the FTS-only result reservation (#687)
+# ---------------------------------------------------------------------------
+
+
+class _Row:
+    """Minimal stand-in for a scored row: the reservation reads has_embedding only."""
+
+    def __init__(self, rid, has_embedding):
+        self.id = rid
+        self.has_embedding = has_embedding
+
+
+def test_fts_only_reservation_is_bounded_and_only_fires_when_needed():
+    """The #687 reservation must be a floor of one, not a general reordering.
+
+    It exists so a row that FTS-matches while its embedding is still pending
+    stays reachable. It must not become a licence to displace good results, so
+    this pins the three boundaries: it promotes at most
+    FTS_ONLY_RESERVED_RESULTS, it stays out of the way when the head already
+    contains such a row, and it does nothing at all to an ordinary result set.
+    """
+    from core_api.constants import FTS_ONLY_RESERVED_RESULTS
+    from core_api.pipeline.steps.search.post_filter_results import _is_fts_only
+    from core_api.search_trim import trim_reserving_fts_only
+
+    def _trim(rows, top_k):
+        return trim_reserving_fts_only(rows, top_k, _is_fts_only)
+
+    # No FTS-only rows anywhere → identical to a plain head slice.
+    embedded = [_Row(i, True) for i in range(10)]
+    assert [r.id for r in _trim(embedded, 5)] == [0, 1, 2, 3, 4]
+
+    # An FTS-only row already inside the head → untouched, nothing promoted.
+    head_has_one = [_Row(0, True), _Row(1, False)] + [_Row(i, True) for i in range(2, 10)]
+    assert [r.id for r in _trim(head_has_one, 5)] == [0, 1, 2, 3, 4]
+
+    # FTS-only rows only beyond the cutoff → exactly the reserved count is
+    # promoted, displacing the same number from the tail of the head, and the
+    # result length is unchanged.
+    beyond = [_Row(i, True) for i in range(5)] + [_Row(100 + i, False) for i in range(4)]
+    out = _trim(beyond, 5)
+    assert len(out) == 5, "the reservation must not change how many rows are returned"
+    promoted = [r.id for r in out if not r.has_embedding]
+    assert len(promoted) == FTS_ONLY_RESERVED_RESULTS, (
+        f"promoted {len(promoted)} FTS-only rows, expected exactly "
+        f"FTS_ONLY_RESERVED_RESULTS={FTS_ONLY_RESERVED_RESULTS} — an unbounded "
+        f"promotion would let a bulk import of unembedded rows flood results"
+    )
+    # The strongest results survive; only the weakest are displaced.
+    assert [r.id for r in out][0] == 0
+
+    # Fewer rows than top_k → head slice semantics preserved.
+    assert len(_trim([_Row(0, True)], 5)) == 1
+
+    # The reservation must never consume the ENTIRE head. top_k=1 is a valid
+    # input (schemas.py: ge=1), and answering a "give me your single best match"
+    # query with only an embed-pending stub — in place of a real, high-scoring
+    # result — is a worse answer than not surfacing the stub at all. #687
+    # promises such a row is discoverable, not that it outranks the best match;
+    # storage's candidate reservation is what keeps that promise here.
+    best_then_stub = [_Row(0, True), _Row(100, False)]
+    assert [r.id for r in _trim(best_then_stub, 1)] == [0], (
+        "a top_k=1 caller must keep their true best match; promoting into the "
+        "only slot displaces it entirely rather than displacing the weakest"
+    )
+    # One slot above the reserved count is the first size that can promote.
+    assert [r.id for r in _trim(best_then_stub, FTS_ONLY_RESERVED_RESULTS + 1)] == [0, 100]
+
+
+def test_fts_only_reservation_constants_stay_in_step_across_services():
+    """core-api can only reserve result slots among rows storage sent it.
+
+    ``_FTS_ONLY_RESERVED_CANDIDATES`` (core-storage-api) is the only supply of
+    FTS-only candidates the result layer is *guaranteed* — the main branch
+    carries such rows just when they earn a slot on score. The two constants sit
+    in separately deployed packages and core-storage-api must not import
+    core-api, so nothing but this test stops them drifting apart.
+    """
+    from core_api.constants import FTS_ONLY_RESERVED_RESULTS
+    from core_storage_api.services.postgres_service import _FTS_ONLY_RESERVED_CANDIDATES
+
+    assert _FTS_ONLY_RESERVED_CANDIDATES >= FTS_ONLY_RESERVED_RESULTS, (
+        f"storage reserves {_FTS_ONLY_RESERVED_CANDIDATES} FTS-only candidate "
+        f"slots but core-api tries to reserve {FTS_ONLY_RESERVED_RESULTS} result "
+        f"slots — the surplus can only be filled incidentally, so the #687 "
+        f"discoverability guarantee silently weakens"
+    )

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -479,17 +479,8 @@ async def _insert_memory_with_embedding(tenant_id, content, *, embedding, fleet_
     return mem
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "caura-memclaw#687: an FTS-matching NULL-embedding row is cut by the "
-        "candidate window before PostFilterResults' cosine-gate exemption can run. "
-        "Fixing it requires a ranking decision (normalise fts_score onto the cosine "
-        "scale, or reserve candidate/result slots for FTS-only rows) — strict=True so "
-        "this fails loudly once that lands and the marker must be removed."
-    ),
-)
-async def test_fts_only_row_survives_a_saturated_candidate_window(tenant_id):
+@pytest.mark.parametrize("use_pipeline", [True, False], ids=["pipeline", "legacy"])
+async def test_fts_only_row_survives_a_saturated_candidate_window(tenant_id, monkeypatch, use_pipeline):
     """An FTS-matching row with no embedding must not be cut by the candidate window.
 
     The scored search fetches ``top_k * SEARCH_OVERFETCH_FACTOR`` candidates
@@ -511,7 +502,11 @@ async def test_fts_only_row_survives_a_saturated_candidate_window(tenant_id):
     subject row is the only FTS match. That isolates the window as the only
     thing that can exclude it.
     """
+    from core_api.services import memory_service
     from core_api.services.memory_service import search_memories
+
+    # Both implementations trim independently, so both need the reservation.
+    monkeypatch.setattr(memory_service, "_USE_PIPELINE_SEARCH", use_pipeline)
 
     top_k = 5
     window = top_k * SEARCH_OVERFETCH_FACTOR


### PR DESCRIPTION
Fixes #687 — option 2 of the three we weighed, plus removal of #699's `xfail(strict=True)` marker.

## Why the exemptions never fired

CAURA-594 admits a NULL-embedding row when it FTS-matches; CAURA-679 scores it on `fts_score` alone so the blend can't bury it. Neither helps it survive the two places that cut by **rank**:

1. storage's candidate `LIMIT` (`top_k * SEARCH_OVERFETCH_FACTOR`)
2. the head slice trimming to the caller's `top_k`

`fts_score` is `ts_rank_cd/(1+ts_rank_cd)` — single digits of a percent for one term — against embedded rows scoring far higher. Measured on prod: **791 memories, embedded rows 0.35–0.39, the FTS-only row 0, a 10-row window.** The row was gone before the cosine-gate exemptions (pipeline's since CAURA-679, legacy's since #697) could run.

**No constant floor fixes this:** `min_similarity` is 0.3, *below* the measured embedded noise floor.

## The change

A small capped allowance in all three places — guaranteeing *discoverable*, not *ranked highly*:

- **`postgres_service`** — a dedicated candidate branch for `embedding IS NULL AND search_vector @@ query`, ordered by FTS relevance and separately capped, unioned into the scored CTE. Rows enter at their own true (low) score; the outer `ORDER BY` still places them last.
- **`post_filter_results`** and **`_search_memories_legacy`** — promote at most `FTS_ONLY_RESERVED_RESULTS`, and only when the head contains none already, displacing the same number of weakest results.

Blast radius is bounded twice: by the caps, and because NULL-embedding rows exist only until the backfill lands (~seconds on prod).

## The bug this nearly shipped with

My first version unioned the two selects directly. That let SQLAlchemy hoist the main branch's `ORDER BY … LIMIT` to the compound statement, **changing the candidate set for embedded rows** — two unrelated graph-fanout tests silently flipped xfail → xpass. Wrapping each operand in its own subquery fixes it, and I only caught it by diffing the xfail/xpass profile against a clean tree. Worth knowing if anyone touches this union again.

## Verification

| Check | Result |
|---|---|
| Full suite (mine) | **4057 passed, 1 xfailed, 3 xpassed** |
| Full suite (clean `main` baseline) | 4054 passed, 2 xfailed, 3 xpassed |
| Delta | exactly the 3 added tests + #699's marker removed; **same 3 pre-existing xpasses** |
| Both halves load-bearing | setting either constant to 0 reproduces the bug |
| Both search paths | saturated test parameterised over `_USE_PIPELINE_SEARCH`; both pass |
| Reservation bounds | unit test: promotes at most the cap, no-ops when the head already has one, untouched for ordinary result sets, result length unchanged |
| mypy | clean — core-api (189 files) and core-storage-api (74) |
| ruff check / format | clean on every file touched; verified against in-place baselines, since comparing via `/tmp` copies misreads isort |

Run against local pgvector 0.8.6 with `alembic upgrade head` (the fixtures use `Base.metadata.create_all`, so without alembic the migration-001 `search_vector` trigger is absent and any FTS test fails for the wrong reason).

## Not done here

**Normalising `fts_score` onto the cosine scale** — option 1. It's the deeper fix and would likely improve keyword recall generally, but it reprices every query and belongs behind a benchmark run rather than my judgement. Worth its own issue.

Also worth a follow-up: nothing tells a caller their just-written memory isn't searchable yet. `embedding_pending` is already in the write response metadata, but undocumented — the cheap half of option 3.