### PR TITLE
perf(contradiction): batch the semantic per-candidate LLM judge (A61)

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -475,15 +475,19 @@ async def _detect(
             len(candidates) if candidates else 0,
         )
         if candidates:
-            # Fire all LLM checks concurrently instead of serially
-            tasks = [
-                asyncio.wait_for(
-                    _llm_contradiction_check(content, c.get("content", ""), tenant_config),
-                    timeout=10.0,
+            # A61 — batch the LLM judge. A single candidate keeps the direct
+            # per-candidate call; multiple candidates (the prod cost driver, up
+            # to 20) are judged in ONE batched call instead of N. Both feed the
+            # SAME _judge_contradiction gates below. ``judged`` is
+            # (verdict, confidence, raw|None).
+            if len(candidates) == 1:
+                _v, _c = await _llm_contradiction_check(
+                    content, candidates[0].get("content", ""), tenant_config
                 )
-                for c in candidates
-            ]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
+                judged: list[tuple[bool, float, dict | None]] = [(_v, _c, None)]
+            else:
+                raws = await _llm_contradiction_check_batch(content, candidates, tenant_config)
+                judged = [(*_judge_contradiction(raw), raw) for raw in raws]
 
             # CAURA-125 — state-corruption guard, same rationale as the
             # RDF path above.
@@ -497,19 +501,7 @@ async def _detect(
             # ``updates`` is empty. Keyed by ``memory_id`` — see
             # ``_merge_status_update`` for the dedupe rationale.
             updates: dict[str, dict] = {}
-            for candidate, result in zip(candidates, results):
-                if isinstance(result, Exception):
-                    logger.warning(
-                        "Contradiction check failed for candidate %s: %s",
-                        candidate.get("id"),
-                        result,
-                    )
-                    continue
-                # A4 #12 — judge now returns (verdict, confidence).
-                # Path A continues to gate only on verdict at this site;
-                # A4 #13 will introduce confidence-weighted vetoes on
-                # Path C's else-branch.
-                verdict, _confidence = result  # type: ignore[misc]
+            for candidate, (verdict, _confidence, _raw) in zip(candidates, judged):
                 # CAURA-132 diag — Path A semantic per-candidate verdict.
                 logger.info(
                     "PATH_A_SEMANTIC verdict memory=%s candidate=%s verdict=%s confidence=%.2f",
@@ -1034,6 +1026,114 @@ async def _llm_contradiction_check(
         service_label="contradiction",
         model_attr="entity_extraction_model",
         timeout=10.0,
+    )
+
+
+# A61 — batched contradiction judge. The semantic path used to fire one
+# ``_llm_contradiction_check`` (one ``complete_json``) PER candidate, up to the
+# candidate cap (20). This judges ALL candidates against the new statement in a
+# single call (~Nx fewer LLM calls, the prod cost driver). The per-candidate raw
+# output is fed through the SAME ``_judge_contradiction`` gates by the caller, so
+# verdict semantics — Gate 1 (cross-subject), Gate 2 (non_conflict_reason),
+# ``_pick_older`` direction — are unchanged. It also emits ``relationship`` /
+# ``diagnosis`` per candidate so a downstream conflict-record write (A55 engine
+# path) can reuse it with no second LLM call.
+BATCH_CONTRADICTION_PROMPT = """\
+You are a contradiction detector for a business memory system.
+
+A NEW statement is compared against several EXISTING candidate statements.
+Judge EACH candidate INDEPENDENTLY against the NEW statement — one candidate's
+verdict must NOT influence another's.
+
+Two statements contradict ONLY IF they make incompatible claims about the SAME
+real-world subject. Different subjects -> NOT a contradiction, even if the
+predicates look opposite.
+
+NEW statement:
+{new_content}
+
+Candidate statements (judge each, by index):
+{candidates_block}
+
+For EACH candidate index decide, applying the rules in order:
+1. same_subject (bool): true ONLY when the candidate and the NEW statement refer
+   to the SAME real-world entity (exact name / known alias / role+name in
+   context / unambiguously resolved pronoun). false for two people sharing a
+   name, different companies/products/projects/teams, or any uncertainty.
+2. non_conflict_reason (exactly one): "none"; "temporal_supersession"
+   (sequential lifecycle states of the same subject, both true in order);
+   "list_valued_predicate" (a multi-valued predicate or two different attributes
+   that both hold); "refinement" (one is a more specific version of the other);
+   "scope_mismatch" (same subject under different implicit qualifiers — time
+   window / whole vs part / context; both hold); "same_name_distinct_subject"
+   (same surface name, plausibly different instances); "conditional_unrealized"
+   (one is hypothetical/irrealis); "event_restatement" (same event restated).
+3. contradicts (bool): true ONLY when same_subject is true AND
+   non_conflict_reason is "none" AND the two assert mutually exclusive states in
+   the same time frame. Updates / corrections about the same subject ARE
+   contradictions ("X lives in Tel Aviv" vs "X lives in Haifa").
+4. relationship (exactly one): "exact_value" (same attribute, different single
+   value); "negation" (asserts P vs not-P); "entailed" (one implies or restates
+   the other); "constraint" (multi-valued predicate, both hold); "probabilistic"
+   (hedged/uncertain); "scope_apparent" (same attribute, different implicit
+   qualifiers); "refinement" (one more specific).
+5. diagnosis (exactly one): "correction" (old was wrong); "temporal_change"
+   (state changed over time); "scope_difference"; "entity_mismatch" (actually
+   different entities); "write_error"; "unresolved".
+
+Reply with ONLY a JSON object mapping each candidate index (as a STRING) to its
+judgment, no prose, no markdown fences:
+{{"0": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true, "relationship": "exact_value", "diagnosis": "temporal_change"}}, "1": {{...}}}}
+"""
+
+
+async def _llm_contradiction_check_batch(
+    new_content: str,
+    candidates: list[dict],
+    tenant_config=None,
+) -> list[dict]:
+    """Judge ALL ``candidates`` against ``new_content`` in ONE ``complete_json``
+    call (A61). Returns one raw judgment dict per candidate, aligned to input
+    order; a missing / malformed entry defaults to a safe non-contradiction
+    (``{"contradicts": False}``) so a partial response never fabricates or drops
+    a contradiction. The caller runs each raw through ``_judge_contradiction``,
+    so the safety gates are identical to the per-candidate path."""
+    provider_name = (
+        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
+    )
+    candidates_block = "\n".join(f"[{i}] {c.get('content', '')[:500]}" for i, c in enumerate(candidates))
+    prompt = BATCH_CONTRADICTION_PROMPT.format(
+        new_content=new_content[:500], candidates_block=candidates_block
+    )
+
+    def _align(obj: object) -> list[dict]:
+        by_index = obj if isinstance(obj, dict) else {}
+        out: list[dict] = []
+        for i in range(len(candidates)):
+            entry = by_index.get(str(i))
+            if entry is None:
+                entry = by_index.get(i)  # tolerate int keys
+            out.append(entry if isinstance(entry, dict) else {"contradicts": False})
+        return out
+
+    async def _do_check(llm) -> list[dict]:
+        raw = await llm.complete_json(prompt)
+        return _align(raw)
+
+    return await call_with_fallback(
+        primary_provider_name=provider_name,
+        call_fn=_do_check,
+        fake_fn=lambda: [
+            {
+                "same_subject": True,
+                "contradicts": _fake_contradiction_check(new_content, c.get("content", "")),
+            }
+            for c in candidates
+        ],
+        tenant_config=tenant_config,
+        service_label="contradiction_batch",
+        model_attr="entity_extraction_model",
+        timeout=15.0,
     )
 
 

--- a/tests/test_contradiction_batch.py
+++ b/tests/test_contradiction_batch.py
@@ -54,10 +54,7 @@ class TestBatchConcurrency:
             return old_content == "contradict"
 
         contents = ["safe", "fail-this", "contradict", "safe2"]
-        tasks = [
-            asyncio.wait_for(mock_check("new", c), timeout=10.0)
-            for c in contents
-        ]
+        tasks = [asyncio.wait_for(mock_check("new", c), timeout=10.0) for c in contents]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         assert results[0] is False
@@ -73,10 +70,7 @@ class TestBatchConcurrency:
             return "contra" in old_content
 
         contents = ["safe memory", "contradicting fact", "another safe one"]
-        tasks = [
-            asyncio.wait_for(mock_check("new", c), timeout=10.0)
-            for c in contents
-        ]
+        tasks = [asyncio.wait_for(mock_check("new", c), timeout=10.0) for c in contents]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         matched = list(zip(contents, results))
@@ -119,19 +113,133 @@ class TestBatchConcurrency:
 class TestBatchIntegrationWithDetect:
     """Verify the batch pattern is wired into _detect correctly."""
 
-    def test_detect_uses_gather_pattern(self):
-        """Verify _detect source code contains asyncio.gather (not serial for loop)."""
+    def test_detect_uses_batched_judge(self):
+        """A61: _detect judges MULTIPLE candidates via ONE batched LLM call
+        (``_llm_contradiction_check_batch``) rather than a per-candidate
+        ``asyncio.gather`` fan-out (the prod OpenAI cost driver). A single
+        candidate keeps the direct per-candidate call."""
         import inspect
+
         from core_api.services.contradiction_detector import _detect
+
         source = inspect.getsource(_detect)
-        assert "asyncio.gather" in source, "_detect should use asyncio.gather for batch checks"
-        assert "return_exceptions=True" in source, "gather should use return_exceptions=True"
+        assert "_llm_contradiction_check_batch" in source, (
+            "_detect should batch multi-candidate judging into one LLM call"
+        )
+        assert "len(candidates) == 1" in source, (
+            "_detect should keep the direct per-candidate call for a single candidate"
+        )
 
     def test_llm_check_has_no_internal_timeout(self):
         """_llm_contradiction_check should NOT have its own wait_for (timeout is at gather level)."""
         import inspect
+
         from core_api.services.contradiction_detector import _llm_contradiction_check
+
         source = inspect.getsource(_llm_contradiction_check)
         assert "wait_for" not in source, (
             "_llm_contradiction_check should not wrap in wait_for — timeout is at gather level"
         )
+
+
+@pytest.mark.unit
+class TestBatchedJudgeA61:
+    """A61 — the single-call batched judge."""
+
+    @pytest.mark.asyncio
+    async def test_batch_aligns_and_defaults_missing(self):
+        """One complete_json call; raws aligned to input order; a missing/
+        malformed entry defaults to a safe non-contradiction."""
+        from unittest.mock import AsyncMock, patch
+
+        from core_api.services.contradiction_detector import (
+            _llm_contradiction_check_batch,
+        )
+
+        cands = [{"content": "a"}, {"content": "b"}, {"content": "c"}]
+        # model returns index 0 + 2 only; index "1" missing; extra junk key
+        model = {
+            "0": {"contradicts": True, "relationship": "negation"},
+            "2": {"contradicts": False},
+            "99": {"contradicts": True},
+        }
+        fake_llm = AsyncMock()
+        fake_llm.complete_json = AsyncMock(return_value=model)
+        calls = {"n": 0}
+
+        async def _one_call(**kw):
+            calls["n"] += 1
+            return await kw["call_fn"](fake_llm)
+
+        with patch(
+            "core_api.services.contradiction_detector.call_with_fallback",
+            side_effect=_one_call,
+        ):
+            raws = await _llm_contradiction_check_batch("new", cands)
+
+        assert calls["n"] == 1  # ONE LLM call for all candidates
+        assert len(raws) == 3  # aligned to input order
+        assert raws[0]["contradicts"] is True
+        assert raws[1] == {"contradicts": False}  # missing -> safe default
+        assert raws[2]["contradicts"] is False
+
+    @pytest.mark.asyncio
+    async def test_detect_multi_candidate_calls_batch_once(self):
+        """_detect with 3 semantic candidates makes ONE batched judge call
+        (not 3), and still applies the supersede effect."""
+        from unittest.mock import AsyncMock, patch
+        from uuid import uuid4
+
+        from core_api.constants import VECTOR_DIM
+        from core_api.services.contradiction_detector import _detect
+
+        from tests._contradiction_batch_compat import install_batch_status_replay_shim
+
+        new = {
+            "id": str(uuid4()),
+            "tenant_id": "t1",
+            "fleet_id": "f1",
+            "content": "Dan lives in Haifa",
+            "subject_entity_id": None,
+            "predicate": None,
+            "object_value": None,
+            "deleted_at": None,
+            "status": "active",
+            "visibility": "scope_team",
+            "supersedes_id": None,
+            "created_at": "2026-04-29T12:00:00+00:00",
+        }
+        cands = [
+            {
+                "id": str(uuid4()),
+                "content": f"Dan lives in city {i}",
+                "status": "active",
+                "created_at": "2026-04-29T10:00:00+00:00",
+            }
+            for i in range(3)
+        ]
+        sc = AsyncMock()
+        sc.find_rdf_conflicts = AsyncMock(return_value=[])
+        sc.find_similar_candidates = AsyncMock(return_value=cands)
+        sc.update_memory_status = AsyncMock()
+        install_batch_status_replay_shim(sc)
+
+        batch = AsyncMock(
+            return_value=[{"same_subject": True, "contradicts": True} for _ in cands]
+        )
+        with (
+            patch(
+                "core_api.services.contradiction_detector.get_storage_client",
+                return_value=sc,
+            ),
+            patch(
+                "core_api.services.contradiction_detector._llm_contradiction_check_batch",
+                batch,
+            ),
+        ):
+            await _detect(new, [0.1] * VECTOR_DIM)
+
+        batch.assert_awaited_once()  # ONE batched call for 3 candidates
+        # effect applied: at least one candidate marked conflicted
+        statuses = [c.args for c in sc.update_memory_status.call_args_list]
+        assert any(s[1] == "conflicted" for s in statuses)

--- a/tests/test_p1_contradiction.py
+++ b/tests/test_p1_contradiction.py
@@ -14,17 +14,16 @@ Integration tests verify:
 
 import hashlib
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
-
 from core_api.constants import (
     CONTRADICTION_CANDIDATE_MAX,
     CONTRADICTION_SIMILARITY_THRESHOLD,
 )
-from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
 # ---------------------------------------------------------------------------
 # Unit tests
@@ -315,10 +314,17 @@ class TestSupersessionSemantics:
                 return_value=mock_sc,
             ),
             patch(
-                "core_api.services.contradiction_detector._llm_contradiction_check",
+                "core_api.services.contradiction_detector._llm_contradiction_check_batch",
                 new_callable=AsyncMock,
-                # A4 #12 — judge returns (verdict, confidence) tuple.
-                return_value=(True, 0.90),
+                # A61 — batched judge; both candidates contradict.
+                return_value=[
+                    {
+                        "same_subject": True,
+                        "contradicts": True,
+                        "non_conflict_reason": "none",
+                    }
+                ]
+                * 2,
             ),
         ):
             contradictions = await _detect(new_memory, [0.1] * 10)
@@ -466,6 +472,7 @@ class TestContradictionIntegration:
     ):
         """Insert a memory with fake embedding via storage client."""
         from core_api.clients.storage_client import get_storage_client
+
         from common.embedding import fake_embedding
 
         ch = hashlib.sha256(f"{tenant_id}:{fleet_id}:{content}".encode()).hexdigest()
@@ -533,6 +540,7 @@ class TestContradictionIntegration:
     async def test_semantic_contradiction_with_fake_llm(self, tenant_id):
         """Semantic conflict using fake LLM heuristic."""
         from core_api.services.contradiction_detector import detect_contradictions
+
         from common.embedding import fake_embedding
 
         old = await self._insert_memory(
@@ -558,6 +566,7 @@ class TestContradictionIntegration:
     async def test_no_false_positive_on_different_topics(self, tenant_id):
         """Different topics should not trigger contradiction."""
         from core_api.services.contradiction_detector import detect_contradictions
+
         from common.embedding import fake_embedding
 
         await self._insert_memory(tenant_id, "Python is a programming language")

--- a/tests/test_p2_contradiction_batch_status.py
+++ b/tests/test_p2_contradiction_batch_status.py
@@ -19,7 +19,6 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
-
 from core_api.constants import VECTOR_DIM
 from core_api.services.contradiction_detector import _detect
 
@@ -134,8 +133,17 @@ async def test_semantic_path_collapses_to_one_batch_call():
             return_value=mock_sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
-            AsyncMock(return_value=(True, 0.9)),  # both verdicts: contradict
+            "core_api.services.contradiction_detector._llm_contradiction_check_batch",
+            AsyncMock(
+                return_value=[
+                    {
+                        "same_subject": True,
+                        "contradicts": True,
+                        "non_conflict_reason": "none",
+                    }
+                    for _ in cands
+                ]
+            ),  # A61 batched judge — both candidates contradict
         ),
     ):
         await _detect(new, [0.1] * VECTOR_DIM)
@@ -221,8 +229,9 @@ async def test_semantic_path_no_verdicts_skips_batch_call():
 
 
 async def test_semantic_path_skips_exception_candidate_still_batches():
-    """One LLM call raises, one returns verdict=True. The exception
-    candidate is skipped; the successful one still ends up in the batch."""
+    """A61: the batched judge returns one non-contradicting (or defaulted)
+    candidate and one contradicting one. The non-verdict candidate is skipped;
+    the contradicting one still ends up in the status batch."""
     new_id = str(uuid4())
     new = _make_new(mid=new_id)
     new["subject_entity_id"] = None
@@ -234,10 +243,13 @@ async def test_semantic_path_skips_exception_candidate_still_batches():
         _make_cand(cid=str(uuid4()), object_value="ok"),
     ]
 
-    async def _judge(new_content, old_content, _cfg):
-        if "explode" in old_content:
-            raise TimeoutError("simulated llm timeout")
-        return (True, 0.9)
+    # First candidate: malformed/defaulted (skipped); second: contradict.
+    batch = AsyncMock(
+        return_value=[
+            {"contradicts": False},
+            {"same_subject": True, "contradicts": True, "non_conflict_reason": "none"},
+        ]
+    )
 
     mock_sc = AsyncMock()
     mock_sc.find_rdf_conflicts = AsyncMock(return_value=[])
@@ -251,8 +263,8 @@ async def test_semantic_path_skips_exception_candidate_still_batches():
             return_value=mock_sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
-            side_effect=_judge,
+            "core_api.services.contradiction_detector._llm_contradiction_check_batch",
+            batch,
         ),
     ):
         await _detect(new, [0.1] * VECTOR_DIM)

--- a/tests/test_visibility_contradiction.py
+++ b/tests/test_visibility_contradiction.py
@@ -7,14 +7,13 @@ Tests:
 4. Supersession first-match-only behavior
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
-
 from core_api.constants import VECTOR_DIM
-from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
 
 # ---------------------------------------------------------------------------
 # 1. Auto-chunk child visibility inheritance
@@ -341,10 +340,17 @@ class TestSupersessionFirstMatchOnly:
                 return_value=mock_sc,
             ),
             patch(
-                "core_api.services.contradiction_detector._llm_contradiction_check",
+                "core_api.services.contradiction_detector._llm_contradiction_check_batch",
                 new_callable=AsyncMock,
-                # A4 #12 — judge returns (verdict, confidence) tuple.
-                return_value=(True, 0.90),
+                # A61 — batched judge; both candidates contradict.
+                return_value=[
+                    {
+                        "same_subject": True,
+                        "contradicts": True,
+                        "non_conflict_reason": "none",
+                    }
+                ]
+                * 2,
             ),
         ):
             embedding = [0.1] * VECTOR_DIM


### PR DESCRIPTION
## The cost bug

The semantic contradiction path fired **one `complete_json` (gpt-nano) call per candidate**, up to the candidate cap (20). So each newly-embedded memory triggered ~20 nano judge calls — and prod (~442 memories/hr, ~86% one tenant's own agent fleet) was making **~10.8k OpenAI calls/hr** on only ~56 searches + 67 writes (~90 calls/op) → **~$250 every 2–3 days**. Not a loop — the *designed* per-candidate fan-out × memory volume.

## The fix — one batched judge call

- **`_llm_contradiction_check_batch`**: a single `complete_json` listing the NEW statement + all candidates; returns one raw judgment per candidate, **aligned to input order**; a missing/malformed entry defaults to a **safe non-contradiction** (never fabricates or drops one).
- **`_detect` Path 2**: a single candidate keeps the direct per-candidate call; **≥2 candidates (the prod cost driver) go through the batched call**. Both feed the **same** `_judge_contradiction` gates (Gate 1 cross-subject, Gate 2 non_conflict_reason, `_pick_older` direction) → verdict/status/supersede semantics unchanged (the golden differential test still passes).
- The batched prompt also emits per-candidate **`relationship`/`diagnosis`**, so the A55 engine-ON conflict-record write can reuse it with **no second LLM call** — **one call serves both** the flag-off (legacy detector) and flag-on (engine) arms.

**~N× fewer LLM calls per memory (up to ~20×).** Cheaper stopgap if needed: drop the candidate cap 20→5. Key-splitting is attribution only, not cost.

## No-degradation evidence

- **Deterministic:** 169 contradiction tests pass, incl. the **golden differential** (status/supersede byte-identical). Batching changes only *how raws are produced*, not the gates.
- **Real-LLM wet test:** seeded 4 similar "Dan lives in Tel Aviv…" facts, wrote the contradicting "Dan lives in Haifa now." Logs show the batch path exercised (`candidates_initial=2/3`); detection fired correctly — all 4 Tel Aviv → `conflicted`, Haifa → `supersedes_id` set. Same effect, one batched call.
- mypy + ruff clean.

A rigorous accuracy A/B (batch vs per-call over a labeled corpus) is regression/STALE-bench territory (A56); the local bench is too noisy run-to-run to certify small deltas from a single pair of runs.

Refs: **A61** (shared task list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)