### PR TITLE
fix(embedding): let bulk callers pass their budget so a slow provider is attributable

### DIFF
--- a/common/embedding/_service.py
+++ b/common/embedding/_service.py
@@ -15,6 +15,7 @@ from collections.abc import Awaitable, Callable
 
 from common.embedding._registry import get_embedding_provider
 from common.embedding.constants import (
+    EMBEDDING_BUDGET_MARGIN_S,
     EMBEDDING_GATE_TIMEOUT_SECONDS,
     EMBEDDING_MAX_CONCURRENCY,
     EMBEDDING_RETRY_ATTEMPTS,
@@ -227,7 +228,10 @@ def _resolve_provider_name(tenant_config: object | None) -> str:
 
 
 async def get_embeddings_batch(
-    texts: list[str], tenant_config: object | None = None
+    texts: list[str],
+    tenant_config: object | None = None,
+    *,
+    budget_s: float | None = None,
 ) -> list[list[float]]:
     """Generate embeddings for multiple texts in a single API call.
 
@@ -247,6 +251,21 @@ async def get_embeddings_batch(
     Note this is the SERVICE layer: a request larger than the backend's
     accepted batch is split inside the provider, which is the only layer
     that knows its own cap, so *texts* has no length limit imposed here.
+
+    *budget_s* is the caller's OWN deadline, and passing it is what keeps a
+    slow backend attributable. Callers enforce their budgets by cancelling
+    us, and a cancellation says only "time ran out" — not which layer ate
+    it. Given the budget, this bounds the provider call at
+    ``budget_s - EMBEDDING_BUDGET_MARGIN_S`` so the inner cap fires first
+    and raises ``TimeoutError`` from HERE, naming the embed as the thing
+    that overran. Without it the provider is free to sit for
+    ``OPENAI_REQUEST_TIMEOUT_SECONDS`` (25 s), which already exceeds the 8 s
+    ``BULK_STRONG_EMBED_TIMEOUT_SECONDS`` outright — that budget could never
+    be the one to fire. Same principle the concurrency gate applies; see
+    ``EMBEDDING_GATE_TIMEOUT_SECONDS``.
+
+    Omitting it keeps the previous behaviour, which is right for callers
+    that have no deadline of their own to be under.
 
     Two error shapes are explicitly accounted for:
 
@@ -290,17 +309,16 @@ async def get_embeddings_batch(
         # this branch already logs unconditionally.
         await _stats.record_failure()
         raise
-    # ``BaseException``, not ``Exception``, and deliberately so. Every caller
-    # wraps this in its own deadline (``BULK_STRONG_EMBED_TIMEOUT_SECONDS`` is
-    # 8 s, ``BULK_EMBEDDING_TIMEOUT_SECONDS`` 30 s) using ``asyncio.timeout`` /
-    # ``wait_for``, and when one of those fires it CANCELS us — so what arrives
-    # here is ``CancelledError``, a ``BaseException``. Under ``except
-    # Exception`` the stats update was skipped for that entire class, which is
-    # the slow-provider outage the bulk streak exists to name: a single
-    # provider request may burn ``OPENAI_REQUEST_TIMEOUT_SECONDS`` (25 s), so
-    # the 8 s budget is already exceeded by ONE request, and chunking a
-    # ``BULK_MAX_ITEMS`` write into ceil(100/32) sequential requests puts the
-    # 30 s budget in reach too.
+    # ``BaseException``, not ``Exception``, and deliberately so. A caller that
+    # passes no ``budget_s`` still enforces its deadline by CANCELLING us, so
+    # what arrives here is ``CancelledError`` — a ``BaseException``. Under
+    # ``except Exception`` the stats update was skipped for that entire class,
+    # which is the slow-provider outage the bulk streak exists to name.
+    #
+    # ``budget_s`` narrows that window rather than closing it: the inner cap
+    # below turns the common case into a local ``TimeoutError``, but a caller
+    # can still cancel us for its own reasons, and the margin can still be
+    # overshot by a single syscall. The broad catch stays.
     #
     # Safe for real shutdown cancellation: the ``raise`` is unconditional, so
     # the cancellation always propagates. ``record_failure`` acquires an
@@ -317,7 +335,15 @@ async def get_embeddings_batch(
     # clears the streak, and on the shutdown path the counter dies with the
     # process anyway.
     try:
-        result = await _call_gated(lambda: provider.embed_batch(texts))
+        if budget_s is None:
+            result = await _call_gated(lambda: provider.embed_batch(texts))
+        else:
+            # Floored rather than skipped: a budget at or under the margin is
+            # a misconfiguration, and the honest response is to fail fast HERE
+            # with an attributable TimeoutError instead of silently reverting
+            # to the unbounded path the margin exists to replace.
+            async with asyncio.timeout(max(0.1, budget_s - EMBEDDING_BUDGET_MARGIN_S)):
+                result = await _call_gated(lambda: provider.embed_batch(texts))
     except BaseException:
         await _stats.record_failure(bulk_batch_size=len(texts))
         raise

--- a/common/embedding/constants.py
+++ b/common/embedding/constants.py
@@ -143,6 +143,24 @@ EMBEDDING_GATE_TIMEOUT_SECONDS: float = read_float_env(
     "EMBEDDING_GATE_TIMEOUT_SECONDS", 5.0
 )
 
+# How far under a caller's own deadline this module aims to fail.
+#
+# Callers enforce their budgets by CANCELLING us (``asyncio.timeout`` /
+# ``wait_for``), and a cancellation carries no attribution — it says the
+# deadline passed, not which layer ate it. The module already applies this
+# principle to the concurrency gate (see EMBEDDING_GATE_TIMEOUT_SECONDS:
+# "deliberately BELOW the callers' deadlines ... so the gate could attribute
+# the failure"), but the provider call itself was left unbounded, so a slow
+# backend surfaced as the caller's anonymous timeout.
+#
+# One margin, subtracted from whatever budget the caller passes, so the
+# ordering holds however an operator retunes the budgets rather than being
+# re-derived per call site. 1 s because the budgets it sits under are 8 s and
+# 30 s, and because the thing being raced is a network round trip whose
+# measured p95 against a loaded sidecar is ~0.4 s — a margin of that order is
+# generous without meaningfully shortening the useful budget.
+EMBEDDING_BUDGET_MARGIN_S: float = read_float_env("EMBEDDING_BUDGET_MARGIN_S", 1.0)
+
 # Cap the texts sent in ONE provider request; larger inputs are split.
 #
 # This is admission control on the SERVER's side of the wire, mirrored on

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -357,7 +357,10 @@ class Settings(BaseSettings):
     def _validate_timeout_ordering(self) -> "Settings":
         # Local import avoids a circular: constants → common.constants,
         # but this file is imported by constants.py's dependents.
-        from common.embedding.constants import EMBEDDING_GATE_TIMEOUT_SECONDS
+        from common.embedding.constants import (
+            EMBEDDING_BUDGET_MARGIN_S,
+            EMBEDDING_GATE_TIMEOUT_SECONDS,
+        )
         from core_api.constants import (
             BULK_EMBEDDING_TIMEOUT_SECONDS,
             BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS,
@@ -439,6 +442,29 @@ class Settings(BaseSettings):
                 "bulk strong-embed path. Lower the gate timeout, or raise "
                 "BULK_STRONG_EMBED_TIMEOUT_SECONDS (keeping it under "
                 "BULK_EMBEDDING_TIMEOUT_SECONDS)."
+            )
+        if BULK_STRONG_EMBED_TIMEOUT_SECONDS - EMBEDDING_BUDGET_MARGIN_S <= EMBEDDING_GATE_TIMEOUT_SECONDS:
+            # The gate check above is necessary but no longer sufficient. The
+            # embed layer now caps the provider call at
+            # ``budget_s - EMBEDDING_BUDGET_MARGIN_S`` — a bound that sits
+            # INSIDE the window the gate's own timeout lives in — so a margin
+            # large enough to pull that cap under the gate timeout means the
+            # budget cap always fires first and a gate-saturation event is
+            # reported as a generic "embed exceeded its budget" instead of the
+            # gate's dedicated warning. That inverts precisely the attribution
+            # the check above exists to guarantee, and it would do so silently.
+            #
+            # Both operands are env-overridable, so like the gate ordering this
+            # is an operator's to break rather than a constant's. Defaults leave
+            # real room: 8 - 1 = 7 > 5.
+            raise ValueError(
+                f"BULK_STRONG_EMBED_TIMEOUT_SECONDS ({BULK_STRONG_EMBED_TIMEOUT_SECONDS}s) minus "
+                f"EMBEDDING_BUDGET_MARGIN_S ({EMBEDDING_BUDGET_MARGIN_S}s) must be > "
+                f"EMBEDDING_GATE_TIMEOUT_SECONDS ({EMBEDDING_GATE_TIMEOUT_SECONDS}s), so a "
+                "saturated embedding gate still reports itself rather than being "
+                "pre-empted by the embed budget cap. Lower EMBEDDING_BUDGET_MARGIN_S, "
+                "lower the gate timeout, or raise BULK_STRONG_EMBED_TIMEOUT_SECONDS "
+                "(keeping it under BULK_EMBEDDING_TIMEOUT_SECONDS)."
             )
         if BULK_STRONG_EMBED_TIMEOUT_SECONDS >= BULK_EMBEDDING_TIMEOUT_SECONDS:
             # The other half of the bound the message above already tells the

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -1227,9 +1227,17 @@ async def create_memories_bulk(
             BULK_EMBEDDING_TIMEOUT_SECONDS if settings.inline_embedding else BULK_STRONG_EMBED_TIMEOUT_SECONDS
         )
         try:
+            # ``budget_s`` as well as the outer ``asyncio.timeout``: the inner
+            # cap is sized just under this budget so the embed layer fails
+            # first and says so, while this stays the backstop. Without it a
+            # slow provider surfaces here as a bare cancellation that names
+            # nothing — and at the strong-embed budget of 8s it always would,
+            # since one provider request may run 25s.
             async with asyncio.timeout(embed_timeout):
                 valid_embeddings = await get_embeddings_batch(
-                    [items[i].content for i in embed_indices], tenant_config
+                    [items[i].content for i in embed_indices],
+                    tenant_config,
+                    budget_s=embed_timeout,
                 )
         except Exception as exc:
             # Inline deployments: this is the only place a row gets its vector, so
@@ -2073,12 +2081,20 @@ async def _reembed_memories_bulk(
         tenant_config = None
 
     try:
-        # 30s cap matches the hot-path bulk embed in create_memories_bulk;
-        # an unbounded provider call in a background task would pin a
-        # Cloud Run worker thread if Vertex / OpenAI hangs.
+        # Cap matches the hot-path bulk embed in create_memories_bulk — now by
+        # construction rather than by two matching literals, because these two
+        # uses MUST stay equal: budget_s makes the embed layer cap itself just
+        # under this and raise an attributable TimeoutError, and that ordering
+        # breaks silently if one copy is retuned and the other is not. An
+        # unbounded provider call in a background task would pin a Cloud Run
+        # worker thread if the provider hangs.
         embeddings = await asyncio.wait_for(
-            get_embeddings_batch([content for _, content in items], tenant_config),
-            timeout=30.0,
+            get_embeddings_batch(
+                [content for _, content in items],
+                tenant_config,
+                budget_s=BULK_EMBEDDING_TIMEOUT_SECONDS,
+            ),
+            timeout=BULK_EMBEDDING_TIMEOUT_SECONDS,
         )
     except Exception:
         # Broad on purpose: any provider failure — auth, HTTP client

--- a/tests/test_bulk_write_mode.py
+++ b/tests/test_bulk_write_mode.py
@@ -250,6 +250,53 @@ def test_startup_rejects_an_override_that_conflicts_with_the_gate(monkeypatch):
 
 
 @pytest.mark.unit
+def test_budget_margin_leaves_the_gate_room_to_report_itself():
+    """The gate ordering above is necessary but not sufficient on its own.
+
+    The embed layer caps the provider call at
+    ``budget_s - EMBEDDING_BUDGET_MARGIN_S``, a bound that sits INSIDE the
+    window the gate's own timeout lives in. So "gate < budget" can hold while
+    the effective cap still lands under the gate.
+    """
+    from common.embedding.constants import (
+        EMBEDDING_BUDGET_MARGIN_S,
+        EMBEDDING_GATE_TIMEOUT_SECONDS,
+    )
+
+    assert (
+        BULK_STRONG_EMBED_TIMEOUT_SECONDS - EMBEDDING_BUDGET_MARGIN_S
+        > EMBEDDING_GATE_TIMEOUT_SECONDS
+    )
+
+
+@pytest.mark.unit
+def test_startup_rejects_a_margin_that_pre_empts_the_gate(monkeypatch):
+    """A margin wide enough to swallow the gate must not start.
+
+    Set it past the headroom and the budget cap always fires first, so a
+    gate-saturation event is reported as a generic "embed exceeded its
+    budget" and the gate's dedicated warning never runs — silently
+    inverting the attribution the gate ordering exists to guarantee.
+
+    Note the gate ordering check alone does NOT catch this: it still passes
+    here, because ``EMBEDDING_GATE_TIMEOUT_SECONDS`` is untouched and remains
+    below ``BULK_STRONG_EMBED_TIMEOUT_SECONDS``. That is the whole reason
+    this is a separate check.
+    """
+    import core_api.config as config_mod
+    from common.embedding.constants import EMBEDDING_GATE_TIMEOUT_SECONDS
+
+    # Just past the headroom: budget - margin lands exactly ON the gate,
+    # which the validator rejects (it requires strictly greater).
+    margin = BULK_STRONG_EMBED_TIMEOUT_SECONDS - EMBEDDING_GATE_TIMEOUT_SECONDS
+    monkeypatch.setattr(
+        "common.embedding.constants.EMBEDDING_BUDGET_MARGIN_S", margin
+    )
+    with pytest.raises(ValueError, match="EMBEDDING_BUDGET_MARGIN_S"):
+        config_mod.Settings()
+
+
+@pytest.mark.unit
 def test_startup_rejects_an_override_above_the_required_embed_cap(monkeypatch):
     """Both ends of the bound are enforced, not just the one the gate can break.
 

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -461,7 +461,7 @@ async def test_bulk_reembed_preserves_batching() -> None:
     # all N items arrive in a single provider roundtrip.
     batch_calls: list[int] = []
 
-    async def _fake_batch(texts, _cfg):
+    async def _fake_batch(texts, _cfg, *, budget_s=None):
         batch_calls.append(len(texts))
         return [[0.1] * VECTOR_DIM for _ in texts]
 
@@ -674,7 +674,7 @@ async def test_bulk_reembed_fallback_passes_is_failure_fallback() -> None:
 
         return _noop()
 
-    async def _failing_batch(_texts, _cfg):
+    async def _failing_batch(_texts, _cfg, *, budget_s=None):
         raise RuntimeError("simulated provider outage")
 
     def _stub_tracked_task(coro, _name, *_a, **_k):
@@ -714,7 +714,7 @@ async def test_bulk_reembed_fallback_catches_unexpected_exception_types() -> Non
         """Stands in for e.g. google.auth.exceptions.RefreshError —
         NOT in the original narrow exception list."""
 
-    async def _failing_batch(_texts, _cfg):
+    async def _failing_batch(_texts, _cfg, *, budget_s=None):
         raise _MockAuthError("token refresh failed")
 
     called: list[dict] = []
@@ -774,7 +774,7 @@ async def test_bulk_reembed_reschedules_items_whose_get_memory_failed() -> None:
     sc.get_memory = AsyncMock(side_effect=_get_memory)
     sc.update_embedding = AsyncMock()
 
-    async def _batch(_texts, _cfg):
+    async def _batch(_texts, _cfg, *, budget_s=None):
         return [[0.1] * VECTOR_DIM, [0.2] * VECTOR_DIM]
 
     def _fake_detect(*args, **_kwargs):
@@ -846,7 +846,7 @@ async def test_bulk_reembed_patch_failure_reschedules_item() -> None:
     sc.get_memory = AsyncMock(side_effect=_get_memory)
     sc.update_embedding = AsyncMock(side_effect=_update_embedding)
 
-    async def _batch(_texts, _cfg):
+    async def _batch(_texts, _cfg, *, budget_s=None):
         return [[0.1] * VECTOR_DIM, [0.2] * VECTOR_DIM]
 
     def _fake_detect(*args, **_kwargs):
@@ -919,7 +919,7 @@ async def test_bulk_reembed_respects_existing_embedding_per_item() -> None:
     sc.get_memory = AsyncMock(side_effect=_get_memory)
     sc.update_embedding = AsyncMock()
 
-    async def _batch(_texts, _cfg):
+    async def _batch(_texts, _cfg, *, budget_s=None):
         return [fresh, fresh]
 
     detect_calls: list[tuple] = []
@@ -975,7 +975,7 @@ async def test_bulk_reembed_falls_back_on_length_mismatch() -> None:
     unembedded."""
     from core_api.services import memory_service
 
-    async def _short_batch(texts, _cfg):
+    async def _short_batch(texts, _cfg, *, budget_s=None):
         # Provider returned 2 embeddings for 5 inputs — real-world shape
         # when a provider partial-fails mid-batch.
         return [[0.1] * VECTOR_DIM for _ in texts[:2]]

--- a/tests/test_embedding_retry.py
+++ b/tests/test_embedding_retry.py
@@ -7,7 +7,9 @@ Unit tests validate:
   - Fake provider never returns None (no retry needed)
 """
 
+import asyncio
 import logging
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -406,8 +408,6 @@ async def test_bulk_failure_counted_when_caller_deadline_cancels_us(
     exists to name: one provider request may burn
     ``OPENAI_REQUEST_TIMEOUT_SECONDS`` (25s), already past the 8s budget.
     """
-    import asyncio
-
     import common.embedding._service as service_mod
     from common.embedding import get_embeddings_batch
     from common.embedding.providers.fake import FakeEmbeddingProvider
@@ -431,6 +431,82 @@ async def test_bulk_failure_counted_when_caller_deadline_cancels_us(
         "a deadline-cancelled bulk call must advance the bulk streak"
     )
     assert service_mod._stats.failures == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_budget_makes_a_slow_provider_attributable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With ``budget_s``, the embed layer fails FIRST and names itself.
+
+    The caller's deadline enforces itself by cancelling us, and a
+    ``CancelledError`` says only "time ran out" — not which layer ate it.
+    Passing the budget caps the provider call just under it, so what the
+    caller sees is a ``TimeoutError`` raised from inside the embed layer.
+
+    This is the ordering that was structurally impossible before: one
+    provider request may run ``OPENAI_REQUEST_TIMEOUT_SECONDS`` (25s),
+    which already exceeds ``BULK_STRONG_EMBED_TIMEOUT_SECONDS`` (8s), so
+    that budget could never be the cap that fired.
+    """
+    import common.embedding._service as service_mod
+    from common.embedding import get_embeddings_batch
+    from common.embedding.providers.fake import FakeEmbeddingProvider
+
+    class _SlowProvider(FakeEmbeddingProvider):
+        async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+            await asyncio.sleep(60)
+            raise AssertionError("unreachable")
+
+    monkeypatch.setattr(service_mod, "_stats", service_mod._EmbeddingStats())
+    monkeypatch.setattr(service_mod, "EMBEDDING_BUDGET_MARGIN_S", 0.05)
+    monkeypatch.setattr(
+        "common.embedding._service.get_embedding_provider",
+        lambda *_a, **_k: _SlowProvider(),
+    )
+
+    # Both caps raise TimeoutError, so the exception type cannot tell them
+    # apart — WHEN it fires is the only discriminator. The outer deadline is
+    # 25x the inner one, and the assertion below is what actually fails if
+    # the inner cap is removed.
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        async with asyncio.timeout(5):
+            await get_embeddings_batch(["a"] * 50, budget_s=0.2)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1, (
+        f"the embed layer's own cap must fire first; took {elapsed:.2f}s, "
+        "which means the caller's 5s deadline was what stopped it"
+    )
+    assert service_mod._stats.consecutive_bulk_failures == 1, (
+        "the inner cap must still count as a bulk failure"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_budget_keeps_the_previous_unbounded_behaviour(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting ``budget_s`` must not impose a cap of its own.
+
+    Two call sites embed auto-chunk children with no deadline to sit
+    under; they have to keep working exactly as before.
+    """
+    import common.embedding._service as service_mod
+    from common.embedding import get_embeddings_batch
+    from common.embedding.providers.fake import FakeEmbeddingProvider
+
+    monkeypatch.setattr(service_mod, "_stats", service_mod._EmbeddingStats())
+    monkeypatch.setattr(
+        "common.embedding._service.get_embedding_provider",
+        lambda *_a, **_k: FakeEmbeddingProvider(),
+    )
+
+    assert len(await get_embeddings_batch(["a", "b", "c"])) == 3
+    assert service_mod._stats.consecutive_bulk_failures == 0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The last of the follow-ups from #721.

## The problem, and why it was structural

Callers enforce their embed deadlines by **cancelling** the call. A `CancelledError` says only "time ran out" — not which layer ate it. The provider call itself was unbounded, so a slow backend surfaced as the caller's anonymous timeout with nothing naming the embed.

At the strong-embed budget that isn't just untidy:

```
BULK_STRONG_EMBED_TIMEOUT_SECONDS   8s   ← the caller's budget
OPENAI_REQUEST_TIMEOUT_SECONDS     25s   ← what ONE provider request may take
```

That budget could **never** be the cap that fired. The module already applies the opposite principle to its own concurrency gate — `EMBEDDING_GATE_TIMEOUT_SECONDS` sits *"deliberately BELOW the callers' deadlines … so the gate could attribute the failure"* — the provider call was simply never brought under it.

## The change

`get_embeddings_batch` takes an optional keyword `budget_s`. Given it, the provider call is bounded at `budget_s - EMBEDDING_BUDGET_MARGIN_S`, so the inner cap fires first and raises `TimeoutError` **from inside the embed layer**. Omitting it keeps the previous behaviour — right for the two auto-chunk call sites that have no deadline of their own to sit under.

One margin constant rather than a subtraction per call site, so the ordering survives an operator retuning the budgets.

This **narrows the window rather than closing it**: a caller can still cancel for its own reasons, so the `BaseException` catch that counts those stays.

## Cost worth naming

Seven test doubles for `get_embeddings_batch` needed updating, and **four tests failed loudly until they did**. A keyword-only argument on a widely-mocked function has real blast radius even when production callers are unaffected. I updated the doubles to mirror the real signature rather than loosening them to `**kwargs`, so the next signature change fails the same way instead of silently passing.

## On the test

The first version of the attribution test **passed with the fix reverted** — both caps raise `TimeoutError`, so the exception type can't tell them apart. It was worthless and I caught it by reverting.

It now asserts on **elapsed time**: an inner budget 25x tighter than the caller's deadline, failing if the caller's is what stopped it.

```
with fix:     0.87s   ✅
without fix:  5.70s   ❌  "took 5.70s, which means the caller's 5s deadline was what stopped it"
```

A second test pins that omitting `budget_s` imposes no cap of its own.

## Context from the load test

Worth recording since it sizes the margin: driving staging TEI from inside the VPC at the gate's own max concurrency (16), a 100-item write's chunked round trips measured **p95 0.394s, worst 0.428s**. A 1s margin is generous against that without meaningfully shortening the useful budget.

That same run answered #721's open load-test question, and refutes the premise of its Medium finding — chunking does **not** cost ~4x hold time, because per-request latency scales with request size:

| concurrency | unchunked p95 | chunked p95 | ratio |
|---|---|---|---|
| 1 | 0.106s | 0.174s | 1.64x |
| 4 | 0.264s | 0.333s | 1.26x |
| 8 | 0.543s | 0.567s | 1.04x |
| **16** | 0.988s | **0.926s** | **0.94x** |

At the concurrency the gate actually permits, chunking is *faster* — smaller requests interleave better across instances. Zero errors at every level. Staging TEI's shape (min 2 / max 3 / concurrency 10) is identical to prod's, so this is a faithful proxy.

## Checks

`ruff check common/ core-api/src/` · `ruff format --check` — clean.
Full `pytest tests/ -m "not benchmark"`: **4108 passed**; 26 failures + 8 errors byte-identical to pristine `main` (no local Postgres). Zero regressions. `uv.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)