### PR TITLE
feat(memory): storage endpoints for the memory_link graph (step 2)

### DIFF
--- a/common/models/__init__.py
+++ b/common/models/__init__.py
@@ -15,6 +15,7 @@ from common.models.lifecycle_audit import LifecycleAudit
 from common.models.memory import Memory
 from common.models.memory_conflict import MemoryConflict
 from common.models.memory_derivation import MemoryDerivation
+from common.models.memory_relation import MemoryRelation
 from common.models.skill_factory import ForgeRejectedFingerprint, SessionTrace
 
 __all__ = [
@@ -36,6 +37,7 @@ __all__ = [
     "LifecycleAudit",
     "Memory",
     "MemoryConflict",
+    "MemoryRelation",
     "MemoryDerivation",
     "MemoryEntityLink",
     "Relation",

--- a/common/models/memory_relation.py
+++ b/common/models/memory_relation.py
@@ -1,0 +1,135 @@
+"""Typed memory-to-memory relations — the store behind the ``memory_link`` tool.
+
+Distinct from the two link tables that already exist, and it is worth being explicit
+about why none of them could serve this:
+
+* ``relations`` is entity <-> entity.
+* ``memory_entity_links`` is memory <-> entity.
+* ``memories.supersedes_id`` is memory -> memory but SINGLE-VALUED, and is written by
+  the contradiction detector.
+
+``memory_link`` promises a typed relation between two MEMORY ids, which is none of
+those, and it was accepted-but-unadvertised until this table existed (memclawd #130).
+
+WHY ``supersedes`` IS NOT STORED HERE. Eldad's call (2026-08-13): ``supersedes``
+reuses ``memories.supersedes_id`` rather than becoming a row here, so the contradiction
+detector and the API write one field instead of two stores that can disagree. The
+consequence is a real asymmetry the tool has to document: ``supersedes`` is 1:1 and a
+second one OVERWRITES, while a second ``elaborates`` is an additional row. The CHECK
+constraint below makes that structural rather than a convention — a ``supersedes`` row
+cannot be written here at all.
+
+WHY ONE DIRECTED ROW, never two. Three of the five stored types are semantically
+symmetric (``contradicts``, ``alternative_to``, ``related_to``), and the tempting
+implementation is to write both directions. That creates pairs which must stay in sync,
+and deleting one leaves a half-edge. So exactly one row is stored, exactly as the caller
+stated it, and symmetry is a READ concern: queries for a symmetric type match
+``from_memory_id = X OR to_memory_id = X``. All per-type knowledge lives in one constant
+(``SYMMETRIC_RELATION_TYPES``) instead of being spread into the schema.
+
+SOFT DELETE leaves rows here untouched. ``memories`` is soft-deleted routinely and that
+is reversible, so cascading on soft-delete would make un-delete lossy. A link whose
+endpoint is soft-deleted simply stops being returned, because the read path already
+joins ``memories`` to fetch endpoint content and can add ``deleted_at IS NULL`` for
+free. Terminal cleanup needs no new machinery: the purge sweep hard-deletes the row and
+``ON DELETE CASCADE`` takes the links with it.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from common.models.base import Base
+
+# The six types in ``contracts/mcp-tools.md`` §8, as specified — Eldad confirmed the set
+# rather than letting it be inferred from the tool description.
+#
+# ``supersedes`` is routed to ``memories.supersedes_id`` and is deliberately NOT in
+# ``STORED_RELATION_TYPES``; it appears here only so the tool's input schema and this
+# module agree on the vocabulary.
+SUPERSEDES_RELATION_TYPE = "supersedes"
+
+# Symmetric in meaning: if A contradicts B then B contradicts A. Stored one-directionally
+# anyway (see module docstring); this set is what the read path and the idempotency check
+# consult. Changing membership is the entire cost of revisiting that decision.
+SYMMETRIC_RELATION_TYPES = frozenset({"contradicts", "alternative_to", "related_to"})
+
+# Asymmetric: direction carries meaning, so a reversed row is a different claim.
+DIRECTED_RELATION_TYPES = frozenset({"elaborates", "depends_on"})
+
+STORED_RELATION_TYPES = frozenset(SYMMETRIC_RELATION_TYPES | DIRECTED_RELATION_TYPES)
+
+ALL_RELATION_TYPES = frozenset(STORED_RELATION_TYPES | {SUPERSEDES_RELATION_TYPE})
+
+
+class MemoryRelation(Base):
+    __tablename__ = "memory_relations"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    tenant_id: Mapped[str] = mapped_column(Text, nullable=False)
+    fleet_id: Mapped[str | None] = mapped_column(Text)
+    from_memory_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("memories.id", ondelete="CASCADE"), nullable=False
+    )
+    relation_type: Mapped[str] = mapped_column(Text, nullable=False)
+    to_memory_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("memories.id", ondelete="CASCADE"), nullable=False
+    )
+    # Caller-supplied, free-form, per ``mcp-tools.md`` §8's optional ``metadata``.
+    # ``metadata_`` because ``metadata`` is reserved on the declarative Base — same
+    # rename ``Memory`` uses, and the API exposes it as ``metadata``.
+    metadata_: Mapped[dict | None] = mapped_column("metadata", JSONB)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("now()"), nullable=False
+    )
+
+    __table_args__ = (
+        # One row per (tenant, from, type, to). This is what makes a repeated
+        # ``memory_link`` call idempotent rather than duplicating the edge. For a
+        # SYMMETRIC type the service must also check the REVERSED pair before
+        # inserting, since (A, contradicts, B) and (B, contradicts, A) are the same
+        # claim and this constraint would happily hold both.
+        UniqueConstraint(
+            "tenant_id",
+            "from_memory_id",
+            "relation_type",
+            "to_memory_id",
+            name="uq_memory_relations_natural_key",
+        ),
+        # Each FK's referencing column needs to be servable as an index PREFIX, and the
+        # natural key above leads with ``tenant_id`` so it covers neither endpoint.
+        # Without these, deleting one memory scans this table across EVERY tenant —
+        # migration 035 landed after exactly that cost 15.3 s of a 15.5 s bulk delete.
+        # ``tests/test_skill_schema_v1.py::test_every_fk_referencing_column_is_index_leading``
+        # fails at PR time if either is dropped.
+        Index("ix_memory_relations_from", "from_memory_id"),
+        Index("ix_memory_relations_to", "to_memory_id"),
+        # Tenant-scoped listing, and the leading column for any future tenant sweep.
+        Index("ix_memory_relations_tenant", "tenant_id"),
+        # ``supersedes`` lives on ``memories.supersedes_id``; admitting it here would
+        # create a second, disagreeing source of truth for the same claim. Enforced in
+        # the schema so the routing cannot be bypassed by a direct insert.
+        CheckConstraint(
+            "relation_type <> 'supersedes'",
+            name="ck_memory_relations_supersedes_not_stored",
+        ),
+        # A memory relating to itself is meaningless for all five stored types, and is
+        # the shape a caller passing the same id twice produces by accident.
+        CheckConstraint(
+            "from_memory_id <> to_memory_id",
+            name="ck_memory_relations_no_self_link",
+        ),
+    )

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/037_memory_relations.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/037_memory_relations.py
@@ -1,0 +1,93 @@
+"""Typed memory-to-memory relations — the store behind the ``memory_link`` tool.
+
+``memory_link`` promises a typed relation between two MEMORY ids, and nothing in the
+schema could hold one: ``relations`` is entity<->entity, ``memory_entity_links`` is
+memory<->entity, and ``memories.supersedes_id`` is memory->memory but single-valued and
+written only by the contradiction detector. The tool was therefore accepted but
+unadvertised (memclawd #130) until this table existed.
+
+Design decisions this encodes, so a reader does not have to reconstruct them:
+
+* **``supersedes`` is NOT stored here.** It reuses ``memories.supersedes_id`` so the
+  detector and the API write one field rather than two stores that can disagree. The
+  CHECK below makes that structural — a ``supersedes`` row cannot be inserted at all.
+* **One directed row per link, never two.** Three of the five stored types are
+  semantically symmetric, but storing both directions creates pairs that must stay in
+  sync and half-edges when one is deleted. Symmetry is handled on READ.
+* **Soft delete leaves rows here.** ``memories`` is soft-deleted routinely and that is
+  reversible; the read path filters on ``deleted_at IS NULL`` instead. ``ON DELETE
+  CASCADE`` handles the terminal case when the purge sweep hard-deletes the row.
+
+No backfill: there is no existing memory<->memory edge data to migrate. The
+contradiction detector's ``supersedes_id`` pointers stay exactly where they are.
+
+Indexes are plain, not CONCURRENTLY: the table is created in this same migration, so it
+is empty and unlocked — the CONCURRENTLY requirement (and
+``test_no_plain_create_index_on_large_tables``) applies to indexes added to large
+PRE-EXISTING tables, which is what crashed six storage-writer boots on 2026-06-16.
+
+Revision ID: 037
+Revises: 036
+Create Date: 2026-08-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "037"
+down_revision: str | None = "036"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "memory_relations",
+        sa.Column(
+            "id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), nullable=False
+        ),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("fleet_id", sa.Text(), nullable=True),
+        sa.Column("from_memory_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("relation_type", sa.Text(), nullable=False),
+        sa.Column("to_memory_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["from_memory_id"], ["memories.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["to_memory_id"], ["memories.id"], ondelete="CASCADE"),
+        # Makes a repeated ``memory_link`` call idempotent instead of duplicating the
+        # edge. For a SYMMETRIC type the service must ALSO check the reversed pair
+        # before inserting — (A, contradicts, B) and (B, contradicts, A) are the same
+        # claim, and this constraint would happily hold both.
+        sa.UniqueConstraint(
+            "tenant_id",
+            "from_memory_id",
+            "relation_type",
+            "to_memory_id",
+            name="uq_memory_relations_natural_key",
+        ),
+        sa.CheckConstraint(
+            "relation_type <> 'supersedes'",
+            name="ck_memory_relations_supersedes_not_stored",
+        ),
+        sa.CheckConstraint(
+            "from_memory_id <> to_memory_id",
+            name="ck_memory_relations_no_self_link",
+        ),
+    )
+    # Both endpoints need to be servable as an index PREFIX. The natural key above
+    # leads with ``tenant_id``, so it covers neither — and an unindexed FK referencing
+    # column turns every parent delete into a full scan of this table across ALL
+    # tenants (migration 035 landed after that cost 15.3 s of a 15.5 s bulk delete).
+    op.create_index("ix_memory_relations_from", "memory_relations", ["from_memory_id"])
+    op.create_index("ix_memory_relations_to", "memory_relations", ["to_memory_id"])
+    op.create_index("ix_memory_relations_tenant", "memory_relations", ["tenant_id"])
+
+
+def downgrade() -> None:
+    # Indexes and constraints go with the table.
+    op.drop_table("memory_relations")

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1532,6 +1532,80 @@ async def get_memory_detail(memory_id: UUID, tenant_id: str) -> dict:
     return detail
 
 
+@router.post("/{memory_id}/relations")
+async def upsert_memory_relation(memory_id: UUID, request: Request) -> dict:
+    """Create (or re-affirm) a typed link from ``memory_id`` to another memory.
+
+    Idempotent: re-issuing the same link returns the existing row rather than 409-ing,
+    and for a SYMMETRIC relation type the REVERSED pair counts as the same link. See
+    ``memory_relation_upsert`` for the reasoning and for the one race it leaves open.
+
+    ``supersedes`` is rejected with 422, not stored: that claim lives on
+    ``memories.supersedes_id``. The DB CHECK would also refuse it, but as a 500.
+
+    Both endpoints must exist, be live, and belong to ``tenant_id`` — checked here so a
+    caller cannot use a link to probe whether another tenant's memory id exists. A
+    missing or cross-tenant endpoint is a flat 404, the same shape the by-id read uses.
+    """
+    body: dict = await request.json()
+    tenant_id = _require(body, "tenant_id")
+    to_memory_id = _require(body, "to_memory_id")
+    relation_type = _require(body, "relation_type")
+    try:
+        to_uuid = UUID(str(to_memory_id))
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail="to_memory_id must be a UUID") from exc
+
+    for endpoint in (memory_id, to_uuid):
+        if await _svc.memory_get_by_id_for_tenant(endpoint, tenant_id) is None:
+            raise HTTPException(status_code=404, detail="Memory not found")
+
+    try:
+        row, _created = await _svc.memory_relation_upsert(
+            {
+                "tenant_id": tenant_id,
+                "fleet_id": body.get("fleet_id"),
+                "from_memory_id": memory_id,
+                "relation_type": relation_type,
+                "to_memory_id": to_uuid,
+                "metadata": body.get("metadata"),
+            }
+        )
+    except ValueError as exc:
+        # Vocabulary and self-link violations — the service raises these before touching
+        # the database precisely so they surface as 422 rather than an IntegrityError 500.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return _relation_to_dict(row)
+
+
+@router.get("/{memory_id}/relations")
+async def list_memory_relations(memory_id: UUID, tenant_id: str, relation_type: str | None = None) -> dict:
+    """Every live link touching ``memory_id``, in either direction.
+
+    Links whose FAR endpoint is soft-deleted are omitted: soft delete leaves the row in
+    place (it is reversible), so this filter is what stops a deleted memory reappearing
+    through its graph.
+    """
+    if await _svc.memory_get_by_id_for_tenant(memory_id, tenant_id) is None:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    rows = await _svc.memory_relation_list(memory_id, tenant_id, relation_type=relation_type)
+    return {"relations": [_relation_to_dict(r) for r in rows]}
+
+
+def _relation_to_dict(row) -> dict:
+    """Serialise a ``MemoryRelation``. ``metadata_`` is exposed as ``metadata``."""
+    return {
+        "id": str(row.id),
+        "tenant_id": row.tenant_id,
+        "fleet_id": row.fleet_id,
+        "from_memory_id": str(row.from_memory_id),
+        "relation_type": row.relation_type,
+        "to_memory_id": str(row.to_memory_id),
+        "metadata": row.metadata_,
+        "created_at": row.created_at,
+    }
+
+
 @router.get("/{memory_id}/contradictions")
 async def get_memory_contradictions(memory_id: UUID, tenant_id: str) -> dict:
     """Raw contradiction rows: ``{memory, supersessors[], older|null}``.

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -42,7 +42,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from sqlalchemy.orm import load_only
+from sqlalchemy.orm import aliased, load_only
 
 from common.constants import (
     CONTRADICTION_CANDIDATE_MAX,
@@ -76,9 +76,15 @@ from common.models import (
     Memory,
     MemoryConflict,
     MemoryEntityLink,
+    MemoryRelation,
     Relation,
 )
 from common.models.capability_usage import CapabilityUsage
+from common.models.memory_relation import (
+    STORED_RELATION_TYPES,
+    SUPERSEDES_RELATION_TYPE,
+    SYMMETRIC_RELATION_TYPES,
+)
 from common.models.organization_settings import OrganizationSettings, OrganizationSettingsAudit
 from common.models.recall_log import RecallCandidate, RecallEvent
 from common.organization_settings_merge import deep_merge, diff_settings
@@ -197,6 +203,11 @@ def _coerce_dt(value: Any) -> Any:
     if isinstance(value, str):
         return datetime.fromisoformat(value)
     return value
+
+
+# ``MemoryRelation``'s JSONB column, as a Column object. Needed because the string key
+# "metadata" resolves against the declarative class to ``Base.metadata``.
+_MEMORY_RELATION_METADATA = MemoryRelation.__table__.c["metadata"]
 
 
 def _relation_weight(relation_type: str, row_weight: float) -> float:
@@ -4745,6 +4756,157 @@ class PostgresService:
                     stmt = stmt.where(Relation.fleet_id == fleet_id)
             result = await session.execute(stmt)
             return list(result.scalars().all())
+
+    # ── memory <-> memory relations (the ``memory_link`` graph) ──
+    #
+    # Separate from the entity ``relation_*`` methods above and NOT interchangeable
+    # with them: those are entity<->entity. See ``common/models/memory_relation.py``
+    # for why ``supersedes`` is absent here (it reuses ``memories.supersedes_id``).
+
+    async def memory_relation_upsert(self, data: dict) -> tuple[MemoryRelation, bool]:
+        """Idempotent link write. Returns ``(row, created)``.
+
+        Idempotent by the natural key, for the reason ``relation_add`` above documents
+        at length: a plain INSERT there drove an ``IntegrityError`` cluster into 5xx
+        storms, with rows committed while the caller saw an error and retried. An agent
+        re-issuing ``memory_link`` must be a no-op, not a 500.
+
+        SYMMETRIC TYPES ALSO MATCH THE REVERSED PAIR. ``(A, contradicts, B)`` and
+        ``(B, contradicts, A)`` are the same claim, but they are different rows under
+        the natural key — the schema accepts both (pinned deliberately by
+        ``tests/test_memory_relations_schema.py``), so the check has to live here. The
+        existing row is returned unchanged rather than re-pointed, so the direction the
+        FIRST caller stated is preserved.
+
+        KNOWN RACE, and why it is left open: two concurrent calls writing opposite
+        directions of the same symmetric link can both pass this check and both insert,
+        leaving two rows that mean one thing. It is benign — a duplicate edge, not
+        corruption — and ``memory_link`` is an agent-initiated, low-rate write. Closing
+        it properly means a partial unique index on
+        ``(tenant_id, least(from, to), greatest(from, to), relation_type)`` limited to
+        the symmetric types, which would make the invariant structural at the cost of a
+        more awkward ON CONFLICT target. Worth doing if duplicates are ever observed;
+        not worth pre-empting.
+        """
+        relation_type = data["relation_type"]
+        if relation_type == SUPERSEDES_RELATION_TYPE:
+            # The CHECK constraint would also refuse this, but as a 500. Callers get a
+            # precise reason instead: the claim belongs on ``memories.supersedes_id``.
+            raise ValueError(
+                "relation_type 'supersedes' is not stored in memory_relations; it is "
+                "represented by memories.supersedes_id"
+            )
+        if relation_type not in STORED_RELATION_TYPES:
+            raise ValueError(
+                f"unknown relation_type {relation_type!r}; expected one of {sorted(STORED_RELATION_TYPES)}"
+            )
+        if data["from_memory_id"] == data["to_memory_id"]:
+            raise ValueError("a memory cannot be linked to itself")
+
+        async with get_session() as session:
+            if relation_type in SYMMETRIC_RELATION_TYPES:
+                existing = (
+                    await session.execute(
+                        select(MemoryRelation).where(
+                            MemoryRelation.tenant_id == data["tenant_id"],
+                            MemoryRelation.relation_type == relation_type,
+                            MemoryRelation.from_memory_id == data["to_memory_id"],
+                            MemoryRelation.to_memory_id == data["from_memory_id"],
+                        )
+                    )
+                ).scalar_one_or_none()
+                if existing is not None:
+                    return existing, False
+
+            # ``metadata`` is the WIRE name; the mapped attribute is ``metadata_``
+            # because ``metadata`` on a declarative class is SQLAlchemy's ``MetaData``.
+            # Passing the wire key straight to ``.values()`` resolves to that object and
+            # fails at execute time with ``'MetaData' object has no attribute
+            # '_bulk_update_tuples'`` — a long way from the cause. Normalise once, here,
+            # so callers keep speaking the wire shape.
+            values = dict(data)
+            supplied_metadata = values.pop("metadata", None)
+            if supplied_metadata is not None:
+                # Only set it when the caller actually sent it. Binding Python ``None``
+                # to a JSONB column stores JSON ``null``, which is NOT SQL NULL — the
+                # COALESCE below would then treat an omitted field as a real value and
+                # blank whatever an earlier link recorded.
+                values["metadata_"] = supplied_metadata
+            insert_stmt = pg_insert(MemoryRelation).values(**values)
+            upsert_stmt = insert_stmt.on_conflict_do_update(
+                constraint="uq_memory_relations_natural_key",
+                # Latest non-NULL metadata wins, so a caller that omits ``metadata``
+                # does not wipe what an earlier link recorded — same COALESCE reasoning
+                # as ``relation_add``'s ``evidence_memory_id``. ``fleet_id`` is
+                # deliberately untouched: first-writer-wins, as there too.
+                # Keyed by the COLUMN OBJECT, never the string ``"metadata"``: that name
+                # resolves against the declarative class to ``Base.metadata`` (the
+                # SQLAlchemy ``MetaData``), not to this column, and the resulting
+                # ``AttributeError: 'MetaData' object has no attribute
+                # '_bulk_update_tuples'`` appears only at execute time. Same
+                # reserved-name collision that forces the ``metadata_`` attribute name.
+                # Keyed by the ORM ATTRIBUTE name ``metadata_``, never the column name
+                # ``"metadata"``: the latter resolves against the declarative class to
+                # ``Base.metadata`` (the SQLAlchemy ``MetaData``), and the resulting
+                # ``AttributeError: 'MetaData' object has no attribute
+                # '_bulk_update_tuples'`` appears only at execute time. Same
+                # reserved-name collision that forces the ``metadata_`` attribute name.
+                set_={
+                    _MEMORY_RELATION_METADATA: func.coalesce(
+                        insert_stmt.excluded["metadata"], _MEMORY_RELATION_METADATA
+                    )
+                },
+            ).returning(MemoryRelation)
+            row = (await session.execute(upsert_stmt)).scalar_one()
+            # ``created`` is inferred from whether the row's id survived: on a conflict
+            # the pre-existing id is kept, so a caller cannot distinguish create from
+            # update by id alone. Report the cheap, honest thing instead — that the
+            # write landed — and let the route return 200 either way.
+            return row, True
+
+    async def memory_relation_list(
+        self,
+        memory_id: UUID,
+        tenant_id: str,
+        *,
+        relation_type: str | None = None,
+    ) -> list[MemoryRelation]:
+        """Every live link touching ``memory_id``, in either direction.
+
+        BOTH directions unconditionally, including for the asymmetric types: a caller
+        asking "what is linked to this memory" wants the edges pointing at it as much as
+        the ones leaving it, and the row carries ``from``/``to`` so direction is never
+        lost. That is also what makes the symmetric types work without storing two rows.
+
+        Endpoints that are SOFT-DELETED are excluded here rather than in the caller —
+        soft delete leaves the row (see the model docstring), so this filter is the only
+        thing that stops a deleted memory reappearing through its graph.
+        """
+        async with get_session() as session:
+            far_end = aliased(Memory)
+            stmt = (
+                select(MemoryRelation)
+                .join(
+                    far_end,
+                    far_end.id
+                    == case(
+                        (MemoryRelation.from_memory_id == memory_id, MemoryRelation.to_memory_id),
+                        else_=MemoryRelation.from_memory_id,
+                    ),
+                )
+                .where(
+                    MemoryRelation.tenant_id == tenant_id,
+                    or_(
+                        MemoryRelation.from_memory_id == memory_id,
+                        MemoryRelation.to_memory_id == memory_id,
+                    ),
+                    far_end.deleted_at.is_(None),
+                )
+                .order_by(MemoryRelation.created_at.desc())
+            )
+            if relation_type is not None:
+                stmt = stmt.where(MemoryRelation.relation_type == relation_type)
+            return list((await session.execute(stmt)).scalars().all())
 
     async def relation_get_outgoing(
         self,

--- a/core-storage-api/tests/test_memory_relations_endpoint.py
+++ b/core-storage-api/tests/test_memory_relations_endpoint.py
@@ -1,0 +1,185 @@
+"""The ``/memories/{id}/relations`` storage endpoints.
+
+``tests/test_memory_relations_schema.py`` covers what the DATABASE refuses. These cover
+what the SERVICE has to get right on top of it, and the interesting half is idempotency:
+
+  * a repeated link is a no-op, not a 409. ``relation_add`` (the entity equivalent) was
+    once a plain INSERT, and the resulting IntegrityError cluster became 5xx storms with
+    rows committed while the caller retried. An agent re-issuing ``memory_link`` must not
+    reproduce that.
+  * for a SYMMETRIC type the REVERSED pair is the same link. The schema accepts both rows
+    — pinned deliberately in the schema tests — so only the service can collapse them.
+  * for an ASYMMETRIC type the reversed pair is a DIFFERENT claim and must not collapse.
+  * ``supersedes`` is a 422 naming the right field, not a 500 from the CHECK constraint.
+  * a soft-deleted far endpoint leaves the row but drops out of the listing.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from httpx import AsyncClient
+
+PREFIX = "/api/v1/storage"
+
+
+def _memory_payload(tenant_id: str, fleet_id: str, content: str) -> dict:
+    return {
+        "tenant_id": tenant_id,
+        "fleet_id": fleet_id,
+        "agent_id": "rel-agent",
+        "memory_type": "fact",
+        "content": content,
+    }
+
+
+async def _memory(client: AsyncClient, tenant_id: str, fleet_id: str, content: str) -> str:
+    r = await client.post(
+        f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id, f"{content} {uuid.uuid4().hex[:8]}")
+    )
+    assert r.status_code in (200, 201), r.text
+    return r.json()["id"]
+
+
+def _body(tenant_id: str, to_id: str, rel: str, **kw) -> dict:
+    return {"tenant_id": tenant_id, "to_memory_id": to_id, "relation_type": rel, **kw}
+
+
+async def _relations(client: AsyncClient, mid: str, tenant_id: str, **params) -> list[dict]:
+    r = await client.get(f"{PREFIX}/memories/{mid}/relations", params={"tenant_id": tenant_id, **params})
+    assert r.status_code == 200, r.text
+    return r.json()["relations"]
+
+
+async def test_link_then_relink_is_idempotent(client: AsyncClient, tenant_id, fleet_id) -> None:
+    a = await _memory(client, tenant_id, fleet_id, "elaborate source")
+    b = await _memory(client, tenant_id, fleet_id, "elaborate target")
+
+    first = await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, b, "elaborates"))
+    assert first.status_code == 200, first.text
+    again = await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, b, "elaborates"))
+    assert again.status_code == 200, again.text
+    assert again.json()["id"] == first.json()["id"], "the row id must survive a re-link"
+    assert len(await _relations(client, a, tenant_id)) == 1, "a repeated link must not add an edge"
+
+
+async def test_a_symmetric_link_is_idempotent_in_the_REVERSED_direction(
+    client: AsyncClient, tenant_id, fleet_id
+) -> None:
+    """The schema cannot enforce this, so the service must — this is the proof."""
+    a = await _memory(client, tenant_id, fleet_id, "claim one")
+    b = await _memory(client, tenant_id, fleet_id, "claim two")
+
+    forward = await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, b, "contradicts"))
+    assert forward.status_code == 200, forward.text
+    reverse = await client.post(f"{PREFIX}/memories/{b}/relations", json=_body(tenant_id, a, "contradicts"))
+    assert reverse.status_code == 200, reverse.text
+
+    assert reverse.json()["id"] == forward.json()["id"], (
+        "(A contradicts B) and (B contradicts A) are the same claim; the reversed call "
+        "must return the existing row rather than storing a second edge"
+    )
+    assert reverse.json()["from_memory_id"] == a, (
+        "the FIRST caller's direction is preserved — a reversed call does not re-point the row"
+    )
+    for endpoint in (a, b):
+        assert len(await _relations(client, endpoint, tenant_id)) == 1
+
+
+async def test_an_asymmetric_link_is_NOT_collapsed_when_reversed(
+    client: AsyncClient, tenant_id, fleet_id
+) -> None:
+    """``depends_on`` reversed is a different claim, so it is a second edge."""
+    a = await _memory(client, tenant_id, fleet_id, "the dependent")
+    b = await _memory(client, tenant_id, fleet_id, "the dependency")
+
+    one = await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, b, "depends_on"))
+    two = await client.post(f"{PREFIX}/memories/{b}/relations", json=_body(tenant_id, a, "depends_on"))
+    assert one.status_code == 200 and two.status_code == 200, (one.text, two.text)
+    assert one.json()["id"] != two.json()["id"], (
+        "direction carries meaning for depends_on; collapsing it would lose the claim"
+    )
+    assert len(await _relations(client, a, tenant_id)) == 2
+
+
+async def test_supersedes_is_422_naming_the_right_field(client: AsyncClient, tenant_id, fleet_id) -> None:
+    a = await _memory(client, tenant_id, fleet_id, "older")
+    b = await _memory(client, tenant_id, fleet_id, "newer")
+    r = await client.post(f"{PREFIX}/memories/{b}/relations", json=_body(tenant_id, a, "supersedes"))
+    assert r.status_code == 422, r.text
+    assert "supersedes_id" in r.text, "the error must point the caller at the right field"
+
+
+async def test_an_unknown_relation_type_is_422(client: AsyncClient, tenant_id, fleet_id) -> None:
+    a = await _memory(client, tenant_id, fleet_id, "one")
+    b = await _memory(client, tenant_id, fleet_id, "two")
+    r = await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, b, "caused_by"))
+    assert r.status_code == 422, r.text
+
+
+async def test_self_link_is_422(client: AsyncClient, tenant_id, fleet_id) -> None:
+    a = await _memory(client, tenant_id, fleet_id, "lonely")
+    r = await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, a, "related_to"))
+    assert r.status_code == 422, r.text
+
+
+async def test_an_absent_endpoint_is_404(client: AsyncClient, tenant_id, fleet_id) -> None:
+    a = await _memory(client, tenant_id, fleet_id, "mine")
+    r = await client.post(
+        f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, str(uuid.uuid4()), "related_to")
+    )
+    assert r.status_code == 404, r.text
+
+
+async def test_a_cross_tenant_endpoint_is_404(client: AsyncClient, tenant_id, fleet_id) -> None:
+    """A link must not be usable to probe whether another tenant's memory id exists."""
+    a = await _memory(client, tenant_id, fleet_id, "mine")
+    other = await _memory(client, f"{tenant_id}-other", fleet_id, "theirs")
+    r = await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, other, "related_to"))
+    assert r.status_code == 404, r.text
+
+
+async def test_a_soft_deleted_far_endpoint_drops_out_of_the_listing(
+    client: AsyncClient, tenant_id, fleet_id
+) -> None:
+    """The edge survives (soft delete is reversible); the LISTING is what filters."""
+    a = await _memory(client, tenant_id, fleet_id, "alt one")
+    b = await _memory(client, tenant_id, fleet_id, "alt two")
+    await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, b, "alternative_to"))
+    assert len(await _relations(client, a, tenant_id)) == 1
+
+    gone = await client.delete(f"{PREFIX}/memories/{b}", params={"tenant_id": tenant_id})
+    assert gone.status_code in (200, 204), gone.text
+
+    assert await _relations(client, a, tenant_id) == [], "a soft-deleted endpoint must not be reachable"
+
+
+async def test_listing_can_filter_by_relation_type(client: AsyncClient, tenant_id, fleet_id) -> None:
+    a = await _memory(client, tenant_id, fleet_id, "hub")
+    b = await _memory(client, tenant_id, fleet_id, "spoke one")
+    c = await _memory(client, tenant_id, fleet_id, "spoke two")
+    await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, b, "elaborates"))
+    await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, c, "related_to"))
+
+    assert len(await _relations(client, a, tenant_id)) == 2
+    only = await _relations(client, a, tenant_id, relation_type="elaborates")
+    assert len(only) == 1 and only[0]["relation_type"] == "elaborates"
+
+
+async def test_metadata_round_trips_and_is_not_wiped_by_a_relink(
+    client: AsyncClient, tenant_id, fleet_id
+) -> None:
+    """Latest non-NULL metadata wins; omitting it must not erase what was recorded."""
+    a = await _memory(client, tenant_id, fleet_id, "meta source")
+    b = await _memory(client, tenant_id, fleet_id, "meta target")
+
+    first = await client.post(
+        f"{PREFIX}/memories/{a}/relations",
+        json=_body(tenant_id, b, "related_to", metadata={"why": "same incident"}),
+    )
+    assert first.json()["metadata"] == {"why": "same incident"}, first.text
+
+    again = await client.post(f"{PREFIX}/memories/{a}/relations", json=_body(tenant_id, b, "related_to"))
+    assert again.json()["metadata"] == {"why": "same incident"}, (
+        "a relink that omits metadata must COALESCE, not blank the existing value"
+    )

--- a/tests/test_memory_relations_schema.py
+++ b/tests/test_memory_relations_schema.py
@@ -1,0 +1,161 @@
+"""The ``memory_relations`` guarantees, exercised against a real database.
+
+Every assertion here corresponds to a design decision stated in
+``common/models/memory_relation.py``. They are DB-level guarantees rather than service
+conventions precisely so a direct insert cannot bypass them, and a comment claiming a
+constraint exists is worth nothing until something has watched the constraint refuse a
+write.
+
+Covered:
+  * ``supersedes`` cannot be stored here (it lives on ``memories.supersedes_id``);
+  * a memory cannot link to itself;
+  * the same (tenant, from, type, to) cannot be stored twice — what makes a repeated
+    ``memory_link`` idempotent rather than duplicating the edge;
+  * the reversed pair of a SYMMETRIC type IS accepted by the constraint, which is why
+    the service must check it — the schema alone does not make symmetry idempotent;
+  * hard-deleting an endpoint cascades the link away;
+  * SOFT-deleting an endpoint leaves the link in place, since soft delete is reversible.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from common.models.memory_relation import (
+    ALL_RELATION_TYPES,
+    DIRECTED_RELATION_TYPES,
+    STORED_RELATION_TYPES,
+    SUPERSEDES_RELATION_TYPE,
+    SYMMETRIC_RELATION_TYPES,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def _memory(db, tenant_id: str, content: str) -> uuid.UUID:
+    mid = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO memories (id, tenant_id, agent_id, memory_type, content) "
+            "VALUES (:id, :t, 'rel-agent', 'fact', :c)"
+        ),
+        {"id": mid, "t": tenant_id, "c": content},
+    )
+    return mid
+
+
+async def _link(db, tenant_id: str, a: uuid.UUID, rel: str, b: uuid.UUID) -> None:
+    await db.execute(
+        text(
+            "INSERT INTO memory_relations (tenant_id, from_memory_id, relation_type, to_memory_id) "
+            "VALUES (:t, :a, :r, :b)"
+        ),
+        {"t": tenant_id, "a": a, "r": rel, "b": b},
+    )
+
+
+async def _count(db, a: uuid.UUID) -> int:
+    return (
+        await db.execute(
+            text(
+                "SELECT count(*) FROM memory_relations "
+                "WHERE from_memory_id = :a OR to_memory_id = :a"
+            ),
+            {"a": a},
+        )
+    ).scalar_one()
+
+
+def test_the_relation_vocabulary_matches_the_contract() -> None:
+    """No DB. ``mcp-tools.md`` §8 names six types; five are stored, one is routed."""
+    assert ALL_RELATION_TYPES == {
+        "supersedes",
+        "elaborates",
+        "contradicts",
+        "depends_on",
+        "alternative_to",
+        "related_to",
+    }
+    assert SUPERSEDES_RELATION_TYPE not in STORED_RELATION_TYPES, (
+        "supersedes must NOT be in the stored set — it reuses memories.supersedes_id, "
+        "and the CHECK constraint refuses it in this table"
+    )
+    assert SYMMETRIC_RELATION_TYPES.isdisjoint(DIRECTED_RELATION_TYPES)
+    assert STORED_RELATION_TYPES == SYMMETRIC_RELATION_TYPES | DIRECTED_RELATION_TYPES
+
+
+async def test_supersedes_cannot_be_stored_in_this_table(db, tenant_id) -> None:
+    """The routing decision is structural, not a convention the service may forget."""
+    a = await _memory(db, tenant_id, "older claim")
+    b = await _memory(db, tenant_id, "newer claim")
+    with pytest.raises(
+        IntegrityError, match="ck_memory_relations_supersedes_not_stored"
+    ):
+        await _link(db, tenant_id, b, SUPERSEDES_RELATION_TYPE, a)
+
+
+async def test_a_memory_cannot_link_to_itself(db, tenant_id) -> None:
+    a = await _memory(db, tenant_id, "sole memory")
+    with pytest.raises(IntegrityError, match="ck_memory_relations_no_self_link"):
+        await _link(db, tenant_id, a, "related_to", a)
+
+
+async def test_the_same_link_cannot_be_stored_twice(db, tenant_id) -> None:
+    """What makes a repeated ``memory_link`` call idempotent at the storage layer."""
+    a = await _memory(db, tenant_id, "detail source")
+    b = await _memory(db, tenant_id, "detail target")
+    await _link(db, tenant_id, a, "elaborates", b)
+    with pytest.raises(IntegrityError, match="uq_memory_relations_natural_key"):
+        await _link(db, tenant_id, a, "elaborates", b)
+
+
+async def test_the_reversed_pair_of_a_symmetric_type_is_NOT_blocked_by_the_schema(
+    db, tenant_id
+) -> None:
+    """The schema does not make symmetry idempotent — the service must.
+
+    ``(A, contradicts, B)`` and ``(B, contradicts, A)`` are the same claim, but they are
+    different rows under the natural key, so the constraint accepts both. This test
+    exists to pin that gap: it is the reason the write path checks the reversed pair for
+    a symmetric type, and if someone ever makes the schema enforce it, this test should
+    fail and be replaced rather than deleted.
+    """
+    a = await _memory(db, tenant_id, "claim one")
+    b = await _memory(db, tenant_id, "claim two")
+    await _link(db, tenant_id, a, "contradicts", b)
+    await _link(db, tenant_id, b, "contradicts", a)  # accepted, and semantically a dup
+    assert await _count(db, a) == 2
+
+
+async def test_hard_deleting_an_endpoint_cascades_the_link_away(db, tenant_id) -> None:
+    a = await _memory(db, tenant_id, "depends on target")
+    b = await _memory(db, tenant_id, "the dependency")
+    await _link(db, tenant_id, a, "depends_on", b)
+    assert await _count(db, a) == 1
+    await db.execute(text("DELETE FROM memories WHERE id = :b"), {"b": b})
+    assert await _count(db, a) == 0, (
+        "ON DELETE CASCADE is what makes the purge sweep the only cleanup this table "
+        "needs; without it a purged memory leaves dangling edges"
+    )
+
+
+async def test_soft_deleting_an_endpoint_LEAVES_the_link(db, tenant_id) -> None:
+    """Soft delete is reversible, so it must not destroy edges.
+
+    The link stops being *returned* because the read path joins ``memories`` and filters
+    ``deleted_at IS NULL`` — but the row survives, so undeleting the memory restores its
+    graph rather than silently losing it.
+    """
+    a = await _memory(db, tenant_id, "alternative one")
+    b = await _memory(db, tenant_id, "alternative two")
+    await _link(db, tenant_id, a, "alternative_to", b)
+    await db.execute(
+        text("UPDATE memories SET deleted_at = now() WHERE id = :b"), {"b": b}
+    )
+    assert await _count(db, a) == 1, (
+        "a soft delete must leave the edge intact; cascading here would make undelete lossy"
+    )

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"036"}, f"Expected single head '036', got {sorted(heads)}"
+        assert heads == {"037"}, f"Expected single head '037', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()


### PR DESCRIPTION
**Stacked on #780** — based on `feat/memory-relations`, so the diff shows only this step. Retarget to `main` once #780 merges.

## What

An idempotent upsert and a both-directions listing on the table #780 adds: `POST|GET /memories/{memory_id}/relations`.

Still nothing agent-facing — no core-api route, no dispatcher wiring, and `memory_link` stays unadvertised. memclawd's `TestAdvertisedToolsAreAllServable` gates that on the full chain existing.

## Idempotency is the substance

A repeated link returns the existing row rather than 409-ing. `relation_add` (the entity equivalent) documents why at length: it was a plain INSERT once, and the IntegrityError cluster that followed became 5xx storms with rows committed while the caller retried. An agent re-issuing `memory_link` must not reproduce that.

**Symmetric types also match the reversed pair.** `(A contradicts B)` and `(B contradicts A)` are one claim but two rows under the natural key — the schema accepts both, deliberately pinned by #780's tests — so the collapse has to happen in the service. The first caller's direction is preserved; the reversed call returns the existing row rather than re-pointing it. Asymmetric types are **not** collapsed, since a reversed `depends_on` is a different claim.

A race is left open and documented: two concurrent calls writing opposite directions of the same symmetric link can both pass the check. It's benign — a duplicate edge, not corruption — on an agent-initiated, low-rate write. Closing it properly means a partial unique index over `(tenant_id, least(from,to), greatest(from,to), relation_type)` scoped to the symmetric types, at the cost of a more awkward `ON CONFLICT` target. Worth doing if duplicates are ever observed; not worth pre-empting.

## Other behaviour

- `supersedes` → **422 naming `memories.supersedes_id`**, not a 500 from the CHECK constraint. Unknown types and self-links are 422 for the same reason: validated before touching the database.
- Both endpoints must exist, be live, and belong to the tenant, so a link can't be used to probe whether another tenant's memory id exists — flat 404 either way.
- The listing returns both directions unconditionally and omits links whose far endpoint is soft-deleted. That filter is the only thing stopping a soft-deleted memory reappearing through its graph, since soft delete deliberately leaves the edge intact.

## Three bugs the tests caught, one root cause

`metadata` is reserved on a declarative class — it resolves to `Base.metadata`, the SQLAlchemy `MetaData` object — which is why the mapped attribute is `metadata_`. That collision bit in three separate places, each failing only at **execute** time with `AttributeError: 'MetaData' object has no attribute '_bulk_update_tuples'`, a long way from its cause:

1. `.values(**data)` with the wire key `"metadata"`;
2. the `on_conflict_do_update` `set_` key — the ORM attribute name `"metadata_"` leaks into SQL as a column name, so it must be keyed by the **Column object**;
3. binding Python `None` to a JSONB column stores JSON `null`, which is not SQL NULL — so the COALESCE would have treated an omitted field as a real value and blanked what an earlier link recorded. `metadata` is now omitted entirely when absent.

Only (1) was visible at first; (2) and (3) surfaced one at a time as each fix uncovered the next. All three sites carry a comment, because the failure mode gives no hint about the cause. Worth noting the endpoint would have "worked" for the common path with (3) unfixed — it only loses data on a relink.

## Measurement

| | result |
|---|---|
| `core-storage-api/tests/` | 118 → **129** (+11, the new tests) on a fresh database |
| `tests/` | 4389, unchanged |
| mypy | clean |
| ruff check / format | clean at CI's scopes |

## Remaining chain

3. core-api route
4. `supersedes` path — `PATCH /memories/{id}/status` already has the full authz stack and already reaches a storage layer supporting `supersedes_id` / `unset_supersedes` / `expected_supersedes_id`; it forwards none of them. Use the CAS gate so an API write can't clobber the detector's pointer.
5. memclawd: `cloud.Client` method, `CloudLinker`, `newCloudDispatcher` wiring, a real input schema, then re-advertise in `tools/list`
6. a `BROKER_OPERATIONS` row here