### PR TITLE
fix(insights): pin findings to status=active and sweep pending zombies

### DIFF
--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -976,6 +976,17 @@ async def _persist_findings(
                 memory_type="insight",
                 content=content,
                 weight=confidence,
+                # Pin the lifecycle status: caller-supplied status wins over
+                # the enrichment classifier (see MergeEnrichmentFields /
+                # create_memories_bulk precedence). Without this, the
+                # classifier reads the finding's imperative "Action:" line as
+                # a not-yet-started plan and files the insight as ``pending``
+                # (measured on the eToro fleet: 70-80% of post-clarity
+                # findings landed pending) — and pending insights escape the
+                # supersede-priors churn, accumulating as permanently-live
+                # zombies. An insight is a finished analysis artifact; it is
+                # born ``active``.
+                status="active",
                 # Embed inline so a finding is semantically searchable as soon as
                 # this persist returns. An insight exists to be recalled, and the
                 # obvious next action after an evolve cycle is to search for what

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -7651,9 +7651,18 @@ class PostgresService:
         scope: str,
         fleet_id: str | None = None,
     ) -> dict:
-        """Atomically select + outdate prior active insights for this
+        """Atomically select + outdate prior live insights for this
         focus/scope/fleet. Ports ``_persist_findings`` prior-select + outdate
         UPDATE into ONE transaction on the PRIMARY.
+
+        Covers ``pending`` as well as ``active``: historically the enrichment
+        classifier filed plan-phrased findings as ``pending``, and those
+        escaped an active-only supersede forever (219+ zombies accumulated on
+        the eToro fleet, one reaching 9,521 recalls). New insights are pinned
+        ``active`` at creation, but widening the supersede retires the
+        already-accumulated zombies organically — each run sweeps its own
+        focus/scope/agent slice, no manual cleanup pass needed. ``confirmed``
+        stays exempt: that's the operator's deliberate keep signal.
 
         ``:focus`` / ``:scope`` compare text-to-text via the ``->>`` jsonb
         text-accessor (NO jsonb cast). Returns ``{prior_ids, outdated_count}``.
@@ -7674,7 +7683,7 @@ class PostgresService:
                     WHERE tenant_id = :tenant_id
                       AND agent_id = :agent_id
                       AND memory_type = 'insight'
-                      AND status = 'active'
+                      AND status IN ('active', 'pending')
                       AND deleted_at IS NULL
                       AND metadata->>'insight_focus' = :focus
                       AND metadata->>'insight_scope' = :scope

--- a/tests/test_insights_service.py
+++ b/tests/test_insights_service.py
@@ -1460,6 +1460,58 @@ def _clean_finding(**kw):
     return base
 
 
+class TestInsightStatusPinned:
+    """Insights are born ``active`` and the supersede sweeps ``pending``.
+
+    The enrichment status classifier reads the finding's imperative
+    "Action:" line as a not-yet-started plan and filed 70-80% of
+    post-clarity insights as ``pending`` on the eToro fleet — and pending
+    escaped the active-only supersede forever. Two-sided fix: pin
+    ``status="active"`` at persist (caller status wins over the
+    classifier), and widen the supersede to sweep already-accumulated
+    pending zombies organically.
+    """
+
+    @pytest.mark.asyncio
+    async def test_new_insights_born_active_and_pending_priors_swept(self, monkeypatch):
+        tag = _uid()
+        tenant_id = f"test-tenant-{tag}"
+        agent_id = f"a-{tag}"
+        from core_api.services import insights_service
+
+        async def fake_run(prompt, config):
+            return {"findings": [_clean_finding()], "summary": "s"}
+
+        monkeypatch.setattr(insights_service, "_run_llm_analysis", fake_run)
+        try:
+            # A pending zombie from a prior run (same focus/scope/agent slice).
+            zombie = await _seed_memory(
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                memory_type="insight",
+                status="pending",
+                content="old plan-phrased finding misfiled as pending",
+                metadata={"insight_focus": "patterns", "insight_scope": "agent"},
+            )
+            # A corpus memory for the analysis to read.
+            await _seed_memory(
+                tenant_id=tenant_id, agent_id=agent_id, content=f"work happened [{tag}]"
+            )
+            from core_api.services.insights_service import generate_insights
+
+            result = await generate_insights(
+                tenant_id=tenant_id, focus="patterns", scope="agent", agent_id=agent_id
+            )
+            assert len(result["insight_memory_ids"]) == 1
+            new_id = result["insight_memory_ids"][0]
+            # Born active — never at the mercy of the enrichment classifier.
+            assert await _status_of(new_id) == "active"
+            # The pending zombie was swept by the widened supersede.
+            assert await _status_of(zombie) == "outdated"
+        finally:
+            await _cleanup_tenant(tenant_id)
+
+
 class TestClarityPersist:
     @pytest.mark.asyncio
     async def test_content_rendered_as_labeled_lines_with_method(self, monkeypatch):

--- a/tests/test_ph5b_insights_storage.py
+++ b/tests/test_ph5b_insights_storage.py
@@ -67,6 +67,24 @@ async def _seed_memory(
     if embedding is not None:
         emb_literal = "[" + ",".join(str(float(x)) for x in embedding) + "]"
     async with get_session() as session:
+        if subject_entity_id is not None:
+            # memories.subject_entity_id now carries an FK to entities —
+            # seed a minimal entity row (idempotent: divergence tests reuse
+            # one entity id across several memories).
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO entities (id, tenant_id, entity_type, canonical_name)
+                    VALUES (CAST(:id AS uuid), :tenant_id, 'test', :name)
+                    ON CONFLICT (id) DO NOTHING
+                    """
+                ),
+                {
+                    "id": subject_entity_id,
+                    "tenant_id": tenant_id,
+                    "name": f"entity-{subject_entity_id[:8]}",
+                },
+            )
         await session.execute(
             text(
                 """
@@ -423,6 +441,48 @@ async def test_supersede_priors_selects_by_jsonb_metadata(sc):
     assert result["outdated_count"] == 1
     assert await _status(match) == "outdated"
     assert await _status(other_focus) == "active"
+
+
+async def test_supersede_priors_covers_pending_but_not_confirmed(sc):
+    """Pending insights (historically misfiled by the enrichment status
+    classifier) must be swept by the supersede alongside active ones — they
+    were escaping forever and accumulating as recallable zombies. ``confirmed``
+    is the operator's deliberate keep signal and stays exempt."""
+    tenant = _t()
+    agent = "a1"
+    meta = {"insight_focus": "discover", "insight_scope": "all"}
+    pending_zombie = await _seed_memory(
+        tenant_id=tenant,
+        agent_id=agent,
+        memory_type="insight",
+        status="pending",
+        content="plan-phrased finding misfiled as pending",
+        metadata=meta,
+    )
+    active_prior = await _seed_memory(
+        tenant_id=tenant,
+        agent_id=agent,
+        memory_type="insight",
+        status="active",
+        content="normal prior finding",
+        metadata=meta,
+    )
+    confirmed_keeper = await _seed_memory(
+        tenant_id=tenant,
+        agent_id=agent,
+        memory_type="insight",
+        status="confirmed",
+        content="operator-kept finding",
+        metadata=meta,
+    )
+    result = await sc.insights_supersede_priors(
+        tenant_id=tenant, agent_id=agent, focus="discover", scope="all", fleet_id=None
+    )
+    assert set(result["prior_ids"]) == {pending_zombie, active_prior}
+    assert result["outdated_count"] == 2
+    assert await _status(pending_zombie) == "outdated"
+    assert await _status(active_prior) == "outdated"
+    assert await _status(confirmed_keeper) == "confirmed"
 
 
 async def test_supersede_priors_fleet_arm(sc):


### PR DESCRIPTION
## Problem

Post-deploy measurement of the clarity contract (#698) on the eToro fleet surfaced a lifecycle regression: **70–80% of new insights land `pending` at birth** (up from ~20% pre-clarity). Mechanism: the enrichment status classifier files plan-phrased content as `pending` ("tasks/plans not yet started"), and the new finding format's imperative `Action:` line reads as exactly that.

`pending` insights escape the active-only supersede-priors churn **forever**: 219+ zombies accumulated pre-clarity (one reached 9,521 recalls via an automation loop), and 35 more piled up in the first 13 post-clarity nights.

## Fix (two-sided)

| Side | Change |
|---|---|
| **Persist** | `BulkMemoryItem(status="active")` in `_persist_findings` — caller-supplied status wins over the enrichment classifier by existing precedence (`MergeEnrichmentFields` / `create_memories_bulk`, both verified). An insight is a finished analysis artifact, not a plan. |
| **Supersede** | `insights_supersede_priors` widens `status = 'active'` → `status IN ('active', 'pending')` — the accumulated zombies get retired **organically**, each nightly run sweeping its own focus/scope/agent slice. No manual cleanup pass against production. `confirmed` stays exempt (operator's deliberate keep signal). |

## Tests

- Storage-level: pending + active priors swept, `confirmed` untouched (`test_supersede_priors_covers_pending_but_not_confirmed`).
- Service-level end-to-end: new insight born `active` in the DB; a seeded pending zombie in the same focus/scope/agent slice is `outdated` by the run (`test_new_insights_born_active_and_pending_priors_swept`).
- Also repairs the shared wet-test seed helper for the new `memories.subject_entity_id` FK (seeds a minimal `entities` row) — the divergence/contradiction tests were failing on a fresh test DB against current main, pre-existing and unrelated to this change.

106/106 across the three insights suites; ruff lint + format clean.

## Expected effect on the fleet

After deploy: night 1 outdates the existing 35 post-clarity pending zombies on etoro0 (insighter/discover/all slice) plus the older insighter-authored pending backlog; every night thereafter maintains a small, live, active-or-confirmed insight set. Pre-clarity zombies from non-recurring agents (cmoclaw one-offs) only get swept if those agents run again — acceptable residue, they're no longer growing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
