### PR TITLE
feat(observability): make the unembedded-row backlog measurable

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -852,6 +852,14 @@ class CoreStorageClient:
             params["fleet_id"] = fleet_id
         return await self._get("/memories/embedding-coverage", **params) or {}
 
+    async def get_embedding_coverage_all(self) -> dict:
+        """Embedding coverage for every tenant (operator view, one query).
+
+        No ``tenant_id``: this is the cross-tenant aggregate, so callers must
+        gate it on the admin key. Counts only.
+        """
+        return await self._get("/memories/embedding-coverage-all") or {}
+
     async def get_type_distribution(
         self,
         tenant_id: str,

--- a/core-api/src/core_api/routes/lifecycle.py
+++ b/core-api/src/core_api/routes/lifecycle.py
@@ -236,6 +236,42 @@ async def fanout_lifecycle_action(
     return {"action": action, "published": published, "failed": failed}
 
 
+@router.get("/admin/lifecycle/embedding-coverage")
+async def embedding_coverage_all_tenants(
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict:
+    """How many live memories are still unembedded, per tenant.
+
+    This is the standing answer to "is the embed-backfill sweep keeping up",
+    and it lives here because that sweep is what acts on the number. Before
+    this, the count existed only inside the VPC: both storage services are
+    internal-ingress, no metric carried it, and reading it meant an AlloyDB
+    Auth Proxy session and a hand-written COUNT — so in practice nobody
+    measured it, including while turning the sweep on.
+
+    Admin-only, and cross-tenant, which is the whole point: an operator asking
+    this question is asking it about the deployment, not about one tenant.
+    ``enforce_admin`` is what keeps the aggregate off a tenant credential — the
+    admin key resolves to ``tenant_id=None``, so there is no tenant scope to
+    fall back on and a missing gate would expose every tenant's row counts.
+    Counts and tenant ids only; no memory content.
+
+    A GET beside the ``POST /admin/lifecycle/{action}`` catch-all below: the
+    methods differ, so the path-param route cannot shadow this one.
+    """
+    auth.enforce_admin()
+    coverage = await get_storage_client().get_embedding_coverage_all()
+    logger.info(
+        "embedding coverage sampled",
+        extra={
+            "total_active": coverage.get("total_active"),
+            "missing_embeddings": coverage.get("missing_embeddings"),
+            "tenants_with_missing": coverage.get("tenants_with_missing"),
+        },
+    )
+    return coverage
+
+
 @router.post("/admin/lifecycle/{action}")
 async def trigger_lifecycle_action(
     action: str,

--- a/core-operations/src/core_operations/app.py
+++ b/core-operations/src/core_operations/app.py
@@ -14,14 +14,16 @@ Lifespan ordering:
    as a no-op; OSS standalone deployments should not deploy this image
    at all, but the flag is a defensive short-circuit.
 3. Otherwise: register cron jobs via ``scheduler.register(...)`` and call
-   ``scheduler.start()``. Nine jobs are registered unconditionally: six daily
+   ``scheduler.start()``. Ten jobs are registered unconditionally: six daily
    lifecycle ticks (``lifecycle-archive-expired``, ``lifecycle-archive-stale``,
    ``lifecycle-purge-soft-deleted``, ``lifecycle-crystallize``,
    ``lifecycle-entity-link``, ``lifecycle-insights``), each wall-clock
    aligned to its configurable UTC hour; ``agent-digest`` (daily) and
    ``agent-digest-weekly`` (weekly) for per-agent activity digests; and
    ``interviewer-schedule`` (hourly, top of hour) which queues Interviewer
-   work — per-tenant settings gate actual command creation. A tenth,
+   work — per-tenant settings gate actual command creation; and
+   ``embedding-coverage`` (hourly, top of hour), a read-only sample that logs
+   how many live memories are still unembedded. An eleventh,
    ``embed-backfill``, registers only when ``embed_backfill_enabled`` is set,
    because its Pub/Sub topic is Terraform-provisioned and firing into an
    unprovisioned topic would just error every night.
@@ -70,6 +72,7 @@ from core_operations.tasks import (
     run_archive_stale_tick,
     run_crystallize_tick,
     run_embed_backfill_tick,
+    run_embedding_coverage_tick,
     run_entity_link_tick,
     run_insights_tick,
     run_interviewer_schedule_tick,
@@ -163,6 +166,17 @@ def _register_scheduled_tasks() -> None:
         "interviewer-schedule",
         3600,
         run_interviewer_schedule_tick,
+        delay_provider=lambda: seconds_until_next_utc_top_of_hour(),
+    )
+    # Read-only coverage sample. Registered unconditionally and NOT gated on
+    # ``embed_backfill_enabled``: the count is most valuable precisely when the
+    # sweep is off, since that is when nothing is draining the backlog. Hourly
+    # so the curve shows whether the nightly sweep actually drains it — a daily
+    # sample taken near the sweep cannot distinguish "drained" from "never grew".
+    scheduler.register(
+        "embedding-coverage",
+        3600,
+        run_embedding_coverage_tick,
         delay_provider=lambda: seconds_until_next_utc_top_of_hour(),
     )
 

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -20,6 +20,12 @@ from core_operations.config import settings
 
 logger = logging.getLogger(__name__)
 
+# Per-tenant embedding-coverage lines emitted per tick. The deployment-wide
+# total is always logged; this bounds only the per-tenant detail, which is
+# ordered worst-first so the cap drops the tenants nobody would act on. Sized
+# so one tick stays a readable handful of lines rather than one per tenant.
+_COVERAGE_TENANT_LOG_CAP = 20
+
 
 async def _fire_fanout(action: str) -> None:
     """POST ``/admin/lifecycle/fanout/<action>``. A non-2xx response
@@ -109,6 +115,86 @@ async def run_embed_backfill_tick() -> None:
     themselves, so this exists for the rows that fell through entirely.
     """
     await _fire_fanout("embed-backfill")
+
+
+async def run_embedding_coverage_tick() -> None:
+    """Log embedding coverage per tenant so the backlog is observable.
+
+    Reads ``GET /admin/lifecycle/embedding-coverage`` on core-api and emits one
+    structured line per tenant plus a deployment-wide total. This is the whole
+    point of the tick: there is no metrics client anywhere in the stack —
+    observability is structlog into Datadog logs — so a periodic log line IS
+    the metric, and without it the count is invisible outside a manual AlloyDB
+    session.
+
+    Read-only and idempotent, so the cadence is a free choice; hourly gives a
+    curve with enough resolution to see whether the nightly sweep actually
+    drains the backlog, which a daily sample taken near the sweep cannot.
+
+    Per-tenant lines are capped: a deployment with thousands of tenants would
+    otherwise turn one tick into thousands of log lines. The total is always
+    emitted, and the per-tenant detail is worst-first, so the cap drops the
+    tenants nobody would act on. The cap is logged when it bites — a silent
+    truncation would read as "only these tenants have gaps".
+    """
+    url = f"{settings.core_api_url.rstrip('/')}/api/v1/admin/lifecycle/embedding-coverage"
+    headers: dict[str, str] = {}
+    if settings.core_api_admin_api_key:
+        headers["X-API-Key"] = settings.core_api_admin_api_key
+    else:
+        logger.warning(
+            "core-operations: CORE_API_ADMIN_API_KEY unset; embedding-coverage sample will be unauthorised",
+        )
+
+    timeout = httpx.Timeout(settings.storage_http_timeout_s)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            resp = await client.get(url, headers=headers)
+        except httpx.HTTPError:
+            logger.exception("embedding-coverage GET failed", extra={"url": url})
+            return
+    if resp.status_code >= 400:
+        logger.error(
+            "embedding-coverage returned non-2xx; will retry next tick",
+            extra={"status_code": resp.status_code, "body": resp.text[:500]},
+        )
+        return
+    try:
+        coverage = resp.json()
+    except ValueError:
+        logger.error(
+            "embedding-coverage returned non-JSON; will retry next tick",
+            extra={"body": resp.text[:200]},
+        )
+        return
+
+    tenants = coverage.get("tenants") or []
+    logger.info(
+        "embedding coverage total",
+        extra={
+            "total_active": coverage.get("total_active"),
+            "missing_embeddings": coverage.get("missing_embeddings"),
+            "tenants_with_missing": coverage.get("tenants_with_missing"),
+            "tenant_count": len(tenants),
+        },
+    )
+    reported = [t for t in tenants if t.get("missing_embeddings")][:_COVERAGE_TENANT_LOG_CAP]
+    for tenant in reported:
+        logger.info(
+            "embedding coverage tenant",
+            extra={
+                "tenant_id": tenant.get("tenant_id"),
+                "total_active": tenant.get("total_active"),
+                "missing_embeddings": tenant.get("missing_embeddings"),
+                "coverage_pct": tenant.get("coverage_pct"),
+            },
+        )
+    with_missing = coverage.get("tenants_with_missing") or 0
+    if with_missing > len(reported):
+        logger.info(
+            "embedding coverage per-tenant lines truncated",
+            extra={"reported": len(reported), "tenants_with_missing": with_missing},
+        )
 
 
 async def run_insights_tick() -> None:

--- a/core-operations/tests/test_app.py
+++ b/core-operations/tests/test_app.py
@@ -27,6 +27,10 @@ _EXPECTED_JOBS = {
     "agent-digest",
     "agent-digest-weekly",
     "interviewer-schedule",
+    # Read-only hourly sample of how many live memories are still unembedded.
+    # Registered unconditionally, unlike ``embed-backfill``: the count matters
+    # most when the sweep is OFF, since nothing is draining the backlog then.
+    "embedding-coverage",
 }
 
 

--- a/core-operations/tests/test_tasks.py
+++ b/core-operations/tests/test_tasks.py
@@ -54,6 +54,16 @@ class _StubAsyncClient:
         assert self._response is not None
         return self._response
 
+    async def get(self, url: str, *, headers: dict | None = None) -> _StubResponse:
+        # Same contract as ``post`` — read-only ticks (embedding-coverage) GET.
+        # ``raise_on_post`` covers both verbs; the field name predates the first
+        # GET caller and renaming it would churn every existing test.
+        self.calls.append((url, headers))
+        if self._raise is not None:
+            raise self._raise
+        assert self._response is not None
+        return self._response
+
 
 @asynccontextmanager
 async def _patch_client(
@@ -216,3 +226,123 @@ async def test_embed_backfill_tick_posts_to_fanout(monkeypatch: pytest.MonkeyPat
     url, headers = stub.calls[0]
     assert url == "http://core-api/api/v1/admin/lifecycle/fanout/embed-backfill"
     assert headers == {"X-API-Key": "admin-key-xyz"}
+
+
+# ---------------------------------------------------------------------------
+# embedding-coverage tick — the log lines ARE the metric, so assert on them
+# ---------------------------------------------------------------------------
+
+
+def _coverage_body(tenants: list[dict]) -> dict:
+    return {
+        "tenants": tenants,
+        "total_active": sum(t["total_active"] for t in tenants),
+        "missing_embeddings": sum(t["missing_embeddings"] for t in tenants),
+        "tenants_with_missing": sum(1 for t in tenants if t["missing_embeddings"]),
+    }
+
+
+def _records(caplog, message: str) -> list:
+    return [r for r in caplog.records if r.getMessage() == message]
+
+
+@pytest.mark.asyncio
+async def test_embedding_coverage_tick_gets_admin_route_and_logs(monkeypatch, caplog):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    body = _coverage_body(
+        [
+            {"tenant_id": "t-bad", "total_active": 100, "missing_embeddings": 40, "coverage_pct": 60.0},
+            {"tenant_id": "t-ok", "total_active": 50, "missing_embeddings": 0, "coverage_pct": 100.0},
+        ]
+    )
+    caplog.set_level("INFO", logger=tasks.logger.name)
+    async with _patch_client(monkeypatch, response=_StubResponse(200, body)) as stub:
+        await tasks.run_embedding_coverage_tick()
+
+    assert len(stub.calls) == 1
+    url, headers = stub.calls[0]
+    assert url == "http://core-api/api/v1/admin/lifecycle/embedding-coverage"
+    assert headers == {"X-API-Key": "admin-key-xyz"}
+
+    total = _records(caplog, "embedding coverage total")
+    assert len(total) == 1
+    assert total[0].total_active == 150
+    assert total[0].missing_embeddings == 40
+    assert total[0].tenants_with_missing == 1
+
+    # Only the tenant that actually has a gap is worth a line.
+    per_tenant = _records(caplog, "embedding coverage tenant")
+    assert [r.tenant_id for r in per_tenant] == ["t-bad"]
+    assert per_tenant[0].missing_embeddings == 40
+
+
+@pytest.mark.asyncio
+async def test_embedding_coverage_tick_caps_per_tenant_lines_and_says_so(monkeypatch, caplog):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    over = tasks._COVERAGE_TENANT_LOG_CAP + 5
+    body = _coverage_body(
+        [
+            {
+                "tenant_id": f"t-{i}",
+                "total_active": 10,
+                "missing_embeddings": 1,
+                "coverage_pct": 90.0,
+            }
+            for i in range(over)
+        ]
+    )
+    caplog.set_level("INFO", logger=tasks.logger.name)
+    async with _patch_client(monkeypatch, response=_StubResponse(200, body)):
+        await tasks.run_embedding_coverage_tick()
+
+    per_tenant = _records(caplog, "embedding coverage tenant")
+    assert len(per_tenant) == tasks._COVERAGE_TENANT_LOG_CAP
+
+    # The cap must announce itself — a silent truncation would read as
+    # "only these tenants have gaps".
+    truncated = _records(caplog, "embedding coverage per-tenant lines truncated")
+    assert len(truncated) == 1
+    assert truncated[0].reported == tasks._COVERAGE_TENANT_LOG_CAP
+    assert truncated[0].tenants_with_missing == over
+
+    # The deployment-wide total is never truncated.
+    assert _records(caplog, "embedding coverage total")[0].missing_embeddings == over
+
+
+@pytest.mark.asyncio
+async def test_embedding_coverage_tick_swallows_non_2xx(monkeypatch, caplog):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    caplog.set_level("INFO", logger=tasks.logger.name)
+    async with _patch_client(monkeypatch, response=_StubResponse(503, "upstream down")):
+        await tasks.run_embedding_coverage_tick()
+
+    assert _records(caplog, "embedding coverage total") == []
+    assert len(_records(caplog, "embedding-coverage returned non-2xx; will retry next tick")) == 1
+
+
+@pytest.mark.asyncio
+async def test_embedding_coverage_tick_swallows_network_error(monkeypatch):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    async with _patch_client(monkeypatch, raise_on_post=httpx.ConnectError("offline")):
+        await tasks.run_embedding_coverage_tick()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_embedding_coverage_tick_swallows_non_json(monkeypatch, caplog):
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    caplog.set_level("INFO", logger=tasks.logger.name)
+    async with _patch_client(monkeypatch, response=_StubResponse(200, "<html>nope</html>")):
+        await tasks.run_embedding_coverage_tick()
+
+    assert _records(caplog, "embedding coverage total") == []
+    assert len(_records(caplog, "embedding-coverage returned non-JSON; will retry next tick")) == 1

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -772,6 +772,27 @@ async def get_embedding_coverage(
     }
 
 
+@router.get("/embedding-coverage-all")
+async def get_embedding_coverage_all() -> dict:
+    """Embedding coverage for every tenant — the operator-facing view.
+
+    Cross-tenant by design, which is why it takes no ``tenant_id`` and why the
+    only caller is core-api's admin route (admin key, ``is_admin``). Counts and
+    tenant ids only; no memory content crosses this boundary.
+
+    Declared ABOVE the ``/{memory_id}`` routes on purpose — FastAPI matches in
+    declaration order, so registering it later would let the path-param route
+    swallow "embedding-coverage-all" and answer 422 on a bad UUID.
+    """
+    rows = await _svc.memory_embedding_coverage_by_tenant()
+    return {
+        "tenants": rows,
+        "total_active": sum(r["total_active"] for r in rows),
+        "missing_embeddings": sum(r["missing_embeddings"] for r in rows),
+        "tenants_with_missing": sum(1 for r in rows if r["missing_embeddings"]),
+    }
+
+
 @router.get("/type-distribution")
 async def get_type_distribution(
     tenant_id: str,

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2460,6 +2460,60 @@ class PostgresService:
             result = await session.execute(stmt)
             return result.scalar() or 0
 
+    async def memory_embedding_coverage_by_tenant(self) -> list[dict]:
+        """Embedding coverage for EVERY tenant, in one pass.
+
+        The per-tenant pair above answers "how is this tenant doing"; this
+        answers "where are the unembedded rows", which is the question an
+        operator actually has and previously could only reach by opening an
+        AlloyDB Auth Proxy session and running the count by hand — both storage
+        services are internal-ingress, and no metric carried the number.
+
+        Deliberately ONE statement with a FILTER'd count rather than a loop over
+        ``memory_count_missing_embeddings`` per tenant: the loop is N round-trips
+        against the same pool that serves live traffic, and it cannot produce a
+        consistent snapshot — tenants counted early and late see different
+        states, so the totals need not add up.
+
+        Same population predicate as the per-tenant pair (``LIVE_MEMORY_STATUSES``,
+        not soft-deleted). Keep the three in sync: a divergence here is what makes
+        the aggregate disagree with ``/embedding-coverage`` for the same tenant and
+        sends someone hunting a phantom bug.
+
+        Returns rows worst-first so the head of the list is the actionable part.
+        Counts only — no memory content crosses this boundary.
+        """
+        missing = func.count().filter(Memory.embedding.is_(None))
+        async with get_read_session() as session:
+            stmt = (
+                select(
+                    Memory.tenant_id,
+                    func.count().label("total_active"),
+                    missing.label("missing_embeddings"),
+                )
+                .select_from(Memory)
+                .where(
+                    Memory.status.in_(LIVE_MEMORY_STATUSES),
+                    Memory.deleted_at.is_(None),
+                )
+                .group_by(Memory.tenant_id)
+                .order_by(missing.desc())
+            )
+            rows = (await session.execute(stmt)).all()
+        return [
+            {
+                "tenant_id": row.tenant_id,
+                "total_active": int(row.total_active or 0),
+                "missing_embeddings": int(row.missing_embeddings or 0),
+                "coverage_pct": (
+                    round((row.total_active - row.missing_embeddings) / row.total_active * 100, 1)
+                    if row.total_active
+                    else 0.0
+                ),
+            }
+            for row in rows
+        ]
+
     async def memory_entity_coverage_count(
         self,
         tenant_id: str,

--- a/docs/component-registry.yaml
+++ b/docs/component-registry.yaml
@@ -58,6 +58,9 @@ cron_ticks:
   - name: interviewer-schedule
     cadence: hourly (top of UTC hour)
     module: core_operations.app
+  - name: embedding-coverage
+    cadence: hourly (top of UTC hour) — read-only sample; logs unembedded row counts per tenant
+    module: core_operations.app
 
 # The str-enum families in common/events/topics.py. Topic strings follow
 # ``memclaw.<domain>.<verb>``.

--- a/tests/test_embedding_coverage_admin.py
+++ b/tests/test_embedding_coverage_admin.py
@@ -1,0 +1,116 @@
+"""Cross-tenant embedding coverage — the operator view of the sweep's backlog.
+
+Before this endpoint the count lived only inside the VPC: both storage services
+are internal-ingress and no metric carried it, so "how many rows are still
+unembedded" required an AlloyDB Auth Proxy session and a hand-written COUNT.
+
+Two properties are worth pinning:
+
+* the aggregate must AGREE with the per-tenant ``/embedding-coverage`` for the
+  same tenant — they share a population predicate, and a divergence sends
+  someone hunting a phantom bug;
+* the route is cross-tenant, so the admin gate is load-bearing. The admin key
+  resolves to ``tenant_id=None``; without the gate there is no tenant scope to
+  fall back on and every tenant's row counts leak to any caller.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from core_api.auth import AuthContext
+from core_api.clients.storage_client import get_storage_client
+from core_api.routes.lifecycle import embedding_coverage_all_tenants
+from tests.conftest import get_test_auth, uid as _uid
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _write(client, tenant_id, headers, fleet_id, agent_id, content):
+    resp = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": agent_id,
+            "fleet_id": fleet_id,
+            "memory_type": "fact",
+            "visibility": "scope_team",
+            "content": content,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def test_aggregate_agrees_with_per_tenant_endpoint(client, monkeypatch):
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet_id, agent_id = f"cov-fleet-{tag}", f"cov-agent-{tag}"
+
+    # Two embedded rows.
+    await _write(client, tenant_id, headers, fleet_id, agent_id, f"embedded row {tag}")
+    target = await _write(
+        client, tenant_id, headers, fleet_id, agent_id, f"second row {tag}"
+    )
+
+    # Null one of them through the content-change path: on a failed re-embed
+    # ``update_memory`` writes ``embedding=NULL`` so the sweep can find the row.
+    # Using the update path rather than the write path on purpose — writes embed
+    # in a background task, so a monkeypatch there races the assertion.
+    async def _failed_embed(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("core_api.services.memory_service.get_embedding", _failed_embed)
+    resp = await client.patch(
+        f"/api/v1/memories/{target}?tenant_id={tenant_id}",
+        json={"content": f"rewritten row {tag}"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    monkeypatch.undo()
+
+    sc = get_storage_client()
+    per_tenant = await sc.get_embedding_coverage(tenant_id, fleet_id)
+    assert per_tenant["missing_embeddings"] == 1, per_tenant
+
+    aggregate = await sc.get_embedding_coverage_all()
+    row = next((r for r in aggregate["tenants"] if r["tenant_id"] == tenant_id), None)
+    assert row is not None, aggregate
+
+    # The aggregate is tenant-wide and the per-tenant call was fleet-scoped, so
+    # compare the property that must hold across both: this fleet's missing row
+    # is counted in the tenant's total, and the deployment total covers it.
+    assert row["missing_embeddings"] >= per_tenant["missing_embeddings"]
+    assert row["total_active"] >= per_tenant["total_active"]
+    assert aggregate["missing_embeddings"] >= row["missing_embeddings"]
+    assert aggregate["tenants_with_missing"] >= 1
+
+
+async def test_aggregate_is_worst_first(client):
+    """Ordering is the contract the per-tenant log cap relies on — it drops the
+    tail, so the tail must be the tenants nobody would act on."""
+    aggregate = await get_storage_client().get_embedding_coverage_all()
+    missing = [r["missing_embeddings"] for r in aggregate["tenants"]]
+    assert missing == sorted(missing, reverse=True), missing
+
+
+async def test_admin_route_rejects_non_admin():
+    """The gate, asserted directly: a tenant credential must not read the
+    cross-tenant aggregate."""
+    tenant_auth = AuthContext(tenant_id="some-tenant", is_admin=False)
+    with pytest.raises(HTTPException) as exc:
+        await embedding_coverage_all_tenants(auth=tenant_auth)
+    assert exc.value.status_code == 403
+
+
+async def test_admin_route_returns_totals(client):
+    admin = AuthContext(tenant_id=None, is_admin=True)
+    body = await embedding_coverage_all_tenants(auth=admin)
+    assert set(body) >= {
+        "tenants",
+        "total_active",
+        "missing_embeddings",
+        "tenants_with_missing",
+    }
+    assert body["total_active"] >= 0
+    assert body["missing_embeddings"] >= 0


### PR DESCRIPTION
## The gap

"How many live memories still have no embedding" had **no answer outside the VPC**. Both storage services are internal-ingress, no metric carried the number, and the only route to it was an AlloyDB Auth Proxy session plus a hand-written `COUNT`.

So in practice nobody measured it — including while turning the nightly embed-backfill sweep on today. The sweep now runs against a backlog of unknown size, and there's no way to tell whether it drains.

## What this adds

| layer | |
|---|---|
| `memory_embedding_coverage_by_tenant` | one `GROUP BY` with a `FILTER`'d count |
| `GET /memories/embedding-coverage-all` | storage-api, cross-tenant |
| `GET /admin/lifecycle/embedding-coverage` | core-api, **admin-gated** |
| `embedding-coverage` tick | hourly, logs totals + per-tenant detail |

**One query, not a loop** over the existing per-tenant helper. The loop would be N round-trips against the pool that serves live traffic, and it can't produce a consistent snapshot — tenants counted early and late see different states, so the totals need not add up.

**The log line is the metric.** There's no metrics client anywhere in this stack; observability is structlog into Datadog logs. So the tick logs rather than emitting a gauge, matching how everything else here is observed.

**Registered unconditionally**, not behind `embed_backfill_enabled` — the count matters most when the sweep is *off*, because that's when nothing is draining the backlog. Hourly rather than daily so the curve distinguishes "the sweep drained it" from "it never grew"; a single daily sample taken near the sweep can't.

## The admin gate is load-bearing

The route is deliberately cross-tenant, and the admin key resolves to `tenant_id=None` — so there's no tenant scope to fall back on. Without `enforce_admin`, every tenant's row counts would be readable by any caller. Counts and tenant ids only; no memory content crosses the boundary.

Verified by removing the gate — `test_admin_route_rejects_non_admin` then reports `DID NOT RAISE`, so the test discriminates rather than passing on a route that merely happens to work.

## Notes for review

- Per-tenant log lines are **capped at 20**, rows ordered worst-first so the cap drops tenants nobody would act on. The cap **announces itself** when it bites — a silent truncation would read as "only these tenants have gaps".
- Coverage tests null a row through the **content-change** path, not the write path: writes embed in a background task, so a monkeypatch there races the assertion. (Found the hard way — the first version of the test failed for exactly that reason.)
- Both drift guards fired and were satisfied rather than bypassed: `test_app.py`'s expected-job set, and `docs/component-registry.yaml`, which `tests/test_component_registry.py` enforces 1:1 against `scheduler.register` calls in both directions.

## Verification

Root suite **4361 passed**, core-operations **49 passed**. `mypy` clean on core-api, core-storage-api and core-operations. `ruff check` + `ruff format --check` clean on every CI-linted scope.

The local core-storage-api suite errors on an unprovisioned `memclaw_storage` database **both with and without this change** — pre-existing, and CI creates that database fresh.

## Unrelated, noticed in passing

`core-operations/.coverage` is not gitignored, so a stray coverage artifact sits untracked in the tree and `git add -A` picks it up. Not touched here to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
