### PR TITLE
ci: enforce the coverage floors both packages already declare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,40 @@ jobs:
           ENTITY_EXTRACTION_PROVIDER: none
           USE_LLM_FOR_MEMORY_CREATION: "false"
 
+      - name: Enforce coverage floors (per package)
+        # The step above collects coverage but enforced no floor. Both packages
+        # declare ``[tool.coverage.report] fail_under = 50``, and coverage
+        # discovers config relative to the CWD — with no root pyproject.toml,
+        # running pytest from the repo root meant neither floor was ever read.
+        # Measured at the time of writing: core-api 83%, core-storage-api 67%.
+        #
+        # Enforced PER PACKAGE rather than on the combined total, because the
+        # blend is dominated by core-api (15,156 statements against 5,558) and
+        # would mask a collapse in the smaller one: core-storage-api falling to
+        # 30% still leaves a combined ~69%, comfortably over a 50% blended
+        # floor. Two declarations mean two floors.
+        #
+        # ``--rcfile`` points at each package's own pyproject so the number
+        # lives in exactly one place; hardcoding 50 here would let the workflow
+        # drift from the declaration it is meant to enforce. Reuses the data
+        # file the pytest run just wrote, so the suite is not run twice.
+        #
+        # Both reports run unconditionally, via ``|| status=1`` rather than
+        # back-to-back commands: GitHub runs a multi-line ``run`` under
+        # ``bash -e``, so a core-api breach would abort the step and a
+        # simultaneous core-storage-api breach would stay invisible until the
+        # first was fixed. Exiting once at the end keeps the step failing on
+        # either breach while always reporting both.
+        run: |
+          status=0
+          uv run coverage report \
+            --rcfile=core-api/pyproject.toml \
+            --include="core-api/src/core_api/*" || status=1
+          uv run coverage report \
+            --rcfile=core-storage-api/pyproject.toml \
+            --include="core-storage-api/src/core_storage_api/*" || status=1
+          exit "$status"
+
       - name: Create the storage-suite database
         # Its own database, NOT the one `tests/` uses. The two suites provision
         # differently — `tests/` conftest calls Base.metadata.create_all, the


### PR DESCRIPTION
core-api and core-storage-api each declare `[tool.coverage.report] fail_under = 50`, and CI enforced **neither**.

The main test step collects coverage from the repo root with no `--cov-config`, and there is no root `pyproject.toml`, so coverage discovers no config and both floors are silently ignored. Demonstrated before fixing: running three tests with those exact `--cov` flags passes with no floor check at all, when coverage across all of `core_api` from three tests is obviously far below 50%.

Follow-up to #768, which fixed the same defect for core-operations via `--cov-config`.

## Measured first

Enabling a floor that isn't met would just break the build, so I ran the full suite before wiring anything — 4,273 tests, ~6 minutes:

| package | statements | missed | coverage |
|---|---:|---:|---:|
| core-api | 15,156 | 2,641 | **83%** |
| core-storage-api | 5,558 | 1,808 | **67%** |
| combined | 20,714 | 4,449 | 79% |

Both clear the declared floor comfortably, so no declaration needed adjusting and nothing had to be escalated.

## Per package, not combined

This is the one real design call. The blend is dominated by core-api — 15,156 statements against 5,558 — so a single combined floor would mask a collapse in the smaller package. Concretely: **core-storage-api falling from 67% to 30% still leaves a combined ~69%**, comfortably over a 50% blended floor. Two declarations mean two floors, and that is what the code already says.

`--rcfile` points each check at that package's own `pyproject.toml`, so the number lives in exactly one place. Hardcoding `50` in the workflow would let it drift from the declaration it exists to enforce.

## No root config

A root `pyproject.toml` holding a shared floor was the obvious alternative, and I checked whether it was safe rather than assuming: one containing only `[tool.coverage.report]` leaves ruff discovery alone — `common/constants.py` still resolves `line-length = 88` from `common/ruff.toml`, and the root `tests/` tree is unaffected — because ruff skips a `pyproject.toml` with no `[tool.ruff]` section and keeps walking. So that option was viable, just less faithful. This adds no root file.

## Verified both directions

The step reuses the data file the pytest run just wrote, so the suite is **not** run twice.

```
core-api            exit=0   TOTAL 82%
core-storage-api    exit=0   TOTAL 67%
```

And it genuinely fails on a regression — temporarily raising core-storage-api's floor to 70:

```
exit=2
Coverage failure: total of 67 is less than fail-under=70
```

Worth noting how this stayed hidden so long: plain `coverage report` prints **nothing** when the floor passes and only speaks up on failure, so the absence of a "Required test coverage" line looked identical to success. The exit code is the only signal. That is also why my first attempt at the core-operations fix in #768 looked right while still being inert.

`actionlint` reports one finding on this file (SC2086 at line 70, the pre-existing install step) both before and after, so this introduces none. Rebased onto main after #768 landed; the new step coexists with the core-operations steps it added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)