### PR TITLE
fix(enrichment): tolerate a junk summary or pii_types

### DIFF
--- a/common/enrichment/schema.py
+++ b/common/enrichment/schema.py
@@ -112,3 +112,65 @@ class EnrichmentResult(BaseModel):
     retrieval_hint: str = ""
     atomic_facts: list[AtomicFact] | None = None
     llm_ms: int = 0
+
+    @field_validator("summary", mode="before")
+    @classmethod
+    def _coerce_summary(cls, raw):
+        """Defensive normalisation, same reason as ``_normalize_tags`` above.
+
+        This model is built from unenforced LLM output, and the caller recovers
+        from a ValidationError by falling through to ``fake_enrich`` — so one
+        junk field discarded a whole good enrichment: title, tags, weight,
+        timestamps, atomic facts and all. ``summary`` was the last field
+        nothing guarded (``_validate_enrichment`` coerces the rest, ``tags``
+        is handled above), and a ``summary`` of ``5`` / ``None`` / ``{...}`` /
+        ``[...]`` raised.
+
+        SCOPED TO ``summary`` DELIBERATELY. ``title`` and ``retrieval_hint``
+        look like they belong here and do not: ``_validate_enrichment`` already
+        rewrites both to ``str`` BEFORE this validator runs, so listing them
+        would advertise a protection that never fires. Note the consequence
+        left in place — a junk ``title`` still persists as its repr
+        (``{'a': 1}`` becomes ``"{'a': 1}"``, ``None`` becomes ``"None"``).
+        That is a pre-existing display bug, not a crash, and fixing it means
+        moving truncation onto the model too; kept out so this stays a crash
+        fix.
+
+        A non-str value is DISCARDED rather than stringified: ``summary`` is
+        user-visible and lands in ``metadata["summary"]`` verbatim, so blank
+        reads as "no information" while ``"{'a': 1}"`` reads as prose the model
+        never wrote.
+        """
+        if raw is None:
+            return ""
+        return raw if isinstance(raw, str) else ""
+
+    @field_validator("pii_types", mode="before")
+    @classmethod
+    def _coerce_pii_types(cls, raw):
+        """Drop non-string entries instead of failing the whole enrichment.
+
+        ``_validate_enrichment`` normalises falsy values via
+        ``raw.get("pii_types") or []``, which leaves the two shapes the LLM
+        actually produces: a bare string (``"email"``) and a list with
+        non-string members (``[1, 2]``). Both raised.
+
+        A bare string is WRAPPED rather than dropped. Note what this does and
+        does not affect: the PII gate keys on ``contains_pii`` alone
+        (``governance_decision.py`` / ``governance_remediation.py``), so this
+        cannot change a drop/flag decision. It is the audit trail and row
+        metadata that matter — a compliance review reading ``categories: []``
+        on a flagged row cannot distinguish "no type declared" from "type lost
+        to normalisation", so the declared value is preserved as evidence.
+
+        ``AtomicFact`` gets no equivalent guard, which is not an oversight:
+        the service's item-walk pre-cleans facts into str-only dicts before
+        this model sees them.
+        """
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            return [raw] if raw.strip() else []
+        if not isinstance(raw, list):
+            return []
+        return [item for item in raw if isinstance(item, str) and item.strip()]

--- a/core-api/src/core_api/services/entity_extraction.py
+++ b/core-api/src/core_api/services/entity_extraction.py
@@ -115,9 +115,9 @@ def _parse_graph_lenient(raw: dict) -> tuple[ExtractedGraph, dict[str, int]]:
     Mirrors the ``atomic_facts`` loop in
     ``common/enrichment/service.py::_validate_enrichment``, which walks that
     provider output item-by-item and ``continue``s past entries it cannot use.
-    Note the mirror is only of the LIST walk: that function's outer
-    ``EnrichmentResult(**raw)`` is still atomic, so enrichment carries this same
-    exposure one level up.
+    That function's outer ``EnrichmentResult(**raw)`` used to be atomic and so
+    carried this same exposure one level up; its two unguarded fields now have
+    model-level ``mode="before"`` validators, so both layers are covered.
 
     A relation whose endpoint entity was dropped is not a dangling reference —
     ``entity_extraction_worker`` only writes an edge when both ids resolve, the

--- a/tests/test_enrichment_junk_field_tolerance.py
+++ b/tests/test_enrichment_junk_field_tolerance.py
@@ -1,0 +1,102 @@
+"""A junk value in one enrichment field must not discard the whole result.
+
+``EnrichmentResult`` is built from unenforced LLM output and its caller recovers
+from a ValidationError by falling through to ``fake_enrich``. For which fields
+were already guarded and why these two were not, see ``_coerce_summary`` and
+``_coerce_pii_types`` in ``common/enrichment/schema.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from common.enrichment.service import _validate_enrichment
+
+pytestmark = [pytest.mark.unit]
+
+
+def _raw(**over) -> dict:
+    """A well-formed enrichment payload, as the LLM should return it."""
+    base = {
+        "memory_type": "fact",
+        "title": "Anna ships Helios",
+        "summary": "Anna shipped the Helios migration.",
+        "weight": 0.8,
+        "status": "active",
+        "tags": ["migration"],
+        "contains_pii": False,
+        "pii_types": [],
+        "business_relevance": "business",
+        "retrieval_hint": "helios migration",
+    }
+    base.update(over)
+    return base
+
+
+# Every shape verified to raise ValidationError before this fix.
+_JUNK = [
+    pytest.param(5, id="number"),
+    pytest.param(None, id="null"),
+    pytest.param({"a": 1}, id="object"),
+    pytest.param(["x"], id="array"),
+]
+
+
+@pytest.mark.parametrize("junk", _JUNK)
+def test_junk_summary_does_not_discard_the_enrichment(junk) -> None:
+    """The other nine fields must survive a bad ``summary``."""
+    result = _validate_enrichment(_raw(summary=junk), llm_ms=12)
+
+    assert result.summary == "", f"a junk summary must normalise to empty; got {result.summary!r}"
+    # The point of the fix: everything else is still the LLM's work, not
+    # fake_enrich's.
+    assert result.title == "Anna ships Helios"
+    assert result.tags == ["migration"]
+    assert result.weight == 0.8
+    assert result.retrieval_hint == "helios migration"
+    assert result.llm_ms == 12
+
+
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [
+        # A bare string is the LLM answering loosely, not wrongly. Wrapped
+        # rather than dropped to preserve audit evidence — the gate itself
+        # keys on contains_pii, not on these types.
+        ("email", ["email"]),
+        ("  ", []),
+        ([1, 2], []),
+        (["email", None, "phone"], ["email", "phone"]),
+        ({"a": 1}, []),
+        (None, []),
+        (["email"], ["email"]),
+    ],
+)
+def test_pii_types_junk_is_normalised_not_fatal(raw_value, expected) -> None:
+    result = _validate_enrichment(_raw(pii_types=raw_value, contains_pii=True), llm_ms=1)
+
+    assert result.pii_types == expected, (
+        f"pii_types={raw_value!r} should normalise to {expected!r}; got {result.pii_types!r}"
+    )
+    # contains_pii is what the gate actually reads, and it is independent of
+    # this field — "PII present, type unknown" must still trigger.
+    assert result.contains_pii is True
+    assert result.title == "Anna ships Helios"
+
+
+def test_clean_payload_is_untouched() -> None:
+    """Control: tolerance must not alter a well-formed enrichment."""
+    result = _validate_enrichment(
+        _raw(summary="A real summary.", pii_types=["email"], contains_pii=True), llm_ms=7
+    )
+
+    assert result.summary == "A real summary."
+    assert result.pii_types == ["email"]
+    assert result.contains_pii is True
+    assert result.title == "Anna ships Helios"
+    assert result.tags == ["migration"]
+
+# The non-dict shape guard (CAURA-651) is already covered, with a stronger
+# message assertion, by
+# tests/test_vertex_response_shape.py::TestEnrichmentValidatorRejectsNonDict.
+# Not duplicated here.


### PR DESCRIPTION
Closes the follow-up #794's docstring pointed at.

## The exposure — narrower than the note implied

`EnrichmentResult` is built from unenforced LLM output at three sites, and the caller recovers from a ValidationError by falling through to `fake_enrich`. So one junk field discarded a whole good enrichment — title, tags, weight, timestamps, atomic facts and all — and replaced it with the heuristic.

I fuzzed every field rather than trusting the earlier note. `_validate_enrichment` **already** guards `memory_type`, `status`, `weight`, `title`, both timestamps, `retrieval_hint`, `atomic_facts`, `contains_pii`, `business_relevance`; `tags` has a model-level validator. Exactly two were unguarded, and every junk shape broke them:

| field | shapes that raised |
|---|---|
| `summary` | `5`, `None`, `{...}`, `[...]` |
| `pii_types` | `"email"`, `[1, 2]`, `{...}`, `["email", None]` |

`pii_types` was *partially* handled by `raw.get("pii_types") or []` — which covers falsy values but not a truthy bare string or a list with non-string members.

## Fixed on the model, not in the service

Mirrors the `_normalize_tags` validator already in that file. Only **one** of the three construction sites routes through `_validate_enrichment`, so the model is the layer that actually covers all of them, and a future fourth site inherits the guard.

`summary` **discards** a non-str rather than stringifying it: the field is user-visible and lands in `metadata["summary"]` verbatim, so blank reads as "no information" while `"{'a': 1}"` reads as prose the model never wrote.

`pii_types` **wraps** a bare string rather than dropping it — but not for the reason I first wrote. My initial comment claimed this "feeds the governance PII gate, where losing a declared type is the unsafe direction." **That was wrong**, and review caught it: the gate keys on `contains_pii` alone (`governance_decision.py:66`, `governance_remediation.py:62`), so this cannot change a drop/flag decision. The real reason is audit evidence — a compliance review reading `categories: []` on a flagged row cannot tell "no type declared" from "type lost to normalisation". Same choice, corrected rationale.

## Deliberately NOT extended to `title` / `retrieval_hint`

My first draft covered them, and that was worse than useless. `_validate_enrichment` rewrites both to `str` **before** a model validator runs, so the validator can never see a non-str value there — listing them advertises a protection that never fires.

The consequence is documented rather than fixed:

```
title={'a': 1}  ->  "{'a': 1}"
title=None      ->  "None"
```

A junk title still persists as its repr. That's a display bug, not a crash, and fixing it means moving truncation onto the model too — out of scope for a crash fix, but it's now stated in the source instead of implied away.

## Also

Updates the cross-reference in `entity_extraction.py` that said this outer parse was still atomic. That note is what pointed here; leaving it would send the next reader after a gap that no longer exists.

## Tests — 12

**9 confirmed to fail against `origin/main`.** The 3 that pass are genuine controls: a clean payload, plus the two `pii_types` shapes the existing `or []` already handled.

The non-dict shape guard (CAURA-651) is **not** re-tested here — `tests/test_vertex_response_shape.py::TestEnrichmentValidatorRejectsNonDict` already covers it with a stronger message assertion, so duplicating it with a bare `pytest.raises(ValueError)` would have been weaker coverage wearing the same name.

`ruff check common/` and `core-api/src/` clean, `mypy` clean (198 files), full suite **4419 passing**. `common/enrichment/` is not in the enterprise vendored-files manifest, so there's no drift gate to re-sync.

## Noted, not done

`AtomicFact` has no equivalent guard — not an oversight: the service's item-walk pre-cleans facts into str-only dicts before the model sees them. Recorded in the validator docstring.

The remaining LLM-output parse boundaries all live in `core-api/src/core_api/services/` (`dedup_judge`, `crystallizer`, `business_classifier`, `contradiction_detector`, `insights`, `interview`, `agent_digest`, `evolve`). A review sweep found them all already item-tolerant, but that's where the same audit would go next.
