### PR TITLE
chore(deps): drop the uv versioning-strategy that measurement showed is inert

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,21 @@
 # The uv services share ONE multi-directory entry for the same reason: four separate
 # entries emitted four near-identical group PRs every week.
 # Mirrors the caura-memclaw-enterprise grouping strategy.
+#
+# NO entry here sets `versioning-strategy`, and that applies to all of them:
+#   * `increase-if-necessary` is IGNORED for `uv` — verified against a live run on
+#     2026-08-10 (#740, reverted), which still raised floors for releases the ranges
+#     already allowed. GitHub documents `uv` as supporting it, so this is a
+#     dependabot-core gap; re-verify before believing it is fixed.
+#   * On an entry with NO committed lock — the `pip` entry below — it is worse than
+#     inert: dependabot-core skips the manifest edit when the new version already
+#     satisfies the range and no lockfile exists, leaving nothing to change, so those
+#     updates stop being reported at all.
+#   * `lockfile-only` IS honoured, but it drops any update needing a manifest change.
+#     Most specs in the uv services are capped, so a real major outside a cap would
+#     vanish silently. This repo is public and those `>=` floors are part of the
+#     contract with OSS consumers, so a raised floor is not purely churn here.
+# Net effect: constraint-widening PRs are a known, accepted cost in this repo.
 
 version: 2
 
@@ -47,29 +62,7 @@ updates:
       - "/core-storage-api"
       - "/core-worker"
       - "/core-operations"
-    # Only touch a requirement in pyproject.toml when the new version actually
-    # falls outside it. The default (`increase`) raises the floor on every
-    # release even when the existing range already permits the new version, and
-    # each of those produced its own ungroupable PR: eight were open at once,
-    # e.g. `uvicorn[standard] >=0.51.0,<1` widened to `>=0.52.0,<1` — for a
-    # version the old range already allowed. The uv.lock in each of these four
-    # directories was already being updated correctly; the manifest edit on top
-    # of it was pure churn.
-    #
-    # Grouping cannot absorb them: `update-types` classifies the semver bump of
-    # a resolved version, and a floor-raise on an already-satisfied range has no
-    # such classification. That is why uv-minor-patch groups the lock updates
-    # into one PR while these arrived individually.
-    #
-    # This works HERE because these specs are capped (22 of 30 in core-api carry
-    # an upper bound), so "not necessary" is a meaningful state and a genuine
-    # case still files — uvicorn 1.0 against `<1` needs the manifest changed and
-    # will get a PR. Do NOT copy this to the `pip` entry above or to caura-ops:
-    # their requirements are open-ended `>=X`, nothing is ever outside them, and
-    # the setting would silence Python updates entirely rather than de-duplicate
-    # them. Those need a committed lock instead (caura-ops did that on
-    # 2026-08-09).
-    versioning-strategy: increase-if-necessary
+    # Deliberately no `versioning-strategy` — see the header before adding one.
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## What

Reverts the `versioning-strategy: increase-if-necessary` added to the `uv` entry in #740, and moves the durable rule to the file header.

## Why — #740 was falsified by its own first real run

#740 shipped with a stated test: the setting should kill the eight individual widening PRs and leave lock-only PRs behind. The test ran, and it failed.

The timing matters, because it is easy to read the evidence backwards:

| when | what |
|---|---|
| 01:41:47Z | scheduled Monday `uv` run produces #738 — **old config** |
| 09:01:46Z | #740 merges |
| 09:34:55Z | config-change re-run closes #738, opens #743 — **new config** |

So the scheduled run everyone was waiting on tested the config *before* the change. The only run that exercised `increase-if-necessary` is the one that produced #743, and #743's manifest edits are identical in kind to #738's:

- `fastapi>=0.140.0,<1` → `>=0.141.1,<1` — 0.141.1 was already allowed
- same shape for `alembic`, `cachetools`, `ruff`, `ddtrace`, `google-cloud-pubsub`
- 56 requirement lines across the four services
- the eight PRs it was meant to retire (#645, #646, #650, #691, #692-#695) were untouched, last updated 07-27 / 08-04

GitHub's options reference *does* list `uv` among the ecosystems supporting `versioning-strategy` ("Supported by: `bundler`, `cargo`, `composer`, `helm`, `mix`, `npm`, `pip`, `pub`, and `uv`"), so this is a gap in dependabot-core, not a mistake in the config. Reverting to the default restores honest behaviour: the file no longer claims to fix something it does not fix.

## Why the rule moved to the header

The most valuable line in the old comment was the warning that the `pip` entry must never take this option — and it sat inside the `uv` entry, 36 lines from the edit it exists to prevent. On a lock-less entry the setting is worse than inert: dependabot-core skips the manifest edit when the new version already satisfies the range and no lockfile exists, so there is nothing left to change and **no PR is filed at all**. That is a silent loss of update coverage, and the warning now lives where both entries can see it.

The header also records why `lockfile-only` is not the answer here: it is honoured, but it drops any update needing a manifest change, most specs in the uv services are capped, and this repo is public — these `>=` floors are part of the contract with OSS consumers, so a raised floor is not purely churn the way it is inside a private service.

Constraint-widening PRs are now documented as a known, accepted cost rather than a solved problem.

## Notes

- Config is 7 lines **shorter** than before #740; the point-in-time census numbers and the nine PR references are deliberately kept in this PR body rather than the config, where nothing fails when they go stale.
- No behaviour change beyond restoring the Dependabot default. All six entries and all ten groups verified intact after the edit.