### PR TITLE
fix(sdk): read recall memories from the key the server actually sends

### DIFF
--- a/clients/python/src/caura_client/models.py
+++ b/clients/python/src/caura_client/models.py
@@ -52,5 +52,23 @@ class RecallResult:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RecallResult:
-        memories = [Memory.from_dict(m) for m in (data.get("supporting_memories") or [])]
+        """Build from a ``POST /api/v1/recall`` body.
+
+        The wire key is ``memories``; the server aliases the identical list under
+        ``items`` as well, for consumers written against ``/search``'s shape, so
+        either is accepted.
+
+        H-01: this used to read ``supporting_memories`` — a key the server has
+        never emitted in any commit. It was invented in this SDK and mirrored into
+        the TypeScript one, so every ``recall()`` returned an empty list while
+        ``summary`` kept working, and the test mocked the invented shape so the
+        suite stayed green against a broken contract.
+
+        The ATTRIBUTE keeps the name ``supporting_memories``: that is published
+        API and renaming it would break callers. Only the wire key was wrong.
+        """
+        raw = data.get("memories")
+        if raw is None:
+            raw = data.get("items")
+        memories = [Memory.from_dict(m) for m in (raw or [])]
         return cls(summary=data.get("summary"), supporting_memories=memories, raw=data)

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -93,15 +93,66 @@ def test_search_raises_on_non_dict_body():
     assert str(exc.value) == "[200] search response must be a JSON object"
 
 
-def test_recall_returns_summary():
+# The exact top-level key set ``POST /api/v1/recall`` returns, per
+# ``core_api.services.recall_service.summarize_memories`` — and pinned server-side
+# by ``tests/test_c4_recall_items_alias.py::_EXPECTED_TOP_LEVEL_KEYS``. Note what
+# is NOT here: ``supporting_memories``. H-01 was this SDK reading that invented
+# key, with a hand-written fixture that mocked it, so the suite passed while every
+# live recall() returned no memories.
+def _live_recall_body(memories):
+    return {
+        "query": "q",
+        "summary": "S",
+        "memory_count": len(memories),
+        "memories": memories,
+        "items": memories,  # server aliases the identical list
+        "recall_ms": 12,
+    }
+
+
+def test_recall_returns_summary_and_memories():
     def handler(request):
         assert request.url.path == "/api/v1/recall"
-        return httpx.Response(200, json={"summary": "S", "supporting_memories": [{"id": "m1", "content": "a"}]})
+        return httpx.Response(200, json=_live_recall_body([{"id": "m1", "content": "a"}]))
 
     result = make_client(handler).recall("q")
     assert isinstance(result, RecallResult)
     assert result.summary == "S"
     assert result.supporting_memories[0].id == "m1"
+
+
+def test_recall_accepts_the_items_alias_alone():
+    """Older/other server shapes may send only ``items``; both name the same list."""
+
+    def handler(request):
+        return httpx.Response(
+            200, json={"summary": "S", "items": [{"id": "m2", "content": "b"}]}
+        )
+
+    result = make_client(handler).recall("q")
+    assert [m.id for m in result.supporting_memories] == ["m2"]
+
+
+def test_recall_with_no_memories_is_empty_not_an_error():
+    def handler(request):
+        return httpx.Response(200, json=_live_recall_body([]))
+
+    result = make_client(handler).recall("q")
+    assert result.supporting_memories == []
+    assert result.summary == "S"
+
+
+def test_recall_ignores_the_key_the_server_never_sends():
+    """Guard against the regression: a body carrying ONLY the invented key must
+    yield no memories, so nobody "fixes" this by reinstating it."""
+
+    def handler(request):
+        return httpx.Response(
+            200, json={"summary": "S", "supporting_memories": [{"id": "ghost"}]}
+        )
+
+    result = make_client(handler).recall("q")
+    assert result.supporting_memories == []
 
 
 def test_health():

--- a/clients/typescript/src/index.test.ts
+++ b/clients/typescript/src/index.test.ts
@@ -79,14 +79,58 @@ test("search throws when 200 items is not a list", async () => {
   });
 });
 
+// The exact top-level key set POST /api/v1/recall returns, per
+// core_api.services.recall_service.summarize_memories — pinned server-side by
+// tests/test_c4_recall_items_alias.py::_EXPECTED_TOP_LEVEL_KEYS. Note what is NOT
+// here: `supporting_memories`. H-01 was this SDK reading that invented key with a
+// fixture that mocked it, so CI passed while every live recall() returned nothing.
+function liveRecallBody(memories: Array<Record<string, unknown>>) {
+  return {
+    query: "q",
+    summary: "S",
+    memory_count: memories.length,
+    memories,
+    items: memories, // server aliases the identical list
+    recall_ms: 12,
+  };
+}
+
 test("recall returns the summary and supporting memories", async () => {
   const client = makeClient((url) => {
     assert.equal(new URL(url).pathname, "/api/v1/recall");
-    return jsonResponse(200, { summary: "S", supporting_memories: [{ id: "m1", content: "a" }] });
+    return jsonResponse(200, liveRecallBody([{ id: "m1", content: "a" }]));
   });
   const result = await client.recall("q");
   assert.equal(result.summary, "S");
   assert.equal(result.supportingMemories[0].id, "m1");
+});
+
+test("recall accepts the items alias alone", async () => {
+  const client = makeClient(() =>
+    jsonResponse(200, { summary: "S", items: [{ id: "m2", content: "b" }] }),
+  );
+  const result = await client.recall("q");
+  assert.deepEqual(
+    result.supportingMemories.map((m) => m.id),
+    ["m2"],
+  );
+});
+
+test("recall with no memories is empty, not an error", async () => {
+  const client = makeClient(() => jsonResponse(200, liveRecallBody([])));
+  const result = await client.recall("q");
+  assert.deepEqual(result.supportingMemories, []);
+  assert.equal(result.summary, "S");
+});
+
+test("recall ignores the key the server never sends", async () => {
+  // Guard against the regression: a body carrying ONLY the invented key must
+  // yield no memories, so nobody "fixes" this by reinstating it.
+  const client = makeClient(() =>
+    jsonResponse(200, { summary: "S", supporting_memories: [{ id: "ghost" }] }),
+  );
+  const result = await client.recall("q");
+  assert.deepEqual(result.supportingMemories, []);
 });
 
 test("health hits /health", async () => {

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -145,7 +145,16 @@ export class Caura {
   async recall(query: string, options: { topK?: number } = {}): Promise<RecallResult> {
     const body = { tenant_id: this.tenantId, query, top_k: options.topK ?? 5 };
     const data = await this.request("POST", "/api/v1/recall", body);
-    const supporting: unknown = data?.supporting_memories;
+    // Wire key is `memories`; the server aliases the identical list under
+    // `items` too, for consumers written against /search's shape.
+    //
+    // H-01: this read `data?.supporting_memories`, a key the server has never
+    // emitted in any commit — it was invented in the Python SDK and mirrored
+    // here, so every recall() returned [] while `summary` kept working, and the
+    // test below mocked the invented shape so CI stayed green. The RESULT FIELD
+    // keeps its name (`supportingMemories`) since that is published API; only
+    // the wire key was wrong.
+    const supporting: unknown = data?.memories ?? data?.items;
     return {
       summary: data?.summary ?? null,
       supportingMemories: Array.isArray(supporting)


### PR DESCRIPTION
Fixes H-01 (#811). Premise re-verified on `main` before changing anything.

## The bug

Both SDKs parsed recall's memories out of `supporting_memories`. **The server never sends that key.** `POST /api/v1/recall` returns `{query, summary, memory_count, memories, items, recall_ms}` — built by `recall_service.summarize_memories` and pinned server-side by `tests/test_c4_recall_items_alias.py::_EXPECTED_TOP_LEVEL_KEYS`.

So every `recall()` against a live deployment returned an **empty memory list** while `summary` kept working — a silent, total loss of the supporting memories, in both the Python and TypeScript clients.

## One correction to the issue's suggested fix

It proposes keeping `supporting_memories` as a legacy fallback. It isn't legacy:

```
git log -S'supporting_memories' --all -- core-api/ core-storage-api/   # → nothing, ever
```

The key first appears in the SDK commits themselves (#352 Python, #356 TypeScript). It was invented client-side and mirrored between the two clients; no server version ever emitted it. A fallback would be dead code that re-implies a contract which never existed — the exact confusion that caused this — so it's dropped rather than kept.

What **is** kept is the field name: `RecallResult.supporting_memories` and TS `supportingMemories` are published API, and renaming them would break callers for no benefit. Only the wire key was ever wrong.

Reads `memories`, falling back to `items` — the server aliases the identical list under both keys deliberately, so consumers written against `/search`'s shape see the same thing.

## Why CI was green through all of this

The tests mocked the invented shape: `json={"summary": "S", "supporting_memories": [...]}`. A hand-written fixture asserting the SDK's own misunderstanding can't catch a contract mismatch — it encodes it. That's the part worth fixing properly, not just the one-line read.

Both suites now build fixtures from a single helper mirroring the real key set, with a comment naming `summarize_memories` and the server-side test that pins it, so the next person editing either client has a source of truth to check against.

Four cases per SDK:
- the live shape;
- `items` alone;
- an empty result staying empty rather than raising;
- a guard asserting a body carrying **only** `supporting_memories` yields no memories — so nobody "fixes" a future report by reinstating the phantom key.

Verified by reverting the one-line read in each client: three of four fail in each, and the guard comes back with `[Memory(id='ghost')] == []`.

## Checks

Python SDK 114 passed, `ruff check src tests` clean. TypeScript SDK 14 passed, `tsc` clean. Both SDK CI workflows are path-filtered to `clients/**`, so both run here. No server-side change, so the main suite is untouched.

`/simplify` skipped deliberately — two one-line wire-key reads plus fixtures, no new logic. The comments' factual claims were verified against history rather than asserted.

## Noticed in passing, not fixed here

`clients/typescript/package-lock.json` on `main` records `version: 0.1.0` while `package.json` says `1.0.0`, so any `npm install` regenerates it. I reverted that incidental churn out of this PR rather than ship an unvalidated lockfile change (it needs Linux-accurate `npm ci` validation). Worth a one-line commit on its own.

Refs #811
