### PR TITLE
fix(search): stop entity_lookup answering a query it cannot fill

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -1,10 +1,13 @@
 """ClassifyQuery — classify incoming query into a retrieval strategy.
 
 Examines the query tokens against the entity full-text index.  When entity
-matches are found the step short-circuits to an *entity_lookup* strategy
+matches are found the step MAY short-circuit to an *entity_lookup* strategy
 (graph-expanded, scored by hop distance) so downstream embedding and scored
-search can be skipped.  Otherwise the query is routed to keyword or semantic
-search based on the adaptive FTS weight.
+search can be skipped — but only when the linked-memory pool can fill the
+caller's ``top_k``.  That route replaces scoring rather than re-ranking it, so
+an under-filled pool falls through instead and the entity hits are applied as a
+hop boost over real scores (H-03).  Otherwise the query is routed to keyword or
+semantic search based on the adaptive FTS weight.
 """
 
 from __future__ import annotations
@@ -144,7 +147,25 @@ class ClassifyQuery:
                         slot_acquired_marker=ctx.data,
                     )
 
-                    if filtered_rows:
+                    # H-03: the short-circuit REPLACES scoring rather than
+                    # re-ranking it, so it is only defensible while the entity
+                    # pool can answer the request on its own. Below top_k it made
+                    # the result strictly worse than never matching an entity:
+                    # memories outside the link set were unreachable at ANY top_k,
+                    # and the pool is itself cut to GRAPH_MAX_BOOSTED_MEMORIES
+                    # before content loads, so the relevant memory could be
+                    # dropped before top_k was even applied.
+                    #
+                    # ``filtered_rows`` is already ``rows[:top_k]``, so this can
+                    # only ever be equality — the real gate is the pre-load pool
+                    # check in _collect_memories, and this re-checks it because
+                    # visibility filtering there can still return short. Keep the
+                    # two in step if _collect_memories ever gains an overfetch
+                    # bound, or this silently becomes always-true.
+                    #
+                    # The truthiness term is not redundant: it keeps a zero-row
+                    # pool from short-circuiting were top_k ever 0.
+                    if filtered_rows and len(filtered_rows) >= top_k:
                         plan = RetrievalPlan(
                             strategy=RetrievalStrategy.ENTITY_LOOKUP,
                             matched_entity_ids=matched_ids,
@@ -159,14 +180,56 @@ class ClassifyQuery:
                         ctx.data["filtered_rows"] = filtered_rows
                         ctx.data["retrieval_plan"] = plan
                         logger.info(
-                            "classify_query: entity_lookup (%d entities)",
+                            "classify_query: entity_lookup (%d entities, pool filled top_k=%d)",
                             len(matched_ids),
+                            top_k,
                         )
                         return None
+                    # Distinct wording from the over-broad decline logged above,
+                    # deliberately: the two have opposite downstream effects (that
+                    # one sets entity_match_declined to SUPPRESS hop-boosting, this
+                    # one must not), so ops has to be able to grep them apart. Same
+                    # reasoning as parallel_embed_entity_boost's distinct reasons.
+                    # Four reachable declines, four messages — ordered so each is
+                    # reached only in its own state. An empty result is ambiguous
+                    # on its own (never loaded vs loaded and wholly filtered), so
+                    # _collect_memories reports both the pool size and whether it
+                    # got as far as the load.
+                    pool_size = ctx.data.pop("_entity_pool_size", None)
+                    pool_loaded = ctx.data.pop("_entity_pool_loaded", False)
+                    if filtered_rows:
+                        # Pool looked adequate before the load and came back short
+                        # anyway — visibility filtering (caller_agent_id / status /
+                        # valid_at) dropped rows. This is the case the post-load
+                        # re-check exists for, so it must not be reported as the
+                        # empty one.
+                        logger.info(
+                            "classify_query: entity_lookup declined as under-filled after "
+                            "visibility filtering (%d rows < top_k=%d), falling through",
+                            len(filtered_rows),
+                            top_k,
+                        )
+                    elif pool_loaded:
+                        # Links existed and the load ran, but visibility filtering
+                        # (caller_agent_id / status / valid_at) dropped every row.
+                        # A permission or lifecycle cause, not a graph one.
+                        logger.info(
+                            "classify_query: entity_lookup declined — loaded a pool of %d "
+                            "but visibility filtering dropped every row, falling through",
+                            pool_size or 0,
+                        )
+                    elif pool_size:
+                        logger.info(
+                            "classify_query: entity_lookup declined as under-filled "
+                            "(pool %d < top_k=%d), falling through",
+                            pool_size,
+                            top_k,
+                        )
+                    else:
+                        logger.info("classify_query: entity matched but no linked memories, falling through")
                     # Preserve entity_hops so _entity_boost_pipeline can skip
                     # re-expansion on the keyword/semantic fallthrough path.
                     ctx.data["_classified_entity_hops"] = entity_hops
-                    logger.info("classify_query: entity matched but no linked memories, falling through")
             except Exception:
                 logger.warning(
                     "classify_query: entity lookup failed, falling back to search",
@@ -367,6 +430,27 @@ class ClassifyQuery:
             )[:GRAPH_MAX_BOOSTED_MEMORIES]
             memory_boost = {mid: memory_boost[mid] for mid in memory_ids_sorted}
 
+        # H-03: stop here when the pool cannot fill top_k. The caller only takes
+        # the exclusive route when it can, and the row build below can never
+        # produce more rows than ``memory_boost`` has entries — so an under-sized
+        # pool cannot pass that gate whatever the load returns. Loading anyway
+        # spent a per-tenant storage permit and pulled full rows (embedding and
+        # tsvector included) for a result the caller discards, and worse, left
+        # ``_storage_slot_acquired`` set so the scored search that does run
+        # skipped the bulkhead. Reporting the pool size lets the caller say why
+        # it declined, since ``[]`` alone cannot distinguish "under-filled" from
+        # "no linked memories at all" (the ``not memory_boost`` return above).
+        #
+        # One-directional on purpose. The converse is NOT decidable here: the
+        # load applies visibility filters (caller_agent_id / status / valid_at)
+        # and rows whose memory did not come back are dropped, so a pool that
+        # looks adequate can still return short. That is why the caller re-checks
+        # after the load rather than trusting this count.
+        if len(memory_boost) < top_k:
+            if slot_acquired_marker is not None:
+                slot_acquired_marker["_entity_pool_size"] = len(memory_boost)
+            return []
+
         # CAURA-687: load memories by ID via the dedicated short-circuit
         # endpoint. Pre-CAURA-687 this POSTed to /memories/scored-search
         # with a ``memory_ids`` key + ``entity_lookup: True`` flag that
@@ -408,6 +492,14 @@ class ClassifyQuery:
         # logical search. Same key as scored-search, intentional —
         # the bucket counts request-level storage pressure, not
         # call-level.
+        # Record that the load ran, and against what size of pool. Without this
+        # the caller cannot tell "no links at all" from "links existed, the load
+        # ran, and visibility filtering dropped every row" — both arrive as an
+        # empty list, and reporting the second as the first would send on-call
+        # looking for a graph problem when the cause is a permission filter.
+        if slot_acquired_marker is not None:
+            slot_acquired_marker["_entity_pool_size"] = len(memory_boost)
+            slot_acquired_marker["_entity_pool_loaded"] = True
         async with per_tenant_storage_slot("storage_search", tenant_id):
             memories = await sc.load_memories_by_ids(search_data)
         if slot_acquired_marker is not None:

--- a/tests/pipeline/test_classify_query.py
+++ b/tests/pipeline/test_classify_query.py
@@ -32,8 +32,15 @@ _DEFAULT_SEARCH_PARAMS = {
 }
 
 
-def _make_ctx(query: str, *, fts_weight: float = 0.3, **extra_data) -> PipelineContext:
+def _make_ctx(
+    query: str, *, fts_weight: float = 0.3, top_k: int | None = None, **extra_data
+) -> PipelineContext:
+    # top_k is a seam because H-03 gated the ENTITY_LOOKUP short-circuit on the
+    # entity pool being able to fill it: a test that wants the short-circuit to
+    # fire has to ask for no more rows than its fixture links.
     sp = {**_DEFAULT_SEARCH_PARAMS, "fts_weight": fts_weight}
+    if top_k is not None:
+        sp["top_k"] = top_k
     data = {
         "query": query,
         "tenant_id": "t1",
@@ -101,7 +108,7 @@ async def test_keyword_for_specific_query(mock_get_sc):
 @patch("core_api.pipeline.steps.search.classify_query.get_storage_client")
 async def test_entity_lookup_with_match(mock_get_sc):
     """Entity match triggers ENTITY_LOOKUP with skip flags and populated filtered_rows."""
-    ctx = _make_ctx("Alice")
+    ctx = _make_ctx("Alice", top_k=1)
 
     entity_id = uuid.uuid4()
     memory_id = uuid.uuid4()
@@ -312,7 +319,7 @@ async def test_entity_lookup_takes_priority_over_temporal(mock_get_sc):
     )
     mock_get_sc.return_value = sc
 
-    ctx = _make_ctx("Alice", temporal_window=timedelta(days=7))
+    ctx = _make_ctx("Alice", temporal_window=timedelta(days=7), top_k=1)
 
     step = ClassifyQuery()
     await step.execute(ctx)
@@ -416,7 +423,7 @@ async def test_entity_lookup_takes_priority_over_recent(mock_get_sc):
     )
     mock_get_sc.return_value = sc
 
-    ctx = _make_ctx("what was I doing with Alice")
+    ctx = _make_ctx("what was I doing with Alice", top_k=1)
 
     step = ClassifyQuery()
     await step.execute(ctx)

--- a/tests/test_c10_storage_slot_dedup.py
+++ b/tests/test_c10_storage_slot_dedup.py
@@ -120,14 +120,25 @@ class _recording_slots:
 
 
 def _make_classify_ctx(
-    query: str, *, tenant_id: str = "t1", **extra
+    query: str, *, tenant_id: str = "t1", top_k: int | None = None, **extra
 ) -> PipelineContext:
-    """Build a PipelineContext with the keys ClassifyQuery reads."""
+    """Build a PipelineContext with the keys ClassifyQuery reads.
+
+    ``top_k`` is a seam because H-03 made _collect_memories bail BEFORE the
+    load when the linked-memory pool cannot fill it. ``_entity_match_sc``
+    links exactly one memory, so tests here that need the load to actually
+    happen — every test about the storage-slot sentinel does — must ask for
+    one row. Otherwise no load runs, no slot is taken, and the sentinel these
+    tests exist to police is never set.
+    """
+    search_params = dict(_DEFAULT_SEARCH_PARAMS_FULL)
+    if top_k is not None:
+        search_params["top_k"] = top_k
     data: dict[str, Any] = {
         "query": query,
         "tenant_id": tenant_id,
         "fleet_ids": ["fleet-1"],
-        "search_params": dict(_DEFAULT_SEARCH_PARAMS_FULL),
+        "search_params": search_params,
         **extra,
     }
     return PipelineContext(data=data)
@@ -233,7 +244,7 @@ async def test_entity_lookup_success_classify_acquires_once_execute_skips():
             }
         ],
     )
-    ctx = _make_classify_ctx("Alice")
+    ctx = _make_classify_ctx("Alice", top_k=1)
 
     with _shared_storage_client(sc), _recording_slots() as acquisitions:
         await ClassifyQuery().execute(ctx)
@@ -269,7 +280,7 @@ async def test_entity_lookup_fallthrough_execute_skips_slot_but_calls_scored_sea
     # the sentinel, then returns [] → classify falls through past the
     # ENTITY_LOOKUP plan-emission.
     sc = _entity_match_sc(eid=eid, mid=mid, memories=[])
-    ctx = _make_classify_ctx("Alice")
+    ctx = _make_classify_ctx("Alice", top_k=1)
 
     with _shared_storage_client(sc), _recording_slots() as acquisitions:
         await ClassifyQuery().execute(ctx)
@@ -333,7 +344,7 @@ async def test_sentinel_only_suppresses_slot_not_scored_search_call():
     eid = str(uuid.uuid4())
     mid = str(uuid.uuid4())
     sc = _entity_match_sc(eid=eid, mid=mid, memories=[])
-    ctx = _make_classify_ctx("Alice")
+    ctx = _make_classify_ctx("Alice", top_k=1)
 
     with _shared_storage_client(sc), _recording_slots() as acquisitions:
         await ClassifyQuery().execute(ctx)
@@ -366,7 +377,7 @@ async def test_sentinel_does_not_leak_across_requests():
     eid = str(uuid.uuid4())
     mid = str(uuid.uuid4())
     sc_first = _entity_match_sc(eid=eid, mid=mid, memories=[])
-    ctx_a = _make_classify_ctx("Alice")
+    ctx_a = _make_classify_ctx("Alice", top_k=1)
 
     with _shared_storage_client(sc_first) as _sc, _recording_slots() as acquisitions:
         await ClassifyQuery().execute(ctx_a)
@@ -404,7 +415,7 @@ async def test_load_failure_does_not_mark_sentinel():
     mid = str(uuid.uuid4())
     boom = RuntimeError("storage exploded")
     sc = _entity_match_sc(eid=eid, mid=mid, memories=None, raise_on_load=boom)
-    ctx = _make_classify_ctx("Alice")
+    ctx = _make_classify_ctx("Alice", top_k=1)
 
     with _shared_storage_client(sc), _recording_slots() as acquisitions:
         # Classify's outer try/except may catch the exception and fall through.

--- a/tests/test_entity_lookup_short_circuit.py
+++ b/tests/test_entity_lookup_short_circuit.py
@@ -18,6 +18,12 @@ selects the ENTITY_LOOKUP strategy end-to-end. ``scored_search`` is
 mocked to return memory rows directly, isolating this test from the
 separate ``_collect_memories`` payload-contract bug (omitted
 ``embedding``/``query``/``search_params``) that is tracked as a follow-up.
+
+H-03 gated the short-circuit on the entity pool being able to fill ``top_k``.
+Fixtures below that link a single memory therefore ask for ``top_k`` 1, so the
+exclusive route stays legitimate and each test keeps testing its own subject
+rather than pool sizing.  The pool-adequacy rule itself is covered by the
+dedicated tests at the end of this file.
 """
 
 from __future__ import annotations
@@ -88,7 +94,11 @@ async def test_entity_lookup_short_circuit_fires_with_dict_shaped_expand_graph()
         "search_params": {
             "fts_weight": 0.3,
             "graph_max_hops": 2,
-            "top_k": 5,
+            # H-03: the short-circuit now requires the entity pool to satisfy the
+            # request. This fixture links one memory, so top_k=1 is what makes the
+            # exclusive route legitimate here; the subject of the test is still the
+            # dict-shaped expand_graph parse.
+            "top_k": 1,
         },
         "temporal_window": None,
     }
@@ -197,7 +207,7 @@ async def test_collect_memories_forwards_valid_at_and_readable_tenant_ids():
     ctx.data = {
         "query": "central control",
         "tenant_id": "home-tenant",
-        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 5},
+        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 1},
         "temporal_window": None,
         "valid_at": valid_at_dt,
         "readable_tenant_ids": ["home-tenant", "source-tenant-a"],
@@ -273,7 +283,7 @@ async def test_collect_memories_omits_readable_tenant_ids_when_single_tenant():
     ctx.data = {
         "query": "central control",
         "tenant_id": "home-tenant",
-        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 5},
+        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 1},
         "temporal_window": None,
         # Single-tenant: readable_tenant_ids unset OR equals [tenant_id]
         "readable_tenant_ids": ["home-tenant"],
@@ -342,7 +352,7 @@ async def test_collect_memories_forwards_single_element_when_different_from_home
     ctx.data = {
         "query": "central control",
         "tenant_id": "home-tenant",
-        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 5},
+        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 1},
         "temporal_window": None,
         # Single element, but NOT the home tenant — must still be forwarded.
         "readable_tenant_ids": ["source-tenant"],
@@ -416,7 +426,7 @@ async def test_entity_lookup_fires_when_match_count_at_threshold():
     ctx.data = {
         "query": "ZenithCorp",
         "tenant_id": "t1",
-        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 5},
+        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": 1},
         "temporal_window": None,
     }
 
@@ -594,3 +604,217 @@ async def test_collect_memories_cap_prefers_multi_matched_entity_gold_over_hub_s
         "A30 regression: the multi-matched-entity gold was dropped by the "
         "fan-out cap — match-count must rank ahead of near-uniform hop-boost."
     )
+
+
+# ── H-03: the short-circuit must not replace scoring it cannot substitute for ──
+
+
+def _entity_fixture(
+    entity_id, memory_ids: list[str], *, loaded_ids: list[str] | None = None
+) -> AsyncMock:
+    """Storage double: one matched entity linking ``memory_ids``.
+
+    ``loaded_ids`` defaults to all of them. Pass a shorter list to model
+    storage's visibility filtering (caller_agent_id / status / valid_at) dropping
+    rows the link table still points at — that is how a pool can look adequate
+    before the load and come back short after it.
+    """
+    fake_storage = AsyncMock()
+    fake_storage.fts_search_entities = AsyncMock(return_value=[str(entity_id)])
+    fake_storage.expand_graph = AsyncMock(
+        return_value={str(entity_id): {"hop": 0, "weight": 1.0}}
+    )
+    fake_storage.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[
+            {"memory_id": mid, "entity_id": str(entity_id), "role": "subject"}
+            for mid in memory_ids
+        ]
+    )
+    fake_storage.load_memories_by_ids = AsyncMock(
+        return_value=[
+            {
+                "id": mid,
+                "tenant_id": "tenant-test",
+                "content": f"linked memory {i}",
+                "memory_type": "task",
+                "weight": 0.5,
+                "status": "active",
+                "ts_valid_start": None,
+                "ts_valid_end": None,
+                "metadata_": {},
+                "fleet_id": None,
+            }
+            for i, mid in enumerate(memory_ids if loaded_ids is None else loaded_ids)
+        ]
+    )
+    return fake_storage
+
+
+async def _classify(fake_storage, top_k: int):
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.search.classify_query import ClassifyQuery
+
+    ctx = PipelineContext()
+    ctx.data = {
+        "query": "central control heartbeat",
+        "tenant_id": "tenant-test",
+        "search_params": {"fts_weight": 0.3, "graph_max_hops": 2, "top_k": top_k},
+        "temporal_window": None,
+    }
+    with patch(
+        "core_api.pipeline.steps.search.classify_query.get_storage_client",
+        return_value=fake_storage,
+    ):
+        await ClassifyQuery().execute(ctx)
+    return ctx
+
+
+async def test_under_filled_entity_pool_falls_through_to_scored_search():
+    """H-03, the production symptom: 3 linked memories answered top_k=20 with 3
+    rows, every similarity None, and nothing outside the link set reachable at
+    any top_k.
+
+    The short-circuit does not re-rank, it REPLACES scoring — so when the pool
+    cannot fill the request it must not take the exclusive route.
+    """
+    from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
+
+    eid = uuid4()
+    sc = _entity_fixture(eid, [str(uuid4()) for _ in range(3)])
+    ctx = await _classify(sc, top_k=20)
+
+    plan = ctx.data["retrieval_plan"]
+    assert plan.strategy != RetrievalStrategy.ENTITY_LOOKUP, (
+        "a 3-memory pool must not be allowed to answer top_k=20 exclusively"
+    )
+    assert plan.skip_scored_search is not True, "scored search has to actually run"
+    assert not ctx.data.get("filtered_rows"), (
+        "falling through must leave row selection to the scored pipeline"
+    )
+    # And it must not pay for rows it throws away. Pool size is knowable from the
+    # link query alone, so the content load — which pulls full rows including the
+    # embedding, and holds one of only four per-tenant storage permits — is
+    # skipped. It also must not set _storage_slot_acquired, or the scored search
+    # that DOES run would slip past the bulkhead unmetered.
+    sc.load_memories_by_ids.assert_not_awaited()
+    assert ctx.data.get("_storage_slot_acquired") is not True
+    # The marker the decline log reads is consumed, not left for the next step.
+    assert "_entity_pool_size" not in ctx.data
+
+
+async def test_falling_through_on_under_fill_keeps_the_entity_signal_as_a_boost():
+    """Falling through must not throw the entity match away.
+
+    The hops are handed to ParallelEmbedAndEntityBoost, which boosts those
+    memories over real scores — the merge this strategy should always have been.
+    Distinct from the >20 over-broad decline, which deliberately sets
+    ``entity_match_declined`` to SUPPRESS boosting because an arbitrary-50
+    lottery buries better-scoring rows. Here the match is narrow and useful, so
+    that flag must stay unset or the fall-through would be a downgrade.
+    """
+    eid = uuid4()
+    ctx = await _classify(_entity_fixture(eid, [str(uuid4()), str(uuid4())]), top_k=10)
+
+    assert ctx.data.get("_classified_entity_hops"), (
+        "entity hops must be preserved so the boost step need not re-expand"
+    )
+    assert eid in ctx.data["_classified_entity_hops"]
+    assert not ctx.data.get("entity_match_declined"), (
+        "under-fill is not the over-broad decline — boosting must stay enabled"
+    )
+
+
+async def test_an_adequate_entity_pool_still_short_circuits():
+    """The strategy is gated, not removed: a pool that can fill the request
+    keeps the exclusive route, which is what makes entity lookup cheap."""
+    from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
+
+    eid = uuid4()
+    memory_ids = [str(uuid4()) for _ in range(5)]
+    ctx = await _classify(_entity_fixture(eid, memory_ids), top_k=5)
+
+    plan = ctx.data["retrieval_plan"]
+    assert plan.strategy == RetrievalStrategy.ENTITY_LOOKUP
+    assert plan.skip_scored_search is True
+    assert len(ctx.data["filtered_rows"]) == 5
+
+
+async def test_post_load_shortfall_declines_and_says_why(caplog) -> None:
+    """The case the post-load re-check exists for, and the reason it cannot be
+    folded into the pre-load one.
+
+    The link table points at 5 memories, so the pre-load pool looks adequate for
+    top_k=5 and the load runs. Storage then returns only 2 — visibility filtering
+    dropped the rest — so the request still cannot be answered exclusively. It
+    must decline, and it must not report itself as the empty case: there ARE
+    linked memories, just too few, and on-call reads these lines.
+    """
+    import logging
+
+    from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
+
+    caplog.set_level(logging.INFO, logger="core_api.pipeline.steps.search.classify_query")
+    eid = uuid4()
+    linked = [str(uuid4()) for _ in range(5)]
+    sc = _entity_fixture(eid, linked, loaded_ids=linked[:2])
+
+    ctx = await _classify(sc, top_k=5)
+
+    # The load DID run — this is not the pre-load exit.
+    sc.load_memories_by_ids.assert_awaited_once()
+    assert ctx.data["retrieval_plan"].strategy != RetrievalStrategy.ENTITY_LOOKUP
+    assert not ctx.data.get("filtered_rows")
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("after visibility filtering" in m for m in messages), messages
+    assert not any("no linked memories" in m for m in messages), (
+        "two rows came back — reporting this as the empty case misleads on-call"
+    )
+
+
+async def test_a_wholly_filtered_pool_is_not_reported_as_no_links(caplog) -> None:
+    """The fourth decline state: links existed, the load ran, and visibility
+    filtering dropped EVERY row.
+
+    An empty result is ambiguous on its own — it is also what "no linked memories
+    at all" produces — so this used to log the graph-shaped message for a
+    permission-shaped cause, sending on-call after the wrong thing.
+    """
+    import logging
+
+    from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
+
+    caplog.set_level(logging.INFO, logger="core_api.pipeline.steps.search.classify_query")
+    eid = uuid4()
+    linked = [str(uuid4()) for _ in range(5)]
+    sc = _entity_fixture(eid, linked, loaded_ids=[])  # storage admitted nothing
+
+    ctx = await _classify(sc, top_k=5)
+
+    # The load must have run — otherwise this would be the pre-load exit and the
+    # test would pass for the wrong reason.
+    sc.load_memories_by_ids.assert_awaited_once()
+    assert ctx.data["retrieval_plan"].strategy != RetrievalStrategy.ENTITY_LOOKUP
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("dropped every row" in m for m in messages), messages
+    assert any("pool of 5" in m for m in messages), messages
+    assert not any("no linked memories" in m for m in messages), (
+        "five links existed — this is a visibility-filter cause, not a graph one"
+    )
+
+
+async def test_the_genuinely_empty_case_still_says_no_linked_memories(caplog) -> None:
+    """And the message it was borrowing must still be reachable, or the fix would
+    just have moved the inaccuracy."""
+    import logging
+
+    caplog.set_level(logging.INFO, logger="core_api.pipeline.steps.search.classify_query")
+    eid = uuid4()
+    sc = _entity_fixture(eid, [])  # entity matched, links none
+
+    await _classify(sc, top_k=5)
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("no linked memories" in m for m in messages), messages
+    sc.load_memories_by_ids.assert_not_awaited()

--- a/tests/test_entity_retrieval_flag.py
+++ b/tests/test_entity_retrieval_flag.py
@@ -59,6 +59,10 @@ _CLASSIFY_LOGGER = "core_api.pipeline.steps.search.classify_query"
 
 _DUMMY_EMBED = [0.1] * 1536
 
+#: Shared by the ctx builder and the entity fixture — the short-circuit only
+#: fires when the pool can fill top_k, so the two must move together.
+_TOP_K = 10
+
 # A query whose tokens WOULD hit the entity index — every classify test below
 # uses it so a passing assertion means the flag suppressed entity retrieval,
 # not that the tokenizer found nothing to look up.
@@ -70,7 +74,7 @@ def _classify_ctx(*, fts_weight: float = 0.3, **extra) -> PipelineContext:
         "query": _ENTITY_QUERY,
         "tenant_id": "t1",
         "fleet_ids": ["fleet-1"],
-        "search_params": {"graph_max_hops": 2, "top_k": 10, "fts_weight": fts_weight},
+        "search_params": {"graph_max_hops": 2, "top_k": _TOP_K, "fts_weight": fts_weight},
         **extra,
     }
     return PipelineContext(data=data)
@@ -91,22 +95,32 @@ def _boost_ctx(extra: dict | None = None) -> PipelineContext:
 
 
 def _entity_match_sc() -> AsyncMock:
-    """Storage client whose entity index WOULD short-circuit to ENTITY_LOOKUP."""
-    eid, mid = str(uuid4()), str(uuid4())
+    """Storage client whose entity index WOULD short-circuit to ENTITY_LOOKUP.
+
+    Links ``top_k`` memories on purpose: H-03 gated the short-circuit on the
+    entity pool being able to fill the request, so a one-memory fixture would no
+    longer take the exclusive route and these tests would stop exercising the
+    flag they exist to test.
+    """
+    eid = str(uuid4())
+    mids = [str(uuid4()) for _ in range(_TOP_K)]
     sc = AsyncMock()
     sc.fts_search_entities = AsyncMock(return_value=[eid])
     sc.expand_graph = AsyncMock(return_value={eid: {"hop": 0, "weight": 1.0}})
     sc.get_memory_ids_by_entity_ids = AsyncMock(
-        return_value=[{"memory_id": mid, "entity_id": eid, "role": "subject"}]
+        return_value=[
+            {"memory_id": mid, "entity_id": eid, "role": "subject"} for mid in mids
+        ]
     )
     sc.load_memories_by_ids = AsyncMock(
         return_value=[
             {
                 "id": mid,
                 "tenant_id": "t1",
-                "content": "Comet 0002 launch_date is 2026-01-01",
+                "content": f"Comet {i:04d} launch_date is 2026-01-01",
                 "memory_type": "fact",
             }
+            for i, mid in enumerate(mids)
         ]
     )
     return sc


### PR DESCRIPTION
Fixes the H-03 recall bug from the 2026-08-14 audit — the one already observed in production. Premise re-verified on `main` before changing anything; the search pipeline had not moved since the issue was filed.

## The bug

`ClassifyQuery` short-circuited to `ENTITY_LOOKUP` whenever entity FTS matched 1..20 entities **and** graph expansion linked at least *one* memory. That plan sets `skip_embedding` + `skip_scored_search`, so `ExecuteScoredSearch` and `RerankResults` SKIP outright and `PostFilterResults` skips on the strategy name — no vector score, no FTS rank, no freshness, no `min_similarity`.

The short-circuit doesn't re-rank, it **replaces** scoring. On "at least one row" that produced exactly the three reported symptoms: `top_k` under-fill (3 linked memories answering `top_k=20` with 3 rows), `similarity=None` on every row, and memories unreachable at *any* `top_k` — the pool is cut to `GRAPH_MAX_BOOSTED_MEMORIES` before content loads, so the relevant memory could be dropped before `top_k` was even applied.

Note the perverse shape: the existing `>20` guard declines when the match is **broad**, so small loose matches hijacked the query while broad ones fell through to the real scorer.

## The fix

The short-circuit now requires the entity pool to fill the caller's `top_k`. Below that, the query falls through to the scored cascade and the entity signal survives as a boost — the hops go to `ParallelEmbedAndEntityBoost`, which applies them over real scores. Entity-linked memories still rank high, now alongside everything else and with a readable similarity.

Two things deliberately **not** done:

- **Not tightened at the FTS layer.** The any-token OR is a prior fix (A7) that stops `Helios telescope` hiding `Helios Robotics`. The bug is the exclusivity, not the recall.
- **Not the two larger alternatives** the issue floats. Retiring the exclusive route entirely, and gating on match *precision*, both stay open — the precision gate needs `fts_search_entities` to return names or rank instead of bare UUIDs, i.e. a core-storage-api contract change.

## The part that would not have been free

Gating only *after* the load would have made the newly-common path pay for rows it discards: a full `load_memories_by_ids` (rows carry the 1536-dim embedding and the tsvector), one of only four per-tenant storage permits, and — worst — `_storage_slot_acquired` left set, so the scored search that *does* run would have slipped past the CAURA-602 bulkhead unmetered. The bulkhead would have been protecting the call that didn't matter and not the one that did.

So `_collect_memories` bails before the load when the pool cannot fill `top_k`. Sound one-directionally: the row build can never yield more rows than `memory_boost` has entries. The converse isn't decidable there — the load applies visibility filters and drops rows whose memory didn't come back — so the post-load check stays as a second gate for a pool that looked adequate and returned short. That second case is the "matched but produced no filtered rows" fall-through the C10 comment already describes, and the pre-load exit is what keeps it rare, as that comment claims.

## Tests

Three new cases: the production symptom (and that the load is *not* issued for it), boost survival, and an adequate pool still taking the exclusive route.

Boost survival is the subtle one. The `>20` over-broad decline deliberately sets `entity_match_declined` to **suppress** hop-boosting, because N ≫ `GRAPH_MAX_BOOSTED_MEMORIES` siblings at hop 0 degenerate into an arbitrary-50 lottery. This new under-fill decline must **not** set it, or falling through would be a downgrade rather than a fix. The two declines log distinct phrases so ops can grep them apart.

Existing fixtures were updated rather than relaxed: several paired a one-memory pool with `top_k` 5 or 10 — precisely the buggy shape. Each now asks for what its fixture links, via a `top_k` seam on the ctx builders, so every test keeps its own subject (dict-shaped `expand_graph`, payload forwarding, the `>20` boundary, slot accounting, the org flag) instead of asserting the bug. Two notes: the `top_k` bump in the `>20` decline test was a no-op — that path clears `matched_ids` before `_collect_memories` runs, as the test's own `assert_not_awaited` proves — and is reverted; and the c10 sentinel tests need the load to actually happen, so they ask for one row rather than ten.

Verified by reverting: dropping the pre-load exit alone fails the "load must not be awaited" assertion while the strategy assertion still passes (the layering working); dropping both fails the strategy and boost assertions.

## Checks

4553 passed, 3 skipped, 1 xfailed. `ruff check` and `ruff format --check` clean on `core-api/src/`. No storage-side change, so the storage suite is untouched. Rebased onto current `main` (`2cc741ee`, which brought CAURA-717) and the suite re-run after.

## Follow-ups this surfaced, not in scope here

- `get_memory_ids_by_entity_ids` is issued twice per fall-through — once in `ClassifyQuery`, again in `_entity_boost_via_storage`. `precomputed_hops` already suppresses the FTS and `expand_graph` re-runs; extending that channel to carry the links would close it.
- `_expand_per_fleet` returns `{}` when every `expand_graph` call fails, and `{} is not None`, so the boost step takes the precomputed branch and silently applies no boost. Pre-existing, but it is the mechanism this fix leans on.
- `RerankResults` reads `r.similarity` by direct attribute access and `PostFilterResults` reads `ctx.data["raw_rows"]`, neither of which the entity path populates — so those skip guards are crash guards, not just cost guards. Worth declaring a candidate-row type before anyone attempts the full merge.

Refs #813
