### PR TITLE
fix(core-api): add the missing capability gates on three write routes

### DIFF
--- a/core-api/src/core_api/routes/agents.py
+++ b/core-api/src/core_api/routes/agents.py
@@ -46,6 +46,16 @@ async def patch_agent_trust(
     auth: AuthContext = Depends(get_auth_context),
 ):
     """Update an agent's trust level (and optionally fleet)."""
+    # A read-only credential must not move the trust ladder. This gate was
+    # missing while the neighbouring fleet-reassignment route had it, so a
+    # capabilities={'read'} key could rewrite the very control the comment
+    # below calls the master key.
+    #
+    # NOT gated on ``enforce_usage_limits``, unlike that neighbour, and
+    # deliberately: this is the route you reach for to DEMOTE a misbehaving
+    # agent. An over-quota tenant must still be able to take trust away, so
+    # quota state must not stand between an operator and a mitigation.
+    auth.enforce_read_only()
     auth.enforce_tenant(tenant_id)
     # Trust changes are the master key to the whole ladder — an agent must not
     # be able to PATCH its own (or a peer's) trust_level to self-promote.

--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -949,10 +949,18 @@ async def create_command(
 ):
     """Queue a command for a fleet node."""
     sc = get_storage_client()
-    # We need to verify node exists and get its tenant_id
-    # The storage client get_node takes tenant_id + node_name, but we have node_id
-    # Create the command via the storage client
+    # Queueing a command is a write, and the tenant it lands in comes from the
+    # REQUEST BODY. Both gates are required, and the order matters: resolve the
+    # target tenant first, then enforce against the resolved value.
+    #
+    # Without ``enforce_tenant`` any authenticated caller could set
+    # ``body.tenant_id`` to a victim tenant and queue commands into their fleet
+    # — the GET sibling immediately below has always enforced this, so the write
+    # was the weaker of the pair. Without ``enforce_read_only`` a
+    # capabilities={'read'} credential could do the same.
+    auth.enforce_read_only()
     tenant_id = body.tenant_id or auth.tenant_id
+    auth.enforce_tenant(tenant_id)
     cmd = await sc.create_command(
         {
             "tenant_id": tenant_id,

--- a/core-api/src/core_api/routes/settings.py
+++ b/core-api/src/core_api/routes/settings.py
@@ -46,8 +46,13 @@ async def update_tenant_settings(
     Regular user requests always use ``auth.user_id`` regardless of the header.
     """
     tid = _resolve_tenant(auth, tenant_id)
-    if auth.is_demo:
-        raise HTTPException(status_code=403, detail="Demo sandbox is read-only")
+    # ``enforce_read_only`` rather than the ``is_demo`` check this replaced: that
+    # check caught the demo sandbox but NOT a credential minted read-only by
+    # construction (capabilities={'read'}), so a viewer/reporting key could
+    # rewrite tenant settings. Both signals live behind this one gate, which is
+    # why write-shaped endpoints are supposed to call it instead of testing
+    # individual flags.
+    auth.enforce_read_only()
     # Tenant settings include security-relevant toggles (e.g. require_agent_approval,
     # which governs whether new agents start quarantined). An agent-scoped
     # credential must not be able to flip them.

--- a/tests/test_route_authz_gaps.py
+++ b/tests/test_route_authz_gaps.py
@@ -284,3 +284,163 @@ async def test_delete_audit_attributes_gateway_agent(client, as_auth, sc):
         )
     assert rows, "expected a delete audit row"
     assert rows[-1].agent_id == "deleter-agent"
+
+
+# ---------------------------------------------------------------------------
+# H-12 / H-13 / H-15 — write-shaped routes missing their capability gates
+#
+# Surfaced by the 2026-08-14 OSS/platform audit. All three are the same shape as
+# the 2026-06-11 findings above: a mutating route that skipped a gate its own
+# neighbours already applied.
+#
+#   H-13  POST /fleet/commands       — no enforce_tenant AND no enforce_read_only,
+#                                      with the target tenant taken from the BODY
+#   H-12  PATCH /agents/{id}/trust   — no enforce_read_only
+#   H-15  PUT  /settings             — checked is_demo by hand, so it caught the
+#                                      demo sandbox but not a read-only credential
+# ---------------------------------------------------------------------------
+
+READ_ONLY = {"read"}
+
+
+async def test_fleet_command_cannot_be_queued_into_another_tenant(client, as_auth):
+    """H-13: the queued command's tenant came from ``body.tenant_id``, unchecked.
+
+    The GET sibling has always called ``enforce_tenant``, so the write was the
+    weaker half of the pair.
+    """
+    victim = f"victim-{_uid()}"
+    attacker = f"attacker-{_uid()}"
+
+    # A real node in the victim's fleet, created by the victim.
+    as_auth(victim)
+    resp = await client.post(
+        "/api/v1/fleet/heartbeat",
+        json={
+            "tenant_id": victim,
+            "node_name": f"node-{_uid()}",
+            "fleet_id": f"fleet-{_uid()}",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    node_id = resp.json()["node_id"]
+
+    as_auth(attacker)
+    resp = await client.post(
+        "/api/v1/fleet/commands",
+        json={
+            "tenant_id": victim,
+            "node_id": node_id,
+            "command": "ping",
+            "payload": {"injected": True},
+        },
+    )
+    assert resp.status_code == 403, resp.text
+
+    # And nothing landed in the victim's queue.
+    as_auth(victim)
+    resp = await client.get(f"/api/v1/fleet/commands?tenant_id={victim}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_fleet_command_rejects_a_read_only_credential(client, as_auth):
+    """H-13, second half: queueing a command is a write."""
+    tenant = f"tenant-{_uid()}"
+
+    as_auth(tenant)
+    resp = await client.post(
+        "/api/v1/fleet/heartbeat",
+        json={
+            "tenant_id": tenant,
+            "node_name": f"node-{_uid()}",
+            "fleet_id": f"fleet-{_uid()}",
+        },
+    )
+    node_id = resp.json()["node_id"]
+
+    as_auth(tenant, capabilities=READ_ONLY)
+    resp = await client.post(
+        "/api/v1/fleet/commands",
+        json={
+            "tenant_id": tenant,
+            "node_id": node_id,
+            "command": "ping",
+            "payload": {},
+        },
+    )
+    assert resp.status_code == 403, resp.text
+
+
+async def test_agent_trust_rejects_a_read_only_credential(client, as_auth, sc):
+    """H-12: trust is the master key to the ladder — a read key must not move it."""
+    tenant = f"tenant-{_uid()}"
+    agent = f"agent-{_uid()}"
+    await _seed_agent(sc, tenant, agent, trust_level=1)
+
+    as_auth(tenant, capabilities=READ_ONLY)
+    resp = await client.patch(
+        f"/api/v1/agents/{agent}/trust?tenant_id={tenant}",
+        json={"trust_level": 3},
+    )
+    assert resp.status_code == 403, resp.text
+
+    # The ladder did not move.
+    as_auth(tenant)
+    resp = await client.get(f"/api/v1/agents?tenant_id={tenant}")
+    assert resp.status_code == 200
+    row = next(a for a in resp.json() if a["agent_id"] == agent)
+    assert row["trust_level"] == 1
+
+
+async def test_agent_trust_still_works_when_over_usage_limits(client, as_auth, sc):
+    """Pins a deliberate omission, so nobody "fixes" it by adding the gate.
+
+    ``enforce_usage_limits`` is NOT applied to this route, unlike the
+    neighbouring fleet-reassignment one. This is the route you reach for to
+    DEMOTE a misbehaving agent, and an over-quota tenant must still be able to
+    take trust away — quota state must not stand between an operator and a
+    mitigation.
+    """
+    tenant = f"tenant-{_uid()}"
+    agent = f"agent-{_uid()}"
+    await _seed_agent(sc, tenant, agent, trust_level=3)
+
+    as_auth(tenant, is_read_only=True)
+    resp = await client.patch(
+        f"/api/v1/agents/{agent}/trust?tenant_id={tenant}",
+        json={"trust_level": 0},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["trust_level"] == 0
+
+
+async def test_settings_rejects_a_read_only_credential(client, as_auth):
+    """H-15: the hand-rolled ``is_demo`` check missed read-only credentials.
+
+    Tenant settings carry security-relevant toggles — ``require_agent_approval``
+    governs whether new agents start quarantined — so a viewer/reporting key
+    rewriting them is a privilege escalation, not a cosmetic gap.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, capabilities=READ_ONLY)
+    resp = await client.put(
+        "/api/v1/settings",
+        json={"tenant_id": tenant, "require_agent_approval": False},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+async def test_settings_still_refuses_the_demo_sandbox(client, as_auth):
+    """Regression guard: the hand-rolled demo branch was REPLACED, not dropped.
+
+    ``enforce_read_only`` covers demo and read-only capabilities together, but
+    that only holds if it really does still refuse demo.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, is_demo=True)
+    resp = await client.put(
+        "/api/v1/settings",
+        json={"tenant_id": tenant, "require_agent_approval": False},
+    )
+    assert resp.status_code == 403, resp.text


### PR DESCRIPTION
First cluster from the 2026-08-14 OSS/platform audit: **H-12, H-13, H-15** — three write-shaped routes that skipped capability gates their own neighbours already applied.

Grouped because they're one bug repeated, not three unrelated fixes, and they're the same shape as the 2026-06-11 findings already covered in `tests/test_route_authz_gaps.py` — so the tests land beside them.

## H-13 · `POST /fleet/commands` — two bugs in one, and the most serious

The target tenant comes from the **request body** (`body.tenant_id or auth.tenant_id`) and was never checked:

```python
tenant_id = body.tenant_id or auth.tenant_id   # caller names the tenant
cmd = await sc.create_command({"tenant_id": tenant_id, ...})
```

So any authenticated caller could set `body.tenant_id` to a victim tenant and queue commands into their fleet. The **GET sibling immediately below has always called `enforce_tenant`** — the write was the weaker half of the pair. It also had no `enforce_read_only`, so a `capabilities={'read'}` credential could do the same.

Both gates added. Order matters: resolve the tenant from the body first, *then* enforce against the resolved value.

## H-12 · `PATCH /agents/{agent_id}/trust` — no `enforce_read_only`

The adjacent fleet-reassignment route had it; this one didn't. So a read-only credential could rewrite the control this file's own comment calls *"the master key to the whole ladder"*.

**`enforce_usage_limits` is deliberately NOT added**, unlike that neighbour. This is the route you reach for to **demote** a misbehaving agent, so an over-quota tenant must still be able to take trust away — quota state must not stand between an operator and a mitigation. A test pins this so nobody "completes" the fix by adding it.

## H-15 · `PUT /settings` — a hand-rolled check that covered half the cases

It tested `auth.is_demo` directly, which caught the demo sandbox but **not** a credential minted read-only by construction. So a viewer/reporting key could rewrite tenant settings — which matters because settings carry security-relevant toggles: `require_agent_approval` governs whether new agents start quarantined.

Replaced with `enforce_read_only`, which covers demo *and* capabilities together. That's precisely why write-shaped endpoints are meant to call the gate rather than test individual flags. Since the branch was **replaced rather than dropped**, a regression test pins that demo is still refused.

## Tests

6 added to `tests/test_route_authz_gaps.py`. **4 fail without this change**, verified by reverting the three route files:

```
FAILED test_fleet_command_cannot_be_queued_into_another_tenant
FAILED test_fleet_command_rejects_a_read_only_credential
FAILED test_agent_trust_rejects_a_read_only_credential
FAILED test_settings_rejects_a_read_only_credential
```

The other 2 pass either way **by design**, and I'd rather say so than imply all 6 detect the bug — they're pins on decisions, not detectors:

- `test_agent_trust_still_works_when_over_usage_limits` — pins the deliberate omission
- `test_settings_still_refuses_the_demo_sandbox` — pins that replacing the branch didn't lose coverage

The cross-tenant test also asserts the victim's queue is still empty afterwards, not just that the call 403'd.

## Checks

Full suite **4434 passed, 3 skipped, 1 xfailed** (`-m "not benchmark"`, against a local Postgres with the same credentials CI uses). `ruff check` and `ruff format --check` clean as separate steps on all four files. The 108 tests specific to the three touched routes (`test_api_fleet`, `test_api_agents`, `test_api_settings`, `test_agent_admin_authz`, `test_agent_identity_guard`, plus heartbeat/settings-invalidation) all pass.

Note: `ruff check` reports a pre-existing `I001` on `tests/test_route_authz_gaps.py:248` (inline imports in a 2026-06-11 test). It's present on `main` and untouched here — CI's ruff scope evidently doesn't include `tests/`, and reordering it would be unrelated churn in a security PR.

## Remaining highs in this audit

This is 3 of 8 security highs. Still open: **H-11** (perimeter boots wide open when `GATEWAY_SHARED_SECRET` is unset), **H-14**/**H-16** (client-trusted identity — `POST /search` and `GET /stm/notes` let an agent credential read a peer's scoped memories), **H-17** (`POST /stm/promote` bypasses the LTM write gates — note the 2026-06-11 pass fixed its read-only/usage gates, so this is the deeper set), **H-18** (fast write mode skips LLM governance). Plus 10 correctness highs.
