### PR TITLE
test: interleave the pipeline-vs-legacy latency paths to stop the flake

### DIFF
--- a/tests/pipeline/test_pipeline_latency.py
+++ b/tests/pipeline/test_pipeline_latency.py
@@ -22,8 +22,12 @@ ITERATIONS = 10
 
 # Two separate tenants so both paths can write the same content
 # without triggering cross-path dedup
-LEGACY_TENANT = f"test-lat-legacy-{uuid.uuid4().hex[:8]}"
-PIPELINE_TENANT = f"test-lat-pipe-{uuid.uuid4().hex[:8]}"
+# ``test-tenant-`` prefix deliberately: conftest's session teardown sweeps on
+# exactly that pattern, and these rows are committed through the service layer
+# so nothing else removes them. Under the old ``test-lat-`` prefix every run
+# leaked 22 rows permanently — 4,334 had accumulated in one dev database.
+LEGACY_TENANT = f"test-tenant-lat-legacy-{uuid.uuid4().hex[:8]}"
+PIPELINE_TENANT = f"test-tenant-lat-pipe-{uuid.uuid4().hex[:8]}"
 FLEET_ID = "test-fleet"
 AGENT_ID = "test-agent"
 
@@ -84,16 +88,33 @@ _COMPARED_META_KEYS = [
 # write_latency_ms, semantic_dedup_ms, llm_ms
 
 
-# Allow the pipeline path's median latency to be up to 1.5x the legacy
-# path's. The earlier absolute 5ms budget was a tight slice of CI-runner
-# variance (median legacy ~33 ms, median pipeline ~39 ms; flaked at 5.4
-# ms over a 5.0 ms budget on a busy runner on 2026-05-25 even though
-# both paths were well within healthy ranges). 1.5x catches a real
-# framework regression (pipeline taking materially longer per step)
-# while tolerating the absolute-time noise on shared runners and the
-# slow drift in both paths as more steps are added — the invariant
-# we actually want to pin is "framework overhead stays bounded
-# relative to legacy", not "always within 5ms".
+# Allow the pipeline path's median latency to be up to 1.5x the legacy path's.
+# The threshold is unchanged; what changed is the measurement, which is what
+# actually flaked (1.545x on 2026-08-09, passing on rerun).
+#
+# The paths used to be timed in separate blocks — ten legacy writes, then ten
+# pipeline writes. Whichever block ran second met the worse conditions, both
+# from runner drift and from cold caches after the first block's work, so the
+# penalty always landed on pipeline. Measured over 20 paired replicates
+# locally: the block shape's ratio has a CV of 10.5% and reached 1.403 on an
+# idle laptop, while interleaving the paths halves it to 4.9% with a worst
+# case of 1.175. Widening the ratio would not have fixed that — the bias is in
+# the ordering, not the number.
+#
+# Median, not minimum: min looks like the noise-robust choice but is not, here.
+# Latency climbs ~28% from the first write to the tenth because the dedup query
+# scans the tenant's rows rather than an ANN index, so per-write cost grows with
+# rows already written. min therefore lands on the first iteration (argmin was
+# i=0 in 15 of 20 replicates) and measures the smallest candidate set rather
+# than the least noise. Measured, it also buys nothing once interleaved — CV
+# 4.50% vs the median's 4.71% across 10 cross-process runs — while going blind
+# to the regressions most likely here: a per-candidate cost added to dedup went
+# undetected 100% of the time against min, and 90-100% detected against the
+# median.
+#
+# Residual known bias, and it is the safe direction: within each pair the second
+# write measures ~3.8pp slower, and pipeline runs second, so the ratio is if
+# anything overstated.
 _PIPELINE_OVERHEAD_RATIO_MAX = 1.5
 
 
@@ -139,26 +160,31 @@ async def test_pipeline_overhead_bounded_relative_to_legacy(db):
             ),
         )
 
-        # ── Measure legacy path ──
-        memory_service._USE_PIPELINE_WRITE = False
-        legacy_latencies = []
-        for i in range(ITERATIONS):
-            data = _make_input(LEGACY_TENANT, i)
+        # ── Measure both paths, interleaved ──
+        # One write of each per iteration, not all of one path then all of the
+        # other: see _PIPELINE_OVERHEAD_RATIO_MAX for why the ordering was the
+        # bug. ``data`` is built by the caller so MemoryCreate construction
+        # stays outside the timed region, as it always has.
+        async def timed_write(use_pipeline: bool, data: MemoryCreate) -> float:
+            memory_service._USE_PIPELINE_WRITE = use_pipeline
             t0 = time.perf_counter()
             result = await create_memory(data)
-            legacy_latencies.append((time.perf_counter() - t0) * 1000)
+            elapsed_ms = (time.perf_counter() - t0) * 1000
             assert isinstance(result, MemoryOut)
+            return elapsed_ms
 
-        # ── Measure pipeline path (same content, different tenant) ──
-        # Force strong mode to match legacy path behavior (both run semantic dedup)
-        memory_service._USE_PIPELINE_WRITE = True
+        legacy_latencies = []
         pipeline_latencies = []
         for i in range(ITERATIONS):
-            data = _make_input(PIPELINE_TENANT, i, write_mode="strong")
-            t0 = time.perf_counter()
-            result = await create_memory(data)
-            pipeline_latencies.append((time.perf_counter() - t0) * 1000)
-            assert isinstance(result, MemoryOut)
+            legacy_latencies.append(
+                await timed_write(False, _make_input(LEGACY_TENANT, i))
+            )
+            pipeline_latencies.append(
+                # strong mode so both paths run semantic dedup
+                await timed_write(
+                    True, _make_input(PIPELINE_TENANT, i, write_mode="strong")
+                )
+            )
 
         # ── DB row count verification ──
         for tenant, label in [(LEGACY_TENANT, "legacy"), (PIPELINE_TENANT, "pipeline")]:
@@ -273,30 +299,36 @@ async def test_pipeline_overhead_bounded_relative_to_legacy(db):
         # ── Latency report ──
         legacy_median = statistics.median(legacy_latencies)
         pipeline_median = statistics.median(pipeline_latencies)
+        legacy_min = min(legacy_latencies)
+        pipeline_min = min(pipeline_latencies)
         overhead = pipeline_median - legacy_median
 
         print(f"\n{'=' * 60}")
-        print(f"LATENCY COMPARISON ({ITERATIONS} iterations each)")
+        print(f"LATENCY COMPARISON ({ITERATIONS} interleaved iterations each)")
         print(f"{'=' * 60}")
         print(
             f"Legacy   — median: {legacy_median:.1f}ms  "
             f"p95: {_percentile(legacy_latencies, 95):.1f}ms  "
-            f"min: {min(legacy_latencies):.1f}ms  "
+            f"min: {legacy_min:.1f}ms  "
             f"max: {max(legacy_latencies):.1f}ms"
         )
         print(
             f"Pipeline — median: {pipeline_median:.1f}ms  "
             f"p95: {_percentile(pipeline_latencies, 95):.1f}ms  "
-            f"min: {min(pipeline_latencies):.1f}ms  "
+            f"min: {pipeline_min:.1f}ms  "
             f"max: {max(pipeline_latencies):.1f}ms"
         )
         print(f"Overhead — {overhead:+.1f}ms (median)")
+        median_ratio = (
+            pipeline_median / legacy_median if legacy_median > 0 else float("inf")
+        )
+        min_ratio = pipeline_min / legacy_min if legacy_min > 0 else float("inf")
+        print(f"Ratio    — median {median_ratio:.2f}x (gate), min {min_ratio:.2f}x")
         print(f"{'=' * 60}")
 
-        ratio = pipeline_median / legacy_median if legacy_median > 0 else float("inf")
         assert pipeline_median <= legacy_median * _PIPELINE_OVERHEAD_RATIO_MAX, (
             f"Pipeline median {pipeline_median:.1f}ms is "
-            f"{ratio:.2f}x legacy median {legacy_median:.1f}ms, exceeds "
+            f"{median_ratio:.2f}x legacy median {legacy_median:.1f}ms, exceeds "
             f"{_PIPELINE_OVERHEAD_RATIO_MAX}x ceiling (overhead={overhead:+.1f}ms)."
         )
 


### PR DESCRIPTION
## The threshold wasn't the problem; the ordering was

`test_pipeline_overhead_bounded_relative_to_legacy` timed **ten legacy writes, then
ten pipeline writes**, and compared medians against a 1.5x ceiling. It failed at
1.545x on 2026-08-09 — a 3% overshoot — and passed on rerun with identical code.

Whichever block ran second met the worse conditions: runner drift, plus caches gone
cold after the first block's work. That was always pipeline. Measured over 20 paired
replicates locally:

| shape | ratio CV | worst replicate | margin to 1.5x |
|---|---|---|---|
| separate blocks (old) | **10.5%** | **1.403** | 7% |
| interleaved (new) | **4.9%** | 1.175 | 28% |

The block shape reached 1.403 on an *idle laptop* in 20 replicates, which is entirely
consistent with 1.545 on a shared runner. There was also a concrete cold-cache
artefact: in block form the pipeline's first write averaged **20.1 ms vs 14.6 ms** for
its second, because its warmup had happened ~10 writes earlier. Interleaved, that
first write is 14.2 ms.

Widening the ratio would have left the bias in place.

## What I got wrong on the first attempt

An earlier version of this change also moved the gate to **min-vs-min**, arguing that
scheduling noise is strictly additive so the minimum is the cleanest estimator. A
`/simplify` review measured that and it was wrong twice over:

- **Latency climbs ~28% from the first write to the tenth**, because the dedup query
  scans the tenant's rows rather than an ANN index (`EXPLAIN ANALYZE` shows
  `Index Scan` + `Sort`, no HNSW). So per-write cost grows with rows already written,
  and `min` lands on the first iteration — argmin was `i=0` in 15 of 20 replicates. It
  measures the **smallest candidate set**, not the least noise.
- **It bought no stability anyway** once interleaved: CV 4.50% (min) vs 4.71%
  (median) across 10 cross-process runs. min was only better in the *block* shape —
  i.e. it was compensating for the variance interleaving already removes.
- And it went blind to the likeliest regression class here. A per-candidate cost added
  to dedup: **0% detected by a min gate, 90-100% by the median.** An intermittent
  slowdown on 70% of writes: 2.9% vs 92.9%.

So the statistic is unchanged. **min is now printed as a diagnostic only**, and the
comment no longer claims noise is the dominant source of within-run spread.

## Also: this test leaked rows on every run, forever

Its tenants used a `test-lat-` prefix, but conftest's session teardown sweeps
`test-tenant-%`. The rows are committed through the service layer, so nothing else
removed them — **every run leaked 22 rows permanently, and 4,334 had accumulated in
one dev database.** Renamed to `test-tenant-lat-*`; verified the sweep now collects
them (0 rows remain after a run).

## Verification

- **8 consecutive local runs**: median ratio **1.00–1.10x** against the 1.5x gate
- `tests/`: **4185 passed, 3 skipped, 1 xfailed** (unchanged); `core-storage-api/tests/`: **114 passed**
- mypy clean both projects; ruff clean at all four CI scopes; generated artifacts byte-identical
- Timing boundary preserved: `_make_input` is still evaluated at the call site, so
  `MemoryCreate` construction stays outside the timed region exactly as before

## Known residual, in the safe direction

Within each interleaved pair the second write measures ~3.8pp slower, and pipeline
runs second — so the ratio is if anything *overstated*. Recorded in the comment.

## Deliberately not in this PR

The review made a strong case that this test is in the wrong tier entirely, and I
agree, but it is a CI-policy change rather than a test fix:

- **It is the only wall-clock ratio test that gates CI.** An identically-shaped
  assertion (`assert ratio < 3.0`) in `tests/test_p5_p6_benchmarks.py:96` is
  `@pytest.mark.benchmark` and therefore deselected. **But nothing ever runs
  `-m benchmark`** — the tier holds 8 tests and is write-only, so marking this one
  without also adding a non-gating scheduled job would trade a flake for silent zero
  coverage.
- `tests/test_p1_contradiction.py:606` and `:646` are pure microbenchmarks whose only
  assertion is a wall-clock number, marked `integration`, gating CI, burning 100k
  timed iterations per run.
- **A timing-free formulation exists**: spy on `get_storage_client` and assert the
  pipeline issues no more storage round-trips than legacy, plus assert
  `result.step_count`. The 1.5x gate permits ~16 ms of slack on a ~33 ms floor, which
  is ~500-1000x the per-step glue it names, so it cannot resolve that invariant at all.
- This test also bundles a durable field-equivalence guard (17 columns + embeddings +
  metadata) with the timing gate, so a runner hiccup and a real equivalence break
  present as the same failure.