### PR TITLE
feat(llm): let a caller declare which failures are not worth retrying

### DIFF
--- a/common/llm/retry.py
+++ b/common/llm/retry.py
@@ -34,6 +34,7 @@ async def call_with_retry(
     max_attempts: int = LLM_RETRY_ATTEMPTS,
     base_delay: float = LLM_RETRY_DELAY_S,
     timeout: float | None = None,
+    non_retryable: tuple[type[BaseException], ...] = (),
 ) -> T:
     """Call *coro_fn* with retry and linear backoff.
 
@@ -49,6 +50,31 @@ async def call_with_retry(
         Base delay in seconds; actual delay = ``base_delay * attempt_number``.
     timeout:
         Optional per-attempt timeout in seconds.
+    non_retryable:
+        Exception types that must NOT be retried within this provider — the
+        first occurrence raises immediately. Empty by default, so every
+        existing caller keeps its current behaviour unchanged.
+
+        OPT-IN, and deliberately not a global classification. The obvious
+        version of this — "a ValidationError can't succeed on retry, so never
+        retry one" — is WRONG for most callers here. It is only true when the
+        call is deterministic, and determinism comes from the CALLER: only
+        entity extraction pins a ``seed`` (a CRC32 of its prompt, precisely so
+        retries reproduce byte-identical output). Every other caller,
+        enrichment included, is unseeded, so a re-ask genuinely may return
+        parseable output and its retry is worth having. Classifying globally
+        would strip a useful retry from ~10 services to save one wasted call
+        on the single deterministic one.
+
+        Keyed on exception TYPE rather than on seeded-ness because a seeded
+        call still has non-deterministic failure modes — a network timeout
+        must be retried no matter how fixed the seed is. Seeding is what makes
+        a SHAPE failure deterministic; the type is what separates shape from
+        transport.
+
+        Note this bounds retries WITHIN a provider only. ``call_with_fallback``
+        still advances to the fallback provider afterwards, which is correct:
+        that is a different model and may well parse what this one mangled.
 
     Raises the last exception if all attempts are exhausted.
     """
@@ -63,6 +89,19 @@ async def call_with_retry(
             return await coro
         except Exception as exc:
             last_exc = exc
+            # ``isinstance(exc, ())`` is False, so an empty tuple makes this a
+            # no-op for every caller that has not opted in.
+            if isinstance(exc, non_retryable):
+                logger.warning(
+                    "%s attempt %d/%d failed (%s: %s); NOT retrying — "
+                    "caller declared this type deterministic",
+                    label,
+                    attempt + 1,
+                    max_attempts,
+                    type(exc).__name__,
+                    exc,
+                )
+                break
             if attempt < max_attempts - 1:
                 delay = base_delay * (attempt + 1)
                 logger.warning(
@@ -90,6 +129,7 @@ async def call_with_fallback(
     timeout: float | None = None,
     max_attempts: int = LLM_RETRY_ATTEMPTS,
     provider_factory: Callable[..., Any] | None = None,
+    non_retryable: tuple[type[BaseException], ...] = (),
 ) -> T:
     """3-tier fallback chain for LLM calls.
 
@@ -127,6 +167,12 @@ async def call_with_fallback(
         Callable ``(name, tenant_config) -> LLMProvider``. Defaults to
         ``common.llm.registry.get_llm_provider`` (imported lazily to avoid
         circular imports).
+    non_retryable:
+        Forwarded to ``call_with_retry`` for BOTH providers — see its docstring
+        for why this is opt-in. Applied to the fallback provider too because
+        the seed travels with the prompt, so a deterministic failure is
+        deterministic there as well; what still runs is the PROVIDER hop, not
+        the retry.
     """
     if provider_factory is None:
         from common.llm.registry import get_llm_provider
@@ -158,6 +204,7 @@ async def call_with_fallback(
                 label=f"{label}-primary",
                 max_attempts=max_attempts,
                 timeout=timeout,
+                non_retryable=non_retryable,
             )
         logger.warning(
             "%s: provider '%s' resolved to FakeLLMProvider (no API key). Trying fallback.",
@@ -201,6 +248,7 @@ async def call_with_fallback(
                         label=f"{label}-fallback-{fb_provider_name}",
                         max_attempts=max_attempts,
                         timeout=timeout,
+                        non_retryable=non_retryable,
                     )
     except Exception:
         logger.warning(

--- a/core-api/src/core_api/services/entity_extraction.py
+++ b/core-api/src/core_api/services/entity_extraction.py
@@ -319,6 +319,17 @@ async def extract_entities_from_content(
         service_label="entity-extraction",
         model_override=extraction_model,
         model_attr="entity_extraction_model",
+        # This caller is the one that can honestly declare a shape failure
+        # non-retryable: ``_do_extract`` pins ``seed`` to a CRC32 of the prompt
+        # SPECIFICALLY so retries reproduce byte-identical output, which means a
+        # second attempt is guaranteed to fail the same way. Only shape types
+        # are listed — a transport failure (timeout, 5xx) stays retryable, seed
+        # or no seed.
+        #
+        # This does NOT skip the fallback provider, only the wasted re-ask
+        # within each one. The alternative model still gets its turn, which is
+        # the whole reason a total loss raises rather than returning empty.
+        non_retryable=(ExtractionShapeError, ValidationError),
     )
     # A33 ①: undo the split-discriminator pattern before resolution.
     return _reattach_subject_discriminators(graph, content)

--- a/tests/test_llm_non_retryable.py
+++ b/tests/test_llm_non_retryable.py
@@ -1,0 +1,178 @@
+"""``non_retryable`` bounds retries within a provider, not the fallback chain.
+
+A retry can only help if the call might return something different. Entity
+extraction pins a seed so retries reproduce byte-identical output, which makes
+a shape failure guaranteed to recur — the second attempt is pure waste. Every
+other caller here is unseeded, so its retries are worth having; hence opt-in
+rather than a global classification. See ``call_with_retry``'s docstring.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from common.llm.retry import call_with_fallback, call_with_retry
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class Shape(ValueError):
+    """Stands in for a deterministic shape failure."""
+
+
+class Transport(RuntimeError):
+    """Stands in for a retryable transport failure."""
+
+
+def _counting(exc: BaseException):
+    """An always-failing coro_fn that records how many times it ran."""
+    calls: list[int] = []
+
+    async def _fn():
+        calls.append(1)
+        raise exc
+
+    return _fn, calls
+
+
+async def test_declared_type_is_not_retried() -> None:
+    fn, calls = _counting(Shape("bad shape"))
+
+    with pytest.raises(Shape):
+        await call_with_retry(fn, label="t", max_attempts=3, base_delay=0, non_retryable=(Shape,))
+
+    assert len(calls) == 1, f"a declared-deterministic failure must run once; ran {len(calls)}x"
+
+
+async def test_undeclared_type_still_retries() -> None:
+    """Control: the classification must be narrow, not a blanket fail-fast."""
+    fn, calls = _counting(Transport("timeout"))
+
+    with pytest.raises(Transport):
+        await call_with_retry(fn, label="t", max_attempts=3, base_delay=0, non_retryable=(Shape,))
+
+    assert len(calls) == 3, f"a transport failure must still use its budget; ran {len(calls)}x"
+
+
+async def test_default_is_a_no_op_for_existing_callers() -> None:
+    """The parameter defaults to (), so ~10 untouched callers are unaffected.
+
+    ``isinstance(exc, ())`` is False for every exception, which is what makes
+    the default a true no-op rather than a behaviour change.
+    """
+    fn, calls = _counting(Shape("bad shape"))
+
+    with pytest.raises(Shape):
+        await call_with_retry(fn, label="t", max_attempts=3, base_delay=0)
+
+    assert len(calls) == 3, "without opting in, nothing may change"
+
+
+async def test_subclasses_are_covered() -> None:
+    """``isinstance`` semantics: declaring a base covers its subclasses."""
+
+    class Narrower(Shape):
+        pass
+
+    fn, calls = _counting(Narrower("bad shape"))
+
+    with pytest.raises(Narrower):
+        await call_with_retry(fn, label="t", max_attempts=3, base_delay=0, non_retryable=(Shape,))
+
+    assert len(calls) == 1
+
+
+async def test_a_success_after_a_retryable_failure_still_succeeds() -> None:
+    """Control: the happy path through the retry loop is unchanged."""
+    attempts: list[int] = []
+
+    async def _fn():
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise Transport("first one fails")
+        return "ok"
+
+    got = await call_with_retry(
+        _fn, label="t", max_attempts=3, base_delay=0, non_retryable=(Shape,)
+    )
+
+    assert got == "ok"
+    assert len(attempts) == 2
+
+
+# ---------------------------------------------------------------------------
+# The load-bearing property: skipping retries must NOT skip the fallback
+# ---------------------------------------------------------------------------
+
+
+class _Provider:
+    is_fake = False
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _Cfg:
+    """Minimal tenant config exposing a fallback provider."""
+
+    def resolve_fallback(self, *_a, **_k):
+        # Real contract: ``(provider_name, model)`` — retry.py unpacks two.
+        return ("gemini", None)
+
+
+async def test_fallback_provider_still_runs_after_a_non_retryable_primary() -> None:
+    """The point of raising instead of returning empty.
+
+    A deterministic failure means "this model cannot parse it", not "no model
+    can" — the alternative provider is a different model and may well succeed.
+    Skipping the wasted re-ask must not cost the provider hop.
+    """
+    seen: list[str] = []
+
+    async def _call_fn(provider):
+        seen.append(provider.name)
+        if provider.name == "openai":
+            raise Shape("primary mangles it")
+        return "fallback-result"
+
+    got = await call_with_fallback(
+        primary_provider_name="openai",
+        call_fn=_call_fn,
+        fake_fn=lambda: "fake-result",
+        tenant_config=_Cfg(),
+        service_label="t",
+        max_attempts=3,
+        provider_factory=lambda name, _cfg, **_k: _Provider(name),
+        non_retryable=(Shape,),
+    )
+
+    assert got == "fallback-result", f"the fallback provider must get its turn; got {got!r}"
+    # One primary attempt (not three), then the fallback.
+    assert seen == ["openai", "gemini"], f"expected one try each; got {seen!r}"
+
+
+async def test_fake_fn_is_the_last_resort_when_both_providers_are_deterministic() -> None:
+    """If every provider fails the same way, the heuristic still answers.
+
+    ``call_with_fallback``'s contract is that it always returns something.
+    """
+    seen: list[str] = []
+
+    async def _call_fn(provider):
+        seen.append(provider.name)
+        raise Shape("nobody parses it")
+
+    got = await call_with_fallback(
+        primary_provider_name="openai",
+        call_fn=_call_fn,
+        fake_fn=lambda: "fake-result",
+        tenant_config=_Cfg(),
+        service_label="t",
+        max_attempts=3,
+        provider_factory=lambda name, _cfg, **_k: _Provider(name),
+        non_retryable=(Shape,),
+    )
+
+    assert got == "fake-result"
+    # Two providers, one attempt each — six attempts before the fix.
+    assert seen == ["openai", "gemini"], f"expected one try per provider; got {seen!r}"


### PR DESCRIPTION
The last follow-up from #788 — but **not** the way #788 framed it, and that difference is the substance of this PR.

## The waste

`call_with_retry` catches broad `Exception` and spends its whole budget on every failure, including ones that cannot succeed on a second attempt. Entity extraction pins `seed` to a CRC32 of its prompt *specifically so retries reproduce byte-identical output* — so a shape failure there is guaranteed to recur. The retry costs a paid LLM call plus a 1s sleep, per provider, to learn nothing.

Measured on the real path, stubbed provider, total-loss payload:

```
before:  4 provider calls   (2 attempts × 2 providers)
after:   2 provider calls   (1 attempt  × 2 providers)
```

## Why the follow-up as written would have been harmful

#788 recorded this as *"classify `ValidationError` as non-retryable in `common/llm/retry.py`"*. Implementing that literally would have been a regression.

**A retry is only pointless when the call is deterministic, and determinism comes from the caller.** I checked every `complete_json` caller: **only entity extraction pins a seed.** Enrichment and the other ~10 consumers are unseeded, so a re-ask genuinely may return parseable output and their retries earn their place. A global classification would have stripped a useful retry from all of them to save one wasted call on the single deterministic one.

So this is **opt-in**: a `non_retryable` tuple defaulting to `()`. `isinstance(exc, ())` is `False` for every exception, which makes the default a true no-op rather than a behaviour change — that matters on a module this widely consumed.

Keyed on exception **type**, not on seeded-ness, because a seeded call still has non-deterministic failure modes: a network timeout must be retried no matter how fixed the seed is. Seeding is what makes a *shape* failure deterministic; the type is what separates shape from transport.

## Scope of the skip

It bounds retries **within** a provider only. `call_with_fallback` still advances to the fallback provider, which is the whole point — a deterministic failure means "this model cannot parse it", not "no model can", and the fallback is a different model. It's the same reasoning that made a total loss raise rather than return empty in #794: skipping the wasted re-ask must not cost the provider hop.

Entity extraction opts in with `(ExtractionShapeError, ValidationError)`. It is currently the only caller that can honestly make the claim.

## Tests — 7

- the declared type runs **once**
- an undeclared transport failure still uses its **full** budget (the classification must be narrow, not a blanket fail-fast)
- the default is a **no-op** — the guard for every caller this PR doesn't touch
- subclasses are covered, via `isinstance` semantics
- the happy path after a retryable failure is unchanged
- **the fallback provider still gets its turn** after a non-retryable primary
- the heuristic still answers when both providers fail the same way

`core-worker`'s suite (71 tests) also exercises this module and passes; full root suite **4426 passing**. `ruff check common/` + `core-api/src/` clean, `mypy` clean (198 files).

Note on the diff: `common/llm/retry.py` is +48 / −0 — I deliberately did not run `ruff format` on it, since `common/` uses an 88-col config and this file isn't in the format-check scope, so formatting it would have reflowed unrelated code into the diff.

## Honest assessment of the value

Modest, and smaller than when #788 filed it. After #794 only a *total*-loss payload raises from that path, so these events are rarer than they were. What this buys is one fewer paid call and ~1s less latency per occurrence, plus the determinism reasoning now living in code where the next person can see why a global classification would be wrong.
