### PR TITLE
fix(embedding): the concurrency gate must cover every caller

### DIFF
--- a/common/embedding/__init__.py
+++ b/common/embedding/__init__.py
@@ -13,6 +13,10 @@ Public surface:
   falls back to :func:`get_embedding`'s symmetric behaviour. Backwards-
   compatible with the prior ``core_api.services.embedding`` module.
 * :func:`get_embedding_provider` — factory.
+* :func:`call_embedding_gated` — runs a caller-supplied embed under the
+  process-wide concurrency gate, for the one caller that holds a provider
+  directly instead of going through the entrypoints above. Never nest it
+  inside them; see its docstring for why that deadlocks.
 * :func:`init_platform_embedding` / :func:`get_platform_embedding` —
   platform-tier singleton, initialised once at service startup from
   ``PLATFORM_EMBEDDING_*`` env vars.
@@ -39,6 +43,7 @@ from common.embedding._platform import (
 )
 from common.embedding._registry import get_embedding_provider
 from common.embedding._service import (
+    call_embedding_gated,
     get_embedding,
     get_embeddings_batch,
     get_query_embedding,
@@ -53,6 +58,7 @@ __all__ = [
     "EmbeddingProvider",
     "FakeEmbeddingProvider",
     "InstructionAwareEmbedder",
+    "call_embedding_gated",
     "fake_embedding",
     "get_embedding",
     "get_embedding_provider",

--- a/common/embedding/_service.py
+++ b/common/embedding/_service.py
@@ -281,7 +281,7 @@ def _background_gate() -> asyncio.Semaphore:
     return _bg_gate
 
 
-async def _call_gated[T](
+async def call_embedding_gated[T](
     make_call: Callable[[], Awaitable[T]], *, background: bool
 ) -> T:
     """Run *make_call* holding a concurrency slot.
@@ -306,6 +306,20 @@ async def _call_gated[T](
     ``cap - reserved`` — precisely the background gate's size — so every
     background holder can still acquire one. Query embeds only ever take
     the shared gate, so they cannot be blocked behind background work.
+
+    **Never nest this call.** :func:`get_embedding`,
+    :func:`get_embeddings_batch` and :func:`get_query_embedding` already
+    gate internally, so wrapping one of them deadlocks under saturation:
+    the outer hold occupies a shared slot while the inner acquire waits
+    for one, and once ``EMBEDDING_MAX_CONCURRENCY`` callers are inside,
+    none can proceed and each burns the full timeout. Callers that hold an
+    :class:`EmbeddingProvider` directly — core-worker's deferred-embed
+    consumer is the only one — call this instead of, never in addition to,
+    those three. The hazard is reachable rather than theoretical: the
+    registry can hand back the platform singleton itself
+    (:func:`common.embedding._registry.get_embedding_provider`), so one
+    provider object is reachable by both routes, which is also why the
+    gate belongs at the call site and not inside the provider.
     """
     # ``AsyncExitStack`` rather than hand-rolled release bookkeeping: it
     # unwinds on ANY escape — TimeoutError, CancelledError, or a failure
@@ -479,7 +493,7 @@ async def get_embeddings_batch(
     # process anyway.
     try:
         if budget_s is None:
-            result = await _call_gated(
+            result = await call_embedding_gated(
                 lambda: provider.embed_batch(texts), background=background
             )
         else:
@@ -488,7 +502,7 @@ async def get_embeddings_batch(
             # with an attributable TimeoutError instead of silently reverting
             # to the unbounded path the margin exists to replace.
             async with asyncio.timeout(max(0.1, budget_s - EMBEDDING_BUDGET_MARGIN_S)):
-                result = await _call_gated(
+                result = await call_embedding_gated(
                     lambda: provider.embed_batch(texts), background=background
                 )
     except BaseException:
@@ -517,7 +531,7 @@ async def _run_with_retry(
     ``"Query embedding"``) interpolated into the per-attempt warning
     and the terminal error log so failures are attributable.
 
-    *background* is forwarded to :func:`_call_gated` — see
+    *background* is forwarded to :func:`call_embedding_gated` — see
     ``EMBEDDING_INTERACTIVE_RESERVED_SLOTS``. It is per-ATTEMPT, like the slot
     itself, so a retrying background call re-queues behind the background
     budget instead of escalating into the reserved slice.
@@ -525,7 +539,7 @@ async def _run_with_retry(
     last_exc: BaseException | None = None
     for attempt in range(1, EMBEDDING_RETRY_ATTEMPTS + 1):
         try:
-            result = await _call_gated(make_call, background=background)
+            result = await call_embedding_gated(make_call, background=background)
             await stats.record_success()
             return result
         # Intentionally broad: must catch all provider-specific errors during retry.

--- a/common/embedding/providers/openai.py
+++ b/common/embedding/providers/openai.py
@@ -260,7 +260,7 @@ class OpenAIEmbeddingProvider:
 
         SEQUENTIAL, unlike the reranker's concurrent ``asyncio.gather``.
         Two reasons, both about not undoing work this module already did:
-        ``_call_gated`` holds ONE ``EMBEDDING_MAX_CONCURRENCY`` slot for
+        ``call_embedding_gated`` holds ONE ``EMBEDDING_MAX_CONCURRENCY`` slot for
         this whole call, so fanning out inside it would multiply the real
         provider concurrency by the chunk count and defeat a cap that
         exists because of the 2026-07-27 connection-pool exhaustion. And

--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -104,11 +104,23 @@ class PubSubEventBus(EventBus):
         # filtering) — preserves the pre-guard behaviour for single-env
         # deployments and in-process tests.
         env: str | None = None,
-        # Batch size per pull. Caps ``workers x max_messages``
-        # concurrent embed calls across the deployed pool, so 25
-        # balances drain throughput against the OpenAI per-org
-        # rate limit and the blast radius of a single wedged
-        # dispatch cycle.
+        # Batch size per pull — how many messages one ``pull`` may return.
+        # NOT a concurrency cap, despite what an earlier version of this
+        # comment claimed: ``_pull_loop`` awaits ``_dispatch_all`` once per
+        # message inside a ``for``, so a batch drains SEQUENTIALLY and only
+        # ONE EVENT's handlers are in flight per pull loop at a time
+        # (``_dispatch_all`` does gather that event's handlers, so a topic
+        # with several handlers runs those concurrently). Handler
+        # concurrency is therefore ``subscriptions x handlers-per-subscription
+        # x instances`` and is independent of this number, which bounds only
+        # how much work one wedged dispatch cycle holds.
+        #
+        # Worth stating rather than leaving implicit: that serialisation is
+        # a property of this loop's shape, not a limit anyone chose. Raising
+        # drain throughput by parallelising it reads as a pure win while
+        # removing the only thing holding per-instance handler concurrency
+        # near one, so anything that lifts it needs a real bound of its own
+        # — see ``common.embedding.call_embedding_gated`` for the embed path.
         max_messages: int = 25,
         pull_timeout: float = 20.0,
         error_backoff: float = 5.0,

--- a/core-worker/src/core_worker/consumer.py
+++ b/core-worker/src/core_worker/consumer.py
@@ -50,7 +50,7 @@ from types import SimpleNamespace
 import httpx
 from pydantic import ValidationError
 
-from common.embedding import get_platform_embedding
+from common.embedding import call_embedding_gated, get_platform_embedding
 from common.enrichment import EnrichmentResult, enrich_memory
 from common.events.base import Event
 from common.events.factory import get_event_bus
@@ -163,16 +163,39 @@ async def handle_embed_request(event: Event) -> None:
                 },
             )
 
-    # Step 2 — provider call (skipped on cache hit).
+    # Step 2 — provider call (skipped on cache hit), under the embedding
+    # gate. ``provider`` is the platform singleton, which does not traverse
+    # the semaphore ``get_embedding`` applies, so this call has to take it
+    # explicitly or take none at all.
+    #
+    # ``background=True`` does NOT buy this process anything: the gate is
+    # per process and core-worker has no interactive embeds, so the slots
+    # ``EMBEDDING_INTERACTIVE_RESERVED_SLOTS`` holds back are unusable here
+    # and the worker is capped at the background budget rather than the
+    # full one. It is still correct, for the resource that is actually
+    # shared: the embedding BACKEND is one pool that core-api's search hits
+    # too, and a deferred backfill is nobody's blocked request, so it
+    # should be the load that yields. Do not "fix" this to False to buy
+    # worker throughput — that spends a shared backend to speed up work no
+    # one is waiting for.
+    #
+    # A gate timeout raises ``TimeoutError``, which propagates and nacks
+    # rather than acking the message embedding-less. Saturation is
+    # transient, so redelivery with Pub/Sub backoff (and the DLQ behind it)
+    # is the right answer for a queue consumer — unlike core-api, which
+    # degrades to ``None`` because an HTTP caller is waiting on it.
     if embedding is None:
-        embedding = await provider.embed(request.content)
+        embedding = await call_embedding_gated(lambda: provider.embed(request.content), background=True)
 
     # Step 3 — persist. Raises on non-2xx → nacks → redelivers.
     # Per-tenant slot scoped to the PATCH roundtrip only, so a
     # tenant-A storm can't park every storage-writer connection here
-    # while tenant B's lone PATCH queues behind. Provider call above
-    # stays unguarded — that's the expensive step and it doesn't
-    # touch the storage-writer pool.
+    # while tenant B's lone PATCH queues behind. Distinct from the
+    # embedding gate above, which bounds the embedding backend rather than
+    # the storage-writer pool. Note this slot is per tenant and that gate
+    # is not, so one tenant's backfill flood can still hold the whole
+    # background budget — core-api wraps its embed in a per-tenant slot
+    # (``memory_service``) and core-worker has no equivalent yet.
     async with per_tenant_storage_slot(request.tenant_id):
         await update_memory_embedding(
             storage,

--- a/core-worker/src/core_worker/per_tenant_concurrency.py
+++ b/core-worker/src/core_worker/per_tenant_concurrency.py
@@ -1,10 +1,14 @@
 """Per-tenant in-flight cap on the worker's storage PATCH-back calls.
 
-The worker consumes ``embed-requested`` and ``enrich-requested`` events
-in batches sized by ``EVENT_BUS_PUBSUB_MAX_MESSAGES`` (default 25). With
-no per-tenant gate, a tenant-A storm fans out into 2 PATCHes per write
-(embed + enrich), all hammering the storage-writer pool while tenant B's
-single PATCH queues behind. That's the 12.7x ``noisy-neighbor-write``
+The worker consumes ``embed-requested`` and ``enrich-requested`` events.
+With no per-tenant gate, a tenant-A storm fans out into 2 PATCHes per
+write (embed + enrich), hammering the storage-writer pool while tenant
+B's single PATCH queues behind. Note the burst is sustained rather than
+wide: ``EVENT_BUS_PUBSUB_MAX_MESSAGES`` (default 25) sizes a PULL, not
+in-flight work — ``_pull_loop`` drains a batch one event at a time, so a
+single instance holds one event's PATCHes per subscription, not 25. An
+earlier version of this docstring read the batch size as the fan-out
+width; the per-tenant burst it describes is real either way. That's the 12.7x ``noisy-neighbor-write``
 regression CAURA-636 ran loadtest 1777538050 against — Option 2 (drop
 ``max_messages`` to 10) confirmed in 1777548665 that aggregate throttling
 is the wrong knob; the issue is per-tenant burst.

--- a/core-worker/tests/test_consumer.py
+++ b/core-worker/tests/test_consumer.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import httpx
 import pytest
 
+import common.embedding._service as embedding_service
 import core_worker.consumer as consumer
 from common.events.base import Event
 from core_worker.config import Settings
@@ -397,3 +399,59 @@ async def test_update_memory_embedding_omits_provenance_when_unknown():
     await update_memory_embedding(client, memory_id=uuid4(), tenant_id="tenant-A", embedding=[0.1] * 768)
 
     assert "embedded_content_hash" not in client.patch.await_args.kwargs["json"]
+
+
+@pytest.mark.asyncio
+async def test_embed_request_is_held_to_the_embedding_concurrency_gate(
+    monkeypatch, settings, mock_provider, mock_storage_client
+):
+    """8 concurrent embed-requests against a background cap of 2 never exceed 2.
+
+    Ungated — ``provider.embed`` called straight on the platform singleton —
+    peak in-flight equals the number of callers instead.
+    """
+    cap = 2
+    callers = 8
+
+    # Only the background cap: this path passes ``background=True``, so that
+    # is the binding one, and leaving the shared cap alone keeps
+    # ``EMBEDDING_INTERACTIVE_RESERVED_SLOTS`` non-zero the way it is in a
+    # real process. The per-loop gate cache rebinds on its own because
+    # pytest-asyncio gives each test a fresh event loop.
+    monkeypatch.setattr(embedding_service, "EMBEDDING_BACKGROUND_MAX_CONCURRENCY", cap)
+
+    in_flight = 0
+    peak = 0
+
+    async def _embed(_text: str) -> list[float]:
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0)  # yield so overlap is observable without wall-clock
+        in_flight -= 1
+        return [0.1] * 768
+
+    mock_provider.embed = AsyncMock(side_effect=_embed)
+
+    consumer.configure(mock_storage_client)
+    monkeypatch.setattr(consumer, "find_embedding_by_content_hash", AsyncMock(return_value=None))
+    monkeypatch.setattr(consumer, "update_memory_embedding", AsyncMock(return_value=None))
+
+    await asyncio.gather(
+        *(
+            consumer.handle_embed_request(
+                _make_event(
+                    {
+                        "memory_id": str(uuid4()),
+                        "tenant_id": "tenant-A",
+                        "content": f"content {i}",
+                    }
+                )
+            )
+            for i in range(callers)
+        )
+    )
+
+    # Every request still embedded — the gate serialises, it does not drop.
+    assert mock_provider.embed.await_count == callers
+    assert peak <= cap, f"peak in-flight {peak} exceeded the gate cap {cap}"

--- a/tests/test_embedding_calls_are_gated.py
+++ b/tests/test_embedding_calls_are_gated.py
@@ -1,0 +1,107 @@
+"""CI guard: no embed call outside ``common/embedding`` skips the gate.
+
+``EMBEDDING_MAX_CONCURRENCY`` only bounds the embedding backend if every
+caller actually passes through the semaphore in
+``common.embedding._service``. The service-level entrypoints
+(:func:`get_embedding`, :func:`get_embeddings_batch`,
+:func:`get_query_embedding`) do that for you. A caller that instead holds an
+``EmbeddingProvider`` — from ``get_platform_embedding()`` or
+``get_embedding_provider()`` — and calls ``.embed()`` on it reaches the
+backend having passed no cap at all, which is how core-worker's
+deferred-embed consumer went unbounded until caura#830's follow-up.
+
+This is a guard rather than a review note on purpose. The same class of
+defect took six review cycles on #830, five of them finding a *different*
+call site that had inherited the fault, and the lesson recorded there was to
+make the mistake structurally impossible instead of auditing for it. A
+reviewer cannot see that a new ``.embed()`` is ungated; this test can.
+
+To satisfy it, wrap the call:
+
+    embedding = await call_embedding_gated(
+        lambda: provider.embed(text), background=True
+    )
+
+Exemptions: ``common/embedding`` itself (it *is* the gate, and providers
+legitimately call their own ``embed`` internally — e.g. ``embed_query``
+delegating to ``embed``), tests, and benchmark/diagnostic scripts, which
+talk to an ``--embed-url`` directly by design and are not request-path code.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# Provider-protocol methods that reach the backend.
+_EMBED_METHODS = {"embed", "embed_batch", "embed_query"}
+# The wrapper that applies the gate; anything lexically inside one of its
+# calls is by definition gated.
+_GATE_FUNC = "call_embedding_gated"
+
+_EXEMPT_PARTS = {
+    ".venv",
+    "site-packages",
+    "node_modules",
+    "__pycache__",
+    "tests",
+    "test",
+    "e2e",
+    "scripts",
+    "migrations",
+    "clients",
+}
+
+
+def _iter_service_py():
+    for p in REPO_ROOT.rglob("*.py"):
+        rel = p.relative_to(REPO_ROOT)
+        if set(rel.parts) & _EXEMPT_PARTS:
+            continue
+        # common/embedding is the gate's own home.
+        if rel.parts[:2] == ("common", "embedding"):
+            continue
+        yield p
+
+
+def _violations(path: pathlib.Path) -> list[tuple[int, str]]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    # Every node lexically inside a call_embedding_gated(...) call is gated,
+    # which covers the ``lambda: provider.embed(text)`` form.
+    gated: set[int] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == _GATE_FUNC
+        ):
+            gated.update(id(n) for n in ast.walk(node))
+
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or id(node) in gated:
+            continue
+        f = node.func
+        if isinstance(f, ast.Attribute) and f.attr in _EMBED_METHODS:
+            hits.append((node.lineno, f".{f.attr}()"))
+    return hits
+
+
+def test_every_embed_call_outside_common_embedding_is_gated():
+    offenders: dict[str, list[tuple[int, str]]] = {}
+    for path in _iter_service_py():
+        v = _violations(path)
+        if v:
+            offenders[str(path.relative_to(REPO_ROOT))] = v
+    assert not offenders, (
+        "Ungated embed call found outside common/embedding. Route it through "
+        "get_embedding/get_embeddings_batch/get_query_embedding, or wrap it in "
+        "call_embedding_gated(lambda: ..., background=...). Offenders:\n"
+        + "\n".join(f"  {f}: {hits}" for f, hits in sorted(offenders.items()))
+    )

--- a/tests/test_embedding_concurrency_gate.py
+++ b/tests/test_embedding_concurrency_gate.py
@@ -81,7 +81,7 @@ class TestEmbeddingConcurrencyGate:
             in_flight -= 1
             return [0.1]
 
-        await asyncio.gather(*(svc._call_gated(fake_call, background=False) for _ in range(30)))
+        await asyncio.gather(*(svc.call_embedding_gated(fake_call, background=False) for _ in range(30)))
 
         assert peak <= 3, f"gate leaked: {peak} concurrent calls with cap 3"
         assert in_flight == 0, "slot not released"
@@ -96,13 +96,13 @@ class TestEmbeddingConcurrencyGate:
 
         for _ in range(3):
             with pytest.raises(RuntimeError):
-                await svc._call_gated(boom, background=False)
+                await svc.call_embedding_gated(boom, background=False)
 
         # If the slot leaked, this would block until the gate timeout.
         async def ok():
             return [0.2]
 
-        assert await svc._call_gated(ok, background=False) == [0.2]
+        assert await svc.call_embedding_gated(ok, background=False) == [0.2]
 
     @pytest.mark.asyncio
     async def test_blocked_waiter_degrades_instead_of_hanging(self, reset_gate):
@@ -124,7 +124,7 @@ class TestEmbeddingConcurrencyGate:
             return [0.3]
 
         with pytest.raises(TimeoutError):
-            await svc._call_gated(never_runs, background=False)
+            await svc.call_embedding_gated(never_runs, background=False)
 
     @pytest.mark.asyncio
     async def test_gate_rebinds_per_event_loop(self, reset_gate):
@@ -174,7 +174,7 @@ class TestQueryEmbeddingReservation:
         # ``total`` of them: enough to hold every shared slot if nothing
         # stopped background from doing so.
         bg_tasks = [
-            asyncio.create_task(svc._call_gated(background_call, background=True))
+            asyncio.create_task(svc.call_embedding_gated(background_call, background=True))
             for _ in range(total)
         ]
         # Wait until the background budget is genuinely occupied and parked.
@@ -186,7 +186,7 @@ class TestQueryEmbeddingReservation:
 
         # No timeout suppression: without the reservation this raises
         # TimeoutError and the test fails.
-        assert await svc._call_gated(query_call, background=False) == [0.2]
+        assert await svc.call_embedding_gated(query_call, background=False) == [0.2]
 
         parked.set()
         assert await asyncio.gather(*bg_tasks) == [[0.1]] * total
@@ -208,7 +208,7 @@ class TestQueryEmbeddingReservation:
             return [0.0]
 
         await asyncio.gather(
-            *(svc._call_gated(call, background=True) for _ in range(40))
+            *(svc.call_embedding_gated(call, background=True) for _ in range(40))
         )
         assert peak <= 3, f"background peaked at {peak}, budget is 3"
 
@@ -235,7 +235,7 @@ class TestQueryEmbeddingReservation:
 
         await asyncio.gather(
             *(
-                svc._call_gated(call, background=bool(i % 2))
+                svc.call_embedding_gated(call, background=bool(i % 2))
                 for i in range(60)
             )
         )
@@ -262,7 +262,7 @@ class TestQueryEmbeddingReservation:
             return [0.3]
 
         with pytest.raises(TimeoutError):
-            await svc._call_gated(never_runs, background=True)
+            await svc.call_embedding_gated(never_runs, background=True)
 
         # The abandoned attempt must have handed its background slot back.
         assert not svc._background_gate().locked(), "background slot leaked on timeout"
@@ -273,7 +273,7 @@ class TestQueryEmbeddingReservation:
         async def ok():
             return [0.4]
 
-        assert await svc._call_gated(ok, background=True) == [0.4]
+        assert await svc.call_embedding_gated(ok, background=True) == [0.4]
 
     @pytest.mark.asyncio
     async def test_get_embedding_honours_background_false(self, reset_gate):
@@ -299,7 +299,7 @@ class TestQueryEmbeddingReservation:
             return [0.1]
 
         bg_tasks = [
-            asyncio.create_task(svc._call_gated(background_call, background=True))
+            asyncio.create_task(svc.call_embedding_gated(background_call, background=True))
             for _ in range(total)
         ]
         for _ in range(total - reserved):
@@ -349,6 +349,6 @@ class TestQueryEmbeddingReservation:
             return [0.0]
 
         await asyncio.gather(
-            *(svc._call_gated(call, background=True) for _ in range(30))
+            *(svc.call_embedding_gated(call, background=True) for _ in range(30))
         )
         assert peak == 3, f"background should reach the full cap of 3, got {peak}"


### PR DESCRIPTION
`EMBEDDING_MAX_CONCURRENCY` only bounds the embedding backend if every caller passes through the semaphore. **One did not.**

core-worker's deferred-embed consumer resolves the platform singleton and calls `provider.embed` on it — a path that never traverses the gate `get_embedding` / `get_embeddings_batch` / `get_query_embedding` apply. A control experiment makes it unambiguous:

| | peak in-flight | gate entries |
|---|---|---|
| core-worker `provider.embed()` | **10** | **0** |
| core-api `get_embedding()` (control) | 2 | 10 |

*(cap forced to 2, 10 concurrent callers, identical stub on both arms)*

## Why it hasn't hurt yet — and why that's not reassuring

`PubSubEventBus._pull_loop` awaits `_dispatch_all` once per message inside a `for`, so a batch drains **sequentially** and one instance holds roughly one embed at a time. That is a property of the loop's shape, not a limit anyone chose. Parallelising it for drain throughput reads as a pure win while removing the only thing bounding this path.

**And the code claimed the bound was real.** `max_messages`' comment said it *"Caps `workers x max_messages` concurrent embed calls across the deployed pool"* — a cap that never existed, sitting on the exact knob someone optimising that loop would read first. `per_tenant_concurrency`'s docstring inherited the same batch-implies-fan-out premise. Both corrected here.

## What changed

- **`call_embedding_gated`** — the gate made public (was `_call_gated`), *renamed rather than aliased* so the module has one name for one behaviour and the never-nest warning lives on the function everything actually calls.
- **core-worker takes it**, `background=True`.
- **A gate timeout propagates and nacks** rather than acking a memory embedding-less. Saturation is transient, so Pub/Sub redelivery is the right backpressure for a queue consumer — unlike core-api, which degrades to `None` because an HTTP caller is waiting.

### Why the gate is at the call site, not inside the provider

Pushing it into the provider would close the hole for all callers without anyone remembering — but it deadlocks. With `EMBEDDING_PROVIDER=openai` and no per-tenant key, `_registry` hands back **the platform singleton itself**, so `get_embedding` → `call_embedding_gated` → `provider.embed` → gate #2. The outer hold occupies a shared slot while the inner acquire waits for one; once `EMBEDDING_MAX_CONCURRENCY` callers are inside, none proceed and each burns the full timeout. (`OpenAIEmbeddingProvider.embed_query` also calls `self.embed`, nesting again.) Documented on the function.

## Tests — both confirmed failing without the fix

1. **Unit** — 8 concurrent `handle_embed_request` against a background cap of 2 never exceed 2 in flight. Ungated it reports `peak in-flight 8 exceeded the gate cap 2`.
2. **AST guard** (`tests/test_embedding_calls_are_gated.py`) — fails on any ungated `.embed()` outside `common/embedding`, naming the offender (`consumer.py:188: .embed()`). A reviewer cannot see that a new `.embed()` is ungated; this can. #830 spent six review cycles, five finding a *different* inherited call site, learning to make this class of mistake structurally impossible rather than auditing for it. Mirrors the existing `test_no_direct_db_outside_storage.py`.

## Honest limits

- **`background=True` buys this process nothing.** The gate is per process and core-worker has no interactive embeds, so the reserved interactive slots are unusable there and the worker is capped at the background budget instead of the full one. It's still right for the resource that *is* shared — the backend pool core-api's search also hits. The comment says this outright rather than implying a local benefit.
- **The gate is not per tenant.** One tenant's backfill flood can hold the whole background budget. core-api wraps its embed in a per-tenant slot; core-worker has no equivalent. Out of scope, now stated in the code.
- **Currently inert in production.** Real per-instance embed concurrency is ~1, so this is preventive. The test manufactures concurrency the production path can't yet produce — don't read it as evidence the gate binds today.

## Verification

- `core-worker/tests/` **72 passed** (baseline on unmodified `main`: 71)
- `tests/test_embedding_concurrency_gate.py` **10 passed** after the 12-reference rename; new guard passes; `test_no_direct_db_outside_storage.py` unaffected
- `ruff check` clean on all 6 CI scopes; `ruff format --check` clean on all 5 plus the `--isolated` 88-col vendored gate
- Both new tests verified to **fail** with the fix reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)