### PR TITLE
ci(review): default the review model to Sonnet 5

### DIFF
--- a/.github/scripts/claude_pr_review.sh
+++ b/.github/scripts/claude_pr_review.sh
@@ -19,11 +19,11 @@
 #   EXTRA_PROMPT      repo context, prepended to the review prompt
 #   REVIEW_PROMPT     review instructions + output format
 # Optional env:
-#   MODEL             model id (default: claude-sonnet-4-6)
+#   MODEL             model id (default: claude-sonnet-5)
 #   MAX_BUDGET_USD    per-review spend ceiling, passed to --max-budget-usd (default 10.00)
 set -euo pipefail
 
-MODEL="${MODEL:-claude-sonnet-4-6}"
+MODEL="${MODEL:-claude-sonnet-5}"
 
 # A ceiling so one runaway review cannot bill without bound. The reviewer reads the repo
 # across turns to judge a diff, which is what makes it useful and also what makes an


### PR DESCRIPTION
Bumps this repo's inlined reviewer from `claude-sonnet-4-6` to `claude-sonnet-5`, the
default the org's shared pipeline has used for both review and declined-finding capture
since `caura-ai/.github@v1`.

`caura-memclaw` is the last repo still on 4.6, and the highest-volume reviewer in the org
— 211 of 292 sampled reviews ran here.

### Why the default is bumped in place rather than inherited

This repo cannot adopt the shared workflow that would have carried the new default in.
GitHub refuses to let a **public** repo consume a reusable workflow or composite action
from a **private** one, which is what blocked #668. The inlined script is therefore
permanent here until `caura-ai/.github` goes public, so the default is set locally.

### Cost

Same tier as 4.6, newer model, and currently cheaper: Sonnet 5 is at an introductory
$2/$10 per MTok against 4.6's $3/$15. The intro rate ends 2026-08-31, after which both
list at $3/$15 — so this is never a price increase.

### Verification

- `bash -n` and `shellcheck` clean.
- Confirmed `claude --print --model claude-sonnet-5 --output-format json` returns a result
  with `total_cost_usd` populated, so the cost footer and the job-summary token table keep
  working. The `MAX_BUDGET_USD` ceiling is model-independent and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)