### PR TITLE
fix(extraction): tolerate a null cluster_id instead of losing the whole graph

### DIFF
--- a/core-api/src/core_api/services/entity_extraction.py
+++ b/core-api/src/core_api/services/entity_extraction.py
@@ -22,7 +22,7 @@ Rules:
 - relation_type: short verb phrase like works_on, uses, belongs_to, created_by, depends_on, manages, located_in
 - Extract every distinct named subject. Include identifiers (PR-2025-A, build-734), product codes (Vermillion-7), model names (gpt-5.4-nano), and version strings as entity_type=identifier or entity_type=artifact when they refer to a specific named thing.
 - Job titles (ceo, engineer, manager, director, officer) classify as entity_type=role — NOT person. Use entity_type=person only when a named individual is referenced (e.g., "Anna Bergstrom"). "the CEO" alone is a role; "Anna, the CEO" is one person entity plus one role entity.
-- mentions: list every surface form referring to an entity in the content, including pronouns. Assign coreferring mentions the same cluster_id integer (0, 1, 2, ...). Link each mention to its entity_canonical when known; use null for unresolved pronouns.
+- mentions: list every surface form referring to an entity in the content, including pronouns. Assign coreferring mentions the same cluster_id integer (0, 1, 2, ...) — cluster_id is never null. Set entity_canonical to the referenced entity, or null if unresolved.
 - If no entities found, return empty lists
 
 Return ONLY valid JSON matching this schema (no markdown fences):
@@ -52,7 +52,14 @@ class ExtractedRelation(BaseModel):
 
 class Mention(BaseModel):
     surface: str
-    cluster_id: int
+    # Nullable because nothing enforces the schema ``_do_extract`` sends (see
+    # there): while this was a bare ``int``, one null cluster_id failed the
+    # WHOLE ``ExtractedGraph``, burning the primary provider's retry budget and
+    # dropping through to the regex heuristic (prod, 2026-08-16). ``None``
+    # means "no coreference cluster assigned" — the surface form is still worth
+    # keeping. Nothing reads ``cluster_id`` today; it stays for the coreference
+    # work A5b (#169) added it for.
+    cluster_id: int | None = None
     entity_canonical: str | None = None
 
 
@@ -157,10 +164,14 @@ async def extract_entities_from_content(
         # integer that survives process restarts — unlike ``hash()`` which
         # is salted per-process for str inputs.
         seed = zlib.crc32(prompt.encode("utf-8"))
-        # A5b #3 — pin the output shape server-side via response_schema.
-        # ExtractedGraph.model_json_schema() encodes the entities /
-        # relations / mentions structure. Providers that don't support
-        # structured outputs ignore this kwarg.
+        # A5b #3 — declare the expected shape via response_schema. It is a
+        # HINT, not the server-side guarantee A5b originally claimed: the
+        # OpenAI provider sends it with ``strict=False`` (see
+        # ``common/llm/providers/openai.py``) and gemini/vertex accept and
+        # ignore it outright, so the provider can and does return values the
+        # schema forbids. The ``ExtractedGraph(**raw)`` parse below is the only
+        # real enforcement — see ``Mention.cluster_id`` for the prod failure
+        # that established this.
         raw = await llm.complete_json(
             prompt,
             seed=seed,

--- a/tests/test_a5b_prompt_and_schema.py
+++ b/tests/test_a5b_prompt_and_schema.py
@@ -311,6 +311,43 @@ def test_extracted_graph_parses_without_mentions_field() -> None:
     )
 
 
+def test_extracted_graph_parses_mention_with_null_cluster_id() -> None:
+    """A null ``cluster_id`` must parse, not raise.
+
+    No provider enforces the ``response_schema`` ``_do_extract`` sends, so this
+    parse is the only guardrail — and while ``cluster_id`` was a bare ``int``,
+    one null failed the ENTIRE graph rather than the single mention carrying
+    it. Prod, 2026-08-16: ``mentions.10.cluster_id  Input should be a valid
+    integer``.
+
+    The surface form is the salvageable part of an unclustered mention, so it
+    must survive rather than take the whole graph down with it.
+    """
+    from core_api.services.entity_extraction import ExtractedGraph
+
+    raw = {
+        "entities": [
+            {"canonical_name": "anna", "entity_type": "person", "role": "subject"},
+        ],
+        "relations": [],
+        "mentions": [
+            {"surface": "Anna", "cluster_id": 0, "entity_canonical": "anna"},
+            # The deviation the provider actually emits.
+            {"surface": "She", "cluster_id": None, "entity_canonical": None},
+        ],
+    }
+
+    graph = ExtractedGraph(**raw)
+
+    assert len(graph.mentions) == 2, (
+        f"a null cluster_id must not drop the mention; got {graph.mentions!r}"
+    )
+    assert graph.mentions[1].cluster_id is None
+    # The clustered sibling must still round-trip as an int — tolerating null
+    # must not silently coerce real cluster ids.
+    assert graph.mentions[0].cluster_id == 0
+
+
 # ---------------------------------------------------------------------------
 # Change 5 — prompt-level role-vs-person distinction
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The failure, in prod right now

`prod-memclaw-core-api` logs `entity-extraction primary provider 'openai' failed after retries` at a rate that climbed today:

| hour (UTC, 2026-08-16) | 07 | 08 | 09 | 10 |
|---|---|---|---|---|
| failures | 1 | 2 | 8 | 11 |

Baseline over the prior week was ~1-2/hour. It is **not** a provider outage:

```
File "core-api/src/core_api/services/entity_extraction.py", line 169, in _do_extract
    return ExtractedGraph(**raw)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ExtractedGraph
mentions.10.cluster_id
  Input should be a valid integer [type=int_type, input_value=None, input_type=NoneType]
```

One null field on mention #10 discarded the whole extraction. Because `_do_extract` pins a stable CRC32 seed precisely so retries reproduce the same output, **every retry was guaranteed to fail identically** — so each occurrence burned the primary provider's full retry budget, then the alternative provider's, before landing on the regex heuristic. Real LLM spend, and degraded extraction quality for those memories.

## Root cause — two things had to agree, and nothing checked they did

The prompt (`entity_extraction.py:25`) read:

> Assign coreferring mentions the same cluster_id integer (0, 1, 2, ...). Link each mention to its entity_canonical when known; **use null for unresolved pronouns.**

That trailing clause was written for `entity_canonical`, but it directly followed a sentence about `cluster_id`, so the model applied it to both. Meanwhile the schema declared `cluster_id: int`, non-optional.

## What this changes

- **`cluster_id: int | None = None`.** Nothing reads this field — the only consumer of `graph.mentions` is `_reattach_subject_discriminators`, which rewrites `entity_canonical` only. It is kept rather than dropped because it is deliberately captured for the coreference work A5b (#169) introduced it for. `None` now means "no coreference cluster assigned", and an unclustered mention keeps its surface form instead of taking the graph down with it.
- **The prompt names the field its null guidance governs**, so the trigger goes away rather than only the symptom.
- **Corrects the stale A5b comment at the `complete_json` call site.** It claimed `response_schema` pins the output shape *"server-side"*. It does not: `common/llm/providers/openai.py` sends it with `strict=False`, and `gemini.py` / `vertex.py` accept-and-ignore it entirely. The Pydantic parse is the only real enforcement. That stale belief is exactly what made a strict model look safe here, so leaving it in place would invite the next instance.

## Test

`test_extracted_graph_parses_mention_with_null_cluster_id` feeds a payload with `cluster_id: None`. **Confirmed it fails on unfixed code** with the same `ValidationError` seen in prod, and passes with the fix. It also asserts the clustered sibling still round-trips as `0`, so tolerating null cannot silently coerce real cluster ids.

## Checks

`ruff check` and `ruff format --check` on `core-api/src/` (run separately), `mypy src/` clean on 198 files, and the full root suite: **4376 passed, 3 skipped, 1 xfailed**.

## Deliberately not in this PR

A review pass surfaced two deeper issues that this fix does not address, both worth their own change:

1. **The same total-failure exposure exists on 7 sibling fields** — `ExtractedEntity.canonical_name/entity_type/role`, `ExtractedRelation.from_entity/relation_type/to_entity`, `Mention.surface` are all non-optional and populated from the same unenforced provider output. A `"role": null` reproduces this incident exactly. The general fix is per-item validation at the `ExtractedGraph(**raw)` boundary — drop malformed items, keep the rest — which is the idiom `common/enrichment/service.py::_validate_enrichment` already uses on the same kind of output.
2. **`common/llm/retry.py` retries deterministic parse failures.** A `ValidationError` cannot succeed on retry, least of all under a fixed seed. Classifying shape errors as non-retryable would fail fast to the next provider instead of consuming the budget, and benefits every `complete_json` caller.

Both are follow-ups rather than blockers: this PR closes the live bleeding narrowly and reverts cleanly.
