### PR TITLE
fix(recall): label the no-LLM summary as unsynthesized

### DIFF
--- a/core-api/src/core_api/services/recall_service.py
+++ b/core-api/src/core_api/services/recall_service.py
@@ -171,8 +171,23 @@ async def summarize_memories(
     )
 
     def _fake_recall() -> str:
-        """No-LLM fallback: join top memory contents."""
-        return " ".join(m.content[:100] for m in memories[:3])
+        """No-LLM fallback: the top memory contents, labelled as unsynthesized.
+
+        Unlike the other fallbacks in this sweep this one is a READ path — the
+        string lands in the response's ``summary`` and is never persisted — so
+        returning something beats returning nothing. What it must not do is pass
+        three truncated memory fragments off as a synthesised answer, which is what
+        an unlabelled join did.
+
+        Marked in the text rather than via a side-channel field because the caller
+        surfaces ``summary`` verbatim to whoever asked; a flag they don't read is
+        the same as no flag. Same shape as ``interview_service._fake_report``'s
+        "(LLM unavailable; unsynthesized)".
+        """
+        joined = " ".join(m.content[:100] for m in memories[:3])
+        if not joined:
+            return "No summary available (no LLM provider answered)."
+        return f"(LLM unavailable; top {min(len(memories), 3)} memories unsynthesized) {joined}"
 
     async def _do_recall(llm) -> str:
         return await llm.complete_text(

--- a/tests/test_no_llm_fallbacks_declare_themselves.py
+++ b/tests/test_no_llm_fallbacks_declare_themselves.py
@@ -1,0 +1,78 @@
+"""A no-LLM recall summary must not pass itself off as synthesis.
+
+The last `fake_fn` site from the sweep behind #821 / #822 that is safe to fix in
+isolation. Unlike those two, ``recall_service`` neither persists its result nor
+retires anything — the string lands in the response's ``summary`` and is surfaced
+verbatim. So returning something beats returning nothing; it just has to say what
+it is, rather than passing three truncated fragments off as an answer.
+
+(``evolve_service._fake_rule`` is the remaining site. It fabricates a
+``memory_type="rule"`` memory, but abstaining there turns on what provider
+``"none"`` should mean, and the test suite's default is ``none`` — see the PR.)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class _Mem(SimpleNamespace):
+    """The attribute surface ``summarize_memories`` actually touches: the prompt
+    formatter's fields, ``ts_valid_start`` for its sort, and ``model_dump`` for the
+    response assembly. A MagicMock cannot stand in — its auto-attributes are truthy
+    but not orderable, so the sort raises before the fallback is ever reached."""
+
+    def model_dump(self, mode: str | None = None) -> dict:
+        return {"content": self.content, "memory_type": self.memory_type}
+
+
+def _mem(content: str) -> _Mem:
+    return _Mem(
+        content=content, memory_type="fact", title=None, status="active", ts_valid_start=None
+    )
+
+
+def _outage_config():
+    config = MagicMock()
+    config.enrichment_provider = "openai"
+    config.enrichment_model = None
+    config.openai_api_key = None
+    config.anthropic_api_key = None
+    config.gemini_api_key = None
+    config.openrouter_api_key = None
+    return config
+
+
+# ── recall: say what it is ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recall_summary_says_it_is_unsynthesized() -> None:
+    """The summary is surfaced verbatim to the caller, so the marker has to be in
+    the text — a side-channel flag nobody reads is the same as no flag."""
+    from core_api.services.recall_service import summarize_memories
+
+    # SimpleNamespace, not MagicMock: summarize_memories sorts on
+    # ``ts_valid_start`` and a MagicMock's auto-attribute is truthy but not
+    # orderable, so mocks blow up in the sort before reaching the fallback.
+    result = await summarize_memories(
+        [
+            _mem("Helios shipped on the 3rd"),
+            _mem("Anna owns the rollback plan"),
+        ],
+        "what happened with helios?",
+        _outage_config(),
+    )
+    summary = result["summary"]
+
+    assert "LLM unavailable" in summary, (
+        f"three truncated fragments must not read as a synthesised answer; got {summary!r}"
+    )
+    # Still returns the content — this is a read path, so degraded beats empty.
+    assert "Helios shipped" in summary


### PR DESCRIPTION
Last of the four `fake_fn` sites from the sweep behind #821 and #822 — and the only
one of the remaining two that is safe to fix in isolation. Read the scope note at
the bottom before merging.

## The problem

`_fake_recall` joined the first three memories' content, each truncated to 100
chars, and returned it as the recall `summary` — the field the caller surfaces
**verbatim** to whoever asked. Spliced fragments read as a synthesised answer, so
on an LLM outage a user got something that looked like analysis and wasn't.

## The fix

Marked in the text:

```
(LLM unavailable; top 3 memories unsynthesized) Helios shipped on the 3rd Anna owns …
```

In the text and not a side-channel field, because the caller passes `summary`
straight through — a flag it doesn't read is the same as no flag. This is the shape
`interview_service._fake_report` already used correctly:
`"Activity window of N events (LLM unavailable; unsynthesized)."`

Unlike the crystallizer and insights sites in #822, this is a **read path** —
nothing persisted, nothing retired — so it keeps returning the content. Degraded
beats empty when the alternative costs the user their answer. The empty case gets
its own sentence rather than a bare prefix with nothing after it.

## Scope: `_fake_rule` is deliberately NOT here

It's the one genuinely alarming site left — it fabricates a generic
*"verify information against the most recent source"* rule at confidence 0.6 and
persists it as a `memory_type="rule"` memory, and rules are recalled and applied as
policy rather than read as facts.

I implemented the abstain, and **it broke 5 existing tests**, which turned out to be
the interesting part:

`ResolvedConfig.enrichment_provider` falls back to `entity_extraction_provider`, and
the test suite runs with that set to **`none`**. So `test_evolve_service.py` and
friends have been using `none` as their "give me a stub" setting — and #821
established `none` → abstain (`none` asks for the feature off; `fake` asks for the
test double, matching how `entity_extraction` splits them).

Fixing evolve therefore means deciding what `none` means repo-wide, and either
updating those 5 tests to ask for `fake` explicitly or accepting `none` as
stub-granting. That's a call worth making deliberately rather than smuggling into a
commit about recall summaries. Reverted from this PR; still open.

## Verification

The recall test fails behaviourally against unfixed code — it collects and runs, the
fallback fires, and the marker is absent:

```
FAILED tests/test_no_llm_fallbacks_declare_themselves.py::test_recall_summary_says_it_is_unsynthesized
```

Two things that took a couple of goes and are worth noting, since both are traps I
have hit before in this workstream:

- The stub is a **real class, not a `MagicMock`**. `summarize_memories` sorts on
  `ts_valid_start`, and a mock's auto-attribute is truthy but not orderable, so a
  mock raises in the sort *before* the fallback is ever reached — the test would
  have failed for the wrong reason.
- New symbols are imported **inside** their tests. At module scope, the unfixed run
  becomes a **collection error**, which proves a symbol is new rather than that
  anything catches the bug. My first control did exactly that and was worthless.

The test drives `summarize_memories`, not the closure, so it would still catch a
caller that stopped surfacing the marker.

- root suite: **4485 passed**, 3 skipped, 1 xfailed
- `ruff check core-api/src/ common/` and `ruff format --check core-api/src/` — both
  verified by exit code