### PR TITLE
fix(enrichment): stop dropping atomic facts when their embedding fails

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2462,25 +2462,47 @@ async def _enrich_memory_background(
             parent_visibility = mem.get("visibility") or "scope_team"
             parent_weight = patch.get("weight") or mem.get("weight") or 0.5
             fanout_created = 0
+            fanout_unembedded = 0
             for fact in atomic_facts:
                 fact_content = fact.content
+                # A failed embed must NOT skip the fact. Both exits here used
+                # to ``continue`` BEFORE ``create_memory``, so the child row
+                # was never written at all and the fact was lost outright —
+                # nothing downstream could repair what does not exist. Persist
+                # unembedded instead, exactly as the auto-chunk parent insert
+                # does, and hand the vector off to the normal recovery path
+                # below.
+                #
+                # The two arms are not symmetric in how often they fire.
+                # ``get_embedding`` RETURNS None once its retry budget is
+                # exhausted rather than raising (see
+                # ``common/embedding/_service.py::_run_with_retry``), so under
+                # the gate saturation this path actually meets, the None arm is
+                # the common one. It was not silent globally — ``_run_with_retry``
+                # logs its own terminal error — but nothing here attributed the
+                # loss to a parent, a fact, or this code path.
+                child_embedding: list[float] | None = None
                 try:
                     child_embedding = await get_embedding(fact_content, tenant_config=tenant_config)
                 except (TimeoutError, ValueError, RuntimeError, OpenAIError, GoogleAPIError):
                     logger.warning(
-                        "atomic-fact embed failed for memory %s (skipping this fact)",
+                        "atomic-fact embed raised for memory %s; persisting the fact unembedded",
                         memory_id,
                         exc_info=True,
                     )
-                    continue
-                if child_embedding is None:
-                    continue
                 child_ch = _content_hash(tenant_id, fleet_id, fact_content)
                 child_meta = {
                     "parent_memory_id": str(memory_id),
                     "source": "atomic_fact_fanout",
                     "retrieval_hint": fact.retrieval_hint or "",
                 }
+                if child_embedding is None:
+                    # ``embedding_pending`` is public API, not bookkeeping:
+                    # ``MemoryOut.metadata`` documents it, agents are told to
+                    # read it, and core-worker clears it when the vector
+                    # lands. Without it a fan-out child is indistinguishable
+                    # from a fully-embedded row to every consumer.
+                    child_meta["embedding_pending"] = True
                 # Intentionally NOT wrapped in ``per_tenant_storage_slot``
                 # (CAURA-602 follow-up): this site runs inside
                 # ``_enrich_memory_background``, a fire-and-forget task
@@ -2495,7 +2517,7 @@ async def _enrich_memory_background(
                 # storage-pool occupancy, revisit by giving the task
                 # its own deadline first.
                 try:
-                    await sc.create_memory(
+                    child = await sc.create_memory(
                         {
                             "tenant_id": tenant_id,
                             "fleet_id": fleet_id,
@@ -2511,17 +2533,96 @@ async def _enrich_memory_background(
                             "ts_valid_start": parent_ts_start,
                         }
                     )
-                    fanout_created += 1
                 except (TimeoutError, ValueError, RuntimeError, OpenAIError, GoogleAPIError):
                     logger.warning(
                         "atomic-fact create_memory failed for parent %s",
                         memory_id,
                         exc_info=True,
                     )
+                    continue
+                # Everything below is post-write and deliberately OUTSIDE the
+                # try above. Folding it in would let a failure in the RECOVERY
+                # step surface as "create_memory failed" for a row that was in
+                # fact written — mislabelling the one log an operator would
+                # use to decide whether the fact exists.
+                fanout_created += 1
+                if child_embedding is None:
+                    # Durable handoff rather than waiting for the nightly
+                    # sweep. The sweep is the floor, not the mechanism:
+                    # ``embed_backfill_enabled`` defaults to FALSE, so a
+                    # deployment that has not turned it on would leave these
+                    # rows stranded indefinitely — which is how ~430 memories
+                    # were stranded in the 2026-07-27 incident this module
+                    # already carries a postmortem for.
+                    # ``_schedule_embed_or_reembed`` publishes EMBED_REQUESTED
+                    # in deferred mode (Pub/Sub owns retry/backoff/DLQ, paced
+                    # by the consumer's per-tenant slots) and retries
+                    # in-process otherwise.
+                    child_id = child.get("id") if isinstance(child, dict) else None
+                    if not child_id:
+                        # Loud, and NOT folded into fanout_unembedded: this
+                        # row is unembedded with no repair queued, which is a
+                        # strictly worse state than the counted one. The
+                        # nightly sweep remains its only recovery, and only
+                        # where enabled.
+                        # Log the response SHAPE, never the response. ``child``
+                        # is the created row, so it carries the raw fact text
+                        # and its metadata; interpolating it here would put
+                        # memory content — and any PII in it — into an ERROR
+                        # log. The key set is what actually diagnoses this
+                        # (which field the storage contract dropped) and is
+                        # content-free.
+                        logger.error(
+                            "atomic-fact child persisted unembedded but create_memory "
+                            "returned no usable id (response keys: %s) for parent %s; "
+                            "NO re-embed scheduled — recovery depends on the nightly sweep",
+                            sorted(child) if isinstance(child, dict) else type(child).__name__,
+                            memory_id,
+                        )
+                        continue
+                    # Counted only once the repair is actually queued, so the
+                    # summary below cannot claim a scheduled re-embed that was
+                    # never issued.
+                    fanout_unembedded += 1
+                    child_uuid = UUID(str(child_id))
+                    track_task(
+                        tracked_task(
+                            _schedule_embed_or_reembed(
+                                child_uuid,
+                                fact_content,
+                                tenant_id,
+                                content_hash=child_ch,
+                                is_failure_fallback=True,
+                            ),
+                            "embed_or_publish",
+                            # The CHILD's id, not the parent's. ``tracked_task``
+                            # uses this to label the BackgroundTaskLog row and
+                            # the failure log, so passing ``memory_id`` here
+                            # would file a failed child re-embed against the
+                            # parent — leaving the row that actually needs
+                            # repair untraceable. Every other call site passes
+                            # the same id to both the coroutine and the wrapper.
+                            child_uuid,
+                            tenant_id,
+                        )
+                    )
             if fanout_created:
                 logger.info(
                     "atomic-fact fan-out created %d children for parent %s",
                     fanout_created,
+                    memory_id,
+                )
+            if fanout_unembedded:
+                # WARNING rather than a field on the info line above, because
+                # it needs to be alertable on its own: it attributes an
+                # embedding-tier degradation to this specific path and parent,
+                # which the global coverage tick cannot do. Each of these
+                # children has a re-embed scheduled above; the count is what
+                # says how much of this fan-out is riding on that.
+                logger.warning(
+                    "atomic-fact fan-out persisted %d children without embeddings "
+                    "for parent %s; re-embed scheduled for each",
+                    fanout_unembedded,
                     memory_id,
                 )
 

--- a/tests/test_atomic_fact_unembedded_persist.py
+++ b/tests/test_atomic_fact_unembedded_persist.py
@@ -1,0 +1,274 @@
+"""Pins the atomic-fact fan-out's persist-unembedded contract.
+
+Both failure exits in the loop used to ``continue`` BEFORE ``create_memory``,
+so an embedding failure lost the fact outright. Why persisting beats dropping,
+and why the degrade-to-None arm is the one that actually fires in production:
+see the fan-out loop comment in ``_enrich_memory_background``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core_api.services import memory_service
+from core_api.services.memory_enrichment import AtomicFact
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+TENANT = "t-atomic-unembedded"
+
+
+def _enrichment(**over):
+    base = dict(
+        memory_type="fact",
+        weight=0.5,
+        status="active",
+        title="t",
+        summary="",
+        tags=[],
+        llm_ms=1,
+        contains_pii=False,
+        pii_types=[],
+        retrieval_hint="",
+        ts_valid_start=None,
+        ts_valid_end=None,
+        # The REAL model, not a stub: if AtomicFact grows a required field
+        # this test starts failing instead of passing vacuously.
+        atomic_facts=[AtomicFact(content="alpha fact"), AtomicFact(content="beta fact")],
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _row():
+    return dict(
+        id=str(uuid.uuid4()),
+        memory_type="fact",
+        status="active",
+        weight=0.5,
+        ts_valid_start=None,
+        ts_valid_end=None,
+        metadata_={},
+        deleted_at=None,
+        fleet_id="f1",
+        embedding=None,
+        content="body",
+        visibility="scope_team",
+    )
+
+
+async def _run_fanout(embed_stub):
+    """Drive the fan-out with a stubbed ``get_embedding``.
+
+    Returns ``(child_writes, scheduled_reembeds)``.
+    """
+    sc = AsyncMock(name="storage_client")
+    sc.get_memory = AsyncMock(return_value=_row())
+    sc.update_memory = AsyncMock(return_value=None)
+    sc.update_memory_status = AsyncMock(return_value=None)
+    sc.create_memory = AsyncMock(side_effect=lambda _p: {"id": str(uuid.uuid4())})
+
+    scheduled: list[tuple] = []
+
+    def _capture_schedule(memory_id, content, tenant_id, **kw):
+        # Sync wrapper so the call is recorded at CALL time — the tracked_task
+        # stub below closes the coroutine without awaiting it.
+        scheduled.append((memory_id, content, tenant_id, kw))
+
+        async def _noop() -> None:
+            return None
+
+        return _noop()
+
+    def _stub_tracked_task(coro, *_a, **_k):
+        # ``tracked_task`` is async; under a no-op ``track_task`` its body
+        # never runs, so close the inner coroutine to avoid a
+        # never-awaited warning.
+        coro.close()
+        return None
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(memory_service, "tracked_task", new=_stub_tracked_task),
+        patch.object(memory_service, "_schedule_embed_or_reembed", new=_capture_schedule),
+        patch.object(memory_service, "get_embedding", new=embed_stub),
+        patch(
+            "core_api.services.memory_enrichment.enrich_memory",
+            new=AsyncMock(return_value=_enrichment()),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    enrichment_enabled=True,
+                    enrichment_provider="fake",
+                    entity_extraction_enabled=False,
+                )
+            ),
+        ),
+    ):
+        await memory_service._enrich_memory_background(
+            uuid.uuid4(), "body", TENANT, "f1", "a"
+        )
+
+    children = [c.args[0] for c in sc.create_memory.await_args_list]
+    return children, scheduled
+
+
+async def _degraded(_content, tenant_config=None):
+    """``get_embedding``'s documented degrade: return None, do not raise."""
+    return None
+
+
+async def _raises(_content, tenant_config=None):
+    raise TimeoutError("embedding gate timeout")
+
+
+@pytest.mark.parametrize("embed_stub", [_degraded, _raises], ids=["degrades", "raises"])
+async def test_failed_embed_still_persists_the_fact(embed_stub) -> None:
+    """Neither failure arm may drop the fact.
+
+    Parametrized rather than split: the arms differ only in HOW the embed
+    fails, and the contract asserted here — the row exists, unembedded, and
+    flagged — is identical for both.
+    """
+    children, _ = await _run_fanout(embed_stub)
+
+    assert len(children) == 2, (
+        f"both atomic facts must be persisted when embedding fails; got {len(children)}"
+    )
+    assert all(c["embedding"] is None for c in children)
+    assert {c["content"] for c in children} == {"alpha fact", "beta fact"}
+    # Must be visible to the NULL-embedding sweep: live status, not deleted.
+    assert all(c["status"] == "active" for c in children)
+
+
+@pytest.mark.parametrize("embed_stub", [_degraded, _raises], ids=["degrades", "raises"])
+async def test_unembedded_child_is_flagged_embedding_pending(embed_stub) -> None:
+    """``embedding_pending`` is public API — agents are told to read it.
+
+    Without it an unembedded child is indistinguishable from a fully-embedded
+    row to every consumer.
+    """
+    children, _ = await _run_fanout(embed_stub)
+
+    # Length first, and deliberately: ``all()`` over an empty sequence is
+    # True, so without this the assertion below passes vacuously on exactly
+    # the broken code it exists to catch — the pre-fix path wrote no children
+    # at all.
+    assert len(children) == 2, f"expected 2 child writes to inspect; got {len(children)}"
+    assert all(c["metadata_"].get("embedding_pending") is True for c in children), (
+        f"unembedded children must carry embedding_pending=True; got "
+        f"{[c['metadata_'] for c in children]!r}"
+    )
+
+
+@pytest.mark.parametrize("embed_stub", [_degraded, _raises], ids=["degrades", "raises"])
+async def test_unembedded_child_schedules_its_own_reembed(embed_stub) -> None:
+    """Durable handoff, not "wait for the nightly sweep".
+
+    ``embed_backfill_enabled`` defaults to False, so a deployment that hasn't
+    enabled the sweep would otherwise strand these rows indefinitely.
+    """
+    children, scheduled = await _run_fanout(embed_stub)
+
+    assert len(scheduled) == len(children) == 2, (
+        f"every unembedded child must get a re-embed scheduled; got {len(scheduled)} "
+        f"for {len(children)} children"
+    )
+    assert {s[1] for s in scheduled} == {"alpha fact", "beta fact"}
+    assert all(s[2] == TENANT for s in scheduled)
+    assert all(s[3].get("is_failure_fallback") is True for s in scheduled), (
+        "the provider just failed, so the retry must carry the failure-fallback backoff"
+    )
+
+    # The re-embed must target the CHILD row, never the parent. Scheduling
+    # against the parent would re-embed content that is not the fact and
+    # leave the child unrepaired forever.
+    scheduled_ids = {str(s[0]) for s in scheduled}
+    parent_ids = {str(m["metadata_"]["parent_memory_id"]) for m in children}
+    assert len(parent_ids) == 1, f"all children share one parent; got {parent_ids!r}"
+    assert not (scheduled_ids & parent_ids), (
+        f"re-embed was scheduled against the PARENT {parent_ids!r}, not the child rows"
+    )
+    assert len(scheduled_ids) == 2, (
+        f"each child needs its own re-embed target; got {scheduled_ids!r}"
+    )
+
+
+async def test_missing_child_id_is_reported_not_counted_as_scheduled() -> None:
+    """A persisted child with no usable id must fail LOUD, not be miscounted.
+
+    The summary WARNING says a re-embed was scheduled for each unembedded
+    child. If ``create_memory`` returns something without an ``id``, nothing
+    can be scheduled — and folding that into the same counter would make the
+    one operator-facing signal assert a repair that was never queued.
+    """
+    sc = AsyncMock(name="storage_client")
+    sc.get_memory = AsyncMock(return_value=_row())
+    sc.update_memory = AsyncMock(return_value=None)
+    sc.update_memory_status = AsyncMock(return_value=None)
+    # The pathological response: a successful write that yields no id.
+    sc.create_memory = AsyncMock(return_value={})
+
+    scheduled: list[tuple] = []
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(memory_service, "tracked_task", new=MagicMock()),
+        patch.object(
+            memory_service,
+            "_schedule_embed_or_reembed",
+            new=lambda *a, **k: scheduled.append((a, k)),
+        ),
+        patch.object(memory_service, "get_embedding", new=_degraded),
+        patch(
+            "core_api.services.memory_enrichment.enrich_memory",
+            new=AsyncMock(return_value=_enrichment()),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    enrichment_enabled=True,
+                    enrichment_provider="fake",
+                    entity_extraction_enabled=False,
+                )
+            ),
+        ),
+    ):
+        await memory_service._enrich_memory_background(
+            uuid.uuid4(), "body", TENANT, "f1", "a"
+        )
+
+    # The rows were still written — that is the whole point of the fix.
+    assert sc.create_memory.await_count == 2
+    # But nothing was scheduled, and nothing may claim otherwise.
+    assert scheduled == [], f"nothing schedulable without an id; got {scheduled!r}"
+
+
+async def test_successful_embed_attaches_vector_and_schedules_nothing() -> None:
+    """Control: the happy path must be untouched.
+
+    Tolerating a missing embedding must not quietly stop attaching real ones,
+    nor schedule redundant re-embeds for rows that already have a vector.
+    """
+    vec = [0.25] * 8
+
+    async def _ok(_content, tenant_config=None):
+        return vec
+
+    children, scheduled = await _run_fanout(_ok)
+
+    assert len(children) == 2
+    assert all(c["embedding"] == vec for c in children)
+    assert all("embedding_pending" not in c["metadata_"] for c in children), (
+        "an embedded child must not be flagged pending"
+    )
+    assert scheduled == [], f"no re-embed should be scheduled for embedded rows; got {scheduled!r}"


### PR DESCRIPTION
## The loss

The atomic-fact fan-out **dropped facts outright** when their embedding failed. Both exits in the loop landed before the write:

```python
except (TimeoutError, ValueError, ...):
    logger.warning("atomic-fact embed failed ... (skipping this fact)")
    continue
if child_embedding is None:
    continue          # ← silent
...
await sc.create_memory({...})   # never reached
```

This is data loss, not a repairable gap. Every recovery path in the system keys off a row with `embedding IS NULL`; none of them can see a row that was never written.

**The two arms are not symmetric, which is why this went unnoticed.** `get_embedding` *returns* None once its retry budget is exhausted rather than raising (`common/embedding/_service.py::_run_with_retry`), so under the embedding-gate saturation this path actually meets, the **silent** arm is the common one. It carried no attribution at this call site, so nothing tied a lost fact to a parent, a path, or a cause — the rate was unmeasurable by construction. (It was not globally silent: `_run_with_retry` logs its own terminal error. What was missing was *whose* fact was dropped and why.)

**core-worker already documents the invariant this restores.** Its consumer asserts:

> The auto-chunk parent and atomic-fact fan-out paths do land as NULL, so this does catch them.

True of auto-chunk. False of the fan-out until this PR.

## Changes

- **Persist the child with `embedding=None`** instead of skipping it.
- **Stamp `metadata.embedding_pending = True`.** That field is public API, not bookkeeping — `MemoryOut.metadata` documents it, agents are told to read it, and core-worker clears it when the vector lands. Without it an unembedded child is indistinguishable from a fully-embedded row to every consumer.
- **Schedule the re-embed via `_schedule_embed_or_reembed`** rather than leaving it to the nightly sweep. This is the part I'd most like reviewed: the sweep is the *floor*, not the mechanism. `embed_backfill_enabled` defaults to **False**, so a deployment that hasn't enabled it would strand these rows indefinitely — which is how ~430 memories were stranded in the 2026-07-27 incident this module already carries a postmortem for. Deferred mode publishes `EMBED_REQUESTED` (Pub/Sub owns retry/backoff/DLQ, paced by the consumer's per-tenant slots); inline mode retries in-process with the failure-fallback backoff. Publishing into a tier that just saturated sounds like piling on, but that's the case the postmortem already adjudicated — the incident was caused by *in-process* retry storms, and the durable path is the paced option.
- **Add a WARNING attributing the degradation to this path and parent.** The hourly coverage tick already reports the global backlog; what was missing was which path produced it.

`fanout_unembedded` is counted only **after** the write succeeds, so the summary can never claim a pending repair for a row that was never persisted.

## Tests

7 cases, parametrized across both failure arms: the fact is persisted, flagged `embedding_pending`, and gets a re-embed scheduled with `is_failure_fallback=True`.

**All 6 contract cases were confirmed to FAIL on unfixed code.** The 7th is a control — the happy path still attaches real vectors and schedules nothing — and passes either way by design.

Worth flagging: one test initially passed on unfixed code **for the wrong reason**. `all()` over an empty sequence is `True`, and the broken path writes no children, so the `embedding_pending` assertion was vacuously satisfied by exactly the bug it existed to catch. It now asserts the child count before inspecting them.

`ruff check`, `ruff format --check`, `mypy` (198 files) clean; full root suite **4383 passed**.

## Not in this PR

The sibling `update` path (`memory_service.py` ~:2696) persists `embedding=None` deliberately and also relies on the sweep with no scheduled re-embed. The same durable-handoff argument applies there if you want the invariant uniform — but it's a separate path with its own reasoning, and I didn't want to widen an incident fix.
