### PR TITLE
CAURA-000- docs: Caura prose sweep — README body, guides, skills, client READMEs

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -1,6 +1,6 @@
-# MemClaw — Self-Install Guide for AI Agents
+# Caura — Self-Install Guide for AI Agents
 
-You are an AI agent. This guide tells you how to clone, install, and run MemClaw locally so you have your own persistent memory server — no external dependencies, no human involvement.
+You are an AI agent. This guide tells you how to clone, install, and run Caura locally so you have your own persistent memory server — no external dependencies, no human involvement.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ You need these on your machine:
 git clone https://github.com/caura-ai/caura-memclaw.git
 cd caura-memclaw
 
-# 2. Start everything (PostgreSQL + pgvector, Redis, MemClaw API)
+# 2. Start everything (PostgreSQL + pgvector, Redis, Caura API)
 docker compose up -d
 
 # 3. Wait for healthy (usually ~15 seconds)
@@ -79,7 +79,7 @@ curl http://localhost:8000/api/v1/health
 # Expected: {"status":"ok","storage":"connected","redis":"connected","event_bus":"ok"}
 ```
 
-MemClaw is running at `http://localhost:8000`.
+Caura is running at `http://localhost:8000`.
 
 ## Pick an Auth Mode
 
@@ -150,7 +150,7 @@ curl -sf -H "X-API-Key: $MEMCLAW_KEY" "$MEMCLAW_URL/api/v1/install-plugin?fleet_
 openclaw gateway restart    # or: systemctl --user restart openclaw-gateway
 ```
 
-This installs the plugin to `~/.openclaw/plugins/memclaw/`, builds it, claims the exclusive memory slot (disabling `memory-core`), and configures `openclaw.json` to allowlist the agent-facing tools. The plugin calls the local MemClaw API over HTTP — same tools as MCP.
+This installs the plugin to `~/.openclaw/plugins/memclaw/`, builds it, claims the exclusive memory slot (disabling `memory-core`), and configures `openclaw.json` to allowlist the agent-facing tools. The plugin calls the local Caura API over HTTP — same tools as MCP.
 
 **MCP vs Plugin — which to use:**
 
@@ -180,7 +180,7 @@ curl -X POST "$MEMCLAW_URL/api/v1/search" \
 curl -X POST "$MEMCLAW_URL/api/v1/memories" \
   -H "X-API-Key: $KEY" \
   -H "Content-Type: application/json" \
-  -d '{"tenant_id": "default", "agent_id": "self", "content": "I installed MemClaw locally and it works."}'
+  -d '{"tenant_id": "default", "agent_id": "self", "content": "I installed Caura locally and it works."}'
 
 # Verify it was stored
 curl "$MEMCLAW_URL/api/v1/memories?tenant_id=default" \
@@ -227,7 +227,7 @@ Then restart the server (`docker compose restart app` or re-run uvicorn).
 
 ## What You Now Have
 
-- A local MemClaw server with full API + MCP
+- A local Caura server with full API + MCP
 - A single-tenant standalone setup (or admin-keyed multi-tenant, depending on which path you picked)
 - 12 tools ready to use (memory ops + document store + Karpathy Loop + stats + keystone governance; skill sharing rides on `memclaw_doc collection=skills`)
 - PostgreSQL with pgvector for semantic search

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to MemClaw
+# Contributing to Caura
 
 Thanks for your interest in contributing! This document covers how to get set
 up, the expected workflow, and how we review changes.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="static/images/memCLAW_logo_dark.png" alt="MemClaw" width="420" />
+  <img src="static/images/memCLAW_logo_dark.png" alt="Caura" width="420" />
 </p>
 
 <h3 align="center">Fleet memory for AI agents &mdash; governed, shared, self-improving.</h3>
@@ -32,22 +32,22 @@ Tool names (<code>memclaw_*</code>), packages, env vars and URLs keep working un
 
 Caura — known until now as MemClaw — is open-source memory for **multi-tenant, multi-agent** AI fleets. Your agents store what they learn, find what the fleet knows, and get smarter with every interaction — learning from each other instead of repeating mistakes.
 
-Agents write plain text. MemClaw turns it into searchable, governed, self-improving memory.
+Agents write plain text. Caura turns it into searchable, governed, self-improving memory.
 
 **One loop, three pillars: write, recall, compound** — every interaction makes the next one smarter.
 
-**Built for fleets, not single agents.** Public agent-memory benchmarks (LoCoMo, LongMemEval) measure one agent, one user, one long conversation — the single-chatbot shape. The deployment shape we see in production is the opposite: dozens or thousands of agents working on behalf of a company, sharing what they learn under governance. MemClaw is architected around that shape from day one — scoped memory, cross-agent outcome propagation, fleet-wide trust tiers — and competes on the axes that compound with agent count: latency, token efficiency, and governance. See [Performance](#performance) for the numbers, or read the [benchmarks write-up](https://memclaw.net/blog/memclaw-benchmarks).
+**Built for fleets, not single agents.** Public agent-memory benchmarks (LoCoMo, LongMemEval) measure one agent, one user, one long conversation — the single-chatbot shape. The deployment shape we see in production is the opposite: dozens or thousands of agents working on behalf of a company, sharing what they learn under governance. Caura is architected around that shape from day one — scoped memory, cross-agent outcome propagation, fleet-wide trust tiers — and competes on the axes that compound with agent count: latency, token efficiency, and governance. See [Performance](#performance) for the numbers, or read the [benchmarks write-up](https://memclaw.net/blog/memclaw-benchmarks).
 
 > **In production at eToro (NASDAQ: ETOR):** 300+ AI agents on one governed
 > memory — 26,500+ memories, 1,372 shared skills, 23 ms p50 search.
 > [Architecture deep-dive →](https://memclaw.net/blog/etoro-company-brain/)
 
 <p align="center">
-  <img src="static/images/memclaw-concept.png" alt="MemClaw — Fleet Memory that Compounds" width="700" />
+  <img src="static/images/memclaw-concept.png" alt="Caura — Fleet Memory that Compounds" width="700" />
 </p>
 
 <p align="center">
-  <img src="static/images/memclaw-demo.gif" alt="MemClaw demo — write, recall, and governed cross-fleet memory in action" width="700" />
+  <img src="static/images/memclaw-demo.gif" alt="Caura demo — write, recall, and governed cross-fleet memory in action" width="700" />
 </p>
 
 ---
@@ -56,7 +56,7 @@ Agents write plain text. MemClaw turns it into searchable, governed, self-improv
 
 ### Try it locally — no API key, no signup
 
-The fastest way to see MemClaw work. Standalone mode runs single-tenant with auth bypassed — write and recall a memory in four commands. (It boots with dummy embeddings so there's nothing to configure; add an AI provider key for semantic search — see [Self-Hosted](#self-hosted-open-source) below.)
+The fastest way to see Caura work. Standalone mode runs single-tenant with auth bypassed — write and recall a memory in four commands. (It boots with dummy embeddings so there's nothing to configure; add an AI provider key for semantic search — see [Self-Hosted](#self-hosted-open-source) below.)
 
 ```bash
 git clone https://github.com/caura-ai/caura-memclaw.git
@@ -87,7 +87,7 @@ Three paths — pick the one that matches your setup:
 |---|---|---|
 | **Managed platform** | Quickest. We host the DB + scaling. | ~2 min |
 | **Self-hosted (Docker)** | Privacy / on-prem / air-gapped. | ~5 min |
-| **OpenClaw plugin** | You already run an OpenClaw fleet — install MemClaw as a plugin against any of the above. | ~3 min |
+| **OpenClaw plugin** | You already run an OpenClaw fleet — install Caura as a plugin against any of the above. | ~3 min |
 
 ### Managed Platform
 
@@ -266,7 +266,7 @@ default for a local OSS install, never sets the flag at all.)
 
 ---
 
-⭐ **If MemClaw just worked for you,
+⭐ **If Caura just worked for you,
 [star the repo](https://github.com/caura-ai/caura-memclaw/stargazers)** —
 it's how other fleet builders find us, and it shapes how much time we can
 invest in the OSS edition.
@@ -321,10 +321,10 @@ python scripts/smoke_test.py --url http://localhost:8000 --api-key <admin-key>
 
 ### OpenClaw Plugin
 
-Already running an OpenClaw fleet? Install MemClaw as a plugin against either the managed platform or your self-hosted stack:
+Already running an OpenClaw fleet? Install Caura as a plugin against either the managed platform or your self-hosted stack:
 
 ```bash
-# Point at whichever URL hosts your MemClaw API
+# Point at whichever URL hosts your Caura API
 export MEMCLAW_URL=https://memclaw.net          # managed
 # or:  export MEMCLAW_URL=http://localhost:8000  # self-hosted
 export MEMCLAW_KEY=your-key                      # `standalone` works in self-hosted standalone mode
@@ -341,16 +341,16 @@ The plugin claims the OpenClaw `memory` slot (replacing `memory-core`) and expos
 
 ### Python client
 
-Talk to any MemClaw deployment (managed or self-hosted) from Python:
+Talk to any Caura deployment (managed or self-hosted) from Python:
 
 ```bash
 pip install memclaw-client
 ```
 
 ```python
-from memclaw_client import MemClaw
+from memclaw_client import Caura
 
-mc = MemClaw("mc_xxx", tenant_id="my-team", agent_id="my-agent")
+mc = Caura("mc_xxx", tenant_id="my-team", agent_id="my-agent")
 mc.write("Q3 revenue target is $4M, set on 2026-04-15.")
 print(mc.recall("Q3 revenue target").summary)
 ```
@@ -366,9 +366,9 @@ npm install @caura/memclaw-client
 ```
 
 ```ts
-import { MemClaw } from "@caura/memclaw-client";
+import { Caura } from "@caura/memclaw-client";
 
-const mc = new MemClaw("mc_xxx", { tenantId: "my-team", agentId: "my-agent" });
+const mc = new Caura("mc_xxx", { tenantId: "my-team", agentId: "my-agent" });
 await mc.write("Q3 revenue target is $4M, set on 2026-04-15.");
 console.log((await mc.recall("Q3 revenue target")).summary);
 ```
@@ -408,13 +408,13 @@ See [`clients/typescript/`](clients/typescript/) for the full client.
 
 ---
 
-## How MemClaw compares
+## How Caura compares
 
 Accuracy benchmarks cluster the leading tools in a narrow band (see
 [Performance](#performance)). Where the field actually diverges is
 fleet capability and governance:
 
-| Capability | MemClaw | Mem0 | Zep | Letta |
+| Capability | Caura | Mem0 | Zep | Letta |
 |---|---|---|---|---|
 | Multi-fleet support | ✅ | ❌ | ❌ | ❌ |
 | Agent trust tiers + keystone policies | ✅ | ❌ | ❌ | ❌ |
@@ -427,7 +427,7 @@ fleet capability and governance:
 | MCP-native | ✅ | ✅ | ✅ | ⚠️ |
 | OSS license | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 |
 
-Mem0, Zep, and Letta are solid projects for single-agent memory. MemClaw's
+Mem0, Zep, and Letta are solid projects for single-agent memory. Caura's
 lane is **governed memory across agent fleets** — multiple agents, teams,
 and vendors on one auditable memory plane. Comparison reflects our reading
 of public docs as of June 2026 — corrections welcome via issue or PR.
@@ -444,7 +444,7 @@ Benchmarked against the two most-cited public agent-memory benchmarks. Full resu
 | Token savings vs full context | **96.6%** | **98.2%** | — |
 | Latency | — | — | **23 ms p50 · 27 ms p95** |
 
-Accuracy sits inside the leading cluster across the field (Mem0, Zep, MemClaw — scores cluster in a narrow band). The axes we push hardest are latency and token efficiency, because those are the ones that compound as agent count grows — a few hundred ms of search latency disappears behind one LLM call, but bills millions of times a day across a fleet.
+Accuracy sits inside the leading cluster across the field (Mem0, Zep, Caura — scores cluster in a narrow band). The axes we push hardest are latency and token efficiency, because those are the ones that compound as agent count grows — a few hundred ms of search latency disappears behind one LLM call, but bills millions of times a day across a fleet.
 
 > Single-agent benchmarks can't measure cross-agent recall, outcome propagation between agents, fleet-scoped visibility, or governance-aware retrieval. Those are the questions that decide whether a memory system is *deployable* inside a company. See [`docs/performance.md`](docs/performance.md#what-these-benchmarks-cant-measure).
 
@@ -454,7 +454,7 @@ Source: [Fast, Token-Efficient, and Built for Fleets](https://memclaw.net/blog/m
 
 ## MCP (Model Context Protocol)
 
-Add MemClaw to any MCP client with one config block.
+Add Caura to any MCP client with one config block.
 
 **Self-hosted** (localhost):
 
@@ -548,7 +548,7 @@ active-only delivery contract + plugin reconcile targets),
 and [`docs/skills-inbox-api.md`](docs/skills-inbox-api.md) (the operator REST
 API for the Skills Inbox).
 The full operator/developer guide lives in the
-[MemClaw docs → Skill Factory](https://memclaw.net/docs/skill-factory).
+[Caura docs → Skill Factory](https://memclaw.net/docs/skill-factory).
 
 ### The Interviewer
 
@@ -561,7 +561,7 @@ It never re-runs the agent — it works only from the real trail, which grounds
 it in actual activity. (LLM synthesis can still mis-read or overstate, so
 treat Interviewer memories as a useful approximation, not a verbatim record.)
 
-It's a third way memories enter MemClaw, alongside realtime writes and
+It's a third way memories enter Caura, alongside realtime writes and
 ingestion. Like Skill Factory it's **opt-in per tenant and off by default** —
 inert until you set `interviewer.enabled = true` in the tenant's org
 settings.
@@ -591,13 +591,13 @@ settings.
 Triggers are a periodic `run` (cron) and/or a session-end `hook`; combining
 them is safe because duplicate submissions dedup. Full setup, per-harness
 wiring, and the protocol are in the
-[MemClaw docs → Interviewer](https://memclaw.net/docs/interviewer).
+[Caura docs → Interviewer](https://memclaw.net/docs/interviewer).
 
-### The MemClaw Broker
+### The Caura Broker
 
-The **MemClaw Broker** is a local daemon (`memclawd`, driven by the `memclaw`
+The **Caura Broker** is a local daemon (`memclawd`, driven by the `memclaw`
 CLI) that runs on a developer's machine and connects coding agents — Claude
-Code, Codex, Cursor, Gemini — to MemClaw. Its job is to be the trust boundary
+Code, Codex, Cursor, Gemini — to Caura. Its job is to be the trust boundary
 on the developer side: it enforces policy, applies redaction, and keeps a
 tamper-evident audit log **before anything leaves the machine**. The Broker
 runs in **personal mode** out of the box; installs that join a **Broker
@@ -615,15 +615,15 @@ breaking-change gates in CI (in this repo the baseline is generated by
 [#620](https://github.com/caura-ai/caura-memclaw/pull/620)), so a
 contract-breaking change fails the build rather than breaking installed
 Brokers. Operations — install, fleet join, policy — are documented at
-[MemClaw docs → Broker Fleet](https://memclaw.net/docs/broker-fleet).
+[Caura docs → Broker Fleet](https://memclaw.net/docs/broker-fleet).
 
 ### Install the skill (Claude Code & Codex)
 
-Install MemClaw's usage guide as a **skill** so your agent knows *when* and
+Install Caura's usage guide as a **skill** so your agent knows *when* and
 *how* to use the 12 tools — the memory/doc mental model, the three rules
 (recall, write, supersede), trust levels, common patterns, and
 anti-patterns. The skill is loaded on-demand (not per-turn), so it costs
-nothing until the agent reaches for MemClaw.
+nothing until the agent reaches for Caura.
 
 > **Prerequisite:** the MCP server is already registered (via `claude mcp add -s user` for Claude Code or the equivalent for Codex — see the config block above). Confirm with `claude mcp list` — you should see `memclaw: ... ✓ Connected`.
 
@@ -694,7 +694,7 @@ installs `memclaw` only.
 
 ## Deployment
 
-The recommended way to run MemClaw is via Docker Compose (see [Quick Start](#quick-start)). This gives you a production-ready PostgreSQL + pgvector + Redis + API stack with a single command.
+The recommended way to run Caura is via Docker Compose (see [Quick Start](#quick-start)). This gives you a production-ready PostgreSQL + pgvector + Redis + API stack with a single command.
 
 ### Published container images
 
@@ -723,7 +723,7 @@ uvicorn core_api.app:app --host 0.0.0.0 --port 8000 --workers 2
 
 ### Deployment topologies
 
-MemClaw ships with two operational modes for the storage layer. **Single-node (default)** is what you get from Docker Compose, `pip install`, or any fresh deploy — one `core-storage-api` instance serves both reads and writes. This is the right choice for any deployment that isn't seeing sustained 100+ writes/sec.
+Caura ships with two operational modes for the storage layer. **Single-node (default)** is what you get from Docker Compose, `pip install`, or any fresh deploy — one `core-storage-api` instance serves both reads and writes. This is the right choice for any deployment that isn't seeing sustained 100+ writes/sec.
 
 The **reader/writer split** is an opt-in topology for high-write-rate deploys that want to scale reads independently of writes — e.g. by pointing read traffic at a Postgres streaming replica. Enabling it means running two `core-storage-api` services with different roles and pointing `core-api` at both:
 
@@ -1064,7 +1064,7 @@ memclaw/
 │       ├── tools.ts               # Tool implementations
 │       ├── agent-auth.ts          # Per-agent credentials (agent-scoped mc_ keys)
 │       ├── context-engine.ts      # Auto-read/write lifecycle
-│       ├── heartbeat.ts           # 60s heartbeat → MemClaw API
+│       ├── heartbeat.ts           # 60s heartbeat → Caura API
 │       └── educate.ts             # Agent education delivery
 │
 ├── common/                        # Shared SQLAlchemy ORM models and constants
@@ -1100,7 +1100,7 @@ python scripts/latency_test.py --url http://localhost:8000 --api-key <admin-key>
 
 ## Public API & Stability
 
-MemClaw v1.x follows [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html). The surfaces below are stable; everything else is internal and may change in any release.
+Caura v1.x follows [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html). The surfaces below are stable; everything else is internal and may change in any release.
 
 ### Stable surfaces
 
@@ -1204,10 +1204,10 @@ Reviewers will block merges to `dev` that touch a stable surface without these m
 
 ## Telemetry and error tracking
 
-MemClaw supports optional [Sentry](https://sentry.io) integration for error tracking and performance monitoring:
+Caura supports optional [Sentry](https://sentry.io) integration for error tracking and performance monitoring:
 
 - **Opt-in only** — set the `SENTRY_DSN` environment variable to enable. No errors are reported unless you explicitly configure a DSN.
-- **No usage analytics** — MemClaw does not collect usage statistics, feature flags, or behavioral data.
+- **No usage analytics** — Caura does not collect usage statistics, feature flags, or behavioral data.
 - **No phone-home** — the application makes zero outbound calls unless you configure a Sentry DSN or an LLM/embedding provider.
 
 ---
@@ -1227,7 +1227,7 @@ application-level limiting in `core-api/src/core_api/middleware/rate_limit.py`.
 
 ## Telemetry
 
-MemClaw **does not phone home** by default. No usage data, analytics, or tracking of any kind.
+Caura **does not phone home** by default. No usage data, analytics, or tracking of any kind.
 
 If you set the `SENTRY_DSN` environment variable, [Sentry](https://sentry.io) error tracking
 is enabled — crash reports and performance traces are sent to your configured Sentry project.
@@ -1242,28 +1242,28 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines,
 
 ## FAQ
 
-**What is MemClaw?**
-MemClaw is open-source governed shared memory for AI agent fleets:
+**What is Caura?**
+Caura is open-source governed shared memory for AI agent fleets:
 cross-agent, cross-fleet recall with visibility scopes, trust tiers,
 keystone policies, audit trails, and tenant isolation enforced on every
 operation — plus self-improving retrieval through outcome-based learning.
 
-**How is MemClaw different from a vector database?**
-MemClaw uses pgvector under the hood but is not a vector DB wrapper. On top
+**How is Caura different from a vector database?**
+Caura uses pgvector under the hood but is not a vector DB wrapper. On top
 of hybrid search it adds fleet orchestration, per-agent retrieval tuning,
 contradiction detection, an 8-status lifecycle, an auto-extracted knowledge
 graph, LLM enrichment on every write, row-level tenant isolation, and audit
 trails on every operation.
 
-**How is MemClaw different from Mem0 or Zep?**
+**How is Caura different from Mem0 or Zep?**
 Mem0 and Zep focus on memory for individual agents; accuracy benchmarks
-cluster all three tools in a narrow band. MemClaw is built for *fleets*:
+cluster all three tools in a narrow band. Caura is built for *fleets*:
 multiple agents across teams and vendors sharing one governed memory plane,
 with trust tiers, keystone policies, and cross-fleet permissions those
-tools don't address. See [How MemClaw compares](#how-memclaw-compares).
+tools don't address. See [How Caura compares](#how-memclaw-compares).
 
-**Does MemClaw work with Claude Desktop, Claude Code, Cursor, or Windsurf?**
-Yes — MemClaw is MCP-native. Paste a JSON config with a URL and API key
+**Does Caura work with Claude Desktop, Claude Code, Cursor, or Windsurf?**
+Yes — Caura is MCP-native. Paste a JSON config with a URL and API key
 into any MCP client and 12 tools appear immediately.
 
 **Can agents from different vendors share memory?**
@@ -1271,14 +1271,14 @@ Yes — that's the point. An Anthropic agent recalls what an OpenAI agent
 wrote, under the same governance rules — with trust tiers and visibility
 scopes deciding what crosses fleet boundaries.
 
-**Is MemClaw really free?**
+**Is Caura really free?**
 The full engine — storage, 12 MCP tools, plugin, audit trail — is Apache
 2.0. Run it yourself forever. The managed platform at
 [memclaw.net](https://memclaw.net) adds hosting, scaling, and enterprise
 governance for teams that don't want to operate infrastructure.
 
-**Who runs MemClaw in production?**
-eToro (NASDAQ: ETOR) runs 300+ agents on MemClaw — 26,500+ memories, 1,372
+**Who runs Caura in production?**
+eToro (NASDAQ: ETOR) runs 300+ agents on Caura — 26,500+ memories, 1,372
 shared skills, 23 ms p50 search.
 [Case study →](https://memclaw.net/blog/etoro-company-brain/)
 
@@ -1286,7 +1286,7 @@ shared skills, 23 ms p50 search.
 
 ## License
 
-MemClaw is licensed under the [Apache License, Version 2.0](LICENSE).
+Caura is licensed under the [Apache License, Version 2.0](LICENSE).
 
 See [NOTICE](NOTICE) for copyright and third-party attributions.
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,9 +1,9 @@
 # memclaw-client
 
-Official Python client for [MemClaw](https://memclaw.net) — governed shared
+Official Python client for [Caura](https://memclaw.net) — governed shared
 memory for AI agent fleets (multi-agent, multi-tenant, MCP-native).
 
-A thin wrapper over the MemClaw REST API. Point it at a managed
+A thin wrapper over the Caura REST API. Point it at a managed
 (`https://memclaw.net`) or self-hosted (`http://localhost:8000`) deployment.
 
 ## Install
@@ -15,9 +15,9 @@ pip install memclaw-client
 ## Quickstart
 
 ```python
-from memclaw_client import MemClaw
+from memclaw_client import Caura
 
-mc = MemClaw("mc_xxx", tenant_id="my-team", agent_id="my-agent")
+mc = Caura("mc_xxx", tenant_id="my-team", agent_id="my-agent")
 
 # Write a memory — enriched server-side with type, title, tags, importance.
 mc.write("Q3 revenue target is $4M, set on 2026-04-15.")
@@ -33,7 +33,7 @@ print(mc.recall("Q3 revenue target").summary)
 Self-hosted? Pass `base_url`:
 
 ```python
-mc = MemClaw("standalone", tenant_id="default", base_url="http://localhost:8000")
+mc = Caura("standalone", tenant_id="default", base_url="http://localhost:8000")
 ```
 
 ## API
@@ -45,23 +45,23 @@ mc = MemClaw("standalone", tenant_id="default", base_url="http://localhost:8000"
 | `recall(query, top_k=5, ...)` | `POST /api/v1/recall` | `RecallResult` |
 | `health()` | `GET /api/v1/health` | `dict` |
 
-The client is a context manager (`with MemClaw(...) as mc:`) and raises
-`AuthError` (401/403), `NotFoundError` (404), or `MemClawAPIError` on failures.
+The client is a context manager (`with Caura(...) as mc:`) and raises
+`AuthError` (401/403), `NotFoundError` (404), or `CauraAPIError` on failures.
 Every result also exposes the full API payload on `.raw`.
 
 For credentials, scopes, and the full API surface, see the
-[MemClaw docs](https://memclaw.net/docs). Production fleets should use
+[Caura docs](https://memclaw.net/docs). Production fleets should use
 [per-agent keys](https://memclaw.net/docs/integrations/per-agent-keys).
 
 ## memclaw-interviewer — Claude Code + Cursor adapter
 
 Installing this package also provides the `memclaw-interviewer` CLI: the
-MemClaw Interviewer's disk-parser adapter for Claude Code and Cursor
+Caura Interviewer's disk-parser adapter for Claude Code and Cursor
 workstations. It reads agent session transcripts **read-only** — Claude
 Code's `~/.claude/projects/…/*.jsonl` or Cursor's
 `~/.cursor/projects/…/agent-transcripts/…/*.jsonl` — tracks a per-file
 cursor via the server's forward-only watermark documents (no local state),
-and submits event windows to `POST /api/v1/interview/submit`, where MemClaw
+and submits event windows to `POST /api/v1/interview/submit`, where Caura
 synthesizes them into typed memories. Requires the tenant to have
 `interviewer.enabled = true`.
 

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,10 +1,10 @@
 # @caura/memclaw-client
 
-Official TypeScript/JavaScript client for [MemClaw](https://memclaw.net) —
+Official TypeScript/JavaScript client for [Caura](https://memclaw.net) —
 governed shared memory for AI agent fleets (multi-agent, multi-tenant,
 MCP-native).
 
-A thin wrapper over the MemClaw REST API. Point it at a managed
+A thin wrapper over the Caura REST API. Point it at a managed
 (`https://memclaw.net`) or self-hosted (`http://localhost:8000`) deployment.
 Zero runtime dependencies — uses native `fetch` (Node 18+).
 
@@ -17,9 +17,9 @@ npm install @caura/memclaw-client
 ## Quickstart
 
 ```ts
-import { MemClaw } from "@caura/memclaw-client";
+import { Caura } from "@caura/memclaw-client";
 
-const mc = new MemClaw("mc_xxx", { tenantId: "my-team", agentId: "my-agent" });
+const mc = new Caura("mc_xxx", { tenantId: "my-team", agentId: "my-agent" });
 
 // Write a memory — enriched server-side with type, title, tags, importance.
 await mc.write("Q3 revenue target is $4M, set on 2026-04-15.");
@@ -36,7 +36,7 @@ console.log((await mc.recall("Q3 revenue target")).summary);
 Self-hosted? Pass `baseUrl`:
 
 ```ts
-const mc = new MemClaw("standalone", { tenantId: "default", baseUrl: "http://localhost:8000" });
+const mc = new Caura("standalone", { tenantId: "default", baseUrl: "http://localhost:8000" });
 ```
 
 ## API
@@ -49,10 +49,10 @@ const mc = new MemClaw("standalone", { tenantId: "default", baseUrl: "http://loc
 | `health()` | `GET /api/v1/health` | `object` |
 
 Failures throw `AuthError` (401/403), `NotFoundError` (404), or
-`MemClawApiError`. Every result also exposes the full API payload on `.raw`.
+`CauraApiError`. Every result also exposes the full API payload on `.raw`.
 
 For credentials, scopes, and the full API surface, see the
-[MemClaw docs](https://memclaw.net/docs). Production fleets should use
+[Caura docs](https://memclaw.net/docs). Production fleets should use
 [per-agent keys](https://memclaw.net/docs/integrations/per-agent-keys).
 
 ## License

--- a/docs/api-surfaces.md
+++ b/docs/api-surfaces.md
@@ -1,6 +1,6 @@
 # API Surface Ownership Charter
 
-MemClaw exposes three callable surfaces — REST, MCP, and the OpenClaw plugin.
+Caura exposes three callable surfaces — REST, MCP, and the OpenClaw plugin.
 They are intentionally **not symmetric**. Each serves a different audience and
 operates under different assumptions. This document records who owns what and
 when to add or move an operation.

--- a/docs/local-embedder.md
+++ b/docs/local-embedder.md
@@ -1,6 +1,6 @@
 # Local Embedder (TEI sidecar)
 
-MemClaw can serve embeddings from a self-hosted [HuggingFace Text Embeddings
+Caura can serve embeddings from a self-hosted [HuggingFace Text Embeddings
 Inference](https://github.com/huggingface/text-embeddings-inference) (TEI)
 container instead of OpenAI's hosted API. **Default model: `BAAI/bge-m3`**
 (1024-dim, MIT-licensed, multilingual, no instruction prefix needed) — matches
@@ -358,5 +358,5 @@ docker compose up -d   # no profile = no TEI sidecar
   cover most differences between back-ends. TEI is the recommended default
   because it's the most mature open-source option for the bge-m3 default.
 * **The OpenClaw plugin works transparently** regardless of which embedder
-  is configured — it talks to MemClaw's REST API, which doesn't expose
+  is configured — it talks to Caura's REST API, which doesn't expose
   the embedder choice. No plugin-side configuration needed.

--- a/docs/mcp-skill-delivery.md
+++ b/docs/mcp-skill-delivery.md
@@ -115,7 +115,7 @@ decision.
 To make skill use *reliable* rather than probabilistic, a skill must be
 installed into the harness's own startup surface (its skill registry /
 filesystem / system-prompt) so it's present before the model thinks —
-which is necessarily per-harness and can't be done from the MemClaw
+which is necessarily per-harness and can't be done from the Caura
 side alone.
 
 So the tiers are:
@@ -126,7 +126,7 @@ So the tiers are:
   integrate deeply (writing `<harness>/skills/<slug>/SKILL.md` so the
   skill is present before the model thinks). Guarantees presence;
   requires a harness-specific adapter. **OpenClaw is the first such
-  harness** (the MemClaw plugin reconciles the catalog to disk every
+  harness** (the Caura plugin reconciles the catalog to disk every
   heartbeat).
 
 They're complementary: MCP-direct is the floor that works everywhere;
@@ -179,7 +179,7 @@ arrays are deduped *across* targets. The summary also carries a
 (`{ dir, mode, installed, added, removed, collisions, protected }`) — so
 an operator can see exactly *which* dir a skill landed in or collided in.
 For the default single-target case it's one entry mirroring the top-level
-arrays. A `registeredDirs[]` array lists the target dirs MemClaw has
+arrays. A `registeredDirs[]` array lists the target dirs Caura has
 ensured are on OpenClaw's skill load path this tick (the `register: true`
 opt-in below); it's empty unless a target opts in.
 
@@ -190,9 +190,9 @@ By default the reconciler manages one **`owned`** dir — the plugin's own
 catalog is pruned. Operators can add extra target dirs via the
 `MEMCLAW_SKILL_TARGETS` env var (JSON array of `{ dir, mode, register? }`):
 
-- **`owned`** — fully MemClaw-managed (destructive prune). Use only for
-  dirs MemClaw exclusively controls.
-- **`additive`** — a **shared/foreign** dir. MemClaw writes its active
+- **`owned`** — fully Caura-managed (destructive prune). Use only for
+  dirs Caura exclusively controls.
+- **`additive`** — a **shared/foreign** dir. Caura writes its active
   skills there but **only ever touches entries it wrote**, tracked by a
   per-skill `.memclaw-owned` marker file:
   - a slug already occupied by an *unowned* skill is a **collision** —
@@ -202,7 +202,7 @@ catalog is pruned. Operators can add extra target dirs via the
   - only marker-bearing entries are updated/pruned.
 
 This makes the "empty catalog / wrong tenant wipes the dir" hazard apply
-only to `owned` dirs — `additive` dirs lose only MemClaw's own entries,
+only to `owned` dirs — `additive` dirs lose only Caura's own entries,
 never the client's.
 
 #### Reaching agents: `register`

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -10,7 +10,7 @@ Operator-grade companion to the public benchmarks write-up. The blog answers *"i
 | Token savings vs full context | **96.6%** | **98.2%** | — |
 | Latency | — | — | **23 ms p50 · 27 ms p95** (warm) |
 
-LoCoMo and LongMemEval are the two most-cited public agent-memory benchmarks. Both measure one agent, one user, one long conversation — the single-chatbot shape. Accuracy across the leading systems (MemClaw, Mem0, Zep) clusters in a narrow band.
+LoCoMo and LongMemEval are the two most-cited public agent-memory benchmarks. Both measure one agent, one user, one long conversation — the single-chatbot shape. Accuracy across the leading systems (Caura, Mem0, Zep) clusters in a narrow band.
 
 **Source:** [Fast, Token-Efficient, and Built for Fleets](https://memclaw.net/blog/memclaw-benchmarks) (2026-04-19).
 
@@ -39,15 +39,15 @@ Single-agent benchmarks can't ask:
 - Is a memory written by the sales fleet visible — or correctly invisible — to an agent in support?
 - Does cross-tenant data ever leak when the recall query is ambiguous?
 
-These are the questions that decide whether a memory system is deployable inside a company. MemClaw was designed around them — scoped memory (agent / fleet / cross-fleet), per-agent trust tiers, PII quarantine before cross-fleet exposure, full audit log, the `memclaw_evolve` → `memclaw_insights` outcome-propagation loop. **None of this moves a recall@k number. All of it moves whether you can deploy.**
+These are the questions that decide whether a memory system is deployable inside a company. Caura was designed around them — scoped memory (agent / fleet / cross-fleet), per-agent trust tiers, PII quarantine before cross-fleet exposure, full audit log, the `memclaw_evolve` → `memclaw_insights` outcome-propagation loop. **None of this moves a recall@k number. All of it moves whether you can deploy.**
 
 The field needs a benchmark for the fleet-shaped problem. We're working toward one. If you're thinking about this too, the [Discord](https://discord.com/invite/aNfpgfpj) is open.
 
-## How MemClaw compares
+## How Caura compares
 
-For a single chatbot, the public-benchmark leaders (MemClaw, Mem0, Zep) cluster in a narrow accuracy band — the choice usually comes down to stack fit, latency, and token budget.
+For a single chatbot, the public-benchmark leaders (Caura, Mem0, Zep) cluster in a narrow accuracy band — the choice usually comes down to stack fit, latency, and token budget.
 
-MemClaw differentiates on the dimensions a single-agent benchmark can't see:
+Caura differentiates on the dimensions a single-agent benchmark can't see:
 
 | Dimension | Why it matters at fleet scale |
 |---|---|

--- a/plugin/skills/memclaw/SKILL.md
+++ b/plugin/skills/memclaw/SKILL.md
@@ -5,18 +5,18 @@ user-invocable: false
 metadata: {"openclaw": {"requires": {"config": ["plugins.entries.memclaw.enabled"]}}}
 ---
 
-# MemClaw Skill
+# Caura Skill
 
-MemClaw is your long-term memory. Anything you learn that you don't write here
+Caura is your long-term memory. Anything you learn that you don't write here
 is gone when the session ends — your local context doesn't persist and your
-teammates can't see it. So treat MemClaw as the default home for every
+teammates can't see it. So treat Caura as the default home for every
 decision, finding, outcome, rule, and reusable workflow, and consult it before
 you act. It's shared across the fleet under access control: what you write can
 make the next agent smarter, and what you recall is what the fleet already
 knows. Using it is the job, not an optional extra.
 
 **The plugin runs a baseline loop for you — the tools are still yours.** On this
-runtime the MemClaw plugin handles the automatic layer: it injects the mandatory
+runtime the Caura plugin handles the automatic layer: it injects the mandatory
 keystones at session start (§1), recalls relevant memory before your substantive
 turns (§11), and writes a short **turn summary** afterward as a backstop
 (`MEMCLAW_AUTO_WRITE_TURNS`, on by default). Treat that as a floor, not a
@@ -129,7 +129,7 @@ visible to the fleet because it went in at `scope_team`.
 Never paste secrets — API keys, tokens, credentials — into memory `content`.
 The PII scan is a safety net, not permission; keep them out entirely.
 
-**Some memories may be written for you.** If your tenant has the MemClaw
+**Some memories may be written for you.** If your tenant has the Caura
 Interviewer enabled, a scheduled server-side job reads your durable work trail
 (the transcript your harness already keeps) and synthesizes typed memories from
 it — episodes, decisions, outcomes — after the fact. You don't invoke it and
@@ -221,9 +221,9 @@ A few habits keep recall trustworthy and sharp:
   transition the stale one. Two live opposing beliefs degrade every future
   recall for everyone.
 
-## 8 · MemClaw vs your workspace files
+## 8 · Caura vs your workspace files
 
-MemClaw is the only place for cross-session, cross-agent knowledge. A
+Caura is the only place for cross-session, cross-agent knowledge. A
 file-based scratchpad in your workspace (e.g. `MEMORY.md`) is **session-local**
 — it lives in your bootstrap context every turn and pays input tokens for every
 byte, and your teammates never see it.
@@ -231,11 +231,11 @@ byte, and your teammates never see it.
 - Keep `MEMORY.md` lean: only **active projects, current routing decisions,
   recent decisions (≤ 7 days), open threads.** Target a few KB; prune anything
   older or larger on session start.
-- Everything else goes to MemClaw via `memclaw_write` (history, finished work,
+- Everything else goes to Caura via `memclaw_write` (history, finished work,
   lessons), `memclaw_doc` collections (reference data with a natural key), or
   entities (people / projects / services).
-- Never copy MemClaw recall results into `MEMORY.md` — they're already
-  retrievable. Never substitute a local file for a MemClaw write.
+- Never copy Caura recall results into `MEMORY.md` — they're already
+  retrievable. Never substitute a local file for a Caura write.
 
 ## 9 · Capture cadence (L1 / L2 / L3)
 
@@ -391,7 +391,7 @@ for, and the behaviors that aren't visible in a parameter list.
 - Guessing `agent_id` / `fleet_id`, or inventing UUIDs.
 - Deleting when you should supersede.
 - Writing org-wide (`scope_org`) anything that isn't genuinely org-relevant.
-- Substituting `MEMORY.md` / local files for a MemClaw write.
+- Substituting `MEMORY.md` / local files for a Caura write.
 - Silently dropping a denied call — surface the error so the orchestrator can decide.
 
 ### Constraints & errors
@@ -403,7 +403,7 @@ for, and the behaviors that aren't visible in a parameter list.
 
 ---
 
-*This skill ships with the MemClaw plugin at its install path; it is visible to
+*This skill ships with the Caura plugin at its install path; it is visible to
 every agent on a node that has the plugin enabled
 (`plugins.entries.memclaw.enabled`). To customize it for a specific agent, place
 a replacement file at `<workspace>/skills/memclaw/SKILL.md` — it takes

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -1,4 +1,4 @@
-# MemClaw — OpenClaw Integration Guide
+# Caura — OpenClaw Integration Guide
 
 ---
 
@@ -7,25 +7,25 @@
 
 ## 1. Overview
 
-MemClaw is a shared memory layer for OpenClaw agents. It runs as a separate API service that agents access through an OpenClaw plugin or any MCP client.
+Caura is a shared memory layer for OpenClaw agents. It runs as a separate API service that agents access through an OpenClaw plugin or any MCP client.
 
 ### Architecture
 
 ```
-MCP Client      → Streamable HTTP  → MemClaw API (/mcp) → Postgres + pgvector
-OpenClaw Agent  → tool call        → MemClaw Plugin → HTTP → MemClaw API → Postgres + pgvector
-Plugin          → heartbeat (60s)  → MemClaw API ← commands (response)
-Browser (UI)    → HTTP             → MemClaw API → Postgres + pgvector
+MCP Client      → Streamable HTTP  → Caura API (/mcp) → Postgres + pgvector
+OpenClaw Agent  → tool call        → Caura Plugin → HTTP → Caura API → Postgres + pgvector
+Plugin          → heartbeat (60s)  → Caura API ← commands (response)
+Browser (UI)    → HTTP             → Caura API → Postgres + pgvector
 ```
 
 ### Components
 
 | Component | Where it runs | What it does |
 |---|---|---|
-| MemClaw API | Any host (Docker, VM, cloud run, local) | FastAPI service — memories, entities, search, enrichment |
+| Caura API | Any host (Docker, VM, cloud run, local) | FastAPI service — memories, entities, search, enrichment |
 | MCP Server | Same process (`/mcp`) | Streamable HTTP endpoint for any MCP client |
 | Postgres + pgvector | Anywhere (Docker, VM, managed) | Vector + relational store |
-| MemClaw Plugin | OpenClaw gateway VM | Thin adapter forwarding tool calls to the API |
+| Caura Plugin | OpenClaw gateway VM | Thin adapter forwarding tool calls to the API |
 | Web UI | Served at `/ui` | Manage, Prism (with Graph button), Playground, Fleet, MCP Test, Ingest, Admin Dashboard |
 
 ### Tools available to agents
@@ -56,7 +56,7 @@ Tool descriptions are derived from the tool registry (`core-api/src/core_api/too
 
 ## 2. MCP Integration (Claude Desktop, Claude Code, Cursor, etc.)
 
-MemClaw includes a built-in MCP server at `/mcp` using Streamable HTTP transport. Any MCP-compatible client connects with just a URL and an API key — no plugin install, no local server.
+Caura includes a built-in MCP server at `/mcp` using Streamable HTTP transport. Any MCP-compatible client connects with just a URL and an API key — no plugin install, no local server.
 
 ### Setup
 
@@ -153,7 +153,7 @@ MCP uses the same tenant-scoped API keys as the REST API. The `X-API-Key` header
 
 ### Example usage
 
-Once configured, the MCP client handles tool discovery. Agents can use MemClaw tools naturally:
+Once configured, the MCP client handles tool discovery. Agents can use Caura tools naturally:
 
 > "Search my memories for anything about the Postgres migration"
 > -> calls `memclaw_recall` with query "Postgres migration"
@@ -190,7 +190,7 @@ The plugin is a TypeScript package in the `plugin/` directory of this repo. It c
 |---|---|---|
 | OpenClaw runtime | **`v2026.3.22`** | First release with `registerContextEngine` + `assemble({prompt, …})`. Older runtimes fall back to the legacy `before_prompt_build` path with reduced functionality. |
 | Node.js | `v18+` | Required to build and run the plugin. |
-| MemClaw backend (this repo's `core-api`) | `v2.4.0` | Backend exposes `/plugin-manifest` for upgrade-path resilience. Plugins on `< v2.4.0` fall back to a hardcoded file list (still works against current backends). |
+| Caura backend (this repo's `core-api`) | `v2.4.0` | Backend exposes `/plugin-manifest` for upgrade-path resilience. Plugins on `< v2.4.0` fall back to a hardcoded file list (still works against current backends). |
 
 The plugin's install script does a soft preflight on `openclaw --version` and prints a warning when the local runtime is older than the recommended minimum. It does NOT hard-fail — operators sometimes run patched older builds, and the plugin still loads partially below the minimum. Upgrade OpenClaw when convenient.
 
@@ -220,7 +220,7 @@ scp -r plugin/dist plugin/package.json plugin/openclaw.plugin.json \
 Add to `~/.openclaw/plugins/memclaw/.env`:
 
 ```bash
-MEMCLAW_API_URL=https://your-memclaw-instance.example.com   # your MemClaw API
+MEMCLAW_API_URL=https://your-memclaw-instance.example.com   # your Caura API
 MEMCLAW_API_KEY=mc_your_key_here                             # tenant-scoped API key
 MEMCLAW_FLEET_ID=fleet-001                                   # identifies this fleet
 MEMCLAW_NODE_NAME=my-gateway                                 # friendly name shown in Fleet page
@@ -296,7 +296,7 @@ The plugin registers 11 tools (the MCP surface minus the MCP-only `memclaw_keyst
 
 - **ContextEngine** — 7 lifecycle hooks: `bootstrap` (smoke test), `ingest` (message buffering + persistence), `assemble` (token-budget-aware recall injection), `compact` (persist summaries), `afterTurn` (auto-write turn summaries), `prepareSubagentSpawn`, `onSubagentEnded`
 - **Memory runtime** — API-backed `search()` and `get()` replacing file-based `memory-core`
-- **Heartbeat** — every 60 seconds, POSTs node status (agents, tools, OS, IP, plugin version, setup_status) to `/api/v1/fleet/heartbeat`. MemClaw responds with any pending commands
+- **Heartbeat** — every 60 seconds, POSTs node status (agents, tools, OS, IP, plugin version, setup_status) to `/api/v1/fleet/heartbeat`. Caura responds with any pending commands
 - **Commands** — the plugin processes HMAC-verified commands from the heartbeat response:
   - `deploy` — fetch all source files to memory, backup originals, write + build, rollback on failure
   - `educate` — write prompts to agent HEARTBEAT.md files + write SKILL.md, TOOLS.md, AGENTS.md to workspaces
@@ -325,7 +325,7 @@ The **Agent Education Status** section in Plugin Manager shows green checkmarks 
 
 ## 4. Agent Trust Levels
 
-MemClaw enforces a 4-tier trust system for agents. Agents are auto-registered on their first `memclaw_write` call at trust level 1.
+Caura enforces a 4-tier trust system for agents. Agents are auto-registered on their first `memclaw_write` call at trust level 1.
 
 | Level | Name | Permissions |
 |---|---|---|
@@ -371,7 +371,7 @@ The Manage page (`/ui/tenant-admin.html`) is the tabbed tenant admin dashboard, 
 Add this to your agent's system prompt (or use Agent Education to let agents self-configure):
 
 ```
-You have access to MemClaw, a shared memory system used by all agents.
+You have access to Caura, a shared memory system used by all agents.
 
 BEFORE starting any task:
 - Use memclaw_recall for semantic + keyword search with graph expansion

--- a/static/skills/company-brain/SKILL.md
+++ b/static/skills/company-brain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: company-brain
-description: How an agent should operate as one mind inside a shared Company Brain built on MemClaw — recall before acting, obey fleet keystones, reuse and publish skills, and report outcomes so every task compounds across the whole organization. Use this whenever you work as part of a MemClaw-connected team or fleet and your work should build on, and feed back into, what the organization already knows; it sets the operating posture. For the mechanics of individual memclaw_* tools, see the companion "memclaw" skill.
+description: How an agent should operate as one mind inside a shared Company Brain built on Caura — recall before acting, obey fleet keystones, reuse and publish skills, and report outcomes so every task compounds across the whole organization. Use this whenever you work as part of a Caura-connected team or fleet and your work should build on, and feed back into, what the organization already knows; it sets the operating posture. For the mechanics of individual memclaw_* tools, see the companion "memclaw" skill.
 user-invocable: false
 ---
 
@@ -59,6 +59,6 @@ you found it." Five habits make that real.
 
 ---
 
-*Posture layer for the MemClaw Company Brain. Pair it with the `memclaw` skill,
-which carries the tool mechanics. Built on the MemClaw protocol (Apache 2.0) —
+*Posture layer for the Caura Company Brain. Pair it with the `memclaw` skill,
+which carries the tool mechanics. Built on the Caura protocol (Apache 2.0) —
 see [memclaw.net](https://memclaw.net).*

--- a/static/skills/memclaw/SKILL.md
+++ b/static/skills/memclaw/SKILL.md
@@ -4,11 +4,11 @@ description: The agent's persistent long-term memory — the only knowledge that
 user-invocable: false
 ---
 
-# MemClaw Skill
+# Caura Skill
 
-MemClaw is your long-term memory. Anything you learn that you don't write here
+Caura is your long-term memory. Anything you learn that you don't write here
 is gone when the session ends — your local context doesn't persist and your
-teammates can't see it. So treat MemClaw as the default home for every
+teammates can't see it. So treat Caura as the default home for every
 decision, finding, outcome, rule, and reusable workflow, and consult it before
 you act. It's shared across the fleet under access control: what you write can
 make the next agent smarter, and what you recall is what the fleet already
@@ -112,7 +112,7 @@ visible to the fleet because it went in at `scope_team`.
 Never paste secrets — API keys, tokens, credentials — into memory `content`.
 The PII scan is a safety net, not permission; keep them out entirely.
 
-**Some memories may be written for you.** If your runtime has the MemClaw
+**Some memories may be written for you.** If your runtime has the Caura
 Interviewer enabled, a scheduled server-side job reads your durable work trail
 (the transcript your harness already keeps) and synthesizes typed memories from
 it — episodes, decisions, outcomes — after the fact. You don't invoke it and
@@ -343,4 +343,4 @@ parameter list.
 this file to `~/.claude/skills/memclaw/SKILL.md` (Claude Code) or
 `~/.agents/skills/memclaw/SKILL.md` (Codex). Per-workspace override: place a copy
 under `.claude/skills/memclaw/` or `.agents/skills/memclaw/`. OpenClaw fleets use
-the variant shipped with the MemClaw plugin.*
+the variant shipped with the Caura plugin.*


### PR DESCRIPTION
## What (rebrand Phase 3c, OSS side)

Case-sensitive whole-word `MemClaw` → `Caura`: 126 occurrences / 13 prose files — README body, AGENT-INSTALL, CONTRIBUTING, `static/docs/integration-guide.md`, both `SKILL.md` copies, company-brain skill, python + TS client READMEs, `docs/*`.

## Protected / unchanged

- Sentinel-protected verbatim: the hero bridge line, `Caura (formerly MemClaw)` heading, trademark line
- All 107 `memclaw_*` tool literals across the two SKILL.md copies — grep-verified intact
- `memclaw.net` URLs (flip at cutover) · package names (Phase 6) · logo assets (pending wordmark)

## Testing

Local run of skill/manifest tests hits the DB-fixture wall (integration tests need Postgres) — CI is authoritative here; the diff is markdown-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)