### PR TITLE
fix(search): put fts_score on the cosine scale (#687)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -117,8 +117,9 @@ invariant. It A/Bs the keyword half of
 similarity = (1 - FTS_WEIGHT) * vec_sim + FTS_WEIGHT * fts_score
 ```
 
-by rescaling `ts_rank_cd` before saturation (`--k`; `k=1` is today's
-`r/(1+r)` formula), ranking the *whole* corpus in both arms. Reports
+by rescaling `ts_rank_cd` before saturation (`--k`, defaulting to what
+production ships; `k=1` is the **pre-#687** `r/(1+r)` formula), ranking the
+*whole* corpus in both arms. Reports
 recall@5/@10/@20, nDCG@10 and MRR with the same paired bootstrap CI and sign
 test, overall, per category, and — separately — over just the queries where
 `plainto_tsquery` matched anything, since the rest are a mathematical no-op that
@@ -138,7 +139,9 @@ python scripts/benchmark_blend_locomo.py \
 ```
 
 `k=1` asserts a delta of exactly zero on every metric — a self-check that the
-harness isn't manufacturing differences the change cannot cause.
+harness isn't manufacturing differences the change cannot cause. Since #687 shipped
+`FTS_RANK_SCALE`, `k=1` is a *historical* arm: an A/B from it measures the delta
+since before that change, not a delta against what production runs today.
 
 Two limits worth knowing before quoting a number from it. Only ~17% of LoCoMo
 questions lexically match any turn (they are paraphrases), so the overall delta is

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -537,6 +537,33 @@ GRAPH_MAX_BOOSTED_MEMORIES = 50  # cap on memories receiving graph boost (preven
 ENTITY_LOOKUP_MAX_MATCHES = 20
 
 FTS_WEIGHT = 0.3  # blend: (1 - FTS_WEIGHT) * vector + FTS_WEIGHT * keyword
+# Scale applied to ts_rank_cd BEFORE the saturating map, putting fts_score on the
+# same scale as cosine so FTS_WEIGHT above bites in effect and not just in name
+# (#687). Division of labour: FTS_WEIGHT is the *preference* between the two
+# signals; this is the *unit conversion* that makes the preference meaningful.
+#
+# The input to the derivation: migration 001 builds ``search_vector`` as a bare
+# ``to_tsvector('english', content)`` with no ``setweight``, so every lexeme is
+# weight D = 0.1 and a modal single-occurrence match scores ts_rank_cd = 0.1 →
+# 0.0909, against measured cosine of 0.35-0.39. Re-derive if that trigger starts
+# weighting lexemes; changing FTS_WEIGHT alone does NOT require it.
+#
+# Why 6: derived, not tuned. k*0.1/(1+k*0.1) ≈ 0.37 lands a modal match in the
+# cosine range. Do not treat it as a free dial.
+#
+# Calibrated at the MODE, not across the distribution: ts_rank_cd's cover-density
+# penalty is not a constant factor, so a spread-out multi-term match still lands
+# well below the band. That residual is arguably right — spread terms are a worse
+# match — but it means "effective ≈ nominal weight" describes the typical query,
+# not a global property. A corpus of spread-term queries will measure lower; that
+# is not the scale being broken.
+#
+# Measured before shipping — see BENCHMARKS.md § First-stage retrieval, and note
+# there that the effect rises monotonically across the whole range swept, so the
+# benchmark does NOT locate an optimum. 6 is the derivation's answer, not the
+# sweep's. 1.0 reproduces the pre-#687 formula exactly; per-tenant override lives
+# at ``search.default_profile.fts_rank_scale``.
+FTS_RANK_SCALE = 6.0
 FTS_WEIGHT_BOOSTED = 0.6  # for short specific queries (1-3 proper nouns / identifiers)
 FTS_BOOST_MAX_TOKENS = 3  # queries with more meaningful tokens than this stay at FTS_WEIGHT
 FTS_BOOST_SPECIFICITY_RATIO = 0.4  # strict >; at N=2 this means >=1 specific token triggers boost

--- a/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
+++ b/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
@@ -6,6 +6,7 @@ from core_api.constants import (
     CANDIDATE_POOL_SIZE,
     FRESHNESS_DECAY_DAYS,
     FRESHNESS_FLOOR,
+    FTS_RANK_SCALE,
     GRAPH_MAX_HOPS,
     MIN_SEARCH_SIMILARITY,
     RECALL_BOOST_CAP,
@@ -60,6 +61,8 @@ class ResolveSearchProfile:
             ),
             "graph_max_hops": resolved_profile.get("graph_max_hops", GRAPH_MAX_HOPS),
             "similarity_blend": resolved_profile.get("similarity_blend", SIMILARITY_BLEND),
+            # #687: scale on ts_rank_cd before saturation; 1.0 = pre-#687 formula.
+            "fts_rank_scale": resolved_profile.get("fts_rank_scale", FTS_RANK_SCALE),
             # A49: 0 = off; >0 = storage selects a cosine-dominant candidate pool of this size.
             "candidate_pool_size": resolved_profile.get("candidate_pool_size", CANDIDATE_POOL_SIZE),
             # A50 unified: 0 = legacy multiplicative score; 1 = unified relevance-dominant formula.

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -54,6 +54,7 @@ from core_api.constants import (
     FRESHNESS_FLOOR,
     FTS_BOOST_MAX_TOKENS,
     FTS_BOOST_SPECIFICITY_RATIO,
+    FTS_RANK_SCALE,
     FTS_WEIGHT,
     FTS_WEIGHT_BOOSTED,
     GRAPH_HOP_BOOST,
@@ -3410,6 +3411,7 @@ async def _search_memories_legacy(
     _recall_decay_window_days = sp.get("recall_decay_window_days", RECALL_DECAY_WINDOW_DAYS)
     _graph_max_hops = sp.get("graph_max_hops", GRAPH_MAX_HOPS)
     _similarity_blend = sp.get("similarity_blend", SIMILARITY_BLEND)
+    _fts_rank_scale = sp.get("fts_rank_scale", FTS_RANK_SCALE)
 
     # Temporal hint
     temporal_window = _extract_temporal_hint(query)
@@ -3456,6 +3458,7 @@ async def _search_memories_legacy(
         "top_k": _overfetch_top_k,
         "min_similarity": _min_similarity,
         "fts_weight": _fts_weight,
+        "fts_rank_scale": _fts_rank_scale,
         "freshness_floor": _freshness_floor,
         "freshness_decay_days": _freshness_decay_days,
         "recall_boost_enabled": recall_boost,

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -1087,6 +1087,11 @@ _SEARCH_PROFILE_RULES: dict[str, tuple[type, tuple, object]] = {
     "top_k": (int, (1, 20), None),
     "min_similarity": (float, (0.1, 0.9), None),
     "fts_weight": (float, (0.0, 1.0), None),
+    # #687: scale on ts_rank_cd before saturation. Floor is 1.0, not 0 — that is
+    # the pre-#687 formula, so a tenant can revert but cannot weaken keyword
+    # relevance below where it has always been. Ceiling is the largest value the
+    # LoCoMo sweep actually measured; above it is untested territory.
+    "fts_rank_scale": (float, (1.0, 20.0), None),
     "freshness_floor": (float, (0.0, 1.0), None),
     "freshness_decay_days": (int, (7, 730), None),
     "recall_boost_cap": (float, (1.0, 3.0), None),

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -127,8 +127,13 @@ async def create_memories_bulk(request: Request) -> list[dict]:
 async def scored_search(request: Request) -> list[dict]:
     body: dict = await request.json()
     # Build search_params from top-level body keys (client sends them flat)
+    # An allowlist, so a scoring parameter the legacy path sends flat is DROPPED
+    # until it is named here — the pipeline sends a nested ``search_params`` and
+    # bypasses this entirely, so a parameter added only there silently applies to
+    # one of the two paths.
     _SEARCH_PARAM_KEYS = {
         "fts_weight",
+        "fts_rank_scale",
         "freshness_floor",
         "freshness_decay_days",
         "recall_boost_cap",

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1164,7 +1164,19 @@ class PostgresService:
 
         ts_query = func.plainto_tsquery("english", query)
         raw_keyword_rank = func.ts_rank_cd(Memory.search_vector, ts_query)
-        fts_score = (raw_keyword_rank / (1.0 + raw_keyword_rank)).label("fts_score")
+        # #687: scale the rank before saturating, so `fts_score` lands on the same
+        # scale as `vec_sim` and the blend below weights keyword relevance by
+        # `_fts_weight` in effect rather than only in name. The derivation and the
+        # tsvector fact it rests on live with the value, at
+        # ``core_api.constants.FTS_RANK_SCALE``.
+        #
+        # Defaults to 1.0 — the pre-#687 formula — when the key is absent, so a
+        # storage revision that rolls out ahead of core-api keeps today's ranking
+        # until core-api starts sending the scale. Deploys are not atomic across
+        # the two services, and the safe direction for the gap is "unchanged".
+        _fts_rank_scale = float(sp.get("fts_rank_scale", 1.0) or 1.0)
+        scaled_keyword_rank = _fts_rank_scale * raw_keyword_rank
+        fts_score = (scaled_keyword_rank / (1.0 + scaled_keyword_rank)).label("fts_score")
 
         # CAURA-679: NULL-embedding rows fall back to `fts_score` alone
         # rather than the `(1 - w) * 0 + w * fts_score` haircut that

--- a/scripts/benchmark_blend_locomo.py
+++ b/scripts/benchmark_blend_locomo.py
@@ -10,7 +10,8 @@ What is under test is the blend in ``postgres_service._execute_scored_search``:
 
     similarity = (1 - fts_weight) * vec_sim + fts_weight * fts_score
 
-``fts_score`` today is ``ts_rank_cd / (1 + ts_rank_cd)``. Because
+Before #687 ``fts_score`` was ``ts_rank_cd / (1 + ts_rank_cd)`` — i.e. this
+harness's ``--k 1``. Production now scales by ``FTS_RANK_SCALE`` first. Because
 ``memories.search_vector`` is built by migration 001 as a bare
 ``to_tsvector('english', content)`` with no ``setweight``, every lexeme carries
 weight D = 0.1, so a typical single-occurrence match scores ~0.0909 while cosine
@@ -19,8 +20,8 @@ survive the difference in dynamic range. See
 ``HANDOFF-2026-08-04-fts-score-scale-normalisation.md``.
 
     corpus      one LoCoMo conversation's dialogue turns
-    baseline    blend using today's fts_score = r/(1+r)
-    treatment   blend using (k*r)/(1+k*r)  — --k scales before saturation
+    baseline    blend at --k 1, the pre-#687 fts_score = r/(1+r)
+    treatment   blend at --k, i.e. (k*r)/(1+k*r)  — production ships FTS_RANK_SCALE
     truth       the QA item's ``evidence`` turn ids (binary relevance)
     ranking     the WHOLE corpus, both arms — no fixed pool
 
@@ -58,6 +59,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+# Production values rather than hand-mirrored literals: the constant's own comment
+# says to re-derive it if the tsvector weighting changes, and a copied default here
+# would make that instruction silently unenforceable.
+from core_api.constants import FTS_RANK_SCALE, FTS_WEIGHT  # noqa: E402
 from _locomo_bench import (  # noqa: E402  (path shim above must run first)
     CATEGORIES,
     embed,
@@ -86,7 +91,7 @@ def _score(rels: list[float], n_relevant: int) -> dict[str, float]:
 
 
 def _saturate(raw: float, k: float) -> float:
-    """``(k*r)/(1+k*r)`` — today's formula is this with k = 1."""
+    """``(k*r)/(1+k*r)`` — the pre-#687 formula is this with k = 1."""
     scaled = k * raw
     return scaled / (1.0 + scaled)
 
@@ -247,16 +252,15 @@ def main() -> None:
     ap.add_argument(
         "--k",
         type=float,
-        default=6.0,
-        help="scale applied to ts_rank_cd before saturation. 1 = today's formula "
-        "(and asserts a zero delta). ~6 puts a single-term match near the cosine "
-        "range, making the effective FTS weight match the nominal one.",
+        default=FTS_RANK_SCALE,
+        help="scale applied to ts_rank_cd before saturation. 1 = the pre-#687 "
+        "formula (and asserts a zero delta). Defaults to what production ships.",
     )
     ap.add_argument(
         "--fts-weight",
         type=float,
-        default=0.3,
-        help="FTS_WEIGHT from core_api.constants (default matches production)",
+        default=FTS_WEIGHT,
+        help="the blend weight; defaults to core_api.constants.FTS_WEIGHT",
     )
     ap.add_argument("--limit-conversations", type=int, default=0, help="0 = all")
     ap.add_argument("--seed", type=int, default=1234)

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -18,6 +18,7 @@ from core_storage_api.services.postgres_service import get_session
 
 from core_api.clients.storage_client import get_storage_client
 from core_api.constants import (
+    FTS_RANK_SCALE,
     FRESHNESS_DECAY_DAYS,
     SEARCH_OVERFETCH_FACTOR,
 )
@@ -535,4 +536,108 @@ async def test_fts_only_row_survives_a_saturated_candidate_window(tenant_id, mon
         f"from the cosine gate — but {window} higher-cosine rows fill the "
         f"top_k({top_k}) * SEARCH_OVERFETCH_FACTOR({SEARCH_OVERFETCH_FACTOR}) window "
         f"first. search returned {len(results)} row(s), none of them the subject."
+    )
+
+
+# ---------------------------------------------------------------------------
+# #687 part two: fts_score on the cosine scale
+# ---------------------------------------------------------------------------
+
+
+async def _rank_and_score(content: str, query: str, scale: float) -> tuple[float, float]:
+    """``(raw ts_rank_cd, fts_score)`` at a given scale, from real Postgres.
+
+    Reads both out of one statement with the production expression rather than
+    recomputing in Python — what ``ts_rank_cd`` feeds the saturating map is the
+    thing under test, so a Python reimplementation would test the wrong function.
+    Binds the scaled rank once via a subquery, mirroring how the production
+    expression reuses it rather than re-evaluating.
+    """
+    async with get_session() as session:
+        row = (
+            await session.execute(
+                text(
+                    "SELECT r, (:k * r) / (1 + :k * r) AS s FROM ("
+                    "  SELECT ts_rank_cd(to_tsvector('english', :c),"
+                    "                    plainto_tsquery('english', :q)) AS r"
+                    ") t"
+                ),
+                {"k": scale, "c": content, "q": query},
+            )
+        ).first()
+    return float(row[0]), float(row[1])
+
+
+@pytest.mark.integration
+async def test_fts_rank_scale_lifts_a_lexical_match_onto_the_cosine_scale():
+    """The scale must move fts_score into cosine's range, not just nudge it.
+
+    #687's first half (#700) made an unembedded FTS-matching row *reachable*. It
+    could not make a lexical match *rank* like one, because fts_score saturates a
+    weight-D ts_rank_cd of 0.1 to 0.0909 while cosine on the same corpus measures
+    0.35-0.39 — so the declared FTS_WEIGHT of 0.3 delivered an effective ~0.09.
+    """
+    content = "a memory that mentions zqxjvbn exactly once"
+
+    _, before = await _rank_and_score(content, "zqxjvbn", 1.0)
+    _, after = await _rank_and_score(content, "zqxjvbn", FTS_RANK_SCALE)
+
+    assert before == pytest.approx(0.0909, abs=0.005), (
+        f"the pre-#687 formula should saturate a single weight-D match to ~0.0909, got {before}"
+    )
+    # Cosine's measured strong-match range on this corpus is 0.35-0.39; landing
+    # inside it is the whole point, and is what makes the nominal FTS_WEIGHT real.
+    assert 0.30 <= after <= 0.45, (
+        f"at FTS_RANK_SCALE={FTS_RANK_SCALE} a modal match should land in cosine's "
+        f"0.35-0.39 range, got {after}"
+    )
+
+
+@pytest.mark.integration
+async def test_fts_rank_scale_of_one_reproduces_the_pre_687_formula():
+    """1.0 is the documented revert, so it must be exact, not merely close."""
+    raw, scaled = await _rank_and_score("another memory mentioning zqxjvbn", "zqxjvbn", 1.0)
+    assert scaled == pytest.approx(raw / (1.0 + raw), abs=1e-12)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_pipeline", [True, False], ids=["pipeline", "legacy"])
+async def test_rank_scale_reaches_the_sql_on_both_search_paths(tenant_id, monkeypatch, use_pipeline):
+    """The scale must arrive where the SQL reads it, on BOTH paths.
+
+    Three places can drop it, and each is invisible to the other two:
+
+      * ``resolve_search_profile`` builds the pipeline's ``search_params``;
+      * ``_search_memories_legacy`` builds its own, and sends the keys FLAT;
+      * the storage route rebuilds ``search_params`` from a flat-key ALLOWLIST
+        (``_SEARCH_PARAM_KEYS``) when no nested dict is present — so a key added
+        to both core-api builders but not to that allowlist still applies only to
+        the pipeline.
+
+    Asserting at the client boundary cannot see the third, because the nesting
+    happens server-side. So this spies on the storage service function that
+    actually reads the value into the SQL expression.
+    """
+    from core_storage_api.services import postgres_service as pg
+
+    from core_api.services import memory_service
+
+    monkeypatch.setattr(memory_service, "_USE_PIPELINE_SEARCH", use_pipeline)
+
+    seen: list = []
+    real = pg.PostgresService.memory_scored_search
+
+    async def _spy(self, *a, **kw):
+        sp = kw.get("search_params") or next((x for x in a if isinstance(x, dict)), None)
+        seen.append((sp or {}).get("fts_rank_scale"))
+        return await real(self, *a, **kw)
+
+    monkeypatch.setattr(pg.PostgresService, "memory_scored_search", _spy)
+    await memory_service.search_memories(tenant_id=tenant_id, query="anything at all", top_k=3)
+
+    path = "pipeline" if use_pipeline else "legacy"
+    assert seen, f"the {path} path never reached memory_scored_search"
+    assert seen[0] == FTS_RANK_SCALE, (
+        f"the {path} path did not deliver fts_rank_scale to the SQL; storage saw "
+        f"{seen[0]!r}, so it would fall back to 1.0 and keep the pre-#687 ranking"
     )

--- a/tests/test_search_default_profile.py
+++ b/tests/test_search_default_profile.py
@@ -135,3 +135,42 @@ async def test_precedence_empty_tenant_default_is_neutral():
     tc = ResolvedConfig({})  # no default_profile
     params = await _resolve(tenant_config=tc, agent_profile=None)
     assert params["min_similarity"] == MIN_SEARCH_SIMILARITY
+
+
+# ── fts_rank_scale (#687) ──
+
+
+def _profile(**kw) -> dict:
+    """The shape ``_validate_default_search_profile`` actually reads.
+
+    It takes the whole settings payload and digs out
+    ``search.default_profile``; handed a bare dict it finds nothing and returns
+    without validating, which is how a bounds test can pass while asserting
+    nothing.
+    """
+    return {"search": {"default_profile": dict(kw)}}
+
+
+def test_fts_rank_scale_is_tenant_overridable():
+    """It joins the other ranking knobs rather than being a hardcoded literal."""
+    _validate_default_search_profile(_profile(fts_rank_scale=3.0))
+    rc = ResolvedConfig({"search": {"default_profile": {"fts_rank_scale": 3.0}}})
+    assert rc.default_search_profile["fts_rank_scale"] == 3.0
+
+
+def test_fts_rank_scale_floor_is_one_not_zero():
+    """1.0 is the pre-#687 formula — the documented revert — and the floor.
+
+    Below 1.0 would weaken keyword relevance below where it has always been,
+    which nothing measured supports and no caller should reach by accident.
+    """
+    with pytest.raises(ValueError, match="fts_rank_scale"):
+        _validate_default_search_profile(_profile(fts_rank_scale=0.5))
+    _validate_default_search_profile(_profile(fts_rank_scale=1.0))  # the revert, allowed
+
+
+def test_fts_rank_scale_ceiling_matches_what_was_measured():
+    """The ceiling is the largest value the LoCoMo sweep covered; above is untested."""
+    _validate_default_search_profile(_profile(fts_rank_scale=20.0))
+    with pytest.raises(ValueError, match="fts_rank_scale"):
+        _validate_default_search_profile(_profile(fts_rank_scale=20.001))


### PR DESCRIPTION
Closes the deeper half of #687. #700 made an unembedded FTS-matching row *reachable*; it could not make a lexical match **rank** like one.

## The defect

`fts_score = ts_rank_cd/(1+ts_rank_cd)` saturated a modal single-term match to **0.0909**, while cosine on the same corpus measures **0.35–0.39**. Blended as if comparable, the `FTS_WEIGHT = 0.3` this repo declares delivered an **effective ~0.09** — keyword relevance structurally under-weighted on *every* query, not just the deferred-embed ones #687 was filed about.

Root cause: migration 001 builds `search_vector` as a bare `to_tsvector('english', content)` with no `setweight`, so every lexeme is weight D = 0.1.

## The fix, and why k=6 is derived rather than picked

`(k*r)/(1+k*r)` with `FTS_RANK_SCALE = 6.0`. Solving `k*0.1/(1+k*0.1) ≈ 0.37` lands a modal match in the cosine range, bringing the effective weight to **0.292** against the nominal **0.300**. `FTS_WEIGHT` remains the *preference* between signals; this is the *unit conversion* that makes the preference mean anything.

## Measured before shipping

Via #714's harness — full LoCoMo, **n=1531**, `FTS_WEIGHT=0.3`. `*` = paired bootstrap CI excludes zero:

| k | overall recall@5 | fts-matched-only recall@5 | matched-only MRR |
|---|---|---|---|
| 1 | +0.0000 | +0.0000 | +0.0000 |
| 3 | +0.0035\* | +0.0211\* | +0.0080\* |
| **6** | **+0.0042\*** | **+0.0250\*** | **+0.0185\*** |
| 10 | +0.0075\* | +0.0445\* | +0.0357\* |
| 20 | +0.0113\* | +0.0672\* | +0.0692\* |

Recall improves at every `k > 1`, significantly on all five metrics, with **zero queries regressing** on recall. The sweep rises monotonically across the whole range, so it confirms direction but **does not locate an optimum** — 6 is the derivation's answer, not the sweep's, and that's recorded beside the constant so nobody bumps it to 20 citing the benchmark.

Two honesty caveats a reviewer should hold me to: the calibration is **at the mode**, not distributional — `ts_rank_cd`'s cover-density penalty isn't a constant factor, so a spread-out multi-term match still lands below the band (arguably correct, but "effective ≈ nominal" describes the typical query). And LoCoMo questions are paraphrases, so only ~17% lexically match anything; the matched-only column is the effect on queries the change can reach.

## It had to go in four places — the fourth is the interesting one

- `resolve_search_profile` — the pipeline's `search_params`
- `_search_memories_legacy` — its own, sent **flat** rather than nested
- **`_SEARCH_PARAM_KEYS` in the storage router** — an allowlist that rebuilds `search_params` from flat keys and **silently drops anything unnamed**. Adding the key to both core-api builders was *not enough*: the legacy path kept the old ranking until it was named here. **The test caught that, not review.**
- `postgres_service`, which reads it and defaults to **1.0** when absent — so a storage revision deployed ahead of core-api keeps today's ranking rather than changing it. Deploys aren't atomic across the two services and the safe direction for the gap is "unchanged".

Threaded as a per-tenant knob rather than a literal, matching `candidate_pool_size` / `score_formula`: `fts_rank_scale` joins `_SEARCH_PROFILE_RULES` bounded `(1.0, 20.0)`. Floor is 1.0 — the pre-#687 formula — so a tenant can revert but can't weaken keyword relevance below where it's always been.

## Hot-path cost: nil, verified not assumed

The compiled SQL renders `ts_rank_cd` **18 times before and after** — the scale multiplies an existing expression object rather than duplicating the call. `k` binds once and the SQL text is byte-identical for any `k`, so one plan and one prepared statement regardless of per-tenant override. EXPLAIN ANALYZE over 4,795 candidate rows: **36.1 ms scaled vs 37.1 ms unscaled**.

## Verification

| | passed | xfailed | xpassed |
|---|---|---|---|
| `main` | 4117 | 1 | 0 |
| this branch | 4124 | 1 | 0 |

+7 is exactly the added tests, with **no existing test's behaviour changed** — the signal that matters when a change reprices every query.

Each assertion confirmed load-bearing by mutation:

| mutation | result |
|---|---|
| revert the scale to 1.0 | cosine-scale test fails (`0.3 <= 0.0909`) |
| drop the key from the pipeline builder | **pipeline** case fails only |
| remove it from the storage allowlist | **legacy** case fails only |
| widen the bounds floor to 0.0 | bounds test fails (`DID NOT RAISE`) |

## Also corrects #714

That PR merged one commit earlier and describes `k=1` as "today's formula" in `BENCHMARKS.md` and three places in the harness — false the moment this lands. Fixed, and the harness's `--k`/`--fts-weight` defaults now come from `core_api.constants` rather than hand-mirrored literals, since the constant's instruction to re-derive it was otherwise silently unenforceable.

## Deliberately out of scope, recorded for follow-up

- **`setweight` is not an alternative.** Measured: uniform `setweight` is exactly a constant multiply capped at ×10 (ladder ×1/×2/×4/×10), and `ts_rank_cd(weights[])` rejects weights > 1.0 — so **no configuration lands in the target band** (needs ×6). A **title/content** weight split would change *relative* ranking and is a genuine opportunity, needing its own benchmark.
- `_SEARCH_PARAM_KEYS` is *also* missing `candidate_pool_size` and `score_formula`, so the legacy rollback lever already reverts two other ranking features. Own diff.
- `fts_score` renders `ts_rank_cd` twice per row (~14% of the query), but the naive subquery hoist gets flattened by the planner; a real fix needs an optimization barrier and its own plan-shape review.
