### PR TITLE
fix(fallbacks): a no-LLM stand-in must not retire the data it replaces

### DIFF
--- a/common/llm/retry.py
+++ b/common/llm/retry.py
@@ -117,6 +117,31 @@ async def call_with_retry(
     raise last_exc  # type: ignore[misc]
 
 
+def deliberate_fake_provider(provider_name: str | None) -> bool:
+    """Which of ``call_with_fallback``'s two ``fake_fn`` contexts is this?
+
+    ``fake_fn`` is invoked for two situations that are NOT the same, and callers
+    that conflate them ship a dev stub's output to production:
+
+    * The operator explicitly configured ``fake`` — dev or CI. The stub IS the
+      intent; it is often the only way a pipeline gets end-to-end coverage without
+      an API key.
+    * A REAL provider was configured and every attempt failed, or its key is
+      missing so it resolved to ``FakeLLMProvider``. That is an outage or a
+      misconfigured deployment, not a request for made-up output.
+
+    ``fake`` ONLY, deliberately not ``none``: "none" asks for the feature to be
+    off, which is an abstain. ``entity_extraction`` draws the same line — empty
+    graph for ``none``, heuristic for ``fake``.
+
+    Callers that persist their result should branch on this and take their own
+    "nothing came back" path in the outage case. See ``contradiction_detector``
+    (abstains rather than guessing a verdict that marks memories ``conflicted``),
+    ``crystallizer_service`` and ``insights_service``.
+    """
+    return provider_name == ProviderName.FAKE
+
+
 async def call_with_fallback(
     primary_provider_name: str,
     call_fn: Callable[..., Coroutine[Any, Any, T]],

--- a/core-api/src/core_api/providers/_retry.py
+++ b/core-api/src/core_api/providers/_retry.py
@@ -7,6 +7,6 @@ sites (``core_api.services.*``, tests) working unchanged.
 
 from __future__ import annotations
 
-from common.llm.retry import call_with_fallback, call_with_retry
+from common.llm.retry import call_with_fallback, call_with_retry, deliberate_fake_provider
 
-__all__ = ["call_with_fallback", "call_with_retry"]
+__all__ = ["call_with_fallback", "call_with_retry", "deliberate_fake_provider"]

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -9,7 +9,7 @@ Multi-provider support:
 - Vertex AI, OpenAI, Anthropic, OpenRouter via provider layer
 - Automatic fallback chain: configured provider -> fallback -> abstain
   (heuristic only when the ``fake`` provider was explicitly asked for; see
-  ``_deliberate_fake_provider``)
+  ``common.llm.retry.deliberate_fake_provider``)
 """
 
 import asyncio
@@ -19,12 +19,11 @@ import uuid as _uuid
 from datetime import datetime
 from uuid import UUID
 
-from common.provider_names import ProviderName
 from core_api.cache import cache_set_nx
 from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
 from core_api.constants import SINGLE_VALUE_PREDICATES
-from core_api.providers._retry import call_with_fallback
+from core_api.providers._retry import call_with_fallback, deliberate_fake_provider
 from core_api.schemas import ContradictionInfo
 from core_api.services.subject_preflight import _subjects_differ_with_certainty
 
@@ -1010,7 +1009,7 @@ async def _llm_contradiction_check(
     1. Try the configured provider (with retry)
     2. Try the configured fallback provider (via resolve_fallback)
     3. Abstain — or, when the operator ASKED for the fake provider, the
-       negation-word heuristic. See :func:`_deliberate_fake_provider`.
+       negation-word heuristic. See :func:`common.llm.retry.deliberate_fake_provider`.
     """
     provider_name = (
         tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
@@ -1135,29 +1134,6 @@ async def _llm_contradiction_check_batch(
     )
 
 
-def _deliberate_fake_provider(provider_name: str | None) -> bool:
-    """Did the operator ASK for no LLM, or did a real one fail?
-
-    ``call_with_fallback`` invokes ``fake_fn`` for both, and they are not the same
-    situation — which is the whole bug this split exists to fix. A ``fake`` provider
-    was explicitly asked for, so the negation-word heuristic is the point: it is the
-    only way the detect → mark → ``conflicted`` pipeline gets end-to-end coverage
-    without an API key (``test_p1_contradiction.py`` relies on exactly this). A
-    configured REAL provider that failed is a production outage, where the same
-    heuristic is not survivable — see :func:`_skip_contradiction_pairwise`.
-
-    ``fake`` ONLY, not ``none``: "none" asks for the feature to be off, which is an
-    abstain, while "fake" asks for the test double. ``entity_extraction`` draws the
-    same line explicitly — ``provider == "none"`` returns an empty graph, ``"fake"``
-    calls its heuristic.
-
-    And the case that motivated all of this: ``entity_extraction_provider="openai"``
-    with no key resolves to ``FakeLLMProvider`` and lands on ``fake_fn`` too. That
-    is a misconfigured deployment, NOT a request for heuristics, so it abstains.
-    """
-    return provider_name == ProviderName.FAKE
-
-
 def _skip_contradiction_pairwise() -> tuple[bool, float]:
     """The no-LLM verdict for the per-candidate path: abstain.
 
@@ -1225,15 +1201,15 @@ def _skip_contradiction_batch(count: int) -> list[dict]:
 def _pairwise_fake_fn(provider_name, new_content: str, old_content: str):
     """The ``fake_fn`` for a per-candidate judge: heuristic if the operator asked
     for the fake provider, abstain otherwise. One place so a new call site cannot
-    pick the wrong side of :func:`_deliberate_fake_provider` by omission."""
-    if _deliberate_fake_provider(provider_name):
+    pick the wrong side of :func:`deliberate_fake_provider` by omission."""
+    if deliberate_fake_provider(provider_name):
         return lambda: (_fake_contradiction_check(new_content, old_content), _CONF_FALLBACK)
     return _skip_contradiction_pairwise
 
 
 def _batch_fake_fn(provider_name, new_content: str, candidates: list[dict]):
     """The ``fake_fn`` for the batch judge. See :func:`_pairwise_fake_fn`."""
-    if _deliberate_fake_provider(provider_name):
+    if deliberate_fake_provider(provider_name):
         return lambda: [
             {
                 "same_subject": True,

--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -38,7 +38,7 @@ from core_api.constants import (
     CRYSTALLIZER_STALE_MAX_WEIGHT,
     MEMORY_TYPES,
 )
-from core_api.providers._retry import call_with_fallback
+from core_api.providers._retry import call_with_fallback, deliberate_fake_provider
 
 logger = logging.getLogger(__name__)
 
@@ -436,15 +436,43 @@ async def _crystallize_cluster(memories: list[dict], config) -> list[dict]:
     return await call_with_fallback(
         primary_provider_name=config.enrichment_provider,
         call_fn=_do_crystallize,
-        fake_fn=lambda: _crystallize_fake(memories),
+        # An outage must yield NOTHING here, not a stand-in. The caller does
+        # ``if not extracted: continue`` before it creates anything, so an empty
+        # list skips the cluster untouched — see ``_crystallize_fake``.
+        fake_fn=(
+            (lambda: _crystallize_fake(memories))
+            if deliberate_fake_provider(config.enrichment_provider)
+            else _skip_crystallize
+        ),
         tenant_config=config,
         service_label="crystallizer",
         timeout=30.0,
     )
 
 
+def _skip_crystallize() -> list[dict]:
+    """No-LLM crystallization: produce nothing, so the cluster is left alone.
+
+    This is not cosmetic. The caller creates one memory per returned fact and then
+    ARCHIVES every source memory in the cluster. With ``_crystallize_fake`` on the
+    outage path — it returns a verbatim copy of the cluster's highest-weight memory
+    — an LLM outage archived N memories and left one duplicate of one of them
+    behind, having synthesised nothing. The other N-1 memories' content is not in
+    the survivor, and ``archived`` is outside ``LIVE_MEMORY_STATUSES``.
+
+    Returning ``[]`` takes the caller's existing ``if not extracted: continue``
+    path, so nothing is created and nothing is archived. The cluster is still there
+    to crystallize once a provider answers.
+    """
+    logger.warning("crystallizer: no LLM — cluster skipped, nothing archived")
+    return []
+
+
 def _crystallize_fake(memories: list[dict]) -> list[dict]:
-    """Fake crystallization for testing: just pick the highest-weight memory from the cluster."""
+    """Stand-in crystallization for an explicitly configured ``fake`` provider:
+    pick the highest-weight memory from the cluster. TEST/DEV ONLY — the production
+    fallback abstains via ``_skip_crystallize``, because this output gets persisted
+    and its sources archived."""
     if not memories:
         return []
     best = max(memories, key=lambda m: m.get("weight", 0.5))

--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -639,7 +639,7 @@ def _format_clusters_for_analysis(clusters: list[dict]) -> tuple[str, set[str]]:
 
 async def _run_llm_analysis(prompt: str, config) -> dict:
     """Send the analysis prompt to the configured LLM provider."""
-    from core_api.providers._retry import call_with_fallback
+    from core_api.providers._retry import call_with_fallback, deliberate_fake_provider
 
     async def _do_analysis(llm) -> dict:
         return await llm.complete_json(prompt, temperature=INSIGHTS_TEMPERATURE)
@@ -647,15 +647,33 @@ async def _run_llm_analysis(prompt: str, config) -> dict:
     return await call_with_fallback(
         primary_provider_name=config.enrichment_provider,
         call_fn=_do_analysis,
-        fake_fn=lambda: _fake_insights(),
+        fake_fn=(_fake_insights if deliberate_fake_provider(config.enrichment_provider) else _skip_insights),
         tenant_config=config,
         service_label="insights",
         model_override=config.enrichment_model,
     )
 
 
+def _skip_insights() -> dict:
+    """No-LLM analysis: no findings, so priors are left standing.
+
+    Persisting findings first transitions the prior insights for this focus/scope
+    to ``outdated`` — and that supersede is guarded by ``if findings:``. So with
+    ``_fake_insights`` on the outage path, an LLM outage retired a tenant's real
+    insights and replaced them with one headlined "Fake insight for testing".
+
+    Empty findings take the existing short-circuit, which exists for exactly this
+    reason: the comment there notes that outdating priors when there is nothing to
+    persist would leave the user with neither.
+    """
+    logger.warning("insights: no LLM — no findings, prior insights left intact")
+    return {"findings": [], "summary": "Analysis unavailable (no LLM provider answered)."}
+
+
 def _fake_insights() -> dict:
-    """Return placeholder findings for the fake/test provider."""
+    """Placeholder findings for an explicitly configured ``fake`` provider.
+    TEST/DEV ONLY — the production fallback abstains via ``_skip_insights``,
+    because persisting findings supersedes the tenant's prior insights."""
     return {
         "findings": [
             {

--- a/tests/test_no_llm_fallbacks_preserve_data.py
+++ b/tests/test_no_llm_fallbacks_preserve_data.py
@@ -1,0 +1,123 @@
+"""A no-LLM fallback must not destroy data it cannot replace.
+
+Two fallbacks produced plausible stand-in output that their callers then treated as
+a real result — and both callers RETIRE the previous data as part of persisting:
+
+* ``crystallizer_service`` creates a memory per returned fact, then ARCHIVES every
+  source memory in the cluster. ``_crystallize_fake`` returns a verbatim copy of
+  the cluster's highest-weight memory, so an outage archived N memories and left
+  one duplicate behind.
+* ``insights_service`` transitions the tenant's prior insights to ``outdated``
+  before persisting, guarded by ``if findings:``. ``_fake_insights`` returns one
+  finding, so an outage retired real insights in favour of "Fake insight for
+  testing".
+
+Both callers already had a correct "nothing came back" path. The fix is to take it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core_api.services.crystallizer_service import (
+    _crystallize_cluster,
+    _crystallize_fake,
+)
+from core_api.services.insights_service import _fake_insights
+
+pytestmark = [pytest.mark.unit]
+
+_MEMORIES = [
+    {"id": "m1", "content": "Helios shipped on the 3rd", "memory_type": "fact", "weight": 0.9},
+    {"id": "m2", "content": "Anna owns the rollback plan", "memory_type": "fact", "weight": 0.4},
+]
+
+
+def _outage_config():
+    """A configured REAL provider whose key is missing — resolves to
+    FakeLLMProvider and lands on ``fake_fn``. The production shape."""
+    config = MagicMock()
+    config.enrichment_provider = "openai"
+    config.enrichment_model = None
+    config.openai_api_key = None
+    config.anthropic_api_key = None
+    config.gemini_api_key = None
+    config.openrouter_api_key = None
+    return config
+
+
+def _fake_config():
+    config = MagicMock()
+    config.enrichment_provider = "fake"
+    config.enrichment_model = None
+    return config
+
+
+# ── crystallizer ──────────────────────────────────────────────────────────────
+
+
+def test_the_stand_in_really_would_have_returned_a_copy() -> None:
+    """Control: proves the outage assertion below is not vacuous."""
+    out = _crystallize_fake(_MEMORIES)
+
+    assert len(out) == 1
+    assert out[0]["content"] == "Helios shipped on the 3rd", (
+        "the stand-in returns the highest-weight memory verbatim — that is the "
+        "behaviour that must not reach production"
+    )
+
+
+@pytest.mark.asyncio
+async def test_crystallizer_returns_nothing_on_an_outage() -> None:
+    """Empty means the caller's ``if not extracted: continue`` fires, so nothing is
+    created and — the point — nothing is archived."""
+    out = await _crystallize_cluster(_MEMORIES, _outage_config())
+
+    assert out == [], (
+        f"a non-empty result archives every source memory in the cluster; got {out!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_crystallizer_keeps_the_stand_in_for_a_deliberate_fake_provider() -> None:
+    """The counterpart: asking for ``fake`` still yields the stand-in, so the
+    dev/CI path that exercises create + archive end to end still works."""
+    out = await _crystallize_cluster(_MEMORIES, _fake_config())
+
+    assert len(out) == 1
+    assert out[0]["content"] == "Helios shipped on the 3rd"
+
+
+# ── insights ──────────────────────────────────────────────────────────────────
+
+
+def test_the_placeholder_finding_really_is_non_empty() -> None:
+    """Control for the insights outage assertion."""
+    assert _fake_insights()["findings"], "placeholder must be non-empty to be dangerous"
+
+
+@pytest.mark.asyncio
+async def test_insights_returns_no_findings_on_an_outage() -> None:
+    """Empty findings skip the supersede, so prior insights stay live.
+
+    Driven through the public analyse entrypoint rather than the fallback, so this
+    would still catch a caller that stopped honouring the empty case.
+    """
+    from core_api.services.insights_service import _run_llm_analysis
+
+    result = await _run_llm_analysis("some prompt", _outage_config())
+
+    assert result["findings"] == [], (
+        f"any finding here outdates the tenant's prior insights; got {result!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_insights_keeps_the_placeholder_for_a_deliberate_fake_provider() -> None:
+    from core_api.services.insights_service import _run_llm_analysis
+
+    result = await _run_llm_analysis("some prompt", _fake_config())
+
+    assert len(result["findings"]) == 1


### PR DESCRIPTION
Two more `fake_fn` sites from the sweep that produced #821. **I classified these as
"moderate — wants a provenance marker" and I was wrong.** Reading their callers
rather than the fallbacks themselves, both destroy real data.

## Why these are not cosmetic

Both callers **retire the previous data as part of persisting**, so a manufactured
result doesn't just add noise — it replaces content that then isn't recoverable.

**`crystallizer_service`** creates one memory per returned fact and then **archives
every source memory in the cluster**. `_crystallize_fake` returns a *verbatim copy*
of the cluster's highest-weight memory. So an LLM outage archived N memories and
left one duplicate of one of them behind, having synthesised nothing — the other
N−1 memories' content is not in the survivor, and `archived` sits outside
`LIVE_MEMORY_STATUSES`.

**`insights_service`** transitions the tenant's prior insights to `outdated`
*before* persisting, guarded by `if findings:`. `_fake_insights` returns one
finding, so an outage retired real insights in favour of one headlined
*"Fake insight for testing"*.

## The fix is to take the path that already existed

Neither caller needed new logic. Both already had a correct "nothing came back"
branch:

- `if not extracted: continue` — before anything is created or archived.
- the empty-findings short-circuit, whose own comment says outdating priors when
  there is nothing to persist "would leave the user with neither".

So the outage path now returns empty and lets those fire.

Applies #821's split: an explicitly configured `fake` provider **keeps** its
stand-in, because that is the intent and it is how the create+archive and
supersede+persist paths get exercised without an API key. A configured real
provider that failed abstains.

## `deliberate_fake_provider` is now shared

It moves from `contradiction_detector` to `common/llm/retry.py`, beside the
`call_with_fallback` whose two invocation contexts it exists to distinguish, and
re-exported through the `providers/_retry` shim. Three callers need it now; leaving
it private would have meant three copies of the FAKE-vs-NONE policy, which is the
same mistake as the six `SortHeader`s in caura-ops#308.

## Verification

Tests assert the **destructive consequence**, not the return value, and run through
the real entrypoints (`_crystallize_cluster`, `_run_llm_analysis`) so they'd still
catch a caller that stopped honouring the empty case:

```
FAILED tests/test_no_llm_fallbacks_preserve_data.py::test_crystallizer_returns_nothing_on_an_outage
FAILED tests/test_no_llm_fallbacks_preserve_data.py::test_insights_returns_no_findings_on_an_outage
2 failed, 4 passed
```

Each has a **control** proving the stand-in is genuinely non-empty (so the abstain
assertions can't pass on bland input), plus a **counterpart** proving the deliberate
`fake` path still returns it. Those four pass either way by design — they're pins,
not gates.

- root suite: **4490 passed**, 3 skipped, 1 xfailed
- `ruff check core-api/src/ common/`, `ruff format --check core-api/src/`, `mypy` —
  all verified by exit code (my first pass reported clean off a piped `tail`'s exit
  status and hid a formatting failure)

## Still open from the sweep

- `_fake_rule` — persists a fabricated generic rule at confidence 0.6 as a
  `memory_type="rule"` memory. Same treatment; separate PR since it writes rather
  than retires.
- `_fake_recall` — returns truncated memory text as a recall *summary*. Read path,
  never persisted, so it wants an honest marker in the text like `_fake_report`'s
  "(LLM unavailable; unsynthesized)", not abstention.
- `documents.py:161-162` defaults missing timestamps to `datetime.min` — year 1,
  which readers sort and display.