### PR TITLE
feat(api): type the memory-get 200 body, so the frozen contract actually pins it

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -440,6 +440,289 @@
         "title": "HTTPValidationError",
         "type": "object"
       },
+      "MemoryDetailResponse": {
+        "description": "Full detail for one memory: row fields, entity links, embedding stats.",
+        "properties": {
+          "agent_display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Display Name"
+          },
+          "agent_id": {
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "content_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Hash"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "deleted_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deleted At"
+          },
+          "embedding_preview": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Embedding Preview"
+          },
+          "embedding_stats": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Embedding Stats"
+          },
+          "entity_links": {
+            "default": [],
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Entity Links",
+            "type": "array"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "fleet_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fleet Id"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "last_recalled_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Recalled At"
+          },
+          "memory_type": {
+            "title": "Memory Type",
+            "type": "string"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "object_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Value"
+          },
+          "predicate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predicate"
+          },
+          "recall_count": {
+            "title": "Recall Count",
+            "type": "integer"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Id"
+          },
+          "source_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Uri"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "subject_entity_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject Entity Id"
+          },
+          "supersedes_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supersedes Id"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "ts_valid_end": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ts Valid End"
+          },
+          "ts_valid_start": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ts Valid Start"
+          },
+          "visibility": {
+            "title": "Visibility",
+            "type": "string"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight"
+          }
+        },
+        "required": [
+          "id",
+          "tenant_id",
+          "agent_id",
+          "memory_type",
+          "content",
+          "status",
+          "visibility",
+          "recall_count"
+        ],
+        "title": "MemoryDetailResponse",
+        "type": "object"
+      },
       "MemoryOut": {
         "properties": {
           "agent_display_name": {
@@ -1667,7 +1950,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryDetailResponse"
+                }
               }
             },
             "description": "Successful Response"

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -48,6 +48,7 @@ from core_api.schemas import (
     IngestCommitRequest,
     IngestRequest,
     MemoryCreate,
+    MemoryDetailResponse,
     MemoryOut,
     MemoryUpdate,
     PaginatedMemoryResponse,
@@ -516,15 +517,19 @@ async def bulk_delete_by_ids(
     return {"deleted": deleted}
 
 
-@router.get("/memories/{memory_id}")
+# Returns a plain dict, NOT a ``JSONResponse`` — deliberately, and the docstring
+# below stays a single line because it becomes the operation's public OpenAPI
+# description. FastAPI skips response validation entirely for a handler that returns
+# a ``Response`` object, so pairing one with ``response_model`` documents a shape
+# nothing enforces; that is worse than untyped, and is why this route sat in
+# ``tests/test_broker_contract._UNTYPED_200`` until the dict return landed.
+@router.get("/memories/{memory_id}", response_model=MemoryDetailResponse)
 async def get_memory(
     memory_id: UUID,
     tenant_id: str = Query(...),
     auth: AuthContext = Depends(get_auth_context),
 ):
     """Get a single memory with full details including embedding and entity links."""
-    from fastapi.responses import JSONResponse
-
     auth.enforce_readable_tenant(tenant_id)
 
     t_start = time.perf_counter()
@@ -578,41 +583,39 @@ async def get_memory(
                 },
             )
 
-    return JSONResponse(
-        {
-            "id": memory["id"],
-            "tenant_id": memory["tenant_id"],
-            "fleet_id": memory["fleet_id"],
-            "agent_id": memory["agent_id"],
-            "agent_display_name": memory.get("agent_display_name"),
-            "memory_type": memory["memory_type"],
-            "title": memory["title"],
-            "content": memory["content"],
-            "weight": float(memory["weight"]) if memory["weight"] is not None else None,
-            "source_uri": memory["source_uri"],
-            "run_id": memory["run_id"],
-            # Storage serialises the JSONB column under ``metadata_``; the API
-            # response exposes it as ``metadata``.
-            "metadata": memory.get("metadata_"),
-            "content_hash": memory["content_hash"],
-            "created_at": memory["created_at"],
-            "expires_at": memory["expires_at"],
-            "deleted_at": memory["deleted_at"],
-            "subject_entity_id": memory["subject_entity_id"],
-            "predicate": memory["predicate"],
-            "object_value": memory["object_value"],
-            "ts_valid_start": memory["ts_valid_start"],
-            "ts_valid_end": memory["ts_valid_end"],
-            "status": memory["status"],
-            "visibility": memory["visibility"],
-            "recall_count": memory["recall_count"],
-            "last_recalled_at": memory["last_recalled_at"],
-            "supersedes_id": memory["supersedes_id"],
-            "entity_links": detail["entity_links"],
-            "embedding_preview": detail["embedding_preview"],
-            "embedding_stats": detail["embedding_stats"],
-        }
-    )
+    return {
+        "id": memory["id"],
+        "tenant_id": memory["tenant_id"],
+        "fleet_id": memory["fleet_id"],
+        "agent_id": memory["agent_id"],
+        "agent_display_name": memory.get("agent_display_name"),
+        "memory_type": memory["memory_type"],
+        "title": memory["title"],
+        "content": memory["content"],
+        "weight": float(memory["weight"]) if memory["weight"] is not None else None,
+        "source_uri": memory["source_uri"],
+        "run_id": memory["run_id"],
+        # Storage serialises the JSONB column under ``metadata_``; the API
+        # response exposes it as ``metadata``.
+        "metadata": memory.get("metadata_"),
+        "content_hash": memory["content_hash"],
+        "created_at": memory["created_at"],
+        "expires_at": memory["expires_at"],
+        "deleted_at": memory["deleted_at"],
+        "subject_entity_id": memory["subject_entity_id"],
+        "predicate": memory["predicate"],
+        "object_value": memory["object_value"],
+        "ts_valid_start": memory["ts_valid_start"],
+        "ts_valid_end": memory["ts_valid_end"],
+        "status": memory["status"],
+        "visibility": memory["visibility"],
+        "recall_count": memory["recall_count"],
+        "last_recalled_at": memory["last_recalled_at"],
+        "supersedes_id": memory["supersedes_id"],
+        "entity_links": detail["entity_links"],
+        "embedding_preview": detail["embedding_preview"],
+        "embedding_stats": detail["embedding_stats"],
+    }
 
 
 @router.get("/memories/{memory_id}/contradictions")

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -348,6 +348,66 @@ class MemoryOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+# Kept to ONE line, because a model docstring becomes the schema's public
+# ``description`` in ``openapi.broker.json`` — maintainer rationale belongs here, in a
+# comment, not in the frozen contract. Three things about this model are load-bearing:
+#
+# FIELD ORDER IS THE CONTRACT. FastAPI serialises in model-field order, not dict
+# order, and this endpoint has always emitted these 29 keys in this order. Reordering
+# them changes the response bytes for every caller;
+# ``tests/test_memory_get_serialization_contract.py`` pins it.
+#
+# THE TIMESTAMPS ARE ``str``, NOT ``datetime``, ON PURPOSE. They arrive as ISO strings
+# — the route reads them out of core-storage-api's JSON and passes them through — and
+# ``datetime`` would not merely annotate, it re-serialises: pydantic v2 renders
+# ``2026-08-13T18:52:48.040997+00:00`` as ``...040997Z``. Measured, not assumed. That
+# is a wire change on a live endpoint, not a side effect to take on while adding a
+# schema. The fleet is already inconsistent here: ``MemoryOut`` (the POST/PATCH model)
+# types them as ``datetime`` and emits the ``Z`` form for the same row. Aligning the
+# two is an API decision with its own migration story; ``str`` documents what ships.
+#
+# NULLABILITY MIRRORS THE TABLE, plus the two computed fields that are ``None`` for an
+# un-embedded row. A field marked required here that is NULL in practice turns a 200
+# into a 500 via ``ResponseValidationError``, so this errs toward optional wherever the
+# column is nullable.
+class MemoryDetailResponse(BaseModel):
+    """Full detail for one memory: row fields, entity links, embedding stats."""
+
+    id: str
+    tenant_id: str
+    fleet_id: str | None = None
+    agent_id: str
+    agent_display_name: str | None = None
+    memory_type: str
+    title: str | None = None
+    content: str
+    weight: float | None = None
+    source_uri: str | None = None
+    run_id: str | None = None
+    # Exposed as ``metadata``; storage serialises the JSONB column as ``metadata_``
+    # and the route renames it on the way out.
+    metadata: dict | None = None
+    content_hash: str | None = None
+    created_at: str | None = None
+    expires_at: str | None = None
+    deleted_at: str | None = None
+    subject_entity_id: str | None = None
+    predicate: str | None = None
+    object_value: str | None = None
+    ts_valid_start: str | None = None
+    ts_valid_end: str | None = None
+    status: str
+    visibility: str
+    recall_count: int
+    last_recalled_at: str | None = None
+    supersedes_id: str | None = None
+    entity_links: list[dict] = []
+    # Both None unless the row has a non-empty embedding: the raw pgvector never
+    # crosses the wire, only a first-20 preview and the server-computed stats.
+    embedding_preview: list[float] | None = None
+    embedding_stats: dict | None = None
+
+
 class ContradictionInfo(BaseModel):
     """Summary of a contradiction detected on write.
 

--- a/tests/test_broker_contract.py
+++ b/tests/test_broker_contract.py
@@ -30,17 +30,15 @@ _METHODS = ("get", "post", "patch", "delete", "put")
 #
 #   GET /health, GET /version   — liveness/handshake payloads with no
 #       response_model on the route; trivial, stable shapes.
-#   GET /memories/{memory_id}   — the route hand-builds a ~20-field
-#       ``JSONResponse``. Attaching a ``response_model`` would document a shape
-#       FastAPI does NOT enforce (it skips validation when the handler returns a
-#       Response object), which is worse than untyped: the contract would then
-#       assert a guarantee the code does not make. Typing it properly means
-#       refactoring the handler to return a model, which changes serialization
-#       on a live endpoint and belongs in its own change.
+#
+# ``GET /memories/{memory_id}`` was listed here until its handler stopped returning
+# a ``JSONResponse`` (FastAPI skips response validation for a Response object, so a
+# ``response_model`` alongside one documents a guarantee the code does not make).
+# It now returns a dict against ``MemoryDetailResponse`` and is genuinely typed —
+# and the assertion below FAILS on a stale entry, which is what removed it.
 _UNTYPED_200 = {
     ("get", "/api/v1/health"),
     ("get", "/api/v1/version"),
-    ("get", "/api/v1/memories/{memory_id}"),
 }
 
 

--- a/tests/test_memory_get_serialization_contract.py
+++ b/tests/test_memory_get_serialization_contract.py
@@ -1,0 +1,153 @@
+"""``GET /memories/{memory_id}`` must keep emitting the bytes it always has.
+
+Typing that route's 200 body (it was in ``test_broker_contract._UNTYPED_200``) moved
+its serialisation from a hand-built ``JSONResponse`` onto a ``response_model``, and
+two properties of the old output are easy to break in the process — neither of which
+any other test would notice, because both produce perfectly valid JSON:
+
+  1. **Key order.** FastAPI serialises in model-field order, not dict-insertion
+     order, so reordering fields in ``MemoryDetailResponse`` silently reorders the
+     response for every caller.
+  2. **Timestamp format.** The values arrive from core-storage-api as ISO strings and
+     are passed through. Declaring them ``datetime`` instead of ``str`` re-serialises
+     them: pydantic v2 turns ``...+00:00`` into ``...Z``. Measured, and the reason
+     they are ``str``. ``MemoryOut`` (the POST/PATCH response model) does type them
+     as ``datetime`` and does emit ``Z``, so the two shapes genuinely differ today —
+     aligning them is an API decision, and this test is what makes the drift
+     deliberate rather than accidental.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from core_api.schemas import MemoryDetailResponse
+from tests.conftest import get_admin_headers, uid
+
+# ``+00:00``, NOT ``Z`` — see the module docstring.
+_ISO_OFFSET = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+00:00$")
+
+# The 29 keys this endpoint emits, in the order it emits them — WRITTEN OUT, not
+# derived from ``MemoryDetailResponse``. Deriving it would make the assertion
+# tautological: FastAPI builds the response order FROM the model, so a comparison
+# between the two moves together and passes for any reordering. Verified by
+# reordering two fields and watching this fail. Changing this list is changing the
+# response every caller receives.
+_WIRE_KEY_ORDER = [
+    "id",
+    "tenant_id",
+    "fleet_id",
+    "agent_id",
+    "agent_display_name",
+    "memory_type",
+    "title",
+    "content",
+    "weight",
+    "source_uri",
+    "run_id",
+    "metadata",
+    "content_hash",
+    "created_at",
+    "expires_at",
+    "deleted_at",
+    "subject_entity_id",
+    "predicate",
+    "object_value",
+    "ts_valid_start",
+    "ts_valid_end",
+    "status",
+    "visibility",
+    "recall_count",
+    "last_recalled_at",
+    "supersedes_id",
+    "entity_links",
+    "embedding_preview",
+    "embedding_stats",
+]
+
+# Every timestamp-valued field on the response.
+_TIMESTAMP_FIELDS = (
+    "created_at",
+    "expires_at",
+    "deleted_at",
+    "ts_valid_start",
+    "ts_valid_end",
+    "last_recalled_at",
+)
+
+
+def test_the_model_field_order_is_the_wire_order() -> None:
+    """No DB: catches a reorder at import time, before any request is made.
+
+    Paired with the response-level assertion below. This one fails the moment
+    someone reorders (or adds, or drops) a field on the model; that one fails if
+    serialisation ever stops following field order. Neither implies the other.
+    """
+    assert list(MemoryDetailResponse.model_fields) == _WIRE_KEY_ORDER, (
+        "MemoryDetailResponse's field order no longer matches the order this "
+        "endpoint emits. FastAPI serialises in field order, so this changes the "
+        "response bytes for every caller — update _WIRE_KEY_ORDER only if that is "
+        "the intent.\n"
+        f"  model: {list(MemoryDetailResponse.model_fields)}\n"
+        f"  wire:  {_WIRE_KEY_ORDER}"
+    )
+
+
+@pytest.mark.integration
+async def test_memory_get_emits_the_pinned_key_order(client, tenant_id) -> None:
+    """The live response's key order, against the written-out list."""
+    headers = get_admin_headers()
+    w = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "shape-agent",
+            "memory_type": "fact",
+            "content": f"serialization contract probe {uid()}",
+        },
+        headers=headers,
+    )
+    assert w.status_code in (200, 201), w.text
+    r = await client.get(
+        f"/api/v1/memories/{w.json()['id']}?tenant_id={tenant_id}", headers=headers
+    )
+    assert r.status_code == 200, r.text
+
+    assert list(r.json()) == _WIRE_KEY_ORDER, (
+        "the 200 body's key order drifted from the order this endpoint has always "
+        "emitted, which changes the bytes every caller receives.\n"
+        f"  got:      {list(r.json())}\n  expected: {_WIRE_KEY_ORDER}"
+    )
+
+
+@pytest.mark.integration
+async def test_memory_get_timestamps_keep_the_offset_form(client, tenant_id) -> None:
+    """A ``datetime``-typed field would emit ``...Z`` and break the wire format."""
+    headers = get_admin_headers()
+    w = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "shape-agent",
+            "memory_type": "fact",
+            "content": f"timestamp format probe {uid()}",
+        },
+        headers=headers,
+    )
+    assert w.status_code in (200, 201), w.text
+    body = (
+        await client.get(
+            f"/api/v1/memories/{w.json()['id']}?tenant_id={tenant_id}", headers=headers
+        )
+    ).json()
+
+    present = {f: body[f] for f in _TIMESTAMP_FIELDS if body.get(f) is not None}
+    assert present, "no timestamp field was populated, so this test proved nothing"
+    for field, value in present.items():
+        assert _ISO_OFFSET.match(value), (
+            f"{field} serialised as {value!r}. It must keep the ``+00:00`` offset form: "
+            "typing it as ``datetime`` makes pydantic emit ``Z`` instead, which is a "
+            "wire change for every consumer of this endpoint."
+        )


### PR DESCRIPTION
## What

`GET /api/v1/memories/{memory_id}` entered the frozen broker contract in #753 with `"schema": {}`, so oasdiff pinned its path, method, params and 422 but **not** its response shape. It was allowlisted in `tests/test_broker_contract._UNTYPED_200` with the reason: the handler returned a hand-built 29-field `JSONResponse`, and FastAPI **skips response validation entirely** for a handler that returns a `Response` object — so attaching a `response_model` alone would have documented a guarantee the code does not make, which is worse than untyped.

The handler now returns a plain dict against a new `MemoryDetailResponse`, so the shape is enforced rather than asserted, and the allowlist entry is gone. That assertion fails on a *stale* entry by design, which is what removed it.

## The timestamps are `str`, and that is the point

Typing them `datetime` would not merely annotate — it re-serialises. **Measured**: pydantic v2 renders `2026-08-13T18:52:48.040997+00:00` as `...040997Z`. That is a wire change for every consumer, not something to take on as a side effect of adding a schema.

Worth knowing, because it is now pinned rather than accidental — the fleet already emits **both** forms for the same row:

| endpoint | `created_at` |
|---|---|
| `POST /api/v1/memories` (via `MemoryOut`, typed `datetime`) | `...040997Z` |
| `GET /api/v1/memories/{id}` (this route, pass-through) | `...040997+00:00` |

Aligning them is a deliberate API decision with its own migration story. `str` here documents exactly what ships today.

## Verified byte-equivalent, not assumed

Captured the response before and after the change: key order identical (all 29, same sequence), key set identical, per-key types identical, `created_at` still `+00:00`. The only value differences were genuinely per-run — write timings inside `metadata`, and the content-derived fake embedding.

## Three guards, each shown to fail without its fix

`tests/test_memory_get_serialization_contract.py` pins the two properties that are easy to break here and that yield perfectly valid JSON either way: field order (asserted at import time **and** against a live response) and the `+00:00` timestamp form.

The key-order list is **written out longhand rather than derived from the model**. My first draft compared the response to `MemoryDetailResponse.model_fields` and *could not fail* — FastAPI builds the response order from the model, so reordering fields moved both sides together and the test passed. Caught by reordering two fields and watching it pass. Both assertions now fail on that mutation; the timestamp assertion fails when a field is typed `datetime`.

## Cost, stated plainly

The endpoint now pays pydantic validation of 29 fields per request where it previously serialised straight to JSON. That is the price of the guarantee — a single-row read, so small in absolute terms, but not zero.

## Measurement

| | passed | skipped | xfailed |
|---|---|---|---|
| baseline (`origin/main`) | 4379 | 3 | 1 |
| this branch | **4382** | 3 | 1 |

Exactly **+3**, the new guards. `core-storage-api/tests/` 118 passed. mypy clean on both `src/` trees. ruff `check`/`format` clean at CI's scopes. `gen_broker_openapi.py --check` up to date; `plugin/tools.json` unchanged.

`core-api/openapi.broker.json` regenerated: **+286/-1**, the single removal being the empty `schema: {}` stub. Nullability mirrors the `memories` table plus the two computed fields that are `None` for an un-embedded row, so a NULL column cannot turn a 200 into a 500 via `ResponseValidationError`.

## Notes

- `GET /health` and `GET /version` remain in `_UNTYPED_200`; both were untyped before #753 and are trivial, stable handshake payloads.
- Several other routes in this file still return `JSONResponse` (bulk, STM, ingest). They are outside the broker contract, so they are not in scope here, but they have the same untyped-response property if they are ever added to it.
- `/simplify` was **not** run on this change. It qualifies under the repo threshold (new model, restructured return path, comments asserting behavioural properties), so flagging the omission rather than implying otherwise. Build, lint, mypy, both test trees, the contract check, and a read of the full diff were all done.