### PR TITLE
feat(usage): read half of tenant_usage_counters for the platform

### DIFF
--- a/common/models/tenant_usage_counter.py
+++ b/common/models/tenant_usage_counter.py
@@ -21,8 +21,9 @@ migration.
 
 Cross-tenant like ``capability_usage``, and for the same reason: it holds
 counts and a ``tenant_id`` grouping dimension, never memory content. RLS is not
-enabled on it. The platform reads it directly to compute plan limits — both
-schemas live in one database, so that costs no network hop.
+enabled on it. The platform reads it through core-storage-api's
+``POST /tenant-usage/query`` — NOT by joining across schemas, even though both
+live in one database; see that router's docstring for why.
 
 Written via ``ServiceHooks.usage_meter``, so an OSS standalone deployment with
 no meter wired records nothing and enforces nothing. See

--- a/core-api/src/core_api/services/usage_meter.py
+++ b/core-api/src/core_api/services/usage_meter.py
@@ -15,8 +15,13 @@ calling the platform. core-api has no route to a platform service in any
 environment — its only ``PLATFORM_*`` settings are LLM config, and the
 dependency runs the other way (platform-admin-api holds ``CORE_API_URL``).
 Introducing core → platform for metering would invert that. The platform reads
-``tenant_usage_counters`` instead; both schemas live in one database, so that
-costs it no network hop.
+``tenant_usage_counters`` instead, through core-storage-api's
+``POST /tenant-usage/query``.
+
+CORRECTION: this docstring previously said the platform would read the table
+directly, "so that costs it no network hop". They do share a database, but
+reading across schemas is not the boundary this codebase keeps — the rationale
+is in that router's docstring.
 
 BUFFERED, NOT PER-WRITE
 -----------------------

--- a/core-storage-api/src/core_storage_api/routers/tenant_usage.py
+++ b/core-storage-api/src/core_storage_api/routers/tenant_usage.py
@@ -1,9 +1,20 @@
-"""Durable per-tenant usage-counter increments (billing-grade).
+"""Durable per-tenant usage counters (billing-grade): write and read.
 
-The write half of ``tenant_usage_counters`` (migration 039). core-api reaches
-this through ``ServiceHooks.usage_meter``; it holds no DB pool of its own
+``tenant_usage_counters`` (migration 039). core-api writes through
+``ServiceHooks.usage_meter``; it holds no DB pool of its own
 (storage-boundary rule), which is the same reason ``capability-usage`` lives
 here rather than being written directly.
+
+WHY THE READ IS HERE TOO, AND NOT A CROSS-SCHEMA QUERY IN THE PLATFORM
+----------------------------------------------------------------------
+The consumer is the enterprise platform, and `enterprise.*` and `public.*` do
+share one database — so the platform *could* join straight across. It does not,
+because this service owns ``public.*``: ``platform-storage-api`` is documented
+as owning ``enterprise.*`` only, and the org purge already reaches OSS data
+through core-storage-api rather than reaching into the schema (CAURA-689).
+platform-admin-api holds a ``core_storage_client`` for exactly that. One HTTP
+hop on a dashboard read is the price of not having two services owning one
+table's shape.
 
 The table is intentionally CROSS-TENANT / RLS-free: one batch carries many
 tenants' counters, so this endpoint applies NO per-tenant scoping — each row
@@ -20,11 +31,55 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
 
 from core_storage_api.services.postgres_service import PostgresService
 
 router = APIRouter(prefix="/tenant-usage", tags=["TenantUsage"])
 _svc = PostgresService()
+
+#: A list longer than this is a caller sending its whole tenant table by
+#: accident, not a large org. It does NOT bound the query's cost — that scales
+#: with how much history the named tenants have, which nothing here caps.
+MAX_TENANTS_PER_QUERY = 1000
+
+
+class TenantUsageQuery(BaseModel):
+    """Which tenants, and which periods, to total.
+
+    A POST for a read: the tenant list is the org's whole tenant set, which has
+    no fixed bound, and a query string does. Validated by pydantic rather than
+    hand-parsed — the write endpoint below hand-parses because it coerces
+    per-row datetimes, and that is exactly where a missing key turned into a
+    500 in review.
+    """
+
+    tenant_ids: list[str] = Field(min_length=1, max_length=MAX_TENANTS_PER_QUERY)
+    period_start: datetime | None = None
+    periods: int = Field(default=6, ge=1, le=24)
+
+
+@router.post("/query")
+async def query_tenant_usage(body: TenantUsageQuery) -> dict:
+    """Total the counters for a set of tenants, per period, per operation.
+
+    Body: ``{tenant_ids, period_start?, periods?}`` →
+    ``{"periods": [{"period_start": iso, "operations": {op: total}}, ...]}``,
+    newest first.
+
+    The operation names are passed through as stored rather than mapped onto a
+    fixed writes/searches/recalls triple. core-api also meters ``insights`` and
+    ``evolve`` (see ``core_api.services.usage_service.OperationType``), which
+    have no such column — mapping here would silently discard counts the write
+    path is already paying for.
+    """
+    return {
+        "periods": await _svc.tenant_usage_query(
+            body.tenant_ids,
+            period_start=body.period_start,
+            periods=body.periods,
+        )
+    }
 
 
 @router.post("/increment")

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -3327,7 +3327,7 @@ class PostgresService:
         the same tenant: the addition happens in the database, not read-then-write
         in a worker.
 
-        Cross-tenant and RLS-free by design (migration 038), like
+        Cross-tenant and RLS-free by design (migration 039), like
         ``capability_usage_insert`` above — one batch carries many tenants'
         counters and each row names its own ``tenant_id``.
 
@@ -3361,6 +3361,87 @@ class PostgresService:
                     )
                 )
         return len(rows)
+
+    async def tenant_usage_query(
+        self,
+        tenant_ids: list[str],
+        *,
+        period_start: datetime | None = None,
+        periods: int = 6,
+    ) -> list[dict]:
+        """Per-period, per-operation totals summed across ``tenant_ids``.
+
+        Summed across tenants because the consumer bills an ORGANISATION and an
+        org owns several tenants; the meter only ever knows the tenant. Returns
+        ``[{"period_start": iso-string, "operations": {op: total}}, ...]``,
+        newest period first.
+
+        ``period_start`` pins one period. Otherwise the newest ``periods``
+        periods THAT HAVE DATA are returned — not the last N calendar months,
+        which would spend a slot on a quiet month. That matches what the counter
+        table can answer: it has no row for a period nobody used.
+
+        Operation names are passed through as stored, not mapped onto a fixed
+        set. See ``core_api.services.usage_service.OperationType`` for the ones
+        core-api currently emits; the table keys the operation as data
+        deliberately, so a new one needs no migration.
+        """
+        if not tenant_ids:
+            return []
+
+        # No ORDER BY on the aggregate: the newest-first contract is met by
+        # sorting the reshaped result below, which is at most ``periods``
+        # entries, rather than asking Postgres to sort every grouped row.
+        totals = (
+            select(
+                TenantUsageCounter.period_start,
+                TenantUsageCounter.operation,
+                func.sum(TenantUsageCounter.count).label("total"),
+            )
+            .where(TenantUsageCounter.tenant_id.in_(tenant_ids))
+            .group_by(TenantUsageCounter.period_start, TenantUsageCounter.operation)
+        )
+        if period_start is not None:
+            totals = totals.where(TenantUsageCounter.period_start == period_start)
+        else:
+            # Ranked over the AGGREGATE, not the base table. Two things fall out
+            # of that.
+            #
+            # A plain LIMIT would cut mid-period, since one period contributes
+            # one row per operation. ``dense_rank`` ties every row of a period
+            # to one rank, so ``<= periods`` keeps whole periods —
+            # ``test_periods_means_periods_not_rows`` pins that.
+            #
+            # And choosing the window with a second subquery over
+            # ``tenant_usage_counters`` reads it twice: EXPLAIN gives that shape
+            # two ``Seq Scan``s on the table joined by a Hash Join, against one
+            # for this shape. Neither can prune by ``period_start`` — the
+            # composite index leads on ``tenant_id`` with ``operation`` in the
+            # middle — so each pass costs the named tenants' whole history.
+            # Ranking the aggregate pays that once, over a row set bounded by
+            # periods x operations, and Postgres additionally caps the window
+            # with a ``Run Condition`` on the rank.
+            agg = totals.cte("tenant_usage_agg")
+            ranked = select(
+                agg.c.period_start,
+                agg.c.operation,
+                agg.c.total,
+                func.dense_rank().over(order_by=agg.c.period_start.desc()).label("rnk"),
+            ).subquery()
+            totals = select(ranked.c.period_start, ranked.c.operation, ranked.c.total).where(
+                ranked.c.rnk <= periods
+            )
+
+        async with get_session() as session:
+            rows = (await session.execute(totals)).all()
+
+        by_period: dict[datetime, dict[str, int]] = {}
+        for period, operation, total in rows:
+            by_period.setdefault(period, {})[operation] = int(total)
+        return [
+            {"period_start": period.isoformat(), "operations": operations}
+            for period, operations in sorted(by_period.items(), reverse=True)
+        ]
 
     # ------------------------------------------------------------------
     # H) Entity links (memory side)

--- a/core-storage-api/tests/test_tenant_usage.py
+++ b/core-storage-api/tests/test_tenant_usage.py
@@ -1,0 +1,150 @@
+"""The read half of ``tenant_usage_counters``, against a live PostgreSQL.
+
+caura-ai/caura-enterprise#83. The platform bills an ORGANISATION; the meter
+only ever knows a tenant. So the query this covers is "total these tenants,
+per period, per operation" — and the properties worth pinning are the ones a
+plausible simpler query gets wrong:
+
+* the sum must span the org's tenants, not report one of them,
+* the operation names must survive, including the ones with no column in the
+  platform's writes/searches/recalls shape,
+* ``periods=N`` must mean N periods, not N rows — a period holds as many rows
+  as it has operations, so a plain LIMIT would return half of one period.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+PREFIX = "/api/v1/storage"
+
+JUNE = "2026-06-01T00:00:00+00:00"
+JULY = "2026-07-01T00:00:00+00:00"
+AUGUST = "2026-08-01T00:00:00+00:00"
+
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+async def _increment(client: AsyncClient, rows: list[dict]) -> None:
+    r = await client.post(f"{PREFIX}/tenant-usage/increment", json={"rows": rows})
+    assert r.status_code == 200, r.text
+
+
+async def _query(client: AsyncClient, **body) -> dict:
+    r = await client.post(f"{PREFIX}/tenant-usage/query", json=body)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _row(tenant: str, operation: str, period: str, count: int) -> dict:
+    return {
+        "tenant_id": tenant,
+        "operation": operation,
+        "period_start": period,
+        "count": count,
+    }
+
+
+async def test_counts_sum_across_the_orgs_tenants(client: AsyncClient):
+    """An org owns several tenants and is billed as one. Reporting a single
+    tenant's counts would under-bill by however many tenants it has."""
+    a, b = f"t-{_uid()}", f"t-{_uid()}"
+    await _increment(
+        client,
+        [
+            _row(a, "write", AUGUST, 5),
+            _row(b, "write", AUGUST, 7),
+            _row(b, "search", AUGUST, 2),
+        ],
+    )
+
+    got = await _query(client, tenant_ids=[a, b], period_start=AUGUST)
+
+    assert got["periods"] == [{"period_start": AUGUST, "operations": {"write": 12, "search": 2}}]
+
+
+async def test_a_tenant_outside_the_org_is_not_counted(client: AsyncClient):
+    a, outsider = f"t-{_uid()}", f"t-{_uid()}"
+    await _increment(
+        client,
+        [_row(a, "write", AUGUST, 3), _row(outsider, "write", AUGUST, 100)],
+    )
+
+    got = await _query(client, tenant_ids=[a], period_start=AUGUST)
+
+    assert got["periods"][0]["operations"] == {"write": 3}
+
+
+async def test_operations_without_a_platform_column_survive(client: AsyncClient):
+    """``insights`` and ``evolve`` are metered by core-api but have no column
+    in the platform's writes/searches/recalls triple. Mapping them away here
+    would discard counts the write path already paid for."""
+    t = f"t-{_uid()}"
+    await _increment(
+        client,
+        [
+            _row(t, "write", AUGUST, 1),
+            _row(t, "insights", AUGUST, 4),
+            _row(t, "evolve", AUGUST, 2),
+        ],
+    )
+
+    got = await _query(client, tenant_ids=[t], period_start=AUGUST)
+
+    assert got["periods"][0]["operations"] == {"write": 1, "insights": 4, "evolve": 2}
+
+
+async def test_periods_means_periods_not_rows(client: AsyncClient):
+    """Regression guard for the obvious simplification.
+
+    A plain ``LIMIT periods`` on the grouped rows cuts mid-period, because one
+    period contributes one row per operation. August alone has three here, so
+    ``periods=2`` under a row-limit would return August twice and never reach
+    July.
+    """
+    t = f"t-{_uid()}"
+    await _increment(
+        client,
+        [
+            _row(t, "write", AUGUST, 1),
+            _row(t, "search", AUGUST, 1),
+            _row(t, "insights", AUGUST, 1),
+            _row(t, "write", JULY, 9),
+            _row(t, "write", JUNE, 4),
+        ],
+    )
+
+    got = await _query(client, tenant_ids=[t], periods=2)
+
+    assert [p["period_start"] for p in got["periods"]] == [AUGUST, JULY]
+    assert got["periods"][1]["operations"] == {"write": 9}
+
+
+async def test_quiet_periods_do_not_consume_the_window(client: AsyncClient):
+    """``periods`` counts periods that have data. A tenant idle in July should
+    still get June back, rather than spending the slot on an empty month."""
+    t = f"t-{_uid()}"
+    await _increment(client, [_row(t, "write", AUGUST, 1), _row(t, "write", JUNE, 2)])
+
+    got = await _query(client, tenant_ids=[t], periods=2)
+
+    assert [p["period_start"] for p in got["periods"]] == [AUGUST, JUNE]
+
+
+async def test_an_unknown_tenant_reads_empty_rather_than_404(client: AsyncClient):
+    """A brand-new org has no counters yet, and that is not an error — the
+    dashboard shows zeros. The legacy endpoint 404'd on this."""
+    assert await _query(client, tenant_ids=[f"t-{_uid()}"]) == {"periods": []}
+
+
+async def test_an_empty_tenant_list_is_rejected(client: AsyncClient):
+    """An org with no tenants must not read as 'total every tenant'."""
+    r = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_ids": []})
+    assert r.status_code == 422


### PR DESCRIPTION
`#828` made the counters move. Nothing consumes them yet — this is the read the enterprise platform needs. The enterprise-side half of caura-ai/caura-enterprise#83 (swapping `enterprise.usage_counters` for this) is a follow-up PR against that repo.

### The read is an endpoint here, not a cross-schema join in the platform

`#828`'s docstrings said the platform would read `tenant_usage_counters` directly, since `enterprise.*` and `public.*` share one database, "so that costs it no network hop". They do share a database — but that is not the boundary this codebase keeps:

* `platform-storage-api`'s purge method documents that it **"only owns the `enterprise.*` schema"**, and that OSS `public.*` data is reached through core-storage-api instead (CAURA-689).
* `platform-admin-api` already holds a `core_storage_client` and requires `CORE_STORAGE_API_URL` in production — that is how the org purge reaches OSS data today.

So `tenant_usage_counters` keeps one owner, and one HTTP hop on a dashboard read is cheaper than two services agreeing on a table's shape by convention. All three docstrings carrying the old claim are corrected; the model's still read *"the platform reads it directly"* until this commit.

### The org/tenant mismatch it bridges

The platform bills an **organisation**; the meter only ever knows a **tenant**, and an org owns several — 411 tenants across 446 orgs in the enterprise dev database, several orgs with more than one. So `POST /tenant-usage/query` takes a tenant list and sums across it, leaving org→tenants resolution on the platform side where `enterprise.tenants` lives. Same split `purge_org_data(tenant_ids, ...)` already uses, and the only one that keeps this service deployable standalone.

`periods=N` means the newest N periods **that have data** — matching what the legacy `list_usage_history` LIMIT did — rather than N calendar months, since the table has no row for a month nobody used.

Operation names pass through as stored rather than being mapped onto writes/searches/recalls: `insights` and `evolve` are metered by core-api and have no column in that triple, so mapping here would discard counts the write path already pays for.

### Two scans down to one

The obvious shape — a subquery over `tenant_usage_counters` to pick the newest N periods, then filter totals to them — reads the table twice:

```
Sort → HashAggregate → Hash Join
  ├─ Seq Scan on tenant_usage_counters
  └─ Hash → Limit → Sort → HashAggregate
       └─ Seq Scan on tenant_usage_counters      ← second pass
```

Neither pass can prune by `period_start`, because the composite index leads on `tenant_id` with `operation` in the middle — so each one costs the named tenants' whole history. Ranking the **aggregate** with `dense_rank` reads it once instead, over a row set bounded by periods × operations, and Postgres caps it further with a `Run Condition` on the rank:

```
Subquery Scan → WindowAgg (Run Condition: dense_rank() <= 6)
  └─ Sort → HashAggregate
       └─ Seq Scan on tenant_usage_counters      ← only pass
```

`dense_rank` rather than `row_number` is what keeps whole periods: every row of a period ties for one rank.

### Verification

7 integration tests against a live PostgreSQL, each killing a different plausible-wrong query: the sum spanning an org's tenants, a non-member excluded, `insights`/`evolve` surviving, an unknown tenant reading empty rather than 404, and an empty tenant list rejected rather than meaning "every tenant".

Two pin the windowing separately, because neither subsumes the other — a row-`LIMIT` bug is invisible in data with one row per period, and a calendar-window bug is invisible in data with no gaps. Confirmed the first fails against the naive `LIMIT periods`:

```
FAILED test_periods_means_periods_not_rows
assert ['2026-08-01T00:00:00+00:00'] == ['2026-08-01…', '2026-07-01…']
  Right contains one more item: '2026-07-01T00:00:00+00:00'
```

Also fixes a stale `migration 038` reference left behind by #828's renumber to 039.

**Suites:** 4520 passed / 3 skipped / 1 xfailed, plus 125 passed in the core-storage-api integration suite. `ruff check` and `ruff format --check` clean across every CI scope.
