### PR TITLE
fix(extraction): stop the regex heuristic guessing entity_type=person

### DIFF
--- a/core-api/src/core_api/services/entity_extraction.py
+++ b/core-api/src/core_api/services/entity_extraction.py
@@ -157,14 +157,39 @@ def _parse_graph_lenient(raw: dict) -> tuple[ExtractedGraph, dict[str, int]]:
     return ExtractedGraph(**fields), dropped
 
 
+# What the regex heuristic declares instead of guessing. NOT one of the ten types
+# the prompt above offers, deliberately: those are classifications, and this path
+# performed no classification. Free-form ``str`` on ``ExtractedEntity`` and no code
+# branches on the value (it is stored by ``entity_service`` and displayed), so this
+# is a change to what we ASSERT, not to what works.
+_UNCLASSIFIED_ENTITY_TYPE = "unknown"
+
+
 def _fake_extract(content: str) -> ExtractedGraph:
-    """Regex-based: extract capitalized multi-word phrases as person entities."""
+    """Regex heuristic: capitalised multi-word phrases, left deliberately untyped.
+
+    This is the last tier of the extraction chain, so its output is not a
+    throwaway — ``entity_extraction_worker`` persists these rows to the entity
+    graph and embeds every name.
+
+    It used to stamp ``entity_type="person"`` on every match, which contradicts
+    the extraction prompt's own rule twelve lines up ("Use entity_type=person only
+    when a named individual is referenced") and is wrong for most of what a
+    capitalised-bigram regex finds: "Helios Migration", "Last Tuesday" and "Good
+    Morning" all became people. On a provider outage that wrong type is what
+    reaches a real tenant's graph.
+
+    A regex cannot classify, so it no longer pretends to. The NAMES are still
+    worth keeping — "Anna Bergstrom" and "Acme Corp" are genuine entities, and
+    when every provider is down this is the only path that catches them — but the
+    type is reported as undetermined rather than invented.
+    """
     pattern = r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b"
     matches = list(set(re.findall(pattern, content)))
     entities = [
         ExtractedEntity(
             canonical_name=m.lower(),
-            entity_type="person",
+            entity_type=_UNCLASSIFIED_ENTITY_TYPE,
             role="mentioned",
         )
         for m in matches

--- a/tests/test_p4_1_llm_fallback.py
+++ b/tests/test_p4_1_llm_fallback.py
@@ -595,6 +595,28 @@ class TestFakeExtract:
         result = _fake_extract("John Smith manages the Auth Team")
         assert result.relations == []
 
+    def test_never_claims_a_type_it_did_not_establish(self):
+        """A capitalised-bigram regex cannot classify, so it must not assert a class.
+
+        Every match used to be typed ``person`` — including "Helios Migration" and
+        "Last Tuesday". This output is PERSISTED to the entity graph on a provider
+        outage, so the wrong type reaches a real tenant.
+        """
+        from core_api.services.entity_extraction import _fake_extract
+
+        result = _fake_extract(
+            "Anna Bergstrom shipped the Helios Migration on Last Tuesday"
+        )
+        types = {e.entity_type for e in result.entities}
+
+        assert result.entities, "expected the regex to find the capitalised phrases"
+        assert types == {"unknown"}, (
+            f"the heuristic must report an undetermined type, not guess; got {types!r}"
+        )
+        # The point is not that 'person' is banned but that nothing is asserted:
+        # 'helios migration' is not a person and neither is 'last tuesday'.
+        assert "person" not in types
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: call_with_fallback max_attempts (recall latency lever)


### PR DESCRIPTION
Second of the two PRs from item 5 of the 2026-08-17 handoff. #805 made the dead
fallback tier visible; this fixes what actually runs on the failure path.

## The heuristic contradicts the extractor's own contract

`_fake_extract` stamped `entity_type="person"` on every capitalised multi-word
match. Twelve lines above it, the extraction prompt says:

> Job titles … classify as entity_type=role — NOT person. Use entity_type=person
> only when a named individual is referenced

A capitalised-bigram regex finds "Helios Migration", "Last Tuesday", "Good
Morning". All became people.

## Why it matters — this path is live, and its output is persisted

Not a dev-only stub. `entity_extraction_worker` puts these rows in the entity
graph (`entity_service` upserts `entity_type`) and computes an embedding for every
name. Prod core-api reaches the heuristic on provider timeouts — 20 in 12h on
2026-08-17 — and per #805 the fallback tier never intercepts, because only one
provider key is configured. So the wrong type reaches a real tenant's graph, and
each bogus entity also spends an embedding against a TEI tier already ~2.7x
oversubscribed at floor.

## The change

Matches are reported as `unknown` — "named thing, type not determined" — which is
what actually happened.

I kept the names rather than returning an empty graph, deliberately. "Anna
Bergstrom" and "Acme Corp" are genuine entities, and when every provider is down
this is the only path that catches them; returning empty would also make
`test_total_loss_falls_back_rather_than_returning_empty` unable to observe that
the fallback chain ran at all, which is the property it exists to pin. So this
narrows what is *asserted* instead of discarding signal.

## Blast radius: none mechanical

- `ExtractedEntity.entity_type` is a free-form `str` — no enum, no validator.
- Nothing in `core-api`, `common`, `core-worker` or `core-storage-api` branches on
  its value; it is stored and displayed.
- I checked the three other occurrences of the literal `"person"`
  (`constants.py:506`, `constants.py:855`, `organization_settings.py:300`) — all
  are **vague-noun blocklists for entity NAMES**, not type allow-lists. Nothing to
  update.
- No existing test asserted the type, only canonical names and empty relations.

## Verification

New test drives the public shape and fails against unfixed code:

```
FAILED tests/test_p4_1_llm_fallback.py::TestFakeExtract::test_never_claims_a_type_it_did_not_establish
1 failed, 40 passed
```

It asserts entities were found *first*, then that the type set is exactly
`{"unknown"}` — so it cannot pass vacuously on an empty extraction, which would
otherwise satisfy the very defect it exists to catch.

- root suite: **4458 passed**, 3 skipped, 1 xfailed
- `ruff check` + `ruff format --check core-api/src/` clean; `mypy` clean (198 files)

## No backfill

Rows already written as `person` are left alone. Nothing distinguishes a
heuristic-written row from an LLM-written one after the fact, so a sweep would
have to assert a provenance it cannot establish — the same reason migration 037
refused to stamp `embedded_content_hash` on pre-existing rows.