### PR TITLE
feat(llm): say so when the fallback provider tier is skipped

### DIFF
--- a/common/llm/retry.py
+++ b/common/llm/retry.py
@@ -220,10 +220,38 @@ async def call_with_fallback(
         )
 
     # --- Step 2: Try fallback provider ---
+    # Record WHY we never reached the fallback, because otherwise this tier can be
+    # dead in a deployment and nothing says so: every skip path below is silent,
+    # and the only symptom is the step-3 warning, which reads as though every
+    # provider had been tried. Measured on prod core-api over 3 days to
+    # 2026-08-17: 82 "All LLM providers failed" and ZERO "falling back from" —
+    # the tier had never once executed, because only one provider key is set.
+    # Names only, never payloads.
+    # ``skip_code`` is the queryable one — ``_add_logrecord_extras`` promotes stdlib
+    # ``extra`` keys to JSON fields, so an operator can group by it instead of
+    # substring-searching prose, which is what answering the question above cost.
+    fallback_skipped: tuple[str, str] | None = None
     try:
-        if tenant_config is not None and hasattr(tenant_config, "resolve_fallback"):
+        if tenant_config is None or not hasattr(tenant_config, "resolve_fallback"):
+            fallback_skipped = ("no_tenant_config", "no tenant config exposing resolve_fallback()")
+        else:
             fb_provider_name, fb_model = tenant_config.resolve_fallback()
-            if fb_provider_name and fb_provider_name != primary_provider_name:
+            if not fb_provider_name:
+                fallback_skipped = (
+                    "no_fallback_configured",
+                    # Both levers, because ``resolve_fallback`` tries them in this
+                    # order: an explicit ``fallback_llm.provider`` is returned with NO
+                    # key check at all, and only if it is unset does it scan for a
+                    # keyed provider differing from the primary.
+                    "no fallback provider configured — set fallback_llm.provider, or "
+                    "supply an API key for a provider other than the primary",
+                )
+            elif fb_provider_name == primary_provider_name:
+                fallback_skipped = (
+                    "fallback_is_primary",
+                    f"resolved fallback is the primary provider '{primary_provider_name}'",
+                )
+            else:
                 fb_provider = provider_factory(
                     fb_provider_name,
                     tenant_config,
@@ -231,6 +259,8 @@ async def call_with_fallback(
                     model_attr=model_attr,
                 )
                 if getattr(fb_provider, "is_fake", False):
+                    # Already its own warning — not folded into ``fallback_skipped``,
+                    # which exists for the paths that had none.
                     logger.warning(
                         "%s: fallback provider '%s' also resolved to FakeLLMProvider (no API key).",
                         label,
@@ -251,10 +281,23 @@ async def call_with_fallback(
                         non_retryable=non_retryable,
                     )
     except Exception:
+        # Left as-is: this path is already loud, so it needs no skip reason.
         logger.warning(
             "%s fallback resolution/provider also failed",
             label,
             exc_info=True,
+        )
+
+    if fallback_skipped is not None:
+        skip_code, skip_detail = fallback_skipped
+        # Not "the next line is not evidence…": these two are adjacent in this
+        # coroutine but interleave with other instances in the aggregated log view,
+        # which is exactly where anyone reads them. State it self-containedly.
+        logger.warning(
+            "%s: fallback provider tier SKIPPED (%s); no second provider was tried",
+            label,
+            skip_detail,
+            extra={"fallback_skip_reason": skip_code},
         )
 
     # --- Step 3: Fake function as last resort ---

--- a/tests/test_provider_protocols.py
+++ b/tests/test_provider_protocols.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 
+import logging
+
 import pytest
 
 from uuid import uuid4
@@ -299,7 +301,7 @@ class TestCallWithFallback:
         assert not call_fn_called
 
     @pytest.mark.asyncio
-    async def test_primary_fails_fallback_succeeds(self):
+    async def test_primary_fails_fallback_succeeds(self, caplog):
         """Primary fails, fallback provider succeeds."""
         attempt = 0
 
@@ -320,6 +322,9 @@ class TestCallWithFallback:
             provider_factory=lambda name, _tc, **kw: _MockRealProvider(),
         )
         assert result == "fallback-ok"
+        # Control for the skip-reason logging below: the tier DID run, so nothing
+        # may claim it was skipped.
+        assert not [r for r in caplog.records if "SKIPPED" in r.getMessage()]
 
     @pytest.mark.asyncio
     async def test_all_fail_returns_fake(self):
@@ -338,6 +343,44 @@ class TestCallWithFallback:
             provider_factory=lambda name, _tc, **kw: _MockRealProvider(),
         )
         assert result == {"empty": True}
+
+    @pytest.mark.parametrize(
+        "tenant_config,expected_reason",
+        [
+            # The prod shape: only one provider key set, so resolve_fallback()
+            # returns (None, None) and the tier never runs.
+            (_MockTenantConfig(fb_provider=None), "no fallback provider configured"),
+            # Resolves, but to the provider that just failed.
+            (_MockTenantConfig(fb_provider="primary"), "resolved fallback is the primary"),
+            # No config at all — e.g. a caller that never plumbed one through.
+            (None, "no tenant config exposing resolve_fallback()"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_skipped_fallback_tier_says_so(self, caplog, tenant_config, expected_reason):
+        """A silently-skipped fallback tier must announce itself.
+
+        Every skip path logged nothing, so "All LLM providers failed" was the only
+        trace — and it reads as though a second provider had been tried. Prod ran
+        3 days with 82 of those lines and zero fallback attempts.
+        """
+
+        async def call_fn(provider):
+            raise RuntimeError("down")
+
+        with caplog.at_level(logging.WARNING, logger="common.llm.retry"):
+            result = await call_with_fallback(
+                "primary",
+                call_fn,
+                fake_fn=lambda: {"empty": True},
+                tenant_config=tenant_config,
+                provider_factory=lambda name, _tc, **kw: _MockRealProvider(),
+            )
+
+        assert result == {"empty": True}
+        skip_lines = [r.getMessage() for r in caplog.records if "SKIPPED" in r.getMessage()]
+        assert len(skip_lines) == 1, f"expected exactly one skip line, got {skip_lines}"
+        assert expected_reason in skip_lines[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
From the 2026-08-17 handoff, item 5 (residual entity-extraction `APITimeoutError`s).
Chasing those timeouts turned up something separate and more interesting than the
timeout rate itself.

## The three-tier fallback chain is a two-tier chain in prod

`call_with_fallback` documents primary → configured fallback provider → heuristic.
`resolve_fallback()` returns a provider only if `fallback_llm.provider` is set, or
if some provider *other than the primary* holds an API key. Prod core-api has only
`OPENAI_API_KEY`. So the middle tier never executes, and **every skip path was
silent**.

The only trace was step 3:

```
All LLM providers failed for entity-extraction, using fake fallback
```

which reads as though a second provider had been tried. Over the three days to
2026-08-17 prod core-api logged **82 of those and zero `falling back from`** — the
tier had never run once, and no line said so.

## What this changes

Names each skip path and logs one warning when it fires:

```
entity-extraction: fallback provider tier SKIPPED (no fallback provider configured
— set fallback_llm.provider, or supply an API key for a provider other than the
primary); no second provider was tried
```

with `fallback_skip_reason=no_fallback_configured` as a **structured field** via
`extra` (`_add_logrecord_extras` promotes it), so this class of question can be
answered with a `group by` instead of the free-text search it cost this time.

The hint names both levers deliberately: `resolve_fallback` returns an explicit
`fallback_llm.provider` with **no key check at all**, and only scans for a keyed
non-primary provider when that is unset. An earlier draft mentioned only the key
scan, which would have pointed an operator at the incidental lever.

## Scope

**Observability only — no behaviour change.** The conditionals are inverted by
De Morgan into named branches; the resolution logic, the `is_fake` warning and the
`except` path are untouched. The new line fires only after the primary has already
failed its retries, which is itself a rare, already-logged event, so there is no
hot-path cost.

Shapes only — provider names and static literals, never payloads.

## Verification

Three parametrized tests drive the three genuinely distinct skip branches
(`(None, None)`, fallback == primary, no config) and assert **exactly one** skip
line each. All three fail against unfixed `common/llm/retry.py`:

```
FAILED ...test_skipped_fallback_tier_says_so[tenant_config0-no fallback provider configured]
FAILED ...test_skipped_fallback_tier_says_so[tenant_config1-resolved fallback is the primary]
FAILED ...test_skipped_fallback_tier_says_so[None-no tenant config exposing resolve_fallback()]
3 failed, 73 passed
```

The control lives on the existing `test_primary_fails_fallback_succeeds` rather
than in a new test that restaged it: a tier which *did* run must never be reported
as skipped.

I also confirmed the structured field actually reaches the record, rather than
assuming `extra` works:

```
extra field fallback_skip_reason = no_fallback_configured
```

- root suite: **4446 passed**, 3 skipped, 1 xfailed
- core-worker: **71 passed**
- `ruff check common/` clean; `mypy core-api/src/` clean (198 files)
- did NOT run `ruff format` on `retry.py` — it is outside CI's `common/` format scope

## What this does *not* fix

The failure path still lands in `_fake_extract`, which labels every capitalised
phrase as `entity_type="person"` with no relations — confidently-wrong graph data.
That is a behaviour change to what gets persisted, so it is a **separate PR**, as
agreed. This one only makes the dead tier visible.

Whether prod core-api *should* carry a second provider key is a deployment
question, not a code one — but this log is what would have surfaced it.