### PR TITLE
ci(review): allow a manual capture backfill, mirroring the shared pipeline's caller

### DIFF
--- a/.github/workflows/claude_code_review.yml
+++ b/.github/workflows/claude_code_review.yml
@@ -103,6 +103,20 @@ on:
     types: [opened, reopened, synchronize, closed]
   issue_comment:
     types: [created]
+  # Manual backfill for claude-capture, mirroring the shared pipeline's caller. Two uses: it makes
+  # capture verifiable the moment MEMCLAW_AGENTS_KEY is added — the on-merge path cannot be tested
+  # on demand, since it needs a real merge that happens to carry a declined finding — and it can
+  # extract declines from pull requests that merged BEFORE capture existed here.
+  #
+  # `required: true` because the only failure mode of an empty value is a confusing one: the script
+  # would request `issues//comments`, get a 404, warn, and exit 0 looking like a repo with nothing
+  # to capture.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Merged PR number to capture declined findings from"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -442,11 +456,15 @@ jobs:
   # Dark and silent without MEMCLAW_AGENTS_KEY, which is the state on the day this lands — the
   # org secret is `private` visibility and this repo is public, so it reads as ''. The job still
   # runs and exits 0 having logged that it was dark, which is the diagnosable outcome.
+  # Only this job answers a workflow_dispatch. pre-checks is gated on `pull_request` and
+  # claude-review needs pre-checks to have succeeded, so a dispatch cannot start a review; the
+  # retrigger needs issue_comment. Nothing else can fire.
   claude-capture:
     if: >-
-      github.event_name == 'pull_request'
-      && github.event.action == 'closed'
-      && github.event.pull_request.merged == true
+      (github.event_name == 'pull_request'
+       && github.event.action == 'closed'
+       && github.event.pull_request.merged == true)
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -469,6 +487,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # pull_request supplies the number; on workflow_dispatch that context is absent and the
+          # input takes over. Ordered this way so a merge never reads a stale dispatch input.
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           MEMCLAW_AGENTS_KEY: ${{ secrets.MEMCLAW_AGENTS_KEY }}
         run: bash .github/scripts/claude_pr_capture.sh


### PR DESCRIPTION
`claude-capture` only fires on a merge, so there was no way to exercise it on demand. That matters now for two reasons.

## 1. It makes the credential verifiable

`MEMCLAW_AGENTS_KEY` isn't set on this repo yet, so recall and capture are both dark. **Recall** is verifiable the moment it's added — it runs on every review and logs whether it injected anything. **Capture** wasn't: confirming it needed a real merge that happened to carry a declined finding, which isn't something you can arrange in order to check a secret.

The shared pipeline's caller has had this dispatch for exactly that reason; this brings the local copy in line.

## 2. Backfill

Capture didn't exist here until #737, so every decline in this repo's history is unrecorded. #735, #737 and #744 each carry findings a maintainer declined **with a stated reason** — precisely what the extractor looks for. One dispatch per PR recovers them.

## Details

`required: true` on the input, because the only failure mode of an empty value is a confusing one: the script would request `issues//comments`, take the 404, warn, and exit 0 looking exactly like a PR with nothing to capture.

**Only `claude-capture` answers a dispatch**, and that falls out of the existing gates rather than needing a new one — `pre-checks` is gated on `pull_request`, `claude-review` needs it to have succeeded, and `claude-retrigger` needs `issue_comment`. So a dispatch can't start a review, which would otherwise be an expensive surprise given a backfill names an already-merged PR.

`PR_NUMBER` reads `github.event.pull_request.number || inputs.pr_number`, in that order, so a merge never picks up a stale dispatch input.

`actionlint` clean.