### PR TITLE
digest: treat reserved agent ids consistently (drop __health_check__; stop mislabeling main-<hex> as 'main')

### DIFF
--- a/core-api/src/core_api/services/report_corpus.py
+++ b/core-api/src/core_api/services/report_corpus.py
@@ -16,10 +16,22 @@ import re
 # generator so "day"/"week" mean the same thing on both surfaces.
 PERIOD_DAYS: dict[str, int] = {"day": 1, "week": 7}
 
-# Episodic activity-log type(s) + the unattributed firehose agent excluded so the
-# report reflects durable, decision-bearing per-agent work.
+# Episodic activity-log type(s) excluded so the report reflects durable,
+# decision-bearing per-agent work.
 NON_DURABLE_TYPES = ("episode",)
-RESERVED_FIREHOSE_AGENTS = ("main",)
+# Reserved / automated write-path identities that are never a real agent: the
+# legacy unattributed ``main`` firehose, and ``__health_check__`` (a monitoring
+# probe that writes ~200 ``memclaw-smoke-*`` facts/day). These must appear in a
+# report neither as a ROW nor as a rollup PARENT (see :func:`resolve_parent`) —
+# otherwise a real agent's work gets mislabeled under a reserved id. Note
+# ``routes/reports.py`` also passes this tuple to storage as a server-side
+# ``exclude_agent_ids`` list, so its entries must stay exact agent ids.
+RESERVED_FIREHOSE_AGENTS = ("main", "__health_check__")
+# Reserved-system id convention: a ``__name__`` (double-underscore-wrapped) id is
+# an automated/system identity, not a real agent. Matching the pattern covers
+# future probes without a code change; the named tuple above stays authoritative
+# for the exact-id storage-side exclude.
+_RESERVED_AGENT_RE = re.compile(r"^__.+__$")
 
 # "Cohesive" filter: heartbeat / health-check / status-poll noise leaks in as
 # NON-episode rows (e.g. action/outcome "heartbeat" or "Checked HEARTBEAT.md"
@@ -33,17 +45,27 @@ NON_COHESIVE_TITLE_REGEX = (
     r"(heartbeat|health[- ]?check|healthz|healthy|watchdog|gpu.?health|no.?change|"
     r"auth error|zero auth|0 auth|encrypted|unreadable|no readable|no actionable|"
     r"no usable|no_reply|polled|quickcheck|app-fleet|discovery script|"
-    r"gateway (active|reachable)|cache refresh)"
+    r"gateway (active|reachable)|cache refresh|memclaw-smoke)"
 )
 _NON_COHESIVE_TITLE_RE = re.compile(NON_COHESIVE_TITLE_REGEX, re.IGNORECASE)
 
 
+def is_reserved_agent(agent_id: str | None) -> bool:
+    """True for firehose / reserved-system agent ids that must never surface in a
+    report — neither as a row (leaf) nor as a rollup parent. Covers the explicit
+    :data:`RESERVED_FIREHOSE_AGENTS` set plus the ``__name__`` reserved-system
+    id convention."""
+    if not agent_id:
+        return False
+    return agent_id in RESERVED_FIREHOSE_AGENTS or bool(_RESERVED_AGENT_RE.match(agent_id))
+
+
 def passes_noise_filter(m: dict) -> bool:
-    """True if a row is real signal — not a firehose agent and not
+    """True if a row is real signal — not a reserved/firehose agent and not
     heartbeat/health/status-poll noise (title-only match). Includes episodes:
     this is the base filter the digest's episode-fallback uses when an agent has
     no durable rows (its activity IS episodic)."""
-    return m.get("agent_id") not in RESERVED_FIREHOSE_AGENTS and not _NON_COHESIVE_TITLE_RE.search(
+    return not is_reserved_agent(m.get("agent_id")) and not _NON_COHESIVE_TITLE_RE.search(
         m.get("title") or ""
     )
 
@@ -68,6 +90,10 @@ def resolve_parent(agent_id: str, known_ids: frozenset[str] | set[str]) -> str:
          (longest such prefix, boundary '-')           -> <parent>
       3. otherwise the agent is already top-level       -> itself
 
+    A reserved / firehose id (:func:`is_reserved_agent`) is never accepted as a
+    parent: an unconfigured ``main-<hex>`` agent stays under its own id rather
+    than rolling up (and being mislabeled) under the retired ``main`` firehose.
+
     ``known_ids`` is the tenant's agent-id set (already fetched by list_agents),
     so this needs no extra query. Prefer ``owner_ref`` upstream once populated.
     """
@@ -80,13 +106,18 @@ def resolve_parent(agent_id: str, known_ids: frozenset[str] | set[str]) -> str:
             nxt = m.group("parent")
         else:
             # longest known-agent prefix on a '-' boundary (avoids matching an
-            # unrelated agent that merely shares a leading substring)
+            # unrelated agent that merely shares a leading substring). Reserved
+            # ids are skipped so they can never become a parent.
             best = ""
             for pid in known_ids:
+                if is_reserved_agent(pid):
+                    continue
                 if pid != cur and cur.startswith(pid + "-") and len(pid) > len(best):
                     best = pid
             nxt = best
-        if not nxt or nxt == cur:
+        # Stop when there's no parent, we've resolved to ourselves, or the
+        # candidate is reserved (also guards the ``agent:main:subagent:`` form).
+        if not nxt or nxt == cur or is_reserved_agent(nxt):
             return cur
         cur = nxt
     return cur

--- a/core-api/tests/test_report_corpus.py
+++ b/core-api/tests/test_report_corpus.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from core_api.services.report_corpus import is_cohesive, passes_noise_filter, resolve_parent
+from core_api.services.report_corpus import (
+    is_cohesive,
+    is_reserved_agent,
+    passes_noise_filter,
+    resolve_parent,
+)
 
 
 def test_resolve_parent_explicit_subagent_convention():
@@ -47,3 +52,43 @@ def test_filter_split_durable_vs_events_vs_noise():
     assert not passes_noise_filter(heartbeat) and not is_cohesive(heartbeat)
     # firehose agent: dropped by both
     assert not passes_noise_filter(firehose) and not is_cohesive(firehose)
+
+
+def test_is_reserved_agent_predicate():
+    assert is_reserved_agent("main")
+    assert is_reserved_agent("__health_check__")
+    assert is_reserved_agent("__anything__")  # reserved-system __name__ convention
+    # a real, unconfigured-identity agent (default main-<hex>) is NOT reserved
+    assert not is_reserved_agent("main-e5366d79a926")
+    assert not is_reserved_agent("quantclaw")
+    assert not is_reserved_agent("")
+    assert not is_reserved_agent(None)
+
+
+def test_health_check_probe_dropped_as_noise():
+    # __health_check__ writes durable-typed 'fact' rows titled 'memclaw-smoke-*';
+    # both the reserved-agent gate and the title regex must drop them so the probe
+    # never tops the leaderboard.
+    probe = _m(mtype="fact", title="memclaw-smoke-1786983933574 identifier", agent="__health_check__")
+    assert not passes_noise_filter(probe) and not is_cohesive(probe)
+    # the memclaw-smoke title alone drops it even under a non-reserved id
+    smoke_titled = _m(mtype="fact", title="memclaw-smoke-123 identifier", agent="someagent")
+    assert not passes_noise_filter(smoke_titled)
+
+
+def test_reserved_id_never_becomes_a_rollup_parent():
+    # bare 'main' is still a known id (historical firehose rows), but an
+    # unconfigured 'main-<hex>' agent must resolve to ITSELF — not be mislabeled
+    # under the retired 'main' firehose.
+    known = frozenset({"main", "main-e5366d79a926", "quantclaw"})
+    assert resolve_parent("main-e5366d79a926", known) == "main-e5366d79a926"
+    # the structured agent:<parent>:subagent: form can't smuggle a reserved parent
+    assert resolve_parent("agent:main:subagent:abc", known) == "agent:main:subagent:abc"
+    # a reserved '__probe__' prefix is likewise never a parent
+    assert resolve_parent("__probe__-task", frozenset({"__probe__"})) == "__probe__-task"
+
+
+def test_legit_rollup_unaffected_by_reserved_skip():
+    # skipping reserved prefixes must not disturb normal family resolution
+    known = frozenset({"main", "cmoclaw", "cmoclaw-affiliate"})
+    assert resolve_parent("cmoclaw-affiliate-ai-fix", known) == "cmoclaw"


### PR DESCRIPTION
## What

Fixes two agent-attribution bugs in the agent-activity digest, both found while investigating an eToro report where **`__health_check__` showed as the most-active agent** and a **`main`** row appeared. Root cause is shared: the leaf noise-filter (`passes_noise_filter`) and the family rollup (`resolve_parent`) didn't agree on what a *reserved* agent id is.

## Bug 1 — a health-check probe topped the leaderboard

`__health_check__` is a write-path smoke test that persists ~200 `memclaw-smoke-<epoch>` **`fact`** rows/day (2,657 on etoro0; recalled 2 times ever). It passed every gate:
- type `fact` → survives the `episode` durable filter
- titles `memclaw-smoke-*` → don't match the heartbeat/health title regex
- id `__health_check__` → wasn't in `RESERVED_FIREHOSE_AGENTS`

**Fix:** add it (and the `__name__` reserved-system convention, via a new shared `is_reserved_agent`) to the leaf filter; add `memclaw-smoke` to the title regex as belt-and-suspenders.

## Bug 2 — a real agent mislabeled as the retired `main` firehose

The `main` row was **not** the firehose (bare `main` has had zero writes since `RESERVED_AGENT_ID_POLICY=reject`). It was a rollup artifact: a real unconfigured-identity agent **`main-e5366d79a926`** (the default `main-<hex>` id, fleet `yoniclaw-fleet`, 51 cohesive writes of genuine SEO/ASO work) whose parent `resolve_parent` walked to `main` — because bare `main` is still a known id and the child starts with `main-`. The firehose *leaf* exclusion was bypassed by the *rollup*.

**Fix:** `resolve_parent` skips reserved ids as prefix candidates and rejects a reserved parent from the structured `agent:main:subagent:` form too. The agent now stays under its **own** id and is shown honestly (per decision: show `main-<hex>` agents under their own id rather than suppress them — they're attributable and did real work).

## Design

`is_reserved_agent()` is the single predicate both surfaces use, so leaf-filtering and rollup finally agree. `RESERVED_FIREHOSE_AGENTS` also feeds `routes/reports.py`'s server-side `exclude_agent_ids`, so the **live Fleet Status dashboard** now drops the probe's 2.6k `fact`s from its durable corpus too. No change for legitimate families (`cmoclaw-*`, etc.).

## Testing

- `tests/test_report_corpus.py` — 9 pass (added: `is_reserved_agent` predicate; probe dropped as noise; reserved id never a rollup parent incl. structured form; legit rollup unaffected).
- `tests/test_agent_digest.py` — 21 pass (no regression).
- `ruff check` clean.

Grounded on read-only prod queries against `oc-memclaw-prod` (etoro0), incl. the actual generated `agent_activity_digests` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
