### PR TITLE
perf(search): halve ts_rank_cd renders in the scored-search SQL

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -251,6 +251,47 @@ def _entity_uf_union(parent: dict[UUID, UUID], rank: dict[UUID, int], a: UUID, b
 _FTS_ONLY_RESERVED_CANDIDATES = 3
 
 
+def _saturate_rank(scaled_rank: Any) -> Any:
+    """Map a scaled ``ts_rank_cd`` onto ``[0, 1)``, naming the rank ONCE.
+
+    ``x / (1 + x)`` is the obvious way to write this and is what shipped until
+    now. It is also a performance bug: ``x`` is not a bound value but the
+    ``ts_rank_cd(search_vector, plainto_tsquery(...))`` expression itself, and
+    SQLAlchemy inlines an expression at every site that names it, so writing it
+    twice makes Postgres evaluate the ranking function twice. The
+    algebraically identical
+
+        x / (1 + x)  ==  1 - 1/(1 + x)
+
+    names ``x`` once, halving the renders contributed by this factor.
+
+    WHAT THIS DOES AND DOES NOT BUY. Compiling the real ``memory_scored_search``
+    statement, ``ts_rank_cd(`` goes from **18 renders to 9** (and
+    ``plainto_tsquery(`` 27 -> 18). NOT to 1: ``similarity`` names ``fts_score``
+    in both branches of its CASE, ``score`` inlines ``similarity``, and both are
+    output columns of the scored CTE — so four live references remain, times the
+    UNION'd reserved branch. Getting to 1 means projecting ``similarity`` and
+    ``vec_sim`` once in an inner derived table and computing ``score`` over
+    that; it also needs a real optimisation barrier, because with references
+    still live Postgres flattens a plain subquery and re-substitutes. That is a
+    separate change to the hot path, with its own plan-shape review.
+
+    Measured in isolation on a 31,446-memory corpus with genuine multi-term
+    matches (scoring 2 renders vs 1, ordered and limited): **32-39% faster**
+    across queries matching 1,875-11,505 rows — 92.0ms -> 56.4ms at 11,505,
+    medians of 7 runs. Read that as the gain on the FTS scoring component
+    alone; the full search also pays six pgvector distance computations per
+    row, so end-to-end it is smaller.
+
+    NOT bit-identical, and the difference is real but negligible: the two forms
+    disagree by at most one ULP (measured max ``|a - b|`` = 5.55e-17 over every
+    matching row of that corpus). That is ~4 orders of magnitude below the
+    tightest tolerance anything here asserts (1e-12) and far below any score
+    gap that could reorder results.
+    """
+    return 1.0 - 1.0 / (1.0 + scaled_rank)
+
+
 # Cached at import time so the per-row column-name filter on the bulk
 # write hot path (100 items x ~25 columns) doesn't pay the cost of
 # walking ``Memory.__table__.columns`` and ``__mapper__.column_attrs``
@@ -1178,7 +1219,7 @@ class PostgresService:
         # the two services, and the safe direction for the gap is "unchanged".
         _fts_rank_scale = float(sp.get("fts_rank_scale", 1.0) or 1.0)
         scaled_keyword_rank = _fts_rank_scale * raw_keyword_rank
-        fts_score = (scaled_keyword_rank / (1.0 + scaled_keyword_rank)).label("fts_score")
+        fts_score = _saturate_rank(scaled_keyword_rank).label("fts_score")
 
         # CAURA-679: NULL-embedding rows fall back to `fts_score` alone
         # rather than the `(1 - w) * 0 + w * fts_score` haircut that

--- a/core-storage-api/tests/test_fts_score_single_render.py
+++ b/core-storage-api/tests/test_fts_score_single_render.py
@@ -1,0 +1,173 @@
+"""``fts_score`` must not name ``ts_rank_cd`` more times than it has to.
+
+The property under test is invisible in the Python source: ``x / (1 + x)`` and
+``1 - 1/(1 + x)`` read almost identically, but when ``x`` is an *expression*
+rather than a bound value, SQLAlchemy inlines it at every site that names it and
+Postgres evaluates the ranking function once per site. Only the compiled SQL
+shows it, so that is what these assert — and they assert it on the statement the
+service actually issues, not just on the factor in isolation, because the factor
+being clean is not the same as the query being clean. See ``_saturate_rank`` for
+the measurements.
+
+No database: the statement is captured on its way to ``session.execute`` and
+compiled, so this is a pure unit test despite living beside the integration
+suite.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+from sqlalchemy import func
+from sqlalchemy.dialects import postgresql
+
+import core_storage_api.services.postgres_service as ps
+from common.constants import SEARCH_KNOBS
+from common.models import Memory
+from core_storage_api.services.postgres_service import _saturate_rank
+
+# What the shipped ``memory_scored_search`` statement renders today. Both
+# directions matter: a rise means someone added a reference and put the per-row
+# cost back, a fall means the inner-projection work landed. Either way,
+# re-measure and move the number deliberately rather than loosening the check.
+_EXPECTED_TS_RANK_CD_RENDERS = 9
+_EXPECTED_TSQUERY_RENDERS = 18
+
+
+def _scaled_rank():
+    """The production argument: a real ``ts_rank_cd`` call, not a bound value."""
+    return 6.0 * func.ts_rank_cd(
+        Memory.search_vector, func.plainto_tsquery("english", "connection pool sizing")
+    )
+
+
+def _render(expr) -> str:
+    # No ``literal_binds``: the regconfig 'english' has no literal renderer, and
+    # only the shape matters here, not the parameter values.
+    return str(expr.compile(dialect=postgresql.dialect()))
+
+
+def _calls(sql: str, fn: str = "ts_rank_cd") -> int:
+    """Count real CALLS of ``fn``.
+
+    Not a bare substring count: SQLAlchemy names the scale's bind parameter
+    after the function it multiplies (``%(ts_rank_cd_1)s``), so a plain
+    ``sql.count("ts_rank_cd")`` double-counts every call. The trailing paren is
+    what distinguishes an invocation from a parameter name.
+    """
+    return sql.count(f"{fn}(")
+
+
+# ── the saturating factor in isolation ─────────────────────────────────────
+
+
+def test_the_saturating_factor_names_the_rank_once() -> None:
+    """Reverting ``_saturate_rank`` to ``x / (1 + x)`` fails here."""
+    sql = _render(_saturate_rank(_scaled_rank()))
+    assert _calls(sql) == 1, (
+        f"the saturating factor must name ts_rank_cd once; compiled SQL calls it {_calls(sql)} times:\n{sql}"
+    )
+
+
+def test_the_naive_form_really_does_render_twice() -> None:
+    """Control: proves ``_calls`` discriminates 1 from 2 for the right reason.
+
+    Without it the test above could pass vacuously — if SQLAlchemy common-
+    subexpression-eliminated repeated references, or if ``_calls`` were simply
+    blind to the second one, a genuinely double-rendering expression would still
+    count 1. This pins that the difference is real and observable.
+    """
+    scaled = _scaled_rank()
+    naive = _render(scaled / (1.0 + scaled))
+    assert _calls(naive) == 2, f"the pre-fix expression should double-render; got {_calls(naive)}"
+
+
+@pytest.mark.parametrize("rank", [0.0, 1e-9, 0.1, 1.0, 1e6])
+def test_the_two_forms_agree_to_within_one_ulp(rank: float) -> None:
+    """Algebraically equal, so the change must not move any score meaningfully.
+
+    Deliberately NOT asserted as exact equality: measured over every matching row
+    of the benchmark corpus the forms differ by up to 5.55e-17, one ULP near 0.5.
+    The bound here is the tightest tolerance anything in the stack asserts on this
+    value (1e-12), which the difference clears by ~4 orders of magnitude. Goes
+    through ``_saturate_rank`` rather than a retyped copy of its body, so editing
+    the helper actually breaks this.
+    """
+    got = _saturate_rank(rank)
+    assert got == pytest.approx(rank / (1.0 + rank), abs=1e-12)
+    # fts_score shares a scale with cosine vec_sim; it must stay in [0, 1).
+    assert 0.0 <= got < 1.0, f"rank {rank} mapped outside [0, 1): {got}"
+
+
+# ── the statement the service actually issues ──────────────────────────────
+
+
+async def _compiled_scored_search_sql(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Compile ``memory_scored_search``'s statement without touching a DB."""
+    captured: list = []
+
+    class _Stop(Exception):
+        pass
+
+    class _Session:
+        async def execute(self, stmt, *args, **kwargs):
+            captured.append(stmt)
+            raise _Stop
+
+    @contextlib.asynccontextmanager
+    async def _fake_session():
+        yield _Session()
+
+    monkeypatch.setattr(ps, "get_read_session", _fake_session)
+
+    # The lower bound of each knob's range is enough — the statement's SHAPE is
+    # under test, not its constants — but the scale must be a real one, since
+    # 1.0 is a documented revert path that could compile differently.
+    search_params = {k: kn.value_type(kn.bounds[0]) for k, kn in SEARCH_KNOBS.items()}
+    search_params["fts_rank_scale"] = 6.0
+
+    with contextlib.suppress(_Stop):
+        await ps.PostgresService().memory_scored_search(
+            tenant_id="t",
+            embedding=[0.1] * 1536,
+            query="connection pool sizing",
+            search_params=search_params,
+            top_k=10,
+        )
+    assert captured, "no statement reached session.execute"
+    return str(captured[0].compile(dialect=postgresql.dialect()))
+
+
+async def test_the_shipped_statement_holds_its_ts_rank_cd_render_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The invariant that actually protects the hot path.
+
+    The isolated-factor test above passes whenever ``_saturate_rank`` is clean,
+    which says nothing about how many times the assembled query names
+    ``fts_score``. This counts the real thing: 18 before the change, 9 after.
+    """
+    sql = await _compiled_scored_search_sql(monkeypatch)
+    assert _calls(sql) == _EXPECTED_TS_RANK_CD_RENDERS, (
+        f"memory_scored_search renders ts_rank_cd {_calls(sql)} times, expected "
+        f"{_EXPECTED_TS_RANK_CD_RENDERS}. Up means a new reference to fts_score "
+        f"(or to similarity/score, which inline it) put the per-row cost back; "
+        f"down means it improved. Re-measure and update the constant either way."
+    )
+
+
+async def test_the_shipped_statement_holds_its_tsquery_render_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``plainto_tsquery`` rides along with every ``ts_rank_cd`` reference.
+
+    Tracked separately because it also appears in the FTS guard and the
+    exact-lexical-match CASE, so the two counts move independently.
+    """
+    sql = await _compiled_scored_search_sql(monkeypatch)
+    got = _calls(sql, "plainto_tsquery")
+    assert got == _EXPECTED_TSQUERY_RENDERS, (
+        f"memory_scored_search renders plainto_tsquery {got} times, expected "
+        f"{_EXPECTED_TSQUERY_RENDERS} (27 before the single-render change)."
+    )

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -534,14 +534,15 @@ async def _rank_and_score(
     Reads both out of one statement with the production expression rather than
     recomputing in Python — what ``ts_rank_cd`` feeds the saturating map is the
     thing under test, so a Python reimplementation would test the wrong function.
-    Binds the scaled rank once via a subquery, mirroring how the production
-    expression reuses it rather than re-evaluating.
+    The saturating half is kept in step with ``saturate_rank``'s single-render
+    form; the subquery is what keeps ``ts_rank_cd`` itself to one evaluation
+    here, since this helper needs the raw rank as a separate column.
     """
     async with get_session() as session:
         row = (
             await session.execute(
                 text(
-                    "SELECT r, (:k * r) / (1 + :k * r) AS s FROM ("
+                    "SELECT r, 1 - 1 / (1 + :k * r) AS s FROM ("
                     "  SELECT ts_rank_cd(to_tsvector('english', :t || ' ' || :c),"
                     "                    plainto_tsquery('english', :q)) AS r"
                     ") t"


### PR DESCRIPTION
## What

`fts_score` was `x / (1 + x)`, where `x` is the `ts_rank_cd(search_vector, plainto_tsquery(...))`
expression — not a bound value. SQLAlchemy inlines an expression at every site that names it, so
writing it twice made Postgres evaluate the ranking function twice.

The algebraically identical form names it once:

```
x / (1 + x)  ==  1 - 1/(1 + x)
```

Compiling the real `memory_scored_search` statement: **`ts_rank_cd(` 18 renders → 9**, and
`plainto_tsquery(` 27 → 18.

## Measured

On a 31,446-memory corpus with genuine multi-term matches, scoring + ordering + limiting, medians
of 7 runs per query:

| query | matching rows | two-render | one-render | delta |
|---|---|---|---|---|
| `case never use` | 11,505 | 92.0 ms | 56.4 ms | **38.7%** |
| `case never project` | 7,222 | 59.6 ms | 37.2 ms | **37.7%** |
| `case never must` | 5,581 | 47.2 ms | 29.9 ms | **36.6%** |
| `case never convent` | 4,016 | 34.6 ms | 22.2 ms | **36.0%** |
| `case never requir` | 1,875 | 19.1 ms | 13.0 ms | **31.8%** |

Read that as the gain on the **FTS scoring component**. The full search also pays six pgvector
distance computations per row, so end-to-end is smaller. Prior attempts to measure this locally
were meaningless: the local corpus's realistic multi-term queries match zero rows, and its only
matching single term returns 3,397 rows that all score the identical 0.375.

## What this does NOT do

It does not get to one render, and the code no longer claims it does. `similarity` names
`fts_score` in both branches of its CASE, `score` inlines `similarity`, and both are output columns
of the scored CTE — four live references remain, times the UNION'd reserved branch.

Getting to 1 means projecting `similarity`/`vec_sim` once in an inner derived table, and it **does**
need a real optimisation barrier: with references still live, Postgres flattens a plain subquery and
re-substitutes. That is a separate change to the hot path with its own plan-shape review. (An
earlier note in this thread claimed no barrier was ever needed — true of the factor in isolation,
false of the statement it composes into.)

## Not bit-identical

The two forms disagree by at most one ULP — measured `max |a - b| = 5.55e-17` over every matching
row of that corpus, not the `0.000e+00` recorded earlier. The old zero was measured where every
matching row scored the same single value, so it had no rank variety to expose the difference.
5.55e-17 is ~4 orders of magnitude below the tightest tolerance anything here asserts (`1e-12`) and
far below any score gap that could reorder results.

## Tests

Two levels, because the factor being clean is not the same as the query being clean:

- the saturating factor in isolation renders `ts_rank_cd` once, plus a control proving the naive
  form really does render twice (so the count-of-one assertion can't pass vacuously);
- **the assembled statement's render counts**, captured on the way to `session.execute` and
  compiled — no DB. This is what catches someone adding a fifth reference to `fts_score`. Reverting
  the fix fails it with `renders ts_rank_cd 18 times, expected 9`.

`_rank_and_score` in the integration suite carried its own copy of the old expression while its
docstring claimed to use the production one; it now matches.

## Verification

- `core-storage-api/tests/`: **114 passed** (105 on `origin/main` + 9 new)
- `tests/`: **4183 passed, 3 skipped, 1 xfailed** — identical to the `a5a55f2` baseline
- mypy clean on both projects; ruff check/format clean at all four CI scopes
- `plugin/tools.json` and the broker OpenAPI regenerate byte-identical