### PR TITLE
chore(deps): stop Dependabot widening uv requirements it doesn't need to

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,29 @@ updates:
       - "/core-storage-api"
       - "/core-worker"
       - "/core-operations"
+    # Only touch a requirement in pyproject.toml when the new version actually
+    # falls outside it. The default (`increase`) raises the floor on every
+    # release even when the existing range already permits the new version, and
+    # each of those produced its own ungroupable PR: eight were open at once,
+    # e.g. `uvicorn[standard] >=0.51.0,<1` widened to `>=0.52.0,<1` — for a
+    # version the old range already allowed. The uv.lock in each of these four
+    # directories was already being updated correctly; the manifest edit on top
+    # of it was pure churn.
+    #
+    # Grouping cannot absorb them: `update-types` classifies the semver bump of
+    # a resolved version, and a floor-raise on an already-satisfied range has no
+    # such classification. That is why uv-minor-patch groups the lock updates
+    # into one PR while these arrived individually.
+    #
+    # This works HERE because these specs are capped (22 of 30 in core-api carry
+    # an upper bound), so "not necessary" is a meaningful state and a genuine
+    # case still files — uvicorn 1.0 against `<1` needs the manifest changed and
+    # will get a PR. Do NOT copy this to the `pip` entry above or to caura-ops:
+    # their requirements are open-ended `>=X`, nothing is ever outside them, and
+    # the setting would silence Python updates entirely rather than de-duplicate
+    # them. Those need a committed lock instead (caura-ops did that on
+    # 2026-08-09).
+    versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Sets `versioning-strategy: increase-if-necessary` on the **uv entry only**, so a requirement in `pyproject.toml` is touched only when the new version actually falls outside it.

## Eight open PRs were doing nothing else

The default (`increase`) raises the floor on every release even when the range already permits the new version:

```
uvicorn[standard]  >=0.51.0,<1  →  >=0.52.0,<1     for a version >=0.51.0,<1 already allowed
```

…once per service directory (#692, #693, #694, #695), plus #645, #646, #650, #691. **The `uv.lock` in all four directories was already being updated correctly** — the manifest edit on top was pure churn.

Grouping can't absorb them: `update-types` classifies the semver bump of a *resolved version*, and a floor-raise on an already-satisfied range has no such classification. That's precisely why `uv-minor-patch` collapses the lock updates into one PR (#703, *"across 4 directories"*) while these arrive one at a time.

## Why this setting is right here and wrong elsewhere

This is the same option I **rejected** for `caura-ops` two days ago, and the distinction is the whole point:

| | this repo's `uv` entry | `caura-ops` |
|---|---|---|
| requirement shape | **capped** — 22 of 30 in `core-api` have an upper bound | open-ended `>=X`, no cap |
| is "outside the range" reachable? | **yes** — uvicorn 1.0 vs `<1` still files a PR | never |
| effect of this setting | de-duplicates churn | would have **silenced Python updates entirely** |
| correct fix | this | commit a lock + switch ecosystem (done 2026-08-09) |

## Deliberately scoped

The **`pip` entry in this same file is untouched.** It has mixed open-ended and capped requirements and no committed root lock, so it needs the `caura-ops` treatment and would be actively harmed by this setting. The file comment says exactly that, placed where someone would be tempted to copy the line.

Verified the value is valid against the schema and that it landed on the `uv` entry alone — `pip`, both `npm` entries, `github-actions` and `docker` all remain on the default.

## Honest limit, and a cheap test

**I could not confirm `increase-if-necessary`'s precise semantics from the docs** — that section of the options reference truncated on three separate fetches. This rests on the option name plus the observed capped-vs-open behaviour across these eight PRs.

It's falsifiable next Monday: the scheduled run should produce **lock-only PRs with no `update X requirement from >=A to >=B` titles**. If widenings still appear, my reading is wrong and this is a one-line revert. I'd rather ship it with the test stated than assert it works.

## What to expect

The eight open widening PRs become obsolete. Dependabot may supersede them on the next run; if not, they can be closed. The remaining five `caura-memclaw` widenings (#633–#637) come from the `pip` entry and need the separate lockfile change.

@claude