### PR TITLE
feat(bench): first-stage blend A/B on LoCoMo, and share the harness plumbing

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -106,6 +106,48 @@ first-stage also applies freshness decay, weight blending and recall boost. It
 answers "is the cross-encoder worth its latency", not "what is the end-to-end
 pipeline delta".
 
+### First-stage retrieval, specifically
+
+[`scripts/benchmark_blend_locomo.py`](scripts/benchmark_blend_locomo.py) is the
+companion one stage earlier: it varies the **first-stage** score, so which turns
+are retrieved at all is what moves, and **recall** is the headline rather than an
+invariant. It A/Bs the keyword half of
+
+```
+similarity = (1 - FTS_WEIGHT) * vec_sim + FTS_WEIGHT * fts_score
+```
+
+by rescaling `ts_rank_cd` before saturation (`--k`; `k=1` is today's
+`r/(1+r)` formula), ranking the *whole* corpus in both arms. Reports
+recall@5/@10/@20, nDCG@10 and MRR with the same paired bootstrap CI and sign
+test, overall, per category, and — separately — over just the queries where
+`plainto_tsquery` matched anything, since the rest are a mathematical no-op that
+only dilutes the average.
+
+Unlike the rerank harness it needs a Postgres, because `ts_rank_cd` is the thing
+under test and reimplementing Postgres FTS in Python would measure something
+else. Any empty database works; it uses a `TEMP` table and never touches
+application tables.
+
+```bash
+python scripts/benchmark_blend_locomo.py \
+    --dataset locomo10.json \
+    --embed-url http://localhost:8080 \
+    --pg-dsn postgresql://memclaw:changeme@localhost:5433/memclaw \
+    --k 6
+```
+
+`k=1` asserts a delta of exactly zero on every metric — a self-check that the
+harness isn't manufacturing differences the change cannot cause.
+
+Two limits worth knowing before quoting a number from it. Only ~17% of LoCoMo
+questions lexically match any turn (they are paraphrases), so the overall delta is
+diluted by a large majority of queries the change cannot affect — read the
+`fts-matched-only` block for the effect on queries it applies to. And the measured
+effect rises monotonically with `k` across the range tested, so this benchmark can
+say whether more keyword weight helps on LoCoMo, but it does **not** locate an
+optimum; don't read the largest `k` as the best one.
+
 ## How MemClaw compares
 
 For a single chatbot, the public-benchmark leaders (MemClaw, Mem0, Zep) cluster

--- a/scripts/_locomo_bench.py
+++ b/scripts/_locomo_bench.py
@@ -1,0 +1,187 @@
+"""Shared pieces for the LoCoMo benchmark harnesses.
+
+Extracted from ``benchmark_rerank_locomo.py`` when the first-stage blend harness
+(``benchmark_blend_locomo.py``) needed the same dataset loader, embedding client
+and paired statistics. The two harnesses measure different stages and keep their
+own docstrings, arms and metrics; only the parts that are genuinely stage-agnostic
+live here.
+
+Stdlib only, deliberately — the rerank harness runs against ``docker compose``
+with no installed dependencies, and this must not take that away from it.
+"""
+
+from __future__ import annotations
+
+import ast
+import collections
+import json
+import math
+import statistics
+import urllib.error
+import urllib.request
+
+CATEGORIES = {1: "multi-hop", 2: "temporal", 3: "open-domain", 4: "single-hop"}
+
+
+# ------------------------------------------------------------------------ http
+
+
+def _post(url: str, body: dict, api_key: str = "", timeout: float = 180.0) -> object:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode(), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as exc:  # surface the body — it says what's wrong
+        raise SystemExit(f"POST {url} -> {exc.code}: {exc.read()[:400]!r}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"POST {url} unreachable: {exc.reason}") from exc
+
+
+def embed(
+    texts: list[str], url: str, model: str, api_key: str, batch: int
+) -> list[list[float]]:
+    out: list[list[float]] = []
+    for i in range(0, len(texts), batch):
+        r = _post(
+            f"{url}/v1/embeddings",
+            {"model": model, "input": texts[i : i + batch]},
+            api_key,
+        )
+        out.extend(d["embedding"] for d in r["data"])
+    return out
+
+
+# --------------------------------------------------------------------- dataset
+
+
+def load_locomo(path: str) -> list[dict]:
+    """Flatten LoCoMo into {sample_id, docs[{id,text}], queries[{q,expected,cat}]}."""
+    with open(path) as fh:
+        raw = json.load(fh)
+    samples, skipped = [], collections.Counter()
+    for sample in raw:
+        turns = []
+        for value in sample["conversation"].values():
+            if not isinstance(value, list):
+                continue  # session_N_date_time and the speaker names
+            for t in value:
+                if isinstance(t, dict) and t.get("dia_id") and t.get("text"):
+                    # keep the speaker: who said it is part of what makes a turn
+                    # the right answer to "when did X do Y".
+                    turns.append(
+                        {
+                            "id": t["dia_id"],
+                            "text": f"{t.get('speaker', '?')}: {t['text']}",
+                        }
+                    )
+        ids = {t["id"] for t in turns}
+
+        queries = []
+        for qa in sample["qa"]:
+            try:
+                cat = int(qa.get("category"))
+            except (TypeError, ValueError):
+                cat = None
+            if cat not in CATEGORIES:
+                skipped[f"category-{cat}"] += 1
+                continue
+            evidence = qa.get("evidence")
+            if isinstance(evidence, str):
+                # the published file stores this as a str repr of a list
+                try:
+                    evidence = ast.literal_eval(evidence)
+                except (ValueError, SyntaxError):
+                    evidence = None
+            evidence = [e for e in (evidence or []) if e in ids]
+            if not evidence:
+                skipped["unresolvable-evidence"] += 1
+                continue
+            queries.append(
+                {"q": qa["question"], "expected": evidence, "cat": CATEGORIES[cat]}
+            )
+        samples.append(
+            {"sample_id": sample["sample_id"], "docs": turns, "queries": queries}
+        )
+
+    print(
+        f"loaded {len(samples)} conversations · "
+        f"{sum(len(s['docs']) for s in samples)} turns · "
+        f"{sum(len(s['queries']) for s in samples)} scorable questions"
+    )
+    if skipped:
+        print(f"  excluded: {dict(skipped)}")
+    return samples
+
+
+# --------------------------------------------------------------------- metrics
+
+
+def _dcg(rels: list[float]) -> float:
+    return sum(r / math.log2(i + 2) for i, r in enumerate(rels))
+
+
+def ndcg(rels: list[float], k: int, n_relevant: int) -> float:
+    ideal = _dcg([1.0] * min(n_relevant, k))
+    return _dcg(rels[:k]) / ideal if ideal else 0.0
+
+
+def mrr(rels: list[float]) -> float:
+    for i, r in enumerate(rels):
+        if r:
+            return 1.0 / (i + 1)
+    return 0.0
+
+
+def recall(rels: list[float], k: int, n_relevant: int) -> float:
+    """Share of ALL relevant docs that made the top ``k``.
+
+    Only meaningful when the ranking covers the whole corpus. A harness that
+    scores a fixed candidate pool holds this constant by construction, so it
+    reports ordering metrics instead.
+    """
+    return sum(rels[:k]) / n_relevant if n_relevant else 0.0
+
+
+def unit(v: list[float]) -> list[float]:
+    n = math.sqrt(sum(x * x for x in v))
+    return [x / n for x in v] if n else v
+
+
+# ------------------------------------------------------------------ statistics
+
+
+def paired_stats(deltas: list[float], rng) -> dict:
+    """Paired bootstrap CI + exact two-sided sign test over per-query deltas.
+
+    Paired because both arms answer the SAME queries: the per-query difference
+    removes query difficulty, which is the dominant source of variance here and
+    would otherwise swamp the effect being measured.
+    """
+    boots = sorted(
+        statistics.fmean([deltas[rng.randrange(len(deltas))] for _ in range(len(deltas))])
+        for _ in range(4000)
+    )
+    lo, hi = boots[100], boots[3900]
+    better = sum(1 for d in deltas if d > 1e-9)
+    worse = sum(1 for d in deltas if d < -1e-9)
+    n = better + worse
+    p = (
+        min(1.0, 2 * sum(math.comb(n, i) for i in range(min(better, worse) + 1)) / 2**n)
+        if n
+        else 1.0
+    )
+    return {
+        "ci": [lo, hi],
+        "better": better,
+        "worse": worse,
+        "ties": len(deltas) - n,
+        "sign_p": p,
+        # A CI straddling zero means the sample can't distinguish the arms —
+        # report it as such rather than quoting the point estimate alone.
+        "significant": not (lo <= 0 <= hi),
+    }

--- a/scripts/benchmark_blend_locomo.py
+++ b/scripts/benchmark_blend_locomo.py
@@ -1,0 +1,310 @@
+"""First-stage blend A/B on LoCoMo — does rescaling ``fts_score`` retrieve better?
+
+The companion to ``benchmark_rerank_locomo.py``, one stage earlier. That harness
+holds a cosine-selected pool fixed and asks whether a reranker orders it better,
+so recall is constant by construction. This one varies the FIRST-STAGE score, so
+which turns are retrieved at all is the thing that moves — and recall is therefore
+the headline metric rather than an invariant.
+
+What is under test is the blend in ``postgres_service._execute_scored_search``:
+
+    similarity = (1 - fts_weight) * vec_sim + fts_weight * fts_score
+
+``fts_score`` today is ``ts_rank_cd / (1 + ts_rank_cd)``. Because
+``memories.search_vector`` is built by migration 001 as a bare
+``to_tsvector('english', content)`` with no ``setweight``, every lexeme carries
+weight D = 0.1, so a typical single-occurrence match scores ~0.0909 while cosine
+on the same corpus runs far higher. The nominal ``FTS_WEIGHT`` therefore does not
+survive the difference in dynamic range. See
+``HANDOFF-2026-08-04-fts-score-scale-normalisation.md``.
+
+    corpus      one LoCoMo conversation's dialogue turns
+    baseline    blend using today's fts_score = r/(1+r)
+    treatment   blend using (k*r)/(1+k*r)  — --k scales before saturation
+    truth       the QA item's ``evidence`` turn ids (binary relevance)
+    ranking     the WHOLE corpus, both arms — no fixed pool
+
+Both arms use identical embeddings and identical ``ts_rank_cd`` values; the only
+difference is the scalar map applied to the rank. ``--k 1`` makes the treatment
+mathematically identical to the baseline, which the harness asserts produces
+exactly zero delta — a self-check that the plumbing isn't inventing differences.
+
+Unlike the rerank harness this needs a **Postgres**, because ``ts_rank_cd`` is
+what it is measuring and reimplementing Postgres FTS in Python would measure
+something else. Any empty database works; the script creates a temp table per
+conversation and never touches application tables.
+
+    python scripts/benchmark_blend_locomo.py \\
+        --dataset locomo10.json \\
+        --embed-url http://localhost:8080 \\
+        --pg-dsn postgresql://memclaw:changeme@localhost:5433/memclaw
+
+Caveat to carry into any conclusion: this measures the blend in isolation. The
+real first-stage additionally applies freshness decay, weight blending and recall
+boost, and then a candidate LIMIT. Those are held out on purpose — they are
+row-age dependent and would add variance unrelated to the scale question — so this
+is not the end-to-end pipeline delta.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import statistics
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _locomo_bench import (  # noqa: E402  (path shim above must run first)
+    CATEGORIES,
+    embed,
+    load_locomo,
+    mrr,
+    ndcg,
+    paired_stats,
+    recall,
+    unit,
+)
+
+# Recall first: it is the question this harness exists to answer, and the one the
+# ranking change can get wrong. The ordering metrics come along because a change
+# that holds recall flat while ordering worse is still a regression.
+METRICS = ("recall@5", "recall@10", "recall@20", "ndcg@10", "mrr")
+
+
+def _score(rels: list[float], n_relevant: int) -> dict[str, float]:
+    return {
+        "recall@5": recall(rels, 5, n_relevant),
+        "recall@10": recall(rels, 10, n_relevant),
+        "recall@20": recall(rels, 20, n_relevant),
+        "ndcg@10": ndcg(rels, 10, n_relevant),
+        "mrr": mrr(rels),
+    }
+
+
+def _saturate(raw: float, k: float) -> float:
+    """``(k*r)/(1+k*r)`` — today's formula is this with k = 1."""
+    scaled = k * raw
+    return scaled / (1.0 + scaled)
+
+
+# ------------------------------------------------------------------ postgres fts
+
+
+async def _ts_rank_cd(dsn: str, texts: list[str], queries: list[str]) -> list[list[float]]:
+    """Return ``ts_rank_cd`` per (query, doc), using real Postgres FTS.
+
+    Mirrors production exactly: ``to_tsvector('english', content)`` with no
+    ``setweight`` (migration 001's trigger) and ``plainto_tsquery('english', q)``
+    (``_execute_scored_search``). Non-matching pairs come back 0.0, which is what
+    the SQL ``ts_rank_cd`` yields and therefore what the blend sees.
+    """
+    import asyncpg
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        await conn.execute("CREATE TEMP TABLE bench_turns (i int, tsv tsvector)")
+        await conn.executemany(
+            "INSERT INTO bench_turns (i, tsv) VALUES ($1, to_tsvector('english', $2))",
+            list(enumerate(texts)),
+        )
+        # One statement per query, all docs at once. Every doc comes back whether
+        # it matched or not: `ts_rank_cd` scores a non-match as 0 rather than
+        # omitting it, and `ORDER BY t.i` holds the rows in `texts` order — so the
+        # caller gets a genuine 0.0 per miss instead of a gap it has to
+        # reconstruct. (`ts_rank_cd` returns NULL only for a NULL tsvector, which
+        # `to_tsvector` of a non-null text cannot produce, so there is nothing to
+        # COALESCE away.)
+        out = []
+        for q in queries:
+            rows = await conn.fetch(
+                """
+                SELECT t.i, ts_rank_cd(t.tsv, plainto_tsquery('english', $1)) AS r
+                FROM bench_turns t
+                ORDER BY t.i
+                """,
+                q,
+            )
+            out.append([float(r["r"]) for r in rows])
+        return out
+    finally:
+        await conn.close()
+
+
+# ------------------------------------------------------------------------- run
+
+
+def run_conversation(conv: dict, args: argparse.Namespace) -> list[dict]:
+    texts = [d["text"] for d in conv["docs"]]
+    ids = [d["id"] for d in conv["docs"]]
+    queries = [q["q"] for q in conv["queries"]]
+    if not queries:
+        return []
+
+    dvecs = [
+        unit(v)
+        for v in embed(texts, args.embed_url, args.embed_model, args.embed_api_key, args.embed_batch)
+    ]
+    qvecs = [
+        unit(v)
+        for v in embed(queries, args.embed_url, args.embed_model, args.embed_api_key, args.embed_batch)
+    ]
+    raw_ranks = asyncio.run(_ts_rank_cd(args.pg_dsn, texts, queries))
+
+    w = args.fts_weight
+    rows = []
+    for q, qvec, raws in zip(conv["queries"], qvecs, raw_ranks):
+        expected = set(q["expected"])
+        n_relevant = len(expected)
+        # vec_sim is cosine on unit vectors, matching `1 - cosine_distance` for
+        # the embedded rows this corpus is entirely made of.
+        vsims = [sum(a * b for a, b in zip(qvec, d)) for d in dvecs]
+
+        def ranked(k: float) -> list[float]:
+            scored = [
+                ((1.0 - w) * v + w * _saturate(r, k), i) for i, (v, r) in enumerate(zip(vsims, raws))
+            ]
+            # Descending by blended similarity; index breaks ties so both arms
+            # order equal-scoring docs identically and a tie can't masquerade as
+            # a win for either.
+            scored.sort(key=lambda t: (-t[0], t[1]))
+            return [1.0 if ids[i] in expected else 0.0 for _, i in scored]
+
+        base_rels = ranked(1.0)
+        treat_rels = ranked(args.k)
+        # Full-corpus ranking, so both arms see every relevant doc somewhere.
+        # If that stops holding, recall@k is no longer comparable.
+        assert sum(base_rels) == sum(treat_rels) == n_relevant, (
+            "a relevant turn is missing from the ranking — the corpus is not whole"
+        )
+
+        rows.append(
+            {
+                "category": q["cat"],
+                "baseline": _score(base_rels, n_relevant),
+                "treatment": _score(treat_rels, n_relevant),
+                "fts_hit": any(r > 0 for r in raws),
+            }
+        )
+    return rows
+
+
+def report(label: str, rows: list[dict], args: argparse.Namespace) -> dict | None:
+    if not rows:
+        print(f"\n{label}: nothing scorable")
+        return None
+
+    hits = sum(1 for r in rows if r["fts_hit"])
+    print(f"\n=== {label} — n={len(rows)} · fts matched on {hits}/{len(rows)} queries ===")
+    print(
+        f"  {'metric':10s} {'k=1 (today)':>12s} {f'k={args.k:g}':>10s} {'delta':>9s} "
+        f"{'95% CI':>20s} {'better/worse/tie':>18s} {'sign p':>8s}"
+    )
+
+    rng = random.Random(args.seed)
+    out = {}
+    for m in METRICS:
+        deltas = [r["treatment"][m] - r["baseline"][m] for r in rows]
+        base = statistics.fmean(r["baseline"][m] for r in rows)
+        treat = statistics.fmean(r["treatment"][m] for r in rows)
+        st = paired_stats(deltas, rng)
+        out[m] = {"baseline": base, "treatment": treat, "delta": treat - base, **st}
+        lo, hi = st["ci"]
+        print(
+            f"  {m:10s} {base:12.4f} {treat:10.4f} {treat - base:+9.4f} "
+            f"[{lo:+.4f},{hi:+.4f}] {st['better']:>6d}/{st['worse']}/{st['ties']:<7d} "
+            f"{st['sign_p']:8.4f}{'  *' if st['significant'] else ''}"
+        )
+
+    if args.k == 1.0:
+        # The treatment formula IS the baseline at k=1, so any non-zero delta
+        # means the harness is producing a difference the change cannot cause.
+        for m in METRICS:
+            assert abs(out[m]["delta"]) < 1e-12, (
+                f"k=1 must reproduce the baseline exactly; {m} moved by {out[m]['delta']}"
+            )
+        print("  self-check: k=1 reproduced the baseline exactly on every metric")
+    return {"n": len(rows), "fts_hits": hits, "metrics": out}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--dataset", required=True, help="path to locomo10.json")
+    ap.add_argument("--embed-url", required=True, help="base URL exposing /v1/embeddings")
+    ap.add_argument(
+        "--pg-dsn",
+        default="postgresql://memclaw:changeme@localhost:5433/memclaw",
+        help="any empty Postgres; used only for ts_rank_cd via a TEMP table",
+    )
+    ap.add_argument("--embed-model", default="BAAI/bge-m3")
+    ap.add_argument("--embed-api-key", default="")
+    ap.add_argument("--embed-batch", type=int, default=32)
+    ap.add_argument(
+        "--k",
+        type=float,
+        default=6.0,
+        help="scale applied to ts_rank_cd before saturation. 1 = today's formula "
+        "(and asserts a zero delta). ~6 puts a single-term match near the cosine "
+        "range, making the effective FTS weight match the nominal one.",
+    )
+    ap.add_argument(
+        "--fts-weight",
+        type=float,
+        default=0.3,
+        help="FTS_WEIGHT from core_api.constants (default matches production)",
+    )
+    ap.add_argument("--limit-conversations", type=int, default=0, help="0 = all")
+    ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument("--json-out", default="", help="write the full result as JSON")
+    args = ap.parse_args()
+
+    if not 0.0 <= args.fts_weight <= 1.0:
+        raise SystemExit("--fts-weight must be in [0, 1]")
+    if args.k <= 0:
+        raise SystemExit("--k must be > 0")
+
+    convs = load_locomo(args.dataset)
+    if args.limit_conversations:
+        convs = convs[: args.limit_conversations]
+
+    all_rows: list[dict] = []
+    for conv in convs:
+        rows = run_conversation(conv, args)
+        all_rows.extend(rows)
+        print(f"  {conv['sample_id']}: {len(rows)} queries scored")
+
+    result = {"overall": report("overall", all_rows, args)}
+
+    # The subgroup that can actually move. Where plainto_tsquery matches no turn,
+    # fts_score is 0 in BOTH arms and the rescale is a mathematical no-op — those
+    # queries only dilute the overall delta toward zero. Reporting them separately
+    # keeps "small effect" and "small effect on the queries it applies to" from
+    # being confused, which is the difference that decides whether to ship.
+    matched = [r for r in all_rows if r["fts_hit"]]
+    if matched and len(matched) < len(all_rows):
+        result["fts-matched-only"] = report("fts-matched-only", matched, args)
+
+    for cat in CATEGORIES.values():
+        subset = [r for r in all_rows if r["category"] == cat]
+        if subset:
+            result[cat] = report(cat, subset, args)
+
+    if args.json_out:
+        payload = {
+            "k": args.k,
+            "fts_weight": args.fts_weight,
+            "embed_model": args.embed_model,
+            "seed": args.seed,
+            "results": result,
+        }
+        Path(args.json_out).write_text(json.dumps(payload, indent=2))
+        print(f"\nwrote {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_rerank_locomo.py
+++ b/scripts/benchmark_rerank_locomo.py
@@ -44,16 +44,12 @@ the point, but it is not the end-to-end pipeline delta.
 from __future__ import annotations
 
 import argparse
-import ast
-import collections
 import json
-import math
 import random
 import statistics
 import sys
 import time
-import urllib.error
-import urllib.request
+from pathlib import Path
 
 # LoCoMo's own category numbering. 5 is deliberately absent — see module docstring.
 #
@@ -69,39 +65,22 @@ import urllib.request
 #      lookup ("What did the charity race raise awareness for?")       -> single-hop
 #   5  every answer is literally None                                  -> adversarial
 # Re-check by sampling qa items per category value, not by consulting a summary.
-CATEGORIES = {1: "multi-hop", 2: "temporal", 3: "open-domain", 4: "single-hop"}
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _locomo_bench import (  # noqa: E402  (path shim above must run first)
+    _post,
+    embed,
+    load_locomo,
+    mrr,
+    ndcg,
+    paired_stats,
+    unit,
+)
+
 METRICS = ("ndcg@5", "ndcg@10", "mrr", "p@5")
 
 
 # --------------------------------------------------------------------------- io
-
-
-def _post(url: str, body: dict, api_key: str = "", timeout: float = 180.0) -> object:
-    headers = {"content-type": "application/json"}
-    if api_key:
-        headers["authorization"] = f"Bearer {api_key}"
-    req = urllib.request.Request(url, data=json.dumps(body).encode(), headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as r:
-            return json.load(r)
-    except urllib.error.HTTPError as exc:  # surface the service's own words
-        raise SystemExit(
-            f"{url} returned HTTP {exc.code}: {exc.read()[:400].decode(errors='replace')}"
-        ) from exc
-
-
-def embed(
-    texts: list[str], url: str, model: str, api_key: str, batch: int
-) -> list[list[float]]:
-    out: list[list[float]] = []
-    for i in range(0, len(texts), batch):
-        r = _post(
-            f"{url}/v1/embeddings",
-            {"model": model, "input": texts[i : i + batch]},
-            api_key,
-        )
-        out.extend(d["embedding"] for d in r["data"])
-    return out
 
 
 def rerank(query: str, texts: list[str], url: str, api_key: str) -> list[float]:
@@ -120,89 +99,14 @@ def rerank(query: str, texts: list[str], url: str, api_key: str) -> list[float]:
 # ---------------------------------------------------------------------- dataset
 
 
-def load_locomo(path: str) -> list[dict]:
-    """Flatten LoCoMo into {sample_id, docs[{id,text}], queries[{q,expected,cat}]}."""
-    with open(path) as fh:
-        raw = json.load(fh)
-    samples, skipped = [], collections.Counter()
-    for sample in raw:
-        turns = []
-        for value in sample["conversation"].values():
-            if not isinstance(value, list):
-                continue  # session_N_date_time and the speaker names
-            for t in value:
-                if isinstance(t, dict) and t.get("dia_id") and t.get("text"):
-                    # keep the speaker: who said it is part of what makes a turn
-                    # the right answer to "when did X do Y".
-                    turns.append(
-                        {
-                            "id": t["dia_id"],
-                            "text": f"{t.get('speaker', '?')}: {t['text']}",
-                        }
-                    )
-        ids = {t["id"] for t in turns}
-
-        queries = []
-        for qa in sample["qa"]:
-            try:
-                cat = int(qa.get("category"))
-            except (TypeError, ValueError):
-                cat = None
-            if cat not in CATEGORIES:
-                skipped[f"category-{cat}"] += 1
-                continue
-            evidence = qa.get("evidence")
-            if isinstance(evidence, str):
-                # the published file stores this as a str repr of a list
-                try:
-                    evidence = ast.literal_eval(evidence)
-                except (ValueError, SyntaxError):
-                    evidence = None
-            evidence = [e for e in (evidence or []) if e in ids]
-            if not evidence:
-                skipped["unresolvable-evidence"] += 1
-                continue
-            queries.append(
-                {"q": qa["question"], "expected": evidence, "cat": CATEGORIES[cat]}
-            )
-        samples.append(
-            {"sample_id": sample["sample_id"], "docs": turns, "queries": queries}
-        )
-
-    print(
-        f"loaded {len(samples)} conversations · "
-        f"{sum(len(s['docs']) for s in samples)} turns · "
-        f"{sum(len(s['queries']) for s in samples)} scorable questions"
-    )
-    if skipped:
-        print(f"  excluded: {dict(skipped)}")
-    return samples
-
-
 # ---------------------------------------------------------------------- metrics
-
-
-def _dcg(rels: list[float]) -> float:
-    return sum(r / math.log2(i + 2) for i, r in enumerate(rels))
-
-
-def _ndcg(rels: list[float], k: int, n_relevant: int) -> float:
-    ideal = _dcg([1.0] * min(n_relevant, k))
-    return _dcg(rels[:k]) / ideal if ideal else 0.0
-
-
-def _mrr(rels: list[float]) -> float:
-    for i, r in enumerate(rels):
-        if r:
-            return 1.0 / (i + 1)
-    return 0.0
 
 
 def _score(rels: list[float], n_relevant: int) -> dict[str, float]:
     return {
-        "ndcg@5": _ndcg(rels, 5, n_relevant),
-        "ndcg@10": _ndcg(rels, 10, n_relevant),
-        "mrr": _mrr(rels),
+        "ndcg@5": ndcg(rels, 5, n_relevant),
+        "ndcg@10": ndcg(rels, 10, n_relevant),
+        "mrr": mrr(rels),
         "p@5": sum(rels[:5]) / 5,
     }
 
@@ -212,11 +116,6 @@ def _cosine_ranked(qvec: list[float], dvecs: list[list[float]], pool: int) -> li
     return [i for _, i in sorted(sims, reverse=True)[:pool]]
 
 
-def _unit(v: list[float]) -> list[float]:
-    n = math.sqrt(sum(x * x for x in v))
-    return [x / n for x in v] if n else v
-
-
 # ------------------------------------------------------------------------- run
 
 
@@ -224,7 +123,7 @@ def run_conversation(conv: dict, args: argparse.Namespace) -> list[dict]:
     texts = [d["text"] for d in conv["docs"]]
     ids = [d["id"] for d in conv["docs"]]
     dvecs = [
-        _unit(v)
+        unit(v)
         for v in embed(
             texts,
             args.embed_url,
@@ -234,7 +133,7 @@ def run_conversation(conv: dict, args: argparse.Namespace) -> list[dict]:
         )
     ]
     qvecs = [
-        _unit(v)
+        unit(v)
         for v in embed(
             [q["q"] for q in conv["queries"]],
             args.embed_url,
@@ -300,39 +199,22 @@ def report(label: str, rows: list[dict], pool: int, seed: int) -> dict | None:
         deltas = [r["reranked"][m] - r["baseline"][m] for r in scored]
         base = statistics.fmean(r["baseline"][m] for r in scored)
         rr = statistics.fmean(r["reranked"][m] for r in scored)
-        # paired bootstrap over per-query deltas
-        boots = sorted(
-            statistics.fmean(
-                [deltas[rng.randrange(len(deltas))] for _ in range(len(deltas))]
-            )
-            for _ in range(4000)
-        )
-        lo, hi = boots[100], boots[3900]
-        better = sum(1 for d in deltas if d > 1e-9)
-        worse = sum(1 for d in deltas if d < -1e-9)
-        n = better + worse
-        # exact two-sided binomial sign test over non-tied queries
-        p = (
-            min(
-                1.0,
-                2 * sum(math.comb(n, i) for i in range(min(better, worse) + 1)) / 2**n,
-            )
-            if n
-            else 1.0
-        )
+        st = paired_stats(deltas, rng)
+        lo, hi = st["ci"]
         out[m] = {
             "baseline": base,
             "reranked": rr,
             "delta": rr - base,
             "ci": [lo, hi],
-            "better": better,
-            "worse": worse,
-            "sign_p": p,
+            "better": st["better"],
+            "worse": st["worse"],
+            "sign_p": st["sign_p"],
         }
-        mark = "" if lo <= 0 <= hi else "  *"
+        mark = "" if not st["significant"] else "  *"
         print(
             f"  {m:9s} {base:11.4f} {rr:9.4f} {rr - base:+9.4f} "
-            f"[{lo:+.4f},{hi:+.4f}] {better:>6d}/{worse}/{len(deltas) - n:<7d} {p:8.4f}{mark}"
+            f"[{lo:+.4f},{hi:+.4f}] {st['better']:>6d}/{st['worse']}/{st['ties']:<7d} "
+            f"{st['sign_p']:8.4f}{mark}"
         )
     print(
         f"  top-1 changed on {sum(1 for r in scored if r['top1_changed'])}/{len(scored)}"


### PR DESCRIPTION
Extends #712 one stage earlier, so the `fts_score` scale question from [HANDOFF-2026-08-04](HANDOFF-2026-08-04-fts-score-scale-normalisation.md) is finally measurable — **and measured**.

## Why #712 couldn't answer it

#712 holds a cosine-selected pool fixed and A/Bs a reranker's ordering, so recall is constant *by construction*. Correct for judging a reranker; wrong for a first-stage change, which moves **which rows are retrieved**. Verified rather than assumed: that script contains no reference to `fts`, `fts_score`, `FTS_WEIGHT`, `similarity_blend` or `ts_rank_cd`.

## What this measures

The keyword half of the production blend, `similarity = (1 - FTS_WEIGHT) * vec_sim + FTS_WEIGHT * fts_score`, by rescaling `ts_rank_cd` before saturation (`--k`; `k=1` is today's `r/(1+r)`), ranking the **whole corpus** in both arms so recall can move. Truth is each QA item's `evidence` turn ids. Same paired bootstrap CI + sign test as #712.

## The numbers

Full LoCoMo, **n=1531** scorable questions (FTS matching on 257), MiniLM-L6-v2, `FTS_WEIGHT=0.3`. Delta vs today; `*` = bootstrap CI excludes zero.

| k | overall recall@5 | fts-matched-only recall@5 | matched-only MRR |
|---|---|---|---|
| 1 | +0.0000 | +0.0000 | +0.0000 |
| 3 | +0.0035\* | +0.0211\* | +0.0080\* |
| 6 | +0.0042\* | +0.0250\* | +0.0185\* |
| 10 | +0.0075\* | +0.0445\* | +0.0357\* |
| 20 | +0.0113\* | +0.0672\* | +0.0692\* |

**Recall does not move the wrong way.** It improves at every `k > 1`, significantly on all five metrics, with **zero** queries getting worse on recall@5/@10/@20.

## Three limits I don't want quoted away

- **It does not locate an optimum.** The effect rises monotonically across the entire range tested — so this says more keyword weight helps *on LoCoMo*, not that `k=20` is right. Picking a production `k` needs an argument this benchmark doesn't supply.
- **Weak instrument for this particular change.** LoCoMo questions are paraphrases, so only ~17% lexically match any turn; the other 83% are a mathematical no-op that dilutes the overall delta. Hence the separate `fts-matched-only` block. Production queries skewing more keyword-shaped would show a larger effect — which is what `_adaptive_fts_weight` already assumes.
- **Blend in isolation.** No freshness decay, weight blending, recall boost, or candidate LIMIT. Not the end-to-end pipeline delta.

All three are in `BENCHMARKS.md` too, so the numbers aren't quotable without them.

## Design decisions worth a reviewer's eye

- **Real Postgres for `ts_rank_cd`.** Reimplementing Postgres FTS in Python would measure a different function, and that function's output scale *is* the question. This costs #712's stdlib-only property, so it's confined to a `TEMP` table that never touches application tables, and mirrors production exactly (bare `to_tsvector('english', content)` per migration 001, `plainto_tsquery('english', q)`).
- **`k=1` asserts a delta of exactly zero** on every metric *and* subgroup — the treatment formula *is* the baseline there, so any movement means the harness is manufacturing differences. Passing.
- **Index breaks score ties**, so both arms order equal-scoring docs identically and a tie can't masquerade as a win.

## The refactor, and how it was verified

Shared plumbing moved to `scripts/_locomo_bench.py` (loader, embed client, nDCG/MRR/recall, paired stats) rather than copied. `benchmark_rerank_locomo.py` imports it and **loses 144 lines**, including its own inline bootstrap.

I can't run that harness here — the TEI reranker has no arm64 image, which the repo's own compose overlay notes. So I verified the refactor by **equivalence** instead: same synthetic scored rows, same seed, through `main`'s `report()` and the rewired one →

```
stdout identical: True
returned dict identical: True
```

No test imports either script, and `scripts/` is outside CI's ruff scope. Both harnesses parse, `--help`, and reject bad `--k` / `--fts-weight`.
