### PR TITLE
fix(events): declare the embed-backfill subscription in the manifest

### DIFF
--- a/common/events/events_manifest.json
+++ b/common/events/events_manifest.json
@@ -12,6 +12,7 @@
     "core-worker": [
       "memclaw.lifecycle.archive-expired-requested",
       "memclaw.lifecycle.archive-stale-requested",
+      "memclaw.lifecycle.embed-backfill-requested",
       "memclaw.lifecycle.purge-soft-deleted-requested",
       "memclaw.memory.embed-requested",
       "memclaw.memory.enrich-requested"

--- a/scripts/gen_events_manifest.py
+++ b/scripts/gen_events_manifest.py
@@ -38,16 +38,23 @@ MANIFEST_PATH = (
     / "events_manifest.json"
 )
 
-# Memory-pipeline subscriptions are registered by each service's own
-# ``register_consumers()`` (core-api/src/core_api/consumer.py and
-# core-worker/src/core_worker/consumer.py). They are listed explicitly here
-# rather than captured dynamically because OSS CI does not install the worker
-# package, so it cannot be imported in this generator. This set is stable; if
-# you add a direct ``bus.subscribe`` in a service's register_consumers(), add it
-# here too.
-_MEMORY_DIRECT: dict[str, list[str]] = {
+# Subscriptions registered by each service's own ``register_consumers()``
+# (core-api/src/core_api/consumer.py and core-worker/src/core_worker/consumer.py)
+# rather than by a shared helper in ``common.events.lifecycle_handlers``. They are
+# listed explicitly here rather than captured dynamically because OSS CI does not
+# install the worker package, so it cannot be imported in this generator. If you
+# add a direct ``bus.subscribe`` in a service's register_consumers(), add it here
+# too — ``test_direct_subscribes_match_consumer_files`` enforces that.
+#
+# Mostly memory-pipeline topics, but not exclusively: a LIFECYCLE topic lands here
+# when its consumer is registered directly instead of through a helper. The
+# embed-backfill sweep is registered in core-worker because the work lives in
+# ``core_worker.backfill``, which core-api — implementing the same lifecycle
+# adapter protocol — cannot run.
+_DIRECT_SUBSCRIBES: dict[str, list[str]] = {
     "core-api": [str(Topics.Memory.ENRICHED), str(Topics.Memory.EMBEDDED)],
     "core-worker": [
+        str(Topics.Lifecycle.EMBED_BACKFILL_REQUESTED),
         str(Topics.Memory.EMBED_REQUESTED),
         str(Topics.Memory.ENRICH_REQUESTED),
     ],
@@ -88,8 +95,8 @@ def build_manifest() -> dict:
     services: dict[str, list[str]] = {}
     # Union both keysets so each dict is independently authoritative — a service
     # added to one but not the other must not be silently dropped.
-    for service in sorted(set(_LIFECYCLE_HELPERS) | set(_MEMORY_DIRECT)):
-        topics: set[str] = set(_MEMORY_DIRECT.get(service, []))
+    for service in sorted(set(_LIFECYCLE_HELPERS) | set(_DIRECT_SUBSCRIBES)):
+        topics: set[str] = set(_DIRECT_SUBSCRIBES.get(service, []))
         for register in _LIFECYCLE_HELPERS.get(service, []):
             topics.update(_capture_helper_topics(register))
         services[service] = sorted(topics)

--- a/tests/test_events/test_events_manifest.py
+++ b/tests/test_events/test_events_manifest.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from common.events.topics import Topics
 from scripts.gen_events_manifest import (
-    _MEMORY_DIRECT,
+    _DIRECT_SUBSCRIBES,
     MANIFEST_PATH,
     _serialize,
     build_manifest,
@@ -27,7 +27,14 @@ _CONSUMER_FILES = {
     "core-api": _REPO_ROOT / "core-api" / "src" / "core_api" / "consumer.py",
     "core-worker": _REPO_ROOT / "core-worker" / "src" / "core_worker" / "consumer.py",
 }
-_MEMORY_SUBSCRIBE_RE = re.compile(r"bus\.subscribe\(\s*Topics\.Memory\.([A-Z_]+)")
+# Matches Memory AND Lifecycle families. It was Memory-only, which is how a
+# directly-registered LIFECYCLE subscribe slipped past this guard: lifecycle
+# topics normally arrive via a helper the generator invokes dynamically, so the
+# combination "lifecycle topic + direct subscribe" fell in the seam between the
+# two mechanisms and matched neither.
+_DIRECT_SUBSCRIBE_RE = re.compile(
+    r"bus\.subscribe\(\s*Topics\.(Memory|Lifecycle)\.([A-Z_]+)"
+)
 
 
 def test_events_manifest_is_in_sync() -> None:
@@ -57,22 +64,29 @@ def test_events_manifest_is_well_formed() -> None:
         )
 
 
-def test_memory_direct_matches_consumer_files() -> None:
-    """Close the _MEMORY_DIRECT blind spot.
+def test_direct_subscribes_match_consumer_files() -> None:
+    """Close the _DIRECT_SUBSCRIBES blind spot.
 
-    Memory-pipeline subscribes are hand-listed in the generator (the worker
+    Directly-registered subscribes are hand-listed in the generator (the worker
     package isn't importable in OSS CI), so the drift test alone can't tell when
     that list falls out of sync with the actual ``register_consumers()``. Grep
-    each consumer file for its ``bus.subscribe(Topics.Memory.*)`` calls and
-    assert they match _MEMORY_DIRECT — a new subscribe added without updating the
-    list now fails here instead of silently shipping an incomplete manifest.
+    each consumer file for its ``bus.subscribe(Topics.<family>.*)`` calls and
+    assert they match _DIRECT_SUBSCRIBES — a new subscribe added without updating
+    the list fails here instead of silently shipping an incomplete manifest.
+
+    Covers Lifecycle as well as Memory. While it matched Memory only, a lifecycle
+    topic registered directly in a consumer satisfied neither mechanism: not the
+    generator's dynamic helper capture, and not this guard. The manifest is what
+    the enterprise ``check_pubsub_provisioning.py`` reads, so an omission there
+    means a consumed topic can ship with no Terraform subscription — the failure
+    that took staging down when ``insights-requested`` shipped unprovisioned.
     """
     for service, path in _CONSUMER_FILES.items():
-        names = _MEMORY_SUBSCRIBE_RE.findall(path.read_text(encoding="utf-8"))
-        found = sorted(str(getattr(Topics.Memory, name)) for name in names)
-        expected = sorted(_MEMORY_DIRECT[service])
+        pairs = _DIRECT_SUBSCRIBE_RE.findall(path.read_text(encoding="utf-8"))
+        found = sorted(str(getattr(getattr(Topics, family), name)) for family, name in pairs)
+        expected = sorted(_DIRECT_SUBSCRIBES[service])
         assert found == expected, (
-            f"{service}: _MEMORY_DIRECT in scripts/gen_events_manifest.py is out of sync "
-            f"with {path.relative_to(_REPO_ROOT)}. Found {found}, expected {expected}. "
-            "Update _MEMORY_DIRECT to match the bus.subscribe(Topics.Memory.*) calls."
+            f"{service}: _DIRECT_SUBSCRIBES in scripts/gen_events_manifest.py is out of "
+            f"sync with {path.relative_to(_REPO_ROOT)}. Found {found}, expected {expected}. "
+            "Update _DIRECT_SUBSCRIBES to match the bus.subscribe(Topics.*) calls."
         )


### PR DESCRIPTION
Found while preparing to provision the Pub/Sub topic for #767 — before the flag was flipped, so nothing broke.

## The gap

#767 added `bus.subscribe(Topics.Lifecycle.EMBED_BACKFILL_REQUESTED, ...)` to core-worker's `register_consumers()`, but never added it to the generator's hand-maintained list. So `common/events/events_manifest.json` does not record that core-worker consumes that topic.

That matters more than a stale file, because of what reads it. From the generator's own docstring:

> It is the contract that lets the enterprise repo's `check_pubsub_provisioning.py` fail CI when OSS adds a consumed topic without the matching Terraform subscription — **the gap that took staging down when `memclaw.lifecycle.insights-requested` shipped unprovisioned.**

An incomplete manifest means that guard is blind to the topic, so the enterprise side could ship without a subscription and nothing would object. The exact class of incident the manifest exists to prevent.

## Why nothing caught it

There are two mechanisms, and this fell between them:

- **Lifecycle** topics are captured *dynamically*, by invoking the shared registration helpers in `common.events.lifecycle_handlers` against a recording bus. Anything registered through a helper is picked up automatically.
- **Directly-registered** subscribes can't be captured that way (OSS CI doesn't install the worker package), so they're hand-listed in `_MEMORY_DIRECT` and cross-checked against the consumer files by `test_memory_direct_matches_consumer_files`.

That check's regex was `bus\.subscribe\(\s*Topics\.Memory\.([A-Z_]+)` — **Memory only**. A *lifecycle* topic registered *directly* matched neither mechanism. #767 created the first such case, because it registers in core-worker deliberately: the work lives in `core_worker.backfill`, and core-api — which implements the same lifecycle adapter protocol — cannot run it.

## The fix

1. Add the topic to the direct list, and regenerate the manifest with `scripts/gen_events_manifest.py` (it says "do not edit by hand", so I didn't).
2. Widen the guard's regex to `Topics\.(Memory|Lifecycle)\.`, closing the seam for the next person.
3. Rename `_MEMORY_DIRECT` → `_DIRECT_SUBSCRIBES`. It no longer holds only memory-pipeline topics, and a name asserting otherwise is precisely the drift that caused this.

## Verified the guard now bites

Removing the new entry while leaving the `bus.subscribe` in place — i.e. reproducing #767's exact omission:

```
AssertionError: core-worker: _DIRECT_SUBSCRIBES in scripts/gen_events_manifest.py is out of
sync with core-worker/src/core_worker/consumer.py.
Found ['memclaw.lifecycle.embed-backfill-requested', 'memclaw.memory.embed-requested', ...],
expected ['memclaw.memory.embed-requested', 'memclaw.memory.enrich-requested'].
```

Before this change, that same state passed.

The only manifest change is one added line:

```diff
     "core-worker": [
       "memclaw.lifecycle.archive-expired-requested",
       "memclaw.lifecycle.archive-stale-requested",
+      "memclaw.lifecycle.embed-backfill-requested",
```

86 events tests pass; `ruff check` clean.

## What follows

With the manifest correct, the enterprise `pubsub-provisioning` check will now require a matching Terraform subscription — which is the next step and lives in caura-memclaw-enterprise: topic, subscription and DLQ for `memclaw.lifecycle.embed-backfill-requested`, staging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)