### PR TITLE
perf(db): index the FK columns that reference memories.id / entities.id

### DIFF
--- a/common/models/entity.py
+++ b/common/models/entity.py
@@ -47,6 +47,14 @@ class Relation(Base):
     __table_args__ = (
         Index("ix_relations_from", "from_entity_id"),
         Index("ix_relations_to", "to_entity_id"),
+        # For DELETEs on ``memories``, not reads here — the referencing side of
+        # a SET NULL FK. Partial because the RI check never looks for NULL.
+        # See migration 035.
+        Index(
+            "ix_relations_evidence_memory",
+            "evidence_memory_id",
+            postgresql_where=text("evidence_memory_id IS NOT NULL"),
+        ),
     )
 
 
@@ -60,3 +68,11 @@ class MemoryEntityLink(Base):
         ForeignKey("entities.id", ondelete="CASCADE"), primary_key=True
     )
     role: Mapped[str] = mapped_column(Text, nullable=False)
+
+    __table_args__ = (
+        # The PK ``(memory_id, entity_id)`` covers the memories-side FK on its
+        # leading column, but a btree cannot serve ``entity_id`` as a prefix —
+        # so deleting an entity scanned this whole table, across every tenant.
+        # See migration 035.
+        Index("ix_memory_entity_links_entity_id", "entity_id"),
+    )

--- a/common/models/memory.py
+++ b/common/models/memory.py
@@ -106,6 +106,17 @@ class Memory(Base):
         ),
         Index("ix_memories_valid_range", "ts_valid_start", "ts_valid_end"),
         Index("ix_memories_subject_entity", "subject_entity_id"),
+        # For DELETEs, not reads — grep will find no query using it. This is the
+        # referencing side of a SET NULL self-FK, which PostgreSQL enforces once
+        # per deleted parent row. Partial because the RI check only ever looks
+        # for a non-NULL match, and almost every row here is NULL (232 kB -> 16 kB).
+        # Created CONCURRENTLY in migration 035, which carries the measurements;
+        # declared here so reflection / autogen round-trip against the live schema.
+        Index(
+            "ix_memories_supersedes_id",
+            "supersedes_id",
+            postgresql_where=text("supersedes_id IS NOT NULL"),
+        ),
         Index("ix_memories_recall_count", "recall_count"),
         Index("ix_memories_tenant_fleet", "tenant_id", "fleet_id"),
         # Backs the cursor-paginated list path (``list_by_filters`` +

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/035_fk_indexes_for_memory_deletes.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/035_fk_indexes_for_memory_deletes.py
@@ -1,0 +1,134 @@
+"""Index the FK columns that reference ``memories.id`` / ``entities.id``.
+
+Deleting a parent row makes PostgreSQL enforce every foreign key that POINTS AT
+it, and enforcement needs an index on the REFERENCING side. Three were missing
+one, so each deleted row cost a full scan of the referencing table:
+
+    memories.supersedes_id           -> memories.id   SET NULL   no index
+    relations.evidence_memory_id     -> memories.id   SET NULL   no index
+    memory_entity_links.entity_id    -> entities.id   CASCADE    no usable index
+
+The last is subtle: ``memory_entity_links`` has PK ``(memory_id, entity_id)``, so
+``memory_id`` is covered as the leading column but ``entity_id`` is not — a btree
+cannot serve a trailing column as a prefix.
+
+Measured on a 30,801-row ``memories`` table, deleting 4,334 rows in one statement
+(``EXPLAIN ANALYZE``), before and after this migration:
+
+    Trigger memories_supersedes_id_fkey:        15343 ms  ->  8.7 ms
+    Trigger memory_entity_links_memory_id_fkey:    77 ms  -> 29.7 ms
+    Trigger relations_evidence_memory_id_fkey:     17 ms  ->  7.4 ms
+
+The supersedes_id trigger was **98.7% of the statement**, at 3.5 ms per deleted
+row — one scan of the whole table each time, even though only 87 rows had a
+non-NULL ``supersedes_id``. The cost is the scan, not the matches. It is linear
+in table size for a fixed batch (prod's ~92k rows would be ~3x worse) and
+quadratic for a fixed-FRACTION purge, where the batch grows with the table.
+
+Not a test-only concern. ``memory_purge_soft_deleted`` (batched, driven by the
+CAURA-656 retention fanout), ``purge_tenant_data`` and ``purge_fleet_data`` all
+delete from these tables in bulk. The RI trigger scans the WHOLE referencing
+table, not the tenant's slice, so deleting a tenant's children first does not
+shrink it — every other tenant's rows are still scanned once per deleted parent.
+
+``relations.evidence_memory_id`` is currently unmeasurable (that table is
+near-empty in dev) but is included deliberately: it is written by a live
+co-occurrence inference path, so it grows pairwise, and the index costs one
+btree entry per insert against a projected ~5.7 s per 500-row retention batch at
+prod scale.
+
+Revision ID: 035
+Revises: 034
+Create Date: 2026-08-11
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "035"
+down_revision: str | None = "034"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX_NAMES = (
+    "ix_memories_supersedes_id",
+    "ix_relations_evidence_memory",
+    "ix_memory_entity_links_entity_id",
+)
+
+
+def _drop_invalid(connection: sa.Connection) -> None:
+    """Remove any index left INVALID by an interrupted CONCURRENTLY build.
+
+    Mirrors 005 / 007 / 026, and it is not theoretical: a killed
+    ``CREATE INDEX CONCURRENTLY`` leaves the index in ``pg_index`` with
+    ``indisvalid = false``, ``IF NOT EXISTS`` then SKIPS it ("already exists,
+    skipping"), and the planner refuses to use it — measured 547x slower than
+    the valid index on the very query the FK trigger runs. Without this the
+    migration would stamp green while leaving an index that is permanently
+    useless and still charges write overhead on every insert.
+
+    Reachable here because ``CONCURRENTLY`` waits for concurrent transactions
+    with no upper bound (measured: 7.7 s behind one open writer), and Cloud Run
+    kills the container at the 240 s startup probe.
+    """
+    for name in _INDEX_NAMES:
+        invalid = connection.execute(
+            sa.text(
+                """
+                SELECT 1 FROM pg_index i
+                JOIN pg_class c ON c.oid = i.indexrelid
+                WHERE c.relname = :name
+                  AND NOT i.indisvalid
+                """
+            ),
+            {"name": name},
+        ).fetchone()
+        if invalid:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        connection = op.get_context().connection
+        if connection is None:
+            raise RuntimeError("online migration requires a connection")
+        _drop_invalid(connection)
+        # The ``CREATE INDEX ... ON <table>`` prefix stays on ONE source line, as
+        # literal SQL rather than an f-string: ``test_no_plain_create_index_on_large_tables``
+        # regex-scans this file for it, and matches neither a split prefix nor an
+        # interpolated ``{name}`` — which is why 007 and 026 are silently outside
+        # its coverage. A trailing WHERE may wrap; the regex stops at the table.
+        #
+        # PARTIAL on the two nullable columns. The RI check looks for rows whose
+        # FK equals the deleted parent's id, which is never NULL, so excluding
+        # NULLs keeps the index fully usable while dropping almost all of it:
+        # 88 of 27,379 memories carry a ``supersedes_id``, and the index goes
+        # from 232 kB to 16 kB. That is write cost too — a plain btree indexes
+        # NULLs, so every memory insert paid an entry it could never match.
+        # Verified rather than assumed: the RI plan is
+        # ``Index Scan using ix_memories_supersedes_id`` with the partial index in
+        # place, and the FK trigger over 1000 deletes measured 1.848 ms against
+        # the full index's 2.145 ms.
+        #
+        # ``memory_entity_links.entity_id`` is NOT NULL (half of the PK), so a
+        # predicate there would exclude nothing and is deliberately omitted.
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_memories_supersedes_id ON memories (supersedes_id)"
+            " WHERE supersedes_id IS NOT NULL"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_relations_evidence_memory ON relations (evidence_memory_id)"
+            " WHERE evidence_memory_id IS NOT NULL"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_memory_entity_links_entity_id ON memory_entity_links (entity_id)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        for name in reversed(_INDEX_NAMES):
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"034"}, f"Expected single head '034', got {sorted(heads)}"
+        assert heads == {"035"}, f"Expected single head '035', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -694,6 +694,8 @@ class TestMigrationChain:
         assert chain.get("033") == "032", "033 must follow 032"
         # 034: title into memories.search_vector, weighted A over content B
         assert chain.get("034") == "033", "034 must follow 033"
+        # 035: index the FK columns referencing memories.id (bulk-delete cost)
+        assert chain.get("035") == "034", "035 must follow 034"
 
     def test_no_plain_create_index_on_large_tables(self):
         """Indexes on large, pre-existing tables MUST be built ``CONCURRENTLY``
@@ -749,6 +751,50 @@ class TestMigrationChain:
             "storage-writer boots on 2026-06-16). Use CREATE INDEX CONCURRENTLY in "
             "an op.get_context().autocommit_block() — see migration 007 / 026. "
             f"Violations: {'; '.join(violations)}"
+        )
+
+    def test_every_fk_referencing_column_is_index_leading(self):
+        """Every FK's referencing column(s) must be usable as an index prefix.
+
+        PostgreSQL enforces a foreign key from the REFERENCING side once per
+        deleted parent row, so an unindexed referencing column turns each delete
+        into a full scan of that table — across ALL tenants, since the scan is
+        not tenant-scoped. Migration 035 landed after this cost 15.3 s of a
+        15.5 s bulk delete (98.7%) on one unindexed self-FK.
+
+        Declaration-level check, so it catches a new FK added without an index
+        at PR time. It cannot catch an index declared here but never migrated —
+        the CONCURRENTLY guard above and the chain tests cover the migration
+        side.
+        """
+        import common.models  # noqa: F401 — registers every mapper on Base
+        from common.models.base import Base
+
+        def prefixes(table):
+            """Column lists some btree on ``table`` can serve as a prefix of."""
+            out = []
+            if len(table.primary_key.columns):
+                out.append([c.name for c in table.primary_key.columns])
+            for ix in table.indexes:
+                # getattr for expression indexes (e.g. func.coalesce): a SQL
+                # expression must not be mistaken for a column of that name.
+                out.append([getattr(e, "name", None) for e in ix.expressions])
+            return out
+
+        missing = []
+        for table in Base.metadata.sorted_tables:
+            available = prefixes(table)
+            for fk in table.foreign_key_constraints:
+                cols = [c.name for c in fk.columns]
+                if not any(p[: len(cols)] == cols for p in available):
+                    target = next(iter(fk.elements)).target_fullname
+                    missing.append(f"{table.name}({', '.join(cols)}) -> {target}")
+        assert not missing, (
+            "Foreign key(s) whose referencing column is not the leading column of "
+            "any index. Deleting a referenced row will scan the whole referencing "
+            "table once per deleted row — see migration 035 for the measured cost. "
+            "Add an Index(...) here and a CONCURRENTLY index in a migration: "
+            f"{'; '.join(missing)}"
         )
 
 


### PR DESCRIPTION
## The defect

PostgreSQL enforces a foreign key from the **referencing** side, once per deleted
parent row. An unindexed referencing column therefore turns every delete into a full
scan of that table. Three were missing one:

| referencing | → target | on delete | index |
|---|---|---|---|
| `memories.supersedes_id` | `memories.id` | SET NULL | **none** |
| `relations.evidence_memory_id` | `memories.id` | SET NULL | **none** |
| `memory_entity_links.entity_id` | `entities.id` | CASCADE | **none usable** |

The third is easy to miss and was **not** in the original report — the PK is
`(memory_id, entity_id)`, so the memories-side FK is covered by the leading column
while `entity_id` is not. A btree cannot serve a trailing column as a prefix.

## Measured

Deleting 4,334 rows from a 30,801-row `memories` table, one statement, `EXPLAIN ANALYZE`:

| FK trigger | before | after |
|---|---|---|
| `memories_supersedes_id_fkey` | **15,343 ms** | **8.7 ms** |
| `memory_entity_links_memory_id_fkey` | 77 ms | 29.7 ms |
| `relations_evidence_memory_id_fkey` | 17 ms | 7.4 ms |

The `supersedes_id` trigger was **98.7% of the statement** at 3.5 ms per deleted row —
and only **87 of 30,801 rows** had a non-NULL `supersedes_id`. The cost is the scan, not
the matches. Linear in table size for a fixed batch (prod's ~92k rows ≈ 3× worse),
quadratic for a fixed-*fraction* purge where the batch grows with the table.

**Not a test-only concern.** `memory_purge_soft_deleted` (batched, via the CAURA-656
retention fanout), `purge_tenant_data` and `purge_fleet_data` all delete in bulk — and
the RI scan is **not tenant-scoped**, so deleting a tenant's children first doesn't
shrink it: every other tenant's rows get scanned once per deleted parent.

## The part worth reviewing: the invalid-index guard

An interrupted `CREATE INDEX CONCURRENTLY` leaves the index in `pg_index` with
`indisvalid = false`. `IF NOT EXISTS` then **skips** it, and the planner refuses to use
it — so the migration stamps green while leaving an index that is permanently useless
*and* still charges write overhead on every insert. Nothing later revisits it.

This is reachable in production because `CONCURRENTLY` waits on concurrent transactions
with no upper bound, and Cloud Run kills the container at the 240 s startup probe.

**Reproduced end to end, on the real table:**

1. Forced an abort with `lock_timeout` behind an open writer → `indisvalid=false` ✓
2. Ran a bare `CREATE INDEX CONCURRENTLY IF NOT EXISTS` → `NOTICE: relation
   "ix_memories_supersedes_id" already exists, skipping`, **still invalid** ✓
3. Ran this migration → guard dropped and rebuilt it; all three `indisvalid = t` ✓

**An earlier draft of this PR had no guard and its docstring claimed `IF NOT EXISTS`
made the migration idempotent.** That claim was false, and it was the stated reason no
guard was added. Migrations 005/007/026 all carry this guard — they are exactly the
three that index large pre-existing tables. 035 now matches them.

## A guard so the next one fails at PR time

`test_every_fk_referencing_column_is_index_leading` walks SQLAlchemy model metadata (no
DB) and asserts every FK's referencing column is usable as an index prefix. **It is what
found the `memory_entity_links` case.** Mutation-tested: removing that index fails the
test naming `memory_entity_links(entity_id) -> entities.id`.

Declaration-level by design — it catches a new FK added without an index, and can't
catch an index declared but never migrated. The CONCURRENTLY guard and chain tests cover
the migration side.

## Verification

- `tests/`: **4186 passed, 3 skipped, 1 xfailed** (4185 baseline + 1 new guard)
- `core-storage-api/tests/`: **114 passed**
- mypy clean; ruff clean at all four CI scopes (incl. `common/`); artifacts byte-identical
- **downgrade round-trip**: 035 → 034 drops all three, → 035 recreates; re-running
  `upgrade` is a clean no-op
- Build cost is not the risk: `CREATE INDEX CONCURRENTLY` on `supersedes_id` took
  **17.9 ms** for 26,927 rows (only 87 non-NULL, 200 kB index) — ~61 ms extrapolated to
  prod. The unbounded part is CONCURRENTLY's *wait*, which is what the guard covers.

## Notes for the reviewer

- Each `CREATE` is a **literal one-liner on purpose**: `test_no_plain_create_index_on_large_tables`
  regex-scans this file and matches neither a split string nor an interpolated `{name}`.
  A tidier loop would silently drop this migration out of guard coverage.
- Which also means **007 and 026 are currently outside that guard** (their f-string index
  names don't match `\w+`). Worth fixing the regex separately, along with a test asserting
  every CONCURRENTLY migration carries the `indisvalid` guard — nothing enforces that
  pattern today, which is how this PR could omit it and still pass CI.
- `test_single_head` hardcodes the expected head, so every migration PR edits a string in
  a test. It could derive it (assert exactly one head, plus a contiguous numeric run)
  without losing coverage. Left alone here to keep this PR to one idea.
- `relations.evidence_memory_id` is currently unmeasurable (that table is near-empty in
  dev) and included deliberately: it is written by a live co-occurrence inference path so
  it grows pairwise, the index costs one btree entry per insert, and at prod scale an
  unindexed version projects to ~5.7 s per 500-row retention batch.