### PR TITLE
fix(write): the server-internal write paths must consult a dedup lookup

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -130,6 +130,131 @@ def _auto_chunk_request_id() -> str:
     return f"auto-chunk:{uuid4()}"
 
 
+async def _live_duplicate_hashes(
+    sc,
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    agent_id: str,
+    hashes: list[str],
+) -> set[str]:
+    """Which of ``hashes`` already have a LIVE row, in dedup scope.
+
+    The server-internal write paths — auto-chunk children (both the pipeline
+    and legacy handlers) and the atomic-fact fanout — attach a ``content_hash``
+    to every child and then insert it without ever consulting a dedup lookup.
+    The public bulk path does consult one (``existing_hashes`` +
+    ``seen_hashes`` in ``create_memories_bulk``), and the single-write path has
+    ``CheckExactDuplicate``; these three had neither. That is why prod carries
+    duplicate content-hash groups with no concurrency involved at all: the same
+    document re-chunked, or an LLM emitting the same fact twice, minted a fresh
+    row every time.
+
+    ``_auto_chunk_request_id()`` cannot substitute for this. It mints a fresh
+    UUID per item per call, so the attempt-idempotency index
+    (``ix_memories_attempt_unique``) sees every re-run as a brand-new attempt —
+    it makes a *retried* batch idempotent only when the caller replays the same
+    ids, which these callers never do.
+
+    Scope is ``(tenant, fleet, agent, content_hash)`` over live rows, matching
+    ``memory_find_by_content_hash`` exactly, so a child is judged a duplicate by
+    the same rule the single-write gate would apply to it.
+
+    WHAT THIS DOES NOT CLOSE. It is check-then-insert, so two concurrent runs can
+    both pass the check and both insert — two overlapping redeliveries enriching
+    the same parent, or two racing auto-chunk requests for the same document.
+    Nothing here can prevent that; only a unique constraint can, and adding one
+    is the second half of #814. So this closes the source that needs NO
+    concurrency to fire — which is the source prod's duplicate groups actually
+    came from — and leaves the race for the index. Do not read a green here as
+    "duplicates are impossible"; read it as "duplicates now require a race".
+    """
+    if not hashes:
+        return set()
+    existing = await sc.bulk_find_by_content_hashes(
+        tenant_id,
+        hashes,
+        fleet_id=fleet_id,
+        agent_id=agent_id,
+    )
+    return set(existing)
+
+
+def _drop_duplicate_facts(
+    facts: list[dict],
+    *,
+    tenant_id: str,
+    fleet_id: str | None,
+    live_hashes: set[str],
+    source: str,
+) -> list[dict]:
+    """Return the chunker's facts minus the ones already recorded.
+
+    Drops two kinds of duplicate, which have to be handled separately because
+    no index can collapse the first:
+
+    * **already live** — the content exists from an earlier call, per
+      ``live_hashes``.
+    * **repeated within this batch** — two children of the SAME call carrying
+      identical content. A unique index cannot resolve this one: the conflict is
+      between two rows of a single INSERT, so it has to be collapsed before the
+      statement runs.
+
+    Applied to the FACTS, before the parent insert and before the batch embed,
+    rather than to the finished child payloads. Two things fall out of that
+    ordering, and both matter more than the slightly earlier call site:
+
+    * the parent's ``child_count`` is the number of children that will exist,
+      not the number the chunker proposed — otherwise this change would make
+      that field silently wrong;
+    * a dropped child never costs an embedding. The embed is the expensive part
+      of this path, and it is a batch call, so paying for text we are about to
+      discard would be the dominant cost of deduping at all.
+
+    Dropping rather than collapsing-and-reporting is deliberate: these children
+    are derived rows, not caller-submitted items. Nothing upstream holds an
+    index into them — both auto-chunk handlers discard ``create_memories``'
+    return value entirely — so there is no per-item result to point at a
+    survivor, and the parent memory is what the caller gets back either way.
+    """
+    kept: list[dict] = []
+    seen: set[str] = set()
+    dropped_live = 0
+    dropped_repeat = 0
+    for fact in facts:
+        content = fact.get("content")
+        if not content:
+            # Outside the dedup contract: an unhashable fact cannot collide.
+            kept.append(fact)
+            continue
+        content_hash = _content_hash(tenant_id, fleet_id, content)
+        if content_hash in live_hashes:
+            dropped_live += 1
+            continue
+        if content_hash in seen:
+            dropped_repeat += 1
+            continue
+        seen.add(content_hash)
+        kept.append(fact)
+
+    if dropped_live or dropped_repeat:
+        # INFO, not WARNING: a re-chunked document hitting this is the feature
+        # working. Logged at all because it is the only account of why a
+        # document that produced N chunks has fewer than N children.
+        logger.info(
+            "dedup dropped %d duplicate auto-chunk children before insert",
+            dropped_live + dropped_repeat,
+            extra={
+                "source": source,
+                "dropped_already_live": dropped_live,
+                "dropped_repeated_in_batch": dropped_repeat,
+                "kept": len(kept),
+                "submitted": len(facts),
+            },
+        )
+    return kept
+
+
 async def _find_semantic_duplicate(
     tenant_id: str,
     fleet_id: str | None,
@@ -500,6 +625,31 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
 
     if len(facts) > 1:
         ch = _content_hash(data.tenant_id, data.fleet_id, data.content)
+        # Give the children the dedup lookup every other write path already has
+        # (OSS #814). Inside the ``len(facts) > 1`` branch rather than above it:
+        # dedup can reduce the count to 1 or 0, and falling out of the branch on
+        # that would write the WHOLE document as a single memory instead — a
+        # different row than either outcome the caller asked for.
+        #
+        # Ahead of ``child_count`` and the batch embed, both deliberately: see
+        # ``_drop_duplicate_facts``.
+        facts = _drop_duplicate_facts(
+            facts,
+            tenant_id=data.tenant_id,
+            fleet_id=data.fleet_id,
+            live_hashes=await _live_duplicate_hashes(
+                sc,
+                tenant_id=data.tenant_id,
+                fleet_id=data.fleet_id,
+                agent_id=data.agent_id,
+                hashes=[
+                    _content_hash(data.tenant_id, data.fleet_id, f["content"])
+                    for f in facts
+                    if f.get("content")
+                ],
+            ),
+            source="auto_chunk",
+        )
         parent_metadata = dict(fields["metadata"])
         parent_metadata["auto_chunked"] = True
         parent_metadata["child_count"] = len(facts)
@@ -598,8 +748,14 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
         # Auto-chunk children — second storage roundtrip in this
         # request after the parent insert above. Same per-tenant cap
         # applies; held only across the bulk call itself.
-        async with per_tenant_storage_slot("storage_write", data.tenant_id):
-            await sc.create_memories(child_payloads)
+        #
+        # ``if child_payloads`` because dedup can empty the list — a document
+        # re-chunked with every fact already live. ``create_memories([])`` would
+        # be a pointless roundtrip, and the storage-side statement builds an
+        # INSERT with no VALUES.
+        if child_payloads:
+            async with per_tenant_storage_slot("storage_write", data.tenant_id):
+                await sc.create_memories(child_payloads)
 
         if tenant_config.entity_extraction_enabled:
             track_task(
@@ -779,6 +935,27 @@ async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:
 
         if len(facts) > 1:
             ch = _content_hash(data.tenant_id, data.fleet_id, data.content)
+            # Same dedup as the pipeline handler, at the same point in the
+            # branch. Applied here too rather than only on the pipeline path:
+            # this is its sibling, and on two of this audit's last three
+            # findings the filed location was only half the problem.
+            facts = _drop_duplicate_facts(
+                facts,
+                tenant_id=data.tenant_id,
+                fleet_id=data.fleet_id,
+                live_hashes=await _live_duplicate_hashes(
+                    sc,
+                    tenant_id=data.tenant_id,
+                    fleet_id=data.fleet_id,
+                    agent_id=data.agent_id,
+                    hashes=[
+                        _content_hash(data.tenant_id, data.fleet_id, f["content"])
+                        for f in facts
+                        if f.get("content")
+                    ],
+                ),
+                source="auto_chunk_legacy",
+            )
             parent_metadata = dict(metadata)
             parent_metadata["auto_chunked"] = True
             parent_metadata["child_count"] = len(facts)
@@ -869,8 +1046,9 @@ async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:
             # Legacy-path auto-chunk children — same bulkhead key as
             # the parent insert above. See ``_handle_auto_chunk_from_ctx``
             # for the pipeline-path equivalent.
-            async with per_tenant_storage_slot("storage_write", data.tenant_id):
-                await sc.create_memories(child_payloads)
+            if child_payloads:
+                async with per_tenant_storage_slot("storage_write", data.tenant_id):
+                    await sc.create_memories(child_payloads)
 
             if tenant_config.entity_extraction_enabled:
                 track_task(
@@ -2622,8 +2800,42 @@ async def _enrich_memory_background(
             parent_weight = patch.get("weight") or mem.get("weight") or 0.5
             fanout_created = 0
             fanout_unembedded = 0
+            # The fanout's dedup lookup (OSS #814), batched once for every fact
+            # rather than per-fact: this loop calls ``create_memory`` (singular)
+            # per child, so a per-fact lookup would double the roundtrips on a
+            # path that already runs one write each.
+            fanout_live_hashes = await _live_duplicate_hashes(
+                sc,
+                tenant_id=tenant_id,
+                fleet_id=fleet_id,
+                agent_id=agent_id,
+                hashes=[_content_hash(tenant_id, fleet_id, f.content) for f in atomic_facts],
+            )
+            # Repeats within this fanout. The live set cannot cover them: those
+            # rows do not exist yet at lookup time, and each is written by its
+            # own ``create_memory`` call, so the second one would land as a
+            # duplicate of a row this very loop just created.
+            fanout_seen_hashes: set[str] = set()
+            fanout_deduped = 0
             for fact in atomic_facts:
                 fact_content = fact.content
+                child_ch = _content_hash(tenant_id, fleet_id, fact_content)
+                if child_ch in fanout_live_hashes or child_ch in fanout_seen_hashes:
+                    # The fact is already recorded — either from an earlier
+                    # enrichment of this parent, or earlier in this very loop.
+                    # Writing it again is one of the two reasons prod carries
+                    # duplicate content-hash groups with no concurrency.
+                    #
+                    # Before the embed below on purpose: a dropped fact must not
+                    # cost an embedding call. This ``continue`` is unlike the two
+                    # inside the embed block — those exit AFTER deciding
+                    # ``child_embedding`` precisely so a failed embed still
+                    # persists the fact (see below); this one decides the fact
+                    # should not be persisted at all, so it is the one case where
+                    # skipping ahead of the embed is correct.
+                    fanout_deduped += 1
+                    continue
+                fanout_seen_hashes.add(child_ch)
                 # A failed embed must NOT skip the fact. Both exits here used
                 # to ``continue`` BEFORE ``create_memory``, so the child row
                 # was never written at all and the fact was lost outright —
@@ -2651,7 +2863,6 @@ async def _enrich_memory_background(
                         memory_id,
                         exc_info=True,
                     )
-                child_ch = _content_hash(tenant_id, fleet_id, fact_content)
                 child_meta = {
                     "parent_memory_id": str(memory_id),
                     "source": "atomic_fact_fanout",
@@ -2771,6 +2982,17 @@ async def _enrich_memory_background(
                 logger.info(
                     "atomic-fact fan-out created %d children for parent %s",
                     fanout_created,
+                    memory_id,
+                )
+            if fanout_deduped:
+                # Its own line rather than a field on the created line above,
+                # because it explains a discrepancy an operator would otherwise
+                # read as loss: the enrichment reported N atomic facts and fewer
+                # than N children exist. INFO because a re-enriched parent
+                # hitting this is the dedup working, not a fault.
+                logger.info(
+                    "atomic-fact fan-out skipped %d facts already recorded for parent %s",
+                    fanout_deduped,
                     memory_id,
                 )
             if fanout_unembedded:

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1352,8 +1352,49 @@ class PostgresService:
                 stmt = stmt.where(Memory.fleet_id.is_(None))
             if agent_id is not None:
                 stmt = stmt.where(Memory.agent_id == agent_id)
+            # H-04 sibling: the dict comprehension below keeps ONE row per hash,
+            # so on a pre-existing duplicate group it silently picks a winner.
+            # Unordered, that winner is whatever the plan happened to emit last —
+            # so the batch lookup could disagree with
+            # ``memory_find_by_content_hash``, which returns the OLDEST after
+            # #839, and two dedup paths would point callers at different rows for
+            # the same content.
+            #
+            # Ascending + first-wins rather than descending + last-wins, because
+            # ``id`` has to break the tie and ties are the common case here:
+            # ``created_at`` is ``server_default=now()``, fixed for a whole
+            # transaction, and the auto-chunk path inserts all its children in
+            # one call — so duplicates minted that way share ``created_at``
+            # exactly. Same ordering, same reason, as #839.
+            stmt = stmt.order_by(Memory.created_at.asc(), Memory.id.asc())
             rows = (await session.execute(stmt)).all()
-            return {row[0]: {"id": row[1], "client_request_id": row[2]} for row in rows}
+            out: dict[str, dict] = {}
+            duplicated: list[str] = []
+            for row in rows:
+                if row[0] in out:
+                    # First extra row for this hash — the group is a duplicate.
+                    if len(duplicated) == 0 or duplicated[-1] != row[0]:
+                        duplicated.append(row[0])
+                    continue
+                out[row[0]] = {"id": row[1], "client_request_id": row[2]}
+            # Warn, for the reason ``_warn_duplicate_content_hash``'s own
+            # docstring gives: it is shared by both dedup gates deliberately,
+            # because a warning from only one of them undercounts the duplicate
+            # population — and that population is the number the partial unique
+            # index decision rests on. Before the ordering above this path could
+            # not report a group honestly (it did not know which row it kept);
+            # now that it does, staying silent would be the remaining half of the
+            # H-04 blind spot rather than a cosmetic gap.
+            for content_hash in duplicated:
+                self._warn_duplicate_content_hash(
+                    tenant_id=tenant_id,
+                    fleet_id=fleet_id,
+                    agent_id=agent_id,
+                    content_hash=content_hash,
+                    kept_id=out[content_hash]["id"],
+                    path="bulk_find_by_content_hashes",
+                )
+            return out
 
     # ------------------------------------------------------------------
     # C) Scored search (CTE-based)

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -14,8 +14,13 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import text
 
 from common.constants import VECTOR_DIM
+
+# The transactional session (commits on success), used by the one test that has
+# to age rows directly — no endpoint sets ``created_at``.
+from core_storage_api.services.postgres_service import get_session as _svc_session
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
@@ -1568,6 +1573,170 @@ class TestMemories:
             entity_ids[2]: "mentioned",
             new_entity["id"]: "mentioned",
         }
+
+    async def test_bulk_hash_lookup_returns_the_oldest_of_a_duplicate_group(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+    ) -> None:
+        """H-04 sibling: the batch lookup keeps one row per hash, so on a
+        pre-existing duplicate group it picks a winner. Unordered, that winner was
+        whatever the scan reached first — which could disagree with
+        ``memory_find_by_content_hash``, which returns the OLDEST after #839. Two
+        dedup paths pointing at different rows for the same content is the bug;
+        agreeing on the oldest is the fix.
+
+        THE INSERTION ORDER IS THE TEST. Rows are written NEWEST-first, so heap
+        order and ``created_at`` order disagree: unordered, the scan reaches the
+        newest row first and keeps it, which is the wrong answer. Written
+        oldest-first instead, the unordered path would return the oldest by
+        accident and the test would pass with the fix removed — measured, on an
+        earlier version of exactly this test: 5 of 5 runs passed with the
+        ``order_by`` reverted.
+
+        Ten independent groups for the same reason: one group can go either way on
+        a plan change, ten agreeing by chance cannot.
+        """
+        agent = f"agent-dupgroup-{_uid()}"
+        groups: dict[str, list[str]] = {}
+
+        for group in range(10):
+            content = f"a duplicated observation {_uid()}-{group}"
+            content_hash = hashlib.sha256(content.encode()).hexdigest()
+            ids = []
+            for _ in range(3):
+                payload = _memory_payload(tenant_id, fleet_id, content=content)
+                payload["agent_id"] = agent
+                payload["content_hash"] = content_hash
+                resp = await client.post(f"{PREFIX}/memories", json=payload)
+                assert resp.status_code == 200, resp.text
+                ids.append(resp.json()["id"])
+            # Written ascending, so ids[0] is the oldest. The rows are then
+            # REWRITTEN newest-first below by shifting created_at, which is what
+            # makes heap order disagree with age.
+            groups[content_hash] = ids
+
+        # Age them in reverse: the last-written row becomes the oldest. Heap order
+        # is unchanged, so "first row the scan reaches" is now the NEWEST.
+        async with _svc_session() as session:
+            for ids in groups.values():
+                for offset, memory_id in enumerate(ids):
+                    await session.execute(
+                        text(
+                            "UPDATE memories SET created_at = "
+                            "timestamptz '2026-01-01 00:00:00+00' - make_interval(days => :d) "
+                            "WHERE id = CAST(:id AS uuid)"
+                        ),
+                        {"d": offset, "id": memory_id},
+                    )
+
+        resp = await client.post(
+            f"{PREFIX}/memories/bulk-by-content-hashes",
+            json={
+                "tenant_id": tenant_id,
+                "fleet_id": fleet_id,
+                "agent_id": agent,
+                "hashes": list(groups),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        resolved = resp.json()
+
+        # After the re-aging, the OLDEST of each group is its last-written row.
+        wrong = {h: (resolved[h]["id"], ids[-1]) for h, ids in groups.items() if resolved[h]["id"] != ids[-1]}
+        assert not wrong, (
+            f"{len(wrong)} of {len(groups)} groups resolved to a row other than "
+            f"the oldest, so the batch lookup disagrees with the single-write "
+            f"dedup gate about which row owns this content: {list(wrong.items())[:3]}"
+        )
+
+    async def test_bulk_hash_lookup_reports_the_duplicate_group_it_resolved(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+        caplog,
+    ) -> None:
+        """``_warn_duplicate_content_hash`` is shared by both dedup gates on
+        purpose — its own docstring says a warning from only one of them
+        undercounts the duplicate population, and that population is the number
+        the partial unique index decision rests on. This path resolved groups
+        silently, so every duplicate seen only here was missing from that count.
+        """
+        import logging
+
+        agent = f"agent-warn-{_uid()}"
+        content = f"a duplicated observation {_uid()}"
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+
+        for _ in range(2):
+            payload = _memory_payload(tenant_id, fleet_id, content=content)
+            payload["agent_id"] = agent
+            payload["content_hash"] = content_hash
+            assert (await client.post(f"{PREFIX}/memories", json=payload)).status_code == 200
+
+        with caplog.at_level(logging.WARNING):
+            resp = await client.post(
+                f"{PREFIX}/memories/bulk-by-content-hashes",
+                json={
+                    "tenant_id": tenant_id,
+                    "fleet_id": fleet_id,
+                    "agent_id": agent,
+                    "hashes": [content_hash],
+                },
+            )
+        assert resp.status_code == 200, resp.text
+
+        warned = [
+            r
+            for r in caplog.records
+            if "duplicate live rows share a content_hash" in r.getMessage()
+            and getattr(r, "dedup_path", None) == "bulk_find_by_content_hashes"
+        ]
+        assert warned, (
+            "the batch lookup resolved a duplicate group without reporting it, "
+            "so duplicates visible only on this path stay uncounted"
+        )
+
+    async def test_bulk_hash_lookup_stays_quiet_when_there_is_no_duplicate(
+        self,
+        client: AsyncClient,
+        tenant_id: str,
+        fleet_id: str,
+        caplog,
+    ) -> None:
+        """The guard against a warning that fires on every healthy lookup — which
+        would make the signal useless for counting anything."""
+        import logging
+
+        agent = f"agent-quiet-{_uid()}"
+        content = f"a unique observation {_uid()}"
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+
+        payload = _memory_payload(tenant_id, fleet_id, content=content)
+        payload["agent_id"] = agent
+        payload["content_hash"] = content_hash
+        assert (await client.post(f"{PREFIX}/memories", json=payload)).status_code == 200
+
+        with caplog.at_level(logging.WARNING):
+            resp = await client.post(
+                f"{PREFIX}/memories/bulk-by-content-hashes",
+                json={
+                    "tenant_id": tenant_id,
+                    "fleet_id": fleet_id,
+                    "agent_id": agent,
+                    "hashes": [content_hash],
+                },
+            )
+        assert resp.status_code == 200, resp.text
+
+        assert not [
+            r
+            for r in caplog.records
+            if "duplicate live rows share a content_hash" in r.getMessage()
+            and getattr(r, "dedup_path", None) == "bulk_find_by_content_hashes"
+        ]
 
 
 # =====================================================================

--- a/tests/test_child_dedup_minting_paths.py
+++ b/tests/test_child_dedup_minting_paths.py
@@ -1,0 +1,624 @@
+"""The server-internal write paths must consult a dedup lookup (OSS #814).
+
+Auto-chunk children (pipeline + legacy handlers) and the atomic-fact fanout each
+attach a ``content_hash`` to every child and then inserted it unconditionally.
+The public bulk path already dedups (``existing_hashes`` + ``seen_hashes``) and
+the single-write path has ``CheckExactDuplicate``; these three had neither, which
+is why prod carries duplicate content-hash groups with no concurrency involved:
+18 groups / 19 surplus rows over 110k live rows, measured before this change.
+
+Two distinct sources, tested separately because only one of them is something an
+index could ever catch:
+
+* already live — the content exists from an earlier call;
+* repeated within one batch/fanout — the conflicting rows are both being written
+  right now, so no constraint can collapse them; they have to be dropped before
+  the write.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core_api.services import memory_service
+from core_api.services.memory_enrichment import AtomicFact
+
+# No ``asyncio`` mark: ``pytest.ini`` sets ``asyncio_mode = auto``, and applying
+# it module-wide here warns on every sync test in the file.
+pytestmark = [pytest.mark.unit]
+
+TENANT = "t-child-dedup"
+FLEET = "f1"
+AGENT = "a"
+
+
+def _fact(content: str) -> dict:
+    return {"content": content, "suggested_type": "fact"}
+
+
+def _drop(facts: list[dict], live: set[str]) -> list[dict]:
+    return memory_service._drop_duplicate_facts(
+        facts,
+        tenant_id=TENANT,
+        fleet_id=FLEET,
+        live_hashes=live,
+        source="auto_chunk",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _drop_duplicate_facts
+# ---------------------------------------------------------------------------
+
+
+def test_a_child_whose_content_is_already_live_is_dropped() -> None:
+    live = {memory_service._content_hash(TENANT, FLEET, "alpha")}
+
+    kept = _drop([_fact("alpha"), _fact("beta")], live)
+
+    assert [f["content"] for f in kept] == ["beta"]
+
+
+def test_a_child_repeated_within_the_batch_is_written_once() -> None:
+    """No index can do this one: both rows are in the same INSERT."""
+    kept = _drop([_fact("same"), _fact("same"), _fact("other")], set())
+
+    assert [f["content"] for f in kept] == ["same", "other"]
+
+
+def test_the_first_occurrence_is_the_one_kept() -> None:
+    """Order matters: the survivor must be the earliest, so the row that lands
+    is the one the chunker emitted first rather than an arbitrary member."""
+    first, second = _fact("dup"), _fact("dup")
+    first["marker"], second["marker"] = "first", "second"
+
+    kept = _drop([first, second], set())
+
+    assert [f["marker"] for f in kept] == ["first"]
+
+
+def test_an_unhashable_child_is_never_dropped() -> None:
+    """Empty content cannot collide, so it is outside the dedup contract and
+    must survive — twice over."""
+    kept = _drop([_fact(""), _fact("")], set())
+
+    assert len(kept) == 2
+
+
+def test_dropping_every_child_returns_empty_rather_than_raising() -> None:
+    """A document re-chunked with every fact already live. The caller must see an
+    empty list — it skips the storage roundtrip on it, and an INSERT with no
+    VALUES is not valid SQL."""
+    live = {memory_service._content_hash(TENANT, FLEET, "alpha")}
+
+    assert _drop([_fact("alpha"), _fact("alpha")], live) == []
+
+
+def test_the_scope_is_tenant_and_fleet_specific() -> None:
+    """The hash folds in tenant and fleet, so a live hash from one fleet must not
+    suppress the same text in another."""
+    other_fleet_live = {memory_service._content_hash(TENANT, "other-fleet", "alpha")}
+
+    kept = _drop([_fact("alpha")], other_fleet_live)
+
+    assert [f["content"] for f in kept] == ["alpha"]
+
+
+# ---------------------------------------------------------------------------
+# _live_duplicate_hashes — the lookup's scope
+# ---------------------------------------------------------------------------
+
+
+async def test_the_lookup_is_scoped_to_tenant_fleet_and_agent() -> None:
+    """Scope is the assertion, not an implementation detail. Dropping ``agent_id``
+    would make two agents recording identical content collide, and dropping
+    ``fleet_id`` would let one fleet's content suppress another's — the same
+    scope ``memory_find_by_content_hash`` uses.
+    """
+    sc = MagicMock()
+    sc.bulk_find_by_content_hashes = AsyncMock(return_value={"h1": {"id": "x"}})
+
+    result = await memory_service._live_duplicate_hashes(
+        sc, tenant_id=TENANT, fleet_id=FLEET, agent_id=AGENT, hashes=["h1", "h2"]
+    )
+
+    assert result == {"h1"}
+    sc.bulk_find_by_content_hashes.assert_awaited_once_with(
+        TENANT, ["h1", "h2"], fleet_id=FLEET, agent_id=AGENT
+    )
+
+
+async def test_no_hashes_means_no_storage_roundtrip() -> None:
+    sc = MagicMock()
+    sc.bulk_find_by_content_hashes = AsyncMock(return_value={})
+
+    assert (
+        await memory_service._live_duplicate_hashes(
+            sc, tenant_id=TENANT, fleet_id=FLEET, agent_id=AGENT, hashes=[]
+        )
+        == set()
+    )
+    sc.bulk_find_by_content_hashes.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the atomic-fact fanout actually consults it
+# ---------------------------------------------------------------------------
+
+
+async def _run_fanout(facts: list[AtomicFact], live: dict[str, dict]) -> list[dict]:
+    """Drive ``_enrich_memory_background``'s fanout, return the child writes.
+
+    Same harness shape as ``test_atomic_fact_unembedded_persist``; the fanout is
+    the most directly drivable of the three minting paths.
+    """
+    row = dict(
+        id=str(uuid.uuid4()),
+        memory_type="fact",
+        status="active",
+        weight=0.5,
+        ts_valid_start=None,
+        ts_valid_end=None,
+        metadata_={},
+        deleted_at=None,
+        fleet_id=FLEET,
+        embedding=None,
+        content="body",
+        visibility="scope_team",
+    )
+    sc = AsyncMock(name="storage_client")
+    sc.get_memory = AsyncMock(return_value=row)
+    sc.update_memory = AsyncMock(return_value=None)
+    sc.update_memory_status = AsyncMock(return_value=None)
+    sc.create_memory = AsyncMock(side_effect=lambda _p: {"id": str(uuid.uuid4())})
+    sc.bulk_find_by_content_hashes = AsyncMock(return_value=live)
+
+    enrichment = SimpleNamespace(
+        memory_type="fact",
+        weight=0.5,
+        status="active",
+        title="t",
+        summary="",
+        tags=[],
+        llm_ms=1,
+        contains_pii=False,
+        pii_types=[],
+        retrieval_hint="",
+        ts_valid_start=None,
+        ts_valid_end=None,
+        atomic_facts=facts,
+    )
+
+    def _stub_tracked_task(coro, *_a, **_k):
+        coro.close()
+        return None
+
+    async def _embed(_content, tenant_config=None, **_kwargs):
+        return [0.0]
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(memory_service, "tracked_task", new=_stub_tracked_task),
+        patch.object(memory_service, "get_embedding", new=_embed),
+        patch(
+            "core_api.services.memory_enrichment.enrich_memory",
+            new=AsyncMock(return_value=enrichment),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    enrichment_enabled=True,
+                    enrichment_provider="fake",
+                    entity_extraction_enabled=False,
+                )
+            ),
+        ),
+    ):
+        await memory_service._enrich_memory_background(
+            uuid.uuid4(), "body", TENANT, FLEET, AGENT
+        )
+
+    return [c.args[0] for c in sc.create_memory.await_args_list]
+
+
+async def test_fanout_skips_a_fact_that_is_already_recorded() -> None:
+    alpha_hash = memory_service._content_hash(TENANT, FLEET, "alpha fact")
+
+    children = await _run_fanout(
+        [AtomicFact(content="alpha fact"), AtomicFact(content="beta fact")],
+        live={alpha_hash: {"id": str(uuid.uuid4()), "client_request_id": None}},
+    )
+
+    assert [c["content"] for c in children] == ["beta fact"], (
+        "the fan-out re-wrote a fact it already had — this is one of the two "
+        "paths that minted prod's duplicate groups"
+    )
+
+
+async def test_fanout_writes_a_repeated_fact_once() -> None:
+    """An LLM emitting the same fact twice in one enrichment. Nothing is live, so
+    the live lookup cannot help — this is the in-fanout case."""
+    children = await _run_fanout(
+        [AtomicFact(content="twice over"), AtomicFact(content="twice over")],
+        live={},
+    )
+
+    assert len(children) == 1, "the same fact was written twice in one fan-out"
+
+
+async def test_fanout_still_writes_everything_when_nothing_is_duplicated() -> None:
+    """The guard against a dedup that eats legitimate facts."""
+    children = await _run_fanout(
+        [AtomicFact(content="alpha fact"), AtomicFact(content="beta fact")],
+        live={},
+    )
+
+    assert [c["content"] for c in children] == ["alpha fact", "beta fact"]
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the auto-chunk children path consults it too
+# ---------------------------------------------------------------------------
+
+
+async def _run_auto_chunk(chunks: list[str], live: dict[str, dict]) -> list[dict]:
+    """Drive ``_handle_auto_chunk_from_ctx``, return the child payloads written.
+
+    The auto-chunk path is where duplicates are most likely to have come from:
+    its children are all inserted in ONE ``create_memories`` call, so they share
+    ``created_at`` exactly — which is the tie #839 had to add ``id`` to break.
+    """
+    from core_api.schemas import MemoryCreate
+
+    parent_row = {
+        "id": str(uuid.uuid4()),
+        "tenant_id": TENANT,
+        "fleet_id": FLEET,
+        "agent_id": AGENT,
+        "memory_type": "fact",
+        "title": "t",
+        "content": "body",
+        "weight": 0.5,
+        "status": "active",
+        "visibility": "scope_team",
+        "recall_count": 0,
+        "created_at": datetime(2026, 8, 20, tzinfo=UTC),
+        "metadata_": {},
+        "embedding": None,
+        "deleted_at": None,
+    }
+    sc = AsyncMock(name="storage_client")
+    sc.create_memory = AsyncMock(return_value=parent_row)
+    sc.create_memories = AsyncMock(return_value=[])
+    sc.bulk_find_by_content_hashes = AsyncMock(return_value=live)
+
+    data = MemoryCreate(
+        tenant_id=TENANT,
+        fleet_id=FLEET,
+        agent_id=AGENT,
+        content="a body long enough to be worth chunking " * 5,
+    )
+    ctx = SimpleNamespace(
+        data={
+            "memory_fields": {
+                "memory_type": "fact",
+                "title": "t",
+                "weight": 0.5,
+                "status": "active",
+                "metadata": {},
+            },
+            "embedding": [0.0],
+            "t0": 0.0,
+        },
+        tenant_config=SimpleNamespace(entity_extraction_enabled=False),
+    )
+
+    async def _chunks(_content, _x, _cfg):
+        return [{"content": c, "suggested_type": "fact"} for c in chunks]
+
+    async def _embeddings(texts, _cfg, background=False):
+        return [[0.0] for _ in texts]
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(memory_service, "get_embeddings_batch", new=_embeddings),
+        patch("core_api.services.ingest_service._chunk_content", new=_chunks),
+    ):
+        await memory_service._handle_auto_chunk_from_ctx(data, ctx)
+
+    if not sc.create_memories.await_args_list:
+        return []
+    return sc.create_memories.await_args_list[0].args[0]
+
+
+async def test_the_parent_child_count_is_the_number_of_children_that_exist() -> None:
+    """``child_count`` is written into the parent's metadata, so deduping after
+    the parent insert would have made it permanently wrong — the field would
+    claim children that were never written and nothing would ever correct it.
+    Hence the dedup runs ahead of the parent insert.
+    """
+    from core_api.schemas import MemoryCreate
+
+    parent_row = {
+        "id": str(uuid.uuid4()),
+        "tenant_id": TENANT,
+        "fleet_id": FLEET,
+        "agent_id": AGENT,
+        "memory_type": "fact",
+        "title": "t",
+        "content": "body",
+        "weight": 0.5,
+        "status": "active",
+        "visibility": "scope_team",
+        "recall_count": 0,
+        "created_at": datetime(2026, 8, 20, tzinfo=UTC),
+        "metadata_": {},
+        "embedding": None,
+        "deleted_at": None,
+    }
+    sc = AsyncMock(name="storage_client")
+    sc.create_memory = AsyncMock(return_value=parent_row)
+    sc.create_memories = AsyncMock(return_value=[])
+    # Two of the three chunks are already recorded.
+    sc.bulk_find_by_content_hashes = AsyncMock(
+        return_value={
+            memory_service._content_hash(TENANT, FLEET, "one"): {
+                "id": str(uuid.uuid4()),
+                "client_request_id": None,
+            },
+            memory_service._content_hash(TENANT, FLEET, "two"): {
+                "id": str(uuid.uuid4()),
+                "client_request_id": None,
+            },
+        }
+    )
+
+    data = MemoryCreate(
+        tenant_id=TENANT, fleet_id=FLEET, agent_id=AGENT, content="body to chunk " * 10
+    )
+    ctx = SimpleNamespace(
+        data={
+            "memory_fields": {
+                "memory_type": "fact",
+                "title": "t",
+                "weight": 0.5,
+                "status": "active",
+                "metadata": {},
+            },
+            "embedding": [0.0],
+            "t0": 0.0,
+        },
+        tenant_config=SimpleNamespace(entity_extraction_enabled=False),
+    )
+
+    async def _chunks(_content, _x, _cfg):
+        return [{"content": c, "suggested_type": "fact"} for c in ("one", "two", "three")]
+
+    async def _embeddings(texts, _cfg, background=False):
+        return [[0.0] for _ in texts]
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(memory_service, "get_embeddings_batch", new=_embeddings),
+        patch("core_api.services.ingest_service._chunk_content", new=_chunks),
+    ):
+        await memory_service._handle_auto_chunk_from_ctx(data, ctx)
+
+    parent_payload = sc.create_memory.await_args_list[0].args[0]
+    assert parent_payload["metadata_"]["child_count"] == 1, (
+        "child_count must count the children that will exist, not the chunks "
+        "the chunker proposed"
+    )
+
+    written = sc.create_memories.await_args_list[0].args[0]
+    assert [c["content"] for c in written] == ["three"]
+
+
+async def test_a_dropped_child_is_never_embedded() -> None:
+    """The embed is the expensive part of this path. Deduping after it would
+    mean paying to vectorise text that is then thrown away."""
+    from core_api.schemas import MemoryCreate
+
+    embedded: list[list[str]] = []
+
+    parent_row = {
+        "id": str(uuid.uuid4()),
+        "tenant_id": TENANT,
+        "fleet_id": FLEET,
+        "agent_id": AGENT,
+        "memory_type": "fact",
+        "title": "t",
+        "content": "body",
+        "weight": 0.5,
+        "status": "active",
+        "visibility": "scope_team",
+        "recall_count": 0,
+        "created_at": datetime(2026, 8, 20, tzinfo=UTC),
+        "metadata_": {},
+        "embedding": None,
+        "deleted_at": None,
+    }
+    sc = AsyncMock(name="storage_client")
+    sc.create_memory = AsyncMock(return_value=parent_row)
+    sc.create_memories = AsyncMock(return_value=[])
+    sc.bulk_find_by_content_hashes = AsyncMock(
+        return_value={
+            memory_service._content_hash(TENANT, FLEET, "stale"): {
+                "id": str(uuid.uuid4()),
+                "client_request_id": None,
+            }
+        }
+    )
+
+    data = MemoryCreate(
+        tenant_id=TENANT, fleet_id=FLEET, agent_id=AGENT, content="body to chunk " * 10
+    )
+    ctx = SimpleNamespace(
+        data={
+            "memory_fields": {
+                "memory_type": "fact",
+                "title": "t",
+                "weight": 0.5,
+                "status": "active",
+                "metadata": {},
+            },
+            "embedding": [0.0],
+            "t0": 0.0,
+        },
+        tenant_config=SimpleNamespace(entity_extraction_enabled=False),
+    )
+
+    async def _chunks(_content, _x, _cfg):
+        return [{"content": c, "suggested_type": "fact"} for c in ("stale", "fresh")]
+
+    async def _embeddings(texts, _cfg, background=False):
+        embedded.append(list(texts))
+        return [[0.0] for _ in texts]
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(memory_service, "get_embeddings_batch", new=_embeddings),
+        patch("core_api.services.ingest_service._chunk_content", new=_chunks),
+    ):
+        await memory_service._handle_auto_chunk_from_ctx(data, ctx)
+
+    assert embedded == [["fresh"]], f"embedded text the dedup had discarded: {embedded}"
+
+
+async def test_auto_chunk_skips_a_child_whose_content_is_already_live() -> None:
+    live_hash = memory_service._content_hash(TENANT, FLEET, "chunk one")
+
+    children = await _run_auto_chunk(
+        ["chunk one", "chunk two"],
+        live={live_hash: {"id": str(uuid.uuid4()), "client_request_id": None}},
+    )
+
+    assert [c["content"] for c in children] == ["chunk two"]
+
+
+async def test_auto_chunk_writes_a_repeated_chunk_once() -> None:
+    children = await _run_auto_chunk(["same chunk", "same chunk", "other"], live={})
+
+    assert [c["content"] for c in children] == ["same chunk", "other"]
+
+
+async def test_auto_chunk_skips_the_storage_call_when_every_child_is_a_duplicate() -> None:
+    """``create_memories([])`` would be a wasted roundtrip, and the storage-side
+    statement would build an INSERT with no VALUES."""
+    live_hash = memory_service._content_hash(TENANT, FLEET, "only chunk")
+
+    children = await _run_auto_chunk(
+        ["only chunk", "only chunk"],
+        live={live_hash: {"id": str(uuid.uuid4()), "client_request_id": None}},
+    )
+
+    assert children == []
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the LEGACY auto-chunk handler, which is the sibling of the above
+# ---------------------------------------------------------------------------
+
+
+async def _run_legacy_auto_chunk(chunks: list[str], live: dict[str, dict]) -> list[dict]:
+    """Drive ``_create_memory_legacy``'s auto-chunk branch.
+
+    Tested separately rather than assumed to match the pipeline handler: on two
+    of this audit's last three findings the filed location was only half the
+    problem, and the untested half was a sibling exactly like this one.
+    """
+    from core_api.schemas import MemoryCreate
+
+    parent_row = {
+        "id": str(uuid.uuid4()),
+        "tenant_id": TENANT,
+        "fleet_id": FLEET,
+        "agent_id": AGENT,
+        "memory_type": "fact",
+        "title": "t",
+        "content": "body",
+        "weight": 0.5,
+        "status": "active",
+        "visibility": "scope_team",
+        "recall_count": 0,
+        "created_at": datetime(2026, 8, 20, tzinfo=UTC),
+        "metadata_": {},
+        "embedding": None,
+        "deleted_at": None,
+    }
+    sc = AsyncMock(name="storage_client")
+    sc.create_memory = AsyncMock(return_value=parent_row)
+    sc.create_memories = AsyncMock(return_value=[])
+    sc.bulk_find_by_content_hashes = AsyncMock(return_value=live)
+    sc.find_embedding_by_content_hash = AsyncMock(return_value=None)
+    sc.find_by_content_hash = AsyncMock(return_value=None)
+
+    # Long enough to clear CHUNKING_THRESHOLD_CHARS, which gates the branch.
+    from core_api.constants import CHUNKING_THRESHOLD_CHARS
+
+    data = MemoryCreate(
+        tenant_id=TENANT,
+        fleet_id=FLEET,
+        agent_id=AGENT,
+        content="x" * (CHUNKING_THRESHOLD_CHARS + 100),
+    )
+
+    async def _chunks(_content, _x, _cfg):
+        return [{"content": c, "suggested_type": "fact"} for c in chunks]
+
+    async def _embeddings(texts, _cfg, background=False):
+        return [[0.0] for _ in texts]
+
+    async def _embedding(_content, _cfg=None, **_kw):
+        return [0.0]
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(memory_service, "get_embeddings_batch", new=_embeddings),
+        patch.object(memory_service, "get_embedding", new=_embedding),
+        patch("core_api.services.ingest_service._chunk_content", new=_chunks),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    enrichment_enabled=False,
+                    enrichment_provider="none",
+                    entity_extraction_enabled=False,
+                    auto_chunk_enabled=True,
+                )
+            ),
+        ),
+    ):
+        await memory_service._create_memory_legacy(data)
+
+    if not sc.create_memories.await_args_list:
+        return []
+    return sc.create_memories.await_args_list[0].args[0]
+
+
+async def test_legacy_auto_chunk_skips_a_child_whose_content_is_already_live() -> None:
+    live_hash = memory_service._content_hash(TENANT, FLEET, "legacy one")
+
+    children = await _run_legacy_auto_chunk(
+        ["legacy one", "legacy two"],
+        live={live_hash: {"id": str(uuid.uuid4()), "client_request_id": None}},
+    )
+
+    assert [c["content"] for c in children] == ["legacy two"]
+
+
+async def test_legacy_auto_chunk_writes_a_repeated_chunk_once() -> None:
+    children = await _run_legacy_auto_chunk(["dup chunk", "dup chunk"], live={})
+
+    assert [c["content"] for c in children] == ["dup chunk"]

--- a/tests/test_embed_stability.py
+++ b/tests/test_embed_stability.py
@@ -184,6 +184,11 @@ async def test_atomic_fact_children_embed_raw_fact_content() -> None:
     install_batch_status_replay_shim(sc)
     sc.create_memory = AsyncMock()
     sc.update_memory = AsyncMock()
+    # The fan-out consults the dedup lookup before writing children (OSS #814).
+    # Empty: this test is about which TEXT gets embedded, so every fact must
+    # reach ``create_memory`` — a non-empty return would skip one and the
+    # assertions below would be checking a shorter list than they think.
+    sc.bulk_find_by_content_hashes = AsyncMock(return_value={})
 
     def _stub_tracked_task(coro, _name, *_a, **_k):
         coro.close()


### PR DESCRIPTION
Refs #814 — this is the **first half**, and #814 stays open deliberately: the unique index is the second half and lands separately (see *Why this must land first*).

## The bug

Three write paths attach a `content_hash` to every row they insert and then never look it up:

| path | function |
|---|---|
| auto-chunk children, pipeline handler | `_handle_auto_chunk_from_ctx` |
| auto-chunk children, legacy handler | `_create_memory_legacy` |
| atomic-fact fanout | `_enrich_memory_background` |

The **public bulk path already dedups** — `existing_hashes` for the cross-batch case, `seen_hashes` for the in-batch one — and the single-write path has `CheckExactDuplicate`. These three had neither, so the same document re-chunked, or an LLM emitting the same fact twice, minted a fresh row every time.

That is why prod carries duplicates **with no concurrency involved at all**: `18 duplicate groups / 19 surplus rows / 110,057 live rows`, measured read-only against prod.

`_auto_chunk_request_id()` is not a substitute: it mints a fresh UUID per item per call, so `ix_memories_attempt_unique` sees every re-run as a brand-new attempt. It makes a *replayed* batch idempotent, which these callers never do.

## The fix

`_live_duplicate_hashes` + `_drop_duplicate_facts`, applied at all three sites, reusing the existing `bulk_find_by_content_hashes` primitive. Scope is `(tenant, fleet, agent, content_hash)` over live rows — the same scope `memory_find_by_content_hash` uses, so a child is judged by the rule the single-write gate would apply to it.

Two kinds of duplicate, handled separately because only one is something a constraint could ever catch:

- **already live** — content exists from an earlier call;
- **repeated inside this batch** — both rows are in the *same* insert, so no unique index can collapse them. They must be dropped before the statement runs.

## Where it sits, and why that matters

On the auto-chunk paths the dedup runs on the **facts**, inside the `len(facts) > 1` branch, **before the parent insert and before the batch embed**:

- `child_count` in the parent's metadata counts children that *will exist*, not chunks the chunker proposed. Deduping after the parent insert would have made that field permanently wrong with nothing to correct it.
- **a dropped child never costs an embedding.** The embed is the expensive part of this path and it is a batch call, so paying to vectorise text we're about to discard would have been the dominant cost of deduping at all.
- inside the branch, not above it: dedup can reduce the count to 1 or 0, and falling out of the branch on that would write the whole document as a single memory — a different row than either outcome the caller asked for.

The fanout skips at the top of its loop for the same embed reason. Its skip is deliberately *unlike* the two `continue`s inside its embed block: those exit **after** deciding `child_embedding` so a failed embed still persists the fact; this one decides the fact should not be persisted at all.

## Also: the H-04 sibling in the batch lookup

`memory_bulk_find_by_content_hashes` keeps one row per hash via a dict comprehension, **unordered** — so on a pre-existing duplicate group the winner was whatever the plan emitted last. That could disagree with `memory_find_by_content_hash`, which returns the oldest after #839, leaving two dedup paths pointing callers at different rows for the same content.

Now ordered `(created_at, id)` ascending, first-wins. `id` breaks the tie because ties are the **common** case here, not an edge: `created_at` is `server_default=now()`, fixed for a whole transaction, and auto-chunk inserts all its children in one call.

## Scope: what this does NOT close

**This PR does not eliminate duplicate content-hash groups in prod.** The gate is check-then-insert, so two concurrent runs can both pass it and both insert — two overlapping redeliveries enriching the same parent, or two racing auto-chunk requests for the same document. No application-level check can prevent that; only a constraint can.

What it removes is the source that needs **no concurrency at all** to fire, which is the source prod's 18 groups actually came from. The unique index in #814's second half closes the race. Read a green here as *"duplicates now require a race"*, not *"duplicates are impossible"*.

## Why this must land first

`memory_add_all`'s `ON CONFLICT` target is pinned to `ix_memories_attempt_unique`, and a statement can only name one. So a content-hash violation would **not** be swallowed — it would raise `IntegrityError` and abort the **whole batch**.

Adding the unique index first would therefore convert today's silent duplication into a 500 on a live path: both auto-chunk handlers batch-insert their children, and the fanout would 409 per child. Hence two PRs, minting paths first.

## Tests

21 new, **each confirmed by reverting the specific thing it covers**:

- `_drop_duplicate_facts` — live drop, in-batch collapse, first-occurrence survives, unhashable content kept, all-dropped returns empty, tenant/fleet scoping. Removing either branch fails exactly its own two.
- **Wiring at all three sites independently.** Removing site 1's call fails 5 tests, site 2's fails 2, the fanout's fails 2. Site 2 gets its own harness rather than being assumed to match site 1 — on two of this audit's last three findings the filed location was only half the problem.
- `child_count == 1` for three chunks of which two are live, and `embedded == [["fresh"]]` — the two assertions that pin the placement.
- The batch lookup returns the **oldest** of a duplicate group, plus the new warning fires on a duplicate group and stays quiet on a healthy lookup.

  The ordering test had to be **rewritten, because my first version of it was a bad test.** It inserted the group oldest-first — which meant the *unordered* path returned the oldest by accident, since the resolver keeps the first row it reaches and heap order is insertion order. Measured: **5 of 5 runs passed with the `order_by` reverted**; an earlier single observed failure had just been luck.

  It now ages the rows in reverse of write order, so heap order and `created_at` order disagree and the unordered path reaches the *newest* row first, and it spans 10 independent groups rather than one — one group can flip on a plan change, ten cannot agree by chance. Measured: passes 3/3 with the fix, fails 5/5 without.

One existing test needed a mock — `test_embed_stability` used a bare `MagicMock` storage client and the fanout now makes one more call on it.

## Gates

- **4597** core-api passed / 3 skipped / 1 xfailed (4579 baseline + 18)
- **132** storage passed (129 baseline + 3)
- `mypy src/` clean — 199 files
- `ruff check` **and** `ruff format --check` clean, run as separate gates
- DCO signed

## Noted while here, not fixed

`memories.metadata` is `json` in the live schema (migration 001) while `common/models/memory.py` declares `JSONB`, so the column type differs between the migration-chain schema and any schema built from that metadata. Found while writing the second half; it needs its own issue rather than a drive-by cast.
