### PR TITLE
feat(memory): contradiction classification logic — L1/L2/L3 (A55 1d)

### DIFF
--- a/core-api/src/core_api/services/contradiction/diagnosis.py
+++ b/core-api/src/core_api/services/contradiction/diagnosis.py
@@ -1,0 +1,148 @@
+"""L2 — diagnosis (cause) classification + the combined L1+L2 classifier (A55).
+
+L2 answers *why* a candidate pair differs: correction / temporal_change /
+scope_difference / entity_mismatch / write_error / unresolved. It builds on L1
+(``relationship``) and the model's existing ``non_conflict_reason`` / same_subject
+signals, so most diagnoses are derivable; the model can also emit ``diagnosis``
+explicitly via the extended prompt.
+
+``classify()`` is the combined entry the engine resolver will call — ONE LLM call
+yields both the L1 relationship and the L2 diagnosis. Like L1 this is dormant
+(nothing wires it into production yet) and never mutates the legacy prompt/verdict.
+See benchmark/a55/subtasks/12-L1-relationship-logic.md (L2 section in 13-…).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from core_api.services.contradiction.relationship import (
+    _CONF_DERIVED,
+    _CONF_FALLBACK,
+    _CONF_MODEL,
+    _CONF_RDF,
+    _RELATIONSHIP_INSTRUCTION,
+    CONTRADICTION_PROMPT,
+    _is_rdf_exact_value,
+    _llm_raw,
+    extract_relationship,
+)
+
+logger = logging.getLogger(__name__)
+
+# Mirror of common/models/memory_conflict.DIAGNOSES.
+DIAGNOSES: frozenset[str] = frozenset(
+    {
+        "correction",
+        "temporal_change",
+        "scope_difference",
+        "entity_mismatch",
+        "write_error",
+        "unresolved",
+    }
+)
+
+# RDF exact-value is ambiguous between "moved" (temporal_change) and "was wrong"
+# (correction). Default to temporal_change so the eventual L3 action (supersede)
+# matches today's RDF behaviour; a temporal/LLM signal can refine it later.
+_CONF_RDF_DEFAULT_DIAG = 0.50
+
+_DIAGNOSIS_INSTRUCTION = """
+
+In the SAME JSON object, ALSO include a "diagnosis" field: WHY the two statements
+differ. Choose EXACTLY one:
+  - "correction": the newer statement fixes an error in the older; the old value
+    was simply wrong ("actually it's X", "correction: Y").
+  - "temporal_change": the subject's state genuinely changed over time; both were
+    true in sequence (moved cities, was promoted, plan -> shipped).
+  - "scope_difference": they describe the same subject under different implicit
+    qualifiers (time window, whole vs part, context) and both can hold.
+  - "entity_mismatch": they are actually about different real-world entities
+    (two people sharing a name, two builds, two events).
+  - "write_error": one is a malformed / mistaken write (garbled, wrong field).
+  - "unresolved": the cause cannot be determined from the text.
+Return ONE JSON object with "relationship" AND "diagnosis" AND the other fields.
+"""
+
+
+def extract_diagnosis(raw: dict, relationship: str | None) -> tuple[str | None, str]:
+    """Read ``diagnosis`` from a model response, or derive it from L1 +
+    non_conflict_reason + same_subject. Returns ``(diagnosis, source)``."""
+    if not isinstance(raw, dict):
+        return None, "none"
+
+    val = raw.get("diagnosis")
+    if isinstance(val, str) and val in DIAGNOSES:
+        return val, "model"
+
+    ncr = raw.get("non_conflict_reason")
+    if raw.get("same_subject") is False or ncr == "same_name_distinct_subject":
+        return "entity_mismatch", "derived"
+    if ncr == "temporal_supersession":
+        return "temporal_change", "derived"
+    if ncr == "scope_mismatch" or relationship == "scope_apparent":
+        return "scope_difference", "derived"
+    if raw.get("contradicts") is True and relationship in {"exact_value", "negation"}:
+        return "correction", "derived"
+    if relationship in {"entailed", "constraint", "refinement", "probabilistic"}:
+        # Both-hold shapes — nothing to resolve.
+        return "unresolved", "derived"
+    return None, "none"
+
+
+def _conf_for(source: str) -> float:
+    return {
+        "model": _CONF_MODEL,
+        "derived": _CONF_DERIVED,
+    }.get(source, _CONF_FALLBACK)
+
+
+@dataclass(frozen=True)
+class ClassifyResult:
+    """Combined L1 + L2 result for a candidate pair."""
+
+    relationship: str
+    relationship_confidence: float
+    diagnosis: str
+    diagnosis_confidence: float
+
+
+async def classify(
+    new_memory: dict,
+    candidate: dict,
+    *,
+    tenant_config=None,
+) -> ClassifyResult:
+    """Combined L1 (relationship) + L2 (diagnosis) classification — ONE LLM call.
+
+    Always returns valid values (relationship defaults to ``exact_value``,
+    diagnosis to ``unresolved``), since a pair only reaches here after retrieval
+    flagged it as a conflict candidate.
+    """
+    # Deterministic RDF exact-value: L1 is certain, L2 defaults (see above).
+    if _is_rdf_exact_value(new_memory, candidate):
+        return ClassifyResult("exact_value", _CONF_RDF, "temporal_change", _CONF_RDF_DEFAULT_DIAG)
+
+    new_content = str(new_memory.get("content", ""))[:500]
+    old_content = str(candidate.get("content", ""))[:500]
+    prompt = (
+        CONTRADICTION_PROMPT.format(new_content=new_content, old_content=old_content)
+        + _RELATIONSHIP_INSTRUCTION
+        + _DIAGNOSIS_INSTRUCTION
+    )
+    raw = await _llm_raw(prompt, tenant_config)
+
+    rel_label, rel_src = extract_relationship(raw)
+    if rel_label is None:
+        rel_label, rel_src = "exact_value", "fallback"
+    diag_label, diag_src = extract_diagnosis(raw, rel_label)
+    if diag_label is None:
+        diag_label, diag_src = "unresolved", "fallback"
+        logger.info(
+            "L2 diagnosis unclassified for new=%s cand=%s -> unresolved",
+            new_memory.get("id"),
+            candidate.get("id"),
+        )
+
+    return ClassifyResult(rel_label, _conf_for(rel_src), diag_label, _conf_for(diag_src))

--- a/core-api/src/core_api/services/contradiction/relationship.py
+++ b/core-api/src/core_api/services/contradiction/relationship.py
@@ -1,0 +1,185 @@
+"""L1 — relationship classification (A55, unified contradiction model).
+
+``classify_relationship(new_memory, candidate)`` returns ``(relationship,
+confidence)`` — the semantic relationship between a candidate pair, independent
+of whether they contradict. It populates ``memory_conflicts.relationship``.
+
+Two branches (see benchmark/a55/subtasks/12-L1-relationship-logic.md):
+  * **deterministic** — RDF exact-value (same subject_entity_id + predicate,
+    different object_value) short-circuits to ``exact_value`` with no LLM call.
+  * **LLM** — the detector's ``CONTRADICTION_PROMPT`` EXTENDED with a relationship
+    instruction; ``extract_relationship`` reads the field, with a derivation
+    fallback from the model's existing ``non_conflict_reason`` taxonomy.
+
+No-degradation: the legacy ``CONTRADICTION_PROMPT`` and the verdict path are
+untouched — L1 appends its instruction to a copy. Nothing wires
+``classify_relationship`` into production yet (the engine resolver does so on the
+ON path in a later slice), so this module is dormant and behaviour-neutral.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core_api.config import settings
+from core_api.providers._retry import call_with_fallback
+from core_api.services.contradiction_detector import CONTRADICTION_PROMPT
+
+logger = logging.getLogger(__name__)
+
+# Mirror of the model's L1 vocabulary (common/models/memory_conflict.RELATIONSHIPS).
+# Imported lazily-safe as a literal so this module never depends on the ORM layer.
+RELATIONSHIPS: frozenset[str] = frozenset(
+    {
+        "exact_value",
+        "negation",
+        "entailed",
+        "constraint",
+        "probabilistic",
+        "scope_apparent",
+        "refinement",
+    }
+)
+
+# Confidence by how the label was obtained.
+_CONF_RDF = 0.95
+_CONF_MODEL = 0.80
+_CONF_DERIVED = 0.55
+_CONF_FALLBACK = 0.50
+
+# Derive a relationship from the model's existing non_conflict_reason taxonomy
+# when it doesn't emit an explicit ``relationship`` (older/partial responses).
+_NCR_TO_RELATIONSHIP: dict[str, str] = {
+    "refinement": "refinement",
+    "scope_mismatch": "scope_apparent",
+    "list_valued_predicate": "constraint",
+    "temporal_supersession": "exact_value",  # temporal aspect is L2, slot is exact_value
+    "event_restatement": "entailed",
+    "conditional_unrealized": "probabilistic",
+}
+
+# Appended to a COPY of CONTRADICTION_PROMPT — never mutates the original.
+_RELATIONSHIP_INSTRUCTION = """
+
+In the SAME JSON object, ALSO include a "relationship" field: the semantic
+relationship between Statement A and Statement B, independent of whether they
+contradict. Choose EXACTLY one:
+  - "exact_value": same attribute/slot of the same subject, different single
+    value (X lives in Tel Aviv vs Haifa; flight at 6pm vs 8pm).
+  - "negation": one asserts P, the other asserts not-P (is active vs is inactive).
+  - "entailed": one logically implies or restates the other (joined vs was hired;
+    "in Munich" implies "in Germany").
+  - "constraint": a multi-valued / list predicate where both can hold at once
+    (speaks English; speaks French).
+  - "probabilistic": one or both are hedged, hypothetical, or uncertain
+    ("might move to B", "probably prefers X").
+  - "scope_apparent": same attribute under different implicit qualifiers — time
+    window, whole vs part, or context (weekday vs weekend); both may hold.
+  - "refinement": one is a more specific version of the other (Europe vs Munich;
+    Q3 vs September 15).
+Return ONE JSON object containing all the fields above PLUS "relationship".
+"""
+
+
+def _is_rdf_exact_value(new_memory: dict, candidate: dict) -> bool:
+    """Deterministic RDF exact-value: same subject_entity_id + predicate, with
+    two different non-null object_values. No LLM needed."""
+    ns, cs = new_memory.get("subject_entity_id"), candidate.get("subject_entity_id")
+    np_, cp = new_memory.get("predicate"), candidate.get("predicate")
+    nv, cv = new_memory.get("object_value"), candidate.get("object_value")
+    return bool(
+        ns
+        and cs
+        and str(ns) == str(cs)
+        and np_
+        and cp
+        and np_ == cp
+        and nv is not None
+        and cv is not None
+        and nv != cv
+    )
+
+
+def extract_relationship(raw: dict) -> tuple[str | None, str]:
+    """Read the ``relationship`` from a model response, or derive it.
+
+    Returns ``(relationship, source)`` where source is ``"model"`` (explicit),
+    ``"derived"`` (mapped from non_conflict_reason / contradicts), or ``"none"``.
+    """
+    if not isinstance(raw, dict):
+        return None, "none"
+
+    val = raw.get("relationship")
+    if isinstance(val, str) and val in RELATIONSHIPS:
+        return val, "model"
+
+    ncr = raw.get("non_conflict_reason")
+    if isinstance(ncr, str) and ncr in _NCR_TO_RELATIONSHIP:
+        return _NCR_TO_RELATIONSHIP[ncr], "derived"
+
+    if raw.get("contradicts") is True:
+        # Same-subject, mutually-exclusive, no non-conflict shape -> same slot.
+        return "exact_value", "derived"
+
+    return None, "none"
+
+
+async def _llm_raw(prompt: str, tenant_config=None) -> dict:
+    """LLM call seam (patched in tests). Uses the standard provider-fallback
+    chain; returns the parsed JSON dict (``{}`` on total failure)."""
+    provider_name = (
+        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
+    )
+
+    async def _do(llm) -> dict:
+        return await llm.complete_json(prompt)
+
+    return await call_with_fallback(
+        primary_provider_name=provider_name,
+        call_fn=_do,
+        fake_fn=lambda: {},
+        tenant_config=tenant_config,
+        service_label="relationship",
+        model_attr="entity_extraction_model",
+        timeout=10.0,
+    )
+
+
+async def classify_relationship(
+    new_memory: dict,
+    candidate: dict,
+    *,
+    tenant_config=None,
+) -> tuple[str, float]:
+    """L1: classify the relationship for a candidate pair. Always returns a
+    valid relationship (defaults to ``exact_value`` when unclassifiable, since a
+    pair only reaches L1 after retrieval flagged it as a conflict candidate).
+
+    The entity-aware variant (Path C, using ENTITY_AWARE_CONTRADICTION_PROMPT +
+    resolved entity context) is a follow-up; this cut covers the base path.
+    """
+    # Branch 1 — deterministic RDF exact-value.
+    if _is_rdf_exact_value(new_memory, candidate):
+        return "exact_value", _CONF_RDF
+
+    # Branch 2 — LLM. Extend a COPY of the base prompt (never mutate the original).
+    new_content = str(new_memory.get("content", ""))[:500]
+    old_content = str(candidate.get("content", ""))[:500]
+    prompt = (
+        CONTRADICTION_PROMPT.format(new_content=new_content, old_content=old_content)
+        + _RELATIONSHIP_INSTRUCTION
+    )
+
+    raw = await _llm_raw(prompt, tenant_config)
+    relationship, source = extract_relationship(raw)
+
+    if relationship is None:
+        logger.info(
+            "L1 relationship unclassified for new=%s cand=%s -> defaulting exact_value",
+            new_memory.get("id"),
+            candidate.get("id"),
+        )
+        return "exact_value", _CONF_FALLBACK
+
+    conf = _CONF_MODEL if source == "model" else _CONF_DERIVED
+    return relationship, conf

--- a/core-api/src/core_api/services/contradiction/resolution.py
+++ b/core-api/src/core_api/services/contradiction/resolution.py
@@ -1,0 +1,102 @@
+"""L3 — resolution: map (relationship x diagnosis x evidence) -> action (A55).
+
+Pure decision function + the unified model's safety invariants. Given the L1
+relationship, the L2 diagnosis, and the evidence dimensions (is_inferred /
+relationship strength / confidence), pick a resolution *action* and a
+human-readable *audit_reason*.
+
+IMPORTANT — this only RECOMMENDS an action for the ``memory_conflicts`` record.
+Applying an effect to the memory row (``status`` / ``supersedes_id``) is done by
+the detector today and is unchanged; the write step (next) persists this
+recommendation additively without mutating that effect, so behaviour is preserved
+(the golden differential test is the gate). Turning a recommendation like
+``replace`` into an actual overwrite is a later, deliberately-flagged step.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Mirror of common/models/memory_conflict.ACTIONS.
+ACTIONS: frozenset[str] = frozenset(
+    {
+        "replace",
+        "supersede",
+        "scope",
+        "merge",
+        "split_entity",
+        "downweight",
+        "mark_disputed",
+        "ask",
+        "no_op",
+    }
+)
+
+# Diagnosis is the dominant signal for the action.
+_DIAGNOSIS_ACTION: dict[str, str] = {
+    "temporal_change": "supersede",  # state changed; keep old as history
+    "correction": "replace",  # old was wrong; new replaces it
+    "scope_difference": "scope",  # both hold under different qualifiers
+    "entity_mismatch": "split_entity",  # different entities; don't supersede
+    "write_error": "mark_disputed",  # malformed; flag for review
+    "unresolved": "ask",  # can't decide from text
+}
+
+# Relationships where both statements hold — never supersede/replace.
+_BOTH_HOLD: frozenset[str] = frozenset({"entailed", "constraint", "refinement"})
+
+# Actions that overturn an existing fact — gated by the safety invariants.
+_DESTRUCTIVE: frozenset[str] = frozenset({"replace", "supersede"})
+
+# Below this classification confidence, don't overturn — flag instead.
+_LOW_CONFIDENCE = 0.5
+
+
+@dataclass(frozen=True)
+class Resolution:
+    action: str
+    audit_reason: str
+
+
+def resolve(
+    relationship: str,
+    diagnosis: str,
+    *,
+    is_inferred: bool = False,
+    confidence: float | None = None,
+) -> Resolution:
+    """Map the classification to a resolution action, applying safety invariants.
+
+    Always returns a valid ``ACTIONS`` value. The invariants (in order) protect
+    against weak evidence overturning strong facts — the unified model's rule
+    that *inference is weaker than explicit contradiction*.
+    """
+    # Both-hold relationships resolve to nothing regardless of diagnosis.
+    if relationship in _BOTH_HOLD:
+        return Resolution("no_op", f"{relationship}: both statements hold; no resolution needed")
+
+    action = _DIAGNOSIS_ACTION.get(diagnosis, "ask")
+    reason = f"{relationship}/{diagnosis} -> {action}"
+
+    # Invariant: a system-inferred memory must not overturn an explicit fact.
+    if is_inferred and action in _DESTRUCTIVE:
+        return Resolution(
+            "mark_disputed",
+            reason + " | downgraded: inferred evidence must not overturn an explicit fact",
+        )
+
+    # Invariant: a hedged/uncertain relationship softens, never hard-replaces.
+    if relationship == "probabilistic" and action in _DESTRUCTIVE:
+        return Resolution(
+            "downweight",
+            reason + " | probabilistic relationship: downweight, not overturn",
+        )
+
+    # Invariant: low classification confidence flags rather than overturns.
+    if confidence is not None and confidence < _LOW_CONFIDENCE and action in _DESTRUCTIVE:
+        return Resolution(
+            "mark_disputed",
+            reason + f" | low confidence {confidence:.2f}: flag rather than overturn",
+        )
+
+    return Resolution(action, reason)

--- a/tests/test_contradiction_diagnosis.py
+++ b/tests/test_contradiction_diagnosis.py
@@ -1,0 +1,168 @@
+"""L2 diagnosis + combined L1+L2 classifier tests (A55)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from core_api.services.contradiction import diagnosis as dx
+from core_api.services.contradiction import relationship as rel
+
+pytestmark = pytest.mark.unit
+
+SUBJ = "00000000-0000-0000-0000-0000000000aa"
+
+
+def _mem(**over) -> dict:
+    base = {
+        "id": "m",
+        "content": "text",
+        "subject_entity_id": None,
+        "predicate": None,
+        "object_value": None,
+    }
+    base.update(over)
+    return base
+
+
+# ── extract_diagnosis: model-emitted, each of the 6 ───────────────────
+@pytest.mark.parametrize(
+    "value",
+    [
+        "correction",
+        "temporal_change",
+        "scope_difference",
+        "entity_mismatch",
+        "write_error",
+        "unresolved",
+    ],
+)
+def test_extract_reads_model_diagnosis(value):
+    assert dx.extract_diagnosis({"diagnosis": value}, "exact_value") == (value, "model")
+
+
+# ── extract_diagnosis: derivation from signals + L1 ───────────────────
+def test_derive_entity_mismatch_from_same_subject_false():
+    assert dx.extract_diagnosis({"same_subject": False}, "negation") == (
+        "entity_mismatch",
+        "derived",
+    )
+
+
+def test_derive_entity_mismatch_from_same_name_distinct():
+    assert dx.extract_diagnosis(
+        {"non_conflict_reason": "same_name_distinct_subject"}, "exact_value"
+    ) == (
+        "entity_mismatch",
+        "derived",
+    )
+
+
+def test_derive_temporal_change_from_supersession():
+    assert dx.extract_diagnosis(
+        {"non_conflict_reason": "temporal_supersession"}, "exact_value"
+    ) == (
+        "temporal_change",
+        "derived",
+    )
+
+
+def test_derive_scope_difference_from_reason_or_relationship():
+    assert dx.extract_diagnosis(
+        {"non_conflict_reason": "scope_mismatch"}, "exact_value"
+    ) == (
+        "scope_difference",
+        "derived",
+    )
+    assert dx.extract_diagnosis({}, "scope_apparent") == ("scope_difference", "derived")
+
+
+def test_derive_correction_from_contradicts_true():
+    assert dx.extract_diagnosis({"contradicts": True}, "exact_value") == (
+        "correction",
+        "derived",
+    )
+    assert dx.extract_diagnosis({"contradicts": True}, "negation") == (
+        "correction",
+        "derived",
+    )
+
+
+def test_derive_unresolved_for_both_hold_shapes():
+    for r in ("entailed", "constraint", "refinement", "probabilistic"):
+        assert dx.extract_diagnosis({}, r) == ("unresolved", "derived")
+
+
+def test_extract_none_when_unclassifiable():
+    assert dx.extract_diagnosis({"contradicts": False}, "exact_value") == (None, "none")
+    assert dx.extract_diagnosis("nope", "exact_value") == (None, "none")
+
+
+# ── combined classify(): RDF deterministic branch (no LLM) ────────────
+@pytest.mark.asyncio
+async def test_classify_rdf_branch_no_llm():
+    new = _mem(subject_entity_id=SUBJ, predicate="lives_in", object_value="Haifa")
+    cand = _mem(subject_entity_id=SUBJ, predicate="lives_in", object_value="Tel Aviv")
+    with patch.object(dx, "_llm_raw", new=AsyncMock()) as llm:
+        res = await dx.classify(new, cand)
+    assert res.relationship == "exact_value"
+    assert res.relationship_confidence == rel._CONF_RDF
+    assert res.diagnosis == "temporal_change"  # RDF default (supersede-preserving)
+    assert res.diagnosis_confidence == dx._CONF_RDF_DEFAULT_DIAG
+    llm.assert_not_called()
+
+
+# ── combined classify(): LLM branch, one call yields both ─────────────
+@pytest.mark.asyncio
+async def test_classify_llm_branch_extracts_both():
+    calls = {"n": 0}
+
+    async def fake_llm(prompt, tenant_config=None):
+        calls["n"] += 1
+        # prompt carries BOTH instructions
+        assert "relationship" in prompt and "diagnosis" in prompt
+        return {
+            "contradicts": True,
+            "relationship": "negation",
+            "diagnosis": "correction",
+        }
+
+    with patch.object(dx, "_llm_raw", new=fake_llm):
+        res = await dx.classify(
+            _mem(content="Alice inactive"), _mem(content="Alice active")
+        )
+
+    assert calls["n"] == 1  # single LLM call for L1 + L2
+    assert (
+        res.relationship == "negation"
+        and res.relationship_confidence == rel._CONF_MODEL
+    )
+    assert res.diagnosis == "correction" and res.diagnosis_confidence == rel._CONF_MODEL
+
+
+@pytest.mark.asyncio
+async def test_classify_llm_branch_derives_when_fields_absent():
+    async def fake_llm(prompt, tenant_config=None):
+        return {"non_conflict_reason": "temporal_supersession"}  # no explicit fields
+
+    with patch.object(dx, "_llm_raw", new=fake_llm):
+        res = await dx.classify(_mem(content="a"), _mem(content="b"))
+    assert res.relationship == "exact_value"  # derived from temporal_supersession
+    assert res.diagnosis == "temporal_change"
+    assert res.diagnosis_confidence == rel._CONF_DERIVED
+
+
+@pytest.mark.asyncio
+async def test_classify_llm_branch_total_fallback():
+    async def fake_llm(prompt, tenant_config=None):
+        return {}
+
+    with patch.object(dx, "_llm_raw", new=fake_llm):
+        res = await dx.classify(_mem(content="a"), _mem(content="b"))
+    assert (
+        res.relationship == "exact_value"
+        and res.relationship_confidence == rel._CONF_FALLBACK
+    )
+    assert (
+        res.diagnosis == "unresolved" and res.diagnosis_confidence == rel._CONF_FALLBACK
+    )

--- a/tests/test_contradiction_relationship.py
+++ b/tests/test_contradiction_relationship.py
@@ -1,0 +1,157 @@
+"""L1 relationship-classification tests (A55)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from core_api.services.contradiction import relationship as rel
+
+pytestmark = pytest.mark.unit
+
+SUBJ = "00000000-0000-0000-0000-0000000000aa"
+
+
+def _mem(**over) -> dict:
+    base = {
+        "id": "m1",
+        "content": "X lives in Haifa",
+        "subject_entity_id": None,
+        "predicate": None,
+        "object_value": None,
+    }
+    base.update(over)
+    return base
+
+
+# ── deterministic RDF branch (no LLM) ──────────────────────────────────
+@pytest.mark.asyncio
+async def test_rdf_exact_value_short_circuits_no_llm():
+    new = _mem(subject_entity_id=SUBJ, predicate="lives_in", object_value="Haifa")
+    cand = _mem(subject_entity_id=SUBJ, predicate="lives_in", object_value="Tel Aviv")
+    with patch.object(rel, "_llm_raw", new=AsyncMock()) as llm:
+        r, c = await rel.classify_relationship(new, cand)
+    assert r == "exact_value"
+    assert c == rel._CONF_RDF
+    llm.assert_not_called()  # deterministic — LLM never invoked
+
+
+def test_is_rdf_exact_value_guards():
+    # same value -> not exact_value
+    assert not rel._is_rdf_exact_value(
+        _mem(subject_entity_id=SUBJ, predicate="p", object_value="A"),
+        _mem(subject_entity_id=SUBJ, predicate="p", object_value="A"),
+    )
+    # different subject -> no
+    assert not rel._is_rdf_exact_value(
+        _mem(subject_entity_id=SUBJ, predicate="p", object_value="A"),
+        _mem(subject_entity_id="other", predicate="p", object_value="B"),
+    )
+    # missing RDF fields -> no
+    assert not rel._is_rdf_exact_value(_mem(), _mem())
+
+
+# ── extract_relationship: model-emitted, each of the 7 ─────────────────
+@pytest.mark.parametrize(
+    "value",
+    [
+        "exact_value",
+        "negation",
+        "entailed",
+        "constraint",
+        "probabilistic",
+        "scope_apparent",
+        "refinement",
+    ],
+)
+def test_extract_reads_model_relationship(value):
+    assert rel.extract_relationship({"relationship": value}) == (value, "model")
+
+
+def test_extract_rejects_invalid_relationship_falls_to_derivation():
+    # invalid explicit value + a derivable non_conflict_reason
+    assert rel.extract_relationship(
+        {"relationship": "bogus", "non_conflict_reason": "scope_mismatch"}
+    ) == ("scope_apparent", "derived")
+
+
+# ── extract_relationship: derivation fallback from non_conflict_reason ──
+@pytest.mark.parametrize(
+    "ncr,expected",
+    [
+        ("refinement", "refinement"),
+        ("scope_mismatch", "scope_apparent"),
+        ("list_valued_predicate", "constraint"),
+        ("temporal_supersession", "exact_value"),
+        ("event_restatement", "entailed"),
+        ("conditional_unrealized", "probabilistic"),
+    ],
+)
+def test_extract_derives_from_non_conflict_reason(ncr, expected):
+    assert rel.extract_relationship({"non_conflict_reason": ncr}) == (
+        expected,
+        "derived",
+    )
+
+
+def test_extract_contradicts_true_defaults_exact_value():
+    assert rel.extract_relationship(
+        {"contradicts": True, "non_conflict_reason": "none"}
+    ) == (
+        "exact_value",
+        "derived",
+    )
+
+
+def test_extract_none_when_nothing_classifiable():
+    assert rel.extract_relationship({"contradicts": False}) == (None, "none")
+    assert rel.extract_relationship({}) == (None, "none")
+    assert rel.extract_relationship("not-a-dict") == (None, "none")
+
+
+# ── LLM branch: prompt is the EXTENDED copy; model output parsed ───────
+@pytest.mark.asyncio
+async def test_llm_branch_uses_extended_prompt_and_parses_model():
+    new = _mem(content="Alice is inactive")
+    cand = _mem(content="Alice is active")
+    captured = {}
+
+    async def fake_llm(prompt, tenant_config=None):
+        captured["prompt"] = prompt
+        return {"contradicts": True, "relationship": "negation"}
+
+    with patch.object(rel, "_llm_raw", new=fake_llm):
+        r, c = await rel.classify_relationship(new, cand)
+
+    assert r == "negation"
+    assert c == rel._CONF_MODEL
+    # The extended instruction is appended to the base prompt (base untouched).
+    assert "relationship" in captured["prompt"]
+    assert rel.CONTRADICTION_PROMPT.split("{")[0].strip()[:20] in captured["prompt"]
+    assert rel._RELATIONSHIP_INSTRUCTION.strip()[:20] in captured["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_llm_branch_derived_confidence_lower():
+    new, cand = _mem(content="a"), _mem(content="b")
+
+    async def fake_llm(prompt, tenant_config=None):
+        return {"non_conflict_reason": "refinement"}  # no explicit relationship
+
+    with patch.object(rel, "_llm_raw", new=fake_llm):
+        r, c = await rel.classify_relationship(new, cand)
+    assert r == "refinement"
+    assert c == rel._CONF_DERIVED
+
+
+@pytest.mark.asyncio
+async def test_llm_branch_unclassifiable_defaults_exact_value_fallback_conf():
+    new, cand = _mem(content="a"), _mem(content="b")
+
+    async def fake_llm(prompt, tenant_config=None):
+        return {}  # nothing usable
+
+    with patch.object(rel, "_llm_raw", new=fake_llm):
+        r, c = await rel.classify_relationship(new, cand)
+    assert r == "exact_value"
+    assert c == rel._CONF_FALLBACK

--- a/tests/test_contradiction_resolution.py
+++ b/tests/test_contradiction_resolution.py
@@ -1,0 +1,89 @@
+"""L3 resolution mapping + safety-invariant tests (A55)."""
+
+from __future__ import annotations
+
+import pytest
+from core_api.services.contradiction.resolution import ACTIONS, resolve
+
+pytestmark = pytest.mark.unit
+
+
+# ── base (relationship x diagnosis) -> action ─────────────────────────
+@pytest.mark.parametrize(
+    "relationship,diagnosis,expected",
+    [
+        ("exact_value", "temporal_change", "supersede"),
+        ("exact_value", "correction", "replace"),
+        ("negation", "correction", "replace"),
+        ("scope_apparent", "scope_difference", "scope"),
+        ("exact_value", "entity_mismatch", "split_entity"),
+        ("exact_value", "write_error", "mark_disputed"),
+        ("exact_value", "unresolved", "ask"),
+    ],
+)
+def test_base_mapping(relationship, diagnosis, expected):
+    r = resolve(relationship, diagnosis)
+    assert r.action == expected
+    assert r.action in ACTIONS
+    assert r.audit_reason
+
+
+# ── both-hold relationships never overturn ────────────────────────────
+@pytest.mark.parametrize("rel", ["entailed", "constraint", "refinement"])
+def test_both_hold_is_noop(rel):
+    # even if the diagnosis would otherwise supersede/replace
+    assert resolve(rel, "temporal_change").action == "no_op"
+    assert resolve(rel, "correction").action == "no_op"
+
+
+# ── invariant: inference must not overturn an explicit fact ───────────
+def test_inferred_downgrades_supersede_to_mark_disputed():
+    r = resolve("exact_value", "temporal_change", is_inferred=True)
+    assert r.action == "mark_disputed"
+    assert "inferred" in r.audit_reason
+
+
+def test_inferred_downgrades_replace_to_mark_disputed():
+    assert (
+        resolve("exact_value", "correction", is_inferred=True).action == "mark_disputed"
+    )
+
+
+def test_inferred_does_not_touch_non_destructive_actions():
+    # scope isn't destructive -> inference flag leaves it alone
+    assert (
+        resolve("scope_apparent", "scope_difference", is_inferred=True).action
+        == "scope"
+    )
+
+
+# ── invariant: probabilistic relationship softens ─────────────────────
+def test_probabilistic_downweights_instead_of_overturning():
+    r = resolve("probabilistic", "temporal_change")
+    assert r.action == "downweight"
+    assert "probabilistic" in r.audit_reason
+
+
+# ── invariant: low confidence flags rather than overturns ─────────────
+def test_low_confidence_flags():
+    assert (
+        resolve("exact_value", "correction", confidence=0.3).action == "mark_disputed"
+    )
+
+
+def test_high_confidence_allows_overturn():
+    assert resolve("exact_value", "correction", confidence=0.9).action == "replace"
+
+
+def test_confidence_gate_only_applies_to_destructive():
+    # scope is non-destructive; low confidence doesn't change it
+    assert (
+        resolve("scope_apparent", "scope_difference", confidence=0.1).action == "scope"
+    )
+
+
+# ── no-degradation anchor: today's confirmed conflicts map to supersede ─
+def test_temporal_change_maps_to_supersede_matching_today():
+    """The RDF/semantic paths today produce a supersede effect. temporal_change
+    (the RDF default diagnosis) -> supersede keeps the recommendation aligned."""
+    assert resolve("exact_value", "temporal_change").action == "supersede"


### PR DESCRIPTION
## What & why

The unified contradiction model's **decision layer** — L1 (relationship) → L2 (diagnosis) → L3 (action) — as **pure, dormant modules**. This is the classification brain for A55 1d, landing *ahead* of the write slice that wires it onto the engine-ON path.

**Behaviour-neutral by construction:** nothing calls these in production yet, and the legacy detector / `CONTRADICTION_PROMPT` / verdict path is untouched. So this PR provably changes nothing.

## The three layers

- **`relationship.py` (L1)** — `classify_relationship` / `extract_relationship`. Deterministic RDF exact-value short-circuit (no LLM); otherwise the detector's `CONTRADICTION_PROMPT` extended **on a copy** with a relationship instruction, plus a derivation fallback from the model's existing `non_conflict_reason` taxonomy. → one of the 7 `RELATIONSHIPS` + confidence.
- **`diagnosis.py` (L2)** — `extract_diagnosis` + the combined `classify()`. **One LLM call** yields both the relationship and the diagnosis; most diagnoses derive from `same_subject` / `non_conflict_reason`. → one of the 6 `DIAGNOSES`.
- **`resolution.py` (L3)** — `resolve()` maps `(relationship × diagnosis × evidence) → action + audit_reason`, applying the **safety invariants**: inference must not overturn an explicit fact; a probabilistic relationship softens (`downweight`); low confidence flags (`mark_disputed`).

## No-degradation

`resolve()` only **recommends** an action for the future `memory_conflicts` record — it does **not** apply any `status`/`supersedes_id` effect (that stays with the detector). So current RDF/semantic/Path-C outcomes are unchanged; `test_temporal_change_maps_to_supersede_matching_today` anchors the alignment. The golden differential test (separate) remains the gate when the write slice wires this in.

## Tests

**56 cases** — L1 21, L2 17, L3 18. mypy clean (196 files), ruff + format clean.

## Next slice (not in this PR)

The **write**: a storage endpoint + client to persist a `memory_conflicts` row and set `memories.confidence`/`is_inferred`/`scope`, wire `classify()`+`resolve()` into the engine resolver on the ON path (additive, status/supersedes untouched), + a `.dev` wet test with the flag on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)