### PR TITLE
fix(search): declare the scored-search wire contract once, in common/

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -398,3 +398,44 @@ SINGLE_VALUE_PREDICATES: frozenset[str] = frozenset(
 # Diverging values would silently produce different archive footprints
 # across the two deployment modes.
 LIFECYCLE_STALE_ARCHIVE_WEIGHT: float = 0.3
+
+
+# ── Scored-search wire contract (#723 / #725) ──
+# The scoring knobs core-api nests under ``search_params`` on the way to
+# core-storage-api's ``/memories/scored-search``, and that
+# ``PostgresService.memory_scored_search`` reads back out. One declaration for
+# both ends: core-api's two search-path builders project through it, so only
+# these keys cross, and storage requires the ones it reads positionally.
+#
+# It lives here, not beside core-api's default VALUES, because what drifts is
+# the key set against the SQL — a two-service concern — and this module is the
+# shared home for exactly that.
+#
+# The set has been wrong in both directions. Keys the SQL needed went missing on
+# one path (``candidate_pool_size`` / ``score_formula``, #723). And keys the SQL
+# never reads travelled anyway, one of which — ``top_k`` — collided with a
+# same-named request parameter and silently became the candidate-window LIMIT,
+# defeating the overfetch on the active path (#725).
+SQL_SCORING_PARAM_KEYS: tuple[str, ...] = (
+    "fts_weight",
+    "freshness_floor",
+    "freshness_decay_days",
+    "recall_boost_cap",
+    "recall_decay_window_days",
+    "similarity_blend",
+    "candidate_pool_size",
+    "score_formula",
+    "fts_rank_scale",
+)
+# The subset read with INDEXED access in the SQL builder, i.e. no server-side
+# default: a payload missing any of these is malformed, and the route rejects it
+# rather than letting it surface as a KeyError 500 from inside the session. The
+# remainder are read with ``sp.get(key, default)`` and may be omitted.
+SQL_SCORING_REQUIRED_KEYS: tuple[str, ...] = (
+    "fts_weight",
+    "freshness_floor",
+    "freshness_decay_days",
+    "recall_boost_cap",
+    "recall_decay_window_days",
+    "similarity_blend",
+)

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -18,6 +18,7 @@ from common.constants import (  # noqa: F401
     SEMANTIC_DEDUP_CANDIDATE_LIMIT,
     SEMANTIC_DEDUP_THRESHOLD,
     SINGLE_VALUE_PREDICATES,
+    SQL_SCORING_PARAM_KEYS,
     TYPE_DECAY_DAYS,
     VECTOR_DIM,
 )
@@ -570,6 +571,10 @@ FTS_BOOST_SPECIFICITY_RATIO = 0.4  # strict >; at N=2 this means >=1 specific to
 SIMILARITY_BLEND = 0.85  # base_score = SIMILARITY_BLEND * similarity + (1 - SIMILARITY_BLEND) * weight (raised from 0.75 — LoCoMo sweep showed +13pp recall)
 SEARCH_OVERFETCH_FACTOR = 2  # fetch top_k * N candidates from storage, trim to top_k after min_similarity filter — gives post-filter headroom
 FTS_ONLY_RESERVED_RESULTS = 1  # #687: result slots held for rows that FTS-match but are not embedded yet (transient deferred-embed window); 0 restores the pre-#687 head-slice behaviour
+# ``SQL_SCORING_PARAM_KEYS`` — the set both search-path builders project through
+# before sending ``search_params`` — is re-exported from ``common.constants``
+# above, because storage reads the same set and the drift that matters is
+# set-against-SQL.
 # A26: recall_count is bumped for every RETURNED row, used or not (see
 # TrackRecalls + memory_increment_recall), and feeds recall_boost back into the
 # rank score — a self-reinforcing "returned → boosted → returned" loop with no

--- a/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
+++ b/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from types import SimpleNamespace
 
 from core_api.clients.storage_client import get_storage_client
-from core_api.constants import SEARCH_OVERFETCH_FACTOR
+from core_api.constants import SEARCH_OVERFETCH_FACTOR, SQL_SCORING_PARAM_KEYS
 from core_api.middleware.per_tenant_concurrency import per_tenant_storage_slot
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepOutcome, StepResult
@@ -63,22 +63,21 @@ class ExecuteScoredSearch:
 
         # Build the request payload for the storage client.
         #
-        # ``top_k`` is stripped: it is the candidate-window LIMIT, not a scoring
-        # knob, and it travels as its own request parameter below. It stays in
-        # ``ctx.data["search_params"]`` because ClassifyQuery and the
-        # ``_ALLOWED_OVERRIDES`` merge above both read it — this is a projection
-        # at the boundary, not a removal at the source.
+        # ``search_params`` is PROJECTED through ``SQL_SCORING_PARAM_KEYS`` rather
+        # than sent whole: ``ctx.data["search_params"]`` is core-api's working set
+        # and a superset of the wire contract, carrying knobs no storage query
+        # reads. Projecting at the boundary — rather than removing them at the
+        # source — keeps them available to the steps that do read them while
+        # guaranteeing they cannot reach the SQL. Why that guarantee is worth
+        # having, and what it costs when it is missing: see the tuple's own note.
         #
-        # Storage ignores a nested ``top_k`` now, so this strip is not what makes
-        # the LIMIT correct; it is here so the payload says what we mean. Removing
-        # only this one key does NOT make the dict scoring-knobs-only, though:
-        # ``min_similarity`` and ``graph_max_hops`` are core-api-local too and
-        # still ride along (storage reads neither). Projecting an explicit
-        # allowlist shared with the legacy builder is the generalisation, and is
-        # deliberately left out of this change.
+        # ``if k in sp``: ResolveSearchProfile always writes the full set, but
+        # unit-test contexts hand-build a partial one (e.g.
+        # tests/test_audit_s6_c1_events.py), so tolerate a subset here and let the
+        # storage route's required-key check be the one place that rejects.
         #
         # The diagnostic branch's widening to 50 was defeated by the same
-        # shadowing and is restored here — but note that mode is half-wired:
+        # shadowing and is restored — but note that mode is half-wired:
         # ``SearchRequest.diagnostic`` is never read by a route and nothing writes
         # ``diagnostic_results``, so no caller reaches it. Whoever reconnects it
         # should know the branch skips ``final_top_k``, so PostFilterResults does
@@ -87,7 +86,7 @@ class ExecuteScoredSearch:
             "tenant_id": data["tenant_id"],
             "query": data["query"],
             "embedding": embedding,
-            "search_params": {k: v for k, v in sp.items() if k != "top_k"},
+            "search_params": {k: sp[k] for k in SQL_SCORING_PARAM_KEYS if k in sp},
             "top_k": top_k,
             "recall_boost_enabled": recall_boost_enabled,
         }

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -71,6 +71,7 @@ from core_api.constants import (
     SCORE_FORMULA,
     SEARCH_OVERFETCH_FACTOR,
     SIMILARITY_BLEND,
+    SQL_SCORING_PARAM_KEYS,
 )
 from core_api.schemas import (
     BulkItemResult,
@@ -3478,10 +3479,22 @@ async def _search_memories_legacy(
     # allowlist that dropped whatever it did not name. Full rationale sits with
     # the deleted code, on the storage ``/scored-search`` route.
     #
-    # ``top_k`` is NOT in this dict: it is the candidate-window LIMIT, not a
-    # scoring knob, and storage takes it from the body-level key below — the
-    # overfetched one. Neither builder nests a ``top_k`` now, and storage no
-    # longer reads one.
+    # Ordered by ``SQL_SCORING_PARAM_KEYS``, the declaration the pipeline builder
+    # projects through too, so the two paths cannot drift about what crosses the
+    # wire. Indexed, not ``.get`` — this path resolves every knob a few lines
+    # above, so a key declared and not resolved here is a mistake worth a
+    # KeyError rather than a silent omission at the SQL.
+    _resolved_scoring = {
+        "fts_weight": _fts_weight,
+        "fts_rank_scale": _fts_rank_scale,
+        "freshness_floor": _freshness_floor,
+        "freshness_decay_days": _freshness_decay_days,
+        "recall_boost_cap": _recall_boost_cap,
+        "recall_decay_window_days": _recall_decay_window_days,
+        "similarity_blend": _similarity_blend,
+        "candidate_pool_size": _candidate_pool_size,
+        "score_formula": _score_formula,
+    }
     search_data = {
         "tenant_id": tenant_id,
         "embedding": embedding,
@@ -3497,17 +3510,7 @@ async def _search_memories_legacy(
         # post-filter below applies it. Kept flat for that reason — a new knob
         # belongs in ``search_params``, not beside this one.
         "min_similarity": _min_similarity,
-        "search_params": {
-            "fts_weight": _fts_weight,
-            "fts_rank_scale": _fts_rank_scale,
-            "freshness_floor": _freshness_floor,
-            "freshness_decay_days": _freshness_decay_days,
-            "recall_boost_cap": _recall_boost_cap,
-            "recall_decay_window_days": _recall_decay_window_days,
-            "similarity_blend": _similarity_blend,
-            "candidate_pool_size": _candidate_pool_size,
-            "score_formula": _score_formula,
-        },
+        "search_params": {k: _resolved_scoring[k] for k in SQL_SCORING_PARAM_KEYS},
         "recall_boost_enabled": recall_boost,
         "temporal_window_days": temporal_window.days if temporal_window else None,
         # Both halves, under their own keys: the SQL gates the entire entity

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
 
+from common.constants import SQL_SCORING_REQUIRED_KEYS
 from common.events.lifecycle_purge_request import (
     MEMORY_RETENTION_MAX_DAYS,
     MEMORY_RETENTION_MIN_DAYS,
@@ -141,11 +142,19 @@ async def scored_search(request: Request) -> list[dict]:
     # Both core-api builders send nested now, so the fallback is gone and the
     # SQL reads what the caller actually sent.
     #
-    # Fail-closed rather than defaulting: ``memory_scored_search`` reads six of
-    # these keys with INDEXED access, so a payload without them is a malformed
-    # request, and 4xx at the edge beats the KeyError 500 it would otherwise
-    # raise from inside the session.
+    # Fail-closed rather than defaulting: ``memory_scored_search`` reads
+    # ``SQL_SCORING_REQUIRED_KEYS`` with INDEXED access, so a payload without them
+    # is a malformed request, and 4xx at the edge beats the KeyError 500 it would
+    # otherwise raise from inside the session. #723 stated that and only checked
+    # the dict was non-empty; naming the keys is what actually enforces it, and
+    # the same shared tuple is what core-api's builders project through.
     search_params = _require_dict(body, "search_params")
+    missing = [k for k in SQL_SCORING_REQUIRED_KEYS if k not in search_params]
+    if missing:
+        raise HTTPException(
+            status_code=422,
+            detail=f"search_params is missing required scoring keys: {', '.join(missing)}",
+        )
 
     # Parse temporal_window from days (legacy) or seconds (pipeline path)
     temporal_window = None

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -581,6 +581,41 @@ class TestMemories:
         resp_empty = await client.post(f"{PREFIX}/memories/scored-search", json={**flat, "search_params": {}})
         assert resp_empty.status_code == 422, resp_empty.text
 
+    async def test_scored_search_names_the_missing_required_scoring_keys(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+    ) -> None:
+        """A partial ``search_params`` is rejected, and the 422 says which keys.
+
+        The SQL builder reads ``SQL_SCORING_REQUIRED_KEYS`` positionally, so an
+        incomplete dict would otherwise raise a KeyError from inside the session
+        and surface as a 500 — a server fault for a malformed request. The
+        omission is named because the caller cannot see which of the six the SQL
+        wanted from a bare 422.
+        """
+        partial = {
+            "tenant_id": tenant_id,
+            "embedding": [0.1] * VECTOR_DIM,
+            "query": "anything",
+            "top_k": 10,
+            # Non-empty, so the dict guard passes; two required keys short.
+            "search_params": {
+                "fts_weight": 0.5,
+                "freshness_floor": 0.5,
+                "freshness_decay_days": 30.0,
+                "similarity_blend": 0.7,
+            },
+        }
+        resp = await client.post(f"{PREFIX}/memories/scored-search", json=partial)
+        assert resp.status_code == 422, (
+            f"a partial search_params must be rejected at the edge, got {resp.status_code}: {resp.text}"
+        )
+        detail = resp.json()["detail"]
+        assert "recall_boost_cap" in detail and "recall_decay_window_days" in detail, detail
+        # The keys that WERE supplied must not be reported missing.
+        assert "fts_weight" not in detail, detail
+
     async def test_scored_search_surfaces_null_embedding_via_fts(
         self,
         client: AsyncClient,

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -25,6 +25,7 @@ from core_api.constants import (
     MIN_SEARCH_SIMILARITY,
     SCORE_FORMULA,
     SEARCH_OVERFETCH_FACTOR,
+    SQL_SCORING_PARAM_KEYS,
 )
 from common.models.memory import Memory
 from common.embedding import fake_embedding
@@ -914,4 +915,89 @@ async def test_post_filter_does_not_starve_the_result_set(monkeypatch, use_pipel
     )
     assert {str(r.id) for r in results} <= qualifying, (
         f"the {path} path returned rows below MIN_SEARCH_SIMILARITY={MIN_SEARCH_SIMILARITY}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_pipeline", [True, False], ids=["pipeline", "legacy"])
+async def test_only_sql_scoring_keys_cross_the_wire(tenant_id, monkeypatch, use_pipeline):
+    """Both paths must deliver EXACTLY the declared key set — no more, no less.
+
+    The per-key tests above pin that specific knobs arrive. This pins the set,
+    which is the assertion that catches the other direction: a core-api-local
+    field added to ``search_params`` and shipped to storage by accident. That is
+    not hypothetical — ``top_k`` did exactly that, and because storage read it as
+    the candidate-window LIMIT it silently defeated ``SEARCH_OVERFETCH_FACTOR``
+    on the active path (#725).
+
+    Equality, not containment, on purpose: containment would pass for every
+    surplus key, which is the failure mode being guarded.
+    """
+    call = await _scored_search_call(monkeypatch, tenant_id, use_pipeline)
+    delivered = set((call.get("search_params") or {}).keys())
+
+    path = "pipeline" if use_pipeline else "legacy"
+    assert delivered == set(SQL_SCORING_PARAM_KEYS), (
+        f"the {path} path's search_params does not match SQL_SCORING_PARAM_KEYS; "
+        f"surplus={sorted(delivered - set(SQL_SCORING_PARAM_KEYS))} "
+        f"missing={sorted(set(SQL_SCORING_PARAM_KEYS) - delivered)}. Surplus keys reach the SQL "
+        f"and can collide with a request parameter; missing keys leave the SQL on its own default"
+    )
+
+
+def test_sql_scoring_param_keys_matches_what_storage_reads():
+    """The declared set must equal the keys ``memory_scored_search`` reads.
+
+    Both services import the tuple, but nothing DERIVES storage's reads from it —
+    the SQL builder names each key inline, which is the readable way to write it.
+    So this compares the declaration against the source, and is what makes the
+    tuple a single registration point rather than a fourth list to keep in sync:
+    add a knob to the SQL without declaring it and this fails, naming it.
+    """
+    import ast
+    import inspect
+    import re
+    import textwrap
+
+    from core_storage_api.services.postgres_service import PostgresService
+
+    # Round-tripped through the AST rather than grepped raw: the storage source
+    # discusses these keys in prose as well as reading them, and a regex over the
+    # text counts a comment as a read. It scored ``top_k`` that way — a key #725
+    # deliberately STOPPED reading, still named in the comment saying so.
+    # ``ast.unparse`` drops comments, so what is left is only code.
+    code = ast.unparse(ast.parse(textwrap.dedent(inspect.getsource(PostgresService.memory_scored_search))))
+    read = set(re.findall(r"""sp(?:\[|\.get\()['"](\w+)['"]""", code))
+
+    assert read, "found no `sp` reads at all — the scan broke, it did not pass"
+    assert read == set(SQL_SCORING_PARAM_KEYS), (
+        f"SQL_SCORING_PARAM_KEYS is out of step with memory_scored_search; "
+        f"storage reads but core-api does not declare: {sorted(read - set(SQL_SCORING_PARAM_KEYS))}; "
+        f"core-api declares but storage never reads: {sorted(set(SQL_SCORING_PARAM_KEYS) - read)}"
+    )
+
+
+def test_required_scoring_keys_are_the_ones_storage_reads_positionally():
+    """``SQL_SCORING_REQUIRED_KEYS`` must be exactly the indexed reads.
+
+    The route rejects a payload missing these. Declare too many and a legitimate
+    caller gets a 422; too few and the omission returns to being a KeyError 500
+    from inside the session, which is the thing the guard exists to prevent.
+    """
+    import ast
+    import inspect
+    import re
+    import textwrap
+
+    from common.constants import SQL_SCORING_REQUIRED_KEYS
+    from core_storage_api.services.postgres_service import PostgresService
+
+    code = ast.unparse(ast.parse(textwrap.dedent(inspect.getsource(PostgresService.memory_scored_search))))
+    indexed = set(re.findall(r"""sp\[['"](\w+)['"]\]""", code))
+
+    assert indexed, "found no indexed `sp[...]` reads — the scan broke, it did not pass"
+    assert indexed == set(SQL_SCORING_REQUIRED_KEYS), (
+        f"SQL_SCORING_REQUIRED_KEYS does not match storage's indexed reads; "
+        f"read positionally but not required: {sorted(indexed - set(SQL_SCORING_REQUIRED_KEYS))}; "
+        f"required but not read positionally: {sorted(set(SQL_SCORING_REQUIRED_KEYS) - indexed)}"
     )


### PR DESCRIPTION
The follow-up #725 named. `search_params` crosses core-api → core-storage-api as a bare dict, and which keys belong in it was written down **nowhere** — which is why the set has now been wrong in both directions:

- keys the SQL **needed** went missing on one path — `candidate_pool_size`, `score_formula` (#723);
- keys the SQL **never reads** travelled anyway, and one of them (`top_k`) collided with a same-named request parameter and silently became the candidate-window LIMIT, defeating the overfetch on the active path (#725).

## The contract, declared once

`common/constants.py` now holds `SQL_SCORING_PARAM_KEYS` (the nine keys `memory_scored_search` reads) and `SQL_SCORING_REQUIRED_KEYS` (the six it reads positionally).

**Why `common/` and not `core_api/constants.py`** — I had it in core-api first, on the reasoning that both consumers live there. That was wrong, and the comment I wrote to justify it ("storage cannot import this") was factually false: `common/constants.py` is documented as *"DB-query constants shared between core-api and core-storage-api"*, and `postgres_service.py:47` already imports twelve names from it, **including ones used inside `memory_scored_search` itself**. What drifts here is the key set against the SQL — a two-service concern — and `common/` is where this repo puts those. It is also not in enterprise's `vendored_files_manifest.json` (only 9 files are), so there is **no re-vendor cost**.

## Both builders project through it

Neither hand-lists the set now, so a core-api-local knob cannot reach the SQL by accident:

- **Pipeline** projects out of a genuine superset — `ctx.data["search_params"]` also carries `top_k`, `min_similarity` and `graph_max_hops`, which `ClassifyQuery` and `PostFilterResults` read and storage does not. Projecting *at the boundary* rather than removing them at the source keeps them available to those steps.
- **Legacy** projects strictly (`_resolved_scoring[k]`, no `if k in`) — it resolves every knob a few lines above, so a key declared and not resolved is a mistake worth a `KeyError`, not a silent omission at the SQL.

## The route now enforces what #723 only described

#723's comment said a payload missing the positionally-read keys is malformed and should 4xx at the edge — but the guard only checked the dict was non-empty, so an *incomplete* one still reached the SQL and surfaced as a `KeyError` 500 from inside the session. It is now a 422 naming exactly which keys are missing.

## Verification

Every new test watched failing for its own reason:

| mutation | result |
|---|---|
| pipeline sends the whole dict | `surplus=['graph_max_hops', 'min_similarity', 'top_k']` |
| drop `candidate_pool_size` from the declaration | `storage reads but core-api does not declare: ['candidate_pool_size']` |
| remove the route's required-key check | partial-payload 422 test fails |

- `tests/` **4170 passed**, 3 skipped, 1 xfailed, 0 xpassed. Baseline measured on a detached `origin/main` checkout: **4166** → +4 is exactly this PR's cases.
- `core-storage-api/tests/` **105** (baseline 104 → +1).
- Ruff clean at all of CI's exact scopes, including `ruff check common/` and the `--isolated` vendored-file check; `F821` over `scripts/` clean; broker OpenAPI regenerated with no diff.

### On the source-scan test

`test_sql_scoring_param_keys_matches_what_storage_reads` is what makes this a *single* registration point rather than a fourth list to maintain: both services import the tuple, but nothing **derives** storage's reads from it, since the SQL builder names each key inline — which is the readable way to write it.

It round-trips the storage source through `ast.unparse` rather than grepping it. That is not incidental: the storage source discusses these keys in prose as well as reading them, and my first version — a regex over the raw text — scored `top_k` as a read, out of the comment explaining why #725 **stopped** reading it. `ast.unparse` drops comments, so what is left is only code.

## What this does not fix

Adding a knob end-to-end still touches `_SEARCH_PROFILE_RULES` (`organization_settings.py:1086`), and forgetting it is the one step no test catches: `validate_search_profile` copies unknown keys through unvalidated and unclamped on the agent-profile path, while a tenant default 422s. Collapsing the remaining lists into one knob table (default + type + range + `sql: bool`) is the real end state, but it restructures both resolvers and the settings-validation table, so it is not this change.

Also still open and separate: `_search_memories_legacy` never merges the A47 `tenant_config.default_search_profile`, so a rollback to the legacy path silently drops tenant-wide search defaults — a divergence in the *values* resolved, not the keys delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)