### PR TITLE
test: give every test its own tenant so committed rows stop leaking between them

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,11 @@ TEST_DB_URL = os.environ.get(
     "postgresql+asyncpg://memclaw:changeme@127.0.0.1:5432/memclaw",
 )
 
+# NOT what the ``tenant_id`` fixture returns — that mints a fresh id per test. This
+# is one id per RUN, kept for the modules whose module-level seed helpers need a
+# tenant without taking a fixture argument. None of them relies on cross-test
+# sharing, so they could each mint their own; threading a tenant through those
+# helpers is the follow-up that would let this go away.
 TENANT_ID = f"test-tenant-{uuid.uuid4().hex[:8]}"
 FLEET_ID = "test-fleet"
 AGENT_ID = "test-agent"
@@ -94,7 +99,7 @@ def get_admin_headers() -> dict:
 
 
 def uid() -> str:
-    """Short unique suffix to avoid duplicate-content 409s across test runs."""
+    """Short unique suffix — for distinct content (409s) and distinct tenant ids."""
     return uuid.uuid4().hex[:8]
 
 
@@ -146,6 +151,13 @@ async def _setup_schema(_engine):
             "entities",
             "memories",
             "audit_log",
+            # One genesis row per tenant (``_audit_chain_one_tenant``), so a
+            # per-test tenant leaves one per test rather than one per run. It was
+            # never swept: a local DB had 9,186 ``test-tenant-`` rows here from
+            # earlier runs. Other tenant-scoped tables (recall_event,
+            # memory_conflicts, dedup_reviews, agents, session_traces) leak the
+            # same way but per-write, so they are a separate cleanup.
+            "audit_chain_head",
             "agent_activity_digests",
             # Keystones and other docs live here. Written through the API's own
             # committed transaction, so the per-test session rollback never
@@ -161,11 +173,13 @@ async def _setup_schema(_engine):
                     text(f"DELETE FROM {table} WHERE tenant_id LIKE 'test-tenant-%'")
                 )
             except Exception:
-                # Best-effort, and it is the PRIMARY isolation for anything
-                # written through the service layer — not a backstop behind the
-                # ``db`` fixture's rollback. Most tests here write via ``sc``,
-                # which commits on its own connections, so that rollback never
-                # sees those rows and this sweep is what removes them.
+                # Best-effort, and the ONLY thing that ever removes rows written
+                # through the service layer — not a backstop behind the ``db``
+                # fixture's rollback. Most tests here write via ``sc``, which
+                # commits on its own connections, so that rollback never sees
+                # those rows. Per-test isolation comes from the unique
+                # ``tenant_id``; this sweep is end-of-run cleanup, so the table
+                # doesn't grow without bound.
                 pass
         # memory_entity_links doesn't have tenant_id — clean via memory join
         try:
@@ -283,16 +297,16 @@ def storage_http(_patch_storage_client):
 
 @pytest.fixture
 def tenant_id():
-    """The run's shared tenant ID — one constant for the whole session.
+    """A tenant ID unique to THIS test.
 
-    NOT unique per test or per module: ``TENANT_ID`` is evaluated once, when this
-    module is imported. Rows any test commits through ``sc`` therefore stay
-    visible to every later test under this id, so an assertion like
-    ``len(results) >= 1`` can be satisfied by another test's data. Where a test
-    needs real isolation, generate its own ``f"test-tenant-…-{uuid4().hex[:8]}"``
-    (keep the ``test-tenant-`` prefix — session teardown sweeps on it).
+    It used to be one constant for the whole run, which let any test's committed
+    rows satisfy a later test's ``len(results) >= 1`` — passing for the wrong
+    reason, or failing only when the run order changed. Nothing removes those rows
+    mid-run; see the sweep in ``_setup_schema`` for why.
+
+    Keep the ``test-tenant-`` prefix: that sweep matches on it.
     """
-    return TENANT_ID
+    return f"test-tenant-{uid()}"
 
 
 @pytest.fixture

--- a/tests/test_fixture_hygiene.py
+++ b/tests/test_fixture_hygiene.py
@@ -1,4 +1,4 @@
-"""Guard: nothing in this tree may request the ``db`` fixture and not use it.
+"""Guards on the two fixtures that decide whether a test is really isolated.
 
 ``db`` (see ``conftest.db``) is a per-test session inside a transaction that is
 rolled back at teardown. Requesting it reads as "this test is transactionally
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 import ast
 import pathlib
+
+from tests import conftest
 
 FIXTURE = "db"
 TESTS_ROOT = pathlib.Path(__file__).parent
@@ -96,4 +98,38 @@ def test_no_test_requests_the_db_fixture_without_using_it() -> None:
         f"tests do not have, since service-layer writes commit on their own "
         f"connections. If one truly needs the open transaction as a side effect, "
         f"add it to SIDE_EFFECT_ONLY with a reason:\n  " + "\n  ".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The other half of the same problem: rows that survive because the TENANT is
+# shared. The ``db``-fixture guards above stop a test from *claiming* isolation
+# it lacks; these stop the tenant id from silently handing one test's committed
+# rows to the next.
+# ---------------------------------------------------------------------------
+
+
+# The fixture's underlying function — the guards assert on what one CALL returns, so
+# they call it directly rather than comparing ids across two test invocations. That
+# alternative needs module-level state, which would be per-worker if this suite ever
+# runs parallel, letting both cases pass vacuously.
+_mint_tenant_id = conftest.tenant_id.__wrapped__
+
+
+def test_tenant_id_fixture_mints_a_fresh_id_per_call() -> None:
+    first, second = _mint_tenant_id(), _mint_tenant_id()
+    assert first != second, (
+        f"the `tenant_id` fixture returned {first!r} twice, so every test sharing "
+        "it also shares committed rows: service-layer writes commit on their own "
+        "connections and nothing removes them until the session-end sweep, which "
+        "lets one test satisfy another's `len(results) >= 1`. Mint a fresh id "
+        "per call."
+    )
+
+
+def test_tenant_id_fixture_keeps_the_swept_prefix() -> None:
+    minted = _mint_tenant_id()
+    assert minted.startswith("test-tenant-"), (
+        f"tenant_id {minted!r} would not be matched by the session-end sweep in "
+        "conftest._setup_schema, so its rows would outlive the run"
     )

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -316,10 +316,11 @@ class TestSearchPipelineEndToEnd:
         from core_api.services.memory_service import search_memories
 
         sc = get_storage_client()
-        # Seed helpers now commit through the storage write session (the rolled-back
-        # ``db`` fixture is invisible to the storage read path), so sibling tests'
-        # rows persist under the shared TENANT_ID. This test asserts an EXACT result
-        # set, so isolate it on its own tenant to avoid top-K pollution.
+        # Seed helpers commit through the storage write session (the rolled-back
+        # ``db`` fixture is invisible to the storage read path), so their rows
+        # outlive the test. The ``tenant_id`` fixture is per-test now, so this
+        # suffix is no longer what isolates the case — it only labels the slice,
+        # which this test wants because it asserts an EXACT result set.
         tenant_id = f"{tenant_id}-softdel"
 
         async def _seed(content: str, *, deleted: bool) -> dict:

--- a/tests/test_p2_semantic_dedup.py
+++ b/tests/test_p2_semantic_dedup.py
@@ -362,9 +362,10 @@ async def _committed_corpus(count: int) -> AsyncIterator[str]:
     layer on its own session — rows sitting in an uncommitted transaction (what
     the ``db`` fixture gives you) are invisible to it.
 
-    Its own tenant, because the ``tenant_id`` fixture is the run's SHARED tenant
-    (see its docstring): its row count is a running total of whatever every
-    other test left behind, not ``count``.
+    Its own tenant, so the slice is labelled and its row count is exactly
+    ``count``. The ``tenant_id`` fixture is per-test now, so that is no longer
+    what isolates this corpus — but the explicit ``DELETE`` below still earns its
+    keep, since nothing else clears these rows before session end.
 
     Both effects are silent, which is why the caller asserts the corpus size
     instead of assuming it.

--- a/tests/test_p3_1_entity_resolution.py
+++ b/tests/test_p3_1_entity_resolution.py
@@ -207,12 +207,6 @@ class TestAliasTracking:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def tenant_id():
-    """Per-test unique tenant_id for isolation (overrides session-level fixture)."""
-    return f"test-tenant-{uuid4().hex[:8]}"
-
-
 @pytest.mark.integration
 class TestEntityResolutionIntegration:
     """End-to-end entity resolution against a real database."""

--- a/tests/test_p3_3_graph_fanout.py
+++ b/tests/test_p3_3_graph_fanout.py
@@ -134,13 +134,15 @@ class TestCappedLinkProcessing:
 
 @pytest.fixture
 def fanout_tenant():
-    """A tenant of this test's own, so no other test's rows can satisfy an assertion.
+    """A labelled tenant of this test's own, so no other test's rows can satisfy an
+    assertion.
 
-    The shared ``tenant_id`` fixture is one constant for the whole session, and
     ``fake_embedding`` is a bag-of-words hash, not a near-orthogonal one: an
     unrelated committed row ("User prefers dark mode in the editor") measures
     cosine 0.33 against a random token — over the 0.3 ``min_similarity`` gate. So
-    a unique query token alone does not isolate these tests; the tenant must.
+    a unique query token alone does not isolate these tests; the tenant must. The
+    ``tenant_id`` fixture is now per-test too, so this adds only the ``fanout``
+    label; it is kept because that label is what makes a leaked row identifiable.
     """
     return f"test-tenant-fanout-{uuid.uuid4().hex[:8]}"
 


### PR DESCRIPTION
## What

`tests/conftest.py`'s `tenant_id` fixture returned **one constant for the whole run**. Most tests here write through `sc`, which commits on its own connections, so the `db` fixture's rollback never sees those rows and nothing removes them until the session-end sweep. Every committed row therefore stayed visible to every later test, and an assertion like `len(results) >= 1` could be satisfied by a **different test's data** — passing for the wrong reason, or failing only when the run order changed.

This is the root cause #749 worked around by removing 107 unused `db` requests.

The fixture now mints `test-tenant-<uid()>` per test, reusing the existing `uid()` helper and keeping the prefix `_setup_schema`'s sweep matches on.

## Scope

Requested by **72 test functions (81 items) across 11 files**. Distinct tenants per run go from **~95 to ~176** — it roughly doubles rather than going 1 → 72, because 94 bespoke `test-tenant-*` ids already existed across 34 files.

Verified safe before changing anything: **no fixture consumes `tenant_id` at all** (only tests and helpers), so `ScopeMismatch` was never possible.

## Guards

Two in `tests/test_fixture_hygiene.py`: the fixture must return a distinct id per call, and it must keep the swept prefix. Both call the fixture's underlying function **directly** rather than comparing ids across two test invocations — that alternative needs module-level state, which would be per-worker if this suite ever runs parallel, letting both cases pass vacuously. A guard that cannot fail is worse than no guard.

Both were confirmed to **fail on the reverted fixture, for their stated reason**, before and after a restructure.

## Also fixed

- **Swept `audit_chain_head`**, which was never in the teardown tuple. It takes one genesis row per tenant, so a per-test tenant leaves one per test. A local database held **9,186** stale `test-tenant-` rows there from earlier runs; this run cleared it to **0**.
- **Four comments that asserted the old shared-tenant behaviour** and would otherwise have taught the wrong model: `test_p3_3_graph_fanout.py`, `test_integration_search.py`, `test_p2_semantic_dedup.py`, and the sweep comment in `conftest.py` that called itself the primary isolation.
- **Deleted the local `tenant_id` override** in `test_p3_1_entity_resolution.py` — byte-identical to the conftest fixture, and its docstring claimed to override a "session-level fixture" that no longer exists.

## Measurement

Re-measured after rebasing onto `af9e2fb7` (the earlier baseline went stale when 23 commits landed mid-work):

| | passed | skipped | xfailed |
|---|---|---|---|
| baseline (`origin/main` af9e2fb7) | 4377 | 3 | 1 |
| this branch | **4379** | 3 | 1 |

Delta is exactly **+2**, the two new guards. `core-storage-api/tests/` 118 passed. mypy clean on both `src/` trees. ruff `check`/`format` clean at CI's scopes; the pre-existing findings under `tests/` are an identical multiset to `origin/main`.

One flake appeared in a contended run — `test_api_interview.py::test_schedule_next_window_resumes_from_watermark` returned 504. It does not use this fixture (it mints its own tenant via `get_test_auth`), and the 504 is an `asyncio.wait_for` timeout. Isolated, it passes 5/5 at **~49–55 s against a 90 s timeout** — inherently tight on a loaded machine. Unrelated to this change, but worth knowing.

## Deliberately not addressed

`get_test_auth()` still returns the shared `"default"` tenant across **172 call sites in 25 files**, and `"default"` does not match the sweep's `LIKE 'test-tenant-%'` — so those API-test rows persist across runs **permanently**. Same defect one layer over; too large for this change.

Separately, `tests/pipeline/test_write_pipeline.py:20` uses a `test-pipeline-` prefix the sweep never matches while genuinely persisting rows, and three `tests/pipeline/` modules use a bare `test-tenant` (no trailing hyphen) that also fails the pattern. Generalising the prefix guard into an AST scan over every tenant literal would catch these, but needs those files fixed first.