### PR TITLE
feat(memory): the memory_relations table behind memory_link (step 1 of the graph)

### DIFF
--- a/common/models/__init__.py
+++ b/common/models/__init__.py
@@ -15,6 +15,7 @@ from common.models.lifecycle_audit import LifecycleAudit
 from common.models.memory import Memory
 from common.models.memory_conflict import MemoryConflict
 from common.models.memory_derivation import MemoryDerivation
+from common.models.memory_relation import MemoryRelation
 from common.models.skill_factory import ForgeRejectedFingerprint, SessionTrace
 
 __all__ = [
@@ -36,6 +37,7 @@ __all__ = [
     "LifecycleAudit",
     "Memory",
     "MemoryConflict",
+    "MemoryRelation",
     "MemoryDerivation",
     "MemoryEntityLink",
     "Relation",

--- a/common/models/memory_relation.py
+++ b/common/models/memory_relation.py
@@ -1,0 +1,135 @@
+"""Typed memory-to-memory relations — the store behind the ``memory_link`` tool.
+
+Distinct from the two link tables that already exist, and it is worth being explicit
+about why none of them could serve this:
+
+* ``relations`` is entity <-> entity.
+* ``memory_entity_links`` is memory <-> entity.
+* ``memories.supersedes_id`` is memory -> memory but SINGLE-VALUED, and is written by
+  the contradiction detector.
+
+``memory_link`` promises a typed relation between two MEMORY ids, which is none of
+those, and it was accepted-but-unadvertised until this table existed (memclawd #130).
+
+WHY ``supersedes`` IS NOT STORED HERE. Eldad's call (2026-08-13): ``supersedes``
+reuses ``memories.supersedes_id`` rather than becoming a row here, so the contradiction
+detector and the API write one field instead of two stores that can disagree. The
+consequence is a real asymmetry the tool has to document: ``supersedes`` is 1:1 and a
+second one OVERWRITES, while a second ``elaborates`` is an additional row. The CHECK
+constraint below makes that structural rather than a convention — a ``supersedes`` row
+cannot be written here at all.
+
+WHY ONE DIRECTED ROW, never two. Three of the five stored types are semantically
+symmetric (``contradicts``, ``alternative_to``, ``related_to``), and the tempting
+implementation is to write both directions. That creates pairs which must stay in sync,
+and deleting one leaves a half-edge. So exactly one row is stored, exactly as the caller
+stated it, and symmetry is a READ concern: queries for a symmetric type match
+``from_memory_id = X OR to_memory_id = X``. All per-type knowledge lives in one constant
+(``SYMMETRIC_RELATION_TYPES``) instead of being spread into the schema.
+
+SOFT DELETE leaves rows here untouched. ``memories`` is soft-deleted routinely and that
+is reversible, so cascading on soft-delete would make un-delete lossy. A link whose
+endpoint is soft-deleted simply stops being returned, because the read path already
+joins ``memories`` to fetch endpoint content and can add ``deleted_at IS NULL`` for
+free. Terminal cleanup needs no new machinery: the purge sweep hard-deletes the row and
+``ON DELETE CASCADE`` takes the links with it.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from common.models.base import Base
+
+# The six types in ``contracts/mcp-tools.md`` §8, as specified — Eldad confirmed the set
+# rather than letting it be inferred from the tool description.
+#
+# ``supersedes`` is routed to ``memories.supersedes_id`` and is deliberately NOT in
+# ``STORED_RELATION_TYPES``; it appears here only so the tool's input schema and this
+# module agree on the vocabulary.
+SUPERSEDES_RELATION_TYPE = "supersedes"
+
+# Symmetric in meaning: if A contradicts B then B contradicts A. Stored one-directionally
+# anyway (see module docstring); this set is what the read path and the idempotency check
+# consult. Changing membership is the entire cost of revisiting that decision.
+SYMMETRIC_RELATION_TYPES = frozenset({"contradicts", "alternative_to", "related_to"})
+
+# Asymmetric: direction carries meaning, so a reversed row is a different claim.
+DIRECTED_RELATION_TYPES = frozenset({"elaborates", "depends_on"})
+
+STORED_RELATION_TYPES = frozenset(SYMMETRIC_RELATION_TYPES | DIRECTED_RELATION_TYPES)
+
+ALL_RELATION_TYPES = frozenset(STORED_RELATION_TYPES | {SUPERSEDES_RELATION_TYPE})
+
+
+class MemoryRelation(Base):
+    __tablename__ = "memory_relations"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    tenant_id: Mapped[str] = mapped_column(Text, nullable=False)
+    fleet_id: Mapped[str | None] = mapped_column(Text)
+    from_memory_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("memories.id", ondelete="CASCADE"), nullable=False
+    )
+    relation_type: Mapped[str] = mapped_column(Text, nullable=False)
+    to_memory_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("memories.id", ondelete="CASCADE"), nullable=False
+    )
+    # Caller-supplied, free-form, per ``mcp-tools.md`` §8's optional ``metadata``.
+    # ``metadata_`` because ``metadata`` is reserved on the declarative Base — same
+    # rename ``Memory`` uses, and the API exposes it as ``metadata``.
+    metadata_: Mapped[dict | None] = mapped_column("metadata", JSONB)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("now()"), nullable=False
+    )
+
+    __table_args__ = (
+        # One row per (tenant, from, type, to). This is what makes a repeated
+        # ``memory_link`` call idempotent rather than duplicating the edge. For a
+        # SYMMETRIC type the service must also check the REVERSED pair before
+        # inserting, since (A, contradicts, B) and (B, contradicts, A) are the same
+        # claim and this constraint would happily hold both.
+        UniqueConstraint(
+            "tenant_id",
+            "from_memory_id",
+            "relation_type",
+            "to_memory_id",
+            name="uq_memory_relations_natural_key",
+        ),
+        # Each FK's referencing column needs to be servable as an index PREFIX, and the
+        # natural key above leads with ``tenant_id`` so it covers neither endpoint.
+        # Without these, deleting one memory scans this table across EVERY tenant —
+        # migration 035 landed after exactly that cost 15.3 s of a 15.5 s bulk delete.
+        # ``tests/test_skill_schema_v1.py::test_every_fk_referencing_column_is_index_leading``
+        # fails at PR time if either is dropped.
+        Index("ix_memory_relations_from", "from_memory_id"),
+        Index("ix_memory_relations_to", "to_memory_id"),
+        # Tenant-scoped listing, and the leading column for any future tenant sweep.
+        Index("ix_memory_relations_tenant", "tenant_id"),
+        # ``supersedes`` lives on ``memories.supersedes_id``; admitting it here would
+        # create a second, disagreeing source of truth for the same claim. Enforced in
+        # the schema so the routing cannot be bypassed by a direct insert.
+        CheckConstraint(
+            "relation_type <> 'supersedes'",
+            name="ck_memory_relations_supersedes_not_stored",
+        ),
+        # A memory relating to itself is meaningless for all five stored types, and is
+        # the shape a caller passing the same id twice produces by accident.
+        CheckConstraint(
+            "from_memory_id <> to_memory_id",
+            name="ck_memory_relations_no_self_link",
+        ),
+    )

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/037_memory_relations.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/037_memory_relations.py
@@ -1,0 +1,93 @@
+"""Typed memory-to-memory relations — the store behind the ``memory_link`` tool.
+
+``memory_link`` promises a typed relation between two MEMORY ids, and nothing in the
+schema could hold one: ``relations`` is entity<->entity, ``memory_entity_links`` is
+memory<->entity, and ``memories.supersedes_id`` is memory->memory but single-valued and
+written only by the contradiction detector. The tool was therefore accepted but
+unadvertised (memclawd #130) until this table existed.
+
+Design decisions this encodes, so a reader does not have to reconstruct them:
+
+* **``supersedes`` is NOT stored here.** It reuses ``memories.supersedes_id`` so the
+  detector and the API write one field rather than two stores that can disagree. The
+  CHECK below makes that structural — a ``supersedes`` row cannot be inserted at all.
+* **One directed row per link, never two.** Three of the five stored types are
+  semantically symmetric, but storing both directions creates pairs that must stay in
+  sync and half-edges when one is deleted. Symmetry is handled on READ.
+* **Soft delete leaves rows here.** ``memories`` is soft-deleted routinely and that is
+  reversible; the read path filters on ``deleted_at IS NULL`` instead. ``ON DELETE
+  CASCADE`` handles the terminal case when the purge sweep hard-deletes the row.
+
+No backfill: there is no existing memory<->memory edge data to migrate. The
+contradiction detector's ``supersedes_id`` pointers stay exactly where they are.
+
+Indexes are plain, not CONCURRENTLY: the table is created in this same migration, so it
+is empty and unlocked — the CONCURRENTLY requirement (and
+``test_no_plain_create_index_on_large_tables``) applies to indexes added to large
+PRE-EXISTING tables, which is what crashed six storage-writer boots on 2026-06-16.
+
+Revision ID: 037
+Revises: 036
+Create Date: 2026-08-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "037"
+down_revision: str | None = "036"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "memory_relations",
+        sa.Column(
+            "id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), nullable=False
+        ),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("fleet_id", sa.Text(), nullable=True),
+        sa.Column("from_memory_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("relation_type", sa.Text(), nullable=False),
+        sa.Column("to_memory_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["from_memory_id"], ["memories.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["to_memory_id"], ["memories.id"], ondelete="CASCADE"),
+        # Makes a repeated ``memory_link`` call idempotent instead of duplicating the
+        # edge. For a SYMMETRIC type the service must ALSO check the reversed pair
+        # before inserting — (A, contradicts, B) and (B, contradicts, A) are the same
+        # claim, and this constraint would happily hold both.
+        sa.UniqueConstraint(
+            "tenant_id",
+            "from_memory_id",
+            "relation_type",
+            "to_memory_id",
+            name="uq_memory_relations_natural_key",
+        ),
+        sa.CheckConstraint(
+            "relation_type <> 'supersedes'",
+            name="ck_memory_relations_supersedes_not_stored",
+        ),
+        sa.CheckConstraint(
+            "from_memory_id <> to_memory_id",
+            name="ck_memory_relations_no_self_link",
+        ),
+    )
+    # Both endpoints need to be servable as an index PREFIX. The natural key above
+    # leads with ``tenant_id``, so it covers neither — and an unindexed FK referencing
+    # column turns every parent delete into a full scan of this table across ALL
+    # tenants (migration 035 landed after that cost 15.3 s of a 15.5 s bulk delete).
+    op.create_index("ix_memory_relations_from", "memory_relations", ["from_memory_id"])
+    op.create_index("ix_memory_relations_to", "memory_relations", ["to_memory_id"])
+    op.create_index("ix_memory_relations_tenant", "memory_relations", ["tenant_id"])
+
+
+def downgrade() -> None:
+    # Indexes and constraints go with the table.
+    op.drop_table("memory_relations")

--- a/tests/test_memory_relations_schema.py
+++ b/tests/test_memory_relations_schema.py
@@ -1,0 +1,161 @@
+"""The ``memory_relations`` guarantees, exercised against a real database.
+
+Every assertion here corresponds to a design decision stated in
+``common/models/memory_relation.py``. They are DB-level guarantees rather than service
+conventions precisely so a direct insert cannot bypass them, and a comment claiming a
+constraint exists is worth nothing until something has watched the constraint refuse a
+write.
+
+Covered:
+  * ``supersedes`` cannot be stored here (it lives on ``memories.supersedes_id``);
+  * a memory cannot link to itself;
+  * the same (tenant, from, type, to) cannot be stored twice — what makes a repeated
+    ``memory_link`` idempotent rather than duplicating the edge;
+  * the reversed pair of a SYMMETRIC type IS accepted by the constraint, which is why
+    the service must check it — the schema alone does not make symmetry idempotent;
+  * hard-deleting an endpoint cascades the link away;
+  * SOFT-deleting an endpoint leaves the link in place, since soft delete is reversible.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from common.models.memory_relation import (
+    ALL_RELATION_TYPES,
+    DIRECTED_RELATION_TYPES,
+    STORED_RELATION_TYPES,
+    SUPERSEDES_RELATION_TYPE,
+    SYMMETRIC_RELATION_TYPES,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def _memory(db, tenant_id: str, content: str) -> uuid.UUID:
+    mid = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO memories (id, tenant_id, agent_id, memory_type, content) "
+            "VALUES (:id, :t, 'rel-agent', 'fact', :c)"
+        ),
+        {"id": mid, "t": tenant_id, "c": content},
+    )
+    return mid
+
+
+async def _link(db, tenant_id: str, a: uuid.UUID, rel: str, b: uuid.UUID) -> None:
+    await db.execute(
+        text(
+            "INSERT INTO memory_relations (tenant_id, from_memory_id, relation_type, to_memory_id) "
+            "VALUES (:t, :a, :r, :b)"
+        ),
+        {"t": tenant_id, "a": a, "r": rel, "b": b},
+    )
+
+
+async def _count(db, a: uuid.UUID) -> int:
+    return (
+        await db.execute(
+            text(
+                "SELECT count(*) FROM memory_relations "
+                "WHERE from_memory_id = :a OR to_memory_id = :a"
+            ),
+            {"a": a},
+        )
+    ).scalar_one()
+
+
+def test_the_relation_vocabulary_matches_the_contract() -> None:
+    """No DB. ``mcp-tools.md`` §8 names six types; five are stored, one is routed."""
+    assert ALL_RELATION_TYPES == {
+        "supersedes",
+        "elaborates",
+        "contradicts",
+        "depends_on",
+        "alternative_to",
+        "related_to",
+    }
+    assert SUPERSEDES_RELATION_TYPE not in STORED_RELATION_TYPES, (
+        "supersedes must NOT be in the stored set — it reuses memories.supersedes_id, "
+        "and the CHECK constraint refuses it in this table"
+    )
+    assert SYMMETRIC_RELATION_TYPES.isdisjoint(DIRECTED_RELATION_TYPES)
+    assert STORED_RELATION_TYPES == SYMMETRIC_RELATION_TYPES | DIRECTED_RELATION_TYPES
+
+
+async def test_supersedes_cannot_be_stored_in_this_table(db, tenant_id) -> None:
+    """The routing decision is structural, not a convention the service may forget."""
+    a = await _memory(db, tenant_id, "older claim")
+    b = await _memory(db, tenant_id, "newer claim")
+    with pytest.raises(
+        IntegrityError, match="ck_memory_relations_supersedes_not_stored"
+    ):
+        await _link(db, tenant_id, b, SUPERSEDES_RELATION_TYPE, a)
+
+
+async def test_a_memory_cannot_link_to_itself(db, tenant_id) -> None:
+    a = await _memory(db, tenant_id, "sole memory")
+    with pytest.raises(IntegrityError, match="ck_memory_relations_no_self_link"):
+        await _link(db, tenant_id, a, "related_to", a)
+
+
+async def test_the_same_link_cannot_be_stored_twice(db, tenant_id) -> None:
+    """What makes a repeated ``memory_link`` call idempotent at the storage layer."""
+    a = await _memory(db, tenant_id, "detail source")
+    b = await _memory(db, tenant_id, "detail target")
+    await _link(db, tenant_id, a, "elaborates", b)
+    with pytest.raises(IntegrityError, match="uq_memory_relations_natural_key"):
+        await _link(db, tenant_id, a, "elaborates", b)
+
+
+async def test_the_reversed_pair_of_a_symmetric_type_is_NOT_blocked_by_the_schema(
+    db, tenant_id
+) -> None:
+    """The schema does not make symmetry idempotent — the service must.
+
+    ``(A, contradicts, B)`` and ``(B, contradicts, A)`` are the same claim, but they are
+    different rows under the natural key, so the constraint accepts both. This test
+    exists to pin that gap: it is the reason the write path checks the reversed pair for
+    a symmetric type, and if someone ever makes the schema enforce it, this test should
+    fail and be replaced rather than deleted.
+    """
+    a = await _memory(db, tenant_id, "claim one")
+    b = await _memory(db, tenant_id, "claim two")
+    await _link(db, tenant_id, a, "contradicts", b)
+    await _link(db, tenant_id, b, "contradicts", a)  # accepted, and semantically a dup
+    assert await _count(db, a) == 2
+
+
+async def test_hard_deleting_an_endpoint_cascades_the_link_away(db, tenant_id) -> None:
+    a = await _memory(db, tenant_id, "depends on target")
+    b = await _memory(db, tenant_id, "the dependency")
+    await _link(db, tenant_id, a, "depends_on", b)
+    assert await _count(db, a) == 1
+    await db.execute(text("DELETE FROM memories WHERE id = :b"), {"b": b})
+    assert await _count(db, a) == 0, (
+        "ON DELETE CASCADE is what makes the purge sweep the only cleanup this table "
+        "needs; without it a purged memory leaves dangling edges"
+    )
+
+
+async def test_soft_deleting_an_endpoint_LEAVES_the_link(db, tenant_id) -> None:
+    """Soft delete is reversible, so it must not destroy edges.
+
+    The link stops being *returned* because the read path joins ``memories`` and filters
+    ``deleted_at IS NULL`` — but the row survives, so undeleting the memory restores its
+    graph rather than silently losing it.
+    """
+    a = await _memory(db, tenant_id, "alternative one")
+    b = await _memory(db, tenant_id, "alternative two")
+    await _link(db, tenant_id, a, "alternative_to", b)
+    await db.execute(
+        text("UPDATE memories SET deleted_at = now() WHERE id = :b"), {"b": b}
+    )
+    assert await _count(db, a) == 1, (
+        "a soft delete must leave the edge intact; cascading here would make undelete lossy"
+    )


### PR DESCRIPTION
## What, and what this deliberately is not

`memory_link` promises a typed relation between two **memory** ids, and nothing in the schema could hold one — `relations` is entity↔entity, `memory_entity_links` is memory↔entity, and `memories.supersedes_id` is memory→memory but single-valued and written only by the contradiction detector. That is why the tool has been accepted-but-unadvertised since memclawd #130.

This adds **the store and nothing else.** Nothing consumes it yet: no storage endpoint, no core-api route, no `cloud.Client` method, no dispatcher wiring, and `memory_link` stays unadvertised. memclawd's `TestAdvertisedToolsAreAllServable` enforces that pairing, so the cloud side must exist before the tool can be re-advertised — this is the prerequisite, landed on its own rather than as part of a cross-repo change.

## Design, decided rather than inferred

The six relation types are `contracts/mcp-tools.md` §8 verbatim; Eldad confirmed the set rather than letting it be read off a tool description.

**`supersedes` is not stored here.** It reuses `memories.supersedes_id` so the detector and the API write one field instead of two stores that can disagree. A CHECK constraint makes that structural — a `supersedes` row cannot be inserted at all. The consequence is a real asymmetry the tool will have to document: `supersedes` is 1:1 and a second one *overwrites*, while a second `elaborates` is an additional row.

**One directed row per link, never two.** Three of the five stored types are semantically symmetric, and writing both directions creates pairs that must stay in sync plus half-edges when one is deleted. Symmetry is a read concern, and all per-type knowledge lives in one constant (`SYMMETRIC_RELATION_TYPES`) instead of spreading into the schema.

**Soft delete leaves the rows.** `memories` is soft-deleted routinely and that is reversible, so cascading would make un-delete lossy. The read path filters `deleted_at IS NULL` — free, since it already joins `memories` for endpoint content — and `ON DELETE CASCADE` covers the terminal case when the purge sweep hard-deletes the row. No new retention machinery.

## Verified rather than asserted

**Model and migration produce byte-identical schemas.** Applied 037 to a scratch database and diffed `\d memory_relations` against the `create_all` result: identical across columns, defaults, all four indexes, both CHECKs, and both CASCADE FKs. Tests build the schema with `create_all` while prod runs alembic, so a divergence there stays invisible until production.

**Seven tests exercise the guarantees against a real database** — a comment claiming a constraint exists is worth nothing until something has watched it refuse a write:

- `supersedes` rejected by CHECK
- self-link rejected by CHECK
- duplicate `(tenant, from, type, to)` rejected by the natural key
- hard-deleting an endpoint cascades the link away
- **soft-deleting an endpoint does *not***

One test pins a **gap** on purpose: the reversed pair of a symmetric type *is* accepted by the natural key. That is exactly why the write path will have to check it — the schema does not make symmetry idempotent, and this documents that where someone would otherwise assume it does. If a later change makes the schema enforce it, that test should fail and be replaced rather than deleted.

## Notes on the migration

Indexes are plain, not `CONCURRENTLY`: the table is created in the same migration, so it is empty and unlocked. `test_no_plain_create_index_on_large_tables` scopes its requirement to large pre-existing tables — the case that crashed six storage-writer boots on 2026-06-16.

Both endpoint columns get their own index because the natural key leads with `tenant_id` and therefore serves neither as a prefix. `test_every_fk_referencing_column_is_index_leading` fails at PR time otherwise, and an unindexed FK referencing column is what cost 15.3 s of a 15.5 s bulk delete before migration 035.

`test_single_head` expectation moved 036 → 037.

## Measurement

| | result |
|---|---|
| `tests/` | 4382 → **4389** (+7, exactly the new tests) |
| `core-storage-api/tests/` | **118** on a fresh database |
| mypy | clean on both `src/` trees |
| ruff check / format | clean at CI's scopes |

One local-only wrinkle worth recording: running `core-storage-api/tests/` against a database where the root `tests/` tree had already run `create_all` gives 106 `DuplicateTableError`s, because `create_all` made `memory_relations` while `alembic_version` still said 036. It is not reachable in CI — that job gets its own fresh Postgres service, and CI runs `alembic upgrade head` before `pytest tests/`, so alembic is always ahead. Flagging it so nobody debugs it as a code defect.

## Remaining chain for `memory_link`

1. storage-api endpoint (upsert + list), with the reversed-pair check for symmetric types
2. core-api route
3. `supersedes` path — `PATCH /memories/{id}/status` already has the full authz stack and already reaches a storage layer supporting `supersedes_id` / `unset_supersedes` / `expected_supersedes_id`; it simply forwards none of them. Use the CAS gate so an API write cannot clobber the detector's pointer.
4. memclawd: `cloud.Client` method, `CloudLinker` capability, `newCloudDispatcher` wiring, a real input schema, then re-advertise in `tools/list`
5. a `BROKER_OPERATIONS` row here