### PR TITLE
fix(core-api): make /stm/promote pay the LTM write gates

### DIFF
--- a/core-api/src/core_api/routes/stm.py
+++ b/core-api/src/core_api/routes/stm.py
@@ -7,13 +7,32 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from common.enrichment.constants import SERVER_RESERVED_MEMORY_TYPES
 from core_api.auth import AuthContext, get_auth_context
 from core_api.config import settings
-from core_api.services.agent_service import broker_owned_agent_id
+from core_api.services.agent_service import enforce_fleet_write, resolve_write_agent
+from core_api.services.usage_service import check_and_increment
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["stm"])
+
+
+def _reject_reserved_memory_type(memory_type: str | None) -> None:
+    """Twin of ``memories._reject_reserved_memory_type``, for the promote door.
+
+    Deliberately a small duplicate rather than an import of that module's
+    private helper: importing across route modules to reach a ``_``-prefixed
+    function invites a circular import for no real gain. The source of truth
+    both share is ``SERVER_RESERVED_MEMORY_TYPES``, so the two cannot disagree
+    about WHICH types are reserved — only about wording.
+    """
+    if memory_type is None or memory_type not in SERVER_RESERVED_MEMORY_TYPES:
+        return
+    raise HTTPException(
+        status_code=422,
+        detail=(f"memory_type='{memory_type}' is server-reserved and cannot be supplied on writes."),
+    )
 
 
 def _check_stm_enabled() -> None:
@@ -147,6 +166,10 @@ async def promote_stm(
     auth.enforce_read_only()
     auth.enforce_usage_limits()
     tenant_id = _require_tenant(auth)
+    # A promote IS an LTM write, so it owes the same gates as POST /memories.
+    # It reached LTM having paid only the two above, which meant the STM door
+    # into long-term memory was cheaper than the front door.
+    _reject_reserved_memory_type(body.memory_type)
     # Bind the promoted memory to the authenticated agent identity when the
     # credential carries one — a caller must not promote into LTM on behalf
     # of an arbitrary peer agent.
@@ -155,13 +178,42 @@ async def promote_stm(
             status_code=403,
             detail=f"agent_id '{body.agent_id}' does not match the authenticated agent identity.",
         )
-    # Broker ownership boundary: an install-credential caller may only promote
-    # under an agent it owns. Degrade a foreign / reserved-namespace agent id to
-    # its own broker:<install> fallback (parity with the data-plane write paths).
-    # The auth.agent_id guard above is a no-op for brokers (auth.agent_id is None),
-    # so this is the check that actually constrains a broker's promote target.
-    if auth.is_install_credential and body.agent_id:
-        body.agent_id = await broker_owned_agent_id(body.agent_id, auth.install_uuid, tenant_id)
+
+    from core_api.services.organization_settings import resolve_config
+
+    write_config = await resolve_config(tenant_id)
+    # ``resolve_write_agent`` is what POST /memories uses, and it SUBSUMES the
+    # bare ``broker_owned_agent_id`` call this replaced: it enforces the same
+    # broker ownership boundary (degrading a foreign / reserved-namespace agent
+    # id to the caller's own broker:<install> fallback) AND applies the
+    # agent-approval policy, returning the agent row the trust gate below needs.
+    # Calling both would have done the ownership work twice.
+    agent, body.agent_id = await resolve_write_agent(
+        body.agent_id,
+        tenant_id,
+        body.fleet_id,
+        is_install_credential=auth.is_install_credential,
+        install_uuid=auth.install_uuid,
+        require_approval=write_config.require_agent_approval,
+    )
+    # A quarantined agent (trust_level 0) must not reach LTM by any door.
+    if agent.get("trust_level", 0) == 0:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Agent '{body.agent_id}' is not approved. Contact tenant admin to set trust_level >= 1.",
+        )
+    # Resolve fleet from the agent's home fleet, as the write path does, so the
+    # fleet-write policy below is evaluated against the fleet the memory will
+    # actually land in rather than against None.
+    if not body.fleet_id and agent.get("fleet_id"):
+        body.fleet_id = agent["fleet_id"]
+    if auth.tenant_id:  # skip enforcement + metering for admin, as POST /memories does
+        await enforce_fleet_write(tenant_id, body.agent_id, body.fleet_id)
+        # Metering, distinct from ``enforce_usage_limits`` above: that one
+        # refuses a write when the org is ALREADY over its plan cap, this one is
+        # what makes the write count toward the cap. Without it a tenant could
+        # promote without limit and never trip the check.
+        await check_and_increment(tenant_id, "write")
 
     from core_api.services.stm_service import promote
 

--- a/tests/test_broker_ingest_stm_ownership.py
+++ b/tests/test_broker_ingest_stm_ownership.py
@@ -19,10 +19,10 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-
 from core_api.auth import AuthContext
 from core_api.routes import memories, stm
 from core_api.schemas import IngestCommitRequest, IngestFact
+from core_api.services import agent_service
 
 pytestmark = pytest.mark.unit
 
@@ -82,7 +82,12 @@ async def test_ingest_commit_non_broker_not_degraded(monkeypatch):
 async def _drive_stm(monkeypatch, *, agent_id, auth):
     monkeypatch.setattr(stm, "_check_stm_enabled", lambda: None)
     gate = AsyncMock(return_value="broker:install-1")
-    monkeypatch.setattr(stm, "broker_owned_agent_id", gate)
+    # Patched on ``agent_service``, not on ``stm``: the promote route now goes
+    # through ``resolve_write_agent`` (parity with POST /memories), which calls
+    # ``broker_owned_agent_id`` itself. So this still patches the REAL gate the
+    # ownership boundary runs on, one level down, rather than a seam the route
+    # no longer has.
+    monkeypatch.setattr(agent_service, "broker_owned_agent_id", gate)
     captured: dict[str, str] = {}
 
     async def _promote(

--- a/tests/test_route_authz_gaps.py
+++ b/tests/test_route_authz_gaps.py
@@ -538,3 +538,49 @@ async def test_a_tenant_credential_may_still_filter_search_by_any_agent(
         },
     )
     assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# H-17 — /stm/promote owed the LTM write gates
+#
+# The June 2026 pass gave promote enforce_read_only / enforce_usage_limits and
+# bound its agent_id to the authenticated identity. It still reached LTM without
+# the gates POST /memories applies, so the STM door into long-term memory was
+# cheaper than the front door: reserved memory types, agent approval, the
+# trust==0 quarantine gate, fleet-write policy and write metering were all
+# skipped.
+# ---------------------------------------------------------------------------
+
+
+async def test_promote_rejects_a_server_reserved_memory_type(
+    client, as_auth, sc, _stm_enabled
+):
+    """POST /memories has rejected these at the boundary; promote did not."""
+    tenant = f"tenant-{_uid()}"
+    await _seed_agent(sc, tenant, "agent-a", trust_level=2)
+
+    as_auth(tenant, agent_id="agent-a")
+    resp = await client.post(
+        "/api/v1/stm/promote",
+        json={
+            "agent_id": "agent-a",
+            "content": "promoted",
+            "memory_type": "rule",
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "server-reserved" in resp.text
+
+
+async def test_promote_refuses_a_quarantined_agent(client, as_auth, sc, _stm_enabled):
+    """trust_level 0 is the quarantine state; it must hold at every LTM door."""
+    tenant = f"tenant-{_uid()}"
+    await _seed_agent(sc, tenant, "agent-q", trust_level=0)
+
+    as_auth(tenant, agent_id="agent-q")
+    resp = await client.post(
+        "/api/v1/stm/promote",
+        json={"agent_id": "agent-q", "content": "promoted"},
+    )
+    assert resp.status_code == 403, resp.text
+    assert "not approved" in resp.text


### PR DESCRIPTION
**H-17** from the 2026-08-14 OSS/platform audit. A promote **is** an LTM write, but it reached long-term memory having paid only `enforce_read_only` and `enforce_usage_limits` — so the STM door into LTM was cheaper than the front door at `POST /memories`.

The June 2026 pass gave promote those two gates and bound its `agent_id` to the authenticated identity. It did not bring the route to parity. Missing, all now applied in the write path's order:

| gate | why it matters here |
|---|---|
| `_reject_reserved_memory_type` | promote takes `memory_type` **from the body**, so a caller could land a server-reserved type the front door refuses |
| agent-approval policy | `require_agent_approval` was never consulted |
| `trust_level == 0` quarantine | a quarantined agent could still reach LTM |
| `enforce_fleet_write` | fleet-write policy unevaluated |
| `check_and_increment(tenant, "write")` | promotes were unmetered |

## Two things worth review attention

**`resolve_write_agent` REPLACES the bare `broker_owned_agent_id` call rather than joining it.** That helper is what `POST /memories` uses, and it subsumes the old call: it runs the same ownership degradation internally (line 33) *and* adds an `_owned_by_other_install` post-check, while returning the agent row the trust gate needs. Calling both would have done the ownership work twice.

Two existing broker tests patched `stm.broker_owned_agent_id`, a seam this removes. They now patch `agent_service.broker_owned_agent_id` — the real gate one level down — so they still exercise the boundary end-to-end through the new call path rather than through a mock of my own code.

**Metering is not the same as `enforce_usage_limits`**, which is why both belong. That gate refuses a write when the org is *already* over its plan cap; `check_and_increment` is what makes the write *count toward* it. Without metering a tenant could promote without limit and never trip the check.

## Deliberately not included

The `@write_limit` rate limiter `POST /memories` carries. It's slowapi's `limiter.limit`, which needs a `Request` in the endpoint signature that this route lacks. Threading one in unverified risked breaking the route for the least security-critical of the five gaps — worth a follow-up rather than a guess here.

## Tests

2 added, **both fail without this change**:

```
FAILED test_promote_rejects_a_server_reserved_memory_type
FAILED test_promote_refuses_a_quarantined_agent
```

Full suite **4443 passed, 3 skipped, 1 xfailed**. `ruff check` / `ruff format --check` clean as separate steps.

**One open thread I could not close and am not hiding:** I also wrote a happy-path test asserting an approved agent's promote returns 200, and it returned **422** — from something downstream of these gates, not from them (the quarantine test passing proves the gates themselves are ordered correctly). I removed the test rather than assert a status I don't understand or paper over it with a weaker assertion. Worth someone establishing what a legitimate promote actually requires — it may want an existing STM note — since the absence of a happy-path test here is a real gap in this PR's coverage.

## Audit status

7 of 8 security highs covered. **H-18** remains (fast write mode on the default inline deployment never enforces LLM governance — PII-drop, non-business drop, `keep_private` silently skipped), plus the 10 correctness highs H-01–H-10.