### PR TITLE
fix(lifecycle): a tick broken by a wiring bug must not report success

### DIFF
--- a/common/events/base.py
+++ b/common/events/base.py
@@ -49,6 +49,30 @@ class CircularPublishChainError(RuntimeError):
     """
 
 
+class PermanentOpError(RuntimeError):
+    """A lifecycle op failed in a way redelivering it cannot fix.
+
+    Raise this instead of a generic exception when the op can tell the fault is
+    not worth retrying — a wiring or shape bug rather than a flaky dependency.
+    The lifecycle runner records the ``failure`` row exactly as it would for any
+    other exception, marks it ``stats={"terminal": True}``, and then ACKS.
+
+    Named to match :class:`common.ranking.errors.PermanentRankError`, which is the
+    same idea one layer over; keeping one word for one concept means a grep for
+    either finds both.
+
+    SCOPE: only ``lifecycle_handlers``' shared runner honours this. Handlers
+    registered directly on the bus (see ``core_worker.consumer``) get no special
+    treatment — neither bus inspects the exception type, so raising it there nacks
+    like anything else. Such a handler owns its own audit row and should write the
+    failure row and return, rather than raise.
+
+    Prefer a plain raise when the op is cheap and idempotent. Suppressing a retry
+    is only worth it where redelivery costs something real; for archive/purge a
+    nack is nearly free, so the extra retry is better than the extra machinery.
+    """
+
+
 class EventBus(ABC):
     """Abstract event bus. Concrete implementations: `InProcessEventBus`,
     `PubSubEventBus`.

--- a/common/events/lifecycle_handlers.py
+++ b/common/events/lifecycle_handlers.py
@@ -28,7 +28,7 @@ from typing import Protocol
 
 from pydantic import ValidationError
 
-from common.events.base import Event
+from common.events.base import Event, PermanentOpError
 from common.events.factory import get_event_bus
 from common.events.lifecycle_archive_request import (
     LifecycleArchiveRequest,
@@ -239,23 +239,53 @@ async def _run_action(
     try:
         count = await run_op(request)
     except Exception as exc:
-        # Wrap the failure update in its own guard: if it raises, the
-        # outer ``raise`` below would never run and the original op
-        # exception would be silently replaced by the audit error,
-        # leaving the row stuck in ``in_progress`` indistinguishable
-        # from a crashed worker.
+        # ``PermanentOpError`` means the op has established that a retry cannot
+        # help, so this handler acks instead of nacking. Both classes write the
+        # SAME row through the same guarded call — one site, so a future edit to
+        # the failure row cannot land on one failure class and miss the other.
+        permanent = isinstance(exc, PermanentOpError)
+        # ``stats`` is what distinguishes the two in the DURABLE record. Without
+        # it a terminal failure and a mid-retry failure are byte-identical rows,
+        # and "nothing more will happen, a human must act" is the whole point —
+        # it has to be queryable, not just present in a log line. Mirrors how the
+        # dedup gate above disambiguates two meanings of ``success`` via
+        # ``stats={"skipped": True}``.
+        recorded = True
         try:
             await adapter.update_lifecycle_audit_row(
                 audit_id,
                 status="failure",
+                stats={"terminal": True} if permanent else None,
                 error_message=str(exc)[:500],
             )
         except Exception:
+            recorded = False
+            # Wrap the failure update in its own guard: if it raises, the
+            # ``raise`` below would never run and the original op exception
+            # would be silently replaced by the audit error, leaving the row
+            # stuck in ``in_progress`` indistinguishable from a crashed worker.
             logger.warning(
                 "lifecycle audit failure update failed; row stuck in_progress",
                 exc_info=True,
                 extra={"audit_id": audit_id, "action": action},
             )
+        if permanent and recorded:
+            # Acking is only defensible because the ``failure`` row IS the durable
+            # record. When the write failed there is no record, so fall through to
+            # the raise and let redelivery have another go at producing one — one
+            # wasted retry is cheaper than a row stuck in_progress forever.
+            logger.error(
+                "lifecycle %s failed permanently; not retrying",
+                action,
+                exc_info=True,
+                extra={
+                    "audit_id": audit_id,
+                    "org_id": org_id,
+                    "triggered_by": triggered_by,
+                    "terminal": True,
+                },
+            )
+            return
         # Re-raise so the bus nacks → Pub/Sub redelivers (subject to
         # max-delivery-attempts → DLQ). The ``failure`` row above is
         # the durable record (when the update succeeded).

--- a/core-api/src/core_api/services/forge/cron_handler.py
+++ b/core-api/src/core_api/services/forge/cron_handler.py
@@ -34,6 +34,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from common.events.base import PermanentOpError
 from core_api.clients.storage_client import get_storage_client
 from core_api.services.forge.forge_service import (
     CandidateWriter,
@@ -249,6 +250,11 @@ async def run_forge_cron_tick(
     Exceptions propagate so the shared lifecycle handler marks the
     audit row ``failure`` with the exception text; the next tick
     retries on its normal schedule.
+
+    Raises :class:`PermanentOpError` when the mining half wrote nothing
+    and hit programming errors — a deterministic wiring failure, which
+    the runner records as ``failure`` WITHOUT redelivering. Anything
+    else raised here is treated as retryable in the usual way.
     """
     cfg = await _resolve_forge_config(tenant_id)
     auto_promote_clean = await _resolve_auto_promote_clean(tenant_id)
@@ -334,4 +340,31 @@ async def run_forge_cron_tick(
         window_end.isoformat(),
         stats,
     )
+
+    # A mining half that wrote nothing AND hit programming errors is a broken
+    # deployment, not a quiet day — so the tick must not report success. Permanent
+    # rather than a generic raise because the failure is deterministic; see
+    # ``PermanentOpError``.
+    #
+    # Raised AFTER the log above, deliberately: the audit row carries only
+    # ``candidates_written + promoted``, and this path forfeits even that, so the
+    # log line is the sole record of what actually happened.
+    #
+    # The condition is about the MINING half only. ``promote_result.promoted`` is
+    # not consulted, so a tick that promoted earlier candidates and then failed to
+    # mine still fails — that promotion work survives in the log line above but not
+    # in the audit row. Deliberate: a wiring bug that silences mining is the more
+    # important signal, and it is what went unnoticed for months. What the guard
+    # does protect is the common case — ``candidates_written`` non-zero means one
+    # malformed cluster among successes, which is routine and must not fail a tick
+    # or page anyone.
+    if forge_result.candidates_skipped_internal_error and not forge_result.candidates_written:
+        raise PermanentOpError(
+            f"forge tick wrote no candidates and hit "
+            f"{forge_result.candidates_skipped_internal_error} programming error(s) "
+            f"across {forge_result.clusters_eligible} eligible cluster(s) "
+            f"(tenant={tenant_id} fleet={fleet_id} run={run_label}) — a code/wiring "
+            f"bug; see candidates_skipped_internal_error and the tracebacks above"
+        )
+
     return stats

--- a/tests/test_forge_cron_tick.py
+++ b/tests/test_forge_cron_tick.py
@@ -18,11 +18,13 @@ adapter wires them up correctly.
 
 from __future__ import annotations
 
+import contextlib
 import re
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from common.events.base import PermanentOpError
 from core_api.services.forge.cron_handler import _resolve_forge_config
 from core_api.services.forge.forge_service import ForgeConfig, ForgeRunResult
 from core_api.services.lifecycle_audit import resolve_publisher_kwargs
@@ -511,3 +513,167 @@ class TestInjectedCallableArity:
         is_poisoned.assert_awaited_once_with(
             tenant_id="t1", fleet_id=None, cluster_fingerprint="fp-from-the-seam"
         )
+
+
+# ── The tick's verdict must be truthful (#818 follow-up, round 2) ──
+
+
+@pytest.mark.unit
+class TestTickVerdict:
+    """A tick that mined nothing because of a wiring bug used to return normally,
+    so the shared lifecycle runner wrote ``status="success"``.
+
+    That is not only dishonest: ``has_recent_lifecycle_success`` gates re-runs on a
+    recent SUCCESS, so the false verdict also blocked the operator's next attempt
+    for the 23h dedup window. Re-curling the fanout to reproduce H-08 would have
+    returned "skipped: recent_success" and not run at all — the false success
+    obstructed its own diagnosis.
+    """
+
+    @staticmethod
+    def _forge_result(**over):
+        base = dict(
+            tenant_id="t1",
+            fleet_id=None,
+            window_start=None,
+            window_end=None,
+            total_traces=0,
+            labeled_traces=0,
+            clusters_total=0,
+            clusters_eligible=2,
+            candidates_written=0,
+            candidates_skipped_poisoned=0,
+            candidates_skipped_sentinel=0,
+            candidates_skipped_distill_error=0,
+            candidates_skipped_io_error=0,
+            candidates_skipped_internal_error=0,
+            candidates_skipped_existing=0,
+            started_at=None,
+            run_label="forge-cron-t1-20260820T0900",
+            candidate_doc_ids=[],
+        )
+        base.update(over)
+        return ForgeRunResult(**base)
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _patched(forge_result, promote_result):
+        """Patch every dependency the tick touches; yields the two op mocks.
+
+        Yielding them (rather than swallowing the handles) is what lets this stand
+        in for the hand-rolled ``with (...)`` blocks the other classes in this file
+        use — those assert on ``run_forge.await_args`` / ``run_promote.await_args``.
+        """
+        P = "core_api.services.forge.cron_handler."
+        with (
+            patch(
+                P + "get_settings_for_display",
+                new=AsyncMock(return_value={"skills_factory": {"forge": {}}}),
+            ),
+            patch(P + "_wire_llm_fn", new=AsyncMock(return_value=AsyncMock())),
+            patch(P + "_make_candidate_writer", return_value=AsyncMock()),
+            patch(P + "_make_status_checker", return_value=AsyncMock()),
+            patch(P + "run_forge_distill", new=AsyncMock(return_value=forge_result)) as run_forge,
+            patch(
+                P + "promote_pending_candidates",
+                new=AsyncMock(return_value=promote_result),
+            ) as run_promote,
+            patch(P + "make_db_poison_checker", return_value=AsyncMock()),
+            patch(P + "make_db_live_data_fetcher", return_value=AsyncMock()),
+            patch(P + "make_db_status_updater", return_value=AsyncMock()),
+        ):
+            yield run_forge, run_promote
+
+    async def _tick(self, forge_result, promote_result):
+        from core_api.services.forge.cron_handler import run_forge_cron_tick
+
+        with self._patched(forge_result, promote_result):
+            return await run_forge_cron_tick(
+                tenant_id="t1", fleet_id=None, run_label="forge-cron-t1-20260820T0900"
+            )
+
+    _NO_PROMOTIONS = PromoterRunResult(
+        tenant_id="t1", fleet_id=None, scanned=0, promoted=0, held=0, auto_approved=0
+    )
+
+    @pytest.mark.asyncio
+    async def test_wrote_nothing_with_programming_errors_fails_the_tick(self):
+
+        with pytest.raises(PermanentOpError) as exc:
+            await self._tick(
+                self._forge_result(candidates_skipped_internal_error=2), self._NO_PROMOTIONS
+            )
+
+        # The message has to name the counter and the scope, or the failure row's
+        # error_message (truncated to 500 chars) tells on-call nothing actionable.
+        assert "candidates_skipped_internal_error" in str(exc.value)
+        assert "code/wiring bug" in str(exc.value)
+        assert "t1" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_it_is_terminal_so_the_runner_will_not_redeliver(self):
+        """Not a generic exception: a deterministic bug hits every cluster every
+        tick, so redelivery only repeats the LLM spend before failing the same
+        way. ``PermanentOpError`` is what tells the runner to ack."""
+
+        with pytest.raises(PermanentOpError):
+            await self._tick(
+                self._forge_result(candidates_skipped_internal_error=1), self._NO_PROMOTIONS
+            )
+
+    @pytest.mark.asyncio
+    async def test_internal_errors_alongside_a_written_candidate_do_not_fail_it(self):
+        """One malformed cluster among successes is routine. Failing the tick over
+        it would discard real work from the audit row and page someone nightly."""
+        stats = await self._tick(
+            self._forge_result(candidates_written=1, candidates_skipped_internal_error=1),
+            self._NO_PROMOTIONS,
+        )
+        assert stats["candidates_written"] == 1
+        assert stats["skipped_internal_error"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_quiet_tick_still_succeeds(self):
+        """Nothing to mine is not a failure — otherwise every idle tenant would
+        fail its tick nightly and the signal would be worthless."""
+        stats = await self._tick(self._forge_result(clusters_eligible=0), self._NO_PROMOTIONS)
+        assert stats["candidates_written"] == 0
+        assert stats["skipped_internal_error"] == 0
+
+    @pytest.mark.asyncio
+    async def test_io_errors_alone_do_not_fail_the_tick(self):
+        """Storage having a bad day is exactly what the tick is meant to survive —
+        and unlike a wiring bug, a retry genuinely might help."""
+        stats = await self._tick(
+            self._forge_result(candidates_skipped_io_error=2), self._NO_PROMOTIONS
+        )
+        assert stats["skipped_io_error"] == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_permanent_error_survives_the_adapter_seam():
+    """The raise has to cross ``_CoreApiLifecycleAdapter.forge_distill`` to reach
+    the runner that acts on it.
+
+    Worth its own test because that adapter is pure wiring, and pure wiring is
+    exactly what went unwatched in H-08: the cron tests stubbed the seam, so a
+    shape mismatch inside it was invisible to every suite. A stray ``try/except``
+    added there later would silently restore the false-success behaviour this
+    change exists to remove, and nothing else would notice.
+    """
+    from core_api.services.lifecycle_audit import _CoreApiLifecycleAdapter
+
+    adapter = _CoreApiLifecycleAdapter(AsyncMock())
+    boom = PermanentOpError("wrote nothing; wiring bug")
+
+    with patch(
+        "core_api.services.forge.cron_handler.run_forge_cron_tick",
+        new=AsyncMock(side_effect=boom),
+    ):
+        with pytest.raises(PermanentOpError) as exc:
+            await adapter.forge_distill(org_id="t1", fleet_id=None, run_label="r1")
+
+    # Identity, not just type: a re-wrapped exception would lose the message the
+    # failure row stores, and would no longer be the class the runner acks on.
+    assert exc.value is boom

--- a/tests/test_lifecycle_handlers.py
+++ b/tests/test_lifecycle_handlers.py
@@ -14,7 +14,7 @@ from functools import partial
 
 import pytest
 
-from common.events.base import Event
+from common.events.base import Event, PermanentOpError
 from common.events.lifecycle_archive_request import LifecycleArchiveRequest
 from common.events.lifecycle_handlers import _run_action
 from common.events.lifecycle_purge_request import LifecyclePurgeRequest
@@ -443,3 +443,82 @@ async def test_archive_op_does_not_invoke_dedup_gate():
     handler = _bind(adapter, action="archive-expired")  # no dedup_window
     await handler(_archive_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
     assert adapter.dedup_calls == []
+
+
+@pytest.mark.asyncio
+async def test_terminal_op_error_marks_failure_but_does_not_reraise():
+    """A ``PermanentOpError`` means "failed, and a retry cannot help".
+
+    The runner previously had one failure path, which always re-raised so the bus
+    nacked. That conflates "did it succeed?" with "should it be retried?" — for a
+    deterministic bug (a wrongly-shaped injectable hitting every cluster, every
+    tick) the honest answers differ, and each redelivery of the Forge tick pays for
+    an LLM call per cluster before failing identically.
+
+    So: same durable ``failure`` row as any other exception, but ACK.
+    """
+
+    err = PermanentOpError("wrote nothing; 2 programming errors — code/wiring bug")
+    adapter = _FakeAdapter(raise_on_op=err)
+    handler = _bind(adapter, action="archive-expired")
+
+    # No pytest.raises: propagating is exactly what must NOT happen here.
+    await handler(_archive_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
+
+    statuses = [c[1] for c in adapter.audit_calls]
+    assert statuses == ["in_progress", "failure"], statuses
+    final = adapter.audit_calls[-1]
+    assert final[3] == "wrote nothing; 2 programming errors — code/wiring bug"
+    # ``stats`` is what makes the two failure classes distinguishable in the
+    # DURABLE record. Without it, "a human must act" and "four more attempts are
+    # coming" are byte-identical rows and nobody can query or alert on the
+    # difference — which would undercut the point of fixing the verdict at all.
+    assert final[2] == {"terminal": True}
+
+
+@pytest.mark.asyncio
+async def test_terminal_failure_is_not_recorded_as_a_recent_success():
+    """The reason the verdict matters: ``has_recent_lifecycle_success`` gates
+    re-runs on a SUCCESS row. A terminal failure must leave that gate open so the
+    operator can re-run to reproduce — the bug this whole change exists to stop is
+    a false success blocking its own diagnosis."""
+
+    adapter = _FakeAdapter(raise_on_op=PermanentOpError("terminal"))
+    handler = _bind(adapter, action="archive-expired")
+
+    await handler(_archive_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))
+
+    assert "success" not in [c[1] for c in adapter.audit_calls]
+
+
+@pytest.mark.asyncio
+async def test_permanent_error_still_reraises_when_the_failure_row_could_not_be_written():
+    """Acking a permanent failure is only defensible because the ``failure`` row is
+    the durable record. When that write fails there IS no record, so this path must
+    fall through to the raise and let redelivery try again to produce one.
+
+    Otherwise the ack makes a row stuck in ``in_progress`` permanent — exactly the
+    state indistinguishable from a crashed worker that the generic path's guard
+    exists to avoid. One wasted retry is the cheaper trade.
+    """
+
+    class _FlakyAuditAdapter(_FakeAdapter):
+        async def update_lifecycle_audit_row(
+            self,
+            audit_id: int,
+            *,
+            status: str,
+            stats: dict | None = None,
+            error_message: str | None = None,
+        ) -> None:
+            self.audit_calls.append((audit_id, status, stats, error_message))
+            if status == "failure":
+                raise RuntimeError("audit endpoint down")
+
+    adapter = _FlakyAuditAdapter(raise_on_op=PermanentOpError("wiring bug"))
+    handler = _bind(adapter, action="archive-expired")
+
+    # The ORIGINAL error propagates, not the audit flake — the bus must see why
+    # the op failed, and the audit error would be a misleading substitute.
+    with pytest.raises(PermanentOpError, match="wiring bug"):
+        await handler(_archive_event(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED))


### PR DESCRIPTION
Third and last piece of the H-08 (#818) follow-up. #833 fixed the arity bug; #834 made the failure class distinguishable and loud. Both left the **verdict** lying: a tick where every cluster raised `TypeError` returned normally, so the shared lifecycle runner wrote `status="success"` with zero candidates written.

## Why the verdict mattered more than it looks

`has_recent_lifecycle_success` gates re-runs on a recent **SUCCESS**. So the false success also blocked the operator's next attempt for the 23h dedup window — someone re-curling the fanout to reproduce H-08 would have got `{"skipped": true, "reason": "recent_success"}` and no run at all. **The false verdict obstructed its own diagnosis.**

## Why not just raise

The runner reaches `status="failure"` only via an exception, and then re-raises so the bus nacks. That conflates two questions — "did it succeed?" and "should it be retried?" — and for a deterministic wiring bug the honest answers differ. A plain raise gets the audit row right, then buys max-delivery-attempts worth of identical re-runs, each paying for an LLM call per cluster before failing the same way.

So: `PermanentOpError`. The runner records the same `failure` row and **acks**. Named to match `common.ranking.errors.PermanentRankError` — the same idea one layer over — so one word covers one concept and a grep for either finds both.

Three details that came out of review rather than the first draft:

- **One write, not two.** Both failure classes flow through a single guarded audit write with `permanent = isinstance(...)` deciding only the tail. Two near-identical blocks would have drifted on exactly the axis this change exists to make trustworthy.
- **`stats={"terminal": True}` on the terminal row.** Without it the two classes are byte-identical rows, and "nothing more will happen, a human must act" lives only in a log line — unqueryable, unalertable. Mirrors how the dedup gate disambiguates two meanings of `success` via `stats={"skipped": True}`.
- **Acking requires the row to have been written.** If the audit update fails there is no durable record — the entire justification for acking — so that case falls through to the raise and lets redelivery try again. One wasted retry beats a row stuck `in_progress` forever.

## Scope, stated in the docstring

Only the lifecycle runner honours this. Handlers registered directly on the bus (`core_worker.consumer`) get no special treatment — neither bus inspects the exception type — and they own their own audit rows, so they should write `failure` and return instead. Deliberately **not** exported from `common.events`: it had zero consumers there, and exporting it advertised a bus-level contract the bus doesn't implement. Also documented: prefer a plain raise for cheap idempotent ops, where a nack costs nothing and the machinery isn't worth it.

## The guard, and what it doesn't cover

Raised when the mining half wrote nothing **and** hit programming errors. `promote_result.promoted` is deliberately not consulted, so a tick that promoted earlier candidates and then failed to mine still fails — that promotion work survives in the log line but not the audit row. A wiring bug that silences mining is the more important signal, and it's what went unnoticed for months.

Worth flagging: an earlier draft of this PR **claimed a promotion carve-out the code did not implement**. `/simplify` caught it; the comment now describes what the code does. That's the highest-yield review category in this repo and I'd rather note that it happened than quietly fix it.

## Tests

Five verdict cases on the tick (fails on wrote-nothing-plus-internal-errors; not on internal-errors-alongside-a-write; not on a genuinely quiet tick; not on io_errors alone) and four on the runner (failure row written, ack rather than re-raise, no success row so the dedup gate stays open, re-raise when the row couldn't be written). Plus one on the adapter seam the raise crosses — pure wiring, which is precisely what went unwatched in H-08, where the cron tests stubbed it.

Each behaviour verified by reverting it: dropping the ack path re-raises; dropping the stats marker fails the durable-record assertion; dropping `and recorded` acks a failure that was never recorded.

## Checks

4571 passed, 3 skipped, 1 xfailed. `ruff check core-api/src/ common/`, `ruff format --check`, and `mypy src/` all clean.

## Follow-ups this surfaced

- `_OpFn` is `Callable[..., Awaitable[int]]`, so an op has exactly one int of expressiveness and "I failed and a retry won't help" has nowhere to go but the exception channel. A result object (`OpOutcome(count, verdict, detail)`) is the principled shape, but it rewrites seven op closures across two services — not this PR.
- `core_worker.consumer.handle_embed_backfill_request` already hand-rolls "failed, don't retry" for its `fleet_id` guard, because it owns its own audit row. Two shapes for one concept is fine while the reason differs; if a third appears, that's the moment for the `OpOutcome` refactor.
- That same call site writes its audit row unguarded, unlike every other audit write in the codebase. Pre-existing, unrelated, worth a one-liner.

Refs #818
