### PR TITLE
fix(api): the read params the plugin advertises must reach the query

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -1491,7 +1491,7 @@
     },
     "/api/v1/memories": {
       "get": {
-        "description": "List memories with filtering, sorting, and pagination.\n\n**Visibility scoping:** When ``agent_id`` is provided, the caller can see\ntheir own ``scope_agent`` memories plus all ``scope_team``/``scope_org``\nmemories. When ``agent_id`` is omitted, ``scope_agent`` memories are hidden\n(safe default). This means memory types like ``insight`` that are typically\ncreated with agent-scoped visibility will only appear when ``agent_id`` is\npassed.\n\n**Pagination:** Both cursor-based and offset-based pagination are supported.\nCursor pagination (via ``cursor``) is recommended for large datasets and only\nworks with ``sort=created_at&order=desc``. Offset pagination works with any\nsort order.",
+        "description": "List memories with filtering, sorting, and pagination.\n\n**Visibility scoping:** When ``agent_id`` is provided, the caller can see\ntheir own ``scope_agent`` memories plus all ``scope_team``/``scope_org``\nmemories. When ``agent_id`` is omitted, ``scope_agent`` memories are hidden\n(safe default). This means memory types like ``insight`` that are typically\ncreated with agent-scoped visibility will only appear when ``agent_id`` is\npassed.\n\n**Author filter:** ``written_by`` selects the authoring agent. It is separate\nfrom ``agent_id`` (the visibility identity) so a caller can ask for a peer's\nauthored rows without claiming that peer's identity; ``agent_id`` remains the\nauthor filter when ``written_by`` is omitted. Filtering by author only ever\nnarrows the caller's existing visibility — it cannot surface a row an\nunfiltered list would have hidden.\n\n**Scope:** ``scope`` is optional and mirrors the MCP / plugin ``caura_list``\ncontract, including its trust ladder (see ``_resolve_scoped_read``). Omit it\nand the route behaves exactly as before.\n\n**Pagination:** Both cursor-based and offset-based pagination are supported.\nCursor pagination (via ``cursor``) is recommended for large datasets and only\nworks with ``sort=created_at&order=desc``. Offset pagination works with any\nsort order.",
         "operationId": "list_memories_api_v1_memories_get",
         "parameters": [
           {
@@ -1540,6 +1540,43 @@
                 }
               ],
               "title": "Agent Id"
+            }
+          },
+          {
+            "description": "Opt-in read scope, mirroring the MCP/plugin contract. 'agent' = your own memories (trust >= 1); 'fleet' = cross-agent within a fleet (own fleet trust >= 1, a different fleet trust >= 2); 'all' = tenant-wide (trust >= 2). Omit for the historical behaviour, where `agent_id` is the author filter.",
+            "in": "query",
+            "name": "scope",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^(agent|fleet|all)$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opt-in read scope, mirroring the MCP/plugin contract. 'agent' = your own memories (trust >= 1); 'fleet' = cross-agent within a fleet (own fleet trust >= 1, a different fleet trust >= 2); 'all' = tenant-wide (trust >= 2). Omit for the historical behaviour, where `agent_id` is the author filter.",
+              "title": "Scope"
+            }
+          },
+          {
+            "description": "Author filter. Distinct from `agent_id`, which also serves as the visibility identity; falls back to `agent_id` when omitted.",
+            "in": "query",
+            "name": "written_by",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Author filter. Distinct from `agent_id`, which also serves as the visibility identity; falls back to `agent_id` when omitted.",
+              "title": "Written By"
             }
           },
           {
@@ -1657,6 +1694,42 @@
                 }
               ],
               "title": "Run Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "weight_min",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Weight Min"
+            }
+          },
+          {
+            "in": "query",
+            "name": "weight_max",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Weight Max"
             }
           },
           {

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -31,7 +31,6 @@ from core_api.auth import get_admin_key
 from core_api.clients.storage_client import KeystoneUpsertPayload, get_storage_client
 from core_api.constants import (
     DEFAULT_SEARCH_TOP_K,
-    DEFAULT_TRUST_LEVEL,
     EVOLVE_OUTCOME_TYPES,
     INSIGHTS_FOCUS_MODES,
     MAX_SEARCH_TOP_K,
@@ -57,6 +56,13 @@ from core_api.services.agent_service import (
     get_or_create_agent,
     resolve_write_agent,
 )
+
+# Re-export so existing `monkeypatch.setattr(mcp_server, "_resolve_read_fleet_gate", ...)`
+# and direct-call sites in tests keep working; production callers should import
+# ``resolve_read_fleet_gate`` directly from ``core_api.services.agent_service``.
+# The REST read routes (``GET /memories``, ``GET /memories/stats``) call the same
+# shared implementation, so the trust ladder cannot drift between the surfaces.
+from core_api.services.agent_service import resolve_read_fleet_gate as _resolve_read_fleet_gate
 from core_api.services.audit_service import log_action, log_cross_tenant_read
 from core_api.services.capability_usage import record_usage
 from core_api.services.entity_service import get_entity
@@ -2188,89 +2194,6 @@ async def caura_doc(
         except Exception as e:
             logger.error("MCP doc op=%s error: %s", op, e, exc_info=True)
             return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
-
-
-async def _resolve_read_fleet_gate(
-    tenant_id: str,
-    agent_id: str,
-    scope: str,
-    fleet_id: str | None,
-) -> tuple[int, str | None]:
-    """Resolve ``(min_trust, effective_fleet_id)`` for the read-enumeration
-    tools (``caura_list`` / ``caura_stats``).
-
-    Trust ladder per the product spec: level 1 = read within the caller's OWN
-    fleet; level 2 = cross-fleet read. The requirement therefore keys off the
-    TARGET, not the ``scope`` string alone:
-
-    * ``scope='agent'`` → ``(1, fleet_id)`` — own memories (caller-filtered
-      upstream); no agent lookup needed.
-    * ``scope='all'``   → ``(2, fleet_id)`` — spans fleets by definition, so it
-      is always a cross-fleet read.
-    * ``scope='fleet'`` → the caller's own fleet is level 1; a DIFFERENT
-      explicit ``fleet_id`` is level 2. Mirrors ``enforce_fleet_read`` and the
-      ``caura_recall`` gate so all read surfaces agree.
-
-    For ``scope='fleet'`` with no ``fleet_id`` this is a security decision, not
-    a convenience: ``memory_list_by_filters`` / ``memory_stats_breakdown`` only
-    apply the ``fleet_id`` filter when it is set, and their visibility predicate
-    returns ``scope_team`` rows across ALL fleets — so an unfiltered level-1 read
-    would fan out to other fleets' shared rows. A constrained caller (trust < 2)
-    that omits ``fleet_id`` is therefore resolved by three cases:
-
-    (a) has a home fleet          → PIN ``fleet_id`` to it (own-fleet read, L1);
-    (b) registered but fleet-less → force L2 — the caller can't prove membership
-        in any fleet, so ``require_trust`` rejects it (trust 1 < 2) rather than
-        granting an unfiltered scan;
-    (c) unregistered (no row)     → soft-pass at L1 with no pin, matching the
-        read-ergonomics soft-pass in ``require_trust`` / ``caura_recall``.
-
-    A trust ≥ 2 caller is never pinned (it is allowed cross-fleet reads). With
-    an explicit fleet it resolves as above; with NO ``fleet_id`` the query would
-    fan out across all fleets, so this returns ``(2, fleet_id)`` — the caller
-    clears L2, while a caller demoted below 2 between this read and the
-    ``_require_trust`` re-read does not.
-    """
-    if scope == "agent":
-        return 1, fleet_id
-    if scope == "all":
-        return 2, fleet_id
-    # scope == "fleet": decide by target fleet vs the caller's home fleet.
-    agent = await get_storage_client().get_agent(agent_id, tenant_id)
-    home_fleet = (agent or {}).get("fleet_id")
-    # trust_level pre-read from the agent storage row (agents.trust_level is the
-    # single source of truth; update_trust_level writes it directly). Used to:
-    #   1. Pick the pin branch (docstring a/b): trust < 2 pins to the home fleet,
-    #      or forces L2 when the caller is fleet-less.
-    #   2. Pick the fan-out branch: trust >= 2 with no fleet_id returns L2, so the
-    #      unfiltered cross-fleet scan is gated at the level it actually needs.
-    # Every branch returns a min_level that MATCHES the access it grants, so a
-    # stale read can only UNDER-grant (a narrower result), never over-grant:
-    # _require_trust re-reads trust and rejects a caller demoted below the
-    # returned bar. get_agent is uncached, keeping even that transient divergence
-    # to a single async context switch (do NOT add caching — it would widen it).
-    trust = (agent or {}).get("trust_level", DEFAULT_TRUST_LEVEL)
-    # A different fleet is cross-fleet (L2). An unregistered / fleet-less caller
-    # (no home_fleet) that names an explicit fleet also can't prove ownership,
-    # so it must clear the L2 gate too — require_trust then rejects an
-    # unregistered id (effective trust 1 < 2) rather than granting an
-    # own-fleet pass for a fleet the caller has no established membership in.
-    if fleet_id and (not home_fleet or fleet_id != home_fleet):
-        return 2, fleet_id  # cross-fleet read → level 2
-    if not fleet_id and trust < 2:
-        if home_fleet:
-            fleet_id = home_fleet  # (a) pin to own fleet → L1
-        elif agent is not None:
-            return 2, fleet_id  # (b) registered fleet-less → L2 (require_trust rejects)
-        # (c) unregistered soft-pass → falls through to (1, None).
-    elif not fleet_id:
-        # trust >= 2, no pin requested — but fleet_id=None means the downstream
-        # query fans out across all fleets (scope_team rows). Return L2 so
-        # _require_trust enforces the correct bar and eliminates the TOCTOU
-        # window: a still-trust-2 caller passes L2; a race-demoted trust-1
-        # caller does not.
-        return 2, fleet_id
-    return 1, fleet_id
 
 
 async def caura_list(

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -68,6 +68,7 @@ from core_api.services.agent_service import (
     enforce_fleet_write,
     get_or_create_agent,
     lookup_agent,
+    resolve_read_fleet_gate,
     resolve_write_agent,
 )
 from core_api.services.audit_service import log_action, log_cross_tenant_read
@@ -91,6 +92,7 @@ from core_api.services.memory_service import (
     update_memory,
 )
 from core_api.services.tenants import list_active_tenant_ids
+from core_api.services.trust_service import parse_trust_error, require_trust
 from core_api.services.usage_service import bulk_check_and_increment, check_and_increment
 
 logger = logging.getLogger(__name__)
@@ -183,11 +185,91 @@ async def list_fleets(
     return await get_storage_client().memory_fleet_distribution(tenant_id, exclude_scope_agent=True)
 
 
+async def _resolve_scoped_read(
+    scope: str,
+    *,
+    auth_tenant_id: str | None,
+    tenant_id: str | None,
+    caller_agent_id: str | None,
+    fleet_id: str | None,
+    written_by: str | None,
+) -> tuple[str | None, str | None]:
+    """Resolve ``(author_filter, effective_fleet_id)`` for an explicit ``scope``
+    on the read-enumeration routes, and enforce the trust ladder.
+
+    ``scope`` is opt-in: the routes only call this when the caller supplied it,
+    so an omitted ``scope`` leaves the historical REST behaviour untouched (the
+    dashboard passes none). It exists because the plugin and the MCP tools
+    advertise a ``scope``/``written_by`` contract that GET /memories previously
+    dropped on the floor — FastAPI ignores undeclared query params, so
+    ``caura_list {agent_id:'me', written_by:'agent-b'}`` silently answered with
+    the caller's OWN memories instead of agent-b's.
+
+    The ladder itself is ``resolve_read_fleet_gate`` — the same implementation
+    the MCP ``caura_list`` / ``caura_stats`` handlers call — so a scoped read
+    over REST cannot be a cheaper way to reach rows the MCP surface gates.
+    Without that, ``scope='all'`` would be a trust-1 tenant-wide read here while
+    MCP requires trust ≥ 2.
+
+    The gate needs a *verifiable* caller to resolve against, so it runs under
+    the same condition ``enforce_fleet_read`` already uses on these routes
+    (``auth.tenant_id and tenant_id and caller_agent_id``). A tenant/user
+    credential has no agent identity and is tenant-wide by design; the trust
+    ladder is an agent-scoped concept and does not apply to it. ``scope='agent'``
+    is the exception — it names an identity it cannot resolve — so it is
+    rejected outright rather than silently degrading to "no author filter",
+    which would widen the very read the caller asked to narrow.
+    """
+    if scope == "agent":
+        if not caller_agent_id:
+            raise HTTPException(
+                status_code=400,
+                detail="scope='agent' requires an agent identity: authenticate with an agent credential or pass agent_id.",
+            )
+        if written_by is not None and written_by != caller_agent_id:
+            raise HTTPException(
+                status_code=400,
+                detail=f"written_by must be omitted or match your own agent_id ('{caller_agent_id}') when scope='agent'.",
+            )
+        # Mirrors the MCP handlers' ``effective_written_by``: scope='agent'
+        # pins the author filter to the caller regardless of other filters.
+        author_filter: str | None = caller_agent_id
+    else:
+        author_filter = written_by
+
+    if auth_tenant_id and tenant_id and caller_agent_id:
+        min_level, fleet_id = await resolve_read_fleet_gate(tenant_id, caller_agent_id, scope, fleet_id)
+        # Read-only path: gate on ``terr`` only. ``caura_list`` is the canonical
+        # "soft-pass OK" call site (see require_trust's warning) — an
+        # unregistered agent_id is cosmetic here because nothing is persisted.
+        _, _, terr = await require_trust(tenant_id, caller_agent_id, min_level=min_level)
+        if terr:
+            raise HTTPException(status_code=403, detail=parse_trust_error(terr))
+    return author_filter, fleet_id
+
+
 @router.get("/memories", response_model=PaginatedMemoryResponse)
 async def list_memories(
     tenant_id: str | None = Query(default=None),
     fleet_id: str | None = Query(default=None),
     agent_id: str | None = Query(default=None),
+    scope: str | None = Query(
+        default=None,
+        pattern=r"^(agent|fleet|all)$",
+        description=(
+            "Opt-in read scope, mirroring the MCP/plugin contract. 'agent' = your own "
+            "memories (trust >= 1); 'fleet' = cross-agent within a fleet (own fleet "
+            "trust >= 1, a different fleet trust >= 2); 'all' = tenant-wide (trust >= 2). "
+            "Omit for the historical behaviour, where `agent_id` is the author filter."
+        ),
+    ),
+    written_by: str | None = Query(
+        default=None,
+        description=(
+            "Author filter. Distinct from `agent_id`, which also serves as the "
+            "visibility identity; falls back to `agent_id` when omitted."
+        ),
+    ),
     memory_type: str | None = Query(default=None),
     exclude_memory_types: list[str] | None = Query(default=None),
     created_after: datetime | None = Query(default=None),
@@ -195,6 +277,8 @@ async def list_memories(
     status: str | None = Query(default=None),
     visibility: str | None = Query(default=None),
     run_id: str | None = Query(default=None),
+    weight_min: float | None = Query(default=None, ge=0, le=1),
+    weight_max: float | None = Query(default=None, ge=0, le=1),
     cursor: str | None = Query(default=None),
     sort: str = Query(
         default="created_at",
@@ -223,6 +307,17 @@ async def list_memories(
     created with agent-scoped visibility will only appear when ``agent_id`` is
     passed.
 
+    **Author filter:** ``written_by`` selects the authoring agent. It is separate
+    from ``agent_id`` (the visibility identity) so a caller can ask for a peer's
+    authored rows without claiming that peer's identity; ``agent_id`` remains the
+    author filter when ``written_by`` is omitted. Filtering by author only ever
+    narrows the caller's existing visibility — it cannot surface a row an
+    unfiltered list would have hidden.
+
+    **Scope:** ``scope`` is optional and mirrors the MCP / plugin ``caura_list``
+    contract, including its trust ladder (see ``_resolve_scoped_read``). Omit it
+    and the route behaves exactly as before.
+
     **Pagination:** Both cursor-based and offset-based pagination are supported.
     Cursor pagination (via ``cursor``) is recommended for large datasets and only
     works with ``sort=created_at&order=desc``. Offset pagination works with any
@@ -246,8 +341,35 @@ async def list_memories(
     # A tenant/user credential (auth.agent_id None) keeps using the param, as the
     # dashboard intends.
     caller_agent_id = auth.agent_id or agent_id
+    # ``written_by`` is the author filter; ``agent_id`` keeps serving as that
+    # filter when ``written_by`` is omitted, so existing callers are unaffected.
+    author_filter = written_by if written_by is not None else agent_id
+    if scope is not None:
+        # An explicit scope decides the author filter and the trust bar, and may
+        # PIN fleet_id to the caller's home fleet (the L1 case). enforce_fleet_read
+        # below then re-checks the pinned value, which is by definition the
+        # caller's own fleet and passes.
+        author_filter, fleet_id = await _resolve_scoped_read(
+            scope,
+            auth_tenant_id=auth.tenant_id,
+            tenant_id=tenant_id,
+            caller_agent_id=caller_agent_id,
+            fleet_id=fleet_id,
+            written_by=written_by,
+        )
+    # Not redundant with the ladder above: scope='agent' resolves to L1 WITHOUT
+    # inspecting the fleet it was handed, so this is the only thing standing
+    # between a constrained caller and `scope=agent&fleet_id=<someone else's>`.
     if auth.tenant_id and tenant_id and caller_agent_id and fleet_id:
         await enforce_fleet_read(tenant_id, caller_agent_id, fleet_id)
+
+    # An inverted range matches nothing. Say so rather than serving an empty
+    # page the caller reads as "no such memories".
+    if weight_min is not None and weight_max is not None and weight_min > weight_max:
+        raise HTTPException(
+            status_code=422,
+            detail=f"weight_min ({weight_min}) must not exceed weight_max ({weight_max}).",
+        )
 
     # Cursor-based pagination (only applies to created_at descending sort)
     if cursor and (sort != "created_at" or order != "desc"):
@@ -266,6 +388,8 @@ async def list_memories(
     # visibility-scoping identity. When present, the caller can see their
     # own scope_agent memories. When absent, scope_agent memories are
     # hidden (safe default — fixes the scope_agent visibility gap).
+    # ``written_by`` splits the two apart when a caller needs a different
+    # author than itself; ``author_filter`` above holds the resolved value.
     # Cross-tenant widening: when the caller's credential carries a
     # readable set wider than home AND didn't pin tenant_id, storage
     # widens to ``tenant_id = ANY($readable)``. Pinning to one tenant
@@ -276,13 +400,15 @@ async def list_memories(
         "tenant_id": tenant_id or "",
         "caller_agent_id": caller_agent_id,  # visibility scoping (authenticated identity)
         "fleet_id": fleet_id,
-        "written_by": agent_id,  # author filter (query param)
+        "written_by": author_filter,  # author filter (written_by, else agent_id)
         "memory_type": memory_type,
         "exclude_memory_types": exclude_memory_types,
         "created_after": created_after.isoformat() if created_after else None,
         "created_before": created_before.isoformat() if created_before else None,
         "status": status,
         "run_id": run_id,
+        "weight_min": weight_min,
+        "weight_max": weight_max,
         "include_deleted": include_deleted,
         "sort": sort,
         "order": order,
@@ -290,8 +416,13 @@ async def list_memories(
         "offset": offset,
         "cursor_ts": c_ts.isoformat() if c_ts else None,
         "cursor_id": str(c_id) if c_id else None,
+        # scope='agent' never widens across tenants — it means "my own memories",
+        # which live in the home tenant. Mirrors the MCP handler, which passes
+        # ``readable_tenant_ids`` only when scope != 'agent'.
         "readable_tenant_ids": (
-            auth.readable_tenant_ids if auth.is_cross_tenant_read and not tenant_id_explicit else None
+            auth.readable_tenant_ids
+            if auth.is_cross_tenant_read and not tenant_id_explicit and scope != "agent"
+            else None
         ),
     }
     rows = await get_storage_client().list_memories_by_filters(list_payload)
@@ -304,9 +435,11 @@ async def list_memories(
         last = rows[limit - 1]
         next_cursor = encode_cursor(datetime.fromisoformat(last["created_at"]), UUID(last["id"]))
 
-    # Cross-tenant audit (F2): count per-tenant from served rows.
+    # Cross-tenant audit (F2): count per-tenant from served rows. Conditioned on
+    # the same expression as ``readable_tenant_ids`` above — scope='agent' does
+    # not widen, so logging it as a cross-tenant read would be a false entry.
     source_tenants = auth.source_tenants_for_audit()
-    if source_tenants and auth.is_cross_tenant_read and not tenant_id_explicit:
+    if source_tenants and auth.is_cross_tenant_read and not tenant_id_explicit and scope != "agent":
         counts: dict[str, int] = {}
         for row in rows[:limit]:
             rt = row.get("tenant_id")
@@ -328,11 +461,28 @@ async def memory_stats(
     tenant_id: str | None = Query(default=None),
     fleet_id: str | None = Query(default=None),
     agent_id: str | None = Query(default=None),
+    scope: str | None = Query(
+        default=None,
+        pattern=r"^(agent|fleet|all)$",
+        description=(
+            "Opt-in aggregate scope, mirroring the MCP/plugin contract. 'agent' = your "
+            "own memories (trust >= 1); 'fleet' = cross-agent within a fleet (own fleet "
+            "trust >= 1, a different fleet trust >= 2); 'all' = tenant-wide (trust >= 2). "
+            "Omit for the historical behaviour."
+        ),
+    ),
     memory_type: str | None = Query(default=None),
     status: str | None = Query(default=None),
     include_deleted: bool = Query(default=False),
     auth: AuthContext = Depends(get_auth_context),
 ):
+    """Aggregate counts: total plus breakdowns by type, agent, and status.
+
+    Mirrors ``GET /memories``: same visibility scoping, same fleet-read gate, and
+    the same optional ``scope`` ladder, so a count can never disagree with the
+    list it summarises or be reachable at a lower trust level than the rows it
+    counts.
+    """
     tenant_id_explicit = bool(tenant_id)
     if tenant_id:
         auth.enforce_readable_tenant(tenant_id)
@@ -341,6 +491,43 @@ async def memory_stats(
             raise HTTPException(status_code=400, detail="tenant_id is required")
         tenant_id = auth.tenant_id
 
+    # ``agent_id`` here is BOTH the author filter and the visibility identity —
+    # it admits the named agent's own scope_agent rows into the counts. An agent
+    # credential naming a PEER would therefore learn that peer's private
+    # per-type/status counts; GET /memories closes the same widening by
+    # preferring the gateway-authenticated agent over the query param.
+    # Stats cannot borrow that fix as-is: with one knob doing both jobs, forcing
+    # it to the caller would silently narrow the historical "no agent_id →
+    # team/org-wide" aggregate. Rejecting the conflict closes the leak and
+    # leaves every legitimate call (omitted, or naming yourself) untouched.
+    if auth.agent_id and agent_id and agent_id != auth.agent_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"agent_id must be omitted or match the authenticated agent ('{auth.agent_id}').",
+        )
+    caller_agent_id = auth.agent_id or agent_id
+    effective_agent_id = agent_id
+    if scope is not None:
+        # scope='fleet'/'all' drops the per-caller filter so cross-agent
+        # aggregates surface; scope='agent' keeps it. Mirrors the MCP handler's
+        # ``effective_agent_id``. The returned author filter is unused here —
+        # stats has a single ``agent_id`` knob — but the call still enforces the
+        # trust ladder and may pin fleet_id.
+        _, fleet_id = await _resolve_scoped_read(
+            scope,
+            auth_tenant_id=auth.tenant_id,
+            tenant_id=tenant_id,
+            caller_agent_id=caller_agent_id,
+            fleet_id=fleet_id,
+            written_by=None,
+        )
+        effective_agent_id = caller_agent_id if scope == "agent" else None
+    # A fleet-scoped aggregate is a fleet-scoped read: gate it exactly as
+    # GET /memories does. Previously absent here, which let a trust-1 agent
+    # read another fleet's breakdown that the list route would have refused.
+    if auth.tenant_id and tenant_id and caller_agent_id and fleet_id:
+        await enforce_fleet_read(tenant_id, caller_agent_id, fleet_id)
+
     # Type/agent/status breakdown (GROUPING SETS) via core-storage-api. Aggregates
     # across the readable set when the caller has cross-tenant read AND didn't pin
     # tenant_id; pinning to a specific tenant returns just that tenant's stats.
@@ -348,12 +535,15 @@ async def memory_stats(
         {
             "tenant_id": tenant_id,
             "fleet_id": fleet_id,
-            "agent_id": agent_id,
+            "agent_id": effective_agent_id,
             "memory_type": memory_type,
             "status": status,
             "include_deleted": include_deleted,
+            # scope='agent' is home-tenant by definition — same rule as the list route.
             "readable_tenant_ids": (
-                auth.readable_tenant_ids if auth.is_cross_tenant_read and not tenant_id_explicit else None
+                auth.readable_tenant_ids
+                if auth.is_cross_tenant_read and not tenant_id_explicit and scope != "agent"
+                else None
             ),
         }
     )

--- a/core-api/src/core_api/services/agent_service.py
+++ b/core-api/src/core_api/services/agent_service.py
@@ -303,6 +303,92 @@ async def enforce_fleet_read(
         )
 
 
+async def resolve_read_fleet_gate(
+    tenant_id: str,
+    agent_id: str,
+    scope: str,
+    fleet_id: str | None,
+) -> tuple[int, str | None]:
+    """Resolve ``(min_trust, effective_fleet_id)`` for the scoped read-enumeration
+    surfaces: the MCP tools ``caura_list`` / ``caura_stats`` and the REST routes
+    ``GET /memories`` / ``GET /memories/stats`` when they are called with an
+    explicit ``scope``. All four share this one implementation so the ladder
+    cannot drift between the surfaces.
+
+    Trust ladder per the product spec: level 1 = read within the caller's OWN
+    fleet; level 2 = cross-fleet read. The requirement therefore keys off the
+    TARGET, not the ``scope`` string alone:
+
+    * ``scope='agent'`` → ``(1, fleet_id)`` — own memories (caller-filtered
+      upstream); no agent lookup needed.
+    * ``scope='all'``   → ``(2, fleet_id)`` — spans fleets by definition, so it
+      is always a cross-fleet read.
+    * ``scope='fleet'`` → the caller's own fleet is level 1; a DIFFERENT
+      explicit ``fleet_id`` is level 2. Mirrors ``enforce_fleet_read`` and the
+      ``caura_recall`` gate so all read surfaces agree.
+
+    For ``scope='fleet'`` with no ``fleet_id`` this is a security decision, not
+    a convenience: ``memory_list_by_filters`` / ``memory_stats_breakdown`` only
+    apply the ``fleet_id`` filter when it is set, and their visibility predicate
+    returns ``scope_team`` rows across ALL fleets — so an unfiltered level-1 read
+    would fan out to other fleets' shared rows. A constrained caller (trust < 2)
+    that omits ``fleet_id`` is therefore resolved by three cases:
+
+    (a) has a home fleet          → PIN ``fleet_id`` to it (own-fleet read, L1);
+    (b) registered but fleet-less → force L2 — the caller can't prove membership
+        in any fleet, so ``require_trust`` rejects it (trust 1 < 2) rather than
+        granting an unfiltered scan;
+    (c) unregistered (no row)     → soft-pass at L1 with no pin, matching the
+        read-ergonomics soft-pass in ``require_trust`` / ``caura_recall``.
+
+    A trust ≥ 2 caller is never pinned (it is allowed cross-fleet reads). With
+    an explicit fleet it resolves as above; with NO ``fleet_id`` the query would
+    fan out across all fleets, so this returns ``(2, fleet_id)`` — the caller
+    clears L2, while a caller demoted below 2 between this read and the
+    ``require_trust`` re-read does not.
+    """
+    if scope == "agent":
+        return 1, fleet_id
+    if scope == "all":
+        return 2, fleet_id
+    # scope == "fleet": decide by target fleet vs the caller's home fleet.
+    agent = await get_storage_client().get_agent(agent_id, tenant_id)
+    home_fleet = (agent or {}).get("fleet_id")
+    # trust_level pre-read from the agent storage row (agents.trust_level is the
+    # single source of truth; update_trust_level writes it directly). Used to:
+    #   1. Pick the pin branch (docstring a/b): trust < 2 pins to the home fleet,
+    #      or forces L2 when the caller is fleet-less.
+    #   2. Pick the fan-out branch: trust >= 2 with no fleet_id returns L2, so the
+    #      unfiltered cross-fleet scan is gated at the level it actually needs.
+    # Every branch returns a min_level that MATCHES the access it grants, so a
+    # stale read can only UNDER-grant (a narrower result), never over-grant:
+    # require_trust re-reads trust and rejects a caller demoted below the
+    # returned bar. get_agent is uncached, keeping even that transient divergence
+    # to a single async context switch (do NOT add caching — it would widen it).
+    trust = (agent or {}).get("trust_level", DEFAULT_TRUST_LEVEL)
+    # A different fleet is cross-fleet (L2). An unregistered / fleet-less caller
+    # (no home_fleet) that names an explicit fleet also can't prove ownership,
+    # so it must clear the L2 gate too — require_trust then rejects an
+    # unregistered id (effective trust 1 < 2) rather than granting an
+    # own-fleet pass for a fleet the caller has no established membership in.
+    if fleet_id and (not home_fleet or fleet_id != home_fleet):
+        return 2, fleet_id  # cross-fleet read → level 2
+    if not fleet_id and trust < 2:
+        if home_fleet:
+            fleet_id = home_fleet  # (a) pin to own fleet → L1
+        elif agent is not None:
+            return 2, fleet_id  # (b) registered fleet-less → L2 (require_trust rejects)
+        # (c) unregistered soft-pass → falls through to (1, None).
+    elif not fleet_id:
+        # trust >= 2, no pin requested — but fleet_id=None means the downstream
+        # query fans out across all fleets (scope_team rows). Return L2 so
+        # require_trust enforces the correct bar and eliminates the TOCTOU
+        # window: a still-trust-2 caller passes L2; a race-demoted trust-1
+        # caller does not.
+        return 2, fleet_id
+    return 1, fleet_id
+
+
 async def authorize_memory_access(
     tenant_id: str,
     caller_agent_id: str | None,

--- a/tests/_mcp_test_helpers.py
+++ b/tests/_mcp_test_helpers.py
@@ -111,6 +111,12 @@ def stub_storage_client(monkeypatch, **method_returns):
     # test must patch the alias on ``mcp_server`` (where Python resolves it at
     # call time) — not the original module path.
     monkeypatch.setattr("core_api.mcp_server.get_storage_client", _factory)
+    # ``resolve_read_fleet_gate`` — the trust ladder behind scope='fleet' for
+    # both the MCP tools and the REST read routes — lives in ``agent_service``
+    # and resolves the factory through THAT module's namespace. Patch its alias
+    # too, or a ``get_agent`` stub set here is silently ignored by the gate and
+    # the pin/level assertions read the real (ASGI-bridged) storage instead.
+    monkeypatch.setattr("core_api.services.agent_service.get_storage_client", _factory)
     return sc
 
 

--- a/tests/test_api_read_scope_params.py
+++ b/tests/test_api_read_scope_params.py
@@ -1,0 +1,561 @@
+"""The read contract the plugin and the MCP tools advertise, over REST.
+
+Regression cover for H-10 (#820). ``plugin/src/tool-definitions.ts`` declares
+``scope``/``written_by``/``weight_min``/``weight_max`` on ``caura_list`` and
+``scope`` on ``caura_stats`` — mirroring ``plugin/tools.json``, which is
+generated from the MCP tool specs — then dispatches both to REST routes that
+declared none of them. FastAPI drops undeclared query params silently, so the
+calls never failed; they answered a different question than the one asked.
+``caura_list {agent_id:'me', written_by:'agent-b'}`` returned the caller's OWN
+memories, labelled as agent-b's.
+
+Two things are asserted here, and they pull in opposite directions:
+
+1. the params now take effect (the tests that would pass trivially before the
+   route accepted them are written so the WRONG answer is the pre-fix answer);
+2. ``scope`` is trust-gated by the same ladder as the MCP tools, so making the
+   param real did not turn a wrong-data bug into a cheaper way to reach rows
+   the MCP surface gates behind trust ≥ 2.
+
+Also covers two gaps this found in ``GET /memories/stats``, which never
+received hardening its list sibling already had: no fleet-read gate at all, and
+an ``agent_id`` that an agent credential could point at a peer.
+"""
+
+import contextlib
+
+import pytest
+
+from tests.conftest import get_test_auth, uid as _uid
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _write(client, tenant_id, headers, *, content, agent_id, fleet_id, weight=None):
+    body = {
+        "tenant_id": tenant_id,
+        "content": content,
+        "agent_id": agent_id,
+        "fleet_id": fleet_id,
+        "memory_type": "fact",
+        # scope_org so the rows are visible to any caller in the tenant: these
+        # tests are about the author/scope/weight FILTERS, not about the
+        # visibility predicate, which has its own cover in test_visibility.py.
+        "visibility": "scope_org",
+    }
+    if weight is not None:
+        body["weight"] = weight
+    resp = await client.post("/api/v1/memories", json=body, headers=headers)
+    assert resp.status_code == 201, f"Write failed: {resp.text}"
+    return resp.json()
+
+
+@contextlib.contextmanager
+def _as_agent(tenant_id: str, agent_id: str):
+    """Run the enclosed requests as an AGENT credential (``auth.agent_id`` set).
+
+    No auth path available to the OSS tests produces one: the admin-key branch
+    returns ``AuthContext(tenant_id=None, is_admin=True)`` and the standalone
+    branch (which wins here, before the gateway branch) returns
+    ``AuthContext(tenant_id=..., org_role="admin")`` — both discard X-Agent-ID.
+    ``test_api_keystones`` documents the same limitation.
+
+    In production the plugin arrives on the gateway path, which sets tenant AND
+    agent, and that is the shape the trust ladder gates on. Overriding the
+    dependency reproduces it while leaving the route body — the code under
+    test — fully exercised end to end, storage included.
+    """
+    from core_api.app import app
+    from core_api.auth import AuthContext, get_auth_context
+
+    app.dependency_overrides[get_auth_context] = lambda: AuthContext(
+        tenant_id=tenant_id, agent_id=agent_id
+    )
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_auth_context, None)
+
+
+async def _set_trust(sc, tenant_id, agent_id, fleet_id, trust_level):
+    """Pin an agent's trust level.
+
+    Called AFTER the writes: ``get_or_create_agent`` on the write path
+    registers an unknown agent at ``DEFAULT_TRUST_LEVEL``, so setting trust
+    first and writing second would leave the row at whatever the write path
+    decided rather than the level the test is exercising.
+    """
+    await sc.create_or_update_agent(
+        {
+            "tenant_id": tenant_id,
+            "agent_id": agent_id,
+            "fleet_id": fleet_id,
+            "trust_level": trust_level,
+        }
+    )
+
+
+def _contents(payload):
+    return {item["content"] for item in payload["items"]}
+
+
+# ---------------------------------------------------------------------------
+# The advertised params now take effect
+# ---------------------------------------------------------------------------
+
+
+async def test_written_by_selects_the_author_not_the_caller(client, sc):
+    """``written_by`` is the author filter, distinct from the caller identity.
+
+    Pre-fix this returned ALICE's memory: ``written_by`` was dropped and
+    ``agent_id`` doubled as the author filter. The answer looked plausible —
+    a populated list — which is why it went unnoticed.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice, bob = f"alice-{tag}", f"bob-{tag}"
+    fleet = f"wb-fleet-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"by alice [{tag}]", agent_id=alice, fleet_id=fleet)
+    await _write(client, tenant_id, headers, content=f"by bob [{tag}]", agent_id=bob, fleet_id=fleet)
+    await _set_trust(sc, tenant_id, alice, fleet, 2)
+
+    resp = await client.get(
+        f"/api/v1/memories?tenant_id={tenant_id}&fleet_id={fleet}&agent_id={alice}&written_by={bob}",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert _contents(resp.json()) == {f"by bob [{tag}]"}
+
+
+async def test_weight_bounds_filter_the_result_set(client, sc):
+    """``weight_min`` / ``weight_max`` narrow by weight.
+
+    Pre-fix both were dropped and all three rows came back.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    agent = f"w-agent-{tag}"
+    fleet = f"w-fleet-{tag}"
+
+    for weight, label in ((0.1, "low"), (0.5, "mid"), (0.9, "high")):
+        await _write(
+            client, tenant_id, headers,
+            content=f"{label} weight [{tag}]", agent_id=agent, fleet_id=fleet, weight=weight,
+        )
+
+    resp = await client.get(
+        f"/api/v1/memories?tenant_id={tenant_id}&fleet_id={fleet}&weight_min=0.4&weight_max=0.6",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert _contents(resp.json()) == {f"mid weight [{tag}]"}
+
+
+async def test_weight_bounds_outside_zero_to_one_are_rejected(client):
+    """The documented range is 0-1; a value outside it is a 422, not a filter
+    that silently matches everything."""
+    tenant_id, headers = get_test_auth()
+    resp = await client.get(f"/api/v1/memories?tenant_id={tenant_id}&weight_min=1.5", headers=headers)
+    assert resp.status_code == 422, resp.text
+
+
+async def test_an_inverted_weight_range_is_rejected(client):
+    """min > max matches nothing. An empty page reads as "no such memories",
+    which is the same silent-wrong-answer shape this whole file is about."""
+    tenant_id, headers = get_test_auth()
+    resp = await client.get(
+        f"/api/v1/memories?tenant_id={tenant_id}&weight_min=0.9&weight_max=0.1", headers=headers
+    )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_scope_all_drops_the_author_filter(client, sc):
+    """``scope='all'`` is tenant-wide: the caller's own agent_id stops acting
+    as an author filter.
+
+    Pre-fix ``scope`` was dropped, so this returned only alice's row — the
+    exact failure the issue describes as "results stay author-filtered to 'me'
+    instead of tenant-wide".
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice, bob = f"alice-{tag}", f"bob-{tag}"
+    fleet = f"sa-fleet-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"by alice [{tag}]", agent_id=alice, fleet_id=fleet)
+    await _write(client, tenant_id, headers, content=f"by bob [{tag}]", agent_id=bob, fleet_id=fleet)
+    await _set_trust(sc, tenant_id, alice, fleet, 2)  # scope='all' needs trust >= 2
+
+    resp = await client.get(
+        f"/api/v1/memories?tenant_id={tenant_id}&fleet_id={fleet}&agent_id={alice}&scope=all",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert _contents(resp.json()) == {f"by alice [{tag}]", f"by bob [{tag}]"}
+
+
+async def test_scope_agent_pins_the_author_filter_to_the_caller(client, sc):
+    """``scope='agent'`` means "my own memories" even when no ``agent_id``
+    query param is supplied — the authenticated identity is the filter.
+
+    Pre-fix, ``scope`` was dropped and no author filter was left, so this
+    returned bob's row too: the caller asked to NARROW and was silently WIDENED.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice, bob = f"alice-{tag}", f"bob-{tag}"
+    fleet = f"sag-fleet-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"by alice [{tag}]", agent_id=alice, fleet_id=fleet)
+    await _write(client, tenant_id, headers, content=f"by bob [{tag}]", agent_id=bob, fleet_id=fleet)
+    await _set_trust(sc, tenant_id, alice, fleet, 1)  # scope='agent' only needs trust >= 1
+
+    with _as_agent(tenant_id, alice):
+        resp = await client.get(f"/api/v1/memories?tenant_id={tenant_id}&fleet_id={fleet}&scope=agent")
+    assert resp.status_code == 200, resp.text
+    assert _contents(resp.json()) == {f"by alice [{tag}]"}
+
+
+async def test_scope_fleet_without_a_fleet_id_pins_to_the_home_fleet(client, sc):
+    """A constrained caller that asks for ``scope='fleet'`` without naming one
+    is pinned to its OWN fleet rather than fanning out across every fleet's
+    shared rows (``resolve_read_fleet_gate`` case (a)).
+
+    Pre-fix ``scope`` was dropped, no fleet filter was applied, and the other
+    fleet's row came back.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice, bob = f"alice-{tag}", f"bob-{tag}"
+    home, other = f"home-{tag}", f"other-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"in home [{tag}]", agent_id=alice, fleet_id=home)
+    await _write(client, tenant_id, headers, content=f"in other [{tag}]", agent_id=bob, fleet_id=other)
+    await _set_trust(sc, tenant_id, alice, home, 1)
+
+    with _as_agent(tenant_id, alice):
+        resp = await client.get(f"/api/v1/memories?tenant_id={tenant_id}&scope=fleet")
+    assert resp.status_code == 200, resp.text
+    contents = _contents(resp.json())
+    assert f"in home [{tag}]" in contents
+    assert f"in other [{tag}]" not in contents
+
+
+# ---------------------------------------------------------------------------
+# scope is trust-gated — the same ladder the MCP tools use
+# ---------------------------------------------------------------------------
+
+
+async def test_scope_all_requires_trust_2(client, sc):
+    """Making ``scope`` real must not make REST a cheaper tenant-wide read than
+    MCP. Pre-fix this returned 200 (the param was ignored entirely)."""
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice = f"alice-{tag}"
+    fleet = f"t1-fleet-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"row [{tag}]", agent_id=alice, fleet_id=fleet)
+    await _set_trust(sc, tenant_id, alice, fleet, 1)
+
+    with _as_agent(tenant_id, alice):
+        resp = await client.get(f"/api/v1/memories?tenant_id={tenant_id}&scope=all")
+    assert resp.status_code == 403, resp.text
+
+
+async def test_scope_fleet_targeting_another_fleet_requires_trust_2(client, sc):
+    """A pin, not a bug demonstration: ``enforce_fleet_read`` already refused
+    this shape, so it passes with or without the scope work. It is here so a
+    future refactor that routes cross-fleet reads through ``scope`` and drops
+    the older gate still has to produce a 403."""
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice = f"alice-{tag}"
+    home, other = f"home-{tag}", f"other-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"row [{tag}]", agent_id=alice, fleet_id=home)
+    await _set_trust(sc, tenant_id, alice, home, 1)
+
+    with _as_agent(tenant_id, alice):
+        resp = await client.get(f"/api/v1/memories?tenant_id={tenant_id}&scope=fleet&fleet_id={other}")
+    assert resp.status_code == 403, resp.text
+
+
+async def test_scope_fleet_from_an_unregistered_caller_requires_trust_2(client):
+    """The case the older gate does NOT cover.
+
+    ``enforce_fleet_read`` returns early for an unknown agent ("registration
+    happens on writes"), so an unregistered caller naming any fleet was allowed
+    straight through. The scope ladder resolves it to L2 instead — it cannot
+    prove membership in the fleet it named — and ``require_trust`` rejects it at
+    effective trust 1. Pre-fix: 200.
+    """
+    tenant_id, _ = get_test_auth()
+    tag = _uid()
+
+    with _as_agent(tenant_id, f"ghost-{tag}"):
+        resp = await client.get(
+            f"/api/v1/memories?tenant_id={tenant_id}&scope=fleet&fleet_id=some-fleet-{tag}"
+        )
+    assert resp.status_code == 403, resp.text
+
+
+async def test_scope_agent_still_cannot_name_another_fleet(client, sc):
+    """``enforce_fleet_read`` is load-bearing even with the ladder in place.
+
+    ``resolve_read_fleet_gate`` short-circuits ``scope='agent'`` to L1 *without
+    inspecting the fleet it was handed* — deliberately, since scope='agent'
+    pins the author filter to the caller. So the older gate is the only thing
+    refusing ``scope=agent&fleet_id=<another fleet>`` here. Pinned as a test
+    because the three agent lookups on this path look redundant from the
+    outside, and dropping this one to save a round-trip would open a hole.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice = f"alice-{tag}"
+    home, other = f"home-{tag}", f"other-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"row [{tag}]", agent_id=alice, fleet_id=home)
+    await _set_trust(sc, tenant_id, alice, home, 1)
+
+    with _as_agent(tenant_id, alice):
+        resp = await client.get(f"/api/v1/memories?tenant_id={tenant_id}&scope=agent&fleet_id={other}")
+    assert resp.status_code == 403, resp.text
+
+
+async def test_scope_agent_rejects_a_foreign_written_by(client, sc):
+    """Mirrors the MCP handler: ``written_by`` must be omitted or be yourself
+    when scope='agent'. Rejecting beats silently overriding — the caller
+    otherwise gets a result set that does not match what it asked for."""
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice, bob = f"alice-{tag}", f"bob-{tag}"
+    fleet = f"fw-fleet-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"row [{tag}]", agent_id=alice, fleet_id=fleet)
+    await _set_trust(sc, tenant_id, alice, fleet, 1)
+
+    with _as_agent(tenant_id, alice):
+        resp = await client.get(f"/api/v1/memories?tenant_id={tenant_id}&scope=agent&written_by={bob}")
+    assert resp.status_code == 400, resp.text
+    assert "written_by" in resp.text
+
+
+async def test_scope_agent_without_an_agent_identity_is_rejected(client):
+    """``scope='agent'`` with no resolvable caller must not silently degrade to
+    "no author filter" — that would widen the very read it asks to narrow."""
+    tenant_id, headers = get_test_auth()
+    resp = await client.get(f"/api/v1/memories?tenant_id={tenant_id}&scope=agent", headers=headers)
+    assert resp.status_code == 400, resp.text
+
+
+async def test_invalid_scope_is_rejected(client):
+    tenant_id, headers = get_test_auth()
+    resp = await client.get(f"/api/v1/memories?tenant_id={tenant_id}&scope=everything", headers=headers)
+    assert resp.status_code == 422, resp.text
+
+
+async def test_both_read_surfaces_share_one_trust_ladder():
+    """The MCP alias and the REST import must resolve to the SAME function.
+
+    The ladder was duplicated-by-move once already; if someone reintroduces a
+    private copy in ``mcp_server``, the two surfaces can drift apart silently
+    and only one of them gets the next fix.
+    """
+    from core_api import mcp_server
+    from core_api.services import agent_service
+
+    assert mcp_server._resolve_read_fleet_gate is agent_service.resolve_read_fleet_gate
+
+
+# ---------------------------------------------------------------------------
+# GET /memories/stats — the hardening its list sibling already had
+# ---------------------------------------------------------------------------
+
+
+async def test_stats_cross_fleet_aggregate_is_gated(client, sc):
+    """A fleet-scoped aggregate is a fleet-scoped read.
+
+    ``GET /memories`` has called ``enforce_fleet_read`` all along; stats never
+    did, so a trust-1 agent could read the breakdown of a fleet whose rows the
+    list route would have refused to show it. Pre-fix: 200.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice = f"alice-{tag}"
+    home, other = f"home-{tag}", f"other-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"row [{tag}]", agent_id=alice, fleet_id=home)
+    await _set_trust(sc, tenant_id, alice, home, 1)
+
+    with _as_agent(tenant_id, alice):
+        resp = await client.get(f"/api/v1/memories/stats?tenant_id={tenant_id}&fleet_id={other}")
+    assert resp.status_code == 403, resp.text
+
+
+async def test_stats_rejects_a_peer_agent_id(client, sc):
+    """``agent_id`` on stats is the visibility identity as well as the author
+    filter, so an agent credential naming a PEER learned that peer's private
+    per-type/status counts. Pre-fix: 200 with bob's numbers.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice, bob = f"alice-{tag}", f"bob-{tag}"
+    fleet = f"peer-fleet-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"row [{tag}]", agent_id=alice, fleet_id=fleet)
+    await _set_trust(sc, tenant_id, alice, fleet, 1)
+
+    with _as_agent(tenant_id, alice):
+        resp = await client.get(f"/api/v1/memories/stats?tenant_id={tenant_id}&agent_id={bob}")
+    assert resp.status_code == 403, resp.text
+
+
+async def test_stats_allows_naming_yourself(client, sc):
+    """The rejection above must not break the legitimate call — an agent asking
+    for its own breakdown, which is what the plugin sends on every caura_stats."""
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice = f"alice-{tag}"
+    fleet = f"self-fleet-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"row [{tag}]", agent_id=alice, fleet_id=fleet)
+    await _set_trust(sc, tenant_id, alice, fleet, 1)
+
+    with _as_agent(tenant_id, alice):
+        resp = await client.get(f"/api/v1/memories/stats?tenant_id={tenant_id}&agent_id={alice}")
+    assert resp.status_code == 200, resp.text
+
+
+async def test_stats_scope_all_requires_trust_2(client, sc):
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    alice = f"alice-{tag}"
+    fleet = f"ss-fleet-{tag}"
+
+    await _write(client, tenant_id, headers, content=f"row [{tag}]", agent_id=alice, fleet_id=fleet)
+    await _set_trust(sc, tenant_id, alice, fleet, 1)
+
+    with _as_agent(tenant_id, alice):
+        resp = await client.get(f"/api/v1/memories/stats?tenant_id={tenant_id}&scope=all")
+    assert resp.status_code == 403, resp.text
+
+
+async def test_stats_without_a_scope_is_unchanged(client):
+    """The legacy shape — no ``scope``, no agent identity — must keep working
+    exactly as before; the dashboard calls it that way."""
+    tenant_id, headers = get_test_auth()
+    resp = await client.get(f"/api/v1/memories/stats?tenant_id={tenant_id}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert "total" in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# The drift guard: what the plugin advertises must be what the route accepts
+# ---------------------------------------------------------------------------
+
+# The plugin dispatches each tool to one core-api endpoint
+# (``ENDPOINT_DISPATCH`` in plugin/src/tool-definitions.ts). Tools that send
+# their params as QUERY args are the ones exposed to this failure mode: FastAPI
+# ignores an undeclared query param instead of rejecting it. Tools that send a
+# JSON BODY are validated by a Pydantic model and are not silently dropped the
+# same way, so they are classified rather than checked here.
+_QUERY_PARAM_TOOLS = {
+    # caura_keystones dispatches to the /api/v1/memclaw legacy alias, which is
+    # mounted with include_in_schema=False; the canonical path below is the
+    # same router and therefore the same signature.
+    "caura_keystones": "/api/v1/keystones",
+    "caura_list": "/api/v1/memories",
+    "caura_stats": "/api/v1/memories/stats",
+    "caura_entity_get": "/api/v1/entities/{entity_id}",
+}
+
+_BODY_DISPATCH_TOOLS = {
+    "caura_doc",      # POST /documents*, GET /documents/collections
+    "caura_evolve",   # POST /evolve/report
+    "caura_insights",  # POST /insights/generate
+    "caura_manage",   # op-dispatched across several endpoints
+    "caura_recall",   # POST /search (+ /recall)
+    "caura_tune",     # PATCH /agents/{id}/tune
+    "caura_write",    # POST /memories, POST /memories/bulk
+}
+
+# Advertised params that are deliberately NOT query params on the target route,
+# each with the reason. Kept explicit — and checked below for staleness — so it
+# cannot quietly become a place to hide a real gap (same shape as the purge
+# coverage guard in the storage suite).
+_NOT_QUERY_PARAMS = {
+    ("caura_entity_get", "entity_id"): "path segment, not a query param",
+}
+
+
+def _accepted_query_params(spec: dict, path: str) -> set[str]:
+    """Query-param names a GET route accepts.
+
+    Read from ``app.openapi()`` rather than by walking ``app.routes``: FastAPI
+    0.137 mounts ``include_router(prefix=...)`` as an opaque ``_IncludedRouter``
+    with no public ``.routes``, so the prefixed paths are not reachable from the
+    route table at all. The same reasoning is spelled out at the
+    ``_TIMEOUT_OPT_OUT_PATHS`` guard in ``core_api/app.py``.
+    """
+    node = spec["paths"].get(path, {}).get("get")
+    assert node is not None, f"No GET route registered at {path}"
+    return {p["name"] for p in node.get("parameters", []) if p.get("in") == "query"}
+
+
+def _plugin_tool_specs():
+    import json
+    from pathlib import Path
+
+    specs_path = Path(__file__).resolve().parents[1] / "plugin" / "tools.json"
+    return {t["name"]: t for t in json.loads(specs_path.read_text())}
+
+
+@pytest.mark.unit
+def test_every_plugin_advertised_query_param_is_accepted_by_its_route():
+    """A param the plugin advertises must be one the route actually reads.
+
+    This is the guard the H-10 class needed: FastAPI drops undeclared query
+    params silently, so the only symptom was a plausible wrong answer. Adding a
+    param to a tool schema without adding it to the route now fails here.
+    """
+    from core_api.app import app
+
+    spec = app.openapi()
+    specs = _plugin_tool_specs()
+    gaps = {}
+    for tool, path in _QUERY_PARAM_TOOLS.items():
+        accepted = _accepted_query_params(spec, path)
+        advertised = {p["name"] for p in specs[tool]["params"]}
+        excused = {name for (t, name) in _NOT_QUERY_PARAMS if t == tool}
+        missing = advertised - accepted - excused
+        if missing:
+            gaps[tool] = sorted(missing)
+    assert not gaps, f"advertised by the plugin but dropped by the route: {gaps}"
+
+
+@pytest.mark.unit
+def test_the_not_query_params_excuse_list_cannot_hide_a_real_gap():
+    """An entry that names a param the route DOES accept is stale, and would
+    mask the next real gap on that tool."""
+    from core_api.app import app
+
+    spec = app.openapi()
+    for (tool, name), reason in _NOT_QUERY_PARAMS.items():
+        assert reason, f"{tool}.{name} needs a reason"
+        accepted = _accepted_query_params(spec, _QUERY_PARAM_TOOLS[tool])
+        assert name not in accepted, f"stale excuse: {tool}.{name} IS accepted by the route"
+
+
+@pytest.mark.unit
+def test_every_plugin_exposed_tool_is_classified():
+    """A new plugin tool must be sorted into query-dispatch or body-dispatch, so
+    it cannot escape the check above just by being new."""
+    specs = _plugin_tool_specs()
+    exposed = {name for name, spec in specs.items() if spec["plugin_exposed"]}
+    classified = set(_QUERY_PARAM_TOOLS) | _BODY_DISPATCH_TOOLS
+    assert exposed - classified == set(), f"unclassified plugin tools: {sorted(exposed - classified)}"
+    assert classified - exposed == set(), f"classified but no longer exposed: {sorted(classified - exposed)}"

--- a/tests/test_cross_tenant_audit_surfaces.py
+++ b/tests/test_cross_tenant_audit_surfaces.py
@@ -326,10 +326,19 @@ async def test_rest_memories_list_emits_cross_tenant_audit(monkeypatch):
 
     auth = _cross_tenant_auth()
 
+    # Every parameter is passed explicitly: calling the endpoint function
+    # directly bypasses FastAPI's dependency resolution, so an omitted argument
+    # arrives as the ``Query(...)`` default OBJECT rather than its default
+    # value — which is neither None nor comparable. A new param must be added
+    # here too.
     await memories_routes.list_memories(
         tenant_id=None,  # broad — triggers widening
         fleet_id=None,
         agent_id=None,
+        scope=None,
+        written_by=None,
+        weight_min=None,
+        weight_max=None,
         memory_type=None,
         exclude_memory_types=None,
         created_after=None,


### PR DESCRIPTION
Fixes #820.

## The bug

`plugin/src/tool-definitions.ts` declares `scope`, `written_by`,
`weight_min` and `weight_max` on `caura_list`, and `scope` on
`caura_stats` — faithfully mirroring `plugin/tools.json`, which is
generated from the MCP tool specs. Both then dispatch to REST routes
that declared **none** of them, and FastAPI drops an undeclared query
param silently.

So the calls never failed. They answered a different question:

* `caura_list {agent_id:'me', written_by:'agent-b'}` — `written_by`
  dropped, `agent_id` doubles as the author filter, so the caller got
  its OWN memories back, presented as agent-b's;
* `caura_list {agent_id:'me', scope:'all'}` — `scope` dropped, results
  stay author-filtered to the caller instead of tenant-wide;
* `weight_min` / `weight_max` never filtered anything.

A plausible-looking populated list is why this went unnoticed.

## Making `scope` real needed its ladder too

`GET /memories` now accepts all four params and `GET /memories/stats`
accepts `scope`. Adding `scope` without its trust gate would have traded
a wrong-data bug for a worse one: REST has no trust ladder on reads, so
`scope=all` would have been a trust-1 tenant-wide read on a surface
where MCP requires trust >= 2.

`_resolve_read_fleet_gate` therefore moves out of `mcp_server` into
`agent_service` as `resolve_read_fleet_gate`, and the MCP tools and the
REST routes now call one implementation. **The executable body is
unchanged** — verified by comparing the ASTs with docstrings stripped;
only the docstring's first paragraph is edited, to name its four callers
instead of two. `mcp_server` keeps a `_resolve_read_fleet_gate` alias,
the same pattern already used there for `_require_trust`.

`scope` is opt-in. Omitted, both routes behave byte-for-byte as before,
so the dashboard and every existing caller are untouched — and no caller
can regress on a param that was being discarded a commit ago.

## Two gaps in `/memories/stats` that this surfaced

Stats never received hardening its list sibling already had:

* **No fleet-read gate at all.** `GET /memories` has called
  `enforce_fleet_read` all along; stats took `fleet_id` and aggregated
  it ungated, so a trust-1 agent could read the breakdown of a fleet
  whose rows the list route would have refused to show it. Now gated
  under the identical condition.
* **`agent_id` was impersonatable.** In `memory_stats_breakdown` it is
  both the author filter *and* the visibility identity, so an agent
  credential naming a peer learned that peer's private per-type/status
  counts — the widening `GET /memories` closes by preferring the
  gateway-authenticated agent. Stats cannot borrow that fix as-is: with
  one knob doing both jobs, forcing it to the caller would silently
  narrow the historical "no `agent_id` -> team/org-wide" aggregate. The
  conflict is rejected instead, which closes the leak and leaves every
  legitimate call — omitted, or naming yourself — working.

## Tests

`tests/test_api_read_scope_params.py`, 21 tests. Sixteen fail on
`origin/main` with only the source reverted; the five that pass either
way are deliberate "do not break this" guards (legacy stats shape,
naming yourself) and structural checks, and the one non-discriminating
ladder test says so in its docstring.

The last three are the guard this class needed. `GET` tools are matched
against `plugin/tools.json`, so a param a tool advertises but its route
does not read now fails a test instead of returning a wrong answer; the
excuse list for genuinely-not-query params is itself checked for
staleness, and every plugin-exposed tool must be classified as
query-dispatch or body-dispatch, so a new tool cannot escape the check
by being new. Same shape as the purge coverage guard in #844.

`tests/_mcp_test_helpers.py::stub_storage_client` now also patches the
`agent_service` alias of `get_storage_client`. Without it the moved gate
resolves the real ASGI-bridged client and five existing `caura_list`
tests read live storage instead of their stub.

## Not included

The plugin needs no change — its params now reach a route that reads
them. One residue is left deliberately: `enrichBody` injects
`MEMCLAW_FLEET_ID` when the caller named no fleet, so `caura_list
{scope:'all'}` from a fleet-configured install still narrows to that
fleet. That is plugin-side param population, identical in effect to
passing `fleet_id` explicitly to the MCP tool, and separable from making
the REST contract honest.

