### PR TITLE
perf(contradiction): batch the Path C entity-aware per-candidate LLM judge (A61)

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1462,6 +1462,136 @@ async def _llm_entity_aware_contradiction_check(
     )
 
 
+# A61 — batched entity-aware judge. Path C's forward-detection loop
+# previously fanned out one ``_llm_entity_aware_contradiction_check`` call
+# per candidate (mirroring the Path A semantic fan-out that #770 batched).
+# For a high-fanout subject (a popular entity referenced by many memories)
+# that is up to ``_ENTITY_LINKS_DETECTION_FETCH_MAX_CANDIDATES`` LLM calls
+# per newly-written memory. This variant judges the whole entity-aware
+# group in ONE ``complete_json`` call, carrying each candidate's OWN
+# resolved entity context so the authoritative same-subject grounding is
+# preserved per candidate.
+BATCH_ENTITY_AWARE_CONTRADICTION_PROMPT = """\
+You are a contradiction detector for a business memory system, running
+the second-pass judgement AFTER entity resolution has already linked every
+statement to its canonical entities.
+
+A NEW statement is compared against several EXISTING candidate statements.
+Judge EACH candidate INDEPENDENTLY against the NEW statement — one
+candidate's verdict must NOT influence another's.
+
+CRITICAL: the RESOLVED ENTITIES blocks are AUTHORITATIVE. The subject of
+each statement has ALREADY been resolved to a specific entity row
+(identified by ``entity_id``) by upstream entity extraction. Do NOT re-do
+that resolution from raw text; use the resolved entities as ground truth
+and decide whether the two statements' CLAIMS about those entities are
+mutually exclusive.
+  * Same subject-role ``entity_id`` on both sides -> same_subject MUST be
+    true (surface qualifiers like "from X", "at Y", possessives, employer /
+    team / location prefixes are extra context about the ONE subject, NOT
+    evidence of different subjects).
+  * Different subject-role ``entity_id`` -> same_subject MUST be false
+    regardless of surface-name similarity (set
+    non_conflict_reason="same_name_distinct_subject" when the canonical
+    names happen to match).
+  * ``entity_id`` starting with "<none-" on either side, or a side missing
+    a subject-role entity -> same_subject=false.
+
+NEW statement: {new_content}
+RESOLVED ENTITIES for the NEW statement:
+{new_entities}
+
+Candidate statements (judge each, by index):
+{candidates_block}
+
+For EACH candidate index decide, applying the rules in order:
+1. same_subject (bool): decided MECHANICALLY by comparing subject-role
+   ``entity_id`` values per the CRITICAL rules above.
+2. non_conflict_reason (exactly one): "none"; "temporal_supersession"
+   (sequential lifecycle states of the same subject, both true in order);
+   "list_valued_predicate" (multi-valued predicate or two different
+   attributes that both hold); "refinement" (one more specific than the
+   other); "scope_mismatch" (same subject, different implicit qualifiers;
+   both hold); "same_name_distinct_subject" (surface names match, resolved
+   entities differ); "conditional_unrealized" (one is hypothetical /
+   irrealis); "event_restatement" (same event restated).
+3. contradicts (bool): true ONLY when same_subject is true AND
+   non_conflict_reason is "none" AND the two assert mutually exclusive
+   states in the same time frame. Corrections / updates about the same
+   subject ARE contradictions.
+4. relationship (exactly one): "exact_value"; "negation"; "entailed";
+   "constraint"; "probabilistic"; "scope_apparent"; "refinement".
+5. diagnosis (exactly one): "correction"; "temporal_change";
+   "scope_difference"; "entity_mismatch"; "write_error"; "unresolved".
+
+Reply with ONLY a JSON object mapping each candidate index (as a STRING)
+to its judgment, no prose, no markdown fences:
+{{"0": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true, "relationship": "exact_value", "diagnosis": "temporal_change"}}, "1": {{...}}}}
+"""
+
+
+async def _llm_entity_aware_contradiction_check_batch(
+    new_content: str,
+    new_entities: list[dict],
+    candidates: list[dict],
+    tenant_config=None,
+) -> list[dict]:
+    """Entity-aware variant of ``_llm_contradiction_check_batch`` (A61 Path C).
+
+    Judge ALL ``candidates`` against ``new_content`` + ``new_entities`` in ONE
+    ``complete_json`` call. Each candidate dict MUST carry ``content`` and its
+    OWN resolved ``entities`` list (the caller assembles these from the
+    per-candidate context fetch). Returns one raw judgment dict per candidate,
+    aligned to input order; a missing / malformed entry defaults to a safe
+    non-contradiction (``{"contradicts": False}``). The caller runs each raw
+    through ``_judge_contradiction`` so the safety gates are identical to the
+    per-candidate entity-aware path.
+    """
+    provider_name = (
+        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
+    )
+    candidates_block = "\n".join(
+        f"[{i}] {c.get('content', '')[:500]}\n    RESOLVED ENTITIES: "
+        f"{_format_entity_context(c.get('entities', []))}"
+        for i, c in enumerate(candidates)
+    )
+    prompt = BATCH_ENTITY_AWARE_CONTRADICTION_PROMPT.format(
+        new_content=new_content[:500],
+        new_entities=_format_entity_context(new_entities),
+        candidates_block=candidates_block,
+    )
+
+    def _align(obj: object) -> list[dict]:
+        by_index = obj if isinstance(obj, dict) else {}
+        out: list[dict] = []
+        for i in range(len(candidates)):
+            entry = by_index.get(str(i))
+            if entry is None:
+                entry = by_index.get(i)  # tolerate int keys
+            out.append(entry if isinstance(entry, dict) else {"contradicts": False})
+        return out
+
+    async def _do_check(llm) -> list[dict]:
+        raw = await llm.complete_json(prompt)
+        return _align(raw)
+
+    return await call_with_fallback(
+        primary_provider_name=provider_name,
+        call_fn=_do_check,
+        fake_fn=lambda: [
+            {
+                "same_subject": True,
+                "contradicts": _fake_contradiction_check(new_content, c.get("content", "")),
+            }
+            for c in candidates
+        ],
+        tenant_config=tenant_config,
+        service_label="contradiction-entity-aware_batch",
+        model_attr="entity_extraction_model",
+        timeout=15.0,
+    )
+
+
 # ---------------------------------------------------------------------------
 # A4 #13 — Retraction phase: re-judge a Path A verdict with full entity
 # context and undo it via the A4 #10 storage primitive when the re-judge
@@ -2009,31 +2139,13 @@ async def detect_contradictions_by_entities_async(
         # entity_links yet — e.g. entity-extraction hasn't completed
         # for the candidate at the time Path C runs).
         new_content = new_memory.get("content", "")
-        tasks = []
         # CAURA-132 diag — record which judge was selected for each
         # candidate so the post-hoc analysis can correlate
         # judge_kind → verdict.
         judge_kinds: list[str] = []
         for c in candidates:
             cand_ctx = contexts.get(str(c.get("id")), []) if contexts_fetched else []
-            if contexts_fetched and new_ctx and cand_ctx:
-                judge_kinds.append("entity_aware")
-                tasks.append(
-                    asyncio.wait_for(
-                        _llm_entity_aware_contradiction_check(
-                            new_content, c.get("content", ""), new_ctx, cand_ctx, tenant_config
-                        ),
-                        timeout=10.0,
-                    )
-                )
-            else:
-                judge_kinds.append("base")
-                tasks.append(
-                    asyncio.wait_for(
-                        _llm_contradiction_check(new_content, c.get("content", ""), tenant_config),
-                        timeout=10.0,
-                    )
-                )
+            judge_kinds.append("entity_aware" if (contexts_fetched and new_ctx and cand_ctx) else "base")
         logger.info(
             "PATH_C_DETECTION judge_selection memory=%s candidates=%d entity_aware=%d base=%d",
             memory_id,
@@ -2041,7 +2153,70 @@ async def detect_contradictions_by_entities_async(
             judge_kinds.count("entity_aware"),
             judge_kinds.count("base"),
         )
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        # A61 — batch the per-candidate judge fan-out. Path C's forward
+        # detection previously issued ONE LLM call per candidate (up to
+        # ``_ENTITY_LINKS_DETECTION_FETCH_MAX_CANDIDATES``); for a popular
+        # subject that is the same per-write cost blow-up #770 fixed on the
+        # Path A semantic path. We now collapse the fan-out into at most TWO
+        # LLM calls — one batched entity-aware call for the candidates whose
+        # context is populated on both sides, one batched base call for the
+        # rest — while keeping the exact judge-selection semantics above.
+        #
+        # A single candidate keeps the direct per-candidate call (mirrors the
+        # Path A ``len == 1`` special case; leaves the large single-candidate
+        # test corpus untouched). ``results`` stays aligned to ``candidates``
+        # and preserves the ``(verdict, confidence)`` / ``Exception`` shape the
+        # downstream loop already handles — a whole-batch failure defaults its
+        # group to ``Exception`` so those candidates are skipped, never
+        # fabricated.
+        results: list = [None] * len(candidates)
+        if len(candidates) == 1:
+            c = candidates[0]
+            try:
+                if judge_kinds[0] == "entity_aware":
+                    cand_ctx = contexts.get(str(c.get("id")), [])
+                    results[0] = await asyncio.wait_for(
+                        _llm_entity_aware_contradiction_check(
+                            new_content, c.get("content", ""), new_ctx, cand_ctx, tenant_config
+                        ),
+                        timeout=10.0,
+                    )
+                else:
+                    results[0] = await asyncio.wait_for(
+                        _llm_contradiction_check(new_content, c.get("content", ""), tenant_config),
+                        timeout=10.0,
+                    )
+            except Exception as e:  # mirror gather(return_exceptions=True)
+                results[0] = e
+        else:
+            ea_idx = [i for i, k in enumerate(judge_kinds) if k == "entity_aware"]
+            base_idx = [i for i, k in enumerate(judge_kinds) if k == "base"]
+            if ea_idx:
+                ea_cands = [
+                    {
+                        "content": candidates[i].get("content", ""),
+                        "entities": contexts.get(str(candidates[i].get("id")), []),
+                    }
+                    for i in ea_idx
+                ]
+                try:
+                    ea_raws = await _llm_entity_aware_contradiction_check_batch(
+                        new_content, new_ctx, ea_cands, tenant_config
+                    )
+                    for j, i in enumerate(ea_idx):
+                        results[i] = _judge_contradiction(ea_raws[j])
+                except Exception as e:
+                    for i in ea_idx:
+                        results[i] = e
+            if base_idx:
+                base_cands = [candidates[i] for i in base_idx]
+                try:
+                    base_raws = await _llm_contradiction_check_batch(new_content, base_cands, tenant_config)
+                    for j, i in enumerate(base_idx):
+                        results[i] = _judge_contradiction(base_raws[j])
+                except Exception as e:
+                    for i in base_idx:
+                        results[i] = e
         found = False
         # CAURA-125 — state-corruption guard; mirrors the RDF and
         # semantic paths in ``_detect()``.

--- a/tests/test_caura_130_path_c_safety.py
+++ b/tests/test_caura_130_path_c_safety.py
@@ -490,7 +490,9 @@ async def test_forward_preflight_caps_fallthrough_set_at_max():
     cand_ids = [uuid4() for _ in range(_ENTITY_LINKS_PREFLIGHT_MAX_CANDIDATES + 5)]
     cands = [_make_candidate(cid, subject_entity_id=None) for cid in cand_ids]
     sc = _sc_for_forward_path(new_mem, cands, {})
-    judge = AsyncMock(return_value=(False, 0.95))
+    # A61 — the fan-out is now ONE batched base call, not N per-candidate
+    # calls. Cap exceeded → fetch skipped → all candidates base kind.
+    judge_batch = AsyncMock(return_value=[{"contradicts": False} for _ in cands])
 
     with (
         patch(
@@ -498,8 +500,8 @@ async def test_forward_preflight_caps_fallthrough_set_at_max():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
-            judge,
+            "core_api.services.contradiction_detector._llm_contradiction_check_batch",
+            judge_batch,
         ),
         patch(
             "core_api.services.contradiction_detector.resolve_config",
@@ -517,7 +519,9 @@ async def test_forward_preflight_caps_fallthrough_set_at_max():
 
     # The fan-out fetch must NOT run when the set exceeds the cap.
     sc.get_entity_links_for_memories.assert_not_called()
-    # Fail-open: judge still runs on each candidate.
-    assert judge.call_count == len(cands), (
-        f"expected {len(cands)} judge calls (fail-open), got {judge.call_count}"
+    # Fail-open: ONE batched base call still covers every candidate.
+    judge_batch.assert_awaited_once()
+    assert len(judge_batch.call_args.args[1]) == len(cands), (
+        f"expected the batched base call to cover {len(cands)} candidates, "
+        f"got {len(judge_batch.call_args.args[1])}"
     )

--- a/tests/test_caura_131_entity_aware_path_c_detection.py
+++ b/tests/test_caura_131_entity_aware_path_c_detection.py
@@ -494,8 +494,11 @@ async def test_fallback_to_base_judge_when_candidate_set_exceeds_cap():
     cands = [_make_candidate(cid, subject_entity_id=None) for cid in cand_ids]
     sc = _sc(new_mem, cands, {})
 
-    base_judge = AsyncMock(return_value=(False, 0.95))
-    entity_aware_judge = AsyncMock(return_value=(True, 0.95))
+    # A61 — the multi-candidate fan-out is now ONE batched base call, not
+    # N per-candidate calls. Raw judgments (one per candidate) run through
+    # ``_judge_contradiction`` in the caller.
+    base_batch = AsyncMock(return_value=[{"contradicts": False} for _ in cands])
+    entity_aware_batch = AsyncMock(return_value=[{"contradicts": False} for _ in cands])
 
     with (
         patch(
@@ -503,12 +506,12 @@ async def test_fallback_to_base_judge_when_candidate_set_exceeds_cap():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
-            base_judge,
+            "core_api.services.contradiction_detector._llm_contradiction_check_batch",
+            base_batch,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
-            entity_aware_judge,
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check_batch",
+            entity_aware_batch,
         ),
         patch(
             "core_api.services.contradiction_detector.resolve_config",
@@ -524,10 +527,10 @@ async def test_fallback_to_base_judge_when_candidate_set_exceeds_cap():
     ):
         await detect_contradictions_by_entities_async(new_id, "t1", "f1")
 
-    # Above the cap: fetch must not run; base judge runs N times.
+    # Above the cap: fetch must not run; base judge runs once (batched).
     sc.get_entity_links_for_memories.assert_not_called()
-    assert base_judge.call_count == len(cands)
-    entity_aware_judge.assert_not_called()
+    base_batch.assert_awaited_once()
+    entity_aware_batch.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -571,8 +574,10 @@ async def test_a1_17_matched_candidates_do_not_count_toward_cap():
         links[c["id"]] = [{"entity_id": "ent:shared", "role": "subject"}]
     sc = _sc(new_mem, cands, links)
 
-    base_judge = AsyncMock(return_value=(False, 0.95))
-    entity_aware_judge = AsyncMock(return_value=(False, 0.95))
+    # A61 — all candidates are entity-aware, so the fan-out collapses to
+    # ONE batched entity-aware call (not N).
+    base_batch = AsyncMock(return_value=[{"contradicts": False} for _ in cands])
+    entity_aware_batch = AsyncMock(return_value=[{"contradicts": False} for _ in cands])
 
     with (
         patch(
@@ -580,12 +585,12 @@ async def test_a1_17_matched_candidates_do_not_count_toward_cap():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
-            base_judge,
+            "core_api.services.contradiction_detector._llm_contradiction_check_batch",
+            base_batch,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
-            entity_aware_judge,
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check_batch",
+            entity_aware_batch,
         ),
         patch(
             "core_api.services.contradiction_detector.resolve_config",
@@ -611,10 +616,13 @@ async def test_a1_17_matched_candidates_do_not_count_toward_cap():
         f"expected {len(cands) + 1} fetch calls (1 new_mem + {len(cands)} cands); "
         f"got {sc.get_entity_links_for_memories.call_count}"
     )
-    # All candidates have non-empty entity context → entity-aware
-    # judge runs on every one. Base judge never runs.
-    assert entity_aware_judge.call_count == len(cands)
-    base_judge.assert_not_called()
+    # All candidates have non-empty entity context → ONE batched
+    # entity-aware call covers them all. Base judge never runs.
+    entity_aware_batch.assert_awaited_once()
+    assert len(entity_aware_batch.call_args.args[2]) == len(cands), (
+        "the batched entity-aware call must cover every candidate"
+    )
+    base_batch.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -655,8 +663,10 @@ async def test_detection_fetch_skipped_when_total_exceeds_detection_cap():
     assert len(cands) > _ENTITY_LINKS_DETECTION_FETCH_MAX_CANDIDATES
 
     sc = _sc(new_mem, cands, {})
-    base_judge = AsyncMock(return_value=(False, 0.95))
-    entity_aware_judge = AsyncMock(return_value=(False, 0.95))
+    # A61 — fetch skipped (over cap) → all candidates base kind → ONE
+    # batched base call.
+    base_batch = AsyncMock(return_value=[{"contradicts": False} for _ in cands])
+    entity_aware_batch = AsyncMock(return_value=[{"contradicts": False} for _ in cands])
 
     with (
         patch(
@@ -664,12 +674,12 @@ async def test_detection_fetch_skipped_when_total_exceeds_detection_cap():
             return_value=sc,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_contradiction_check",
-            base_judge,
+            "core_api.services.contradiction_detector._llm_contradiction_check_batch",
+            base_batch,
         ),
         patch(
-            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
-            entity_aware_judge,
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check_batch",
+            entity_aware_batch,
         ),
         patch(
             "core_api.services.contradiction_detector.resolve_config",
@@ -687,10 +697,89 @@ async def test_detection_fetch_skipped_when_total_exceeds_detection_cap():
 
     # Total over cap → fetch must not run.
     sc.get_entity_links_for_memories.assert_not_called()
-    # Fall-back: base judge runs on every candidate; entity-aware
+    # Fall-back: ONE batched base call covers every candidate; entity-aware
     # never invoked.
-    assert base_judge.call_count == len(cands)
-    entity_aware_judge.assert_not_called()
+    base_batch.assert_awaited_once()
+    assert len(base_batch.call_args.args[1]) == len(cands)
+    entity_aware_batch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# A61 — batched entity-aware judge (cost fix) still applies the effect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a61_multi_candidate_entity_aware_batches_once_and_flags():
+    """A61 — three entity-aware candidates against one new memory make ONE
+    batched entity-aware call (not three), and a contradicting verdict still
+    marks the older row conflicted. Mirrors the Path A ``test_detect_multi_
+    candidate_calls_batch_once`` guard for Path C."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id = uuid4()
+    new_mem = _make_new_memory(
+        new_id, subject_entity_id=None, content="Priya lives in Haifa."
+    )
+    cand_ids = [uuid4() for _ in range(3)]
+    cands = [
+        _make_candidate(
+            cid, subject_entity_id=None, content=f"Priya lives in city {i}."
+        )
+        for i, cid in enumerate(cand_ids)
+    ]
+    links = {str(new_id): [{"entity_id": "ent:priya", "role": "subject"}]}
+    for c in cands:
+        links[c["id"]] = [{"entity_id": "ent:priya", "role": "subject"}]
+    sc = _sc(new_mem, cands, links)
+
+    # Batched entity-aware judge: all three contradict.
+    entity_aware_batch = AsyncMock(
+        return_value=[
+            {"same_subject": True, "non_conflict_reason": "none", "contradicts": True}
+            for _ in cands
+        ]
+    )
+    base_batch = AsyncMock(return_value=[{"contradicts": False} for _ in cands])
+
+    with (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check_batch",
+            entity_aware_batch,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check_batch",
+            base_batch,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    # ONE batched entity-aware call covers all three candidates.
+    entity_aware_batch.assert_awaited_once()
+    assert len(entity_aware_batch.call_args.args[2]) == 3
+    base_batch.assert_not_called()
+    # Effect applied: at least one candidate marked conflicted.
+    statuses = [c.args for c in sc.update_memory_status.call_args_list]
+    assert any(len(s) > 1 and s[1] == "conflicted" for s in statuses), (
+        f"expected a conflicted status write; got {statuses}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Finishes **A61** (the OpenAI-cost bug). #770 batched the Path A semantic per-candidate LLM fan-out — the measured cost driver. This PR does the same for the remaining fan-out: **Path C's forward entity-overlap detection**.

Path C's forward loop issued **one LLM judge call per candidate**:
- `_llm_entity_aware_contradiction_check` for candidates with resolved entity context on both sides,
- `_llm_contradiction_check` (base) for the rest,

fanning out up to `_ENTITY_LINKS_DETECTION_FETCH_MAX_CANDIDATES` calls per newly-written memory. For a popular subject that is a large per-write cost — the same shape #770 fixed on Path A.

## How

Collapse the fan-out into **at most two batched calls**:
- a new `_llm_entity_aware_contradiction_check_batch` covering the entity-aware group, each candidate carrying its **own** resolved entity context so the authoritative same-subject grounding is preserved per candidate;
- the existing #770 `_llm_contradiction_check_batch` for the base group.

Everything downstream is unchanged:
- judge-selection logic (entity-aware vs base) is byte-for-byte the same;
- each raw judgment runs through `_judge_contradiction`, so the safety gates are identical to the per-candidate path;
- `results` stays aligned to `candidates` and keeps the `(verdict, confidence)` / `Exception` shape the existing loop handles — a whole-batch failure defaults its group to *skipped*, never fabricated;
- a **single candidate keeps the direct call** (mirrors the Path A `len == 1` special case).

Path C forward detection is **status-only** (no engine conflict-record wiring — that lives in Path A), so behavior is identical whether `contradiction_write_conflict_record` is on or off. Serves both the flag-off and flag-on arms.

## Tests

- Updated the three multi-candidate Path C tests (caura_130 preflight-cap, caura_131 detection-cap + a1_17 matched-set) from per-candidate `call_count == len(cands)` assertions to batched-call assertions.
- Added `test_a61_multi_candidate_entity_aware_batches_once_and_flags` — three entity-aware candidates → one batched call, contradiction effect still applied.
- Full unit suite green (2366 passed); no new mypy errors in the changed file; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)