### PR TITLE
fix(forge): give the cron's poison checker the shape the distill seam calls

### DIFF
--- a/core-api/src/core_api/services/forge/cron_handler.py
+++ b/core-api/src/core_api/services/forge/cron_handler.py
@@ -125,12 +125,26 @@ def _make_memory_fetcher(tenant_id: str):
     return _fetch
 
 
-def _make_poison_checker():
+def _make_poison_checker(tenant_id: str, fleet_id: str | None):
     """Adapt :func:`is_fingerprint_poisoned` (storage-backed) to the
-    ``(tenant, fleet, fp) → bool`` shape the gate evaluator expects.
+    ``PoisonChecker`` seam ``run_forge_distill`` actually calls:
+    ``(fingerprint) → bool``, with the tenant and fleet closed over.
+
+    H-08: this used to take ``(tenant_id, fleet_id, fingerprint)`` — the shape
+    ``evaluate_auto_gates`` wants — while its only caller feeds
+    ``run_forge_distill``, which invokes ``await poison_checker(fingerprint.fp)``
+    with one argument. Every cluster therefore raised ``TypeError`` after the LLM
+    distill call, ``run_forge_distill``'s broad ``except Exception`` counted it as
+    ``skipped_io_error``, and the tick reported success having written nothing.
+
+    The gate-evaluator shape was never needed here: ``promote_pending_candidates``
+    is handed :func:`make_db_poison_checker` (skill_promoter), which is the
+    three-arg wrapper for that path. Closing over the identifiers instead mirrors
+    ``scripts/forge_dry_run.py``'s ``_wire_poison_checker``, which is why the
+    dry-run CLI was never affected.
     """
 
-    async def _check(tenant_id: str, fleet_id: str | None, fingerprint: str) -> bool:
+    async def _check(fingerprint: str) -> bool:
         return await is_fingerprint_poisoned(
             tenant_id=tenant_id,
             fleet_id=fleet_id,
@@ -239,7 +253,7 @@ async def run_forge_cron_tick(
 
     llm_fn = await _wire_llm_fn()
     memory_fetcher = _make_memory_fetcher(tenant_id)
-    poison_checker = _make_poison_checker()
+    poison_checker = _make_poison_checker(tenant_id, fleet_id)
     candidate_writer = _make_candidate_writer()
     status_checker = _make_status_checker()
 

--- a/tests/test_forge_cron_tick.py
+++ b/tests/test_forge_cron_tick.py
@@ -376,3 +376,132 @@ class TestRunForgeCronTick:
                 # Replace common with a stub missing ``llm``.
                 with patch.dict(sys.modules, {"common.llm": None}):
                     await _wire_llm_fn()
+
+
+# ── H-08: the injected callables must match the seams that call them ──
+
+
+@pytest.mark.unit
+class TestInjectedCallableArity:
+    """The cron adapter's whole job is wiring, and a shape mismatch here is
+    invisible to every other suite.
+
+    ``run_forge_distill`` swallows exceptions from ``_distill_cluster`` into
+    ``skipped_io_error`` so one bad cluster cannot abort a tick. That also means a
+    ``TypeError`` from a wrongly-shaped injectable looks exactly like a storage
+    hiccup: the tick returns success with zero candidates written. H-08 was that
+    bug — the poison checker took ``(tenant, fleet, fp)`` while
+    ``_distill_cluster`` calls ``await poison_checker(fingerprint.fp)`` — and it
+    survived because the test above stubs ``run_forge_distill``, so nothing ever
+    called what the cron handed it.
+
+    These tests call the injectables through the same seam the service does.
+    """
+
+    @pytest.mark.asyncio
+    async def test_make_poison_checker_takes_only_a_fingerprint(self):
+        """The ``PoisonChecker`` seam is ``Callable[[str], Awaitable[bool]]``."""
+        from core_api.services.forge.cron_handler import _make_poison_checker
+
+        checker = _make_poison_checker("t1", "fleet-a")
+
+        with patch(
+            "core_api.services.forge.cron_handler.is_fingerprint_poisoned",
+            new=AsyncMock(return_value=True),
+        ) as is_poisoned:
+            # Exactly how forge_service._distill_cluster invokes it.
+            assert await checker("fp-abc123") is True
+
+        # The identifiers must survive being closed over, or the check would
+        # silently consult the wrong tenant's cooloff rows.
+        is_poisoned.assert_awaited_once_with(
+            tenant_id="t1", fleet_id="fleet-a", cluster_fingerprint="fp-abc123"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cron_hands_run_forge_distill_a_checker_it_can_actually_call(self):
+        """The regression guard for H-08.
+
+        Captures the callable the cron passes and invokes it the way the service
+        does. Pre-fix this raised ``TypeError: _check() missing 2 required
+        positional arguments``, which the service would have buried in
+        ``skipped_io_error``.
+        """
+        from core_api.services.forge.cron_handler import run_forge_cron_tick
+
+        fake_forge_result = ForgeRunResult(
+            tenant_id="t1",
+            fleet_id=None,
+            window_start=None,
+            window_end=None,
+            total_traces=0,
+            labeled_traces=0,
+            clusters_total=0,
+            clusters_eligible=0,
+            candidates_written=0,
+            candidates_skipped_poisoned=0,
+            candidates_skipped_sentinel=0,
+            candidates_skipped_distill_error=0,
+            candidates_skipped_io_error=0,
+            candidates_skipped_existing=0,
+            started_at=None,
+            run_label="forge-cron-t1-20260819T1200",
+            candidate_doc_ids=[],
+        )
+        fake_promote_result = PromoterRunResult(
+            tenant_id="t1", fleet_id=None, scanned=0, promoted=0, held=0, auto_approved=0
+        )
+
+        with (
+            patch(
+                "core_api.services.forge.cron_handler.get_settings_for_display",
+                new=AsyncMock(return_value={"skills_factory": {"forge": {}}}),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler._wire_llm_fn",
+                new=AsyncMock(return_value=AsyncMock()),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler._make_candidate_writer",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler._make_status_checker",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler.run_forge_distill",
+                new=AsyncMock(return_value=fake_forge_result),
+            ) as run_forge,
+            patch(
+                "core_api.services.forge.cron_handler.promote_pending_candidates",
+                new=AsyncMock(return_value=fake_promote_result),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler.make_db_poison_checker",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler.make_db_live_data_fetcher",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "core_api.services.forge.cron_handler.make_db_status_updater",
+                return_value=AsyncMock(),
+            ),
+        ):
+            await run_forge_cron_tick(
+                tenant_id="t1", fleet_id=None, run_label="forge-cron-t1-20260819T1200"
+            )
+
+            injected = run_forge.await_args.kwargs["poison_checker"]
+
+            with patch(
+                "core_api.services.forge.cron_handler.is_fingerprint_poisoned",
+                new=AsyncMock(return_value=False),
+            ) as is_poisoned:
+                assert await injected("fp-from-the-seam") is False
+
+        is_poisoned.assert_awaited_once_with(
+            tenant_id="t1", fleet_id=None, cluster_fingerprint="fp-from-the-seam"
+        )


### PR DESCRIPTION
Fixes H-08 (#818): a total, silent outage of the production Forge mining path. Premise re-verified on `main` at `2cc741ee` before changing anything.

## The bug

`run_forge_distill` declares `PoisonChecker = Callable[[str], Awaitable[bool]]` and `_distill_cluster` calls `await poison_checker(fingerprint.fp)` — **one** argument. The cron built its checker from `_make_poison_checker()`, whose inner `_check` required **three**: `(tenant_id, fleet_id, fingerprint)`.

So every eligible cluster raised `TypeError` at the poison check — which sits *after* the LLM distill call. `run_forge_distill`'s broad `except Exception` (correctly there so one bad cluster can't abort a tick) counted each as `skipped_io_error`. For any tenant with `skills_factory` enabled: `candidates_written` always 0, the LLM spend paid and thrown away per cluster, the poison cooloff never consulted, and the audit row reporting **success**.

## Why the wrong shape was there

The three-arg form is the gate evaluator's — `skill_lifecycle` calls `await poison_checker(tenant_id, fleet_id, fingerprint)`. But that path is already served: `promote_pending_candidates` is handed `make_db_poison_checker()` from `skill_promoter`, and `cron_handler` already imports it. So `_make_poison_checker`'s only consumer was the one-arg distill seam, and its gate-evaluator shape served nobody — it was a near-duplicate of `make_db_poison_checker` wired into the wrong seam.

## The fix

Close over `tenant_id` / `fleet_id` and take only the fingerprint. That matches the seam, drops the duplication, and mirrors `scripts/forge_dry_run.py`'s `_wire_poison_checker(db, tenant, fleet)` — which is precisely why the dry-run CLI was unaffected while production was dead.

## Why no test caught it, and what now does

`tests/test_forge_cron_tick.py` asserts `candidates_written == 3` — from a `ForgeRunResult` the test fabricates while `run_forge_distill` is stubbed. The cron adapter's entire job is wiring, and the only suite covering it never invoked what the wiring produced. A shape mismatch was therefore invisible everywhere: the service suites inject their own correct callables, and the CLI wires its own.

Two tests, both calling the injectable through the same seam the service uses:

- `_make_poison_checker(...)` accepts one argument and forwards the closed-over identifiers — wrong identifiers would silently consult another tenant's cooloff rows, which is a quieter bug than the `TypeError`.
- **The regression guard:** run the real cron tick, capture the callable actually passed to `run_forge_distill`, and await it with a single fingerprint.

Reverting the fix fails the second with the production error verbatim:

```
TypeError: _make_poison_checker.<locals>._check() missing 2 required positional arguments: 'fleet_id' and 'fingerprint'
```

## Checks

4552 passed, 3 skipped, 1 xfailed. `ruff check` and `ruff format --check` clean on `core-api/src/`. No storage-side change.

I skipped `/simplify` deliberately: this is a signature plus one call site, with no new control flow or abstraction, so it sits below the threshold. The docstring's factual claims (that `make_db_poison_checker` serves the gate path, that the CLI wires the one-arg shape) were each verified against the code rather than asserted.

## Follow-up this surfaced, not in scope

The broad `except Exception` in `run_forge_distill` is what made this silent for months. It's load-bearing — one malformed cluster must not abort a tick — but it buckets programming errors as `skipped_io_error`, so an arity bug is indistinguishable from a storage hiccup in the counters an operator reads. Separating `TypeError`/`AttributeError` from genuine I/O there would turn this class of bug from silent into loud, and is worth its own change.

Refs #818
