### PR TITLE
fix(write): a committed row must not be abandoned by a failed entity link

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
+++ b/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
@@ -12,6 +12,11 @@ from core_api.services.hooks import get_hooks
 
 logger = logging.getLogger(__name__)
 
+#: Per-link ERROR lines emitted per request before falling back to the single
+#: summary below. ``entity_links`` has no schema bound, so this is what keeps
+#: log volume from tracking caller input.
+_MAX_LINK_ERROR_LOGS = 5
+
 
 class WriteMemoryRow:
     @property
@@ -80,20 +85,104 @@ class WriteMemoryRow:
         memory = await sc.create_memory(memory_data)
         timings["storage_ms"] = round((time.perf_counter() - storage_t0) * 1000)
 
+        # H-05: the row above is COMMITTED, so everything after it degrades rather
+        # than raising. A raise here marks the pipeline FAILED and breaks before
+        # ``ScheduleBackgroundTasks`` — which is what schedules the embed and
+        # enrichment backfill — so the caller got a 500 for a write that persisted
+        # and the row was left unreachable and unrepairable. The test in
+        # tests/pipeline/test_write_pipeline.py carries the full incident.
+        #
+        # ``entity_links`` are caller-supplied UUIDs with no upstream existence
+        # check, so one bad id is an FK violation → storage 500 → HTTPStatusError.
+        # Per-link rather than one try around the loop: a single bad id must not
+        # discard the valid links beside it.
         links_t0 = time.perf_counter()
+        linked: list = []
+        link_failures: list[dict] = []
         for link in data.entity_links:
-            await sc.create_entity_link(
-                {
-                    "memory_id": memory["id"],
-                    # Stringify the UUID for JSON transport — mirrors
-                    # line 60's handling of ``subject_entity_id`` and
-                    # the bulk write path. SQLAlchemy auto-coerces on
-                    # receive, so the persisted value is identical.
-                    "entity_id": str(link.entity_id),
-                    "role": link.role,
-                }
-            )
+            try:
+                await sc.create_entity_link(
+                    {
+                        "memory_id": memory["id"],
+                        # Stringify the UUID for JSON transport — mirrors
+                        # line 60's handling of ``subject_entity_id`` and
+                        # the bulk write path. SQLAlchemy auto-coerces on
+                        # receive, so the persisted value is identical.
+                        "entity_id": str(link.entity_id),
+                        "role": link.role,
+                    }
+                )
+            except Exception as exc:
+                # Still degrade in EVERY case — the row is committed, and letting
+                # anything propagate here is exactly the H-05 bug. But the two
+                # causes need different operator responses, so they are not
+                # logged identically:
+                #
+                #   * 4xx — the caller named a memory/entity that does not exist,
+                #     or a pair already linked. Permanent, their input, one link.
+                #   * anything else (5xx, connect, timeout) — storage's problem,
+                #     ours to chase. If it hits every link in the request it is an
+                #     outage, not N independent data-loss events, and an outage
+                #     with zero failed requests is the worst kind to diagnose.
+                #
+                # This distinction only became possible once the links route
+                # started returning 409 for a bad id; before that an FK violation
+                # and an unreachable storage service were both a bare 500.
+                status = getattr(getattr(exc, "response", None), "status_code", None)
+                permanent = status is not None and 400 <= status < 500
+                link_failures.append(
+                    {"entity_id": str(link.entity_id), "role": link.role, "permanent": permanent}
+                )
+                if len(link_failures) <= _MAX_LINK_ERROR_LOGS:
+                    # ERROR, not warning: unlike the audit hook, a dropped link is
+                    # user-visible data loss — the memory exists but is not
+                    # reachable through that entity, and a link that was never
+                    # created leaves no row for ``GET /entities/broken-links`` to
+                    # find later. The row itself is fine, so the write stands.
+                    logger.error(
+                        "entity link failed; memory kept without it",
+                        exc_info=True,
+                        extra={
+                            "memory_id": memory["id"],
+                            "tenant_id": data.tenant_id,
+                            "entity_id": str(link.entity_id),
+                            "role": link.role,
+                            "error_type": type(exc).__name__,
+                            "status_code": status,
+                            # False → chase storage, not the caller.
+                            "permanent": permanent,
+                        },
+                    )
+                continue
+            linked.append(link)
         timings["entity_links_ms"] = round((time.perf_counter() - links_t0) * 1000)
+        # Read by ``_memory_out_with_created_links``, which echoes these rather
+        # than the request so the caller is told what actually persisted.
+        ctx.data["entity_links_created"] = linked
+        if link_failures:
+            ctx.data["entity_link_failures"] = link_failures
+            transient = sum(1 for f in link_failures if not f["permanent"])
+            if len(link_failures) > _MAX_LINK_ERROR_LOGS or transient:
+                # One summary, because ``entity_links`` is unbounded: a caller
+                # sending a thousand bad ids would otherwise emit a thousand ERROR
+                # lines, and log volume proportional to caller input is a
+                # denial-of-observability. Also fires whenever ANY failure was
+                # transient — that is the outage signal, and it must not be the
+                # thing the cap swallowed.
+                logger.error(
+                    "entity links dropped: %d of %d (%d transient)",
+                    len(link_failures),
+                    len(data.entity_links),
+                    transient,
+                    extra={
+                        "memory_id": memory["id"],
+                        "tenant_id": data.tenant_id,
+                        "dropped": len(link_failures),
+                        "requested": len(data.entity_links),
+                        "transient": transient,
+                        "logged_individually": min(len(link_failures), _MAX_LINK_ERROR_LOGS),
+                    },
+                )
 
         detail = {
             "memory_type": fields["memory_type"],

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -271,6 +271,26 @@ async def create_memory(data: MemoryCreate) -> MemoryOut:
     return await _create_memory_legacy(data)
 
 
+def _memory_out_with_created_links(ctx, memory: dict) -> MemoryOut:
+    """Build the response echoing the links that PERSISTED, not the requested ones.
+
+    H-05: ``WriteMemoryRow`` degrades a failed entity link instead of failing the
+    write, so "requested" and "created" can differ. Reporting a link that does not
+    exist would be a quieter wrong answer than the 500 this replaces.
+
+    Shared because BOTH callers of the persist pipeline return from here — the main
+    create path and the auto-chunk fall-through — and only one of them was fixed
+    first. A third caller would have drifted the same way.
+    """
+    return _memory_to_out(
+        memory,
+        entity_links=[
+            EntityLinkOut(entity_id=link.entity_id, role=link.role)
+            for link in ctx.data["entity_links_created"]
+        ],
+    )
+
+
 async def _create_memory_pipeline(data: MemoryCreate) -> MemoryOut:
     """Pipeline-based create_memory — same logic, decomposed into timed steps."""
     from core_api.pipeline.compositions.write import (
@@ -406,12 +426,7 @@ async def _create_memory_pipeline(data: MemoryCreate) -> MemoryOut:
             raise _exc
 
         memory = ctx.data["memory"]
-        return _memory_to_out(
-            memory,
-            entity_links=[
-                EntityLinkOut(entity_id=link.entity_id, role=link.role) for link in data.entity_links
-            ],
-        )
+        return _memory_out_with_created_links(ctx, memory)
     finally:
         timings = ctx.data.get("phase_timings", {})
         # Defensive ``.get`` — when the pipeline raised, ``ctx.data["memory"]``
@@ -448,6 +463,14 @@ async def _create_memory_pipeline(data: MemoryCreate) -> MemoryOut:
                 "embedding_pending": bool(memory_metadata.get("embedding_pending")),
                 "enrichment_pending": bool(memory_metadata.get("enrichment_pending")),
                 "cached_embedding": ctx.data.get("cached_embedding") is not None,
+                # H-05: how many caller-supplied entity links were dropped. The
+                # write still succeeds, so ``success`` alone cannot show it, and a
+                # link that was never created leaves no row for
+                # ``GET /entities/broken-links`` to find later — the per-link ERROR
+                # log and this count are the only traces. Sits beside the
+                # ``*_pending`` flags because it is the same kind of statement:
+                # the row is real, one aspect of it is not settled.
+                "entity_links_failed": len(ctx.data.get("entity_link_failures") or ()),
                 "success": _exc is None,
             },
         )
@@ -606,10 +629,9 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
         raise HTTPException(status_code=500, detail="Memory write pipeline failed unexpectedly")
 
     memory = ctx.data["memory"]
-    return _memory_to_out(
-        memory,
-        entity_links=[EntityLinkOut(entity_id=link.entity_id, role=link.role) for link in data.entity_links],
-    )
+    # Same persist pipeline as the main path, so the same truthful echo. This site
+    # is reachable when auto-chunking extracts 0-1 facts and falls through.
+    return _memory_out_with_created_links(ctx, memory)
 
 
 async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -362,7 +362,15 @@ async def find_relation(
 @router.post("/links")
 async def create_memory_entity_link(request: Request) -> dict:
     body: dict = await request.json()
-    link = await _svc.entity_add_entity_link(body)
+    try:
+        link = await _svc.entity_add_entity_link(body)
+    except ValueError as e:
+        # H-05 follow-up: a caller-supplied memory_id/entity_id that does not
+        # exist, or a pair already linked, is a client error. It used to escape as
+        # an IntegrityError → 500, which core-api could not tell apart from
+        # storage being unreachable — so a bad id and an outage degraded
+        # identically. Same 409 mapping ``create_entity`` above already uses.
+        raise HTTPException(status_code=409, detail=str(e))
     return orm_to_dict(link, MEMORY_ENTITY_LINK_FIELDS)
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -5384,7 +5384,35 @@ class PostgresService:
         async with get_session() as session:
             link = MemoryEntityLink(**data)
             session.add(link)
-            await session.flush()
+            try:
+                await session.flush()
+            except IntegrityError as exc:
+                # H-05 follow-up: ``memory_id`` and ``entity_id`` are both
+                # caller-supplied and both carry an FK, so pointing at a row that
+                # does not exist is a CLIENT error. It used to escape as a bare
+                # IntegrityError → 500, which made the fault indistinguishable
+                # from storage being down: core-api saw HTTPStatusError(500) for
+                # both and could only treat them the same.
+                #
+                # ``ValueError`` because the router already maps it to 409 for
+                # ``entity_add`` (routers/entities.py) — same shape, one
+                # convention. The composite PK ``(memory_id, entity_id)`` lands
+                # here too: re-linking an existing pair is a conflict, not a
+                # server fault.
+                #
+                # The raw ``exc.orig`` is logged, never interpolated into the
+                # message: that message becomes the 409 ``detail`` the caller
+                # reads, and the driver text carries constraint names and the
+                # offending values. ``entity_add`` above draws the same line.
+                logger.info(
+                    "Entity link rejected for memory %s → entity %s: %s",
+                    data.get("memory_id"),
+                    data.get("entity_id"),
+                    exc.orig,
+                )
+                raise ValueError(
+                    "entity link rejected: memory_id or entity_id does not exist, or the link already exists"
+                ) from exc
             return link
 
     async def entity_bulk_upsert_links(self, items: list[dict]) -> list[dict]:

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -1817,6 +1817,37 @@ class TestEntities:
         resp = await client.get(f"{PREFIX}/entities/{fake_id}")
         assert resp.status_code == 404
 
+    async def test_link_to_ghost_entity_409s_without_leaking_driver_text(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """A caller-supplied id that does not exist is a 409, and the body says so
+        without quoting the database.
+
+        Review round 2: the message becomes the 409 ``detail`` the caller reads, so
+        interpolating ``exc.orig`` hands out the constraint name, the table name and
+        the offending value. ``entity_add`` draws the same line.
+        """
+        mem = (await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))).json()
+        ghost_entity_id = str(uuid.uuid4())
+
+        resp = await client.post(
+            f"{PREFIX}/entities/links",
+            json={
+                "memory_id": mem["id"],
+                "entity_id": ghost_entity_id,
+                "role": "subject",
+            },
+        )
+
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert ghost_entity_id not in detail, "the offending value must not be echoed back"
+        assert "violates" not in detail.lower(), "raw driver text reached the caller"
+        assert "memory_entity_links" not in detail, "internal table name reached the caller"
+
 
 # =====================================================================
 # Agents

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -33,7 +33,7 @@ def _make_input(
         agent_id=AGENT_ID,
         content=content,
         persist=persist,
-        entity_links=[],
+        # entity_links rides **kwargs — MemoryCreate already defaults it to [].
         **kwargs,
     )
 
@@ -900,5 +900,293 @@ async def test_auto_mode_decision_type_routes_to_strong():
         assert isinstance(result, MemoryOut)
         assert result.metadata is not None
         assert result.metadata.get("write_mode") == "strong"
+    finally:
+        memory_service._USE_PIPELINE_WRITE = original
+
+
+# ---------------------------------------------------------------------------
+# H-05: a committed row must not be abandoned by a later failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bad_entity_link_does_not_abandon_the_committed_row(caplog):
+    """H-05: the memory row commits BEFORE entity links are written.
+
+    A raise in the link loop marked the pipeline FAILED and broke before
+    ``ScheduleBackgroundTasks``, so the caller got a 500 for a write that had
+    persisted — and in deferred-embedding deployments the row kept
+    ``embedding=NULL`` forever, invisible to semantic search, while a retry hit
+    CheckExactDuplicate and 409'd pointing at that same degraded row. Neither
+    writable nor repairable.
+
+    ``entity_links`` are caller-supplied UUIDs with no upstream existence check,
+    so a nonexistent id is an FK violation — which is what this drives.
+    """
+    import logging
+
+    from core_api.schemas import EntityLinkIn
+    from core_api.services import memory_service
+
+    original = memory_service._USE_PIPELINE_WRITE
+    memory_service._USE_PIPELINE_WRITE = True
+    try:
+        from core_api.services.memory_service import create_memory
+
+        ghost = uuid.uuid4()  # no such entity row
+        data = _make_input(
+            content="H-05 probe: a memory whose entity link cannot resolve, at length.",
+            entity_links=[EntityLinkIn(entity_id=ghost, role="subject")],
+        )
+
+        with caplog.at_level(logging.ERROR, logger="core_api.pipeline.steps.write.write_memory_row"):
+            result = await create_memory(data)
+
+        # 1. The write stands. Previously a 500.
+        assert isinstance(result, MemoryOut)
+        assert result.id
+
+        # 2. The response is TRUTHFUL: it reports the link as absent rather than
+        #    echoing the request, which would claim a link that does not exist.
+        assert result.entity_links == [], result.entity_links
+
+        # 3. The drop is loud — this is user-visible data loss, unlike the audit
+        #    hook next to it which is genuinely non-critical.
+        errors = [r for r in caplog.records if "entity link failed" in r.getMessage()]
+        assert errors, "a dropped entity link left no trace"
+        assert getattr(errors[0], "entity_id", None) == str(ghost)
+    finally:
+        memory_service._USE_PIPELINE_WRITE = original
+
+
+@pytest.mark.asyncio
+async def test_good_entity_links_are_still_reported():
+    """The truthful-echo change must not under-report a link that DID persist —
+    otherwise the fix would trade a loud failure for a quiet one."""
+    from core_api.schemas import EntityLinkIn
+    from core_api.services import memory_service
+
+    original = memory_service._USE_PIPELINE_WRITE
+    memory_service._USE_PIPELINE_WRITE = True
+    try:
+        from core_api.clients.storage_client import get_storage_client
+        from core_api.services.memory_service import create_memory
+
+        sc = get_storage_client()
+        entity = await sc.create_entity(
+            {
+                "tenant_id": TENANT_ID,
+                "fleet_id": FLEET_ID,
+                "canonical_name": f"h05-entity-{uuid.uuid4().hex[:8]}",
+                "entity_type": "other",
+            }
+        )
+        data = _make_input(
+            content="H-05 probe: a memory whose entity link resolves cleanly, at length.",
+            entity_links=[EntityLinkIn(entity_id=uuid.UUID(entity["id"]), role="subject")],
+        )
+
+        result = await create_memory(data)
+
+        assert [str(link.entity_id) for link in result.entity_links] == [entity["id"]]
+    finally:
+        memory_service._USE_PIPELINE_WRITE = original
+
+
+@pytest.mark.asyncio
+async def test_one_bad_link_does_not_discard_the_good_ones():
+    """The property the per-link try/except exists for, and the only one the
+    all-fail and all-succeed cases above cannot show.
+
+    Without this, a refactor to a single ``try`` around the whole loop — or to a
+    batch call that aborts on first violation — passes every other test in this
+    file while silently dropping valid links beside a bad one.
+    """
+    from core_api.schemas import EntityLinkIn
+    from core_api.services import memory_service
+
+    original = memory_service._USE_PIPELINE_WRITE
+    memory_service._USE_PIPELINE_WRITE = True
+    try:
+        from core_api.clients.storage_client import get_storage_client
+        from core_api.services.memory_service import create_memory
+
+        sc = get_storage_client()
+        real = await sc.create_entity(
+            {
+                "tenant_id": TENANT_ID,
+                "fleet_id": FLEET_ID,
+                "canonical_name": f"h05-mixed-{uuid.uuid4().hex[:8]}",
+                "entity_type": "other",
+            }
+        )
+        ghost = uuid.uuid4()
+
+        # Ghost FIRST, so a loop that aborts on the first failure loses the real one.
+        data = _make_input(
+            content="H-05 probe: one resolvable link and one ghost, mixed together.",
+            entity_links=[
+                EntityLinkIn(entity_id=ghost, role="subject"),
+                EntityLinkIn(entity_id=uuid.UUID(real["id"]), role="object"),
+            ],
+        )
+
+        result = await create_memory(data)
+
+        assert [str(link.entity_id) for link in result.entity_links] == [real["id"]], (
+            "the valid link beside a bad one was discarded"
+        )
+    finally:
+        memory_service._USE_PIPELINE_WRITE = original
+
+
+@pytest.mark.asyncio
+async def test_bad_link_still_runs_the_post_write_step(monkeypatch):
+    """The actual harm H-05 caused, asserted directly.
+
+    The 500 was the visible symptom. The damage was that the pipeline broke BEFORE
+    ``ScheduleBackgroundTasks``, so the embed and enrichment backfill were never
+    scheduled — in a deferred-embedding deployment the row kept ``embedding=NULL``
+    and stayed permanently invisible to semantic search.
+
+    Asserts the STEP RAN rather than that a particular task was scheduled. What the
+    step schedules is config-gated (the embed branch needs ``embedding is None``,
+    i.e. deferred mode and no cached embedding), so an assertion on the task would
+    be vacuous in an inline-embedding environment like this one — green for the
+    wrong reason. "The step after a committed write still runs" is the invariant,
+    and it holds in every configuration.
+    """
+    from core_api.pipeline.steps.write.schedule_background_tasks import (
+        ScheduleBackgroundTasks,
+    )
+    from core_api.schemas import EntityLinkIn
+    from core_api.services import memory_service
+
+    ran: list[bool] = []
+    original_execute = ScheduleBackgroundTasks.execute
+
+    async def _spy(self, ctx):
+        ran.append(True)
+        return await original_execute(self, ctx)
+
+    monkeypatch.setattr(ScheduleBackgroundTasks, "execute", _spy)
+
+    original = memory_service._USE_PIPELINE_WRITE
+    memory_service._USE_PIPELINE_WRITE = True
+    try:
+        from core_api.services.memory_service import create_memory
+
+        data = _make_input(
+            content=f"H-05 probe {uuid.uuid4().hex}: post-write step must still run.",
+            entity_links=[EntityLinkIn(entity_id=uuid.uuid4(), role="subject")],
+        )
+
+        result = await create_memory(data)
+
+        assert isinstance(result, MemoryOut)
+        assert ran, (
+            "ScheduleBackgroundTasks was skipped — the embed/enrich backfill would "
+            "never be scheduled, which is the real H-05 damage"
+        )
+    finally:
+        memory_service._USE_PIPELINE_WRITE = original
+
+
+@pytest.mark.asyncio
+async def test_a_bad_id_is_classified_permanent_not_transient(caplog):
+    """Review round 1: degrading every failure identically meant a caller's bad id
+    and an unreachable storage service looked the same in the logs.
+
+    They now differ, which only became possible after the links route started
+    returning 409 for a bad id — before that an FK violation and an outage were
+    both a bare 500, so no core-api-side classification could have separated them.
+    """
+    import logging
+
+    from core_api.schemas import EntityLinkIn
+    from core_api.services import memory_service
+
+    original = memory_service._USE_PIPELINE_WRITE
+    memory_service._USE_PIPELINE_WRITE = True
+    try:
+        from core_api.services.memory_service import create_memory
+
+        with caplog.at_level(
+            logging.ERROR, logger="core_api.pipeline.steps.write.write_memory_row"
+        ):
+            await create_memory(
+                _make_input(
+                    content=f"H-05 probe {uuid.uuid4().hex}: a ghost id is the caller's fault.",
+                    entity_links=[EntityLinkIn(entity_id=uuid.uuid4(), role="subject")],
+                )
+            )
+
+        dropped = [r for r in caplog.records if "entity link failed" in r.getMessage()]
+        assert dropped, "the dropped link left no trace"
+        assert getattr(dropped[0], "permanent") is True, (
+            "a nonexistent entity_id is the caller's input, not a storage outage — "
+            "misclassifying it sends on-call after the wrong system"
+        )
+        assert getattr(dropped[0], "status_code") == 409
+    finally:
+        memory_service._USE_PIPELINE_WRITE = original
+
+
+@pytest.mark.asyncio
+async def test_a_storage_outage_is_classified_transient_and_summarised(caplog):
+    """The case the review was really worried about: if the links endpoint is down,
+    every link in every write drops and the API still returns 201 — an outage with
+    zero failed requests. It must be distinguishable from a bad id, and it must
+    survive the per-link log cap."""
+    import logging
+    from unittest.mock import AsyncMock, patch
+
+    import httpx
+
+    from core_api.schemas import EntityLinkIn
+    from core_api.services import memory_service
+
+    original = memory_service._USE_PIPELINE_WRITE
+    memory_service._USE_PIPELINE_WRITE = True
+    try:
+        from core_api.clients.storage_client import get_storage_client
+        from core_api.services.memory_service import create_memory
+
+        sc = get_storage_client()
+        # More links than the per-link log cap, so the cap and the summary both
+        # get exercised.
+        links = [EntityLinkIn(entity_id=uuid.uuid4(), role="subject") for _ in range(7)]
+        outage = httpx.HTTPStatusError(
+            "storage down",
+            request=httpx.Request("POST", "http://storage/entities/links"),
+            response=httpx.Response(503),
+        )
+
+        with (
+            patch.object(sc, "create_entity_link", new=AsyncMock(side_effect=outage)),
+            caplog.at_level(logging.ERROR, logger="core_api.pipeline.steps.write.write_memory_row"),
+        ):
+            result = await create_memory(
+                _make_input(
+                    content=f"H-05 probe {uuid.uuid4().hex}: storage links endpoint is down.",
+                    entity_links=links,
+                )
+            )
+
+        # The write still stands — degrading is not negotiable.
+        assert isinstance(result, MemoryOut)
+        assert result.entity_links == []
+
+        per_link = [r for r in caplog.records if "entity link failed" in r.getMessage()]
+        assert all(getattr(r, "permanent") is False for r in per_link), (
+            "a 503 is storage's problem, not the caller's"
+        )
+        # Capped, so log volume does not track caller input.
+        assert len(per_link) == 5, f"expected the cap to hold, got {len(per_link)}"
+        # ...and the cap does not hide the outage.
+        summary = [r for r in caplog.records if "entity links dropped" in r.getMessage()]
+        assert summary, "the cap swallowed the outage signal"
+        assert getattr(summary[0], "transient") == 7
+        assert getattr(summary[0], "dropped") == 7
     finally:
         memory_service._USE_PIPELINE_WRITE = original


### PR DESCRIPTION
Fixes H-05 (#815). Premise re-verified on `main` before changing anything.

## The bug

`WriteMemoryRow` commits the memory row, then wrote entity links with no error handling. `entity_links` are caller-supplied UUIDs with no upstream existence check, so one nonexistent id is an FK violation → storage 500 → the runner marked the step FAILED and broke **before** `ScheduleBackgroundTasks`:

- the caller got a **500 for a write that had persisted**;
- the embed and enrichment backfill were never scheduled — in a deferred-embed deployment the row kept `embedding=NULL`, permanently invisible to semantic search;
- a retry hit `CheckExactDuplicate` and **409'd pointing at that same degraded row**.

Neither writable nor repairable.

## The fix

Per-link `try/except` that logs ERROR and continues. Per-link rather than one `try` around the loop — one bad id must not discard the valid links beside it — and that's sound because `entity_add_entity_link` opens its own session per call, so an `IntegrityError` on link 1 doesn't poison link 2's transaction.

ERROR rather than the WARNING the audit hook below uses: a dropped link is user-visible data loss, and a link that was never created leaves **no row for `GET /entities/broken-links` to find afterwards**. The log is the only trace, which is also why the count now rides the existing `memory_write_latency` line beside the `*_pending` flags — `success` alone can't show it, because the write succeeded.

## The response had to change too

`_memory_to_out` was echoing the **requested** links. Degrading without touching that would have reported links that don't exist — a quieter wrong answer than the 500 it replaces.

Both callers of the persist pipeline now go through one `_memory_out_with_created_links` helper. **Both deliberately:** the auto-chunk fall-through (0–1 facts extracted) runs the same pipeline and returns separately, so fixing only the main path would have left one caller lying. A shared helper means a third caller can't drift the same way.

## Tests

Four, each failing without the fix with the real `ForeignKeyViolationError` rather than a mocked raise:

1. ghost link → 201 not 500, response reports the link as absent;
2. a good link still reported — guards the truthful echo from *under*-reporting, which would trade a loud failure for a quiet one;
3. **ghost first, then a real link → the valid one survives.** The only test that pins the per-link design; a refactor to one `try`, or to a batch call that aborts on first violation, passes everything else;
4. `ScheduleBackgroundTasks` still runs — the actual harm.

Worth noting how (4) ended up: two earlier versions asserted on `_schedule_embed_or_reembed` and **passed vacuously**. That branch is gated on `embedding is None`, so it never fires in an inline-embedding environment, and forcing deferred mode still missed because `defer_embedding` additionally requires no cached embedding. So it now asserts the **step ran** — "the step after a committed write runs" is the invariant, and it holds in every configuration.

## Checks

4577 passed, 3 skipped, 1 xfailed. `ruff check` / `ruff format --check` clean on `core-api/src/`.

## Two follow-ups worth filing, both surfaced by `/simplify`

**`entity_bulk_upsert_links` already does this, server-side, in one roundtrip.** I verified it: it opens a session per item *precisely* so "an FK violation on item N would otherwise roll back items 0..N-1", and returns a per-slot error — same semantics as this loop, plus idempotent and N→1 roundtrips. Adopting it would put the degradation logic in the layer that owns and tests it. Not done here because it needs the router's 500-item cap handled against an unbounded `entity_links`, and it pairs naturally with the next item.

**The bulk and legacy write paths may discard `entity_links` entirely.** Both pass them *inside* the `create_memory` payload, and `_filter_memory_fields` keeps only real columns — `Memory` has no `entity_links` column — while still echoing them to the caller. Same genre as this bug and strictly quieter. I read the path but did **not** prove it end-to-end, so it wants its own issue and test rather than a claim here.

Refs #815
