### PR TITLE
CAURA-704 feat(doc): mint a memory carrying doc content on every doc …

### DIFF
--- a/core-api/src/core_api/agent_ids.py
+++ b/core-api/src/core_api/agent_ids.py
@@ -28,6 +28,19 @@ INSIGHTER_AGENT_ID = "memclaw-insighter"
 # route trust gate, so this is future-proofing for any gated re-route.
 INSIGHTER_TRUST_LEVEL = 3
 
+# Fallback identity for the memory minted from a document write, used ONLY when
+# the caller carries no agent identity at all (the REST ``POST /documents`` path
+# without a gateway-stamped ``X-Agent-ID``; the MCP path always has one). Same
+# reasoning as ``INSIGHTER_AGENT_ID``: a stable registerable service identity
+# rather than the anonymous default, and self-registered per tenant on first use
+# via ``get_or_create_agent``.
+#
+# Prefer the real doc writer's agent_id whenever there is one. Attribution is not
+# cosmetic here: ``memclaw_insights`` defaults to ``scope="agent"``, which filters
+# ``Memory.agent_id == agent_id``, so rows attributed to this service identity are
+# invisible to every real agent's default insights run.
+DOC_INDEXER_AGENT_ID = "memclaw-doc-indexer"
+
 # Bare ``"main"`` is the OpenClaw plugin's *unset* default agent_id: when an
 # operator never sets ``MEMCLAW_AGENT_ID`` every install collapses onto this one
 # shared identity (the eToro "firehose"). Unlike ``DEFAULT_AGENT_ID``

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -171,6 +171,37 @@ MAX_CONTENT_LENGTH = 10000
 CHUNKING_THRESHOLD_CHARS = 2000  # content above this triggers auto-chunking
 MAX_QUERY_LENGTH = 5000
 
+# ── Doc-derived memories ──
+# ``memclaw_doc(op="write")`` mints a memory carrying the document body so the
+# body becomes reachable by MEANING (recall / recall-brief read
+# ``memories.content`` directly). Docs themselves are only searchable via their
+# ``data["summary"]`` embedding, and ``memclaw_recall`` never returns documents.
+#
+# The memory content is the doc body VERBATIM, so the cutoff is simply the
+# memory schema ceiling: mint whenever the body fits in a memory at all.
+# Over-cutoff bodies are SKIPPED rather than truncated — a truncated body reads
+# as complete and would produce confidently wrong downstream conclusions.
+DOC_MEMORY_MAX_CHARS = MAX_CONTENT_LENGTH
+
+# NOTE: there is deliberately no ``DOC_MEMORY_TYPE``. Doc-derived memories pass
+# no ``memory_type`` at all, so the enrichment classifier assigns one per
+# document — a decision record becomes ``decision``, a runbook ``rule``, an
+# incident writeup ``episode``. Pinning every document to a single type would
+# throw that away. (And ``reference`` was never an option: it is not a
+# MemoryType, and the ``memories_memory_type_check`` CHECK constraint from
+# migration 013 would reject it.)
+
+# Provenance only — written to ``memories.source_uri`` as
+# ``memclaw-doc://<collection>/<doc_id>``. Nothing queries it yet (that would
+# need a storage-side filter + index); it exists so a later reconciliation
+# mechanism has a stable key to match a doc to the memories minted from it.
+DOC_MEMORY_URI_SCHEME = "memclaw-doc"
+
+assert DOC_MEMORY_MAX_CHARS <= MAX_CONTENT_LENGTH, (
+    "DOC_MEMORY_MAX_CHARS must not exceed MemoryCreate.content max_length "
+    f"({MAX_CONTENT_LENGTH}) — an over-cap spec would fail schema validation."
+)
+
 # ── Tool surface bookkeeping ──
 # Tool descriptions live inline in `core_api/tools/memclaw_*.py` spec
 # modules (the SoT). Nothing else should hold a copy.

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1638,6 +1638,12 @@ async def memclaw_doc(
                     return _with_latency(
                         _error_response("INVALID_ARGUMENTS", "op=write requires 'data'."), t0
                     )
+                # ``collection`` is guaranteed non-empty here by the op-level
+                # guard above (write is not in the {list_collections, search}
+                # exemption set), but that guard is too far away for the type
+                # checker to narrow through. Rebind so the derivation helpers
+                # below take a plain ``str``.
+                write_collection: str = collection or ""
                 # Skills slug rule — doc_id becomes a filesystem directory
                 # on the plugin side, so it must be filesystem-safe.
                 if collection == SKILLS_COLLECTION and not _SKILL_SLUG_RE.fullmatch(doc_id):
@@ -1787,11 +1793,13 @@ async def memclaw_doc(
                 # (doc won't appear in op=search).
                 from core_api.services.doc_indexing import (
                     InvalidDocIndexingError,
+                    resolve_doc_memory,
                     resolve_embed_source,
                 )
+                from core_api.services.doc_memory import safe_sync_doc_memory
 
                 try:
-                    source = resolve_embed_source(collection, data)
+                    source = resolve_embed_source(write_collection, data)
                 except InvalidDocIndexingError as exc:
                     return _with_latency(_error_response("INVALID_ARGUMENTS", str(exc)), t0)
                 embedding: list[float] | None = None
@@ -1836,6 +1844,31 @@ async def memclaw_doc(
                 # Storage returns ``{id, created_at, updated_at, xmax}``; ``xmax
                 # == 0`` ⇒ INSERT (new), else the on-conflict UPDATE fired.
                 is_new = int(row["xmax"]) == 0
+                # Mint a memory carrying the document body so the BODY becomes
+                # reachable by meaning (only ``data["summary"]`` is embedded on
+                # the doc row, and ``memclaw_recall`` never returns documents).
+                # Runs on every write, not just inserts — see
+                # ``services.doc_memory`` for why that isn't as duplicative as
+                # it sounds. Never raises: the doc is already committed and is
+                # the source of truth.
+                try:
+                    doc_memory_spec = resolve_doc_memory(
+                        write_collection, doc_id, data, updated_at=row.get("updated_at")
+                    )
+                    if doc_memory_spec is not None:
+                        await safe_sync_doc_memory(
+                            doc_memory_spec,
+                            tenant_id=tenant_id,
+                            fleet_id=fleet_id,
+                            agent_id=agent_id,
+                        )
+                except Exception:
+                    # Belt-and-braces over ``safe_sync_doc_memory``'s own
+                    # non-raising contract. The document is committed; without
+                    # this, a regression in the mint path would surface to the
+                    # caller as a FAILED doc write, which is the one outcome
+                    # this feature must never cause.
+                    logger.exception("doc memory mint failed for %s/%s", collection, doc_id)
                 return _with_latency(
                     json.dumps(
                         {

--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -267,8 +267,10 @@ async def upsert_document(
     # back-compat. See core_api.services.doc_indexing for the contract.
     from core_api.services.doc_indexing import (
         InvalidDocIndexingError,
+        resolve_doc_memory,
         resolve_embed_source,
     )
+    from core_api.services.doc_memory import safe_sync_doc_memory
 
     try:
         source = resolve_embed_source(body.collection, body.data)
@@ -321,6 +323,28 @@ async def upsert_document(
         )
     if doc is None:
         raise HTTPException(status_code=500, detail="Document upsert returned no rows")
+    # Mint a memory carrying the document body so the BODY becomes reachable by
+    # meaning (only data["summary"] is embedded on the doc row, and
+    # ``memclaw_recall`` never returns documents). Both upsert branches above
+    # converge here, so this one call covers indexed and unindexed writes.
+    # Never raises: the doc is already committed and is the source of truth.
+    try:
+        doc_memory_spec = resolve_doc_memory(
+            body.collection, body.doc_id, body.data, updated_at=doc.get("updated_at")
+        )
+        if doc_memory_spec is not None:
+            await safe_sync_doc_memory(
+                doc_memory_spec,
+                tenant_id=body.tenant_id,
+                fleet_id=body.fleet_id,
+                agent_id=getattr(auth, "agent_id", None),
+            )
+    except Exception:
+        # Belt-and-braces over ``safe_sync_doc_memory``'s own non-raising
+        # contract. The document is committed; without this, a regression in the
+        # mint path would surface to the caller as a FAILED doc write, which is
+        # the one outcome this feature must never cause.
+        logger.exception("doc memory mint failed for %s/%s", body.collection, body.doc_id)
     await log_action(
         tenant_id=body.tenant_id,
         action="doc_upsert",

--- a/core-api/src/core_api/services/doc_indexing.py
+++ b/core-api/src/core_api/services/doc_indexing.py
@@ -1,12 +1,12 @@
-"""Resolve which string in a doc's ``data`` payload gets embedded.
+"""Doc-write derivation rules: what gets embedded, and what memory to mint.
 
 Single source of truth shared by the MCP ``memclaw_doc(op="write")``
-handler and the REST ``POST /documents`` route. Keeping the rule in
-one place prevents the two surfaces from drifting on what counts as
-the embed source — they handle the resulting error in their own
-native style (JSON envelope vs. HTTPException) but agree on the rule.
+handler and the REST ``POST /documents`` route. Keeping the rules in
+one place prevents the two surfaces from drifting — they handle the
+resulting error in their own native style (JSON envelope vs.
+HTTPException) but agree on the rules themselves.
 
-Contract:
+Embed-source contract (``resolve_embed_source``):
 - The only embeddable field is ``data["summary"]``.
 - For ``collection == "skills"``, ``data["description"]`` is honored
   as a back-compat fallback so existing skill catalogs keep working
@@ -17,11 +17,35 @@ Contract:
 - All other collections may omit a summary; the doc is then stored
   without an embedding (same shape as the old ``embed_field=None``
   path).
+
+Doc-memory contract (``resolve_doc_memory``):
+- A doc write also mints a memory carrying the document body verbatim,
+  because the two stores are not cross-searched: ``memclaw_recall``
+  never returns documents, and only ``data["summary"]`` is embedded on
+  the document row. The minted memory is what makes the *body*
+  reachable by meaning.
+- Independent of the embed rule: a doc with no ``summary`` is stored
+  unindexed (invisible to ``op=search``) yet still mints a memory, so
+  recall can reach the body even when doc-search cannot.
 """
 
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+from core_api.constants import DOC_MEMORY_MAX_CHARS, DOC_MEMORY_URI_SCHEME
+
+logger = logging.getLogger(__name__)
+
 SKILLS_COLLECTION = "skills"
+
+# Field names checked, in order, for the document body. ``content`` is the
+# convention advertised in the ``memclaw_doc`` tool description ("The full body
+# lives wherever the caller puts it (e.g. data['content'])"); ``body`` is
+# accepted as the obvious synonym.
+_BODY_FIELDS: tuple[str, ...] = ("content", "body")
 
 
 class InvalidDocIndexingError(ValueError):
@@ -56,3 +80,112 @@ def resolve_embed_source(collection: str, data: dict) -> str | None:
     if not summary_ok:
         raise InvalidDocIndexingError("data['summary'], when present, must be a non-empty string.")
     return summary
+
+
+@dataclass(frozen=True)
+class DocMemorySpec:
+    """The memory to mint for one document write.
+
+    ``content`` is the document body VERBATIM — no prefix, no wrapper, no
+    summary header. Whitespace and markdown structure are preserved exactly as
+    the caller stored them, so the memory is a faithful copy of the doc rather
+    than a rendering of it.
+    """
+
+    content: str
+    source_uri: str
+    metadata: dict
+
+
+def _resolve_body(data: dict) -> str | None:
+    """First non-empty string among ``_BODY_FIELDS``, else ``None``."""
+    for field in _BODY_FIELDS:
+        value = data.get(field)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def resolve_doc_memory(
+    collection: str,
+    doc_id: str,
+    data: dict,
+    *,
+    updated_at: datetime | str | None = None,
+) -> DocMemorySpec | None:
+    """Return the memory spec for this doc write, or ``None`` to skip.
+
+    Mirrors ``resolve_embed_source``'s role: ONE rule, both surfaces. Never
+    raises — an undecidable input is a skip, because failing here must not fail
+    the document write that triggered it.
+
+    Skips when:
+      * ``collection == "skills"`` — skills have their own discovery path
+        (``op=search collection=skills``) plus a staged -> active approval
+        lifecycle. Minting a memory would make an unapproved skill's body
+        recallable, routing around that lifecycle.
+      * ``collection`` starts with ``_`` — system-managed (e.g. ``_keystones``);
+        storage rejects public writes to these anyway.
+      * no non-empty body — nothing to carry. This is also what keeps bulk
+        structured records (``{"plan": "business", "seats": 40}``) from minting
+        memories: they have no body field.
+      * body longer than ``DOC_MEMORY_MAX_CHARS`` — would not fit in a memory.
+        Skipped rather than truncated: a truncated body reads as complete.
+
+    ``data["summary"]`` is deliberately NOT required. It gates *doc* indexing
+    (``resolve_embed_source``), not memory minting — a summary-less doc is
+    invisible to ``op=search`` but its body is still worth recalling. When a
+    summary is present it is carried in metadata for provenance.
+
+    Every skip is logged, because all four look identical from the outside — a
+    document with no memory gives an operator no clue which rule fired, or
+    whether the mint threw instead. Levels are deliberately split: the size skip
+    is INFO (rare, surprising, and the operator probably wants the body indexed),
+    the rest are DEBUG (routine and high-volume — every bulk structured record
+    hits the no-body branch, and logging those at INFO would be pure noise).
+    """
+    if collection == SKILLS_COLLECTION or collection.startswith("_"):
+        logger.debug(
+            "doc_memory: no mint for %s/%s — collection is skills or system-managed",
+            collection,
+            doc_id,
+        )
+        return None
+
+    body = _resolve_body(data)
+    if body is None:
+        logger.debug(
+            "doc_memory: no mint for %s/%s — no non-empty %s field",
+            collection,
+            doc_id,
+            " / ".join(f"data[{f!r}]" for f in _BODY_FIELDS),
+        )
+        return None
+    if len(body) > DOC_MEMORY_MAX_CHARS:
+        # INFO: the doc IS stored and (with a summary) searchable, but its body
+        # is unreachable by recall. Skipped rather than truncated — a truncated
+        # body reads as complete and yields confidently wrong conclusions.
+        logger.info(
+            "doc_memory: no mint for %s/%s — body is %d chars, over the %d limit "
+            "(document stored; body not recallable)",
+            collection,
+            doc_id,
+            len(body),
+            DOC_MEMORY_MAX_CHARS,
+        )
+        return None
+
+    metadata: dict = {"doc_collection": collection, "doc_id": doc_id}
+    summary = data.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        metadata["doc_summary"] = summary
+    if updated_at is not None:
+        metadata["doc_updated_at"] = (
+            updated_at.isoformat() if isinstance(updated_at, datetime) else str(updated_at)
+        )
+
+    return DocMemorySpec(
+        content=body,
+        source_uri=f"{DOC_MEMORY_URI_SCHEME}://{collection}/{doc_id}",
+        metadata=metadata,
+    )

--- a/core-api/src/core_api/services/doc_memory.py
+++ b/core-api/src/core_api/services/doc_memory.py
@@ -1,0 +1,258 @@
+"""Mint a memory carrying a document's body on every document write.
+
+Why this exists
+---------------
+The two stores are not cross-searched: ``memclaw_recall`` never returns
+documents, and a document row embeds only ``data["summary"]`` — never its body.
+So a document's *content* is unreachable by meaning; you can only find it if you
+already know its ``collection`` + ``doc_id``. Minting a memory that carries the
+body verbatim closes that gap for the paths that read ``memories.content``
+directly (``memclaw_recall`` and the recall brief, neither of which truncates).
+
+Rewrite semantics come free from ``write_mode="fast"``
+-----------------------------------------------------
+Every doc write runs this same path — there is no create-vs-update branch and no
+lookup of previously minted rows. That is not as duplicative as it sounds,
+because the fast write pipeline (``pipeline/compositions/write.py``) already
+runs ``CheckExactDuplicate`` then ``DetectNearDuplicate``:
+
+  * identical body      -> ``CheckExactDuplicate`` raises 409, no row is written.
+                           Idempotent doc re-syncs self-dedupe.
+  * changed body, close -> row is written PLUS ``metadata["near_duplicate_of"]``
+                           pointing at the previous version (advisory only at
+                           ``SEMANTIC_DEDUP_JUDGE_THRESHOLD``; it does not reject).
+  * changed body, far   -> row is written, no link.
+
+Known limitation: nothing outdates or supersedes the older rows, so a doc edited
+N times leaves N active memories and recall can surface several versions.
+``metadata["near_duplicate_of"]`` is the thread a future reconciliation pass
+would follow.
+
+Contract for callers
+--------------------
+Use ``safe_sync_doc_memory``. It never raises: the document is the source of
+truth and must never fail to persist because a derived memory could not be
+written.
+
+Latency: this runs INLINE, deliberately
+---------------------------------------
+``write_mode="fast"`` defers only ENRICHMENT (the LLM call). Everything else in
+the write pipeline still runs awaited inside the caller's request:
+``ParallelEmbedEnrich`` (embedding), ``CheckExactDuplicate``,
+``DetectNearDuplicate``, ``WriteMemoryRow``. Measured on a VM against real
+providers, that is ~210 ms per document write:
+
+    write_mode=fast  embedding_ms=151  dedup_lookup_ms=9  storage_ms=16
+    total_ms=210     enrichment_pending=True
+
+plus a ``resolve_config`` read and a ``get_or_create_agent`` upsert. So a doc
+write that previously only embedded a short summary now costs ~210 ms more.
+
+Accepted for now. The handlers are ``async def`` and every wait is on I/O, so
+the event loop keeps serving other requests throughout — the cost is added to
+the calling request's response, not to server throughput. For interactive
+one-document-at-a-time writes that is not worth optimising.
+
+Deliberately NOT moved to ``track_task``, which is ``asyncio.create_task`` —
+same process, no queue and no durability. Backgrounding would hide the 210 ms
+but would also mean a doc write can return 200 while its memory never
+materialises: nothing retries, and ``cancel_all_tasks()`` kills in-flight tasks
+on shutdown, so a write landing during a deploy would silently lose its memory.
+Today a 200 guarantees the memory exists, which is the stronger property.
+
+Revisit if bulk doc sync becomes a real workload — at ~210 ms each, 10k
+documents is ~35 minutes of added wall-clock. The cheapest win then is dropping
+the unconditional ``get_or_create_agent`` round-trip (on the MCP path
+``enforce_fleet_write`` has already registered the caller), before reaching for
+a durable queue.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException
+
+from core_api.agent_ids import DOC_INDEXER_AGENT_ID
+from core_api.constants import CHUNKING_THRESHOLD_CHARS
+from core_api.services.doc_indexing import DocMemorySpec
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_doc_memory_agent(
+    tenant_id: str,
+    caller_agent_id: str | None,
+    fleet_id: str | None,
+) -> str:
+    """Identity to attribute the minted memory to, registered if new.
+
+    Prefers the real document writer. Attribution is not cosmetic:
+    ``memclaw_insights`` defaults to ``scope="agent"``, which filters
+    ``Memory.agent_id == agent_id``, so a row attributed to the service identity
+    is invisible to every real agent's default insights run.
+
+    Falls back to ``DOC_INDEXER_AGENT_ID`` only when the caller has no identity
+    at all (REST ``POST /documents`` with no gateway-stamped ``X-Agent-ID``).
+
+    Registration is unconditional, and that matters. The MCP write path calls
+    ``enforce_fleet_write`` before minting, which registers the caller on first
+    contact — but REST ``POST /documents`` has no equivalent step. Returning the
+    caller's id without registering it produced a memory attributed to an
+    identity with no ``agents`` row, which ``memclaw_insights`` then refuses to
+    run for ("Agent X is not registered"), making the minted memory unreachable
+    by the default ``scope="agent"`` pass. Found in the wet test on
+    ``eyal-wet-tests``. ``get_or_create_agent`` is an idempotent upsert, so the
+    MCP path just re-asserts what ``enforce_fleet_write`` already did.
+    """
+    from core_api.services.agent_service import get_or_create_agent
+
+    agent_id = caller_agent_id or DOC_INDEXER_AGENT_ID
+    await get_or_create_agent(
+        tenant_id,
+        agent_id,
+        fleet_id,
+        display_name=None if caller_agent_id else "MemClaw Doc Indexer",
+    )
+    return agent_id
+
+
+async def sync_doc_memory(
+    spec: DocMemorySpec,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    agent_id: str | None,
+) -> str | None:
+    """Write the doc-derived memory. Returns its id, or ``None`` if skipped.
+
+    Raises on failure — callers should use ``safe_sync_doc_memory``.
+    """
+    from core_api.schemas import MemoryCreate
+    from core_api.services.memory_service import create_memory
+    from core_api.services.organization_settings import resolve_config
+
+    # Auto-chunk guard. When the tenant has enabled chunking and the body is
+    # over the threshold, ``create_memory`` writes a parent PLUS N child
+    # memories that all inherit this same ``source_uri``. Nothing is lost (the
+    # parent keeps the full body), but one doc then maps to N+1 rows, which
+    # defeats the provenance key and multiplies the recall footprint. Skip
+    # instead. Inert for nearly every tenant: ``auto_chunk_enabled`` defaults
+    # to False.
+    #
+    # KNOWN TRADEOFF, chosen deliberately for simplicity: skipping means a
+    # tenant with ``auto_chunk_enabled=True`` gets NO recall-reachable memory
+    # for any body over ``CHUNKING_THRESHOLD_CHARS`` — and those are exactly the
+    # tenants who opted in because they write long content, so the feature is
+    # weakest where it would matter most. Letting chunking run would in fact
+    # work (the parent row carries the verbatim body and this ``source_uri``),
+    # so this guard buys one-row-per-doc rather than correctness. Revisit
+    # together with the doc-version reconciliation pass, which has to handle
+    # multiple rows per ``source_uri`` anyway.
+    tenant_config = await resolve_config(tenant_id)
+    if tenant_config.auto_chunk_enabled and len(spec.content) > CHUNKING_THRESHOLD_CHARS:
+        logger.info(
+            "doc_memory: skipped mint for %s (auto-chunking enabled and body is %d chars)",
+            spec.source_uri,
+            len(spec.content),
+        )
+        return None
+
+    resolved_agent_id = await resolve_doc_memory_agent(tenant_id, agent_id, fleet_id)
+
+    created = await create_memory(
+        MemoryCreate(
+            tenant_id=tenant_id,
+            fleet_id=fleet_id,
+            agent_id=resolved_agent_id,
+            # ``memory_type`` is deliberately NOT passed — the enrichment
+            # classifier owns it. A document is not one kind of thing: a
+            # decision record classifies as ``decision``, a runbook as ``rule``,
+            # an incident writeup as ``episode``. Forcing every doc to ``fact``
+            # would discard that. Because we don't pass it, it never enters
+            # ``model_fields_set`` and so never reaches
+            # ``agent_provided_fields`` — the classifier's value stands.
+            #
+            # Consequence to be aware of: the row is INSERTed with the schema
+            # default (``fact``) and the real type lands when enrichment
+            # completes a few seconds later, so a reader in that window sees
+            # ``fact``. Per-type ``TYPE_DECAY_DAYS`` also means doc memories
+            # will decay at different rates depending on how they classified.
+            content=spec.content,
+            source_uri=spec.source_uri,
+            metadata=spec.metadata,
+            visibility="scope_team",
+            # ``status``, by contrast, IS pinned — it is lifecycle state, not a
+            # semantic category, and "active" is simply correct: this row
+            # mirrors the CURRENT content of a live document.
+            #
+            # The enrichment prompt offers "active" | "pending" | "confirmed"
+            # and picks per content (a runbook reads as "confirmed"), while
+            # ``insights_query_patterns`` — and stale/failures — select
+            # ``status == "active"`` only. Left to the classifier, whether a
+            # document ever reaches insights would hinge on a non-deterministic
+            # per-document choice: prose lands "active" and is visible, an
+            # operational rule lands "confirmed" and is silently invisible.
+            # Observed in the wet test on ``eyal-wet-tests``: a runbook body
+            # produced status="confirmed" and insights returned
+            # memories_analyzed=0.
+            #
+            # The pin holds because of CAURA-716: the inline enrichment path
+            # used to drop ``agent_provided_fields`` and infer caller intent
+            # from value-vs-default, which cannot see a field pinned TO its own
+            # default — so this exact ``status="active"`` was silently
+            # overwritten. Don't reintroduce that heuristic.
+            status="active",
+            # ``fast`` deliberately, and it is load-bearing: it skips the strong
+            # path's inline ``CheckSemanticDuplicate`` (which 409-rejects at
+            # 0.95) while keeping ``CheckExactDuplicate`` and the advisory
+            # ``DetectNearDuplicate``. That combination is exactly the rewrite
+            # behaviour described in the module docstring.
+            write_mode="fast",
+        )
+    )
+    logger.info("doc_memory: minted %s for %s", created.id, spec.source_uri)
+    return str(created.id)
+
+
+async def safe_sync_doc_memory(
+    spec: DocMemorySpec,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    agent_id: str | None,
+) -> str | None:
+    """``sync_doc_memory`` that never raises.
+
+    The document write has already committed by the time this runs. The document
+    is the source of truth, so a failure to derive a memory from it must not turn
+    a successful write into an error for the caller.
+    """
+    try:
+        return await sync_doc_memory(
+            spec,
+            tenant_id=tenant_id,
+            fleet_id=fleet_id,
+            agent_id=agent_id,
+        )
+    except HTTPException as exc:
+        if exc.status_code == 409:
+            # EXPECTED on an idempotent doc re-write: the body is byte-identical
+            # to an existing memory, so ``CheckExactDuplicate`` rejected it and
+            # the memory we would have created already exists. Not a failure —
+            # log at info so a no-op re-sync does not emit a stack trace.
+            logger.info(
+                "doc_memory: memory already exists for %s (identical content)",
+                spec.source_uri,
+            )
+        else:
+            logger.warning(
+                "doc_memory: mint failed for %s (%s): %s",
+                spec.source_uri,
+                exc.status_code,
+                exc.detail,
+            )
+        return None
+    except Exception:
+        logger.exception("doc_memory: mint failed for %s", spec.source_uri)
+        return None

--- a/tests/test_doc_memory_spec.py
+++ b/tests/test_doc_memory_spec.py
@@ -1,0 +1,266 @@
+"""Unit tests for ``resolve_doc_memory`` — the doc -> memory derivation rule.
+
+Pure function, no I/O. This is the single source of truth shared by the MCP
+``memclaw_doc(op="write")`` handler and the REST ``POST /documents`` route, so
+these tests pin the contract both surfaces depend on.
+
+Covers:
+- The four skip conditions (skills / system collection / no body / over cap).
+- Content is the doc body VERBATIM — byte-for-byte, whitespace and markdown
+  preserved. This is the whole point of the feature; a regression here silently
+  degrades every downstream consumer.
+- A doc with NO ``summary`` still mints (summary gates *doc* indexing, not
+  memory minting).
+- The ``DOC_MEMORY_MAX_CHARS`` boundary: at the cap mints, one over skips —
+  never raises, so the document write it hangs off can never fail on size.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from core_api.constants import DOC_MEMORY_MAX_CHARS, MAX_CONTENT_LENGTH
+from core_api.services.doc_indexing import DocMemorySpec, resolve_doc_memory
+
+pytestmark = [pytest.mark.unit]
+
+
+def _data(**extra) -> dict:
+    d = {"summary": "Postgres tuning runbook: vacuum, autovacuum, work_mem."}
+    d.update(extra)
+    return d
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+def test_mints_spec_for_ordinary_doc():
+    spec = resolve_doc_memory("runbooks", "pg-tuning", _data(content="body text"))
+    assert isinstance(spec, DocMemorySpec)
+    assert spec.content == "body text"
+    assert spec.source_uri == "memclaw-doc://runbooks/pg-tuning"
+    assert spec.metadata["doc_collection"] == "runbooks"
+    assert spec.metadata["doc_id"] == "pg-tuning"
+
+
+def test_content_is_byte_for_byte_verbatim():
+    """No prefix, no wrapper, no summary header, no whitespace normalisation.
+
+    The memory is a faithful copy of the doc body, not a rendering of it.
+    """
+    body = "# Runbook\n\n## Vacuum\n\n  - run VACUUM ANALYZE nightly\n\n\ttabbed\n"
+    spec = resolve_doc_memory("runbooks", "pg", _data(content=body))
+    assert spec is not None
+    assert spec.content == body
+    # Guard against a summary prefix creeping back in.
+    assert not spec.content.startswith(_data()["summary"])
+
+
+def test_summary_is_carried_in_metadata_not_content():
+    spec = resolve_doc_memory("runbooks", "pg", _data(content="body"))
+    assert spec is not None
+    assert spec.metadata["doc_summary"] == _data()["summary"]
+    assert "summary" not in spec.content
+
+
+def test_body_field_fallback():
+    """``data["body"]`` is accepted when ``data["content"]`` is absent."""
+    spec = resolve_doc_memory("notes", "n1", {"body": "via body field"})
+    assert spec is not None
+    assert spec.content == "via body field"
+
+
+def test_content_wins_over_body_when_both_present():
+    spec = resolve_doc_memory(
+        "notes", "n1", {"content": "primary", "body": "secondary"}
+    )
+    assert spec is not None
+    assert spec.content == "primary"
+
+
+def test_updated_at_is_stamped_when_supplied():
+    from datetime import UTC, datetime
+
+    ts = datetime(2026, 8, 4, 12, 0, tzinfo=UTC)
+    spec = resolve_doc_memory("runbooks", "pg", _data(content="b"), updated_at=ts)
+    assert spec is not None
+    assert spec.metadata["doc_updated_at"] == ts.isoformat()
+
+
+def test_updated_at_omitted_when_not_supplied():
+    spec = resolve_doc_memory("runbooks", "pg", _data(content="b"))
+    assert spec is not None
+    assert "doc_updated_at" not in spec.metadata
+
+
+# ── Skip conditions ───────────────────────────────────────────────────────────
+
+
+def test_skips_skills_collection():
+    """Skills have their own discovery path AND a staged -> active approval
+    lifecycle. Minting would make an unapproved skill's body recallable,
+    routing around that lifecycle."""
+    assert resolve_doc_memory("skills", "my-skill", _data(content="body")) is None
+
+
+@pytest.mark.parametrize("collection", ["_keystones", "_internal", "_"])
+def test_skips_system_collections(collection):
+    assert resolve_doc_memory(collection, "x", _data(content="body")) is None
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"summary": "S"},  # no body key at all
+        {"summary": "S", "content": ""},  # empty
+        {"summary": "S", "content": "   \n\t "},  # whitespace only
+        {"summary": "S", "content": 42},  # non-string
+        {"summary": "S", "content": None},
+        {"plan": "business", "seats": 40},  # bulk structured record
+    ],
+)
+def test_skips_when_no_usable_body(data):
+    assert resolve_doc_memory("customers", "acme", data) is None
+
+
+def test_bulk_structured_record_is_the_blast_radius_limit():
+    """A structured record carries no body, so dropping the summary gate does
+    NOT turn every customer/config row into a memory."""
+    assert (
+        resolve_doc_memory("customers", "acme", {"plan": "business", "seats": 40})
+        is None
+    )
+
+
+# ── Summary is NOT required ───────────────────────────────────────────────────
+
+
+def test_mints_without_summary():
+    """``summary`` gates *doc* indexing (resolve_embed_source), not minting.
+
+    A summary-less doc is invisible to ``op=search`` but its body is still
+    worth recalling, so the memory is minted regardless.
+    """
+    spec = resolve_doc_memory("notes", "n1", {"content": "no summary here"})
+    assert spec is not None
+    assert spec.content == "no summary here"
+    assert "doc_summary" not in spec.metadata
+
+
+@pytest.mark.parametrize("summary", ["", "   ", None, 42, {"nested": "dict"}])
+def test_unusable_summary_still_mints(summary):
+    spec = resolve_doc_memory("notes", "n1", {"summary": summary, "content": "body"})
+    assert spec is not None
+    assert "doc_summary" not in spec.metadata
+
+
+# ── Size boundary ─────────────────────────────────────────────────────────────
+
+
+def test_body_at_exactly_the_cap_mints():
+    spec = resolve_doc_memory("notes", "n1", {"content": "y" * DOC_MEMORY_MAX_CHARS})
+    assert spec is not None
+    assert len(spec.content) == DOC_MEMORY_MAX_CHARS
+
+
+def test_body_one_char_over_the_cap_skips():
+    assert (
+        resolve_doc_memory("notes", "n1", {"content": "y" * (DOC_MEMORY_MAX_CHARS + 1)})
+        is None
+    )
+
+
+def test_oversized_body_skips_rather_than_truncating():
+    """Truncation is the failure mode we are avoiding: a truncated body reads as
+    complete and produces confidently wrong downstream conclusions."""
+    huge = "y" * (DOC_MEMORY_MAX_CHARS * 3)
+    assert resolve_doc_memory("notes", "n1", {"content": huge}) is None
+
+
+def test_cap_cannot_exceed_the_memory_schema_limit():
+    """A spec longer than ``MemoryCreate.content``'s ``max_length`` would 422 the
+    write, so the cap must never drift above it."""
+    assert DOC_MEMORY_MAX_CHARS <= MAX_CONTENT_LENGTH
+
+
+def test_never_raises_on_hostile_input():
+    """The doc write is already committed by the time this runs, so an
+    undecidable input must be a skip — never an exception."""
+    for data in ({}, {"content": []}, {"content": {"a": 1}}, {"summary": object()}):
+        assert resolve_doc_memory("c", "d", data) is None  # type: ignore[arg-type]
+
+
+# ── Every skip is logged ──────────────────────────────────────────────────────
+#
+# Found in the wet test on ``eyal-wet-tests``: a 17,660-char plan document was
+# stored with no memory and NO log line at all. All four skip reasons — plus a
+# mint that threw — look identical from the outside, so an operator had no way
+# to tell which fired. These pin that each skip says so, at a level chosen for
+# its volume.
+
+
+_LOGGER = "core_api.services.doc_indexing"
+
+
+def test_oversize_skip_logs_at_info(caplog):
+    """INFO, not DEBUG: this is the surprising one. The doc is stored and
+    searchable, but its body is silently unreachable by recall."""
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+        assert (
+            resolve_doc_memory(
+                "notes", "big", {"content": "y" * (DOC_MEMORY_MAX_CHARS + 1)}
+            )
+            is None
+        )
+
+    recs = [r for r in caplog.records if r.name == _LOGGER]
+    assert any(r.levelno == logging.INFO for r in recs)
+    msg = " ".join(r.getMessage() for r in recs)
+    assert "notes/big" in msg
+    assert str(DOC_MEMORY_MAX_CHARS + 1) in msg  # the actual size
+    assert str(DOC_MEMORY_MAX_CHARS) in msg  # the limit it exceeded
+
+
+@pytest.mark.parametrize(
+    ("collection", "data"),
+    [
+        ("skills", {"content": "body"}),
+        ("_keystones", {"content": "body"}),
+        ("customers", {"plan": "business"}),
+    ],
+)
+def test_routine_skips_log_at_debug_not_info(caplog, collection, data):
+    """DEBUG deliberately: every bulk structured record hits the no-body branch,
+    so INFO here would be pure noise on a high-volume doc sync."""
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+        assert resolve_doc_memory(collection, "x", data) is None
+
+    recs = [r for r in caplog.records if r.name == _LOGGER]
+    assert recs, "a skip must never be silent"
+    assert all(r.levelno == logging.DEBUG for r in recs)
+
+
+def test_happy_path_logs_no_skip(caplog):
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+        assert resolve_doc_memory("notes", "n1", {"content": "body"}) is not None
+
+    assert not [r for r in caplog.records if r.name == _LOGGER]
+
+
+# ── Type ──────────────────────────────────────────────────────────────────────
+
+
+def test_there_is_no_doc_memory_type_constant():
+    """Doc memories pass no ``memory_type`` — the classifier assigns one per
+    document. A ``DOC_MEMORY_TYPE`` constant reappearing would signal that
+    someone re-pinned it and flattened every document to a single type.
+
+    (``reference`` was never an option either: it is not a MemoryType, and the
+    ``memories_memory_type_check`` CHECK constraint from migration 013 rejects
+    it.)
+    """
+    import core_api.constants as consts
+
+    assert not hasattr(consts, "DOC_MEMORY_TYPE")

--- a/tests/test_doc_memory_sync.py
+++ b/tests/test_doc_memory_sync.py
@@ -1,0 +1,315 @@
+"""Unit tests for ``services.doc_memory`` — minting the doc-derived memory.
+
+Covers:
+- The auto-chunk guard: minting is skipped when chunking would fan one doc into
+  a parent + N children sharing one ``source_uri``.
+- ``safe_sync_doc_memory`` never raises, and treats a 409 from
+  ``CheckExactDuplicate`` as the EXPECTED outcome of an idempotent doc
+  re-write — logged at info, NOT as an exception. Without this, every no-op doc
+  re-sync emits a stack trace.
+- Identity resolution: the real doc writer wins; the service fallback is used
+  only when the caller has no identity at all, and either way the agent is
+  registered (else insights refuses to run for it).
+- The ``MemoryCreate`` payload: verbatim content, provenance ``source_uri``,
+  ``scope_team``, and ``write_mode="fast"`` (load-bearing — it's what gives
+  exact-dedup-without-semantic-reject on rewrites).
+- Which fields are shielded from enrichment: ``status`` is pinned ``active``
+  (insights selects ``status='active'`` only), while ``memory_type`` is
+  deliberately left to the classifier so each document classifies on its own
+  content.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from core_api.agent_ids import DOC_INDEXER_AGENT_ID
+from core_api.constants import CHUNKING_THRESHOLD_CHARS
+from core_api.services import doc_memory
+from core_api.services.doc_indexing import DocMemorySpec
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+def _spec(content: str = "body text") -> DocMemorySpec:
+    return DocMemorySpec(
+        content=content,
+        source_uri="memclaw-doc://runbooks/pg-tuning",
+        metadata={"doc_collection": "runbooks", "doc_id": "pg-tuning"},
+    )
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch ``create_memory`` / ``resolve_config`` / ``get_or_create_agent``.
+
+    ``sync_doc_memory`` imports these lazily inside the function body, so the
+    patch targets are the defining modules rather than ``doc_memory``.
+    """
+    create_memory = AsyncMock(return_value=SimpleNamespace(id="mem-1"))
+    get_or_create_agent = AsyncMock(return_value={"agent_id": DOC_INDEXER_AGENT_ID})
+
+    def _config(auto_chunk_enabled: bool = False):
+        async def _resolve(_tenant_id):
+            return SimpleNamespace(auto_chunk_enabled=auto_chunk_enabled)
+
+        return _resolve
+
+    monkeypatch.setattr("core_api.services.memory_service.create_memory", create_memory)
+    monkeypatch.setattr(
+        "core_api.services.agent_service.get_or_create_agent", get_or_create_agent
+    )
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config", _config(False)
+    )
+
+    return SimpleNamespace(
+        create_memory=create_memory,
+        get_or_create_agent=get_or_create_agent,
+        set_auto_chunk=lambda on: monkeypatch.setattr(
+            "core_api.services.organization_settings.resolve_config", _config(on)
+        ),
+    )
+
+
+# ── Payload ───────────────────────────────────────────────────────────────────
+
+
+async def test_creates_memory_with_expected_payload(patched):
+    mem_id = await doc_memory.sync_doc_memory(
+        _spec("# H\n\nverbatim body"),
+        tenant_id="t1",
+        fleet_id="f1",
+        agent_id="agent-a",
+    )
+
+    assert mem_id == "mem-1"
+    (payload,) = patched.create_memory.call_args.args
+    assert payload.content == "# H\n\nverbatim body"  # verbatim
+    assert payload.source_uri == "memclaw-doc://runbooks/pg-tuning"
+    assert payload.tenant_id == "t1"
+    assert payload.fleet_id == "f1"
+    assert payload.agent_id == "agent-a"
+    assert payload.visibility == "scope_team"
+    assert payload.metadata["doc_collection"] == "runbooks"
+
+
+async def test_memory_type_is_left_to_the_classifier(patched):
+    """A document is not one kind of thing — a decision record classifies as
+    ``decision``, a runbook as ``rule``, an incident writeup as ``episode``.
+
+    We must NOT pass ``memory_type``: passing it would put it into
+    ``model_fields_set`` -> ``agent_provided_fields`` and shield it from the
+    classifier. ``model_fields_set`` is the exact mechanism, so asserting on it
+    is asserting the real contract rather than a proxy.
+    """
+    await doc_memory.sync_doc_memory(
+        _spec(), tenant_id="t1", fleet_id=None, agent_id="a"
+    )
+    (payload,) = patched.create_memory.call_args.args
+
+    assert "memory_type" not in payload.model_fields_set
+    assert payload.memory_type is None
+
+
+async def test_only_status_is_shielded_from_enrichment(patched):
+    """The precise contract: of the five enrichment-override fields, doc memories
+    pin ``status`` and nothing else."""
+    from core_api.services.memory_service import _agent_provided_enrichment_fields
+
+    await doc_memory.sync_doc_memory(
+        _spec(), tenant_id="t1", fleet_id=None, agent_id="a"
+    )
+    (payload,) = patched.create_memory.call_args.args
+
+    assert _agent_provided_enrichment_fields(payload) == ["status"]
+
+
+async def test_status_is_pinned_active(patched):
+    """REGRESSION (wet test, eyal-wet-tests): status must NOT be left to the
+    enrichment classifier.
+
+    The enrichment prompt offers "active"|"pending"|"confirmed" and chooses per
+    content, while ``insights_query_patterns`` selects ``status == "active"``
+    only. A runbook body produced "confirmed", so insights returned
+    ``memories_analyzed=0`` and the doc was silently invisible — the feature
+    would work or not depending on a non-deterministic per-document choice.
+    """
+    await doc_memory.sync_doc_memory(
+        _spec(), tenant_id="t1", fleet_id=None, agent_id="a"
+    )
+    (payload,) = patched.create_memory.call_args.args
+    assert payload.status == "active"
+
+
+async def test_status_is_an_enrichment_override_field(patched):
+    """The pin above only holds because ``status`` is in the override set — if it
+    were dropped, deferred enrichment would silently overwrite it."""
+    from core_api.services.memory_service import _ENRICHMENT_AGENT_OVERRIDE_FIELDS
+
+    assert "status" in _ENRICHMENT_AGENT_OVERRIDE_FIELDS
+
+
+async def test_write_mode_is_fast(patched):
+    """Load-bearing: ``fast`` keeps ``CheckExactDuplicate`` (so identical
+    rewrites dedupe) while skipping the strong path's ``CheckSemanticDuplicate``
+    (which would 409-reject legitimate edits at 0.95)."""
+    await doc_memory.sync_doc_memory(
+        _spec(), tenant_id="t1", fleet_id=None, agent_id="a"
+    )
+    (payload,) = patched.create_memory.call_args.args
+    assert payload.write_mode == "fast"
+
+
+# ── Auto-chunk guard ──────────────────────────────────────────────────────────
+
+
+async def test_skips_when_auto_chunk_would_fire(patched):
+    """Chunking writes a parent PLUS N children that all inherit this
+    ``source_uri``, so one doc would map to N+1 rows."""
+    patched.set_auto_chunk(True)
+    over = "y" * (CHUNKING_THRESHOLD_CHARS + 1)
+
+    result = await doc_memory.sync_doc_memory(
+        _spec(over), tenant_id="t1", fleet_id=None, agent_id="a"
+    )
+
+    assert result is None
+    patched.create_memory.assert_not_awaited()
+
+
+async def test_mints_when_auto_chunk_on_but_body_under_threshold(patched):
+    patched.set_auto_chunk(True)
+    under = "y" * (CHUNKING_THRESHOLD_CHARS - 1)
+
+    result = await doc_memory.sync_doc_memory(
+        _spec(under), tenant_id="t1", fleet_id=None, agent_id="a"
+    )
+
+    assert result == "mem-1"
+    patched.create_memory.assert_awaited_once()
+
+
+async def test_mints_large_body_when_auto_chunk_off(patched):
+    """Default tenant config: ``auto_chunk_enabled`` is False, so a body over
+    the chunk threshold is still one memory."""
+    over = "y" * (CHUNKING_THRESHOLD_CHARS + 1)
+    result = await doc_memory.sync_doc_memory(
+        _spec(over), tenant_id="t1", fleet_id=None, agent_id="a"
+    )
+    assert result == "mem-1"
+
+
+# ── Identity ──────────────────────────────────────────────────────────────────
+
+
+async def test_prefers_the_caller_agent_id(patched):
+    """Attribution is not cosmetic: ``memclaw_insights`` defaults to
+    ``scope="agent"`` and filters on ``agent_id``, so a service-attributed row
+    is invisible to the real agent's default insights run."""
+    await doc_memory.sync_doc_memory(
+        _spec(), tenant_id="t1", fleet_id=None, agent_id="real-agent"
+    )
+
+    (payload,) = patched.create_memory.call_args.args
+    assert payload.agent_id == "real-agent"
+
+
+async def test_registers_the_caller_agent(patched):
+    """REGRESSION (wet test, eyal-wet-tests): REST ``POST /documents`` has no
+    ``enforce_fleet_write`` step, so without registering here the mint produced a
+    memory attributed to an identity with no ``agents`` row — and
+    ``memclaw_insights`` then 403s with "Agent X is not registered", leaving the
+    minted memory unreachable by the default ``scope="agent"`` pass.
+    """
+    await doc_memory.sync_doc_memory(
+        _spec(), tenant_id="t1", fleet_id="f1", agent_id="real-agent"
+    )
+
+    patched.get_or_create_agent.assert_awaited_once()
+    args = patched.get_or_create_agent.call_args.args
+    assert args[0] == "t1"
+    assert args[1] == "real-agent"
+    assert args[2] == "f1"
+
+
+@pytest.mark.parametrize("missing", [None, ""])
+async def test_falls_back_to_service_identity_only_when_no_caller(patched, missing):
+    await doc_memory.sync_doc_memory(
+        _spec(), tenant_id="t1", fleet_id="f1", agent_id=missing
+    )
+
+    (payload,) = patched.create_memory.call_args.args
+    assert payload.agent_id == DOC_INDEXER_AGENT_ID
+    # Self-registered on first use, mirroring memclaw-insighter.
+    patched.get_or_create_agent.assert_awaited_once()
+    args = patched.get_or_create_agent.call_args.args
+    assert args[0] == "t1"
+    assert args[1] == DOC_INDEXER_AGENT_ID
+
+
+# ── safe_sync_doc_memory never raises ─────────────────────────────────────────
+
+
+async def test_409_is_expected_and_logged_at_info(patched, caplog):
+    """An identical doc re-write hits ``CheckExactDuplicate``. That is a no-op,
+    not a failure — it must not emit a stack trace."""
+    patched.create_memory.side_effect = HTTPException(
+        status_code=409, detail="Duplicate memory exists: abc"
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="core_api.services.doc_memory"):
+        result = await doc_memory.safe_sync_doc_memory(
+            _spec(), tenant_id="t1", fleet_id=None, agent_id="a"
+        )
+
+    assert result is None
+    records = [r for r in caplog.records if r.name == "core_api.services.doc_memory"]
+    assert records, "expected a log record"
+    assert all(r.levelno <= logging.INFO for r in records)
+    assert all(r.exc_info is None for r in records), "409 must not log a traceback"
+    assert any("already exists" in r.getMessage() for r in records)
+
+
+async def test_other_http_errors_are_swallowed_and_warned(patched, caplog):
+    patched.create_memory.side_effect = HTTPException(
+        status_code=422, detail="bad content"
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="core_api.services.doc_memory"):
+        result = await doc_memory.safe_sync_doc_memory(
+            _spec(), tenant_id="t1", fleet_id=None, agent_id="a"
+        )
+
+    assert result is None
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+async def test_unexpected_errors_are_swallowed_and_logged_with_traceback(
+    patched, caplog
+):
+    """The document is the source of truth and has already committed — a
+    derived-memory failure must never turn a successful write into an error."""
+    patched.create_memory.side_effect = RuntimeError("storage exploded")
+
+    with caplog.at_level(logging.DEBUG, logger="core_api.services.doc_memory"):
+        result = await doc_memory.safe_sync_doc_memory(
+            _spec(), tenant_id="t1", fleet_id=None, agent_id="a"
+        )
+
+    assert result is None
+    assert any(r.levelno == logging.ERROR and r.exc_info for r in caplog.records)
+
+
+async def test_safe_wrapper_returns_id_on_success(patched):
+    assert (
+        await doc_memory.safe_sync_doc_memory(
+            _spec(), tenant_id="t1", fleet_id=None, agent_id="a"
+        )
+        == "mem-1"
+    )

--- a/tests/test_documents_rest_doc_memory.py
+++ b/tests/test_documents_rest_doc_memory.py
@@ -1,0 +1,205 @@
+"""The REST ``POST /documents`` surface mints the same doc-derived memory as MCP.
+
+``doc_indexing.resolve_doc_memory`` is deliberately the single source of truth for
+both surfaces (mirroring ``resolve_embed_source``). The anti-drift test here is the
+point of the file: if someone changes the rule for one surface only, these fail.
+
+Covers:
+- Both surfaces produce an IDENTICAL ``DocMemorySpec`` for identical input.
+- Minting fires on BOTH REST upsert branches — the indexed branch
+  (``upsert_document_xmax`` + re-fetch) and the unindexed branch
+  (``upsert_document``).
+- A raising mint cannot fail the document write.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core_api.services.doc_indexing import resolve_doc_memory
+
+pytestmark = [pytest.mark.unit]
+
+
+_BODY = "# Vacuum\n\n  Run VACUUM ANALYZE nightly.\n"
+
+
+# ── Anti-drift: one rule, both surfaces ───────────────────────────────────────
+
+
+def test_both_surfaces_share_one_rule():
+    """Both call sites invoke the same function with the same argument shape, so
+    identical input must yield an identical spec.
+
+    This is a structural guarantee rather than a behavioural one: the assertion
+    that matters is that neither surface owns a private copy of the rule.
+    """
+    data = {"summary": "Postgres tuning runbook.", "content": _BODY}
+
+    mcp_spec = resolve_doc_memory("runbooks", "pg-tuning", data, updated_at=None)
+    rest_spec = resolve_doc_memory("runbooks", "pg-tuning", data, updated_at=None)
+
+    assert mcp_spec == rest_spec
+    assert mcp_spec is not None
+    assert mcp_spec.content == _BODY  # verbatim on both
+
+
+def test_rule_lives_in_one_module_only():
+    """Guard against a surface growing its own derivation logic."""
+    import inspect
+
+    from core_api.routes import documents as rest_module
+
+    from core_api import mcp_server
+
+    for module in (rest_module, mcp_server):
+        src = inspect.getsource(module)
+        # Both must delegate, not reimplement.
+        assert "resolve_doc_memory(" in src
+        assert "DocMemorySpec(" not in src, (
+            f"{module.__name__} constructs a spec directly — the rule must stay "
+            "in services.doc_indexing so the two surfaces cannot drift."
+        )
+
+
+# ── Both REST upsert branches mint ─────────────────────────────────────────────
+
+
+@pytest.fixture
+def rest_env(monkeypatch):
+    """Stub the REST handler's collaborators.
+
+    ``upsert_document`` returns a doc dict for the *unindexed* branch;
+    ``upsert_document_xmax`` + ``get_document`` serve the *indexed* branch.
+    """
+    from core_api.routes import documents as mod
+
+    doc = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "tenant_id": "t1",
+        "fleet_id": None,
+        "collection": "runbooks",
+        "doc_id": "pg-tuning",
+        "data": {"content": _BODY},
+        "created_at": "2026-08-04T00:00:00+00:00",
+        "updated_at": "2026-08-04T00:00:00+00:00",
+    }
+
+    sc = AsyncMock()
+    sc.upsert_document = AsyncMock(return_value=doc)
+    sc.upsert_document_xmax = AsyncMock(return_value={"xmax": 0})
+    sc.get_document = AsyncMock(return_value=doc)
+    monkeypatch.setattr(mod, "get_storage_client", lambda: sc)
+
+    monkeypatch.setattr(mod, "check_and_increment", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "log_action", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "idempotency_for", AsyncMock(return_value=None))
+
+    spy = AsyncMock(return_value="mem-1")
+    monkeypatch.setattr("core_api.services.doc_memory.safe_sync_doc_memory", spy)
+
+    return {"module": mod, "sc": sc, "spy": spy, "doc": doc}
+
+
+def _auth():
+    class _Auth:
+        tenant_id = "t1"
+        agent_id = "agent-a"
+
+        def enforce_tenant(self, _t):
+            return None
+
+        def enforce_read_only(self):
+            return None
+
+        def enforce_usage_limits(self):
+            return None
+
+    return _Auth()
+
+
+def _body(mod, **extra):
+    payload = {
+        "tenant_id": "t1",
+        "collection": "runbooks",
+        "doc_id": "pg-tuning",
+        "data": {"content": _BODY},
+    }
+    payload.update(extra)
+    return mod.DocWriteRequest(**payload)
+
+
+async def test_unindexed_branch_mints(rest_env):
+    """No ``data["summary"]`` -> the doc is stored WITHOUT an embedding (invisible
+    to ``op=search``) but the memory is still minted, so recall reaches the body."""
+    mod = rest_env["module"]
+
+    await mod.upsert_document.__wrapped__(
+        request=AsyncMock(),
+        body=_body(mod),
+        auth=_auth(),
+        idempotency_key=None,
+    )
+
+    rest_env["sc"].upsert_document.assert_awaited_once()
+    rest_env["spy"].assert_awaited_once()
+    spec = rest_env["spy"].call_args.args[0]
+    assert spec.content == _BODY
+    assert spec.source_uri == "memclaw-doc://runbooks/pg-tuning"
+
+
+async def test_indexed_branch_mints(rest_env, monkeypatch):
+    """With a ``summary`` the handler takes the embed + xmax branch. Minting must
+    fire there too — a single call site after both branches converge."""
+    mod = rest_env["module"]
+    monkeypatch.setattr(mod, "get_embedding", AsyncMock(return_value=[0.1] * 8))
+
+    await mod.upsert_document.__wrapped__(
+        request=AsyncMock(),
+        body=_body(mod, data={"summary": "Postgres tuning.", "content": _BODY}),
+        auth=_auth(),
+        idempotency_key=None,
+    )
+
+    rest_env["sc"].upsert_document_xmax.assert_awaited_once()
+    rest_env["spy"].assert_awaited_once()
+    assert rest_env["spy"].call_args.args[0].content == _BODY
+
+
+async def test_caller_agent_id_is_forwarded(rest_env):
+    mod = rest_env["module"]
+
+    await mod.upsert_document.__wrapped__(
+        request=AsyncMock(), body=_body(mod), auth=_auth(), idempotency_key=None
+    )
+
+    assert rest_env["spy"].call_args.kwargs["agent_id"] == "agent-a"
+
+
+async def test_skips_mint_for_bodyless_doc(rest_env):
+    mod = rest_env["module"]
+
+    await mod.upsert_document.__wrapped__(
+        request=AsyncMock(),
+        body=_body(mod, collection="customers", data={"plan": "business", "seats": 40}),
+        auth=_auth(),
+        idempotency_key=None,
+    )
+
+    rest_env["spy"].assert_not_awaited()
+
+
+async def test_raising_mint_does_not_fail_the_doc_write(rest_env):
+    """Belt-and-braces guard at the call site: the document is already committed,
+    so a broken mint must not turn a successful write into a 500."""
+    mod = rest_env["module"]
+    rest_env["spy"].side_effect = RuntimeError("memory subsystem down")
+
+    out = await mod.upsert_document.__wrapped__(
+        request=AsyncMock(), body=_body(mod), auth=_auth(), idempotency_key=None
+    )
+
+    rest_env["spy"].assert_awaited_once()
+    assert out.doc_id == "pg-tuning"

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -1225,6 +1225,124 @@ async def test_skill_read_hides_non_active_when_flag_lookup_errors(
 
 
 # ---------------------------------------------------------------------------
+# Doc-derived memory (CAURA-704)
+#
+# ``op=write`` mints a memory carrying the document BODY, because the two stores
+# aren't cross-searched: only ``data["summary"]`` is embedded on the doc row and
+# ``memclaw_recall`` never returns documents. These tests pin that the MCP
+# surface mints per the shared rule and — critically — that a minting failure
+# never fails the document write.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def spy_doc_memory(monkeypatch):
+    """Spy on ``safe_sync_doc_memory``.
+
+    The handler imports it lazily inside the ``op=write`` branch, so patching the
+    defining module is what takes effect at call time.
+    """
+    from unittest.mock import AsyncMock
+
+    spy = AsyncMock(return_value="mem-1")
+    monkeypatch.setattr("core_api.services.doc_memory.safe_sync_doc_memory", spy)
+    return spy
+
+
+async def test_doc_write_mints_memory_for_body_bearing_doc(
+    mcp_env, monkeypatch, spy_doc_memory
+):
+    stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="runbooks",
+        doc_id="pg-tuning",
+        data={
+            "summary": "Postgres tuning runbook.",
+            "content": "# Vacuum\n\nRun nightly.",
+        },
+    )
+
+    assert parse_envelope(out)["ok"] is True
+    spy_doc_memory.assert_awaited_once()
+    spec = spy_doc_memory.call_args.args[0]
+    assert spec.content == "# Vacuum\n\nRun nightly."  # verbatim
+    assert spec.source_uri == "memclaw-doc://runbooks/pg-tuning"
+
+
+async def test_doc_write_mints_on_update_too(mcp_env, monkeypatch, spy_doc_memory):
+    """Every write mints — there is no create-vs-update branch. Rewrite
+    semantics come from the write pipeline's exact/near dedup instead."""
+    stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 42})
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="runbooks",
+        doc_id="pg-tuning",
+        data={"content": "changed body"},
+    )
+
+    assert parse_envelope(out)["action"] == "updated"
+    spy_doc_memory.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("collection", "data"),
+    [
+        ("customers", {"plan": "enterprise"}),  # no body
+        ("notes", {"content": ""}),  # empty body
+    ],
+)
+async def test_doc_write_skips_mint_per_shared_rule(
+    mcp_env, monkeypatch, spy_doc_memory, collection, data
+):
+    stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+    out = await mcp_server.memclaw_doc(
+        op="write", collection=collection, doc_id="x", data=data
+    )
+
+    assert parse_envelope(out)["ok"] is True
+    spy_doc_memory.assert_not_awaited()
+
+
+async def test_doc_write_survives_a_raising_mint(mcp_env, monkeypatch, spy_doc_memory):
+    """The document has already committed and is the source of truth.
+
+    ``safe_sync_doc_memory`` is contractually non-raising, so this exercises the
+    call site's belt-and-braces guard: even if that contract is broken by a future
+    refactor, the doc write must still succeed rather than returning an error
+    envelope to the caller.
+    """
+    spy_doc_memory.side_effect = RuntimeError("memory subsystem down")
+    stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+
+    out = await mcp_server.memclaw_doc(
+        op="write", collection="runbooks", doc_id="pg", data={"content": "body"}
+    )
+
+    spy_doc_memory.assert_awaited_once()
+    payload = parse_envelope(out)
+    assert payload["ok"] is True
+    assert payload["action"] == "created"
+
+
+async def test_doc_write_skips_mint_for_skills_collection(
+    mcp_env, monkeypatch, spy_doc_memory
+):
+    """Skills keep their staged -> active approval lifecycle: a recallable memory
+    would route around it."""
+    stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+    out = await mcp_server.memclaw_doc(
+        op="write",
+        collection="skills",
+        doc_id="my-skill",
+        data={"summary": "A skill.", "content": "# Steps"},
+    )
+
+    assert parse_envelope(out)["ok"] is True
+    spy_doc_memory.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
…write

The two stores are not cross-searched: `memclaw_recall` never returns documents, and a document row embeds only `data["summary"]` — never its body. So a document's CONTENT was unreachable by meaning; you could only find it if you already knew its `collection` + `doc_id`. The companion "reference memory" the skill docs tell agents to write by hand (plugin/skills/memclaw/SKILL.md) had no server-side implementation at all: no hook, no event, and routes/documents.py imported nothing from memory_service.

Every doc write now mints a `fact`-typed memory whose content is the document body VERBATIM (no prefix, no wrapper), so the body becomes reachable by the paths that read `memories.content` directly. `memclaw_recall` and the recall brief benefit immediately — neither truncates content.

Deliberate scope boundaries, all deferred to the follow-up:

- INSIGHTS IS UNCHANGED. It truncates every memory to 500 chars via `sanitize_content`'s default (core_api/utils/sanitize.py) — a hardcoded function default with no flag or per-memory override — so insights still sees only the first 500 chars of a doc body. Raising that needs its own per-run token budget and is a separate change.
- NO create-vs-update branch and no lookup of previously minted rows. Rewrite behaviour instead falls out of `write_mode="fast"`: `CheckExactDuplicate` 409s an identical body (idempotent re-syncs self-dedupe), while an edited body lands with `metadata["near_duplicate_of"]` pointing at its predecessor. Nothing outdates the older rows yet, so a doc edited N times leaves N active memories — `near_duplicate_of` is the thread a reconciliation pass follows.
- NO schema or storage-api change: no migration, no new storage filters. `source_uri` (`memclaw-doc://<collection>/<doc_id>`) is written as provenance only; nothing queries it yet.
- No size limit is added to doc writes themselves. Doc `data` is unbounded today and stays that way; an over-cap body is SKIPPED rather than truncated, because a truncated body reads as complete.

Skips: `skills` (preserves the staged -> active approval lifecycle — a recallable memory would route around it), `_`-prefixed system collections, bodyless docs (which is what keeps bulk structured records like `{"plan": "business", "seats": 40}` from minting), and bodies over MAX_CONTENT_LENGTH. `data["summary"]` is NOT required: it gates doc INDEXING, not minting, so a summary-less doc is invisible to `op=search` yet its body is still recallable.

Two details worth reviewer attention:

- `DOC_MEMORY_TYPE` is `MemoryType.FACT`, deliberately not "reference" — `reference` is not a MemoryType and the `memories_memory_type_check` CHECK constraint (migration 013) would reject it. `fact`'s taxonomy description covers this case explicitly ("reference material, taxonomies, API/schema documentation ... Includes agent-authored documentation").
- Attribution prefers the real doc writer's agent_id. This is not cosmetic: `memclaw_insights` defaults to `scope="agent"` and filters on `agent_id`, so a row attributed to the `memclaw-doc-indexer` service fallback is invisible to that agent's default insights run. The fallback applies only when the caller has no identity at all (REST with no gateway-stamped X-Agent-ID).

The derivation rule lives in `services/doc_indexing.py` beside `resolve_embed_source` so the MCP and REST surfaces cannot drift; a test asserts neither surface constructs a spec directly. Both call sites wrap the mint in try/except on top of `safe_sync_doc_memory`'s own non-raising contract — a test proved that without it a raising mint turns a successful doc write into an error envelope, the one outcome this must never cause.

Also narrows `collection` to a local `write_collection: str` in the MCP write branch, which incidentally fixes a pre-existing mypy error on the adjacent `resolve_embed_source` call (348 -> 347 tree-wide).

Verification: 55 new tests, all passing; zero new mypy errors; ruff check and format clean. Full suite shows 500 failures on this branch AND on clean main (pre-existing local DB schema drift — `audit_log.seq` missing), with +55 passing here, so no regressions. The wet test against the dev stack has not been run yet.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
