### PR TITLE
fix(search): settle graph_max_hops at 3 across every surface

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -418,8 +418,10 @@ LIFECYCLE_STALE_ARCHIVE_WEIGHT: float = 0.3
 # NOT yet the declaration the request SCHEMAS derive from: ``SearchProfileUpdate``
 # and the ``memclaw_tune`` MCP signature still enumerate their own subset (9 of
 # these 12 — the three A/B knobs are deliberately not agent-tunable) with their
-# own bounds, and those have already drifted: ``graph_max_hops`` is (0, 5) here
-# and ge=0/le=3 there.
+# own bounds. Those bounds now AGREE with this table, and
+# ``test_agent_tunable_bounds_match_the_knob_table`` fails if they drift again —
+# but they are still written out by hand in three places. Deriving them from
+# here is the remaining step.
 #
 # One table because the same knob used to be registered in four places — the
 # validation rules, both search-path builders, and the storage route's key list —
@@ -455,7 +457,12 @@ SEARCH_KNOBS: dict[str, SearchKnob] = {
     # ── core-api-local: resolved here, never sent to storage ──
     "top_k": SearchKnob(int, (1, 20)),
     "min_similarity": SearchKnob(float, (0.1, 0.9)),
-    "graph_max_hops": SearchKnob(int, (0, 5)),
+    # Ceiling 3, matching the agent-facing ingress (``SearchProfileUpdate`` and
+    # the ``memclaw_tune`` MCP signature). It read 5 here until 2026-08-07 while
+    # both of those said 3, so a tenant-wide default could hold a depth no agent
+    # profile could ever set. Depth drives graph expansion cost, so 3 is the
+    # deliberate ceiling rather than the widest of the three.
+    "graph_max_hops": SearchKnob(int, (0, 3)),
     # ── scoring knobs storage reads positionally ──
     "fts_weight": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True),
     "freshness_floor": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True),

--- a/tests/test_search_default_profile.py
+++ b/tests/test_search_default_profile.py
@@ -174,3 +174,56 @@ def test_fts_rank_scale_ceiling_matches_what_was_measured():
     _validate_default_search_profile(_profile(fts_rank_scale=20.0))
     with pytest.raises(ValueError, match="fts_rank_scale"):
         _validate_default_search_profile(_profile(fts_rank_scale=20.001))
+
+
+# ── agent-facing ingress vs the knob table ──
+
+
+def test_agent_tunable_bounds_match_the_knob_table():
+    """``SearchProfileUpdate``'s bounds must equal ``SEARCH_KNOBS``'.
+
+    The request model still writes its own ``ge``/``le`` per field rather than
+    deriving them, and it drifted: ``graph_max_hops`` was capped at 3 here while
+    the table allowed 5, so a tenant-wide default could hold a depth no agent
+    profile could ever set. Resolved to 3 on 2026-08-07 — the ingress value, not
+    the widest of the three, because depth drives graph-expansion cost.
+
+    Asserts the bounds rather than merely the names, since matching names with
+    different limits is exactly the failure that hid for months.
+    """
+    from common.constants import SEARCH_KNOBS
+    from core_api.schemas import SearchProfileUpdate
+
+    checked = 0
+    for name, field in SearchProfileUpdate.model_fields.items():
+        assert name in SEARCH_KNOBS, (
+            f"SearchProfileUpdate exposes {name!r}, which is not a declared search knob"
+        )
+        lo = next((m.ge for m in field.metadata if hasattr(m, "ge")), None)
+        hi = next((m.le for m in field.metadata if hasattr(m, "le")), None)
+        assert (lo, hi) == SEARCH_KNOBS[name].bounds, (
+            f"{name}: SearchProfileUpdate allows {(lo, hi)} but SEARCH_KNOBS declares "
+            f"{SEARCH_KNOBS[name].bounds} — the tenant-default path and the agent path would "
+            f"accept different values for the same knob"
+        )
+        checked += 1
+
+    assert checked == 9, f"expected 9 agent-tunable knobs, checked {checked}"
+
+
+def test_the_three_ab_knobs_are_not_agent_tunable():
+    """``fts_rank_scale`` / ``candidate_pool_size`` / ``score_formula`` stay off the ingress.
+
+    They are the A/B knobs — held at their global defaults until the offline
+    comparison validates them, and flipped per TENANT via ``default_profile``,
+    not per agent. The 9-of-12 split is deliberate; this records which three and
+    why, so a future reader does not "fix" the omission.
+    """
+    from common.constants import SEARCH_KNOBS
+    from core_api.schemas import SearchProfileUpdate
+
+    assert set(SEARCH_KNOBS) - set(SearchProfileUpdate.model_fields) == {
+        "fts_rank_scale",
+        "candidate_pool_size",
+        "score_formula",
+    }


### PR DESCRIPTION
Closes the divergence #728 flagged and left open pending a decision. **Eldad chose 3.**

## The inconsistency

| surface | ceiling |
|---|---|
| `SEARCH_KNOBS` (`common/constants.py`) | **5** |
| `SearchProfileUpdate` (`schemas.py:550`) | 3 |
| `memclaw_tune` (`mcp_server.py:1340`) | 3 |

Same knob, two ceilings. Since `_validate_default_search_profile` derives its bounds from the table, a tenant-wide `default_profile` could be written with a graph-expansion depth **no per-agent profile was allowed to set**.

## Why 3 rather than 5

Depth drives graph-expansion cost, so this is a performance ceiling, not a formality. Two of the three surfaces already said 3, and raising the other two would have widened a public request schema on the strength of a bound nobody appears to have chosen deliberately — `(0, 5)` was inherited from the old `_SEARCH_PROFILE_RULES` table.

**Nothing depended on 4–5:** `GRAPH_MAX_HOPS` defaults to **2**, every `graph_max_hops` in the test suite is 2, and the agent ingress has always refused above 3. A stored tenant default above 3 would now clamp to 3 on read (via the existing warning path) and 422 on the next write — and the only way to have created one is the A47 tenant-default path, which is admin-only and recent.

`plugin/tools.json` needed no change: it is generated from the MCP registry, already described the knob as `"0-3"`, and regenerates byte-identical (verified — no drift).

## Two tests, so it cannot drift again

- **`test_agent_tunable_bounds_match_the_knob_table`** — every `SearchProfileUpdate` field's `ge`/`le` must equal `SEARCH_KNOBS[name].bounds`. It asserts the **bounds**, not just the names: matching names with mismatched limits is precisely what hid here. This test was impossible to write before this change, because it would have failed.
- **`test_the_three_ab_knobs_are_not_agent_tunable`** — records that the 9-of-12 split is deliberate and names the three A/B knobs (`fts_rank_scale`, `candidate_pool_size`, `score_formula`) that stay off the agent ingress, so the omission doesn't get "fixed" by someone reading it as an oversight.

Verified by mutation — restoring `(0, 5)`:

```
AssertionError: graph_max_hops: SearchProfileUpdate allows (0, 3) but
SEARCH_KNOBS declares (0, 5) — the tenant-default path and the agent path
would accept different values for the same knob
```

## Verification

`tests/` **4176 passed**, 3 skipped, 1 xfailed (baseline on `origin/main` is 4174 → +2 is exactly this PR's tests). `core-storage-api/tests/` 105, unchanged. Ruff clean at all of CI's exact scopes including `common/`; `export_tool_specs.py` regenerates `plugin/tools.json` with no diff.

## Follow-up this unblocks

`SearchProfileUpdate` and `memclaw_tune` still write their bounds by hand in three places — they now merely *agree*. Deriving them from `SEARCH_KNOBS` (`pydantic.create_model` plus an `agent_tunable` flag) is the remaining step, and the first test above is what makes that refactor safe to attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)