### PR TITLE
fix(documents): a NULL timestamp must serialise, not 500 the read

### DIFF
--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -143,14 +143,36 @@ class DocOut(BaseModel):
     collection: str
     doc_id: str
     data: dict
-    created_at: datetime
-    updated_at: datetime
+    # NULLABLE because the columns are. ``documents.created_at`` / ``updated_at``
+    # carry ``server_default=now()`` but were never declared ``nullable=False``
+    # (001_initial_schema, never tightened since), so a NULL is representable. This
+    # model previously required a ``datetime``, which meant such a row could not be
+    # serialised at all — the read raised ValidationError and the route 500'd. No
+    # client can be relying on non-null for those rows, because they were never
+    # served; ``null`` strictly widens what this endpoint can return.
+    created_at: datetime | None
+    updated_at: datetime | None
 
 
 # ── Helpers ──
 
 
 def _dict_to_out(d: dict) -> DocOut:
+    # ``.get(key, datetime.min)`` covered only the MISSING-KEY case and left the
+    # present-but-None one, which is the one the schema actually permits — so the
+    # default never fired where it mattered and the route 500'd instead. And where
+    # it did fire it served year 1 (naive, in a tz-aware field) to a caller with no
+    # way to recognise it as a sentinel. Pass the value through and let ``null``
+    # mean unknown.
+    if d.get("created_at") is None or d.get("updated_at") is None:
+        # Identifier only, never ``data`` — that is caller-supplied document content.
+        logger.warning(
+            "document_timestamp_null id=%s collection=%s created_at_null=%s updated_at_null=%s",
+            d.get("id"),
+            d.get("collection"),
+            d.get("created_at") is None,
+            d.get("updated_at") is None,
+        )
     return DocOut(
         id=str(d.get("id", "")),
         tenant_id=d.get("tenant_id", ""),
@@ -158,8 +180,8 @@ def _dict_to_out(d: dict) -> DocOut:
         collection=d.get("collection", ""),
         doc_id=d.get("doc_id", ""),
         data=d.get("data", {}),
-        created_at=d.get("created_at", datetime.min),
-        updated_at=d.get("updated_at", datetime.min),
+        created_at=d.get("created_at"),
+        updated_at=d.get("updated_at"),
     )
 
 

--- a/tests/test_document_null_timestamps.py
+++ b/tests/test_document_null_timestamps.py
@@ -1,0 +1,94 @@
+"""A document row with NULL timestamps must serialise, not 500.
+
+`documents.created_at` / `updated_at` carry `server_default=now()` but were never
+declared `nullable=False` (001_initial_schema, never tightened), so a NULL is
+representable. `DocOut` required a `datetime`, and `_dict_to_out` guarded with
+`d.get(key, datetime.min)` — which only substitutes when the KEY IS ABSENT. For the
+case the schema actually permits, key present with value `None`, the default never
+fired and pydantic raised inside the read route.
+
+The sentinel was also wrong on its own terms where it did fire: `datetime.min` is
+year 1 and naive, in a timezone-aware field, handed to a caller with no way to
+recognise it as anything but a real timestamp.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_api.routes.documents import _dict_to_out
+
+pytestmark = [pytest.mark.unit]
+
+
+def _row(**over) -> dict:
+    """A storage row as the documents endpoints receive it."""
+    base = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "tenant_id": "t1",
+        "fleet_id": None,
+        "collection": "invoices",
+        "doc_id": "inv-1",
+        "data": {"total": 42},
+        "created_at": "2026-08-18T10:00:00Z",
+        "updated_at": "2026-08-18T10:00:00Z",
+    }
+    base.update(over)
+    return base
+
+
+def test_a_null_created_at_serialises_as_null() -> None:
+    """The case the old guard missed: key present, value None."""
+    out = _dict_to_out(_row(created_at=None))
+
+    assert out.created_at is None
+    assert out.updated_at is not None, "only the null field becomes null"
+    assert out.data == {"total": 42}, "the rest of the document still round-trips"
+
+
+def test_both_timestamps_null_serialises() -> None:
+    out = _dict_to_out(_row(created_at=None, updated_at=None))
+
+    assert out.created_at is None and out.updated_at is None
+
+
+def test_a_missing_key_is_null_not_year_one() -> None:
+    """The case the old guard DID cover, but covered wrongly.
+
+    ``datetime.min`` sorts before every real row and renders as 0001-01-01, which a
+    client cannot distinguish from a genuine timestamp.
+    """
+    row = _row()
+    del row["created_at"]
+
+    out = _dict_to_out(row)
+
+    assert out.created_at is None, f"expected null, not a sentinel date; got {out.created_at!r}"
+
+
+def test_the_null_case_is_logged_with_identifiers_only(caplog) -> None:
+    """It should be findable — a NULL here means a row written outside the normal
+    path. And the log must not carry ``data``, which is caller-supplied content.
+    """
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="core_api.routes.documents"):
+        _dict_to_out(_row(created_at=None, data={"secret": "shh"}))
+
+    lines = [r.getMessage() for r in caplog.records if "document_timestamp_null" in r.getMessage()]
+    assert len(lines) == 1, f"expected one warning; got {lines}"
+    assert "11111111-1111-1111-1111-111111111111" in lines[0]
+    assert "secret" not in lines[0] and "shh" not in lines[0], (
+        f"document data must never reach log storage; got {lines[0]!r}"
+    )
+
+
+def test_a_normal_row_is_untouched_and_silent(caplog) -> None:
+    """Control: the fix must not fire on the overwhelmingly common case."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="core_api.routes.documents"):
+        out = _dict_to_out(_row())
+
+    assert out.created_at is not None and out.updated_at is not None
+    assert not [r for r in caplog.records if "document_timestamp_null" in r.getMessage()]


### PR DESCRIPTION
Last item from the sentinel half of the sweep behind #821/#822/#823/#825. **I logged
it as cosmetic; it is a real bug.**

## Two problems, and the guard only addressed the one that couldn't happen

`documents.created_at` / `updated_at` carry `server_default=now()` but were never
declared `nullable=False` — `001_initial_schema`, and I checked that no later
migration tightened it. So a NULL is representable.

`DocOut` required a `datetime`, and `_dict_to_out` guarded with:

```python
created_at=d.get("created_at", datetime.min),
```

`.get(key, default)` substitutes only when the **key is absent**. For the case the
schema actually permits — **key present, value `None`** — the default never fires,
`None` reaches a non-optional `datetime`, and pydantic raises *inside the read
route*. Verified:

```
DocOut(..., created_at=None) -> REJECTED None -> ValidationError
```

`_dict_to_out` has six call sites, three of them list endpoints, so one such row
could take a whole page down rather than just its own record.

And where the default *did* fire it was wrong on its own terms: `datetime.min` is
year 1 **and naive**, in a timezone-aware field, handed to an API client with no way
to read it as anything but a real timestamp. It also sorts before every genuine row.

## The fix

Make the response model match the data model: `datetime | None`.

That **strictly widens** what the endpoint can return. Rows with NULL timestamps
could not be served at all before, so no client can be relying on non-null for them;
rows with real timestamps are unaffected. A 500 becoming `null` is an improvement for
every caller.

The NULL case is logged, since it means a row written outside the normal insert path
and should be zero in practice. Identifiers only — `id` and `collection`, never
`data`, which is caller-supplied document content.

## Verification

4 of 5 tests fail against unfixed code, behaviourally:

```
FAILED tests/test_document_null_timestamps.py::test_a_null_created_at_serialises_as_null
FAILED tests/test_document_null_timestamps.py::test_both_timestamps_null_serialises
FAILED tests/test_document_null_timestamps.py::test_a_missing_key_is_null_not_year_one
FAILED tests/test_document_null_timestamps.py::test_the_null_case_is_logged_with_identifiers_only
4 failed, 1 passed
```

The 5th is the control — a normal row, unchanged and silent — and passes either way
by design.

One test asserts the log carries the id but **not** the document's `data`, so the
shape-not-payload rule is gated rather than just intended.

- root suite: **4505 passed**, 3 skipped, 1 xfailed
- `ruff check`, `ruff format --check`, `mypy` — verified by exit code

## Follow-up not taken here

The columns arguably *should* be `NOT NULL` — every insert path sets them via
`server_default`. Tightening them is a migration against a live table and a separate
decision; this PR makes the API honest about what the current schema allows.