### PR TITLE
fix(embedding): chunk bulk embeds to the backend's batch cap, and report bulk-only outages

### DIFF
--- a/common/embedding/_service.py
+++ b/common/embedding/_service.py
@@ -31,6 +31,10 @@ class _EmbeddingStats:
     Three consecutive failures fire a single ERROR log (per cycle) so a
     sustained provider outage shows up loudly without spamming once-per-
     request. Reset on the next success.
+
+    Bulk calls additionally keep their OWN streak, which only a bulk
+    success clears — see :meth:`record_failure` for the outage the shared
+    streak structurally cannot see.
     """
 
     def __init__(self) -> None:
@@ -38,27 +42,94 @@ class _EmbeddingStats:
         self.successes = 0
         self.last_failure_time = 0.0
         self.consecutive_failures = 0
+        self.consecutive_bulk_failures = 0
         self._lock = asyncio.Lock()
 
-    async def record_success(self) -> None:
+    @staticmethod
+    def _is_report_point(streak: int) -> bool:
+        """Report on first detection (3) then every 10th (13, 23, 33, …).
+
+        Loud enough to alert on a fresh outage, quiet enough not to spam
+        during a sustained one — a 10x reduction, NOT a fixed bound:
+        reports still grow linearly with a condition that recurs on every
+        request, so this caps the slope, not the total. The next success
+        resets the streak, so a later outage re-fires from 3.
+        """
+        return streak >= 3 and (streak - 3) % 10 == 0
+
+    async def record_success(self, *, bulk: bool = False) -> None:
+        """*bulk* additionally clears the bulk-only streak."""
         async with self._lock:
             self.successes += 1
             self.consecutive_failures = 0
+            if bulk:
+                self.consecutive_bulk_failures = 0
 
-    async def record_failure(self) -> None:
+    async def record_failure(self, *, bulk_batch_size: int | None = None) -> None:
+        """Count a failure and report at :meth:`_is_report_point`.
+
+        Passing *bulk_batch_size* marks this as a failed BULK call: it
+        advances a second streak that only a bulk success clears, and
+        reports it separately.
+
+        That second streak exists because the shared one cannot see a
+        bulk-only outage. Every path through this module shares one
+        process-wide ``_stats``, so a service that also serves search
+        traffic records a success per query embed, which resets
+        ``consecutive_failures`` and holds it under the threshold no
+        matter how many bulk calls fail in between. Not hypothetical:
+        prod TEI rejected 100% of bulk embeds for 30+ days on a
+        batch-size cap and "Embedding service degraded" never fired once,
+        because query embeds kept clearing the streak.
+
+        What the bulk report adds over the callers' own per-batch ERROR
+        (which already carries the provider's traceback) is the CONSECUTIVE
+        count: N failures with no bulk success in between distinguishes
+        "systematically broken" from "occasionally flaky", which a stream
+        of independent tracebacks cannot. It is not the per-occurrence
+        detector — the callers' ERROR is — so WARNING, not ERROR: by
+        contract this cascades into the per-item fallback, which usually
+        still persists correct embeddings. Degradation, not data loss.
+
+        *bulk_batch_size* is the size the CALLER asked for, which is not
+        necessarily the size of any single request — the provider splits
+        oversized requests to its own backend's cap. The message says so
+        rather than naming a number: this class is provider-agnostic (Fake
+        and Local never chunk; the OpenAI provider's cap is 32 self-hosted
+        but 2048 hosted), so quoting one constant here would be wrong for
+        most backends and would send an operator to re-tune a knob their
+        deployment does not use — the same misdirection in the opposite
+        direction. The size is still worth reporting: it identifies which
+        caller is affected (bulk write at 100 vs re-embed at 50) without
+        expanding a traceback.
+
+        LIMITATION worth knowing: the streak is process-wide and NOT keyed
+        on the provider, so in a multi-tenant process one tenant's healthy
+        bulk success clears a different tenant's broken backend — the same
+        masking, one level down. ``common/ranking``'s ``_permanent_scope``
+        is the per-backend answer; applying it here means keying all of
+        ``_stats``, which is a wider change than this. Do not read the
+        streak as per-backend.
+        """
         async with self._lock:
             self.failures += 1
             self.consecutive_failures += 1
             self.last_failure_time = time.monotonic()
-            # Fire on first detection (failure 3) and then every 10
-            # failures thereafter (13, 23, 33, …). Loud enough to alert
-            # on a fresh outage, quiet enough not to spam during a
-            # sustained provider degradation. The next success resets
-            # the counter, so a subsequent streak re-fires from 3.
-            if (
-                self.consecutive_failures >= 3
-                and (self.consecutive_failures - 3) % 10 == 0
-            ):
+            if bulk_batch_size is not None:
+                self.consecutive_bulk_failures += 1
+                if self._is_report_point(self.consecutive_bulk_failures):
+                    logger.warning(
+                        "Bulk embedding failing: %d consecutive bulk call(s) "
+                        "failed (requested batch=%d), cascading to the "
+                        "per-item fallback. Embeddings may still be correct; "
+                        "batching is not. The provider already splits a "
+                        "request to its own backend's cap, so a batch-size "
+                        "rejection is unlikely — look at auth, network, "
+                        "quota and the callers' timeouts.",
+                        self.consecutive_bulk_failures,
+                        bulk_batch_size,
+                    )
+            if self._is_report_point(self.consecutive_failures):
                 logger.error(
                     "Embedding service degraded: %d consecutive failures (total: %d/%d)",
                     self.consecutive_failures,
@@ -169,6 +240,14 @@ async def get_embeddings_batch(
     degraded-provider trip-wire fires consistently with the single-embed
     paths (``get_embedding`` / ``get_query_embedding``).
 
+    A failed ``embed_batch`` also advances a bulk-only failure streak that
+    single-embed successes cannot reset — see ``record_failure`` for why
+    that is needed and for the incident behind it.
+
+    Note this is the SERVICE layer: a request larger than the backend's
+    accepted batch is split inside the provider, which is the only layer
+    that knows its own cap, so *texts* has no length limit imposed here.
+
     Two error shapes are explicitly accounted for:
 
     1. ``ValueError`` from ``get_embedding_provider`` — env-var
@@ -176,10 +255,11 @@ async def get_embeddings_batch(
        ``SEND_DIMENSIONS`` mismatch). Used to propagate as an unhandled
        exception that bulk callers caught generically but bypassed
        ``_stats.record_failure``, so the trip-wire never fired under
-       sustained misconfig. Now records a failure and re-raises.
+       sustained misconfig. Now records a failure and re-raises. Counted
+       as a plain failure, NOT a bulk failure — the batch never ran.
     2. Any provider-side exception from ``embed_batch`` — auth, HTTP
-       client errors, Vertex quota, etc. Same record_failure + re-raise
-       contract as before.
+       client errors, provider quota, a batch-size cap. Re-raises as
+       before; now also counted as a bulk failure.
     """
     provider_name = _resolve_provider_name(tenant_config)
     # Provider construction and embed dispatch are wrapped in *separate*
@@ -205,14 +285,43 @@ async def get_embeddings_batch(
             "Bulk embedding: provider misconfiguration",
             exc_info=True,
         )
+        # Deliberately NOT record_bulk_failure: the bulk call never ran,
+        # so there is no batch to attribute a bulk-cap-style fault to, and
+        # this branch already logs unconditionally.
         await _stats.record_failure()
         raise
+    # ``BaseException``, not ``Exception``, and deliberately so. Every caller
+    # wraps this in its own deadline (``BULK_STRONG_EMBED_TIMEOUT_SECONDS`` is
+    # 8 s, ``BULK_EMBEDDING_TIMEOUT_SECONDS`` 30 s) using ``asyncio.timeout`` /
+    # ``wait_for``, and when one of those fires it CANCELS us — so what arrives
+    # here is ``CancelledError``, a ``BaseException``. Under ``except
+    # Exception`` the stats update was skipped for that entire class, which is
+    # the slow-provider outage the bulk streak exists to name: a single
+    # provider request may burn ``OPENAI_REQUEST_TIMEOUT_SECONDS`` (25 s), so
+    # the 8 s budget is already exceeded by ONE request, and chunking a
+    # ``BULK_MAX_ITEMS`` write into ceil(100/32) sequential requests puts the
+    # 30 s budget in reach too.
+    #
+    # Safe for real shutdown cancellation: the ``raise`` is unconditional, so
+    # the cancellation always propagates. ``record_failure`` acquires an
+    # uncontended ``asyncio.Lock`` — every critical section in
+    # ``_EmbeddingStats`` is await-free, so the acquire takes its fast path and
+    # never yields, and there is no suspension point at which a pending
+    # cancellation could be re-delivered. If one ever were, we would land back
+    # on today's behaviour (stat missed, cancellation still propagating), never
+    # worse.
+    #
+    # Accepted cost: a cancellation that is NOT a deadline — a client
+    # disconnect, process shutdown — also counts as a bulk failure. Bounded on
+    # both sides: three consecutive are needed to report, the next bulk success
+    # clears the streak, and on the shutdown path the counter dies with the
+    # process anyway.
     try:
         result = await _call_gated(lambda: provider.embed_batch(texts))
-    except Exception:
-        await _stats.record_failure()
+    except BaseException:
+        await _stats.record_failure(bulk_batch_size=len(texts))
         raise
-    await _stats.record_success()
+    await _stats.record_success(bulk=True)
     return result
 
 

--- a/common/embedding/constants.py
+++ b/common/embedding/constants.py
@@ -142,3 +142,43 @@ EMBEDDING_MAX_CONCURRENCY: int = read_int_env("EMBEDDING_MAX_CONCURRENCY", 16)
 EMBEDDING_GATE_TIMEOUT_SECONDS: float = read_float_env(
     "EMBEDDING_GATE_TIMEOUT_SECONDS", 5.0
 )
+
+# Cap the texts sent in ONE provider request; larger inputs are split.
+#
+# This is admission control on the SERVER's side of the wire, mirrored on
+# ours. A self-hosted TEI sidecar defaults ``--max-client-batch-size`` to
+# 32 and answers anything larger with
+# ``413 batch size N > maximum allowed batch size 32`` — while our bulk
+# write path sends up to ``BULK_MAX_ITEMS`` (100) texts in one call and
+# the re-embed path sends ``EMBEDDING_REEMBED_BATCH_SIZE`` (50). Neither
+# chunked, so both were rejected outright.
+#
+# That ran unnoticed in production for 30+ days: the failure cascades into
+# a per-item fallback that produces CORRECT embeddings, so the only
+# symptoms were ~50x the requests and the sidecar's own 413 log. Raising
+# the server's cap fixes one deployment; capping here fixes every
+# deployment, including the docker-compose local-embedder stack, which
+# starts TEI without the flag.
+#
+# 32 to match TEI's own default — the safe assumption about a backend
+# whose cap we cannot see. This applies to SELF-HOSTED, OpenAI-compatible
+# backends, i.e. those reached via ``base_url``; see
+# ``EMBEDDING_HOSTED_MAX_BATCH`` for the hosted default and
+# ``OpenAIEmbeddingProvider`` for the dispatch.
+#
+# ``common/ranking`` reached the identical conclusion first, for the same
+# sidecar and the same 413 — see ``RANK_REMOTE_MAX_BATCH``.
+EMBEDDING_REMOTE_MAX_BATCH: int = read_int_env("EMBEDDING_REMOTE_MAX_BATCH", 32)
+
+# The same cap for HOSTED OpenAI — no ``base_url``, so we know the backend
+# and its documented limit: 2048 inputs per embeddings request.
+#
+# Split from the self-hosted value rather than sharing one number, because
+# 32 is a guess about an opaque sidecar and 2048 is a documented fact
+# about a known API. Collapsing them would silently turn one hosted bulk
+# write of BULK_MAX_ITEMS (100) into 4 sequential round trips for no
+# reason — chunking should cost nothing where the backend accepts the
+# whole batch. Still env-overridable so a hosted deployment that wants
+# smaller requests (rate-limit shaping, latency smoothing) has a
+# config-only lever.
+EMBEDDING_HOSTED_MAX_BATCH: int = read_int_env("EMBEDDING_HOSTED_MAX_BATCH", 2048)

--- a/common/embedding/providers/openai.py
+++ b/common/embedding/providers/openai.py
@@ -9,8 +9,10 @@ import openai
 
 from common.constants import VECTOR_DIM
 from common.embedding.constants import (
+    EMBEDDING_HOSTED_MAX_BATCH,
     EMBEDDING_HTTPX_MAX_CONNECTIONS,
     EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+    EMBEDDING_REMOTE_MAX_BATCH,
     OPENAI_EMBEDDING_MODEL,
     OPENAI_REQUEST_TIMEOUT_SECONDS,
 )
@@ -35,12 +37,43 @@ class OpenAIEmbeddingProvider:
         send_dimensions: bool = True,
         query_instruction: str | None = None,
         truncate_to_dim: int | None = None,
+        max_batch: int | None = None,
     ) -> None:
         self._api_key = api_key
         self._model = model
         self._send_dimensions = send_dimensions
         self._query_instruction = query_instruction
         self._truncate_to_dim = truncate_to_dim
+        # Derived from the backend, because the right cap is a property of
+        # WHICH backend this is. ``base_url`` set means a self-hosted
+        # OpenAI-compatible server whose admission limit we cannot see, so
+        # assume TEI's conservative default; unset means hosted OpenAI,
+        # whose documented limit is 2048 and which gains nothing from being
+        # split. This is the same discriminator the registry already uses
+        # to decide ``send_dimensions``.
+        #
+        # Explicit ``max_batch`` overrides both — injectable so a test can
+        # exercise chunking without a 33-text fixture. The registry never
+        # passes it, so every real provider derives; that is also why it is
+        # not part of the registry's cache key.
+        if max_batch is None:
+            max_batch = (
+                EMBEDDING_REMOTE_MAX_BATCH if base_url else EMBEDDING_HOSTED_MAX_BATCH
+            )
+        # Same defence-in-depth argument as truncate_to_dim above, and the
+        # failure it prevents is worse. The env path is already safe
+        # (``read_int_env`` rejects non-positive), but direct construction
+        # is not, and a non-positive cap does NOT fail cleanly:
+        # ``max_batch=-1`` makes ``range(0, n, -1)`` empty, so embed_batch
+        # returns ZERO embeddings for n texts with no error at all — and
+        # callers zip the result onto rows positionally. Silent data loss.
+        # (``max_batch=0`` raises deep in the loop instead.) Fail here.
+        if max_batch < 1:
+            raise ValueError(
+                f"max_batch={max_batch} must be >= 1; it is the number of "
+                "texts sent per provider request."
+            )
+        self._max_batch = max_batch
         # Defence in depth: the registry's ``get_embedding_provider``
         # already validates this knob before constructing a provider,
         # but direct construction (a one-off script, a migration helper,
@@ -138,8 +171,8 @@ class OpenAIEmbeddingProvider:
         response = await self._client.embeddings.create(**kwargs)
         return self._postprocess(response.data[0].embedding)
 
-    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
-        """Generate embedding vectors for multiple texts in one call."""
+    async def _embed_batch_chunk(self, texts: list[str]) -> list[list[float]]:
+        """One request's worth of texts. Caller guarantees the size cap."""
         kwargs: dict = {"model": self._model, "input": texts}
         if self._send_dimensions:
             kwargs["dimensions"] = VECTOR_DIM
@@ -147,6 +180,44 @@ class OpenAIEmbeddingProvider:
         # OpenAI returns embeddings sorted by index
         sorted_data = sorted(response.data, key=lambda x: x.index)
         return [self._postprocess(item.embedding) for item in sorted_data]
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Embed multiple texts, splitting across requests if needed.
+
+        Chunking is invisible in the result because each text is embedded
+        INDEPENDENTLY — a vector does not depend on what shares its
+        request — so N chunks return exactly what one large call would, in
+        input order. (Contrast ``common/ranking``'s remote reranker, where
+        the same optimisation is only safe because a cross-encoder scores
+        pairs independently, and would break for a listwise model.)
+
+        See ``EMBEDDING_REMOTE_MAX_BATCH`` for why the cap exists: without
+        it, a bulk write of up to ``BULK_MAX_ITEMS`` texts is rejected
+        outright by a TEI sidecar at its default cap of 32, and the
+        failure hides in a per-item fallback that still produces correct
+        embeddings.
+
+        SEQUENTIAL, unlike the reranker's concurrent ``asyncio.gather``.
+        Two reasons, both about not undoing work this module already did:
+        ``_call_gated`` holds ONE ``EMBEDDING_MAX_CONCURRENCY`` slot for
+        this whole call, so fanning out inside it would multiply the real
+        provider concurrency by the chunk count and defeat a cap that
+        exists because of the 2026-07-27 connection-pool exhaustion. And
+        the budget is wide enough not to need it: bulk callers arm 30 s
+        (``BULK_EMBEDDING_TIMEOUT_SECONDS``) where the reranker had 0.5 s,
+        against four ~10 ms sidecar round trips for a 100-text write.
+        """
+        # A pool that fits one request behaves exactly as it did before
+        # chunking existed — no extra allocation, and the provider
+        # exception propagates with its own traceback.
+        if len(texts) <= self._max_batch:
+            return await self._embed_batch_chunk(texts)
+
+        embeddings: list[list[float]] = []
+        for start in range(0, len(texts), self._max_batch):
+            chunk = texts[start : start + self._max_batch]
+            embeddings.extend(await self._embed_batch_chunk(chunk))
+        return embeddings
 
     async def embed_query(
         self, text: str, instruction: str | None = None

--- a/tests/test_embedding_openai_compat.py
+++ b/tests/test_embedding_openai_compat.py
@@ -145,6 +145,170 @@ async def test_embed_batch_respects_send_dimensions(
 
 
 # ---------------------------------------------------------------------------
+# embed_batch chunking — a request larger than the backend's cap is split
+# ---------------------------------------------------------------------------
+
+
+def _size_matched_create(create: AsyncMock) -> None:
+    """Make the mocked ``embeddings.create`` return one vector per input,
+    so a chunked call assembles a correctly-sized result."""
+
+    async def _respond(**kwargs):
+        texts = kwargs["input"]
+        return SimpleNamespace(
+            data=[
+                SimpleNamespace(index=i, embedding=[float(i)] * VECTOR_DIM)
+                for i in range(len(texts))
+            ]
+        )
+
+    create.side_effect = _respond
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_embed_batch_splits_requests_above_max_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A batch larger than ``max_batch`` is split, and no single request
+    exceeds the cap.
+
+    This is the regression test for the 30+ day production bug: a TEI
+    sidecar at its default ``--max-client-batch-size=32`` answered every
+    50-text bulk embed with ``413 batch size 50 > maximum allowed batch
+    size 32``. The failure was invisible because it cascaded into a
+    per-item fallback that produced correct embeddings.
+    """
+    provider, _, create = _patched_provider(monkeypatch, max_batch=32)
+    _size_matched_create(create)
+
+    # 50 is the incident's exact batch size (EMBEDDING_REEMBED_BATCH_SIZE).
+    result = await provider.embed_batch([f"t{i}" for i in range(50)])
+
+    assert len(result) == 50, "chunking must not drop or duplicate texts"
+    sent = [len(call.kwargs["input"]) for call in create.call_args_list]
+    assert sent == [32, 18], f"expected a 32+18 split, got {sent}"
+    assert max(sent) <= 32, "no request may exceed the backend's cap"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_embed_batch_at_or_below_cap_makes_one_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fast path is preserved exactly: a batch that fits sends one
+    request, so chunking costs nothing for the common case."""
+    provider, _, create = _patched_provider(monkeypatch, max_batch=32)
+    _size_matched_create(create)
+
+    result = await provider.embed_batch([f"t{i}" for i in range(32)])
+
+    assert len(result) == 32
+    assert create.await_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_embed_batch_preserves_input_order_across_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chunking must be invisible in the result.
+
+    Each chunk's response is indexed from 0, so concatenating without
+    care would interleave or reorder vectors relative to *texts*. The
+    contract callers rely on (``memory_service`` zips embeddings back
+    onto rows positionally) is that result[i] belongs to texts[i].
+    """
+    provider, _, create = _patched_provider(monkeypatch, max_batch=2)
+
+    async def _respond(**kwargs):
+        # Echo each input's own identity into its vector so a reorder is
+        # detectable rather than merely a length change.
+        return SimpleNamespace(
+            data=[
+                SimpleNamespace(index=i, embedding=[float(t)] * VECTOR_DIM)
+                for i, t in enumerate(kwargs["input"])
+            ]
+        )
+
+    create.side_effect = _respond
+
+    texts = [str(n) for n in range(7)]
+    result = await provider.embed_batch(texts)
+
+    assert [vec[0] for vec in result] == [float(n) for n in range(7)]
+    assert create.await_count == 4  # 2+2+2+1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_hosted_openai_is_not_chunked_at_the_self_hosted_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``base_url`` means hosted OpenAI, which accepts 2048 inputs.
+
+    The 32 default is a guess about an opaque self-hosted sidecar. Applying
+    it to hosted OpenAI would split one bulk write of ``BULK_MAX_ITEMS``
+    into 4 sequential round trips for nothing — chunking must cost nothing
+    where the backend takes the whole batch.
+    """
+    provider, _, create = _patched_provider(monkeypatch)  # no base_url
+    _size_matched_create(create)
+
+    result = await provider.embed_batch([f"t{i}" for i in range(100)])
+
+    assert len(result) == 100
+    assert create.await_count == 1, "hosted OpenAI must not be split at 32"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_self_hosted_base_url_is_chunked_at_the_conservative_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``base_url`` means a backend whose cap we cannot see, so the
+    conservative TEI-shaped default applies — the incident's config."""
+    provider, _, create = _patched_provider(monkeypatch, base_url="http://tei:80/v1")
+    _size_matched_create(create)
+
+    await provider.embed_batch([f"t{i}" for i in range(100)])
+
+    sent = [len(call.kwargs["input"]) for call in create.call_args_list]
+    assert sent == [32, 32, 32, 4], f"expected a 32-capped split, got {sent}"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [0, -1])
+def test_openai_provider_init_rejects_non_positive_max_batch(
+    monkeypatch: pytest.MonkeyPatch, bad: int
+) -> None:
+    """A non-positive cap must fail at construction, not silently.
+
+    ``max_batch=-1`` makes ``range(0, n, -1)`` empty, so ``embed_batch``
+    would return ZERO embeddings for n texts with no error — and callers
+    zip the result onto rows positionally. ``max_batch=0`` raises deep in
+    the loop instead. Neither is acceptable at a distance from the cause.
+    """
+    with pytest.raises(ValueError, match="max_batch"):
+        _patched_provider(monkeypatch, max_batch=bad)
+
+
+@pytest.mark.unit
+def test_embed_batch_default_cap_matches_tei_default() -> None:
+    """The default must not exceed a stock TEI sidecar's own cap.
+
+    ``BULK_MAX_ITEMS`` (100) and ``EMBEDDING_REEMBED_BATCH_SIZE`` (50)
+    both exceed TEI's default of 32, so a default above 32 reintroduces
+    the incident for any deployment that does not pass
+    ``--max-client-batch-size`` — including the docker-compose
+    local-embedder stack.
+    """
+    from common.embedding.constants import EMBEDDING_REMOTE_MAX_BATCH
+
+    assert EMBEDDING_REMOTE_MAX_BATCH <= 32
+
+
+# ---------------------------------------------------------------------------
 # Option B — Matryoshka truncation + L2 renormalization
 # ---------------------------------------------------------------------------
 

--- a/tests/test_embedding_retry.py
+++ b/tests/test_embedding_retry.py
@@ -7,6 +7,7 @@ Unit tests validate:
   - Fake provider never returns None (no retry needed)
 """
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -198,7 +199,6 @@ async def test_value_error_in_provider_construction_does_not_propagate(
     """The degradation guard logs at ERROR level on the first failure
     so operators see the misconfiguration in their logs — silent
     return-None would obscure the cause."""
-    import logging
 
     from common.embedding import get_embedding
 
@@ -229,7 +229,6 @@ async def test_misconfiguration_error_logged_only_once_per_provider(
     gates the ERROR to one emit per resolved provider name per process
     — failure stats still increment on every call so the degraded
     trip-wire keeps working, but the log stays readable."""
-    import logging
 
     from common.embedding import get_embedding
 
@@ -284,3 +283,179 @@ async def test_failure_stats_still_increment_under_misconfig_dedup(
     # one logged.
     assert service_mod._stats.failures == 4
     assert service_mod._stats.consecutive_failures == 4
+
+
+def _bulk_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``get_embeddings_batch`` at a provider whose bulk call always
+    fails and whose single-embed call always succeeds — the shape of a
+    provider-side batch-size cap that the per-item fallback rides out.
+
+    Subclasses the real fake so the stand-in still satisfies the
+    ``EmbeddingProvider`` protocol (``provider_name`` / ``model``) rather
+    than being a shape that could not exist in production.
+    """
+    import common.embedding._service as service_mod
+    from common.embedding.providers.fake import FakeEmbeddingProvider
+
+    class _CappedProvider(FakeEmbeddingProvider):
+        async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+            raise RuntimeError(
+                f"batch size {len(texts)} > maximum allowed batch size 32"
+            )
+
+    monkeypatch.setattr(service_mod, "_stats", service_mod._EmbeddingStats())
+    monkeypatch.setattr(
+        "common.embedding._service.get_embedding_provider",
+        lambda *_a, **_k: _CappedProvider(),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bulk_failure_reports_even_while_single_embeds_succeed(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A bulk-only outage must still report while other paths succeed.
+
+    This is the regression test for the bug that hid for 30+ days: prod
+    TEI rejected 100% of bulk embeds on a batch-size cap while single
+    embeds kept working, and ``consecutive_failures`` — shared by every
+    call path through the process-wide ``_stats`` — was reset by each
+    successful query embed, so the degraded-provider ERROR never fired.
+
+    Interleaving a success after every failure is the whole point: with
+    only ``consecutive_failures`` to go on, the streak never reaches the
+    reporting threshold and NOTHING is logged here.
+    """
+    import common.embedding._service as service_mod
+    from common.embedding import get_embedding, get_embeddings_batch
+
+    _bulk_provider(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="common.embedding._service"):
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                await get_embeddings_batch(["a"] * 50)
+            # A healthy single embed between every bulk failure — exactly
+            # what search traffic does to the shared streak.
+            assert await get_embedding("q") is not None
+
+    assert service_mod._stats.consecutive_failures == 0, (
+        "precondition: the interleaved successes must clear the shared "
+        "streak, otherwise this test is not exercising the masking"
+    )
+
+    matches = [
+        rec
+        for rec in caplog.records
+        if "Bulk embedding failing" in rec.getMessage()
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one bulk-failure report, got {len(matches)}"
+    )
+    # The batch size is the datum that names this class of bug outright.
+    assert "batch=50" in matches[0].getMessage()
+    assert matches[0].levelno == logging.WARNING
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bulk_failure_report_is_rate_limited_not_per_call(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Log volume must not track the traffic curve.
+
+    A batch-size cap fails on EVERY bulk write, so an unconditional
+    warning would put log volume on request rate. Reporting at 3 and then
+    every 10th (13, 23, …) keeps a sustained fault bounded.
+    """
+    from common.embedding import get_embeddings_batch
+
+    _bulk_provider(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="common.embedding._service"):
+        for _ in range(13):
+            with pytest.raises(RuntimeError):
+                await get_embeddings_batch(["a"] * 50)
+
+    matches = [
+        rec
+        for rec in caplog.records
+        if "Bulk embedding failing" in rec.getMessage()
+    ]
+    # 13 consecutive failures, reports at streak 3 and streak 13.
+    assert len(matches) == 2, (
+        f"expected reports at streak 3 and 13, got {len(matches)}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bulk_failure_counted_when_caller_deadline_cancels_us(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller's timeout must still count as a bulk failure.
+
+    Every caller wraps ``get_embeddings_batch`` in its own deadline
+    (``BULK_STRONG_EMBED_TIMEOUT_SECONDS`` is 8s) and enforces it by
+    CANCELLING us, so what arrives is ``CancelledError`` — a
+    ``BaseException``, which ``except Exception`` does not catch. That
+    silently skipped the streak for the slow-provider outage the streak
+    exists to name: one provider request may burn
+    ``OPENAI_REQUEST_TIMEOUT_SECONDS`` (25s), already past the 8s budget.
+    """
+    import asyncio
+
+    import common.embedding._service as service_mod
+    from common.embedding import get_embeddings_batch
+    from common.embedding.providers.fake import FakeEmbeddingProvider
+
+    class _HangingProvider(FakeEmbeddingProvider):
+        async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+            await asyncio.sleep(60)
+            raise AssertionError("unreachable")
+
+    monkeypatch.setattr(service_mod, "_stats", service_mod._EmbeddingStats())
+    monkeypatch.setattr(
+        "common.embedding._service.get_embedding_provider",
+        lambda *_a, **_k: _HangingProvider(),
+    )
+
+    with pytest.raises(TimeoutError):
+        async with asyncio.timeout(0.05):
+            await get_embeddings_batch(["a"] * 50)
+
+    assert service_mod._stats.consecutive_bulk_failures == 1, (
+        "a deadline-cancelled bulk call must advance the bulk streak"
+    )
+    assert service_mod._stats.failures == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bulk_success_rearms_the_bulk_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bulk success clears the bulk streak, so a later regression
+    re-reports from 3 instead of staying silent forever."""
+    import common.embedding._service as service_mod
+    from common.embedding import get_embeddings_batch
+
+    _bulk_provider(monkeypatch)
+
+    for _ in range(3):
+        with pytest.raises(RuntimeError):
+            await get_embeddings_batch(["a"] * 50)
+    # Provider recovers.
+    class _HealthyProvider:
+        async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+            return [[0.0] for _ in texts]
+
+    monkeypatch.setattr(
+        "common.embedding._service.get_embedding_provider",
+        lambda *_a, **_k: _HealthyProvider(),
+    )
+    assert len(await get_embeddings_batch(["a", "b"])) == 2
+    assert service_mod._stats.consecutive_bulk_failures == 0


### PR DESCRIPTION
## The premise changed once I checked prod

The task was "make the embedding fallback audible — one warning when a bulk embed fails and cascades to per-item, so this can never again be invisible."

**The fallback was already audible.** `memory_service.py:2080` logs at ERROR with a full traceback, and the traceback ends in:

```
openai.APIStatusError: Error code: 413 - {'message': 'batch size 50 > maximum allowed batch size 32', 'code': 413, 'type': 'Validation'}
```

87 of those in prod over 30 days, structured JSON, with `dd.trace_id`. The batch size, the cap, and the diagnosis were all already in our own logs. Nobody was reading them. So adding a second log line would have been the one thing guaranteed not to help.

Checking the codebase turned up what was actually missing.

## Finding 1 — the real fix is chunking, and the sibling module already shipped it

`common/ranking` hit **the same 413, from the same sidecar**, and fixed it in #709: `RANK_REMOTE_MAX_BATCH` (default 32, explicitly "TEI's own `--max-client-batch-size` default") chunks the candidate pool so the cap *cannot* reject it. `tests/test_ranking_remote.py` even asserts against `batch size 51 > maximum allowed batch size 32`.

The embedding provider had no equivalent. `OpenAIEmbeddingProvider.embed_batch` sent `input=texts` verbatim, and callers send up to `BULK_MAX_ITEMS` (100) or `EMBEDDING_REEMBED_BATCH_SIZE` (50).

So this adds `EMBEDDING_REMOTE_MAX_BATCH` (default 32) and chunks inside the provider. **This makes the bug impossible rather than merely audible** — and it fixes it for every deployment, not just the one where someone remembered the server flag.

That includes the shipped OSS stack: `docker-compose.yml` starts TEI with only `--model-id` and `--auto-truncate`, so **any bulk write over 32 items 413s today** for anyone following `docs/local-embedder.md`.

Sequential, not the reranker's concurrent `gather` — `_call_gated` holds one `EMBEDDING_MAX_CONCURRENCY` slot for the whole call, so fanning out inside it would multiply real provider concurrency by the chunk count and defeat a cap that exists because of the 2026-07-27 pool exhaustion. Bulk callers arm 30s where the reranker had 0.5s, so there's no need.

## Finding 2 — the aggregate trip-wire was structurally unable to fire

`_EmbeddingStats` is process-wide and shared by every call path. core-api serves search constantly, so every successful *query* embed resets `consecutive_failures`. A 100%-broken bulk path therefore never accumulates a streak.

Verified against prod: `"Embedding service degraded"` never fired **once** in 30 days, while staging fired it repeatedly for an unrelated condition.

Fixed with a bulk-only streak that only a bulk success clears, reported at WARNING with the batch size. What it adds over the existing ERROR is the **consecutive count** — "N failures with no bulk success between" distinguishes systematically-broken from flaky, which a stream of independent tracebacks cannot. It is explicitly *not* the per-occurrence detector; that's the existing ERROR plus the Datadog monitor in enterprise#980.

## Scope note

Chunking is wider than the task as written. I judged it in scope because the goal was "this can never again be invisible" and chunking means it never happens — and because leaving OSS without the fix its own sibling module already has is the kind of asymmetry that bites the next person. Say the word and I'll split it.

## Known limitation, documented in code

The streak is not keyed on the provider, so in a multi-tenant process one tenant's healthy bulk success clears another's broken backend — the same masking, one level down. Keying it properly means keying all of `_stats` (ranking's `_permanent_scope` is the model), which is a wider change. The docstring says so rather than implying a guarantee the code doesn't give.

## Tests

Four new tests, **each verified to fail without its fix**:

| Test | Claim |
|---|---|
| `test_embed_batch_splits_requests_above_max_batch` | 50 texts (the incident's exact size) → `[32, 18]`, nothing over the cap |
| `test_embed_batch_at_or_below_cap_makes_one_request` | fast path preserved — chunking costs nothing at ≤32 |
| `test_embed_batch_preserves_input_order_across_chunks` | `result[i]` still belongs to `texts[i]` (callers zip positionally) |
| `test_bulk_failure_reports_even_while_single_embeds_succeed` | interleaves a successful single embed after every bulk failure — the shape that defeated the shared streak — and asserts `consecutive_failures == 0` as a *precondition* so the test can't silently stop exercising the bug |

Also reviewed and applied: dropped a dead `batch_size` fixture parameter, and `_CappedProvider` now subclasses the real `FakeEmbeddingProvider` so the stand-in actually satisfies the `EmbeddingProvider` protocol.

## Corrections made during review

Two comments I'd written asserted things that turned out to be false, and are fixed:
- "keeps log volume off the traffic curve … bounded number of times" — it's a 10x reduction, linear not bounded.
- A justification citing Vertex behaviour — there is no Vertex embedding provider; `_platform.py` rejects it outright.

## Checks

`ruff check common/` (discovery, no `--config`) · `ruff check core-api/src/` · `ruff format --check --isolated` — clean.
Full `pytest tests/ -m "not benchmark"`: **4090 passed**, and the 26 failures + 8 errors are byte-identical to pristine `main` (no local Postgres). Zero regressions. `core-api/uv.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)