### PR TITLE
fix(rerank): distinguish permanent config faults from transient failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,11 @@ OPENAI_API_KEY=
 # Per-call scoring deadline (seconds); over this, degrade to first-stage order.
 # RANK_TIMEOUT_SECONDS=0.5
 # Max candidates re-scored per search; rows past the cap keep first-stage order.
+# With RANK_PROVIDER=remote the whole pool goes in ONE /rerank request, so the
+# sidecar must admit this many per call — a TEI reranker allows only 32 unless
+# started with --max-client-batch-size. If it doesn't, every search with more
+# candidates than the sidecar's cap is rejected and silently keeps first-stage
+# order (look for "Ranking failed permanently" in the core-api logs).
 # RANK_CANDIDATE_LIMIT=50
 
 # -- LLM enrichment ---------------------------------------------------------

--- a/common/ranking/__init__.py
+++ b/common/ranking/__init__.py
@@ -12,6 +12,7 @@ Public entrypoint: :func:`common.ranking.get_ranking`.
 from __future__ import annotations
 
 from common.ranking._service import get_ranking
+from common.ranking.errors import PermanentRankError
 from common.ranking.protocols import RankCandidate, RankProvider
 
-__all__ = ["RankCandidate", "RankProvider", "get_ranking"]
+__all__ = ["PermanentRankError", "RankCandidate", "RankProvider", "get_ranking"]

--- a/common/ranking/_service.py
+++ b/common/ranking/_service.py
@@ -24,6 +24,7 @@ from common.ranking.constants import (
     RANK_RETRY_DELAY_S,
     RANK_TIMEOUT_SECONDS,
 )
+from common.ranking.errors import PermanentRankError
 from common.ranking.protocols import RankCandidate
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,52 @@ _stats = _RankStats()
 # One-shot misconfiguration log dedup, keyed on provider name — a bad
 # ``RANK_PROVIDER`` would otherwise log once per search.
 _misconfiguration_logged: set[str] = set()
+
+# Same log-once posture for permanent provider faults, keyed on
+# ``PermanentRankError.key`` (a stable backend+condition string, NOT the
+# message — that embeds a response body and varies per request). A permanent
+# fault recurs on every search by definition, so logging it in full each time
+# would make ERROR volume a function of traffic rather than of the fault.
+# ``_stats.record_failure()`` still fires every time, so the degraded
+# trip-wire keeps counting occurrences.
+#
+# Entries are cleared per BACKEND on that backend's next success, never
+# wholesale: one process serves many tenants and holds a rank provider per
+# ``(base_url, api_key, model)``, so a healthy tenant's success must not
+# re-arm — or suppress — a different tenant's broken sidecar. Clearing
+# globally would put ERROR volume right back on a traffic curve, this time
+# driven by unrelated tenants.
+_permanent_logged: set[str] = set()
+
+# Bound it. Each entry is one (backend, condition) pair, so the steady state is
+# tiny — but a provider whose scope is per-instance means a long-lived process
+# that rotates tenant rank config accumulates a dead entry per retired backend,
+# the same leak ``_registry.py`` caps its ranker cache at 32 to avoid. On
+# overflow we drop the whole set rather than track recency: the only cost is
+# that a still-broken backend may report once more than strictly needed, which
+# is the safe direction to fail.
+_PERMANENT_LOGGED_MAX = 256
+
+
+def _permanent_scope(provider: object) -> str:
+    """Dedup namespace for ``provider`` — see ``PermanentRankError.key``.
+
+    Falls back to the provider name for providers that don't declare a scope
+    (``noop``/``fake`` never raise permanently, and a third-party provider
+    without one still gets coarse per-name dedup rather than none).
+    """
+    scope = getattr(provider, "dedup_scope", None)
+    if scope:
+        return str(scope)
+    return str(getattr(provider, "provider_name", "unknown"))
+
+
+def _clear_permanent_for(provider: object) -> None:
+    """Re-arm the ERROR for one backend after it succeeds again."""
+    prefix = f"{_permanent_scope(provider)}|"
+    _permanent_logged.difference_update(
+        {key for key in _permanent_logged if key.startswith(prefix)}
+    )
 
 
 def _resolve_provider_name(tenant_config: object | None) -> str:
@@ -131,6 +178,11 @@ async def get_ranking(
                     f"ranker returned {len(scores)} scores for {len(candidates)} candidates"
                 )
             await _stats.record_success()
+            # Re-arm THIS backend's permanent-fault ERROR: if it was fixed and
+            # later regresses, the next fault reports in full rather than
+            # staying silent at DEBUG forever. Scoped, so a healthy tenant
+            # can't re-arm a still-broken one.
+            _clear_permanent_for(provider)
             return scores
         except TimeoutError:
             logger.warning(
@@ -139,6 +191,28 @@ async def get_ranking(
                 RANK_RETRY_ATTEMPTS,
                 RANK_TIMEOUT_SECONDS,
             )
+        # A configuration-class fault (see common/ranking/errors.py): it fails
+        # identically next attempt, so stop instead of spending the turn's
+        # latency to reach the same answer. ERROR, not warning, because the
+        # search still succeeds on first-stage order — this log line is the
+        # only symptom the fault has. Deduped per condition; see
+        # ``_permanent_logged``.
+        except PermanentRankError as exc:
+            await _stats.record_failure()
+            if exc.key in _permanent_logged:
+                logger.debug("Ranking permanently failing (already reported): %s", exc)
+            else:
+                if len(_permanent_logged) >= _PERMANENT_LOGGED_MAX:
+                    _permanent_logged.clear()
+                _permanent_logged.add(exc.key)
+                logger.error(
+                    "Ranking failed permanently, not retrying; keeping "
+                    "first-stage order. This recurs until the configuration "
+                    "changes; further occurrences log at DEBUG until the next "
+                    "success. %s",
+                    exc,
+                )
+            return None
         # Intentionally broad: any provider error degrades to first-stage.
         except Exception:
             logger.warning(

--- a/common/ranking/errors.py
+++ b/common/ranking/errors.py
@@ -1,0 +1,55 @@
+"""Ranking failure classification.
+
+Every rerank failure degrades to first-stage order — that is the component's
+whole posture and it does not change here. What this adds is the distinction
+between the two *reasons* a rerank can fail, because they want opposite
+handling:
+
+* **Transient** (timeout, 429, 5xx, connection reset): the next attempt might
+  succeed. Retry it, log at ``warning``. This is the default for anything not
+  explicitly classified, so a new failure mode never silently stops retrying.
+* **Permanent** (:class:`PermanentRankError`): a configuration-class fault that
+  will fail *identically* on every subsequent call until a human changes
+  something — a batch cap below the candidate limit, a base URL pointing at a
+  service that doesn't speak ``/rerank``, a rejected API key. Retrying spends
+  the turn's latency budget to reach the same failure, so the service layer
+  stops immediately and logs at ``error`` with the provider's detail.
+
+The split matters because the two are indistinguishable from the outside: both
+serve first-stage order and neither breaks recall, so a misconfiguration looks
+exactly like load. Providers raise the specific type; the service layer stays
+transport-agnostic and only reacts to it.
+"""
+
+from __future__ import annotations
+
+
+class PermanentRankError(Exception):
+    """A rerank failure that will recur until the configuration changes.
+
+    Raise this instead of a generic exception when the provider can tell the
+    fault is not worth retrying. The message is surfaced verbatim in the
+    service layer's ``error`` log, so it should carry everything an operator
+    needs to act on without opening the provider's own logs.
+
+    ``key`` identifies the *condition* for log-deduplication. It is required —
+    there is no default, because every plausible default is wrong: the message
+    embeds a response body and varies per request, which would defeat the
+    dedup silently rather than loudly. Two properties it must have:
+
+    * **Stable** across occurrences of the same fault, or the service layer
+      logs a fresh ERROR every search and volume tracks traffic.
+    * **Scoped to the failing backend**, via the provider's
+      :attr:`dedup_scope`. One process can hold several remote rankers at once
+      (``common/ranking/_registry.py`` caches them per
+      ``(base_url, api_key, model)`` so per-tenant ``rank_base_url`` overrides
+      each get their own). A bare ``"remote:413"`` would let one tenant's
+      logged fault suppress a different tenant's unrelated one.
+
+    Build it as ``f"{provider.dedup_scope}|{condition}"`` — see
+    :class:`~common.ranking.providers.remote.RemoteRanker`.
+    """
+
+    def __init__(self, message: str, *, key: str) -> None:
+        super().__init__(message)
+        self.key = key

--- a/common/ranking/providers/local.py
+++ b/common/ranking/providers/local.py
@@ -4,8 +4,9 @@ Lazy-loads a sentence-transformers ``CrossEncoder`` under an
 ``asyncio.Lock`` and scores (query, content) pairs in a thread executor
 (``predict`` is sync CPU work). ``sentence-transformers`` is lazy-imported
 so it stays an optional dependency — if it is absent the load raises
-``ImportError``, which the service layer treats as a provider failure and
-degrades to first-stage order.
+``PermanentRankError``, so the service layer degrades to first-stage order
+immediately (no retry, since the dependency will still be missing) and reports
+it once at ERROR rather than per search.
 
 Viable only at small pools: MiniLM-L6 (22M) is ~50-150ms CPU at pool<=20
 (A50 latency spike); a large model (bge-base, 278M) is NOT CPU-viable
@@ -18,6 +19,7 @@ import asyncio
 import logging
 
 from common.ranking.constants import RANK_MAX_LENGTH, RANK_MODEL
+from common.ranking.errors import PermanentRankError
 from common.ranking.protocols import RankCandidate
 
 logger = logging.getLogger(__name__)
@@ -39,6 +41,14 @@ class LocalCrossEncoderRanker:
         return "local"
 
     @property
+    def dedup_scope(self) -> str:
+        """Namespace for permanent-fault log dedup — see ``PermanentRankError``.
+
+        Model-scoped to match the registry's per-``rank_model`` instance cache.
+        """
+        return f"local:{self._model_name}"
+
+    @property
     def model(self) -> str:
         return self._model_name
 
@@ -51,10 +61,16 @@ class LocalCrossEncoderRanker:
             try:
                 from sentence_transformers import CrossEncoder
             except ImportError:
-                raise ImportError(
+                # Permanent by construction: the dependency will still be
+                # missing on the next search, so retrying just spends the
+                # rerank deadline. The default image deliberately ships without
+                # torch, which makes this the most likely way to land here
+                # after flipping RANK_PROVIDER=local.
+                raise PermanentRankError(
                     "sentence-transformers is required for the local reranker "
                     "(RANK_PROVIDER=local). Install it with: "
-                    "pip install sentence-transformers"
+                    "pip install sentence-transformers",
+                    key=f"{self.dedup_scope}|missing-sentence-transformers",
                 ) from None
             logger.info("Loading local cross-encoder model: %s", self._model_name)
             loop = asyncio.get_running_loop()

--- a/common/ranking/providers/remote.py
+++ b/common/ranking/providers/remote.py
@@ -21,14 +21,47 @@ order — the caller (RerankResults) owns the sort.
 
 from __future__ import annotations
 
+import itertools
 import logging
 
 import httpx
 
 from common.ranking.constants import RANK_TIMEOUT_SECONDS
+from common.ranking.errors import PermanentRankError
 from common.ranking.protocols import RankCandidate
 
 logger = logging.getLogger(__name__)
+
+# 4xx statuses that ARE worth retrying: a request timeout and rate limiting are
+# both about *when* the call happened, not what it contained. Every other 4xx
+# says the request itself is unacceptable and will be rejected identically next
+# time. 5xx stays transient (it falls through to raise_for_status below).
+#
+# Deliberately NOT the same policy as ``common/http_retry.RETRYABLE_STATUS_CODES``
+# ({502,503,504}, and 4xx never retried). That module serves the storage
+# clients, where a 429 means "back off, you are hammering a shared database".
+# Here the callee is a single-tenant sidecar doing one idempotent read per
+# search, so its 408/429 are load signals worth one more attempt inside the
+# rerank deadline. If the two policies ever need to agree, reconcile them
+# explicitly rather than assuming one was a typo.
+_RETRYABLE_CLIENT_STATUSES = frozenset({408, 429})
+
+# Response bodies land in an error log, so cap them. Volume is the obvious
+# reason (a misrouted base URL can return a full HTML page), but the
+# load-bearing one is disclosure: a 4xx body from an arbitrary sidecar or an
+# intervening proxy may echo the request back, and the request carries the
+# user's stored memory text. This cap bounds how much of that a rerank
+# misconfiguration can write into logs that may ship off-box. Raise it only
+# with that in mind. (``common/llm/providers/_shape_error.py`` caps at 1024 for
+# the same job; smaller here because a rerank body is a short JSON error.)
+_ERROR_BODY_LIMIT = 300
+
+# Opaque per-instance identity for ``dedup_scope``. A counter beats deriving the
+# scope from the backend config twice over: no credential ever enters the scope
+# string (hashing one is a fast-hash-of-a-secret, which CodeQL rightly flags),
+# and the scope is a fixed shape that cannot collide under the prefix matching
+# ``_clear_permanent_for`` does. See ``dedup_scope`` for the tradeoff.
+_instance_seq = itertools.count()
 
 
 class RemoteRanker:
@@ -43,6 +76,7 @@ class RemoteRanker:
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._model = model
+        self._instance_id = next(_instance_seq)
         headers = {}
         if api_key:
             # Bearer for Cohere / token-gated TEI; harmless for open TEI.
@@ -63,6 +97,31 @@ class RemoteRanker:
         return "remote"
 
     @property
+    def dedup_scope(self) -> str:
+        """Namespace for permanent-fault log dedup — see ``PermanentRankError``.
+
+        Per INSTANCE, which stands in for per backend config: the registry
+        caches one ranker per ``(base_url, api_key, model)``, so live instances
+        are distinct backends. That covers the collisions a URL-only scope
+        would miss — same URL with a per-tenant ``rank_model``, or same URL and
+        model behind different ``rank_api_key`` credentials — without putting
+        any of those values, least of all the credential, into the string. The
+        URL still reaches the operator: it is in the message.
+
+        The instance is a proxy for the config, not a permanent name for it:
+        ``_remote_ranker_cache`` is LRU-bounded (32), so a process cycling
+        through more backends than that can evict and later rebuild the ranker
+        for the same triple, and the rebuilt one gets a fresh scope. A
+        still-broken backend then re-reports once. That is deliberate — it errs
+        toward saying too much about a real fault rather than too little, the
+        same direction ``_PERMANENT_LOGGED_MAX`` overflow errs in. Deriving the
+        scope from the config instead would hold across eviction, but only by
+        reintroducing a value-derived key over tenant-supplied strings, which
+        is what the credential and delimiter problems came from.
+        """
+        return f"remote:{self._instance_id}"
+
+    @property
     def model(self) -> str:
         return self._model or "remote"
 
@@ -70,18 +129,71 @@ class RemoteRanker:
         """Close the httpx pool cleanly (called on registry cache eviction)."""
         await self._client.aclose()
 
+    def _reject_detail(self, resp: httpx.Response, candidate_count: int) -> str:
+        """Build the operator-facing message for a permanently rejected call.
+
+        Carries what it takes to act without opening the sidecar's own logs:
+        the endpoint, the status, how many candidates we sent, and the
+        service's own words.
+        """
+        detail = (
+            f"rerank sidecar rejected the request: HTTP {resp.status_code} from "
+            f"{self._base_url}/rerank with {candidate_count} candidate(s). "
+            f"Response: {resp.text[:_ERROR_BODY_LIMIT]}"
+        )
+        if resp.status_code == 413:
+            # By far the most common way to land here, and the fix is not
+            # guessable from "413": the pool we send is RANK_CANDIDATE_LIMIT
+            # (50 by default) but a TEI reranker admits only 32 per request
+            # unless --max-client-batch-size is raised.
+            detail += (
+                " A 413 here usually means the sidecar's max client batch size "
+                "is below RANK_CANDIDATE_LIMIT — raise it (TEI: "
+                "--max-client-batch-size) or lower RANK_CANDIDATE_LIMIT."
+            )
+        return detail
+
     async def rank(self, query: str, candidates: list[RankCandidate]) -> list[float]:
         if not candidates:
             return []
         body: dict = {"query": query, "texts": [c.content for c in candidates]}
         resp = await self._client.post("/rerank", json=body)
+        if resp.is_client_error and resp.status_code not in _RETRYABLE_CLIENT_STATUSES:
+            raise PermanentRankError(
+                self._reject_detail(resp, len(candidates)),
+                # Stable + backend-scoped; the detail embeds a response body
+                # and must not reach the dedup key.
+                key=f"{self.dedup_scope}|{resp.status_code}",
+            )
+        # Everything else (5xx, 408, 429) keeps the original behaviour: raise,
+        # and let the service layer's retry budget decide.
         resp.raise_for_status()
-        data = resp.json()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            # A 200 carrying a non-JSON body (an HTML error page from a
+            # misrouted base URL, a proxy interstitial) is the same
+            # wrong-endpoint fault as the not-a-ranked-list case below, and
+            # equally unfixable by retrying.
+            raise PermanentRankError(
+                f"rerank response from {self._base_url}/rerank was not JSON "
+                f"({exc}) — does RANK_BASE_URL point at a reranker? "
+                f"Response: {resp.text[:_ERROR_BODY_LIMIT]}",
+                key=f"{self.dedup_scope}|invalid-json",
+            ) from exc
 
         # TEI returns a bare list; Cohere-style wraps it in {"results": [...]}.
         results = data.get("results", data) if isinstance(data, dict) else data
         if not isinstance(results, list):
-            raise ValueError(f"rerank response not a list: {type(results).__name__}")
+            # A 200 that isn't a ranked list means this endpoint does not speak
+            # /rerank at all — almost always RANK_BASE_URL pointing somewhere
+            # else. Retrying re-fetches the same wrong shape.
+            raise PermanentRankError(
+                f"rerank response from {self._base_url}/rerank was not a ranked "
+                f"list but {type(results).__name__} — does RANK_BASE_URL point "
+                f"at a reranker? Response: {resp.text[:_ERROR_BODY_LIMIT]}",
+                key=f"{self.dedup_scope}|response-not-a-list",
+            )
 
         # Re-project the ranked results back onto the INPUT order. Missing
         # indices (a partial response) keep 0.0 — the sort then places them

--- a/tests/test_ranking_component.py
+++ b/tests/test_ranking_component.py
@@ -92,3 +92,35 @@ async def test_get_ranking_length_contract_violation_degrades(monkeypatch):
     )
     cands = [_cand("a", "x", 0.5), _cand("b", "y", 0.5)]
     assert await get_ranking("q", cands, SimpleNamespace(rank_provider="bad")) is None
+
+
+@pytest.mark.asyncio
+async def test_local_provider_missing_dependency_is_permanent(monkeypatch, caplog):
+    """``RANK_PROVIDER=local`` without sentence-transformers is a config fault.
+
+    The default image ships without torch, so this is the likely outcome of
+    flipping the provider. It can never succeed on retry, so it must classify
+    as permanent rather than burn the retry budget at warning level.
+    """
+    import sys
+
+    from common.ranking.errors import PermanentRankError
+    from common.ranking.providers.local import LocalCrossEncoderRanker
+
+    # Force the optional import to fail even where the package is installed.
+    monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+    ranker = LocalCrossEncoderRanker()
+    with pytest.raises(PermanentRankError, match="sentence-transformers is required"):
+        await ranker.rank("q", [_cand("a", "x", 0.5)])
+
+    # ...and the service degrades rather than raising, logging at ERROR once.
+    monkeypatch.setattr(
+        "common.ranking._service.get_rank_provider", lambda name, tc=None: ranker
+    )
+    monkeypatch.setattr("common.ranking._service._permanent_logged", set())
+    with caplog.at_level("ERROR"):
+        out = await get_ranking(
+            "q", [_cand("a", "x", 0.5)], SimpleNamespace(rank_provider="local")
+        )
+    assert out is None
+    assert any("not retrying" in rec.getMessage() for rec in caplog.records)

--- a/tests/test_ranking_remote.py
+++ b/tests/test_ranking_remote.py
@@ -15,7 +15,8 @@ from types import SimpleNamespace
 import httpx
 import pytest
 
-from common.ranking import RankCandidate, get_ranking
+import common.ranking._service as svc_mod
+from common.ranking import PermanentRankError, RankCandidate, get_ranking
 from common.ranking.protocols import RankProvider
 from common.ranking.providers.remote import RemoteRanker
 
@@ -27,11 +28,11 @@ def _cands(*contents):
     ]
 
 
-def _client_with(handler):
+def _client_with(handler, base_url="http://sidecar:80"):
     """Build a RemoteRanker whose httpx client uses a MockTransport handler."""
-    r = RemoteRanker(base_url="http://sidecar:80", model="test-model")
+    r = RemoteRanker(base_url=base_url, model="test-model")
     r._client = httpx.AsyncClient(
-        base_url="http://sidecar:80", transport=httpx.MockTransport(handler)
+        base_url=base_url, transport=httpx.MockTransport(handler)
     )
     return r
 
@@ -85,28 +86,6 @@ async def test_empty_candidates_short_circuits():
     assert await r.rank("q", []) == []
 
 
-@pytest.mark.asyncio
-async def test_get_ranking_remote_degrades_on_http_error():
-    # 503 from the sidecar → provider raises → service returns None (keep order).
-    def handler(request):
-        return httpx.Response(503, text="unavailable")
-
-    import common.ranking._service as svc
-
-    r = _client_with(handler)
-    # Force the service to use our mock-backed remote ranker.
-    orig = svc.get_rank_provider
-    svc.get_rank_provider = lambda name, tc=None: r
-    try:
-        out = await get_ranking(
-            "q", _cands("a", "b"), SimpleNamespace(rank_provider="remote")
-        )
-    finally:
-        svc.get_rank_provider = orig
-    assert out is None
-    await r._client.aclose()
-
-
 def test_registry_remote_requires_base_url():
     from common.ranking._registry import get_rank_provider
 
@@ -123,3 +102,314 @@ def test_registry_remote_builds_with_tenant_base_url():
     )
     assert isinstance(p, RemoteRanker)
     assert p.model == "m"
+
+
+# --- failure classification: permanent (config-class) vs transient ----------
+#
+# Both kinds degrade to first-stage order, so `out is None` cannot tell them
+# apart. What these assert is the difference that matters operationally: a
+# permanent fault must NOT burn the retry budget, and must leave an ERROR
+# carrying enough detail to fix it without reading the sidecar's own logs.
+
+
+@pytest.fixture(autouse=True)
+def _isolate_permanent_dedup(monkeypatch):
+    """``_permanent_logged`` is module-global; give each test a fresh set.
+
+    Per-TEST, not per-call: the dedup tests below drive get_ranking twice and
+    need the state to survive between those calls.
+    """
+    monkeypatch.setattr("common.ranking._service._permanent_logged", set())
+    # _RankStats accumulates process-wide; its "degraded: N consecutive
+    # failures" trip-wire would add ERROR records that make the counts below
+    # depend on test order.
+    monkeypatch.setattr("common.ranking._service._stats", svc_mod._RankStats())
+
+
+def _counting_handler(status, text="", json_body=None):
+    """Handler that records how many times the sidecar was called."""
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        if json_body is not None:
+            return httpx.Response(status, json=json_body)
+        return httpx.Response(status, text=text)
+
+    return handler, calls
+
+
+async def _run_service(ranker, monkeypatch, attempts=3):
+    """Drive get_ranking against `ranker` with a known retry budget."""
+    # RANK_RETRY_ATTEMPTS defaults to 1 (no retry), which makes "permanent vs
+    # transient" invisible — both would call once. Raise it so the difference
+    # is observable. Do NOT "simplify" this back to the default: it would gut
+    # every retry-budget assertion below into a tautology.
+    monkeypatch.setattr("common.ranking._service.RANK_RETRY_ATTEMPTS", attempts)
+    monkeypatch.setattr("common.ranking._service.RANK_RETRY_DELAY_S", 0.0)
+    monkeypatch.setattr(
+        "common.ranking._service.get_rank_provider", lambda name, tc=None: ranker
+    )
+    return await get_ranking(
+        "q", _cands("a", "b"), SimpleNamespace(rank_provider="remote")
+    )
+
+
+@pytest.mark.asyncio
+async def test_413_raises_permanent_error_with_actionable_detail():
+    handler, _ = _counting_handler(
+        413, text='{"error":"batch size 51 > maximum allowed batch size 32"}'
+    )
+    r = _client_with(handler)
+    with pytest.raises(PermanentRankError) as ei:
+        await r.rank("q", _cands("a", "b"))
+    msg = str(ei.value)
+    # status, endpoint, candidate count, and the sidecar's own words
+    assert "413" in msg
+    assert "http://sidecar:80/rerank" in msg
+    assert "2 candidate(s)" in msg
+    assert "maximum allowed batch size 32" in msg
+    # the fix is not guessable from "413", so it is spelled out
+    assert "max-client-batch-size" in msg
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_permanent_failure_is_not_retried_and_logs_error(monkeypatch, caplog):
+    handler, calls = _counting_handler(413, text="too big")
+    r = _client_with(handler)
+    with caplog.at_level("WARNING"):
+        out = await _run_service(r, monkeypatch, attempts=3)
+    assert out is None  # still degrades to first-stage order
+    # One call, not three. NB this saving only materialises where
+    # RANK_RETRY_ATTEMPTS is raised above its default of 1 — at the default the
+    # deliverable is the ERROR level and the actionable detail, asserted below.
+    assert len(calls) == 1
+    errors = [rec for rec in caplog.records if rec.levelname == "ERROR"]
+    assert errors, "a permanent rerank failure must log at ERROR"
+    joined = " ".join(rec.getMessage() for rec in errors)
+    assert "413" in joined and "not retrying" in joined
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_transient_5xx_still_uses_the_full_retry_budget(monkeypatch, caplog):
+    handler, calls = _counting_handler(503, text="unavailable")
+    r = _client_with(handler)
+    with caplog.at_level("WARNING"):
+        out = await _run_service(r, monkeypatch, attempts=3)
+    assert out is None
+    assert len(calls) == 3, "a 5xx may succeed on retry — budget must be spent"
+    assert any(
+        "attempt" in rec.getMessage() and rec.levelname == "WARNING"
+        for rec in caplog.records
+    )
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_429_is_transient_despite_being_4xx(monkeypatch):
+    handler, calls = _counting_handler(429, text="slow down")
+    r = _client_with(handler)
+    out = await _run_service(r, monkeypatch, attempts=3)
+    assert out is None
+    assert len(calls) == 3, "rate limiting is about timing, not the request"
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_408_is_transient_despite_being_4xx(monkeypatch):
+    handler, calls = _counting_handler(408, text="request timeout")
+    r = _client_with(handler)
+    out = await _run_service(r, monkeypatch, attempts=3)
+    assert out is None
+    assert len(calls) == 3
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_200_that_is_not_a_ranked_list_is_permanent(monkeypatch):
+    # Wrong service behind RANK_BASE_URL: 200s, but not a /rerank shape.
+    handler, calls = _counting_handler(200, json_body={"detail": "not a reranker"})
+    r = _client_with(handler)
+    out = await _run_service(r, monkeypatch, attempts=3)
+    assert out is None
+    assert len(calls) == 1, "a wrong endpoint returns the same shape on retry"
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_permanent_error_logs_once_then_debug_until_next_success(
+    monkeypatch, caplog
+):
+    """A permanent fault recurs every search, so it must not ERROR every time.
+
+    Without dedup, ERROR volume tracks traffic instead of the fault, and
+    alerting on ERROR rate pages on QPS.
+    """
+    handler, _ = _counting_handler(413, text="too big")
+    r = _client_with(handler)
+    with caplog.at_level("DEBUG"):
+        await _run_service(r, monkeypatch, attempts=1)
+        first = [rec for rec in caplog.records if rec.levelname == "ERROR"]
+        assert len(first) == 1, "first occurrence reports in full"
+
+        caplog.clear()
+        await _run_service(r, monkeypatch, attempts=1)
+        assert not [rec for rec in caplog.records if rec.levelname == "ERROR"], (
+            "a repeat of the same condition must not ERROR again"
+        )
+        assert [rec for rec in caplog.records if rec.levelname == "DEBUG"]
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_success_re_arms_the_permanent_error(monkeypatch, caplog):
+    """A fixed-then-regressed backend must report again, not stay silent.
+
+    Recovery is per backend, so this drives ONE ranker whose sidecar flips
+    413 -> 200 -> 413. (A *different* backend recovering must NOT re-arm this
+    one — see test_one_backend_recovering_does_not_re_arm_another.)
+    """
+    state = {"ok": False}
+
+    def flipping(request):
+        if state["ok"]:
+            return httpx.Response(200, json=[{"index": 0, "score": 1.0}])
+        return httpx.Response(413, text="too big")
+
+    r = _client_with(flipping)
+    def permanent():
+        return [
+            rec for rec in caplog.records if "failed permanently" in rec.getMessage()
+        ]
+    with caplog.at_level("ERROR"):
+        await _run_service(r, monkeypatch, attempts=1)
+        assert len(permanent()) == 1
+        # the same backend recovers, clearing its own dedup key...
+        state["ok"] = True
+        assert await _run_service(r, monkeypatch, attempts=1) is not None
+        caplog.clear()
+        # ...so a regression reports in full again rather than at DEBUG.
+        state["ok"] = False
+        await _run_service(r, monkeypatch, attempts=1)
+        assert len(permanent()) == 1, "post-recovery regression must re-report"
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dedup_is_scoped_per_backend_not_process_wide(monkeypatch, caplog):
+    """Two tenants on two broken sidecars must each get their own ERROR.
+
+    The registry caches a ranker per (base_url, api_key, model), so one
+    process can hold several. A process-wide dedup key would let the first
+    tenant's 413 silently suppress the second tenant's unrelated 413.
+    """
+    a_handler, _ = _counting_handler(413, text="tenant A sidecar too small")
+    b_handler, _ = _counting_handler(413, text="tenant B sidecar too small")
+    a = _client_with(a_handler, base_url="http://sidecar-a:80")
+    b = _client_with(b_handler, base_url="http://sidecar-b:80")
+
+    with caplog.at_level("ERROR"):
+        await _run_service(a, monkeypatch, attempts=1)
+        await _run_service(b, monkeypatch, attempts=1)
+    msgs = [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.levelname == "ERROR" and "failed permanently" in rec.getMessage()
+    ]
+    assert len(msgs) == 2, "each backend reports its own fault"
+    assert any("sidecar-a" in m for m in msgs)
+    assert any("sidecar-b" in m for m in msgs)
+    await a._client.aclose()
+    await b._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_one_backend_recovering_does_not_re_arm_another(monkeypatch, caplog):
+    """A healthy tenant's success must not re-arm a still-broken tenant.
+
+    Guards the failure mode where a global clear() puts ERROR volume back on a
+    traffic curve — driven by *unrelated* tenants succeeding.
+    """
+    broken_handler, _ = _counting_handler(413, text="still broken")
+    broken = _client_with(broken_handler, base_url="http://sidecar-broken:80")
+    healthy = _client_with(
+        lambda req: httpx.Response(200, json=[{"index": 0, "score": 1.0}]),
+        base_url="http://sidecar-healthy:80",
+    )
+
+    with caplog.at_level("ERROR"):
+        await _run_service(broken, monkeypatch, attempts=1)
+        assert len(caplog.records) == 1
+        caplog.clear()
+        # unrelated backend succeeds repeatedly...
+        for _ in range(3):
+            assert await _run_service(healthy, monkeypatch, attempts=1) is not None
+        # ...and the broken one stays deduped.
+        await _run_service(broken, monkeypatch, attempts=1)
+        assert not caplog.records, (
+            "another backend's success must not re-arm this one's ERROR"
+        )
+    await broken._client.aclose()
+    await healthy._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dedup_scope_separates_same_url_different_model(monkeypatch, caplog):
+    """Same base_url, different rank_model = two backends, two ERRORs.
+
+    The registry caches per (base_url, api_key, model), so a per-tenant
+    rank_model override yields a distinct instance. A URL-only dedup scope
+    would collide these and hide one tenant's fault.
+    """
+    h1, _ = _counting_handler(413, text="model-a too big")
+    h2, _ = _counting_handler(413, text="model-b too big")
+    a = _client_with(h1)
+    b = _client_with(h2)
+    # Same URL, distinct instances (what the registry hands out for distinct
+    # rank_model / rank_api_key) → distinct dedup scopes.
+    assert a.dedup_scope != b.dedup_scope
+
+    with caplog.at_level("ERROR"):
+        await _run_service(a, monkeypatch, attempts=1)
+        await _run_service(b, monkeypatch, attempts=1)
+    permanent = [
+        rec for rec in caplog.records if "failed permanently" in rec.getMessage()
+    ]
+    assert len(permanent) == 2
+    await a._client.aclose()
+    await b._client.aclose()
+
+
+def test_dedup_scope_carries_no_credential_but_still_separates_keys():
+    """No secret in the scope, yet two credentials still get distinct scopes.
+
+    Deriving the scope from the api_key (even hashed) would be a fast hash of a
+    secret; instance identity gets the same separation for free.
+    """
+    a = RemoteRanker(base_url="http://sidecar:80", api_key="super-secret-token")
+    b = RemoteRanker(base_url="http://sidecar:80", api_key="a-different-token")
+    assert "super-secret-token" not in a.dedup_scope
+    assert "a-different-token" not in b.dedup_scope
+    assert a.dedup_scope != b.dedup_scope
+
+
+@pytest.mark.asyncio
+async def test_200_with_non_json_body_is_permanent(monkeypatch):
+    # Misrouted RANK_BASE_URL returning an HTML page: same wrong-endpoint
+    # fault as a non-list body, so it must not burn the retry budget either.
+    def handler(request):
+        return httpx.Response(200, text="<html><body>nginx 200</body></html>")
+
+    calls = []
+
+    def counting(request):
+        calls.append(request)
+        return handler(request)
+
+    r = _client_with(counting)
+    out = await _run_service(r, monkeypatch, attempts=3)
+    assert out is None
+    assert len(calls) == 1, "a wrong endpoint returns the same body on retry"
+    await r._client.aclose()


### PR DESCRIPTION
Closes #704 (the classification half; chunking stays open — see Scope below).

## The problem

Reranking degrades to first-stage order on any failure, by design — recall must never break. That posture is unchanged here. What was missing is the distinction between the two *reasons* it can fail, which want opposite handling.

A permanent, configuration-class fault was reported exactly like a transient one:

```
WARNING  Ranking attempt 1/1 failed
ERROR    Ranking failed after 1 attempt(s); keeping first-stage order
```

No status code, no response body, no endpoint. So a misconfiguration was indistinguishable from load, and the actual cause never reached the log.

**The failure that motivated this:** a TEI reranker admits **32** texts per request by default, but core-api sends up to `RANK_CANDIDATE_LIMIT` (**50**) in ONE call — so every search with a larger pool came back `413`. `raise_for_status()` turned that into a generic exception, the broad handler swallowed it, and the search quietly served first-stage order. Recall never broke, so it read as *"reranking isn't helping"*. It took hours and the sidecar's own logs to find — twice.

## The change

New `common/ranking/errors.py` with `PermanentRankError`. Providers, which know their own transport, classify; `_service.py` stays transport-agnostic and only reacts to the type (it already dispatched on `TimeoutError`, so no new concept there). **Anything not explicitly classified stays transient**, so a new failure mode can never silently stop retrying.

- **`remote.py`** — 4xx except `408`/`429` is permanent; those two are about *when* the call happened, not what it contained. 5xx and network errors keep the existing retry path untouched. A `200` whose body isn't a ranked list is also permanent: that means `RANK_BASE_URL` points at something that doesn't speak `/rerank`. The message carries endpoint, status, candidate count and the service's own words, plus a specific hint for 413 — the batch-cap coupling isn't guessable from the status code.
- **`local.py`** — a missing `sentence-transformers` is permanent by construction. The default image ships without torch, so it's the likely result of flipping `RANK_PROVIDER=local`, and it was being retried at warning level.
- **`.env.example`** — documents the `RANK_CANDIDATE_LIMIT` ↔ sidecar-cap constraint where the value is actually set, so it's preventive rather than post-mortem.

### Log-once, not log-per-search

A permanent fault recurs on every search by definition, so the full ERROR fires **once per condition** and repeats drop to DEBUG — reusing the log-once posture this module already applies to provider misconfiguration. Otherwise ERROR volume would track traffic rather than the fault, and alerting on ERROR rate would page on QPS.

The dedup key comes from the exception (`"remote:413"`), deliberately **not** the message — that embeds a per-request response body and would defeat the dedup. A success clears it, so a fixed-then-regressed sidecar reports again. `record_failure()` still fires every occurrence, so the degraded trip-wire keeps counting.

### One thing worth knowing

The retry-skip is a **no-op at the shipped default** of `RANK_RETRY_ATTEMPTS=1` — one attempt happens either way. For a default deployment the deliverable is the ERROR level and the actionable detail. The tests raise the budget so the distinction is observable at all; there's a comment saying so, because "simplifying" it back to the default would turn every budget assertion into a tautology.

## Scope

Classification only. **Chunking** the candidate pool to the sidecar's cap — which would make the batch-cap fault structurally impossible — stays open in #704. The two are complementary rather than alternatives: `401`/`403`, a wrong endpoint, and the wrong-shape case are permanent regardless of chunking. Chunking arguably *depends* on this, since the sidecar's cap isn't discoverable from config and would otherwise have to be learned from a 413.

## Verification

23 tests pass. The meaningful check — reverting just the two providers, leaving the service layer in place:

```
5 failed, 18 passed
  FAILED test_413_raises_permanent_error_with_actionable_detail
  FAILED test_permanent_failure_is_not_retried_and_logs_error
  FAILED test_200_that_is_not_a_ranked_list_is_permanent
  FAILED test_permanent_error_logs_once_then_debug_until_next_success
  FAILED test_local_provider_missing_dependency_is_permanent
```

Exactly the 5 classification tests, while the transient ones — 503, 429 and 408 each still spending the full budget — keep passing. They assert *preserved* behaviour rather than restating the change.

`ruff check common/` + the gated scopes clean, `ruff format` clean, `mypy` clean (189 source files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)