### PR TITLE
feat(db): documents.created_at / updated_at NOT NULL

### DIFF
--- a/core-storage-api/src/core_storage_api/database/migrations/versions/038_documents_timestamps_not_null.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/038_documents_timestamps_not_null.py
@@ -1,0 +1,92 @@
+"""``documents.created_at`` / ``updated_at`` NOT NULL.
+
+Both columns were created with ``server_default=now()`` but WITHOUT
+``nullable=False`` (001_initial_schema, never tightened since), so a NULL has
+always been representable even though every insert path sets them. OSS #826 made
+the API honest about that — ``DocOut`` required a ``datetime``, so a NULL row
+raised ValidationError inside the read route and 500'd it, across six call sites
+including three list endpoints. This closes the hole at the source, which is where
+it belongs: the columns describe row lifecycle, not optional user data.
+
+BACKFILL FIRST, because ``SET NOT NULL`` on a table containing a NULL fails — and
+migrations here run in the FastAPI lifespan startup hook, so a failed one means the
+new revision never becomes ready and the deploy stalls (Cloud Run keeps the old
+revision serving; it fails safe, but it fails).
+
+The backfill derives from the row where it can: a NULL ``created_at`` takes
+``updated_at``, which is an upper bound on it, and vice versa. When BOTH are NULL
+there is nothing to derive from — ``id`` is ``gen_random_uuid()`` (v4), so it
+carries no time — and ``now()`` is the only available value. That asserts the row
+was created at migration time, which is false; it is chosen because the alternative
+is refusing to migrate. Such rows are identifiable afterwards by sharing a
+near-identical timestamp with each other and with this migration's run.
+
+LOCK SAFETY. ``documents`` is one of this repo's declared large tables (see
+``test_no_plain_create_index_on_large_tables``), and a bare ``SET NOT NULL`` takes
+an AccessExclusive lock while it full-scans to verify — blocking writes for the
+duration and holding the migration advisory lock, which is the shape that crashed
+6 storage-writer boots on 2026-06-16 (migration 025). Instead:
+
+    ADD CONSTRAINT ... CHECK (col IS NOT NULL) NOT VALID   -- AccessExclusive, O(1)
+    VALIDATE CONSTRAINT ...                                -- ShareUpdateExclusive,
+                                                           -- scans WITHOUT blocking
+                                                           -- reads or writes
+    ALTER COLUMN ... SET NOT NULL                          -- AccessExclusive, but
+                                                           -- PG12+ skips the scan
+                                                           -- given the valid CHECK
+    DROP CONSTRAINT ...                                    -- now redundant
+
+Each step is its own transaction (``autocommit_block``), which is the whole point:
+run them inside one and the AccessExclusive from step 1 is held across the scan in
+step 2, reproducing exactly the blocking this pattern exists to avoid.
+
+Revision ID: 038
+Revises: 037
+Create Date: 2026-08-18
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "038"
+down_revision: str | None = "037"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_COLUMNS = ("created_at", "updated_at")
+
+
+def upgrade() -> None:
+    # Row locks on the NULL rows only, so this stays in the normal transaction.
+    # ``created_at`` first: a both-NULL row then takes ``now()`` here and the same
+    # value below, rather than two timestamps a few milliseconds apart.
+    op.execute(
+        "UPDATE documents SET created_at = COALESCE(created_at, updated_at, now()) WHERE created_at IS NULL"
+    )
+    op.execute(
+        "UPDATE documents SET updated_at = COALESCE(updated_at, created_at, now()) WHERE updated_at IS NULL"
+    )
+
+    # ``autocommit_block`` commits the backfill above before the DDL runs, which is
+    # required: VALIDATE must see the rows as committed, and each ALTER needs its
+    # own transaction so no lock spans the scan.
+    with op.get_context().autocommit_block():
+        for column in _COLUMNS:
+            constraint = f"ck_documents_{column}_not_null"
+            # Postgres has no ADD CONSTRAINT IF NOT EXISTS, and a migration that
+            # fails after the ADD would otherwise be unretryable — same
+            # re-runnability rationale as 037's DROP INDEX ... IF EXISTS.
+            op.execute(f"ALTER TABLE documents DROP CONSTRAINT IF EXISTS {constraint}")
+            op.execute(
+                f"ALTER TABLE documents ADD CONSTRAINT {constraint} CHECK ({column} IS NOT NULL) NOT VALID"
+            )
+            op.execute(f"ALTER TABLE documents VALIDATE CONSTRAINT {constraint}")
+            op.execute(f"ALTER TABLE documents ALTER COLUMN {column} SET NOT NULL")
+            op.execute(f"ALTER TABLE documents DROP CONSTRAINT {constraint}")
+
+
+def downgrade() -> None:
+    # Metadata-only; dropping a NOT NULL needs no scan, so no autocommit dance.
+    for column in _COLUMNS:
+        op.execute(f"ALTER TABLE documents ALTER COLUMN {column} DROP NOT NULL")

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -643,6 +643,53 @@ class TestRouteSlugRegex:
 
 
 @pytest.mark.unit
+def _strip_docstrings_and_comments(src: str) -> str:
+    """Source with comments and docstrings removed, everything else verbatim.
+
+    A migration guard that greps raw source can be satisfied by a COMMENT, which
+    makes it documentation-checking rather than code-checking. Found by mutation:
+    stripping the real ``autocommit_block`` from 038 still passed, because the
+    module docstring named it.
+
+    Line-based on purpose. Rebuilding from ``tokenize`` output re-spaces the source
+    (``op . get_context ( )``) and, on 3.12+, splits f-strings into parts — either
+    of which silently breaks a literal substring check, which is the same class of
+    bug this helper exists to catch. Ordinary string literals are KEPT: the guarded
+    statements are themselves strings (``op.execute("ALTER TABLE ...")``).
+    """
+    import ast
+    import io
+    import tokenize
+
+    lines = src.splitlines()
+
+    drop: set[int] = set()
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        body = getattr(node, "body", [])
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            drop.update(range(body[0].lineno, (body[0].end_lineno or body[0].lineno) + 1))
+
+    # Truncate each line at its comment, if any (1-indexed rows, 0-indexed cols).
+    cut: dict[int, int] = {}
+    for tok in tokenize.generate_tokens(io.StringIO(src).readline):
+        if tok.type == tokenize.COMMENT:
+            cut.setdefault(tok.start[0], tok.start[1])
+
+    kept = [
+        line[: cut[i]] if i in cut else line
+        for i, line in enumerate(lines, start=1)
+        if i not in drop
+    ]
+    return "\n".join(kept)
+
+
 class TestMigrationChain:
     """Sanity check that the Phase 0 migrations (020 / 021 / 022) chain
     correctly off the prior head (019). Detects accidental down_revision
@@ -664,7 +711,7 @@ class TestMigrationChain:
     def test_single_head(self):
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"037"}, f"Expected single head '037', got {sorted(heads)}"
+        assert heads == {"038"}, f"Expected single head '038', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -701,6 +748,81 @@ class TestMigrationChain:
         # 037: memories.embedded_content_hash — embedding provenance, so a
         # vector computed from superseded text becomes detectable
         assert chain.get("037") == "036", "037 must follow 036"
+        # 038: documents.created_at/updated_at NOT NULL — the columns were always
+        # nullable, so a NULL row 500'd the documents read path (OSS #826)
+        assert chain.get("038") == "037", "038 must follow 037"
+
+    def test_no_plain_set_not_null_on_large_tables(self):
+        """Tightening a column to NOT NULL on a large table must not full-scan
+        under an AccessExclusive lock.
+
+        Same hazard as the CREATE INDEX guard below, different statement: a bare
+        ``SET NOT NULL`` scans the whole table to verify while holding
+        AccessExclusive, blocking writes and pinning the migration advisory lock.
+        The safe shape adds a ``CHECK (col IS NOT NULL) NOT VALID``, VALIDATEs it
+        (ShareUpdateExclusive — does not block reads or writes), and only then sets
+        NOT NULL, which PG12+ satisfies from the validated constraint without a
+        second scan. Each step needs its own transaction, hence ``autocommit_block``.
+
+        Catches BOTH spellings, because the existing index guard learned this the
+        hard way: it originally checked only raw SQL, and ``op.create_index(...)``
+        carried the identical defect straight past it.
+        """
+        import re
+
+        large_tables = {
+            "audit_log",
+            "memories",
+            "entities",
+            "documents",
+            "memory_entity_links",
+            "relations",
+        }
+        # ALTER TABLE <table> ALTER COLUMN <col> SET NOT NULL
+        #
+        # The column position accepts ``{...}`` as well as a bare name, because
+        # ``ruff format`` collapses these statements into f-strings and a ``\w+``
+        # column would then match nothing — the guard would go SILENT on the very
+        # file it is meant to check, which is the documented blind spot that leaves
+        # 007 and 026 outside the CREATE INDEX guard below. Verified by mutation
+        # both ways.
+        #
+        # KNOWN GAP, same as that guard: an interpolated TABLE name cannot be
+        # classified against ``large_tables``, so ``f"ALTER TABLE {tbl} ..."`` is
+        # not caught. Keep the table literal in migrations.
+        raw_pat = re.compile(
+            r"ALTER\s+TABLE\s+(\w+)\s+ALTER\s+COLUMN\s+[\w{}]+\s+SET\s+NOT\s+NULL",
+            re.IGNORECASE,
+        )
+        # op.alter_column("<table>", "<col>", ..., nullable=False)
+        api_pat = re.compile(
+            r"op\.alter_column\(\s*[\"\'](\w+)[\"\'][^)]*nullable\s*=\s*False",
+            re.DOTALL,
+        )
+        versions = pathlib.Path(
+            "core-storage-api/src/core_storage_api/database/migrations/versions"
+        )
+        violations: list[str] = []
+        for f in sorted(versions.glob("*.py")):
+            prefix = f.stem.split("_")[0]
+            if not prefix.isdigit() or int(prefix) < 5:
+                continue
+            src = f.read_text()
+            tables = set(raw_pat.findall(src)) | set(api_pat.findall(src))
+            hit = {t for t in tables if t.lower() in large_tables}
+            if not hit:
+                continue
+            # Look at CODE, not prose. Checking the raw source let a migration
+            # satisfy this by DESCRIBING the safe pattern in its docstring while
+            # not doing it — caught by mutation: stripping the real
+            # ``autocommit_block`` still passed, because the docstring named it.
+            code = _strip_docstrings_and_comments(src)
+            if "VALIDATE CONSTRAINT" not in code.upper() or ".autocommit_block()" not in code:
+                violations.append(
+                    f"{f.name}: SET NOT NULL on {sorted(hit)} without the "
+                    "CHECK-NOT-VALID / VALIDATE / autocommit_block pattern"
+                )
+        assert not violations, "unsafe NOT NULL tightening:\n" + "\n".join(violations)
 
     def test_no_plain_create_index_on_large_tables(self):
         """Indexes on large, pre-existing tables MUST be built ``CONCURRENTLY``


### PR DESCRIPTION
Follow-up to #826, which made the API honest that these columns could be NULL. This
closes the hole at the source — they describe row lifecycle, not optional user data.

**Migration against a live table.** Merging runs it on prod at service startup, so
the verification section below is the part worth reading.

## Backfill first, because a failed migration stalls the deploy

`SET NOT NULL` fails if the table contains a NULL, and migrations run in the FastAPI
lifespan startup hook — so a failure means the new revision never becomes ready.
Cloud Run keeps the old one serving, which fails safe, but it fails.

The backfill derives from the row where it can: a NULL `created_at` takes
`updated_at` (an upper bound on it), and vice versa. When **both** are NULL there is
nothing to derive from — `id` is `gen_random_uuid()`, so it carries no time — and
`now()` is the only available value. That asserts the row was created at migration
time, which is **false**; it's chosen because the alternative is refusing to migrate.
The migration says so, and says how to identify those rows afterwards (they share a
near-identical timestamp with each other and with the migration run).

## Lock safety, because `documents` is a declared large table

It's in this repo's own `large_tables` set. A bare `SET NOT NULL` full-scans under
AccessExclusive — the shape that crashed 6 storage-writer boots on 2026-06-16. So:

```
ADD CONSTRAINT ... CHECK (col IS NOT NULL) NOT VALID   -- AccessExclusive, O(1)
VALIDATE CONSTRAINT ...                                -- ShareUpdateExclusive:
                                                       -- scans WITHOUT blocking
                                                       -- reads or writes
ALTER COLUMN ... SET NOT NULL                          -- PG12+ skips the scan
DROP CONSTRAINT ...                                    -- now redundant
```

Each step in its own transaction via `autocommit_block` — **that is the whole
point**. Run them inside one transaction and the AccessExclusive from step 1 is held
across the scan in step 2, reproducing exactly the blocking the pattern avoids.

## New guard, and two things mutation caught in it

The existing `test_no_plain_create_index_on_large_tables` covers CREATE INDEX only;
nothing stopped the naive `SET NOT NULL`. Added
`test_no_plain_set_not_null_on_large_tables`, catching raw SQL, the
`op.alter_column(..., nullable=False)` API spelling, and the **f-string column form
`ruff format` produces**.

That last one mattered. My first regex used `\w+` for the column, so once the
formatter collapsed the statements into f-strings, the guard went **silent on this
very migration** — passing by invisibility rather than on its merits. That is the
documented blind spot which leaves 007 and 026 outside the CREATE INDEX guard.

Then the second: the guard could be satisfied by a **docstring** that merely named
`autocommit_block` while the code didn't use it. Stripping the real one still
passed. It now strips docstrings and comments before checking — line-based, because
rebuilding from `tokenize` re-spaces the source (`op . get_context ( )`) and splits
f-strings on 3.12+, either of which silently breaks a substring check.

Six mutations, all caught, small tables correctly allowed:

| mutation | result |
|---|---|
| naive raw SQL on `memories` | caught |
| `op.alter_column("documents", ..., nullable=False)` | caught |
| f-string column, naive | caught |
| strip real `autocommit_block` (docstring still names it) | caught |
| strip real `VALIDATE CONSTRAINT` (docstring still describes it) | caught |
| same statement on a small table | allowed |

## Verified against real Postgres, not asserted

Seeded a row for each NULL combination at revision 037, then ran the migration:

| row | before | after |
|---|---|---|
| `a-normal` | 01-01 / 02-01 | unchanged |
| `b-null-created` | NULL / 03-01 | **03-01** / 03-01 |
| `c-null-updated` | 04-01 / NULL | 04-01 / **04-01** |
| `d-both-null` | NULL / NULL | both `now()`, **identical** |

`d-both-null` getting one timestamp rather than two milliseconds apart is why the
backfill orders `created_at` first.

Also confirmed: both columns `is_nullable=NO`; helper constraints dropped (0 remain);
a NULL insert is now rejected; the default insert path still works; downgrade and
re-upgrade both clean. And a simulated **mid-migration crash** — leaving a stale
constraint behind, then re-running — succeeds, which is what `DROP CONSTRAINT IF
EXISTS` is there for.

- root suite: **4506 passed**, 3 skipped, 1 xfailed
- `ruff check` on `core-storage-api/src/`, `core-api/src/`, `common/`; `ruff format
  --check` on both src scopes — all verified by exit code

## Note

#826's `datetime | None` on `DocOut` stays. It's now defensive rather than load-bearing,
and I'd rather the API tolerate a shape the DB no longer produces than re-tighten it
in the same breath.