### PR TITLE
ci(review): name the reviewer at the top of the verdict, mirroring the shared pipeline

### DIFF
--- a/.github/scripts/claude_pr_review.sh
+++ b/.github/scripts/claude_pr_review.sh
@@ -227,8 +227,27 @@ if [ "${#REVIEW}" -gt "$MAX_BODY" ]; then
 _[Review truncated — exceeded GitHub's comment size limit.]_"
 fi
 
+# WHICH REVIEWER WROTE THIS, said before the review rather than only after it. Mirrors the shared
+# pipeline (caura-ai/.github#34, released in v1.5.1) so a verdict reads the same wherever it was
+# posted — which is the point of mirroring it at all: someone comparing a review here against one
+# on a repo that runs the shared pipeline should not have to work out that the formats differ.
+#
+# A blockquote, not a heading: a verdict opens with its own `## Summary` or `### Issue Title`, and
+# a second heading above those would compete with the review's structure instead of labelling it.
+#
+# Hardcoded rather than read from an AGENT_LABEL variable, unlike upstream. This copy runs ONE
+# reviewer and is deliberately standalone, so a variable with a single possible value would be
+# indirection without a second caller — the same reasoning that inlined recall here.
+#
+# Deliberately NOT the string "Reviewed by \`" — claude_pr_capture.sh greps exactly that to decide
+# whether a pull request was reviewed at all, and the footer below is what it is meant to find. A
+# header carrying the same phrase would still match, but it would make that gate depend on which
+# of the two lines survived thread truncation, and capture keeps the TAIL.
+#
 # Footer surfaces per-review spend on the PR itself, not just the job log.
-post "${REVIEW}
+post "> 🤖 Review by **Claude Code**
+
+${REVIEW}
 
 ---
 *Reviewed by \`${MODEL}\` · cost \$${COST:-unknown}*"


### PR DESCRIPTION
[caura-ai/.github#34](https://github.com/caura-ai/.github/pull/34) moved reviewer attribution to the **first** line of a verdict rather than a footer under what is often a long review, released in **v1.5.1**. This repo posts its own verdict from its local copy, so without this it's the one place a review looks different — and someone comparing a review here against one from a shared-pipeline repo would have to work out that the *formats* differ rather than the reviewers.

```markdown
> 🤖 Review by **Claude Code**

## Summary
…

---
*Reviewed by `claude-sonnet-5` · cost $0.60*
```

Byte-identical to what the shared pipeline emits once its `AGENT_LABEL` resolves.

## Three choices carried over, one changed

**Hardcoded** rather than read from a variable, unlike upstream — this copy runs one reviewer and is deliberately standalone, so a variable with a single possible value is indirection without a second caller. Same reasoning that inlined recall here instead of adding a `review_lib.sh`.

**A blockquote, not a heading** — a verdict opens with its own `## Summary`, and a second heading would compete with the review's structure rather than label it.

**The header avoids the string `Reviewed by \``** — `claude_pr_capture.sh` greps exactly that to decide a PR was reviewed, and the footer is what it should find. A header matching it too would make that gate depend on which line survived thread truncation, and capture keeps the **tail**. Verified against the rendered body: first line is the header with no gate string, footer carries it.

> [!NOTE]
> The drift checker **cannot** catch this one. It compares five behavioural facts and the verdict *format* isn't among them, so this mirror rests on `CLAUDE.md` and on someone noticing. Worth remembering next time the two copies diverge in something the checker doesn't measure.

`shellcheck` and `bash -n` clean.