### PR TITLE
fix(core-api): bind read-path identity to the authenticated agent

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1431,6 +1431,31 @@ async def _search_inner(
     # content, so this is a direct disclosure, not just id harvesting). A
     # tenant/user credential (auth.agent_id None, no filter) keeps full-tenant
     # search, unchanged.
+    # An agent credential may only filter to ITSELF. ``eff_agent_id`` below is
+    # body-first, and it feeds BOTH the visibility identity (which scope_agent
+    # rows are readable) AND the trust/fleet enforcement a few lines down, so a
+    # caller-asserted ``filter_agent_id`` bought two escalations at once:
+    #
+    #   1. Disclosure — naming a peer made that peer the visibility identity, so
+    #      its scope_agent memories (and private STM notes surfaced through
+    #      search) came back with full content, not just ids.
+    #   2. Gate evasion — the trust < 2 fleet forcing below runs against this
+    #      same id, so naming a trust-3 peer skipped the forcing entirely. That
+    #      is the identical escalation /memories/redistribute was fixed for in
+    #      the 2026-06-11 audit, which ran its trust gate against a
+    #      caller-supplied agent_id.
+    #
+    # A tenant/user credential (``auth.agent_id`` is None) is unaffected and may
+    # still filter by any agent — the restriction is on agent-scoped credentials,
+    # which is where the threat is.
+    if auth.agent_id and body.filter_agent_id and body.filter_agent_id != auth.agent_id:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"filter_agent_id '{body.filter_agent_id}' does not match the "
+                f"authenticated agent identity '{auth.agent_id}'."
+            ),
+        )
     eff_agent_id = body.filter_agent_id or auth.agent_id
     if auth.tenant_id:  # skip for admin
         if eff_agent_id:

--- a/core-api/src/core_api/routes/stm.py
+++ b/core-api/src/core_api/routes/stm.py
@@ -43,6 +43,18 @@ async def get_notes(
 ):
     _check_stm_enabled()
     tenant_id = _require_tenant(auth)
+    # Authenticated agent identity (gateway X-Agent-ID) takes precedence over the
+    # caller-supplied query param. Notes are per-agent PRIVATE (see the section
+    # header), so an agent credential must not read a peer's by naming it.
+    #
+    # The DELETE twin directly below has enforced this since the 2026-06-11
+    # audit, which left the pair lopsided: a peer's notes could not be cleared,
+    # only read. Disclosure was the half still open.
+    if auth.agent_id and agent_id != auth.agent_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"agent_id '{agent_id}' does not match the authenticated agent identity.",
+        )
     from core_api.services.stm_service import read_notes
 
     notes = await read_notes(tenant_id, agent_id, limit=limit)

--- a/tests/test_route_authz_gaps.py
+++ b/tests/test_route_authz_gaps.py
@@ -444,3 +444,97 @@ async def test_settings_still_refuses_the_demo_sandbox(client, as_auth):
         json={"tenant_id": tenant, "require_agent_approval": False},
     )
     assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# H-14 / H-16 — client-trusted identity on READ paths
+#
+# The 2026-06-11 pass fixed the identity precedence on WRITE paths (delete/update
+# memory, DELETE /stm/notes, POST /stm/promote) and on /memories/redistribute's
+# trust gate. It left two reads trusting a caller-supplied agent id:
+#
+#   H-16  GET  /stm/notes  — reads a peer's per-agent PRIVATE notes by naming it
+#   H-14  POST /search     — filter_agent_id became the visibility identity AND
+#                            the subject of the trust<2 fleet forcing
+# ---------------------------------------------------------------------------
+
+
+async def test_stm_notes_of_a_peer_agent_cannot_be_read(client, as_auth, _stm_enabled):
+    """H-16: the DELETE twin has enforced this since June; the read had not.
+
+    So a peer's notes could not be cleared, only read — disclosure was the half
+    left open.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, agent_id="agent-a")
+    resp = await client.get("/api/v1/stm/notes?agent_id=agent-b")
+    assert resp.status_code == 403, resp.text
+
+
+async def test_stm_notes_of_own_agent_are_still_readable(client, as_auth, _stm_enabled):
+    """The guard must not break an agent reading its OWN notes."""
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, agent_id="agent-a")
+    resp = await client.get("/api/v1/stm/notes?agent_id=agent-a")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent_id"] == "agent-a"
+
+
+async def test_search_cannot_borrow_a_peer_identity_via_filter_agent_id(
+    client, as_auth
+):
+    """H-14: ``filter_agent_id`` fed the visibility identity AND the trust gate.
+
+    Naming a peer both exposed that peer's scope_agent rows (with content, so a
+    direct disclosure) and skipped the trust<2 fleet forcing when the named peer
+    was trust>=2 — the same escalation /memories/redistribute was fixed for.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, agent_id="agent-a")
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "tenant_id": tenant,
+            "query": "anything",
+            "top_k": 5,
+            "filter_agent_id": "agent-b",
+        },
+    )
+    assert resp.status_code == 403, resp.text
+
+
+async def test_search_filtering_to_own_agent_id_is_allowed(client, as_auth):
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, agent_id="agent-a")
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "tenant_id": tenant,
+            "query": "anything",
+            "top_k": 5,
+            "filter_agent_id": "agent-a",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def test_a_tenant_credential_may_still_filter_search_by_any_agent(
+    client, as_auth
+):
+    """Pins the preserved case: the restriction targets AGENT-scoped credentials.
+
+    A tenant/user credential (``auth.agent_id`` is None) is what the dashboard
+    uses to inspect a given agent's memories, and must keep working.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant)  # no agent_id
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "tenant_id": tenant,
+            "query": "anything",
+            "top_k": 5,
+            "filter_agent_id": "agent-b",
+        },
+    )
+    assert resp.status_code == 200, resp.text


### PR DESCRIPTION
Second cluster from the 2026-08-14 OSS/platform audit: **H-14, H-16** — two read paths that trusted a caller-supplied agent id. Follows #799 (the capability-gate cluster).

These two belong together because they're one class: **the June 2026 pass fixed identity precedence on the write paths and left the reads.** `delete`/`update_memory`, `DELETE /stm/notes`, `POST /stm/promote` and `/memories/redistribute`'s trust gate were all hardened then. The same bug survived where the consequence is *disclosure* rather than mutation.

## H-16 · `GET /stm/notes`

Took `agent_id` from the query string and read straight through. Notes are per-agent **private** — that section's own header says so — so an agent credential could read a peer's by naming it.

The `DELETE` twin *immediately below* has enforced this since June, which left the pair lopsided: a peer's notes could not be cleared, only read.

## H-14 · `POST /search` — two escalations in one line

```python
eff_agent_id = body.filter_agent_id or auth.agent_id   # body-first
```

That value feeds **both** the visibility identity (`caller_agent_id`, which decides whose `scope_agent` rows are readable) **and** the trust/fleet enforcement below it. So a caller-asserted `filter_agent_id` bought:

1. **Disclosure** — naming a peer made that peer the visibility identity, so its `scope_agent` memories came back with **full content**, not just ids.
2. **Gate evasion** — the `trust < 2` fleet forcing runs against the same id, so naming a trust-3 peer skipped the forcing entirely. That is the *identical* escalation `/memories/redistribute` was fixed for in June.

Worth noting what the existing comments show: the **omitted** case was thought through carefully (fall back to `auth.agent_id` so a constrained agent stays bound — there's a whole paragraph on it). The **conflicting** case, body naming a *different* agent, was not considered.

## Scope of the restriction

Agent-scoped credentials only. A tenant/user credential (`auth.agent_id` is None) still filters by any agent — that's what the dashboard uses to inspect a given agent's memories, and there's a test pinning it. The restriction lands exactly where the threat is.

## On style

Both fixes use the precedence pattern already at three sites, **inline rather than behind a new helper**, to match the surrounding code — that pattern's own comment says "Mirrors the precedence pattern in delete/update_memory."

Consolidating all five copies into one `AuthContext` method is a reasonable follow-up and I'd support it, but introducing a competing idiom (new helper at 2 sites, inline at 3) inside a security fix seemed worse than either consistent option.

## Tests

5 added to `tests/test_route_authz_gaps.py`, beside the June findings they extend. **2 fail without this change**:

```
FAILED test_stm_notes_of_a_peer_agent_cannot_be_read
FAILED test_search_cannot_borrow_a_peer_identity_via_filter_agent_id
```

The other 3 are pins that pass either way **by design**, and I'd rather say so than imply all 5 are detectors: own-agent read still works, filter-to-self still works, and the tenant-credential case is untouched.

## Checks

Full suite **4438 passed, 3 skipped, 1 xfailed** (`-m "not benchmark"`, local Postgres with CI's credentials). Notably **no existing test depended on the body-first behaviour**, which is some evidence the restriction doesn't break a real use.

`ruff check` / `ruff format --check` clean as separate steps on all three files. (`ruff check` still reports a pre-existing `I001` at `tests/test_route_authz_gaps.py:248` — present on `main`, untouched here, as noted on #799.)

## Remaining highs

4 of 8 security highs now covered across #799 and this. Still open: **H-11** (perimeter boots wide open when `GATEWAY_SHARED_SECRET` is unset), **H-17** (`POST /stm/promote` bypasses the LTM write gates — June fixed its read-only/usage gates, so this is the deeper set: agent approval/trust, fleet-write policy, reserved memory types, write metering, rate limiter), **H-18** (fast write mode skips PII-drop / non-business-drop / keep_private governance on the default inline deployment). Plus the 10 correctness highs.
