### PR TITLE
fix(forge): make a wiring bug fail CI, and stop it reading as storage trouble

### DIFF
--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -166,6 +166,10 @@ module = [
 ]
 ignore_errors = true
 
+[[tool.mypy.overrides]]
+module = "core_api.services.forge.*"
+ignore_errors = false
+
 [tool.coverage.run]
 source = ["src"]
 branch = true

--- a/core-api/src/core_api/services/forge/cron_handler.py
+++ b/core-api/src/core_api/services/forge/cron_handler.py
@@ -36,7 +36,12 @@ from typing import Any
 
 from core_api.clients.storage_client import get_storage_client
 from core_api.services.forge.forge_service import (
+    CandidateWriter,
     ForgeConfig,
+    LlmFn,
+    MemoryFetcher,
+    PoisonChecker,
+    StatusChecker,
     run_forge_distill,
 )
 from core_api.services.forge.poison import is_fingerprint_poisoned
@@ -107,7 +112,7 @@ async def _resolve_auto_promote_clean(org_id: str) -> bool:
 # ── Injectable factories ──────────────────────────────────────────
 
 
-def _make_memory_fetcher(tenant_id: str):
+def _make_memory_fetcher(tenant_id: str) -> MemoryFetcher:
     """Bulk-load ``memories.content`` by id via core-storage-api.
 
     Mirrors the dry-run CLI's fetcher. NULL-safe (storage coerces a NULL
@@ -125,7 +130,7 @@ def _make_memory_fetcher(tenant_id: str):
     return _fetch
 
 
-def _make_poison_checker(tenant_id: str, fleet_id: str | None):
+def _make_poison_checker(tenant_id: str, fleet_id: str | None) -> PoisonChecker:
     """Adapt :func:`is_fingerprint_poisoned` (storage-backed) to the
     ``PoisonChecker`` seam ``run_forge_distill`` actually calls:
     ``(fingerprint) → bool``, with the tenant and fleet closed over.
@@ -154,7 +159,7 @@ def _make_poison_checker(tenant_id: str, fleet_id: str | None):
     return _check
 
 
-def _make_candidate_writer():
+def _make_candidate_writer() -> CandidateWriter:
     """Persist a fresh Forge candidate via the storage HTTP client.
 
     Uses ``upsert_document`` so re-running the same cluster (same
@@ -168,7 +173,7 @@ def _make_candidate_writer():
     return _write
 
 
-def _make_status_checker():
+def _make_status_checker() -> StatusChecker:
     """Existence check used to skip writes against already-active /
     rejected / quarantined docs. Returns the live ``data.status`` or
     ``None`` if the slug doesn't exist yet.
@@ -185,7 +190,7 @@ def _make_status_checker():
     return _check
 
 
-async def _wire_llm_fn():
+async def _wire_llm_fn() -> LlmFn:
     """Resolve a working LLM callable from the project's existing
     provider plumbing. Falls back to a structured ``RuntimeError`` if
     the provider chain isn't importable — the cron should NEVER
@@ -237,7 +242,7 @@ async def run_forge_cron_tick(
         in this tick (matches ``ForgeRunResult.candidates_written``).
       * ``promoted`` — number of candidates that flowed
         ``candidate → staged`` in the same tick.
-      * ``scanned``, ``held``, plus the 5 Forge skip counters — so an
+      * ``scanned``, ``held``, plus the 6 Forge skip counters — so an
         operator inspecting an audit row can see exactly what the
         tick did without running the dry-run CLI to reproduce.
 
@@ -301,13 +306,24 @@ async def run_forge_cron_tick(
         "auto_approved": promote_result.auto_approved,
         "scanned": promote_result.scanned,
         "held": promote_result.held,
-        # Surface the 5 Forge skip buckets so audit rows are
-        # actionable — "3 io_errors" vs "1 sentinel block" vs
-        # "5 poisoned" tells an operator very different stories.
+        # Surface the 6 Forge skip buckets so the structured log line below is
+        # actionable — "3 io_errors" vs "1 sentinel block" vs "5 poisoned" tells
+        # an operator very different stories.
+        #
+        # These reach the LOG, not the audit row: ``lifecycle_audit`` reduces this
+        # whole dict to ``candidates_written + promoted`` and stores that single
+        # int as ``stats.candidates_produced``. So a log-based alert can key on
+        # these; an audit-row query cannot. (The previous wording claimed audit
+        # rows, for five buckets — it was wrong then too.)
         "skipped_poisoned": forge_result.candidates_skipped_poisoned,
         "skipped_sentinel": forge_result.candidates_skipped_sentinel,
         "skipped_distill_error": forge_result.candidates_skipped_distill_error,
         "skipped_io_error": forge_result.candidates_skipped_io_error,
+        # Non-zero here means a bug in our code, not a bad day for storage — the
+        # distinction H-08 (#818) did not have. Unlike every other bucket, a
+        # healthy deployment never produces this one, which makes it the one worth
+        # alerting on.
+        "skipped_internal_error": forge_result.candidates_skipped_internal_error,
         "skipped_existing": forge_result.candidates_skipped_existing,
     }
     logger.info(

--- a/core-api/src/core_api/services/forge/forge_service.py
+++ b/core-api/src/core_api/services/forge/forge_service.py
@@ -109,6 +109,25 @@ CandidateWriter = Callable[[dict[str, Any]], Awaitable[None]]
 # expected — that's how Forge refines its own candidates over time).
 StatusChecker = Callable[[str, str, str], Awaitable[str | None]]
 
+#: Exceptions that mean OUR code is wrong, not that an external system had a bad
+#: moment. Classified separately from I/O throughout the cluster loop because the
+#: two demand opposite responses: an I/O failure says "look at storage, maybe
+#: retry", this says "read the traceback as a bug report". They are also
+#: near-always DETERMINISTIC — they hit every cluster this tick and every tick
+#: after — where I/O failures are transient.
+#:
+#: This is the classification H-08 (#818) lacked: a 3-arg poison checker wired
+#: into the 1-arg seam raised ``TypeError`` on every cluster, all of it landed in
+#: ``candidates_skipped_io_error``, and the tick reported success having written
+#: nothing for ~2.5 months.
+#:
+#: Deliberately just these two. ``KeyError`` is not included — the dict subscripts
+#: in this module are on dicts it builds itself, and a bad-DATA ``ValueError`` from
+#: a validator is not a bug in us (``DistillParseError`` already covers the
+#: LLM-shaped case, and is caught earlier). Widening this set would re-blur the
+#: line it exists to draw.
+_PROGRAMMING_ERRORS = (TypeError, AttributeError)
+
 
 # ── Run summary ───────────────────────────────────────────────────
 
@@ -154,6 +173,11 @@ class ForgeRunResult:
     # distill errors so the run summary actionably surfaces "3 parse
     # errors" vs "2 storage hiccups".
     candidates_skipped_io_error: int
+    # Programming errors from an injected callable or cluster handling — see
+    # ``_PROGRAMMING_ERRORS``. Deliberately NOT defaulted: a construction site
+    # that forgets it would report "no internal errors", which is the same
+    # silent-zero failure this counter exists to end.
+    candidates_skipped_internal_error: int
     # Candidates where ``status_checker`` reported the target doc_id
     # already exists with a non-``candidate`` status (active, rejected,
     # quarantined, stale, deprecated). Forge skips the write to avoid
@@ -251,6 +275,7 @@ async def run_forge_distill(
     skipped_sentinel = 0
     skipped_distill_error = 0
     skipped_io_error = 0
+    skipped_internal_error = 0
     skipped_existing = 0
 
     # 5. Distill each eligible cluster.
@@ -287,6 +312,13 @@ async def run_forge_distill(
             logger.warning("forge: skipping cluster — LLM response unparseable: %s", exc)
             skipped_distill_error += 1
             continue
+        except _PROGRAMMING_ERRORS:
+            # Still ``continue`` rather than abort: one malformed cluster must not
+            # cost the whole tick, and these are not ALWAYS deterministic. The
+            # run-level summary below is what escalates when they clearly are.
+            logger.exception("forge: cluster distill raised a programming error (not I/O) — skipping cluster")
+            skipped_internal_error += 1
+            continue
         except Exception:
             # Transient I/O failures inside _distill_cluster
             # (memory_fetcher / poison_checker DB hiccup, entity-
@@ -304,6 +336,13 @@ async def run_forge_distill(
         if status_checker is not None:
             try:
                 existing_status = await status_checker(tenant_id, "skills", candidate_doc["doc_id"])
+            except _PROGRAMMING_ERRORS:
+                logger.exception(
+                    "forge: status_checker raised a programming error (not I/O) for slug=%s — skipping write",
+                    candidate_doc.get("data", {}).get("slug"),
+                )
+                skipped_internal_error += 1
+                continue
             except Exception:
                 # storage-layer failure → I/O bucket, not parse-error.
                 logger.exception(
@@ -323,6 +362,15 @@ async def run_forge_distill(
 
         try:
             await candidate_writer(candidate_doc)
+        except _PROGRAMMING_ERRORS:
+            # A writer with the wrong signature would otherwise read as a
+            # UNIQUE-violation or a network drop.
+            logger.exception(
+                "forge: candidate_writer raised a programming error (not I/O) for slug=%s — skipping",
+                candidate_doc.get("data", {}).get("slug"),
+            )
+            skipped_internal_error += 1
+            continue
         except Exception:
             # candidate_writer failure (UNIQUE-violation, schema
             # validator hiccup, network drop) → I/O bucket.
@@ -339,6 +387,32 @@ async def run_forge_distill(
         # (tenant_id, collection, doc_id) primary-key shape.
         written_ids.append(candidate_doc["doc_id"])
 
+    # The signal H-08 never produced. Per-cluster tracebacks existed even then —
+    # the bug was that nothing summarised them, so a tick that mined nothing at
+    # all still returned a result the audit row rendered as success. A run that
+    # had eligible clusters, wrote NOTHING, and hit programming errors is not a
+    # quiet day: it is a broken deployment, and one line at ERROR says so.
+    #
+    # Guarded on ``written_ids`` being empty rather than on the error count alone,
+    # because a single malformed cluster among many successes is genuinely routine
+    # and must not page anyone. ``eligible`` is not re-tested: every increment site
+    # is inside the loop over it, so a non-zero counter already implies it was
+    # non-empty. Says "almost certainly" rather than "is" a bug because one shape
+    # reaches here honestly — a provider returning an unexpected object makes
+    # ``llm_fn`` raise AttributeError on every cluster, which looks identical.
+    if not written_ids and skipped_internal_error:
+        logger.error(
+            "forge: run wrote NOTHING and hit %d programming error(s) across %d attempted "
+            "cluster(s) — almost certainly a code/wiring bug rather than storage, and every "
+            "cluster paid for its LLM call before failing. Read the tracebacks above; the "
+            "counter is candidates_skipped_internal_error (tenant=%s fleet=%s run=%s).",
+            skipped_internal_error,
+            len(eligible[: cfg.max_writes_per_run]),
+            tenant_id,
+            fleet_id,
+            run_label,
+        )
+
     result = ForgeRunResult(
         tenant_id=tenant_id,
         fleet_id=fleet_id,
@@ -353,6 +427,7 @@ async def run_forge_distill(
         candidates_skipped_sentinel=skipped_sentinel,
         candidates_skipped_distill_error=skipped_distill_error,
         candidates_skipped_io_error=skipped_io_error,
+        candidates_skipped_internal_error=skipped_internal_error,
         candidates_skipped_existing=skipped_existing,
         candidate_doc_ids=written_ids,
         started_at=run_started_at,
@@ -361,7 +436,7 @@ async def run_forge_distill(
     logger.info(
         "forge_run: run_label=%s tenant=%s fleet=%s traces=%d labeled=%d "
         "clusters=%d eligible=%d written=%d poisoned=%d sentinel=%d "
-        "distill_errors=%d io_errors=%d existing=%d",
+        "distill_errors=%d io_errors=%d internal_errors=%d existing=%d",
         result.run_label,
         result.tenant_id,
         result.fleet_id,
@@ -374,6 +449,7 @@ async def run_forge_distill(
         result.candidates_skipped_sentinel,
         result.candidates_skipped_distill_error,
         result.candidates_skipped_io_error,
+        result.candidates_skipped_internal_error,
         result.candidates_skipped_existing,
     )
     return result

--- a/scripts/forge_dry_run.py
+++ b/scripts/forge_dry_run.py
@@ -340,6 +340,7 @@ async def _run(args: argparse.Namespace) -> int:
             "candidates_skipped_sentinel": result.candidates_skipped_sentinel,
             "candidates_skipped_distill_error": result.candidates_skipped_distill_error,
             "candidates_skipped_io_error": result.candidates_skipped_io_error,
+            "candidates_skipped_internal_error": result.candidates_skipped_internal_error,
             "candidates_skipped_existing": result.candidates_skipped_existing,
             "candidate_doc_ids": result.candidate_doc_ids,
         }
@@ -362,6 +363,7 @@ async def _run(args: argparse.Namespace) -> int:
             f"sentinel={result.candidates_skipped_sentinel} "
             f"distill_errors={result.candidates_skipped_distill_error} "
             f"io_errors={result.candidates_skipped_io_error} "
+            f"internal_errors={result.candidates_skipped_internal_error} "
             f"existing={result.candidates_skipped_existing}"
         )
         if result.candidate_doc_ids:

--- a/tests/test_forge_cron_tick.py
+++ b/tests/test_forge_cron_tick.py
@@ -184,6 +184,7 @@ class TestRunForgeCronTick:
             candidates_skipped_sentinel=0,
             candidates_skipped_distill_error=0,
             candidates_skipped_io_error=0,
+            candidates_skipped_internal_error=0,
             candidates_skipped_existing=0,
             started_at=None,
             run_label="forge-cron-t1-20260608T2100",
@@ -254,6 +255,9 @@ class TestRunForgeCronTick:
         # Skip counters surface from the Forge result.
         assert stats["skipped_poisoned"] == 1
         assert stats["skipped_sentinel"] == 0
+        # The bucket that means "we shipped a bug" has to reach the stats dict,
+        # since that is the structured line an alert would key on.
+        assert stats["skipped_internal_error"] == 0
         # auto_approved surfaces from the promoter result (0 here — the
         # flag defaults off because the patched settings omit it).
         assert stats["auto_approved"] == 0
@@ -278,6 +282,7 @@ class TestRunForgeCronTick:
             candidates_skipped_sentinel=0,
             candidates_skipped_distill_error=0,
             candidates_skipped_io_error=0,
+            candidates_skipped_internal_error=0,
             candidates_skipped_existing=0,
             started_at=None,
             run_label="forge-cron-t1-20260610T0000",
@@ -443,6 +448,7 @@ class TestInjectedCallableArity:
             candidates_skipped_sentinel=0,
             candidates_skipped_distill_error=0,
             candidates_skipped_io_error=0,
+            candidates_skipped_internal_error=0,
             candidates_skipped_existing=0,
             started_at=None,
             run_label="forge-cron-t1-20260819T1200",

--- a/tests/test_forge_distill.py
+++ b/tests/test_forge_distill.py
@@ -508,6 +508,21 @@ def _passing_traces(n: int) -> list[SessionTraceRow]:
     ]
 
 
+def _two_eligible_clusters() -> list:
+    """Two clusters that both clear the volume + diversity gates.
+
+    Module-level because two test classes need it: TestForgeRunResilience (one
+    seam fails, the others still run) and TestInternalErrorBucket (the same shape
+    for programming errors rather than I/O).
+    """
+    return [
+        _trace(run_id=f"r{i}", agent_id=f"a{i}", entity_ids=["e1", "e2", "e3"]) for i in range(4)
+    ] + [
+        _trace(run_id=f"r{i + 10}", agent_id=f"b{i}", entity_ids=["x1", "x2", "x3"])
+        for i in range(4)
+    ]
+
+
 async def _llm_returns_golden(_prompt: str) -> str:
     return json.dumps(_golden_llm_response())
 
@@ -825,18 +840,10 @@ class TestForgeRunResilience:
         import core_api.services.forge.forge_service as svc
         monkeypatch.setattr(svc, "build_session_traces", fake_build)
 
-    def _two_eligible_clusters(self):
-        return (
-            [_trace(run_id=f"r{i}", agent_id=f"a{i}", entity_ids=["e1", "e2", "e3"])
-             for i in range(4)]
-            +
-            [_trace(run_id=f"r{i+10}", agent_id=f"b{i}", entity_ids=["x1", "x2", "x3"])
-             for i in range(4)]
-        )
 
     @pytest.mark.asyncio
     async def test_llm_timeout_on_one_cluster_skips_it(self, monkeypatch):
-        self._patch_build(monkeypatch, self._two_eligible_clusters())
+        self._patch_build(monkeypatch, _two_eligible_clusters())
 
         call = {"n": 0}
         async def llm(_prompt: str) -> str:
@@ -867,7 +874,7 @@ class TestForgeRunResilience:
 
     @pytest.mark.asyncio
     async def test_memory_fetcher_error_skips_cluster(self, monkeypatch):
-        self._patch_build(monkeypatch, self._two_eligible_clusters())
+        self._patch_build(monkeypatch, _two_eligible_clusters())
 
         call = {"n": 0}
         async def fetcher(mids):
@@ -893,7 +900,7 @@ class TestForgeRunResilience:
 
     @pytest.mark.asyncio
     async def test_poison_checker_error_skips_cluster(self, monkeypatch):
-        self._patch_build(monkeypatch, self._two_eligible_clusters())
+        self._patch_build(monkeypatch, _two_eligible_clusters())
 
         call = {"n": 0}
         async def poisoner(_fp):
@@ -925,7 +932,7 @@ class TestForgeRunResilience:
         smuggle a malformed doc past Sentinel into the inbox.
         Treat as a distill error so the cluster is skipped and
         counted, not silently written."""
-        self._patch_build(monkeypatch, self._two_eligible_clusters())
+        self._patch_build(monkeypatch, _two_eligible_clusters())
 
         call = {"n": 0}
         async def llm(_prompt: str) -> str:
@@ -954,7 +961,7 @@ class TestForgeRunResilience:
         # Two eligible clusters; the first WRITE fails (e.g. UNIQUE
         # violation, schema validator hiccup). The second cluster
         # must still get persisted.
-        self._patch_build(monkeypatch, self._two_eligible_clusters())
+        self._patch_build(monkeypatch, _two_eligible_clusters())
 
         # Unique slug per LLM call so we can tell them apart in the
         # writer.
@@ -1311,3 +1318,149 @@ class TestForgeDeterminism:
         fp1 = cap1[0]["data"]["cluster_fingerprint"]
         fp2 = cap2[0]["data"]["cluster_fingerprint"]
         assert fp1 == fp2  # cluster identity is stable across runs
+
+
+# ── Programming errors are their own bucket, not I/O (#818 follow-up) ──
+
+
+@pytest.mark.unit
+class TestInternalErrorBucket:
+    """H-08 was invisible for two months because a ``TypeError`` from a
+    wrongly-wired injectable landed in ``candidates_skipped_io_error`` — the same
+    bucket as a storage hiccup. The two need opposite responses: I/O says look at
+    storage and maybe retry, this says look at the code. These tests pin the split
+    using the actual shape of that bug.
+    """
+
+    def _patch_build(self, monkeypatch, traces):
+        async def fake_build(*_args, **_kwargs):
+            return list(traces)
+
+        import core_api.services.forge.forge_service as svc
+
+        monkeypatch.setattr(svc, "build_session_traces", fake_build)
+
+    @pytest.mark.asyncio
+    async def test_the_h08_wiring_bug_lands_in_internal_not_io(self, monkeypatch):
+        """The exact H-08 shape: a 3-arg poison checker in the 1-arg seam."""
+        self._patch_build(monkeypatch, _two_eligible_clusters())
+
+        async def three_arg_checker(tenant_id, fleet_id, fingerprint) -> bool:
+            return False  # never reached — the call itself raises
+
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            run_label="test-run",
+            tenant_id="t1",
+            fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=three_arg_checker,
+            candidate_writer=writer,
+        )
+
+        assert result.clusters_eligible == 2
+        assert result.candidates_written == 0
+        # The whole point of the split: this must NOT read as storage trouble.
+        assert result.candidates_skipped_internal_error == 2
+        assert result.candidates_skipped_io_error == 0
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_one_bad_cluster_does_not_cost_the_others(self, monkeypatch):
+        """These are not always deterministic, so a single bad cluster must still
+        only cost itself — the tick keeps going."""
+        self._patch_build(monkeypatch, _two_eligible_clusters())
+
+        call = {"n": 0}
+
+        async def flaky_checker(fp: str) -> bool:
+            call["n"] += 1
+            if call["n"] == 1:
+                raise AttributeError("simulated shape bug on one cluster")
+            return False
+
+        captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            run_label="test-run",
+            tenant_id="t1",
+            fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=flaky_checker,
+            candidate_writer=writer,
+        )
+
+        assert result.candidates_skipped_internal_error == 1
+        assert result.candidates_written == 1
+        assert result.candidates_skipped_io_error == 0
+
+    @pytest.mark.asyncio
+    async def test_a_run_that_wrote_nothing_says_so_at_error_level(self, monkeypatch, caplog):
+        """The signal H-08 never produced. Per-cluster tracebacks already existed;
+        what was missing was one line saying the run as a whole was broken."""
+        import logging
+
+        self._patch_build(monkeypatch, _two_eligible_clusters())
+        caplog.set_level(logging.ERROR, logger="core_api.services.forge.forge_service")
+
+        async def three_arg_checker(tenant_id, fleet_id, fingerprint) -> bool:
+            return False
+
+        _captured, writer = _capture_writer()
+        await run_forge_distill(
+            run_label="test-run",
+            tenant_id="t1",
+            fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=three_arg_checker,
+            candidate_writer=writer,
+        )
+
+        errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+        summary = [m for m in errors if "wrote NOTHING" in m]
+        assert summary, f"expected a run-level ERROR summary; got {errors}"
+        # It has to name the cause and the counter, or it is just noise.
+        assert "code/wiring bug" in summary[0]
+        assert "candidates_skipped_internal_error" in summary[0]
+
+    @pytest.mark.asyncio
+    async def test_a_run_that_wrote_something_does_not_page_anyone(self, monkeypatch, caplog):
+        """One malformed cluster among successes is routine. If this summary fired
+        there too it would be ignored within a week, which is how alerts die."""
+        import logging
+
+        self._patch_build(monkeypatch, _two_eligible_clusters())
+        caplog.set_level(logging.ERROR, logger="core_api.services.forge.forge_service")
+
+        call = {"n": 0}
+
+        async def flaky_checker(fp: str) -> bool:
+            call["n"] += 1
+            if call["n"] == 1:
+                raise TypeError("simulated shape bug on one cluster")
+            return False
+
+        _captured, writer = _capture_writer()
+        result = await run_forge_distill(
+            run_label="test-run",
+            tenant_id="t1",
+            fleet_id=None,
+            window_start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            llm_fn=_llm_returns_golden,
+            memory_fetcher=_memory_fetcher_always,
+            poison_checker=flaky_checker,
+            candidate_writer=writer,
+        )
+
+        assert result.candidates_written == 1
+        assert result.candidates_skipped_internal_error == 1
+        assert not [r for r in caplog.records if "wrote NOTHING" in r.getMessage()]


### PR DESCRIPTION
Follow-up to H-08 (#818). That bug merged as a one-line arity fix; this addresses **why it survived ~2.5 months in production**.

## What let it hide

`run_forge_distill`'s cluster loop ends in a broad `except Exception` that counts everything as `candidates_skipped_io_error` and continues. The handler has to stay — one malformed cluster must not abort a tick — but it meant a `TypeError` from a wrongly-shaped injectable was indistinguishable from a storage hiccup in the only counters an operator reads. The tick returned success with zero candidates written, every day, and the counters said storage was flaky.

## Two changes, at different depths

**1. Programming errors get their own bucket.** `_PROGRAMMING_ERRORS = (TypeError, AttributeError)` is caught ahead of the broad handler at all three injected seams and counted as `candidates_skipped_internal_error`. Still `continue` — these aren't *always* deterministic — but they no longer masquerade as I/O.

Scoped deliberately: `KeyError` is excluded (the dict subscripts here are on dicts this module builds itself) and `ValueError` is excluded (validators raise it on legitimately bad *data*, and the LLM-shaped case already has `DistillParseError`). Widening the set would re-blur the line it exists to draw.

Plus a run-level ERROR line when a run wrote **nothing** and hit programming errors. Per-cluster tracebacks already existed during H-08; what was missing was one line saying the run as a whole was broken. Guarded on zero writes so one bad cluster among successes never pages anyone — there's a test for that negative case, because an alert that cries wolf is worse than no alert.

**2. The same class of bug now fails CI.** This matters more, and it came out of reviewing part 1.

`cron_handler`'s five injectable factories had **no return annotations**, so the closures they returned were implicitly `Any` and satisfied any seam. They now carry the alias they must satisfy (`-> PoisonChecker` etc.), matching what sibling `skill_promoter` already did.

Annotations alone were **inert**, though: `[tool.mypy.overrides]` sets `ignore_errors = true` for `core_api.services.*`, so the whole services layer is exempt from type checking — the actual reason H-08 was statically undetectable. So this adds a narrower override re-enabling it for `core_api.services.forge.*`, which is free today: that subpackage is already mypy-clean (0 errors).

Verified with CI's own command (`cd core-api && mypy src/`) rather than in isolation — my first attempt at proving this was a single-file invocation that resolved the alias to `Any` and reported nothing, which is exactly the trap the override creates. Re-introducing the 3-arg checker now gives:

```
src/core_api/services/forge/cron_handler.py:159: error: Incompatible return value type
(got "Callable[[str, str | None, str], Coroutine[Any, Any, bool]]",
 expected "Callable[[str], Awaitable[bool]]")  [return-value]
```

and the fixed shape is clean. **Note this constrains future forge changes to stay type-clean** — a deliberate tightening, scoped to one subpackage.

## Surfacing

The counter reaches all four places the other buckets do, not just one: the service's `forge_run:` INFO summary, the cron stats dict, and both dry-run CLI outputs (JSON + human). A counter that exists only in a dataclass isn't observability.

Corrected while here: the cron stats comment claimed these buckets make "audit rows actionable". They don't — `lifecycle_audit` reduces the whole dict to `candidates_written + promoted` and stores that single int. The buckets reach the structured **log**, which is what an alert can key on. That comment was wrong before this change too, for five buckets.

The new field is deliberately **not** defaulted: a construction site that forgets it would report "no internal errors", the same silent-zero failure the counter exists to end. Better a loud `TypeError` at construction. Three test literals updated accordingly.

## Checks

4562 passed, 3 skipped, 1 xfailed. `ruff check` / `ruff format --check` clean on `core-api/src/`; mypy clean including the newly-checked forge subpackage. Each half verified by reverting it: dropping the except branch fails all four new tests, dropping the summary fails only the summary test.

`/simplify` found real problems in my first draft, worth noting since they shaped the result: the counter had landed in 1 of 4 enumeration surfaces; the dataclass default was justified by naming two callers that don't construct the type; a comment claimed `KeyError` was covered when it wasn't; and the guard carried a dead `eligible and` term. All fixed.

## Not done — the biggest remaining question

A tick that errors on every cluster **still returns success**, so `lifecycle_audit` writes `status="success"`. Worse, that false success arms the 23h dedup gate, so an operator re-running the fanout to reproduce gets `skipped: recent_success` and no run at all — the false success obstructs its own diagnosis. Raising under the same guard would flip the durable verdict, at the cost of a Pub/Sub nack and redelivery. That's a behaviour change rather than an observability one, so it's deliberately out of scope and worth its own decision.

Refs #818
