### PR TITLE
feat(storage): one live memory per (tenant, fleet, agent, content_hash)

### DIFF
--- a/common/models/memory.py
+++ b/common/models/memory.py
@@ -148,6 +148,32 @@ class Memory(Base):
                 "deleted_at IS NULL AND client_request_id IS NOT NULL"
             ),
         ),
+        # Enforces the dedup contract the write path advertises: one LIVE row
+        # per (tenant, fleet, agent, content_hash). Created ``CONCURRENTLY`` in
+        # migration 040 with the same key and predicate; declared here so
+        # reflection / autogen round-trip against the live schema, and so the
+        # suites that build a schema from this metadata rather than from the
+        # migration chain (``tests/conftest.py`` uses
+        # ``Base.metadata.create_all``) exercise the constraint too.
+        #
+        # ``ix_memories_content_hash`` above is NOT a substitute: it is
+        # non-unique and keyed on ``(tenant_id, content_hash)`` only — it makes
+        # the lookup fast, it never made it correct.
+        #
+        # ``agent_id`` is in the key because two agents recording identical
+        # content are two independent observations, which is the same scope
+        # ``memory_find_by_content_hash`` dedups on. ``COALESCE(fleet_id, '')``
+        # for the reason 007 needs it: PostgreSQL treats NULLs as distinct, so
+        # without it fleetless rows would escape the constraint entirely.
+        Index(
+            "uq_memories_live_content_hash",
+            "tenant_id",
+            func.coalesce(text("fleet_id"), ""),
+            "agent_id",
+            "content_hash",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL AND content_hash IS NOT NULL"),
+        ),
         Index("ix_memories_valid_range", "ts_valid_start", "ts_valid_end"),
         Index("ix_memories_subject_entity", "subject_entity_id"),
         # For DELETEs, not reads — grep will find no query using it. This is the

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -19,6 +19,38 @@ from core_api.config import settings
 
 logger = logging.getLogger(__name__)
 
+_DUPLICATE_FALLBACK_DETAIL = "Duplicate memory exists"
+
+
+class DuplicateMemoryError(Exception):
+    """Storage refused a memory insert: a live row already holds this content.
+
+    Only raisable since migration 040 gave ``(tenant, fleet, agent,
+    content_hash)`` a partial unique index. Before it, an insert of duplicate
+    content succeeded and quietly created a second row.
+
+    Carries storage's ``detail`` verbatim, which names the winning row's id — an
+    agent told "duplicate" without being told *which* row cannot use the one it
+    should have got. Callers that own an HTTP contract map this to 409, matching
+    ``CheckExactDuplicate``: that gate answers the duplicate it can see before
+    the write, this answers the race it cannot, and callers should not have to
+    tell the two apart.
+    """
+
+
+def _storage_detail(response: httpx.Response) -> str:
+    """Storage's ``detail`` string, or a safe stand-in.
+
+    Defensive about the body because this runs on an error path: a 409 whose body
+    is not JSON, or is JSON without ``detail``, must not turn a clean 409 into a
+    JSONDecodeError from inside the exception handler.
+    """
+    try:
+        detail = response.json().get("detail")
+    except (ValueError, AttributeError):
+        return _DUPLICATE_FALLBACK_DETAIL
+    return detail if isinstance(detail, str) and detail else _DUPLICATE_FALLBACK_DETAIL
+
 
 def _reject_reserved_write_id(agent_id: str | None) -> None:
     """Storage-boundary reserved-id backstop. No-op under ``allow``/``warn``;
@@ -442,7 +474,23 @@ class CoreStorageClient:
         # ({"main"}) reject; the de-collapsed main-<install_id> form (#507) and
         # every named id pass untouched.
         _reject_reserved_write_id(data.get("agent_id"))
-        return await self._post("/memories", data)
+        try:
+            return await self._post("/memories", data)
+        except httpx.HTTPStatusError as exc:
+            # Migration 040's unique index can now REJECT this insert, which
+            # storage maps to 409. Recognised here, at the single boundary every
+            # memory insert funnels through, so no caller has to know that a
+            # storage 409 is a thing this endpoint does.
+            #
+            # A TYPED error rather than ``HTTPException``: nothing else in
+            # ``core_api/clients/`` raises a FastAPI type, and the app-level
+            # ``httpx.HTTPStatusError`` handler documents the reason it cannot do
+            # this job either — it deliberately re-raises 4xx as "a bug in OUR
+            # request shape", which a legitimate duplicate is not. Callers that
+            # own an HTTP contract translate it; see ``WriteMemoryRow``.
+            if exc.response.status_code != 409:
+                raise
+            raise DuplicateMemoryError(_storage_detail(exc.response)) from exc
 
     async def create_memories(self, data: list[dict]) -> list[dict]:
         """Bulk-insert memories with per-attempt idempotency (CAURA-602).
@@ -465,7 +513,21 @@ class CoreStorageClient:
         # Defense-in-depth reserved-id chokepoint (see create_memory).
         for item in data:
             _reject_reserved_write_id(item.get("agent_id"))
-        return await self._post("/memories/bulk", data)
+        try:
+            return await self._post("/memories/bulk", data)
+        except httpx.HTTPStatusError as exc:
+            # Same translation as ``create_memory``, for the same reason — and it
+            # has to be here too, not only there: migration 040's constraint can
+            # abort a whole batch, and ON CONFLICT cannot arbitrate a second
+            # index, so the bulk route answers 409 as well. Without this the two
+            # endpoints would disagree about what a duplicate looks like to a
+            # core-api caller.
+            #
+            # NOTE the batch is all-or-nothing: a 409 here means NOTHING in the
+            # batch was written, unlike the per-item outcomes a success returns.
+            if exc.response.status_code != 409:
+                raise
+            raise DuplicateMemoryError(_storage_detail(exc.response)) from exc
 
     async def get_memory(self, memory_id: str, *, read: bool = True) -> dict | None:
         """Fetch one memory by id.

--- a/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
+++ b/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import logging
 import time
 
-from core_api.clients.storage_client import get_storage_client
+from fastapi import HTTPException
+
+from core_api.clients.storage_client import DuplicateMemoryError, get_storage_client
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
 from core_api.services.hooks import get_hooks
@@ -82,7 +84,23 @@ class WriteMemoryRow:
             "visibility": data.visibility or "scope_team",
         }
         storage_t0 = time.perf_counter()
-        memory = await sc.create_memory(memory_data)
+        try:
+            memory = await sc.create_memory(memory_data)
+        except DuplicateMemoryError as exc:
+            # Migration 040's unique index rejected the insert. ``CheckExactDuplicate``
+            # ran earlier in this same pipeline and found nothing, so reaching here
+            # means a concurrent writer committed the same content in between — the
+            # one duplicate case a check-then-insert gate cannot see.
+            #
+            # 409, the same code and shape that gate raises, because it is the same
+            # answer: the content is already stored, here is the row. Without this
+            # the step would be marked FAILED and the caller would get "Memory
+            # write pipeline failed unexpectedly" — a 500 for a completely ordinary
+            # race, and one that says nothing about which row to use instead.
+            #
+            # Nothing has been committed by THIS request at this point, so unlike
+            # everything below, raising here is correct rather than a strand.
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         timings["storage_ms"] = round((time.perf_counter() - storage_t0) * 1000)
 
         # H-05: the row above is COMMITTED, so everything after it degrades rather

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 from fastapi import HTTPException
 from sqlalchemy.exc import SQLAlchemyError
 
-from core_api.clients.storage_client import get_storage_client
+from core_api.clients.storage_client import DuplicateMemoryError, get_storage_client
 from core_api.config import settings
 from core_api.middleware.per_tenant_concurrency import per_tenant_slot, per_tenant_storage_slot
 from core_api.services.agent_identity import ReservedAgentIdError, enforce_reserved_write_id
@@ -253,6 +253,75 @@ def _drop_duplicate_facts(
             },
         )
     return kept
+
+
+async def _insert_children_or_degrade(
+    payloads: list[dict],
+    *,
+    tenant_id: str,
+    parent_id: str,
+    source: str,
+) -> None:
+    """Insert auto-chunk children; a duplicate refusal degrades, never raises.
+
+    The parent row is ALREADY COMMITTED by the time this runs. Raising here would
+    hand the caller a 500 for a write that persisted, and leave the parent
+    childless with nothing recording why — the H-05 shape (#815), for which the
+    established answer is to degrade and report rather than abort.
+
+    Only ``DuplicateMemoryError`` is degraded, and it is the one exception where
+    degrading loses nothing: migration 040's constraint refuses the batch only
+    when the content is already stored, so the children this call would have
+    written already exist. Every other failure still propagates, because for
+    those the rows genuinely are missing.
+
+    The batch is all-or-nothing — ON CONFLICT cannot arbitrate a second index, so
+    one refused row aborts the statement. So this can drop children that were NOT
+    duplicates, which is why it logs at WARNING with the count: the parent's
+    ``child_count`` will overstate what exists, and this line is the only record
+    of the gap.
+
+    Empty list short-circuits: dedup can empty it (a document re-chunked with
+    every fact already live), ``create_memories([])`` is a pointless roundtrip,
+    and the storage-side statement would build an INSERT with no VALUES.
+    """
+    if not payloads:
+        return
+    async with per_tenant_storage_slot("storage_write", tenant_id):
+        try:
+            await get_storage_client().create_memories(payloads)
+        except DuplicateMemoryError:
+            logger.warning(
+                "auto-chunk children refused as duplicates; parent kept without them",
+                extra={
+                    "source": source,
+                    "parent_memory_id": parent_id,
+                    "children_dropped": len(payloads),
+                },
+            )
+
+
+async def _create_memory_or_409(payload: dict) -> dict:
+    """``create_memory``, with migration 040's duplicate rejection mapped to 409.
+
+    Since 040 the insert can be REFUSED where it previously duplicated silently.
+    Untranslated that is a 500 — the pipeline marks the step FAILED and the caller
+    reads "write pipeline failed unexpectedly" — for what is an ordinary race, and
+    an outcome the dedup contract already has a code for.
+
+    409 with the winning row's id, matching ``CheckExactDuplicate`` exactly: that
+    gate answers the duplicate visible before the write, this answers the race it
+    cannot see, and a caller should not have to tell the two apart.
+
+    A helper rather than a try at each site because there are three of them (the
+    auto-chunk parent on both handlers, plus the legacy single write) and each
+    passes a long inline dict; wrapping them individually would re-indent all
+    three for no gain. It fetches the client itself so the swap is call-for-call.
+    """
+    try:
+        return await get_storage_client().create_memory(payload)
+    except DuplicateMemoryError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 async def _find_semantic_duplicate(
@@ -662,7 +731,7 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
         # tenant doing heavy auto-chunking can't park more storage
         # connections than the cap allows.
         async with per_tenant_storage_slot("storage_write", data.tenant_id):
-            parent = await sc.create_memory(
+            parent = await _create_memory_or_409(
                 {
                     "tenant_id": data.tenant_id,
                     "fleet_id": data.fleet_id,
@@ -745,17 +814,15 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
                     "visibility": data.visibility or "scope_team",
                 }
             )
-        # Auto-chunk children — second storage roundtrip in this
-        # request after the parent insert above. Same per-tenant cap
-        # applies; held only across the bulk call itself.
-        #
-        # ``if child_payloads`` because dedup can empty the list — a document
-        # re-chunked with every fact already live. ``create_memories([])`` would
-        # be a pointless roundtrip, and the storage-side statement builds an
-        # INSERT with no VALUES.
-        if child_payloads:
-            async with per_tenant_storage_slot("storage_write", data.tenant_id):
-                await sc.create_memories(child_payloads)
+        # Auto-chunk children — second storage roundtrip in this request after
+        # the parent insert above. The parent is committed, so a refusal here
+        # degrades rather than raising; see ``_insert_children_or_degrade``.
+        await _insert_children_or_degrade(
+            child_payloads,
+            tenant_id=data.tenant_id,
+            parent_id=str(parent_id),
+            source="auto_chunk",
+        )
 
         if tenant_config.entity_extraction_enabled:
             track_task(
@@ -964,7 +1031,7 @@ async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:
             # Legacy-path auto-chunk parent insert. Mirrors the
             # pipeline-path coverage in ``_handle_auto_chunk_from_ctx``.
             async with per_tenant_storage_slot("storage_write", data.tenant_id):
-                parent = await sc.create_memory(
+                parent = await _create_memory_or_409(
                     {
                         "tenant_id": data.tenant_id,
                         "fleet_id": data.fleet_id,
@@ -1043,12 +1110,15 @@ async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:
                         "visibility": data.visibility or "scope_team",
                     }
                 )
-            # Legacy-path auto-chunk children — same bulkhead key as
-            # the parent insert above. See ``_handle_auto_chunk_from_ctx``
-            # for the pipeline-path equivalent.
-            if child_payloads:
-                async with per_tenant_storage_slot("storage_write", data.tenant_id):
-                    await sc.create_memories(child_payloads)
+            # Legacy-path auto-chunk children. See
+            # ``_handle_auto_chunk_from_ctx`` for the pipeline-path equivalent;
+            # the parent is committed here too, so the same degrade applies.
+            await _insert_children_or_degrade(
+                child_payloads,
+                tenant_id=data.tenant_id,
+                parent_id=str(parent_id),
+                source="auto_chunk_legacy",
+            )
 
             if tenant_config.entity_extraction_enabled:
                 track_task(
@@ -1127,7 +1197,7 @@ async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:
     # route-entry slot (``per_tenant_slot("write", ...)``) was already
     # held; this slot is held only across the storage call.
     async with per_tenant_storage_slot("storage_write", data.tenant_id):
-        created = await sc.create_memory(
+        created = await _create_memory_or_409(
             {
                 "tenant_id": data.tenant_id,
                 "fleet_id": data.fleet_id,
@@ -1766,7 +1836,21 @@ async def create_memories_bulk(
             asyncio.timeout(settings.storage_bulk_timeout_seconds),
             per_tenant_storage_slot("storage_write", data.tenant_id),
         ):
-            storage_results = await sc.create_memories([d for _, d in pending])
+            try:
+                storage_results = await sc.create_memories([d for _, d in pending])
+            except DuplicateMemoryError as exc:
+                # Migration 040's constraint aborted the batch. 409, not the 500
+                # an untranslated error would give: nothing was written, and the
+                # cause is a duplicate rather than a fault.
+                #
+                # Whole-request rather than per-item, unlike everything else this
+                # function returns, because the INSERT is one statement — there is
+                # no per-item outcome to report when none of them landed. This
+                # path is reachable only by a race: the loop above already
+                # resolved every duplicate it could see, through
+                # ``existing_hashes`` and ``seen_hashes``. A retry re-runs those
+                # against the now-committed winner and succeeds.
+                raise HTTPException(status_code=409, detail=str(exc)) from exc
 
         # Map each storage result back to its source item via
         # ``client_request_id``. Postgres ``RETURNING`` order is
@@ -2905,6 +2989,19 @@ async def _enrich_memory_background(
                             "ts_valid_start": parent_ts_start,
                         }
                     )
+                except DuplicateMemoryError:
+                    # NOT an error here, and deliberately not routed through
+                    # ``_create_memory_or_409``: this loop has no HTTP contract to
+                    # honour — it runs inside a fire-and-forget background task, so
+                    # a 409 would go nowhere and abort the remaining facts.
+                    #
+                    # A 409 means the fact is already recorded, which is the
+                    # outcome this loop wants. The dedup lookup above catches the
+                    # ordinary case; reaching here means a concurrent enrichment of
+                    # the same parent committed it in between. Counted with the
+                    # deduped facts because that is what it is.
+                    fanout_deduped += 1
+                    continue
                 except (TimeoutError, ValueError, RuntimeError, OpenAIError, GoogleAPIError):
                     logger.warning(
                         "atomic-fact create_memory failed for parent %s",

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/040_memories_content_hash_unique.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/040_memories_content_hash_unique.py
@@ -1,0 +1,191 @@
+"""One live memory per ``(tenant, fleet, agent, content_hash)``.
+
+H-04 second half (OSS #814). ``ix_memories_content_hash`` is NON-unique and
+covers only ``(tenant_id, content_hash)``, so nothing in the schema has ever
+enforced the dedup contract the write path advertises. #839 stopped the wedge —
+two live rows sharing a hash made ``scalar_one_or_none()`` raise
+``MultipleResultsFound`` → storage 500 → every subsequent write of that content
+500ing forever — but it stopped it by *tolerating* duplicates (oldest wins).
+This closes the hole instead of degrading around it.
+
+MEASURED ON PROD BEFORE WRITING THIS, because a unique index over existing data
+either applies or fails the deploy — there is no third outcome:
+
+    duplicate_groups: 18   surplus_rows: 19   worst_group: 3   live_rows: 110,057
+
+So the index would fail today, and the cleanup is 19 rows. The ``GROUP BY`` in
+that query is character-for-character the key below, so the count really does
+describe this index and not an approximation of it.
+
+CLEANUP FIRST, in the normal transaction. Migrations run in the FastAPI lifespan
+startup hook, so a failed one is a failed deploy (Cloud Run keeps the old
+revision serving — it fails safe, but it fails). Same ordering rationale as
+``038_documents_timestamps_not_null``.
+
+The survivor is the OLDEST row per group, ordered ``(created_at, id)``. That is
+not an arbitrary tie-break: it is exactly what ``memory_find_by_content_hash``
+returns after #839, so the row this migration keeps is the row the dedup gate
+would already have handed callers. Anything else would silently re-point live
+lookups at a different row. ``id`` breaks ties because ties are the COMMON case
+here rather than an edge — ``created_at`` is ``server_default=now()``, fixed for
+a whole transaction, and the auto-chunk path inserts all its children in one
+call, so duplicates minted that way share ``created_at`` exactly.
+
+The surplus rows are SOFT-deleted, never hard-deleted, and stamped
+``metadata.deduped_by_migration`` so all 19 stay findable afterwards:
+
+    SELECT id FROM memories WHERE metadata ->> 'deduped_by_migration' = '040'
+
+Soft is what makes this reviewable rather than a mass mutation — the rows keep
+their content, their entity links and their children, and the predicate below
+excludes them from the index by construction.
+
+Revision ID: 040
+Revises: 039
+Create Date: 2026-08-20
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "040"
+down_revision: str | None = "039"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX_NAME = "uq_memories_live_content_hash"
+
+# The key, in one place: the cleanup's PARTITION BY and the index's column list
+# must not drift apart, or the migration deletes rows against one definition and
+# then builds a constraint over another.
+_KEY = "tenant_id, COALESCE(fleet_id, ''), agent_id, content_hash"
+
+# Matches the index predicate. ``content_hash`` is nullable and a NULL means
+# "not hashed", not "hashed to nothing", so those rows are outside the contract
+# entirely; ``deleted_at IS NULL`` keeps soft-deleted rows out, which is what
+# lets the cleanup below resolve a conflict by soft-deleting.
+_LIVE = "deleted_at IS NULL AND content_hash IS NOT NULL"
+
+# Module-level, and public, so the test can execute the EXACT statement this
+# migration runs. The cleanup is the part that mutates rows, and it had never
+# once run against a real duplicate — both local databases were already clean, so
+# it went green having soft-deleted nothing. A test that re-typed the SQL would
+# have pinned a copy rather than this.
+CLEANUP_SQL = f"""
+    WITH ranked AS (
+        SELECT id,
+               row_number() OVER (
+                   PARTITION BY {_KEY}
+                   ORDER BY created_at, id
+               ) AS rn
+        FROM memories
+        WHERE {_LIVE}
+    )
+    UPDATE memories m
+    SET deleted_at = now(),
+        status = 'deleted',
+        metadata = CASE
+                       WHEN jsonb_typeof(m.metadata::jsonb) = 'object'
+                       THEN m.metadata::jsonb
+                       ELSE '{{}}'::jsonb
+                   END
+                   || '{{"deduped_by_migration": "040"}}'::jsonb
+    FROM ranked r
+    WHERE m.id = r.id
+      AND r.rn > 1
+"""
+
+
+def _drop_invalid(connection: sa.Connection) -> None:
+    """Remove the index if an interrupted CONCURRENTLY build left it INVALID.
+
+    Mirrors 005 / 007 / 026 / 035, and it is not theoretical: a killed
+    ``CREATE INDEX CONCURRENTLY`` leaves the index in ``pg_index`` with
+    ``indisvalid = false``, ``IF NOT EXISTS`` then SKIPS it ("already exists,
+    skipping"), and the planner refuses to use it — 035 measured 547x slower on
+    the query its index existed for.
+
+    For a UNIQUE index the stakes are higher than a slow plan: an invalid unique
+    index does not enforce uniqueness either, so without this the migration
+    stamps green while the constraint it exists to add is silently absent, and
+    ``memory_add`` starts trusting a guarantee it does not have.
+
+    Reachable because CONCURRENTLY waits on concurrent transactions with no
+    upper bound (035 measured 7.7 s behind a single open writer) and Cloud Run
+    kills the container at the 240 s startup probe.
+    """
+    invalid = connection.execute(
+        sa.text(
+            """
+            SELECT 1 FROM pg_index i
+            JOIN pg_class c ON c.oid = i.indexrelid
+            WHERE c.relname = :name
+              AND NOT i.indisvalid
+            """
+        ),
+        {"name": _INDEX_NAME},
+    ).fetchone()
+    if invalid:
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")
+
+
+def upgrade() -> None:
+    # Row locks on the surplus rows only (19 in prod), so this stays in the
+    # normal transaction and commits before the DDL below.
+    #
+    # ``m.metadata::jsonb`` is load-bearing, not defensive. The live column is
+    # ``json`` (migration 001), while ``common/models/memory.py`` declares
+    # ``JSONB`` — so the type differs between the migration-chain schema and any
+    # schema built from that metadata. Without the cast, COALESCE cannot unify
+    # ``json`` with a ``'{}'::jsonb`` literal and the statement fails outright
+    # with ``COALESCE could not convert type jsonb to json``, which on this
+    # migration path means a failed deploy. Casting the COLUMN (rather than
+    # casting the result) is what makes the same statement correct against
+    # either type; verified against both.
+    #
+    # ``jsonb_typeof(...) = 'object'`` rather than ``COALESCE(..., '{}')``,
+    # because SQL NULL is not the only non-object this column can hold: JSON
+    # ``null`` is a value, COALESCE passes it straight through, and
+    # ``'null'::jsonb || '{...}'::jsonb`` does not fail — it WRAPS both in an
+    # array. That would silently drop the marker (``->> 'key'`` on an array is
+    # NULL) and replace the row's metadata with ``[null, {...}]``. Reachable:
+    # SQLAlchemy's JSON type stores a Python ``None`` as JSON ``null`` unless the
+    # column sets ``none_as_null``, which this one does not. The CASE covers SQL
+    # NULL, JSON null, and any array/scalar the column has ever been given.
+    op.execute(CLEANUP_SQL)
+
+    # ``autocommit_block`` commits the cleanup above before the build starts,
+    # which is required both ways round: CONCURRENTLY cannot run inside a
+    # transaction at all, and the build must see the soft-deletes as committed
+    # or it fails on the very rows just resolved.
+    with op.get_context().autocommit_block():
+        connection = op.get_context().connection
+        if connection is None:
+            raise RuntimeError("online migration requires a connection")
+        _drop_invalid(connection)
+        # The ``CREATE ... INDEX ... ON <table>`` prefix stays on ONE source line
+        # AND spells the index name literally, because
+        # ``test_no_plain_create_index_on_large_tables`` regex-scans this file for
+        # it: its ``\w+`` for the name matches neither a split prefix nor an
+        # interpolated ``{_INDEX_NAME}``, which is how 007 and 026 ended up
+        # outside its coverage despite doing the right thing. Hence the one
+        # deliberate duplication of the name in this file — being inside the
+        # guard is worth more than the constant. The trailing key and predicate
+        # may wrap; the regex stops at the table name.
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_memories_live_content_hash ON memories"
+            f" ({_KEY}) WHERE {_LIVE}"
+        )
+
+
+def downgrade() -> None:
+    # Only the index is reversed. The soft-deletes are deliberately NOT undone:
+    # restoring them would re-create the exact duplicate groups this migration
+    # resolved, and on a re-upgrade they would be soft-deleted again — a loop
+    # that mutates rows on every schema round-trip. They remain recoverable by
+    # hand via the ``metadata.deduped_by_migration = '040'`` marker, which is
+    # why the marker is written.
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -17,7 +17,11 @@ from common.events.lifecycle_purge_request import (
 from core_storage_api.observability import bind_timer, log_request
 from core_storage_api.routers._validation import _require, _require_dict
 from core_storage_api.schemas import MEMORY_FIELDS, MEMORY_LIST_FIELDS, orm_to_dict
-from core_storage_api.services.postgres_service import BulkValidationError, PostgresService
+from core_storage_api.services.postgres_service import (
+    BulkValidationError,
+    DuplicateContentHashError,
+    PostgresService,
+)
 
 router = APIRouter(prefix="/memories", tags=["Memories"])
 _svc = PostgresService()
@@ -81,7 +85,20 @@ def _validate_pg_regex(value: str | None, field: str) -> None:
 async def create_memory(request: Request) -> dict:
     body: dict = await request.json()
     _parse_datetimes(body)
-    memory = await _svc.memory_add(body)
+    try:
+        memory = await _svc.memory_add(body)
+    except DuplicateContentHashError as exc:
+        # Migration 040's unique index rejected the insert. 409, not 500: the
+        # dedup contract already promises this code — ``CheckExactDuplicate``
+        # raises it upstream when the duplicate is visible before the write, and
+        # this is the same answer for the race it cannot see. The detail carries
+        # the winning row's id, so a caller can use the row it should have got.
+        #
+        # Catches the dedicated subclass, NOT bare ``ValueError``, for the reason
+        # spelled out on ``BulkValidationError`` below: the try spans a call that
+        # opens a session, so a broad catch would relabel a server fault as a
+        # client error.
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return orm_to_dict(memory, MEMORY_FIELDS)
 
 
@@ -103,6 +120,13 @@ async def create_memories_bulk(request: Request) -> list[dict]:
         _parse_datetimes(item)
     try:
         return await _svc.memory_add_all(body)
+    except DuplicateContentHashError as exc:
+        # Migration 040's constraint aborted the batch. 409 for the same reason
+        # the single-row route gives it: the content is already stored, and
+        # nothing here was written. Listed BEFORE ``BulkValidationError`` only
+        # for readability — the two are siblings under ``ValueError``, neither is
+        # a subclass of the other, so the order does not affect which one runs.
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except BulkValidationError as exc:
         # Malformed batch (an item missing ``client_request_id``, or mixed
         # ``tenant_id`` / ``fleet_id``). Unwrapped it escaped as a 500 — a

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -481,6 +481,52 @@ def _attach_agent_display_names(rows: Any) -> list[Memory]:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
+# Migration 040's partial unique index. Named here because ``memory_add`` has to
+# tell it apart from ``ix_memories_attempt_unique``, which can raise the same
+# IntegrityError and means something different.
+_INDEX_MEMORIES_LIVE_CONTENT_HASH = "uq_memories_live_content_hash"
+
+
+class DuplicateContentHashError(ValueError):
+    """A live row already holds this ``(tenant, fleet, agent, content_hash)``.
+
+    Its own class, for the same reason ``BulkValidationError`` is: the route maps
+    exactly this to 409 and lets anything else from inside the session keep
+    surfacing as a 500. A bare ``except ValueError`` around the call would
+    relabel a genuine server fault as a client error.
+
+    Subclasses ``ValueError`` so the 409 convention the entities routes already
+    use (``except ValueError -> HTTPException(409)``) keeps working unchanged.
+    """
+
+
+def _content_hash_fleet_scope(fleet_id: str | None):
+    """Fleet predicate matching ``uq_memories_live_content_hash``'s grouping.
+
+    NOT ``fleet_id == x`` / ``IS NULL`` chosen on falsiness, which is what every
+    dedup lookup here used to do. The index keys on ``COALESCE(fleet_id, '')``,
+    so a NULL and an empty string are the SAME group to it — while a
+    falsiness-branching lookup filters ``IS NULL`` for a caller who passed ``''``
+    and therefore cannot see a row stored as ``''``.
+
+    That divergence is reachable, not theoretical: ``fleet_id`` is
+    ``str | None`` with no empty-string normalisation anywhere on the write path,
+    so ``POST /memories`` with ``fleet_id: ""`` stores a literal ``''``.
+    Reproduced before this was written — two such writes got the index's 409, but
+    the winner lookup missed the live row and reported "no longer live; retry the
+    write", which is advice that can only 409 again.
+
+    One helper rather than the predicate written out three times, so the gate
+    (``memory_find_by_content_hash``), its sibling
+    (``memory_find_duplicate_hash``) and the winner lookup cannot drift apart
+    from each other or from the constraint they all describe.
+
+    Also index-friendly: equality on the same ``COALESCE`` expression the index
+    is built over remains usable by the planner.
+    """
+    return func.coalesce(Memory.fleet_id, "") == (fleet_id or "")
+
+
 class BulkValidationError(ValueError):
     """A bulk batch violated its input contract before any DB work started.
 
@@ -558,11 +604,78 @@ class PostgresService:
         return out
 
     async def memory_add(self, data: dict) -> Memory:
+        try:
+            async with get_session() as session:
+                memory = Memory(**self._filter_memory_fields(data))
+                session.add(memory)
+                await session.flush()
+                return memory
+        except IntegrityError as exc:
+            # Migration 040 gave ``(tenant, fleet, agent, content_hash)`` a
+            # partial unique index, so this insert can now be REJECTED where
+            # before it silently duplicated. Unhandled that is a 500 for what is
+            # squarely the 409 the dedup contract already promises —
+            # ``CheckExactDuplicate`` raises exactly that when it sees the row up
+            # front. This is the same outcome for the case that gate cannot see:
+            # it looked, found nothing, and a concurrent writer won the race.
+            #
+            # Matched on the index NAME, not on IntegrityError broadly:
+            # ``ix_memories_attempt_unique`` can also fire here, and that one
+            # means "this attempt id already committed", which is a different
+            # answer. Relabelling it as duplicate content would tell the caller
+            # the wrong thing about their own retry.
+            if _INDEX_MEMORIES_LIVE_CONTENT_HASH not in str(exc.orig):
+                raise
+            # The try wraps the WHOLE ``async with``, not just the flush, so by
+            # the time this runs the failed session has unwound and rolled back.
+            # That is required, not tidiness: ``get_session`` holds an explicit
+            # ``session.begin()``, so rolling back inside it and then querying
+            # raises "Can't operate on closed transaction inside context
+            # manager" — which would turn every duplicate insert into the 500
+            # this handler exists to prevent. The lookup below therefore opens a
+            # fresh session of its own.
+            raise DuplicateContentHashError(await self._describe_content_hash_winner(data)) from exc
+
+    async def _describe_content_hash_winner(self, data: dict) -> str:
+        """Message naming the row that already holds this content.
+
+        Re-SELECTed rather than omitted, and it is the whole reason this raises a
+        message instead of a bare flag: ``CheckExactDuplicate``'s 409 says
+        ``Duplicate memory exists: <id>``, and an agent that gets a 409 without an
+        id cannot find the row it is supposed to use instead. Same
+        re-SELECT-the-winner shape as ``entity_add``'s dedup race.
+
+        Opens its OWN session, and takes no session parameter so it cannot be
+        handed the failed one: the caller reaches here only after an
+        ``IntegrityError`` has unwound ``get_session``'s ``session.begin()``, and
+        a query on that session raises ``InvalidRequestError`` rather than
+        answering.
+
+        Ordered ``(created_at, id)`` so the id handed back is the same row
+        ``memory_find_by_content_hash`` returns — a 409 pointing at a different
+        row than the lookup would give is worse than no id at all.
+        """
+        stmt = select(Memory.id).where(
+            Memory.tenant_id == data["tenant_id"],
+            Memory.content_hash == data.get("content_hash"),
+            Memory.agent_id == data["agent_id"],
+            Memory.deleted_at.is_(None),
+        )
+        # Same ``COALESCE`` grouping as the index — see
+        # ``_content_hash_fleet_scope``. The previous form branched on falsiness
+        # and so could not find a winner stored with ``fleet_id = ''``.
+        stmt = stmt.where(_content_hash_fleet_scope(data.get("fleet_id")))
         async with get_session() as session:
-            memory = Memory(**self._filter_memory_fields(data))
-            session.add(memory)
-            await session.flush()
-            return memory
+            winner = (
+                await session.execute(stmt.order_by(Memory.created_at.asc(), Memory.id.asc()).limit(1))
+            ).scalar_one_or_none()
+        if winner is None:
+            # The winner was soft-deleted between the conflict and this read, so
+            # the content is free again. Reported honestly rather than retried
+            # here: a retry inside the failed transaction's handler is a loop
+            # waiting to happen, and the caller's own retry will now succeed.
+            return "Duplicate memory exists but is no longer live; retry the write"
+        return f"Duplicate memory exists: {winner}"
 
     async def memory_add_all(self, items: list[dict]) -> list[dict]:
         """Insert with per-attempt idempotency (CAURA-602).
@@ -654,9 +767,40 @@ class PostgresService:
                 )
                 .returning(Memory.id, Memory.client_request_id)
             )
-            inserted: dict[str, UUID] = {
-                row.client_request_id: row.id for row in (await session.execute(stmt)).all()
-            }
+            try:
+                result = await session.execute(stmt)
+            except IntegrityError as exc:
+                # ON CONFLICT arbitrates ONE index, and this statement's is
+                # ``ix_memories_attempt_unique``. A violation of migration 040's
+                # ``uq_memories_live_content_hash`` therefore is NOT swallowed —
+                # it aborts the whole multi-row INSERT, taking the batch's
+                # unrelated items with it. Unhandled that is a 500, which is
+                # exactly the outcome the single-row path above stopped
+                # producing; leaving the bulk path behind would mean the same
+                # duplicate answers 409 or 500 depending only on which endpoint
+                # the caller used.
+                #
+                # A second arbiter is not available (a statement names one), and
+                # per-row upserts would trade the batch's single roundtrip for N.
+                # So the batch fails as a unit and says so — which is honest,
+                # because nothing was written.
+                #
+                # Same index-name match as ``memory_add``: the attempt-idempotency
+                # index means "this attempt already committed", a different answer
+                # that must keep its own handling.
+                if _INDEX_MEMORIES_LIVE_CONTENT_HASH not in str(exc.orig):
+                    raise
+                # Raw driver text to the log, never to the caller — it carries
+                # the constraint name and the offending values.
+                logger.info(
+                    "Bulk insert rejected by the live content_hash constraint: %s",
+                    exc.orig,
+                )
+                raise DuplicateContentHashError(
+                    "bulk insert rejected: an item's content already exists for "
+                    "this agent; nothing in this batch was written"
+                ) from exc
+            inserted: dict[str, UUID] = {row.client_request_id: row.id for row in result.all()}
 
             # Items the conflict swallowed already exist — committed by a
             # prior attempt with the same ``X-Bulk-Attempt-Id``. Re-read
@@ -1007,10 +1151,13 @@ class PostgresService:
                 Memory.content_hash == content_hash,
                 Memory.deleted_at.is_(None),
             )
-            if fleet_id:
-                stmt = stmt.where(Memory.fleet_id == fleet_id)
-            else:
-                stmt = stmt.where(Memory.fleet_id.is_(None))
+            # ``COALESCE`` grouping, matching the unique index rather than
+            # branching on falsiness — see ``_content_hash_fleet_scope``. All
+            # three content-hash lookups get it: a gate that disagrees with the
+            # constraint hands the write path a clean "no duplicate" and lets the
+            # INSERT be rejected instead, which is the mismatch this PR's index
+            # would otherwise make load-bearing.
+            stmt = stmt.where(_content_hash_fleet_scope(fleet_id))
             if agent_id is not None:
                 stmt = stmt.where(Memory.agent_id == agent_id)
             # H-04: oldest-first + LIMIT 2, not ``scalar_one_or_none()``.
@@ -1066,10 +1213,13 @@ class PostgresService:
                 Memory.content_hash == content_hash,
                 Memory.deleted_at.is_(None),
             )
-            if fleet_id:
-                stmt = stmt.where(Memory.fleet_id == fleet_id)
-            else:
-                stmt = stmt.where(Memory.fleet_id.is_(None))
+            # ``COALESCE`` grouping, matching the unique index rather than
+            # branching on falsiness — see ``_content_hash_fleet_scope``. All
+            # three content-hash lookups get it: a gate that disagrees with the
+            # constraint hands the write path a clean "no duplicate" and lets the
+            # INSERT be rejected instead, which is the mismatch this PR's index
+            # would otherwise make load-bearing.
+            stmt = stmt.where(_content_hash_fleet_scope(fleet_id))
             if agent_id is not None:
                 stmt = stmt.where(Memory.agent_id == agent_id)
             if exclude_id is not None:
@@ -1346,10 +1496,13 @@ class PostgresService:
                 Memory.content_hash.in_(hashes),
                 Memory.deleted_at.is_(None),
             )
-            if fleet_id:
-                stmt = stmt.where(Memory.fleet_id == fleet_id)
-            else:
-                stmt = stmt.where(Memory.fleet_id.is_(None))
+            # ``COALESCE`` grouping, matching the unique index rather than
+            # branching on falsiness — see ``_content_hash_fleet_scope``. All
+            # three content-hash lookups get it: a gate that disagrees with the
+            # constraint hands the write path a clean "no duplicate" and lets the
+            # INSERT be rejected instead, which is the mismatch this PR's index
+            # would otherwise make load-bearing.
+            stmt = stmt.where(_content_hash_fleet_scope(fleet_id))
             if agent_id is not None:
                 stmt = stmt.where(Memory.agent_id == agent_id)
             # H-04 sibling: the dict comprehension below keeps ONE row per hash,

--- a/core-storage-api/tests/conftest.py
+++ b/core-storage-api/tests/conftest.py
@@ -100,3 +100,74 @@ def tenant_id() -> str:
 @pytest.fixture
 def fleet_id() -> str:
     return f"test-fleet-{_session_suffix}"
+
+
+# ---------------------------------------------------------------------------
+# Duplicate content_hash — the constraint has to come off to fabricate one
+# ---------------------------------------------------------------------------
+
+UQ_LIVE_CONTENT_HASH = "uq_memories_live_content_hash"
+
+# Mirrors migration 040's index. Rebuilt (not CONCURRENTLY — a plain session is
+# in a transaction) after each test that drops it.
+UQ_LIVE_CONTENT_HASH_SQL = (
+    f"CREATE UNIQUE INDEX {UQ_LIVE_CONTENT_HASH} ON memories "
+    "(tenant_id, COALESCE(fleet_id, ''), agent_id, content_hash) "
+    "WHERE deleted_at IS NULL AND content_hash IS NOT NULL"
+)
+
+
+def load_migration_040():
+    """Load migration 040 as a module.
+
+    By path because the versions directory is not an importable package and the
+    filename starts with a digit. Shared so the fixture below and the migration's
+    own tests both execute the REAL ``CLEANUP_SQL`` — a re-typed copy in either
+    place could drift from the migration and still pass.
+    """
+    import importlib.util
+    import pathlib
+
+    path = (
+        pathlib.Path("core-storage-api/src/core_storage_api/database/migrations/versions")
+        / "040_memories_content_hash_unique.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_040", path)
+    assert spec is not None and spec.loader is not None, f"cannot load {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+async def without_content_hash_index(_ensure_schema):
+    """Drop migration 040's unique index for the duration of a test.
+
+    Shared because two kinds of test need it, and both are legitimate: the
+    migration's own cleanup tests, which must create the duplicates the cleanup
+    resolves, and the dedup-gate tests, which assert what the LOOKUPS do when a
+    pre-existing duplicate group is present. Neither state is creatable while the
+    constraint stands — that is the point of the constraint.
+
+    Teardown runs the migration's own ``CLEANUP_SQL`` before rebuilding, because
+    a test that fabricated duplicates has by definition left the table
+    un-indexable; without that step the rebuild raises and every such test ends
+    in a teardown ERROR. Using the migration's statement rather than an ad-hoc
+    DELETE also means the fixture restores the invariant the same way production
+    does.
+
+    Uses the service's transactional ``get_session`` so the DDL commits; the
+    FastAPI dependency generator in ``database.init`` does not commit.
+    """
+    from sqlalchemy import text
+
+    from core_storage_api.services.postgres_service import get_session
+
+    async with get_session() as session:
+        await session.execute(text(f"DROP INDEX IF EXISTS {UQ_LIVE_CONTENT_HASH}"))
+    yield
+    cleanup_sql = load_migration_040().CLEANUP_SQL
+    async with get_session() as session:
+        await session.execute(text(f"DROP INDEX IF EXISTS {UQ_LIVE_CONTENT_HASH}"))
+        await session.execute(text(cleanup_sql))
+        await session.execute(text(UQ_LIVE_CONTENT_HASH_SQL))

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -1579,6 +1579,7 @@ class TestMemories:
         client: AsyncClient,
         tenant_id: str,
         fleet_id: str,
+        without_content_hash_index,
     ) -> None:
         """H-04 sibling: the batch lookup keeps one row per hash, so on a
         pre-existing duplicate group it picks a winner. Unordered, that winner was
@@ -1657,6 +1658,7 @@ class TestMemories:
         tenant_id: str,
         fleet_id: str,
         caplog,
+        without_content_hash_index,
     ) -> None:
         """``_warn_duplicate_content_hash`` is shared by both dedup gates on
         purpose — its own docstring says a warning from only one of them

--- a/core-storage-api/tests/test_migration_040_content_hash_cleanup.py
+++ b/core-storage-api/tests/test_migration_040_content_hash_cleanup.py
@@ -1,0 +1,601 @@
+"""Migration 040's duplicate cleanup, run against actual duplicates.
+
+The cleanup is the only part of 040 that mutates rows, and it needs its own test
+for a specific reason: it went green on both local databases having soft-deleted
+**zero** rows, because neither had a duplicate to find. Green there proved the
+statement parses, nothing more. Against prod it will resolve 19 rows.
+
+The tests drop the unique index, insert real duplicates, run the migration's own
+``CLEANUP_SQL`` (imported, not re-typed, so a drift between the two cannot pass),
+assert the outcome, and rebuild the index to prove the cleanup actually made the
+table indexable.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+
+# The service's ``get_session``, not ``database.init``'s: this one is an
+# ``asynccontextmanager`` that commits on success. ``init``'s is a FastAPI
+# dependency generator and does not commit, so every write here would roll back
+# and the tests would assert against an empty table.
+from core_storage_api.services.postgres_service import get_session
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+# Both from conftest, which owns the ``without_content_hash_index`` fixture that
+# drops and rebuilds this index — one definition of the index shape for the
+# tests, so the fixture and the assertions cannot drift apart.
+from tests.conftest import UQ_LIVE_CONTENT_HASH as _INDEX  # noqa: E402
+from tests.conftest import UQ_LIVE_CONTENT_HASH_SQL as _INDEX_SQL  # noqa: E402
+from tests.conftest import load_migration_040  # noqa: E402
+
+
+def _cleanup_sql() -> str:
+    """The migration's own ``CLEANUP_SQL``, via conftest's loader."""
+    return load_migration_040().CLEANUP_SQL
+
+
+async def _insert(
+    session,
+    *,
+    tenant,
+    fleet,
+    agent,
+    content_hash,
+    created_at,
+    metadata="null",
+    row_id=None,
+):
+    """Insert a live memory row directly, bypassing the service layer.
+
+    Direct SQL because the point is to create states the application refuses to
+    create — duplicates, and duplicates sharing ``created_at`` exactly.
+
+    ``row_id`` is explicit where a test needs insertion order to differ from id
+    order; otherwise random, as the app's ``gen_random_uuid()`` default is.
+    """
+    row_id = row_id or uuid.uuid4()
+    await session.execute(
+        text(
+            """
+            INSERT INTO memories
+                (id, tenant_id, fleet_id, agent_id, memory_type, content,
+                 content_hash, created_at, status, metadata)
+            VALUES
+                (:id, :tenant, :fleet, :agent, 'fact', :content,
+                 :content_hash, :created_at, 'active', CAST(:metadata AS json))
+            """
+        ),
+        {
+            "id": row_id,
+            "tenant": tenant,
+            "fleet": fleet,
+            "agent": agent,
+            "content": f"body {row_id}",
+            "content_hash": content_hash,
+            "created_at": created_at,
+            "metadata": metadata,
+        },
+    )
+    return row_id
+
+
+async def test_cleanup_keeps_the_oldest_and_soft_deletes_the_rest(without_content_hash_index) -> None:
+    suffix = uuid.uuid4().hex[:8]
+    tenant, fleet, agent = f"t-040-{suffix}", f"f-040-{suffix}", f"a-040-{suffix}"
+    content_hash = f"hash-040-{suffix}"
+
+    async with get_session() as session:
+        oldest = await _insert(
+            session,
+            tenant=tenant,
+            fleet=fleet,
+            agent=agent,
+            content_hash=content_hash,
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        # The three metadata shapes this column actually holds. JSON ``null`` is
+        # the one that matters: COALESCE passes it through, and
+        # ``'null'::jsonb || '{...}'::jsonb`` WRAPS both in an array rather than
+        # failing — which would drop the marker and corrupt the row's metadata.
+        # Reachable because SQLAlchemy's JSON type stores a Python ``None`` as
+        # JSON ``null`` unless the column sets ``none_as_null``.
+        sql_null = await _insert(
+            session,
+            tenant=tenant,
+            fleet=fleet,
+            agent=agent,
+            content_hash=content_hash,
+            created_at=datetime(2026, 2, 1, tzinfo=UTC),
+            metadata=None,
+        )
+        json_null = await _insert(
+            session,
+            tenant=tenant,
+            fleet=fleet,
+            agent=agent,
+            content_hash=content_hash,
+            created_at=datetime(2026, 3, 1, tzinfo=UTC),
+            metadata="null",
+        )
+        with_keys = await _insert(
+            session,
+            tenant=tenant,
+            fleet=fleet,
+            agent=agent,
+            content_hash=content_hash,
+            created_at=datetime(2026, 4, 1, tzinfo=UTC),
+            metadata='{"source": "auto_chunk"}',
+        )
+
+    async with get_session() as session:
+        await session.execute(text(_cleanup_sql()))
+
+    async with get_session() as session:
+        rows = (
+            await session.execute(
+                text(
+                    """
+                    SELECT id, deleted_at, status,
+                           metadata::jsonb ->> 'deduped_by_migration' AS marker,
+                           metadata::jsonb ->> 'source' AS source
+                    FROM memories WHERE content_hash = :h ORDER BY created_at
+                    """
+                ),
+                {"h": content_hash},
+            )
+        ).all()
+
+    by_id = {r.id: r for r in rows}
+    assert by_id[oldest].deleted_at is None, (
+        "the oldest row is the one the dedup gate returns after #839 — deleting "
+        "it would silently re-point every live lookup at a different row"
+    )
+    assert by_id[oldest].marker is None, "the survivor must not be marked as deduped"
+
+    for row_id in (sql_null, json_null, with_keys):
+        assert by_id[row_id].deleted_at is not None, "surplus row was left live"
+        assert by_id[row_id].status == "deleted"
+        assert by_id[row_id].marker == "040", (
+            "without the marker the 19 rows this touches in prod are unfindable afterwards"
+        )
+
+    assert by_id[with_keys].source == "auto_chunk", (
+        "the marker must merge into existing metadata, not replace it"
+    )
+
+
+async def test_cleanup_breaks_a_created_at_tie_by_id(without_content_hash_index) -> None:
+    """The tie is the COMMON case, not an edge.
+
+    ``created_at`` is ``server_default=now()``, which Postgres fixes for a whole
+    transaction, and the auto-chunk path inserts all its children in one call —
+    so duplicates minted that way share ``created_at`` exactly. ``ORDER BY
+    created_at`` alone would leave the choice to the plan, which is the
+    instability the ``id`` tie-break exists to remove.
+
+    MANY GROUPS, not one, and that is the load-bearing part of the design.
+
+    A single tied group cannot falsify this: which tie a sort emits first is
+    plan-dependent and not controllable from SQL, so reverting the ``id``
+    tie-break leaves a one-group test passing much of the time — measured, on
+    this very test: 2 of 3 runs passed with the fix removed, even inserting in
+    reverse id order. That is precisely the trap of a green tie-break test.
+
+    Across 20 independent groups, an unordered tie would have to pick the lowest
+    id in ALL of them to pass. Verified: reverting the tie-break fails this.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    tenant, fleet, agent = f"t-tie-{suffix}", f"f-tie-{suffix}", f"a-tie-{suffix}"
+    same_instant = datetime(2026, 4, 1, 12, tzinfo=UTC)
+
+    groups: dict[str, list[uuid.UUID]] = {}
+    async with get_session() as session:
+        for group in range(20):
+            content_hash = f"hash-tie-{suffix}-{group}"
+            ids = sorted(uuid.uuid4() for _ in range(4))
+            groups[content_hash] = ids
+            # Descending id order, so "first inserted" and "lowest id" are never
+            # the same row — the wrong answer cannot coincide with the right one.
+            for row_id in reversed(ids):
+                await _insert(
+                    session,
+                    tenant=tenant,
+                    fleet=fleet,
+                    agent=agent,
+                    content_hash=content_hash,
+                    created_at=same_instant,
+                    row_id=row_id,
+                )
+
+    async with get_session() as session:
+        await session.execute(text(_cleanup_sql()))
+
+    async with get_session() as session:
+        rows = (
+            await session.execute(
+                text(
+                    "SELECT content_hash, id FROM memories "
+                    "WHERE content_hash = ANY(:hashes) AND deleted_at IS NULL"
+                ),
+                {"hashes": list(groups)},
+            )
+        ).all()
+
+    survivors = {r.content_hash: r.id for r in rows}
+    assert len(survivors) == len(groups), (
+        f"expected one survivor per group, got {len(rows)} rows across {len(survivors)} groups"
+    )
+    wrong = {h: (survivors[h], min(ids)) for h, ids in groups.items() if survivors[h] != min(ids)}
+    assert not wrong, (
+        f"{len(wrong)} of {len(groups)} groups kept a row other than the lowest "
+        f"id on a created_at tie: {list(wrong.items())[:3]}"
+    )
+
+
+async def test_cleanup_leaves_rows_outside_the_key_alone(without_content_hash_index) -> None:
+    """The guard against a cleanup that over-reaches. Same content hash, but a
+    different agent and a different fleet are different keys, so all three rows
+    are legitimately live and none may be touched."""
+    suffix = uuid.uuid4().hex[:8]
+    tenant = f"t-scope-{suffix}"
+    content_hash = f"hash-scope-{suffix}"
+
+    async with get_session() as session:
+        a = await _insert(
+            session,
+            tenant=tenant,
+            fleet=f"f-{suffix}",
+            agent="agent-one",
+            content_hash=content_hash,
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        b = await _insert(
+            session,
+            tenant=tenant,
+            fleet=f"f-{suffix}",
+            agent="agent-two",
+            content_hash=content_hash,
+            created_at=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+        c = await _insert(
+            session,
+            tenant=tenant,
+            fleet=f"other-{suffix}",
+            agent="agent-one",
+            content_hash=content_hash,
+            created_at=datetime(2026, 1, 3, tzinfo=UTC),
+        )
+        fleetless = await _insert(
+            session,
+            tenant=tenant,
+            fleet=None,
+            agent="agent-one",
+            content_hash=content_hash,
+            created_at=datetime(2026, 1, 4, tzinfo=UTC),
+        )
+
+    async with get_session() as session:
+        await session.execute(text(_cleanup_sql()))
+
+    async with get_session() as session:
+        live = set(
+            (
+                await session.execute(
+                    text("SELECT id FROM memories WHERE content_hash = :h AND deleted_at IS NULL"),
+                    {"h": content_hash},
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert live == {a, b, c, fleetless}, (
+        "the cleanup touched a row outside its key: agent and fleet are part of "
+        "the dedup scope, and a NULL fleet is its own group via COALESCE"
+    )
+
+
+async def test_an_already_soft_deleted_duplicate_is_not_re_marked(without_content_hash_index) -> None:
+    """Soft-deleted rows are outside the predicate, so a re-run is a no-op on
+    them. That is what makes the migration re-runnable rather than something that
+    re-stamps rows on every deploy."""
+    suffix = uuid.uuid4().hex[:8]
+    tenant, fleet, agent = f"t-rerun-{suffix}", f"f-rerun-{suffix}", f"a-rerun-{suffix}"
+    content_hash = f"hash-rerun-{suffix}"
+
+    async with get_session() as session:
+        await _insert(
+            session,
+            tenant=tenant,
+            fleet=fleet,
+            agent=agent,
+            content_hash=content_hash,
+            created_at=datetime(2026, 5, 1, tzinfo=UTC),
+        )
+        await _insert(
+            session,
+            tenant=tenant,
+            fleet=fleet,
+            agent=agent,
+            content_hash=content_hash,
+            created_at=datetime(2026, 5, 2, tzinfo=UTC),
+        )
+
+    async with get_session() as session:
+        await session.execute(text(_cleanup_sql()))
+    async with get_session() as session:
+        first_pass = (
+            (
+                await session.execute(
+                    text(
+                        "SELECT deleted_at FROM memories WHERE content_hash = :h AND deleted_at IS NOT NULL"
+                    ),
+                    {"h": content_hash},
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    async with get_session() as session:
+        await session.execute(text(_cleanup_sql()))
+    async with get_session() as session:
+        second_pass = (
+            (
+                await session.execute(
+                    text(
+                        "SELECT deleted_at FROM memories WHERE content_hash = :h AND deleted_at IS NOT NULL"
+                    ),
+                    {"h": content_hash},
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(first_pass) == 1
+    assert first_pass == second_pass, "a re-run moved deleted_at on an already-resolved row"
+
+
+async def test_the_index_builds_once_the_cleanup_has_run(without_content_hash_index) -> None:
+    """The end-to-end claim the migration makes: after the cleanup the table is
+    actually indexable. Without the cleanup this build raises."""
+    suffix = uuid.uuid4().hex[:8]
+    tenant, fleet, agent = f"t-build-{suffix}", f"f-build-{suffix}", f"a-build-{suffix}"
+    content_hash = f"hash-build-{suffix}"
+
+    async with get_session() as session:
+        for day in (1, 2, 3):
+            await _insert(
+                session,
+                tenant=tenant,
+                fleet=fleet,
+                agent=agent,
+                content_hash=content_hash,
+                created_at=datetime(2026, 6, day, tzinfo=UTC),
+            )
+
+    # Not built CONCURRENTLY here: this is a plain session, and CONCURRENTLY
+    # cannot run inside a transaction. The migration's own build is
+    # CONCURRENTLY and ``test_no_plain_create_index_on_large_tables`` enforces
+    # that; what this test is about is whether the data permits the constraint.
+    async with get_session() as session:
+        with pytest.raises(Exception, match=r"could not create unique index|is duplicated"):
+            await session.execute(text(_INDEX_SQL))
+
+    async with get_session() as session:
+        await session.execute(text(_cleanup_sql()))
+
+    async with get_session() as session:
+        await session.execute(text(_INDEX_SQL))
+
+    async with get_session() as session:
+        valid = (
+            await session.execute(
+                text(
+                    "SELECT indisunique AND indisvalid FROM pg_index i "
+                    "JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = :n"
+                ),
+                {"n": _INDEX},
+            )
+        ).scalar()
+    assert valid is True
+
+
+async def test_a_duplicate_insert_is_refused_with_the_winning_row_id(client) -> None:
+    """The insert path end-to-end, against the real index and a real session.
+
+    Deliberately NOT mocked. The conflict handler has to roll back and then
+    re-SELECT on the same session, and ``get_session`` wraps its body in an
+    explicit ``session.begin()`` — so whether a query is even legal after that
+    rollback is a property of the real session, not something a mock can tell us.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    payload = {
+        "tenant_id": f"t-409-{suffix}",
+        "fleet_id": f"f-409-{suffix}",
+        "agent_id": f"a-409-{suffix}",
+        "memory_type": "fact",
+        "content": f"a memory written twice {suffix}",
+        "content_hash": f"hash-409-{suffix}",
+    }
+
+    first = await client.post("/api/v1/storage/memories", json=payload)
+    assert first.status_code == 200, first.text
+    winner_id = first.json()["id"]
+
+    second = await client.post("/api/v1/storage/memories", json=payload)
+
+    assert second.status_code == 409, (
+        f"a duplicate insert returned {second.status_code}, not 409: {second.text}"
+    )
+    assert winner_id in second.json()["detail"], (
+        "the 409 must name the row that already holds this content — without the "
+        "id the caller cannot use the row it should have got"
+    )
+
+
+async def test_a_second_agent_may_write_the_same_content(client) -> None:
+    """The scope guard: ``agent_id`` is in the key because two agents recording
+    identical content are two independent observations."""
+    suffix = uuid.uuid4().hex[:8]
+    base = {
+        "tenant_id": f"t-scope409-{suffix}",
+        "fleet_id": f"f-scope409-{suffix}",
+        "memory_type": "fact",
+        "content": f"a shared observation {suffix}",
+        "content_hash": f"hash-scope409-{suffix}",
+    }
+
+    first = await client.post("/api/v1/storage/memories", json={**base, "agent_id": "agent-one"})
+    second = await client.post("/api/v1/storage/memories", json={**base, "agent_id": "agent-two"})
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["id"] != second.json()["id"]
+
+
+async def test_a_bulk_batch_containing_a_duplicate_is_refused_with_409(client) -> None:
+    """ON CONFLICT arbitrates ONE index, and this statement's is
+    ``ix_memories_attempt_unique`` — so a content-hash violation is not swallowed,
+    it aborts the whole multi-row INSERT. Untranslated that is a 500, which would
+    mean the same duplicate answers 409 or 500 depending only on which endpoint
+    the caller used.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    base = {
+        "tenant_id": f"t-bulk409-{suffix}",
+        "fleet_id": f"f-bulk409-{suffix}",
+        "agent_id": f"a-bulk409-{suffix}",
+        "memory_type": "fact",
+    }
+    hash_a = f"hash-bulk409-{suffix}"
+
+    first = await client.post(
+        "/api/v1/storage/memories",
+        json={**base, "content": "already stored", "content_hash": hash_a},
+    )
+    assert first.status_code == 200, first.text
+
+    # One fresh item and one that collides with the row above.
+    resp = await client.post(
+        "/api/v1/storage/memories/bulk",
+        json=[
+            {
+                **base,
+                "content": f"fresh {suffix}",
+                "content_hash": f"hash-fresh-{suffix}",
+                "client_request_id": f"bulk-{suffix}-0",
+            },
+            {
+                **base,
+                "content": "already stored",
+                "content_hash": hash_a,
+                "client_request_id": f"bulk-{suffix}-1",
+            },
+        ],
+    )
+
+    assert resp.status_code == 409, (
+        f"a bulk batch with a duplicate returned {resp.status_code}, not 409: {resp.text}"
+    )
+    detail = resp.json()["detail"]
+    assert "already exists" in detail
+    assert "violates" not in detail.lower(), "raw driver text reached the caller"
+    assert hash_a not in detail, "the offending value must not be echoed back"
+
+
+async def test_a_refused_bulk_batch_writes_nothing(client) -> None:
+    """The batch is one statement, so the message's "nothing in this batch was
+    written" has to be true — a caller that retries must not find half of it
+    already there."""
+    suffix = uuid.uuid4().hex[:8]
+    base = {
+        "tenant_id": f"t-bulkatomic-{suffix}",
+        "fleet_id": f"f-bulkatomic-{suffix}",
+        "agent_id": f"a-bulkatomic-{suffix}",
+        "memory_type": "fact",
+    }
+    hash_dup = f"hash-dup-{suffix}"
+    hash_fresh = f"hash-fresh-{suffix}"
+
+    await client.post(
+        "/api/v1/storage/memories",
+        json={**base, "content": "already stored", "content_hash": hash_dup},
+    )
+
+    refused = await client.post(
+        "/api/v1/storage/memories/bulk",
+        json=[
+            {
+                **base,
+                "content": f"fresh {suffix}",
+                "content_hash": hash_fresh,
+                "client_request_id": f"atomic-{suffix}-0",
+            },
+            {
+                **base,
+                "content": "already stored",
+                "content_hash": hash_dup,
+                "client_request_id": f"atomic-{suffix}-1",
+            },
+        ],
+    )
+    assert refused.status_code == 409, refused.text
+
+    # The fresh item must NOT have landed.
+    found = await client.post(
+        "/api/v1/storage/memories/bulk-by-content-hashes",
+        json={
+            "tenant_id": base["tenant_id"],
+            "fleet_id": base["fleet_id"],
+            "agent_id": base["agent_id"],
+            "hashes": [hash_fresh],
+        },
+    )
+    assert found.json() == {}, (
+        "the aborted batch left a row behind, so the 409's claim that nothing was written is false"
+    )
+
+
+@pytest.mark.parametrize("fleet", ["", None], ids=["empty-string", "null"])
+async def test_the_409_names_the_winner_for_either_fleet_shape(client, fleet) -> None:
+    """Review round 2: the index groups by ``COALESCE(fleet_id, '')``, so a NULL
+    and an empty string are the SAME key to it — but every dedup lookup branched
+    on falsiness and filtered ``fleet_id IS NULL``, so none of them could see a
+    row stored as ``''``.
+
+    Reachable, not theoretical: ``fleet_id`` is ``str | None`` with no
+    empty-string normalisation on the write path, so ``fleet_id: ""`` is stored
+    literally. The visible symptom was worse than a wrong message — the caller
+    was told "no longer live; retry the write", advice that can only 409 again.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    payload = {
+        "tenant_id": f"t-fleetscope-{suffix}",
+        "fleet_id": fleet,
+        "agent_id": f"a-fleetscope-{suffix}",
+        "memory_type": "fact",
+        "content": f"body {suffix}",
+        "content_hash": f"hash-fleetscope-{suffix}",
+    }
+
+    first = await client.post("/api/v1/storage/memories", json=payload)
+    assert first.status_code == 200, first.text
+    winner_id = first.json()["id"]
+    assert first.json()["fleet_id"] == fleet, "the write path normalised fleet_id"
+
+    second = await client.post("/api/v1/storage/memories", json=payload)
+
+    assert second.status_code == 409, second.text
+    detail = second.json()["detail"]
+    assert winner_id in detail, f"the 409 did not name the live winner for fleet_id={fleet!r}: {detail!r}"
+    assert "no longer live" not in detail, (
+        "the lookup missed a live row and told the caller to retry — advice that can only 409 again"
+    )

--- a/tests/test_duplicate_insert_conflict_409.py
+++ b/tests/test_duplicate_insert_conflict_409.py
@@ -1,0 +1,417 @@
+"""A rejected duplicate insert must surface as 409, not 500 (OSS #814).
+
+Migration 040 gave ``(tenant, fleet, agent, content_hash)`` a partial unique
+index, so an insert of duplicate content is now REFUSED where it previously
+succeeded and quietly created a second row. That refusal has to land on the code
+the dedup contract already uses: ``CheckExactDuplicate`` raises 409 for the
+duplicate it can see before the write, and this is the same answer for the race
+it cannot see — the gate looked, found nothing, and a concurrent writer committed
+in between.
+
+Untranslated it is a 500. The pipeline marks the step FAILED and the caller reads
+"Memory write pipeline failed unexpectedly", which says nothing about which row
+to use instead.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from core_api.clients.storage_client import (
+    DuplicateMemoryError,
+    _storage_detail,
+)
+from core_api.services import memory_service
+
+pytestmark = [pytest.mark.unit]
+
+WINNER = str(uuid.uuid4())
+
+
+def _response(status: int, body) -> httpx.Response:
+    return httpx.Response(
+        status_code=status,
+        json=body,
+        request=httpx.Request("POST", "http://storage/memories"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _storage_detail — the id has to survive the trip
+# ---------------------------------------------------------------------------
+
+
+def test_the_winning_row_id_is_carried_through() -> None:
+    """An agent told "duplicate" without being told WHICH row cannot use the row
+    it should have got. The id is the useful half of the message."""
+    detail = _storage_detail(_response(409, {"detail": f"Duplicate memory exists: {WINNER}"}))
+
+    assert WINNER in detail
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"detail": None},
+        {"detail": ""},
+        {"detail": {"nested": "object"}},
+        {"other": "key"},
+        [],
+    ],
+    ids=["null", "empty", "non-string", "missing", "not-a-dict"],
+)
+def test_a_malformed_body_still_yields_a_usable_message(body) -> None:
+    """This runs on an error path, so it must not raise. A 409 whose body is not
+    the expected shape must still produce a 409 with something readable, rather
+    than a TypeError from inside the exception handler."""
+    assert _storage_detail(_response(409, body)) == "Duplicate memory exists"
+
+
+def test_a_non_json_body_still_yields_a_usable_message() -> None:
+    resp = httpx.Response(
+        status_code=409,
+        content=b"<html>gateway</html>",
+        request=httpx.Request("POST", "http://storage/memories"),
+    )
+
+    assert _storage_detail(resp) == "Duplicate memory exists"
+
+
+# ---------------------------------------------------------------------------
+# The client raises the typed error, and ONLY for 409
+# ---------------------------------------------------------------------------
+
+
+async def _client_create(status: int, body) -> None:
+    from core_api.clients.storage_client import CoreStorageClient
+
+    client = CoreStorageClient()
+    err = httpx.HTTPStatusError(
+        "upstream", request=_response(status, body).request, response=_response(status, body)
+    )
+    with patch.object(CoreStorageClient, "_post", new=AsyncMock(side_effect=err)):
+        await client.create_memory({"agent_id": "a", "tenant_id": "t"})
+
+
+@pytest.mark.asyncio
+async def test_a_storage_409_becomes_the_typed_duplicate_error() -> None:
+    with pytest.raises(DuplicateMemoryError) as caught:
+        await _client_create(409, {"detail": f"Duplicate memory exists: {WINNER}"})
+
+    assert WINNER in str(caught.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [400, 404, 422, 500, 503])
+async def test_every_other_status_propagates_unchanged(status) -> None:
+    """Narrow on purpose. A 500 must keep reaching the app's upstream handler,
+    which turns it into a retryable 503; swallowing it here would relabel a
+    storage outage as a duplicate."""
+    with pytest.raises(httpx.HTTPStatusError):
+        await _client_create(status, {"detail": "something else"})
+
+
+# ---------------------------------------------------------------------------
+# The service helper turns it into the 409 the contract promises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_helper_maps_the_duplicate_to_409_with_the_id() -> None:
+    sc = MagicMock()
+    sc.create_memory = AsyncMock(
+        side_effect=DuplicateMemoryError(f"Duplicate memory exists: {WINNER}")
+    )
+
+    with patch.object(memory_service, "get_storage_client", lambda: sc):
+        with pytest.raises(HTTPException) as caught:
+            await memory_service._create_memory_or_409({"tenant_id": "t"})
+
+    assert caught.value.status_code == 409
+    assert WINNER in caught.value.detail
+
+
+@pytest.mark.asyncio
+async def test_the_helper_passes_a_successful_write_straight_through() -> None:
+    sc = MagicMock()
+    sc.create_memory = AsyncMock(return_value={"id": WINNER})
+
+    with patch.object(memory_service, "get_storage_client", lambda: sc):
+        assert await memory_service._create_memory_or_409({"tenant_id": "t"}) == {"id": WINNER}
+
+
+@pytest.mark.asyncio
+async def test_the_helper_does_not_swallow_other_failures() -> None:
+    """The guard against a helper that turns every write failure into a 409."""
+    sc = MagicMock()
+    sc.create_memory = AsyncMock(side_effect=RuntimeError("storage exploded"))
+
+    with patch.object(memory_service, "get_storage_client", lambda: sc):
+        with pytest.raises(RuntimeError):
+            await memory_service._create_memory_or_409({"tenant_id": "t"})
+
+
+# ---------------------------------------------------------------------------
+# The main write path: WriteMemoryRow turns it into the caller's 409
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_write_pipeline_returns_409_not_a_pipeline_failure() -> None:
+    """The end-to-end claim. ``CheckExactDuplicate`` runs earlier in this same
+    pipeline and found nothing, so a refusal at the insert is the race — and it
+    has to reach the caller as the same 409 that gate would have raised.
+
+    Without the translation the step is marked FAILED and the runner converts it
+    to "Memory write pipeline failed unexpectedly" (500), which tells the caller
+    nothing about which row now owns the content.
+    """
+    from core_api.clients import storage_client as sc_mod
+
+    original = memory_service._USE_PIPELINE_WRITE
+    memory_service._USE_PIPELINE_WRITE = True
+    try:
+        from core_api.schemas import MemoryCreate
+        from core_api.services.memory_service import create_memory
+
+        refuse = AsyncMock(
+            side_effect=DuplicateMemoryError(f"Duplicate memory exists: {WINNER}")
+        )
+        with patch.object(sc_mod.CoreStorageClient, "create_memory", new=refuse):
+            with pytest.raises(HTTPException) as caught:
+                await create_memory(
+                    MemoryCreate(
+                        tenant_id="t-pipeline-409",
+                        fleet_id="f1",
+                        agent_id="a",
+                        content=(
+                            "content long enough to clear the quality gate on the "
+                            f"write pipeline for this duplicate-race test {uuid.uuid4().hex}"
+                        ),
+                    )
+                )
+    finally:
+        memory_service._USE_PIPELINE_WRITE = original
+
+    assert caught.value.status_code == 409, (
+        f"a duplicate race surfaced as {caught.value.status_code}, not the 409 the "
+        "dedup contract promises"
+    )
+    assert WINNER in str(caught.value.detail)
+
+
+# ---------------------------------------------------------------------------
+# The fanout treats it as "already recorded", not as an error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_fanout_treats_a_duplicate_as_recorded_and_keeps_going() -> None:
+    """The fan-out has no HTTP contract to honour — it runs in a fire-and-forget
+    task, so a 409 would go nowhere and would abort the facts after it. A refusal
+    there means the fact is already stored, which is the outcome it wants.
+
+    The second fact must still be written: that is the "keeps going" half, and it
+    is what a bare ``raise`` would break.
+    """
+    from core_api.services.memory_enrichment import AtomicFact
+
+    tenant, fleet, agent = "t-dup409", "f1", "a"
+    row = dict(
+        id=str(uuid.uuid4()),
+        memory_type="fact",
+        status="active",
+        weight=0.5,
+        ts_valid_start=None,
+        ts_valid_end=None,
+        metadata_={},
+        deleted_at=None,
+        fleet_id=fleet,
+        embedding=None,
+        content="body",
+        visibility="scope_team",
+    )
+    first_hash = memory_service._content_hash(tenant, fleet, "alpha fact")
+
+    async def _create(payload):
+        # Only the first fact is refused, so the loop has to survive it and go on
+        # to write the second.
+        if payload["content_hash"] == first_hash:
+            raise DuplicateMemoryError(f"Duplicate memory exists: {WINNER}")
+        return {"id": str(uuid.uuid4())}
+
+    sc = AsyncMock(name="storage_client")
+    sc.get_memory = AsyncMock(return_value=row)
+    sc.update_memory = AsyncMock(return_value=None)
+    sc.update_memory_status = AsyncMock(return_value=None)
+    sc.create_memory = AsyncMock(side_effect=_create)
+    # Empty: the point here is the WRITE being refused, not the lookup catching
+    # it. A non-empty return would skip the fact before it ever reached storage
+    # and the test would prove nothing about the 409 path.
+    sc.bulk_find_by_content_hashes = AsyncMock(return_value={})
+
+    enrichment = SimpleNamespace(
+        memory_type="fact",
+        weight=0.5,
+        status="active",
+        title="t",
+        summary="",
+        tags=[],
+        llm_ms=1,
+        contains_pii=False,
+        pii_types=[],
+        retrieval_hint="",
+        ts_valid_start=None,
+        ts_valid_end=None,
+        atomic_facts=[AtomicFact(content="alpha fact"), AtomicFact(content="beta fact")],
+    )
+
+    def _stub_tracked_task(coro, *_a, **_k):
+        coro.close()
+        return None
+
+    async def _embed(_content, tenant_config=None, **_kwargs):
+        return [0.0]
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(memory_service, "tracked_task", new=_stub_tracked_task),
+        patch.object(memory_service, "get_embedding", new=_embed),
+        patch(
+            "core_api.services.memory_enrichment.enrich_memory",
+            new=AsyncMock(return_value=enrichment),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    enrichment_enabled=True,
+                    enrichment_provider="fake",
+                    entity_extraction_enabled=False,
+                )
+            ),
+        ),
+    ):
+        # Must not raise: a DuplicateMemoryError escaping the loop would surface
+        # as a failed background task.
+        await memory_service._enrich_memory_background(
+            uuid.uuid4(), "body", tenant, fleet, agent
+        )
+
+    attempted = [c.args[0]["content"] for c in sc.create_memory.await_args_list]
+    assert attempted == ["alpha fact", "beta fact"], (
+        "the refusal aborted the rest of the fan-out instead of being treated as "
+        f"already-recorded: {attempted}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The bulk child insert must DEGRADE — the parent is already committed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_refused_child_batch_does_not_strand_the_committed_parent() -> None:
+    """The H-05 shape (#815), reachable again through the new constraint.
+
+    The auto-chunk parent is committed BEFORE its children, and the child insert
+    is one statement that a single duplicate aborts. Raising would hand the caller
+    a 500 for a write that persisted and leave the parent childless with no record
+    of why.
+
+    Degrading loses nothing in this specific case: the constraint refuses the
+    batch only when that content is already stored, so the children this call
+    would have written already exist.
+    """
+    caught: list[str] = []
+
+    async def _refuse(_payloads):
+        raise DuplicateMemoryError("bulk insert rejected: an item's content already exists")
+
+    sc = MagicMock()
+    sc.create_memories = AsyncMock(side_effect=_refuse)
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(
+            memory_service.logger, "warning", lambda msg, **kw: caught.append(msg)
+        ),
+    ):
+        # Must not raise.
+        await memory_service._insert_children_or_degrade(
+            [{"content_hash": "h1"}, {"content_hash": "h2"}],
+            tenant_id="t",
+            parent_id=WINNER,
+            source="auto_chunk",
+        )
+
+    assert caught, "the dropped children left no trace at all"
+    assert "parent kept without them" in caught[0]
+
+
+@pytest.mark.asyncio
+async def test_every_other_child_insert_failure_still_raises() -> None:
+    """The guard against a degrade that hides real loss. Only a duplicate refusal
+    is safe to swallow — for anything else the rows genuinely are missing."""
+    sc = MagicMock()
+    sc.create_memories = AsyncMock(side_effect=RuntimeError("storage exploded"))
+
+    with patch.object(memory_service, "get_storage_client", lambda: sc):
+        with pytest.raises(RuntimeError):
+            await memory_service._insert_children_or_degrade(
+                [{"content_hash": "h1"}],
+                tenant_id="t",
+                parent_id=WINNER,
+                source="auto_chunk",
+            )
+
+
+@pytest.mark.asyncio
+async def test_an_empty_child_list_makes_no_storage_call() -> None:
+    """Dedup can empty the list, and ``create_memories([])`` builds an INSERT with
+    no VALUES."""
+    sc = MagicMock()
+    sc.create_memories = AsyncMock()
+
+    with patch.object(memory_service, "get_storage_client", lambda: sc):
+        await memory_service._insert_children_or_degrade(
+            [], tenant_id="t", parent_id=WINNER, source="auto_chunk"
+        )
+
+    sc.create_memories.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_the_bulk_client_translates_a_409_the_same_way() -> None:
+    """Both endpoints have to agree about what a duplicate looks like, or a
+    core-api caller sees a different failure depending only on which one it used.
+    """
+    from core_api.clients.storage_client import CoreStorageClient
+
+    resp = _response(409, {"detail": "bulk insert rejected: an item's content already exists"})
+    err = httpx.HTTPStatusError("upstream", request=resp.request, response=resp)
+
+    with patch.object(CoreStorageClient, "_post", new=AsyncMock(side_effect=err)):
+        with pytest.raises(DuplicateMemoryError) as caught:
+            await CoreStorageClient().create_memories([{"agent_id": "a", "tenant_id": "t"}])
+
+    assert "already exists" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_the_bulk_client_still_propagates_other_statuses() -> None:
+    from core_api.clients.storage_client import CoreStorageClient
+
+    resp = _response(503, {"detail": "upstream down"})
+    err = httpx.HTTPStatusError("upstream", request=resp.request, response=resp)
+
+    with patch.object(CoreStorageClient, "_post", new=AsyncMock(side_effect=err)):
+        with pytest.raises(httpx.HTTPStatusError):
+            await CoreStorageClient().create_memories([{"agent_id": "a", "tenant_id": "t"}])

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -731,7 +731,7 @@ class TestMigrationChain:
         """
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"039"}, f"Expected single head '039', got {sorted(heads)}"
+        assert heads == {"040"}, f"Expected single head '040', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -773,6 +773,9 @@ class TestMigrationChain:
         assert chain.get("038") == "037", "038 must follow 037"
         # 039: tenant_usage_counters — durable per-tenant, per-period counts
         assert chain.get("039") == "038", "039 must follow 038"
+        # 040: one LIVE memory per (tenant, fleet, agent, content_hash) — the
+        # dedup contract had no schema behind it (OSS #814)
+        assert chain.get("040") == "039", "040 must follow 039"
 
     def test_no_plain_set_not_null_on_large_tables(self):
         """Tightening a column to NOT NULL on a large table must not full-scan


### PR DESCRIPTION
Fixes #814 — the second half, on top of #841. #841 closed the paths that minted duplicates with **no concurrency at all**; this adds the constraint that makes them impossible, and turns the resulting rejection into the 409 the dedup contract already promises.

## Why a constraint is needed at all

`ix_memories_content_hash` is **non-unique** and covers only `(tenant_id, content_hash)`, so nothing in the schema has ever enforced the dedup contract the write path advertises. #839 stopped the wedge — two live rows sharing a hash made `scalar_one_or_none()` raise `MultipleResultsFound` → storage 500 → every subsequent write of that content 500ing forever — but it did so by *tolerating* duplicates. #841 removed the source that needed no race. What remains is the race, and only a constraint closes it: every application-side gate here is check-then-insert.

Measured against prod **before** writing the migration, because a unique index over existing data either applies or fails the deploy — there is no third outcome:

```
duplicate_groups: 18   surplus_rows: 19   worst_group: 3   live_rows: 110,057
```

The `GROUP BY` in that query is character-for-character the key below, so the count describes *this* index rather than an approximation of it.

## Migration 040

Cleanup first in the normal transaction, then the index in an `autocommit_block`. Migrations run in the FastAPI lifespan startup hook, so a failed one is a failed deploy — Cloud Run keeps the old revision serving. Same ordering rationale as 038.

- **The survivor is the oldest per group**, ordered `(created_at, id)` — exactly what `memory_find_by_content_hash` returns after #839, so the row kept is the row the dedup gate would already have handed callers. Anything else silently re-points live lookups at a different row.
- Surplus rows are **soft**-deleted and stamped `metadata.deduped_by_migration`, so all 19 stay findable: `SELECT id FROM memories WHERE metadata ->> 'deduped_by_migration' = '040'`.
- `CREATE UNIQUE INDEX CONCURRENTLY` inside `autocommit_block`, with `_drop_invalid` first. For a *unique* index the invalid-index hazard is worse than 035's measured 547× slower plan: **an invalid unique index does not enforce uniqueness either**, so without that step the migration stamps green while the constraint it exists to add is silently absent.
- The `CREATE ... INDEX ... ON memories` prefix is on **one line with the index name spelled literally**, so `test_no_plain_create_index_on_large_tables` actually covers it — its `\w+` for the name matches neither a split prefix nor an interpolated constant, which is how 007 and 026 ended up outside its coverage while doing the right thing. Verified: removing `CONCURRENTLY` fails that test.

## Two things the migration got wrong until a test caught them

Both found by writing the cleanup test — which is the point of having written it. The cleanup had gone green **twice** against local databases having soft-deleted *zero* rows, because neither had a duplicate to find.

1. **`COALESCE could not convert type jsonb to json`.** The live `metadata` column is `json` (migration 001) while `common/models/memory.py` declares `JSONB`, so the type differs between the migration-chain schema and any schema built from that metadata. Casting the *column* (not the result) makes one statement correct against both.
2. **JSON `null` is not SQL NULL.** `COALESCE` passes it straight through, and `'null'::jsonb || '{...}'::jsonb` does not fail — it **wraps both in an array**, which drops the marker (`->> 'key'` on an array is NULL) and replaces the row's metadata with `[null, {...}]`. Reachable: SQLAlchemy's JSON type stores a Python `None` as JSON `null` unless the column sets `none_as_null`, which this one does not. Now guarded with `jsonb_typeof(...) = 'object'`.

## The rejection must be a 409, not a 500

`memory_add` was a bare `add` + `flush`. With the index in place a duplicate insert raises, and unhandled that is a 500 — the caller reads "Memory write pipeline failed unexpectedly" for an ordinary race, with nothing said about which row now owns the content.

| layer | behaviour |
|---|---|
| storage service | `DuplicateContentHashError`, re-SELECTing the winner so the message names it. Matched on the **index name**, not `IntegrityError` broadly — `ix_memories_attempt_unique` can fire here too and means something different. |
| `POST /memories` | maps exactly that to 409 |
| storage client | raises a typed `DuplicateMemoryError`, **not** an `HTTPException` — nothing else in `core_api/clients/` raises a FastAPI type, and the app-level `httpx.HTTPStatusError` handler documents why it can't do this job either (it deliberately re-raises 4xx as "a bug in OUR request shape", which a legitimate duplicate is not) |
| `WriteMemoryRow`, `_create_memory_or_409` | translate to 409, matching `CheckExactDuplicate` |
| atomic-fact fanout | deliberately does **not** translate — it runs in a fire-and-forget task with no HTTP contract, so a 409 would go nowhere and would abort the facts after it. A refusal there means the fact is already recorded, which is the outcome it wants |

## The end-to-end test that caught a bug the mocked ones could not

`POST /memories` twice with the same hash, against the real index and a real session.

The first version of `memory_add` rolled back and re-SELECTed on the **same** session, and `get_session` holds an explicit `session.begin()` — so the lookup raised:

```
InvalidRequestError: Can't operate on closed transaction inside context manager
```

**Every duplicate insert would have 500'd** — precisely the failure this change exists to remove, shipped inside the fix for it. Nothing mocked could have found it: the unit tests stub the client and the service, so the session semantics never run.

The handler now wraps the whole `async with`, so the failed session has unwound before the lookup, and `_describe_content_hash_winner` opens its own session and **takes no session parameter**, so it cannot be handed the dead one again.

## The `created_at` tie deserves its own note

A tie-break test that passes for the wrong reason is the failure mode here. `created_at` is `server_default=now()`, fixed for a whole transaction, and auto-chunk inserts all its children in one call — so **ties are the common case, not an edge**.

A single tied group cannot falsify the tie-break: which tie a sort emits first is plan-dependent and not controllable. Measured at **2 of 3 runs passing with the `id` reverted**. Across 20 independent groups an unordered tie would have to pick the lowest id in all 20. Measured: passes 3/3 with the fix, **fails 3/3 without** (13, 8 and 16 of 20 groups wrong).

## Tests

33 new, each confirmed by reverting the thing it covers.

- **Cleanup:** survivor is the oldest; the marker merges into existing metadata rather than replacing it, across all three metadata shapes (SQL NULL, JSON null, object with keys); rows outside the key are untouched, including the `COALESCE`'d NULL-fleet group; a re-run does not re-stamp resolved rows; and the index **builds** after the cleanup where it raised before it.
- **409:** the winner's id survives the trip; a malformed or non-JSON body still yields a usable message rather than raising inside the error path; only 409 is translated (400/404/422/500/503 propagate, so a storage outage is not relabelled as a duplicate); the write pipeline returns 409 rather than the 500 (reverting shows exactly `HTTPException(500, 'Memory write pipeline failed unexpectedly')`); the fanout treats a refusal as recorded **and** still writes the fact after it; and a second agent may write the same content.

Two of #841's tests now take a `without_content_hash_index` fixture: they fabricate duplicate groups to assert what the *lookups* do, and that state is no longer creatable while the constraint stands — which is the constraint working. The fixture's teardown runs the migration's own `CLEANUP_SQL` before rebuilding, because a test that fabricated duplicates has by definition left the table un-indexable.

## The bulk path gets the same treatment

`memory_add_all`'s `ON CONFLICT` arbitrates **one** index — `ix_memories_attempt_unique` — so a content-hash violation there is not swallowed: it aborts the whole multi-row INSERT. Left alone that would be a 500, meaning the same duplicate answers 409 or 500 depending only on which endpoint the caller used.

A second arbiter isn't available (a statement names one) and per-row upserts would trade the batch's single roundtrip for N, so **the batch fails as a unit and says so** — honest, because nothing was written. There's a test asserting exactly that: after a refused batch, the non-duplicate item in it is confirmed absent.

**The auto-chunk children need something different from a 409.** The parent row is already committed when the children go in, so a 409 there would report failure for a write that partly persisted and leave the parent childless — the H-05 shape (#815). Both call sites therefore route through `_insert_children_or_degrade`, which swallows **only** `DuplicateMemoryError` and logs at WARNING with the dropped count. Degrading loses nothing in that case: the constraint refuses the batch only when the content is already stored, so those children already exist. Every other failure still propagates.

Because the batch is all-or-nothing, a refusal *can* drop children that were not duplicates — hence the WARNING and the count. The parent's `child_count` will overstate what exists, and that line is the only record of the gap.

Reachability, for the record: this is a **race**, not a routine outcome. #841 gave the children path an in-batch collapse and a live-hash lookup, and `/memories/bulk` dedups via `existing_hashes` + `seen_hashes` before it calls storage. A duplicate reaches the INSERT only when two concurrent writes of the same content interleave.

## Gates

- **4620** core-api passed / 3 skipped / 1 xfailed
- **141** storage passed
- `mypy src/` clean — 199 files
- `ruff check` **and** `ruff format --check` clean, run as separate gates
- DCO signed

## Deploy note

The cleanup mutates 19 rows in prod on first boot of the new revision. They are soft-deleted, not removed, and all 19 are recoverable by the `metadata.deduped_by_migration = '040'` marker. If the index build is interrupted (Cloud Run's 240 s startup probe vs `CONCURRENTLY`'s unbounded wait on concurrent transactions), `_drop_invalid` clears the half-built index on the next attempt rather than leaving a non-enforcing one behind.
