### PR TITLE
fix(crystallizer): read the embedding-coverage keys the endpoint returns

### DIFF
--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -575,12 +575,24 @@ async def _check_missing_embeddings(
     tenant_id: str,
     fleet_id: str | None,
 ) -> dict:
-    """Memories with no embedding vector."""
+    """Memories with no embedding vector.
+
+    ``GET /memories/embedding-coverage`` returns exactly three keys —
+    ``total_active``, ``missing_embeddings``, ``coverage_pct`` — so this reads
+    ``missing_embeddings``. It previously read ``missing_count`` and
+    ``missing_ids``, neither of which the endpoint has ever returned, so both
+    ``.get()`` calls fell through to their defaults and the check reported
+    ``count: 0`` for every tenant no matter how many rows were unembedded.
+
+    No ``affected_ids`` is returned because the endpoint exposes only counts,
+    not ids. ``_generate_issues`` defaults the field to ``[]``, so the finding
+    keeps the same shape as its siblings. Populating it would mean extending
+    the storage endpoint to select ids as well — worth doing only if something
+    starts consuming them.
+    """
     sc = get_storage_client()
     coverage = await sc.get_embedding_coverage(tenant_id, fleet_id)
-    missing_count = coverage.get("missing_count", 0)
-    missing_ids = coverage.get("missing_ids", [])
-    return {"count": missing_count, "affected_ids": [str(i) for i in missing_ids][:MAX_AFFECTED_IDS]}
+    return {"count": coverage.get("missing_embeddings", 0)}
 
 
 async def _check_expired_still_active(

--- a/tests/test_p5_crystallizer.py
+++ b/tests/test_p5_crystallizer.py
@@ -371,3 +371,77 @@ class TestCrystallizeCluster:
         assert result[0]["memory_type"] == "fact"
         assert result[1]["memory_type"] == "fact"  # INVALID -> fact
         assert result[2]["weight"] == 1.0  # 5.0 clamped to 1.0
+
+
+class TestMissingEmbeddingsCheck:
+    """``_check_missing_embeddings`` must read the keys the endpoint returns.
+
+    It previously read ``missing_count`` / ``missing_ids``, neither of which
+    ``GET /memories/embedding-coverage`` has ever returned, so both ``.get()``
+    calls fell through to their defaults and every tenant reported
+    ``count: 0`` — a silent all-clear while prod was logging "Storing memory
+    without embedding; deferred backfill scheduled" hundreds of times a day.
+    """
+
+    #: Exactly what the storage endpoint returns — see
+    #: core-storage-api/src/core_storage_api/routers/memories.py::get_embedding_coverage.
+    COVERAGE_RESPONSE = {
+        "total_active": 10,
+        "missing_embeddings": 4,
+        "coverage_pct": 60.0,
+    }
+
+    @pytest.mark.asyncio
+    async def test_reports_missing_embeddings_count(self):
+        """4 missing out of 10 is reported as 4, not 0."""
+        from unittest.mock import AsyncMock, patch
+
+        from core_api.services.crystallizer_service import _check_missing_embeddings
+
+        sc = AsyncMock()
+        sc.get_embedding_coverage.return_value = dict(self.COVERAGE_RESPONSE)
+        with patch(
+            "core_api.services.crystallizer_service.get_storage_client",
+            return_value=sc,
+        ):
+            result = await _check_missing_embeddings("tenant-1", None)
+
+        assert result["count"] == 4
+
+    @pytest.mark.asyncio
+    async def test_clean_tenant_reports_zero(self):
+        """Full coverage still reports zero — guards against inverting the read."""
+        from unittest.mock import AsyncMock, patch
+
+        from core_api.services.crystallizer_service import _check_missing_embeddings
+
+        sc = AsyncMock()
+        sc.get_embedding_coverage.return_value = {
+            "total_active": 10,
+            "missing_embeddings": 0,
+            "coverage_pct": 100.0,
+        }
+        with patch(
+            "core_api.services.crystallizer_service.get_storage_client",
+            return_value=sc,
+        ):
+            result = await _check_missing_embeddings("tenant-1", None)
+
+        assert result["count"] == 0
+
+    def test_endpoint_contract_is_pinned(self):
+        """The endpoint's response keys, asserted against the endpoint itself.
+
+        The bug was a silent key mismatch across a service boundary, so pin the
+        contract here: if the endpoint's keys change, this fails rather than the
+        check quietly returning 0 again.
+        """
+        import inspect
+
+        from core_storage_api.routers.memories import get_embedding_coverage
+
+        source = inspect.getsource(get_embedding_coverage)
+        for key in self.COVERAGE_RESPONSE:
+            assert f'"{key}"' in source, f"endpoint no longer returns {key!r}"
+        assert '"missing_count"' not in source
+        assert '"missing_ids"' not in source


### PR DESCRIPTION
## The bug

`_check_missing_embeddings` read keys that have never existed:

```python
missing_count = coverage.get("missing_count", 0)
missing_ids = coverage.get("missing_ids", [])
```

`GET /memories/embedding-coverage` (`core-storage-api/.../routers/memories.py:751-772`) returns exactly three keys:

```python
{"total_active": total, "missing_embeddings": missing, "coverage_pct": ...}
```

Neither `missing_count` nor `missing_ids` is among them, so both `.get()` calls fell through to their defaults and the check returned `{"count": 0, "affected_ids": []}` **unconditionally**. Every tenant reported a clean bill of health regardless of how many rows were unembedded — and because it fails to the "healthy" value, nothing ever looked wrong.

**This is live, not theoretical.** Prod logs `Storing memory without embedding; deferred backfill scheduled` (`core_api.pipeline.steps.write.write_memory_row`) **322 times in the last 48 hours** and over 5,000 in 30 days. The condition this check exists to surface happens constantly and has never once been reported.

## Why `affected_ids` is dropped rather than repaired

The endpoint exposes only counts; there is no id source behind it. `memory_count_missing_embeddings` (`postgres_service.py:2371`) is the only relevant service method and it returns a `COUNT`.

Dropping the key is safe and changes nothing on the wire:

- `_generate_issues` builds every finding with `"affected_ids": (affected_ids or [])[:MAX_AFFECTED_IDS]`, so the field is always present and the `MISSING_EMBEDDINGS` finding keeps the same shape as its five siblings.
- The response is **byte-identical to today's**, because today that list is *already* always empty — that was the second half of the same bug.
- Nothing in the repo reads `affected_ids`: a search across `*.py`, `*.ts`, `*.tsx` and `*.md` for the whole project tree returns no consumer outside `crystallizer_service.py` itself.

Populating it would mean extending the storage endpoint to select ids as well. Worth doing if a consumer appears; not worth a cross-service change for a field nobody reads.

`MAX_AFFECTED_IDS` is still used by nine other call sites, so no dead constant.

## Not affected

`_compute_health` reads `coverage.get("coverage_pct", 0.0)` — a real key — and keeps working. That asymmetry is what made this hard to spot: the coverage percentage on the health report has been correct the whole time, so the report looked internally consistent while the hygiene check beside it said zero.

## Tests

Three, in a new `TestMissingEmbeddingsCheck`:

1. **The regression** — a coverage response of `{"total_active": 10, "missing_embeddings": 4, "coverage_pct": 60.0}` must report `count == 4`. Confirmed failing before the fix:

   ```
   >       assert result["count"] == 4
   E       assert 0 == 4
   ```

2. Full coverage still reports `0`, so the read can't be inverted into "count the ones that are fine".

3. **The endpoint's key names, asserted against the endpoint's own source.** The failure mode here was a silent key mismatch across a service boundary — a unit test with a hand-written mock would have passed happily against the broken code, since the mock would have been written from the same wrong assumption. Pinning the contract means a change on the storage side fails here rather than quietly reverting the check to 0.

47 passed across the three crystallizer test files. `ruff check` and `ruff format --check` clean.

## One thing deliberately left out of this PR

`_remediate_missing_embeddings` (same file, ~line 227) has the **same class of bug** and is also a permanent no-op: it reads `candidates.get("missing_embeddings", [])` from `GET /lifecycle-candidates`, which returns only `expired_still_active` and `stale_low_weight`. It is called unconditionally from `run_crystallization`, so no crystallization run has ever re-embedded anything.

It is not in scope here because **it cannot be fixed by renaming a key** — no endpoint or service method returns missing-embedding *rows* (`id` + `content`), which is what it needs. The real options are to add such an endpoint, or to delete the function in favour of `core-worker/src/core_worker/backfill.py`, which already scans NULL rows and publishes `EMBED_REQUESTED` through the normal deferred path. That is a design decision, and inlining embedding writes into a crystallization run also competes for the same saturated concurrency gate behind the current prod bursts. Tracked separately.

Together the two bugs explain the pattern: nothing surfaced missing embeddings, and nothing repaired them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)