### PR TITLE
refactor(search): one knob table instead of four registration points

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -1,4 +1,13 @@
-"""DB-query constants shared between core-api and core-storage-api."""
+"""Constants shared between core-api and core-storage-api.
+
+Mostly DB-query values both services need to agree on. Also ``SEARCH_KNOBS``
+and the wire contract derived from it: storage reads only the derived key
+tuples, but the knob table is one declaration on purpose — splitting the
+bounds into core-api and the flags into here would put the knob NAME in two
+files, which is the drift it exists to remove.
+"""
+
+from typing import NamedTuple
 
 # ── Memory liveness ──
 # The statuses that mean "this memory is live". Broader than the literal
@@ -400,42 +409,74 @@ SINGLE_VALUE_PREDICATES: frozenset[str] = frozenset(
 LIFECYCLE_STALE_ARCHIVE_WEIGHT: float = 0.3
 
 
-# ── Scored-search wire contract (#723 / #725) ──
-# The scoring knobs core-api nests under ``search_params`` on the way to
-# core-storage-api's ``/memories/scored-search``, and that
-# ``PostgresService.memory_scored_search`` reads back out. One declaration for
-# both ends: core-api's two search-path builders project through it, so only
-# these keys cross, and storage requires the ones it reads positionally.
+# ── Search tuning knobs (#723 / #725 / #727) ──
+# The declaration of each search knob's type, accepted range, and whether it
+# crosses the wire to core-storage-api. Ranges and types drive validation on
+# both the agent-profile and tenant-default write paths; the ``sql`` flags
+# derive the wire contract below.
 #
-# It lives here, not beside core-api's default VALUES, because what drifts is
-# the key set against the SQL — a two-service concern — and this module is the
-# shared home for exactly that.
+# NOT yet the declaration the request SCHEMAS derive from: ``SearchProfileUpdate``
+# and the ``memclaw_tune`` MCP signature still enumerate their own subset (9 of
+# these 12 — the three A/B knobs are deliberately not agent-tunable) with their
+# own bounds, and those have already drifted: ``graph_max_hops`` is (0, 5) here
+# and ge=0/le=3 there.
 #
-# The set has been wrong in both directions. Keys the SQL needed went missing on
-# one path (``candidate_pool_size`` / ``score_formula``, #723). And keys the SQL
-# never reads travelled anyway, one of which — ``top_k`` — collided with a
-# same-named request parameter and silently became the candidate-window LIMIT,
-# defeating the overfetch on the active path (#725).
-SQL_SCORING_PARAM_KEYS: tuple[str, ...] = (
-    "fts_weight",
-    "freshness_floor",
-    "freshness_decay_days",
-    "recall_boost_cap",
-    "recall_decay_window_days",
-    "similarity_blend",
-    "candidate_pool_size",
-    "score_formula",
-    "fts_rank_scale",
-)
-# The subset read with INDEXED access in the SQL builder, i.e. no server-side
-# default: a payload missing any of these is malformed, and the route rejects it
-# rather than letting it surface as a KeyError 500 from inside the session. The
-# remainder are read with ``sp.get(key, default)`` and may be omitted.
-SQL_SCORING_REQUIRED_KEYS: tuple[str, ...] = (
-    "fts_weight",
-    "freshness_floor",
-    "freshness_decay_days",
-    "recall_boost_cap",
-    "recall_decay_window_days",
-    "similarity_blend",
-)
+# One table because the same knob used to be registered in four places — the
+# validation rules, both search-path builders, and the storage route's key list —
+# and every omission was silent in a different way. Keys the SQL needed went
+# missing on one path (``candidate_pool_size`` / ``score_formula``, #723). Keys
+# the SQL never reads travelled anyway, one of which — ``top_k`` — collided with
+# a same-named request parameter and became the candidate-window LIMIT, defeating
+# the overfetch on the active path (#725). And a knob absent from the rules was
+# accepted UNVALIDATED and UNCLAMPED on the agent path while the tenant-default
+# path rejected it as unknown.
+#
+# It lives here, not beside core-api's default VALUES, because what drifts is the
+# key set against storage's SQL — a two-service concern, which is this module's
+# subject. The defaults stay in ``core_api.constants``: those are core-api policy,
+# and three of them are not constants at all (``fts_weight`` is query-adaptive,
+# ``top_k`` and ``min_similarity`` fall back to the caller's request).
+
+
+class SearchKnob(NamedTuple):
+    """Type, bounds, and wire disposition for one search tuning knob."""
+
+    value_type: type
+    bounds: tuple[float, float]
+    # Crosses the wire in ``search_params``; storage reads it in the scoring SQL.
+    sql: bool = False
+    # Storage reads it with INDEXED access, i.e. no server-side default, so a
+    # payload omitting it is malformed and the route rejects it rather than
+    # letting it surface as a KeyError 500 from inside the session.
+    sql_required: bool = False
+
+
+SEARCH_KNOBS: dict[str, SearchKnob] = {
+    # ── core-api-local: resolved here, never sent to storage ──
+    "top_k": SearchKnob(int, (1, 20)),
+    "min_similarity": SearchKnob(float, (0.1, 0.9)),
+    "graph_max_hops": SearchKnob(int, (0, 5)),
+    # ── scoring knobs storage reads positionally ──
+    "fts_weight": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True),
+    "freshness_floor": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True),
+    "freshness_decay_days": SearchKnob(int, (7, 730), sql=True, sql_required=True),
+    "recall_boost_cap": SearchKnob(float, (1.0, 3.0), sql=True, sql_required=True),
+    "recall_decay_window_days": SearchKnob(int, (7, 365), sql=True, sql_required=True),
+    "similarity_blend": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True),
+    # ── scoring knobs with a server-side default, so optional on the wire ──
+    # #687: scale on ts_rank_cd before saturation. Floor is 1.0, not 0 — that is
+    # the pre-#687 formula, so a tenant can revert but cannot weaken keyword
+    # relevance below where it has always been. Ceiling is the largest value the
+    # LoCoMo sweep actually measured; above it is untested territory.
+    "fts_rank_scale": SearchKnob(float, (1.0, 20.0), sql=True),
+    # A49: 0 = off (candidate pool by boosted score); >0 = cosine-dominant pool of this size.
+    "candidate_pool_size": SearchKnob(int, (0, 200), sql=True),
+    # A50 unified: 0 = legacy multiplicative score; 1 = unified relevance-dominant formula.
+    "score_formula": SearchKnob(int, (0, 1), sql=True),
+}
+
+# The wire contract, derived. Core-api's two search-path builders project
+# ``search_params`` through the first; the storage route rejects a payload
+# missing any of the second.
+SQL_SCORING_PARAM_KEYS: tuple[str, ...] = tuple(k for k, v in SEARCH_KNOBS.items() if v.sql)
+SQL_SCORING_REQUIRED_KEYS: tuple[str, ...] = tuple(k for k, v in SEARCH_KNOBS.items() if v.sql_required)

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from cachetools import TTLCache
 from croniter import CroniterBadCronError, croniter
 
+from common.constants import SEARCH_KNOBS
 from common.events.base import Event
 from common.events.factory import get_event_bus
 from common.events.lifecycle_purge_request import (
@@ -507,7 +508,7 @@ def _validate_default_search_profile(payload: dict) -> None:
     agent-tune path), an org-wide setting write should fail loudly so an
     operator gets a 422 rather than a value that was quietly clamped. Unknown
     keys, wrong types, and out-of-range values all raise. Keys and ranges are
-    the same source of truth as agent profiles (``_SEARCH_PROFILE_RULES``).
+    the same source of truth as agent profiles (``SEARCH_KNOBS``).
     """
     dp = payload.get("search", {}).get("default_profile")
     if dp is None:
@@ -515,11 +516,10 @@ def _validate_default_search_profile(payload: dict) -> None:
     if not isinstance(dp, dict):
         raise ValueError("search.default_profile must be an object")
     for key, value in dp.items():
-        if key not in _SEARCH_PROFILE_RULES:
-            raise ValueError(
-                f"search.default_profile: unknown key {key!r} (allowed: {sorted(_SEARCH_PROFILE_RULES)})"
-            )
-        expected_type, (lo, hi), _ = _SEARCH_PROFILE_RULES[key]
+        knob = SEARCH_KNOBS.get(key)
+        if knob is None:
+            raise ValueError(f"search.default_profile: unknown key {key!r} (allowed: {sorted(SEARCH_KNOBS)})")
+        expected_type, (lo, hi) = knob.value_type, knob.bounds
         # Accept an int where a float is expected (e.g. min_similarity=0 → 0.0),
         # but never a bool (bool is an int subclass and would slip through).
         if expected_type is float and isinstance(value, int) and not isinstance(value, bool):
@@ -1082,54 +1082,40 @@ class ResolvedConfig:
         return global_settings.security_audit_alert_score_drop_delta
 
 
-# Search profile validation
-_SEARCH_PROFILE_RULES: dict[str, tuple[type, tuple, object]] = {
-    "top_k": (int, (1, 20), None),
-    "min_similarity": (float, (0.1, 0.9), None),
-    "fts_weight": (float, (0.0, 1.0), None),
-    # #687: scale on ts_rank_cd before saturation. Floor is 1.0, not 0 — that is
-    # the pre-#687 formula, so a tenant can revert but cannot weaken keyword
-    # relevance below where it has always been. Ceiling is the largest value the
-    # LoCoMo sweep actually measured; above it is untested territory.
-    "fts_rank_scale": (float, (1.0, 20.0), None),
-    "freshness_floor": (float, (0.0, 1.0), None),
-    "freshness_decay_days": (int, (7, 730), None),
-    "recall_boost_cap": (float, (1.0, 3.0), None),
-    "recall_decay_window_days": (int, (7, 365), None),
-    "graph_max_hops": (int, (0, 5), None),
-    "similarity_blend": (float, (0.0, 1.0), None),
-    # A49: 0 = off (candidate pool by boosted score); >0 = cosine-dominant pool of this size.
-    "candidate_pool_size": (int, (0, 200), None),
-    # A50 unified: 0 = legacy multiplicative score; 1 = unified relevance-dominant formula.
-    "score_formula": (int, (0, 1), None),
-}
-
-
 def validate_search_profile(profile: dict) -> dict:
-    """Validate and sanitise a search_profile dict."""
+    """Validate and sanitise a search_profile dict against ``SEARCH_KNOBS``.
+
+    Lenient by design, unlike ``_validate_default_search_profile``: a known key
+    out of range is clamped and a known key of the wrong type is dropped, but an
+    UNKNOWN key is passed through untouched. That last one looks backwards — an
+    unknown key survives where a known-but-malformed one does not — and the
+    reason is persistence, not laxity. Both write ingresses are closed Pydantic
+    models, so an unknown key can only come from a row written by a DIFFERENT
+    build; dropping it here would make a rollback silently erase a tenant's
+    tuning for a knob this build has not heard of.
+    """
     if not profile:
         return {}
 
     cleaned: dict = {}
     for key, value in profile.items():
-        if key not in _SEARCH_PROFILE_RULES:
+        knob = SEARCH_KNOBS.get(key)
+        if knob is None:
             cleaned[key] = value
             continue
 
-        expected_type, (lo, hi), default = _SEARCH_PROFILE_RULES[key]
+        expected_type, (lo, hi) = knob.value_type, knob.bounds
 
         if expected_type is float and isinstance(value, int):
             value = float(value)
 
         if not isinstance(value, expected_type):
             logger.warning(
-                "search_profile key '%s' has wrong type %s (expected %s), using default",
+                "search_profile key '%s' has wrong type %s (expected %s), dropping key",
                 key,
                 type(value).__name__,
                 expected_type.__name__,
             )
-            if default is not None:
-                cleaned[key] = default
             continue
 
         if value < lo or value > hi:

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -945,59 +945,78 @@ async def test_only_sql_scoring_keys_cross_the_wire(tenant_id, monkeypatch, use_
     )
 
 
-def test_sql_scoring_param_keys_matches_what_storage_reads():
-    """The declared set must equal the keys ``memory_scored_search`` reads.
+# ``SQL_SCORING_PARAM_KEYS`` / ``SQL_SCORING_REQUIRED_KEYS`` no longer need their
+# own source-scan tests: both are derived from ``SEARCH_KNOBS``'s ``sql`` flags,
+# so pinning the flags against storage (below) pins the tuples with them.
 
-    Both services import the tuple, but nothing DERIVES storage's reads from it —
-    the SQL builder names each key inline, which is the readable way to write it.
-    So this compares the declaration against the source, and is what makes the
-    tuple a single registration point rather than a fourth list to keep in sync:
-    add a knob to the SQL without declaring it and this fails, naming it.
+
+async def test_resolve_search_profile_emits_every_declared_knob():
+    """``ResolveSearchProfile`` must resolve exactly the declared knob set.
+
+    The resolver still names each knob one by one, to attach a default the table
+    deliberately does not carry (see ``SEARCH_KNOBS``). This makes skipping one
+    loud.
+
+    The wire knobs are already covered — a declared-but-unresolved one fails
+    ``test_only_sql_scoring_keys_cross_the_wire`` on both paths. This adds the
+    three core-api-local knobs (``top_k``, ``min_similarity``,
+    ``graph_max_hops``), which never reach the wire at all. Dropping one of those
+    today does still break other tests, but as a KeyError from whichever step
+    reads it downstream; this is the one that fails with the key's name and the
+    reason. No DB — a bare context through a pure step.
     """
-    import ast
-    import inspect
-    import re
-    import textwrap
+    from common.constants import SEARCH_KNOBS
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.search.resolve_search_profile import ResolveSearchProfile
 
-    from core_storage_api.services.postgres_service import PostgresService
+    ctx = PipelineContext()
+    ctx.data.update({"query": "anything at all", "top_k": 5, "search_profile": None})
+    await ResolveSearchProfile().execute(ctx)
 
-    # Round-tripped through the AST rather than grepped raw: the storage source
-    # discusses these keys in prose as well as reading them, and a regex over the
-    # text counts a comment as a read. It scored ``top_k`` that way — a key #725
-    # deliberately STOPPED reading, still named in the comment saying so.
-    # ``ast.unparse`` drops comments, so what is left is only code.
-    code = ast.unparse(ast.parse(textwrap.dedent(inspect.getsource(PostgresService.memory_scored_search))))
-    read = set(re.findall(r"""sp(?:\[|\.get\()['"](\w+)['"]""", code))
-
-    assert read, "found no `sp` reads at all — the scan broke, it did not pass"
-    assert read == set(SQL_SCORING_PARAM_KEYS), (
-        f"SQL_SCORING_PARAM_KEYS is out of step with memory_scored_search; "
-        f"storage reads but core-api does not declare: {sorted(read - set(SQL_SCORING_PARAM_KEYS))}; "
-        f"core-api declares but storage never reads: {sorted(set(SQL_SCORING_PARAM_KEYS) - read)}"
+    emitted = set(ctx.data["search_params"])
+    assert emitted == set(SEARCH_KNOBS), (
+        f"ResolveSearchProfile is out of step with SEARCH_KNOBS; "
+        f"declared but not resolved: {sorted(set(SEARCH_KNOBS) - emitted)}; "
+        f"resolved but not declared: {sorted(emitted - set(SEARCH_KNOBS))}"
     )
 
 
-def test_required_scoring_keys_are_the_ones_storage_reads_positionally():
-    """``SQL_SCORING_REQUIRED_KEYS`` must be exactly the indexed reads.
+def test_sql_flags_match_how_storage_reads_each_knob():
+    """``sql`` / ``sql_required`` must match storage's actual reads.
 
-    The route rejects a payload missing these. Declare too many and a legitimate
-    caller gets a 422; too few and the omission returns to being a KeyError 500
-    from inside the session, which is the thing the guard exists to prevent.
+    The flags derive both wire tuples, so they are the single registration step
+    for a new scoring knob — which only holds while they describe what the SQL
+    really does. ``sql`` is any read; ``sql_required`` is the indexed subset,
+    where a missing key is a KeyError rather than a server-side default.
     """
     import ast
     import inspect
     import re
     import textwrap
 
-    from common.constants import SQL_SCORING_REQUIRED_KEYS
+    from common.constants import SQL_SCORING_PARAM_KEYS, SQL_SCORING_REQUIRED_KEYS
     from core_storage_api.services.postgres_service import PostgresService
 
+    # Round-tripped through the AST, not grepped: the storage source discusses
+    # these keys in prose as well as reading them, and a regex over raw text
+    # scores a comment as a read — it picked up ``top_k`` from the note saying
+    # #725 stopped reading it. ``ast.unparse`` drops comments.
     code = ast.unparse(ast.parse(textwrap.dedent(inspect.getsource(PostgresService.memory_scored_search))))
+    read = set(re.findall(r"""sp(?:\[|\.get\()['"](\w+)['"]""", code))
     indexed = set(re.findall(r"""sp\[['"](\w+)['"]\]""", code))
 
-    assert indexed, "found no indexed `sp[...]` reads — the scan broke, it did not pass"
-    assert indexed == set(SQL_SCORING_REQUIRED_KEYS), (
-        f"SQL_SCORING_REQUIRED_KEYS does not match storage's indexed reads; "
-        f"read positionally but not required: {sorted(indexed - set(SQL_SCORING_REQUIRED_KEYS))}; "
-        f"required but not read positionally: {sorted(set(SQL_SCORING_REQUIRED_KEYS) - indexed)}"
+    # Against the DERIVED tuples, which is the same assertion one step on: they
+    # are literally ``{k for k, v in SEARCH_KNOBS.items() if v.sql}``.
+    flagged, required = set(SQL_SCORING_PARAM_KEYS), set(SQL_SCORING_REQUIRED_KEYS)
+
+    assert read and indexed, "found no `sp` reads — the scan broke, it did not pass"
+    assert read == flagged, (
+        f"SEARCH_KNOBS `sql` flags disagree with storage; "
+        f"reads-but-not-flagged: {sorted(read - flagged)}; "
+        f"flagged-but-unread: {sorted(flagged - read)}"
+    )
+    assert indexed == required, (
+        f"SEARCH_KNOBS `sql_required` flags disagree with storage's indexed reads; "
+        f"indexed-but-not-required: {sorted(indexed - required)}; "
+        f"required-but-not-indexed: {sorted(required - indexed)}"
     )


### PR DESCRIPTION
The last item from the #723 → #725 → #727 thread. A search tuning knob had to be registered in **four** places, and every omission was silent in a different way:

| forgotten | symptom |
|---|---|
| a search-path builder | the knob applies on one path only (#723) |
| the wire-contract tuple | a core-api-local key reaches the SQL — `top_k` became the candidate-window LIMIT (#725) |
| `_SEARCH_PROFILE_RULES` | **accepted unvalidated and unclamped** on the agent path, while the tenant-default path rejects it as unknown |

## One table

`common/constants.py` now holds `SEARCH_KNOBS` — per knob: type, bounds, and whether it crosses the wire. Everything else derives:

- `SQL_SCORING_PARAM_KEYS` = knobs flagged `sql`
- `SQL_SCORING_REQUIRED_KEYS` = knobs flagged `sql_required` (storage's indexed reads)
- `_SEARCH_PROFILE_RULES` — **deleted**; both validators read the table directly

Its third `default` slot went with it: `None` for all twelve entries, so the branch consuming it was unreachable. The log line that said *"using default"* now says *"dropping key"*, which is what actually happens.

## Why the table carries no defaults

Three of them aren't constants — `fts_weight` is query-adaptive, `top_k` and `min_similarity` fall back to the caller's request. A `default` column would need a sentinel and the resolvers would stay hand-written regardless, which is precisely the shape of the dead slot just removed. So the resolver is pinned by a test instead.

## Tests: two in, two out

- **`test_resolve_search_profile_emits_every_declared_knob`** — asserts the resolver emits exactly the declared set. This is what makes a forgotten resolver loud, and it is the only *direct* cover for the three knobs that never reach the wire (`top_k`, `min_similarity`, `graph_max_hops`).
- **`test_sql_flags_match_how_storage_reads_each_knob`** — pins `sql` / `sql_required` against storage's actual reads, indexed vs `.get`.

The two source-scan tests #727 added are **deleted, not weakened**: they asserted the tuples against storage, and the tuples are now derived from the flags this test pins. Same property, one place.

Each verified by mutation, with the offending key named every time:

```
declare a knob, skip the resolver  → declared but not resolved: ['brand_new_knob']
flip sql_required → sql            → indexed-but-not-required: ['similarity_blend']
drop a knob from the resolver      → declared but not resolved: ['graph_max_hops']
```

## Verification

- `tests/` **4172 passed**, 3 skipped, 1 xfailed, 0 xpassed — identical to the `origin/main` baseline I measured on a detached checkout, as expected: two tests added, two superseded ones removed.
- `core-storage-api/tests/` 105, unchanged. Ruff clean at all of CI's exact scopes including `common/`; broker OpenAPI regenerated with no diff.

## Not addressed — now stated rather than implied

`SearchProfileUpdate` (`schemas.py:540`) and the `memclaw_tune` MCP signature still enumerate their own subset with their own bounds, and **they have already drifted**: `graph_max_hops` is `(0, 5)` in the table and `ge=0, le=3` there, so the same knob accepts 5 from a tenant default and rejects it from the REST ingress. That predates this change. Deriving those from the table would alter a public request schema and needs a decision on which bound is correct, so I have flagged it in the table's own comment rather than silently picking one.

Also still open: the two resolvers remain separate, and `_search_memories_legacy` never merges the A47 `tenant_config.default_search_profile`, so tenant-wide search defaults reach the pipeline path only. Extracting one shared resolver is the largest remaining win here and would let the new resolver test pin both paths at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)