### PR TITLE
ci: run core-worker's lint, types and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,20 @@ jobs:
         # have broken confusingly the first time core-operations grew a
         # dependency core-api lacks. Resolution cost of adding it: one extra
         # package (119 vs 118).
+        #
+        # core-worker likewise, and for a sharper reason: it had NO CI at all —
+        # not installed, linted, type-checked or tested by any workflow — while
+        # being the production write path in deferred/SaaS mode. It owns
+        # ``handle_embed_request`` (essentially all production embedding), the
+        # embed-backfill sweep consumer and the enrich consumer. The cost of
+        # that gap is not hypothetical: caura#786 shipped embedding provenance
+        # through every write path EXCEPT core-worker's, which would have left
+        # every production row permanently at ``unknown_provenance``; it was
+        # caught by human review because no automated check covered the tree.
         run: |
           uv venv .venv
           source .venv/bin/activate
-          uv pip install -e core-storage-api/[dev] -e core-api/[dev] -e core-operations/[dev]
+          uv pip install -e core-storage-api/[dev] -e core-api/[dev] -e core-operations/[dev] -e core-worker/[dev]
           echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
 
       # --- Broker↔cloud API-versioning gate (Gate C / Phase 1, deliverables A+B) ---
@@ -163,6 +173,14 @@ jobs:
         # rather than common/'s 88, so the format check below is safe to gate.
         run: uv run ruff check core-operations/src/ core-operations/tests/
 
+      - name: Run Ruff linter (core-worker)
+        # Same pairing as core-operations above — an unlinted tree drifts, and
+        # this one was unlinted AND unrun despite being the deferred-mode
+        # production write path. core-worker/pyproject.toml declares its own
+        # line-length = 110, matching core-api / core-storage-api / core-operations
+        # rather than common/'s 88, so the format check below is safe to gate.
+        run: uv run ruff check core-worker/src/ core-worker/tests/
+
       - name: Run Ruff formatter check (core-api)
         run: uv run ruff format --check core-api/src/
 
@@ -174,6 +192,9 @@ jobs:
 
       - name: Run Ruff formatter check (core-operations)
         run: uv run ruff format --check core-operations/src/ core-operations/tests/
+
+      - name: Run Ruff formatter check (core-worker)
+        run: uv run ruff format --check core-worker/src/ core-worker/tests/
 
       - name: Run Ruff formatter check (vendored common/ files at ruff defaults)
         # This list mirrors the policy=identical entries of caura-memclaw-enterprise's
@@ -219,6 +240,12 @@ jobs:
         # mypy as a dev dep, same as its two siblings above; only the CI step
         # was missing.
         run: cd core-operations && uv run mypy src/
+
+      - name: Run mypy (core-worker)
+        # core-worker/pyproject.toml already carries a [tool.mypy] block with
+        # ``mypy_path = "src"`` and mypy as a dev dep — the config was there all
+        # along, nothing ever ran it.
+        run: cd core-worker && uv run mypy src/
 
       - name: Enable pgvector extension
         run: PGPASSWORD=changeme psql -h localhost -U memclaw -d memclaw -c "CREATE EXTENSION IF NOT EXISTS vector;"
@@ -354,6 +381,40 @@ jobs:
           # uploads coverage.xml to Codecov.
           COVERAGE_FILE: .coverage.core-operations
 
+      - name: Run core-worker tests
+        # core-worker had NO CI of any kind — the tree was never installed,
+        # linted, type-checked or run, while being the production write path in
+        # deferred/SaaS mode (``handle_embed_request``, the embed-backfill sweep
+        # consumer, the enrich consumer). Same blind spot the core-operations
+        # step above closed, on a service with more production surface.
+        #
+        # Two things that had rotted behind it, both fixed in this PR:
+        #   * ``test_post_gives_up_after_max_attempts_on_connect_timeout``
+        #     asserted a hardcoded 3 attempts and had been failing since the
+        #     connect-phase budget was raised to 5 after the 2026-06-16 prod
+        #     incident. It now asserts ``CONNECT_PHASE_MAX_ATTEMPTS`` itself.
+        #   * caura#786 threaded embedding provenance through every write path
+        #     EXCEPT this one, caught only by human review.
+        #
+        # No PYTHONPATH, deliberately — core-worker/pytest.ini sets its own
+        # ``pythonpath = src ..`` (src for core_worker, .. for common) and
+        # pytest resolves it as the configfile for this path rather than
+        # inheriting the root pytest.ini, so an env var here would be inert.
+        # Verified by running the suite with PYTHONPATH unset. No database
+        # either: the conftest pins ``EVENT_BUS_BACKEND=inprocess``.
+        #
+        # ``--cov-config`` is load-bearing for the same reason as
+        # core-operations: core-worker declares ``fail_under = 50`` and coverage
+        # discovers config relative to the CWD, so without the flag the run
+        # collects coverage while silently ignoring the floor. Currently ~70%.
+        run: |
+          uv run pytest core-worker/tests/ -v --tb=short \
+            --cov=core-worker/src/core_worker \
+            --cov-config=core-worker/pyproject.toml \
+            --cov-report=term-missing
+        env:
+          COVERAGE_FILE: .coverage.core-worker
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
@@ -363,11 +424,14 @@ jobs:
       - name: Build packages
         # core-operations included now that CI installs, lints, type-checks and
         # tests it — a broken pyproject/build-backend would otherwise surface
-        # only in its Docker build.
+        # only in its Docker build. core-worker joins for exactly the same
+        # reason, now that this workflow covers it: it ships as a package with
+        # its own pyproject, and until this PR nothing here exercised any of it.
         run: |
           cd core-api && uv build && cd ..
           cd core-storage-api && uv build && cd ..
-          cd core-operations && uv build
+          cd core-operations && uv build && cd ..
+          cd core-worker && uv build
 
   image-version:
     # Guards the /api/v1/version surface end-to-end: builds the actual

--- a/core-worker/tests/test_storage_client_retry.py
+++ b/core-worker/tests/test_storage_client_retry.py
@@ -28,6 +28,7 @@ from uuid import uuid4
 import httpx
 import pytest
 
+from common.http_retry import CONNECT_PHASE_MAX_ATTEMPTS
 from core_worker.clients import identity_token, storage_client
 
 pytestmark = pytest.mark.asyncio
@@ -85,13 +86,22 @@ async def test_post_retries_on_connect_timeout_then_succeeds() -> None:
 
 
 async def test_post_gives_up_after_max_attempts_on_connect_timeout() -> None:
+    """Gives up after ``CONNECT_PHASE_MAX_ATTEMPTS``, whatever that is.
+
+    Asserted against the constant rather than a literal. This test hardcoded 3
+    and silently rotted when the connect-phase budget was raised to 5 after the
+    2026-06-16 prod incident ("3 attempts (~0.6s of backoff) is too short to
+    ride out a cold start"). Nothing caught it because core-worker had no CI —
+    the gap this suite is being wired into CI to close. Pinning the constant
+    means a future change to the budget moves the expectation with it.
+    """
     client = MagicMock(spec=httpx.AsyncClient)
     client.post = AsyncMock(side_effect=httpx.ConnectTimeout("storage unreachable"))
 
     with pytest.raises(httpx.ConnectTimeout):
         await storage_client.archive_stale(client, tenant_id="t1", fleet_id=None)
 
-    assert client.post.await_count == 3
+    assert client.post.await_count == CONNECT_PHASE_MAX_ATTEMPTS
 
 
 async def test_post_does_not_retry_on_read_timeout() -> None:


### PR DESCRIPTION
## core-worker had no CI at all

```
$ grep -rn "core-worker" .github/workflows/
(no matches)
```

Never installed, linted, type-checked, or run — by any workflow. While being the **production write path in deferred/SaaS mode** (`DEPLOYMENT_MODE=deferred`, which is what prod core-api runs). It owns `handle_embed_request` — essentially all production embedding — plus the embed-backfill sweep consumer and the enrich consumer.

Same gap #768 closed for core-operations, on a service with more production surface. This adds the package to the install step, plus ruff check, ruff format --check, mypy, and the test suite.

## Two things had already rotted behind it

**1. A test has been failing on a clean checkout.** `test_post_gives_up_after_max_attempts_on_connect_timeout` asserted a hardcoded `3`, but the connect-phase budget was deliberately raised to `CONNECT_PHASE_MAX_ATTEMPTS = 5` after the 2026-06-16 prod incident — *"3 attempts (~0.6s of backoff) is too short to ride out a cold start"*.

The production code is right; the test was stale. It now asserts **the constant itself** rather than a literal, so it moves with the budget instead of rotting again. Diagnosed before wiring the suite in, so the new step doesn't land red.

**2. caura#786** threaded embedding provenance through every write path *except* core-worker's `update_memory_embedding` — which would have left every production row permanently at `unknown_provenance`. Caught by human review. No automated check could have caught it, because none ran.

## Each gate verified to actually gate

A step that passes on broken input is worse than no step, so each was broken deliberately:

| injected | result |
|---|---|
| unused import | `ruff check` **FAILS** ✓ |
| bad return type | `mypy` **FAILS** ✓ |
| mangled spacing | `ruff format --check` **FAILS** ✓ |
| `assert False` | `pytest` **FAILS** ✓ |

All restored to green afterwards.

## Wiring notes

- **No `PYTHONPATH`,** deliberately. `core-worker/pytest.ini` sets `pythonpath = src ..` and pytest resolves it as the configfile for that path rather than inheriting the root `pytest.ini`, so an env var would be inert. Confirmed by running the suite with `PYTHONPATH` unset — **67 passed**.
- **No database.** The conftest pins `EVENT_BUS_BACKEND=inprocess`.
- **`--cov-config` is load-bearing**, same as core-operations: core-worker declares `fail_under = 50` and coverage discovers config relative to the CWD, so without the flag the run collects coverage while silently ignoring the floor. Measured before gating: **70.20%**, and the run prints *"Required test coverage of 50.0% reached"*.
- **Line-length 110** for core-worker, matching its siblings rather than `common/`'s 88 — so the format check is safe to gate.
- `actionlint`: the same single pre-existing SC2086 (unquoted `$GITHUB_PATH`) as `main` — one finding on each, unchanged. The line number shifts only because this adds comment lines above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
