### PR TITLE
fix(memory): unshadow HTTPException so pipeline failures surface as 500

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -287,8 +287,6 @@ async def _create_memory_pipeline(data: MemoryCreate) -> MemoryOut:
         from core_api.config import settings as _stm_settings
 
         if not _stm_settings.use_stm:
-            from fastapi import HTTPException
-
             raise HTTPException(
                 status_code=422,
                 detail="STM is not enabled. Set USE_STM=true to enable short-term memory.",

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -300,6 +300,61 @@ async def test_merge_enrichment_leaves_non_deprecated_caller_type_intact():
     assert ctx.data["memory_fields"]["memory_type"] == "episode"
 
 
+@pytest.mark.asyncio
+async def test_pipeline_failed_result_surfaces_http_500_not_unbound_local(caplog):
+    """A step that fails WITHOUT raising must surface as a clean 500.
+
+    Distinct from ``test_pipeline_emits_latency_log_on_pipeline_failure``,
+    which covers the path where ``Pipeline.run`` *raises*. When a step
+    raises a plain (non-``HTTPException``) error the runner catches it,
+    records ``FAILED`` and RETURNS — so ``pipeline.run`` completes
+    normally and ``if result.failed`` is the branch that fires instead.
+    That branch was unreachable: an inline ``from fastapi import
+    HTTPException`` deeper in the function made the name function-local,
+    so constructing the exception raised ``UnboundLocalError``. Both
+    symptoms are asserted — the caller got an opaque ``UnboundLocalError``
+    instead of the 500, and because the error fired while evaluating the
+    right-hand side, ``_exc`` stayed ``None`` and the latency log recorded
+    ``success=True`` for a write that had in fact failed.
+    """
+    import logging
+
+    from fastapi import HTTPException
+
+    from core_api.pipeline.runner import Pipeline, PipelineResult
+    from core_api.services.memory_service import _create_memory_pipeline
+
+    async def _failed_result(self, ctx):
+        return PipelineResult(pipeline_name="write", failed=True)
+
+    tenant_config = type(
+        "Cfg", (), {"auto_chunk_enabled": False, "default_write_mode": "fast"}
+    )()
+
+    with (
+        caplog.at_level(logging.INFO, logger="core_api.services.memory_service"),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            AsyncMock(return_value=tenant_config),
+        ),
+        patch.object(Pipeline, "run", _failed_result),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await _create_memory_pipeline(_make_input())
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Memory write pipeline failed unexpectedly"
+
+    latency_records = [
+        r for r in caplog.records if r.getMessage() == "memory_write_latency"
+    ]
+    assert len(latency_records) == 1, (
+        f"expected exactly one memory_write_latency log, got {len(latency_records)}"
+    )
+    # The regression that made failed writes invisible on dashboards.
+    assert latency_records[0].success is False
+
+
 # ---------------------------------------------------------------------------
 # Integration tests (require PostgreSQL)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Deletes one redundant inline `from fastapi import HTTPException` in `_create_memory_pipeline`, and adds the regression test that was missing.

## Why

The inline import sat two conditionals deep inside the STM branch, so it almost never executed — but it made `HTTPException` **function-local for the whole function body**. The module already imports the name at top level, so it was pure redundancy with a sharp edge.

Verified at the bytecode level, before the fix:

```
line 290: STORE_FAST        HTTPException
line 292: LOAD_FAST_BORROW  HTTPException   <- safe, dominated by the STORE
line 307: LOAD_FAST_CHECK   HTTPException   <- UnboundLocalError
line 323: LOAD_FAST_CHECK   HTTPException   <- UnboundLocalError
line 407: LOAD_FAST_CHECK   HTTPException   <- UnboundLocalError
```

`LOAD_FAST_CHECK` is the opcode that emits `cannot access local variable 'X' where it is not associated with a value`. After the fix all four sites are `LOAD_GLOBAL`.

Line 407 is on the standard persist path (`_USE_PIPELINE_WRITE = True` is a hard constant), reached whenever **any** write-pipeline step fails without raising — `pipeline/runner.py` catches a non-`HTTPException` step error, records `FAILED` and returns rather than re-raising. So the trigger is not exotic; it is any upstream failure. Observed ~1100 times on staging since 2026-06-24.

## Two consequences beyond the 500

1. **Metrics recorded these failures as successes.** The error fires while evaluating the right-hand side, so the assignment to `_exc` never completes and `_exc` stays `None`. The `finally` block then logs `memory_write_latency` with `"success": _exc is None`. Captured from the pre-fix test run:

   ```
   {"path": "memory-write", ..., "success": true, "message": "memory_write_latency"}
   ```

   Any dashboard built on that field has been reporting these as clean writes.

2. **It masked the real incidents.** The runner already logs the failing step with `exc_info`, so each `UnboundLocalError` had a companion line naming the actual culprit — that is how the storage-side 500s and the nightly `discover_cross_links` 504s were found.

## Test

`test_pipeline_failed_result_surfaces_http_500_not_unbound_local` drives the `result.failed` branch and asserts both symptoms.

The existing `test_pipeline_emits_latency_log_on_pipeline_failure` covers the path where `Pipeline.run` **raises**, where `_exc` is bound by the `except BaseException` handler — which is why it stayed green through all of this. The branch where `run` returns a failed result had no coverage at all.

Confirmed the test fails without the fix:

```
>       _exc = HTTPException(status_code=500, detail="Memory write pipeline failed unexpectedly")
E       UnboundLocalError: cannot access local variable 'HTTPException' where it is not associated with a value
core-api/src/core_api/services/memory_service.py:407: UnboundLocalError
```

and passes with it. Full module: 35 passed. `ruff check` and `ruff format --check` both clean.

Found while triaging the prod/staging error-alerts backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)