### PR TITLE
feat(usage): route usage metering through a service hook

### DIFF
--- a/core-api/src/core_api/services/hooks.py
+++ b/core-api/src/core_api/services/hooks.py
@@ -15,12 +15,25 @@ from __future__ import annotations
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core_api.services.usage_service import UsageCheckResult
 
 logger = logging.getLogger(__name__)
 
 # Type alias for the audit hook signature.
 AuditHook = Callable[..., Awaitable[None]]
 # Signature: (*, tenant_id, agent_id, action, resource_type, resource_id, detail) -> None
+
+# Type alias for the usage-metering hook signature.
+# Signature: (*, tenant_id, operation, count) -> UsageCheckResult | None
+#
+# ``type`` (PEP 695) rather than a plain assignment: it is evaluated lazily, so
+# the ``usage_service`` import stays under TYPE_CHECKING and the cycle never
+# forms. Worth it over ``Any`` — spelling the return type is what makes a
+# platform-supplied implementation checkable at all.
+type UsageHook = Callable[..., Awaitable[UsageCheckResult | None]]
 
 
 @dataclass
@@ -32,6 +45,11 @@ class ServiceHooks:
     """
 
     audit_log: AuditHook | None = None
+    # METERING, not enforcement — the name is deliberate. See the
+    # ``usage_service`` module docstring for why, and for the implementation
+    # guidance (enqueue and return ``None``; report counters only if that costs
+    # no round-trip — this hook runs on the write path).
+    usage_meter: UsageHook | None = None
 
 
 _hooks = ServiceHooks()
@@ -41,7 +59,11 @@ def configure_hooks(hooks: ServiceHooks) -> None:
     """Wire platform hooks. Called once at app startup."""
     global _hooks
     _hooks = hooks
-    logger.info("Service hooks configured: audit=%s", hooks.audit_log is not None)
+    logger.info(
+        "Service hooks configured: audit=%s usage=%s",
+        hooks.audit_log is not None,
+        hooks.usage_meter is not None,
+    )
 
 
 def get_hooks() -> ServiceHooks:

--- a/core-api/src/core_api/services/usage_service.py
+++ b/core-api/src/core_api/services/usage_service.py
@@ -1,24 +1,78 @@
-"""Usage tracking stubs for OSS standalone mode.
+"""Usage metering — a no-op in OSS standalone, hook-backed on a platform deploy.
 
-In enterprise mode, usage enforcement is handled by the enterprise platform-admin-api.
-In OSS standalone mode, there are no usage limits — all operations are allowed.
+OSS standalone has no usage limits, so with no hook wired every call here
+returns "allowed, unlimited" and records nothing. That is the intended
+behaviour, not a gap: the core engine must run without a billing plane.
+
+A platform deployment wires ``ServiceHooks.usage_meter`` at startup and these
+functions delegate to it, which is what connects the write paths to durable
+per-period counters.
+
+WHY THIS AND NOT ``capability_usage``
+-------------------------------------
+core-api already counts per-tenant operations —
+``services/capability_usage.py``, fed by ``middleware/request_observation.py``.
+That path is deliberately lossy: it buffers in memory and its own docstring
+notes counts "are lost if the process dies", and it appends rows to be SUMmed
+rather than upserting a period total. Right for adoption analytics, unfit for
+anything a plan cap is computed from. Hence a second, exact path rather than a
+rewrite of that one.
+
+METERING, NOT ENFORCEMENT — AND THAT IS BY DESIGN
+--------------------------------------------------
+Nothing in core-api reads the returned ``allowed``, and that is not an
+oversight waiting to be corrected. Enforcement arrives out-of-band: the
+platform computes "over plan" from the persisted counters and stamps
+``x-org-read-only`` on the request, which ``AuthContext.is_read_only`` reads
+and ``enforce_usage_limits()`` turns into a 403 at ~22 write routes. So a hook
+returning ``allowed=False`` blocks nothing here, by design — the decision it
+would express is already travelling a different way.
+
+What the result IS used for: the ``X-RateLimit-Limit`` /
+``X-RateLimit-Remaining`` response headers on three routes. Everything else
+discards it.
+
+Implementation guidance for the platform side: enqueue and return ``None``.
+This runs on the write path, and this codebase has twice moved off per-request
+round-trips there — CAURA-628 for audit, and ``capability_usage``'s in-memory
+aggregation. Report counters only when doing so costs no network call.
 """
 
+from __future__ import annotations
+
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
+from core_api.services.hooks import get_hooks
+
+logger = logging.getLogger(__name__)
+
 OperationType = Literal["write", "search", "recall", "insights", "evolve"]
+
+# One traceback per failed write would turn a meter outage into a log-volume
+# incident on top of a metering one. Same throttle shape as ``audit_queue``'s
+# drop counter, for the same reason.
+_METER_FAILURE_LOG_EVERY = 100
+_meter_failures = 0
 
 
 @dataclass
 class UsageCheckResult:
+    """What a meter reports back. Only ``limit`` and ``remaining`` are read.
+
+    The rest default so a platform implementation constructs what it actually
+    knows rather than filling six slots to deliver two — and so it is not
+    nudged into setting ``allowed``, which core-api ignores (module docstring).
+    """
+
     allowed: bool
     operation: str
-    current: int
-    limit: int | None
-    remaining: int | None
-    resets_at: datetime | None
+    current: int = 0
+    limit: int | None = None
+    remaining: int | None = None
+    resets_at: datetime | None = None
     plan: str = "free"
 
     def get(self, key: str, default=None):
@@ -27,36 +81,65 @@ class UsageCheckResult:
 
 
 def _allowed(op: str) -> UsageCheckResult:
-    return UsageCheckResult(
-        allowed=True,
-        operation=op,
-        current=0,
-        limit=None,
-        remaining=None,
-        resets_at=None,
-    )
+    return UsageCheckResult(allowed=True, operation=op)
+
+
+async def _meter(tenant_id: str, operation: OperationType, count: int) -> UsageCheckResult:
+    """Delegate to the wired meter, or report unlimited when there is none."""
+    global _meter_failures
+    hook = get_hooks().usage_meter
+    if hook is None:
+        return _allowed(operation)
+    try:
+        result = await hook(tenant_id=tenant_id, operation=operation, count=count)
+    except Exception:
+        # FAIL OPEN. This sits on the write path of every metered route, and a
+        # metering backend that is down must not turn into a failed customer
+        # write — losing a count is the cheaper error.
+        #
+        # ⚠ Revisit the moment ``allowed`` gains a reader in core-api:
+        # fail-open would then read "meter down ⇒ every tenant unlimited", the
+        # standard billing bypass. It is safe today only because enforcement
+        # travels via ``x-org-read-only`` instead (module docstring).
+        _meter_failures += 1
+        if _meter_failures == 1 or _meter_failures % _METER_FAILURE_LOG_EVERY == 0:
+            logger.exception(
+                "usage meter failed (%d since start) for tenant=%s operation=%s; reporting unlimited",
+                _meter_failures,
+                tenant_id,
+                operation,
+            )
+        return _allowed(operation)
+    # A hook may legitimately report nothing — it recorded the usage and has no
+    # counters to hand back. ``is not None`` rather than truthiness, so a
+    # falsy-but-valid result is not silently discarded.
+    return result if result is not None else _allowed(operation)
 
 
 async def check_and_increment(
-    org_id,
-    operation: OperationType,
-    count: int = 1,
-) -> UsageCheckResult:
-    return _allowed(operation)
-
-
-async def check_and_increment_by_tenant(
     tenant_id: str,
     operation: OperationType,
     count: int = 1,
 ) -> UsageCheckResult:
-    # ``db`` is ignored (usage accounting is a no-op stub in OSS). Accepts
-    # ``None`` so storage-routed callers (Fix 2 Ph5b insights) can forward it.
-    return _allowed(operation)
+    """Record ``count`` of ``operation`` against ``tenant_id``.
+
+    The first parameter was named ``org_id``, which was safe only while the
+    body ignored it: every call site passes a tenant id. A meter trusting the
+    old name would have keyed those writes on the wrong entity.
+    """
+    return await _meter(tenant_id, operation, count)
+
+
+# The same function under the name five modules import it by — all of them as
+# ``check_and_increment_by_tenant as check_and_increment``, so no call site
+# spells it. An alias rather than a copy, so there is visibly one
+# implementation.
+check_and_increment_by_tenant = check_and_increment
 
 
 async def bulk_check_and_increment(
     tenant_id: str,
     count: int,
 ) -> UsageCheckResult:
-    return _allowed("write")
+    """Record a bulk write of ``count`` items as a single metered call."""
+    return await _meter(tenant_id, "write", count)

--- a/tests/test_usage_meter_hook.py
+++ b/tests/test_usage_meter_hook.py
@@ -1,0 +1,144 @@
+"""Usage metering routes through ``ServiceHooks``, and OSS standalone is unchanged.
+
+Rationale lives in the ``usage_service`` module docstring.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core_api.services import usage_service
+from core_api.services.hooks import ServiceHooks, configure_hooks
+from core_api.services.usage_service import (
+    UsageCheckResult,
+    bulk_check_and_increment,
+    check_and_increment,
+    check_and_increment_by_tenant,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+# Only ``limit``/``remaining`` are ever read; the rest default.
+_METERED = UsageCheckResult(allowed=True, operation="write", limit=100, remaining=93)
+
+
+@pytest.fixture(autouse=True)
+def _reset_failure_throttle():
+    """The log throttle counts process-wide, so a prior test's failures would
+    otherwise decide whether this one logs."""
+    usage_service._meter_failures = 0
+
+
+# ── OSS standalone: unchanged ────────────────────────────────────────────────
+
+
+async def test_no_hook_reports_unlimited_and_records_nothing():
+    for call in (
+        check_and_increment("t-1", "write"),
+        check_and_increment_by_tenant("t-1", "search"),
+        bulk_check_and_increment("t-1", 20),
+    ):
+        result = await call
+        assert result.allowed is True
+        assert result.limit is None
+        assert result.remaining is None
+
+
+# ── Wired: the call reaches the meter ────────────────────────────────────────
+
+
+async def test_a_wired_meter_receives_tenant_operation_and_count():
+    meter = AsyncMock(return_value=_METERED)
+    configure_hooks(ServiceHooks(usage_meter=meter))
+
+    await check_and_increment("t-1", "write")
+
+    meter.assert_awaited_once_with(tenant_id="t-1", operation="write", count=1)
+
+
+async def test_the_bulk_path_passes_its_COUNT():
+    """The bulk write is one call for N items; metering it as 1 loses N-1."""
+    meter = AsyncMock(return_value=_METERED)
+    configure_hooks(ServiceHooks(usage_meter=meter))
+
+    await bulk_check_and_increment("t-1", 20)
+
+    meter.assert_awaited_once_with(tenant_id="t-1", operation="write", count=20)
+
+
+async def test_the_meters_counters_reach_the_caller():
+    """The result feeds ``X-RateLimit-*``; a swallowed one makes headers lie."""
+    configure_hooks(ServiceHooks(usage_meter=AsyncMock(return_value=_METERED)))
+
+    result = await check_and_increment("t-1", "write")
+
+    assert result.limit == 100
+    assert result.remaining == 93
+
+
+async def test_a_meter_that_reports_nothing_degrades_to_unlimited():
+    """Recording without reporting counters is legitimate, not an error."""
+    configure_hooks(ServiceHooks(usage_meter=AsyncMock(return_value=None)))
+
+    result = await check_and_increment("t-1", "write")
+
+    assert result.allowed is True
+    assert result.limit is None
+
+
+# ── Failure behaviour ────────────────────────────────────────────────────────
+
+
+async def test_a_failing_meter_does_not_fail_the_write(caplog):
+    """Fail OPEN, and loudly. This sits on the write path of every metered
+    route: a metering backend that is down must cost a count, not a customer
+    write — but the lost count still has to reach ops."""
+    configure_hooks(
+        ServiceHooks(usage_meter=AsyncMock(side_effect=RuntimeError("meter down")))
+    )
+
+    with caplog.at_level("ERROR"):
+        result = await check_and_increment("t-1", "write")
+
+    assert result.allowed is True
+    assert result.limit is None
+    assert any("usage meter failed" in r.message for r in caplog.records)
+
+
+async def test_repeated_failures_are_throttled(caplog):
+    """A dead meter must not emit one traceback per write.
+
+    Without the throttle a metering outage becomes a log-volume incident on top
+    of a metering one — the failure mode ``audit_queue`` already guards against.
+    """
+    configure_hooks(
+        ServiceHooks(usage_meter=AsyncMock(side_effect=RuntimeError("meter down")))
+    )
+
+    with caplog.at_level("ERROR"):
+        for _ in range(30):
+            await check_and_increment("t-1", "write")
+
+    logged = [r for r in caplog.records if "usage meter failed" in r.message]
+    assert len(logged) == 1, f"30 failures produced {len(logged)} log records"
+
+
+# ── One function, two names ──────────────────────────────────────────────────
+
+
+async def test_both_entry_points_are_the_same_function():
+    """Callers import them interchangeably — several as
+    ``check_and_increment_by_tenant as check_and_increment`` — so a meter wired
+    for one and not the other would silently drop half the traffic."""
+    assert check_and_increment_by_tenant is check_and_increment
+
+    meter = AsyncMock(return_value=_METERED)
+    configure_hooks(ServiceHooks(usage_meter=meter))
+
+    await check_and_increment("t-1", "write")
+    await check_and_increment_by_tenant("t-1", "search")
+
+    assert [c.kwargs["operation"] for c in meter.await_args_list] == ["write", "search"]
+    assert {c.kwargs["tenant_id"] for c in meter.await_args_list} == {"t-1"}


### PR DESCRIPTION
OSS half of caura-ai/caura-enterprise#83 ("usage counters never increment"). **On its own this changes no behaviour** — it creates the seam the platform side needs. Counters do not start incrementing until the follow-up lands.

## What was actually wrong

`usage_service` was three no-op stubs with no way for a platform deployment to substitute an implementation, so the write paths and the platform's per-period counters were two subsystems that never met. Measured on a stack that had served traffic for a day:

```
 writes | searches | recalls | count
      5 |        3 |       0 |    25     ← every row identical, 25 distinct orgs
```

…while the same database held **3,180** memories. `recalls = 0` everywhere is the cleanest tell.

They now delegate to `ServiceHooks.usage_meter`. `ServiceHooks` is the existing platform→core injection point (`audit_log` already uses it, wired at `app.py:272`) and is the **only** one — the providers registry is a closed name→class factory and there are no entry points — so this completes a pattern rather than inventing one. With no hook wired, behaviour is exactly as before: allowed, unlimited, nothing recorded. OSS standalone must run without a billing plane.

## Two things found while doing it

**`check_and_increment`'s first parameter was named `org_id`, and no caller has ever passed one.** All ~21 call sites pass a tenant id, including the two importing that name specifically (`routes/stm.py:216`, `routes/memories.py:870`). Harmless while the body ignored the value — a meter trusting the name would have keyed those writes on the wrong entity. `org_id` is a real, distinct field on `AuthContext`, so this was not a harmless synonym.

**`check_and_increment` and `check_and_increment_by_tenant` were identical** once the parameter was corrected. Now an alias assignment rather than a duplicated body: the long name appears on five import lines, all aliasing it to the short one, so no invocation anywhere spells it.

## Why the result is not an enforcement decision

Nothing in core-api reads `allowed`, and that is **by design**. Enforcement arrives out-of-band: the platform computes "over plan" from the persisted counters and stamps `x-org-read-only`, which `AuthContext.is_read_only` reads and `enforce_usage_limits()` turns into a 403 at ~22 write routes. The module docstring says so, so a platform implementer does not build enforcement into a return value that is discarded.

That is also what makes **fail-open** correct on hook failure — this is on the write path of every metered route, and a metering backend that is down must cost a count, not a customer write. The comment names the condition that would invalidate it: the moment `allowed` gains a reader, fail-open becomes "meter down ⇒ every tenant unlimited".

Failure logging is **throttled** (first, then every 100th) rather than one traceback per write — same shape as `audit_queue`'s drop counter, so a meter outage isn't also a log-volume incident.

Also documented why this is a second counter and not a change to `capability_usage`: that path buffers in memory, loses counts on process death by its own docstring, and appends rows to be SUMmed rather than upserting a period total. Right for adoption analytics, unfit for a plan cap.

## Tests — 8, with an honest note

Most exercise a **new capability** and fail against the old code with `TypeError: unexpected keyword argument 'usage_meter'`. That shows the wiring is new, not that old behaviour was broken — the old behaviour (no-op) was correct for OSS, and the defect was the *absence of a seam*, which has no "before" to regress against. I'd rather say that than claim a before/after I don't have.

The one test that must pass identically either way, and does, is the OSS-standalone pin. The throttle test does have a real before/after: without it, 30 failures produce 30 log records instead of 1.

Full suite: **4492 passed**, 3 skipped, 1 xfailed. `ruff check` + `ruff format --check` clean across every CI scope.

## Next

The platform-side wiring (an enterprise implementation registered at startup) is the follow-up that makes counters actually move.