### PR TITLE
feat(usage): durable per-tenant counters behind the usage meter

### DIFF
--- a/common/models/__init__.py
+++ b/common/models/__init__.py
@@ -16,6 +16,7 @@ from common.models.memory import Memory
 from common.models.memory_conflict import MemoryConflict
 from common.models.memory_derivation import MemoryDerivation
 from common.models.skill_factory import ForgeRejectedFingerprint, SessionTrace
+from common.models.tenant_usage_counter import TenantUsageCounter
 
 __all__ = [
     "Agent",
@@ -40,4 +41,5 @@ __all__ = [
     "MemoryEntityLink",
     "Relation",
     "SessionTrace",
+    "TenantUsageCounter",
 ]

--- a/common/models/tenant_usage_counter.py
+++ b/common/models/tenant_usage_counter.py
@@ -1,0 +1,88 @@
+"""Durable per-tenant, per-period usage counters (billing-grade).
+
+The exact counterpart to :mod:`common.models.capability_usage`, and separate
+from it on purpose. That table is adoption analytics: core-api buffers counts
+in memory and flushes on a short interval, so anything since the last flush is
+lost if the process dies, and rows are appended to be SUMmed with no unique
+constraint. Both are right for "which capabilities get used" and wrong for
+anything a plan cap is computed from — a lost flush is a customer under-billed
+or over-served, and an unbounded append makes every cap check a growing SUM.
+
+This one upserts: one row per ``(tenant_id, operation, period_start)``,
+incremented atomically with ``ON CONFLICT DO UPDATE SET count = count +
+excluded.count``. No buffering, no loss window, bounded rows, and a period
+total that is a single-row read.
+
+ROW PER OPERATION rather than a column per operation. The platform's
+``enterprise.usage_counters`` has ``writes``/``searches``/``recalls`` columns,
+which is why ``insights`` and ``evolve`` — both metered in core-api — have
+nowhere to go there. Keying the operation as data takes a new one without a
+migration.
+
+Cross-tenant like ``capability_usage``, and for the same reason: it holds
+counts and a ``tenant_id`` grouping dimension, never memory content. RLS is not
+enabled on it. The platform reads it directly to compute plan limits — both
+schemas live in one database, so that costs no network hop.
+
+Written via ``ServiceHooks.usage_meter``, so an OSS standalone deployment with
+no meter wired records nothing and enforces nothing. See
+``core_api.services.usage_service``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, Index, Text, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from common.models.base import Base
+
+
+class TenantUsageCounter(Base):
+    __tablename__ = "tenant_usage_counters"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    # Tenant the usage is attributed to. Grouping dimension, not an RLS key.
+    tenant_id: Mapped[str] = mapped_column(Text, nullable=False)
+    # One of core-api's metered operations: write | search | recall | insights
+    # | evolve. Stored as data so a sixth needs no schema change.
+    operation: Mapped[str] = mapped_column(Text, nullable=False)
+    # Start of the billing period, UTC. Supplied by the caller (month-truncated)
+    # rather than derived here, so a row cannot land in a period other than the
+    # one the caller believes it is counting, and a backfill can target a closed
+    # period explicitly.
+    period_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    count: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, server_default=text("0")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("now()"), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("now()"), nullable=False
+    )
+
+    __table_args__ = (
+        # Names and columns must match migration 039 exactly, so a
+        # model-created schema (create_all / autogenerate) agrees with the
+        # migration-created one.
+        #
+        # This unique index is the ``ON CONFLICT`` target. Without it the
+        # upsert has nothing to bind to and concurrent writers quietly create
+        # duplicate rows for one period — the append-and-SUM shape this table
+        # exists to avoid.
+        Index(
+            "uq_tenant_usage_counters_key",
+            "tenant_id",
+            "operation",
+            "period_start",
+            unique=True,
+        ),
+        # The platform sweeps a whole period across tenants; the unique index
+        # above already covers the tenant-scoped read.
+        Index("ix_tenant_usage_counters_period", "period_start"),
+    )

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -268,8 +268,16 @@ async def lifespan(app):
         # hook was removed with core-api's repositories/DB pool.
         from core_api.services.audit_service import log_action
         from core_api.services.hooks import ServiceHooks, configure_hooks
+        from core_api.services.usage_meter import UsageMeter
 
-        configure_hooks(ServiceHooks(audit_log=log_action))
+        # caura-ai/caura-enterprise#83. Wired unconditionally: the counters are
+        # written through core-api's own storage client, so there is no
+        # platform dependency to gate on, and a standalone deployment gets
+        # accurate usage numbers for free. It still enforces nothing — limits
+        # arrive out-of-band via ``x-org-read-only`` (see ``usage_service``).
+        usage_meter = UsageMeter()
+        usage_meter.start()
+        configure_hooks(ServiceHooks(audit_log=log_action, usage_meter=usage_meter.record))
 
         # CAURA-628: bind + start the audit batch flusher. ``log_action``
         # checks for an active queue and falls back to a synchronous
@@ -506,6 +514,10 @@ async def lifespan(app):
             # rationale as the audit queue (the flush writes via the DB
             # session, which must still be live).
             shutdown_steps.append(capability_usage_agg.stop(timeout=5.0))
+        # Same ordering rationale: the final flush writes through the storage
+        # client, so it has to run before that client closes below. Without it
+        # a clean shutdown would discard up to one flush interval of counts.
+        shutdown_steps.append(usage_meter.stop(timeout=5.0))
         shutdown_steps.extend(
             [
                 event_bus.stop(),

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1154,6 +1154,18 @@ class CoreStorageClient:
         result = await self._post("/capability-usage", {"rows": rows})
         return result.get("inserted", 0)  # type: ignore[union-attr]
 
+    async def increment_tenant_usage(self, rows: list[dict]) -> int:
+        """ADD to per-tenant, per-period counters in ``tenant_usage_counters``.
+
+        Cross-tenant by design (each row carries its own ``tenant_id``).
+        ``period_start`` must be an ISO string. Additive and applied in the
+        database, so concurrent core-api instances metering one tenant all
+        land — unlike ``flush_capability_usage``, which appends rows for
+        consumers to SUM. Returns the rows-touched count.
+        """
+        result = await self._post("/tenant-usage/increment", {"rows": rows})
+        return result.get("updated", 0)  # type: ignore[union-attr]
+
     # =====================================================================
     # Entities
     # =====================================================================

--- a/core-api/src/core_api/services/usage_meter.py
+++ b/core-api/src/core_api/services/usage_meter.py
@@ -1,0 +1,178 @@
+"""The storage-backed implementation behind ``ServiceHooks.usage_meter``.
+
+caura-ai/caura-enterprise#83. ``usage_service`` provides the seam; this is what
+gets wired into it, and it is what makes the counters actually move.
+
+WHY THIS LIVES IN OSS AND WRITES TO core-storage-api
+-----------------------------------------------------
+The counts have to come from core-api — no interceptor upstream of it can see
+``len(body.items)`` on a bulk write, the ``if auth.tenant_id:`` admin skip at
+every metered call site, or the idempotent replay that deliberately consumes no
+quota. So the meter runs here.
+
+It writes through the storage client core-api already holds, rather than
+calling the platform. core-api has no route to a platform service in any
+environment — its only ``PLATFORM_*`` settings are LLM config, and the
+dependency runs the other way (platform-admin-api holds ``CORE_API_URL``).
+Introducing core → platform for metering would invert that. The platform reads
+``tenant_usage_counters`` instead; both schemas live in one database, so that
+costs it no network hop.
+
+BUFFERED, NOT PER-WRITE
+-----------------------
+This sits on the write path of every metered route. Two prior decisions in this
+codebase point the same way — CAURA-628 moved audit off per-mutation POSTs, and
+``capability_usage`` aggregates in memory "so the request hot path pays only a
+dict update". So the meter coalesces in a dict and flushes on an interval.
+
+The difference from ``capability_usage``, and the reason this is safe for
+billing: the flush is an **additive upsert**, so a crash loses only the counts
+buffered since the last flush rather than corrupting a total, and two instances
+flushing the same period both land. The buffer is also flushed on shutdown.
+Under a short interval the exposure is seconds of counts — the price of not
+putting a storage round-trip in front of every write.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections import defaultdict
+from datetime import UTC, datetime
+
+from core_api.clients.storage_client import get_storage_client
+
+logger = logging.getLogger(__name__)
+
+#: How often buffered counts are written. Short enough that a crash costs
+#: seconds, long enough that a busy tenant is one upsert rather than thousands.
+FLUSH_INTERVAL_SECONDS = 15
+
+
+def current_period_start(now: datetime | None = None) -> datetime:
+    """Start of the billing period ``now`` falls in — UTC, month-truncated.
+
+    Computed here rather than in the database so a row cannot land in a period
+    other than the one the caller counted in, and so a backfill can name a
+    closed period explicitly.
+    """
+    ts = (now or datetime.now(UTC)).astimezone(UTC)
+    return ts.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+class UsageMeter:
+    """Coalesces metered operations and flushes them as additive upserts."""
+
+    def __init__(self, flush_interval: float = FLUSH_INTERVAL_SECONDS) -> None:
+        self._counts: dict[tuple[str, str, datetime], int] = defaultdict(int)
+        self._flush_interval = flush_interval
+        self._task: asyncio.Task | None = None
+        # Guards the swap in ``flush``. Increments themselves are plain dict
+        # updates under the event loop's single thread, so they need no lock;
+        # the swap does, or a concurrent flush could drop the other's batch.
+        self._lock = asyncio.Lock()
+
+    async def record(self, *, tenant_id: str, operation: str, count: int = 1):
+        """The hook entry point. Buffers and returns ``None``.
+
+        ``None`` rather than counters: reporting ``limit``/``remaining`` would
+        mean a read per write, and nothing enforces the verdict here anyway —
+        core-api's limit enforcement arrives out-of-band via
+        ``x-org-read-only``. See ``usage_service``.
+        """
+        self._counts[(tenant_id, operation, current_period_start())] += count
+        return None
+
+    async def flush(self) -> int:
+        """Write and clear the buffer. Returns the number of rows sent."""
+        async with self._lock:
+            if not self._counts:
+                return 0
+            batch = self._counts
+            self._counts = defaultdict(int)
+        rows = [
+            {
+                "tenant_id": tenant_id,
+                "operation": operation,
+                "period_start": period.isoformat(),
+                "count": count,
+            }
+            for (tenant_id, operation, period), count in batch.items()
+        ]
+        sent = False
+        try:
+            written = await get_storage_client().increment_tenant_usage(rows)
+            sent = True
+            return written
+        except Exception:
+            logger.exception(
+                "usage meter flush failed; %d counter rows returned to the buffer",
+                len(rows),
+            )
+            return 0
+        finally:
+            if not sent:
+                # Put the counts BACK rather than dropping them: the upsert is
+                # additive, so re-sending is safe, and a transient storage blip
+                # should cost latency rather than billing accuracy. Merged with
+                # whatever arrived while the flush was in flight.
+                #
+                # In ``finally`` rather than in the ``except``, because the
+                # batch is already out of the buffer and NOTHING may leave this
+                # frame without putting it back. ``stop()`` cancels this task,
+                # and a CancelledError landing on the await above is a
+                # BaseException that walks straight past ``except Exception`` —
+                # dropping precisely the counts ``stop()``'s final flush exists
+                # to save.
+                #
+                # This ``acquire`` runs while that cancellation is propagating,
+                # and completes because it takes the uncontended fast path,
+                # which does not yield. That holds because ``flush`` is never
+                # re-entered concurrently: its only callers are the loop task
+                # and ``stop()``, and ``stop()`` joins the task before its own
+                # call. A third caller would have to re-check this.
+                async with self._lock:
+                    for (tenant_id, operation, period), count in batch.items():
+                        self._counts[(tenant_id, operation, period)] += count
+
+    async def _run(self) -> None:
+        while True:
+            await asyncio.sleep(self._flush_interval)
+            try:
+                await self.flush()
+            except Exception:  # pragma: no cover - defence, flush self-handles
+                logger.exception("usage meter flush loop error")
+
+    def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self, *, timeout: float = 5.0) -> None:
+        """Cancel the loop and flush what is left, within ``timeout``.
+
+        The final flush is the difference between a clean shutdown costing
+        nothing and costing up to one interval of counts. Cancelling the loop
+        can land inside that loop's own in-flight flush; ``flush`` returns its
+        batch to the buffer on every failure path, so this method's cancel
+        never drops counts and the flush below re-sends them.
+
+        The deadline is the same trade ``audit_queue`` documents: the storage
+        client will wait 120s on a read, which is far longer than Cloud Run
+        grants a terminating revision. Blocking here past the grace period
+        would lose these counts to SIGKILL *and* take the remaining shutdown
+        steps — the event bus and the storage client's own close — with it.
+        """
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        try:
+            await asyncio.wait_for(self.flush(), timeout=timeout)
+        except TimeoutError:
+            logger.warning(
+                "usage meter final flush did not complete within %ss; %d counter rows are lost to shutdown",
+                timeout,
+                len(self._counts),
+            )

--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -49,6 +49,7 @@ from core_storage_api.routers import (
     skill_factory_router,
     tasks_router,
     tenant_suppression_router,
+    tenant_usage_router,
     tenants_router,
 )
 
@@ -180,6 +181,7 @@ def create_app() -> FastAPI:
     # one flush batch carries many tenants' counters. core-api's in-process
     # aggregator POSTs here on its flush interval via the storage_client.
     app.include_router(capability_usage_router, prefix=prefix)
+    app.include_router(tenant_usage_router, prefix=prefix)
 
     return app
 

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/039_tenant_usage_counters.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/039_tenant_usage_counters.py
@@ -1,0 +1,89 @@
+"""Durable per-tenant, per-period usage counters (billing-grade).
+
+The exact counterpart to ``capability_usage`` (023), and deliberately a
+separate table rather than a change to it. That one is adoption analytics:
+core-api buffers in memory and flushes every ~15s, so counts since the last
+flush are lost if the process dies, and it appends rows to be SUMmed with no
+unique constraint. Both properties are right for "which capabilities get used"
+and wrong for anything a plan cap is computed from — a lost flush is a customer
+under-billed or over-served, and an unbounded append is a growing SUM on the
+read path.
+
+This table upserts instead: one row per ``(tenant_id, operation,
+period_start)``, incremented atomically by
+``INSERT … ON CONFLICT DO UPDATE SET count = count + excluded.count``. No
+buffering, no loss window, bounded row count, and a period total that is a
+single-row read.
+
+ROW PER OPERATION, not a column per operation. The platform's
+``enterprise.usage_counters`` has ``writes``/``searches``/``recalls`` columns,
+which is why ``insights`` and ``evolve`` — both metered operations in core-api
+— have nowhere to go there. A row keyed by the operation name takes a new
+operation without a migration.
+
+Cross-tenant by design, like 023: it holds counts and a ``tenant_id`` grouping
+dimension, no memory content. The platform reads it directly — both schemas
+live in the same database, so aggregating a plan cap costs no network hop.
+
+Part of caura-ai/caura-enterprise#83. The write path reaches this through
+``ServiceHooks.usage_meter`` (added in #824), so an OSS standalone deployment
+with no meter wired still records nothing and keeps no limits.
+
+Revision ID: 039
+Revises: 038
+Create Date: 2026-08-18
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "039"
+down_revision: str | None = "038"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tenant_usage_counters",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("operation", sa.Text(), nullable=False),
+        # Start of the billing period the count belongs to, UTC. The caller
+        # supplies it (truncated to the month) rather than the database
+        # deriving it, so a row cannot land in a different period than the one
+        # the caller believes it is counting — and so a backfill can target a
+        # closed period explicitly.
+        sa.Column("period_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("count", sa.BigInteger(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    # The upsert target. Without it ``ON CONFLICT`` has nothing to bind to and
+    # concurrent writers silently create duplicate rows for one period —
+    # exactly the append-and-SUM shape this table exists to avoid.
+    op.execute(
+        "CREATE UNIQUE INDEX uq_tenant_usage_counters_key "
+        "ON tenant_usage_counters (tenant_id, operation, period_start)"
+    )
+    # The read a plan cap actually makes: everything for one tenant in one
+    # period. Covered by the unique index's leading columns for the
+    # tenant-scoped case, but the platform also sweeps a whole period across
+    # tenants, which wants period_start leading.
+    op.execute("CREATE INDEX ix_tenant_usage_counters_period ON tenant_usage_counters (period_start)")
+
+
+def downgrade() -> None:
+    op.drop_table("tenant_usage_counters")

--- a/core-storage-api/src/core_storage_api/routers/__init__.py
+++ b/core-storage-api/src/core_storage_api/routers/__init__.py
@@ -19,12 +19,14 @@ from core_storage_api.routers.reports import router as reports_router
 from core_storage_api.routers.skill_factory import router as skill_factory_router
 from core_storage_api.routers.tasks import router as tasks_router
 from core_storage_api.routers.tenant_suppression import router as tenant_suppression_router
+from core_storage_api.routers.tenant_usage import router as tenant_usage_router
 from core_storage_api.routers.tenants import router as tenants_router
 
 __all__ = [
     "agents_router",
     "audit_router",
     "capability_usage_router",
+    "tenant_usage_router",
     "debug_router",
     "documents_router",
     "entities_router",

--- a/core-storage-api/src/core_storage_api/routers/tenant_usage.py
+++ b/core-storage-api/src/core_storage_api/routers/tenant_usage.py
@@ -1,0 +1,86 @@
+"""Durable per-tenant usage-counter increments (billing-grade).
+
+The write half of ``tenant_usage_counters`` (migration 039). core-api reaches
+this through ``ServiceHooks.usage_meter``; it holds no DB pool of its own
+(storage-boundary rule), which is the same reason ``capability-usage`` lives
+here rather than being written directly.
+
+The table is intentionally CROSS-TENANT / RLS-free: one batch carries many
+tenants' counters, so this endpoint applies NO per-tenant scoping — each row
+names its own ``tenant_id``.
+
+Increments are ADDITIVE and applied in the database, so several core-api
+instances metering the same tenant in the same period all land. That is the
+property distinguishing this from ``capability-usage``, which appends rows for
+consumers to SUM.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Request
+
+from core_storage_api.services.postgres_service import PostgresService
+
+router = APIRouter(prefix="/tenant-usage", tags=["TenantUsage"])
+_svc = PostgresService()
+
+
+@router.post("/increment")
+async def increment_tenant_usage(request: Request) -> dict:
+    """Add to per-tenant, per-period counters.
+
+    Body: ``{"rows": [{tenant_id, operation, period_start, count}, ...]}`` →
+    ``{"updated": int}``.
+
+    ``period_start`` may arrive as an ISO-8601 string (JSON has no datetime)
+    and is coerced here, because the column is ``DateTime(timezone=True)`` and
+    asyncpg rejects a bare string with ``CannotCoerceError`` → 500. Same
+    treatment ``capability-usage`` gives ``ts_bucket``, for the same reason.
+    """
+    body: dict = await request.json()
+    rows = body.get("rows")
+    if not isinstance(rows, list):
+        raise HTTPException(status_code=422, detail="'rows' must be a list")
+    if not rows:
+        return {"updated": 0}
+
+    coerced: list[dict] = []
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise HTTPException(status_code=422, detail=f"row {i} must be an object")
+        r = dict(row)
+        ps = r.get("period_start")
+        if isinstance(ps, str):
+            try:
+                r["period_start"] = datetime.fromisoformat(ps)
+            except ValueError:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"row {i}: invalid ISO datetime for 'period_start': {ps!r}",
+                ) from None
+        if not r.get("tenant_id") or not r.get("operation"):
+            raise HTTPException(
+                status_code=422,
+                detail=f"row {i}: 'tenant_id' and 'operation' are required",
+            )
+        # ``.get`` deliberately: a row omitting the key entirely would raise
+        # KeyError here, and this loop sits OUTSIDE the try/except below — so
+        # the miss surfaced as the 500 this whole coercion block exists to
+        # prevent, instead of the intended 422.
+        if not isinstance(r.get("period_start"), datetime):
+            raise HTTPException(status_code=422, detail=f"row {i}: 'period_start' is required")
+        coerced.append(r)
+
+    try:
+        updated = await _svc.tenant_usage_increment(coerced)
+    except (TypeError, KeyError) as exc:
+        # An unexpected column name would raise from the insert construction —
+        # surface as a client 422 rather than a 500, and keep the row contents
+        # out of the message (mirrors the capability-usage endpoint).
+        raise HTTPException(
+            status_code=422,
+            detail=f"invalid tenant-usage row: {type(exc).__name__}",
+        ) from exc
+    return {"updated": updated}

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -81,6 +81,7 @@ from common.models import (
 from common.models.capability_usage import CapabilityUsage
 from common.models.organization_settings import OrganizationSettings, OrganizationSettingsAudit
 from common.models.recall_log import RecallCandidate, RecallEvent
+from common.models.tenant_usage_counter import TenantUsageCounter
 from common.organization_settings_merge import deep_merge, diff_settings
 from core_storage_api.observability import db_measure
 from core_storage_api.schemas import MEMORY_LIST_FIELDS, orm_to_dict
@@ -3315,6 +3316,50 @@ class PostgresService:
             return 0
         async with get_session() as session:
             session.add_all([CapabilityUsage(**r) for r in rows])
+        return len(rows)
+
+    async def tenant_usage_increment(self, rows: list[dict]) -> int:
+        """Atomically add to ``tenant_usage_counters``, ONE txn. Returns rows touched.
+
+        Each row is ``{tenant_id, operation, period_start, count}``. Upserts on
+        ``uq_tenant_usage_counters_key`` and ADDS to the existing count, which
+        is what makes this safe for many concurrent core-api instances metering
+        the same tenant: the addition happens in the database, not read-then-write
+        in a worker.
+
+        Cross-tenant and RLS-free by design (migration 038), like
+        ``capability_usage_insert`` above — one batch carries many tenants'
+        counters and each row names its own ``tenant_id``.
+
+        Deliberately NOT append-only: this backs plan limits, so the read has to
+        be a single row per period rather than a SUM over an unbounded history.
+        """
+        if not rows:
+            return 0
+        async with get_session() as session:
+            for r in rows:
+                stmt = pg_insert(TenantUsageCounter).values(
+                    tenant_id=r["tenant_id"],
+                    operation=r["operation"],
+                    period_start=r["period_start"],
+                    count=r.get("count", 1),
+                )
+                await session.execute(
+                    stmt.on_conflict_do_update(
+                        index_elements=[
+                            TenantUsageCounter.tenant_id,
+                            TenantUsageCounter.operation,
+                            TenantUsageCounter.period_start,
+                        ],
+                        set_={
+                            # ``+`` on the COLUMN, not on a value read earlier:
+                            # two instances incrementing the same period both
+                            # land, where a read-modify-write would lose one.
+                            "count": TenantUsageCounter.count + stmt.excluded.count,
+                            "updated_at": text("now()"),
+                        },
+                    )
+                )
         return len(rows)
 
     # ------------------------------------------------------------------

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -697,6 +697,7 @@ class TestMigrationChain:
 
     def _load(self) -> dict[str, str | None]:
         chain: dict[str, str | None] = {}
+        declared_by: dict[str, str] = {}
         versions = pathlib.Path(
             "core-storage-api/src/core_storage_api/database/migrations/versions"
         )
@@ -705,13 +706,32 @@ class TestMigrationChain:
             assert spec is not None and spec.loader is not None
             mod = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(mod)
+            # Keyed by revision, so a duplicate id would overwrite rather than
+            # fork — and every assertion below would read a chain that looks
+            # fine. Two branches numbering a migration the same is the common
+            # way this happens (it happened on #828), and alembic answers it
+            # with "Multiple head revisions are present", at deploy time.
+            assert mod.revision not in chain, (
+                f"revision {mod.revision!r} is declared twice: "
+                f"{declared_by[mod.revision]} and {f.name} — "
+                "renumber the newer one onto the current head"
+            )
             chain[mod.revision] = mod.down_revision
+            declared_by[mod.revision] = f.name
         return chain
 
     def test_single_head(self):
+        """One head, and it is the newest migration.
+
+        The expected value is pinned rather than derived, so adding a migration
+        is a deliberate edit here — that is what catches a second head created
+        by two branches both claiming the same ``down_revision``. Bump it when
+        you add one; do not compute it, or the test stops detecting the fork it
+        exists for.
+        """
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"038"}, f"Expected single head '038', got {sorted(heads)}"
+        assert heads == {"039"}, f"Expected single head '039', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -751,6 +771,8 @@ class TestMigrationChain:
         # 038: documents.created_at/updated_at NOT NULL — the columns were always
         # nullable, so a NULL row 500'd the documents read path (OSS #826)
         assert chain.get("038") == "037", "038 must follow 037"
+        # 039: tenant_usage_counters — durable per-tenant, per-period counts
+        assert chain.get("039") == "038", "039 must follow 038"
 
     def test_no_plain_set_not_null_on_large_tables(self):
         """Tightening a column to NOT NULL on a large table must not full-scan

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -1,0 +1,255 @@
+"""The storage-backed usage meter — the half that makes counters actually move.
+
+caura-ai/caura-enterprise#83. ``usage_service`` (#824) added the seam; this
+covers the implementation wired into it.
+
+What matters here is not that a counter goes up — it is the three properties
+that make buffered counting safe for billing, each pinned separately:
+
+* coalescing must not lose the **count** (a bulk write of 20 is not 1),
+* a failed flush must **return** the counts, not drop them,
+* shutdown must flush, or a clean restart silently costs an interval.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from core_api.services.usage_meter import UsageMeter, current_period_start
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def sc(monkeypatch):
+    client = AsyncMock()
+    client.increment_tenant_usage = AsyncMock(return_value=1)
+    monkeypatch.setattr(
+        "core_api.services.usage_meter.get_storage_client", lambda: client
+    )
+    return client
+
+
+def _rows(sc):
+    return sc.increment_tenant_usage.await_args.args[0]
+
+
+# ── The period key ───────────────────────────────────────────────────────────
+
+
+def test_period_start_is_the_utc_month():
+    got = current_period_start(datetime(2026, 8, 18, 14, 32, 9, tzinfo=UTC))
+    assert got == datetime(2026, 8, 1, 0, 0, 0, tzinfo=UTC)
+
+
+def test_period_start_normalises_a_non_utc_instant():
+    """A row must land in the period the caller counted in, not the one the
+    server's local clock suggests."""
+    from datetime import timedelta, timezone
+
+    # 2026-09-01 00:30 at +02:00 is still 2026-08-31 in UTC.
+    late_august = datetime(2026, 9, 1, 0, 30, tzinfo=timezone(timedelta(hours=2)))
+    assert current_period_start(late_august) == datetime(2026, 8, 1, tzinfo=UTC)
+
+
+# ── Coalescing ───────────────────────────────────────────────────────────────
+
+
+async def test_repeated_operations_become_one_row_with_the_summed_count(sc):
+    meter = UsageMeter()
+    for _ in range(5):
+        await meter.record(tenant_id="t-1", operation="write")
+    await meter.flush()
+
+    rows = _rows(sc)
+    assert len(rows) == 1
+    assert rows[0]["tenant_id"] == "t-1"
+    assert rows[0]["operation"] == "write"
+    assert rows[0]["count"] == 5
+
+
+async def test_a_bulk_count_is_carried_not_flattened(sc):
+    """A bulk write of 20 items is 20, not 1. Losing the count here would
+    under-bill by the factor that makes bulk worth having."""
+    meter = UsageMeter()
+    await meter.record(tenant_id="t-1", operation="write", count=20)
+    await meter.record(tenant_id="t-1", operation="write", count=3)
+    await meter.flush()
+
+    assert _rows(sc)[0]["count"] == 23
+
+
+async def test_tenants_and_operations_stay_separate(sc):
+    meter = UsageMeter()
+    await meter.record(tenant_id="t-1", operation="write")
+    await meter.record(tenant_id="t-1", operation="search")
+    await meter.record(tenant_id="t-2", operation="write")
+    await meter.flush()
+
+    keys = {(r["tenant_id"], r["operation"]) for r in _rows(sc)}
+    assert keys == {("t-1", "write"), ("t-1", "search"), ("t-2", "write")}
+
+
+async def test_the_buffer_is_cleared_so_counts_are_not_written_twice(sc):
+    meter = UsageMeter()
+    await meter.record(tenant_id="t-1", operation="write")
+    await meter.flush()
+    await meter.flush()
+
+    assert sc.increment_tenant_usage.await_count == 1, "second flush re-sent counts"
+
+
+async def test_an_empty_buffer_makes_no_call(sc):
+    assert await UsageMeter().flush() == 0
+    sc.increment_tenant_usage.assert_not_awaited()
+
+
+# ── Failure behaviour ────────────────────────────────────────────────────────
+
+
+async def test_a_failed_flush_returns_the_counts_to_the_buffer(sc):
+    """The upsert is additive, so re-sending is safe — and dropping is not.
+
+    A storage blip must cost latency, not billing accuracy.
+    """
+    sc.increment_tenant_usage.side_effect = RuntimeError("storage down")
+    meter = UsageMeter()
+    await meter.record(tenant_id="t-1", operation="write", count=7)
+    assert await meter.flush() == 0
+
+    sc.increment_tenant_usage.side_effect = None
+    sc.increment_tenant_usage.return_value = 1
+    await meter.flush()
+
+    assert _rows(sc)[0]["count"] == 7, "counts were dropped by the failed flush"
+
+
+async def test_counts_arriving_during_a_failed_flush_are_merged_not_lost(sc):
+    sc.increment_tenant_usage.side_effect = RuntimeError("storage down")
+    meter = UsageMeter()
+    await meter.record(tenant_id="t-1", operation="write", count=2)
+    await meter.flush()
+    await meter.record(tenant_id="t-1", operation="write", count=3)
+
+    sc.increment_tenant_usage.side_effect = None
+    await meter.flush()
+
+    assert _rows(sc)[0]["count"] == 5
+
+
+# ── Lifecycle ────────────────────────────────────────────────────────────────
+
+
+async def test_stop_flushes_what_is_buffered(sc):
+    """Without the final flush a clean shutdown silently costs up to one
+    interval of counts."""
+    meter = UsageMeter(flush_interval=3600)
+    meter.start()
+    await meter.record(tenant_id="t-1", operation="write", count=4)
+    await meter.stop()
+
+    assert _rows(sc)[0]["count"] == 4
+
+
+async def test_a_shutdown_landing_inside_a_flush_does_not_drop_the_batch(sc):
+    """``stop()`` cancels the loop, and the cancel can land in the flush's
+    network call — the one window where the restore-on-failure path is the
+    difference between billing accuracy and silence.
+
+    Regression: ``CancelledError`` is a ``BaseException``, so an
+    ``except Exception:`` restore never fired for it, and the batch — already
+    swapped out of the buffer — was gone before ``stop()``'s final flush looked.
+    """
+    in_flight = asyncio.Event()
+
+    async def hang(rows):
+        in_flight.set()
+        await asyncio.Event().wait()  # never returns; the cancel lands here
+
+    sc.increment_tenant_usage.side_effect = hang
+
+    meter = UsageMeter(flush_interval=0.01)
+    await meter.record(tenant_id="t-1", operation="write", count=9)
+    meter.start()
+    await asyncio.wait_for(in_flight.wait(), timeout=5)
+
+    sc.increment_tenant_usage.side_effect = None
+    sc.increment_tenant_usage.return_value = 1
+    await meter.stop()
+
+    assert sc.increment_tenant_usage.await_count == 2, (
+        "the cancelled batch was never re-sent — stop() found an empty buffer"
+    )
+    assert _rows(sc)[0]["count"] == 9
+
+
+async def test_a_wedged_storage_does_not_hold_shutdown_open(sc):
+    """``stop()`` runs inside core-api's shutdown chain, ahead of the event bus
+    and the storage client's own close.
+
+    The storage client waits 120s on a read — far past the grace period Cloud
+    Run gives a terminating revision — so an unbounded final flush would lose
+    these counts to SIGKILL *and* strand every step behind it. Bounded, it
+    costs only the counts.
+    """
+
+    async def hang(rows):
+        await asyncio.Event().wait()
+
+    sc.increment_tenant_usage.side_effect = hang
+
+    meter = UsageMeter(flush_interval=3600)
+    await meter.record(tenant_id="t-1", operation="write", count=6)
+    await meter.stop(timeout=0.05)  # returns rather than hanging
+
+    assert meter._counts, "the batch was dropped instead of returned to the buffer"
+
+
+async def test_the_hook_signature_matches_what_usage_service_calls(sc):
+    """``record`` is handed to ``ServiceHooks.usage_meter``, which
+    ``usage_service._meter`` invokes by keyword. A rename here would fail
+    open at runtime — silently, since the meter's errors are swallowed there."""
+    from core_api.services.hooks import ServiceHooks, configure_hooks, reset_hooks
+    from core_api.services.usage_service import check_and_increment
+
+    meter = UsageMeter()
+    configure_hooks(ServiceHooks(usage_meter=meter.record))
+    try:
+        result = await check_and_increment("t-1", "write", 3)
+        await meter.flush()
+    finally:
+        reset_hooks()
+
+    assert result.allowed is True  # metering never blocks
+    assert _rows(sc)[0] == {
+        "tenant_id": "t-1",
+        "operation": "write",
+        "period_start": current_period_start().isoformat(),
+        "count": 3,
+    }
+
+
+# ── The storage endpoint's validation ────────────────────────────────────────
+
+
+async def test_a_row_missing_period_start_is_a_422_not_a_500():
+    """Regression: the check indexed ``r["period_start"]``.
+
+    A row omitting the key raised KeyError inside the validation loop, which
+    sits OUTSIDE the try/except below it — so the miss surfaced as exactly the
+    500 the coercion block exists to prevent. Caught in review.
+    """
+    from core_storage_api.routers.tenant_usage import increment_tenant_usage
+    from fastapi import HTTPException
+
+    class _Req:
+        async def json(self):
+            return {"rows": [{"tenant_id": "t-1", "operation": "write"}]}
+
+    with pytest.raises(HTTPException) as exc:
+        await increment_tenant_usage(_Req())
+    assert exc.value.status_code == 422
+    assert "period_start" in str(exc.value.detail)


### PR DESCRIPTION
Platform half of caura-ai/caura-enterprise#83 — the half that makes counters actually move. #824 added the `ServiceHooks.usage_meter` seam; this is the implementation wired into it, plus the storage it writes to.

## Why the counts are written here, not sent to the platform

The counts must originate in core-api: no interceptor upstream can see `len(body.items)` on a bulk write, the `if auth.tenant_id:` admin skip at every metered call site, or the idempotent replay that deliberately consumes no quota. (`middleware/request_observation.py` already *is* that interceptor and still can't.)

But **core-api has no route to a platform service in any environment** — its only `PLATFORM_*` settings are LLM config, and the dependency runs the other way (`platform-admin-api` holds `CORE_API_URL`). So the meter writes through the storage client core-api already has, and the platform reads `tenant_usage_counters` directly. Both schemas live in one database, so that costs it no network hop and inverts no boundary. This is option A from the discussion on #83.

## Why a second table rather than changing `capability_usage`

That one is adoption analytics and says so: it buffers in memory, its docstring notes counts *"are lost if the process dies"*, and it appends rows to be SUMmed with no unique constraint. Right for "which capabilities get used", wrong for a plan cap — a lost flush is a customer under-billed, and an unbounded append makes every cap check a growing SUM.

`tenant_usage_counters` upserts additively: one row per `(tenant_id, operation, period_start)`, incremented with `ON CONFLICT DO UPDATE SET count = count + excluded.count`.

**Row per operation, not column per operation.** The platform's `enterprise.usage_counters` has `writes`/`searches`/`recalls` columns — which is why `insights` and `evolve`, both metered in core-api, have nowhere to go there.

## Buffered, and why that's safe for billing

The meter coalesces in a dict and flushes every 15s rather than putting a round-trip in front of every write — the same conclusion CAURA-628 reached for audit and `capability_usage` for analytics. What makes it safe here is that the flush is an **additive upsert**:

- a crash loses only the seconds buffered, rather than corrupting a total
- two instances flushing the same period both land
- a **failed flush returns the counts to the buffer** instead of dropping them
- shutdown flushes

## Verified against a real database, not just mocks

- migration applies to head on a fresh database (037 → 038)
- **50 concurrent `+1` plus one `+20` on the same key summed to exactly 70** — the read-modify-write bug this shape exists to avoid would have lost nearly all of them

## Tests

11 unit tests covering the three properties that make buffered counting safe — coalescing preserves the **count** (a bulk write of 20 is not 1), a failed flush **returns** counts, shutdown **flushes** — plus the period key (including a non-UTC instant landing in the right month) and the hook signature `usage_service` invokes by keyword.

`test_single_head` bumped 037 → 038, with a comment saying not to compute it: the pin is what catches two branches both claiming the same `down_revision`.

Full suite: **4516 passed**, 3 skipped, 1 xfailed. `ruff check` + `ruff format --check` clean across every CI scope.

## Next

Counters start moving when this deploys. Making the platform **read** them — replacing or projecting `enterprise.usage_counters` — is the remaining enterprise-side step on #83.