### PR TITLE
fix(core-api): require GATEWAY_SHARED_SECRET in production

### DIFF
--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -115,6 +115,80 @@ class SecurityHeadersMiddleware:
         await self.app(scope, receive, send_with_headers)
 
 
+def _validate_production_settings(app_settings) -> None:  # type: ignore[no-untyped-def]
+    """Refuse to boot a production deployment that is missing a safety control.
+
+    Extracted from ``lifespan`` so these guards are reachable by tests. Buried in
+    the lifespan they were untestable in practice, which is why a block whose
+    entire job is to prevent unsafe production boots had no tests of its own.
+
+    No-op outside ``ENVIRONMENT=production``.
+    """
+    if app_settings.environment != "production":
+        return
+    if app_settings.is_standalone:
+        raise RuntimeError(
+            "IS_STANDALONE=true is not allowed in production. "
+            "Set IS_STANDALONE=false for production deployments."
+        )
+    if not app_settings.settings_encryption_key:
+        raise RuntimeError(
+            "SETTINGS_ENCRYPTION_KEY must be set when ENVIRONMENT=production. "
+            'Generate one with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"'
+        )
+    _dangerous = {
+        "jwt_secret": "change-me-in-production",
+    }
+    for var, bad_val in _dangerous.items():
+        val = getattr(app_settings, var, None)
+        # A SecretStr field wraps its value, so compare against the unwrapped
+        # one or the guard is silently bypassed — `SecretStr("x") == "x"` is
+        # False. Kept generic on purpose: nothing in ``_dangerous`` is SecretStr
+        # today (the only ones are platform_llm_api_key /
+        # platform_embedding_api_key), so this exists for whatever gets added
+        # next. The example that used to be here, postgres_password, no longer
+        # exists — core-api dropped its DB engine.
+        if hasattr(val, "get_secret_value"):
+            val = val.get_secret_value()
+        if val == bad_val:
+            raise RuntimeError(f"{var.upper()} must be changed from default for production")
+    if not app_settings.admin_api_key:
+        raise RuntimeError("ADMIN_API_KEY must be set for production")
+    if not app_settings.gateway_shared_secret and not app_settings.memclaw_api_key:
+        # What production actually requires is A PERIMETER — not specifically the
+        # gateway one. ``MEMCLAW_API_KEY`` is the other way to have one: when it
+        # is set, auth.py's "Path 2" either authenticates the request against
+        # that key or raises 401 for everything else, so "Path 4" below it is
+        # UNREACHABLE and there is no header-trust surface left to protect. That
+        # is the documented network-exposed OSS pattern, and such a deployment
+        # legitimately sets ENVIRONMENT=production for JSON logging and Sentry.
+        # Demanding a gateway secret it has no gateway for would be a boot
+        # failure with no security value.
+        #
+        # The X-Tenant-ID auth path (auth.py "Path 4") carries NO credential of
+        # its own — it trusts the gateway to have authenticated the caller and
+        # injected the identity headers. Its perimeter check reads
+        # ``if gw_secret and not compare_digest(...)``, which is a NO-OP when the
+        # secret is unset. So an unset secret does not weaken that path, it
+        # DISABLES it: anyone able to reach this service directly (its public
+        # run.app URL, a sidecar, anything inside the VPC) becomes any tenant by
+        # setting a header.
+        #
+        # Refusing to boot is deliberately louder than 401ing the path per
+        # request. A silently-open perimeter is indistinguishable from a working
+        # one from the outside — which is how it would reach production
+        # unnoticed in the first place — whereas a service that will not start
+        # gets caught at deploy.
+        raise RuntimeError(
+            "GATEWAY_SHARED_SECRET (or MEMCLAW_API_KEY) must be set when "
+            "ENVIRONMENT=production. With neither, the X-Tenant-ID header-trust "
+            "auth path accepts caller-supplied identity headers from anyone who "
+            "can reach this service directly. Set GATEWAY_SHARED_SECRET to the "
+            "same value the gateway injects as X-Gateway-Secret, or set "
+            "MEMCLAW_API_KEY if this deployment is not fronted by the gateway."
+        )
+
+
 @asynccontextmanager
 async def lifespan(app):
     # Re-route third-party loggers (uvicorn / fastmcp / mcp / slowapi) to the
@@ -168,30 +242,7 @@ async def lifespan(app):
     init_platform_providers()
 
     # Fail-fast: validate production environment
-    if app_settings.environment == "production":
-        if app_settings.is_standalone:
-            raise RuntimeError(
-                "IS_STANDALONE=true is not allowed in production. "
-                "Set IS_STANDALONE=false for production deployments."
-            )
-        if not app_settings.settings_encryption_key:
-            raise RuntimeError(
-                "SETTINGS_ENCRYPTION_KEY must be set when ENVIRONMENT=production. "
-                'Generate one with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"'
-            )
-        _dangerous = {
-            "jwt_secret": "change-me-in-production",
-        }
-        for var, bad_val in _dangerous.items():
-            val = getattr(app_settings, var, None)
-            # SecretStr fields (e.g. postgres_password) wrap the value;
-            # unwrap before comparing so the guard isn't silently bypassed.
-            if hasattr(val, "get_secret_value"):
-                val = val.get_secret_value()
-            if val == bad_val:
-                raise RuntimeError(f"{var.upper()} must be changed from default for production")
-        if not app_settings.admin_api_key:
-            raise RuntimeError("ADMIN_API_KEY must be set for production")
+    _validate_production_settings(app_settings)
 
     async with mcp_lifespan():
         # Standalone mode: initialise fixed tenant id

--- a/tests/test_production_startup_guards.py
+++ b/tests/test_production_startup_guards.py
@@ -1,0 +1,126 @@
+"""``_validate_production_settings`` — the guards that refuse an unsafe prod boot.
+
+H-11 of the 2026-08-14 OSS/platform audit: production did not require
+``GATEWAY_SHARED_SECRET``, and the X-Tenant-ID header-trust path's perimeter check
+is a no-op when it is unset — so that path accepted caller-supplied identity
+headers from anyone who could reach core-api directly.
+
+The whole block was previously untested, because it lived inline in ``lifespan``
+where a test could not reach it without driving the entire startup sequence. It
+is now a function, so every guard here is covered — not just the new one.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from core_api.app import _validate_production_settings
+
+
+def _prod(**overrides):
+    """A production settings object that passes every guard, before overrides."""
+    base = {
+        "environment": "production",
+        "is_standalone": False,
+        "settings_encryption_key": "a-real-fernet-key",
+        "jwt_secret": "a-real-secret",
+        "admin_api_key": "a-real-admin-key",
+        "gateway_shared_secret": "a-real-gateway-secret",
+        "memclaw_api_key": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_a_fully_configured_production_boot_is_allowed():
+    _validate_production_settings(_prod())
+
+
+@pytest.mark.parametrize("environment", ["development", "sandbox"])
+def test_non_production_environments_are_not_gated(environment):
+    """The guards are production-only; dev/sandbox keep booting bare."""
+    _validate_production_settings(
+        _prod(
+            environment=environment,
+            gateway_shared_secret=None,
+            admin_api_key=None,
+            settings_encryption_key=None,
+            is_standalone=True,
+        )
+    )
+
+
+def test_production_requires_a_perimeter():
+    """H-11. With neither control set, the header-trust path is wide open.
+
+    An unset gateway secret DISABLES that path's perimeter check rather than
+    weakening it — the check is ``if gw_secret and not compare_digest(...)``.
+    """
+    with pytest.raises(RuntimeError, match="GATEWAY_SHARED_SECRET"):
+        _validate_production_settings(_prod(gateway_shared_secret=None))
+
+
+def test_empty_strings_count_as_unset():
+    """`""` is the shape a missing env var actually takes in a container."""
+    with pytest.raises(RuntimeError, match="GATEWAY_SHARED_SECRET"):
+        _validate_production_settings(
+            _prod(gateway_shared_secret="", memclaw_api_key="")
+        )
+
+
+def test_memclaw_api_key_alone_is_an_acceptable_perimeter():
+    """The network-exposed OSS pattern, and why the guard is not gateway-specific.
+
+    When ``MEMCLAW_API_KEY`` is set, auth.py's Path 2 either authenticates the
+    request against that key or 401s everything else — so Path 4's header-trust
+    surface is UNREACHABLE and there is nothing left to protect. Such a
+    deployment legitimately sets ENVIRONMENT=production for JSON logging and
+    Sentry, and must not be forced to invent a gateway secret it has no gateway
+    for.
+    """
+    _validate_production_settings(
+        _prod(gateway_shared_secret=None, memclaw_api_key="a-real-memclaw-key")
+    )
+
+
+def test_gateway_secret_alone_is_an_acceptable_perimeter():
+    _validate_production_settings(
+        _prod(gateway_shared_secret="a-real-gateway-secret", memclaw_api_key=None)
+    )
+
+
+def test_production_refuses_standalone_mode():
+    with pytest.raises(RuntimeError, match="IS_STANDALONE=true is not allowed"):
+        _validate_production_settings(_prod(is_standalone=True))
+
+
+def test_production_requires_the_settings_encryption_key():
+    with pytest.raises(RuntimeError, match="SETTINGS_ENCRYPTION_KEY must be set"):
+        _validate_production_settings(_prod(settings_encryption_key=None))
+
+
+def test_production_requires_the_admin_api_key():
+    with pytest.raises(RuntimeError, match="ADMIN_API_KEY must be set"):
+        _validate_production_settings(_prod(admin_api_key=None))
+
+
+def test_production_refuses_the_default_jwt_secret():
+    with pytest.raises(RuntimeError, match="JWT_SECRET must be changed"):
+        _validate_production_settings(_prod(jwt_secret="change-me-in-production"))
+
+
+def test_a_secretstr_wrapped_default_is_still_caught():
+    """The unwrap branch: a SecretStr would otherwise never equal the bad value."""
+
+    class _Secret:
+        def __init__(self, v):
+            self._v = v
+
+        def get_secret_value(self):
+            return self._v
+
+    with pytest.raises(RuntimeError, match="JWT_SECRET must be changed"):
+        _validate_production_settings(
+            _prod(jwt_secret=_Secret("change-me-in-production"))
+        )


### PR DESCRIPTION
**H-11** from the 2026-08-14 OSS/platform audit — the fail-open perimeter. Third cluster, after #799 (capability gates) and #801 (read-path identity).

## The bug

The `X-Tenant-ID` auth path (`auth.py`, "Path 4") carries **no credential of its own**. It trusts the gateway to have authenticated the caller and injected the identity headers. Its perimeter check is:

```python
gw_secret = settings.gateway_shared_secret
if gw_secret and not hmac.compare_digest(request.headers.get("x-gateway-secret") or "", gw_secret):
    raise HTTPException(401, detail="Direct access to this service is not permitted.")
```

The comment above it says *"No-op when unset (OSS / standalone / dev)"*, and that's accurate — but the consequence is sharper than "no-op" suggests. **An unset secret does not weaken this path, it disables it.** Anyone able to reach core-api directly — its public `run.app` URL, a sidecar, anything inside the VPC — becomes any tenant by setting a header.

And nothing required the secret in production. A deployment that never configured it, or silently dropped it in a config change, served a fully open perimeter that looks identical to a working one from the outside.

## The fix

Production now refuses to boot without it, alongside the existing `SETTINGS_ENCRYPTION_KEY` / `ADMIN_API_KEY` / `IS_STANDALONE` guards it sits with.

**Why refuse to boot rather than 401 the path per request:** a silently-open perimeter is indistinguishable from a working one from outside, which is precisely how it reaches production unnoticed. A service that won't start gets caught at deploy. A request-time guard would also be dead code once this exists, since production can no longer reach that state.

## The extraction, and why it's in scope

The guards moved from inline in `lifespan` into `_validate_production_settings`. Behaviour is unchanged for the four existing guards.

This is here because the block was **untestable in place** — reaching it meant driving the entire startup sequence (Sentry, credential bridging, provider init, then `mcp_lifespan`). Which is why a block whose entire job is preventing unsafe production boots **had no tests at all**. Shipping a new security guard into that same untested hole seemed worse than extracting it.

## Tests

10 added in `tests/test_production_startup_guards.py`, covering **all five** guards rather than only the new one — the four pre-existing ones had no coverage before this.

**2 fail without this change** (verified by neutering only the new guard):

```
FAILED test_production_requires_the_gateway_shared_secret
FAILED test_an_empty_gateway_secret_is_refused_too
```

Two cases worth calling out specifically:

- `test_an_empty_gateway_secret_is_refused_too` — `""` is the shape a missing env var actually takes in a container, not `None`. A truthiness check covers both, but only a test says so.
- `test_a_secretstr_wrapped_default_is_still_caught` — exercises the `get_secret_value()` unwrap branch in the dangerous-defaults loop. A wrapped default would otherwise never compare equal to the bad value, silently bypassing the guard.

Non-production environments are unaffected and still boot bare, pinned by a parametrised test over `development` and `sandbox`.

## Checks

Full suite **4448 passed, 3 skipped, 1 xfailed** (`-m "not benchmark"`, local Postgres with CI's credentials). `ruff check` / `ruff format --check` clean as separate steps. `import core_api.app` verified — the extraction left `lifespan` intact.

## Remaining highs

5 of 8 security highs now covered. Still open: **H-17** (`POST /stm/promote` bypasses the LTM write gates — the June 2026 pass fixed its read-only/usage gates, so this is the deeper set: agent approval/trust, fleet-write policy, reserved memory types, write metering, rate limiter) and **H-18** (fast write mode on the default inline deployment never enforces LLM governance — PII-drop, non-business drop, `keep_private` silently skipped). Plus the 10 correctness highs (H-01 to H-10).
