### PR TITLE
ci: restore the local review workflow, modernised, after the shared pipeline could not load

### DIFF
--- a/.github/scripts/claude_pr_review.sh
+++ b/.github/scripts/claude_pr_review.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Shared Claude PR review.
+#
+# Fetches a pull request's diff from the GitHub API, reviews it with Claude, and
+# posts the result as a PR comment. BOTH the on-open `claude-review` job and the
+# `@claude` `claude-retrigger` job call this same script, so the two paths are
+# guaranteed identical — historically they diverged, and the on-open path (the
+# claude-code-action agent) never actually received the diff: it tried to fetch
+# it via `gh`, hit the headless permission wall, and the workflow then stamped a
+# meaningless "No issues found". Feeding the diff on stdin to `claude --print`
+# is the mechanism that demonstrably works.
+#
+# Required env:
+#   REPO              owner/name
+#   PR_NUMBER         pull request number
+#   ANTHROPIC_API_KEY Anthropic API key
+#   GH_TOKEN          token with pull-requests:write / issues:write
+#   EXTRA_PROMPT      repo context, prepended to the review prompt
+#   REVIEW_PROMPT     review instructions + output format
+# Optional env:
+#   MODEL             model id (default: claude-sonnet-5)
+#   MAX_BUDGET_USD    per-review spend ceiling, passed to --max-budget-usd (default 10.00)
+set -euo pipefail
+
+MODEL="${MODEL:-claude-sonnet-5}"
+
+# A ceiling so one runaway review cannot bill without bound. The reviewer reads the repo
+# across turns to judge a diff, which is what makes it useful and also what makes an
+# unbounded run possible; sibling repos on the org's shared pipeline have billed $6.11 on a
+# two-file diff. The org-membership gate above stops a fork pull request from triggering a
+# review at all, but it does not bound what a member's large pull request costs.
+#
+# A runaway guard, not a budget target. The CLI checks the ceiling BETWEEN turns, so a run
+# can overshoot it by roughly one turn, and on a single hung turn it never fires at all —
+# the job timeout is the only bound there. Sized above observed spend on purpose: the
+# expensive reviews are the ones that find real defects, so capping near the average would
+# truncate exactly the runs worth paying for.
+MAX_BUDGET_USD="${MAX_BUDGET_USD:-10.00}"
+# Shape, then value. Shape does not require a leading digit, so `.50` is accepted the way the
+# CLI accepts it, while `.`, `1.`, `10,00`, `$10`, `-1` and `1e3` are rejected. Value is
+# checked arithmetically rather than with a second pattern: a zero ceiling is accepted by the
+# CLI and makes every review fail on its first turn — which reads as a broken pipeline rather
+# than a bad setting — and spelling "zero" as a regex means enumerating 0, 00, 0.0, .0, 0.00
+# and .00, where the no-leading-digit forms are the easy ones to miss.
+if ! [[ "$MAX_BUDGET_USD" =~ ^[0-9]*\.?[0-9]+$ ]] \
+   || ! awk -v v="$MAX_BUDGET_USD" 'BEGIN { exit !(v + 0 > 0) }'; then
+  echo "::error::MAX_BUDGET_USD must be a positive decimal number, got '${MAX_BUDGET_USD}'" >&2
+  exit 1
+fi
+
+post() { gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$1" >/dev/null; }
+
+DIFF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" -H "Accept: application/vnd.github.diff")
+if [ -z "$DIFF" ]; then
+  echo "::notice::Empty diff for PR #${PR_NUMBER} — nothing to review"
+  exit 0
+fi
+
+PROMPT="${EXTRA_PROMPT}
+${REVIEW_PROMPT}
+
+Review the PR diff provided on stdin. Review ONLY the changed lines. If after a careful review you find no real issues, reply with exactly this single line and nothing else:
+**Claude Code Review** :white_check_mark: No issues found."
+
+# No 2>&1: claude's stderr (warnings/progress) must not contaminate the JSON on
+# stdout, or jq would parse garbage and yield an empty review. A non-zero exit is
+# still caught below; stderr goes to the workflow log for debugging.
+# --tools is the security half, and it matters more here than anywhere: this repo is PUBLIC.
+# The threat is concrete — a prompt injection in the diff reaching a CLI whose environment holds
+# GH_TOKEN with pull-requests:write. Restricting the reviewer to read-only tools leaves the
+# injection nothing to act through. Reviewing a diff needs Read, Grep and Glob and nothing else.
+#
+# --bare closes two paths the allow-list provably does not reach, so it is load-bearing rather
+# than belt-and-braces. --tools names tools from the BUILT-IN set, so it does nothing about
+# MCP-provided ones: a pull request adding an .mcp.json would otherwise hand the reviewer tools
+# outside the allow-list entirely. --bare also skips CLAUDE.md auto-discovery, so a reviewed
+# tree's own CLAUDE.md cannot quietly steer the review of that same tree.
+#
+# Both flags exist in the pinned 2.1.159 installed above. Verify them again when bumping the pin
+# — a build that dropped either would review in a writable mode without saying so.
+RESULT=$(printf '%s' "$DIFF" | claude --print --model "$MODEL" --output-format json \
+  --bare \
+  --tools "Read,Grep,Glob" \
+  --max-budget-usd "$MAX_BUDGET_USD" \
+  "$PROMPT") || {
+  CLAUDE_EXIT=$?
+  # `VAR=$(cmd)` keeps cmd's stdout even when cmd fails, and claude reports several failures
+  # (auth, quota, and budget exhaustion) there rather than on stderr. This branch used to
+  # discard it and post "check workflow logs" above a log that held nothing — which would have
+  # made a ceiling hit the least diagnosable outcome in the script.
+  echo "Claude exited ${CLAUDE_EXIT}. First 2000 chars of its stdout:" >&2
+  printf '%s\n' "${RESULT:0:2000}" >&2
+  # Budget exhaustion is an EXPECTED outcome carrying a machine-readable marker, and it exits
+  # 1 exactly like a crash, so without this branch the ceiling would surface as a bare exit
+  # code and read as a broken pipeline. `jq -e` rather than `grep -q`: grep stops reading on
+  # match, the upstream printf takes SIGPIPE, and pipefail then turns a MATCH into a non-zero
+  # pipeline. jq drains stdin.
+  if printf '%s' "$RESULT" | jq -e '.subtype == "error_max_budget_usd"' >/dev/null 2>&1; then
+    SPENT=$(printf '%s' "$RESULT" | jq -r '.total_cost_usd // "unknown"' 2>/dev/null || echo unknown)
+    post "⚠️ Claude Code review reached the \$${MAX_BUDGET_USD} spend ceiling after \$${SPENT} without finishing. Split the PR, or raise \`MAX_BUDGET_USD\` on the workflow step."
+    exit 1
+  fi
+  post "⚠️ Claude Code review failed: exit ${CLAUDE_EXIT} (see workflow logs)."
+  exit 1
+}
+
+# jq runs under `set -e`; a parse failure (claude returned non-JSON — a warning
+# banner, rate-limit HTML) must not silently kill the script before we post an
+# error. On failure, log the raw response so the workflow log actually has
+# something to check, then post a visible error.
+REVIEW=$(printf '%s' "$RESULT" | jq -r '.result // empty' 2>/dev/null) || {
+  echo "Claude returned non-JSON output. First 2000 chars of the raw response:" >&2
+  printf '%s\n' "${RESULT:0:2000}" >&2
+  post "⚠️ Claude Code review failed: response was not valid JSON (see workflow logs)."
+  exit 1
+}
+
+# Bail before logging any cost, so an empty .result can't leave a cost table in
+# the job summary next to a "review failed" comment.
+if [ -z "$REVIEW" ]; then
+  post "⚠️ Claude Code review failed: empty result."
+  exit 1
+fi
+
+COST=$(printf '%s' "$RESULT" | jq -r '.total_cost_usd // empty' 2>/dev/null || echo "unknown")
+echo "::notice::Claude review cost: \$${COST:-unknown} (model ${MODEL}, PR #${PR_NUMBER})"
+
+# Cost + token table in the Actions job summary (when running in a workflow).
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ -n "$COST" ] && [ "$COST" != "unknown" ]; then
+  TOKENS_IN=$(printf '%s' "$RESULT" | jq -r '.usage.input_tokens // empty' 2>/dev/null || true)
+  TOKENS_OUT=$(printf '%s' "$RESULT" | jq -r '.usage.output_tokens // empty' 2>/dev/null || true)
+  {
+    echo "### Claude Code Review Cost"
+    echo "| Metric | Value |"
+    echo "|--------|-------|"
+    echo "| Cost | \$${COST} |"
+    echo "| Input tokens | ${TOKENS_IN:-?} |"
+    echo "| Output tokens | ${TOKENS_OUT:-?} |"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# GitHub caps comment bodies at 65536 chars; truncate so a very large review
+# can't 422 and then silently fail under set -e.
+MAX_BODY=65000
+if [ "${#REVIEW}" -gt "$MAX_BODY" ]; then
+  REVIEW="${REVIEW:0:$MAX_BODY}
+
+_[Review truncated — exceeded GitHub's comment size limit.]_"
+fi
+
+# Footer surfaces per-review spend on the PR itself, not just the job log.
+post "${REVIEW}
+
+---
+*Reviewed by \`${MODEL}\` · cost \$${COST:-unknown}*"

--- a/.github/workflows/claude_code_review.yml
+++ b/.github/workflows/claude_code_review.yml
@@ -1,80 +1,420 @@
-# Claude Code Review — this repo's caller for the org's shared review pipeline.
+# Claude Code Review
 #
-# Replaces a 297-line local copy of the pipeline. Everything that was here is now in
-# caura-ai/.github: the skip rules, the org-membership gate, the reviewer scripts, the prompt.
-# What stays is what is genuinely per-repo — the triggers, which GitHub does not let a reusable
-# workflow declare, and the repo blurb below.
+# DELIBERATELY A LOCAL COPY, NOT THE ORG'S SHARED PIPELINE. Do not "consolidate" this into
+# ``uses: caura-ai/.github/...`` — that was tried in #733 and it CANNOT work here. This
+# repository is PUBLIC and ``caura-ai/.github`` is PRIVATE, and GitHub allows a component
+# (reusable workflow or composite action) in a private repository to be used only by private
+# repositories. The failure mode is silent and easy to misread: the run dies instantly with
+# "This run likely failed because of a workflow file issue", creates ZERO jobs and writes no
+# logs, so it looks like malformed YAML rather than a refusal. Every run between 2026-08-08 and
+# the revert failed that way, and no pull request here was reviewed in that window.
 #
-# The local copy needed nothing bespoke to migrate: its max-files (30), its CLI pin (2.1.159) and
-# its source-file filter were all byte-identical to the shared defaults, and its REVIEW_PROMPT was
-# an older copy of the shared template. Inheriting the shared one is therefore an upgrade, not a
-# compromise — the copy here still carried a "Fix All Prompts" section that was removed upstream
-# in v1.3.0 because it duplicated every per-issue prompt.
+# Sharing this with the org would require the pipeline to live in a PUBLIC repository. That is a
+# real option, not a dead end — it is just a decision about publishing the pipeline, and until
+# it is taken this copy is the supported arrangement. Keep it in step with the shared pipeline
+# by porting changes deliberately rather than by pointing at it.
+#
+# Runs automatically when a PR is opened/reopened by a public member of
+# the ``caura-ai`` organization. Commenting "@claude" on the PR triggers a
+# review too (also restricted to org members) — that is how you re-review
+# after a push, AND the only way to review a draft. See "TWO ENTRY POINTS"
+# below, because the two paths do not enforce the same conditions.
+#
+# Why org-only: this workflow consumes ``ANTHROPIC_API_KEY`` and burns
+# real budget per review. ``pull_request`` events from forks don't
+# receive secrets anyway (GitHub strips them); restricting to org
+# members makes the policy explicit and stops fork PRs from triggering
+# silent-failure runs.
+#
+# TWO ENTRY POINTS, AND THEY DO NOT SHARE GATES. This is the single most
+# surprising thing about this workflow, so read it before adding a check.
+#
+#   ``pull_request``  -> pre-checks -> claude-review
+#   ``issue_comment`` -> claude-retrigger          (pre-checks never runs)
+#
+# ``pre-checks`` is gated on ``if: github.event_name == 'pull_request'``,
+# and ``claude-retrigger`` has no ``needs: pre-checks``. So on a comment
+# event ``pre-checks`` does not run at all, and EVERY condition it owns is
+# absent from that path. Today that is all six of them: org membership of
+# the PR author, synchronize-event skip, draft skip, bot skip, the
+# ``MAX_FILES`` cap, and the tests/docs/config-only skip.
+#
+# Consequences worth knowing:
+#
+#   * A DRAFT PR GETS NO REVIEW ON OPEN. ``pre-checks`` reports
+#     ``reason=draft PR`` and ``claude-review`` is skipped. Commenting
+#     "@claude" on that same draft DOES produce a full review, because the
+#     retrigger path never consults the draft check. So the effective
+#     policy is "drafts get opt-in review, not automatic review" — which is
+#     deliberate (drafts are unfinished; each review costs real budget), and
+#     is the intended way to request one. It is not discoverable from the
+#     skip message, which is why it is written down here.
+#   * The ``MAX_FILES`` cap is likewise bypassed on the comment path, so an
+#     "@claude" comment can review a PR of any size. Left as-is on purpose:
+#     it is a useful escape hatch for a large but genuinely reviewable PR.
+#     If that ever needs to change, change it deliberately — a member may
+#     be relying on it.
+#   * Membership IS still enforced on the comment path, but it validates the
+#     COMMENTER (``claude-retrigger``'s job-level ``author_association``
+#     gate plus its step-level re-check), not the PR author. A member
+#     vouching for someone else's PR is therefore a supported flow.
+#
+# MAINTAINER NOTE: adding a condition to ``pre-checks`` applies it to the
+# ``pull_request`` path ONLY. If a new gate should hold universally, it has
+# to be duplicated into ``claude-retrigger`` or lifted somewhere both jobs
+# consult. See issue #683 for the history.
+#
+# OPERATIONAL REQUIREMENT: every member who wants their pull requests
+# reviewed must set their caura-ai org membership to **Public**
+# (Organization -> People -> their row -> Public). Nobody can set it on
+# their behalf. A member whose membership is private is skipped exactly
+# like a stranger — silently, behind a green check. This is not a
+# preference; it is what the gate below can actually see.
+#
+# Membership is checked at runtime against ``orgs/caura-ai/members/{user}``.
+# That endpoint answers for its CALLER, and ``GITHUB_TOKEN`` sees only
+# PUBLIC members: 204 for a public member, 404 for a private member and
+# for a non-member alike.
+#
+# Why not the payload's ``author_association``, which needs no API call:
+# it does not report org membership for a private member on a
+# ``pull_request`` event. Observed values here, all for the same private
+# member of this org:
+#
+#   github.event.pull_request.author_association  ->  CONTRIBUTOR
+#   github.event.comment.author_association       ->  MEMBER
+#   GET /repos/{repo}/pulls/{n} .author_association -> MEMBER
+#
+# Three things follow. The two payloads DISAGREE, which is why an
+# ``@claude`` retrigger worked for private members while the on-open
+# review did not. ``CONTRIBUTOR`` is unusable as a gate on a public repo,
+# since anyone with a merged commit earns it. And the REST value is
+# computed for whoever asks — a personal token reports ``MEMBER`` where
+# CI sees ``CONTRIBUTOR`` — so it must NOT be used to check this gate's
+# behaviour. Verify against a real workflow run, not a local ``gh`` call.
 
 name: Claude Code Review
 
 on:
   pull_request:
     branches: [main, dev]
-    # `closed` is new, and it feeds claude-capture ONLY (merged pull requests). The shared
-    # pre-checks job excludes it, which is what stops a merge triggering a fresh review.
-    types: [opened, reopened, synchronize, closed]
+    types: [opened, reopened, synchronize]
   issue_comment:
     types: [created]
-  # Manual backfill for claude-capture on a pull request that merged before capture existed.
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "Merged PR number to capture declined findings from"
-        required: true
-        type: string
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
-  # REQUIRED OF EVERY CALLER, and it must be granted here even though this repo does not run the
-  # Gemini reviewer. GitHub validates a reusable workflow's whole permissions graph at load time,
-  # statically, regardless of any callee job's `if:` — so a callee job requesting id-token: write
-  # that the caller withheld makes GitHub refuse to load the ENTIRE workflow. That is a
-  # startup_failure which takes the Claude review down too. Harmless to grant: nothing here
-  # requests the token, and mode=gemini-review is refused outright on a public repository.
-  id-token: write
+
+env:
+  EXTRA_PROMPT: "This is a FastAPI + PostgreSQL (pgvector) backend with a TypeScript OpenClaw plugin. Uses requirements.txt (not uv/pyproject.toml). Tests are in tests/ directory."
+  REVIEW_PROMPT: |
+    Do NOT review files under tests/ or test_* files. Focus only on source code.
+
+    Review this PR for real issues only — not style preferences.
+
+    ## Format
+
+    For each issue:
+
+    ### Issue Title
+    **Severity**: Critical/High/Medium/Low
+    **File**: `path/to/file.py:line-range`
+    **Problem**: One sentence.
+
+    <details>
+    <summary>🤖 Claude Code Prompt</summary>
+
+    ```
+    [Self-contained prompt with exact file paths, line numbers, what to change and why]
+    ```
+
+    </details>
+
+    ---
+
+    ## Sections
+    1. **Summary**: 2-3 sentences
+    2. **Critical/High Issues**: Must fix before merge
+    3. **Medium/Low Issues**: Should fix, not blocking
+    4. **Suggestions**: Nice-to-have
+    Skip empty sections.
+
+    Every prompt above is self-contained, so do not repeat them in a combined "fix all" block at the
+    end. One prompt per issue, once. Output nothing after the last issue.
+
+    Everything inside a prompt block is text for a person or an agent to READ. Never emit tool calls,
+    function-call syntax, or JSON arrays of edit operations (`{"tool_code": ...}`,
+    `default_api.replace(...)`, `old_string`/`new_string` pairs). Describe the change in words and
+    name the file and lines; do not write code that performs it.
 
 jobs:
-  claude-code-review:
-    # An `on: issue_comment` workflow is dispatched for every comment in the repo. Without this
-    # gate the caller job succeeds even when every callee job skips, leaving a green
-    # "Claude Code Review" check sitting on unrelated issues.
-    #
-    # It deliberately does NOT test for `@claude`. That filter did not disappear in the
-    # migration, it moved: the callee's claude-retrigger job carries
-    # `contains(github.event.comment.body, '@claude')`, and /remember and @gemini are gated the
-    # same way on their own jobs. Naming the commands here too would duplicate the callee's
-    # triggers in every caller, which is the drift the shared pipeline exists to remove.
-    #
-    # A comment with no command therefore costs nothing: every callee job evaluates its `if:` to
-    # false and skips, skipped jobs allocate no runner, and this caller job has no steps of its
-    # own — it is a bare `uses:`, so nothing is checked out and no CLI is installed.
+  pre-checks:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.decide.outputs.skip }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - name: Evaluate skip conditions
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAX_FILES: "30"
+          PR_ACTION: ${{ github.event.action }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_ACTOR: ${{ github.actor }}
+          ORG: caura-ai
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+
+          # 1. Org membership gate — checked at runtime, not via the
+          # payload's ``author_association``, which on a ``pull_request``
+          # event reports ``CONTRIBUTOR`` for a private org member and so
+          # cannot distinguish one from any past contributor. The values
+          # are measured and recorded in the file header; read them before
+          # changing this, and note that a local ``gh`` call reports a
+          # DIFFERENT value than CI sees. The ``orgs/{org}/members/{user}``
+          # endpoint returns 204 for public members and 404 for private
+          # members and non-members alike. We distinguish
+          # 404 (skip with the membership reason) from other failures
+          # (rate-limit, network, bad token — skip but log a warning so
+          # operators can tell a real "non-member" from a transient
+          # API hiccup).
+          MEMBERSHIP_STATUS=$(gh api "orgs/${ORG}/members/${PR_ACTOR}" \
+            -i 2>&1 | grep -m1 -E '^HTTP/' | awk '{print $2}')
+          if [[ "$MEMBERSHIP_STATUS" == "204" ]]; then
+            : # member — proceed
+          elif [[ "$MEMBERSHIP_STATUS" == "404" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=PR author '${PR_ACTOR}' is not a public member of the '${ORG}' org" >> "$GITHUB_OUTPUT"
+            exit 0
+          else
+            echo "::warning::Org membership API returned HTTP ${MEMBERSHIP_STATUS:-?} for '${PR_ACTOR}' — skipping review as a precaution"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=Org membership API returned unexpected status ${MEMBERSHIP_STATUS:-?} for '${PR_ACTOR}'" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 2. Skip synchronize events (push to PR branch) — use @claude to re-trigger
+          #
+          # notify=false because this is the ONE skip that repeats: it fires on every push to
+          # every open pull request, and the comment below would stack one "skipped" note per
+          # push. The others each explain a one-off decision worth a comment. This has not been
+          # visible until now only because the membership check above returns first for an author
+          # whose org membership is not public, which pre-empted it.
+          if [[ "$PR_ACTION" == "synchronize" ]]; then
+            {
+              echo "skip=true"
+              echo "notify=false"
+              echo "reason=push to PR branch (synchronize) — comment @claude to re-trigger"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 3. Skip draft PRs
+          if [[ "$PR_DRAFT" == "true" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=draft PR" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 4. Skip bot PRs
+          if [[ "$PR_ACTOR" == "dependabot[bot]" || "$PR_ACTOR" == "renovate[bot]" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=bot PR ($PR_ACTOR)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 5. Too many changed files
+          # --paginate, and the sum, are both load-bearing. This endpoint returns 30 items per
+          # page by default, which is exactly MAX_FILES — so unpaginated, FILE_COUNT could never
+          # exceed 30 and `-gt 30` could never fire. The cap read as enforced and enforced
+          # nothing. The awk sum is because `--paginate --jq` applies the filter per page and
+          # emits one number per page; summing is correct whether that is one line or many.
+          FILE_COUNT=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq 'length' \
+            | awk '{s+=$1} END {print s+0}')
+          if [[ "$FILE_COUNT" -gt "$MAX_FILES" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=PR has ${FILE_COUNT} files (limit: ${MAX_FILES})" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 6. Only test/config/docs files changed — no source to review
+          # Paginated for the same reason as the count above, and here the failure is worse than
+          # a dead cap: unpaginated, a pull request whose first 30 files are all docs would be
+          # skipped as "no source files" even with source changes on page two.
+          SRC_FILES=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '[.[] | select(.filename | (startswith("tests/") or startswith("test_") or test("^(Dockerfile|helm/|docs/|.*\\.(md|toml|lock|ya?ml)$)")) | not)] | length' \
+            | awk '{s+=$1} END {print s+0}')
+          if [[ "$SRC_FILES" -eq 0 ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=no source files to review (only tests/docs/config)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "reason=" >> "$GITHUB_OUTPUT"
+
+      # `!= 'false'` rather than `== 'true'`: every skip branch except the synchronize one leaves
+      # `notify` unset, which reads as empty, and an empty value must still post.
+      - name: Log skip reason
+        if: steps.decide.outputs.skip == 'true' && steps.decide.outputs.notify != 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REASON: ${{ steps.decide.outputs.reason }}
+        run: |
+          echo "::notice::Skipping Claude review — $REASON"
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            -f body="**Claude Code Review** — skipped: ${REASON}" 2>/dev/null || true
+
+  # Runs on PR opened/reopened — reviews the diff via the shared script.
+  # Gated on org membership transitively through ``pre-checks``: when
+  # ``pre-checks`` skips a non-member PR, ``needs.pre-checks.result``
+  # is ``'skipped'`` (not ``'success'``), so the ``== 'success'`` clause
+  # below already short-circuits this job. Don't re-check
+  # ``author_association`` here — keeping the gate in one place avoids
+  # the two conditions drifting out of sync.
+  claude-review:
+    needs: pre-checks
     if: >-
-      github.event_name != 'issue_comment'
-      || github.event.issue.pull_request != null
-    uses: caura-ai/.github/.github/workflows/claude-code-review.yml@v1
-    with:
-      extra-prompt: >-
-        This is a FastAPI + PostgreSQL (pgvector) backend with a TypeScript OpenClaw plugin.
-        Uses requirements.txt (not uv/pyproject.toml). Tests are in the tests/ directory.
-      pr-number: ${{ inputs.pr_number || '' }}
-      # Nothing else is set on purpose. max-files, the source-file filter and the CLI pin all
-      # match the shared defaults already, and author-gate's `auto` derives from repository
-      # visibility — this repo is PUBLIC, so the gate is ON and pull requests from anyone who is
-      # not a public member of the org are skipped, exactly as the local copy did.
-      #
-      # NOTE the operational cost of that gate, which bit this repo before: GITHUB_TOKEN resolves
-      # only PUBLIC org members, so a member whose membership is private is skipped silently
-      # behind a green check. Every reviewer here has to set their org membership to Public.
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      # Optional. Absent, it resolves to '' and review-memory recall and capture become silent
-      # no-ops, leaving the review byte-for-byte unchanged.
-      memclaw-agents-key: ${{ secrets.MEMCLAW_AGENTS_KEY }}
+      github.event_name == 'pull_request'
+      && needs.pre-checks.result == 'success'
+      && needs.pre-checks.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      # Checks out the PR merge ref, so the review runs THIS PR's version of the
+      # review script (lets a workflow/script change self-test on its own PR).
+      # Secrets are withheld from fork-PR runs and pre-checks gate the rest.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code@2.1.159 # pinned: reproducible reviews; bump deliberately
+
+      # Same script as the @claude retrigger job below — feed the real diff to
+      # `claude --print`. Replaces the claude-code-action agent, which never
+      # received the diff (it tried `gh`, hit the headless permission wall) and
+      # produced an empty result that got stamped "No issues found".
+      - name: Review PR diff
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXTRA_PROMPT: ${{ env.EXTRA_PROMPT }}
+          REVIEW_PROMPT: ${{ env.REVIEW_PROMPT }}
+        run: bash .github/scripts/claude_pr_review.sh
+
+  # Runs on @claude comment — only for public org members (MEMBER or OWNER).
+  claude-retrigger:
+    # Hardening: gate at the job level on author_association so the runner never
+    # even starts for a non-member's @claude comment. The step-level "Check
+    # commenter is org member" below still re-validates and sets the
+    # ``authorized`` output for defense-in-depth — both read the same
+    # ``author_association`` field, so the two conditions cannot disagree.
+    if: >-
+      github.event_name == 'issue_comment'
+      && contains(github.event.comment.body, '@claude')
+      && contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Check commenter is org member
+        id: auth
+        env:
+          AUTHOR_ASSOC: ${{ github.event.comment.author_association }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          # ``author_association`` is set by GitHub on the event payload
+          # and reflects the commenter's relationship to the repo's
+          # owner organization. ``MEMBER`` = org member, ``OWNER`` = org
+          # owner.
+          #
+          # On an ``issue_comment`` payload this DOES resolve for a private
+          # org member — observed reporting ``MEMBER`` for a member whose
+          # org membership was private — which is why this path kept
+          # working while the on-open review was skipping everyone. Do not
+          # "align" the two gates by moving pre-checks onto this field: on a
+          # ``pull_request`` payload the same person reports ``CONTRIBUTOR``.
+          # See the header comment for the measured values.
+          #
+          # ``COLLABORATOR`` (non-org members granted direct repo write
+          # access via Settings → Collaborators) is INTENTIONALLY
+          # excluded — the policy is "members of our org only", which
+          # is stricter than the previous ``write``/``admin`` permission
+          # check. If a future operator wants to widen this, do it
+          # explicitly; do not "fix" it back as a presumed bug.
+          case "$AUTHOR_ASSOC" in
+            MEMBER|OWNER)
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "authorized=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::@claude triggered by ${COMMENTER} (author_association: ${AUTHOR_ASSOC}) — skipping, org membership required"
+              ;;
+          esac
+
+      - name: Get PR details
+        if: steps.auth.outputs.authorized == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.issue.number }}
+          REPO=${{ github.repository }}
+
+          # Verify this is a PR comment, not an issue comment. Only the exit status is used —
+          # the captured value was never read, and it held the PR number rather than the HTTP
+          # code its name claimed.
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.number' >/dev/null 2>&1 || {
+            echo "Not a PR comment, skipping"
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          echo "is_pr=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      # Check out the BASE repo's default branch — deliberately NOT the PR/fork
+      # code. This job runs on ``issue_comment``, which (unlike fork
+      # ``pull_request`` events) DOES receive repo secrets (ANTHROPIC_API_KEY, a
+      # write GH_TOKEN). The review script below is fetched from trusted base
+      # code and pulls the PR diff via the GitHub API, so a malicious fork can
+      # never get its code executed with our secrets. This also fixes the old
+      # failure: the previous ``ref: <head_ref>`` pointed at the fork's branch,
+      # which doesn't exist in the base repo, so checkout exited 1 (.github#111).
+      - name: Checkout base repo (trusted review script)
+        if: steps.auth.outputs.authorized == 'true' && steps.pr.outputs.is_pr == 'true'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Install Claude CLI
+        if: steps.auth.outputs.authorized == 'true' && steps.pr.outputs.is_pr == 'true'
+        run: npm install -g @anthropic-ai/claude-code@2.1.159 # pinned: reproducible reviews; bump deliberately
+
+      # Same script as the on-open claude-review job above.
+      - name: Review PR diff
+        if: steps.auth.outputs.authorized == 'true' && steps.pr.outputs.is_pr == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          EXTRA_PROMPT: ${{ env.EXTRA_PROMPT }}
+          REVIEW_PROMPT: ${{ env.REVIEW_PROMPT }}
+        run: bash .github/scripts/claude_pr_review.sh


### PR DESCRIPTION
## This repo has not been reviewed since 2026-08-08

caura-memclaw#733 replaced the local review workflow with a caller into the org's shared pipeline. Every run since has failed instantly — **6 of 6, zero jobs created, no logs**:

```
run 31304400763 -> jobs created: 0
run 31304399944 -> jobs created: 0
run 31279132213 -> jobs created: 0
run 31278978009 -> jobs created: 0
run 31278973492 -> jobs created: 0
run 31278893982 -> jobs created: 0
```

[#734](https://github.com/caura-ai/caura-memclaw/pull/734) went unreviewed.

## Why, and why it can't be fixed in place

A component — reusable workflow **or** composite action — in a **private** repository can be used only by **private** repositories. GitHub's docs state it plainly: *"Access is allowed only from private repositories."*

`caura-ai/.github` is private. This repo is public. So `uses: caura-ai/.github/...@v1` can never resolve here, and an unresolvable component fails *before* any job exists — surfacing as "This run likely failed because of a workflow file issue", which reads like malformed YAML. That's why it went unnoticed for a day.

The six repos that migrated earlier are **all private**, which is exactly why the pattern looked proven. This was the first public caller.

Ruled out first: the caller is `actionlint`-clean; its inputs and secrets all exist in `v1`'s `workflow_call` contract; it grants every permission the callee jobs request; and `v1` resolves fine.

## Not a plain revert — three things are brought up to date

### 1. Security: the reviewer was unrestricted, on a public repo

This is the reason a `git revert` would have been the wrong move. The old script invoked the CLI as:

```bash
claude --print --model … --max-budget-usd …
```

No `--bare`, no `--tools`. So the reviewer ran with the **full built-in toolset** and auto-discovered `.mcp.json` and `CLAUDE.md` **from the checked-out PR tree** — in a job holding `ANTHROPIC_API_KEY` and a write `GH_TOKEN`. Now:

```bash
claude --print --model … --bare --tools "Read,Grep,Glob" --max-budget-usd …
```

`--tools` leaves a prompt injection in the diff nothing to act through. `--bare` closes the two paths the allow-list cannot reach — `--tools` names only *built-in* tools, so a PR-supplied `.mcp.json` would otherwise hand the reviewer tools outside it entirely, and `--bare` also skips `CLAUDE.md` auto-discovery so a reviewed tree can't steer its own review. Both flags exist in the pinned `2.1.159`.

### 2. Shorter prompt, shorter verdicts

The `## 🚀 Fix All Prompts` section is gone. It asked for one combined block per severity **repeating every per-issue prompt** — most of what made these comments long. Replaced by the shared prompt's current constraints: one prompt per issue, nothing after the last issue, and no tool-call or JSON-edit syntax inside prompt blocks.

### 3. A dead assignment

`HTTP_CODE=$(gh api …)` was never read — only the exit status mattered, and it held the PR *number*, not an HTTP code. `actionlint` flagged it once the file was linted.

## Also restored

#733 deleted `.github/scripts/claude_pr_review.sh` (141 lines) as well, so the workflow alone would have been broken. Both come back.

The header now records why this copy is deliberate, so it doesn't get "consolidated" a second time. Sharing with the org is still possible — it needs the pipeline in a **public** repo, which is a decision about publishing, not a technical dead end.

## Checks

`actionlint`, `shellcheck`, `bash -n` — all clean.
