### PR TITLE
refactor(search): derive SearchProfileUpdate from the knob table

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -451,25 +451,30 @@ class SearchKnob(NamedTuple):
     # payload omitting it is malformed and the route rejects it rather than
     # letting it surface as a KeyError 500 from inside the session.
     sql_required: bool = False
+    # Exposed on the agent-facing tuning surface (``SearchProfileUpdate``, and the
+    # ``memclaw_tune`` MCP tool). False for the A/B knobs, which are held at their
+    # global defaults until the offline comparison validates them and are flipped
+    # per TENANT via ``search.default_profile``, not per agent.
+    agent_tunable: bool = False
 
 
 SEARCH_KNOBS: dict[str, SearchKnob] = {
     # ── core-api-local: resolved here, never sent to storage ──
-    "top_k": SearchKnob(int, (1, 20)),
-    "min_similarity": SearchKnob(float, (0.1, 0.9)),
+    "top_k": SearchKnob(int, (1, 20), agent_tunable=True),
+    "min_similarity": SearchKnob(float, (0.1, 0.9), agent_tunable=True),
     # Ceiling 3, matching the agent-facing ingress (``SearchProfileUpdate`` and
     # the ``memclaw_tune`` MCP signature). It read 5 here until 2026-08-07 while
     # both of those said 3, so a tenant-wide default could hold a depth no agent
     # profile could ever set. Depth drives graph expansion cost, so 3 is the
     # deliberate ceiling rather than the widest of the three.
-    "graph_max_hops": SearchKnob(int, (0, 3)),
+    "graph_max_hops": SearchKnob(int, (0, 3), agent_tunable=True),
     # ── scoring knobs storage reads positionally ──
-    "fts_weight": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True),
-    "freshness_floor": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True),
-    "freshness_decay_days": SearchKnob(int, (7, 730), sql=True, sql_required=True),
-    "recall_boost_cap": SearchKnob(float, (1.0, 3.0), sql=True, sql_required=True),
-    "recall_decay_window_days": SearchKnob(int, (7, 365), sql=True, sql_required=True),
-    "similarity_blend": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True),
+    "fts_weight": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True, agent_tunable=True),
+    "freshness_floor": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True, agent_tunable=True),
+    "freshness_decay_days": SearchKnob(int, (7, 730), sql=True, sql_required=True, agent_tunable=True),
+    "recall_boost_cap": SearchKnob(float, (1.0, 3.0), sql=True, sql_required=True, agent_tunable=True),
+    "recall_decay_window_days": SearchKnob(int, (7, 365), sql=True, sql_required=True, agent_tunable=True),
+    "similarity_blend": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True, agent_tunable=True),
     # ── scoring knobs with a server-side default, so optional on the wire ──
     # #687: scale on ts_rank_cd before saturation. Floor is 1.0, not 0 — that is
     # the pre-#687 formula, so a tenant can revert but cannot weaken keyword
@@ -487,3 +492,6 @@ SEARCH_KNOBS: dict[str, SearchKnob] = {
 # missing any of the second.
 SQL_SCORING_PARAM_KEYS: tuple[str, ...] = tuple(k for k, v in SEARCH_KNOBS.items() if v.sql)
 SQL_SCORING_REQUIRED_KEYS: tuple[str, ...] = tuple(k for k, v in SEARCH_KNOBS.items() if v.sql_required)
+# The agent-facing tuning surface, derived the same way: ``SearchProfileUpdate``
+# and the ``memclaw_tune`` MCP tool expose exactly these.
+AGENT_TUNABLE_KEYS: tuple[str, ...] = tuple(k for k, v in SEARCH_KNOBS.items() if v.agent_tunable)

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -1,9 +1,10 @@
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, create_model, model_validator
 
+from common.constants import AGENT_TUNABLE_KEYS, SEARCH_KNOBS
 from core_api.constants import (
     BULK_MAX_ITEMS,
     DEFAULT_MEMORY_TYPE,
@@ -537,18 +538,32 @@ class AgentTrustUpdate(BaseModel):
     fleet_id: str | None = None
 
 
-class SearchProfileUpdate(BaseModel):
-    """Per-agent search tuning knobs. All fields optional — only override what you set."""
+# Derived from ``SEARCH_KNOBS`` rather than written out. The fields and their
+# bounds were hand-maintained here, in the MCP ``memclaw_tune`` signature and in
+# the knob table, and they had already drifted: ``graph_max_hops`` was capped at 3
+# here while the table allowed 5, so a tenant-wide default could hold a depth no
+# agent profile could set (#730). One declaration removes the class of drift
+# rather than testing for it.
+#
+# ``agent_tunable`` is what selects the nine; the three A/B knobs
+# (``fts_rank_scale``, ``candidate_pool_size``, ``score_formula``) stay off this
+# surface deliberately — they are tenant-level A/B levers, not per-agent tuning.
+# ``dict[str, Any]`` explicitly: ``create_model``'s overloads take
+# ``**field_definitions: Any | tuple[Any, Any]``, and mypy will not match a
+# comprehension it infers as ``dict[Any, tuple[Any, None]]`` against them.
+_PROFILE_FIELDS: dict[str, Any] = {
+    name: (
+        SEARCH_KNOBS[name].value_type | None,
+        Field(default=None, ge=SEARCH_KNOBS[name].bounds[0], le=SEARCH_KNOBS[name].bounds[1]),
+    )
+    for name in AGENT_TUNABLE_KEYS
+}
 
-    top_k: int | None = Field(default=None, ge=1, le=20)
-    min_similarity: float | None = Field(default=None, ge=0.1, le=0.9)
-    fts_weight: float | None = Field(default=None, ge=0.0, le=1.0)
-    freshness_floor: float | None = Field(default=None, ge=0.0, le=1.0)
-    freshness_decay_days: int | None = Field(default=None, ge=7, le=730)
-    recall_boost_cap: float | None = Field(default=None, ge=1.0, le=3.0)
-    recall_decay_window_days: int | None = Field(default=None, ge=7, le=365)
-    graph_max_hops: int | None = Field(default=None, ge=0, le=3)
-    similarity_blend: float | None = Field(default=None, ge=0.0, le=1.0)
+SearchProfileUpdate = create_model(
+    "SearchProfileUpdate",
+    __doc__="Per-agent search tuning knobs. All fields optional — only override what you set.",
+    **_PROFILE_FIELDS,
+)
 
 
 # --- Background Task ---

--- a/tests/test_search_default_profile.py
+++ b/tests/test_search_default_profile.py
@@ -179,36 +179,65 @@ def test_fts_rank_scale_ceiling_matches_what_was_measured():
 # ── agent-facing ingress vs the knob table ──
 
 
-def test_agent_tunable_bounds_match_the_knob_table():
-    """``SearchProfileUpdate``'s bounds must equal ``SEARCH_KNOBS``'.
+def test_search_profile_update_is_derived_from_the_knob_table():
+    """The request model must expose exactly the agent-tunable knobs, with their bounds.
 
-    The request model still writes its own ``ge``/``le`` per field rather than
-    deriving them, and it drifted: ``graph_max_hops`` was capped at 3 here while
-    the table allowed 5, so a tenant-wide default could hold a depth no agent
-    profile could ever set. Resolved to 3 on 2026-08-07 — the ingress value, not
-    the widest of the three, because depth drives graph-expansion cost.
-
-    Asserts the bounds rather than merely the names, since matching names with
-    different limits is exactly the failure that hid for months.
+    It is now built by ``create_model`` over ``SEARCH_KNOBS``, so this cannot
+    drift the way it did before (#730: ``graph_max_hops`` was capped at 3 here
+    while the table allowed 5). Kept as a cheap check that the derivation still
+    produces a usable model — a botched comprehension would yield a model with
+    the wrong field set or no constraints at all, which nothing else would catch.
     """
-    from common.constants import SEARCH_KNOBS
+    from common.constants import AGENT_TUNABLE_KEYS, SEARCH_KNOBS
     from core_api.schemas import SearchProfileUpdate
 
-    checked = 0
+    assert set(SearchProfileUpdate.model_fields) == set(AGENT_TUNABLE_KEYS)
     for name, field in SearchProfileUpdate.model_fields.items():
-        assert name in SEARCH_KNOBS, (
-            f"SearchProfileUpdate exposes {name!r}, which is not a declared search knob"
-        )
         lo = next((m.ge for m in field.metadata if hasattr(m, "ge")), None)
         hi = next((m.le for m in field.metadata if hasattr(m, "le")), None)
-        assert (lo, hi) == SEARCH_KNOBS[name].bounds, (
-            f"{name}: SearchProfileUpdate allows {(lo, hi)} but SEARCH_KNOBS declares "
-            f"{SEARCH_KNOBS[name].bounds} — the tenant-default path and the agent path would "
-            f"accept different values for the same knob"
+        assert (lo, hi) == SEARCH_KNOBS[name].bounds, f"{name}: {(lo, hi)} != {SEARCH_KNOBS[name].bounds}"
+
+
+def test_memclaw_tune_signature_matches_the_knob_table():
+    """The MCP tool is the LAST hand-written copy of this surface — pin it.
+
+    ``memclaw_tune`` declares its knobs as named parameters, which a reusable
+    model cannot express: the signature IS the tool schema that ships to clients
+    in ``plugin/tools.json``. So it stays hand-written, and this is what stops it
+    drifting from the table the way ``SearchProfileUpdate`` did.
+
+    Also checks the human-readable ranges in each parameter's description, since
+    those are what an agent actually reads before choosing a value — a bound that
+    moves in the table while the description still advertises the old one is a
+    silently wrong instruction, not just stale prose.
+    """
+    import inspect
+    import re
+
+    from common.constants import AGENT_TUNABLE_KEYS, SEARCH_KNOBS
+    from core_api.mcp_server import memclaw_tune
+
+    params = [p for p in inspect.signature(memclaw_tune).parameters if p != "agent_id"]
+    assert set(params) == set(AGENT_TUNABLE_KEYS), (
+        f"memclaw_tune exposes {sorted(set(params) ^ set(AGENT_TUNABLE_KEYS))} "
+        f"differently from the knob table"
+    )
+
+    hints = inspect.get_annotations(memclaw_tune, eval_str=True)
+    checked = 0
+    for name in params:
+        meta = getattr(hints[name], "__metadata__", ())
+        desc = next((getattr(m, "description", "") for m in meta), "") or ""
+        # Only parameters whose description IS a range, e.g. "1-20." or "0.1-0.9.".
+        m = re.fullmatch(r"(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)\.?", desc.strip())
+        if not m:
+            continue
+        lo, hi = SEARCH_KNOBS[name].bounds
+        assert (float(m.group(1)), float(m.group(2))) == (float(lo), float(hi)), (
+            f"memclaw_tune documents {name} as {desc!r} but the knob table says {(lo, hi)}"
         )
         checked += 1
-
-    assert checked == 9, f"expected 9 agent-tunable knobs, checked {checked}"
+    assert checked >= 6, f"only {checked} descriptions parsed as ranges — the format changed"
 
 
 def test_the_three_ab_knobs_are_not_agent_tunable():


### PR DESCRIPTION
Item #2 of the post-thread list: close the last registration point for a search knob.

## Why

`SearchProfileUpdate` wrote out its nine fields and their `ge`/`le` by hand, duplicating `SEARCH_KNOBS`. That duplication had already produced a real defect — `graph_max_hops` capped at 3 here while the table allowed 5, so a tenant-wide `default_profile` could hold a graph depth no per-agent profile could set. #730 settled the value; this removes the mechanism that produced it.

## What

The model is built by `create_model` over the table, selected by a new **`agent_tunable`** flag on `SearchKnob`. `AGENT_TUNABLE_KEYS` derives from it exactly as the two SQL tuples already do.

That flag also records, in the one place it matters, **why the split is 9 of 12**: `fts_rank_scale`, `candidate_pool_size` and `score_formula` are tenant-level A/B levers held at their global defaults, not per-agent tuning. Previously that was an undocumented omission a reader could plausibly "fix".

## What stays hand-written, and why

`memclaw_tune`'s MCP signature. It declares its knobs as **named parameters**, and that signature *is* the tool schema shipped to clients in `plugin/tools.json` — `create_model` cannot express it. So it becomes the last copy, and a test pins it: both the parameter set **and the human-readable ranges in each description**, because a bound that moves in the table while the description still advertises the old one is a silently wrong instruction to an agent, not merely stale prose.

The previous bounds test would be tautological against a derived model, so it is **retargeted rather than kept**: one cheap assertion that the derivation still yields a usable model (a botched comprehension would produce the wrong field set or drop constraints entirely), and the real guard moved onto the MCP signature.

## Verification

Mutation-verified in both directions:

```
widen graph_max_hops in the table →
  memclaw_tune documents graph_max_hops as '0-3.' but the knob table says (0, 5)
drop agent_tunable from top_k →
  memclaw_tune exposes ['top_k'] differently from the knob table
```

`tests/` **4183**, `core-storage-api/tests/` 105, ruff clean at every CI scope. **`plugin/tools.json` and the broker OpenAPI both regenerate byte-identical** — the derivation reproduces the previous model exactly, so no client-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)