### PR TITLE
test(search): make three flaky xfail/xpass search tests deterministic

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,11 @@
 [pytest]
+# An xfail that starts passing is a failure, not a silent pass. Without this,
+# a stale marker keeps reporting green as XPASS and the xfail/xpass profile
+# stops being a usable signal — which is how three markers went stale here,
+# two of them masking fixtures that wrote to a rolled-back transaction and
+# asserted against other tests' leftovers. Both remaining markers were checked
+# against this setting; use `strict=False` on a marker that genuinely needs it.
+xfail_strict = true
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
 asyncio_default_test_loop_scope = session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -270,7 +270,15 @@ def storage_http(_patch_storage_client):
 
 @pytest.fixture
 def tenant_id():
-    """Unique tenant ID per test module."""
+    """The run's shared tenant ID — one constant for the whole session.
+
+    NOT unique per test or per module: ``TENANT_ID`` is evaluated once, when this
+    module is imported. Rows any test commits through ``sc`` therefore stay
+    visible to every later test under this id, so an assertion like
+    ``len(results) >= 1`` can be satisfied by another test's data. Where a test
+    needs real isolation, generate its own ``f"test-tenant-…-{uuid4().hex[:8]}"``
+    (keep the ``test-tenant-`` prefix — session teardown sweeps on it).
+    """
     return TENANT_ID
 
 

--- a/tests/test_p3_3_graph_fanout.py
+++ b/tests/test_p3_3_graph_fanout.py
@@ -9,11 +9,13 @@ from uuid import UUID
 
 import pytest
 
+from common.embedding import fake_embedding
 from core_api.constants import (
     GRAPH_HOP_BOOST,
     GRAPH_MAX_BOOSTED_MEMORIES,
     DEFAULT_SEARCH_TOP_K,
 )
+from core_api.services.memory_service import search_memories
 
 
 # ---------------------------------------------------------------------------
@@ -130,91 +132,94 @@ class TestCappedLinkProcessing:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def fanout_tenant():
+    """A tenant of this test's own, so no other test's rows can satisfy an assertion.
+
+    The shared ``tenant_id`` fixture is one constant for the whole session, and
+    ``fake_embedding`` is a bag-of-words hash, not a near-orthogonal one: an
+    unrelated committed row ("User prefers dark mode in the editor") measures
+    cosine 0.33 against a random token — over the 0.3 ``min_similarity`` gate. So
+    a unique query token alone does not isolate these tests; the tenant must.
+    """
+    return f"test-tenant-fanout-{uuid.uuid4().hex[:8]}"
+
+
 @pytest.mark.integration
 class TestGraphFanoutIntegration:
     """Verify fan-out cap works in the real search pipeline."""
 
-    async def _create_entity_with_memories(
-        self, db, tenant_id, fleet_id, entity_name, num_memories, embedding
-    ):
-        """Create an entity and link it to N memories."""
-        from common.models.entity import Entity, MemoryEntityLink
-        from common.models.memory import Memory
-        from sqlalchemy import text as sql_text
+    async def _create_entity_with_memories(self, sc, tenant_id, fleet_id, entity_name, num_memories):
+        """Create an entity and link it to N memories, committed so search sees them.
 
-        entity = Entity(
-            tenant_id=tenant_id,
-            entity_type="concept",
-            canonical_name=entity_name,
-            fleet_id=fleet_id,
+        Writes through ``sc``, not ``db`` — ``db`` rolls its transaction back at
+        teardown, so rows added there are never visible to the separate connection
+        ``search_memories`` runs on. That is why these tests carried an xfail
+        blaming "fake embeddings produce low similarity": the real cause was
+        storage returning 0 rows, and the reason they *xpassed* in a full run was
+        that ``len(results) >= 1`` was satisfied by other tests' committed
+        leftovers in the shared tenant.
+
+        Both ``entities.search_vector`` and ``memories.search_vector`` are filled
+        by triggers that live only in migration 001, so this needs a database
+        ``alembic upgrade head`` has run against — ``Base.metadata.create_all``
+        alone leaves them NULL and the entity would never match, silently skipping
+        the graph boost whose cap is what this class tests. CI migrates first.
+        """
+        entity = await sc.create_entity({
+            "tenant_id": tenant_id,
+            "entity_type": "concept",
+            "canonical_name": entity_name,
+            "fleet_id": fleet_id,
+        })
+        # Embed the entity name itself, and query by it, so cosine is 1.0 rather
+        # than an incidental value — the cap is what's under test, not the gate.
+        embedding = fake_embedding(entity_name)
+        created = await sc.create_memories([
+            {
+                "tenant_id": tenant_id,
+                "fleet_id": fleet_id,
+                "agent_id": "test-agent",
+                "memory_type": "fact",
+                "content": f"Memory {i} about {entity_name}",
+                "embedding": embedding,
+                "weight": 0.5,
+                "content_hash": f"hash-{entity_name}-{i}",
+                "status": "active",
+                "client_request_id": str(uuid.uuid4()),
+            }
+            for i in range(num_memories)
+        ])
+        memory_ids = [row["id"] for row in created]
+        assert all(memory_ids), "bulk insert did not return an id for every memory"
+        await sc.bulk_upsert_entity_links([
+            {"input_idx": i, "memory_id": mid, "entity_id": entity["id"], "role": "subject"}
+            for i, mid in enumerate(memory_ids)
+        ])
+        return memory_ids
+
+    async def test_small_fanout_all_boosted(self, sc, fanout_tenant, fleet_id):
+        """Below the cap, all linked memories are returned."""
+        entity_name = f"pythonprog{uuid.uuid4().hex[:8]}"
+        memory_ids = await self._create_entity_with_memories(
+            sc, fanout_tenant, fleet_id, entity_name, 5,
         )
-        db.add(entity)
-        await db.flush()
 
-        # Set search_vector for entity matching
-        await db.execute(sql_text(
-            "UPDATE entities SET search_vector = to_tsvector('english', :name) WHERE id = :id"
-        ), {"name": entity_name, "id": entity.id})
+        results = await search_memories(fanout_tenant, entity_name, fleet_ids=[fleet_id], top_k=10)
 
-        memories = []
-        for i in range(num_memories):
-            mem = Memory(
-                tenant_id=tenant_id,
-                fleet_id=fleet_id,
-                agent_id="test-agent",
-                memory_type="fact",
-                content=f"Memory {i} about {entity_name}",
-                embedding=embedding,
-                weight=0.5,
-                content_hash=f"hash-{entity_name}-{i}-{uuid.uuid4().hex[:8]}",
-                status="active",
-            )
-            db.add(mem)
-            await db.flush()
-            memories.append(mem)
+        # Assert on this test's own rows, not on a bare count.
+        assert {str(r.id) for r in results} == set(memory_ids)
 
-            db.add(MemoryEntityLink(
-                memory_id=mem.id,
-                entity_id=entity.id,
-                role="subject",
-            ))
-
-        await db.flush()
-        return entity, memories
-
-    @pytest.mark.xfail(reason="Fake embeddings produce low similarity — search returns empty. Works with real embeddings.")
-    async def test_small_fanout_all_boosted(self, db, tenant_id, fleet_id):
-        """Below the cap, all linked memories get their boost."""
-        from common.embedding import fake_embedding
-
-        emb = fake_embedding("python programming language")
-        entity, memories = await self._create_entity_with_memories(
-            db, tenant_id, fleet_id, "python programming", 5, emb,
-        )
-        await db.commit()
-
-        from core_api.services.memory_service import search_memories
-
-        results = await search_memories(tenant_id, "python programming", fleet_ids=[fleet_id], top_k=10,
-        )
-        # All 5 should be searchable (boosted or not)
-        assert len(results) >= 1
-
-    @pytest.mark.xfail(reason="Fake embeddings produce low similarity — search returns empty. Works with real embeddings.")
-    async def test_large_fanout_capped(self, db, tenant_id, fleet_id):
+    async def test_large_fanout_capped(self, sc, fanout_tenant, fleet_id):
         """A popular entity with many linked memories doesn't break search."""
-        from common.embedding import fake_embedding
-        from core_api.services.memory_service import search_memories
-
-        emb = fake_embedding("popular topic")
+        entity_name = f"populartopic{uuid.uuid4().hex[:8]}"
         num_memories = GRAPH_MAX_BOOSTED_MEMORIES + 30
-        entity, memories = await self._create_entity_with_memories(
-            db, tenant_id, fleet_id, "popular topic", num_memories, emb,
+        memory_ids = await self._create_entity_with_memories(
+            sc, fanout_tenant, fleet_id, entity_name, num_memories,
         )
-        await db.commit()
 
-        # Should complete without error and return at most `limit` results
-        results = await search_memories(tenant_id, "popular topic", fleet_ids=[fleet_id], top_k=10,
-        )
-        assert len(results) <= 10
-        assert len(results) >= 1
+        results = await search_memories(fanout_tenant, entity_name, fleet_ids=[fleet_id], top_k=10)
+
+        # top_k is honoured despite the fan-out, and every slot is one of ours.
+        assert len(results) == 10
+        assert {str(r.id) for r in results} <= set(memory_ids)

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -546,7 +546,6 @@ class TestBackwardCompatibility:
         await db.refresh(mem)
         assert mem.visibility == "scope_team"
 
-    @pytest.mark.xfail(reason="Fake embeddings produce low similarity — search returns empty. Works with real embeddings.")
     async def test_search_without_visibility_params_unchanged(
         self,
         db,


### PR DESCRIPTION
## What

Three integration tests carried `xfail(reason="Fake embeddings produce low similarity — search returns empty")` and **xpassed** in a full run. This makes them deterministic and removes the last xpass from the suite.

They matter because the xfail/xpass profile is the signal that caught #700's near-miss — where a bare `union()` silently changed the candidate set for embedded rows, invisible to every test written for it and visible only as an xpass count of 3 vs 1 against clean `main`. Noise in that signal is expensive.

**The stated reason was a misdiagnosis in both cases.**

## `tests/test_p3_3_graph_fanout.py` — wrong fixture, not low similarity

These wrote setup through the `db` fixture, which opens a transaction and rolls it back at teardown — per its own docstring, *"session.commit() flushes data without committing the outer transaction"*. `search_memories` runs on a **separate connection**, so it never saw those rows. Storage logged `row_count: 0`: they failed at the SQL layer, nowhere near the similarity gate.

They xpassed in a full run only because `assert len(results) >= 1` was satisfied by **other tests' committed rows** — `tenant_id` is a single session-wide constant and 13 files commit into it via `sc`. So even when green, they asserted nothing about fan-out.

Now they write via `sc` — the fixture documented for precisely this ("use this instead of `db.add()` when the data needs to be visible … e.g. search") — using the bulk insert and bulk link helpers, and assert on **their own memory ids** instead of a bare count.

They also get a tenant of their own. A unique query token is **not** sufficient isolation, and this is measured rather than assumed: `fake_embedding` is a bag-of-words hash, not a near-orthogonal one, and an unrelated committed row (`"User prefers dark mode in the editor"`) scores cosine **0.3341** against a random token — above the 0.3 `min_similarity` gate. A foreign row can still take a top_k slot.

## `tests/test_visibility.py` — simply a stale marker

Already wrote via `sc`, and xpasses in isolation on a clean database (3/3 runs). Nothing flaky; the marker was obsolete. Dropped.

## So it cannot recur silently

- **`xfail_strict = true`** in `pytest.ini`. An xfail that starts passing is now a failure rather than a green XPASS nobody reads. Verified by probe — re-adding a stale marker turns that test `FAILED`. Both remaining markers were checked against the setting: one is already `strict=True`, and the other (dedup-vs-visibility) genuinely xfails, reproducibly and in isolation. **This is the one change here with suite-wide reach — flagging it explicitly; happy to drop it if you'd rather it landed on its own.**
- **Corrected the `tenant_id` docstring**, which claimed *"Unique tenant ID per test module"* while returning one session-wide constant. That is the misconception these tests were built on, and 70 tests across 11 files read it.

## Verification

Both rewritten assertions confirmed load-bearing by mutation — inverting, not deleting: linking 4 of 5 memories fails the set-equality check; searching at `top_k=3` fails the top_k assertion. Restored, both green.

I also confirmed the graph-boost path these tests exist to cover **does** fire, rather than assuming it — `entities.search_vector` is populated by migration 001's trigger (`'populartopic…':1`), and `fts_search_entities` matches the entity, so the boost and its `GRAPH_MAX_BOOSTED_MEMORIES` cap are genuinely exercised. The helper docstring records that this depends on the DB having been migrated: `Base.metadata.create_all` alone leaves the column NULL and would skip the boost silently. The raw `UPDATE entities SET search_vector` that came out was redundant with that trigger.

Full suite against local pgvector with `alembic upgrade head`:

| | passed | xfailed | xpassed |
|---|---|---|---|
| `main` | 4081 | 2 | 3 |
| this branch | 4084 | 2 | **0** |

The +3 are these three tests now passing for real. `core-storage-api/tests/` 103 passed. Root `tests/` is not in CI's ruff scope, so nothing was reformatted there.

## Noted, deliberately not in scope

- `tests/test_p2_semantic_dedup.py:374` has the same `db`-write-then-storage-read trap; its "100 memories" / "1000 memories" latency labels measure whatever is committed in the shared tenant. It is `@pytest.mark.benchmark` and CI excludes benchmarks, so it misleads local numbers only.
- 64 of 128 tests that request `db` never use it, which makes them *look* transactionally isolated while committing through the service layer. That is the leftover-row generator behind the old xpasses. A suite-wide cleanup is a bigger change than this fix.
