### PR TITLE
feat(insights): persist findings with write_mode="strong"

### DIFF
--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -911,17 +911,29 @@ async def _persist_findings(
     # write_mode behaviour change vs the pre-#29 path
     # -----------------------------------------------
     # The previous serial path passed ``write_mode="strong"`` on every
-    # ``MemoryCreate``. ``BulkMemoryItem`` now carries a ``write_mode`` too, but
-    # it governs only whether the embedding runs inline, and these items don't
-    # set it — so the bulk path still drops the strong mode override in the sense
-    # that matters below. The only behavioural delta between the strong and
-    # fast pipelines is the inline ``CheckSemanticDuplicate`` step (see
-    # ``core_api/pipeline/compositions/write.py``); everything else
-    # (embed, enrich, exact-dedup, write, schedule background tasks) is
-    # identical. The post-write fire-and-forget tasks — entity extraction,
-    # async contradiction detection, deferred enrichment — are still
-    # scheduled per memory by the bulk path's ``ScheduleBackgroundTasks``-
-    # equivalent loop, so contradiction detection coverage is intact.
+    # ``MemoryCreate``. The items below set it again, so the inline-embed half of
+    # that is restored: a finding is semantically searchable the moment this
+    # persist returns rather than after the deferred backfill.
+    #
+    # It is only that half. ``BulkMemoryItem.write_mode`` governs the embedding
+    # and nothing else — the inline ``CheckSemanticDuplicate`` step (see
+    # ``core_api/pipeline/compositions/write.py``) has no bulk equivalent at any
+    # write_mode, so the strong pipeline's one other behavioural delta stays
+    # dropped here regardless. That is fine for insights, for the reason spelled
+    # out below; the point is that "strong" on this path is not the same promise
+    # as "strong" on the single-write path, and reading it as such would be wrong.
+    #
+    # Everything else (enrich, exact-dedup, write, schedule background tasks) was
+    # already identical between the two pipelines. The post-write
+    # fire-and-forget tasks — entity extraction, async contradiction detection,
+    # deferred enrichment — are still scheduled per memory by the bulk path's
+    # ``ScheduleBackgroundTasks``-equivalent loop, so contradiction detection
+    # coverage is intact.
+    #
+    # Cost: one batched embedding call per evolve cycle moves onto the request
+    # path, capped by ``BULK_STRONG_EMBED_TIMEOUT_SECONDS`` and falling back to
+    # the backfill if the provider fails, so the worst case is the latency this
+    # path had before rather than a failed persist.
     #
     # Why dropping inline semantic dedup is acceptable for insights
     # specifically: the supersede-priors block above ALREADY transitions
@@ -964,6 +976,13 @@ async def _persist_findings(
                 memory_type="insight",
                 content=content,
                 weight=confidence,
+                # Embed inline so a finding is semantically searchable as soon as
+                # this persist returns. An insight exists to be recalled, and the
+                # obvious next action after an evolve cycle is to search for what
+                # it produced — landing in the backfill window makes it look like
+                # nothing was written. See the write_mode note above for what this
+                # does and does not restore.
+                write_mode="strong",
                 metadata={
                     "insight_focus": focus,
                     "insight_scope": scope,

--- a/tests/test_insights_service.py
+++ b/tests/test_insights_service.py
@@ -1931,3 +1931,83 @@ class TestGateRepairLoop:
             ]
         finally:
             await _cleanup_tenant(tenant_id)
+
+
+class TestInsightsWriteMode:
+    """Insight findings are persisted with ``write_mode="strong"``.
+
+    An insight exists to be recalled, and the obvious next action after an evolve
+    cycle is to search for what it produced. Persisted at the deployment's default
+    write mode, a finding lands in the deferred-embed window and a semantic search
+    right after the cycle returns nothing — which reads as "no insights were
+    written". This pins the opt-in that avoids that.
+    """
+
+    @pytest.mark.asyncio
+    async def test_findings_are_persisted_with_strong_write_mode(self, monkeypatch):
+        from core_api.services import insights_service
+
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        agent_id = f"agent-{tag}"
+        try:
+            await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                fleet_id=None,
+                memory_type="fact",
+                content=f"Fact [{tag}]",
+                visibility="scope_agent",
+            )
+            await _stub_llm(
+                monkeypatch,
+                findings=[
+                    {
+                        "type": "patterns",
+                        "title": "First",
+                        "description": "one",
+                        "confidence": 0.5,
+                        "related_memory_ids": [],
+                        "recommendation": "none",
+                    },
+                    {
+                        "type": "patterns",
+                        "title": "Second",
+                        "description": "two",
+                        "confidence": 0.6,
+                        "related_memory_ids": [],
+                        "recommendation": "none",
+                    },
+                ],
+            )
+
+            # ``_persist_findings`` imports create_memories_bulk inside the
+            # function, so patching the module attribute intercepts the real call.
+            import core_api.services.memory_service as ms_mod
+
+            seen: list = []
+            real_bulk = ms_mod.create_memories_bulk
+
+            async def capturing_bulk(data, *, bulk_attempt_id):
+                seen.extend(data.items)
+                return await real_bulk(data, bulk_attempt_id=bulk_attempt_id)
+
+            monkeypatch.setattr(ms_mod, "create_memories_bulk", capturing_bulk)
+
+            await insights_service.generate_insights(
+                tenant_id=tenant_id,
+                focus="patterns",
+                scope="agent",
+                fleet_id=None,
+                agent_id=agent_id,
+            )
+
+            assert seen, "expected _persist_findings to reach create_memories_bulk"
+            modes = [i.write_mode for i in seen]
+            assert modes == ["strong"] * len(seen), (
+                f"every insight finding must be persisted strong, got {modes} — "
+                "at the deployment default these land in the deferred-embed window "
+                "and a recall right after the evolve cycle finds nothing"
+            )
+        finally:
+            await _cleanup_tenant(tenant_id)


### PR DESCRIPTION
Your call from #710's review, implemented.

> **Base is `feat/bulk-write-mode-inline-embed` (#710), not `main`** — the field does nothing without that PR's mechanism. GitHub will retarget this to `main` once #710 merges. The diff here is one commit.

## Why

An insight exists to be recalled, and the obvious next action after an evolve cycle is to search for what it produced. Persisted at the deployment's default write mode, a finding lands in the deferred-embed window — so a semantic search straight after the cycle returns nothing, which reads as *"no insights were written"*.

This restores the inline-embed half of what the pre-#29 serial path had. That path passed `write_mode="strong"` on every `MemoryCreate`; the migration to `create_memories_bulk` dropped it because `BulkMemoryItem` had no such field. It has one now, so this is the field that comment block was written to apologise for finally getting used.

## What it does *not* restore, stated rather than implied

`BulkMemoryItem.write_mode` governs the embedding and nothing else. The strong pipeline's other behavioural delta is the inline `CheckSemanticDuplicate` step, which has **no bulk equivalent at any `write_mode`** — so that stays dropped.

That's fine for insights, for the reason already documented directly below in that comment: the supersede-priors block transitions any prior insight for this focus/scope/agent to `outdated` before this persist runs, which covers the cross-run "same insight regenerated" case. The reason to spell it out is that *"strong" here is not the same promise as "strong" on the single-write path*, and a future reader who assumes parity would be wrong.

## Cost, and why opting in is safe

One batched embedding call per evolve cycle moves onto the request path, capped by `BULK_STRONG_EMBED_TIMEOUT_SECONDS` (8s default, derived from the embedding concurrency gate) and **falling back to the background backfill if the provider fails**. So the worst case is the latency this path already had — not a failed persist. That fallback, from #710, is what makes this an opt-in rather than a reliability trade.

## Verification

The test captures the items at the `create_memories_bulk` boundary and asserts every one carries the mode. Confirmed load-bearing rather than assumed — flipping the value to `"fast"`:

```
assert ['fast', 'fast'] == ['strong', 'strong']
```

| | passed | xfailed | xpassed |
|---|---|---|---|
| #710 head (base) | 4116 | 1 | 0 |
| this branch | 4117 | 1 | 0 |

+1 is exactly the added test. `ruff check` and `ruff format --check` clean from inside `core-api`; `mypy` clean on 190 files; broker OpenAPI baseline unaffected.
