### PR TITLE
fix(consumer): route the embed/enrich back-channel read-backs to the writer

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -467,8 +467,16 @@ class CoreStorageClient:
             _reject_reserved_write_id(item.get("agent_id"))
         return await self._post("/memories/bulk", data)
 
-    async def get_memory(self, memory_id: str) -> dict | None:
-        return await self._get(f"/memories/{memory_id}")
+    async def get_memory(self, memory_id: str, *, read: bool = True) -> dict | None:
+        """Fetch one memory by id.
+
+        ``read=False`` routes to the WRITER. Pass it for a read-your-write — a
+        read-back of a row this request (or an event's producer) just wrote, where
+        replica lag would make the row or the freshly-PATCHed column invisible.
+        Same reasoning as the write-path dedup gate below, which passes it for the
+        same reason.
+        """
+        return await self._get(f"/memories/{memory_id}", read=read)
 
     async def get_memory_for_tenant(self, tenant_id: str, memory_id: str) -> dict | None:
         return await self._get(f"/memories/{memory_id}", tenant_id=tenant_id)

--- a/core-api/src/core_api/consumer.py
+++ b/core-api/src/core_api/consumer.py
@@ -79,11 +79,16 @@ async def handle_memory_enriched(event: Event) -> None:
         return
 
     sc = get_storage_client()
-    memory = await sc.get_memory(str(payload.memory_id))
+    # H-02: ``read=False`` (WRITER). This is a read-your-write — the worker PATCHes
+    # the enrichment and publishes immediately after, and Pub/Sub delivery is
+    # typically sub-second, so a replica read races replication. On the replica the
+    # miss lands in the ack-drop below, which never redelivers, and this handler is
+    # one of only two contradiction-detection triggers on the deferred path.
+    memory = await sc.get_memory(str(payload.memory_id), read=False)
     if memory is None:
-        # Row was deleted between the worker's PATCH and our handler
-        # picking up the event. Common-enough race to ack-drop without
-        # noise; matches the worker's 404 handling.
+        # Genuinely deleted between the worker's PATCH and this handler — which the
+        # writer read makes true. Read from the replica it was not: an unreplicated
+        # row is also absent, so this branch silently absorbed lag as deletion.
         logger.info(
             "memory-enriched: target row missing; ack-dropping",
             extra={
@@ -182,11 +187,16 @@ async def handle_memory_embedded(event: Event) -> None:
         return
 
     sc = get_storage_client()
-    memory = await sc.get_memory(str(payload.memory_id))
+    # H-02: ``read=False`` (WRITER) — see handle_memory_enriched. The embed path is
+    # the sharper case: on the deferred-embed path this back-channel is the SOLE
+    # Path A contradiction trigger, and with tenant enrichment disabled no ENRICHED
+    # event ever fires to cover for it, so a lagged read dropped detection
+    # unconditionally. Contradictory memories then both stay ``active`` and recall
+    # keeps returning the stale one.
+    memory = await sc.get_memory(str(payload.memory_id), read=False)
     if memory is None:
-        # Row was deleted between the worker's PATCH and our handler
-        # picking up the event. Common-enough race to ack-drop without
-        # noise; matches the worker's 404 handling.
+        # Genuinely deleted — true against the writer, not against a replica, where
+        # an unreplicated row is indistinguishable from a deleted one.
         logger.info(
             "memory-embedded: target row missing; ack-dropping",
             extra={
@@ -198,10 +208,15 @@ async def handle_memory_embedded(event: Event) -> None:
 
     embedding = memory.get("embedding")
     if not embedding:
-        # Should not happen — the embed worker just PATCHed it before
-        # publishing — but guard against a soft-delete or column
-        # rewrite race rather than passing None into the detector.
-        logger.warning(
+        # Now genuinely "should not happen": the worker PATCHes the embedding, waits
+        # for it, and only then publishes, so the writer has it. Reading the replica
+        # this fired routinely under lag while claiming to be impossible.
+        #
+        # ERROR, not warning: the only remaining causes are a real invariant
+        # violation (a column rewrite, a soft-delete racing the PATCH), and the cost
+        # is a silently-missed contradiction check. Still ack — a retry would read
+        # the same writer row and reach the same branch.
+        logger.error(
             "memory-embedded: embedding missing on read-back; ack-dropping",
             extra={
                 "memory_id": str(payload.memory_id),

--- a/tests/test_consumer_enriched.py
+++ b/tests/test_consumer_enriched.py
@@ -100,7 +100,11 @@ async def test_handle_memory_enriched_invokes_contradiction_detection(
 
     await consumer.handle_memory_enriched(event)
 
-    mock_storage_client.get_memory.assert_awaited_once_with(str(memory_id))
+    # H-02: the read-back MUST go to the writer. This is a read-your-write —
+    # the worker PATCHes then publishes immediately, so a replica read races
+    # replication and the miss ack-drops, killing one of only two
+    # contradiction-detection triggers on the deferred path.
+    mock_storage_client.get_memory.assert_awaited_once_with(str(memory_id), read=False)
     # ``new_memory`` is passed kwarg-only — threading the row through
     # eliminates the redundant second ``get_memory`` inside
     # ``detect_contradictions_async``.
@@ -286,3 +290,82 @@ async def test_register_consumers_subscribes_to_both_topics() -> None:
         consumer.handle_org_settings_changed,
         broadcast=True,
     )
+
+
+# ── H-02: both back-channel read-backs must hit the WRITER ────────────────
+
+
+def _embedded_event(memory_id, tenant_id: str = "tenant-A", content: str = "postgres it is") -> Event:
+    """EMBEDDED envelope. ``_make_event`` above hardcodes ENRICHED, and the two
+    payloads are different models, so this stays separate rather than growing a
+    topic parameter onto a helper every other test calls with no arguments."""
+    return Event(
+        event_type=Topics.Memory.EMBEDDED,
+        tenant_id=tenant_id,
+        payload={
+            "memory_id": str(memory_id),
+            "tenant_id": tenant_id,
+            "content": content,
+        },
+    )
+
+
+
+
+@pytest.mark.asyncio
+async def test_embedded_handler_reads_the_writer_not_the_replica(
+    mock_storage_client, mock_detect
+) -> None:
+    """``handle_memory_embedded`` is the sharper of the two.
+
+    On the deferred-embed path this back-channel is the SOLE Path A contradiction
+    trigger, and when a tenant has enrichment disabled no ENRICHED event ever fires
+    to cover for it. So a lagged replica read dropped detection unconditionally, and
+    contradictory memories both stayed ``active`` — recall kept serving the stale
+    one, silently.
+    """
+    memory_id = uuid.uuid4()
+    mock_storage_client.get_memory.return_value = {
+        "id": str(memory_id),
+        "tenant_id": "tenant-A",
+        "fleet_id": "fleet-X",
+        "content": "postgres it is",
+        "embedding": [0.2] * 1536,
+    }
+
+    await consumer.handle_memory_embedded(
+        _embedded_event(memory_id)
+    )
+
+    mock_storage_client.get_memory.assert_awaited_once_with(str(memory_id), read=False)
+
+
+@pytest.mark.asyncio
+async def test_embedded_handler_does_not_silently_absorb_a_missing_embedding(
+    mock_storage_client, mock_detect, caplog
+) -> None:
+    """Reading the writer makes "should not happen" true, so if it DOES happen it is
+    a real invariant violation and must not hide at warning level.
+
+    Still acked: a retry reads the same writer row and reaches the same branch.
+    """
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="core_api.consumer")
+    memory_id = uuid.uuid4()
+    mock_storage_client.get_memory.return_value = {
+        "id": str(memory_id),
+        "tenant_id": "tenant-A",
+        "fleet_id": None,
+        "content": "x",
+        "embedding": None,
+    }
+
+    await consumer.handle_memory_embedded(
+        _embedded_event(memory_id)
+    )
+
+    mock_detect.assert_not_awaited()
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, f"expected an ERROR; got {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    assert "embedding missing on read-back" in errors[0].getMessage()


### PR DESCRIPTION
Fixes H-02 (#812). Premise re-verified on `main` before changing anything.

## The bug

`handle_memory_embedded` reads the memory back with `sc.get_memory(...)`, whose `_get` defaults to `read=True` — the **read-replica** pool when `CORE_STORAGE_READ_URL` is set. But this is a read-your-write: the worker PATCHes the embedding and publishes `Topics.Memory.EMBEDDED` immediately after, and Pub/Sub delivery is typically sub-second, so the read races replication.

Under lag it lands in one of two **ack-drop** branches — row not yet replicated (read as "deleted"), or row visible but the embedding PATCH not (read as "should not happen"). Both ack, so the event never redelivers.

On the deferred-embed path this back-channel is the **sole** Path A contradiction trigger, and when a tenant has enrichment disabled no `ENRICHED` event ever fires to cover for it — so the drop is unconditional. Outcome: contradictory memories are never marked outdated, both stale and fresh stay `active`, and recall keeps serving the stale one. Silently.

## Both handlers, not just the one filed

The issue names `handle_memory_embedded`. **`handle_memory_enriched` has the identical pattern** — same unqualified `get_memory`, same ack-drop, same PATCH-then-publish producer — and per `memory_service.py` those two are the *pair* that own deferred-path contradiction detection. Fixing one would have left the other racing, so both are routed.

## The fix

`get_memory` grows `read: bool = True` (default preserved for its eight other callers) and both back-channel reads pass `read=False`.

Not a new idea in this client: the write-path dedup gate already passes `read=False` with a comment citing exactly this staleness. And a writer read cannot miss, because the producer awaits the PATCH — its own committed transaction storage-side — before publishing, as its own comment says ("the embedding is durable in storage either way").

**The comments were the other half of the bug.** Both ack-drop branches asserted causes that were false under lag — "row was deleted" and "should not happen" — so the code documented an impossibility it was hitting routinely. Against the writer those become true, and they now say why.

The missing-embedding branch is also escalated to **ERROR**: its only remaining causes are real invariant violations, and the cost is a silently-missed contradiction check. It still acks — a retry reads the same writer row and reaches the same branch.

## Tests

The existing enriched test already pinned the call shape, so it failed on the change; it now pins `read=False` and carries the reason. Two new cases: the embedded handler routes to the writer, and a missing embedding surfaces at ERROR rather than hiding at warning.

Verified by reverting: dropping `read=False` fails both routing tests; leaving the log at warning fails the escalation test.

## Checks

4573 passed, 3 skipped, 1 xfailed. `ruff check` / `ruff format --check` clean on `core-api/src/`.

`/simplify` skipped deliberately: one keyword argument, two call sites, and comment corrections — no new logic or control flow. The comments' load-bearing claims (producer ordering, per-PATCH commit, and that these two handlers are the only deferred-path triggers) were each read out of the code rather than assumed.

## Noticed, not changed

`contradiction_detector.py` has three more `get_memory` read-backs (lines ~200, ~1964, and a `refreshed = ...` at ~1981) that may be read-your-writes on the write path. I didn't touch them — they're outside this issue's mechanism and each needs its own check of whether a preceding write is involved. Worth a look if someone wants the sweep.

Refs #812
