### PR TITLE
feat(memory): wire conflict-record write into the detector, flag-gated (A55 1d)

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -297,6 +297,11 @@ class Settings(BaseSettings):
     # paths are behaviourally identical (the engine delegates to the same
     # detector); the flag exists so the old arch can be retired later.
     contradiction_engine_enabled: bool = False
+    # A55 1d — when True, the detector additionally writes a memory_conflicts
+    # classification record for each confirmed conflict (via the resolver).
+    # Additive: it never changes the status/supersedes effect, so retrieval is
+    # unaffected. Default False; enable to start populating conflict records.
+    contradiction_write_conflict_record: bool = False
     crystallizer_enabled: bool = True
     crystallizer_stale_days: int = 180
     crystallizer_dedup_sample_size: int = 1000

--- a/core-api/src/core_api/services/contradiction/resolver.py
+++ b/core-api/src/core_api/services/contradiction/resolver.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 
 from core_api.clients.storage_client import get_storage_client
-from core_api.services.contradiction.diagnosis import classify
+from core_api.services.contradiction.diagnosis import ClassifyResult, classify
 from core_api.services.contradiction.resolution import resolve
 
 logger = logging.getLogger(__name__)
@@ -41,10 +41,17 @@ async def record_conflict(
     tenant_id: str,
     fleet_id: str | None,
     tenant_config=None,
+    result: ClassifyResult | None = None,
 ) -> dict | None:
     """Classify + resolve a candidate pair and persist the ``memory_conflicts``
-    record. Best-effort: returns None (logged) if the write fails."""
-    result = await classify(new_memory, candidate, tenant_config=tenant_config)
+    record. Best-effort: returns None (logged) if the write fails.
+
+    ``result`` lets a caller that already classified the pair skip the (possibly
+    LLM-backed) ``classify()`` — used by ``record_conflict_from_verdict`` to avoid
+    a second LLM call on the detector's semantic path.
+    """
+    if result is None:
+        result = await classify(new_memory, candidate, tenant_config=tenant_config)
 
     # Invariant input: weak (inferred) evidence must not overturn explicit facts.
     is_inferred = bool(new_memory.get("is_inferred") or candidate.get("is_inferred"))
@@ -82,3 +89,50 @@ async def record_conflict(
             exc_info=True,
         )
         return None
+
+
+async def record_conflict_from_verdict(
+    new_memory: dict,
+    candidate: dict,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    confidence: float | None = None,
+) -> dict | None:
+    """Record a conflict the detector already CONFIRMED (semantic / Path C)
+    WITHOUT a second LLM call. The detector's effect is a supersede, so the
+    record is aligned to it: exact_value / temporal_change / supersede. Richer
+    L1/L2 classification of confirmed conflicts is a follow-up."""
+    conf = confidence if confidence is not None else 0.5
+    result = ClassifyResult("exact_value", conf, "temporal_change", conf)
+    return await record_conflict(new_memory, candidate, tenant_id=tenant_id, fleet_id=fleet_id, result=result)
+
+
+async def record_detected_conflicts(
+    new_memory: dict,
+    pairs: list[tuple[dict, str, float | None]],
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    tenant_config=None,
+) -> None:
+    """Write a memory_conflicts record for each ``(candidate, kind, confidence)``
+    the detector confirmed. ``rdf`` pairs classify deterministically (no LLM);
+    ``semantic`` / Path-C pairs reuse the detector's verdict (no second LLM)."""
+    for candidate, kind, confidence in pairs:
+        if kind == "rdf":
+            await record_conflict(
+                new_memory,
+                candidate,
+                tenant_id=tenant_id,
+                fleet_id=fleet_id,
+                tenant_config=tenant_config,
+            )
+        else:
+            await record_conflict_from_verdict(
+                new_memory,
+                candidate,
+                tenant_id=tenant_id,
+                fleet_id=fleet_id,
+                confidence=confidence,
+            )

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -280,6 +280,9 @@ async def _detect(
     """
     sc = get_storage_client()
     contradictions: list[ContradictionInfo] = []
+    # A55 1d — (candidate_row, kind, confidence) pairs to persist as
+    # memory_conflicts records after the effect is applied (flag-gated below).
+    _record_pairs: list[tuple[dict, str, float | None]] = []
 
     memory_id = new_memory.get("id")
     subject_entity_id = new_memory.get("subject_entity_id")
@@ -412,6 +415,7 @@ async def _detect(
                     direction=direction,
                 )
             )
+            _record_pairs.append((old, "rdf", None))
             logger.info(
                 "RDF contradiction: memory %s outdated by %s "
                 "(subject=%s predicate=%s old_value=%s new_value=%s direction=%s)",
@@ -577,6 +581,7 @@ async def _detect(
                             direction=direction,
                         )
                     )
+                    _record_pairs.append((candidate, "semantic", _confidence))
                     logger.info(
                         "Semantic contradiction: memory %s conflicted by %s direction=%s",
                         older_id,
@@ -596,6 +601,22 @@ async def _detect(
                         memory_id,
                         sem_result["skipped"],
                     )
+
+    # A55 1d — additionally persist a memory_conflicts classification record for
+    # each confirmed conflict. Flag-gated (default off); never touches the
+    # status/supersedes effect above, so retrieval behaviour is unchanged.
+    if _record_pairs and settings.contradiction_write_conflict_record:
+        from core_api.services.contradiction.resolver import (
+            record_detected_conflicts,
+        )
+
+        await record_detected_conflicts(
+            new_memory,
+            _record_pairs,
+            tenant_id=tenant_id,
+            fleet_id=new_memory.get("fleet_id"),
+            tenant_config=tenant_config,
+        )
 
     return contradictions
 

--- a/tests/test_contradiction_resolver.py
+++ b/tests/test_contradiction_resolver.py
@@ -112,3 +112,44 @@ async def test_storage_failure_is_swallowed():
     with patch.object(rv, "get_storage_client", return_value=sc):
         rec = await rv.record_conflict(new, old, tenant_id="t1", fleet_id="f1")
     assert rec is None  # best-effort; never raises
+
+
+@pytest.mark.asyncio
+async def test_record_conflict_from_verdict_supersede():
+    """Detector-confirmed conflict (no second LLM) -> exact_value / temporal_change
+    / supersede, aligned with the detector's supersede effect."""
+    sc = _mock_storage()
+    with patch.object(rv, "get_storage_client", return_value=sc):
+        await rv.record_conflict_from_verdict(
+            _mem("n"), _mem("c"), tenant_id="t", fleet_id="f", confidence=0.7
+        )
+    p = sc.record_memory_conflict.await_args.args[0]
+    assert p["relationship"] == "exact_value"
+    assert p["diagnosis"] == "temporal_change"
+    assert p["action"] == "supersede"
+    assert p["relationship_confidence"] == 0.7
+
+
+@pytest.mark.asyncio
+async def test_record_detected_conflicts_dispatches_by_kind():
+    calls = []
+
+    async def fake_rc(nm, cand, **kw):
+        calls.append(("rc", cand["id"]))
+        return {}
+
+    async def fake_fv(nm, cand, **kw):
+        calls.append(("fv", cand["id"], kw.get("confidence")))
+        return {}
+
+    with (
+        patch.object(rv, "record_conflict", new=fake_rc),
+        patch.object(rv, "record_conflict_from_verdict", new=fake_fv),
+    ):
+        await rv.record_detected_conflicts(
+            _mem("n"),
+            [(_mem("c1"), "rdf", None), (_mem("c2"), "semantic", 0.8)],
+            tenant_id="t",
+            fleet_id="f",
+        )
+    assert calls == [("rc", "c1"), ("fv", "c2", 0.8)]

--- a/tests/test_contradiction_wire.py
+++ b/tests/test_contradiction_wire.py
@@ -1,0 +1,108 @@
+"""Detector -> conflict-record wiring (A55 1d), flag-gated.
+
+Proves: with contradiction_write_conflict_record ON, a confirmed conflict in
+``_detect`` schedules a memory_conflicts record; with it OFF (default) it does
+not. Either way the status/supersedes effect is unchanged (no degradation).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from core_api.constants import VECTOR_DIM
+from core_api.services.contradiction_detector import _detect
+
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
+
+pytestmark = pytest.mark.unit
+
+SUBJ = "00000000-0000-0000-0000-0000000000aa"
+
+
+def _new(object_value: str, ts: str) -> dict:
+    return {
+        "id": str(uuid4()),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "content": f"X lives in {object_value}",
+        "subject_entity_id": SUBJ,
+        "predicate": "lives_in",
+        "object_value": object_value,
+        "deleted_at": None,
+        "status": "active",
+        "visibility": "scope_team",
+        "supersedes_id": None,
+        "created_at": ts,
+    }
+
+
+def _cand(object_value: str, ts: str) -> dict:
+    return {
+        "id": str(uuid4()),
+        "content": f"X lives in {object_value}",
+        "status": "active",
+        "object_value": object_value,
+        "created_at": ts,
+    }
+
+
+def _rdf_conflict_sc() -> AsyncMock:
+    cand = _cand("Tel Aviv", "2026-04-29T10:00:00+00:00")
+    sc = AsyncMock()
+    sc.find_rdf_conflicts = AsyncMock(return_value=[cand])
+    sc.find_similar_candidates = AsyncMock(return_value=[])
+    sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
+    return sc, cand
+
+
+async def _run(flag: bool):
+    new = _new("Haifa", "2026-04-29T12:00:00+00:00")
+    sc, cand = _rdf_conflict_sc()
+    rec = AsyncMock()
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction.resolver.record_detected_conflicts",
+            rec,
+        ),
+        patch("core_api.config.settings.contradiction_write_conflict_record", flag),
+    ):
+        await _detect(new, [0.1] * VECTOR_DIM)
+    return new, cand, sc, rec
+
+
+@pytest.mark.asyncio
+async def test_flag_on_records_conflict_and_preserves_effect():
+    new, cand, sc, rec = await _run(True)
+
+    # Record path fired once, with the RDF pair.
+    rec.assert_awaited_once()
+    pairs = rec.await_args.args[1]
+    assert pairs[0][0]["id"] == cand["id"] and pairs[0][1] == "rdf"
+    assert rec.await_args.kwargs["tenant_id"] == "t1"
+
+    # Effect unchanged: candidate marked outdated, new supersedes it.
+    calls = [c.args for c in sc.update_memory_status.call_args_list]
+    assert (cand["id"], "outdated") in calls
+    new_call = [
+        c
+        for c in sc.update_memory_status.call_args_list
+        if c.args and c.args[0] == new["id"]
+    ]
+    assert new_call and new_call[0].kwargs.get("supersedes_id") == cand["id"]
+
+
+@pytest.mark.asyncio
+async def test_flag_off_does_not_record_but_still_applies_effect():
+    _, cand, sc, rec = await _run(False)
+
+    rec.assert_not_awaited()  # no record write when flag is off (default)
+    # Effect still applied — identical to today.
+    calls = [c.args for c in sc.update_memory_status.call_args_list]
+    assert (cand["id"], "outdated") in calls


### PR DESCRIPTION
## What & why

Completes the **conflict-record side of A55 1d**: when `contradiction_write_conflict_record` is **ON** (default **OFF**), `_detect` additionally persists a `memory_conflicts` classification record for each confirmed conflict. **Additive** — it never touches the `status`/`supersedes_id` effect, so retrieval is unchanged.

## How

- **config:** `contradiction_write_conflict_record` (default `False`).
- **`_detect`:** collects `(candidate, kind, confidence)` pairs at the RDF + semantic confirm sites and — behind the flag, *after* the effect is applied — calls `record_detected_conflicts` (deferred import to avoid the detector↔resolver import cycle).
- **resolver:**
  - `record_conflict(..., result=…)` skips re-classification when the caller already has it.
  - `record_conflict_from_verdict` records a detector-confirmed conflict **without a second LLM call** — aligned to the supersede effect (`exact_value` / `temporal_change` / `supersede`).
  - `record_detected_conflicts` dispatches `rdf` → classify (deterministic, no LLM) vs `semantic` → verdict.

## No-degradation

- Flag-ON test: records the RDF pair **and** preserves the `outdated`+`supersedes` effect.
- Flag-OFF test: records nothing but still applies the effect (identical to today).
- Broad contradiction sweep: **497 passed**, only the known pre-existing create_all `ph5b` failure — **zero new failures**. Golden differential unchanged. mypy + ruff clean.

## Validation still to do (with the flag)

A `.dev`/local **wet test with both flags ON** — write two contradicting memories, confirm a `memory_conflicts` row lands and status/supersedes are unchanged. Belongs to the flag-rollout step.

## Explicitly out of scope (follow-ups)

- Path C (entity-aware) record wiring + richer semantic-conflict classification.
- Populating `memories.confidence`/`is_inferred`/`scope` → **A59**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)