### PR TITLE
test: stop 107 tests advertising isolation they don't have

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,12 @@ async def _setup_schema(_engine):
                     text(f"DELETE FROM {table} WHERE tenant_id LIKE 'test-tenant-%'")
                 )
             except Exception:
-                pass  # Best-effort cleanup; per-test rollback is the primary isolation
+                # Best-effort, and it is the PRIMARY isolation for anything
+                # written through the service layer — not a backstop behind the
+                # ``db`` fixture's rollback. Most tests here write via ``sc``,
+                # which commits on its own connections, so that rollback never
+                # sees those rows and this sweep is what removes them.
+                pass
         # memory_entity_links doesn't have tenant_id — clean via memory join
         try:
             await conn.execute(
@@ -360,9 +365,11 @@ from tests._mcp_test_helpers import mcp_env, parse_envelope, strip_latency  # no
 def _reset_hooks():
     """Ensure hooks are wired for integration tests.
 
-    In production, hooks are configured at app startup (lifespan).  Tests that
-    use the ``db`` fixture bypass the app lifespan, so we wire hooks here to
-    guarantee audit logging behaves identically to the running server.
+    In production, hooks are configured at app startup (lifespan). Tests that
+    exercise the services directly bypass that lifespan, so we wire hooks here
+    to guarantee audit logging behaves identically to the running server. This
+    is autouse because that covers nearly every test in this tree, not only the
+    ones holding a ``db`` session.
     """
     from core_api.services.audit_service import log_action
     from core_api.services.hooks import ServiceHooks, configure_hooks, reset_hooks

--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -25,7 +25,7 @@ _SEED_CONTENTS = [
 ]
 
 
-async def _seed_memories(db, count: int = 3) -> list[MemoryOut]:
+async def _seed_memories(count: int = 3) -> list[MemoryOut]:
     """Insert test memories via the legacy write path and return them."""
     from core_api.services.memory_service import create_memory
 
@@ -460,11 +460,11 @@ async def test_parallel_embed_gather_has_timeout():
 
 
 @pytest.mark.asyncio
-async def test_pipeline_search_returns_results(db):
+async def test_pipeline_search_returns_results():
     """Pipeline search path returns MemoryOut results for seeded memories."""
     from core_api.services import memory_service
 
-    seeded = await _seed_memories(db, count=2)
+    seeded = await _seed_memories(count=2)
     tid = seeded[0].tenant_id
 
     original = memory_service._USE_PIPELINE_SEARCH
@@ -485,11 +485,11 @@ async def test_pipeline_search_returns_results(db):
 
 
 @pytest.mark.asyncio
-async def test_legacy_search_returns_results(db):
+async def test_legacy_search_returns_results():
     """Legacy search path returns results (baseline)."""
     from core_api.services import memory_service
 
-    seeded = await _seed_memories(db, count=2)
+    seeded = await _seed_memories(count=2)
     tid = seeded[0].tenant_id
 
     original = memory_service._USE_PIPELINE_SEARCH
@@ -509,7 +509,7 @@ async def test_legacy_search_returns_results(db):
 
 
 @pytest.mark.asyncio
-async def test_search_pipeline_equivalence(db):
+async def test_search_pipeline_equivalence():
     """Pipeline and legacy paths produce equivalent results (order, scores to 4 decimals, entity links)."""
     from core_api.services import memory_service
     from core_api.services.memory_service import (
@@ -517,7 +517,7 @@ async def test_search_pipeline_equivalence(db):
         _search_memories_pipeline,
     )
 
-    seeded = await _seed_memories(db, count=3)
+    seeded = await _seed_memories(count=3)
     tid = seeded[0].tenant_id
 
     query = "quick brown fox sunny afternoon"
@@ -553,7 +553,7 @@ async def test_search_pipeline_equivalence(db):
 
 
 @pytest.mark.asyncio
-async def test_search_pipeline_empty_results(db):
+async def test_search_pipeline_empty_results():
     """Pipeline search returns empty list for no-match query."""
     from core_api.services import memory_service
 

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -306,7 +306,7 @@ async def test_merge_enrichment_leaves_non_deprecated_caller_type_intact():
 
 
 @pytest.mark.asyncio
-async def test_pipeline_path_creates_memory(db):
+async def test_pipeline_path_creates_memory():
     """Pipeline path creates a memory and returns valid MemoryOut."""
     from core_api.services import memory_service
 
@@ -329,7 +329,7 @@ async def test_pipeline_path_creates_memory(db):
 
 
 @pytest.mark.asyncio
-async def test_pipeline_emits_memory_write_latency_log(db, caplog):
+async def test_pipeline_emits_memory_write_latency_log(caplog):
     """CAURA-682 Phase 1: write pipeline emits ``memory_write_latency``
     structured log with per-phase timings + tenant_id at INFO level.
 
@@ -393,7 +393,7 @@ async def test_pipeline_emits_memory_write_latency_log(db, caplog):
 
 
 @pytest.mark.asyncio
-async def test_pipeline_emits_latency_log_on_pipeline_failure(db, caplog):
+async def test_pipeline_emits_latency_log_on_pipeline_failure(caplog):
     """CAURA-682 Phase 1: timeouts (the actual noisy-neighbor failure mode)
     must also produce a ``memory_write_latency`` log with ``success=False``
     and whatever partial timings landed before the exception.
@@ -451,7 +451,7 @@ async def test_pipeline_emits_latency_log_on_pipeline_failure(db, caplog):
 
 
 @pytest.mark.asyncio
-async def test_legacy_path_creates_memory(db):
+async def test_legacy_path_creates_memory():
     """Legacy path creates a memory and returns valid MemoryOut (baseline)."""
     from core_api.services import memory_service
 
@@ -500,7 +500,7 @@ async def test_pipeline_extract_only(db):
 
 
 @pytest.mark.asyncio
-async def test_pipeline_hash_dedup(db):
+async def test_pipeline_hash_dedup():
     """Pipeline path raises 409 on duplicate content_hash."""
     from fastapi import HTTPException
     from core_api.services import memory_service
@@ -524,7 +524,7 @@ async def test_pipeline_hash_dedup(db):
 
 
 @pytest.mark.asyncio
-async def test_pipeline_quality_gate(db):
+async def test_pipeline_quality_gate():
     """Pipeline path rejects short content with 422."""
     from fastapi import HTTPException
     from core_api.services import memory_service
@@ -543,7 +543,7 @@ async def test_pipeline_quality_gate(db):
 
 
 @pytest.mark.asyncio
-async def test_pipeline_equivalence(db):
+async def test_pipeline_equivalence():
     """Pipeline and legacy paths produce equivalent MemoryOut fields."""
     from core_api.services import memory_service
     from core_api.services.memory_service import (
@@ -776,7 +776,7 @@ async def test_schedule_background_tasks_strong_mode_fires_entity_and_contradict
 
 
 @pytest.mark.asyncio
-async def test_fast_mode_creates_memory_with_pending_enrichment(db):
+async def test_fast_mode_creates_memory_with_pending_enrichment():
     """Fast mode creates memory with enrichment_pending=True and write_mode=fast."""
     from core_api.services import memory_service
 
@@ -801,7 +801,7 @@ async def test_fast_mode_creates_memory_with_pending_enrichment(db):
 
 
 @pytest.mark.asyncio
-async def test_strong_mode_creates_memory_same_as_today(db):
+async def test_strong_mode_creates_memory_same_as_today():
     """Strong mode produces same result as today's pipeline (full enrichment inline)."""
     from core_api.services import memory_service
 
@@ -826,7 +826,7 @@ async def test_strong_mode_creates_memory_same_as_today(db):
 
 
 @pytest.mark.asyncio
-async def test_auto_mode_decision_type_routes_to_strong(db):
+async def test_auto_mode_decision_type_routes_to_strong():
     """Auto mode with memory_type=decision routes to strong path."""
     from core_api.services import memory_service
 

--- a/tests/test_bulk_write_mode.py
+++ b/tests/test_bulk_write_mode.py
@@ -79,7 +79,7 @@ def deferring_deployment(monkeypatch):
 
 
 @pytest.mark.integration
-async def test_strong_item_embeds_inline_when_deployment_defers(db, _engine, deferring_deployment):
+async def test_strong_item_embeds_inline_when_deployment_defers(_engine, deferring_deployment):
     rows = await _write(_item("Strong write embeds on the request path.", write_mode="strong"))
 
     assert await _embedded(_engine, rows[0].id), (
@@ -89,7 +89,7 @@ async def test_strong_item_embeds_inline_when_deployment_defers(db, _engine, def
 
 
 @pytest.mark.integration
-async def test_omitted_write_mode_still_defers(db, _engine, deferring_deployment):
+async def test_omitted_write_mode_still_defers(_engine, deferring_deployment):
     """Control: without the opt-in, nothing about the deferred path changes."""
     rows = await _write(_item("Ordinary write keeps deferring."))
 
@@ -97,7 +97,7 @@ async def test_omitted_write_mode_still_defers(db, _engine, deferring_deployment
 
 
 @pytest.mark.integration
-async def test_mixed_batch_embeds_only_the_strong_item(db, _engine, deferring_deployment):
+async def test_mixed_batch_embeds_only_the_strong_item(_engine, deferring_deployment):
     """The per-item guarantee: one item's opt-in does not leak onto its neighbours."""
     rows = await _write(
         _item("Deferred neighbour one."),
@@ -112,7 +112,7 @@ async def test_mixed_batch_embeds_only_the_strong_item(db, _engine, deferring_de
 
 
 @pytest.mark.integration
-async def test_unknown_write_mode_behaves_as_fast(db, _engine, deferring_deployment):
+async def test_unknown_write_mode_behaves_as_fast(_engine, deferring_deployment):
     """An unrecognised value must degrade, not 422 the whole batch.
 
     ``BulkMemoryItem`` deliberately avoids schema constraints that reject every
@@ -128,7 +128,7 @@ async def test_unknown_write_mode_behaves_as_fast(db, _engine, deferring_deploym
 
 
 @pytest.mark.integration
-async def test_inline_deployment_embeds_everything_regardless(db, _engine):
+async def test_inline_deployment_embeds_everything_regardless(_engine):
     """On a deployment that embeds inline, ``write_mode`` changes nothing."""
     assert settings.inline_embedding, "local default is expected to embed inline"
     rows = await _write(_item("No opt-in here."), _item("Opted in.", write_mode="strong"))
@@ -137,7 +137,7 @@ async def test_inline_deployment_embeds_everything_regardless(db, _engine):
 
 
 @pytest.mark.integration
-async def test_strong_embed_failure_does_not_fail_the_batch(db, _engine, deferring_deployment):
+async def test_strong_embed_failure_does_not_fail_the_batch(_engine, deferring_deployment):
     """A failed opt-in embed falls back to the backfill instead of 5xx-ing.
 
     These rows were going to defer anyway, so one item's opportunistic inline
@@ -157,7 +157,7 @@ async def test_strong_embed_failure_does_not_fail_the_batch(db, _engine, deferri
 
 
 @pytest.mark.integration
-async def test_inline_deployment_still_fails_loudly_on_embed_error(db):
+async def test_inline_deployment_still_fails_loudly_on_embed_error():
     """The pre-existing contract for inline deployments is unchanged.
 
     There the embed is not opportunistic — it is how every row gets its vector —

--- a/tests/test_caura702_deprecated_memory_types.py
+++ b/tests/test_caura702_deprecated_memory_types.py
@@ -98,7 +98,7 @@ def test_filter_description_still_lists_every_stored_type():
 
 
 @pytest.mark.asyncio
-async def test_bulk_write_demotes_deprecated_semantic_to_fact(db):
+async def test_bulk_write_demotes_deprecated_semantic_to_fact():
     tenant = _tenant()
     req = BulkMemoryCreate(
         tenant_id=tenant,
@@ -120,7 +120,7 @@ async def test_bulk_write_demotes_deprecated_semantic_to_fact(db):
 
 
 @pytest.mark.asyncio
-async def test_bulk_write_keeps_non_deprecated_type(db):
+async def test_bulk_write_keeps_non_deprecated_type():
     """Control: an ordinary writable type is stored unchanged."""
     tenant = _tenant()
     req = BulkMemoryCreate(
@@ -142,7 +142,7 @@ async def test_bulk_write_keeps_non_deprecated_type(db):
 
 
 @pytest.mark.asyncio
-async def test_update_demotes_deprecated_semantic_to_fact(db):
+async def test_update_demotes_deprecated_semantic_to_fact():
     """The update path (PATCH / MCP op=update) folds a caller-supplied deprecated
     type into the default — it bypasses MergeEnrichmentFields, so update_memory
     enforces the merger itself. Created as ``decision`` so the demotion (current
@@ -168,7 +168,7 @@ async def test_update_demotes_deprecated_semantic_to_fact(db):
 
 
 @pytest.mark.asyncio
-async def test_update_semantic_on_fact_row_is_noop(db):
+async def test_update_semantic_on_fact_row_is_noop():
     """A semantic->fact PATCH on a row already stored as the default records no
     phantom change (guards the demotion block against an old==new audit entry)."""
     tenant = _tenant()

--- a/tests/test_evolve_service.py
+++ b/tests/test_evolve_service.py
@@ -259,7 +259,7 @@ async def _outcome_memories(tenant_id):
 
 
 @pytest.mark.asyncio
-async def test_evolve_success_increases_weight(db, sc):
+async def test_evolve_success_increases_weight(sc):
     """Report success on a memory → weight increases by SUCCESS_DELTA."""
     from core_api.constants import EVOLVE_SUCCESS_DELTA
 
@@ -281,7 +281,7 @@ async def test_evolve_success_increases_weight(db, sc):
 
 
 @pytest.mark.asyncio
-async def test_evolve_failure_decreases_weight(db, sc):
+async def test_evolve_failure_decreases_weight(sc):
     """Report failure on a memory → weight decreases by FAILURE_DELTA."""
     from core_api.constants import EVOLVE_FAILURE_DELTA
 
@@ -302,7 +302,7 @@ async def test_evolve_failure_decreases_weight(db, sc):
 
 
 @pytest.mark.asyncio
-async def test_evolve_partial_slight_increase(db, sc):
+async def test_evolve_partial_slight_increase(sc):
     """Report partial on a memory → weight increases by PARTIAL_DELTA."""
     from core_api.constants import EVOLVE_PARTIAL_DELTA
 
@@ -322,7 +322,7 @@ async def test_evolve_partial_slight_increase(db, sc):
 
 
 @pytest.mark.asyncio
-async def test_evolve_weight_floor(db, sc):
+async def test_evolve_weight_floor(sc):
     """Weight never goes below EVOLVE_WEIGHT_FLOOR."""
     from core_api.constants import EVOLVE_WEIGHT_FLOOR
 
@@ -340,7 +340,7 @@ async def test_evolve_weight_floor(db, sc):
 
 
 @pytest.mark.asyncio
-async def test_evolve_weight_cap(db, sc):
+async def test_evolve_weight_cap(sc):
     """Weight never goes above EVOLVE_WEIGHT_CAP."""
     from core_api.constants import EVOLVE_WEIGHT_CAP
 
@@ -358,7 +358,7 @@ async def test_evolve_weight_cap(db, sc):
 
 
 @pytest.mark.asyncio
-async def test_evolve_nonexistent_memory_skipped(db):
+async def test_evolve_nonexistent_memory_skipped():
     """Non-existent memory UUID is skipped gracefully."""
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
@@ -372,7 +372,7 @@ async def test_evolve_nonexistent_memory_skipped(db):
 
 
 @pytest.mark.asyncio
-async def test_evolve_invalid_uuid_skipped(db):
+async def test_evolve_invalid_uuid_skipped():
     """Invalid UUID string is skipped gracefully."""
     tag = _uid()
     tenant_id = f"test-tenant-{tag}"
@@ -385,7 +385,7 @@ async def test_evolve_invalid_uuid_skipped(db):
 
 
 @pytest.mark.asyncio
-async def test_evolve_truncates_related_ids_above_cap(db, caplog):
+async def test_evolve_truncates_related_ids_above_cap(caplog):
     """related_ids longer than EVOLVE_MAX_RELATED_IDS are truncated with a warning."""
     import logging
 

--- a/tests/test_fixture_hygiene.py
+++ b/tests/test_fixture_hygiene.py
@@ -1,0 +1,99 @@
+"""Guard: nothing in this tree may request the ``db`` fixture and not use it.
+
+``db`` (see ``conftest.db``) is a per-test session inside a transaction that is
+rolled back at teardown. Requesting it reads as "this test is transactionally
+isolated" — but almost everything here writes through the service layer, which
+commits on its own connections, so that rollback never touches those rows. A
+test that takes ``db`` and never uses it therefore advertises isolation it does
+not have, and pays a connection + transaction + rollback for nothing.
+
+107 signatures had drifted into that state before this guard existed. Two
+assertions keep it from coming back, and together they also close the
+indirect case:
+
+  1. no HELPER may take ``db`` without using it, and
+  2. no TEST may request ``db`` without using it.
+
+(1) is what makes (2) sufficient. Without it, ``helper(db, ...)`` counts as a
+use of the name while the helper quietly drops the parameter — which is exactly
+how 34 of those 107 stayed hidden from the first sweep.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+FIXTURE = "db"
+TESTS_ROOT = pathlib.Path(__file__).parent
+
+# Tests that genuinely need the fixture's SIDE EFFECT (an open transaction) but
+# never name it. Empty today; add an entry with a reason rather than deleting
+# the assertion, so the exception is visible in review.
+SIDE_EFFECT_ONLY: frozenset[str] = frozenset()
+
+
+def _params(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    a = fn.args
+    return [p.arg for p in (a.posonlyargs + a.args + a.kwonlyargs)]
+
+
+def _names_loaded(fn: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> bool:
+    """Is ``name`` read anywhere in the body — including nested scopes?"""
+    return any(
+        isinstance(n, ast.Name) and n.id == name and isinstance(n.ctx, ast.Load)
+        for n in ast.walk(fn)
+    )
+
+
+def _functions() -> list[tuple[pathlib.Path, ast.FunctionDef | ast.AsyncFunctionDef]]:
+    found = []
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError:  # pragma: no cover - a broken file fails its own tests
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                found.append((path, node))
+    return found
+
+
+def _offenders(*, tests: bool) -> list[str]:
+    out = []
+    for path, fn in _functions():
+        is_test = fn.name.startswith("test_")
+        if is_test is not tests:
+            continue
+        if FIXTURE not in _params(fn) or _names_loaded(fn, FIXTURE):
+            continue
+        if is_test and fn.name in SIDE_EFFECT_ONLY:
+            continue
+        out.append(f"{path.relative_to(TESTS_ROOT)}:{fn.lineno} {fn.name}")
+    return out
+
+
+def test_no_helper_takes_the_db_fixture_without_using_it() -> None:
+    """A helper with a dead ``db`` param forces its callers to request one too.
+
+    This is the assertion that makes the test-level one below meaningful: it is
+    why passing ``db`` to a helper can be trusted as a real use.
+    """
+    offenders = _offenders(tests=False)
+    assert not offenders, (
+        f"{len(offenders)} helper(s) take the `{FIXTURE}` fixture and never use it. "
+        f"Drop the parameter and the argument at each call site — otherwise every "
+        f"caller must keep requesting a session that goes nowhere:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_no_test_requests_the_db_fixture_without_using_it() -> None:
+    offenders = _offenders(tests=True)
+    assert not offenders, (
+        f"{len(offenders)} test(s) request the `{FIXTURE}` fixture and never use it. "
+        f"Remove it from the signature: it implies transactional isolation these "
+        f"tests do not have, since service-layer writes commit on their own "
+        f"connections. If one truly needs the open transaction as a side effect, "
+        f"add it to SIDE_EFFECT_ONLY with a reason:\n  " + "\n  ".join(offenders)
+    )

--- a/tests/test_governance_e2e.py
+++ b/tests/test_governance_e2e.py
@@ -81,7 +81,6 @@ def _make_input(tenant_id: str, content: str, **kwargs) -> MemoryCreate:
 
 
 async def _seed_governance(
-    db,
     tenant_id: str,
     *,
     pii: dict | None = None,
@@ -157,9 +156,9 @@ async def _assert_chain_valid(tenant_id: str) -> None:
 # ── PII deterministic gate (GovernanceScanContent) through a real write ──────
 
 
-async def test_pii_mask_stores_redacted_content_and_audits(db):
+async def test_pii_mask_stores_redacted_content_and_audits():
     tenant = _tenant()
-    await _seed_governance(db, tenant, pii={"enabled": True, "action": "mask"})
+    await _seed_governance(tenant, pii={"enabled": True, "action": "mask"})
     content = f"Reach me at john.doe@example.com or card 4111 1111 1111 1111.{_PADDING}"
     result = await create_memory(_make_input(tenant, content))
 
@@ -180,9 +179,9 @@ async def test_pii_mask_stores_redacted_content_and_audits(db):
     await _assert_chain_valid(tenant)
 
 
-async def test_pii_drop_rejects_write_and_persists_nothing(db):
+async def test_pii_drop_rejects_write_and_persists_nothing():
     tenant = _tenant()
-    await _seed_governance(db, tenant, pii={"enabled": True, "action": "drop"})
+    await _seed_governance(tenant, pii={"enabled": True, "action": "drop"})
     content = f"My card is 4111 1111 1111 1111, please remember it.{_PADDING}"
     with pytest.raises(HTTPException) as exc:
         await create_memory(_make_input(tenant, content))
@@ -201,9 +200,9 @@ async def test_pii_drop_rejects_write_and_persists_nothing(db):
     await _assert_chain_valid(tenant)
 
 
-async def test_pii_flag_keeps_content_and_marks_metadata(db):
+async def test_pii_flag_keeps_content_and_marks_metadata():
     tenant = _tenant()
-    await _seed_governance(db, tenant, pii={"enabled": True, "action": "flag"})
+    await _seed_governance(tenant, pii={"enabled": True, "action": "flag"})
     content = f"Ping me on john.doe@example.com about the rollout.{_PADDING}"
     result = await create_memory(_make_input(tenant, content))
 
@@ -215,10 +214,9 @@ async def test_pii_flag_keeps_content_and_marks_metadata(db):
     assert any(r["action"] == "pii_flag" for r in rows), rows
 
 
-async def test_pii_category_toggle_limits_scope(db):
+async def test_pii_category_toggle_limits_scope():
     tenant = _tenant()
     await _seed_governance(
-        db,
         tenant,
         pii={"enabled": True, "action": "mask", "categories": {"email": True}},
     )
@@ -228,7 +226,7 @@ async def test_pii_category_toggle_limits_scope(db):
     assert "4111 1111 1111 1111" in result.content  # card not in scope
 
 
-async def test_governance_disabled_is_a_noop(db):
+async def test_governance_disabled_is_a_noop():
     tenant = _tenant()
     # No governance seeded at all → gate skips, content untouched, no audit.
     content = f"Email john.doe@example.com, card 4111 1111 1111 1111.{_PADDING}"
@@ -239,13 +237,13 @@ async def test_governance_disabled_is_a_noop(db):
 
 
 @pytest.mark.parametrize("write_mode", ["fast", "strong"])
-async def test_pii_mask_runs_in_every_write_mode(db, write_mode):
+async def test_pii_mask_runs_in_every_write_mode(write_mode):
     # The deterministic scan is wired into all write-mode compositions; a real
     # write in each LTM mode must redact and record the mode in the audit detail.
     # (STM is covered by test_governance_scan_wired_into_stm — driving it here
     # would require the global USE_STM flag, which the default test env leaves off.)
     tenant = _tenant()
-    await _seed_governance(db, tenant, pii={"enabled": True, "action": "mask"})
+    await _seed_governance(tenant, pii={"enabled": True, "action": "mask"})
     content = f"Contact john.doe@example.com for access.{_PADDING}"
     result = await create_memory(_make_input(tenant, content, write_mode=write_mode)
     )
@@ -267,10 +265,9 @@ _NEUTRAL = (
 )
 
 
-async def test_personal_content_kept_private(db, monkeypatch):
+async def test_personal_content_kept_private(monkeypatch):
     tenant = _tenant()
     await _seed_governance(
-        db,
         tenant,
         non_business={"enabled": True, "disposition": "keep_private"},
     )
@@ -281,10 +278,9 @@ async def test_personal_content_kept_private(db, monkeypatch):
     assert any(r["action"] == "nonbusiness_keep_private" for r in rows), rows
 
 
-async def test_personal_content_dropped(db, monkeypatch):
+async def test_personal_content_dropped(monkeypatch):
     tenant = _tenant()
     await _seed_governance(
-        db,
         tenant,
         non_business={"enabled": True, "disposition": "drop"},
     )
@@ -296,10 +292,9 @@ async def test_personal_content_dropped(db, monkeypatch):
     assert any(r["action"] == "nonbusiness_drop" for r in rows), rows
 
 
-async def test_business_content_flows_through(db, monkeypatch):
+async def test_business_content_flows_through(monkeypatch):
     tenant = _tenant()
     await _seed_governance(
-        db,
         tenant,
         non_business={"enabled": True, "disposition": "drop"},
     )
@@ -313,10 +308,9 @@ async def test_business_content_flows_through(db, monkeypatch):
     )
 
 
-async def test_non_business_store_disposition_is_noop(db, monkeypatch):
+async def test_non_business_store_disposition_is_noop(monkeypatch):
     tenant = _tenant()
     await _seed_governance(
-        db,
         tenant,
         non_business={"enabled": True, "disposition": "store"},
     )
@@ -327,10 +321,9 @@ async def test_non_business_store_disposition_is_noop(db, monkeypatch):
     assert (result.metadata or {}).get("business_relevance") == "personal"
 
 
-async def test_llm_pii_signal_drops(db, monkeypatch):
+async def test_llm_pii_signal_drops(monkeypatch):
     tenant = _tenant()
     await _seed_governance(
-        db,
         tenant,
         pii={"enabled": True, "action": "drop"},
     )
@@ -344,12 +337,11 @@ async def test_llm_pii_signal_drops(db, monkeypatch):
     assert drop is not None and drop["detail"].get("source") == "llm", rows
 
 
-async def test_both_gates_act_on_one_memory(db, monkeypatch):
+async def test_both_gates_act_on_one_memory(monkeypatch):
     # A memory the LLM flags as BOTH PII-bearing and personal: PII flag (mask
     # config can't redact a free-form span) + non-business keep_private both fire.
     tenant = _tenant()
     await _seed_governance(
-        db,
         tenant,
         pii={"enabled": True, "action": "flag"},
         non_business={"enabled": True, "disposition": "keep_private"},
@@ -382,9 +374,9 @@ def _bulk(tenant: str, contents: list[str]) -> BulkMemoryCreate:
     )
 
 
-async def test_bulk_drop_rejects_only_the_pii_item(db):
+async def test_bulk_drop_rejects_only_the_pii_item():
     tenant = _tenant()
-    await _seed_governance(db, tenant, pii={"enabled": True, "action": "drop"})
+    await _seed_governance(tenant, pii={"enabled": True, "action": "drop"})
     clean = f"Quarterly planning notes for the team.{_PADDING}"
     dirty = f"Customer card 4111 1111 1111 1111 is on file.{_PADDING}"
     resp = await create_memories_bulk(_bulk(tenant, [clean, dirty]), bulk_attempt_id=uuid.uuid4().hex
@@ -397,9 +389,9 @@ async def test_bulk_drop_rejects_only_the_pii_item(db):
     assert drop is not None and drop["detail"]["write_mode"] == "bulk", rows
 
 
-async def test_bulk_mask_redacts_stored_item(db):
+async def test_bulk_mask_redacts_stored_item():
     tenant = _tenant()
-    await _seed_governance(db, tenant, pii={"enabled": True, "action": "mask"})
+    await _seed_governance(tenant, pii={"enabled": True, "action": "mask"})
     dirty = f"Reach me at jane.roe@example.com about the deal.{_PADDING}"
     resp = await create_memories_bulk(_bulk(tenant, [dirty]), bulk_attempt_id=uuid.uuid4().hex
     )
@@ -412,9 +404,9 @@ async def test_bulk_mask_redacts_stored_item(db):
     ), rows
 
 
-async def test_bulk_flag_marks_stored_metadata(db):
+async def test_bulk_flag_marks_stored_metadata():
     tenant = _tenant()
-    await _seed_governance(db, tenant, pii={"enabled": True, "action": "flag"})
+    await _seed_governance(tenant, pii={"enabled": True, "action": "flag"})
     dirty = f"Ping jane.roe@example.com for the rollout plan.{_PADDING}"
     resp = await create_memories_bulk(_bulk(tenant, [dirty]), bulk_attempt_id=uuid.uuid4().hex
     )

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -135,7 +135,7 @@ async def _link_memory_entity(memory_id, entity_id, role="mentioned"):
 class TestSearchPipelineEndToEnd:
     """Full search_memories pipeline with all P0 fixes applied."""
 
-    async def test_basic_search_returns_results(self, db, tenant_id):
+    async def test_basic_search_returns_results(self, tenant_id):
         """Baseline: search returns stored memories sorted by relevance."""
         await _insert_memory(tenant_id, "Python is a programming language", weight=0.7
         )
@@ -148,7 +148,7 @@ class TestSearchPipelineEndToEnd:
         # The Python memory should rank higher
         assert "Python" in results[0].content
 
-    async def test_freshness_prefers_recent_events(self, db, tenant_id):
+    async def test_freshness_prefers_recent_events(self, tenant_id):
         """P0-2: memory about recent event ranks higher than old memory about same topic."""
         now = datetime.now(timezone.utc)
 
@@ -173,7 +173,7 @@ class TestSearchPipelineEndToEnd:
         # The one with recent ts_valid_start should rank higher
         assert "critical patch" in results[0].content
 
-    async def test_expired_memory_ranked_lower(self, db, tenant_id):
+    async def test_expired_memory_ranked_lower(self, tenant_id):
         """P0-2: expired memory (ts_valid_end in past) gets freshness floor."""
         now = datetime.now(timezone.utc)
 
@@ -195,7 +195,7 @@ class TestSearchPipelineEndToEnd:
         # Valid memory should rank above expired one
         assert "this Friday" in results[0].content
 
-    async def test_recall_boost_decays_over_time(self, db, tenant_id):
+    async def test_recall_boost_decays_over_time(self, tenant_id):
         """P0-3: frequently recalled but stale memory doesn't dominate."""
         now = datetime.now(timezone.utc)
 
@@ -221,7 +221,7 @@ class TestSearchPipelineEndToEnd:
         # Memory B (recently recalled) should not be dominated by A (stale popular)
         # Both are relevant — the key is A's 50 recalls don't give it unfair advantage
 
-    async def test_similarity_beats_weight(self, db, tenant_id):
+    async def test_similarity_beats_weight(self, tenant_id):
         """P0-4: highly similar + low weight ranks above moderately similar + high weight."""
         # Use very different content to get clearly different similarity scores
         await _insert_memory(            tenant_id,
@@ -240,7 +240,7 @@ class TestSearchPipelineEndToEnd:
         # The highly similar kafka memory should rank first despite low weight
         assert "kafka" in results[0].content
 
-    async def test_entity_boost_with_stopword_filtering(self, db, tenant_id):
+    async def test_entity_boost_with_stopword_filtering(self, tenant_id):
         """P0-1 + entity boost: stopwords don't pollute entity matching."""
         # Create entity
         entity = await _insert_entity(tenant_id, "kafka cluster")
@@ -264,7 +264,7 @@ class TestSearchPipelineEndToEnd:
         assert len(results) >= 1
         assert "kafka" in results[0].content
 
-    async def test_search_with_all_fixes_combined(self, db, tenant_id):
+    async def test_search_with_all_fixes_combined(self, tenant_id):
         """Smoke test: all four P0 fixes working together."""
         now = datetime.now(timezone.utc)
 
@@ -371,7 +371,7 @@ class TestConflictedExactMatchSurfaces:
     query; ``outdated`` (a definitive retraction) stays excluded.
     """
 
-    async def test_conflicted_exact_match_is_surfaced(self, db, tenant_id):
+    async def test_conflicted_exact_match_is_surfaced(self, tenant_id):
         # Distinctive token "zylqx" appears only in the conflicted gold, so the
         # query FTS-matches the gold and nothing else.
         await _insert_memory(            tenant_id,
@@ -394,7 +394,7 @@ class TestConflictedExactMatchSurfaces:
             "conflicted exact-match gold was excluded from results"
         )
 
-    async def test_conflicted_non_match_still_excluded(self, db, tenant_id):
+    async def test_conflicted_non_match_still_excluded(self, tenant_id):
         # A conflicted row that does NOT lexically match the query stays hidden
         # (carve-out is scoped to exact matches, not all conflicted rows).
         await _insert_memory(            tenant_id,
@@ -415,7 +415,7 @@ class TestConflictedExactMatchSurfaces:
             "conflicted non-matching row should remain excluded"
         )
 
-    async def test_outdated_exact_match_still_excluded(self, db, tenant_id):
+    async def test_outdated_exact_match_still_excluded(self, tenant_id):
         # ``outdated`` is a definitive retraction — it stays excluded even on an
         # exact lexical match (only ``conflicted`` gets the carve-out).
         await _insert_memory(            tenant_id,

--- a/tests/test_organization_settings_storage.py
+++ b/tests/test_organization_settings_storage.py
@@ -118,12 +118,12 @@ def test_resolved_config_tenant_override_wins():
 # ── Storage: get_raw_settings / update_settings ───────────────────────────
 
 
-async def test_get_empty_returns_empty_dict(db):
+async def test_get_empty_returns_empty_dict():
     raw = await get_raw_settings(_tid())
     assert raw == {}
 
 
-async def test_get_display_empty_returns_schema_with_nulls(db):
+async def test_get_display_empty_returns_schema_with_nulls():
     display = await get_settings_for_display(_tid())
     # Every schema key from DEFAULT_SETTINGS should be present
     for key in DEFAULT_SETTINGS:
@@ -132,7 +132,7 @@ async def test_get_display_empty_returns_schema_with_nulls(db):
     assert display["enrichment"]["provider"] is None
 
 
-async def test_update_persists_overrides(db):
+async def test_update_persists_overrides():
     tid = _tid()
     await update_settings(tid,
         {"enrichment": {"provider": "vertex", "model": "gemini-2.0-flash"}},
@@ -143,7 +143,7 @@ async def test_update_persists_overrides(db):
     assert raw["enrichment"]["model"] == "gemini-2.0-flash"
 
 
-async def test_update_merges_nested_keys(db):
+async def test_update_merges_nested_keys():
     """Partial update of one nested key doesn't wipe sibling keys in the same block."""
     tid = _tid()
     await update_settings(tid, {"enrichment": {"provider": "openai", "model": "gpt-4"}}
@@ -156,7 +156,7 @@ async def test_update_merges_nested_keys(db):
     assert raw["enrichment"]["model"] == "gpt-4"  # preserved
 
 
-async def test_update_partial_preserves_other_features(db):
+async def test_update_partial_preserves_other_features():
     """Updating security_audit doesn't clear a previously-set enrichment override."""
     tid = _tid()
     await update_settings(tid, {"enrichment": {"provider": "openai"}})
@@ -210,7 +210,7 @@ async def test_audit_no_row_on_noop(db):
     assert after_count == before_count
 
 
-async def test_resolve_config_reads_from_db(db):
+async def test_resolve_config_reads_from_db():
     tid = _tid()
     await update_settings(tid, {"security_audit": {"schedule_enabled": True}})
     invalidate_cache(tid)
@@ -222,7 +222,7 @@ async def test_resolve_config_reads_from_db(db):
 # ── Cache semantics ───────────────────────────────────────────────────────
 
 
-async def test_cache_hit_avoids_storage_fetch(db, monkeypatch):
+async def test_cache_hit_avoids_storage_fetch(monkeypatch):
     """Second call to get_raw_settings for the same tenant should not re-fetch
     from core-storage-api — the TTL cache short-circuits before the HTTP call."""
     tid = _tid()
@@ -243,7 +243,7 @@ async def test_cache_hit_avoids_storage_fetch(db, monkeypatch):
     assert calls["n"] == 0, "Cache hits should not fetch from storage"
 
 
-async def test_update_invalidates_local_cache(db):
+async def test_update_invalidates_local_cache():
     """After update_settings, the next read returns the new value without waiting for TTL."""
     tid = _tid()
     # Prime cache with empty
@@ -264,7 +264,7 @@ async def test_update_invalidates_local_cache(db):
 # short-circuits the storage fetch entirely.
 
 
-async def test_get_raw_settings_works_when_db_is_none(db):
+async def test_get_raw_settings_works_when_db_is_none():
     """Cold-cache call with ``db=None`` must resolve via the storage client
     (no DB session needed) and land the result in the cache for next time."""
     tid = _tid()
@@ -280,7 +280,7 @@ async def test_get_raw_settings_works_when_db_is_none(db):
     assert tid in ts_svc._settings_cache
 
 
-async def test_resolve_config_works_without_db_session(db):
+async def test_resolve_config_works_without_db_session():
     """End-to-end: ``resolve_config(tenant_id)`` (the path the
     fire-and-forget contradiction detector + the CAURA-595 Phase 5a
     consumer take) must return a usable ``ResolvedConfig`` without a

--- a/tests/test_p1_contradiction.py
+++ b/tests/test_p1_contradiction.py
@@ -453,7 +453,6 @@ class TestContradictionIntegration:
 
     async def _insert_memory(
         self,
-        db,
         tenant_id,
         content,
         *,
@@ -488,7 +487,7 @@ class TestContradictionIntegration:
         }
         return await sc.create_memory(payload)
 
-    async def test_rdf_contradiction_correct_supersession(self, db, tenant_id):
+    async def test_rdf_contradiction_correct_supersession(self, tenant_id):
         """RDF conflict: new memory's supersedes_id → old memory's id."""
         from core_api.clients.storage_client import get_storage_client
         from core_api.services.contradiction_detector import detect_contradictions
@@ -504,7 +503,6 @@ class TestContradictionIntegration:
         entity_id = entity["id"]
 
         old = await self._insert_memory(
-            db,
             tenant_id,
             "Alice lives in Tel Aviv",
             subject_entity_id=entity_id,
@@ -512,7 +510,6 @@ class TestContradictionIntegration:
             object_value="Tel Aviv",
         )
         new = await self._insert_memory(
-            db,
             tenant_id,
             "Alice lives in Haifa",
             subject_entity_id=entity_id,
@@ -533,18 +530,16 @@ class TestContradictionIntegration:
         refreshed_old = await sc.get_memory(old["id"])
         assert refreshed_old["status"] == "outdated"
 
-    async def test_semantic_contradiction_with_fake_llm(self, db, tenant_id):
+    async def test_semantic_contradiction_with_fake_llm(self, tenant_id):
         """Semantic conflict using fake LLM heuristic."""
         from core_api.services.contradiction_detector import detect_contradictions
         from common.embedding import fake_embedding
 
         old = await self._insert_memory(
-            db,
             tenant_id,
             "The deployment pipeline is running correctly today",
         )
         new = await self._insert_memory(
-            db,
             tenant_id,
             "The deployment pipeline is not running correctly today",
         )
@@ -560,13 +555,13 @@ class TestContradictionIntegration:
         assert len(contradictions) >= 1
         assert contradictions[0].reason == "semantic_conflict"
 
-    async def test_no_false_positive_on_different_topics(self, db, tenant_id):
+    async def test_no_false_positive_on_different_topics(self, tenant_id):
         """Different topics should not trigger contradiction."""
         from core_api.services.contradiction_detector import detect_contradictions
         from common.embedding import fake_embedding
 
-        await self._insert_memory(db, tenant_id, "Python is a programming language")
-        new = await self._insert_memory(db, tenant_id, "The weather is sunny today")
+        await self._insert_memory(tenant_id, "Python is a programming language")
+        new = await self._insert_memory(tenant_id, "The weather is sunny today")
         emb = fake_embedding(new["content"])
 
         with patch(

--- a/tests/test_p2_semantic_dedup.py
+++ b/tests/test_p2_semantic_dedup.py
@@ -24,12 +24,17 @@ import hashlib
 import random
 import statistics
 import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import delete, func, select
 
+from common.embedding import fake_embedding
+from common.models.memory import Memory
 from core_api.constants import (
     CONTRADICTION_SIMILARITY_THRESHOLD,
     CRYSTALLIZER_DEDUP_THRESHOLD,
@@ -37,7 +42,8 @@ from core_api.constants import (
     SEMANTIC_DEDUP_THRESHOLD,
     VECTOR_DIM,
 )
-from common.embedding import fake_embedding
+from core_api.services.memory_service import _find_semantic_duplicate
+from core_storage_api.services import postgres_service as ps
 
 
 # ---------------------------------------------------------------------------
@@ -90,7 +96,6 @@ class TestFindSemanticDuplicateMocked:
 
     async def test_returns_none_when_no_match(self):
         from unittest.mock import patch
-        from core_api.services.memory_service import _find_semantic_duplicate
 
         mock_sc = AsyncMock()
         mock_sc.find_semantic_duplicate = AsyncMock(return_value=None)
@@ -102,7 +107,6 @@ class TestFindSemanticDuplicateMocked:
 
     async def test_returns_memory_when_match_found(self):
         from unittest.mock import patch
-        from core_api.services.memory_service import _find_semantic_duplicate
 
         mock_memory = {"id": str(uuid4()), "content": "test"}
         mock_sc = AsyncMock()
@@ -116,7 +120,6 @@ class TestFindSemanticDuplicateMocked:
     async def test_passes_fleet_id_filter(self):
         """Verify that fleet_id is passed to storage client."""
         from unittest.mock import patch
-        from core_api.services.memory_service import _find_semantic_duplicate
 
         mock_sc = AsyncMock()
         mock_sc.find_semantic_duplicate = AsyncMock(return_value=None)
@@ -131,7 +134,6 @@ class TestFindSemanticDuplicateMocked:
     async def test_passes_exclude_id(self):
         """Verify that exclude_id is passed to storage client."""
         from unittest.mock import patch
-        from core_api.services.memory_service import _find_semantic_duplicate
 
         mock_sc = AsyncMock()
         mock_sc.find_semantic_duplicate = AsyncMock(return_value=None)
@@ -206,7 +208,7 @@ class TestSemanticDedupIntegration:
     """End-to-end semantic dedup with real DB."""
 
     async def _insert_memory(
-        self, db, tenant_id, content, *,
+        self, tenant_id, content, *,
         embedding=None, fleet_id=None, status="active",
         agent_id="test-agent", memory_type="fact", deleted_at=None,
     ):
@@ -232,12 +234,10 @@ class TestSemanticDedupIntegration:
 
     # -- Regression: exact duplicate still caught --
 
-    async def test_exact_duplicate_still_rejected(self, db, tenant_id):
+    async def test_exact_duplicate_still_rejected(self, tenant_id):
         """Hash-based exact dedup must still work (regression)."""
-        from core_api.services.memory_service import _find_semantic_duplicate
-
         content = "Alice prefers dark mode"
-        await self._insert_memory(db, tenant_id, content)
+        await self._insert_memory(tenant_id, content)
 
         # Exact same embedding should be found
         emb = fake_embedding(content)
@@ -246,12 +246,10 @@ class TestSemanticDedupIntegration:
 
     # -- Near-duplicate caught --
 
-    async def test_near_duplicate_caught(self, db, tenant_id):
+    async def test_near_duplicate_caught(self, tenant_id):
         """Insert memory, then try close embedding with different content → found."""
-        from core_api.services.memory_service import _find_semantic_duplicate
-
         base_content = "The quarterly report shows 15% revenue growth"
-        await self._insert_memory(db, tenant_id, base_content)
+        await self._insert_memory(tenant_id, base_content)
 
         # Close embedding (noise-perturbed) should still be caught
         emb = close_embedding(base_content)
@@ -260,11 +258,9 @@ class TestSemanticDedupIntegration:
 
     # -- Below-threshold passes --
 
-    async def test_below_threshold_passes(self, db, tenant_id):
+    async def test_below_threshold_passes(self, tenant_id):
         """Completely different content should not be flagged."""
-        from core_api.services.memory_service import _find_semantic_duplicate
-
-        await self._insert_memory(db, tenant_id, "Alice prefers dark mode")
+        await self._insert_memory(tenant_id, "Alice prefers dark mode")
 
         emb = fake_embedding("The server is running on port 8080")
         dup = await _find_semantic_duplicate(tenant_id, None, emb)
@@ -272,14 +268,12 @@ class TestSemanticDedupIntegration:
 
     # -- Fleet isolation --
 
-    async def test_different_fleet_not_blocked(self, db, tenant_id):
+    async def test_different_fleet_not_blocked(self, tenant_id):
         """Same embedding in fleet-a should not block fleet-b."""
-        from core_api.services.memory_service import _find_semantic_duplicate
-
         content = "Bob likes tea"
         emb = fake_embedding(content)
 
-        await self._insert_memory(db, tenant_id, content, fleet_id="fleet-a")
+        await self._insert_memory(tenant_id, content, fleet_id="fleet-a")
 
         # Search in fleet-b should find nothing
         dup = await _find_semantic_duplicate(tenant_id, "fleet-b", emb)
@@ -287,13 +281,11 @@ class TestSemanticDedupIntegration:
 
     # -- Deleted memory doesn't block --
 
-    async def test_deleted_memory_doesnt_block(self, db, tenant_id):
+    async def test_deleted_memory_doesnt_block(self, tenant_id):
         """Soft-deleted memory should not be considered a duplicate."""
-        from core_api.services.memory_service import _find_semantic_duplicate
-
         content = "Important meeting tomorrow"
         await self._insert_memory(
-            db, tenant_id, content,
+            tenant_id, content,
             deleted_at=datetime.now(timezone.utc),
         )
 
@@ -303,12 +295,10 @@ class TestSemanticDedupIntegration:
 
     # -- Archived memory doesn't block --
 
-    async def test_archived_memory_doesnt_block(self, db, tenant_id):
+    async def test_archived_memory_doesnt_block(self, tenant_id):
         """Archived status is not in (active, confirmed, pending) → ignored."""
-        from core_api.services.memory_service import _find_semantic_duplicate
-
         content = "Old project plan from last year"
-        await self._insert_memory(db, tenant_id, content, status="archived")
+        await self._insert_memory(tenant_id, content, status="archived")
 
         emb = fake_embedding(content)
         dup = await _find_semantic_duplicate(tenant_id, None, emb)
@@ -316,12 +306,10 @@ class TestSemanticDedupIntegration:
 
     # -- 409 response includes memory ID --
 
-    async def test_409_includes_memory_id(self, db, tenant_id):
+    async def test_409_includes_memory_id(self, tenant_id):
         """The returned duplicate should have a valid UUID."""
-        from core_api.services.memory_service import _find_semantic_duplicate
-
         content = "Deployment scheduled for Friday"
-        mem = await self._insert_memory(db, tenant_id, content)
+        mem = await self._insert_memory(tenant_id, content)
 
         emb = fake_embedding(content)
         dup = await _find_semantic_duplicate(tenant_id, None, emb)
@@ -330,16 +318,14 @@ class TestSemanticDedupIntegration:
 
     # -- Update path: near-duplicate of another → blocked --
 
-    async def test_update_near_duplicate_blocked(self, db, tenant_id):
+    async def test_update_near_duplicate_blocked(self, tenant_id):
         """Updating content to match another memory should be caught."""
-        from core_api.services.memory_service import _find_semantic_duplicate
-
         existing_content = "API latency is under 50ms"
-        await self._insert_memory(db, tenant_id, existing_content)
+        await self._insert_memory(tenant_id, existing_content)
 
         # Second memory being "updated" to similar content
         updating_mem = await self._insert_memory(
-            db, tenant_id, "Something completely different",
+            tenant_id, "Something completely different",
         )
 
         emb = fake_embedding(existing_content)
@@ -349,12 +335,10 @@ class TestSemanticDedupIntegration:
 
     # -- Update path: own content doesn't false-positive --
 
-    async def test_update_own_content_not_blocked(self, db, tenant_id):
+    async def test_update_own_content_not_blocked(self, tenant_id):
         """Minor edit to own content should not false-positive (exclude_id)."""
-        from core_api.services.memory_service import _find_semantic_duplicate
-
         content = "Database migration completed successfully"
-        mem = await self._insert_memory(db, tenant_id, content)
+        mem = await self._insert_memory(tenant_id, content)
 
         # Same embedding but excluding self
         emb = fake_embedding(content)
@@ -367,75 +351,111 @@ class TestSemanticDedupIntegration:
 # Benchmark tests
 # ---------------------------------------------------------------------------
 
-@pytest.mark.benchmark
-class TestSemanticDedupBenchmarks:
-    """Measure _find_semantic_duplicate query latency."""
+_BENCH_ITERATIONS = 20
 
-    async def _seed_memories(self, db, tenant_id, count):
-        """Insert N memories with unique content and embeddings."""
-        from common.models.memory import Memory
 
+@asynccontextmanager
+async def _committed_corpus(count: int) -> AsyncIterator[str]:
+    """Yield a fresh tenant holding exactly ``count`` committed memories.
+
+    Committed, because the query under test reaches Postgres through the service
+    layer on its own session — rows sitting in an uncommitted transaction (what
+    the ``db`` fixture gives you) are invisible to it.
+
+    Its own tenant, because the ``tenant_id`` fixture is the run's SHARED tenant
+    (see its docstring): its row count is a running total of whatever every
+    other test left behind, not ``count``.
+
+    Both effects are silent, which is why the caller asserts the corpus size
+    instead of assuming it.
+
+    Keeps the ``test-tenant-`` prefix so session teardown sweeps the rows even
+    if the explicit cleanup below does not run.
+    """
+    tenant = f"test-tenant-dedupbench-{uuid4().hex[:8]}"
+    async with ps.get_session() as session:
         for i in range(count):
             content = f"Benchmark memory number {i} with unique content {uuid4().hex}"
-            emb = fake_embedding(content)
-            ch = _content_hash(tenant_id, None, content)
-            db.add(Memory(
-                tenant_id=tenant_id,
-                fleet_id=None,
-                agent_id="bench-agent",
-                memory_type="fact",
-                content=content,
-                weight=0.5,
-                embedding=emb,
-                content_hash=ch,
-                status="active",
-            ))
-        await db.flush()
+            session.add(
+                Memory(
+                    tenant_id=tenant,
+                    fleet_id=None,
+                    agent_id="bench-agent",
+                    memory_type="fact",
+                    content=content,
+                    weight=0.5,
+                    embedding=fake_embedding(content),
+                    content_hash=_content_hash(tenant, None, content),
+                    status="active",
+                )
+            )
+    try:
+        yield tenant
+    finally:
+        async with ps.get_session() as session:
+            await session.execute(delete(Memory).where(Memory.tenant_id == tenant))
 
-    async def test_latency_100_memories(self, db, tenant_id):
-        """Query latency with 100 memories should be < 10ms mean."""
-        from core_api.services.memory_service import _find_semantic_duplicate
 
-        await self._seed_memories(db, tenant_id, 100)
+async def _visible_count(tenant: str) -> int:
+    """Rows visible to the same session accessor the query under test uses.
 
-        emb = fake_embedding("A completely new memory for benchmark")
-        times = []
-        for _ in range(20):
-            t0 = time.perf_counter()
-            await _find_semantic_duplicate(tenant_id, None, emb)
-            times.append((time.perf_counter() - t0) * 1000)
+    ``get_session``, not ``get_read_session``: ``memory_find_semantic_duplicate``
+    runs in the writer session, and in tests both factories happen to be bound
+    to the one engine — so reading through the reader would agree only by
+    accident, and would stop being evidence the day a replica is configured.
+    """
+    async with ps.get_session() as session:
+        return (
+            await session.execute(
+                select(func.count())
+                .select_from(Memory)
+                .where(Memory.tenant_id == tenant, Memory.deleted_at.is_(None))
+            )
+        ).scalar_one()
 
-        mean_ms = statistics.mean(times)
-        p50_ms = statistics.median(times)
-        p99_ms = sorted(times)[int(len(times) * 0.99)]
+
+async def _measure(tenant: str) -> tuple[float, float, float]:
+    """``(mean, median, max)`` ms over ``_BENCH_ITERATIONS`` dedup lookups.
+
+    ``max``, not "p99": at 20 samples the 99th-percentile index is the last
+    element, so calling it p99 dressed up the slowest single run as a tail
+    statistic.
+    """
+    emb = fake_embedding("A completely new memory for benchmark")
+    times = []
+    for _ in range(_BENCH_ITERATIONS):
+        t0 = time.perf_counter()
+        await _find_semantic_duplicate(tenant, None, emb)
+        times.append((time.perf_counter() - t0) * 1000)
+    return statistics.mean(times), statistics.median(times), max(times)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize(
+    ("count", "budget_ms"),
+    [(100, 10), (1000, 50)],
+    ids=["100_memories", "1000_memories"],
+)
+async def test_semantic_dedup_query_latency(count: int, budget_ms: float) -> None:
+    """Dedup query latency against a corpus of the stated size.
+
+    The corpus assertion is load-bearing, not a sanity check: an empty table
+    comfortably meets both budgets, so a corpus the query cannot see would pass
+    silently while measuring nothing.
+    """
+    async with _committed_corpus(count) as tenant:
+        visible = await _visible_count(tenant)
+        assert visible == count, (
+            f"benchmark corpus is not visible to the query under test: expected "
+            f"{count} rows under {tenant}, the query's own session sees {visible}. "
+            f"Measuring latency now would report the wrong corpus size."
+        )
+
+        mean_ms, median_ms, max_ms = await _measure(tenant)
 
         print(f"\n{'─' * 60}")
-        print("SEMANTIC DEDUP QUERY (100 memories, 20 iterations)")
-        print(f"  mean={mean_ms:.2f}ms  p50={p50_ms:.2f}ms  p99={p99_ms:.2f}ms")
+        print(f"SEMANTIC DEDUP QUERY ({count} memories, {_BENCH_ITERATIONS} iterations)")
+        print(f"  mean={mean_ms:.2f}ms  median={median_ms:.2f}ms  max={max_ms:.2f}ms")
         print(f"{'─' * 60}")
 
-        assert mean_ms < 10, f"Too slow with 100 memories: {mean_ms:.1f}ms"
-
-    async def test_latency_1000_memories(self, db, tenant_id):
-        """Query latency with 1000 memories should be < 50ms mean."""
-        from core_api.services.memory_service import _find_semantic_duplicate
-
-        await self._seed_memories(db, tenant_id, 1000)
-
-        emb = fake_embedding("A completely new memory for benchmark")
-        times = []
-        for _ in range(20):
-            t0 = time.perf_counter()
-            await _find_semantic_duplicate(tenant_id, None, emb)
-            times.append((time.perf_counter() - t0) * 1000)
-
-        mean_ms = statistics.mean(times)
-        p50_ms = statistics.median(times)
-        p99_ms = sorted(times)[int(len(times) * 0.99)]
-
-        print(f"\n{'─' * 60}")
-        print("SEMANTIC DEDUP QUERY (1000 memories, 20 iterations)")
-        print(f"  mean={mean_ms:.2f}ms  p50={p50_ms:.2f}ms  p99={p99_ms:.2f}ms")
-        print(f"{'─' * 60}")
-
-        assert mean_ms < 50, f"Too slow with 1000 memories: {mean_ms:.1f}ms"
+        assert mean_ms < budget_ms, f"Too slow with {count} memories: {mean_ms:.1f}ms"

--- a/tests/test_p3_1_entity_resolution.py
+++ b/tests/test_p3_1_entity_resolution.py
@@ -218,7 +218,7 @@ class TestEntityResolutionIntegration:
     """End-to-end entity resolution against a real database."""
 
     async def _insert_entity(
-        self, db, tenant_id, fleet_id, entity_type, canonical_name, name_embedding=None
+        self, tenant_id, fleet_id, entity_type, canonical_name, name_embedding=None
     ):
         """Helper: insert entity via upsert_entity."""
         from core_api.schemas import EntityUpsert
@@ -235,46 +235,46 @@ class TestEntityResolutionIntegration:
         )
 
     @pytest.mark.asyncio
-    async def test_exact_match_same_entity(self, db, tenant_id, fleet_id):
+    async def test_exact_match_same_entity(self, tenant_id, fleet_id):
         """Insert 'john smith' twice → same entity."""
         emb = fake_embedding("john smith")
         e1 = await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "john smith", emb
+            tenant_id, fleet_id, "person", "john smith", emb
         )
         e2 = await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "john smith", emb
+            tenant_id, fleet_id, "person", "john smith", emb
         )
         assert e1.id == e2.id
 
     @pytest.mark.asyncio
-    async def test_fuzzy_match_similar_name(self, db, tenant_id, fleet_id):
+    async def test_fuzzy_match_similar_name(self, tenant_id, fleet_id):
         """Insert 'john smith', then 'jon smith' with close embedding → same entity."""
         emb1 = fake_embedding("john smith")
         e1 = await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "john smith", emb1
+            tenant_id, fleet_id, "person", "john smith", emb1
         )
 
         # Close embedding simulates what a real model would give for a name variant
         emb2 = close_embedding("john smith", noise=0.001)
         e2 = await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "jon smith", emb2
+            tenant_id, fleet_id, "person", "jon smith", emb2
         )
         assert e1.id == e2.id
 
     @pytest.mark.asyncio
-    async def test_type_guard_prevents_merge(self, db, tenant_id, fleet_id):
+    async def test_type_guard_prevents_merge(self, tenant_id, fleet_id):
         """'john smith' (person) and 'john smith' (technology) → different entities."""
         emb = fake_embedding("john smith")
         e1 = await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "john smith", emb
+            tenant_id, fleet_id, "person", "john smith", emb
         )
         e2 = await self._insert_entity(
-            db, tenant_id, fleet_id, "technology", "john smith", emb
+            tenant_id, fleet_id, "technology", "john smith", emb
         )
         assert e1.id != e2.id
 
     @pytest.mark.asyncio
-    async def test_canonical_name_preserves_first_seen(self, db, tenant_id, fleet_id):
+    async def test_canonical_name_preserves_first_seen(self, tenant_id, fleet_id):
         """A5a: insert 'john smith', then 'dr. john smith' → merged via fuzzy
         match; canonical stays as 'john smith' (first-seen wins). The
         previous behaviour promoted the longer name as canonical, which
@@ -283,12 +283,12 @@ class TestEntityResolutionIntegration:
         and remains searchable."""
         emb1 = fake_embedding("john smith")
         e1 = await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "john smith", emb1
+            tenant_id, fleet_id, "person", "john smith", emb1
         )
 
         emb2 = close_embedding("john smith", noise=0.001)
         e2 = await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "dr. john smith", emb2
+            tenant_id, fleet_id, "person", "dr. john smith", emb2
         )
 
         assert e1.id == e2.id
@@ -298,16 +298,16 @@ class TestEntityResolutionIntegration:
         assert "dr. john smith" in aliases
 
     @pytest.mark.asyncio
-    async def test_distant_names_not_merged(self, db, tenant_id, fleet_id):
+    async def test_distant_names_not_merged(self, tenant_id, fleet_id):
         """'alice smith' and 'bob smith' → different entities."""
         emb1 = fake_embedding("alice smith")
         e1 = await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "alice smith", emb1
+            tenant_id, fleet_id, "person", "alice smith", emb1
         )
 
         emb2 = distant_embedding()
         e2 = await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "bob smith", emb2
+            tenant_id, fleet_id, "person", "bob smith", emb2
         )
         assert e1.id != e2.id
 
@@ -318,15 +318,15 @@ class TestEntityResolutionIntegration:
 
         emb1 = fake_embedding("john smith")
         e1 = await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "john smith", emb1
+            tenant_id, fleet_id, "person", "john smith", emb1
         )
 
         emb2 = close_embedding("john smith", noise=0.001)
-        await self._insert_entity(db, tenant_id, fleet_id, "person", "jon smith", emb2)
+        await self._insert_entity(tenant_id, fleet_id, "person", "jon smith", emb2)
 
         emb3 = close_embedding("john smith", noise=0.0005)
         await self._insert_entity(
-            db, tenant_id, fleet_id, "person", "dr. john smith", emb3
+            tenant_id, fleet_id, "person", "dr. john smith", emb3
         )
 
         # Read entity directly to check aliases

--- a/tests/test_p3_2_relation_weights.py
+++ b/tests/test_p3_2_relation_weights.py
@@ -203,7 +203,7 @@ class TestExpandGraphRelationWeights:
         })
         return rel
 
-    async def test_strong_relation_returns_high_weight(self, db, tenant_id, fleet_id):
+    async def test_strong_relation_returns_high_weight(self, tenant_id, fleet_id):
         from core_api.clients.storage_client import get_storage_client
         from core_api.services.memory_service import expand_graph
 
@@ -223,7 +223,7 @@ class TestExpandGraphRelationWeights:
         assert hop == 1
         assert weight == RELATION_TYPE_WEIGHTS["manages"]
 
-    async def test_weak_relation_returns_low_weight(self, db, tenant_id, fleet_id):
+    async def test_weak_relation_returns_low_weight(self, tenant_id, fleet_id):
         from core_api.clients.storage_client import get_storage_client
         from core_api.services.memory_service import expand_graph
 
@@ -241,7 +241,7 @@ class TestExpandGraphRelationWeights:
         assert hop == 1
         assert weight == RELATION_TYPE_WEIGHTS["located_in"]
 
-    async def test_multiple_relations_keeps_strongest(self, db, tenant_id, fleet_id):
+    async def test_multiple_relations_keeps_strongest(self, tenant_id, fleet_id):
         """If two relations connect the same entities, keep the strongest."""
         from core_api.clients.storage_client import get_storage_client
         from core_api.services.memory_service import expand_graph
@@ -262,7 +262,7 @@ class TestExpandGraphRelationWeights:
         _, weight = result[person_id]
         assert weight == RELATION_TYPE_WEIGHTS["manages"]
 
-    async def test_seed_entities_have_weight_1(self, db, tenant_id, fleet_id):
+    async def test_seed_entities_have_weight_1(self, tenant_id, fleet_id):
         from core_api.clients.storage_client import get_storage_client
         from core_api.services.memory_service import expand_graph
 
@@ -275,7 +275,7 @@ class TestExpandGraphRelationWeights:
         assert hop == 0
         assert weight == 1.0
 
-    async def test_db_weight_multiplies_type_weight(self, db, tenant_id, fleet_id):
+    async def test_db_weight_multiplies_type_weight(self, tenant_id, fleet_id):
         """Relation.weight column (DB) multiplies the type-based weight."""
         from core_api.clients.storage_client import get_storage_client
         from core_api.services.memory_service import expand_graph

--- a/tests/test_p5_crystallizer.py
+++ b/tests/test_p5_crystallizer.py
@@ -206,7 +206,7 @@ class TestBatchANNIntegration:
         return [v / norm for v in noisy]
 
     @pytest.mark.asyncio
-    async def test_finds_near_duplicates(self, db, tenant_id, fleet_id):
+    async def test_finds_near_duplicates(self, tenant_id, fleet_id):
         """Batch ANN should find near-duplicate pairs above threshold."""
         from core_api.services.crystallizer_service import _check_near_duplicates
 
@@ -225,7 +225,7 @@ class TestBatchANNIntegration:
         assert result["pairs"][0]["similarity"] >= CRYSTALLIZER_DEDUP_THRESHOLD
 
     @pytest.mark.asyncio
-    async def test_skips_already_checked(self, db, tenant_id, fleet_id):
+    async def test_skips_already_checked(self, tenant_id, fleet_id):
         """Memories with last_dedup_checked_at set should be skipped."""
         from core_api.services.crystallizer_service import _check_near_duplicates
 
@@ -251,7 +251,7 @@ class TestBatchANNIntegration:
         assert result["count"] == 0, "Already-checked memories should be skipped"
 
     @pytest.mark.asyncio
-    async def test_updates_dedup_timestamp(self, db, tenant_id, fleet_id):
+    async def test_updates_dedup_timestamp(self, tenant_id, fleet_id):
         """After processing, memories should have last_dedup_checked_at set."""
         from core_api.clients.storage_client import get_storage_client
         from core_api.services.crystallizer_service import _check_near_duplicates
@@ -269,7 +269,7 @@ class TestBatchANNIntegration:
         )
 
     @pytest.mark.asyncio
-    async def test_no_false_positives_different_topics(self, db, tenant_id, fleet_id):
+    async def test_no_false_positives_different_topics(self, tenant_id, fleet_id):
         """Unrelated memories should not appear as near-duplicates."""
         from core_api.services.crystallizer_service import _check_near_duplicates
 

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -234,7 +234,6 @@ class TestVisibilityFiltering:
 
     async def test_private_invisible_to_other_agents(
         self,
-        db,
         sc,
         tenant_id,
         fleet_id,
@@ -260,7 +259,6 @@ class TestVisibilityFiltering:
 
     async def test_private_visible_to_owner(
         self,
-        db,
         sc,
         tenant_id,
         fleet_id,
@@ -286,7 +284,6 @@ class TestVisibilityFiltering:
 
     async def test_fleet_visible_in_same_fleet(
         self,
-        db,
         sc,
         tenant_id,
         fleet_id,
@@ -311,7 +308,6 @@ class TestVisibilityFiltering:
 
     async def test_fleet_invisible_in_other_fleet(
         self,
-        db,
         sc,
         tenant_id,
     ):
@@ -335,7 +331,6 @@ class TestVisibilityFiltering:
 
     async def test_tenant_visible_across_fleets(
         self,
-        db,
         sc,
         tenant_id,
     ):
@@ -359,7 +354,6 @@ class TestVisibilityFiltering:
 
     async def test_tenant_visible_in_tenant_wide_search(
         self,
-        db,
         sc,
         tenant_id,
     ):
@@ -382,7 +376,6 @@ class TestVisibilityFiltering:
 
     async def test_multi_fleet_search(
         self,
-        db,
         sc,
         tenant_id,
     ):
@@ -415,7 +408,6 @@ class TestVisibilityFiltering:
 
     async def test_multi_fleet_excludes_other_fleets(
         self,
-        db,
         sc,
         tenant_id,
     ):
@@ -474,7 +466,6 @@ class TestVisibilityFiltering:
 
     async def test_admin_sees_team_and_org_not_agent_scoped(
         self,
-        db,
         sc,
         tenant_id,
         fleet_id,
@@ -548,7 +539,6 @@ class TestBackwardCompatibility:
 
     async def test_search_without_visibility_params_unchanged(
         self,
-        db,
         sc,
         tenant_id,
         fleet_id,
@@ -610,7 +600,6 @@ class TestDedupWithVisibility:
 
     async def test_dedup_within_same_visibility(
         self,
-        db,
         tenant_id,
         fleet_id,
         agent_id,
@@ -646,7 +635,6 @@ class TestDedupWithVisibility:
     )
     async def test_no_cross_visibility_dedup(
         self,
-        db,
         tenant_id,
         fleet_id,
         agent_id,

--- a/tests/test_write_path_audit_signature_regression.py
+++ b/tests/test_write_path_audit_signature_regression.py
@@ -63,7 +63,7 @@ def _use_pipeline_write():
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_memory_write_audit_hook_does_not_fail(db, caplog, _use_pipeline_write):
+async def test_memory_write_audit_hook_does_not_fail(caplog, _use_pipeline_write):
     """A memory create must invoke the audit hook WITHOUT the swallowed
     TypeError. Captures ``write_memory_row``'s logger: if the hook raises
     (the #491 regression — positional ``ctx.db`` into keyword-only


### PR DESCRIPTION
## The signal that was wrong

`tests/conftest.py`'s `db` fixture is a per-test session inside a transaction that
is **rolled back** at teardown. Requesting it reads as "this test is transactionally
isolated."

Almost everything in `tests/` writes through the service layer instead, which commits
on its own connections — so that rollback never touches those rows. **107 test
signatures had drifted into requesting `db` and never using it**: a false isolation
claim, plus a connection, transaction and rollback bought for nothing.

Nothing is lost by dropping it. The autouse `_patch_storage_client`
(`tests/conftest.py:185`) already depends on `_engine` and `_setup_schema`, so every
test gets schema setup either way.

## 73 were direct; 34 were hidden

Five helpers take `db` and never touch it — `_seed_governance`, `_seed_memories`, two
different `_insert_memory`, and `_insert_entity`. `helper(db, ...)` looks like a use
of the name while the parameter goes nowhere, so their callers had to keep requesting
a session that was discarded. Those helpers and their **46 call sites** lose the
argument too.

Worth knowing for anyone repeating this: **seven different `_insert_memory` helpers
exist across `tests/`, and some genuinely use `db`** (e.g. `test_redistribute.py:88`).
Matching by bare name would have broken them, so this was scoped per file.

26 tests still request `db`, and all 26 genuinely use it.

## A guard, so it cannot silently come back

`tests/test_fixture_hygiene.py` asserts two things:

1. no **helper** may take `db` without using it, and
2. no **test** may request `db` without using it.

(1) is what makes (2) sufficient — without it, forwarding to a helper that drops the
parameter reads as a use, which is exactly how 34 of the 107 stayed hidden from the
first sweep. Verified by mutation: reintroducing a dead `db` on a test trips (2),
reintroducing one on a helper trips (1).

## No speedup, and none claimed

The fixture costs **~0.111 ms per use**, so 73 removals is **~0.008 s** against a
~210 s suite. This is hygiene, not performance. (The 258.7 s → 255.7 s I first
observed is noise, ~375× larger than the real saving.)

## The concrete damage: the dedup benchmarks measured an empty table

`tests/test_p2_semantic_dedup.py`'s benchmarks seeded via `db.add()` + `db.flush()` —
into the transaction that rolls back — while the query under test reached Postgres on
a separate connection. **Measured: seed 100, the query sees 0.**

So both `test_latency_100_memories` and `test_latency_1000_memories` timed an empty
table, met their 10 ms and 50 ms budgets comfortably, and said nothing. They were also
using the run's **shared** tenant, whose size is a running total of whatever every
other test left behind rather than the stated count.

They now commit their corpus under their own tenant, **assert it is actually visible
before timing anything**, and clean up after. That assertion is load-bearing, not a
sanity check — it is precisely what was missing. Real numbers, and they scale now:

| corpus | mean | median | max |
|---|---|---|---|
| 100 memories | 3.54 ms | 2.44 ms | 22.57 ms |
| 1000 memories | 4.56 ms | 4.31 ms | 6.22 ms |

## Two conftest comments asserted the belief being removed

- `conftest.py:164` said `per-test rollback is the primary isolation`. It isn't — the
  end-of-session `LIKE 'test-tenant-%'` sweep is what removes service-layer writes.
- `_reset_hooks`'s docstring said tests "that use the `db` fixture" bypass the app
  lifespan, which described a minority even before this change.

## Incidental, in blocks already being edited

13 in-body imports of `_find_semantic_duplicate` made redundant by hoisting it; one
unused `MagicMock`. And the benchmark's "p99" is now `max` — at 20 samples the
99th-percentile index *is* the last element, so it was a max wearing a percentile's
name.

## Verification

- `tests/`: **4185 passed, 3 skipped, 1 xfailed** — the 4183 baseline plus the 2 new
  guard tests. Confirmed under random ordering, not just a pinned seed.
- `core-storage-api/tests/`: **114 passed**, unchanged
- mypy clean on both projects; ruff clean at all four CI scopes
- `plugin/tools.json` and the broker OpenAPI regenerate byte-identical
- `tests/` is outside CI's ruff scope, so no formatter could tidy up after a bulk
  edit — the rewrite was AST-guided and every changed line was read. Per-file ruff
  counts are unchanged everywhere except `test_p2_semantic_dedup.py`, which improves
  from 6 findings to 1.

## Deliberately not in this PR

- **Making `tenant_id` unique per test** — the actual root fix, since the shared
  tenant is the leftover-row generator. It looks like a one-line conftest change and
  measured green in a scratch run, but it changes isolation semantics for 72 tests
  across 11 files and deserves its own PR and its own verification.
- **`memories.supersedes_id` has no index**, so its `ON DELETE SET NULL` self-FK
  fires a full table scan per deleted row — measured 1.9 s to delete 1000 rows from a
  28k-row table, growing linearly. That affects production deletes, not just tests.
- **Three more tests that assert against their own simulation** rather than the code
  they name: `test_visibility.py:678` (benchmarks a local Python reimplementation and
  concludes "<1% overhead" about the real SQL), `test_redistribute.py:125-255`, and
  `test_p0_3_recall_boost.py:225`. Same defect class as the benchmark fixed here.