### PR TITLE
fix(contradiction): abstain instead of guessing when no LLM answered

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -7,7 +7,9 @@ P1 fixes:
 
 Multi-provider support:
 - Vertex AI, OpenAI, Anthropic, OpenRouter via provider layer
-- Automatic fallback chain: configured provider -> fallback -> heuristic
+- Automatic fallback chain: configured provider -> fallback -> abstain
+  (heuristic only when the ``fake`` provider was explicitly asked for; see
+  ``_deliberate_fake_provider``)
 """
 
 import asyncio
@@ -17,6 +19,7 @@ import uuid as _uuid
 from datetime import datetime
 from uuid import UUID
 
+from common.provider_names import ProviderName
 from core_api.cache import cache_set_nx
 from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
@@ -1006,7 +1009,8 @@ async def _llm_contradiction_check(
     Uses the standard 3-tier fallback chain:
     1. Try the configured provider (with retry)
     2. Try the configured fallback provider (via resolve_fallback)
-    3. Fall back to negation-word heuristic
+    3. Abstain — or, when the operator ASKED for the fake provider, the
+       negation-word heuristic. See :func:`_deliberate_fake_provider`.
     """
     provider_name = (
         tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
@@ -1021,7 +1025,7 @@ async def _llm_contradiction_check(
     return await call_with_fallback(
         primary_provider_name=provider_name,
         call_fn=_do_check,
-        fake_fn=lambda: (_fake_contradiction_check(new_content, old_content), _CONF_FALLBACK),
+        fake_fn=_pairwise_fake_fn(provider_name, new_content, old_content),
         tenant_config=tenant_config,
         service_label="contradiction",
         model_attr="entity_extraction_model",
@@ -1123,13 +1127,7 @@ async def _llm_contradiction_check_batch(
     return await call_with_fallback(
         primary_provider_name=provider_name,
         call_fn=_do_check,
-        fake_fn=lambda: [
-            {
-                "same_subject": True,
-                "contradicts": _fake_contradiction_check(new_content, c.get("content", "")),
-            }
-            for c in candidates
-        ],
+        fake_fn=_batch_fake_fn(provider_name, new_content, candidates),
         tenant_config=tenant_config,
         service_label="contradiction_batch",
         model_attr="entity_extraction_model",
@@ -1137,8 +1135,120 @@ async def _llm_contradiction_check_batch(
     )
 
 
+def _deliberate_fake_provider(provider_name: str | None) -> bool:
+    """Did the operator ASK for no LLM, or did a real one fail?
+
+    ``call_with_fallback`` invokes ``fake_fn`` for both, and they are not the same
+    situation — which is the whole bug this split exists to fix. A ``fake`` provider
+    was explicitly asked for, so the negation-word heuristic is the point: it is the
+    only way the detect → mark → ``conflicted`` pipeline gets end-to-end coverage
+    without an API key (``test_p1_contradiction.py`` relies on exactly this). A
+    configured REAL provider that failed is a production outage, where the same
+    heuristic is not survivable — see :func:`_skip_contradiction_pairwise`.
+
+    ``fake`` ONLY, not ``none``: "none" asks for the feature to be off, which is an
+    abstain, while "fake" asks for the test double. ``entity_extraction`` draws the
+    same line explicitly — ``provider == "none"`` returns an empty graph, ``"fake"``
+    calls its heuristic.
+
+    And the case that motivated all of this: ``entity_extraction_provider="openai"``
+    with no key resolves to ``FakeLLMProvider`` and lands on ``fake_fn`` too. That
+    is a misconfigured deployment, NOT a request for heuristics, so it abstains.
+    """
+    return provider_name == ProviderName.FAKE
+
+
+def _skip_contradiction_pairwise() -> tuple[bool, float]:
+    """The no-LLM verdict for the per-candidate path: abstain.
+
+    ``(False, _CONF_FALLBACK)`` is not a new convention — it is exactly what
+    ``_judge_contradiction`` returns for a malformed response, and per the rubric
+    above 0.50 means "could not tell, parser conservative-default". With no LLM we
+    are in precisely that position.
+
+    This replaced ``_fake_contradiction_check``'s verdict on the production
+    fallback, because a ``True`` here is not advisory. ``detect_contradictions``
+    acts on the boolean ALONE — the confidence is unpacked as ``_confidence`` and
+    only logged, since A4 #13's confidence-weighted veto is still deferred (the
+    only live threshold, ``RETRACTION_CONFIDENCE_THRESHOLD``, gates retraction and
+    not marking) — so it sets the older memory's ``status`` to ``"conflicted"``.
+
+    What that costs, stated precisely rather than dramatically:
+
+    * ``memory_scored_search`` does NOT drop every conflicted row. It keeps one that
+      is an exact lexical match, un-demoted; otherwise the row is demoted and falls
+      out of non-exact-match recall. So the damage is to semantic/vector recall,
+      which is the path that matters for a memory product, not to lookup-by-phrasing.
+    * Recovery exists but is narrow. No sweep re-checks the status, and Path C's
+      retraction judge (:func:`_attempt_path_c_retraction`) only restores the
+      canonical direction, needs resolved entities on both sides, needs confidence
+      ≥ ``RETRACTION_CONFIDENCE_THRESHOLD`` (0.90), and is tenant kill-switchable.
+      A flipped-direction mark is never revisited.
+
+    Abstaining instead loses a real contradiction during an outage, which leaves a
+    memory retrievable that should have been superseded — the recoverable direction,
+    and the same stance ``_fake_dedup_check`` takes when it errs toward keeping a
+    duplicate rather than dropping data.
+    """
+    logger.warning("contradiction_check_skipped candidates=1 reason=no_llm_abstained")
+    return False, _CONF_FALLBACK
+
+
+def _skip_contradiction_batch(count: int) -> list[dict]:
+    """The no-LLM verdict for the batch path: abstain for every candidate.
+
+    An EMPTY dict per candidate, deliberately — not ``_align``'s
+    ``{"contradicts": False}``. Every batch raw is fed straight to
+    ``_judge_contradiction``, and the two shapes score differently there:
+    ``{"contradicts": False}`` is a non-empty dict, so it misses the malformed
+    branch, trips no gate, and comes back ``(False, _CONF_CLEAN)`` — 0.90, which
+    reads as "confidently no contradiction". ``{}`` returns
+    ``(False, _CONF_FALLBACK)`` — 0.50, "could not tell" — matching
+    :func:`_skip_contradiction_pairwise` for the identical situation. Verdict is
+    ``False`` either way, so this is inert today; it stops being inert the moment
+    A4 #13 gates on confidence, when an abstain would otherwise present as a
+    high-confidence clean verdict.
+
+    (``_align`` is right to use ``{"contradicts": False}``: there the model DID
+    answer, just not for that index. This path has no answer at all.)
+
+    The previous fallback hardcoded ``same_subject: True`` for every candidate,
+    which contradicted the batch prompt's own rule — "Set true ONLY when subject_a
+    and subject_b refer to the SAME real-world entity", and "If same_subject is
+    false, contradicts MUST be false". See ``_skip_contradiction_pairwise`` for
+    what acting on that costs.
+    """
+    logger.warning("contradiction_check_skipped candidates=%d reason=no_llm_abstained", count)
+    return [{} for _ in range(count)]
+
+
+def _pairwise_fake_fn(provider_name, new_content: str, old_content: str):
+    """The ``fake_fn`` for a per-candidate judge: heuristic if the operator asked
+    for the fake provider, abstain otherwise. One place so a new call site cannot
+    pick the wrong side of :func:`_deliberate_fake_provider` by omission."""
+    if _deliberate_fake_provider(provider_name):
+        return lambda: (_fake_contradiction_check(new_content, old_content), _CONF_FALLBACK)
+    return _skip_contradiction_pairwise
+
+
+def _batch_fake_fn(provider_name, new_content: str, candidates: list[dict]):
+    """The ``fake_fn`` for the batch judge. See :func:`_pairwise_fake_fn`."""
+    if _deliberate_fake_provider(provider_name):
+        return lambda: [
+            {
+                "same_subject": True,
+                "contradicts": _fake_contradiction_check(new_content, c.get("content", "")),
+            }
+            for c in candidates
+        ]
+    return lambda: _skip_contradiction_batch(len(candidates))
+
+
 def _fake_contradiction_check(new_content: str, old_content: str) -> bool:
-    """Simple heuristic for testing: flag if negation words differ."""
+    """Simple negation-word heuristic. TEST UTILITY ONLY — deliberately NOT wired
+    to the production fallback; see ``_skip_contradiction_pairwise`` for why a
+    heuristic verdict here is not survivable. Exercised directly by
+    ``tests/test_p1_contradiction.py``."""
     negations = {
         "not",
         "no",
@@ -1454,7 +1564,7 @@ async def _llm_entity_aware_contradiction_check(
     return await call_with_fallback(
         primary_provider_name=provider_name,
         call_fn=_do_check,
-        fake_fn=lambda: (_fake_contradiction_check(new_content, old_content), _CONF_FALLBACK),
+        fake_fn=_pairwise_fake_fn(provider_name, new_content, old_content),
         tenant_config=tenant_config,
         service_label="contradiction-entity-aware",
         model_attr="entity_extraction_model",
@@ -1578,13 +1688,7 @@ async def _llm_entity_aware_contradiction_check_batch(
     return await call_with_fallback(
         primary_provider_name=provider_name,
         call_fn=_do_check,
-        fake_fn=lambda: [
-            {
-                "same_subject": True,
-                "contradicts": _fake_contradiction_check(new_content, c.get("content", "")),
-            }
-            for c in candidates
-        ],
+        fake_fn=_batch_fake_fn(provider_name, new_content, candidates),
         tenant_config=tenant_config,
         service_label="contradiction-entity-aware_batch",
         model_attr="entity_extraction_model",
@@ -1624,7 +1728,8 @@ async def _llm_entity_aware_contradiction_check_batch(
 #   0.85 — gate 2 fired (model named a non_conflict_reason)
 #   0.60 — gate 1 fired (model said contradicts=True same_subject=False;
 #          parser overrode). THIS IS THE STOCHASTIC FLIP CASE.
-#   0.50 — malformed / heuristic fallback
+#   0.50 — malformed response, or a no-LLM abstain (``_skip_contradiction_*``).
+#          NOT a heuristic verdict any more: the production fallback abstains.
 #
 # Raising the floor to 0.90 means retraction only fires on clean
 # agreement — both gates of the parser say "not a contradiction" with
@@ -1778,8 +1883,8 @@ async def _attempt_path_c_retraction(
         # Below the CAURA-128 floor (0.90). Covers gate-1 (0.60, the
         # stochastic-flip case where parser overrode ``contradicts=True
         # same_subject=False`` to False), gate-2 (0.85, single-gate
-        # ``non_conflict_reason``), and the heuristic / malformed
-        # fallback (0.50). None are trustworthy enough on their own —
+        # ``non_conflict_reason``), and the malformed / no-LLM-abstain
+        # case (0.50). None are trustworthy enough on their own —
         # the judge call is the same prompt + same inputs as Path A's
         # semantic judge, so a single-gate disagreement is just an
         # independent LLM roll flipping. Leave Path A's verdict in

--- a/tests/test_contradiction_fallback_abstains.py
+++ b/tests/test_contradiction_fallback_abstains.py
@@ -1,0 +1,158 @@
+"""With no LLM, contradiction detection must ABSTAIN rather than guess.
+
+A ``True`` verdict here is not advisory: ``detect_contradictions`` acts on the
+boolean alone and marks the older memory ``conflicted``, which demotes it out of
+semantic recall. The precise cost — including the exact-lexical-match carve-out
+that keeps some conflicted rows, and how narrow Path C's restoration actually is —
+is documented once, on ``_skip_contradiction_pairwise``. Not restated here, so the
+two cannot drift.
+
+The old fallback made that call from a negation-word heuristic whose own docstring
+said "for testing". These tests pin that it no longer can.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core_api.services.contradiction_detector import (
+    _CONF_FALLBACK,
+    _fake_contradiction_check,
+    _judge_contradiction,
+    _llm_contradiction_check,
+    _llm_contradiction_check_batch,
+    _llm_entity_aware_contradiction_check,
+    _llm_entity_aware_contradiction_check_batch,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+class _NoLLM:
+    """Feature explicitly disabled — ``none`` means off, so the judge abstains."""
+
+    entity_extraction_provider = "none"
+
+
+def _outage_config():
+    """The production shape: a configured REAL provider whose key is missing, so it
+    resolves to FakeLLMProvider and lands on the fallback. MagicMock because
+    ``call_with_fallback`` and the provider factory read several attributes."""
+    config = MagicMock()
+    config.entity_extraction_provider = "openai"
+    config.openai_api_key = None
+    config.anthropic_api_key = None
+    config.gemini_api_key = None
+    config.openrouter_api_key = None
+    return config
+
+
+# Chosen so the OLD fallback would have returned True: negation present on
+# exactly one side, and 3+ shared non-negation words. The control test below
+# proves that, so the abstain assertions cannot pass vacuously on bland input.
+_NEW = "the helios migration is not finished this quarter"
+_OLD = "the helios migration is finished this quarter"
+
+
+def test_the_heuristic_really_would_have_flagged_this() -> None:
+    """Control. Without this, the tests below prove nothing about the inputs."""
+    assert _fake_contradiction_check(_NEW, _OLD) is True, (
+        "test inputs must be heuristic-positive, or the abstain assertions are vacuous"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pairwise_fallback_abstains() -> None:
+    verdict, confidence = await _llm_contradiction_check(_NEW, _OLD, tenant_config=_NoLLM())
+
+    assert verdict is False, (
+        "with no LLM the fallback must abstain — a True marks the older memory "
+        "conflicted, which removes it from recall with no path back"
+    )
+    # The rubric's documented "could not tell" confidence, same as the value
+    # _judge_contradiction returns for a malformed response.
+    assert confidence == _CONF_FALLBACK
+
+
+@pytest.mark.asyncio
+async def test_batch_fallback_abstains_for_every_candidate() -> None:
+    candidates = [
+        {"id": "a", "content": _OLD},
+        {"id": "b", "content": "something unrelated entirely"},
+    ]
+
+    out = await _llm_contradiction_check_batch(_NEW, candidates, tenant_config=_NoLLM())
+
+    assert len(out) == len(candidates), "one entry per candidate, or _align mis-pairs them"
+    # Both call sites feed each raw to _judge_contradiction, so pin what they
+    # actually derive. This also catches the 0.90 shape: {"contradicts": False} is a
+    # non-empty dict and scores _CONF_CLEAN, which reads as a confident clean verdict.
+    assert [_judge_contradiction(e) for e in out] == [(False, _CONF_FALLBACK)] * len(candidates)
+
+
+@pytest.mark.asyncio
+async def test_batch_fallback_never_claims_same_subject() -> None:
+    """The old fallback hardcoded ``same_subject: True`` for every candidate.
+
+    That contradicted the batch prompt's own rule — "Set true ONLY when subject_a
+    and subject_b refer to the SAME real-world entity", and "If same_subject is
+    false, contradicts MUST be false" — for candidates it had never compared.
+    """
+    candidates = [{"id": "a", "content": _OLD}, {"id": "b", "content": "unrelated"}]
+
+    out = await _llm_contradiction_check_batch(_NEW, candidates, tenant_config=_NoLLM())
+
+    assert not any(e.get("same_subject") is True for e in out), (
+        f"abstaining must not assert same-subject for uncompared candidates; got {out!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pairwise_abstains_on_a_real_provider_outage() -> None:
+    """The case that actually matters: a real provider configured, key missing."""
+    verdict, confidence = await _llm_contradiction_check(_NEW, _OLD, _outage_config())
+
+    assert verdict is False
+    assert confidence == _CONF_FALLBACK
+
+
+@pytest.mark.asyncio
+async def test_batch_abstains_on_a_real_provider_outage() -> None:
+    out = await _llm_contradiction_check_batch(
+        _NEW, [{"id": "a", "content": _OLD}], _outage_config()
+    )
+
+    assert [_judge_contradiction(e) for e in out] == [(False, _CONF_FALLBACK)]
+    assert not any(e.get("same_subject") is True for e in out)
+
+
+# The entity-aware judges are the two sites Path C uses, and every existing
+# entity-aware test patches call_with_fallback or the batch function outright, so
+# fake_fn is never reached there. Without these, either site could be reverted to
+# the heuristic with the whole suite still green.
+
+
+@pytest.mark.asyncio
+async def test_entity_aware_pairwise_abstains() -> None:
+    verdict, confidence = await _llm_entity_aware_contradiction_check(
+        _NEW, _OLD, [{"name": "helios migration"}], [{"name": "helios migration"}],
+        _outage_config(),
+    )
+
+    assert verdict is False
+    assert confidence == _CONF_FALLBACK
+
+
+@pytest.mark.asyncio
+async def test_entity_aware_batch_abstains() -> None:
+    out = await _llm_entity_aware_contradiction_check_batch(
+        _NEW,
+        [{"name": "helios migration"}],
+        [{"id": "a", "content": _OLD}],
+        _outage_config(),
+    )
+
+    assert [_judge_contradiction(e) for e in out] == [(False, _CONF_FALLBACK)]
+    assert not any(e.get("same_subject") is True for e in out)

--- a/tests/test_contradiction_providers.py
+++ b/tests/test_contradiction_providers.py
@@ -188,40 +188,52 @@ class TestFallbackChain:
         assert verdict is False
 
     @pytest.mark.asyncio
-    async def test_fake_provider_triggers_heuristic_via_fallback(self):
-        """When provider resolves to FakeLLMProvider, call_with_fallback skips to fake_fn."""
+    async def test_missing_credentials_abstains_instead_of_guessing(self):
+        """A configured REAL provider with no key is a misconfigured deployment, not
+        a request for heuristics — so the judge must abstain.
 
-        from core_api.services.contradiction_detector import _llm_contradiction_check
+        This assertion used to be ``verdict is True``: it pinned the negation-word
+        heuristic returning a contradiction verdict on exactly the production-outage
+        path. That verdict is acted on — ``detect_contradictions`` marks the older
+        memory ``conflicted`` on the boolean alone — so the old test was pinning the
+        mechanism. See ``_skip_contradiction_pairwise`` for what that costs.
+        """
+        from core_api.services.contradiction_detector import _CONF_FALLBACK, _llm_contradiction_check
 
         config = MagicMock()
         config.entity_extraction_provider = "openai"
         config.openai_api_key = None  # no credentials -> FakeLLMProvider
 
-        # Negation difference → heuristic returns True
+        # Content the heuristic WOULD flag: negation on one side, 3+ shared words.
+        verdict, conf = await _llm_contradiction_check(
+            "the system is not running and it crashed",
+            "the system is running and it works fine",
+            config,
+        )
+        assert verdict is False
+        assert conf == _CONF_FALLBACK
+
+    @pytest.mark.asyncio
+    async def test_deliberate_fake_provider_still_exercises_the_heuristic(self):
+        """The counterpart: an explicitly requested ``fake`` provider KEEPS the
+        heuristic, because it is the only way the detect -> mark -> conflicted
+        pipeline gets end-to-end coverage without an API key
+        (``test_p1_contradiction.py::test_semantic_contradiction_with_fake_llm``).
+
+        Same inputs as the test above, opposite expectation — that is the whole
+        point of the split, and why one blanket abstain would not have done.
+        """
+        from core_api.services.contradiction_detector import _llm_contradiction_check
+
+        config = MagicMock()
+        config.entity_extraction_provider = "fake"
+
         verdict, _conf = await _llm_contradiction_check(
             "the system is not running and it crashed",
             "the system is running and it works fine",
             config,
         )
         assert verdict is True
-
-    @pytest.mark.asyncio
-    async def test_no_credentials_heuristic_returns_false(self):
-        """When no credentials and no negation difference, heuristic returns False."""
-
-        from core_api.services.contradiction_detector import _llm_contradiction_check
-
-        config = MagicMock()
-        config.entity_extraction_provider = "openai"
-        config.openai_api_key = None
-        config.anthropic_api_key = None
-        config.openrouter_api_key = None
-
-        # No negation → heuristic returns False
-        verdict, _conf = await _llm_contradiction_check(
-            "the system works", "the system is fine", config
-        )
-        assert verdict is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Found by sweeping every `fake_fn=` site for the same shape as #807 — a dev stub
standing in on a production failure path. There are 15; most are fine. **This is
the severe one.**

## The chain

1. The no-LLM fallback was `_fake_contradiction_check` — a **negation-word
   heuristic** whose own docstring said *"Simple heuristic for testing"*.
2. Its verdict is not advisory. `detect_contradictions` acts on the **boolean
   alone**: confidence is unpacked as `_confidence` and only logged, because A4
   #13's confidence-weighted veto is still deferred. The one live threshold,
   `RETRACTION_CONFIDENCE_THRESHOLD`, gates retraction, not marking.
3. So it sets the older memory's `status = "conflicted"`, which **demotes it out of
   semantic recall**.
4. Two of the four fallback sites also hardcoded `same_subject: True` for *every*
   candidate — directly against the batch prompt's own rule: *"Set true ONLY when
   subject_a and subject_b refer to the SAME real-world entity"* and *"If
   same_subject is false, contradicts MUST be false."*

A heuristic labelled "for testing" could degrade recall in a product whose job is
recall.

## The fix: split what `call_with_fallback` conflates

`call_with_fallback` invokes `fake_fn` for two different situations, and they are
not the same — which is the same one-thing-two-purposes shape as #305, #306 and
#807.

- **Explicitly configured `fake` provider** → keeps the heuristic. It is the only
  end-to-end coverage of the detect → mark pipeline without an API key, and
  `test_p1_contradiction.py::test_semantic_contradiction_with_fake_llm` depends on
  it. A blanket abstain would have silently deleted that coverage.
- **A configured REAL provider that failed** → abstains.

`fake` only, **not `none`**: "none" asks for the feature to be off. That is not my
invention — `entity_extraction.py` already draws the same line, returning an empty
graph for `none` and calling its heuristic for `fake`.

The abstain reuses the module's own documented encoding rather than a new one:
`(False, _CONF_FALLBACK)` is exactly what `_judge_contradiction` returns for a
malformed response, and the rubric already calls 0.50 "conservative-default".

The batch path returns an **empty dict** per candidate, not `_align`'s
`{"contradicts": False}`. That shape is non-empty, so it misses the malformed
branch and scores `_CONF_CLEAN` — verified: `0.90` vs `{}`'s `0.50`. An abstain
presenting as a confident clean verdict is inert today and stops being inert the
moment A4 #13 gates on confidence.

## Two claims I had wrong, and corrected

My first draft of these docstrings asserted two things that the code contradicts.
Flagging them because the PR is *about* unverified claims:

| I wrote | Actually |
|---|---|
| "`memory_scored_search` excludes `conflicted` rows" | There's an `or_` **carve-out** ([postgres_service.py:1653](core-storage-api/src/core_storage_api/services/postgres_service.py:1653)) retaining a conflicted row that's an exact lexical match, un-demoted. The damage is to semantic/vector recall, not lookup-by-phrasing. |
| "Nothing ever re-evaluates that status" | Path C's retraction judge **does** restore `conflicted` → `active`. Narrowly: canonical direction only, resolved entities both sides, ≥0.90 confidence, tenant kill-switchable. No *sweep* exists. |

The cost is now stated precisely, in one place, with the tests cross-referencing it
rather than restating it — so the two can't drift.

## Verification — by mutation, not just by running the tests

| mutation | result |
|---|---|
| `_deliberate_fake_provider` → always `True` (the original bug) | **8 failed** |
| batch abstain → `{"contradicts": False}` (the 0.90 shape) | **3 failed** |
| entity-aware pairwise site → back to the heuristic | **1 failed** |

That last one matters: the two **entity-aware** sites had *no* abstain coverage —
every existing entity-aware test patches `call_with_fallback` or the batch function
outright, so `fake_fn` was never reached. Either could have been reverted with the
whole suite green. They're also the sites Path C uses.

Batch assertions pin what the **consumer** derives (`_judge_contradiction(entry) ==
(False, _CONF_FALLBACK)`) rather than the raw dict shape — that's where the
0.90-vs-0.50 distinction actually lives.

`test_the_heuristic_really_would_have_flagged_this` is a deliberate vacuity guard:
it proves the test inputs are heuristic-positive, so the abstain assertions can't
pass on bland input. It passes either way by design.

## Two existing tests changed, and why

- `test_fake_provider_triggers_heuristic_via_fallback` → renamed
  `test_missing_credentials_abstains_instead_of_guessing`. It set provider `openai`
  with **no API key** — the production-outage path — and asserted `verdict is
  True`. It pinned the defect.
- Added `test_deliberate_fake_provider_still_exercises_the_heuristic`: same inputs,
  opposite expectation. That pair is the whole point of the split.

- root suite: **4484 passed**, 3 skipped, 1 xfailed
- `ruff check core-api/src/` + `format --check` + `ruff check common/` clean;
  `mypy` clean (198 files)

## Not in this PR

The four moderate sweep findings — `_crystallize_fake` (writes a copy of the
highest-weight memory as a "crystallized insight"), `_fake_insights` (persists a
finding headlined *"Fake insight for testing"*), `_fake_rule` (a generic rule at
confidence 0.6), and `_fake_recall` (truncated memory text as a summary) — all want
a provenance marker following `fake_enrich`'s pattern, where `llm_ms=0` is actually
consumed downstream. One follow-up PR.