### PR TITLE
fix(storage): duplicate content hashes must 409, not 500 forever

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -956,6 +956,40 @@ class PostgresService:
     # B) Content hash / dedup
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _warn_duplicate_content_hash(
+        *,
+        tenant_id: str,
+        fleet_id: str | None,
+        agent_id: str | None,
+        content_hash: str,
+        kept_id: UUID,
+        path: str,
+        excluded_self: bool = False,
+    ) -> None:
+        """Report live rows that violate the uniqueness the schema never enforced.
+
+        H-04: shared by both dedup gates deliberately. They hit the same anomaly,
+        and a warning emitted from only one of them would undercount the duplicate
+        population — which is the number the partial unique index decision rests
+        on. One call site for the message also means the two cannot drift.
+        """
+        logger.warning(
+            "duplicate live rows share a content_hash — dedup returns the oldest",
+            extra={
+                "tenant_id": tenant_id,
+                "fleet_id": fleet_id,
+                "agent_id": agent_id,
+                "content_hash": content_hash[:12],
+                "kept_memory_id": str(kept_id),
+                # Which gate saw it, so the two are separable in a log query.
+                "dedup_path": path,
+                # True → the count excludes the row being updated, so the real
+                # group is one larger than what this gate could see.
+                "excluded_self": excluded_self,
+            },
+        )
+
     async def memory_find_by_content_hash(
         self,
         tenant_id: str,
@@ -979,7 +1013,44 @@ class PostgresService:
                 stmt = stmt.where(Memory.fleet_id.is_(None))
             if agent_id is not None:
                 stmt = stmt.where(Memory.agent_id == agent_id)
-            return (await session.execute(stmt)).scalar_one_or_none()
+            # H-04: oldest-first + LIMIT 2, not ``scalar_one_or_none()``.
+            #
+            # Nothing in the schema enforces one live row per
+            # (tenant, fleet, agent, content_hash) — ``ix_memories_content_hash``
+            # is a NON-unique index on (tenant_id, content_hash) — and several
+            # paths mint duplicates without any concurrency at all (auto-chunk
+            # children carry a content_hash and skip the dedup lookup entirely).
+            # ``scalar_one_or_none()`` raises ``MultipleResultsFound`` on two live
+            # rows, which surfaces as a storage 500 → a FAILED pipeline step →
+            # "Memory write pipeline failed unexpectedly". Permanently: every
+            # subsequent write of that content 500s instead of 409ing, and no code
+            # path heals it short of deleting a row by hand.
+            #
+            # Returning a row instead means duplicates degrade to the 409 the
+            # contract always intended. Oldest first so it is the row that
+            # legitimately won that contract.
+            #
+            # ``id`` breaks ties, and ties are the COMMON case here, not an edge:
+            # ``created_at`` is ``server_default=now()``, which Postgres fixes for
+            # the whole transaction, and the auto-chunk path inserts all its
+            # children in one ``create_memories`` call — so duplicates minted that
+            # way share ``created_at`` exactly. On a tie ``ORDER BY created_at``
+            # alone leaves the pick to the plan, which would defeat the stability
+            # this ordering exists to provide. Ordering by ``id`` is not
+            # chronological, but among rows of the same instant there is no
+            # chronology to preserve — only a stable answer to give.
+            stmt = stmt.order_by(Memory.created_at.asc(), Memory.id.asc()).limit(2)
+            rows = (await session.execute(stmt)).scalars().all()
+            if len(rows) > 1:
+                self._warn_duplicate_content_hash(
+                    tenant_id=tenant_id,
+                    fleet_id=fleet_id,
+                    agent_id=agent_id,
+                    content_hash=content_hash,
+                    kept_id=rows[0].id,
+                    path="find_by_content_hash",
+                )
+            return rows[0] if rows else None
 
     async def memory_find_duplicate_hash(
         self,
@@ -1003,7 +1074,34 @@ class PostgresService:
                 stmt = stmt.where(Memory.agent_id == agent_id)
             if exclude_id is not None:
                 stmt = stmt.where(Memory.id != exclude_id)
-            return (await session.execute(stmt)).scalar_one_or_none()
+            # Same H-04 wedge as ``memory_find_by_content_hash`` above: this is the
+            # UPDATE path's dedup gate, and two live rows sharing a hash made every
+            # content update to that value 500 rather than 409. Caller only needs
+            # "is there one, and which", so the oldest is as good an answer as any
+            # and a stable one.
+            #
+            # LIMIT 2 rather than 1 for the same reason as the read path: one extra
+            # row is what makes the anomaly observable. Reporting from only one of
+            # the two affected gates would undercount the duplicate population that
+            # the unique index decision depends on.
+            rows = (
+                (await session.execute(stmt.order_by(Memory.created_at.asc(), Memory.id.asc()).limit(2)))
+                .scalars()
+                .all()
+            )
+            if len(rows) > 1:
+                self._warn_duplicate_content_hash(
+                    tenant_id=tenant_id,
+                    fleet_id=fleet_id,
+                    agent_id=agent_id,
+                    content_hash=content_hash,
+                    kept_id=rows[0],
+                    path="find_duplicate_hash",
+                    # This gate excludes the row being updated, so >1 here means at
+                    # least two OTHER rows already share the hash.
+                    excluded_self=exclude_id is not None,
+                )
+            return rows[0] if rows else None
 
     async def memory_find_embedding_by_content_hash(
         self,

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -610,6 +610,177 @@ class TestMemories:
         # check_exact_duplicate step reads dup["id"] straight off this.
         assert resp.json()["content_hash"] == content_hash
 
+    async def test_duplicate_hashes_return_the_oldest_instead_of_500ing(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """H-04: two live rows sharing a content_hash must not wedge the gate.
+
+        Nothing enforces one live row per (tenant, fleet, agent, content_hash) —
+        ``ix_memories_content_hash`` is non-unique — and paths like auto-chunk mint
+        duplicates with no concurrency at all. ``scalar_one_or_none()`` raised
+        ``MultipleResultsFound`` on two rows, which became a storage 500 and a
+        FAILED write-pipeline step, PERMANENTLY: every later write of that content
+        500'd instead of 409ing, with no path that heals it.
+
+        Returning the oldest row degrades the state to the 409 the contract always
+        intended.
+        """
+        content = f"duplicate hash content {_uid()}"
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+
+        # Two live rows, same hash — exactly what the non-unique index permits.
+        # Distinct client_request_ids so the idempotency gate does not fold them.
+        first = await client.post(
+            f"{PREFIX}/memories",
+            json=_memory_payload(tenant_id, fleet_id, content=content, content_hash=content_hash),
+        )
+        second = await client.post(
+            f"{PREFIX}/memories",
+            json=_memory_payload(tenant_id, fleet_id, content=content, content_hash=content_hash),
+        )
+        assert first.status_code in (200, 201), first.text
+        assert second.status_code in (200, 201), second.text
+        assert first.json()["id"] != second.json()["id"], (
+            "storage accepted both rows — if this ever fails, a unique constraint "
+            "landed and this test's premise is gone (which would be good news)"
+        )
+
+        resp = await client.get(
+            f"{PREFIX}/memories/by-content-hash",
+            params={
+                "tenant_id": tenant_id,
+                "content_hash": content_hash,
+                "fleet_id": fleet_id,
+            },
+        )
+
+        # The whole point: 200 with a row, not 500.
+        assert resp.status_code == 200, resp.text
+        # And deterministically the OLDER row — the one that legitimately won the
+        # 409 contract — so repeated calls agree rather than following the planner.
+        assert resp.json()["id"] == first.json()["id"]
+
+    async def test_same_transaction_duplicates_resolve_stably(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """H-04: the tie case, which is the COMMON one rather than an edge.
+
+        ``created_at`` is ``server_default=now()`` and Postgres fixes ``now()`` for
+        the whole transaction, so duplicates inserted together — which is exactly
+        how the auto-chunk path writes its children, one ``create_memories`` call —
+        share ``created_at`` to the microsecond. Ordering by ``created_at`` alone
+        then leaves the pick to the query plan, so "returns the oldest, stably"
+        would hold only by luck.
+
+        HONEST LIMIT: this test does NOT fail if the ``Memory.id`` tie-break is
+        removed. Instability is plan-dependent, and on a table this small Postgres
+        returns heap order, which happens to be stable and insertion-ordered. So
+        treat this as an assertion about the intended OUTCOME — ties exist, the
+        answer is stable, and it is the tie-break winner — not as proof that the
+        unordered form is broken. The guarantee comes from the ORDER BY being
+        total, which no fixture can force Postgres to violate on demand.
+        """
+        content = f"same-txn duplicate {_uid()}"
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+        attempt = _uid()
+        items = [
+            {
+                **_memory_payload(tenant_id, fleet_id, content=content, content_hash=content_hash),
+                "client_request_id": f"{attempt}:{idx}",
+            }
+            for idx in range(3)
+        ]
+
+        resp = await client.post(f"{PREFIX}/memories/bulk", json=items)
+        assert resp.status_code == 200, resp.text
+        inserted = [e["id"] for e in resp.json() if e["was_inserted"]]
+        assert len(inserted) == 3, f"expected 3 live duplicates, got {resp.json()}"
+
+        # Prove the premise rather than assuming it: if these rows did NOT share
+        # created_at, the assertions below would pass on ordinary chronological
+        # ordering and prove nothing about the tie-break.
+        stamps = set()
+        for mid in inserted:
+            row = await client.get(f"{PREFIX}/memories/{mid}")
+            assert row.status_code == 200, row.text
+            stamps.add(row.json()["created_at"])
+        assert len(stamps) == 1, f"expected one shared created_at, got {stamps}"
+
+        params = {
+            "tenant_id": tenant_id,
+            "content_hash": content_hash,
+            "fleet_id": fleet_id,
+        }
+        picks = []
+        for _ in range(4):
+            r = await client.get(f"{PREFIX}/memories/by-content-hash", params=params)
+            assert r.status_code == 200, r.text
+            picks.append(r.json()["id"])
+
+        # Same answer every time, and it is the tie-break winner (lowest id among
+        # the tied rows) rather than whatever the plan produced this run.
+        assert len(set(picks)) == 1, f"unstable pick across calls: {picks}"
+        assert picks[0] == min(inserted)
+
+    async def test_update_path_gate_also_reports_duplicates(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+        caplog,
+    ) -> None:
+        """H-04 round 2: the UPDATE path's gate hits the same anomaly.
+
+        Both gates were wedging on ``MultipleResultsFound``; only the read path was
+        made observable. Reporting from one of two affected gates undercounts the
+        duplicate population, and that count is what the partial unique index
+        decision rests on — so this pins the other half.
+        """
+        import logging
+
+        content = f"update-path duplicate {_uid()}"
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+        attempt = _uid()
+        # No fleet: the ``/duplicate-hash`` route takes only tenant_id +
+        # content_hash + exclude_id, so it queries ``fleet_id IS NULL``. Rows with a
+        # fleet would not match it at all — a pre-existing narrowness of that route
+        # (the service method supports fleet_id and agent_id; the route exposes
+        # neither), noted rather than changed here since widening it would alter
+        # dedup scope.
+        items = [
+            {
+                **_memory_payload(tenant_id, fleet_id, content=content, content_hash=content_hash),
+                "fleet_id": None,
+                "client_request_id": f"{attempt}:{idx}",
+            }
+            for idx in range(3)
+        ]
+        resp = await client.post(f"{PREFIX}/memories/bulk", json=items)
+        assert resp.status_code == 200, resp.text
+        inserted = sorted(e["id"] for e in resp.json() if e["was_inserted"])
+        assert len(inserted) == 3
+
+        with caplog.at_level(logging.WARNING, logger="core_storage_api.services.postgres_service"):
+            r = await client.get(
+                f"{PREFIX}/memories/duplicate-hash",
+                params={"tenant_id": tenant_id, "content_hash": content_hash},
+            )
+
+        # 200 with a row, not the 500 this used to be.
+        assert r.status_code == 200, r.text
+        assert r.json()["memory_id"] == inserted[0]
+
+        warnings = [rec for rec in caplog.records if "share a content_hash" in rec.getMessage()]
+        assert warnings, "the update-path gate resolved a duplicate silently"
+        # Tagged with which gate saw it, so the two are separable in a log query.
+        assert getattr(warnings[-1], "dedup_path", None) == "find_duplicate_hash"
+
     async def test_find_by_content_hash_not_found(
         self,
         client: AsyncClient,


### PR DESCRIPTION
First half of H-04 (#814) — the half that stops the outage. Premise re-verified on `main` before changing anything.

## The wedge

Nothing in the schema enforces one live row per `(tenant_id, fleet_id, agent_id, content_hash)` — `ix_memories_content_hash` is non-unique in migration 001 *and* in the ORM model. Once two live rows share a hash, `memory_find_by_content_hash` raised `MultipleResultsFound` → storage 500 → `raise_for_status` → write-pipeline step FAILED → core-api 500 "Memory write pipeline failed unexpectedly".

**Permanently.** From then on every write of that content by that agent 500s instead of 409ing, and no code path heals it short of deleting a row by hand.

## Both lookups, not just the one filed

The issue cites `memory_find_by_content_hash`. **`memory_find_duplicate_hash` — the UPDATE path's dedup gate — ended in the same `scalar_one_or_none()`**, so content updates to a duplicated value 500'd identically. Both are fixed.

## The fix

Return a row instead of raising: ordered oldest-first with a `LIMIT`, so duplicates degrade to the 409 the contract always intended. Oldest because that's the row which legitimately won the contract — and because a *stable* answer beats whatever the planner returns. The previous query had no `ORDER BY` at all, so even the non-duplicate path was only accidentally deterministic.

`memory_find_by_content_hash` takes `LIMIT 2` rather than 1 so it can notice the duplicate and log a warning naming the tenant, agent, hash prefix and kept row. **That log is the instrument this problem lacked**: duplicates were invisible until one wedged a write, and nobody can add the unique index this table should have had without first knowing how many exist.

## Why duplicates exist at all — this isn't a rare race

Not only the check-then-insert race (whose window in strong mode spans a semantic-dup roundtrip *plus* an up-to-10s LLM judge). The **auto-chunk child payloads are built with a `content_hash` and no preceding dedup lookup**, so that path mints duplicates with zero concurrency; same for the atomic-fact fanout. Any deployment that auto-chunks repeated content likely has duplicates already — which is why the wedge needed healing first.

## Deliberately not in this PR

The partial unique index on `(tenant_id, COALESCE(fleet_id,''), agent_id, content_hash) WHERE deleted_at IS NULL`, plus mapping the insert conflict to 409. That's the half that *prevents* new duplicates, and it can't land safely yet:

- migrations run in the storage service's lifespan startup, so a failing `CREATE UNIQUE INDEX` is a **failed deploy** (the old revision keeps serving);
- given the auto-chunk path above, duplicates are likely already present, so it would fail;
- resolving them means mutating production rows under a keep/delete policy nobody has chosen.

The warning this PR adds is what turns that from a guess into a measurement.

## Test

Two live rows with the same hash, then the dedup GET: 200 with the older row rather than a 500. Reverting the fix reproduces the production error exactly — `sqlalchemy.exc.MultipleResultsFound: Multiple rows were found when one or none was required`.

The test also asserts both inserts really landed, so if a unique constraint ever arrives it fails loudly rather than passing vacuously on a dead premise.

## Checks

126 storage tests passed (125 baseline + 1), 4573 core-api passed, 3 skipped, 1 xfailed. `ruff check` and `ruff format --check` clean on `core-storage-api/src/` and `core-storage-api/tests/`.

Refs #814
