### PR TITLE
feat(broker): gate the four memory operations the broker already calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,13 @@ jobs:
           echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
 
       # --- Broker↔cloud API-versioning gate (Gate C / Phase 1, deliverables A+B) ---
-      # core-api/openapi.broker.json is the FROZEN v1 contract for the four
-      # broker-facing gateway endpoints (POST /api/v1/memories/bulk,
-      # POST /api/v1/search, GET /api/v1/health, GET /api/v1/version) that
-      # memclawd calls against Caura cloud. It is a subset of the full ~91-path
+      # core-api/openapi.broker.json is the FROZEN v1 contract for the
+      # broker-facing gateway operations that memclawd calls against Caura
+      # cloud. The authoritative list is BROKER_OPERATIONS in
+      # core-api/scripts/gen_broker_openapi.py — deliberately not duplicated
+      # here, because this comment listed four endpoints while the broker had
+      # grown to eight, and a list in a comment is exactly what goes stale.
+      # It is a subset of the full ~91-path
       # OpenAPI surface, with info normalized to the frozen contract version so
       # it changes ONLY when a broker endpoint's shape changes. Regenerate with
       # `python core-api/scripts/gen_broker_openapi.py` and commit the result;

--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -757,6 +757,231 @@
         "title": "MemoryType",
         "type": "string"
       },
+      "MemoryUpdate": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "maxLength": 10000,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "entity_links": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/EntityLinkIn"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Links"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "memory_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MemoryType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Memory type. Auto-classified by LLM if omitted. Valid values: fact, episode, decision, preference, task, intention, plan, commitment, action, cancellation."
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "metadata_mode": {
+            "anyOf": [
+              {
+                "pattern": "^(merge|replace)$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "How to apply ``metadata``: ``merge`` (default when omitted or ``null``) does a top-level JSONB ``||`` merge, preserving keys not present in the patch; ``replace`` overwrites the column wholesale.",
+            "title": "Metadata Mode"
+          },
+          "object_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Value"
+          },
+          "predicate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predicate"
+          },
+          "source_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Uri"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "pattern": "^(active|pending|confirmed|cancelled|outdated|conflicted|archived|deleted)$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "subject_entity_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject Entity Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "ts_valid_end": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ts Valid End"
+          },
+          "ts_valid_start": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ts Valid Start"
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "pattern": "^(scope_agent|scope_team|scope_org)$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Visibility"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight"
+          }
+        },
+        "title": "MemoryUpdate",
+        "type": "object"
+      },
+      "PaginatedMemoryResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/MemoryOut"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "PaginatedMemoryResponse",
+        "type": "object"
+      },
       "SearchRequest": {
         "properties": {
           "diagnostic": {
@@ -981,6 +1206,283 @@
         ]
       }
     },
+    "/api/v1/memories": {
+      "get": {
+        "description": "List memories with filtering, sorting, and pagination.\n\n**Visibility scoping:** When ``agent_id`` is provided, the caller can see\ntheir own ``scope_agent`` memories plus all ``scope_team``/``scope_org``\nmemories. When ``agent_id`` is omitted, ``scope_agent`` memories are hidden\n(safe default). This means memory types like ``insight`` that are typically\ncreated with agent-scoped visibility will only appear when ``agent_id`` is\npassed.\n\n**Pagination:** Both cursor-based and offset-based pagination are supported.\nCursor pagination (via ``cursor``) is recommended for large datasets and only\nworks with ``sort=created_at&order=desc``. Offset pagination works with any\nsort order.",
+        "operationId": "list_memories_api_v1_memories_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "tenant_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tenant Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fleet_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Fleet Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "memory_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Memory Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "exclude_memory_types",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Exclude Memory Types"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_after",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created After"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created Before"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "visibility",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Visibility"
+            }
+          },
+          {
+            "in": "query",
+            "name": "run_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Run Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "created_at",
+              "pattern": "^(created_at|weight|memory_type|agent_id|status|recall_count|fleet_id|tenant_id|expires_at|deleted_at)$",
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "desc",
+              "pattern": "^(asc|desc)$",
+              "title": "Order",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Items per page, 1-500. A value above 500 is rejected with 422 (not silently clamped); page via `cursor`/`offset` for more.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Items per page, 1-500. A value above 500 is rejected with 422 (not silently clamped); page via `cursor`/`offset` for more.",
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_deleted",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Deleted",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedMemoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "List Memories",
+        "tags": [
+          "Memory"
+        ]
+      }
+    },
     "/api/v1/memories/bulk": {
       "post": {
         "description": "Write up to 100 memories with per-attempt idempotency (CAURA-602).\n\nRequired header ``X-Bulk-Attempt-Id`` identifies the *attempt*. A\nretry of the same logical batch reuses the same value; storage's\nper-item unique constraint then converts each row into either\n``created`` or ``duplicate_attempt`` deterministically. The route\nreturns:\n\n- ``200`` when every item resolved as ``created``,\n  ``duplicate_attempt``, or ``duplicate_content``.\n- ``207 Multi-Status`` when at least one item has ``status=\"error\"``\n  (validation, enrichment timeout, missing storage id) AND at least\n  one item succeeded — partial outcomes are explicit, never inferred\n  from a 5xx with side effects.\n- ``200`` when every item is an error too — the request was processed\n  successfully; per-item ``status`` carries the rejection. We\n  deliberately don't reuse 422 here because FastAPI already emits\n  422 for request-body Pydantic validation, and clients that branch\n  on status code alone shouldn't have to disambiguate \"request was\n  malformed\" from \"request parsed and every item was rejected on\n  merit.\"\n- ``504`` when the bulk-only budget burns before storage commits;\n  the response carries no per-item state, so a retry with the same\n  attempt id is the recovery path.\n\nThe pre-existing ``Idempotency-Key`` header still controls\n*response*-level replay; ``X-Bulk-Attempt-Id`` is a separate\ncontract operating one layer down. Both are honoured: the header\ncache short-circuits when the receipt is final, the per-row\nconstraint resolves the slow path when the receipt is missing or\npending.",
@@ -1067,6 +1569,227 @@
           }
         ],
         "summary": "Write Memories Bulk",
+        "tags": [
+          "Memory"
+        ]
+      }
+    },
+    "/api/v1/memories/{memory_id}": {
+      "delete": {
+        "operationId": "delete_memory_api_v1_memories__memory_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "memory_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Memory Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Delete Memory",
+        "tags": [
+          "Memory"
+        ]
+      },
+      "get": {
+        "description": "Get a single memory with full details including embedding and entity links.",
+        "operationId": "get_memory_api_v1_memories__memory_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "memory_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Memory Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Get Memory",
+        "tags": [
+          "Memory"
+        ]
+      },
+      "patch": {
+        "description": "Update a memory. Only provide fields you want to change.\n\nIf content changes, embedding and entity extraction are re-run automatically.\n\nConcurrency contract (intentional, not a bug):\n\n- Each top-level column is **last-write-wins**. Two concurrent PATCHes that\n  set the same column (e.g. ``title``) will both return 200 and the row\n  will hold whichever update commits second. There is no compare-and-swap\n  and no optimistic-lock token — callers that need that must coordinate\n  externally or use ``If-Match`` semantics layered on top.\n- ``metadata`` defaults to a **JSONB top-level merge** (``||``): keys not\n  present in the patch are preserved, keys present in both patches resolve\n  last-write-wins per key. Pass ``metadata_mode: \"replace\"`` for a full\n  overwrite. Two concurrent PATCHes that each set a distinct metadata key\n  will therefore leave **both keys present** on the row — that is the\n  defined behaviour, not a partial-merge anomaly.",
+        "operationId": "update_memory_endpoint_api_v1_memories__memory_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "memory_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Memory Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          },
+          {
+            "description": "C7: alias for the body field of the same name. Body wins on conflict. When supplied as a query param without a matching ``metadata`` field in the body, returns 422 (same contract as the body-side validator). Provided so SDK callers that thread the toggle through a URL query don't silently get the default merge behaviour.",
+            "in": "query",
+            "name": "metadata_mode",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^(merge|replace)$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "C7: alias for the body field of the same name. Body wins on conflict. When supplied as a query param without a matching ``metadata`` field in the body, returns 422 (same contract as the body-side validator). Provided so SDK callers that thread the toggle through a URL query don't silently get the default merge behaviour.",
+              "title": "Metadata Mode"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemoryUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Update Memory Endpoint",
         "tags": [
           "Memory"
         ]

--- a/core-api/scripts/README.md
+++ b/core-api/scripts/README.md
@@ -2,22 +2,53 @@
 
 ## `gen_broker_openapi.py` — frozen v1 broker OpenAPI contract
 
-`../openapi.broker.json` is the **frozen v1 contract** for the four
-broker-facing gateway endpoints that memclawd (the on-prem broker) calls
-against Caura cloud:
+`../openapi.broker.json` is the **frozen v1 contract** for the broker-facing
+gateway operations that memclawd (the on-prem broker) calls against Caura
+cloud:
 
-| Method | Path                     |
-| ------ | ------------------------ |
-| POST   | `/api/v1/memories/bulk`  |
-| POST   | `/api/v1/search`         |
-| GET    | `/api/v1/health`         |
-| GET    | `/api/v1/version`        |
+| Method | Path                            | Broker caller (`internal/cloud`) |
+| ------ | ------------------------------- | -------------------------------- |
+| POST   | `/api/v1/memories/bulk`         | `SaveMemory` (`memory_save`, audit mirror) |
+| POST   | `/api/v1/search`                | `Search` (`memory_search`)       |
+| GET    | `/api/v1/health`                | health probe                     |
+| GET    | `/api/v1/version`               | version handshake                |
+| GET    | `/api/v1/memories`              | `ListMemories` (`memory_list`)   |
+| GET    | `/api/v1/memories/{memory_id}`  | `GetMemory` (`memory_recall`)    |
+| PATCH  | `/api/v1/memories/{memory_id}`  | `UpdateMemory` (`memory_update`) |
+| DELETE | `/api/v1/memories/{memory_id}`  | `DeleteMemory` (`memory_delete`) |
+
+Selection is **method-level** (`BROKER_OPERATIONS` in
+`gen_broker_openapi.py`), not path-level: `/api/v1/memories` also serves POST
+and DELETE, which the broker never calls, and gating those would fail this gate
+on unrelated changes.
 
 The baseline is a **subset** of core-api's full (~91-path) OpenAPI surface:
-only these four paths plus the schema / security components they reach. Its
+only these operations plus the schema / security components they reach. Its
 `info` is normalized to a fixed contract identity (`CONTRACT_VERSION = "v1"`,
 not core-api's rolling package version), so it changes **only when a broker
 endpoint's shape changes** — not on every release.
+
+### Adding a broker endpoint — the cross-repo obligation
+
+**Nothing in this repo can detect that the broker started calling a new cloud
+endpoint.** The gate only protects operations listed in `BROKER_OPERATIONS`;
+one that is missing is simply unguarded, silently. That is how the last four
+rows above went unprotected — the broker's MCP dispatcher was wired to serve
+`memory_recall` / `memory_list` / `memory_update` / `memory_delete`, and the
+baseline was never widened to match.
+
+So when a new `internal/cloud` client method lands in memclawd against a
+core-api endpoint, add it here in the same change. Adding a row is **additive**
+— it only widens what the gate protects, so it does not move
+`CONTRACT_VERSION`. Removing one, or renaming a path/method the broker calls,
+is a breaking contract change and does.
+
+Endpoints the broker calls that live in the **enterprise** stack
+(`/api/v1/installs/*` in platform-auth-api, `POST /api/v1/audit-log` in
+platform-audit-api) have their own per-service baselines in that repo. As of
+2026-08-11 those cover claim / heartbeat / policy-stream / register and the
+audit-log write, but **not** `POST /api/v1/installs/leave` or
+`POST /api/v1/installs/commands/ack`, which the broker also calls.
 
 ### Regenerate
 

--- a/core-api/scripts/gen_broker_openapi.py
+++ b/core-api/scripts/gen_broker_openapi.py
@@ -2,17 +2,28 @@
 """Generate / verify the frozen v1 broker OpenAPI contract for core-api.
 
 The baseline (``core-api/openapi.broker.json``) is the FROZEN v1 contract for
-the four broker-facing gateway endpoints that memclawd (the on-prem broker)
-calls against Caura cloud. It is a *subset* of core-api's full ~91-path
-OpenAPI surface: only the four broker paths plus the schema / security
-components those operations reach (transitively).
+the broker-facing gateway operations that memclawd (the on-prem broker) calls
+against Caura cloud. It is a *subset* of core-api's full ~91-path OpenAPI
+surface: only the broker operations plus the schema / security components
+those operations reach (transitively).
 
-Broker endpoints (gateway paths):
+Broker operations (gateway paths), all of them called by ``internal/cloud``
+in caura-ai/memclawd:
 
-    POST /api/v1/memories/bulk
-    POST /api/v1/search
-    GET  /api/v1/health
-    GET  /api/v1/version
+    POST   /api/v1/memories/bulk
+    POST   /api/v1/search
+    GET    /api/v1/health
+    GET    /api/v1/version
+    GET    /api/v1/memories                  (memory_list)
+    GET    /api/v1/memories/{memory_id}      (memory_recall)
+    PATCH  /api/v1/memories/{memory_id}      (memory_update)
+    DELETE /api/v1/memories/{memory_id}      (memory_delete)
+
+The last four were added once the broker's MCP dispatcher was wired to serve
+``memory_list`` / ``memory_recall`` / ``memory_update`` / ``memory_delete``.
+The tools shipped; the contract baseline was not widened with them, so a
+breaking change to those operations passed this gate. That is the same
+undeclared-contract failure mode as the #723-#736 series, one layer out.
 
 ``info`` is normalized to a fixed contract identity (``CONTRACT_VERSION``)
 rather than core-api's rolling package version, so the baseline only changes
@@ -41,14 +52,40 @@ import json
 import sys
 from pathlib import Path
 
-# The four broker-facing gateway paths that make up the frozen v1 contract.
-# Adding or removing an entry is itself a contract change -- keep in sync with
-# the broker<->cloud API-versioning RFC.
-BROKER_PATHS: tuple[str, ...] = (
-    "/api/v1/memories/bulk",
-    "/api/v1/search",
-    "/api/v1/health",
-    "/api/v1/version",
+# The broker-facing gateway OPERATIONS that make up the frozen v1 contract,
+# as ``path -> methods``. Removing an entry, or renaming a path/method the
+# broker calls, is itself a breaking contract change -- keep in sync with the
+# broker<->cloud API-versioning RFC. ADDING an entry is additive: it only
+# widens what the oasdiff gate protects, so it does not move CONTRACT_VERSION.
+#
+# METHOD-level, not path-level. ``/api/v1/memories`` also serves POST and
+# DELETE, which the broker never calls; gating the whole path item would fail
+# this PR's own gate on unrelated changes to those operations and train people
+# to ignore it.
+#
+# Each entry must correspond to something memclawd actually calls -- see the
+# ``internal/cloud`` client in caura-ai/memclawd:
+#
+#   /memories/bulk        POST    cloud.Client.SaveMemory  (memory_save, mirror)
+#   /search               POST    cloud.Client.Search      (memory_search)
+#   /health               GET     health probe
+#   /version              GET     version handshake
+#   /memories             GET     cloud.Client.ListMemories   (memory_list)
+#   /memories/{memory_id} GET     cloud.Client.GetMemory      (memory_recall)
+#                         PATCH   cloud.Client.UpdateMemory   (memory_update)
+#                         DELETE  cloud.Client.DeleteMemory   (memory_delete)
+BROKER_OPERATIONS: dict[str, tuple[str, ...]] = {
+    "/api/v1/memories/bulk": ("post",),
+    "/api/v1/search": ("post",),
+    "/api/v1/health": ("get",),
+    "/api/v1/version": ("get",),
+    "/api/v1/memories": ("get",),
+    "/api/v1/memories/{memory_id}": ("get", "patch", "delete"),
+}
+
+# Path-item keys that are not operations and must survive filtering.
+_NON_OPERATION_KEYS = frozenset(
+    {"summary", "description", "servers", "parameters", "$ref"}
 )
 
 # Frozen broker-contract version, deliberately decoupled from core-api's
@@ -57,6 +94,11 @@ CONTRACT_VERSION = "v1"
 CONTRACT_TITLE = "MemClaw core-api broker contract"
 
 BASELINE_PATH = Path(__file__).resolve().parent.parent / "openapi.broker.json"
+
+
+def _operation_count() -> int:
+    """Total operations in the contract, for the CLI summary line."""
+    return sum(len(methods) for methods in BROKER_OPERATIONS.values())
 
 
 def _collect_refs(node: object) -> set[str]:
@@ -111,16 +153,31 @@ def build_broker_spec() -> dict:
     full = app.openapi()
     all_paths = full.get("paths", {})
 
-    missing = [p for p in BROKER_PATHS if p not in all_paths]
+    # Verify at METHOD granularity: a path that survives while the operation
+    # the broker calls is renamed or dropped is exactly as breaking as losing
+    # the path, and a path-only check would sail past it.
+    missing = [
+        f"{method.upper()} {path}"
+        for path, methods in BROKER_OPERATIONS.items()
+        for method in methods
+        if method not in all_paths.get(path, {})
+    ]
     if missing:
         raise SystemExit(
-            "gen_broker_openapi: broker path(s) missing from core-api OpenAPI: "
-            + ", ".join(missing)
+            "gen_broker_openapi: broker operation(s) missing from core-api OpenAPI: "
+            + ", ".join(sorted(missing))
             + "\nA broker endpoint was renamed or removed -- that is itself a "
-            "breaking contract change. Update BROKER_PATHS and the RFC."
+            "breaking contract change. Update BROKER_OPERATIONS and the RFC."
         )
 
-    paths = {p: all_paths[p] for p in BROKER_PATHS}
+    paths = {
+        path: {
+            key: value
+            for key, value in all_paths[path].items()
+            if key in methods or key in _NON_OPERATION_KEYS
+        }
+        for path, methods in BROKER_OPERATIONS.items()
+    }
 
     # Transitive closure of components (any type) reachable from the broker
     # paths via ``$ref``, so every reference in the baseline resolves.
@@ -211,12 +268,12 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 1
-        print(f"broker OpenAPI baseline up to date ({len(BROKER_PATHS)} paths).")
+        print(f"broker OpenAPI baseline up to date ({_operation_count()} operations).")
         return 0
 
     out = args.out or BASELINE_PATH
     out.write_text(rendered, encoding="utf-8")
-    print(f"wrote {out} ({len(BROKER_PATHS)} broker paths)")
+    print(f"wrote {out} ({_operation_count()} broker operations)")
     return 0
 
 

--- a/tests/test_broker_contract.py
+++ b/tests/test_broker_contract.py
@@ -1,0 +1,119 @@
+"""Guards on the frozen broker contract baseline (``openapi.broker.json``).
+
+CI already checks that the baseline is fresh (``gen_broker_openapi.py --check``)
+and that it introduces no breaking change vs main (``oasdiff breaking``). What
+neither catches is a broker operation entering the contract with an **untyped**
+response body: oasdiff can only flag a breaking response change against a
+declared shape, so ``"schema": {}`` means the operation is listed in the gate
+while its response is not actually pinned by it.
+
+That is the failure mode this whole baseline exists to prevent — a gate that
+reads as protection and isn't — so the untyped set is an explicit allowlist
+rather than a footnote.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+_BASELINE = (
+    pathlib.Path(__file__).resolve().parent.parent / "core-api" / "openapi.broker.json"
+)
+_METHODS = ("get", "post", "patch", "delete", "put")
+
+# Operations whose 200 body is deliberately NOT pinned by the contract, each
+# with the reason. Adding an entry is a conscious decision to leave a response
+# shape unguarded — that is the point of listing them here.
+#
+#   GET /health, GET /version   — liveness/handshake payloads with no
+#       response_model on the route; trivial, stable shapes.
+#   GET /memories/{memory_id}   — the route hand-builds a ~20-field
+#       ``JSONResponse``. Attaching a ``response_model`` would document a shape
+#       FastAPI does NOT enforce (it skips validation when the handler returns a
+#       Response object), which is worse than untyped: the contract would then
+#       assert a guarantee the code does not make. Typing it properly means
+#       refactoring the handler to return a model, which changes serialization
+#       on a live endpoint and belongs in its own change.
+_UNTYPED_200 = {
+    ("get", "/api/v1/health"),
+    ("get", "/api/v1/version"),
+    ("get", "/api/v1/memories/{memory_id}"),
+}
+
+
+def _baseline() -> dict:
+    return json.loads(_BASELINE.read_text())
+
+
+def _operations():
+    for path, path_item in sorted(_baseline()["paths"].items()):
+        for method, operation in sorted(path_item.items()):
+            if method in _METHODS:
+                yield method, path, operation
+
+
+@pytest.mark.unit
+def test_every_broker_response_is_typed_or_explicitly_allowlisted() -> None:
+    """A contract entry with an untyped 200 body is not actually pinned by it."""
+    untyped = set()
+    for method, path, operation in _operations():
+        body = (operation.get("responses", {}).get("200", {}).get("content") or {}).get(
+            "application/json"
+        )
+        # No 200 content at all (e.g. DELETE returns 204) is not an untyped body.
+        if body is not None and not body.get("schema"):
+            untyped.add((method, path))
+
+    unexpected = untyped - _UNTYPED_200
+    assert not unexpected, (
+        "broker operation(s) added to the frozen contract with an UNTYPED 200 body: "
+        + ", ".join(f"{m.upper()} {p}" for m, p in sorted(unexpected))
+        + ". oasdiff cannot detect a breaking response change without a declared "
+        "shape, so listing these in the contract does not protect their responses. "
+        "Give the route a response_model it genuinely honours, or add it to "
+        "_UNTYPED_200 with the reason."
+    )
+
+    # The allowlist must not outlive the problem: an entry that is now typed
+    # should be removed, or it quietly permits a future regression.
+    stale = _UNTYPED_200 - untyped
+    assert not stale, (
+        "allowlisted operation(s) now have a typed 200 body — remove them from "
+        "_UNTYPED_200 so it keeps meaning something: "
+        + ", ".join(f"{m.upper()} {p}" for m, p in sorted(stale))
+    )
+
+
+@pytest.mark.unit
+def test_baseline_operations_match_the_generator_table() -> None:
+    """The committed baseline must contain exactly ``BROKER_OPERATIONS``.
+
+    ``--check`` in CI regenerates and compares, which covers this too; asserting
+    it here means a hand-edited baseline fails in the local test run rather than
+    only on the runner.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_gen_broker_openapi",
+        _BASELINE.parent / "scripts" / "gen_broker_openapi.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    declared = {
+        (method, path)
+        for path, methods in module.BROKER_OPERATIONS.items()
+        for method in methods
+    }
+    present = {(method, path) for method, path, _ in _operations()}
+    assert present == declared, (
+        f"baseline drifted from BROKER_OPERATIONS.\n"
+        f"  in baseline only: {sorted(present - declared)}\n"
+        f"  in table only:    {sorted(declared - present)}\n"
+        f"Regenerate with core-api/scripts/gen_broker_openapi.py."
+    )


### PR DESCRIPTION
## The gap

`core-api/openapi.broker.json` exists so that a breaking change to a broker-facing
endpoint fails CI. **It covered 4 operations. The broker calls 8.**

Once memclawd's MCP dispatcher was wired to serve `memory_recall`, `memory_list`,
`memory_update` and `memory_delete` — all five capability interfaces are live in
`newCloudDispatcher` today — the broker started depending on:

| | | broker caller |
|---|---|---|
| `GET` | `/api/v1/memories` | `cloud.Client.ListMemories` (`memory_list`) |
| `GET` | `/api/v1/memories/{memory_id}` | `cloud.Client.GetMemory` (`memory_recall`) |
| `PATCH` | `/api/v1/memories/{memory_id}` | `cloud.Client.UpdateMemory` (`memory_update`) |
| `DELETE` | `/api/v1/memories/{memory_id}` | `cloud.Client.DeleteMemory` (`memory_delete`) |

The baseline was never widened, so a breaking change to any of them **passed the gate
silently**. This is the same failure mode as the #723–#736 series, one layer out: the
code grew a dependency and nothing declared it.

## Method-level, not path-level

`BROKER_OPERATIONS` is now `path -> methods`. `/api/v1/memories` also serves POST and
DELETE that the broker never calls — gating the whole path item would fail this gate on
unrelated changes to those operations, which is how a gate gets trained into noise.

The missing-operation preflight checks methods too. A path that survives while the
operation the broker calls is renamed is exactly as breaking as losing the path, and the
old path-only check sailed straight past it. Verified by adding a `PUT` the app doesn't
serve:

```
gen_broker_openapi: broker operation(s) missing from core-api OpenAPI: PUT /api/v1/memories
```

## Additive — `CONTRACT_VERSION` stays v1

This widens what the gate *protects*; it changes no API shape. Verified three ways:

- the four pre-existing path items are **byte-identical**, nothing removed
- `info` unchanged (`v1`)
- **the real gate passes**: I ran the exact CI oasdiff image *and digest* against main's
  baseline → `No breaking changes to report`, exit 0 (4 ops → 8 ops)

## Docs, because a list in a comment is what went stale

`ci.yml`'s comment enumerated four endpoints while the broker had grown to eight. It now
points at `BROKER_OPERATIONS` rather than restating it.

`core-api/scripts/README.md` gains the **cross-repo obligation** that caused this gap:
nothing in this repo can detect that the broker started calling a new cloud endpoint, so
a new `internal/cloud` client method must add its row here in the same change.

## Same gap in the other repo — not fixed here

Enterprise has its own per-service broker baselines. As of 2026-08-11 they cover
`/installs/{claim,heartbeat,policy/stream,register}` and `POST /api/v1/audit-log`, but
**not** `POST /api/v1/installs/leave` or `POST /api/v1/installs/commands/ack`, which the
broker calls from `internal/cloud/leave.go` and `internal/cloud/command_ack.go`. That
needs a separate enterprise PR; recorded in the README so it isn't lost.

## Verification

- `tests/`: **4187 passed, 3 skipped, 1 xfailed**; `core-storage-api/tests/`: **116 passed**
- mypy clean both projects; ruff clean at all four CI scopes; `plugin/tools.json` byte-identical
- `gen_broker_openapi.py` and `--check` both clean (8 operations)
- `actionlint` on `ci.yml`: **1 finding before my change, 1 after** — pre-existing, not
  introduced. (My first comparison showed 0-vs-1 and was wrong: actionlint skips files
  outside a workflows path, so the baseline run had silently linted nothing.)