### PR TITLE
feat(memory): conflict-record write machinery — storage + resolver (A55 1d)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -638,6 +638,12 @@ class CoreStorageClient:
         queue's failure modes."""
         return await self._post("/memories/dedup-reviews", payload, read=False)  # type: ignore[return-value]
 
+    async def record_memory_conflict(self, payload: dict) -> dict:
+        """A55 — persist a ``memory_conflicts`` classification record. Additive:
+        the memory-row status/supersedes effect is applied separately, so this
+        never changes retrieval behaviour."""
+        return await self._post("/memories/conflicts", payload, read=False)  # type: ignore[return-value]
+
     async def list_dedup_reviews(self, params: dict) -> list[dict]:
         """List reviews for a tenant, default ``status='pending'``."""
         return await self._get(  # type: ignore[return-value]

--- a/core-api/src/core_api/services/contradiction/resolver.py
+++ b/core-api/src/core_api/services/contradiction/resolver.py
@@ -1,0 +1,84 @@
+"""ConflictResolver — run L1+L2+L3 on a candidate pair and persist the record (A55).
+
+``record_conflict(new_memory, candidate)`` classifies the pair (L1 relationship +
+L2 diagnosis), resolves an action with the safety invariants (L3), and writes a
+``memory_conflicts`` row via storage. It returns the stored record (or None on a
+storage failure — best-effort, like the rest of the post-commit contradiction work).
+
+ADDITIVE by design: this writes the classification RECORD only. The memory-row
+effect (``status`` / ``supersedes_id``) is still applied by the detector and is
+unchanged, so retrieval behaviour is identical (the golden differential test is
+the gate). Wiring this onto the engine-ON path is done separately behind a flag.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core_api.clients.storage_client import get_storage_client
+from core_api.services.contradiction.diagnosis import classify
+from core_api.services.contradiction.resolution import resolve
+
+logger = logging.getLogger(__name__)
+
+_CREATED_BY = "contradiction-engine"
+
+
+def _evidence_strength(relationship: str, is_inferred: bool) -> str:
+    """Map to the memory_conflicts.evidence_strength vocabulary
+    (explicit / entailed / probabilistic)."""
+    if relationship == "probabilistic":
+        return "probabilistic"
+    if is_inferred:
+        return "entailed"
+    return "explicit"
+
+
+async def record_conflict(
+    new_memory: dict,
+    candidate: dict,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    tenant_config=None,
+) -> dict | None:
+    """Classify + resolve a candidate pair and persist the ``memory_conflicts``
+    record. Best-effort: returns None (logged) if the write fails."""
+    result = await classify(new_memory, candidate, tenant_config=tenant_config)
+
+    # Invariant input: weak (inferred) evidence must not overturn explicit facts.
+    is_inferred = bool(new_memory.get("is_inferred") or candidate.get("is_inferred"))
+    gate_confidence = min(result.relationship_confidence, result.diagnosis_confidence)
+    resolution = resolve(
+        result.relationship,
+        result.diagnosis,
+        is_inferred=is_inferred,
+        confidence=gate_confidence,
+    )
+
+    payload = {
+        "tenant_id": tenant_id,
+        "fleet_id": fleet_id,
+        "new_memory_id": str(new_memory["id"]),
+        "old_memory_id": str(candidate["id"]),
+        "relationship": result.relationship,
+        "relationship_confidence": result.relationship_confidence,
+        "diagnosis": result.diagnosis,
+        "diagnosis_confidence": result.diagnosis_confidence,
+        "evidence_strength": _evidence_strength(result.relationship, is_inferred),
+        "action": resolution.action,
+        "audit_reason": resolution.audit_reason,
+        "created_by": _CREATED_BY,
+    }
+
+    try:
+        sc = get_storage_client()
+        return await sc.record_memory_conflict(payload)
+    except Exception:
+        logger.warning(
+            "memory_conflicts write failed for new=%s old=%s",
+            new_memory.get("id"),
+            candidate.get("id"),
+            exc_info=True,
+        )
+        return None

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -968,6 +968,37 @@ _DEDUP_REVIEW_FIELDS = [
 ]
 
 
+_MEMORY_CONFLICT_FIELDS = [
+    "id",
+    "tenant_id",
+    "fleet_id",
+    "new_memory_id",
+    "old_memory_id",
+    "relationship",
+    "relationship_confidence",
+    "diagnosis",
+    "diagnosis_confidence",
+    "evidence_strength",
+    "action",
+    "audit_reason",
+    "created_by",
+    "created_at",
+    "metadata_",
+]
+
+
+@router.post("/conflicts")
+async def record_memory_conflict(request: Request) -> dict:
+    """A55 — persist a memory_conflicts classification record (additive; the
+    memory-row status/supersedes effect is applied separately)."""
+    body: dict = await request.json()
+    try:
+        row = await _svc.memory_conflict_record(body)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return orm_to_dict(row, _MEMORY_CONFLICT_FIELDS)
+
+
 @router.post("/dedup-reviews")
 async def enqueue_dedup_review(request: Request) -> dict:
     body: dict = await request.json()

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -74,6 +74,7 @@ from common.models import (
     IdempotencyResponse,
     LifecycleAudit,
     Memory,
+    MemoryConflict,
     MemoryEntityLink,
     Relation,
 )
@@ -1049,6 +1050,63 @@ class PostgresService:
                     else None
                 ),
                 decision_band=band,
+            )
+            session.add(row)
+            await session.flush()
+            return row
+
+    async def memory_conflict_record(self, payload: dict) -> MemoryConflict:
+        """Insert an A55 ``memory_conflicts`` classification record.
+
+        Required: ``tenant_id``, ``new_memory_id``, ``old_memory_id``,
+        ``relationship``. Optional: ``fleet_id``, ``relationship_confidence``,
+        ``diagnosis``, ``diagnosis_confidence``, ``evidence_strength``,
+        ``action``, ``audit_reason``, ``created_by``, ``metadata``.
+
+        Enum-like fields are validated against the model vocab so a bad value is a
+        400 (ValueError) rather than a DB CHECK violation at flush. This records
+        the classification only — the memory-row effect (``status`` /
+        ``supersedes_id``) is applied separately and is unchanged.
+        """
+        from common.models.memory_conflict import (
+            ACTIONS,
+            DIAGNOSES,
+            EVIDENCE_STRENGTHS,
+            RELATIONSHIPS,
+        )
+
+        relationship = payload.get("relationship")
+        if relationship not in RELATIONSHIPS:
+            raise ValueError(f"unknown relationship: {relationship!r}")
+        diagnosis = payload.get("diagnosis")
+        if diagnosis is not None and diagnosis not in DIAGNOSES:
+            raise ValueError(f"unknown diagnosis: {diagnosis!r}")
+        evidence = payload.get("evidence_strength")
+        if evidence is not None and evidence not in EVIDENCE_STRENGTHS:
+            raise ValueError(f"unknown evidence_strength: {evidence!r}")
+        action = payload.get("action")
+        if action is not None and action not in ACTIONS:
+            raise ValueError(f"unknown action: {action!r}")
+
+        def _conf(key: str) -> float | None:
+            v = payload.get(key)
+            return float(v) if v is not None else None
+
+        async with get_session() as session:
+            row = MemoryConflict(
+                tenant_id=payload["tenant_id"],
+                fleet_id=payload.get("fleet_id"),
+                new_memory_id=UUID(str(payload["new_memory_id"])),
+                old_memory_id=UUID(str(payload["old_memory_id"])),
+                relationship=relationship,
+                relationship_confidence=_conf("relationship_confidence"),
+                diagnosis=diagnosis,
+                diagnosis_confidence=_conf("diagnosis_confidence"),
+                evidence_strength=evidence,
+                action=action,
+                audit_reason=payload.get("audit_reason"),
+                created_by=payload.get("created_by"),
+                metadata_=payload.get("metadata"),
             )
             session.add(row)
             await session.flush()

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -189,6 +189,64 @@ class TestMemories:
         assert fetched["is_inferred"] is False
         assert fetched["scope"] == {}
 
+    async def test_a55_memory_conflict_record_round_trip(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """A55 — POST /memories/conflicts inserts a classification record
+        (relationship/diagnosis/evidence/action + confidences + audit + metadata)
+        referencing two real memories."""
+        a = (await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))).json()
+        b = (await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))).json()
+        payload = {
+            "tenant_id": tenant_id,
+            "fleet_id": fleet_id,
+            "new_memory_id": a["id"],
+            "old_memory_id": b["id"],
+            "relationship": "exact_value",
+            "relationship_confidence": 0.9,
+            "diagnosis": "temporal_change",
+            "diagnosis_confidence": 0.8,
+            "evidence_strength": "explicit",
+            "action": "supersede",
+            "audit_reason": "exact_value/temporal_change -> supersede",
+            "created_by": "test",
+            "metadata": {"k": "v"},
+        }
+        resp = await client.post(f"{PREFIX}/memories/conflicts", json=payload)
+        assert resp.status_code == 200, resp.text
+        row = resp.json()
+        assert row["relationship"] == "exact_value"
+        assert row["diagnosis"] == "temporal_change"
+        assert row["evidence_strength"] == "explicit"
+        assert row["action"] == "supersede"
+        assert row["new_memory_id"] == a["id"]
+        assert row["old_memory_id"] == b["id"]
+        assert row["relationship_confidence"] == 0.9
+        assert row["metadata_"] == {"k": "v"}
+
+    async def test_a55_memory_conflict_rejects_bad_relationship(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """A bad enum value is a 400 (validated) rather than a 500 CHECK violation."""
+        a = (await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))).json()
+        b = (await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))).json()
+        resp = await client.post(
+            f"{PREFIX}/memories/conflicts",
+            json={
+                "tenant_id": tenant_id,
+                "new_memory_id": a["id"],
+                "old_memory_id": b["id"],
+                "relationship": "bogus",
+            },
+        )
+        assert resp.status_code == 400
+
     async def test_update_status_via_patch(
         self,
         client: AsyncClient,

--- a/tests/test_contradiction_resolver.py
+++ b/tests/test_contradiction_resolver.py
@@ -1,0 +1,114 @@
+"""ConflictResolver.record_conflict tests (A55) — classify+resolve+persist."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from core_api.services.contradiction import resolver as rv
+
+pytestmark = pytest.mark.unit
+
+SUBJ = "00000000-0000-0000-0000-0000000000aa"
+
+
+def _mem(mid, **over) -> dict:
+    base = {
+        "id": mid,
+        "content": "text",
+        "subject_entity_id": None,
+        "predicate": None,
+        "object_value": None,
+        "is_inferred": False,
+    }
+    base.update(over)
+    return base
+
+
+def _mock_storage():
+    sc = MagicMock()
+    sc.record_memory_conflict = AsyncMock(side_effect=lambda p: {**p, "id": "rec-1"})
+    return sc
+
+
+@pytest.mark.asyncio
+async def test_rdf_pair_records_supersede():
+    """RDF exact-value pair -> relationship=exact_value, diagnosis=temporal_change,
+    action=supersede (matching today's RDF effect). No LLM."""
+    new = _mem(
+        "m-new", subject_entity_id=SUBJ, predicate="lives_in", object_value="Haifa"
+    )
+    old = _mem(
+        "m-old", subject_entity_id=SUBJ, predicate="lives_in", object_value="Tel Aviv"
+    )
+    sc = _mock_storage()
+    with patch.object(rv, "get_storage_client", return_value=sc):
+        rec = await rv.record_conflict(new, old, tenant_id="t1", fleet_id="f1")
+
+    sc.record_memory_conflict.assert_awaited_once()
+    payload = sc.record_memory_conflict.await_args.args[0]
+    assert payload["relationship"] == "exact_value"
+    assert payload["diagnosis"] == "temporal_change"
+    assert payload["action"] == "supersede"
+    assert payload["evidence_strength"] == "explicit"
+    assert payload["new_memory_id"] == "m-new" and payload["old_memory_id"] == "m-old"
+    assert payload["created_by"] == "contradiction-engine"
+    assert rec["id"] == "rec-1"
+
+
+@pytest.mark.asyncio
+async def test_llm_pair_records_classification():
+    new, old = _mem("a"), _mem("b")
+
+    async def fake_classify(nm, cand, *, tenant_config=None):
+        from core_api.services.contradiction.diagnosis import ClassifyResult
+
+        return ClassifyResult("negation", 0.8, "correction", 0.8)
+
+    sc = _mock_storage()
+    with (
+        patch.object(rv, "classify", new=fake_classify),
+        patch.object(rv, "get_storage_client", return_value=sc),
+    ):
+        await rv.record_conflict(new, old, tenant_id="t1", fleet_id=None)
+
+    payload = sc.record_memory_conflict.await_args.args[0]
+    assert payload["relationship"] == "negation"
+    assert payload["diagnosis"] == "correction"
+    assert (
+        payload["action"] == "replace"
+    )  # correction -> replace (high conf, not inferred)
+
+
+@pytest.mark.asyncio
+async def test_inferred_memory_downgrades_action_via_invariant():
+    """If either memory is inferred, a destructive action is downgraded to
+    mark_disputed (invariant: inference must not overturn an explicit fact)."""
+    new = _mem("a", is_inferred=True)
+    old = _mem("b")
+
+    async def fake_classify(nm, cand, *, tenant_config=None):
+        from core_api.services.contradiction.diagnosis import ClassifyResult
+
+        return ClassifyResult("exact_value", 0.9, "correction", 0.9)
+
+    sc = _mock_storage()
+    with (
+        patch.object(rv, "classify", new=fake_classify),
+        patch.object(rv, "get_storage_client", return_value=sc),
+    ):
+        await rv.record_conflict(new, old, tenant_id="t1", fleet_id="f1")
+
+    payload = sc.record_memory_conflict.await_args.args[0]
+    assert payload["action"] == "mark_disputed"
+    assert payload["evidence_strength"] == "entailed"  # inferred evidence
+
+
+@pytest.mark.asyncio
+async def test_storage_failure_is_swallowed():
+    new, old = _mem("a"), _mem("b")
+    sc = MagicMock()
+    sc.record_memory_conflict = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch.object(rv, "get_storage_client", return_value=sc):
+        rec = await rv.record_conflict(new, old, tenant_id="t1", fleet_id="f1")
+    assert rec is None  # best-effort; never raises


### PR DESCRIPTION
## What & why

The machinery to persist the L1/L2/L3 classification as a `memory_conflicts` row. **Additive and dormant** — nothing calls the resolver in production yet (the detector wiring is a following slice behind its own flag), and it writes only the classification **record**; the memory-row `status`/`supersedes_id` effect stays with the detector, unchanged. The golden differential test is unaffected.

## Storage
- `postgres_service.memory_conflict_record` — insert a `memory_conflicts` row, validating enum-like fields against the model vocab (bad value → **400**, not a DB CHECK 500).
- `POST /memories/conflicts` + `_MEMORY_CONFLICT_FIELDS`.
- `storage_client.record_memory_conflict`.

## Resolver — `services/contradiction/resolver.py`
`record_conflict(new_memory, candidate, …)`:
1. `classify()` (L1 relationship + L2 diagnosis)
2. `resolve()` (L3 action + audit_reason; `is_inferred` from either memory gates destructive actions)
3. build payload (+ `evidence_strength`) → `record_memory_conflict()`

Best-effort: a storage failure returns `None` (logged), never breaks the write path.

## No-degradation
Record-only — no `status`/`supersedes_id` mutation. The RDF-pair test asserts `exact_value/temporal_change → supersede`, matching today's RDF effect.

## Tests
Storage round-trip + bad-enum 400; resolver RDF→supersede, LLM→classification, inferred→invariant downgrade, storage-failure swallowed. **Storage suite 118 passed; core-api contradiction suite 71 passed.** mypy + ruff clean.

## Next (final sub-slice, not here)
Wire `record_conflict` into the detector where it already holds both memories (RDF/semantic/Path-C), behind a new `contradiction_write_conflict_record` flag (default OFF), avoiding the double-LLM on the semantic path; new test that flag-ON writes a row + golden proves status/supersedes unchanged; then a `.dev` wet test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)