### PR TITLE
feat(embeddings): make stale vectors detectable via embedding provenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ reports/
 !core-storage-api/uv.lock
 !core-worker/uv.lock
 !core-operations/uv.lock
+
+# Coverage data files. Untracked-but-present artefacts kept getting swept
+# into commits by `git add -A` (twice during the 2026-08 embedding work).
+.coverage
+.coverage.*

--- a/common/models/memory.py
+++ b/common/models/memory.py
@@ -42,6 +42,25 @@ class Memory(Base):
     )
     title: Mapped[str | None] = mapped_column(Text)
     content_hash: Mapped[str | None] = mapped_column(Text)
+    # Provenance for ``embedding``: the ``content_hash`` of the text the
+    # vector was actually computed from. Without it a vector left over
+    # from earlier content is byte-identical to a correct one, so a
+    # mis-embedded row is undetectable — ``embedding IS NOT NULL`` says
+    # only that *something* was embedded, never *what*.
+    #
+    # Staleness is then expressible:
+    #     embedding IS NOT NULL
+    #     AND embedded_content_hash IS NOT NULL      -- provenance known
+    #     AND embedded_content_hash IS DISTINCT FROM content_hash
+    #
+    # NULL means "provenance unknown", NOT "stale": every row written
+    # before migration 037 has no recorded hash, and calling those stale
+    # would report the entire historical corpus as damaged.
+    #
+    # Which is why the second line is load-bearing rather than redundant:
+    # ``NULL IS DISTINCT FROM <hash>`` is TRUE, so dropping it silently
+    # folds every unknown row into the stale count.
+    embedded_content_hash: Mapped[str | None] = mapped_column(Text)
     # Per-attempt idempotency token (CAURA-602). Server-derived from
     # ``X-Bulk-Attempt-Id + ":" + index`` on the bulk path; NULL for
     # single-write and pre-rollout rows. The partial unique index

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -807,14 +807,22 @@ class CoreStorageClient:
         memory_id: str,
         tenant_id: str,
         embedding: list[float],
+        embedded_content_hash: str | None = None,
     ) -> dict | None:
         # ``tenant_id`` (the row's home tenant) scopes the by-id embedding
         # write so a worker/backfill can't overwrite a foreign tenant's
         # vector.
-        return await self._patch(
-            f"/memories/{memory_id}/embedding",
-            {"embedding": embedding, "tenant_id": tenant_id},
-        )
+        #
+        # ``embedded_content_hash`` is the hash of the text this caller
+        # embedded. Pass it whenever the content is in hand: it is what makes
+        # a later content change detectable as a stale vector. Omitting it
+        # records provenance as unknown rather than guessing — storage will
+        # NOT infer it from the row, because the row can move between the
+        # caller's read and this write.
+        payload: dict[str, Any] = {"embedding": embedding, "tenant_id": tenant_id}
+        if embedded_content_hash is not None:
+            payload["embedded_content_hash"] = embedded_content_hash
+        return await self._patch(f"/memories/{memory_id}/embedding", payload)
 
     async def update_memory_entities(
         self,

--- a/core-api/src/core_api/routes/lifecycle.py
+++ b/core-api/src/core_api/routes/lifecycle.py
@@ -267,6 +267,8 @@ async def embedding_coverage_all_tenants(
             "total_active": coverage.get("total_active"),
             "missing_embeddings": coverage.get("missing_embeddings"),
             "tenants_with_missing": coverage.get("tenants_with_missing"),
+            "stale_embeddings": coverage.get("stale_embeddings"),
+            "unknown_provenance": coverage.get("unknown_provenance"),
         },
     )
     return coverage

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2041,7 +2041,16 @@ async def _reembed_memory(
                 )
             )
             return
-        await sc.update_embedding(str(memory_id), tenant_id, embedding)
+        # Record WHICH text this vector came from. ``content`` is the string
+        # just embedded above, so hashing it here — rather than letting
+        # storage read the row's current hash — keeps the record accurate
+        # even if a content PATCH landed while we were embedding.
+        await sc.update_embedding(
+            str(memory_id),
+            tenant_id,
+            embedding,
+            embedded_content_hash=_content_hash(tenant_id, mem.get("fleet_id"), content),
+        )
         logger.info("Background re-embed succeeded for memory %s", memory_id)
     except (TimeoutError, ValueError, RuntimeError, OpenAIError, GoogleAPIError):
         logger.exception("Background re-embed error for memory %s", memory_id)
@@ -2235,7 +2244,14 @@ async def _reembed_memories_bulk(
             )
             continue
         try:
-            await sc.update_embedding(str(memory_id), tenant_id, embedding)
+            # Same provenance stamp as the single-row path above: hash the
+            # text we embedded, not whatever the row says now.
+            await sc.update_embedding(
+                str(memory_id),
+                tenant_id,
+                embedding,
+                embedded_content_hash=_content_hash(tenant_id, mem.get("fleet_id"), content),
+            )
         except Exception:
             # Broad match for the same reason as the outer batch-call
             # except: httpx-layer errors, pool exhaustion, auth, etc.

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -175,10 +175,25 @@ async def run_embedding_coverage_tick() -> None:
             "total_active": coverage.get("total_active"),
             "missing_embeddings": coverage.get("missing_embeddings"),
             "tenants_with_missing": coverage.get("tenants_with_missing"),
+            # A vector computed from text the row no longer holds. Tracked
+            # separately from ``missing`` because the nightly sweep CANNOT
+            # repair it — the column is non-NULL, so the sweep never sees the
+            # row. A rising number here means silently degraded recall.
+            "stale_embeddings": coverage.get("stale_embeddings"),
+            "tenants_with_stale": coverage.get("tenants_with_stale"),
+            # Embedded before provenance existed: undetermined, not damaged.
+            # Expected to fall over time; it is a measurement gap closing, so
+            # do not alert on it.
+            "unknown_provenance": coverage.get("unknown_provenance"),
             "tenant_count": len(tenants),
         },
     )
-    reported = [t for t in tenants if t.get("missing_embeddings")][:_COVERAGE_TENANT_LOG_CAP]
+    # A tenant is worth a line if it has EITHER defect. Filtering on missing
+    # alone would hide a tenant whose rows are all embedded but wrong — the
+    # exact case this release makes visible.
+    reported = [t for t in tenants if t.get("missing_embeddings") or t.get("stale_embeddings")][
+        :_COVERAGE_TENANT_LOG_CAP
+    ]
     for tenant in reported:
         logger.info(
             "embedding coverage tenant",
@@ -186,14 +201,16 @@ async def run_embedding_coverage_tick() -> None:
                 "tenant_id": tenant.get("tenant_id"),
                 "total_active": tenant.get("total_active"),
                 "missing_embeddings": tenant.get("missing_embeddings"),
+                "stale_embeddings": tenant.get("stale_embeddings"),
+                "unknown_provenance": tenant.get("unknown_provenance"),
                 "coverage_pct": tenant.get("coverage_pct"),
             },
         )
-    with_missing = coverage.get("tenants_with_missing") or 0
-    if with_missing > len(reported):
+    affected = sum(1 for t in tenants if t.get("missing_embeddings") or t.get("stale_embeddings"))
+    if affected > len(reported):
         logger.info(
             "embedding coverage per-tenant lines truncated",
-            extra={"reported": len(reported), "tenants_with_missing": with_missing},
+            extra={"reported": len(reported), "tenants_affected": affected},
         )
 
 

--- a/core-operations/tests/test_tasks.py
+++ b/core-operations/tests/test_tasks.py
@@ -307,7 +307,9 @@ async def test_embedding_coverage_tick_caps_per_tenant_lines_and_says_so(monkeyp
     truncated = _records(caplog, "embedding coverage per-tenant lines truncated")
     assert len(truncated) == 1
     assert truncated[0].reported == tasks._COVERAGE_TENANT_LOG_CAP
-    assert truncated[0].tenants_with_missing == over
+    # ``tenants_affected`` counts BOTH defects — a tenant whose rows are all
+    # embedded but stale is just as worth a line as one missing embeddings.
+    assert truncated[0].tenants_affected == over
 
     # The deployment-wide total is never truncated.
     assert _records(caplog, "embedding coverage total")[0].missing_embeddings == over
@@ -346,3 +348,49 @@ async def test_embedding_coverage_tick_swallows_non_json(monkeypatch, caplog):
 
     assert _records(caplog, "embedding coverage total") == []
     assert len(_records(caplog, "embedding-coverage returned non-JSON; will retry next tick")) == 1
+
+
+@pytest.mark.asyncio
+async def test_embedding_coverage_tick_reports_stale_separately(monkeypatch, caplog):
+    """Stale must not be folded into missing.
+
+    The nightly sweep repairs ``missing`` and CANNOT repair ``stale`` (the
+    column is non-NULL, so the sweep never sees the row). Collapsing them
+    would make a rising stale count look like something already being fixed.
+    """
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    body = {
+        "tenants": [
+            {
+                "tenant_id": "t-stale",
+                "total_active": 100,
+                "missing_embeddings": 0,
+                "stale_embeddings": 7,
+                "unknown_provenance": 3,
+                "coverage_pct": 100.0,
+            }
+        ],
+        "total_active": 100,
+        "missing_embeddings": 0,
+        "tenants_with_missing": 0,
+        "stale_embeddings": 7,
+        "tenants_with_stale": 1,
+        "unknown_provenance": 3,
+    }
+    caplog.set_level("INFO", logger=tasks.logger.name)
+    async with _patch_client(monkeypatch, response=_StubResponse(200, body)):
+        await tasks.run_embedding_coverage_tick()
+
+    total = _records(caplog, "embedding coverage total")[0]
+    assert total.missing_embeddings == 0
+    assert total.stale_embeddings == 7
+    assert total.unknown_provenance == 3
+
+    # The tenant has ZERO missing but 7 stale — it must still get a line.
+    # Filtering on missing alone would hide exactly the case this release
+    # exists to surface.
+    per_tenant = _records(caplog, "embedding coverage tenant")
+    assert [r.tenant_id for r in per_tenant] == ["t-stale"]
+    assert per_tenant[0].stale_embeddings == 7

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/037_memories_embedded_content_hash.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/037_memories_embedded_content_hash.py
@@ -1,0 +1,107 @@
+"""Embedding provenance: ``memories.embedded_content_hash``.
+
+``memories`` carries ``embedding`` and ``content_hash``, but nothing recording
+WHICH content a given vector was computed from. A vector left over from earlier
+content is therefore byte-identical to a correct one: ``embedding IS NOT NULL``
+says only that something was embedded, never what. That made mis-embedded rows
+undetectable — the NULL-embedding sweep cannot see them (the column is
+non-NULL), and no query could distinguish them.
+
+This column records the ``content_hash`` of the text the vector was actually
+computed from, making staleness expressible:
+
+    embedding IS NOT NULL
+    AND embedded_content_hash IS NOT NULL          -- provenance known
+    AND embedded_content_hash IS DISTINCT FROM content_hash
+
+The ``IS NOT NULL`` term is load-bearing and easy to drop by accident. NULL
+means "provenance unknown", and ``NULL IS DISTINCT FROM <hash>`` evaluates to
+TRUE — so omitting it silently reclassifies every pre-migration row as stale,
+which is precisely the conclusion this migration exists to avoid.
+
+``IS DISTINCT FROM`` rather than ``<>`` for the comparison itself: ``<>``
+against a NULL yields NULL, so a row would drop out of a ``WHERE`` clause
+rather than being counted either way. Both halves are needed — one to keep
+unknown OUT of stale, the other to stop rows vanishing.
+
+NO BACKFILL, deliberately. Existing rows get NULL, which means "provenance
+unknown" — NOT "stale". The two must stay distinct: marking every pre-migration
+row stale would report the whole historical corpus as damaged, and marking it
+fresh would assert a correctness we cannot know. Rows acquire provenance as
+they are written or re-embedded, so the unknown bucket drains on its own.
+
+The partial index carries the ``IS NOT NULL`` term. Without it the index would
+cover every unknown-provenance row — on day one, the entire pre-migration table
+— making a "partial" index a full-table one and inverting the reason for making
+it partial at all.
+
+It does NOT carry the detector's ``status IN LIVE_MEMORY_STATUSES`` filter, so
+it is BROADER than the query it serves. That is deliberate, not an oversight.
+``LIVE_MEMORY_STATUSES`` is a Python tuple in ``common/constants.py``; copying
+its members into an immutable migration would put the same rule in two places
+with nothing checking they agree — the exact failure this column exists to
+expose, and one this PR hit twice already (an index predicate broader than the
+detector, then an ORM comparison narrower than it). A literal here would rot
+silently the first time that tuple changes.
+
+The cost is bounded. The index is already restricted to rows whose vector
+disagrees with their content, which in a healthy corpus is near zero whatever
+the status, so the status term adds little further selectivity. Measured on a
+deliberately pathological seed — every row stale, statuses spread evenly — the
+index covered 3002 rows against the 1002 the query wanted; on a realistic
+corpus both are small. Postgres still uses it for the narrower query, applying
+``status`` as a filter on top (verified with EXPLAIN), so this is a size
+question and not a correctness one.
+
+Revision ID: 037
+Revises: 036
+Create Date: 2026-08-15
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "037"
+down_revision: str | None = "036"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Metadata-only on PG11+: a nullable ADD COLUMN with no default rewrites
+    # nothing, so this is safe in-transaction on a large table.
+    op.add_column(
+        "memories",
+        sa.Column("embedded_content_hash", sa.Text(), nullable=True),
+    )
+    # CONCURRENTLY, in an autocommit block — ``memories`` is one of the known
+    # large tables. A plain in-transaction CREATE INDEX takes an AccessExclusive
+    # lock that blocks writes AND holds the migration advisory lock for the whole
+    # build; that is what crashed 6 storage-writer boots on 2026-06-16 (migration
+    # 025 indexed ``audit_log`` without it).
+    #
+    # ``op.execute`` with the ``CREATE INDEX ... ON <table>`` prefix on ONE
+    # source line, as literal SQL: ``test_no_plain_create_index_on_large_tables``
+    # regex-scans for exactly that shape. The first version of this migration
+    # used ``op.create_index(...)``, which the guard does not inspect at all —
+    # it passed while carrying precisely the defect the guard exists to prevent.
+    with op.get_context().autocommit_block():
+        # A CONCURRENTLY build that fails leaves an INVALID index behind, and a
+        # retry would then trip over the existing name. Dropping first makes the
+        # migration re-runnable after a failed attempt.
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_memories_stale_embedding")
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_memories_stale_embedding ON memories (tenant_id) "
+            "WHERE embedding IS NOT NULL "
+            "AND embedded_content_hash IS NOT NULL "
+            "AND embedded_content_hash IS DISTINCT FROM content_hash "
+            "AND deleted_at IS NULL"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_memories_stale_embedding")
+    op.drop_column("memories", "embedded_content_hash")

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -763,11 +763,21 @@ async def get_embedding_coverage(
     and made coverage read high on any tenant with more missing rows than
     that.
     """
-    missing = await _svc.memory_count_missing_embeddings(tenant_id, fleet_id)
-    total = await _svc.memory_count_active(tenant_id, fleet_id)
+    # One statement for all four counts, mirroring /embedding-coverage-all.
+    # Separate queries would not only cost extra round trips on a route ops
+    # tooling polls — they cannot see a consistent snapshot, so a concurrent
+    # write could leave the buckets failing to add up to the total they are
+    # reported against.
+    #
+    # The provenance counts are reported here as well as in the cross-tenant
+    # view: omitting them would make this route read as "no stale rows" for a
+    # tenant the aggregate flags, and absence is indistinguishable from zero.
+    total, missing, stale, unknown = await _svc.memory_embedding_coverage_for_tenant(tenant_id, fleet_id)
     return {
         "total_active": total,
         "missing_embeddings": missing,
+        "stale_embeddings": stale,
+        "unknown_provenance": unknown,
         "coverage_pct": round((total - missing) / total * 100, 1) if total > 0 else 0.0,
     }
 
@@ -790,6 +800,14 @@ async def get_embedding_coverage_all() -> dict:
         "total_active": sum(r["total_active"] for r in rows),
         "missing_embeddings": sum(r["missing_embeddings"] for r in rows),
         "tenants_with_missing": sum(1 for r in rows if r["missing_embeddings"]),
+        # Vectors computed from text the row no longer holds. Reported
+        # separately from ``missing`` because the repair differs: a missing
+        # vector is swept automatically, a stale one is invisible to that
+        # sweep and needs a re-embed of the row as it stands now.
+        "stale_embeddings": sum(r["stale_embeddings"] for r in rows),
+        "tenants_with_stale": sum(1 for r in rows if r["stale_embeddings"]),
+        # Embedded before provenance was recorded — undetermined, not damaged.
+        "unknown_provenance": sum(r["unknown_provenance"] for r in rows),
     }
 
 
@@ -1726,6 +1744,11 @@ async def update_embedding(memory_id: UUID, request: Request) -> dict:
         tenant_id=tenant_id,
         embedding=body["embedding"],
         metadata=body.get("metadata"),
+        # Optional: the hash of the text the caller actually embedded. Absent
+        # leaves provenance NULL ("unknown"), which is honest — the service
+        # deliberately does not infer it from the row, since the row may have
+        # moved on while the caller was embedding.
+        embedded_content_hash=body.get("embedded_content_hash"),
     )
     if not updated:
         # No row for this (id, tenant) — surface 404 rather than a silent

--- a/core-storage-api/src/core_storage_api/schemas.py
+++ b/core-storage-api/src/core_storage_api/schemas.py
@@ -70,6 +70,11 @@ MEMORY_FIELDS: list[str] = [
     "created_at",
     "title",
     "content_hash",
+    # Which content the row's vector was computed from (migration 037).
+    # Exposed so a single row's provenance can be inspected — without it the
+    # only view is the aggregate coverage counters, which tell an operator that
+    # N rows are stale but never which, or why a specific row was classified.
+    "embedded_content_hash",
     "client_request_id",
     "expires_at",
     "deleted_at",

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -534,7 +534,27 @@ class PostgresService:
 
     @staticmethod
     def _filter_memory_fields(data: dict) -> dict:
-        return {k: v for k, v in data.items() if k in _MEMORY_VALID_FIELDS}
+        out = {k: v for k, v in data.items() if k in _MEMORY_VALID_FIELDS}
+        # Stamp embedding provenance on insert. Both single (``memory_add``)
+        # and bulk (``memory_add_all``) go through here, so the two cannot
+        # drift apart — the reason this lives in the shared mapper rather
+        # than in each caller.
+        #
+        # Only when the row is inserted WITH a vector: a row created with
+        # ``embedding=None`` (deferred mode, or a failed inline embed) gets
+        # its provenance later, from whichever path supplies the vector.
+        # Writing a hash now would describe an embedding that does not exist.
+        #
+        # An explicit ``embedded_content_hash`` from the caller wins — a
+        # re-embed path that knows exactly which text it encoded is a better
+        # authority than this inference.
+        if (
+            out.get("embedding") is not None
+            and out.get("content_hash")
+            and not out.get("embedded_content_hash")
+        ):
+            out["embedded_content_hash"] = out["content_hash"]
+        return out
 
     async def memory_add(self, data: dict) -> Memory:
         async with get_session() as session:
@@ -725,6 +745,35 @@ class PostgresService:
         values: dict = {
             key: val for key, val in patch.items() if key != "metadata_patch" and hasattr(Memory, key)
         }
+        # Embedding provenance, derived here rather than at every call site.
+        # A patch that rewrites ``content`` carries the new ``content_hash``
+        # and the re-embedded vector together (see ``update_memory``), so the
+        # hash in THIS patch is by construction the text the vector was
+        # computed from. Stamping it keeps the row self-describing.
+        #
+        # Both keys must be present. Embedding without content_hash cannot be
+        # attributed, and content_hash without embedding means the text moved
+        # while the vector did not — precisely the stale state, which must
+        # keep its OLD provenance so the mismatch stays visible. Overwriting
+        # it there would forge freshness.
+        #
+        # ``embedding = None`` (a failed re-embed, per caura#775) clears
+        # provenance too: the row is genuinely unembedded, and leaving a hash
+        # behind would describe a vector that no longer exists.
+        # An explicit ``embedded_content_hash`` in the same patch WINS over this
+        # derivation, matching ``_filter_memory_fields`` on the insert path. A
+        # caller that names the hash knows which text it encoded; this branch is
+        # only an inference from "content and embedding moved together".
+        #
+        # Latent today — core-worker's PATCH sends ``embedded_content_hash``
+        # without ``content_hash``, so no caller currently hits all three — but
+        # the failure it prevents is the bad direction: overriding a caller's
+        # hash with the row's new one would stamp a genuinely stale write as
+        # freshly embedded, which is precisely what this column exists to catch.
+        if "embedding" in values and "content_hash" in values and "embedded_content_hash" not in values:
+            values["embedded_content_hash"] = (
+                values["content_hash"] if values["embedding"] is not None else None
+            )
         async with get_session() as session:
             # Existence check FIRST — runs even on empty / all-unknown-
             # keys patches so a PATCH on an absent or soft-deleted row
@@ -868,6 +917,7 @@ class PostgresService:
         tenant_id: str,
         embedding: list[float],
         metadata: dict | None = None,
+        embedded_content_hash: str | None = None,
     ) -> bool:
         # ``tenant_id`` scopes the write to the row's home tenant: a
         # memory_id from another tenant matches no row, so a stale or
@@ -875,8 +925,23 @@ class PostgresService:
         # Returns whether a row matched so the route can surface a 404 on
         # a no-op (mirrors memory_update / memory_update_status) instead of
         # a silent 200 that lets callers over-count successful writes.
+        #
+        # ``embedded_content_hash`` is the hash of the text the CALLER
+        # embedded, and is deliberately a parameter rather than being read
+        # off the row here. Copying the row's current ``content_hash`` would
+        # be wrong in exactly the case this column exists to catch: the
+        # worker fetches content, embeds it, then writes back, and a content
+        # PATCH landing inside that window means the row it writes has moved
+        # on. Reading the hash at write time would stamp the NEW hash onto a
+        # vector computed from the OLD text — recording the row as freshly
+        # embedded at the precise moment it became stale.
+        #
+        # Left NULL when the caller does not supply it: unknown provenance is
+        # honest, a wrong hash is not.
         async with get_session() as session:
             values: dict = {"embedding": embedding}
+            if embedded_content_hash is not None:
+                values["embedded_content_hash"] = embedded_content_hash
             if metadata is not None:
                 values["metadata_"] = metadata
             result = await session.execute(
@@ -2460,6 +2525,55 @@ class PostgresService:
             result = await session.execute(stmt)
             return result.scalar() or 0
 
+    async def memory_embedding_coverage_for_tenant(
+        self,
+        tenant_id: str,
+        fleet_id: str | None = None,
+    ) -> tuple[int, int, int, int]:
+        """``(total_active, missing, stale, unknown_provenance)`` for one tenant.
+
+        The per-tenant twin of ``memory_embedding_coverage_by_tenant``, and the
+        single source for ``GET /embedding-coverage``. Without the provenance
+        counts that route omits the keys entirely, and a caller comparing it
+        against ``/embedding-coverage-all`` reads "no stale rows" where the
+        aggregate says otherwise — absence looking like zero.
+
+        All four counts in ONE statement, mirroring the aggregate. The route
+        previously issued three sequential queries; besides the extra round
+        trips on an ops-polled endpoint, separate statements cannot see a
+        consistent snapshot, so a concurrent write could make the buckets fail
+        to add up to the total it is reported against.
+
+        Same population predicate and the same ``is_distinct_from`` NULL
+        handling as the aggregate; keep the two in step.
+        """
+        async with get_read_session() as session:
+            stmt = (
+                select(
+                    func.count(),
+                    func.count().filter(Memory.embedding.is_(None)),
+                    func.count().filter(
+                        Memory.embedding.isnot(None),
+                        Memory.embedded_content_hash.isnot(None),
+                        Memory.embedded_content_hash.is_distinct_from(Memory.content_hash),
+                    ),
+                    func.count().filter(
+                        Memory.embedding.isnot(None),
+                        Memory.embedded_content_hash.is_(None),
+                    ),
+                )
+                .select_from(Memory)
+                .where(
+                    Memory.tenant_id == tenant_id,
+                    Memory.status.in_(LIVE_MEMORY_STATUSES),
+                    Memory.deleted_at.is_(None),
+                )
+            )
+            if fleet_id:
+                stmt = stmt.where(Memory.fleet_id == fleet_id)
+            row = (await session.execute(stmt)).one()
+        return int(row[0] or 0), int(row[1] or 0), int(row[2] or 0), int(row[3] or 0)
+
     async def memory_embedding_coverage_by_tenant(self) -> list[dict]:
         """Embedding coverage for EVERY tenant, in one pass.
 
@@ -2482,14 +2596,51 @@ class PostgresService:
 
         Returns rows worst-first so the head of the list is the actionable part.
         Counts only — no memory content crosses this boundary.
+
+        Three distinct states, deliberately not collapsed:
+
+        * ``missing`` — no vector at all. The nightly sweep repairs these.
+        * ``stale`` — a vector computed from DIFFERENT text than the row now
+          holds (``embedded_content_hash`` disagrees with ``content_hash``).
+          Non-NULL, so no NULL-based sweep can see it; recall silently ranks
+          the row against text it no longer has.
+        * ``unknown_provenance`` — embedded, but written before migration 037,
+          so there is no hash to compare. NOT stale: it is undetermined.
+          Reporting it as stale would flag the entire historical corpus as
+          damaged; reporting it as fresh would assert a correctness nobody
+          verified. It drains as rows are rewritten or re-embedded.
         """
         missing = func.count().filter(Memory.embedding.is_(None))
+        stale = func.count().filter(
+            Memory.embedding.isnot(None),
+            Memory.embedded_content_hash.isnot(None),
+            # ``is_distinct_from``, NOT ``!=``. SQLAlchemy's ``!=`` compiles to
+            # plain ``<>``, which yields NULL when ``content_hash`` is NULL (it
+            # is a nullable column) — and ``COUNT(*) FILTER`` drops NULL. Such a
+            # row has a KNOWN provenance hash, so it is not ``unknown``; it has
+            # an embedding, so it is not ``missing``; and the NULL comparison
+            # kept it out of ``stale``. It counted in ``total_active`` and in no
+            # defect bucket at all — silently unaccounted for by the very
+            # detector this column exists to provide.
+            #
+            # This also keeps the ORM in step with the migration's partial index
+            # predicate, which uses IS DISTINCT FROM. The two encode one rule in
+            # two languages and nothing checks they agree, so they must be read
+            # together whenever either changes.
+            Memory.embedded_content_hash.is_distinct_from(Memory.content_hash),
+        )
+        unknown = func.count().filter(
+            Memory.embedding.isnot(None),
+            Memory.embedded_content_hash.is_(None),
+        )
         async with get_read_session() as session:
             stmt = (
                 select(
                     Memory.tenant_id,
                     func.count().label("total_active"),
                     missing.label("missing_embeddings"),
+                    stale.label("stale_embeddings"),
+                    unknown.label("unknown_provenance"),
                 )
                 .select_from(Memory)
                 .where(
@@ -2497,7 +2648,12 @@ class PostgresService:
                     Memory.deleted_at.is_(None),
                 )
                 .group_by(Memory.tenant_id)
-                .order_by(missing.desc())
+                # Worst-first on what is actionable TODAY: a stale row is
+                # actively wrong, a missing one is merely absent, so stale
+                # leads. Unknown is not ranked — it is a measurement gap, not
+                # a defect, and letting it sort the list would bury real
+                # damage under untriaged history.
+                .order_by((stale + missing).desc())
             )
             rows = (await session.execute(stmt)).all()
         return [
@@ -2505,6 +2661,8 @@ class PostgresService:
                 "tenant_id": row.tenant_id,
                 "total_active": int(row.total_active or 0),
                 "missing_embeddings": int(row.missing_embeddings or 0),
+                "stale_embeddings": int(row.stale_embeddings or 0),
+                "unknown_provenance": int(row.unknown_provenance or 0),
                 "coverage_pct": (
                     round((row.total_active - row.missing_embeddings) / row.total_active * 100, 1)
                     if row.total_active

--- a/core-worker/src/core_worker/clients/storage_client.py
+++ b/core-worker/src/core_worker/clients/storage_client.py
@@ -185,6 +185,7 @@ async def update_memory_embedding(
     memory_id: UUID,
     tenant_id: str,
     embedding: list[float],
+    embedded_content_hash: str | None = None,
 ) -> None:
     """PATCH the embedding onto the memory row.
 
@@ -202,15 +203,36 @@ async def update_memory_embedding(
     deferring the embed; clear it via ``metadata_patch`` on the same
     PATCH so a read-after-success returns clean state instead of
     confusingly claiming the row is still pending.
+
+    ``embedded_content_hash`` records WHICH text this vector came from
+    (migration 037). This is the deferred/SaaS write path, so without it
+    every row embedded here would sit at ``unknown_provenance`` forever
+    and the staleness detector would be blind to exactly the deployment
+    mode that does the embedding.
+
+    Sent as its own key rather than as ``content_hash``: storage stamps
+    provenance from ``content_hash`` only when it is patching ``content``
+    too, and ``content_hash`` is a real column — sending it here would
+    WRITE it, overwriting the row's hash with a value from an event that
+    may already be stale. The explicit key sets provenance alone and
+    touches nothing else.
+
+    Stays on ``PATCH /memories/{id}`` rather than the dedicated
+    ``/embedding`` route: that route replaces ``metadata`` wholesale,
+    which would clobber every key the ``metadata_patch`` merge above
+    exists to preserve.
     """
+    body: dict = {
+        "tenant_id": tenant_id,
+        "embedding": embedding,
+        "metadata_patch": {"embedding_pending": False},
+    }
+    if embedded_content_hash is not None:
+        body["embedded_content_hash"] = embedded_content_hash
     resp = await _signed_call(
         client.patch,
         f"{_PREFIX}/memories/{memory_id}",
-        json={
-            "tenant_id": tenant_id,
-            "embedding": embedding,
-            "metadata_patch": {"embedding_pending": False},
-        },
+        json=body,
     )
     if resp.status_code == 404:
         # Row was deleted after the event was published — common-enough

--- a/core-worker/src/core_worker/consumer.py
+++ b/core-worker/src/core_worker/consumer.py
@@ -179,6 +179,13 @@ async def handle_embed_request(event: Event) -> None:
             memory_id=request.memory_id,
             tenant_id=request.tenant_id,
             embedding=embedding,
+            # Provenance: the hash of the text this vector describes. Correct on
+            # both branches above — a fresh embed encodes ``request.content``,
+            # and a cache hit reuses a vector found BY this same hash, so either
+            # way the vector belongs to content hashing to this value. None when
+            # the publisher omitted it, which honestly records "unknown" rather
+            # than guessing.
+            embedded_content_hash=request.content_hash,
         )
 
     # Back-channel: announce successful embed so core-api can fire

--- a/core-worker/tests/test_consumer.py
+++ b/core-worker/tests/test_consumer.py
@@ -298,3 +298,102 @@ def test_register_consumers_subscribes_to_topic(monkeypatch):
     bus = get_event_bus()
     assert Topics.Memory.EMBED_REQUESTED in bus._handlers
     assert consumer.handle_embed_request in bus._handlers[Topics.Memory.EMBED_REQUESTED]
+
+
+@pytest.mark.asyncio
+async def test_embed_request_forwards_content_hash_as_provenance(
+    monkeypatch, settings, mock_provider, mock_storage_client
+):
+    """The deferred path must stamp provenance (migration 037).
+
+    This is the production write path in SaaS/deferred mode, so if it does not
+    forward the hash, every row it embeds sits at ``unknown_provenance``
+    permanently and the staleness detector is blind to precisely the mode that
+    does the embedding.
+    """
+    consumer.configure(mock_storage_client)
+    monkeypatch.setattr(consumer, "find_embedding_by_content_hash", AsyncMock(return_value=None))
+    patch_call = AsyncMock(return_value=None)
+    monkeypatch.setattr(consumer, "update_memory_embedding", patch_call)
+
+    event = _make_event(
+        {
+            "memory_id": str(uuid4()),
+            "tenant_id": "tenant-A",
+            "content": "hello async world",
+            "content_hash": "h1",
+        }
+    )
+    await consumer.handle_embed_request(event)
+
+    assert patch_call.await_args.kwargs["embedded_content_hash"] == "h1"
+
+
+@pytest.mark.asyncio
+async def test_embed_request_forwards_provenance_on_cache_hit_too(
+    monkeypatch, settings, mock_provider, mock_storage_client
+):
+    """A cached vector was found BY this hash, so it belongs to content hashing
+    to it — the cache branch must stamp provenance just like a fresh embed."""
+    consumer.configure(mock_storage_client)
+    monkeypatch.setattr(consumer, "find_embedding_by_content_hash", AsyncMock(return_value=[0.5] * 768))
+    patch_call = AsyncMock(return_value=None)
+    monkeypatch.setattr(consumer, "update_memory_embedding", patch_call)
+
+    event = _make_event(
+        {
+            "memory_id": str(uuid4()),
+            "tenant_id": "tenant-A",
+            "content": "cached content",
+            "content_hash": "h-cached",
+        }
+    )
+    await consumer.handle_embed_request(event)
+
+    mock_provider.embed.assert_not_awaited()
+    assert patch_call.await_args.kwargs["embedded_content_hash"] == "h-cached"
+
+
+@pytest.mark.asyncio
+async def test_update_memory_embedding_sends_provenance_key():
+    """Sent as ``embedded_content_hash``, NOT ``content_hash``.
+
+    ``content_hash`` is a real column: sending it would WRITE it, overwriting
+    the row's hash with a value from an event that may already be stale. The
+    explicit key sets provenance alone.
+    """
+    from core_worker.clients.storage_client import update_memory_embedding
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status = MagicMock(return_value=None)
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.patch = AsyncMock(return_value=response)
+
+    await update_memory_embedding(
+        client,
+        memory_id=uuid4(),
+        tenant_id="tenant-A",
+        embedding=[0.1] * 768,
+        embedded_content_hash="h1",
+    )
+
+    body = client.patch.await_args.kwargs["json"]
+    assert body["embedded_content_hash"] == "h1"
+    assert "content_hash" not in body, body
+    # The metadata merge must survive alongside it.
+    assert body["metadata_patch"] == {"embedding_pending": False}
+
+
+@pytest.mark.asyncio
+async def test_update_memory_embedding_omits_provenance_when_unknown():
+    """No hash → key absent, leaving provenance NULL. Honest beats guessed."""
+    from core_worker.clients.storage_client import update_memory_embedding
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status = MagicMock(return_value=None)
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.patch = AsyncMock(return_value=response)
+
+    await update_memory_embedding(client, memory_id=uuid4(), tenant_id="tenant-A", embedding=[0.1] * 768)
+
+    assert "embedded_content_hash" not in client.patch.await_args.kwargs["json"]

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import uuid
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -813,7 +813,9 @@ async def test_bulk_reembed_reschedules_items_whose_get_memory_failed() -> None:
         )
 
     # Item B went through the normal write pass.
-    sc.update_embedding.assert_awaited_once_with(str(mem_b_id), TENANT_ID, [0.2] * VECTOR_DIM)
+    sc.update_embedding.assert_awaited_once_with(
+        str(mem_b_id), TENANT_ID, [0.2] * VECTOR_DIM, embedded_content_hash=ANY
+    )
     # Item A was rescheduled as a per-item retry (reembed task) AND
     # item B scheduled contradiction detection — both tracked.
     names = [call.args[1] for call in tracked.call_args_list]
@@ -838,7 +840,10 @@ async def test_bulk_reembed_patch_failure_reschedules_item() -> None:
     async def _get_memory(mid: str):
         return {"id": mid, "deleted_at": None, "fleet_id": "f", "embedding": None}
 
-    async def _update_embedding(mid: str, _tenant, _emb):
+    # Accepts ``embedded_content_hash``: the re-embed paths now record which
+    # text each vector came from, so a fake that rejects it would fail on the
+    # kwarg rather than on the behaviour under test.
+    async def _update_embedding(mid: str, _tenant, _emb, embedded_content_hash=None):
         if mid == str(mem_a_id):
             raise _MockHTTPError("connection pool exhausted for item A")
 
@@ -960,7 +965,9 @@ async def test_bulk_reembed_respects_existing_embedding_per_item() -> None:
 
     # mem_a: race guard → no PATCH, contradiction on the EXISTING embedding
     # mem_b: normal path → PATCH fresh, contradiction on the fresh embedding
-    sc.update_embedding.assert_awaited_once_with(str(mem_b_id), TENANT_ID, fresh)
+    sc.update_embedding.assert_awaited_once_with(
+        str(mem_b_id), TENANT_ID, fresh, embedded_content_hash=ANY
+    )
     assert len(detect_calls) == 2
     # Order matches the input order; arg[0]=memory_id, arg[4]=embedding
     by_id = {args[0]: args[4] for args in detect_calls}

--- a/tests/test_embedding_coverage_admin.py
+++ b/tests/test_embedding_coverage_admin.py
@@ -114,3 +114,169 @@ async def test_admin_route_returns_totals(client):
     }
     assert body["total_active"] >= 0
     assert body["missing_embeddings"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# Stale detection — a vector computed from text the row no longer holds
+# ---------------------------------------------------------------------------
+
+
+async def _coverage_for(tenant_id: str) -> dict:
+    agg = await get_storage_client().get_embedding_coverage_all()
+    return next((r for r in agg["tenants"] if r["tenant_id"] == tenant_id), {})
+
+
+async def test_content_change_without_reembed_is_detected_as_stale(client):
+    """The failure the NULL-sweep can never see.
+
+    Rewriting ``content`` (+ ``content_hash``) while leaving ``embedding``
+    untouched is exactly what ``update_memory`` used to do on a failed
+    re-embed. The row stays non-NULL, so no sweep finds it; only comparing
+    the vector's provenance against the current content reveals it.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet_id, agent_id = f"stale-fleet-{tag}", f"stale-agent-{tag}"
+
+    memory_id = await _write(
+        client, tenant_id, headers, fleet_id, agent_id, f"original text {tag}"
+    )
+
+    before = await _coverage_for(tenant_id)
+    stale_before = before.get("stale_embeddings", 0)
+
+    # Move the content WITHOUT touching the embedding — the vector now
+    # describes text the row no longer holds.
+    sc = get_storage_client()
+    updated = await sc.update_memory(
+        memory_id,
+        tenant_id,
+        {
+            "content": f"REPLACED text {tag}",
+            "content_hash": f"hash-of-replaced-{tag}",
+        },
+    )
+    assert updated is not None
+
+    after = await _coverage_for(tenant_id)
+    assert after["stale_embeddings"] == stale_before + 1, after
+    # It is NOT missing — that is the whole point. A NULL-based sweep is blind
+    # to this row.
+    assert after["missing_embeddings"] == before.get("missing_embeddings", 0), after
+
+
+async def test_normal_write_records_provenance_and_is_not_stale(client):
+    """A row embedded at write time must not be reported as stale or unknown."""
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet_id, agent_id = f"fresh-fleet-{tag}", f"fresh-agent-{tag}"
+
+    before = await _coverage_for(tenant_id)
+    await _write(client, tenant_id, headers, fleet_id, agent_id, f"fresh text {tag}")
+    after = await _coverage_for(tenant_id)
+
+    # The new row adds to the total but to neither defect bucket, and it does
+    # NOT land in unknown_provenance — the insert stamped the hash.
+    assert after["total_active"] == before.get("total_active", 0) + 1, after
+    assert after["stale_embeddings"] == before.get("stale_embeddings", 0), after
+    assert after["unknown_provenance"] == before.get("unknown_provenance", 0), after
+
+
+async def test_null_content_hash_row_is_not_lost_from_every_bucket(client):
+    """A row with known provenance but NULL ``content_hash`` must still land
+    somewhere.
+
+    ``content_hash`` is nullable. Comparing with ``!=`` compiles to ``<>``,
+    which yields NULL against a NULL and is dropped by ``COUNT(*) FILTER`` — so
+    such a row was counted in ``total_active`` and in NO defect bucket: not
+    stale (NULL comparison), not unknown (its provenance IS known), not missing
+    (it has a vector). Silently unaccounted for by the detector itself.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet_id, agent_id = f"nullhash-fleet-{tag}", f"nullhash-agent-{tag}"
+
+    memory_id = await _write(
+        client, tenant_id, headers, fleet_id, agent_id, f"content {tag}"
+    )
+
+    # Clear content_hash while leaving the embedding and its provenance intact.
+    sc = get_storage_client()
+    assert (
+        await sc.update_memory(memory_id, tenant_id, {"content_hash": None}) is not None
+    )
+
+    cov = await sc.get_embedding_coverage(tenant_id, fleet_id)
+    buckets = (
+        cov["missing_embeddings"] + cov["stale_embeddings"] + cov["unknown_provenance"]
+    )
+    assert cov["total_active"] == 1, cov
+    # The row must be accounted for — it is stale (its vector describes content
+    # whose hash no longer matches), not invisible.
+    assert cov["stale_embeddings"] == 1, cov
+    assert buckets == 1, cov
+
+
+async def test_per_tenant_and_aggregate_report_the_same_fields(client):
+    """Both coverage views must expose the same provenance keys.
+
+    If the per-tenant view omits them, a caller comparing it against the
+    aggregate reads absence as zero and concludes a flagged tenant is clean.
+    """
+    tenant_id, _ = get_test_auth()
+    sc = get_storage_client()
+    per_tenant = await sc.get_embedding_coverage(tenant_id)
+    aggregate_row = await _coverage_for(tenant_id)
+
+    provenance_keys = {"missing_embeddings", "stale_embeddings", "unknown_provenance"}
+    assert provenance_keys <= set(per_tenant), per_tenant
+    assert provenance_keys <= set(aggregate_row), aggregate_row
+    # And they must AGREE for the same tenant, not merely both be present.
+    for key in provenance_keys:
+        assert per_tenant[key] == aggregate_row[key], (key, per_tenant, aggregate_row)
+
+
+async def test_explicit_provenance_wins_over_derivation_on_update(client):
+    """A caller-supplied ``embedded_content_hash`` must survive a patch that
+    also carries ``content`` + ``content_hash``.
+
+    The insert path documents "explicit caller value wins"; the update path must
+    agree. Overriding the caller here would stamp the row's NEW hash onto a
+    vector the caller told us came from OLD text — marking a genuinely stale
+    write as freshly embedded, the exact inversion this column exists to catch.
+
+    Latent today (core-worker sends provenance without ``content_hash``), so
+    this test is what stops a future caller silently losing its stamp.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    fleet_id, agent_id = f"explicit-fleet-{tag}", f"explicit-agent-{tag}"
+
+    memory_id = await _write(
+        client, tenant_id, headers, fleet_id, agent_id, f"orig {tag}"
+    )
+    sc = get_storage_client()
+
+    # All FOUR keys at once. ``embedding`` is required to reach the derivation
+    # branch at all — without it the block never fires and the assertion below
+    # would hold either way, which is no test.
+    from common.constants import VECTOR_DIM
+
+    assert (
+        await sc.update_memory(
+            memory_id,
+            tenant_id,
+            {
+                "content": f"new text {tag}",
+                "content_hash": f"hash-new-{tag}",
+                "embedding": [0.25] * VECTOR_DIM,
+                "embedded_content_hash": f"hash-OLD-{tag}",
+            },
+        )
+        is not None
+    )
+
+    # The explicit stamp survived, so the row reads as stale — not silently
+    # "refreshed" by the derivation.
+    cov = await sc.get_embedding_coverage(tenant_id, fleet_id)
+    assert cov["stale_embeddings"] == 1, cov

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -664,7 +664,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"036"}, f"Expected single head '036', got {sorted(heads)}"
+        assert heads == {"037"}, f"Expected single head '037', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -698,6 +698,9 @@ class TestMigrationChain:
         assert chain.get("035") == "034", "035 must follow 034"
         # 036: unified contradiction model (A55) — conflict/derivation tables + columns
         assert chain.get("036") == "035", "036 must follow 035"
+        # 037: memories.embedded_content_hash — embedding provenance, so a
+        # vector computed from superseded text becomes detectable
+        assert chain.get("037") == "036", "037 must follow 036"
 
     def test_no_plain_create_index_on_large_tables(self):
         """Indexes on large, pre-existing tables MUST be built ``CONCURRENTLY``
@@ -732,6 +735,11 @@ class TestMigrationChain:
             r"(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+(\w+)",
             re.IGNORECASE,
         )
+        # op.create_index("<name>", "<table>", ...) — the Alembic API form.
+        api_pat = re.compile(
+            r"op\.create_index\(\s*[\"'][^\"']+[\"']\s*,\s*[\"'](\w+)[\"']",
+            re.DOTALL,
+        )
         versions = pathlib.Path(
             "core-storage-api/src/core_storage_api/database/migrations/versions"
         )
@@ -744,9 +752,23 @@ class TestMigrationChain:
                 or int(prefix) in applied_debt
             ):
                 continue
-            for concurrently, table in pat.findall(f.read_text()):
+            src = f.read_text()
+            for concurrently, table in pat.findall(src):
                 if table.lower() in large_tables and not concurrently:
                     violations.append(f"{f.name}: plain CREATE INDEX on '{table}'")
+            # ``op.create_index(...)`` is the SAME hazard via Alembic's API
+            # rather than raw SQL: it emits a plain, in-transaction CREATE
+            # INDEX. The raw-SQL regex above cannot see it, so migration 037
+            # originally shipped a plain index build on ``memories`` and this
+            # guard passed. Alembic has no CONCURRENTLY option on
+            # ``create_index``, so on a large table the API form is always
+            # wrong — flag every occurrence.
+            for table in api_pat.findall(src):
+                if table.lower() in large_tables:
+                    violations.append(
+                        f"{f.name}: op.create_index() on '{table}' "
+                        "(no CONCURRENTLY option — use op.execute in an autocommit_block)"
+                    )
         assert not violations, (
             "Plain (non-CONCURRENTLY) CREATE INDEX on a large table blocks writes "
             "and holds the migration advisory lock for the whole build (crashed "
@@ -1012,7 +1034,9 @@ class TestBackfill034MatchesMigration:
         """Both directions: ``--revert`` must undo exactly what the forward pass did."""
         import re
 
-        src = pathlib.Path("core-storage-api/src/core_storage_api/scripts/backfill_034_search_vector.py").read_text()
+        src = pathlib.Path(
+            "core-storage-api/src/core_storage_api/scripts/backfill_034_search_vector.py"
+        ).read_text()
         m = re.search(rf'^{const} = "(.+)"$', src, re.M)
         assert m, f"backfill_034_search_vector.py no longer defines {const} on one line"
 


### PR DESCRIPTION
## The last embedding failure with no detector

`memories` carried `embedding` and `content_hash`, but nothing recording **which** content a vector was computed from. So a vector left over from earlier content was byte-identical to a correct one — `embedding IS NOT NULL` says only that *something* was embedded, never *what*.

That left mis-embedded rows undetectable. The nightly NULL sweep can't see them (the column is non-NULL), and recall silently ranks them against text they no longer hold. #775 stopped new ones being created; it could not find existing ones, and nothing could have.

Migration **037** adds `memories.embedded_content_hash`, making staleness a query:

```sql
embedding IS NOT NULL
AND embedded_content_hash IS DISTINCT FROM content_hash
```

`IS DISTINCT FROM` rather than `<>` — with `<>` every NULL-provenance row evaluates to NULL and silently drops out of the `WHERE`, which is the same disappearing-evidence failure this column exists to end.

## Stamped in the storage layer, with one deliberate exception

Provenance is set in storage rather than at each call site, so paths can't drift: `_filter_memory_fields` covers both inserts (single + bulk), and `memory_update` derives it when a patch carries embedding and content_hash together.

`memory_update_embedding` is the exception — it takes the hash as a **parameter** and never reads it off the row. The worker fetches content, embeds, then writes back. A content PATCH landing inside that window means the row has moved on, and copying its current hash at write time would stamp the **new** hash onto a vector computed from the **old** text — recording the row as freshly embedded at the precise moment it became stale. Callers that know what they encoded pass it; the rest leave it NULL, because unknown provenance is honest and a wrong hash is not.

## Three states, deliberately not collapsed

| state | meaning | repairable by the sweep? |
|---|---|---|
| `missing` | no vector | ✅ yes |
| `stale` | wrong vector | ❌ **no** — non-NULL, invisible to it |
| `unknown_provenance` | embedded pre-037 | n/a — undetermined, not damaged |

Conflating unknown with stale would report the whole historical corpus as broken; conflating it with fresh would assert a correctness nobody verified. It drains on its own as rows are rewritten.

## Two guards caught real mistakes — including one that didn't

`test_single_head` pinned the head at 036; updated to 037 with a chain link, which is the deliberate-update step it exists to force.

**`test_no_plain_create_index_on_large_tables` did not catch the first draft.** It regex-scans raw `op.execute("CREATE INDEX …")` only, and the draft used `op.create_index(...)` — the Alembic API form, which emits a plain in-transaction `CREATE INDEX` on `memories` and carries exactly the defect the guard exists to prevent (a plain build took an AccessExclusive lock and crashed 6 storage-writer boots on 2026-06-16).

So this PR does both: the migration now builds **CONCURRENTLY** in an autocommit block, **and** the guard is extended to flag the API form on large tables. Verified by reverting to the broken form and watching it fail with a clear message.

## Verification

**Migration** — ran the real Alembic chain against a fresh database: head reaches `037`, column and partial index created, detector predicate executes, and `downgrade → re-upgrade` is clean.

**Detection** — verified by breaking it:

- stale counter forced to zero → **1 test fails**
- insert provenance removed → **2 tests fail**

Both restore green, so the tests discriminate rather than passing on shape.

The stale test creates a genuinely stale row the way the bug did — rewriting `content` + `content_hash` while leaving `embedding` untouched — and asserts it lands in `stale`, **not** `missing`. That distinction is the whole point.

Suites: root **4372 passed**, core-operations **50 passed**. `mypy` clean on all three packages; `ruff check` + `format --check` clean on every CI scope, including `common/` at its own line-length 88.

## Also

Adds `.coverage` to `.gitignore` — an untracked artefact that `git add -A` swept into a commit twice during this work. Unrelated to the feature; drop the line if you'd rather keep this PR pure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
