### PR TITLE
refactor(search): one resolver for both search paths, and A47 reaches legacy

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
+++ b/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
@@ -1,22 +1,15 @@
-"""ResolveSearchProfile — resolve per-agent search profile with fallback to constants."""
+"""ResolveSearchProfile — adapt ``ctx.data`` to the shared knob resolver.
+
+The resolution ladder itself (agent profile → tenant default → constant) lives in
+``memory_service.resolve_search_params``, because the legacy search path needs the
+identical answer.
+"""
 
 from __future__ import annotations
 
-from core_api.constants import (
-    CANDIDATE_POOL_SIZE,
-    FRESHNESS_DECAY_DAYS,
-    FRESHNESS_FLOOR,
-    FTS_RANK_SCALE,
-    GRAPH_MAX_HOPS,
-    MIN_SEARCH_SIMILARITY,
-    RECALL_BOOST_CAP,
-    RECALL_DECAY_WINDOW_DAYS,
-    SCORE_FORMULA,
-    SIMILARITY_BLEND,
-)
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
-from core_api.services.memory_service import _adaptive_fts_weight
+from core_api.services.memory_service import resolve_search_params
 
 
 class ResolveSearchProfile:
@@ -25,47 +18,10 @@ class ResolveSearchProfile:
         return "resolve_search_profile"
 
     async def execute(self, ctx: PipelineContext) -> StepResult | None:
-        from core_api.services.organization_settings import validate_search_profile
-
-        search_profile = ctx.data.get("search_profile")
-        resolved_profile = validate_search_profile(search_profile) if search_profile else {}
-
-        # Tenant-wide default profile (A47) sits BELOW the agent profile and
-        # ABOVE the global constants: a per-agent tuned knob wins, the tenant
-        # default fills the gaps, and the constant is the final fallback.
-        # ``tenant_config`` is a ResolvedConfig on the primary search/recall
-        # paths (routes resolve it before calling); guard for callers that
-        # don't pass one so behaviour is unchanged when it's absent.
-        tenant_config = ctx.tenant_config
-        if tenant_config is not None:
-            tenant_default = getattr(tenant_config, "default_search_profile", {}) or {}
-            if tenant_default:
-                resolved_profile = {**tenant_default, **resolved_profile}
-
-        query = ctx.data["query"]
-        top_k = ctx.data["top_k"]
-
-        ctx.data["search_params"] = {
-            "top_k": resolved_profile.get("top_k", top_k),
-            "min_similarity": resolved_profile.get("min_similarity", MIN_SEARCH_SIMILARITY),
-            "fts_weight": (
-                resolved_profile["fts_weight"]
-                if "fts_weight" in resolved_profile
-                else _adaptive_fts_weight(query)
-            ),
-            "freshness_floor": resolved_profile.get("freshness_floor", FRESHNESS_FLOOR),
-            "freshness_decay_days": resolved_profile.get("freshness_decay_days", FRESHNESS_DECAY_DAYS),
-            "recall_boost_cap": resolved_profile.get("recall_boost_cap", RECALL_BOOST_CAP),
-            "recall_decay_window_days": resolved_profile.get(
-                "recall_decay_window_days", RECALL_DECAY_WINDOW_DAYS
-            ),
-            "graph_max_hops": resolved_profile.get("graph_max_hops", GRAPH_MAX_HOPS),
-            "similarity_blend": resolved_profile.get("similarity_blend", SIMILARITY_BLEND),
-            # #687: scale on ts_rank_cd before saturation; 1.0 = pre-#687 formula.
-            "fts_rank_scale": resolved_profile.get("fts_rank_scale", FTS_RANK_SCALE),
-            # A49: 0 = off; >0 = storage selects a cosine-dominant candidate pool of this size.
-            "candidate_pool_size": resolved_profile.get("candidate_pool_size", CANDIDATE_POOL_SIZE),
-            # A50 unified: 0 = legacy multiplicative score; 1 = unified relevance-dominant formula.
-            "score_formula": resolved_profile.get("score_formula", SCORE_FORMULA),
-        }
+        ctx.data["search_params"] = resolve_search_params(
+            ctx.data.get("search_profile"),
+            query=ctx.data["query"],
+            top_k=ctx.data["top_k"],
+            tenant_config=ctx.tenant_config,
+        )
         return None

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -95,6 +95,7 @@ from core_api.services.governance_gate import (
     pii_audit_detail,
 )
 from core_api.services.hooks import get_hooks
+from core_api.services.organization_settings import validate_search_profile
 from core_api.services.task_tracker import tracked_task
 
 logger = logging.getLogger(__name__)
@@ -2874,6 +2875,68 @@ def _adaptive_fts_weight(query: str) -> float:
     return FTS_WEIGHT
 
 
+def resolve_search_params(
+    search_profile: dict | None,
+    *,
+    query: str,
+    top_k: int,
+    tenant_config=None,
+) -> dict:
+    """Resolve every search knob for one query, for both search paths.
+
+    Precedence: per-agent profile → tenant-wide default (A47) → global constant.
+    A tuned agent knob wins, the tenant default fills the gaps, the constant is
+    the last word.
+
+    Shared because there were two copies of this ladder and only one merged the
+    tenant default, so a tenant-wide search default applied on the pipeline path
+    alone — including the per-tenant ``fts_rank_scale = 1.0`` revert documented
+    for #687.
+
+    Scoped to RESOLUTION, deliberately: this makes both paths resolve the same
+    knobs from the same sources, and does NOT make them deliver the same ranking.
+    ``ClassifyQuery`` writes per-strategy ``search_param_overrides`` that
+    ``ExecuteScoredSearch`` merges over the result — TEMPORAL and RECENT_CONTEXT
+    both force ``freshness_floor`` / ``freshness_decay_days`` — and that happens
+    on the pipeline path only. So on a query with a temporal hint the pipeline
+    overrides a tenant's freshness knobs where the legacy path honours them. The
+    two paths are not interchangeable; see the handoff for the full list.
+
+    Returns every knob in ``SEARCH_KNOBS``, which is what lets one test pin the
+    set for both paths at once. Callers take what they need: the wire payload is
+    a projection through ``SQL_SCORING_PARAM_KEYS``; ``top_k``,
+    ``min_similarity`` and ``graph_max_hops`` are core-api-local.
+
+    ``tenant_config`` is a ``ResolvedConfig`` on the primary search/recall paths
+    (routes resolve it before calling); ``None`` is tolerated so callers that
+    don't have one behave exactly as before A47.
+    """
+    resolved = validate_search_profile(search_profile) if search_profile else {}
+
+    if tenant_config is not None:
+        tenant_default = getattr(tenant_config, "default_search_profile", {}) or {}
+        if tenant_default:
+            resolved = {**tenant_default, **resolved}
+
+    return {
+        "top_k": resolved.get("top_k", top_k),
+        "min_similarity": resolved.get("min_similarity", MIN_SEARCH_SIMILARITY),
+        "graph_max_hops": resolved.get("graph_max_hops", GRAPH_MAX_HOPS),
+        # The one default that is not a constant: it adapts to the query unless
+        # tuned, so this is an ``in`` check rather than ``.get`` — a ``.get``
+        # default would run the tokenizer on every call, tuned or not.
+        "fts_weight": resolved["fts_weight"] if "fts_weight" in resolved else _adaptive_fts_weight(query),
+        "freshness_floor": resolved.get("freshness_floor", FRESHNESS_FLOOR),
+        "freshness_decay_days": resolved.get("freshness_decay_days", FRESHNESS_DECAY_DAYS),
+        "recall_boost_cap": resolved.get("recall_boost_cap", RECALL_BOOST_CAP),
+        "recall_decay_window_days": resolved.get("recall_decay_window_days", RECALL_DECAY_WINDOW_DAYS),
+        "similarity_blend": resolved.get("similarity_blend", SIMILARITY_BLEND),
+        "fts_rank_scale": resolved.get("fts_rank_scale", FTS_RANK_SCALE),
+        "candidate_pool_size": resolved.get("candidate_pool_size", CANDIDATE_POOL_SIZE),
+        "score_formula": resolved.get("score_formula", SCORE_FORMULA),
+    }
+
+
 def _normalize_query_for_cache(query: str) -> str:
     """Normalize query for cache key: lowercase, strip, collapse whitespace."""
     return re.sub(r"\s+", " ", query.strip().lower())
@@ -3424,22 +3487,10 @@ async def _search_memories_legacy(
     """Legacy search -- uses scored_search storage API endpoint."""
     sc = get_storage_client()
 
-    # Resolve per-agent search profile with fallback to constants
-    from core_api.services.organization_settings import validate_search_profile
-
-    sp = validate_search_profile(search_profile) if search_profile else {}
-    _top_k = sp.get("top_k", top_k)
-    _min_similarity = sp.get("min_similarity", MIN_SEARCH_SIMILARITY)
-    _fts_weight = sp["fts_weight"] if "fts_weight" in sp else _adaptive_fts_weight(query)
-    _freshness_floor = sp.get("freshness_floor", FRESHNESS_FLOOR)
-    _freshness_decay_days = sp.get("freshness_decay_days", FRESHNESS_DECAY_DAYS)
-    _recall_boost_cap = sp.get("recall_boost_cap", RECALL_BOOST_CAP)
-    _recall_decay_window_days = sp.get("recall_decay_window_days", RECALL_DECAY_WINDOW_DAYS)
-    _graph_max_hops = sp.get("graph_max_hops", GRAPH_MAX_HOPS)
-    _similarity_blend = sp.get("similarity_blend", SIMILARITY_BLEND)
-    _fts_rank_scale = sp.get("fts_rank_scale", FTS_RANK_SCALE)
-    _candidate_pool_size = sp.get("candidate_pool_size", CANDIDATE_POOL_SIZE)
-    _score_formula = sp.get("score_formula", SCORE_FORMULA)
+    # Same resolver the pipeline step uses — see ``resolve_search_params``.
+    sp = resolve_search_params(search_profile, query=query, top_k=top_k, tenant_config=tenant_config)
+    _top_k = sp["top_k"]
+    _min_similarity = sp["min_similarity"]
 
     # Temporal hint
     temporal_window = _extract_temporal_hint(query)
@@ -3449,7 +3500,7 @@ async def _search_memories_legacy(
     # deprecated legacy search honours the org switch exactly like the pipeline.
     emb_task = asyncio.ensure_future(_get_or_cache_embedding(query, tenant_id, tenant_config))
     ent_task = asyncio.ensure_future(
-        _entity_boost_pipeline(query, tenant_id, fleet_ids, graph_expand, _graph_max_hops)
+        _entity_boost_pipeline(query, tenant_id, fleet_ids, graph_expand, sp["graph_max_hops"])
         if entity_retrieval
         else _no_entity_boost()
     )
@@ -3479,22 +3530,6 @@ async def _search_memories_legacy(
     # allowlist that dropped whatever it did not name. Full rationale sits with
     # the deleted code, on the storage ``/scored-search`` route.
     #
-    # Ordered by ``SQL_SCORING_PARAM_KEYS``, the declaration the pipeline builder
-    # projects through too, so the two paths cannot drift about what crosses the
-    # wire. Indexed, not ``.get`` — this path resolves every knob a few lines
-    # above, so a key declared and not resolved here is a mistake worth a
-    # KeyError rather than a silent omission at the SQL.
-    _resolved_scoring = {
-        "fts_weight": _fts_weight,
-        "fts_rank_scale": _fts_rank_scale,
-        "freshness_floor": _freshness_floor,
-        "freshness_decay_days": _freshness_decay_days,
-        "recall_boost_cap": _recall_boost_cap,
-        "recall_decay_window_days": _recall_decay_window_days,
-        "similarity_blend": _similarity_blend,
-        "candidate_pool_size": _candidate_pool_size,
-        "score_formula": _score_formula,
-    }
     search_data = {
         "tenant_id": tenant_id,
         "embedding": embedding,
@@ -3510,7 +3545,10 @@ async def _search_memories_legacy(
         # post-filter below applies it. Kept flat for that reason — a new knob
         # belongs in ``search_params``, not beside this one.
         "min_similarity": _min_similarity,
-        "search_params": {k: _resolved_scoring[k] for k in SQL_SCORING_PARAM_KEYS},
+        # Indexed, unlike the pipeline's tolerant projection: the resolver above
+        # always returns every declared knob, so a missing one is a bug worth a
+        # KeyError rather than a silent omission at the SQL.
+        "search_params": {k: sp[k] for k in SQL_SCORING_PARAM_KEYS},
         "recall_boost_enabled": recall_boost,
         "temporal_window_days": temporal_window.days if temporal_window else None,
         # Both halves, under their own keys: the SQL gates the entire entity

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -642,7 +642,7 @@ def _spy_on_scored_search(monkeypatch) -> list[tuple[dict, list]]:
 
 
 async def _scored_search_call(
-    monkeypatch, tenant_id, use_pipeline, *, search_profile=None, boost=None, top_k=3
+    monkeypatch, tenant_id, use_pipeline, *, search_profile=None, boost=None, top_k=3, tenant_config=None
 ):
     """Run one search; return the kwargs ``memory_scored_search`` received.
 
@@ -680,6 +680,7 @@ async def _scored_search_call(
         query="anything at all",
         top_k=top_k,
         search_profile=search_profile,
+        tenant_config=tenant_config,
     )
 
     path = "pipeline" if use_pipeline else "legacy"
@@ -689,41 +690,57 @@ async def _scored_search_call(
 
 @pytest.mark.integration
 @pytest.mark.parametrize("use_pipeline", [True, False], ids=["pipeline", "legacy"])
-@pytest.mark.parametrize("tuned", [False, True], ids=["defaults", "tuned"])
+@pytest.mark.parametrize(
+    "via", [None, "agent_profile", "tenant_default"], ids=["defaults", "agent", "tenant_default"]
+)
 async def test_scoring_knobs_reach_the_sql_on_both_search_paths(
-    tenant_id, monkeypatch, use_pipeline, tuned
+    tenant_id, monkeypatch, use_pipeline, via
 ):
     """Every quiet scoring knob must arrive where the SQL reads it, on BOTH paths.
 
-    Two builders and one server-side decision can each drop a key, and each is
-    invisible to the other two:
+    One builder per path and one server-side decision can each drop a key, and
+    each is invisible to the others:
 
-      * ``resolve_search_profile`` builds the pipeline's ``search_params``;
-      * ``_search_memories_legacy`` builds its own payload;
+      * ``resolve_search_params`` resolves the knobs for both paths;
+      * each path projects its own wire payload out of that;
       * the storage route decides what ``search_params`` the SQL finally sees.
 
-    Asserting at the client boundary cannot see the third, because the nesting
+    Asserting at the client boundary cannot see the last one, because the nesting
     happens server-side — which is why this asserts against the dict the storage
     service actually received. A key that never arrives leaves the SQL on its own
     fallback, so the feature applies to one path only and the documented legacy
-    rollback lever reverts it as a side effect.
+    rollback lever changes ranking as a side effect.
 
-    Both cases are needed. ``defaults`` pins the wiring, but two of these
-    constants are currently 0, so on its own it cannot tell a delivered value
-    from a builder that hardcoded the same number; ``tuned`` moves every knob off
-    its default and makes the value itself the assertion.
+    All three sources are needed. ``defaults`` pins the wiring, but two of these
+    constants are currently 0, so on its own it cannot tell a delivered value from
+    a builder that hardcoded the same number. ``agent`` moves every knob off its
+    default and makes the value itself the assertion. ``tenant_default`` sends the
+    same values down the A47 tenant-wide rung instead — which the legacy path
+    used to skip entirely, resolving its own ladder without the tenant merge, so
+    a tenant-wide default reached the pipeline path alone.
     """
-    profile = {key: t for key, _, t in _SQL_SCORING_KEYS} if tuned else None
-    expected = profile or {key: const for key, const, _ in _SQL_SCORING_KEYS}
+    from core_api.services.organization_settings import ResolvedConfig
 
-    call = await _scored_search_call(monkeypatch, tenant_id, use_pipeline, search_profile=profile)
+    tuned = {key: t for key, _, t in _SQL_SCORING_KEYS}
+    profile = tuned if via == "agent_profile" else None
+    tenant_config = (
+        ResolvedConfig({"search": {"default_profile": tuned}}) if via == "tenant_default" else None
+    )
+    expected = tuned if via else {key: const for key, const, _ in _SQL_SCORING_KEYS}
+
+    call = await _scored_search_call(
+        monkeypatch,
+        tenant_id,
+        use_pipeline,
+        search_profile=profile,
+        tenant_config=tenant_config,
+    )
     delivered = {k: (call.get("search_params") or {}).get(k) for k in expected}
 
     path = "pipeline" if use_pipeline else "legacy"
     assert delivered == expected, (
-        f"the {path} path did not deliver every scoring knob to the SQL; storage saw "
-        f"{delivered} instead of {expected}, so the SQL falls back to its own default "
-        f"and the feature applies to the other path only"
+        f"the {path} path did not deliver every scoring knob from {via or 'the constants'} "
+        f"to the SQL; storage saw {delivered} instead of {expected}"
     )
 
 
@@ -950,32 +967,25 @@ async def test_only_sql_scoring_keys_cross_the_wire(tenant_id, monkeypatch, use_
 # so pinning the flags against storage (below) pins the tuples with them.
 
 
-async def test_resolve_search_profile_emits_every_declared_knob():
-    """``ResolveSearchProfile`` must resolve exactly the declared knob set.
+def test_resolve_search_params_emits_every_declared_knob():
+    """The resolver must resolve exactly the declared knob set.
 
-    The resolver still names each knob one by one, to attach a default the table
-    deliberately does not carry (see ``SEARCH_KNOBS``). This makes skipping one
-    loud.
+    It names each knob one by one, to attach a default the table deliberately does
+    not carry (see ``SEARCH_KNOBS``). This makes skipping one loud.
 
-    The wire knobs are already covered — a declared-but-unresolved one fails
-    ``test_only_sql_scoring_keys_cross_the_wire`` on both paths. This adds the
-    three core-api-local knobs (``top_k``, ``min_similarity``,
-    ``graph_max_hops``), which never reach the wire at all. Dropping one of those
-    today does still break other tests, but as a KeyError from whichever step
-    reads it downstream; this is the one that fails with the key's name and the
-    reason. No DB — a bare context through a pure step.
+    Asserted against ``resolve_search_params`` rather than either search path
+    because there is now only one resolver — so this pins BOTH. The three
+    core-api-local knobs (``top_k``, ``min_similarity``, ``graph_max_hops``) are
+    the part no other test covers: they never reach the wire, so dropping one
+    surfaces elsewhere only as a KeyError from whichever step reads it
+    downstream. Here it fails with the key's name.
     """
     from common.constants import SEARCH_KNOBS
-    from core_api.pipeline.context import PipelineContext
-    from core_api.pipeline.steps.search.resolve_search_profile import ResolveSearchProfile
+    from core_api.services.memory_service import resolve_search_params
 
-    ctx = PipelineContext()
-    ctx.data.update({"query": "anything at all", "top_k": 5, "search_profile": None})
-    await ResolveSearchProfile().execute(ctx)
-
-    emitted = set(ctx.data["search_params"])
+    emitted = set(resolve_search_params(None, query="anything at all", top_k=5))
     assert emitted == set(SEARCH_KNOBS), (
-        f"ResolveSearchProfile is out of step with SEARCH_KNOBS; "
+        f"resolve_search_params is out of step with SEARCH_KNOBS; "
         f"declared but not resolved: {sorted(set(SEARCH_KNOBS) - emitted)}; "
         f"resolved but not declared: {sorted(emitted - set(SEARCH_KNOBS))}"
     )


### PR DESCRIPTION
The last structural item from the #723 → #725 → #727 → #728 thread. Branched off `main` after #728 merged, so **not** a stacked PR.

## The bug

The knob resolution ladder — agent profile → tenant-wide default (A47) → global constant — was written out **twice**: in `ResolveSearchProfile` and inline in `_search_memories_legacy`. The copies had diverged: only the pipeline merged `tenant_config.default_search_profile`.

So a tenant-wide search default applied on the active path alone, and the per-tenant `fts_rank_scale = 1.0` revert **documented for #687** did nothing on the path you would flip to in an emergency. Measured, with the legacy path resolving its own ladder:

```
[tenant_default-legacy]  storage saw {'fts_rank_scale': 6.0, 'candidate_pool_size': 0, 'score_formula': 0}
                         where the tenant asked for {3.0, 25, 1}
```

## The change

`resolve_search_params()` is the single ladder; both callers use it. The legacy path drops from twelve resolved locals to two and projects its wire payload straight off the resolved dict. The pipeline step becomes the `ctx.data` adapter it always was — 72 lines to 27 — and keeps its class, because the runner emits per-step `step_ms` and resolving inline would delete `resolve_search_profile` from the prod latency breakdown.

Because a knob is now resolved in one place, `test_resolve_search_params_emits_every_declared_knob` covers **both** paths at once.

## Scoped to resolution — this does NOT make the paths interchangeable

I want to be explicit, because my first draft of the docstring claimed the rollback lever now "reproduces" ranking and that is **false in the other direction**. `ClassifyQuery` writes per-strategy `search_param_overrides` that `ExecuteScoredSearch` merges over the resolved dict — TEMPORAL and RECENT_CONTEXT both force `freshness_floor` and `freshness_decay_days` — and that is pipeline-only. So on a query with a temporal hint the **pipeline overrides a tenant's freshness knobs where legacy honours them**: a second divergence, opposite in direction to the one fixed here.

The remaining divergences are enumerated in the handoff. The one to know about: **`readable_tenant_ids` is not forwarded to the legacy path at all** — the dispatcher's call omits it and the signature lacks it — so cross-tenant reads silently narrow to the home tenant there. Also legacy-only-missing: the hard `date_range` filter, the `ENTITY_LOOKUP` short-circuit, rerank, STM injection, and `TrackRecalls`' A26 `caller_agent_id` gate (legacy increments unconditionally and synchronously).

## Verification

- `tests/` **4174 passed**, 3 skipped, 1 xfailed, 0 xpassed. Baseline measured on a detached `origin/main` checkout: **4172** → +2 is exactly the new source axis.
- `core-storage-api/tests/` 105, unchanged. Ruff clean at all of CI's exact scopes; broker OpenAPI regenerated with no diff.
- The A47 fix rides the existing both-paths delivery test as a third source axis (`defaults` / `agent` / `tenant_default`) rather than a separate test — which covers all three quiet knobs through the tenant rung instead of the one knob my first version checked. Verified by mutation, above. The knob-set test still fails with the key named when a knob is dropped from the resolver.

`/simplify` found the false equivalence claim above, folded my standalone test into the existing one, and cut a war story I had told at four sites down to one. It also confirmed the module-level hoist of `validate_search_profile` creates no cycle (`organization_settings` imports nothing from `core_api.services`) and costs 1.37 ms of a 539 ms import.

## Follow-ups

- Seven sibling `resolve_config` imports in `memory_service.py` are still function-local; this change's module-level import is the proof they were never cycle-avoidance. Left alone to keep the diff readable.
- Still the next duplication worth collapsing: `SearchProfileUpdate` and the `memclaw_tune` signature enumerate their own knob subset with their own bounds, and `graph_max_hops` has already drifted — `(0, 5)` in `SEARCH_KNOBS` vs `le=3` there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)