### PR TITLE
fix(evolve): a disabled or failed provider must not fabricate a rule

### DIFF
--- a/core-api/src/core_api/services/evolve_service.py
+++ b/core-api/src/core_api/services/evolve_service.py
@@ -381,8 +381,33 @@ async def _adjust_weights(
 # -- Rule generation ----------------------------------------------------------
 
 
+def _skip_rule() -> None:
+    """No-LLM rule generation: produce nothing.
+
+    ``None`` fails the caller's ``isinstance(raw, dict)`` check, so it returns
+    ``("llm_failed", None)`` and no rule is written. That path already exists for a
+    provider that raised; this routes the no-provider case to it too.
+
+    Why this one matters: the result is persisted as a ``memory_type="rule"``
+    memory, and ``rule`` is in ``SERVER_RESERVED_MEMORY_TYPES`` — the enrichment
+    classifier is forbidden from emitting it, and any hallucinated ``rule`` is
+    demoted to the default type. So the reserved types carry the implicit provenance
+    "an internal flow authored this deliberately", not "a model guessed". A
+    fabricated one borrows that authority: ``_fake_rule`` returns a generic "verify
+    information against the most recent source" rule at confidence 0.6, plausible
+    enough to survive review and attributable to nobody.
+
+    (Nothing in recall boosts or prioritises ``rule`` today — I checked before
+    claiming it. The reserved-type provenance is the actual argument.)
+    """
+    logger.warning("evolve: no LLM — no rule generated")
+    return None
+
+
 def _fake_rule() -> dict:
-    """Placeholder rule for fake/test LLM provider."""
+    """Placeholder rule for an explicitly configured ``fake`` provider. TEST/DEV
+    ONLY — the production fallback abstains via ``_skip_rule``, because this output
+    is persisted as a ``rule``-type memory."""
     return {
         "condition": "When encountering a similar situation",
         "action": "Verify information against the most recent source before acting",
@@ -424,7 +449,7 @@ async def _generate_rule(
     examples) can light up without a signature break.
     """
     from core_api.clients.storage_client import get_storage_client
-    from core_api.providers._retry import call_with_fallback
+    from core_api.providers._retry import call_with_fallback, deliberate_fake_provider
 
     sc = get_storage_client()
 
@@ -477,7 +502,10 @@ async def _generate_rule(
         raw = await call_with_fallback(
             primary_provider_name=config.enrichment_provider,
             call_fn=_do_generate,
-            fake_fn=_fake_rule,
+            # An outage or a disabled provider must not invent a rule — see
+            # ``_skip_rule``. ``none`` counts as disabled, not as a request for a
+            # stub; only an explicit ``fake`` provider gets one.
+            fake_fn=(_fake_rule if deliberate_fake_provider(config.enrichment_provider) else _skip_rule),
             tenant_config=config,
             service_label="evolve-rule",
             model_override=config.enrichment_model,

--- a/tests/test_evolve_service.py
+++ b/tests/test_evolve_service.py
@@ -486,13 +486,18 @@ async def test_evolve_generate_rule_returns_valid_structure(sc):
     mid, _ = await _create_test_memory_via_sc(sc, tenant_id, weight=0.5)
 
     from core_api.services.evolve_service import _generate_rule
-    from core_api.services.organization_settings import resolve_config
+    from core_api.services.organization_settings import ResolvedConfig
 
     # Audit P3 (evolve): ``_generate_rule`` no longer takes ``db`` —
     # callers resolve the tenant config first and pass it in. This
     # lets the MCP tool close its session before the LLM round-trip.
-    # Fix 2 Ph5b (PR2): resolve_config is storage-routed; db=None.
-    config = await resolve_config(tenant_id)
+    #
+    # Asks for ``fake`` EXPLICITLY rather than using ``resolve_config``, which
+    # would inherit the suite's ``ENTITY_EXTRACTION_PROVIDER=none``. ``none`` now
+    # means the feature is off and the generator abstains, so relying on it to
+    # hand back a stub is what this test used to do by accident. ``_generate_rule``
+    # reads only ``enrichment_provider`` and ``enrichment_model`` off the config.
+    config = ResolvedConfig({"enrichment": {"provider": "fake"}})
 
     # A10: _generate_rule now returns (skip_reason, rule_dict) tuple.
     reason, rule = await _generate_rule(
@@ -517,8 +522,39 @@ async def test_evolve_generate_rule_returns_valid_structure(sc):
     assert 0.0 <= rule["confidence"] <= 1.0
 
 
+@pytest.mark.asyncio
+async def test_evolve_generates_no_rule_when_provider_is_none(sc):
+    """``none`` means the feature is off: abstain, do not invent a rule.
+
+    The result is persisted as a ``memory_type="rule"`` memory, and ``rule`` is
+    server-reserved — the classifier may not emit it, so it carries the provenance
+    "an internal flow authored this". ``_fake_rule`` returns a generic rule at
+    confidence 0.6 that borrows that authority. See ``_skip_rule``.
+    """
+    tag = _uid()
+    tenant_id = f"test-tenant-{tag}"
+    mid, _ = await _create_test_memory_via_sc(sc, tenant_id, weight=0.5)
+
+    from core_api.services.evolve_service import _generate_rule
+    from core_api.services.organization_settings import ResolvedConfig
+
+    reason, rule = await _generate_rule(
+        tenant_id=tenant_id,
+        outcome=f"Failed because of bad info [{tag}]",
+        outcome_type="failure",
+        related_ids=[mid],
+        config=ResolvedConfig({"enrichment": {"provider": "none"}}),
+        agent_id="evolve-test-agent",
+        fleet_id=None,
+    )
+
+    assert rule is None, f"a disabled provider must not fabricate a rule; got {rule!r}"
+    assert reason == "llm_failed"
+
+
 class TestFakeRuleFallback:
-    """Test _fake_rule (used when ALL LLM providers fail, not when fake is primary)."""
+    """Test _fake_rule — reachable only via an explicitly configured ``fake``
+    provider now, NOT when a real provider fails or the feature is off."""
 
     def test_fake_rule_has_sufficient_confidence(self):
         from core_api.constants import EVOLVE_RULE_CONFIDENCE_THRESHOLD


### PR DESCRIPTION
Closes the sweep behind #821, #822 and #823. This was the site I backed out of #823
because it turned on a decision — **Eldad's call: `none` means abstain.**

## The problem

`_fake_rule` returns a generic *"verify information against the most recent source"*
rule at confidence 0.6, and the caller persists it as a `memory_type="rule"` memory.

`rule` is in `SERVER_RESERVED_MEMORY_TYPES`: the enrichment classifier may not emit
it, and a hallucinated one is demoted to the default type. So the reserved types
carry the implicit provenance *"an internal flow authored this deliberately"* rather
than *"a model guessed"*. A fabricated rule borrows that authority — plausible
enough to survive review, attributable to nobody.

## The fix

Abstaining returns `None`, which fails the caller's `isinstance(raw, dict)` check and
yields `("llm_failed", None)`, so no rule is written. That path already existed for a
provider that raised; this routes the no-provider case to it.

`none` is not a request for a stub — only an explicit `fake` provider is, matching
how `entity_extraction` already splits them and what #821 established.

## The test change, and a correction to what I told you

`ResolvedConfig.enrichment_provider` falls back to `entity_extraction_provider`, and
the suite runs with that set to `none`. So tests using `resolve_config` were
inheriting `none` as their way of getting a stub.

**Exactly one test depended on it** — `test_evolve_generate_rule_returns_valid_structure`.
It now builds `ResolvedConfig({"enrichment": {"provider": "fake"}})` and asks
explicitly; `_generate_rule` reads only `enrichment_provider` and `enrichment_model`
off the config, so that is sufficient and faithful.

I earlier reported **five** tests. That count came from a tree that also carried the
recall change from #823 and was wrong — on clean `main` it is one. Correcting it
here because it was the whole reason this got deferred.

## Verification

New test pins the decision, and fails behaviourally against unfixed code — it
collects and runs, so this is not an import artefact:

```
FAILED tests/test_evolve_service.py::test_evolve_generates_no_rule_when_provider_is_none
1 failed, 53 passed
```

The updated existing test passes either way by design: with `provider="fake"`, old
and new code both reach `_fake_rule`. It is a pin, not a gate.

- root suite: **4492 passed**, 3 skipped, 1 xfailed
- `ruff check`, `ruff format --check`, `mypy` — all verified by exit code

## One claim I removed

My first draft asserted rules "are recalled and applied as policy rather than read
as facts". Nothing in recall boosts or prioritises `rule` today — the only grep hit
for that idea was my own comment. The reserved-type provenance is the argument that
actually holds, and the docstring now records the negative finding too, so the next
reader doesn't have to re-check it.

That is the third claim in this sweep I had to verify down rather than up. It is
also the pattern the whole sweep was about: a marker or a type that *looks* like it
means something to a reader, where nothing actually reads it.