### PR TITLE
CAURA-716 fix(memory): honour agent_provided_fields on the inline enrich path

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -1914,22 +1914,33 @@ async def _schedule_enrich_or_inline(
     those columns on every redelivery.
     """
     if settings.inline_enrichment:
-        # NOTE: ``agent_provided_fields`` and ``reference_datetime``
-        # are intentionally NOT forwarded to ``_enrich_memory_background``.
-        # The inline path pre-dates these concepts and uses an
-        # equivalent gate by reading the row's current value vs the
-        # schema default (``if mem.get("memory_type") == "fact" and
-        # enrichment.memory_type:`` etc., see the body of
-        # ``_enrich_memory_background``). When the agent set
-        # ``memory_type="rule"`` the column already reads ``"rule"``
-        # not ``"fact"``, and the inline gate skips.
+        # CAURA-716: ``agent_provided_fields`` IS now forwarded here.
         #
-        # The two paths converge on the same agent-wins outcome via
-        # different mechanisms; unifying them on
-        # ``agent_provided_fields`` is a reasonable cleanup but out of
-        # scope for CAURA-595 — there's no observable behavioural
-        # delta between the gates today.
-        await _enrich_memory_background(memory_id, content, tenant_id, fleet_id, agent_id)
+        # It previously was not, on the reasoning that the inline path's
+        # value-vs-schema-default comparison was an equivalent gate — "when the
+        # agent set ``memory_type="rule"`` the column already reads ``"rule"``
+        # not ``"fact"``, and the inline gate skips" — and therefore that there
+        # was "no observable behavioural delta between the gates".
+        #
+        # There is one, and it is silent: the comparison cannot distinguish
+        # "caller pinned this to the default" from "caller said nothing". A
+        # write passing ``memory_type="fact", status="active"`` landed as
+        # ``fact``/``active`` and was rewritten to ``decision``/``confirmed``
+        # by this background task seconds later. ``fact`` and ``active`` are the
+        # schema defaults precisely because they are the neutral choices, which
+        # is exactly why a caller pins them.
+        #
+        # ``reference_datetime`` is still not forwarded — the inline path
+        # resolves relative dates against the enrichment call's own clock, and
+        # that is a separate concern.
+        await _enrich_memory_background(
+            memory_id,
+            content,
+            tenant_id,
+            fleet_id,
+            agent_id,
+            agent_provided_fields=agent_provided_fields,
+        )
     else:
         await publish_memory_enrich_request(
             memory_id=memory_id,
@@ -2284,11 +2295,31 @@ async def _enrich_memory_background(
     tenant_id: str,
     fleet_id: str | None,
     agent_id: str,
+    *,
+    agent_provided_fields: list[str] | None = None,
 ) -> None:
     """Background task: run LLM enrichment on a fast-path memory, then patch the row.
 
     After enrichment completes, fires entity extraction and contradiction detection
     as sub-tasks.
+
+    ``agent_provided_fields`` names the enrichment columns the caller set
+    EXPLICITLY at write time (computed by ``_agent_provided_enrichment_fields``
+    from ``model_fields_set``); those are left untouched. It is the same list
+    the deferred/worker path already receives via
+    ``publish_memory_enrich_request``.
+
+    CAURA-716: this parameter previously did not exist, and the inline path
+    instead inferred caller intent by comparing the row's current value against
+    the schema default (``mem["memory_type"] == "fact"``, ``mem["status"] ==
+    "active"``, ``mem["weight"] == 0.5``). That heuristic silently loses any
+    value a caller pins TO its own default — and ``fact`` / ``active`` are
+    defaults precisely because they are the sensible neutral choices, so they
+    are exactly what a caller pins. Passing ``memory_type="fact",
+    status="active"`` produced a row that read ``fact``/``active`` at insert and
+    ``decision``/``confirmed`` seconds later. The default-comparison is retained
+    as a fallback for callers that pass no list (``None``), so behaviour is
+    unchanged for them.
     """
     from core_api.services.memory_enrichment import enrich_memory
     from core_api.services.organization_settings import resolve_config
@@ -2318,11 +2349,26 @@ async def _enrich_memory_background(
         if mem is None or mem.get("deleted_at") is not None:
             return
 
-        # Build update patch
+        # Build update patch.
+        #
+        # CAURA-716: ``_agent_pinned`` is the authoritative "the caller set this
+        # explicitly" test when the caller supplied a list. The
+        # ``value == default`` comparisons that follow it are the legacy
+        # fallback, used only when no list was passed (``agent_provided_fields
+        # is None``) — see this function's docstring for why the comparison
+        # alone is not sufficient.
+        pinned = set(agent_provided_fields or ())
+
+        def _agent_pinned(field: str, legacy_default_matches: bool) -> bool:
+            """True when the caller owns ``field`` and enrichment must not touch it."""
+            if agent_provided_fields is not None:
+                return field in pinned
+            return not legacy_default_matches
+
         patch: dict = {}
-        if mem.get("memory_type") == "fact" and enrichment.memory_type:
+        if not _agent_pinned("memory_type", mem.get("memory_type") == "fact") and enrichment.memory_type:
             patch["memory_type"] = enrichment.memory_type
-        if mem.get("weight") == 0.5 and enrichment.weight is not None:
+        if not _agent_pinned("weight", mem.get("weight") == 0.5) and enrichment.weight is not None:
             patch["weight"] = enrichment.weight
         if enrichment.title:
             patch["title"] = enrichment.title
@@ -2345,13 +2391,18 @@ async def _enrich_memory_background(
             # Persisted for debugging / auditability only; no longer used
             # to shape the embedding (see CAURA-222).
             meta["retrieval_hint"] = enrichment.retrieval_hint
-        # Temporal resolution
-        if mem.get("ts_valid_start") is None and enrichment.ts_valid_start:
+        # Temporal resolution. ``None`` is not a settable value, so the legacy
+        # is-None check cannot suffer the pin-to-default problem — but route it
+        # through the same gate so all five override fields behave uniformly.
+        if (
+            not _agent_pinned("ts_valid_start", mem.get("ts_valid_start") is None)
+            and enrichment.ts_valid_start
+        ):
             patch["ts_valid_start"] = enrichment.ts_valid_start
-        if mem.get("ts_valid_end") is None and enrichment.ts_valid_end:
+        if not _agent_pinned("ts_valid_end", mem.get("ts_valid_end") is None) and enrichment.ts_valid_end:
             patch["ts_valid_end"] = enrichment.ts_valid_end
-        # Status: only upgrade from default "active"
-        if mem.get("status") == "active" and enrichment.status:
+        # Status: enrichment may set it only when the caller did not.
+        if not _agent_pinned("status", mem.get("status") == "active") and enrichment.status:
             patch["status"] = enrichment.status
 
         meta.pop("enrichment_pending", None)

--- a/tests/test_enrich_agent_provided_fields.py
+++ b/tests/test_enrich_agent_provided_fields.py
@@ -1,0 +1,315 @@
+"""CAURA-716 — the inline enrichment path must honour ``agent_provided_fields``.
+
+Background
+----------
+``_schedule_enrich_or_inline`` computes ``agent_provided_fields`` (via
+``_agent_provided_enrichment_fields`` → Pydantic ``model_fields_set``) and hands
+it to the deferred/worker path, but used to DROP it on the inline/OSS branch. The
+inline task instead inferred caller intent by comparing the row's current value
+against the schema default::
+
+    if mem.get("memory_type") == "fact" and enrichment.memory_type: ...
+    if mem.get("status")      == "active" and enrichment.status:      ...
+    if mem.get("weight")      == 0.5     and enrichment.weight:       ...
+
+That comparison cannot distinguish "the caller pinned this to the default" from
+"the caller said nothing" — so a write passing ``memory_type="fact",
+status="active"`` was silently rewritten to the LLM's classification seconds
+later. ``fact`` / ``active`` are the defaults precisely because they are the
+neutral choices, which is exactly why a caller pins them.
+
+These tests pin the contract at both layers: the argument is forwarded, and the
+gate honours it. The legacy default-comparison is retained for callers that pass
+no list, so the no-list cases below assert unchanged behaviour.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core_api.services import memory_service
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+TENANT = "t-716"
+
+
+def _enrichment(**over):
+    """An enrichment result that wants to change every override field."""
+    base = dict(
+        memory_type="decision",
+        weight=0.9,
+        status="confirmed",
+        title="Enriched title",
+        summary="",
+        tags=[],
+        llm_ms=12,
+        contains_pii=False,
+        pii_types=[],
+        retrieval_hint="",
+        ts_valid_start=None,
+        ts_valid_end=None,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _row(**over):
+    """A stored row as ``get_memory_for_tenant`` returns it — all defaults."""
+    base = dict(
+        id=str(uuid.uuid4()),
+        memory_type="fact",  # schema default
+        status="active",  # schema default
+        weight=0.5,  # schema default
+        ts_valid_start=None,
+        ts_valid_end=None,
+        metadata_={},
+        deleted_at=None,
+        fleet_id="f1",
+        embedding=None,
+        content="body",
+    )
+    base.update(over)
+    return base
+
+
+async def _run(agent_provided_fields, *, row=None, enrichment=None):
+    """Invoke the inline task and capture what it patched.
+
+    Returns ``(patch_dict, status_calls)`` — status is applied through
+    ``update_memory_status`` rather than the generic patch, so it is captured
+    separately.
+    """
+    # AsyncMock so every storage method is awaitable — the function under test
+    # touches several, and a plain MagicMock would fail on the first await of
+    # one this harness didn't anticipate.
+    sc = AsyncMock(name="storage_client")
+    sc.get_memory = AsyncMock(return_value=row or _row())
+    # Real contract (see ``_enrich_memory_background``): non-status fields go
+    # through ``update_memory(id, tenant_id, patch)``; status goes through
+    # ``update_memory_status(id, status, tenant_id=...)``.
+    sc.update_memory = AsyncMock(return_value=None)
+    sc.update_memory_status = AsyncMock(return_value=None)
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch(
+            "core_api.services.memory_enrichment.enrich_memory",
+            new=AsyncMock(return_value=enrichment or _enrichment()),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    enrichment_enabled=True,
+                    enrichment_provider="fake",
+                    entity_extraction_enabled=False,
+                )
+            ),
+        ),
+    ):
+        kwargs = {}
+        if agent_provided_fields is not _SENTINEL:
+            kwargs["agent_provided_fields"] = agent_provided_fields
+        await memory_service._enrich_memory_background(
+            uuid.uuid4(), "body", TENANT, "f1", "a", **kwargs
+        )
+
+    applied: dict = {}
+    for call in sc.update_memory.await_args_list:
+        for arg in list(call.args) + list(call.kwargs.values()):
+            if isinstance(arg, dict):
+                applied.update(arg)
+    statuses = [
+        c.args[1] if len(c.args) > 1 else c.kwargs.get("status")
+        for c in sc.update_memory_status.await_args_list
+    ]
+    return applied, statuses
+
+
+_SENTINEL = object()
+
+
+# ── The regression: pinning a field to its own default ────────────────────────
+
+
+async def test_pinned_memory_type_survives_even_when_equal_to_default():
+    """The bug: caller passes ``memory_type="fact"`` — the default — and the
+    value-vs-default gate read that as "not set" and overwrote it."""
+    applied, _ = await _run(["memory_type"])
+    assert "memory_type" not in applied, (
+        "enrichment overwrote a caller-pinned memory_type"
+    )
+
+
+async def test_pinned_status_survives_even_when_equal_to_default():
+    """Same bug for ``status="active"``. This is the one that made doc-derived
+    memories invisible to ``insights focus=patterns`` (which selects
+    ``status='active'`` only)."""
+    _, statuses = await _run(["status"])
+    assert statuses == [], f"enrichment overwrote a caller-pinned status: {statuses}"
+
+
+async def test_pinned_weight_survives_even_when_equal_to_default():
+    applied, _ = await _run(["weight"])
+    assert "weight" not in applied
+
+
+async def test_pinning_both_fields_together():
+    """The real doc-memory call site pins memory_type AND status."""
+    applied, statuses = await _run(["memory_type", "status"])
+    assert "memory_type" not in applied
+    assert statuses == []
+    # weight was NOT pinned, so enrichment still owns it.
+    assert applied.get("weight") == 0.9
+
+
+# ── Unpinned fields are still enriched ───────────────────────────────────────
+
+
+async def test_unpinned_fields_are_still_enriched():
+    """An empty list means "caller pinned nothing" — enrichment owns everything."""
+    applied, statuses = await _run([])
+    assert applied.get("memory_type") == "decision"
+    assert applied.get("weight") == 0.9
+    assert statuses == ["confirmed"]
+
+
+async def test_title_is_always_enriched_regardless_of_pins():
+    """``title`` is not an override field — enrichment always owns it."""
+    applied, _ = await _run(["memory_type", "status", "weight"])
+    assert applied.get("title") == "Enriched title"
+
+
+# ── Legacy fallback: no list passed (behaviour must not change) ───────────────
+
+
+async def test_no_list_falls_back_to_default_comparison_and_enriches():
+    """Callers that pass no list keep the pre-CAURA-716 behaviour: a row still
+    holding the defaults gets enriched."""
+    applied, statuses = await _run(_SENTINEL)
+    assert applied.get("memory_type") == "decision"
+    assert applied.get("weight") == 0.9
+    assert statuses == ["confirmed"]
+
+
+async def test_no_list_still_respects_a_non_default_row_value():
+    """The legacy gate's one working case: a row whose value already differs from
+    the default is left alone. Must keep working."""
+    applied, statuses = await _run(
+        _SENTINEL, row=_row(memory_type="rule", status="pending", weight=0.8)
+    )
+    assert "memory_type" not in applied
+    assert "weight" not in applied
+    assert statuses == []
+
+
+async def test_explicit_none_behaves_like_no_list():
+    """``None`` means "no information" — same legacy path, not "pin nothing"."""
+    applied, statuses = await _run(None)
+    assert applied.get("memory_type") == "decision"
+    assert statuses == ["confirmed"]
+
+
+# ── Timestamps route through the same gate ───────────────────────────────────
+
+
+async def test_pinned_timestamps_are_not_overwritten():
+    from datetime import UTC, datetime
+
+    enr = _enrichment(
+        ts_valid_start=datetime(2026, 1, 1, tzinfo=UTC),
+        ts_valid_end=datetime(2026, 2, 1, tzinfo=UTC),
+    )
+    applied, _ = await _run(["ts_valid_start", "ts_valid_end"], enrichment=enr)
+    assert "ts_valid_start" not in applied
+    assert "ts_valid_end" not in applied
+
+
+async def test_unpinned_timestamps_are_resolved():
+    from datetime import UTC, datetime
+
+    enr = _enrichment(ts_valid_start=datetime(2026, 1, 1, tzinfo=UTC))
+    applied, _ = await _run([], enrichment=enr)
+    assert applied.get("ts_valid_start") == datetime(2026, 1, 1, tzinfo=UTC)
+
+
+# ── The argument is actually forwarded (the drop was the bug) ─────────────────
+
+
+async def test_schedule_enrich_forwards_the_list_to_the_inline_path():
+    """The list was computed correctly and then dropped on the inline branch.
+    This asserts the wiring, not the gate."""
+    seen: dict = {}
+
+    async def _capture(*args, **kwargs):
+        seen.update(kwargs)
+
+    with (
+        patch.object(memory_service, "_enrich_memory_background", new=_capture),
+        patch.object(memory_service.settings, "deployment_mode", "inline"),
+    ):
+        await memory_service._schedule_enrich_or_inline(
+            uuid.uuid4(),
+            "body",
+            TENANT,
+            "f1",
+            "a",
+            SimpleNamespace(enrichment_enabled=True),
+            agent_provided_fields=["memory_type", "status"],
+        )
+
+    assert seen.get("agent_provided_fields") == ["memory_type", "status"]
+
+
+async def test_deferred_path_still_receives_the_list():
+    """The deferred/worker branch already worked — don't regress it."""
+    seen: dict = {}
+
+    async def _capture_publish(**kwargs):
+        seen.update(kwargs)
+
+    with (
+        patch.object(
+            memory_service, "publish_memory_enrich_request", new=_capture_publish
+        ),
+        patch.object(memory_service.settings, "deployment_mode", "deferred"),
+    ):
+        await memory_service._schedule_enrich_or_inline(
+            uuid.uuid4(),
+            "body",
+            TENANT,
+            "f1",
+            "a",
+            SimpleNamespace(enrichment_enabled=True),
+            agent_provided_fields=["status"],
+        )
+
+    assert seen.get("agent_provided_fields") == ["status"]
+
+
+# ── The mechanism the fix depends on ─────────────────────────────────────────
+
+
+async def test_model_fields_set_captures_a_pin_to_default():
+    """``_agent_provided_enrichment_fields`` is what makes the fix possible: it
+    records the pin even when the value equals the default, which the
+    value-comparison provably cannot."""
+    from core_api.schemas import MemoryCreate
+
+    m = MemoryCreate(
+        tenant_id=TENANT,
+        agent_id="a",
+        content="body",
+        memory_type="fact",  # == default
+        status="active",  # == default
+    )
+    assert memory_service._agent_provided_enrichment_fields(m) == [
+        "memory_type",
+        "status",
+    ]


### PR DESCRIPTION
## Problem

`_schedule_enrich_or_inline` computes `agent_provided_fields` — which enrichment columns the caller set explicitly, from Pydantic's `model_fields_set` — and forwards it to the deferred/worker branch. **The inline (OSS) branch dropped it**, inferring caller intent instead by comparing the stored value against the schema default:

```python
if mem.get("memory_type") == "fact"   and enrichment.memory_type: ...
if mem.get("status")      == "active" and enrichment.status:      ...
if mem.get("weight")      == 0.5      and enrichment.weight:      ...
```

The dropped forward carried a comment asserting the gates were equivalent — *"there's no observable behavioural delta between the gates today."* There is one, and it's silent.

That comparison can't distinguish **"caller pinned this to the default"** from **"caller said nothing."** And `fact` / `active` are the defaults *precisely because* they're the neutral choices — which is exactly why a caller pins them.

## Evidence (live VM, real provider)

A write passing `memory_type="fact", status="active"` INSERTs correctly, then gets rewritten seconds later:

| | `memory_type` | `status` | `weight` |
|---|---|---|---|
| at insert | `fact` | `active` | `0.5` |
| +8s | **`decision`** | **`confirmed`** | `0.9` |

`weight` is correct there — not pinned, so enrichment rightly owns it. Both pinned fields lost.

Found while wet-testing #756 (CAURA-704), where the lost `status="active"` made doc-derived memories invisible to `insights focus=patterns` (selects `status='active'` only) — the document never reached the reflection pass.

## Fix

Forward the list; gate on it when present. A small `_agent_pinned` helper routes all five override fields (`memory_type`, `weight`, `status`, `ts_valid_start`, `ts_valid_end`) through one decision so they can't drift apart again.

The value-vs-default comparison is **retained as the fallback** when no list is passed (`agent_provided_fields is None`), so behaviour is unchanged for every existing caller. `reference_datetime` is still deliberately not forwarded — the inline path resolves relative dates against the enrichment call's own clock, a separate concern.

## Scope note for reviewers

This is in the write path every memory traverses. The behavioural delta is precisely: *a caller who explicitly passed one of the five override fields now keeps their value on the inline path* — which the deferred path already does and the dropped comment already claimed. **No caller gains or loses enrichment it was previously getting.**

## Verification

- **14 new tests. 10 fail against pre-fix source**; the other 4 assert deliberately-unchanged behaviour (legacy fallback, deferred path, the `model_fields_set` mechanism) and pass on both sides.
- Full suite: **526 failed / 3688 passed** here vs **526 failed / 3674 passed** on clean `main` — identical failure count (pre-existing local DB schema drift), **+14 passing**.
- **0 new mypy errors** (343 both sides). `ruff check` / `format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)