### PR TITLE
fix(embedding): set per-phase httpx timeouts, matching the LLM client

### DIFF
--- a/common/embedding/constants.py
+++ b/common/embedding/constants.py
@@ -96,6 +96,27 @@ EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS: int = clamp_keepalive(
     max_keepalive_var="EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS",
 )
 
+# Per-phase connect timeout, mirroring ``OPENAI_HTTPX_CONNECT_TIMEOUT_SECONDS``
+# on the LLM side. Passing a bare float to ``AsyncOpenAI(timeout=...)`` looks
+# like it sets the whole budget but leaves httpx's DEFAULT 5 s connect phase in
+# place. On Cloud Run with a VPC connector in ``all-traffic`` egress mode every
+# outbound call intermittently exceeds 5 s, which surfaces as
+# ``httpcore.ConnectTimeout`` well inside the nominal request budget. The LLM
+# client took this fix; the embedding client kept the bare float, so the same
+# trickle continued here — visible as the staging
+# "pubsub handler raised; nacking for redelivery" loop, where the worker's
+# embed call is the only handler that can propagate. Only connect/pool get the
+# headroom; the read phase stays governed by ``OPENAI_REQUEST_TIMEOUT_SECONDS``.
+EMBEDDING_HTTPX_CONNECT_TIMEOUT_SECONDS: float = read_float_env(
+    "EMBEDDING_HTTPX_CONNECT_TIMEOUT_SECONDS", 15.0
+)
+# None ⇒ the pool phase tracks the request budget, preserving the bare-float
+# behaviour this replaces for every existing configuration. Set the env var
+# only to decouple them (e.g. fail fast under pool pressure).
+EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS: float | None = read_float_env(
+    "EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS", None
+)
+
 
 # ── Client-side concurrency cap (backpressure) ───────────────────────
 #

--- a/common/embedding/providers/openai.py
+++ b/common/embedding/providers/openai.py
@@ -11,8 +11,10 @@ import openai
 from common.constants import VECTOR_DIM
 from common.embedding.constants import (
     EMBEDDING_HOSTED_MAX_BATCH,
+    EMBEDDING_HTTPX_CONNECT_TIMEOUT_SECONDS,
     EMBEDDING_HTTPX_MAX_CONNECTIONS,
     EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+    EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS,
     EMBEDDING_REMOTE_MAX_BATCH,
     OPENAI_EMBEDDING_MODEL,
     OPENAI_REQUEST_TIMEOUT_SECONDS,
@@ -113,7 +115,20 @@ class OpenAIEmbeddingProvider:
         # tenants' embed calls at the pool layer.
         client_kwargs: dict = {
             "api_key": api_key,
-            "timeout": OPENAI_REQUEST_TIMEOUT_SECONDS,
+            "timeout": httpx.Timeout(
+                connect=EMBEDDING_HTTPX_CONNECT_TIMEOUT_SECONDS,
+                # read AND write keep the full request budget — the bare float
+                # this replaces set every phase to it.
+                read=OPENAI_REQUEST_TIMEOUT_SECONDS,
+                write=OPENAI_REQUEST_TIMEOUT_SECONDS,
+                # Pool tracks the request budget unless explicitly decoupled,
+                # preserving the previous behaviour for every configuration.
+                pool=(
+                    EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS
+                    if EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS is not None
+                    else OPENAI_REQUEST_TIMEOUT_SECONDS
+                ),
+            ),
             "http_client": httpx.AsyncClient(
                 limits=httpx.Limits(
                     max_connections=EMBEDDING_HTTPX_MAX_CONNECTIONS,

--- a/tests/test_embedding_openai_compat.py
+++ b/tests/test_embedding_openai_compat.py
@@ -98,6 +98,47 @@ def test_base_url_omitted_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Per-phase timeouts (parity with the LLM client)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_timeout_sets_connect_phase_not_bare_float(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``timeout`` must be an ``httpx.Timeout``, not a bare float.
+
+    A bare float looks like it sets the whole budget but leaves httpx's
+    default 5 s CONNECT phase in place. Cloud Run VPC egress intermittently
+    exceeds 5 s, so connects failed well inside the nominal request budget
+    and surfaced as ``httpcore.ConnectTimeout`` — which on the worker's
+    embed handler becomes a nack-and-redeliver loop. The LLM provider
+    already sets per-phase timeouts; this asserts the embedding provider
+    does too, so the two cannot drift apart again.
+    """
+    import httpx
+
+    from common.embedding.constants import (
+        EMBEDDING_HTTPX_CONNECT_TIMEOUT_SECONDS,
+        OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
+
+    _, async_openai_ctor, _ = _patched_provider(monkeypatch)
+    timeout = async_openai_ctor.call_args.kwargs["timeout"]
+
+    assert isinstance(timeout, httpx.Timeout), (
+        f"expected httpx.Timeout so the connect phase is explicit, got {type(timeout).__name__}"
+    )
+    assert timeout.connect == EMBEDDING_HTTPX_CONNECT_TIMEOUT_SECONDS
+    assert timeout.connect > 5.0, "must beat httpx's 5s default — the whole point"
+    # Read/write/pool keep the request budget, matching the bare float this
+    # replaced so no existing deployment sees a shorter budget.
+    assert timeout.read == OPENAI_REQUEST_TIMEOUT_SECONDS
+    assert timeout.write == OPENAI_REQUEST_TIMEOUT_SECONDS
+    assert timeout.pool == OPENAI_REQUEST_TIMEOUT_SECONDS
+
+
+# ---------------------------------------------------------------------------
 # A.5 — send_dimensions toggle
 # ---------------------------------------------------------------------------
 
@@ -509,7 +550,9 @@ async def test_embed_query_constructor_default_instruction(
         query_instruction="Default task",
     )
     await provider.embed_query("query body")
-    assert create.call_args.kwargs["input"] == "Instruct: Default task\nQuery: query body"
+    assert (
+        create.call_args.kwargs["input"] == "Instruct: Default task\nQuery: query body"
+    )
 
 
 @pytest.mark.unit
@@ -844,9 +887,9 @@ def test_registry_no_warning_when_send_dimensions_false(
     with caplog.at_level(logging.WARNING, logger="common.embedding._registry"):
         get_embedding_provider("openai")
 
-    assert not any(
-        "SEND_DIMENSIONS" in rec.getMessage() for rec in caplog.records
-    ), "no SEND_DIMENSIONS warning expected when correctly set to false"
+    assert not any("SEND_DIMENSIONS" in rec.getMessage() for rec in caplog.records), (
+        "no SEND_DIMENSIONS warning expected when correctly set to false"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Replaces the bare-float `timeout` on the embedding provider's `AsyncOpenAI` client with an explicit `httpx.Timeout`, mirroring what `common/llm/providers/openai.py` already does.

## Why

`AsyncOpenAI(timeout=<float>)` looks like it sets the whole budget, but it leaves **httpx's default 5 s connect phase** in place. On Cloud Run with a VPC connector in `all-traffic` egress mode, outbound connects intermittently exceed 5 s — so calls failed as `httpcore.ConnectTimeout` well inside the nominal 25 s request budget.

This is not a new diagnosis. The LLM client took exactly this fix, and `common/llm/constants.py:110-113` names the two symptoms it was meant to cure:

> ...handlers ("pubsub handler raised; nacking for redelivery" + "Entity extraction failed" — the latter permanently skips entity links for that memory).

The embedding client was simply missed, so the same trickle continued there.

## Why it turned into 321 alerts

The worker's `provider.embed(...)` in `core-worker/consumer.py` is the one Pub/Sub handler that can propagate an exception — `handle_enrich_request` falls through to a heuristic and core-api's handlers use `track_task`. When it propagates, `common/events/pubsub.py:749-758` nacks with `"ack_deadline_seconds": 0`, i.e. redeliver immediately, and there is no delivery-attempt counter or dead-letter topic anywhere in the code. Staging logged 8,720 occurrences and sent **321 alert notifications** off roughly two dozen distinct failures.

Worth being precise about scope: **this bounds the per-attempt connect, not the redelivery loop.** A dead-letter topic and a retry policy on the staging subscriptions are still wanted, and by design those live in infra rather than here (`pubsub.py:7-14`). This removes the cause; that would cap the blast radius.

## Compatibility

Only connect gains headroom (15 s, env-tunable). `read` and `write` keep `OPENAI_REQUEST_TIMEOUT_SECONDS`, and `pool` tracks it unless explicitly decoupled via `EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS` — so **no existing deployment sees a shorter budget than the bare float gave it**, including one running `OPENAI_REQUEST_TIMEOUT_SECONDS=60`. Same shape and naming as the LLM-side constants.

## Test

`test_timeout_sets_connect_phase_not_bare_float` asserts the client is constructed with an `httpx.Timeout` whose connect phase beats httpx's 5 s default, and that read/write/pool still carry the request budget. It pins the two providers together so they cannot drift apart again.

Confirmed it fails without the fix:

```
E       AssertionError: expected httpx.Timeout so the connect phase is explicit, got float
```

51 passed in that module; 78 passed across the embedding suites. `ruff check` and `ruff format --check` clean on the touched files.

> Deliberately **not** included: raising `EMBEDDING_REMOTE_MAX_BATCH` from 32 to 128. I had that on my list, but the constant's own comment is right — the local `docker-compose` stack starts TEI without `--max-client-batch-size`, so TEI's own default of 32 applies and a code-default change would cause 413s there. That belongs in the prod/staging deployment env, where TEI is explicitly launched with 128.

Found while triaging the prod/staging error-alerts backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)