### PR TITLE
fix(reports): anchor working-on lane keywords to word starts

### DIFF
--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from collections.abc import Awaitable
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -144,6 +145,31 @@ _LANE_KEYWORDS = {
         "on-call",
         "stall",
     ),
+}
+# Each lane's keywords, anchored at a word START (``\b``) but deliberately NOT at
+# a word end, so the prefixes above still match their inflections — "complian"
+# still matches compliance/compliant, "reliab" reliability, "build" building.
+#
+# The anchor is what is load-bearing. Bare substring matching fired on a keyword
+# buried inside an unrelated word, and the collisions are common English, not
+# exotica: "feedback" contains "dba" (Operating), "ownership" and "partnership"
+# contain "ship" (Building), "install" contains "stall" (Operating), "distrust"
+# contains "trust" (Governing). Each one silently outranked the memory-type
+# fallback, so a `decision` whose content merely said "customer feedback" was
+# filed under Operating rather than Governing.
+#
+# It also made classification depend on random data: the tests seed a
+# ``uuid4().hex`` id into content, and any hex id containing "dba" — ~0.15% of
+# them, since d/b/a are all hex digits — moved a memory to Operating. That is
+# the flake in test_report_internal_group_durable_filter (CI run 31636233722).
+#
+# Trade accepted: prefixed forms no longer match ("rebuild", "redeploy",
+# "unhealthy", "unreliable"). They fall through to the memory-type lane, which
+# is the intended default for text this heuristic cannot place, and that is a
+# better failure than matching inside arbitrary words.
+_LANE_PATTERNS = {
+    lane: re.compile(r"\b(?:" + "|".join(re.escape(k) for k in keywords) + r")")
+    for lane, keywords in _LANE_KEYWORDS.items()
 }
 _TYPE_LANE = {
     "rule": "Governing",
@@ -460,7 +486,7 @@ async def get_report(
         for m in durable:
             text = (_title(m) + " " + (m.get("content") or "")).lower()
             lane = next(
-                (name for name, kws in _LANE_KEYWORDS.items() if any(k in text for k in kws)),
+                (name for name, pattern in _LANE_PATTERNS.items() if pattern.search(text)),
                 None,
             )
             if lane is None:

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -6,14 +6,35 @@ Real FastAPI app + in-process storage (see conftest). Validates:
 - period validation.
 """
 
+import uuid
+
 import pytest
 
 from core_api.app import app
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
-from tests.conftest import get_test_auth, uid as _uid
+from tests.conftest import get_test_auth
 
 pytestmark = pytest.mark.asyncio
+
+
+def _uid() -> str:
+    """Decimal-only unique suffix — deliberately NOT ``conftest.uid()``.
+
+    Same job (a unique tail so seeded content can't 409 against an earlier
+    run), but digits instead of hex. This module seeds the suffix into memory
+    CONTENT, and the report's working-on lanes keyword-match content, so a
+    suffix that happens to spell a lane keyword silently moves a memory out of
+    the lane a test asserts on. ``conftest.uid()`` is ``uuid4().hex``, and d, b
+    and a are all hex digits, so ~0.15% of ids contain "dba" — an Operating
+    keyword. That is what made test_report_internal_group_durable_filter fail
+    on CI run 31636233722 with Governing 1 instead of 2.
+
+    Digits cannot spell any lane keyword, so classification in this module no
+    longer depends on random data. The word-start anchoring in reports.py fixes
+    the substring collision itself; this keeps the tests independent of it.
+    """
+    return f"{uuid.uuid4().int % 10**12:012d}"
 
 
 async def _register(tenant_id, fleet, *agents):
@@ -90,6 +111,63 @@ async def test_report_internal_group_durable_filter(client):
         "working_on"
     ]  # 2 decisions
     assert body["working_on"]["Building"]["count"] == 1, body["working_on"]  # 1 fact
+
+
+async def test_report_lane_keywords_do_not_match_inside_words(client):
+    """A lane keyword buried inside an unrelated word must not classify.
+
+    Lane matching runs BEFORE the memory-type fallback, so a substring hit
+    silently outranks the type. These three contents each contain a lane
+    keyword inside a longer token and nothing else a lane matches, so under
+    bare substring matching every one of them left Governing:
+
+      "feedback"  contains "dba"  -> Operating
+      "ownership" contains "ship" -> Building
+      "a1dba234"  contains "dba"  -> Operating  (a hex id, which is how this
+                                     reached CI as a ~0.6%-per-run flake in
+                                     test_report_internal_group_durable_filter)
+
+    All three are `decision`, so all three belong in Governing via _TYPE_LANE.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet, a1 = f"rep-fleet-{tag}", f"rep-a1-{tag}"
+    await _register(tenant_id, fleet, a1)
+
+    for content in (
+        f"customer feedback reviewed {_uid()}",
+        f"ownership of the account {_uid()}",
+        f"correlation id a1dba234 noted {_uid()}",
+    ):
+        r = await client.post(
+            "/api/v1/memories",
+            json={
+                "tenant_id": tenant_id,
+                "agent_id": a1,
+                "fleet_id": fleet,
+                "memory_type": "decision",
+                "visibility": "scope_team",
+                "content": content,
+            },
+            headers=headers,
+        )
+        assert r.status_code == 201, r.text
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "internal_group",
+            "agent_id": a1,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    lanes = resp.json()["working_on"]
+    assert lanes["Governing"]["count"] == 3, lanes
+    assert lanes["Operating"]["count"] == 0, lanes
+    assert lanes["Building"]["count"] == 0, lanes
 
 
 async def test_report_owner_1to1_is_self(client):


### PR DESCRIPTION
## What

`working_on` lane keywords now match at a **word start** instead of anywhere in the string.

## The bug is bigger than the flake that surfaced it

Lane matching runs *before* the memory-type fallback, so any substring hit silently outranks the type. The matcher was a bare `k in text`, and the collisions are ordinary English:

| content | contains | wrong lane |
|---|---|---|
| customer **feedback** reviewed | `dba` | Operating |
| **ownership** / **partnership** | `ship` | Building |
| **install** the CLI | `stall` | Operating |
| **distrust** between teams | `trust` | Governing |

A `decision` saying "customer feedback reviewed" was filed under Operating rather than Governing. Checked the full keyword list against `/usr/share/dict/words` — `"ship"` alone matches **1044** words it was never meant to (airship, leadership, relationship…).

## How it surfaced

`tests/test_reports.py` seeds a `uuid4().hex` id into content. `d`, `b` and `a` are all hex digits, so ~0.145% of ids contain `"dba"` — an Operating keyword. That is the ~0.6%-per-run flake behind `test_report_internal_group_durable_filter` failing on [CI run 31634…](https://github.com/caura-ai/caura-memclaw/actions/runs/31636233722) with `Governing 1` instead of `2` (2/1/0 → 1/1/1). The identical commit passed on re-run with no code change.

## The fix

One precompiled pattern per lane, each alternative anchored `\b` at the word **start** but deliberately **not** at the word end. The trailing half is what would break things: the list relies on deliberate prefixes, so `\bcomplian\b` would stop matching "compliance". Verified the intended prefixes still match — `complian`→compliance, `reliab`→reliability, `build`→building, `audit`→auditing, and the hyphenated `on-call`.

**Trade accepted:** prefixed forms no longer match (`rebuild`, `redeploy`, `unhealthy`, `unreliable`). They fall through to the memory-type lane — the intended default for text the heuristic can't place, and a better failure than matching inside arbitrary words. Flagging it rather than burying it, since it's a real behaviour change.

## Two changes, deliberately

Either alone would stop the flake; they fix different things.

1. **`reports.py`** — the product behaviour above.
2. **`tests/test_reports.py`** — seeds a decimal-only unique suffix instead of conftest's hex `uid()`, so these assertions no longer depend on random data at all. Digits cannot spell a lane keyword. Only this module asserts on lanes, so nothing else is affected.

## Verification

The new test fails without the fix. Reverting only the matcher line, leaving everything else in place:

```
AssertionError: {'Building':  {'count': 1, ...},
                 'Governing': {'count': 0, 'items': []},
                 'Operating': {'count': 2, ...}}
```

— all three `decision` rows pulled out of Governing. With the fix: 3/0/0.

Full suite **4355 passed**, 3 skipped, 1 xfailed. `mypy` clean. `ruff check` and `ruff format --check` clean on `core-api/src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
