### PR TITLE
feat(search): index memories.title, at the same weight as content

### DIFF
--- a/core-storage-api/src/core_storage_api/database/migrations/versions/034_memories_search_vector_title_weighting.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/034_memories_search_vector_title_weighting.py
@@ -1,0 +1,173 @@
+"""Index ``memories.title`` in ``search_vector``, at the same weight as content.
+
+Revision ID: 034
+Revises: 033
+Create Date: 2026-08-07
+
+``title`` has never been in the tsvector. Migration 001's trigger builds it as
+``to_tsvector('english', coalesce(NEW.content, ''))``, so a memory whose title
+carries the distinguishing words — and the LLM enrichment writes a title on every
+enriched memory — **cannot be found by FTS on those words at all** unless the
+content happens to repeat them. Measured against real Postgres, query
+"pool sizing" against title "Postgres connection pool sizing" with those terms
+absent from the content: ``ts_rank_cd`` 0.0000 before, 0.1000 after. Unreachable,
+not merely ranked low. That is the whole reason for this change.
+
+SAME WEIGHT, DELIBERATELY. The two fields are concatenated and tokenised
+together, so every lexeme keeps the weight D it has always had. ``setweight``
+with title A / content B was the other candidate and is NOT what shipped: it
+multiplies every content rank by 4 (D=0.1 -> B=0.4), which forces
+``FTS_RANK_SCALE`` to be re-derived, and it moves the modal ENRICHED row a long
+way — titles are LLM summaries that reuse the content's salient terms, so most
+rows match in both fields, and there the weights add. Measured:
+
+                              content-only   title-only   title-echo
+    today                        0.1000        0.0000       0.1000
+    title A / content B          0.4000        1.0000       1.5429
+    this migration               0.1000        0.1000       0.2250
+
+Keeping one weight means **a content-only match scores exactly what it scored
+before** — 0.1000, so ``FTS_RANK_SCALE`` stays 6.0 and no bound, default or
+calibration moves anywhere in the stack. The only rows whose score changes are
+ones that could not be found at all before, plus rows whose title repeats a
+content term (0.1 -> 0.225). That second effect is not a field-weighting
+decision: it is the ordinary boost ``ts_rank_cd`` gives ANY repeated term, the
+same as if the content itself had said the word twice.
+
+Preferring the field split would be a relevance claim — that a title hit beats a
+content hit — and nothing available here can test it: the LoCoMo benchmark
+corpus is dialogue turns with no titles.
+
+WHY THE TRIGGER ALSO CHANGES ITS FIRE CONDITION. 001 declared
+``BEFORE INSERT OR UPDATE OF content``. With ``title`` in the vector, an update
+that changes only the title would leave a stale ``search_vector`` behind — the
+enrichment path writes the title, and on the async-enrich flow it lands after the
+row already exists, which is the common case rather than an edge one.
+``OF content, title`` covers both.
+
+A ``GENERATED ALWAYS AS (...) STORED`` column would make the stale-vector class
+unrepresentable — no ``UPDATE OF`` list to fall out of sync — and produces a
+byte-identical vector. Not done here: converting needs DROP + ADD COLUMN, a full
+table rewrite under ACCESS EXCLUSIVE plus a GIN rebuild, strictly worse than this
+migration. The moment for it is a future migration already rewriting ``memories``.
+
+BACKFILL. Existing rows keep the content-only vector until next written, so their
+titles stay unsearchable — the bug persists for them, but nothing they could
+already do gets worse, because content lexemes and their weight are unchanged.
+It runs in COMMITTED BATCHES inside ``autocommit_block``, the shape 012 uses:
+this holds the startup advisory lock, and a single-transaction rewrite of a
+multi-million-row table would exceed Cloud Run's 240 s startup probe, get
+SIGKILLed, roll back every batch and restart from zero — the non-converging crash
+loop that took out six writer boots on 2026-06-16. Committed batches make it
+resumable, and the ``IS DISTINCT FROM`` predicate skips rows already done.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "034"
+down_revision: str | None = "033"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_BATCH = 5000
+
+
+def _vector(prefix: str = "") -> str:
+    """Title and content tokenised together, one weight throughout.
+
+    One definition: the trigger and the backfill computing different vectors
+    would be a silent indexing bug. ``coalesce`` because ``title`` is nullable —
+    only the enrichment path sets it — and ``NULL || text`` is NULL, which would
+    empty the whole vector rather than contribute nothing.
+    """
+    return f"to_tsvector('english', coalesce({prefix}title, '') || ' ' || coalesce({prefix}content, ''))"
+
+
+def _content_only(prefix: str = "") -> str:
+    """001's expression, for the downgrade."""
+    return f"to_tsvector('english', coalesce({prefix}content, ''))"
+
+
+def _rebuild(build) -> None:
+    """Rewrite every row whose stored vector differs, in committed batches.
+
+    Walks the PRIMARY KEY with a keyset cursor rather than re-running the filter
+    from the top each pass. ``search_vector IS DISTINCT FROM <expr>`` is not
+    indexable — the GIN index serves ``@@``, not equality — so a bare
+    ``WHERE ... LIMIT n`` loop rescans and re-evaluates a growing prefix of
+    already-rebuilt rows every iteration, which is O(n^2 / batch) tsvector
+    computations. That is the same blow-up this migration's backfill exists to
+    avoid, just relocated from lock duration into CPU. ``id > :last`` with
+    ``ORDER BY id`` seeks forward instead, making the whole backfill one pass.
+
+    The predicate stays as a FILTER: a row with no title tokenises identically
+    either side of this migration, so it needs no rewrite and this skips it.
+
+    ``build`` is called twice with different prefixes — the filter reads the bare
+    columns, the UPDATE reads them through the ``m`` alias.
+
+    ``search_vector`` is not in the trigger's ``UPDATE OF`` list, so writing it
+    here does not recurse.
+    """
+    with op.get_context().autocommit_block():
+        bind = op.get_bind()
+        last = None
+        while True:
+            # ``sa.text`` rather than ``exec_driver_sql``: the bind is asyncpg,
+            # whose paramstyle is positional ``$1``, and driver-level SQL would
+            # need that spelled correctly per driver. One statement per batch,
+            # returning the ids it wrote so the cursor advances without a second
+            # round trip. ``CAST(:last AS uuid)`` because the first pass binds
+            # NULL and asyncpg needs the type.
+            rows = bind.execute(
+                sa.text(f"""
+                    WITH batch AS (
+                        SELECT id FROM memories
+                         WHERE search_vector IS DISTINCT FROM ({build("")})
+                           AND (CAST(:last AS uuid) IS NULL OR id > CAST(:last AS uuid))
+                         ORDER BY id
+                         LIMIT {_BATCH}
+                    )
+                    UPDATE memories m SET search_vector = ({build("m.")})
+                      FROM batch WHERE m.id = batch.id
+                    RETURNING m.id
+                """),
+                {"last": last},
+            ).fetchall()
+            if not rows:
+                break
+            # RETURNING has no defined order; the CTE's ORDER BY makes the batch a
+            # contiguous id range, so its max is the cursor.
+            last = max(r[0] for r in rows)
+
+
+def _set_trigger(vector: str, update_of: str) -> None:
+    op.execute(f"""
+        CREATE OR REPLACE FUNCTION memories_search_vector_update() RETURNS trigger AS $$
+        BEGIN
+            NEW.search_vector := {vector};
+            RETURN NEW;
+        END
+        $$ LANGUAGE plpgsql;
+    """)
+    # Recreated rather than altered: the fire condition is part of the CREATE, and
+    # ``CREATE OR REPLACE TRIGGER`` needs PG 14+ while this schema's floor is 13.
+    op.execute("DROP TRIGGER IF EXISTS memories_search_vector_trigger ON memories")
+    op.execute(f"""
+        CREATE TRIGGER memories_search_vector_trigger
+        BEFORE INSERT OR UPDATE OF {update_of} ON memories
+        FOR EACH ROW EXECUTE FUNCTION memories_search_vector_update();
+    """)
+
+
+def upgrade() -> None:
+    _set_trigger(_vector("NEW."), "content, title")
+    _rebuild(_vector)
+
+
+def downgrade() -> None:
+    _set_trigger(_content_only("NEW."), "content")
+    _rebuild(_content_only)

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -81,17 +81,11 @@ async def _insert_memory(
 
     mem = await sc.create_memory(payload)
 
-    # Populate search_vector for FTS scoring (normally done by app/trigger),
-    # committed via the storage write session so the storage-routed search path
-    # sees it (the rolled-back ``db`` fixture would be invisible to it).
+    # ``search_vector`` is NOT written here. 001's trigger populates it on INSERT,
+    # and since 034 it indexes the title too — a hand-rolled
+    # ``to_tsvector(content)`` would overwrite that with a title-less vector and
+    # quietly un-test the change. Let the trigger own it.
     async with get_session() as session:
-        await session.execute(
-            text(
-                "UPDATE memories SET search_vector = to_tsvector('english', :content) "
-                "WHERE id = CAST(:id AS uuid)"
-            ),
-            {"content": content, "id": mem["id"]},
-        )
         # Override created_at if provided (server_default set it on create).
         if created_at:
             await session.execute(
@@ -343,16 +337,8 @@ class TestSearchPipelineEndToEnd:
             }
             if deleted:
                 payload["deleted_at"] = datetime.now(timezone.utc).isoformat()
-            mem = await sc.create_memory(payload)
-            async with get_session() as session:
-                await session.execute(
-                    text(
-                        "UPDATE memories SET search_vector = to_tsvector('english', :content) "
-                        "WHERE id = CAST(:id AS uuid)"
-                    ),
-                    {"content": content, "id": mem["id"]},
-                )
-            return mem
+            # search_vector comes from the trigger (title-inclusive since 034).
+            return await sc.create_memory(payload)
 
         deleted_mem = await _seed(
             "kubernetes pod restart troubleshooting guide", deleted=True
@@ -472,17 +458,8 @@ async def _insert_memory_with_embedding(tenant_id, content, *, embedding, fleet_
         "recall_count": 0,
         "visibility": "scope_team",
     }
-    mem = await sc.create_memory(payload)
-    async with get_session() as session:
-        await session.execute(
-            text(
-                "UPDATE memories SET search_vector = to_tsvector('english', :content) "
-                "WHERE id = CAST(:id AS uuid)"
-            ),
-            {"content": content, "id": mem["id"]},
-        )
-        await session.commit()
-    return mem
+    # search_vector comes from the trigger (title-inclusive since 034).
+    return await sc.create_memory(payload)
 
 
 @pytest.mark.parametrize("use_pipeline", [True, False], ids=["pipeline", "legacy"])
@@ -549,7 +526,9 @@ async def test_fts_only_row_survives_a_saturated_candidate_window(tenant_id, mon
 # ---------------------------------------------------------------------------
 
 
-async def _rank_and_score(content: str, query: str, scale: float) -> tuple[float, float]:
+async def _rank_and_score(
+    content: str, query: str, scale: float, *, title: str = ""
+) -> tuple[float, float]:
     """``(raw ts_rank_cd, fts_score)`` at a given scale, from real Postgres.
 
     Reads both out of one statement with the production expression rather than
@@ -563,11 +542,11 @@ async def _rank_and_score(content: str, query: str, scale: float) -> tuple[float
             await session.execute(
                 text(
                     "SELECT r, (:k * r) / (1 + :k * r) AS s FROM ("
-                    "  SELECT ts_rank_cd(to_tsvector('english', :c),"
+                    "  SELECT ts_rank_cd(to_tsvector('english', :t || ' ' || :c),"
                     "                    plainto_tsquery('english', :q)) AS r"
                     ") t"
                 ),
-                {"k": scale, "c": content, "q": query},
+                {"k": scale, "c": content, "q": query, "t": title},
             )
         ).first()
     return float(row[0]), float(row[1])
@@ -1029,4 +1008,139 @@ def test_sql_flags_match_how_storage_reads_each_knob():
         f"SEARCH_KNOBS `sql_required` flags disagree with storage's indexed reads; "
         f"indexed-but-not-required: {sorted(indexed - required)}; "
         f"required-but-not-indexed: {sorted(required - indexed)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 034: title in the tsvector, at the same weight as content
+# ---------------------------------------------------------------------------
+
+
+async def _insert_titled(tenant_id, title, content):
+    """Insert with a title, letting 001/034's trigger build the vector."""
+    sc = get_storage_client()
+    return await sc.create_memory({
+        "tenant_id": tenant_id,
+        "fleet_id": None,
+        "agent_id": "test-agent",
+        "memory_type": "fact",
+        "title": title,
+        "content": content,
+        "weight": 0.5,
+        "embedding": fake_embedding(content),
+        "content_hash": _hash(tenant_id, None, content),
+        "status": "active",
+        "recall_count": 0,
+        "visibility": "scope_team",
+    })
+
+
+async def _stored_rank(memory_id, query) -> float:
+    """``ts_rank_cd`` against the row's REAL stored vector, as the SQL reads it."""
+    async with get_session() as session:
+        return float(
+            (
+                await session.execute(
+                    text(
+                        "SELECT ts_rank_cd(search_vector, plainto_tsquery('english', :q)) "
+                        "FROM memories WHERE id = CAST(:id AS uuid)"
+                    ),
+                    {"q": query, "id": memory_id},
+                )
+            ).scalar()
+        )
+
+
+@pytest.mark.integration
+async def test_title_text_is_searchable_at_all():
+    """A memory must be findable by words appearing ONLY in its title.
+
+    This is the point of 034, and it is missing recall rather than a ranking
+    preference: 001 built ``search_vector`` from content alone, so the title the
+    enrichment writes on every enriched memory could never be matched. Measured
+    before the migration, a title-only term scored exactly 0.0 — the row was
+    unreachable, not ranked low.
+    """
+    isolated = f"test-tenant-title-{uuid.uuid4().hex[:8]}"
+    token = f"zqxjvbn{uuid.uuid4().hex[:10]}"
+    mem = await _insert_titled(
+        isolated,
+        title=f"quarterly {token} planning",
+        content="unrelated body text about irrigation schedules and runoff",
+    )
+
+    assert await _stored_rank(mem["id"], token) > 0.0, (
+        "a term present only in the title scored 0.0 — the title is not in the tsvector, "
+        "so the memory cannot be reached by FTS on its own title"
+    )
+
+
+@pytest.mark.integration
+async def test_a_title_match_scores_the_same_as_a_content_match():
+    """One weight throughout — this is what keeps 034 a pure searchability fix.
+
+    The alternative was ``setweight`` title-A / content-B, which multiplies every
+    content rank by 4 and forces ``FTS_RANK_SCALE`` to be re-derived, and which
+    moves the modal enriched row (titles summarise content, so most rows match
+    both fields) from 0.375 to ~0.70. Preferring a title hit over a content hit
+    is a relevance claim, and the corpus that would test it does not exist here —
+    LoCoMo is dialogue turns with no titles. So: equal weight, and this test is
+    what says so.
+    """
+    isolated = f"test-tenant-eqweight-{uuid.uuid4().hex[:8]}"
+    t_token = f"zqxjvbn{uuid.uuid4().hex[:10]}"
+    c_token = f"zqxjvbn{uuid.uuid4().hex[:10]}"
+
+    in_title = await _insert_titled(isolated, title=f"heading {t_token} here", content="plain body")
+    in_content = await _insert_titled(isolated, title="plain heading", content=f"body {c_token} here")
+
+    assert await _stored_rank(in_title["id"], t_token) == pytest.approx(
+        await _stored_rank(in_content["id"], c_token)
+    ), "a title match and a content match must rank identically — 034 sets no field preference"
+
+
+@pytest.mark.integration
+async def test_content_only_scoring_is_untouched_by_034():
+    """A content-only match must score exactly what it scored before 034.
+
+    This is why ``FTS_RANK_SCALE`` stays 6.0 and no bound or default moves
+    anywhere in the stack. Both fields are tokenised together at the same weight,
+    so adding the title contributes lexemes without rescaling the existing ones —
+    a modal single-term content match is 0.1 raw and 0.375 scored, before and
+    after. If someone reaches for ``setweight`` later, this fails.
+    """
+    content = "a memory that mentions zqxjvbn exactly once"
+
+    raw, scored = await _rank_and_score(content, "zqxjvbn", FTS_RANK_SCALE, title="an unrelated heading")
+
+    assert raw == pytest.approx(0.1, abs=1e-6), (
+        f"a modal single-term content match should stay at the weight-D rank 0.1, got {raw} — "
+        f"a weighting change would rescale it and invalidate FTS_RANK_SCALE={FTS_RANK_SCALE}"
+    )
+    assert scored == pytest.approx(0.375, abs=0.001), f"expected the unchanged 0.375, got {scored}"
+
+
+@pytest.mark.integration
+async def test_editing_only_the_title_reindexes_the_row():
+    """The trigger must fire on a title-only UPDATE, not just on content.
+
+    001 declared ``BEFORE INSERT OR UPDATE OF content``. With the title in the
+    vector that is a stale-index bug in waiting, and not a rare one: the
+    async-enrich path writes the title after the row already exists, so those
+    words would never become searchable. 034 widens it to ``OF content, title``.
+    """
+    isolated = f"test-tenant-retitle-{uuid.uuid4().hex[:8]}"
+    token = f"zqxjvbn{uuid.uuid4().hex[:10]}"
+    mem = await _insert_titled(isolated, title="placeholder", content="body about irrigation")
+
+    async with get_session() as session:
+        await session.execute(
+            text("UPDATE memories SET title = :t WHERE id = CAST(:id AS uuid)"),
+            {"t": f"revised {token} heading", "id": mem["id"]},
+        )
+        await session.commit()
+
+    assert await _stored_rank(mem["id"], token) > 0.0, (
+        "a title-only UPDATE left search_vector stale — the trigger's UPDATE OF list "
+        "does not include title"
     )

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"033"}, f"Expected single head '033', got {sorted(heads)}"
+        assert heads == {"034"}, f"Expected single head '034', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -692,6 +692,8 @@ class TestMigrationChain:
         assert chain.get("032") == "031", "032 must follow 031"
         # 033: HNSW index on entities.name_embedding (cross-link discovery perf)
         assert chain.get("033") == "032", "033 must follow 032"
+        # 034: title into memories.search_vector, weighted A over content B
+        assert chain.get("034") == "033", "034 must follow 033"
 
     def test_no_plain_create_index_on_large_tables(self):
         """Indexes on large, pre-existing tables MUST be built ``CONCURRENTLY``


### PR DESCRIPTION
> Reworked from the `setweight` A/B split after Eldad's call: **same weight for title and content**. No calibration question remains, and the diff shrank to one migration plus its tests.

## The bug

`memories.title` has **never been in the tsvector**. Migration 001 builds `search_vector` from content alone, so a memory whose title carries the distinguishing words — and enrichment writes a title on *every* enriched memory — cannot be found by FTS on those words at all.

```
query "pool sizing", title "Postgres connection pool sizing",
terms absent from content:      ts_rank_cd = 0.0000   ← unreachable, not ranked low
```

## What 034 does

- tokenises title and content **together**, so every lexeme keeps the weight D it has always had
- widens the trigger to **`UPDATE OF content, title`** — a title-only edit otherwise leaves a stale index, and that is the async-enrich path's *normal* case, not an edge one
- backfills existing rows

## Why one weight, not `setweight` A/B

The split multiplies every content rank by 4 (D=0.1 → B=0.4), which forces `FTS_RANK_SCALE` to be re-derived, and it moves the modal *enriched* row a long way — titles are LLM summaries that reuse the content's salient terms, so most rows match both fields and the weights add:

| | content-only | title-only | title-echo |
|---|---|---|---|
| today | 0.1000 | **0.0000** | 0.1000 |
| title A / content B | 0.4000 | 1.0000 | 1.5429 |
| **this migration** | **0.1000** | **0.1000** | 0.2250 |

Equal weight keeps a content-only match at **exactly its historical 0.1000**, so `FTS_RANK_SCALE` stays 6.0 and no bound, default or calibration moves anywhere in the stack — that is why this touches three files instead of seven.

The only rows that score differently are ones that **could not be found at all** before, plus rows whose title repeats a content term (0.1 → 0.225). That second effect isn't a field preference: it's the boost `ts_rank_cd` gives *any* repeated term, exactly as if the content had said the word twice.

Preferring a title hit over a content hit would be a relevance claim, and nothing here can test it — `benchmark_blend_locomo.py`'s corpus is LoCoMo dialogue turns, which have no titles. So the benchmark this change was expected to need cannot measure it, and the change is scoped to avoid needing it.

## Backfill safety

Committed batches inside `autocommit_block`, the shape migration 012 uses. A single-transaction rewrite would hold the startup advisory lock past Cloud Run's 240 s probe, get SIGKILLed and restart from zero — the non-converging crash loop that took out six writer boots on 2026-06-16. Resumable via the `IS DISTINCT FROM` predicate. Verified over 21k rows, round-tripped down and up, zero left unbackfilled.

A `GENERATED ALWAYS AS (...) STORED` column would make the stale-vector class unrepresentable and produces a byte-identical vector — noted in the migration, not done here, because converting needs DROP + ADD COLUMN: a full table rewrite under ACCESS EXCLUSIVE plus a GIN rebuild. The moment for it is a future migration already rewriting `memories`.

## Verification

- `tests/` **4180** vs a 4176 baseline on `origin/main` — exactly the 4 new tests. `core-storage-api/tests/` 105. Ruff clean at every CI scope.
- Mutation-verified: **downgrading to 033** fails the title test with `scored 0.0` and the reindex test with `stale`.
- Four tests: title is searchable at all; a title match scores **the same** as a content match (this is what pins the no-preference decision); content-only scoring is untouched at 0.1 raw / 0.375 scored; a title-only UPDATE reindexes.
- Three test sites that hand-wrote a content-only `search_vector` are deleted in favour of the trigger — left alone they would have overwritten the title and silently un-tested the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)