### PR TITLE
fix(search): move 034's backfill out of the startup path

### DIFF
--- a/core-storage-api/src/core_storage_api/database/migrations/versions/034_memories_search_vector_title_weighting.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/034_memories_search_vector_title_weighting.py
@@ -51,28 +51,47 @@ byte-identical vector. Not done here: converting needs DROP + ADD COLUMN, a full
 table rewrite under ACCESS EXCLUSIVE plus a GIN rebuild, strictly worse than this
 migration. The moment for it is a future migration already rewriting ``memories``.
 
-BACKFILL. Existing rows keep the content-only vector until next written, so their
-titles stay unsearchable — the bug persists for them, but nothing they could
-already do gets worse, because content lexemes and their weight are unchanged.
-It runs in COMMITTED BATCHES inside ``autocommit_block``, the shape 012 uses:
-this holds the startup advisory lock, and a single-transaction rewrite of a
-multi-million-row table would exceed Cloud Run's 240 s startup probe, get
-SIGKILLed, roll back every batch and restart from zero — the non-converging crash
-loop that took out six writer boots on 2026-06-16. Committed batches make it
-resumable, and the ``IS DISTINCT FROM`` predicate skips rows already done.
+BACKFILL IS OUT OF BAND — ``scripts/backfill_034_search_vector.py``, run once
+after deploy. It is NOT in this migration, and that is not a style preference:
+
+An earlier version of 034 backfilled here, in committed batches, and it took
+staging down's deploy path on 2026-08-08. Every instance boots, blocks on the
+migration advisory lock, and Cloud Run's startup probe kills the container after
+240 s; the leader never finishes, so ``Running upgrade 033 -> 034`` appears at
+09:30, 09:34, 09:39, 09:43, 09:47 and never completes. Committed batches were
+supposed to make that converge, and they do NOT: the keyset cursor lives in
+process memory, so each restart resumes from the top and re-evaluates the
+``IS DISTINCT FROM`` predicate — one ``to_tsvector`` per row — across an
+ever-growing prefix of already-rebuilt rows. The quadratic cost moves from
+within a run to across restarts. (Cloud Run kept the previous revision serving
+throughout, so it was a blocked deploy, not an outage.)
+
+The house rule already said this: DDL belongs in the migration, non-DDL backfills
+belong in one-off scripts. What is left here is instant.
+
+``downgrade()`` is symmetric and equally data-free: it restores the content-only
+trigger and rewrites nothing. Reverting rows is the same volume of work as the
+forward pass and would reintroduce the same startup-probe failure. Run
+``scripts/backfill_034_search_vector.py --revert`` after downgrading if the split
+matters — until then, rows the forward backfill already rebuilt keep matching on
+title terms while rows written after the downgrade do not.
+
+A PARTIAL BACKFILL IS SAFE, which is what makes out-of-band viable and is a
+direct consequence of the equal-weight choice above. A row not yet rebuilt keeps
+its content-only vector, and content lexemes and their weight are identical
+either side of this migration — so it scores exactly as it always did and merely
+has not gained title search yet. There is no window in which two rows are scored
+on different scales.
 """
 
 from collections.abc import Sequence
 
-import sqlalchemy as sa
 from alembic import op
 
 revision: str = "034"
 down_revision: str | None = "033"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
-
-_BATCH = 5000
 
 
 def _vector(prefix: str = "") -> str:
@@ -89,59 +108,6 @@ def _vector(prefix: str = "") -> str:
 def _content_only(prefix: str = "") -> str:
     """001's expression, for the downgrade."""
     return f"to_tsvector('english', coalesce({prefix}content, ''))"
-
-
-def _rebuild(build) -> None:
-    """Rewrite every row whose stored vector differs, in committed batches.
-
-    Walks the PRIMARY KEY with a keyset cursor rather than re-running the filter
-    from the top each pass. ``search_vector IS DISTINCT FROM <expr>`` is not
-    indexable — the GIN index serves ``@@``, not equality — so a bare
-    ``WHERE ... LIMIT n`` loop rescans and re-evaluates a growing prefix of
-    already-rebuilt rows every iteration, which is O(n^2 / batch) tsvector
-    computations. That is the same blow-up this migration's backfill exists to
-    avoid, just relocated from lock duration into CPU. ``id > :last`` with
-    ``ORDER BY id`` seeks forward instead, making the whole backfill one pass.
-
-    The predicate stays as a FILTER: a row with no title tokenises identically
-    either side of this migration, so it needs no rewrite and this skips it.
-
-    ``build`` is called twice with different prefixes — the filter reads the bare
-    columns, the UPDATE reads them through the ``m`` alias.
-
-    ``search_vector`` is not in the trigger's ``UPDATE OF`` list, so writing it
-    here does not recurse.
-    """
-    with op.get_context().autocommit_block():
-        bind = op.get_bind()
-        last = None
-        while True:
-            # ``sa.text`` rather than ``exec_driver_sql``: the bind is asyncpg,
-            # whose paramstyle is positional ``$1``, and driver-level SQL would
-            # need that spelled correctly per driver. One statement per batch,
-            # returning the ids it wrote so the cursor advances without a second
-            # round trip. ``CAST(:last AS uuid)`` because the first pass binds
-            # NULL and asyncpg needs the type.
-            rows = bind.execute(
-                sa.text(f"""
-                    WITH batch AS (
-                        SELECT id FROM memories
-                         WHERE search_vector IS DISTINCT FROM ({build("")})
-                           AND (CAST(:last AS uuid) IS NULL OR id > CAST(:last AS uuid))
-                         ORDER BY id
-                         LIMIT {_BATCH}
-                    )
-                    UPDATE memories m SET search_vector = ({build("m.")})
-                      FROM batch WHERE m.id = batch.id
-                    RETURNING m.id
-                """),
-                {"last": last},
-            ).fetchall()
-            if not rows:
-                break
-            # RETURNING has no defined order; the CTE's ORDER BY makes the batch a
-            # contiguous id range, so its max is the cursor.
-            last = max(r[0] for r in rows)
 
 
 def _set_trigger(vector: str, update_of: str) -> None:
@@ -165,9 +131,7 @@ def _set_trigger(vector: str, update_of: str) -> None:
 
 def upgrade() -> None:
     _set_trigger(_vector("NEW."), "content, title")
-    _rebuild(_vector)
 
 
 def downgrade() -> None:
     _set_trigger(_content_only("NEW."), "content")
-    _rebuild(_content_only)

--- a/scripts/backfill_034_search_vector.py
+++ b/scripts/backfill_034_search_vector.py
@@ -1,0 +1,134 @@
+"""Backfill ``memories.search_vector`` for migration 034 (title in the tsvector).
+
+034 changes the trigger so new and updated rows index their title. Rows written
+before it keep a content-only vector: they score exactly as they always did —
+content lexemes and their weight are unchanged — they just have not gained title
+search yet. This walks the table once and rebuilds them.
+
+RUN IT OUT OF BAND, after the storage deploy is healthy. It deliberately does NOT
+live in the migration. The first version of 034 backfilled during the alembic
+startup hook and blocked the staging deploy on 2026-08-08: every instance boots,
+serialises on the migration advisory lock, and Cloud Run's startup probe kills the
+container at 240 s, so the leader never finishes. Committed batches did not save
+it — the cursor lives in process memory, so each restart resumed from the top and
+re-evaluated one ``to_tsvector`` per row across a growing prefix of already-done
+rows, turning a linear job quadratic across restarts.
+
+    python scripts/backfill_034_search_vector.py \\
+        --dsn postgresql://user:pw@host:5432/db          # or $DATABASE_URL
+    python scripts/backfill_034_search_vector.py --from-id <uuid>   # resume
+    python scripts/backfill_034_search_vector.py --dry-run          # count only
+    python scripts/backfill_034_search_vector.py --revert           # after a 034 downgrade
+
+Safe to re-run, safe to interrupt, and safe to run while serving: each batch is
+its own transaction, and the trigger is not in the ``UPDATE OF`` list so writing
+``search_vector`` cannot recurse. Interrupting prints the id to resume from.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+import asyncpg
+
+# Must stay byte-identical to migration 034's ``_vector()``. If these diverge the
+# backfill writes vectors the trigger would not have written, and the difference
+# is invisible until a search misses.
+_VECTOR = "to_tsvector('english', coalesce(m.title, '') || ' ' || coalesce(m.content, ''))"
+# 001's expression, for ``--revert``. Migration 034's ``downgrade()`` restores the
+# content-only TRIGGER but deliberately touches no data — reverting rows is the
+# same volume of work as the forward pass, so doing it in the migration would
+# reintroduce the startup-probe failure this split exists to fix. Without this
+# mode a downgrade leaves a split corpus: rows already rebuilt keep matching on
+# title terms while rows written after the downgrade do not.
+_CONTENT_ONLY = "to_tsvector('english', coalesce(m.content, ''))"
+
+
+async def _run(dsn: str, batch: int, from_id: str | None, dry_run: bool, revert: bool) -> int:
+    target = _CONTENT_ONLY if revert else _VECTOR
+    conn = await asyncpg.connect(dsn)
+    try:
+        total = await conn.fetchval("SELECT count(*) FROM memories")
+        print(f"{total} rows; mode={'revert' if revert else 'forward'}", flush=True)
+        if dry_run:
+            # The only whole-table predicate pass, and it is opt-in: it costs a
+            # to_tsvector per row, comparable to the rebuild itself on a large
+            # table. A real run learns the same thing from its per-batch tallies.
+            stale = await conn.fetchval(
+                f"SELECT count(*) FROM memories m WHERE m.search_vector IS DISTINCT FROM {target}"
+            )
+            print(f"{stale} need rebuilding", flush=True)
+            return 0
+
+        last, done = from_id, 0
+        while True:
+            # Window bounds come from the PRIMARY KEY index alone — no predicate —
+            # so picking the next slice is an index scan rather than a scan that
+            # re-evaluates ``to_tsvector`` over rows already handled. That is the
+            # part the in-migration version got wrong.
+            ids = await conn.fetch(
+                "SELECT id FROM memories WHERE ($1::uuid IS NULL OR id > $1::uuid) "
+                "ORDER BY id LIMIT $2",
+                last,
+                batch,
+            )
+            if not ids:
+                break
+            hi = ids[-1]["id"]
+
+            # The predicate applies INSIDE the window, so untitled rows — whose
+            # vector is unchanged by 034 — cost a comparison and no write.
+            tag = await conn.execute(
+                f"""
+                UPDATE memories m SET search_vector = {target}
+                 WHERE m.id > COALESCE($1::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+                   AND m.id <= $2::uuid
+                   AND m.search_vector IS DISTINCT FROM {target}
+                """,
+                last,
+                hi,
+            )
+            done += int(tag.split()[-1])
+            last = hi
+            print(f"  ... {done} rebuilt, cursor {last}", flush=True)
+
+        # The loop visited every id, so ``done`` is the answer — no second
+        # whole-table pass. Rows written while it ran were handled by the trigger.
+        print(f"done: {done} rewritten", flush=True)
+        return 0
+    finally:
+        await conn.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dsn", default=os.environ.get("DATABASE_URL", ""))
+    ap.add_argument("--batch", type=int, default=5000)
+    ap.add_argument("--from-id", default=None, help="resume cursor printed by an interrupted run")
+    ap.add_argument("--dry-run", action="store_true", help="count what needs rebuilding, change nothing")
+    ap.add_argument(
+        "--revert",
+        action="store_true",
+        help="rewrite rows back to the content-only vector, after downgrading 034",
+    )
+    args = ap.parse_args()
+
+    if not args.dsn:
+        print("need --dsn or DATABASE_URL", file=sys.stderr)
+        return 2
+    # asyncpg speaks the bare protocol; strip the SQLAlchemy driver suffix so the
+    # service's own DATABASE_URL can be pasted in unchanged.
+    dsn = args.dsn.replace("postgresql+asyncpg://", "postgresql://")
+
+    try:
+        return asyncio.run(_run(dsn, args.batch, args.from_id, args.dry_run, args.revert))
+    except KeyboardInterrupt:
+        print("\ninterrupted — re-run with --from-id <the last cursor printed above>", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -929,3 +929,49 @@ class TestMigration022Sentinel:
         assert "- '_migrated_by'" in downgrade_section, (
             "Downgrade must drop _migrated_by after using it"
         )
+
+
+class TestBackfill034MatchesMigration:
+    """The out-of-band backfill must write what migration 034's trigger writes.
+
+    034 keeps only DDL — the backfill lives in ``scripts/`` because running it in
+    the alembic startup hook blocked the staging deploy on 2026-08-08. That split
+    buys deploy safety and costs a second copy of the tsvector expression, and a
+    silent divergence between them is invisible until a search misses: the script
+    would rewrite rows to a vector the trigger would never produce, and the next
+    write of that row would flip it back.
+    """
+
+    def _migration_expr(self, builder: str) -> str:
+        import importlib.util
+        import pathlib
+
+        f = pathlib.Path(
+            "core-storage-api/src/core_storage_api/database/migrations/versions/"
+            "034_memories_search_vector_title_weighting.py"
+        )
+        spec = importlib.util.spec_from_file_location(f.stem, f)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return getattr(mod, builder)("m.")
+
+    @pytest.mark.parametrize(
+        "const,builder",
+        [("_VECTOR", "_vector"), ("_CONTENT_ONLY", "_content_only")],
+    )
+    def test_script_expressions_match_the_migration(self, const, builder):
+        """Both directions: ``--revert`` must undo exactly what the forward pass did."""
+        import re
+
+        src = pathlib.Path("scripts/backfill_034_search_vector.py").read_text()
+        m = re.search(rf'^{const} = "(.+)"$', src, re.M)
+        assert m, f"backfill_034_search_vector.py no longer defines {const} on one line"
+
+        expected = self._migration_expr(builder)
+        assert m.group(1) == expected, (
+            f"the backfill script and migration 034 disagree on {const}:\n"
+            f"  script:    {m.group(1)}\n"
+            f"  migration: {expected}\n"
+            f"They must be byte-identical, or the script writes vectors the trigger never would."
+        )


### PR DESCRIPTION
> **Fixes a blocked staging deploy caused by #731.** Staging was never down — Cloud Run kept the previous revision serving — but the new storage revision could not become healthy, so nothing rolled forward.

## What happened

Migration 034 backfilled `memories.search_vector` inside the alembic startup hook. Every instance boots, serialises on the migration advisory lock, and Cloud Run's startup probe kills the container after **240 s**:

```
09:30:46  Running upgrade 033 -> 034 …
09:34:37  Running upgrade 033 -> 034 …
09:39:16  Running upgrade 033 -> 034 …
09:43:06  Running upgrade 033 -> 034 …
09:47:16  Running upgrade 033 -> 034 …          ← never completes
ERROR: Container failed to become healthy. Startup probes timed out after 4m
```

**Committed batches were supposed to make this converge, and they don't.** The keyset cursor lives in process memory, so every restart resumes from the top and re-evaluates the `IS DISTINCT FROM` predicate — one `to_tsvector` per row — across an ever-growing prefix of rows it has already rebuilt. The quadratic cost I removed from *within* a run came back *across* restarts, which is strictly worse: within a run it was merely slow; across restarts it cannot finish.

That is the same failure mode 034's own docstring described and claimed to prevent. The batching addressed lock duration, which was never the binding constraint — wall-clock against a fixed probe was.

## The fix

**034 is now DDL only — 0.28 s.** The backfill moves to `scripts/backfill_034_search_vector.py`, which is what the house convention said in the first place: DDL in the migration, non-DDL backfills in one-off scripts.

The script takes its window bounds from the **primary key index alone, with no predicate**, so choosing the next slice is an index scan rather than a scan that re-evaluates `to_tsvector` over rows already handled. The predicate then applies *inside* the window, so untitled rows — whose vector 034 does not change — cost a comparison and no write. Resumable via `--from-id`, prints its cursor, idempotent.

Verified locally: 924 rows across 74 windows in **0.78 s**; a re-run reports `0 need rebuilding`.

## Why a partial backfill is safe

This is what makes out-of-band viable at all, and it falls directly out of the equal-weight decision on #731: a row not yet rebuilt keeps its content-only vector and **scores exactly as it always did**, because content lexemes and their weight are identical either side of 034. It has simply not gained title search yet. There is no window in which two rows are scored on different scales — which would not have been true of the `setweight` A/B version.

## Deploy sequence

1. Merge → storage deploys, 034 applies instantly, new and updated rows index their titles from the trigger.
2. Run the script once against staging, then prod, when convenient.

Staging's DB is already in exactly this state: the trigger applied (it commits before the backfill), the backfill partial, alembic still at 033 because the migration never completed. Re-running 034 is idempotent — `CREATE OR REPLACE` / `DROP … IF EXISTS`.

## Verification

`tests/` **4181**, `core-storage-api/tests/` 105, ruff clean at every CI scope, `--select F821` over `scripts/` clean.

The tsvector expression now exists in two places, so a test asserts they are **byte-identical** — a divergence would have the script write vectors the trigger would never produce, invisible until a search misses. Mutation-verified: changing `coalesce(m.title, '')` to `coalesce(m.title, ' ')` in the script fails it with both expressions printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)