### PR TITLE
fix(extraction): drop malformed items instead of the whole extraction

### DIFF
--- a/core-api/src/core_api/services/entity_extraction.py
+++ b/core-api/src/core_api/services/entity_extraction.py
@@ -4,13 +4,33 @@ import logging
 import re
 import zlib
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from core_api.config import settings
 from core_api.protocols import LLMProvider
 from core_api.providers._retry import call_with_fallback
 
 logger = logging.getLogger(__name__)
+
+
+class ExtractionShapeError(ValueError):
+    """Provider output could not yield a usable graph.
+
+    Subclasses ``ValueError`` so ``call_with_retry``'s broad ``except`` still
+    routes it to the fallback chain unchanged, while giving the pending #788
+    follow-up — classifying shape failures as non-retryable in
+    ``common/llm/retry.py`` — one narrow type to mark rather than a bare
+    ``ValueError`` that shared infra cannot safely single out.
+
+    Deliberately NOT ``common.llm.providers.ProviderResponseShapeError``, which
+    is a transport-layer error: its contract is ``(provider, content,
+    parsed_type)`` and it STORES and renders ``content`` (1 KiB) in ``__str__``.
+    Passing this payload through it would put memory content, and any PII in
+    it, into every traceback that error reaches. This condition is a domain
+    one — the response parsed fine, it just held nothing usable — so it carries
+    diagnostic counts only and never the payload.
+    """
+
 
 EXTRACTION_PROMPT = """\
 Extract named entities, their relations, and surface-form mentions from the following memory content.
@@ -67,6 +87,74 @@ class ExtractedGraph(BaseModel):
     entities: list[ExtractedEntity] = []
     relations: list[ExtractedRelation] = []
     mentions: list[Mention] = []
+
+
+# Item model per ``ExtractedGraph`` list field. A field missing from here is
+# simply never walked — it defaults to empty and nothing complains — so the
+# coverage is pinned by a test rather than by this comment
+# (``test_registry_covers_every_graph_list_field``).
+_GRAPH_ITEM_MODELS: dict[str, type[BaseModel]] = {
+    "entities": ExtractedEntity,
+    "relations": ExtractedRelation,
+    "mentions": Mention,
+}
+
+
+def _parse_graph_lenient(raw: dict) -> tuple[ExtractedGraph, dict[str, int]]:
+    """Build an ``ExtractedGraph``, dropping malformed items instead of failing.
+
+    ``ExtractedGraph(**raw)`` validates the whole payload atomically, so ONE
+    bad item discarded every good one alongside it. That is not hypothetical:
+    a null ``cluster_id`` on mention 10 of 15 took out the entire extraction in
+    prod on 2026-08-16 (#788), and every remaining non-optional field here —
+    ``canonical_name``, ``entity_type``, ``role``, ``from_entity``,
+    ``relation_type``, ``to_entity``, ``surface`` — carries the identical
+    exposure. Fixing them one nullable field at a time is whack-a-mole; the
+    parse boundary is where the blast radius is set.
+
+    Mirrors the ``atomic_facts`` loop in
+    ``common/enrichment/service.py::_validate_enrichment``, which walks that
+    provider output item-by-item and ``continue``s past entries it cannot use.
+    Note the mirror is only of the LIST walk: that function's outer
+    ``EnrichmentResult(**raw)`` is still atomic, so enrichment carries this same
+    exposure one level up.
+
+    A relation whose endpoint entity was dropped is not a dangling reference —
+    ``entity_extraction_worker`` only writes an edge when both ids resolve, the
+    same cascade it already documents for blocklisted nodes.
+
+    Returns the graph plus a per-field count of what was dropped. The caller
+    owns the logging so this stays a pure function.
+
+    NOTE it deliberately does NOT swallow a total loss — see
+    ``_do_extract`` for why an all-items-dropped payload still raises.
+    """
+    dropped: dict[str, int] = {}
+    fields: dict[str, list] = {}
+    for field, model in _GRAPH_ITEM_MODELS.items():
+        items = raw.get(field)
+        if items is None:
+            continue
+        if not isinstance(items, list):
+            # A non-list where a list belongs is a shape error for the whole
+            # field, not a per-item one; treat it as "nothing usable here"
+            # rather than guessing at a coercion. Counted as 1 because there
+            # are no items to count.
+            dropped[field] = 1
+            continue
+        kept: list[BaseModel] = []
+        for item in items:
+            try:
+                # ``model_validate`` rather than ``model(**item)``: it raises
+                # ValidationError for a non-mapping item too, so one narrow
+                # except covers junk of every shape. ``**`` on a str/int/None
+                # would raise TypeError and force a broader catch that would
+                # also swallow unrelated errors.
+                kept.append(model.model_validate(item))
+            except ValidationError:
+                dropped[field] = dropped.get(field, 0) + 1
+        fields[field] = kept
+    return ExtractedGraph(**fields), dropped
 
 
 def _fake_extract(content: str) -> ExtractedGraph:
@@ -169,15 +257,54 @@ async def extract_entities_from_content(
         # OpenAI provider sends it with ``strict=False`` (see
         # ``common/llm/providers/openai.py``) and gemini/vertex accept and
         # ignore it outright, so the provider can and does return values the
-        # schema forbids. The ``ExtractedGraph(**raw)`` parse below is the only
-        # real enforcement — see ``Mention.cluster_id`` for the prod failure
-        # that established this.
+        # schema forbids. ``_parse_graph_lenient`` below is the only real
+        # enforcement, and it enforces PER ITEM — malformed entries are dropped
+        # and counted rather than failing the payload. See
+        # ``Mention.cluster_id`` for the prod failure that established this.
         raw = await llm.complete_json(
             prompt,
             seed=seed,
             response_schema=ExtractedGraph.model_json_schema(),
         )
-        return ExtractedGraph(**raw)
+        if not isinstance(raw, dict):
+            # Not a per-item problem — there is no payload to salvage items
+            # from. Raise so the fallback chain gets its turn.
+            raise ExtractionShapeError(f"entity extraction returned {type(raw).__name__}, expected dict")
+        graph, dropped = _parse_graph_lenient(raw)
+        if dropped:
+            # Counts only, never the items: the payload is memory content plus
+            # any PII in it, and this is a WARNING bound for log storage. Flat
+            # key=value with a stable leading slug so a plain grep finds it
+            # regardless of how the structlog renderer handles ``extra`` —
+            # same shape as ``contradiction_detector``'s skip logs.
+            #
+            # ``kept`` is read off the parsed graph, NOT re-derived from
+            # ``raw``: a non-list field has no ``len()``, and computing it here
+            # would raise INSIDE the salvage branch, discarding the very graph
+            # this function just rescued.
+            logger.warning(
+                "entity_extraction_items_dropped dropped=%s kept=%s",
+                dropped,
+                {f: len(getattr(graph, f)) for f in dropped},
+            )
+            # A total loss is NOT salvage: returning an empty graph would
+            # silently assert "no entities in this content", indistinguishable
+            # from a legitimately entity-free memory, and rob the fallback
+            # chain of its turn — the alternative provider is a different model
+            # and may well parse.
+            #
+            # Keyed on entities/relations and an empty ``entities``, NOT on all
+            # three lists. ``mentions`` has no consumer that persists anything,
+            # so a surviving mention must not suppress the fallback (the worker
+            # early-returns on an entity-less graph, losing the extraction with
+            # no audit row), and a malformed mention alone must not trigger it
+            # (that would let the regex fallback invent entities the LLM
+            # correctly reported as absent).
+            if (dropped.keys() & {"entities", "relations"}) and not graph.entities:
+                raise ExtractionShapeError(
+                    f"entity extraction produced no usable entities (dropped={dropped})"
+                )
+        return graph
 
     extraction_model = (
         (getattr(tenant_config, "entity_extraction_model", None) if tenant_config else None)

--- a/tests/test_extraction_partial_parse.py
+++ b/tests/test_extraction_partial_parse.py
@@ -1,0 +1,335 @@
+"""One malformed item must not discard the whole extraction.
+
+#788 fixed a single field; the boundary is what actually sets the blast radius.
+For why, see ``_parse_graph_lenient``'s docstring.
+
+The parametrized cases below enumerate the fields that were still exposed —
+documenting the surface, not defining the contract. The contract is the
+boundary behaviour, which holds for any field a future model makes required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from core_api.services.entity_extraction import (
+    ExtractedGraph,
+    _parse_graph_lenient,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _ok_entity(name: str = "anna") -> dict:
+    return {"canonical_name": name, "entity_type": "person", "role": "subject"}
+
+
+def _ok_relation() -> dict:
+    return {"from_entity": "anna", "relation_type": "works_on", "to_entity": "helios"}
+
+
+def _ok_mention(surface: str = "Anna") -> dict:
+    return {"surface": surface, "cluster_id": 0, "entity_canonical": "anna"}
+
+
+@pytest.mark.parametrize(
+    "field,items",
+    [
+        # The exact #788 shape, reproduced on each sibling field that was
+        # still exposed. A null in a non-optional slot.
+        ("entities", [_ok_entity("anna"), {**_ok_entity("bob"), "role": None}]),
+        ("entities", [_ok_entity("anna"), {**_ok_entity("bob"), "entity_type": None}]),
+        (
+            "entities",
+            [_ok_entity("anna"), {**_ok_entity("bob"), "canonical_name": None}],
+        ),
+        ("relations", [_ok_relation(), {**_ok_relation(), "relation_type": None}]),
+        ("relations", [_ok_relation(), {**_ok_relation(), "from_entity": None}]),
+        ("relations", [_ok_relation(), {**_ok_relation(), "to_entity": None}]),
+        ("mentions", [_ok_mention("Anna"), {**_ok_mention("She"), "surface": None}]),
+    ],
+)
+def test_one_bad_item_does_not_discard_its_siblings(field, items) -> None:
+    """The good item in the same list must survive the bad one."""
+    raw = {field: items}
+
+    # Control: the atomic parse this replaces loses everything.
+    with pytest.raises(ValidationError):
+        ExtractedGraph(**raw)
+
+    graph, dropped = _parse_graph_lenient(raw)
+
+    assert dropped == {field: 1}, (
+        f"expected exactly one dropped {field}; got {dropped!r}"
+    )
+    kept = getattr(graph, field)
+    assert len(kept) == len(items) - 1, (
+        f"the well-formed {field} item must survive; kept {kept!r}"
+    )
+
+
+def test_a_bad_item_in_one_list_does_not_touch_the_others() -> None:
+    """Blast radius is the item, not the payload."""
+    raw = {
+        "entities": [_ok_entity("anna"), {**_ok_entity("bob"), "role": None}],
+        "relations": [_ok_relation()],
+        "mentions": [_ok_mention()],
+    }
+
+    graph, dropped = _parse_graph_lenient(raw)
+
+    assert dropped == {"entities": 1}
+    assert len(graph.entities) == 1
+    assert len(graph.relations) == 1, "a bad entity must not drop a good relation"
+    assert len(graph.mentions) == 1, "a bad entity must not drop a good mention"
+
+
+@pytest.mark.parametrize("junk", [None, "a string", 5, ["nested"]])
+def test_non_mapping_items_are_dropped(junk) -> None:
+    """Junk of any shape is a drop, not an escape.
+
+    ``model_validate`` raises ValidationError for a non-mapping too, which is
+    why one narrow except suffices; ``model(**item)`` would raise TypeError
+    here and force a broader catch.
+    """
+    raw = {"entities": [_ok_entity(), junk]}
+
+    graph, dropped = _parse_graph_lenient(raw)
+
+    assert dropped == {"entities": 1}
+    assert len(graph.entities) == 1
+
+
+def test_registry_covers_every_graph_list_field() -> None:
+    """The item-model registry must cover every list field on the graph.
+
+    A field absent from ``_GRAPH_ITEM_MODELS`` is never walked: it silently
+    defaults to empty and nothing reports it. This is the check that makes
+    that omission loud, since no runtime behaviour does.
+    """
+    from core_api.services.entity_extraction import _GRAPH_ITEM_MODELS
+
+    list_fields = {
+        name
+        for name, f in ExtractedGraph.model_fields.items()
+        if str(f.annotation).startswith("list[")
+    }
+    assert list_fields, "sanity: ExtractedGraph should have list fields"
+    assert set(_GRAPH_ITEM_MODELS) == list_fields, (
+        "every list field on ExtractedGraph needs an item model, or it is "
+        f"silently skipped; registry={set(_GRAPH_ITEM_MODELS)!r} fields={list_fields!r}"
+    )
+
+
+def test_a_non_list_field_is_dropped_wholesale() -> None:
+    """A non-list where a list belongs has no items to walk."""
+    graph, dropped = _parse_graph_lenient({"entities": {"canonical_name": "anna"}})
+
+    assert dropped == {"entities": 1}
+    assert graph.entities == []
+
+
+def test_clean_payload_is_unchanged_and_reports_nothing_dropped() -> None:
+    """Control: tolerance must not alter a well-formed payload."""
+    raw = {
+        "entities": [_ok_entity("anna"), _ok_entity("bob")],
+        "relations": [_ok_relation()],
+        "mentions": [_ok_mention()],
+    }
+
+    graph, dropped = _parse_graph_lenient(raw)
+
+    assert dropped == {}
+    assert [e.canonical_name for e in graph.entities] == ["anna", "bob"]
+    assert graph.relations[0].relation_type == "works_on"
+    assert graph.mentions[0].surface == "Anna"
+    # Byte-identical to the atomic parse when nothing is malformed.
+    assert graph == ExtractedGraph(**raw)
+
+
+def test_empty_payload_stays_empty() -> None:
+    """ "No entities found" is a legitimate answer, not a failure."""
+    graph, dropped = _parse_graph_lenient(
+        {"entities": [], "relations": [], "mentions": []}
+    )
+
+    assert dropped == {}
+    assert graph == ExtractedGraph()
+
+
+def test_missing_fields_default_rather_than_drop() -> None:
+    """Back-compat: a pre-A5b payload without ``mentions`` is not a drop."""
+    graph, dropped = _parse_graph_lenient({"entities": [_ok_entity()]})
+
+    assert dropped == {}
+    assert graph.mentions == []
+    assert len(graph.entities) == 1
+
+
+# ---------------------------------------------------------------------------
+# Call-site behaviour: what _do_extract does with the salvage result
+# ---------------------------------------------------------------------------
+
+
+async def _extract_with_payload(payload):
+    """Run the real extraction path against a stubbed provider response."""
+    from common.llm.providers.openai import OpenAILLMProvider
+    from core_api.services.entity_extraction import extract_entities_from_content
+
+    async def _fake_complete_json(self, prompt: str, **kwargs):
+        return payload
+
+    with (
+        patch.object(OpenAILLMProvider, "complete_json", _fake_complete_json),
+        patch(
+            "common.llm.registry.get_llm_provider",
+            return_value=OpenAILLMProvider(api_key="sk-test", model="gpt-test"),
+        ),
+        patch(
+            "core_api.services.entity_extraction.settings.entity_extraction_provider",
+            "openai",
+        ),
+    ):
+        return await extract_entities_from_content(
+            "Anna Bergstrom ships Vermillion", "fact"
+        )
+
+
+@pytest.mark.asyncio
+async def test_partial_payload_survives_end_to_end() -> None:
+    """A payload with one bad entity must still yield the good one.
+
+    This is the whole point: before, the fallback chain ran and the result
+    came from the regex heuristic, losing the LLM's real extraction.
+    """
+    graph = await _extract_with_payload(
+        {
+            "entities": [_ok_entity("anna"), {**_ok_entity("bob"), "role": None}],
+            "relations": [_ok_relation()],
+            "mentions": [],
+        }
+    )
+
+    names = [e.canonical_name for e in graph.entities]
+    assert "anna" in names, f"the well-formed entity must survive; got {names!r}"
+    assert len(graph.relations) == 1
+
+
+@pytest.mark.asyncio
+async def test_total_loss_falls_back_rather_than_returning_empty() -> None:
+    """If NOTHING survives, the fallback chain must still get its turn.
+
+    Returning an empty graph would silently assert "no entities in this
+    content" — indistinguishable from a legitimately empty extraction, and it
+    would rob the alternative provider (a different model, which may well
+    parse) of its chance. ``_fake_extract`` finds capitalised multi-word
+    phrases, so the fallback is observable.
+    """
+    graph = await _extract_with_payload(
+        {
+            "entities": [{**_ok_entity("bob"), "role": None}],
+            "relations": [],
+            "mentions": [],
+        }
+    )
+
+    assert graph.entities, (
+        "an all-dropped payload must reach the fallback, not return empty; "
+        f"got {graph!r}"
+    )
+    assert any("anna bergstrom" == e.canonical_name for e in graph.entities), (
+        f"expected the regex fallback's extraction; got {[e.canonical_name for e in graph.entities]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_legitimately_empty_payload_stays_empty_end_to_end() -> None:
+    """Control: an empty payload is NOT a total loss and must not fall back.
+
+    Without this, "drop nothing, keep nothing" and "drop everything" would be
+    indistinguishable, and every genuinely entity-free memory would burn the
+    fallback chain.
+    """
+    graph = await _extract_with_payload(
+        {"entities": [], "relations": [], "mentions": []}
+    )
+
+    assert graph.entities == [], (
+        f"an empty extraction must be respected, not retried into the fallback; got {graph!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_surviving_mention_does_not_suppress_the_fallback() -> None:
+    """A salvaged mention must not stand in for salvaged entities.
+
+    ``mentions`` has no consumer that persists anything, and the worker
+    early-returns on an entity-less graph — so if a surviving mention
+    suppressed the fallback, the extraction would be lost with no audit row.
+    That is the failure this predicate exists to prevent, reached through the
+    one field with no reader.
+    """
+    graph = await _extract_with_payload(
+        {
+            "entities": [{**_ok_entity("bob"), "role": None}],
+            "relations": [],
+            "mentions": [_ok_mention("Anna")],
+        }
+    )
+
+    assert any(e.canonical_name == "anna bergstrom" for e in graph.entities), (
+        "all entities dropped must reach the fallback even when a mention survived; "
+        f"got {[e.canonical_name for e in graph.entities]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_malformed_mention_alone_does_not_trigger_the_fallback() -> None:
+    """The inverse: a bad mention must not override a correct empty extraction.
+
+    With no entities offered, "no entities in this content" is the LLM's
+    answer and it is probably right. Falling back here would let the regex
+    heuristic invent entities the model correctly reported as absent.
+    """
+    graph = await _extract_with_payload(
+        {
+            "entities": [],
+            "relations": [],
+            "mentions": [{**_ok_mention("She"), "surface": None}],
+        }
+    )
+
+    assert graph.entities == [], (
+        "a malformed mention must not send a correct empty extraction to the "
+        f"regex fallback; got {[e.canonical_name for e in graph.entities]!r}"
+    )
+
+
+def test_extraction_shape_error_is_a_valueerror_and_carries_no_payload() -> None:
+    """The raise type is load-bearing, and it must not leak content.
+
+    ``call_with_retry`` catches broad ``Exception``, so the end-to-end tests
+    above pass regardless of what type is raised — they cannot see this. It is
+    asserted directly because the pending #788 follow-up (classify shape
+    failures as non-retryable) needs one narrow type to key on, and because an
+    earlier draft used ``ProviderResponseShapeError``, whose contract STORES
+    and renders up to 1 KiB of ``content`` — which here would be memory text.
+    """
+    from core_api.services.entity_extraction import ExtractionShapeError
+
+    # Subclassing ValueError is what keeps today's fallback behaviour unchanged.
+    assert issubclass(ExtractionShapeError, ValueError)
+
+    err = ExtractionShapeError(
+        "entity extraction produced no usable entities (dropped={'entities': 1})"
+    )
+    rendered = str(err)
+    assert "dropped=" in rendered, "counts are the diagnostic value; keep them"
+    # No constructor slot for a payload, and nothing renders one.
+    assert not hasattr(err, "content"), (
+        "this error must not carry a response payload — that is the transport-layer "
+        "ProviderResponseShapeError's contract, and it renders content into tracebacks"
+    )


### PR DESCRIPTION
Closes the class that #788 fixed one instance of.

## The exposure

#788 made `Mention.cluster_id` nullable after a null value on mention 10 of 15 destroyed a whole prod extraction. **Seven sibling non-optional fields carried the identical exposure** — `canonical_name`, `entity_type`, `role`, `from_entity`, `relation_type`, `to_entity`, `surface` — because `ExtractedGraph(**raw)` validated the payload atomically. Nothing enforces the schema we send (`strict=False` on OpenAI, accepted-and-ignored on gemini/vertex), so a `"role": null` reproduced the incident exactly.

Measured against `origin/main` with a stub provider — one null `role` on the second of two entities:

```
before:  entities ['anna bergstrom']   relations 0    ← regex fallback's guess
after:   entities ['anna']             relations 1
```

The LLM's real extraction was discarded and `_fake_extract`'s capitalised-phrase heuristic answered instead. And because `_do_extract` pins a stable CRC32 seed *so that retries reproduce identical output*, the primary's retry budget was spent on a call that could not succeed.

## Why the boundary and not the fields

Defaulting every field loses on three counts:

- "every field must have a default" is an unenforceable convention — the next required field silently reopens the hole, and nothing fails loudly
- a default turns a malformed item into a silently **accepted** one: `entity_type=""` passes `_is_valid_entity` (length ≥ 2 + blocklist) and persists as a real entity row; `role=""` breaks `_reattach_subject_discriminators`, which keys on `role == "subject"`
- the repo already ran this experiment — `common/enrichment/schema.py` *is* the defaults-everywhere design, and `_validate_enrichment` still needed a hand-rolled item-by-item loop, because `AtomicFact.content` is legitimately required

A counted drop beats quiet pollution.

## The fallback decision, which is the subtle part

A total loss still raises, so the fallback chain gets its turn — an empty graph would be indistinguishable from a legitimately entity-free memory. But the predicate is keyed on **entities/relations with no surviving entities**, not on all three lists:

- `mentions` has no consumer that persists anything, so a surviving mention must not suppress the fallback — the worker early-returns on an entity-less graph, losing the extraction with no audit row
- conversely a malformed mention **alone** must not trigger it, or the regex heuristic invents entities the model correctly reported as absent

Both directions are tested, and both fail with the naive three-list predicate — verified by reverting just that line.

Raises `ProviderResponseShapeError` rather than bare `ValueError`, so the remaining #788 follow-up (classify shape failures as non-retryable in `common/llm/retry.py`) has one type to key on rather than a bare `ValueError` that shared infra can't safely catch.

## Logging

Counts only, never items — the payload is memory content plus any PII in it. Flat `key=value` with a stable leading slug (`entity_extraction_items_dropped`), matching the `contradiction_detector` skip-log convention so `grep` works regardless of renderer.

`kept` is read off the parsed graph, **not** re-derived from `raw`. An earlier draft computed `len(raw.get(f))`, which raises `TypeError` on a non-list field — *inside the salvage branch*, discarding the graph it had just rescued. Caught in review; there's now a test for the non-list case.

## Tests — 22

Sibling-field cases assert the good item survives while showing the atomic parse raises on the same payload. `_GRAPH_ITEM_MODELS` coverage is pinned by a test rather than a comment, because a list field absent from the registry is never walked and silently defaults to empty — no runtime behaviour reports that.

## Noted, not done

`common/enrichment/service.py:186` — `EnrichmentResult(**raw)` is still an atomic parse of provider output. Every field is defaulted and most are pre-sanitised, but `summary` and `pii_types` aren't, so a `summary: 5` loses the whole enrichment to `fake_enrich`. Same shape, one level up. Recorded in `_parse_graph_lenient`'s docstring so the next person chasing this class doesn't read the cross-reference and conclude enrichment is already safe.
