### PR TITLE
feat(write): honour per-item write_mode on the bulk path

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -293,6 +293,18 @@
               }
             ],
             "title": "Weight"
+          },
+          "write_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-item write mode. 'strong' embeds this item inline, so it is searchable as soon as the write is persisted rather than after the background backfill — at the cost of an embedding provider call on the request path. Any other value behaves as 'fast': the item follows the deployment's embedding mode. On a deployment that already embeds inline this has no effect, since every item is embedded inline anyway. Narrower than MemoryCreate.write_mode: on the bulk path 'strong' affects only the embedding — LLM enrichment defers either way — and the tenant's default_write_mode is not consulted, so only an explicit per-item opt-in embeds inline.",
+            "title": "Write Mode"
           }
         },
         "required": [

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -357,9 +357,11 @@ class Settings(BaseSettings):
     def _validate_timeout_ordering(self) -> "Settings":
         # Local import avoids a circular: constants → common.constants,
         # but this file is imported by constants.py's dependents.
+        from common.embedding.constants import EMBEDDING_GATE_TIMEOUT_SECONDS
         from core_api.constants import (
             BULK_EMBEDDING_TIMEOUT_SECONDS,
             BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS,
+            BULK_STRONG_EMBED_TIMEOUT_SECONDS,
         )
 
         if self.request_timeout_seconds < BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS:
@@ -420,6 +422,39 @@ class Settings(BaseSettings):
                 f"bulk_request_timeout_seconds "
                 f"({self.bulk_request_timeout_seconds}s) so the storage-phase "
                 f"cap fires before the umbrella."
+            )
+        if EMBEDDING_GATE_TIMEOUT_SECONDS >= BULK_STRONG_EMBED_TIMEOUT_SECONDS:
+            # The opportunistic ``write_mode="strong"`` embed must be able to
+            # outwait the concurrency gate. The gate timeout sits deliberately
+            # below callers' deadlines so a saturated gate surfaces as
+            # attributable backpressure rather than an anonymous caller timeout;
+            # invert that and every gate-saturated strong write is reported as a
+            # generic embed failure instead. Checked here because the gate value
+            # is read from an env var at import, so the ordering is an operator's
+            # to break, not a constant's.
+            raise ValueError(
+                f"EMBEDDING_GATE_TIMEOUT_SECONDS ({EMBEDDING_GATE_TIMEOUT_SECONDS}s) must be < "
+                f"BULK_STRONG_EMBED_TIMEOUT_SECONDS ({BULK_STRONG_EMBED_TIMEOUT_SECONDS}s) so a "
+                "saturated embedding gate stays attributable on the opportunistic "
+                "bulk strong-embed path. Lower the gate timeout, or raise "
+                "BULK_STRONG_EMBED_TIMEOUT_SECONDS (keeping it under "
+                "BULK_EMBEDDING_TIMEOUT_SECONDS)."
+            )
+        if BULK_STRONG_EMBED_TIMEOUT_SECONDS >= BULK_EMBEDDING_TIMEOUT_SECONDS:
+            # The other half of the bound the message above already tells the
+            # operator to respect. The derived default clamps here, so only an
+            # explicit env override can reach this — and it must not, twice over:
+            # an opportunistic embed allowed to run as long as a required one stops
+            # being opportunistic and can hold a whole batch for that budget, for
+            # one item's opt-in; and the additive ordering check above assumes the
+            # embed phase never exceeds BULK_EMBEDDING_TIMEOUT_SECONDS, so letting
+            # it through would silently invalidate that proof rather than just
+            # degrade this path.
+            raise ValueError(
+                f"BULK_STRONG_EMBED_TIMEOUT_SECONDS ({BULK_STRONG_EMBED_TIMEOUT_SECONDS}s) must be < "
+                f"BULK_EMBEDDING_TIMEOUT_SECONDS ({BULK_EMBEDDING_TIMEOUT_SECONDS}s): the "
+                "opportunistic bulk strong-embed budget cannot exceed the required embed cap, "
+                "which the storage-phase ordering check above is proved against."
             )
         return self
 

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -22,6 +22,10 @@ from common.constants import (  # noqa: F401
     VECTOR_DIM,
 )
 
+# The embedding concurrency-gate timeout, which the bulk strong-embed budget
+# below must stay ordered above — see BULK_STRONG_EMBED_TIMEOUT_SECONDS.
+from common.embedding.constants import EMBEDDING_GATE_TIMEOUT_SECONDS
+
 # Re-export memory-vocabulary constants from common.enrichment (CAURA-595).
 # common is the source of truth so core-api and core-worker stay in sync.
 from common.enrichment.constants import (  # noqa: F401
@@ -34,6 +38,7 @@ from common.enrichment.constants import (  # noqa: F401
     SERVER_RESERVED_MEMORY_TYPES,
     MemoryType,
 )
+from common.env_utils import read_float_env
 
 # Re-export LLM provider constants from common.llm (CAURA-595).
 from common.llm.constants import (  # noqa: F401
@@ -702,6 +707,61 @@ BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS = 30.0
 # ``storage_bulk_timeout_seconds`` per-phase deadline can fire before the
 # umbrella ``bulk_request_timeout_seconds``.
 BULK_EMBEDDING_TIMEOUT_SECONDS = 30.0
+
+# Margin over the concurrency gate for the opportunistic embed's default budget,
+# and the floor that margin can't take it below.
+_STRONG_EMBED_GATE_MARGIN_SECONDS = 3.0
+_STRONG_EMBED_MIN_SECONDS = 8.0
+
+
+def _default_strong_embed_timeout(gate_seconds: float, required_seconds: float) -> float:
+    """Default budget for the opportunistic bulk embed.
+
+    Derived from the gate rather than fixed, so raising
+    ``EMBEDDING_GATE_TIMEOUT_SECONDS`` — an operator's env var — can never leave a
+    deployment unable to start. A fixed literal here would do exactly that: any
+    install that had already raised the gate past it would fail the startup
+    ordering check on upgrade, fixable only by a code change.
+
+    Must land STRICTLY between the two, since that is what the startup validator
+    enforces: ``gate < budget < required``. Clamping to ``required_seconds`` is not
+    enough — for a gate within the margin of the cap that clamp lands exactly ON
+    the cap, and the validator then refuses to start for an operator who only
+    raised the gate to a legitimate value below it. So when the full margin doesn't
+    fit, take the midpoint of the remaining room, which is strictly inside the
+    bound for any ``gate < required``.
+
+    A gate at or above the cap has no such room, and is incoherent on its own terms
+    — it would outlive the embed it gates. That returns ``required_seconds`` and
+    lets the validator say so rather than papering over it.
+    """
+    preferred = max(_STRONG_EMBED_MIN_SECONDS, gate_seconds + _STRONG_EMBED_GATE_MARGIN_SECONDS)
+    if preferred < required_seconds:
+        return preferred
+    if gate_seconds < required_seconds:
+        return (gate_seconds + required_seconds) / 2.0
+    return required_seconds
+
+
+# Cap on the *opportunistic* bulk embed — the one a ``write_mode="strong"`` item
+# triggers on a deployment that otherwise defers. Much tighter than the required
+# cap above, because this branch's documented fallback is "defer to the backfill
+# anyway": spending 30s to reach an outcome that was free is latency charged to
+# every other item in the batch, none of which asked for inline embedding.
+#
+# Must stay ABOVE ``EMBEDDING_GATE_TIMEOUT_SECONDS``, which is deliberately set
+# below callers' deadlines so a saturated concurrency gate surfaces as
+# attributable backpressure rather than an anonymous caller timeout. Drop below it
+# and every gate-saturated strong write is reported as a generic embed failure.
+#
+# The default is derived from that gate so the ordering holds however the operator
+# tunes it, and is env-overridable so a deployment that needs a specific value has
+# a config-only lever rather than a code change. ``_validate_timeout_ordering`` in
+# config.py still rejects an explicit override that conflicts with the gate.
+BULK_STRONG_EMBED_TIMEOUT_SECONDS = read_float_env(
+    "BULK_STRONG_EMBED_TIMEOUT_SECONDS",
+    _default_strong_embed_timeout(EMBEDDING_GATE_TIMEOUT_SECONDS, BULK_EMBEDDING_TIMEOUT_SECONDS),
+)
 
 # ── Lifecycle automation ──
 LIFECYCLE_INTERVAL_HOURS = 24  # run lifecycle cycle every N hours

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -109,6 +109,30 @@ class BulkMemoryItem(BaseModel):
     ts_valid_end: datetime | None = None
     reference_datetime: datetime | None = None
     status: str | None = Field(default=None)  # validated per-item (status_errors); see note above
+    # Per ITEM, not per batch, deliberately: callers that funnel through the bulk
+    # endpoint may coalesce writes from unrelated sources into one request (the
+    # broker's durable queue does exactly this), so one item asking for 'strong'
+    # must not force inline embedding on everything batched alongside it.
+    #
+    # Untyped ``str`` rather than a Literal, per this model's additive-tolerance
+    # policy above: a Literal would 422 the WHOLE batch over one item's unknown
+    # value (e.g. 'stm' copied from a single-write payload). Only 'strong' has an
+    # effect; every other value, known or not, behaves as 'fast'.
+    write_mode: str | None = Field(
+        default=None,
+        description=(
+            "Per-item write mode. 'strong' embeds this item inline, so it is "
+            "searchable as soon as the write is persisted rather than after the "
+            "background backfill — at the cost of an embedding provider call on "
+            "the request path. Any other value behaves as 'fast': the item follows "
+            "the deployment's embedding mode. On a deployment that already embeds "
+            "inline this has no effect, since every item is embedded inline anyway. "
+            "Narrower than MemoryCreate.write_mode: on the bulk path 'strong' "
+            "affects only the embedding — LLM enrichment defers either way — and "
+            "the tenant's default_write_mode is not consulted, so only an explicit "
+            "per-item opt-in embeds inline."
+        ),
+    )
 
 
 class BulkMemoryCreate(BaseModel):
@@ -279,11 +303,15 @@ class MemoryOut(BaseModel):
     #   enrichment_pending: true  — title/memory_type/weight/status/ts_valid_* are
     #     still the caller-supplied or default values; the LLM pass will PATCH them.
     #
-    # Absent (or false) means that stage ran inline. `write_mode="strong"` embeds
-    # and enriches inline, so neither flag appears — that is the supported
-    # read-your-own-write opt-out, at the cost of the provider calls on the
-    # request path. A deployment running embedding inline (OSS local default)
-    # never sets embedding_pending, even in fast mode.
+    # Absent (or false) means that stage ran inline. On the single-write path
+    # `write_mode="strong"` embeds and enriches inline, so neither flag appears —
+    # that is the supported read-your-own-write opt-out, at the cost of the
+    # provider calls on the request path. A deployment running embedding inline
+    # (OSS local default) never sets embedding_pending, even in fast mode.
+    #
+    # `BulkMemoryItem.write_mode` is narrower: there 'strong' governs the
+    # embedding only, enrichment defers either way, and the bulk path sets neither
+    # flag — so a bulk caller cannot read pendingness off its own write response.
     metadata: dict | None
     created_at: datetime
     expires_at: datetime | None

--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -911,17 +911,29 @@ async def _persist_findings(
     # write_mode behaviour change vs the pre-#29 path
     # -----------------------------------------------
     # The previous serial path passed ``write_mode="strong"`` on every
-    # ``MemoryCreate``. ``BulkMemoryItem`` carries no ``write_mode``
-    # field, and ``create_memories_bulk`` doesn't pick the strong vs fast
-    # pipeline per item — so the bulk path effectively drops the strong
-    # mode override. The only behavioural delta between the strong and
-    # fast pipelines is the inline ``CheckSemanticDuplicate`` step (see
-    # ``core_api/pipeline/compositions/write.py``); everything else
-    # (embed, enrich, exact-dedup, write, schedule background tasks) is
-    # identical. The post-write fire-and-forget tasks — entity extraction,
-    # async contradiction detection, deferred enrichment — are still
-    # scheduled per memory by the bulk path's ``ScheduleBackgroundTasks``-
-    # equivalent loop, so contradiction detection coverage is intact.
+    # ``MemoryCreate``. The items below set it again, so the inline-embed half of
+    # that is restored: a finding is semantically searchable the moment this
+    # persist returns rather than after the deferred backfill.
+    #
+    # It is only that half. ``BulkMemoryItem.write_mode`` governs the embedding
+    # and nothing else — the inline ``CheckSemanticDuplicate`` step (see
+    # ``core_api/pipeline/compositions/write.py``) has no bulk equivalent at any
+    # write_mode, so the strong pipeline's one other behavioural delta stays
+    # dropped here regardless. That is fine for insights, for the reason spelled
+    # out below; the point is that "strong" on this path is not the same promise
+    # as "strong" on the single-write path, and reading it as such would be wrong.
+    #
+    # Everything else (enrich, exact-dedup, write, schedule background tasks) was
+    # already identical between the two pipelines. The post-write
+    # fire-and-forget tasks — entity extraction, async contradiction detection,
+    # deferred enrichment — are still scheduled per memory by the bulk path's
+    # ``ScheduleBackgroundTasks``-equivalent loop, so contradiction detection
+    # coverage is intact.
+    #
+    # Cost: one batched embedding call per evolve cycle moves onto the request
+    # path, capped by ``BULK_STRONG_EMBED_TIMEOUT_SECONDS`` and falling back to
+    # the backfill if the provider fails, so the worst case is the latency this
+    # path had before rather than a failed persist.
     #
     # Why dropping inline semantic dedup is acceptable for insights
     # specifically: the supersede-priors block above ALREADY transitions
@@ -964,6 +976,13 @@ async def _persist_findings(
                 memory_type="insight",
                 content=content,
                 weight=confidence,
+                # Embed inline so a finding is semantically searchable as soon as
+                # this persist returns. An insight exists to be recalled, and the
+                # obvious next action after an evolve cycle is to search for what
+                # it produced — landing in the backfill window makes it look like
+                # nothing was written. See the write_mode note above for what this
+                # does and does not restore.
+                write_mode="strong",
                 metadata={
                     "insight_focus": focus,
                     "insight_scope": scope,

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -42,6 +42,7 @@ from core_api.constants import (
     BULK_EMBEDDING_TIMEOUT_SECONDS,
     BULK_ENRICHMENT_CONCURRENCY,
     BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS,
+    BULK_STRONG_EMBED_TIMEOUT_SECONDS,
     CHUNKING_THRESHOLD_CHARS,
     CLASSIFIER_DEPRECATED_MEMORY_TYPES,
     CRYSTALLIZER_SHORT_CONTENT_CHARS,
@@ -1191,16 +1192,53 @@ async def create_memories_bulk(
             valid_indices = [i for i in valid_indices if i not in governance_errors]
 
     embeddings: list = [None] * n
-    if valid_indices and settings.inline_embedding:
+    # Items embedded here keep their vector; the rest fall to the background
+    # ``reembed_batch`` below. ``write_mode="strong"`` opts an item in even when
+    # the deployment defers, so it is searchable the moment it persists rather
+    # than after the backfill. Only the embedding: enrichment defers regardless
+    # on this path, unlike single-write strong.
+    #
+    # Deliberately NOT via ``_resolve_write_mode``: that also consults
+    # ``tenant_config.default_write_mode`` and escalates ``_STRONG_TYPES``, which
+    # would put a provider call on the request path for callers who never asked —
+    # including the broker fan-in this endpoint is tuned for. Only an explicit
+    # per-item opt-in counts here.
+    if settings.inline_embedding:
+        embed_indices = valid_indices
+    else:
+        embed_indices = [i for i in valid_indices if items[i].write_mode == "strong"]
+
+    if embed_indices:
+        # An opportunistic embed gets a tighter deadline than a required one. The
+        # required path can justify 30s because the alternative is a 504; this one
+        # would spend it and then land on the deferred outcome it already accepted
+        # for free — latency charged to the whole batch for one item's opt-in.
+        embed_timeout = (
+            BULK_EMBEDDING_TIMEOUT_SECONDS if settings.inline_embedding else BULK_STRONG_EMBED_TIMEOUT_SECONDS
+        )
         try:
-            async with asyncio.timeout(BULK_EMBEDDING_TIMEOUT_SECONDS):
+            async with asyncio.timeout(embed_timeout):
                 valid_embeddings = await get_embeddings_batch(
-                    [items[i].content for i in valid_indices], tenant_config
+                    [items[i].content for i in embed_indices], tenant_config
                 )
-        except TimeoutError:
-            raise HTTPException(status_code=504, detail="Bulk embedding timed out")
-        for emb_pos, item_idx in enumerate(valid_indices):
-            embeddings[item_idx] = valid_embeddings[emb_pos]
+        except Exception as exc:
+            # Inline deployments: this is the only place a row gets its vector, so
+            # a failure fails the request rather than persisting vectorless rows.
+            if settings.inline_embedding:
+                if isinstance(exc, TimeoutError):
+                    raise HTTPException(status_code=504, detail="Bulk embedding timed out")
+                raise
+            # Deferred: falling through leaves ``embeddings[i] is None``, so the
+            # background re-embed picks these up. One item's opt-in must not fail a
+            # batch of items that never asked for inline embedding.
+            logger.warning(
+                "bulk inline embed for %d write_mode=strong item(s) failed; deferring to backfill",
+                len(embed_indices),
+                exc_info=True,
+            )
+        else:
+            for emb_pos, item_idx in enumerate(embed_indices):
+                embeddings[item_idx] = valid_embeddings[emb_pos]
 
     enrichments: list = [None] * n
     # CAURA-595: ``deployment_mode=deferred`` defers the LLM call to

--- a/tests/test_bulk_write_mode.py
+++ b/tests/test_bulk_write_mode.py
@@ -1,0 +1,271 @@
+"""Per-item ``write_mode`` on the bulk write path.
+
+``write_mode="strong"`` asks for the embedding to be generated inline so the row
+is searchable as soon as it persists, instead of after the background backfill.
+On a deployment that already embeds inline it is a no-op.
+
+The granularity is per ITEM, not per batch, because callers funnel unrelated
+writes through one bulk request — the broker's durable queue coalesces them — so
+one item opting in must not change how anything batched alongside it is treated.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+
+from core_api.config import settings
+from core_api.constants import (
+    BULK_EMBEDDING_TIMEOUT_SECONDS,
+    BULK_STRONG_EMBED_TIMEOUT_SECONDS,
+)
+from core_api.schemas import BulkMemoryCreate, BulkMemoryItem
+from core_api.services.memory_service import create_memories_bulk
+
+# Long enough to clear CheckContentLength's minimum-length quality gate.
+_PADDING = " This memory carries enough surrounding context to pass the content-length gate."
+
+
+def _item(content: str, **kw) -> BulkMemoryItem:
+    return BulkMemoryItem(content=content + _PADDING, **kw)
+
+
+def _request(*items: BulkMemoryItem) -> BulkMemoryCreate:
+    return BulkMemoryCreate(
+        # ``test-tenant-%`` rows are auto-cleaned by the conftest schema fixture.
+        # A fresh tenant per call keeps these independent of committed leftovers.
+        tenant_id=f"test-tenant-writemode-{uuid.uuid4().hex[:8]}",
+        fleet_id="test-fleet",
+        agent_id="test-agent",
+        items=list(items),
+    )
+
+
+async def _write(*items: BulkMemoryItem):
+    """Write a batch, assert every item was created, return the result rows."""
+    resp = await create_memories_bulk(_request(*items), bulk_attempt_id=uuid.uuid4().hex)
+    assert [r.status for r in resp.results] == ["created"] * len(items), resp.results
+    return resp.results
+
+
+async def _embedded(engine, memory_id) -> bool:
+    """True when the stored row has an embedding.
+
+    Read straight from the column: ``get_memory`` omits the embedding (it is
+    deliberately excluded from the serialised field set), and ``vec_sim`` would
+    conflate "no embedding" with "orthogonal".
+    """
+    async with engine.connect() as conn:
+        row = (
+            await conn.execute(
+                text("SELECT embedding IS NOT NULL FROM memories WHERE id = :i"),
+                {"i": memory_id},
+            )
+        ).first()
+    assert row is not None, f"memory {memory_id} not found"
+    return bool(row[0])
+
+
+@pytest.fixture
+def deferring_deployment(monkeypatch):
+    """Make the deployment defer embedding, as SaaS does.
+
+    ``settings.inline_embedding`` is a read-only property over
+    ``deployment_mode``, so the mode is what has to move.
+    """
+    monkeypatch.setattr(settings, "deployment_mode", "deferred")
+    assert not settings.inline_embedding
+
+
+@pytest.mark.integration
+async def test_strong_item_embeds_inline_when_deployment_defers(db, _engine, deferring_deployment):
+    rows = await _write(_item("Strong write embeds on the request path.", write_mode="strong"))
+
+    assert await _embedded(_engine, rows[0].id), (
+        "write_mode='strong' must embed inline even when the deployment defers — "
+        "that is the whole point of the opt-in"
+    )
+
+
+@pytest.mark.integration
+async def test_omitted_write_mode_still_defers(db, _engine, deferring_deployment):
+    """Control: without the opt-in, nothing about the deferred path changes."""
+    rows = await _write(_item("Ordinary write keeps deferring."))
+
+    assert not await _embedded(_engine, rows[0].id)
+
+
+@pytest.mark.integration
+async def test_mixed_batch_embeds_only_the_strong_item(db, _engine, deferring_deployment):
+    """The per-item guarantee: one item's opt-in does not leak onto its neighbours."""
+    rows = await _write(
+        _item("Deferred neighbour one."),
+        _item("The one that opted in.", write_mode="strong"),
+        _item("Deferred neighbour two.", write_mode="fast"),
+    )
+
+    embedded = [await _embedded(_engine, r.id) for r in rows]
+    assert embedded == [False, True, False], (
+        f"only the write_mode='strong' item should be embedded inline, got {embedded}"
+    )
+
+
+@pytest.mark.integration
+async def test_unknown_write_mode_behaves_as_fast(db, _engine, deferring_deployment):
+    """An unrecognised value must degrade, not 422 the whole batch.
+
+    ``BulkMemoryItem`` deliberately avoids schema constraints that reject every
+    item over one item's bad field — 'stm' is valid on the single-write schema and
+    a caller reusing that payload shape must not lose the batch for it.
+    """
+    rows = await _write(
+        _item("Copied a single-write payload.", write_mode="stm"),
+        _item("Nonsense value.", write_mode="banana"),
+    )
+
+    assert [await _embedded(_engine, r.id) for r in rows] == [False, False]
+
+
+@pytest.mark.integration
+async def test_inline_deployment_embeds_everything_regardless(db, _engine):
+    """On a deployment that embeds inline, ``write_mode`` changes nothing."""
+    assert settings.inline_embedding, "local default is expected to embed inline"
+    rows = await _write(_item("No opt-in here."), _item("Opted in.", write_mode="strong"))
+
+    assert [await _embedded(_engine, r.id) for r in rows] == [True, True]
+
+
+@pytest.mark.integration
+async def test_strong_embed_failure_does_not_fail_the_batch(db, _engine, deferring_deployment):
+    """A failed opt-in embed falls back to the backfill instead of 5xx-ing.
+
+    These rows were going to defer anyway, so one item's opportunistic inline
+    embed must not take down a batch containing items that never asked for it.
+    """
+    with patch(
+        "core_api.services.memory_service.get_embeddings_batch",
+        side_effect=RuntimeError("provider exploded"),
+    ):
+        rows = await _write(
+            _item("Innocent bystander."),
+            _item("Opted in, will fail.", write_mode="strong"),
+        )
+
+    # Both fell back to the deferred path; neither is lost.
+    assert [await _embedded(_engine, r.id) for r in rows] == [False, False]
+
+
+@pytest.mark.integration
+async def test_inline_deployment_still_fails_loudly_on_embed_error(db):
+    """The pre-existing contract for inline deployments is unchanged.
+
+    There the embed is not opportunistic — it is how every row gets its vector —
+    so a failure must surface rather than silently persisting unembedded rows.
+    """
+    from fastapi import HTTPException
+
+    assert settings.inline_embedding
+    with (
+        patch(
+            "core_api.services.memory_service.get_embeddings_batch",
+            side_effect=TimeoutError("too slow"),
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await create_memories_bulk(
+            _request(_item("Inline deployment, embed fails.")),
+            bulk_attempt_id=uuid.uuid4().hex,
+        )
+    assert exc.value.status_code == 504
+
+
+@pytest.mark.unit
+def test_opportunistic_embed_budget_sits_between_the_gate_and_the_required_cap():
+    """The opt-in deadline is bounded on both sides, and neither bound is cosmetic.
+
+    Below the concurrency-gate timeout, a saturated gate stops being attributable
+    as backpressure and shows up as an anonymous caller timeout instead. At or
+    above the required cap, the opt-in stops being opportunistic — it would spend
+    a required embed's full budget to reach an outcome it already accepted for
+    free, charged to every other item in the batch.
+    """
+    from common.embedding.constants import EMBEDDING_GATE_TIMEOUT_SECONDS
+
+    assert EMBEDDING_GATE_TIMEOUT_SECONDS < BULK_STRONG_EMBED_TIMEOUT_SECONDS
+    assert BULK_STRONG_EMBED_TIMEOUT_SECONDS < BULK_EMBEDDING_TIMEOUT_SECONDS
+
+
+@pytest.mark.unit
+def test_default_budget_tracks_the_gate_so_raising_it_cannot_break_startup():
+    """The default is derived, not fixed, and that is an upgrade-safety property.
+
+    ``EMBEDDING_GATE_TIMEOUT_SECONDS`` is an operator's env var. Against a fixed
+    literal, any install that had already raised the gate past it — plausible
+    after a gate-saturation incident — would fail the startup ordering check on
+    upgrade, fixable only by a code change and redeploy. Deriving the default
+    keeps the ordering true however the gate is tuned.
+    """
+    from core_api.constants import _default_strong_embed_timeout
+
+    required = BULK_EMBEDDING_TIMEOUT_SECONDS
+    # Sweeps the band where the full margin does NOT fit under the cap
+    # (>= required - margin), which is where a clamp-to-cap lands exactly ON the
+    # bound the validator rejects. An earlier version asserted ``got <= required``
+    # and stopped at 25.0, so it passed while every gate in [27, 30) produced a
+    # config that could not start.
+    for gate in (1.0, 5.0, 7.9, 10.0, 25.0, 26.9, 27.0, 28.0, 29.0, 29.99):
+        got = _default_strong_embed_timeout(gate, required)
+        assert gate < got < required, (
+            f"gate={gate} must yield a budget STRICTLY inside (gate, required) — "
+            f"that is the bound _validate_timeout_ordering enforces — got {got}"
+        )
+
+    # A gate at or above the required cap has no room to sit inside, and is
+    # incoherent on its own terms: it would outlive the very embed it gates.
+    # Returns the cap so the startup validator reports it, rather than inventing a
+    # budget that looks valid.
+    assert _default_strong_embed_timeout(required, required) == required
+    assert _default_strong_embed_timeout(required + 10.0, required) == required
+
+
+@pytest.mark.unit
+def test_startup_rejects_an_override_that_conflicts_with_the_gate(monkeypatch):
+    """The lower bound is enforced, not merely documented.
+
+    With the default derived, this fires only when an operator explicitly sets
+    ``BULK_STRONG_EMBED_TIMEOUT_SECONDS`` into conflict with the gate — still
+    worth catching at startup rather than letting every gate-saturated strong
+    write be reported as a generic embed failure, and consistent with the other
+    cross-constant orderings in ``_validate_timeout_ordering``.
+    """
+    import core_api.config as config_mod
+
+    monkeypatch.setattr(
+        "common.embedding.constants.EMBEDDING_GATE_TIMEOUT_SECONDS",
+        BULK_STRONG_EMBED_TIMEOUT_SECONDS + 1.0,
+    )
+    with pytest.raises(ValueError, match="EMBEDDING_GATE_TIMEOUT_SECONDS"):
+        config_mod.Settings()
+
+
+@pytest.mark.unit
+def test_startup_rejects_an_override_above_the_required_embed_cap(monkeypatch):
+    """Both ends of the bound are enforced, not just the one the gate can break.
+
+    The derived default clamps here, so only an explicit
+    ``BULK_STRONG_EMBED_TIMEOUT_SECONDS`` override can exceed the required cap —
+    and it must not. An opportunistic embed permitted to run as long as a required
+    one stops being opportunistic and can hold a whole batch for that budget on one
+    item's opt-in. It would also invalidate the storage-phase additive ordering
+    check, which is proved against the embed phase never exceeding
+    ``BULK_EMBEDDING_TIMEOUT_SECONDS``.
+    """
+    import core_api.config as config_mod
+
+    monkeypatch.setattr(
+        "core_api.constants.BULK_STRONG_EMBED_TIMEOUT_SECONDS",
+        BULK_EMBEDDING_TIMEOUT_SECONDS + 1.0,
+    )
+    with pytest.raises(ValueError, match="BULK_STRONG_EMBED_TIMEOUT_SECONDS"):
+        config_mod.Settings()

--- a/tests/test_insights_service.py
+++ b/tests/test_insights_service.py
@@ -1931,3 +1931,83 @@ class TestGateRepairLoop:
             ]
         finally:
             await _cleanup_tenant(tenant_id)
+
+
+class TestInsightsWriteMode:
+    """Insight findings are persisted with ``write_mode="strong"``.
+
+    An insight exists to be recalled, and the obvious next action after an evolve
+    cycle is to search for what it produced. Persisted at the deployment's default
+    write mode, a finding lands in the deferred-embed window and a semantic search
+    right after the cycle returns nothing — which reads as "no insights were
+    written". This pins the opt-in that avoids that.
+    """
+
+    @pytest.mark.asyncio
+    async def test_findings_are_persisted_with_strong_write_mode(self, monkeypatch):
+        from core_api.services import insights_service
+
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        agent_id = f"agent-{tag}"
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                fleet_id=None,
+                memory_type="fact",
+                content=f"Fact [{tag}]",
+                visibility="scope_agent",
+            )
+            await _stub_llm(
+                monkeypatch,
+                findings=[
+                    {
+                        "type": "patterns",
+                        "title": "First",
+                        "description": "one",
+                        "confidence": 0.5,
+                        "related_memory_ids": [],
+                        "recommendation": "none",
+                    },
+                    {
+                        "type": "patterns",
+                        "title": "Second",
+                        "description": "two",
+                        "confidence": 0.6,
+                        "related_memory_ids": [],
+                        "recommendation": "none",
+                    },
+                ],
+            )
+
+            # ``_persist_findings`` imports create_memories_bulk inside the
+            # function, so patching the module attribute intercepts the real call.
+            import core_api.services.memory_service as ms_mod
+
+            seen: list = []
+            real_bulk = ms_mod.create_memories_bulk
+
+            async def capturing_bulk(data, *, bulk_attempt_id):
+                seen.extend(data.items)
+                return await real_bulk(data, bulk_attempt_id=bulk_attempt_id)
+
+            monkeypatch.setattr(ms_mod, "create_memories_bulk", capturing_bulk)
+
+            await insights_service.generate_insights(
+                tenant_id=tenant_id,
+                focus="patterns",
+                scope="agent",
+                fleet_id=None,
+                agent_id=agent_id,
+            )
+
+            assert seen, "expected _persist_findings to reach create_memories_bulk"
+            modes = [i.write_mode for i in seen]
+            assert modes == ["strong"] * len(seen), (
+                f"every insight finding must be persisted strong, got {modes} — "
+                "at the deployment default these land in the deferred-embed window "
+                "and a recall right after the evolve cycle finds nothing"
+            )
+        finally:
+            await _cleanup_tenant(tenant_id)


### PR DESCRIPTION
Cloud half of adding a read-your-own-write opt-out to the **bulk** write surface. Prerequisite for the broker change that follows — the broker writes via `/api/v1/memories/bulk`, and that endpoint had no `write_mode` concept at all, so broker-side passthrough alone would have shipped a field the cloud silently drops.

## What was missing

`write_mode` existed only on `MemoryCreate`. Neither `BulkMemoryItem` nor `BulkMemoryCreate` carried it, and the bulk path gated inline embedding purely on `settings.inline_embedding` — `_resolve_write_mode` never ran for bulk. On a deferring deployment, *every* bulk-written memory waited for the background backfill before becoming semantically searchable, with no opt-out.

`write_mode="strong"` on an item now embeds that item inline.

**Per item, not per batch**, deliberately: callers coalesce writes from unrelated sources into one request — the broker's durable queue does exactly this — so a batch-level flag would let one caller's opt-in put a provider call on the request path for everyone else's items, or be lost among them. `tests/test_bulk_write_mode.py` pins the mixed-batch case at `[False, True, False]`.

## Scope boundaries — stated in the field description, not left to be discovered

- **Embedding only.** Single-write `strong` also enriches inline; here enrichment defers either way. Honouring the enrich half would put N semaphored LLM calls on a fan-in request — a much larger commitment than one batched embed.
- **Not routed through `_resolve_write_mode`.** That also consults `tenant_config.default_write_mode` and escalates `_STRONG_TYPES`, which would add a request-path provider call for callers who never asked. Only an explicit per-item opt-in counts. *(Worth a reviewer's opinion: closing that asymmetry is defensible, but it's a latency change for strong-defaulting tenants that nobody requested, so I left it and documented it.)*
- **`str`, not `Literal`.** This model deliberately avoids schema constraints that reject a whole batch over one item's field, so an unrecognised value (`"stm"` copied from a single-write payload) degrades to fast instead of 422-ing every sibling. A `Literal` here would have fought that documented policy.

## Two failure modes handled rather than inherited

**A failed opt-in embed does not fail the request.** Those rows were going to defer anyway, so falling through to the background re-embed costs only the latency they'd have had — where raising would let one opt-in item take down a batch of items that never asked for inline embedding. Inline deployments keep the pre-existing contract: the embed is how every row there gets its vector, so a timeout is still 504 and other errors still propagate.

**The opt-in embed gets its own tighter deadline** — `BULK_STRONG_EMBED_TIMEOUT_SECONDS = 8.0` instead of borrowing the required path's 30s. A required embed can justify 30s because the alternative is a 504; an opportunistic one would spend it and then land on the outcome it already accepted for free, with the latency charged to the whole batch. The 8s is bounded on both sides and both bounds matter: it must stay **above** `EMBEDDING_GATE_TIMEOUT_SECONDS` (5.0), which sits deliberately below callers' deadlines so a saturated gate reads as attributable backpressure rather than an anonymous timeout. A unit test pins both bounds.

No double work: an inline-embedded item is excluded from `reembed_batch` by the existing `embeddings[orig_idx] is None` gate and reaches contradiction detection with its vector in hand.

## One thing I built, then deliberately removed

I had this also setting `metadata.embedding_pending` on deferred bulk rows, for parity with the single path. I dropped it after checking what clears it: **nothing does, on this path.** core-worker clears the flag via `metadata_patch` (its docstring: that exists "so a read-after-success returns clean state instead of confusingly claiming the row is still pending"), but bulk backfills in-process through `_reembed_memories_bulk` → core-api's `update_embedding`, which sends only `{embedding, tenant_id}`.

Every deferred bulk row would have claimed to be pending forever, including after it was embedded and searchable — worse than no signal at all, given #706 documented that flag as the read-your-own-write indicator and `plugin/tools.json` tells agents not to re-write on it. `BulkItemResult` returns no metadata either, so it bought nothing at write time. Making it honest means teaching `update_embedding` to patch metadata, which is its own change.

Also corrects two comments this change falsified: `insights_service`'s note that "`BulkMemoryItem` carries no `write_mode` field", and the `MemoryOut.metadata` note I added in #706, which described single-write `strong` in terms that don't hold for bulk.

## Verification

Full suite against local pgvector with `alembic upgrade head`:

| | passed | xfailed | xpassed |
|---|---|---|---|
| `main` | 4088 | 1 | 0 |
| this branch | 4096 | 1 | 0 |

+8 is exactly the added tests, with **no change to any existing test's behaviour** — worth stating, since this touches a write path much of the suite exercises.

Every new assertion confirmed load-bearing by mutation, inverting rather than deleting:

| mutation | result |
|---|---|
| drop the strong subset | opt-in + mixed-batch cases fail |
| make the opportunistic embed fatal | fallback case fails |
| remove the timeout→504 mapping | inline-deployment case fails |
| raise the opt-in budget to the required cap | bounds test fails (`assert 30.0 < 30.0`) |

`ruff check` and `ruff format --check` clean, run separately and from inside `core-api`; `mypy` clean on 190 files.

## Known follow-ups, not in scope here

- A `strong` item that turns out to be a **content duplicate** still pays a discarded embed — the embed runs before the hash-dedup lookup. Pre-existing ordering for inline deployments, newly reachable on deferring ones, and the fix is a reorder of an existing hot path.
- The MCP `memclaw_write` batch branch doesn't forward a top-level `write_mode` into items. The param is accurately documented "(single only)", so nothing is misleading today, but per-item mode isn't reachable from that surface.
