### PR TITLE
fix(memory): null the vector when a content-change re-embed fails

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2645,8 +2645,19 @@ async def update_memory(
     patch: dict = {}
     if content_changed:
         patch["content"] = data.content
-        if new_embedding is not None:
-            patch["embedding"] = new_embedding
+        # Write the embedding unconditionally — including None. ``get_embedding``
+        # returns None only on failure (exhausted retries, or a degraded /
+        # misconfigured provider), and its contract is that callers "persist rows
+        # with ``embedding=NULL`` and let the async-embed worker backfill".
+        #
+        # Guarding this on ``is not None`` omitted the key instead, which left the
+        # PREVIOUS content's vector on a row whose content had just changed. That
+        # is wrong twice over: the row is silently mis-embedded (recall ranks it
+        # against text it no longer holds, with no error anywhere), and because
+        # the column is non-NULL neither the async-embed worker nor the nightly
+        # NULL-embedding sweep can ever see it — so it stays wrong forever. NULL
+        # is the honest state and the one the existing repair paths look for.
+        patch["embedding"] = new_embedding
         patch["content_hash"] = _content_hash(tenant_id, mem.get("fleet_id"), data.content)
         # P1-2: Clear stale contradiction/supersession state on content change
         if mem.get("supersedes_id") is not None:

--- a/tests/test_update_memory_embedding.py
+++ b/tests/test_update_memory_embedding.py
@@ -1,0 +1,109 @@
+"""``PATCH /memories/{id}`` must never leave the previous content's vector.
+
+``get_embedding`` returns ``None`` on failure (exhausted retries, or a degraded
+/ misconfigured provider) rather than raising — its documented contract is that
+callers "persist rows with ``embedding=NULL`` and let the async-embed worker
+backfill".
+
+``update_memory`` used to guard the write on ``if new_embedding is not None``,
+which omitted the key entirely and so left the OLD content's vector on a row
+whose content had just changed. That row is wrong twice over: recall ranks it
+against text it no longer holds, and because the column is non-NULL neither the
+async-embed worker nor the nightly NULL-embedding sweep can ever find it.
+"""
+
+import pytest
+
+from core_api.clients.storage_client import get_storage_client
+from tests.conftest import get_test_auth, uid as _uid
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _missing(tenant_id: str, fleet_id: str) -> int:
+    """Rows the NULL-embedding sweep would see for this fleet."""
+    coverage = await get_storage_client().get_embedding_coverage(tenant_id, fleet_id)
+    return int(coverage.get("missing_embeddings", 0))
+
+
+async def test_content_change_with_failed_embedding_nulls_the_vector(
+    client, monkeypatch
+):
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet_id, agent_id = f"upd-fleet-{tag}", f"upd-agent-{tag}"
+
+    resp = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": agent_id,
+            "fleet_id": fleet_id,
+            "memory_type": "fact",
+            "visibility": "scope_team",
+            "content": f"original content {tag}",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    memory_id = resp.json()["id"]
+
+    # Baseline: the write embedded normally, so the sweep sees nothing.
+    assert await _missing(tenant_id, fleet_id) == 0
+
+    # Now make the re-embed fail the way a provider hiccup does.
+    async def _failed_embed(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "core_api.services.memory_service.get_embedding",
+        _failed_embed,
+    )
+
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}",
+        json={"content": f"REPLACED content {tag}"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # The content change must have landed...
+    got = await get_storage_client().get_memory_for_tenant(tenant_id, memory_id)
+    assert got is not None
+    assert got["content"] == f"REPLACED content {tag}"
+
+    # ...and the row must now be NULL-embedded, i.e. visible to the sweep.
+    # Before the fix this was 0: the patch omitted ``embedding`` entirely, so
+    # the row kept the ORIGINAL content's vector and no repair path could see it.
+    assert await _missing(tenant_id, fleet_id) == 1
+
+
+async def test_content_change_with_working_embedding_still_embeds(client):
+    """The success path is unchanged — a good embedding is still written."""
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet_id, agent_id = f"upd-ok-fleet-{tag}", f"upd-ok-agent-{tag}"
+
+    resp = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": agent_id,
+            "fleet_id": fleet_id,
+            "memory_type": "fact",
+            "visibility": "scope_team",
+            "content": f"original content {tag}",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    memory_id = resp.json()["id"]
+
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}",
+        json={"content": f"rewritten content {tag}"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert await _missing(tenant_id, fleet_id) == 0


### PR DESCRIPTION
## The bug

`update_memory` wrote the re-embedded vector only `if new_embedding is not None`:

```python
patch["content"] = data.content
if new_embedding is not None:          # <-- the guard
    patch["embedding"] = new_embedding
```

`get_embedding` returns `None` on **failure** rather than raising. So on any embed failure the guard omitted the key entirely, and the row kept the **previous content's vector** while its content was replaced.

That row is wrong twice over:

- **Recall ranks it against text it no longer holds.** Nothing errors — the PATCH returns 200 and the row looks healthy.
- **The column is non-NULL**, so neither the async-embed worker nor the nightly NULL-embedding sweep (caura-enterprise#1051, live as of today) can ever see it. Mis-embedded rather than unembedded, and therefore permanent.

`get_embedding`'s own docstring states the contract the call site was breaking:

> *"a transient OpenAI/Vertex hiccup returns `None` rather than raising, so write paths can persist rows with `embedding=NULL` and let the async-embed worker backfill"*

## Why nulling is safe

Both `None` paths are genuine failures — a registry `ValueError` from `_resolve_provider_or_degrade` (env misconfiguration) and exhausted retries in `_run_with_retry`. There is **no** "embeddings intentionally disabled" path that returns `None`, so this cannot wipe a vector a tenant meant to keep.

## The null actually reaches the column

The whole fix depends on this, so it was traced rather than assumed:

| layer | behaviour |
|---|---|
| `storage_client.update_memory` | passes the patch through as the JSON body |
| `PATCH /memories/{id}` route | no `exclude_none` — body forwarded untouched |
| `memory_update` | filters on `hasattr(Memory, key)` **only**, not on the value |

So `{"embedding": None}` becomes `SET embedding = NULL`. The sibling `patch["supersedes_id"] = None` a few lines above relies on the same behaviour.

## Verification

The regression test asserts the property that actually matters — that the row becomes **visible to the sweep** — using `missing_embeddings` from `/memories/embedding-coverage`, the same count the sweep keys on. Not "did we call the embedder", which would pass either way.

Confirmed it fails without the fix. Reverting only the guarded write, leaving everything else in place:

```
tests/test_update_memory_embedding.py:76: assert 0 == 1
FAILED test_content_change_with_failed_embedding_nulls_the_vector
1 failed, 1 passed
```

`0 == 1` is exactly the defect: the row stayed non-NULL and invisible. The companion test pins the success path, and passes either way by design.

Full suite **4357 passed**, 3 skipped, 1 xfailed. `mypy` clean; `ruff check` and `ruff format --check` clean on `core-api/src/`.

## Scope

This is the third of the three embedding-loss write paths, and the only one the sweep could not repair. The other two (auto-chunk parent, atomic-fact fan-out) land as `NULL` and are already swept; they're untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
