### PR TITLE
fix(rerank): chunk the remote candidate pool so the sidecar's cap can't reject it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,12 +146,15 @@ OPENAI_API_KEY=
 # Per-call scoring deadline (seconds); over this, degrade to first-stage order.
 # RANK_TIMEOUT_SECONDS=0.5
 # Max candidates re-scored per search; rows past the cap keep first-stage order.
-# With RANK_PROVIDER=remote the whole pool goes in ONE /rerank request, so the
-# sidecar must admit this many per call — a TEI reranker allows only 32 unless
-# started with --max-client-batch-size. If it doesn't, every search with more
-# candidates than the sidecar's cap is rejected and silently keeps first-stage
-# order (look for "Ranking failed permanently" in the core-api logs).
 # RANK_CANDIDATE_LIMIT=50
+# With RANK_PROVIDER=remote the pool is split into concurrent /rerank requests
+# of at most this many texts, so this and RANK_CANDIDATE_LIMIT above are
+# independent — that one is a quality/latency choice, this is purely what the
+# sidecar will accept per call. The default matches TEI's own
+# --max-client-batch-size default. Set it higher than your sidecar actually
+# allows and requests come back rejected (loudly: "Ranking failed permanently"
+# in the core-api logs, naming this variable).
+# RANK_REMOTE_MAX_BATCH=32
 
 # -- LLM enrichment ---------------------------------------------------------
 USE_LLM_FOR_MEMORY_CREATION=true

--- a/common/ranking/constants.py
+++ b/common/ranking/constants.py
@@ -67,3 +67,17 @@ RANK_RETRY_DELAY_S: float = float(os.environ.get("RANK_RETRY_DELAY_S", "0.5"))
 # Rows beyond this cap keep their first-stage order, appended after the
 # re-ranked head.
 RANK_CANDIDATE_LIMIT: int = int(os.environ.get("RANK_CANDIDATE_LIMIT", "50"))
+
+# Largest batch the ``remote`` sidecar accepts in ONE /rerank request. The
+# provider splits the candidate pool into chunks of this size and issues them
+# concurrently, so RANK_CANDIDATE_LIMIT is no longer bounded by what the sidecar
+# admits. The coupling moves rather than vanishes, though: the pool size now
+# sets FAN-OUT, ``ceil(RANK_CANDIDATE_LIMIT / this)`` concurrent requests per
+# search (2 at the defaults).
+#
+# Default 32 = TEI's own ``--max-client-batch-size`` default, so stock-vs-stock
+# works. Raise it to match a sidecar started with a larger cap and a full pool
+# goes over in one request again. Cohere-shaped endpoints admit far more per
+# call, so 32 is very conservative there — worth raising to at least
+# RANK_CANDIDATE_LIMIT if that is the backend.
+RANK_REMOTE_MAX_BATCH: int = int(os.environ.get("RANK_REMOTE_MAX_BATCH", "32"))

--- a/common/ranking/providers/remote.py
+++ b/common/ranking/providers/remote.py
@@ -21,12 +21,13 @@ order — the caller (RerankResults) owns the sort.
 
 from __future__ import annotations
 
+import asyncio
 import itertools
 import logging
 
 import httpx
 
-from common.ranking.constants import RANK_TIMEOUT_SECONDS
+from common.ranking.constants import RANK_REMOTE_MAX_BATCH, RANK_TIMEOUT_SECONDS
 from common.ranking.errors import PermanentRankError
 from common.ranking.protocols import RankCandidate
 
@@ -73,10 +74,16 @@ class RemoteRanker:
         api_key: str = "",
         model: str = "",
         timeout: float = RANK_TIMEOUT_SECONDS,
+        max_batch: int = RANK_REMOTE_MAX_BATCH,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._model = model
         self._instance_id = next(_instance_seq)
+        # Guard a non-positive override: negative yields no chunks at all (and
+        # so no scores), 0 blows up the range step below. Coerced rather than
+        # rejected because no real deployment reaches it — but note 1 means one
+        # HTTP request per candidate.
+        self._max_batch = max(1, max_batch)
         headers = {}
         if api_key:
             # Bearer for Cohere / token-gated TEI; harmless for open TEI.
@@ -142,20 +149,27 @@ class RemoteRanker:
             f"Response: {resp.text[:_ERROR_BODY_LIMIT]}"
         )
         if resp.status_code == 413:
-            # By far the most common way to land here, and the fix is not
-            # guessable from "413": the pool we send is RANK_CANDIDATE_LIMIT
-            # (50 by default) but a TEI reranker admits only 32 per request
-            # unless --max-client-batch-size is raised.
+            # The fix is not guessable from "413". Note this is about
+            # RANK_REMOTE_MAX_BATCH, NOT RANK_CANDIDATE_LIMIT: since chunking,
+            # the pool size no longer determines the request size, so lowering
+            # the candidate limit is no longer the remedy.
             detail += (
-                " A 413 here usually means the sidecar's max client batch size "
-                "is below RANK_CANDIDATE_LIMIT — raise it (TEI: "
-                "--max-client-batch-size) or lower RANK_CANDIDATE_LIMIT."
+                f" A 413 here means RANK_REMOTE_MAX_BATCH ({self._max_batch}) "
+                "exceeds what this sidecar accepts per request — lower it, or "
+                "raise the sidecar's cap (TEI: --max-client-batch-size). "
+                "RANK_CANDIDATE_LIMIT is unrelated; the pool is already split "
+                "into requests of at most RANK_REMOTE_MAX_BATCH."
             )
         return detail
 
-    async def rank(self, query: str, candidates: list[RankCandidate]) -> list[float]:
-        if not candidates:
-            return []
+    async def _rank_chunk(
+        self, query: str, candidates: list[RankCandidate]
+    ) -> list[float]:
+        """Score ONE request's worth of candidates, in the order given.
+
+        Everything about the wire contract and failure classification lives
+        here; :meth:`rank` only decides how the pool is split across calls.
+        """
         body: dict = {"query": query, "texts": [c.content for c in candidates]}
         resp = await self._client.post("/rerank", json=body)
         if resp.is_client_error and resp.status_code not in _RETRYABLE_CLIENT_STATUSES:
@@ -209,3 +223,65 @@ class RemoteRanker:
                 score = item.get("relevance_score")
             scores[idx] = float(score)
         return scores
+
+    async def rank(self, query: str, candidates: list[RankCandidate]) -> list[float]:
+        """Score every candidate, splitting across requests if the pool is big.
+
+        Chunking is safe to do here — and invisible in the result — because a
+        cross-encoder scores each ``(query, text)`` pair INDEPENDENTLY, so a
+        candidate's score does not depend on what shares its batch. Splitting
+        therefore returns exactly what one large call would.
+
+        That property is load-bearing: it does NOT hold for a listwise reranker
+        that scores a set jointly. If one is ever put behind this provider,
+        chunking silently changes the ranking and this method needs revisiting.
+        """
+        if not candidates:
+            return []
+        # Fast path: a pool that fits in one request behaves exactly as it did
+        # before chunking existed — no gather, and the exception propagates with
+        # its own traceback rather than being captured and re-raised.
+        if len(candidates) <= self._max_batch:
+            return await self._rank_chunk(query, candidates)
+
+        chunks = [
+            candidates[i : i + self._max_batch]
+            for i in range(0, len(candidates), self._max_batch)
+        ]
+        # CONCURRENTLY, not in sequence. The service layer wraps this whole call
+        # in a single RANK_TIMEOUT_SECONDS deadline (0.5s by default) while one
+        # warm 50-candidate rerank already measures ~285ms, so two sequential
+        # chunks would blow it — turning a silent batch-cap rejection into a
+        # silent timeout, which is the same user-visible outcome and harder to
+        # diagnose.
+        #
+        # What this buys is removing CLIENT-side serialisation, not server-side
+        # compute: one sidecar replica still scores the same number of pairs, so
+        # budget against roughly the unchunked figure plus a round-trip, not N
+        # times it.
+        #
+        # return_exceptions=True so every chunk is awaited before we look at any
+        # of them: a bare gather propagates the first failure and leaves its
+        # siblings running unobserved.
+        results = await asyncio.gather(
+            *(self._rank_chunk(query, chunk) for chunk in chunks),
+            return_exceptions=True,
+        )
+
+        failures = [r for r in results if isinstance(r, BaseException)]
+        if failures:
+            # Fail the WHOLE rank: the alternative — scoring the failed chunk's
+            # candidates 0.0 — would bury real results at the bottom of the
+            # list and call it success, which is worse than not reranking at
+            # all.
+            #
+            # Surface a permanent failure over a transient one when both
+            # happened: a batch cap set too high is permanent no matter what
+            # unrelated blip another chunk hit, and misreporting it as
+            # transient would spend the retry budget re-earning the same 413.
+            raise next(
+                (f for f in failures if isinstance(f, PermanentRankError)),
+                failures[0],
+            )
+
+        return [score for chunk_scores in results for score in chunk_scores]

--- a/tests/test_ranking_remote.py
+++ b/tests/test_ranking_remote.py
@@ -9,6 +9,7 @@ TEI wet test still happens at sidecar-deploy time (see PR notes).
 
 from __future__ import annotations
 
+import asyncio
 import json
 from types import SimpleNamespace
 
@@ -28,9 +29,9 @@ def _cands(*contents):
     ]
 
 
-def _client_with(handler, base_url="http://sidecar:80"):
+def _client_with(handler, base_url="http://sidecar:80", max_batch=32):
     """Build a RemoteRanker whose httpx client uses a MockTransport handler."""
-    r = RemoteRanker(base_url=base_url, model="test-model")
+    r = RemoteRanker(base_url=base_url, model="test-model", max_batch=max_batch)
     r._client = httpx.AsyncClient(
         base_url=base_url, transport=httpx.MockTransport(handler)
     )
@@ -139,7 +140,7 @@ def _counting_handler(status, text="", json_body=None):
     return handler, calls
 
 
-async def _run_service(ranker, monkeypatch, attempts=3):
+async def _run_service(ranker, monkeypatch, attempts=3, candidates=None):
     """Drive get_ranking against `ranker` with a known retry budget."""
     # RANK_RETRY_ATTEMPTS defaults to 1 (no retry), which makes "permanent vs
     # transient" invisible — both would call once. Raise it so the difference
@@ -151,7 +152,9 @@ async def _run_service(ranker, monkeypatch, attempts=3):
         "common.ranking._service.get_rank_provider", lambda name, tc=None: ranker
     )
     return await get_ranking(
-        "q", _cands("a", "b"), SimpleNamespace(rank_provider="remote")
+        "q",
+        candidates if candidates is not None else _cands("a", "b"),
+        SimpleNamespace(rank_provider="remote"),
     )
 
 
@@ -412,4 +415,122 @@ async def test_200_with_non_json_body_is_permanent(monkeypatch):
     out = await _run_service(r, monkeypatch, attempts=3)
     assert out is None
     assert len(calls) == 1, "a wrong endpoint returns the same body on retry"
+    await r._client.aclose()
+
+
+# --- chunking the candidate pool across requests ---------------------------
+
+
+def _chunk_recorder(status=200, score_for=None):
+    """Async handler recording each request's texts and peak in-flight count."""
+    state = {"inflight": 0, "peak": 0, "batches": []}
+
+    async def handler(request):
+        body = json.loads(request.content)
+        state["batches"].append(body["texts"])
+        state["inflight"] += 1
+        state["peak"] = max(state["peak"], state["inflight"])
+        # Yield so a concurrent sibling can be observed in flight; a sequential
+        # implementation can never overlap here no matter how long we sleep.
+        await asyncio.sleep(0.02)
+        state["inflight"] -= 1
+        if status != 200:
+            return httpx.Response(status, text="nope")
+        n = len(body["texts"])
+        return httpx.Response(
+            200,
+            json=[
+                {"index": i, "score": (score_for(body["texts"][i]) if score_for else 1.0)}
+                for i in range(n)
+            ],
+        )
+
+    return handler, state
+
+
+@pytest.mark.asyncio
+async def test_pool_at_or_below_cap_stays_one_request():
+    handler, state = _chunk_recorder()
+    r = _client_with(handler, max_batch=32)
+    await r.rank("q", _cands(*[f"c{i}" for i in range(32)]))
+    assert len(state["batches"]) == 1, "exactly-at-cap must not split"
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pool_above_cap_splits_and_preserves_input_order():
+    # Score = position, so a mis-merged result is immediately visible.
+    order = {f"c{i}": float(i) for i in range(50)}
+    handler, state = _chunk_recorder(score_for=lambda t: order[t])
+    r = _client_with(handler, max_batch=32)
+    scores = await r.rank("q", _cands(*[f"c{i}" for i in range(50)]))
+
+    assert len(state["batches"]) == 2
+    assert [len(b) for b in state["batches"]] in ([32, 18], [18, 32])
+    # every candidate sent exactly once, none duplicated or dropped
+    sent = [t for b in state["batches"] for t in b]
+    assert sorted(sent) == sorted(order)
+    # merged back onto INPUT order, not response or chunk order
+    assert scores == [float(i) for i in range(50)]
+    # ...and issued CONCURRENTLY. Sequential chunks would blow
+    # RANK_TIMEOUT_SECONDS, turning a batch-cap rejection into a silent timeout
+    # — same symptom, harder to diagnose.
+    assert state["peak"] >= 2, (
+        f"chunks ran sequentially (peak in-flight {state['peak']}) — "
+        "wall-clock would be the sum, not one chunk"
+    )
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_one_failed_chunk_fails_the_whole_rank(monkeypatch):
+    """Partial failure must degrade, never return a partially-scored list.
+
+    Scoring the failed chunk 0.0 would bury real results at the bottom and
+    call it success — worse than not reranking.
+    """
+    calls = {"n": 0}
+
+    async def handler(request):
+        calls["n"] += 1
+        # first request in flight succeeds, the other 503s
+        if calls["n"] == 1:
+            texts = json.loads(request.content)["texts"]
+            return httpx.Response(
+                200, json=[{"index": i, "score": 1.0} for i in range(len(texts))]
+            )
+        return httpx.Response(503, text="unavailable")
+
+    r = _client_with(handler, max_batch=32)
+    with pytest.raises(httpx.HTTPStatusError):
+        await r.rank("q", _cands(*[f"c{i}" for i in range(50)]))
+    # and through the service layer a CHUNKED failure degrades rather than
+    # raising into search (the default 2-candidate pool would take the fast
+    # path and never exercise chunking at all)
+    out = await _run_service(
+        r, monkeypatch, attempts=1, candidates=_cands(*[f"c{i}" for i in range(50)])
+    )
+    assert out is None
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_permanent_chunk_failure_wins_over_a_transient_sibling(monkeypatch):
+    """A 413 on one chunk must not be reported as a retryable failure.
+
+    Misreporting it transient would spend the retry budget re-earning the same
+    rejection.
+    """
+    async def handler(request):
+        texts = json.loads(request.content)["texts"]
+        await asyncio.sleep(0.01)
+        # The SHORT TAIL chunk (18 of 50) is the permanently-rejected one, so a
+        # naive `raise failures[0]` surfaces the transient 503 from chunk 0 and
+        # this test fails. Keying off size rather than call order is what makes
+        # the assertion actually guard the permanent-wins scan.
+        return httpx.Response(413 if len(texts) == 18 else 503, text="cap exceeded")
+
+    r = _client_with(handler, max_batch=32)
+    with pytest.raises(PermanentRankError, match="RANK_REMOTE_MAX_BATCH"):
+        await r.rank("q", _cands(*[f"c{i}" for i in range(50)]))
     await r._client.aclose()


### PR DESCRIPTION
Closes #704. Completes the pair with #708: that made a batch-cap rejection **loud**, this makes it **not happen**.

## The problem

`RemoteRanker.rank()` posted the whole candidate pool as ONE `/rerank` request, up to `RANK_CANDIDATE_LIMIT` (50). A TEI reranker admits **32** per request unless started with `--max-client-batch-size`, so the **default pair was broken out of the box**: every search returning more than 32 candidates was rejected and silently served first-stage order.

An operator could fix it by raising the sidecar's cap — but nothing in the library enforced the coupling, and stock-vs-stock didn't work.

## The change

The pool is split into chunks of **`RANK_REMOTE_MAX_BATCH`** (new, default **32** = TEI's own default) and issued **concurrently**. The two settings are independent from here: `RANK_CANDIDATE_LIMIT` is a quality/latency choice, `RANK_REMOTE_MAX_BATCH` is purely what the sidecar accepts per call.

### Why splitting is invisible in the result

A cross-encoder scores each `(query, text)` pair **independently** — a candidate's score doesn't depend on what shares its batch — so chunk-then-merge returns exactly what one large call would. Not an approximation.

That property is load-bearing and does **not** hold for a listwise reranker that scores a set jointly. The docstring says so, because putting one behind this provider would silently change rankings.

### Two deliberate design points

**Concurrent, not sequential.** The service layer wraps the whole call in one `RANK_TIMEOUT_SECONDS` deadline (0.5s) while a warm 50-candidate rerank already measures ~285ms — sequential chunks would blow it, converting a silent batch-cap rejection into a silent *timeout*: same symptom, harder to diagnose. `gather(return_exceptions=True)` so every chunk is awaited before any is inspected; a bare `gather` propagates the first failure and leaves siblings running unobserved.

To be precise about what this buys: it removes **client-side serialisation**, not server-side compute. One replica still scores the same number of pairs, so budget against roughly the unchunked figure plus a round-trip, not N× it.

**Any chunk failing fails the whole rank.** Scoring the failed chunk's candidates `0.0` would bury real results at the bottom and call it success — worse than not reranking. A `PermanentRankError` is surfaced over a transient sibling: a cap set too high is permanent regardless of what blip another chunk hit, and misreporting it transient would spend the retry budget re-earning the same 413.

## Blast radius is smaller than it looks

The default `top_k` of 5 with 2× overfetch yields a **10-candidate pool** → single-request fast path → byte-for-byte identical on the wire to before. Splitting begins around `top_k >= 17`.

**Operational note:** a deployment already running its sidecar with `--max-client-batch-size 64` should set `RANK_REMOTE_MAX_BATCH=64` to keep single-request behaviour at every `top_k`.

Also corrected: #708's 413 hint advised lowering `RANK_CANDIDATE_LIMIT`, which is no longer the remedy since pool size no longer determines request size. It now names `RANK_REMOTE_MAX_BATCH` and its live value.

## Verification

Each mechanism was reverted individually to confirm the matching test actually guards it:

| Reverted | Result |
|---|---|
| chunking entirely | all new tests fail |
| chunked but **sequential** | the split/order test fails on its peak-in-flight assertion — **and only that one** |
| `raise failures[0]` instead of the permanent-wins scan | the permanent-over-transient test fails |

That last one matters: in an earlier draft the test was **vacuous** — `gather` preserves order and chunk 0 happened to hold the 413, so the naive implementation satisfied it. The handler now keys the status off chunk *size*, making the short tail chunk the permanent one. Removing that shared-counter handler also fixed a one-off flake: **45 runs of the file under deliberate CPU contention, zero failures.**

`ruff check common/` + gated scopes clean, format clean, `mypy` clean (190 files), `bandit` clean, no `uv.lock` drift.

## Not in scope

`RANK_MODEL` still defaults to `cross-encoder/ms-marco-MiniLM-L-6-v2`, which hf.co answers with a 307 to the canonical `…MiniLM-L6-v2` (established in caura-memclaw-enterprise#972). Harmless today, worth a one-line follow-up rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)