### PR TITLE
docs(core-api): record the two invariants #806's review surfaced

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -1998,7 +1998,24 @@ async def _schedule_enrich_or_inline(
         # cannot reach this branch today (``not settings.inline_enrichment``
         # guards it), so the flag is defence against that guard being relaxed.
         #
+        # ⚠ The default is OFF, which means a new caller that reaches this
+        # branch without passing the flag silently skips governance — the exact
+        # shape of H-18. If you add a third call site, it MUST pass
+        # ``run_governance_remediation=True`` unless it has already applied
+        # ``GovernanceDecision`` synchronously for the same write. Deriving it
+        # here instead is not possible today: only the caller knows the resolved
+        # write mode, and that is what decides whether the synchronous step ran.
+        #
         # ``enriched_row`` is ``None`` exactly when no verdict was produced.
+        #
+        # ``tenant_config`` is the snapshot the pipeline resolved for this write,
+        # while ``_enrich_memory_background`` re-resolves its own to decide
+        # whether to enrich at all. With a 5-minute TTL cache they are the same
+        # object in practice; if an org toggles governance in the window between
+        # pipeline start and enrichment completing, the enrich decision and the
+        # policy decision can come from different snapshots. Deliberate — using
+        # the pipeline's snapshot keeps the whole write governed by the config it
+        # started under, rather than one that changed underneath it.
         #
         # Deliberately unguarded, matching ``consumer.py`` on the deferred path.
         # This is the last statement of the task — extraction and Path A are


### PR DESCRIPTION
Comment-only follow-up to #806 (H-18). **No behaviour change** — the diff is 17 added comment lines and nothing else.

The final review of #806 passed with no blocking issues but raised two suggestions. Both are the kind of thing that belongs in the code rather than only in a merged PR thread, so this records them where the next person will actually hit them.

### 1. `run_governance_remediation` defaults to OFF

Correct for the two callers that exist — strong mode applies `GovernanceDecision` synchronously and would otherwise double-apply, producing duplicate audit rows and a second drop on a row policy already acted on.

But a silent-off default on a compliance control is the exact shape of H-18 itself. A third call site that reaches the inline branch and forgets the flag would stop enforcing PII-drop / non-business-drop with no error and no failing test.

The comment states the obligation for future callers and why the callee cannot just derive it: only the caller knows the resolved write mode, and that is what determines whether the synchronous step already ran. (Making the parameter required was considered and not done here — it would touch four unrelated tests whose mocked `_enrich_memory_background` returns a truthy row, which would then drive remediation against config doubles that carry no governance attributes. Worth doing as its own change if the footgun is judged serious enough.)

### 2. Two config snapshots per write

The remediation uses the pipeline's `tenant_config`, while `_enrich_memory_background` re-resolves its own to decide whether to enrich at all. The 5-minute TTL cache makes these the same object in all but a narrow window, but an org toggling governance mid-write can have the two decisions read different snapshots.

Recorded as deliberate rather than accidental: using the pipeline's snapshot keeps the write governed by the config it started under, rather than one that changed underneath it.

---

Gates: `ruff check` and `ruff format --check` clean on `core-api/src/`; the 15 governance tests from #806 still pass.