### PR TITLE
fix(search): deliver every scoring knob to the SQL on both search paths

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -43,6 +43,7 @@ from core_api.constants import (
     BULK_ENRICHMENT_CONCURRENCY,
     BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS,
     BULK_STRONG_EMBED_TIMEOUT_SECONDS,
+    CANDIDATE_POOL_SIZE,
     CHUNKING_THRESHOLD_CHARS,
     CLASSIFIER_DEPRECATED_MEMORY_TYPES,
     CRYSTALLIZER_SHORT_CONTENT_CHARS,
@@ -67,6 +68,7 @@ from core_api.constants import (
     OPENAI_EMBEDDING_MODEL,
     RECALL_BOOST_CAP,
     RECALL_DECAY_WINDOW_DAYS,
+    SCORE_FORMULA,
     SEARCH_OVERFETCH_FACTOR,
     SIMILARITY_BLEND,
 )
@@ -101,6 +103,13 @@ logger = logging.getLogger(__name__)
 # rollback is needed, flip these to False and ship a hotfix — do NOT re-introduce
 # env-level configuration, since that caused prior silent divergence between
 # deployments and the default code path.
+#
+# A ``_USE_PIPELINE_SEARCH = False`` hotfix must be cut from a core-api at or
+# after the commit that moved the legacy search path onto nested
+# ``search_params``. Storage no longer accepts the flat scoring keys an older
+# core-api would send, so flipping the lever on a stale build 422s every search
+# instead of degrading it. Rolling storage back is not the fix — a storage
+# revision predating that commit reads nested params fine.
 _USE_PIPELINE_WRITE = True
 _USE_PIPELINE_SEARCH = True
 
@@ -3412,6 +3421,8 @@ async def _search_memories_legacy(
     _graph_max_hops = sp.get("graph_max_hops", GRAPH_MAX_HOPS)
     _similarity_blend = sp.get("similarity_blend", SIMILARITY_BLEND)
     _fts_rank_scale = sp.get("fts_rank_scale", FTS_RANK_SCALE)
+    _candidate_pool_size = sp.get("candidate_pool_size", CANDIDATE_POOL_SIZE)
+    _score_formula = sp.get("score_formula", SCORE_FORMULA)
 
     # Temporal hint
     temporal_window = _extract_temporal_hint(query)
@@ -3444,7 +3455,25 @@ async def _search_memories_legacy(
     # starving the final result set. Mirrors pipeline ExecuteScoredSearch behavior.
     _overfetch_top_k = _top_k * SEARCH_OVERFETCH_FACTOR
 
-    # Use scored_search storage API endpoint
+    # Use scored_search storage API endpoint.
+    #
+    # Scoring knobs go in a NESTED ``search_params``, exactly as the pipeline
+    # path sends them; they used to be sent flat and rebuilt server-side from an
+    # allowlist that dropped whatever it did not name. Full rationale sits with
+    # the deleted code, on the storage ``/scored-search`` route.
+    #
+    # ``top_k`` is deliberately NOT in this dict. Storage reads the SQL LIMIT as
+    # ``search_params.get("top_k", top_k)``, so a ``top_k`` here would shadow
+    # the overfetched body-level value below and narrow the candidate window to
+    # the caller's unmultiplied top_k — dropping the post-filter headroom that
+    # ``SEARCH_OVERFETCH_FACTOR`` exists to provide.
+    #
+    # This describes only THIS builder. The pipeline builder does not avoid it:
+    # ``resolve_search_profile`` puts the unmultiplied ``top_k`` in its
+    # ``search_params`` and ``ExecuteScoredSearch`` multiplies only its local
+    # copy, so on that path — the active one — the SQL LIMIT is the unmultiplied
+    # value and the overfetch is inert. Measured, not inferred; being fixed
+    # separately, because widening that pool changes ranking on every query.
     search_data = {
         "tenant_id": tenant_id,
         "embedding": embedding,
@@ -3456,17 +3485,28 @@ async def _search_memories_legacy(
         "status_filter": status_filter,
         "valid_at": valid_at.isoformat() if valid_at else None,
         "top_k": _overfetch_top_k,
+        # Core-api-local, NOT a scoring knob: the route never reads it, and the
+        # post-filter below applies it. Kept flat for that reason — a new knob
+        # belongs in ``search_params``, not beside this one.
         "min_similarity": _min_similarity,
-        "fts_weight": _fts_weight,
-        "fts_rank_scale": _fts_rank_scale,
-        "freshness_floor": _freshness_floor,
-        "freshness_decay_days": _freshness_decay_days,
+        "search_params": {
+            "fts_weight": _fts_weight,
+            "fts_rank_scale": _fts_rank_scale,
+            "freshness_floor": _freshness_floor,
+            "freshness_decay_days": _freshness_decay_days,
+            "recall_boost_cap": _recall_boost_cap,
+            "recall_decay_window_days": _recall_decay_window_days,
+            "similarity_blend": _similarity_blend,
+            "candidate_pool_size": _candidate_pool_size,
+            "score_formula": _score_formula,
+        },
         "recall_boost_enabled": recall_boost,
-        "recall_boost_cap": _recall_boost_cap,
-        "recall_decay_window_days": _recall_decay_window_days,
-        "similarity_blend": _similarity_blend,
         "temporal_window_days": temporal_window.days if temporal_window else None,
-        "boosted_memory_ids": {str(mid): factor for mid, factor in memory_boost_factor.items()}
+        # Both halves, under their own keys: the SQL gates the entire entity
+        # boost on ``boosted_memory_ids AND memory_boost_factor``, so they
+        # travel as a pair or the boost is skipped outright.
+        "boosted_memory_ids": [str(mid) for mid in boosted_memory_ids] if boosted_memory_ids else None,
+        "memory_boost_factor": {str(mid): factor for mid, factor in memory_boost_factor.items()}
         if memory_boost_factor
         else None,
     }

--- a/core-storage-api/src/core_storage_api/routers/_validation.py
+++ b/core-storage-api/src/core_storage_api/routers/_validation.py
@@ -18,6 +18,20 @@ def _require(body: dict, key: str) -> str:
     return val
 
 
+def _require_dict(body: dict, key: str) -> dict:
+    """Fail-closed object guard — 422 on missing / non-dict / empty.
+
+    ``_require`` is not enough for a nested params object: it admits any truthy
+    value, so a list or a string would pass and then fail deeper in as a type
+    error. Empty is rejected too — callers pass these dicts to be read key by
+    key, so ``{}`` is the same malformed request as a missing key.
+    """
+    val = body.get(key)
+    if not isinstance(val, dict) or not val:
+        raise HTTPException(status_code=422, detail=f"{key} (non-empty object) is required")
+    return val
+
+
 def _require_number(body: dict, key: str) -> float:
     """Fail-closed numeric guard — 422 on missing / non-numeric.
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -14,7 +14,7 @@ from common.events.lifecycle_purge_request import (
     MEMORY_RETENTION_MIN_DAYS,
 )
 from core_storage_api.observability import bind_timer, log_request
-from core_storage_api.routers._validation import _require
+from core_storage_api.routers._validation import _require, _require_dict
 from core_storage_api.schemas import MEMORY_FIELDS, MEMORY_LIST_FIELDS, orm_to_dict
 from core_storage_api.services.postgres_service import BulkValidationError, PostgresService
 
@@ -126,21 +126,26 @@ async def create_memories_bulk(request: Request) -> list[dict]:
 @router.post("/scored-search")
 async def scored_search(request: Request) -> list[dict]:
     body: dict = await request.json()
-    # Build search_params from top-level body keys (client sends them flat)
-    # An allowlist, so a scoring parameter the legacy path sends flat is DROPPED
-    # until it is named here — the pipeline sends a nested ``search_params`` and
-    # bypasses this entirely, so a parameter added only there silently applies to
-    # one of the two paths.
-    _SEARCH_PARAM_KEYS = {
-        "fts_weight",
-        "fts_rank_scale",
-        "freshness_floor",
-        "freshness_decay_days",
-        "recall_boost_cap",
-        "recall_decay_window_days",
-        "similarity_blend",
-    }
-    search_params = body.get("search_params") or {k: body[k] for k in _SEARCH_PARAM_KEYS if k in body}
+    # ``search_params`` arrives nested, from every caller. THE rationale for the
+    # whole change lives here, because the code it replaces lived here:
+    #
+    # This used to fall back to rebuilding the dict from top-level body keys
+    # named in a hardcoded allowlist, for callers that sent the scoring knobs
+    # flat. That allowlist was a third place every knob had to be registered —
+    # after the pipeline's builder and the legacy path's — and the only one no
+    # test could observe, because the nesting happens here, server-side, past
+    # the boundary a client-side assertion can see. Two ranking features
+    # (``candidate_pool_size``, ``score_formula``) shipped applying to the
+    # pipeline search path only as a result, which also meant the documented
+    # ``_USE_PIPELINE_SEARCH = False`` rollback lever silently reverted them.
+    # Both core-api builders send nested now, so the fallback is gone and the
+    # SQL reads what the caller actually sent.
+    #
+    # Fail-closed rather than defaulting: ``memory_scored_search`` reads six of
+    # these keys with INDEXED access, so a payload without them is a malformed
+    # request, and 4xx at the edge beats the KeyError 500 it would otherwise
+    # raise from inside the session.
+    search_params = _require_dict(body, "search_params")
 
     # Parse temporal_window from days (legacy) or seconds (pipeline path)
     temporal_window = None

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -550,6 +550,37 @@ class TestMemories:
         resp = await client.get(f"{PREFIX}/memories/{fake_id}")
         assert resp.status_code == 404
 
+    async def test_scored_search_rejects_a_payload_without_nested_search_params(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+    ) -> None:
+        """Scoring knobs must arrive nested; flat top-level keys are not read.
+
+        The route used to rebuild ``search_params`` from top-level keys named in
+        a hardcoded allowlist — see the rationale on the route itself. A flat
+        payload must now fail LOUDLY at the edge rather than sail through with
+        every knob silently dropped.
+        """
+        flat = {
+            "tenant_id": tenant_id,
+            "embedding": [0.1] * VECTOR_DIM,
+            "query": "anything",
+            "top_k": 10,
+            # Flat, the way the allowlist used to accept it. Nothing reads it here.
+            "fts_weight": 0.5,
+        }
+        resp = await client.post(f"{PREFIX}/memories/scored-search", json=flat)
+        assert resp.status_code == 422, (
+            f"a flat-key payload must be rejected at the edge, got {resp.status_code}: {resp.text}"
+        )
+        assert "search_params" in resp.json()["detail"]
+
+        # Present-but-empty is the same malformed request: the scoring keys are
+        # read out of it one by one, so ``{}`` leaves every one of them missing.
+        resp_empty = await client.post(f"{PREFIX}/memories/scored-search", json={**flat, "search_params": {}})
+        assert resp_empty.status_code == 422, resp_empty.text
+
     async def test_scored_search_surfaces_null_embedding_via_fts(
         self,
         client: AsyncClient,

--- a/tests/test_entity_retrieval_flag.py
+++ b/tests/test_entity_retrieval_flag.py
@@ -313,7 +313,9 @@ async def test_legacy_path_flag_off_skips_entity_boost():
     assert results == []
     boost_mock.assert_not_called()
     # No hop-boost payload reaches storage on the disabled path.
-    assert sc.scored_search.call_args[0][0]["boosted_memory_ids"] is None
+    payload = sc.scored_search.call_args[0][0]
+    assert payload["boosted_memory_ids"] is None
+    assert payload["memory_boost_factor"] is None
 
 
 async def test_legacy_path_flag_on_runs_entity_boost():
@@ -338,7 +340,13 @@ async def test_legacy_path_flag_on_runs_entity_boost():
         await memory_service._search_memories_legacy("t1", _ENTITY_QUERY)
 
     boost_mock.assert_called_once()
-    assert sc.scored_search.call_args[0][0]["boosted_memory_ids"] == {str(mid): 1.3}
+    # Both halves, under their own keys. This previously asserted the factor MAP
+    # as the value of ``boosted_memory_ids`` — the shape the payload actually
+    # had, which is why asserting it here passed while the storage SQL, gating on
+    # ``boosted_memory_ids AND memory_boost_factor``, skipped the boost entirely.
+    payload = sc.scored_search.call_args[0][0]
+    assert payload["boosted_memory_ids"] == [str(mid)]
+    assert payload["memory_boost_factor"] == {str(mid): 1.3}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -18,8 +18,10 @@ from core_storage_api.services.postgres_service import get_session
 
 from core_api.clients.storage_client import get_storage_client
 from core_api.constants import (
+    CANDIDATE_POOL_SIZE,
     FTS_RANK_SCALE,
     FRESHNESS_DECAY_DAYS,
+    SCORE_FORMULA,
     SEARCH_OVERFETCH_FACTOR,
 )
 from common.models.memory import Memory
@@ -600,44 +602,142 @@ async def test_fts_rank_scale_of_one_reproduces_the_pre_687_formula():
     assert scaled == pytest.approx(raw / (1.0 + raw), abs=1e-12)
 
 
-@pytest.mark.integration
-@pytest.mark.parametrize("use_pipeline", [True, False], ids=["pipeline", "legacy"])
-async def test_rank_scale_reaches_the_sql_on_both_search_paths(tenant_id, monkeypatch, use_pipeline):
-    """The scale must arrive where the SQL reads it, on BOTH paths.
+# The scoring knobs that fail SILENTLY. ``memory_scored_search`` reads these
+# three as ``sp.get(key, fallback)``, so one that never arrives degrades ranking
+# with no error anywhere; its other six scoring keys are read as ``sp[key]`` and
+# raise, which the route's ``search_params`` guard turns into a 422. Only the
+# quiet ones need a delivery test, and each is paired here with the constant it
+# falls back to plus a tuned value inside ``validate_search_profile``'s range.
+_SQL_SCORING_KEYS = (
+    ("fts_rank_scale", FTS_RANK_SCALE, 3.0),
+    ("candidate_pool_size", CANDIDATE_POOL_SIZE, 25),
+    ("score_formula", SCORE_FORMULA, 1),
+)
 
-    Three places can drop it, and each is invisible to the other two:
 
-      * ``resolve_search_profile`` builds the pipeline's ``search_params``;
-      * ``_search_memories_legacy`` builds its own, and sends the keys FLAT;
-      * the storage route rebuilds ``search_params`` from a flat-key ALLOWLIST
-        (``_SEARCH_PARAM_KEYS``) when no nested dict is present — so a key added
-        to both core-api builders but not to that allowlist still applies only to
-        the pipeline.
+async def _scored_search_call(monkeypatch, tenant_id, use_pipeline, *, search_profile=None, boost=None):
+    """Run one search; return the kwargs ``memory_scored_search`` received.
 
-    Asserting at the client boundary cannot see the third, because the nesting
-    happens server-side. So this spies on the storage service function that
-    actually reads the value into the SQL expression.
+    Spies on the storage *service* rather than the HTTP client because the
+    route decides server-side what the SQL finally reads; an assertion made at
+    the client boundary cannot see what that decision kept or dropped.
+
+    ``boost`` forces a non-empty entity-boost result. The two paths compute it
+    in different places — the legacy helper and the pipeline step — so both are
+    stubbed; whichever one the path under test uses is the one that matters, and
+    a stub that fails to take effect shows up as an empty boost at the assert.
     """
     from core_storage_api.services import postgres_service as pg
 
+    from core_api.pipeline.steps.search import parallel_embed_entity_boost as peb
     from core_api.services import memory_service
 
     monkeypatch.setattr(memory_service, "_USE_PIPELINE_SEARCH", use_pipeline)
 
-    seen: list = []
+    if boost is not None:
+        ids, factors = boost
+
+        async def _stub_boost(*a, **kw):
+            return ids, factors
+
+        monkeypatch.setattr(memory_service, "_entity_boost_pipeline", _stub_boost)
+
+        real_exec = peb.ParallelEmbedAndEntityBoost.execute
+
+        async def _exec(self, ctx):
+            result = await real_exec(self, ctx)
+            ctx.data["boosted_memory_ids"] = ids
+            ctx.data["memory_boost_factor"] = factors
+            return result
+
+        monkeypatch.setattr(peb.ParallelEmbedAndEntityBoost, "execute", _exec)
+
+    seen: list[dict] = []
     real = pg.PostgresService.memory_scored_search
 
     async def _spy(self, *a, **kw):
-        sp = kw.get("search_params") or next((x for x in a if isinstance(x, dict)), None)
-        seen.append((sp or {}).get("fts_rank_scale"))
+        seen.append(dict(kw))
         return await real(self, *a, **kw)
 
     monkeypatch.setattr(pg.PostgresService, "memory_scored_search", _spy)
-    await memory_service.search_memories(tenant_id=tenant_id, query="anything at all", top_k=3)
+    await memory_service.search_memories(
+        tenant_id=tenant_id,
+        query="anything at all",
+        top_k=3,
+        search_profile=search_profile,
+    )
 
     path = "pipeline" if use_pipeline else "legacy"
     assert seen, f"the {path} path never reached memory_scored_search"
-    assert seen[0] == FTS_RANK_SCALE, (
-        f"the {path} path did not deliver fts_rank_scale to the SQL; storage saw "
-        f"{seen[0]!r}, so it would fall back to 1.0 and keep the pre-#687 ranking"
+    return seen[0]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_pipeline", [True, False], ids=["pipeline", "legacy"])
+@pytest.mark.parametrize("tuned", [False, True], ids=["defaults", "tuned"])
+async def test_scoring_knobs_reach_the_sql_on_both_search_paths(
+    tenant_id, monkeypatch, use_pipeline, tuned
+):
+    """Every quiet scoring knob must arrive where the SQL reads it, on BOTH paths.
+
+    Two builders and one server-side decision can each drop a key, and each is
+    invisible to the other two:
+
+      * ``resolve_search_profile`` builds the pipeline's ``search_params``;
+      * ``_search_memories_legacy`` builds its own payload;
+      * the storage route decides what ``search_params`` the SQL finally sees.
+
+    Asserting at the client boundary cannot see the third, because the nesting
+    happens server-side — which is why this asserts against the dict the storage
+    service actually received. A key that never arrives leaves the SQL on its own
+    fallback, so the feature applies to one path only and the documented legacy
+    rollback lever reverts it as a side effect.
+
+    Both cases are needed. ``defaults`` pins the wiring, but two of these
+    constants are currently 0, so on its own it cannot tell a delivered value
+    from a builder that hardcoded the same number; ``tuned`` moves every knob off
+    its default and makes the value itself the assertion.
+    """
+    profile = {key: t for key, _, t in _SQL_SCORING_KEYS} if tuned else None
+    expected = profile or {key: const for key, const, _ in _SQL_SCORING_KEYS}
+
+    call = await _scored_search_call(monkeypatch, tenant_id, use_pipeline, search_profile=profile)
+    delivered = {k: (call.get("search_params") or {}).get(k) for k in expected}
+
+    path = "pipeline" if use_pipeline else "legacy"
+    assert delivered == expected, (
+        f"the {path} path did not deliver every scoring knob to the SQL; storage saw "
+        f"{delivered} instead of {expected}, so the SQL falls back to its own default "
+        f"and the feature applies to the other path only"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_pipeline", [True, False], ids=["pipeline", "legacy"])
+async def test_entity_boost_inputs_reach_the_sql_on_both_search_paths(
+    tenant_id, monkeypatch, use_pipeline
+):
+    """Both halves of the entity boost must arrive, on BOTH paths.
+
+    The SQL gates the entire entity-boost stack on ``boosted_memory_ids AND
+    memory_boost_factor`` — the ids alone buy nothing. The legacy path sent the
+    per-memory factors *under the ids key* and never sent the factors key, so
+    the guard saw a falsy factor map and skipped the whole stack: graph
+    expansion and hop boosts ran in core-api on every legacy search and were
+    then discarded at the storage boundary.
+
+    Same failure mode as the scoring knobs above — a ranking input that reaches
+    one search path only, so the documented legacy rollback lever quietly
+    changes ranking rather than reproducing it.
+    """
+    mid = uuid.uuid4()
+    call = await _scored_search_call(
+        monkeypatch, tenant_id, use_pipeline, boost=({mid}, {mid: 1.5})
+    )
+
+    path = "pipeline" if use_pipeline else "legacy"
+    assert call.get("boosted_memory_ids"), f"the {path} path delivered no boosted_memory_ids"
+    assert call.get("memory_boost_factor"), (
+        f"the {path} path delivered boosted_memory_ids but no memory_boost_factor, so the SQL's "
+        f"`if boosted_memory_ids and memory_boost_factor` guard skips the entity boost entirely"
     )


### PR DESCRIPTION
## The bug

`candidate_pool_size` (A49) and `score_formula` (A50) applied on the **pipeline search path only**.

Three places had to agree, and each was invisible to the other two:

| | builds | sent both keys? |
|---|---|---|
| `resolve_search_profile` | pipeline's nested `search_params` | ✅ |
| `_search_memories_legacy` | its own payload, keys **flat** | ❌ |
| storage `/scored-search` route | rebuilt `search_params` from a hardcoded **allowlist** when no nested dict was present | ❌ |

So on the legacy path both features silently vanished, and the documented `_USE_PIPELINE_SEARCH = False` rollback lever (`memory_service.py`) reverted two ranking features as a side effect. #722 was the third time that allowlist bit — and a test caught it, not review, because the allowlist was the one registration point **no client-boundary assertion can see**: the nesting happens server-side.

## The fix

Not "add the two names to the allowlist". `_search_memories_legacy` was the only non-test flat-key sender left in the repo — every storage test already posts nested `search_params` — so it now sends nested like the pipeline. That makes the allowlist dead code:

- **deleted** `_SEARCH_PARAM_KEYS` and the flat rebuild;
- the route now **requires** `search_params`, via a new `_require_dict` in the shared `routers/_validation.py` (422). Fail-closed rather than defaulting, because `memory_scored_search` reads six of those keys with **indexed** access — so a payload without them is malformed, and 4xx at the edge beats the KeyError 500 it would otherwise raise from inside the session.

Three registration points become two.

### `top_k` is deliberately not nested

Storage reads the SQL LIMIT as `search_params.get("top_k", top_k)`, so a `top_k` in the nested dict **shadows** the overfetched body-level value. Nesting it would have silently narrowed the legacy candidate window from `top_k * SEARCH_OVERFETCH_FACTOR` to `top_k`. Measured, `top_k=3`:

```
[legacy]   body top_k=6  search_params top_k=None  => SQL LIMIT=6   ✅ overfetch intact
```

## Second instance of the same class, found on the way

The legacy payload sent the per-memory boost factors as the **value of `boosted_memory_ids`** and never sent `memory_boost_factor` at all. The SQL gates the entire entity boost on `if boosted_memory_ids and memory_boost_factor` (`postgres_service.py:1342`), so it saw a falsy factor map and **skipped the whole stack** — graph expansion and hop boosts were computed on every legacy search and then discarded at the storage boundary. Measured before the fix:

```
[pipeline] ids={...} factors={UUID(...): 1.5}  => entity_boost_applies=True
[legacy]   ids={...} factors=None              => entity_boost_applies=False
```

`tests/test_entity_retrieval_flag.py` asserted the buggy shape (`boosted_memory_ids == {str(mid): 1.3}`) at the client boundary, which is why it passed while the SQL skipped the boost. Updated to assert both keys.

## Verification

Tests are parametrised over **both** paths and assert against the dict `PostgresService.memory_scored_search` actually receives — not the client boundary, which cannot see this.

Every test was watched **failing on the legacy path for the stated reason** before the fix (3 quiet knobs at defaults and at tuned values, the boost pair, the route guard); pipeline cases pass throughout, since that path was never broken.

- `tests/` — **4144 passed**, 3 skipped, 1 xfailed, 0 xpassed. Baseline measured on a detached `origin/main` checkout: **4140** → +4 is exactly this PR's new cases.
- `core-storage-api/tests/` — **104 passed** (baseline 103 → +1).
- `ruff check` / `ruff format --check` clean at all of CI's exact scopes, plus `--select F821` over `scripts/`.
- `core-api/openapi.broker.json` regenerated: **no diff**.

`/simplify` run: 9 findings applied (reuse the shared `_require_dict` rather than an 8th inline guard; consolidated a rationale that had been duplicated across 4 files; merged 8 integration cases into 4; corrected a comment that overclaimed which keys it covered). 4 skipped as out-of-diff or behaviour-affecting — see "Deliberately not in this PR".

## Deliberately not in this PR

1. **`SEARCH_OVERFETCH_FACTOR` is inert on the pipeline path** — a live defect this PR's `top_k` reasoning uncovered. `resolve_search_profile` puts the un-overfetched `top_k` in `search_params`; `execute_scored_search` overfetches only the body-level value; storage prefers the nested one. Measured: `caller top_k=3, factor=2 → SQL LIMIT=3`, so `PostFilterResults` has none of the headroom its comment says it has. Widening it changes recall on every query, so it wants its own benchmark and review — same treatment #722 got.
2. **Extracting one shared `search_params` builder.** Two hand-built dicts remain, and they have *already* drifted: the A47 `tenant_config.default_search_profile` merge exists only in `resolve_search_profile`, so a per-tenant default never reaches the legacy path. Restructuring both builders is outside this diff and behaviour-affecting.
3. **Adopting the dead `ScoredSearchRequest` schema** (`schemas.py:260`) — it already declares this endpoint's contract, including `search_params` as required, and has zero references. Adopting it is the deeper fix for the guard, but it changes the 422 body shape and touches every field parse in a hot handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)