### PR TITLE
fix(contradictions): a detection lock must not outlive the run it guards

### DIFF
--- a/core-api/src/core_api/cache.py
+++ b/core-api/src/core_api/cache.py
@@ -78,6 +78,42 @@ async def cache_delete(key: str) -> bool:
         return False
 
 
+# Release-if-owner. GET-then-DEL from the client would be two round trips with a
+# window in between, which is the whole bug this guards against; the compare and
+# the delete have to be one atomic step, so they run server-side.
+_DELETE_IF_SCRIPT = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+end
+return 0
+"""
+
+
+async def cache_delete_if(key: str, expected: str) -> bool:
+    """Delete ``key`` only while it still holds ``expected``. Returns True iff
+    this call deleted it.
+
+    For releasing a ``cache_set_nx`` lock. An unconditional ``DEL`` is the
+    classic distributed-lock footgun: a holder whose work outruns the lock's
+    TTL no longer owns the key, and deleting it then destroys a SUCCESSOR's
+    lock rather than its own. Pairing SET NX with a per-acquisition token and
+    releasing through this compare-and-delete makes a release a no-op once the
+    lock has moved on.
+
+    Same fail-quiet contract as its neighbours: no Redis, or a failed EVAL,
+    returns False rather than raising. Callers release inside ``finally``
+    blocks on paths whose never-raises property is load-bearing.
+    """
+    r = await _get_redis()
+    if r is None:
+        return False
+    try:
+        return bool(await r.eval(_DELETE_IF_SCRIPT, 1, key, expected))
+    except Exception:
+        logger.debug("cache_delete_if failed for key=%s", key, exc_info=True)
+        return False
+
+
 async def cache_set_nx(key: str, value: str, ttl: int) -> bool:
     """Atomic SET-if-not-exists with TTL. Returns True iff we newly set
     the key (i.e. the caller "owns" the lock); False if the key already

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -13,13 +13,14 @@ Multi-provider support:
 """
 
 import asyncio
+import hashlib
 import logging
 import time
 import uuid as _uuid
 from datetime import datetime
 from uuid import UUID
 
-from core_api.cache import cache_set_nx
+from core_api.cache import cache_delete_if, cache_set_nx
 from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
 from core_api.constants import SINGLE_VALUE_PREDICATES
@@ -41,22 +42,82 @@ logger = logging.getLogger(__name__)
 _DETECTION_LOCK_TTL_SECONDS = 3600
 
 
-async def _acquire_path_a_lock(memory_id) -> bool:
+def _content_fingerprint(content: str) -> str:
+    """Short stable digest of the text a detection run examined.
+
+    Part of the lock key (H-06). Keyed on ``memory_id`` alone, the lock also
+    deduped runs that were checking DIFFERENT text: ``update_memory`` clears
+    supersession state and re-fires detection on a content edit, but a memory
+    corrected within the TTL — the normal case for a quick fix — still held the
+    write-time lock, so the edited content was never checked and no later
+    trigger re-fired. Including the content makes an edit a different lock.
+
+    Hashed rather than embedded: memory content is unbounded and Redis keys are
+    values. Truncated because this only has to separate versions of ONE
+    memory's text, not resist collision across a corpus.
+    """
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:32]
+
+
+def _path_a_lock_key(memory_id, content: str) -> str:
+    return f"contradiction:path_a:{memory_id}:{_content_fingerprint(content)}"
+
+
+def _path_c_lock_key(memory_id, content: str) -> str:
+    return f"contradiction:path_c:{memory_id}:{_content_fingerprint(content)}"
+
+
+def _lock_token() -> str:
+    """A fresh per-acquisition owner token — see ``_release_lock``."""
+    return _uuid.uuid4().hex
+
+
+async def _acquire_path_a_lock(memory_id, content: str, token: str) -> bool:
     """Try to acquire the Path A (semantic + RDF) idempotency lock for
-    ``memory_id``. Returns True iff this caller owns the lock and should
-    proceed; False if another caller already holds it and we should skip.
+    ``memory_id`` at this ``content``. Returns True iff this caller owns the
+    lock and should proceed; False if another caller already holds it and we
+    should skip.
 
     Lock is keyed per-path so Path A and Path C run independently for
-    the same memory.
+    the same memory, and per-content so an edit is not deduped against the
+    run that checked the previous text. ``token`` identifies THIS acquisition
+    so the release can tell its own lock from a successor's.
     """
-    return await cache_set_nx(f"contradiction:path_a:{memory_id}", "1", _DETECTION_LOCK_TTL_SECONDS)
+    return await cache_set_nx(_path_a_lock_key(memory_id, content), token, _DETECTION_LOCK_TTL_SECONDS)
 
 
-async def _acquire_path_c_lock(memory_id) -> bool:
+async def _acquire_path_c_lock(memory_id, content: str, token: str) -> bool:
     """Try to acquire the Path C (entity-overlap) idempotency lock for
-    ``memory_id``. Returns True iff this caller owns the lock; False
-    means another caller already ran detection for this memory."""
-    return await cache_set_nx(f"contradiction:path_c:{memory_id}", "1", _DETECTION_LOCK_TTL_SECONDS)
+    ``memory_id`` at this ``content``. Returns True iff this caller owns the
+    lock; False means another caller already ran detection for this memory at
+    this content."""
+    return await cache_set_nx(_path_c_lock_key(memory_id, content), token, _DETECTION_LOCK_TTL_SECONDS)
+
+
+async def _release_lock(key: str, token: str) -> None:
+    """Drop a detection lock so the next trigger can retry.
+
+    Released ONLY when a run did not reach a verdict — it threw, or it exited
+    before examining anything (a missing / soft-deleted row). A run that
+    concluded keeps its lock for the full TTL, INCLUDING the "no candidates"
+    and "preflight dropped them all" outcomes, which are results rather than
+    failures. Collapsing the back-to-back ENRICHED and EMBEDDED deliveries is
+    the entire point of the lock: releasing on success would let the second
+    delivery re-run every LLM judgement whenever it landed more than one
+    detection apart from the first.
+
+    Compare-and-delete on ``token``, never a bare DEL. A run whose work outran
+    the 3600s TTL no longer owns the key: by then the lock may have expired and
+    been re-taken by a NEW run, and an unconditional delete would take that
+    successor's lock away and hand it a duplicate detection — the exact
+    guarantee this lock exists to provide. Releasing by token makes a late
+    release a no-op instead.
+
+    ``cache_delete_if`` is total — it swallows both a missing Redis and a
+    failed EVAL — so this cannot break the never-raises contract that lets the
+    Pub/Sub consumers ack unconditionally.
+    """
+    await cache_delete_if(key, token)
 
 
 def _parse_dt(value) -> datetime | None:
@@ -183,7 +244,18 @@ async def detect_contradictions_async(
     t_start = time.monotonic()
     n_conflicts = 0
     skipped = False
+    lock_held = False
+    concluded = False
+    lock_key = None
+    lock_token = ""
     try:
+        if new_memory is None:
+            sc = get_storage_client()
+            new_memory = await sc.get_memory(str(memory_id))
+        if not new_memory or new_memory.get("deleted_at") is not None:
+            # Resolved before the lock is taken, so a gone row never holds one.
+            return
+
         # A4 #14 — back-channel idempotency. Both the ENRICHED and
         # EMBEDDED handlers fire ``detect_contradictions_async`` for
         # the same memory; whichever arrives first owns the lock and
@@ -191,18 +263,37 @@ async def detect_contradictions_async(
         # unavailable, ``_acquire_path_a_lock`` returns True and we
         # fall back to the prior double-detection behaviour (storage
         # CAS still keeps writes idempotent).
-        if not await _acquire_path_a_lock(memory_id):
+        # H-06: keyed on the CONTENT as well as the memory, so an edit
+        # re-fired by ``update_memory`` is not deduped against the run that
+        # checked the previous text.
+        #
+        # Fingerprint the text detection will ACTUALLY examine — ``_detect``
+        # reads ``new_memory``, not the ``content`` parameter. The parameter is
+        # the caller's copy: the back-channel consumers pass the write-time
+        # payload, which a mid-flight update leaves stale. Keying on it would
+        # put a lock on text nobody looked at, and would make the fix depend on
+        # every future caller keeping the two in step. ``content`` remains the
+        # fallback for a row with no content at all.
+        # ``is None``, not ``or``: an EMPTY row content is a real value, and
+        # ``_detect`` reads it as one (``new_memory.get("content", "")``).
+        # Falling back to the caller's copy for it would key the lock on text
+        # detection never looks at — the very divergence this line exists to
+        # close. The caller's ``content`` is only a stand-in for a row that has
+        # no content field at all, and the final ``or ""`` keeps a str reaching
+        # the fingerprint: an AttributeError there lands in the outer handler
+        # and silently costs that memory its detection.
+        raw_content = new_memory.get("content")
+        examined = raw_content if raw_content is not None else (content or "")
+        lock_key = _path_a_lock_key(memory_id, examined)
+        lock_token = _lock_token()
+        if not await _acquire_path_a_lock(memory_id, examined, lock_token):
             skipped = True
             return
-
-        if new_memory is None:
-            sc = get_storage_client()
-            new_memory = await sc.get_memory(str(memory_id))
-        if not new_memory or new_memory.get("deleted_at") is not None:
-            return
+        lock_held = True
 
         tenant_config = await resolve_config(tenant_id)
         contradictions = await _detect(new_memory, embedding, tenant_config)
+        concluded = True
         n_conflicts = len(contradictions) if contradictions else 0
 
         if contradictions:
@@ -214,6 +305,14 @@ async def detect_contradictions_async(
     except Exception:
         logger.exception("Async contradiction detection failed for memory %s", memory_id)
     finally:
+        # H-06: keep the lock only for a run that reached a verdict. The lock
+        # is taken BEFORE detection, so without this one transient LLM or
+        # storage failure suppressed every later trigger for this memory for a
+        # full hour, with nothing scheduled to retry. A run that concluded
+        # keeps its lock — that is the duplicate-delivery collapse the lock
+        # exists for. Mirrors the Path C block below.
+        if lock_held and not concluded and lock_key is not None:
+            await _release_lock(lock_key, lock_token)
         elapsed_ms = round((time.monotonic() - t_start) * 1000)
         logger.info(
             "path_a_completed for memory %s n_conflicts=%d skipped=%s elapsed_ms=%d tenant_id=%s",
@@ -1951,19 +2050,35 @@ async def detect_contradictions_by_entities_async(
     n_conflicts = 0
     n_retractions = 0
     skipped = False
+    lock_held = False
+    concluded = False
+    lock_key = None
+    lock_token = ""
     try:
-        # A4 #14 — back-channel idempotency. Entity extraction can
-        # complete more than once per memory (delta re-extraction,
-        # partial retry), each completion firing Path C. First caller
-        # wins the lock; the rest skip. Fail-open on Redis outage.
-        if not await _acquire_path_c_lock(memory_id):
-            skipped = True
-            return
-
+        # The row is fetched BEFORE the lock is taken, unlike Path A. The lock
+        # key carries a fingerprint of the content this run will examine (H-06)
+        # and Path C — unlike Path A — is not handed that content by its
+        # caller. The extra GET on a duplicate delivery is cheap beside the LLM
+        # work the lock protects, and fetching first also means a soft-deleted
+        # row no longer burns a lock for the rest of the TTL.
         sc = get_storage_client()
         new_memory = await sc.get_memory(str(memory_id))
         if not new_memory or new_memory.get("deleted_at") is not None:
             return
+
+        # A4 #14 — back-channel idempotency. Entity extraction can
+        # complete more than once per memory (delta re-extraction,
+        # partial retry), each completion firing Path C. First caller
+        # wins the lock; the rest skip. Fail-open on Redis outage.
+        # H-06: per-content, so entity re-extraction after a content edit is
+        # not deduped against the run that examined the previous text.
+        content = new_memory.get("content") or ""
+        lock_key = _path_c_lock_key(memory_id, content)
+        lock_token = _lock_token()
+        if not await _acquire_path_c_lock(memory_id, content, lock_token):
+            skipped = True
+            return
+        lock_held = True
 
         tenant_config = await resolve_config(tenant_id)
 
@@ -2005,6 +2120,7 @@ async def detect_contradictions_by_entities_async(
             n_candidates,
         )
         if not candidates:
+            concluded = True
             return
 
         # A1 #17 — subject preflight. Drop candidates whose
@@ -2038,6 +2154,7 @@ async def detect_contradictions_by_entities_async(
                 n_preflight_skipped,
                 memory_id,
             )
+            concluded = True
             return
 
         # CAURA-130 (L3.4) — entity-links subject preflight. The A1 #17
@@ -2211,6 +2328,7 @@ async def detect_contradictions_by_entities_async(
                 n_entity_links_skipped,
                 memory_id,
             )
+            concluded = True
             return
 
         # CAURA-131 — entity-aware judge for each surviving candidate
@@ -2403,9 +2521,17 @@ async def detect_contradictions_by_entities_async(
                     memory_id,
                     path_c_result["skipped"],
                 )
+        concluded = True
     except Exception:
         logger.exception("Entity-based contradiction detection failed for %s", memory_id)
     finally:
+        # H-06 — see the matching block in ``detect_contradictions_async``.
+        # ``concluded`` is set at each legitimate exit rather than once early,
+        # so a throw ANYWHERE in the judging loop still releases: a failure
+        # half way through must not block the retry for the rest of the TTL.
+        # The storage writes are CAS-guarded, so re-running is safe.
+        if lock_held and not concluded and lock_key is not None:
+            await _release_lock(lock_key, lock_token)
         elapsed_ms = round((time.monotonic() - t_start) * 1000)
         logger.info(
             "path_c_completed for memory %s n_candidates=%d n_conflicts=%d "

--- a/tests/test_a4_14_back_channel_idempotency.py
+++ b/tests/test_a4_14_back_channel_idempotency.py
@@ -25,9 +25,11 @@ line. Falls back gracefully (allow detection) when Redis is
 unavailable, preserving current behaviour rather than silently
 blocking detection.
 
-Lock keys (separate per path so Path A and Path C don't block each other):
-  ``contradiction:path_a:<memory_id>``
-  ``contradiction:path_c:<memory_id>``
+Lock keys (separate per path so Path A and Path C don't block each other,
+and per content so an EDIT is not deduped against the run that checked the
+previous text — H-06, see ``test_h06_contradiction_lock.py``):
+  ``contradiction:path_a:<memory_id>:<content fingerprint>``
+  ``contradiction:path_c:<memory_id>:<content fingerprint>``
 
 TTL: 3600s (1h). Long enough for any detection to complete (worst
 case ~10s × N candidates); short enough that a process crash holding
@@ -140,8 +142,13 @@ async def test_path_a_first_call_runs_when_lock_acquired():
 
 @pytest.mark.asyncio
 async def test_path_c_second_call_skips_when_lock_already_held():
-    """When the first Path C call has the lock, the second skips
-    without fetching the new memory or running detection."""
+    """When the first Path C call has the lock, the second skips detection.
+
+    It DOES still fetch the row: since H-06 the lock key carries a fingerprint
+    of the content to be examined, and Path C is not handed that content by its
+    caller, so the fetch necessarily precedes the lock. The expensive work —
+    candidate search and the LLM judgements — is what the skip must avoid.
+    """
     from core_api.services.contradiction_detector import (
         detect_contradictions_by_entities_async,
     )
@@ -242,8 +249,8 @@ async def test_path_a_and_path_c_use_independent_locks():
         new=fake_set_nx,
         create=True,
     ):
-        await _acquire_path_a_lock(mid)
-        await _acquire_path_c_lock(mid)
+        await _acquire_path_a_lock(mid, "memory content", "tok")
+        await _acquire_path_c_lock(mid, "memory content", "tok")
 
     assert len(captured) == 2
     assert captured[0] != captured[1], (
@@ -276,7 +283,7 @@ async def test_path_a_runs_when_redis_unavailable():
         new=redis_down,
         create=True,
     ):
-        assert await _acquire_path_a_lock(uuid4()) is True
+        assert await _acquire_path_a_lock(uuid4(), "memory content", "tok") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_h06_contradiction_lock.py
+++ b/tests/test_h06_contradiction_lock.py
@@ -1,0 +1,558 @@
+"""H-06 (#816) — the detection idempotency lock must not outlive its purpose.
+
+The A4 #14 lock exists to collapse the two back-channel deliveries (ENRICHED
+and EMBEDDED) that both fire Path A for one memory. It was keyed on
+``memory_id`` alone, taken before detection, and never released, with a 1h TTL.
+Two consequences, both fixed here:
+
+1. **An edit within the hour was never checked.** ``update_memory`` clears
+   supersession state and re-fires detection on a content change — the
+   documented "P1-2: Re-check contradictions after content update" — but the
+   write-time lock was still held, so the UPDATE run exited at the lock and the
+   edited text was never examined. Since the update also resets ``status`` to
+   ``active`` and ``supersedes_id`` to ``None``, a memory edited into direct
+   contradiction with another active memory stayed unflagged, and nothing
+   re-fired later. Same on Path C via entity re-extraction.
+
+2. **One transient failure blocked re-detection for an hour.** The lock is
+   taken before detection and was kept even when detection threw, with no
+   retry scheduled.
+
+The fix keys the lock on ``(memory_id, content fingerprint)`` and releases it
+on any exit that is not a completed run. What must NOT change is the dedup
+itself: a COMPLETED run keeps its lock, so the second delivery still skips.
+Several tests below exist to pin exactly that.
+
+Locks are modelled with a real in-memory SETNX/DEL store rather than by
+patching the ``_acquire_*`` helpers, so the assertions run against the actual
+key derivation — which is the thing that changed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from tests._contradiction_batch_compat import install_batch_status_replay_shim
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeLocks:
+    """Faithful model of Redis ``SET NX`` plus the compare-and-delete release.
+
+    Values are modelled, not just key presence, because the release is
+    ownership-checked: a run may only drop the lock it took itself.
+    """
+
+    def __init__(self) -> None:
+        self.keys: dict[str, str] = {}
+        self.acquired: list[str] = []
+        self.released: list[str] = []
+
+    async def set_nx(self, key: str, value: str, ttl: int) -> bool:  # noqa: ARG002
+        if key in self.keys:
+            return False
+        self.keys[key] = value
+        self.acquired.append(key)
+        return True
+
+    async def delete_if(self, key: str, expected: str) -> bool:
+        if self.keys.get(key) != expected:
+            return False
+        del self.keys[key]
+        self.released.append(key)
+        return True
+
+    def expire(self, key: str) -> None:
+        """Model the TTL lapsing while a run is still in flight."""
+        self.keys.pop(key, None)
+
+
+def _locks(fake: _FakeLocks):
+    """Patch both cache primitives the detector uses onto ``fake``."""
+    return (
+        patch("core_api.services.contradiction_detector.cache_set_nx", new=fake.set_nx),
+        patch("core_api.services.contradiction_detector.cache_delete_if", new=fake.delete_if),
+    )
+
+
+def _memory(mid, *, content: str, deleted: bool = False) -> dict:
+    return {
+        "id": str(mid),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "agent_id": "a1",
+        "content": content,
+        "status": "active",
+        "visibility": "scope_team",
+        "supersedes_id": None,
+        "deleted_at": "2026-08-21T00:00:00+00:00" if deleted else None,
+        "created_at": "2026-08-21T10:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Consequence 1 — an edit is a different lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_path_a_edit_within_the_ttl_is_still_checked():
+    """The whole point. Two deliveries of the SAME text collapse to one run;
+    the EDIT that follows must still be examined.
+
+    Pre-fix the third call skipped: same ``memory_id``, lock still held from
+    the write-time run, edited content never checked.
+    """
+    from core_api.services.contradiction_detector import detect_contradictions_async
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    original, edited = "the sky is blue", "the sky is green"
+
+    a, d = _locks(fake)
+    with (
+        a,
+        d,
+        patch(
+            "core_api.services.contradiction_detector._detect",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as detect_mock,
+    ):
+        # ENRICHED then EMBEDDED — same content, must collapse to one run.
+        await detect_contradictions_async(
+            mid, "t1", "f1", original, [0.1] * 10, new_memory=_memory(mid, content=original)
+        )
+        await detect_contradictions_async(
+            mid, "t1", "f1", original, [0.1] * 10, new_memory=_memory(mid, content=original)
+        )
+        assert detect_mock.call_count == 1, "duplicate delivery must still be deduped"
+
+        # The user corrects the memory; update_memory re-fires with new content.
+        await detect_contradictions_async(
+            mid, "t1", "f1", edited, [0.2] * 10, new_memory=_memory(mid, content=edited)
+        )
+
+    assert detect_mock.call_count == 2, "the edited content must be checked"
+
+
+@pytest.mark.asyncio
+async def test_path_c_edit_within_the_ttl_is_still_checked():
+    """Path C has the identical defect, reached via entity re-extraction after
+    an edit. Its content comes from the row it fetches, not from its caller."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    sc = AsyncMock()
+    sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
+    sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
+
+    sc.get_memory = AsyncMock(return_value=_memory(mid, content="the sky is blue"))
+
+    a, d = _locks(fake)
+    with a, d, patch("core_api.services.contradiction_detector.get_storage_client", return_value=sc):
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+        assert sc.find_entity_overlap_candidates.call_count == 1, "re-extraction must dedupe"
+
+        # Content edited; entity extraction re-runs and fires Path C again.
+        sc.get_memory = AsyncMock(return_value=_memory(mid, content="the sky is green"))
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+
+    assert sc.find_entity_overlap_candidates.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Consequence 2 — a failed run must not hold the lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_path_a_releases_the_lock_when_detection_raises():
+    """One transient LLM/storage failure must not suppress every later trigger
+    for the rest of the hour. Pre-fix the retry skipped at the lock."""
+    from core_api.services.contradiction_detector import detect_contradictions_async
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    content = "the sky is blue"
+    mem = _memory(mid, content=content)
+
+    a, d = _locks(fake)
+    with (
+        a,
+        d,
+        patch(
+            "core_api.services.contradiction_detector._detect",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("provider timeout"),
+        ) as detect_mock,
+    ):
+        # The detector swallows the failure — the consumers rely on that to ack.
+        await detect_contradictions_async(mid, "t1", "f1", content, [0.1] * 10, new_memory=mem)
+        assert detect_mock.call_count == 1
+        assert fake.released, "a failed run must drop its lock"
+
+        # A later trigger for the same memory and the same content can retry.
+        detect_mock.side_effect = None
+        detect_mock.return_value = []
+        await detect_contradictions_async(mid, "t1", "f1", content, [0.1] * 10, new_memory=mem)
+
+    assert detect_mock.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_path_c_releases_the_lock_when_detection_raises():
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    sc = AsyncMock()
+    sc.get_memory = AsyncMock(return_value=_memory(mid, content="the sky is blue"))
+    sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
+    sc.find_entity_overlap_candidates = AsyncMock(side_effect=RuntimeError("storage down"))
+
+    a, d = _locks(fake)
+    with a, d, patch("core_api.services.contradiction_detector.get_storage_client", return_value=sc):
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+        assert fake.released, "a failed Path C run must drop its lock"
+
+        sc.find_entity_overlap_candidates = AsyncMock(return_value=[])
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+
+    assert sc.find_entity_overlap_candidates.call_count == 1, "the retry must reach detection"
+
+
+@pytest.mark.asyncio
+async def test_path_c_releases_the_lock_when_it_throws_mid_detection():
+    """A failure AFTER the candidate search must release too.
+
+    The obvious shortcut is one "we got past the candidate search" marker set
+    early — but then a throw in the judging loop or the status write keeps the
+    lock, which is the very half of Consequence 2 the issue describes. The
+    conclusion markers therefore sit at each legitimate exit instead.
+    """
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    sc = AsyncMock()
+    sc.get_memory = AsyncMock(return_value=_memory(mid, content="the sky is blue"))
+    sc.update_memory_status = AsyncMock()
+    install_batch_status_replay_shim(sc)
+    # Candidates come back fine; the failure lands downstream of them, in the
+    # subject preflight — which runs for every candidate immediately after the
+    # search and before any of the "concluded" exits.
+    sc.find_entity_overlap_candidates = AsyncMock(
+        return_value=[_memory(uuid4(), content="the sky is red")]
+    )
+
+    a, d = _locks(fake)
+    with (
+        a,
+        d,
+        patch("core_api.services.contradiction_detector.get_storage_client", return_value=sc),
+        patch(
+            "core_api.services.contradiction_detector._subjects_differ_with_certainty",
+            side_effect=RuntimeError("preflight exploded"),
+        ) as preflight,
+    ):
+        await detect_contradictions_by_entities_async(mid, "t1", "f1")
+
+    assert preflight.called, "the failure must land AFTER the candidate search"
+    assert fake.released, "a throw after the lock must drop it wherever it happens"
+
+
+@pytest.mark.asyncio
+async def test_a_gone_row_never_takes_a_lock_at_all():
+    """A soft-deleted row is resolved before the lock, so there is nothing to
+    hold and nothing to release — and a later trigger (an undelete inside the
+    window) still gets a real run rather than an hour of silence."""
+    from core_api.services.contradiction_detector import detect_contradictions_async
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    content = "the sky is blue"
+
+    a, d = _locks(fake)
+    with (
+        a,
+        d,
+        patch(
+            "core_api.services.contradiction_detector._detect",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as detect_mock,
+    ):
+        await detect_contradictions_async(
+            mid, "t1", "f1", content, [0.1] * 10, new_memory=_memory(mid, content=content, deleted=True)
+        )
+        detect_mock.assert_not_called()
+        assert fake.acquired == [], "a gone row must not consume a lock"
+
+        await detect_contradictions_async(
+            mid, "t1", "f1", content, [0.1] * 10, new_memory=_memory(mid, content=content)
+        )
+
+    detect_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_path_a_keys_on_the_row_that_will_be_examined_not_the_caller_copy():
+    """``_detect`` reads ``new_memory``; the ``content`` parameter is only the
+    caller's copy of it, and the back-channel consumers pass the write-time
+    payload — which a mid-flight update leaves stale. The lock must describe
+    the text that was actually looked at, so the fix cannot be undone by a
+    caller that lets the two drift apart.
+    """
+    from core_api.services.contradiction_detector import (
+        _path_a_lock_key,
+        detect_contradictions_async,
+    )
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    stale, current = "the sky is blue", "the sky is green"
+
+    a, d = _locks(fake)
+    with (
+        a,
+        d,
+        patch(
+            "core_api.services.contradiction_detector._detect",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        await detect_contradictions_async(
+            mid, "t1", "f1", stale, [0.1] * 10, new_memory=_memory(mid, content=current)
+        )
+
+    assert fake.acquired == [_path_a_lock_key(mid, current)]
+
+
+# ---------------------------------------------------------------------------
+# What must NOT change — these pass before the fix too, by design
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_completed_run_keeps_its_lock():
+    """Guard, not a bug demonstration.
+
+    Releasing on success would have been the obvious reading of the issue's
+    "release the lock in a finally block", and it would have silently destroyed
+    the dedup the lock exists for: the two back-channel deliveries are often
+    further apart than one detection takes, so the second would re-run every
+    LLM judgement. Pinned so that reading cannot be reintroduced.
+
+    It does not discriminate against pre-fix ``main`` — the module had no
+    ``cache_delete`` to patch there, so it errors rather than failing on
+    behaviour. The five tests above are the ones that demonstrate the bug.
+    """
+    from core_api.services.contradiction_detector import detect_contradictions_async
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    content = "the sky is blue"
+    mem = _memory(mid, content=content)
+
+    a, d = _locks(fake)
+    with (
+        a,
+        d,
+        patch(
+            "core_api.services.contradiction_detector._detect",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as detect_mock,
+    ):
+        await detect_contradictions_async(mid, "t1", "f1", content, [0.1] * 10, new_memory=mem)
+        assert fake.released == [], "a completed run must NOT release its lock"
+        await detect_contradictions_async(mid, "t1", "f1", content, [0.1] * 10, new_memory=mem)
+
+    assert detect_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_late_release_cannot_take_a_successor_s_lock():
+    """The release is ownership-checked, not a bare DEL.
+
+    Introducing a release introduced this risk with it: a run whose work
+    outlives the 3600s TTL no longer owns the key, and by then a NEW run may
+    hold it. An unconditional delete would hand that successor a duplicate
+    detection — destroying the guarantee the lock exists for, which is worse
+    than the bug being fixed.
+
+    Modelled here by expiring the key mid-run and letting a second run take it
+    before the first one's ``finally`` fires.
+    """
+    from core_api.services.contradiction_detector import (
+        _path_a_lock_key,
+        detect_contradictions_async,
+    )
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    content = "the sky is blue"
+    mem = _memory(mid, content=content)
+    key = _path_a_lock_key(mid, content)
+
+    async def _detect_then_lose_the_lock(*_a, **_kw):
+        # The TTL lapses while this run is still working, and a fresh run
+        # acquires the same key before we reach the finally block.
+        fake.expire(key)
+        await fake.set_nx(key, "successor-token", 3600)
+        raise RuntimeError("slow provider finally gave up")
+
+    a, d = _locks(fake)
+    with (
+        a,
+        d,
+        patch(
+            "core_api.services.contradiction_detector._detect",
+            new=_detect_then_lose_the_lock,
+        ),
+    ):
+        await detect_contradictions_async(mid, "t1", "f1", content, [0.1] * 10, new_memory=mem)
+
+    assert fake.keys.get(key) == "successor-token", (
+        "the late release must not delete the lock a successor now holds"
+    )
+    assert fake.released == [], "nothing was owned by the time release ran"
+
+
+@pytest.mark.asyncio
+async def test_a_row_with_no_content_still_gets_a_usable_key():
+    """``_content_fingerprint`` hashes a str. A row with empty content and a
+    ``None`` from the caller must still produce a key rather than an
+    AttributeError — which the outer handler would swallow, silently costing
+    that memory its detection on this trigger."""
+    from core_api.services.contradiction_detector import detect_contradictions_async
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    mem = _memory(mid, content="")
+    mem["content"] = None
+
+    a, d = _locks(fake)
+    with (
+        a,
+        d,
+        patch(
+            "core_api.services.contradiction_detector._detect",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as detect_mock,
+    ):
+        await detect_contradictions_async(mid, "t1", "f1", None, [0.1] * 10, new_memory=mem)
+
+    detect_mock.assert_called_once()
+    assert len(fake.acquired) == 1
+
+
+@pytest.mark.asyncio
+async def test_an_empty_row_content_is_a_real_value_not_a_missing_one():
+    """``""`` on the row is content, and ``_detect`` reads it as content
+    (``new_memory.get("content", "")``). Falling back to the caller's copy for
+    it — which an ``or`` chain does — would key the lock on text detection
+    never looks at, undoing the guarantee two tests above.
+    """
+    from core_api.services.contradiction_detector import (
+        _path_a_lock_key,
+        detect_contradictions_async,
+    )
+
+    mid = uuid4()
+    fake = _FakeLocks()
+    mem = _memory(mid, content="")
+
+    a, d = _locks(fake)
+    with (
+        a,
+        d,
+        patch(
+            "core_api.services.contradiction_detector._detect",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        await detect_contradictions_async(
+            mid, "t1", "f1", "a stale caller copy", [0.1] * 10, new_memory=mem
+        )
+
+    assert fake.acquired == [_path_a_lock_key(mid, "")]
+
+
+@pytest.mark.asyncio
+async def test_paths_keep_independent_locks_per_content():
+    """Path A and Path C must still not block each other, now per content."""
+    from core_api.services.contradiction_detector import (
+        _path_a_lock_key,
+        _path_c_lock_key,
+    )
+
+    mid = uuid4()
+    assert _path_a_lock_key(mid, "x") != _path_c_lock_key(mid, "x")
+    assert _path_a_lock_key(mid, "x") != _path_a_lock_key(mid, "y")
+    # Same inputs must be stable across calls, or the dedup never fires at all.
+    assert _path_a_lock_key(mid, "x") == _path_a_lock_key(mid, "x")
+    assert str(mid) in _path_a_lock_key(mid, "x")
+
+
+@pytest.mark.asyncio
+async def test_cache_delete_if_is_total():
+    """The release runs in a ``finally`` on a code path whose never-raises
+    contract is what lets the Pub/Sub consumers ack unconditionally. That rests
+    on ``cache_delete_if`` swallowing a failing Redis rather than propagating."""
+    from core_api.cache import cache_delete_if
+
+    class _Boom:
+        async def eval(self, *a, **kw):
+            raise RuntimeError("connection reset")
+
+    with patch("core_api.cache._get_redis", new_callable=AsyncMock, return_value=_Boom()):
+        assert await cache_delete_if("k", "tok") is False
+
+    with patch("core_api.cache._get_redis", new_callable=AsyncMock, return_value=None):
+        assert await cache_delete_if("k", "tok") is False
+
+
+@pytest.mark.asyncio
+async def test_cache_delete_if_only_deletes_a_matching_value():
+    """The compare and the delete must be one server-side step, and must not
+    fire when the value has moved on."""
+    from core_api.cache import cache_delete_if
+
+    class _Redis:
+        def __init__(self):
+            self.store = {"k": "mine"}
+            self.evals = 0
+
+        async def eval(self, script, numkeys, key, arg):  # noqa: ARG002
+            self.evals += 1
+            if self.store.get(key) == arg:
+                del self.store[key]
+                return 1
+            return 0
+
+    r = _Redis()
+    with patch("core_api.cache._get_redis", new_callable=AsyncMock, return_value=r):
+        assert await cache_delete_if("k", "someone-else") is False
+        assert r.store == {"k": "mine"}, "a non-matching release must not delete"
+        assert await cache_delete_if("k", "mine") is True
+        assert r.store == {}
+    assert r.evals == 2, "compare+delete must be a single round trip each time"


### PR DESCRIPTION
Fixes #816.

## The bug

The A4 #14 idempotency lock exists for one job: the ENRICHED and
EMBEDDED back-channels both fire Path A for the same memory, and
whichever loses the race should skip. It was keyed on `memory_id`
alone, taken *before* detection, never released, with a 1h TTL. Two
consequences follow, and they are independent.

**An edit inside the hour was never checked.** `update_memory` clears
supersession state and re-fires detection on a content change — the
documented "P1-2: Re-check contradictions after content update". But a
memory corrected shortly after it was written, which is the normal
shape of a quick correction, still held the write-time lock, so the
UPDATE run exited at the lock and the edited text was never examined.
The same update resets `status` to `active` and `supersedes_id` to
`None`, so a memory edited into direct contradiction with another
active memory stays unflagged — and nothing re-fires later, because an
update publishes no EMBEDDED/ENRICHED event and schedules no re-embed
when the inline embed succeeds. Path C has it too, via the entity
re-extraction an update triggers.

**One transient failure blocked re-detection for an hour.** The lock is
taken before detection and was kept when detection threw. A single LLM
or storage blip suppressed every later trigger for that memory, with
nothing scheduled to retry.

## The fix, and the part that is easy to get wrong

Both locks are now keyed on `(memory_id, content fingerprint)`, so an
edit is simply a different lock, and released whenever a run did not
reach a verdict.

**Releasing in a `finally` — the issue's first suggestion, read
literally — would have destroyed the deduplication the lock exists
for.** The two back-channel deliveries are frequently further apart
than one detection takes, so releasing on success just lets the second
delivery re-run every LLM judgement. A run that concluded therefore
KEEPS its lock for the full TTL; only the content key lets a genuine
edit through. `test_a_completed_run_keeps_its_lock` pins that so the
literal reading cannot be reintroduced.

Content is a safe key here because enrichment does not write it — the
routing table covers metadata only (`summary`, `tags`,
`retrieval_hint`, `contains_pii`), so both back-channels publish the
same string for a given version and still collapse to one run.

**"Concluded" is not "reached the end of the function".** Path C has
three early returns after the lock — no candidates, and two preflights
that can drop every candidate — which are *results*, not failures, and
the commonest outcomes at that. Marking completion once, early, would
have kept the lock on a throw in the judging loop, leaving half of the
second consequence unfixed; marking it once, late, would have released
the lock on the most common path of all and destroyed the dedup
entirely. Each legitimate exit is marked instead.
`test_path_c_releases_the_lock_when_it_throws_mid_detection` fails
under the early-marker variant; the Path C dedup tests fail under the
late one.

**Both paths fingerprint the row they will actually examine, not the
caller's copy of it.** `_detect` reads `new_memory`; the `content`
parameter is only what the caller believed the content was, and the
back-channel consumers pass the write-time payload, which a mid-flight
update leaves stale. Keying on that would put a lock on text nobody
looked at, and would make the fix depend on every future caller keeping
the two in step. So both paths now resolve the row first and key on it,
which also means a soft-deleted row never takes a lock at all.

The cost is one `get_memory` on a duplicate delivery that would
previously have been refused at the lock. It falls only on callers that
do not already pass `new_memory` — and the duplicate-heavy path, the two
back-channel consumers, does pass it. Against the alternative branch,
which runs a candidate search plus an LLM judgement per candidate, a
single-row GET is the cheaper half by a wide margin.

## Ownership on the release

Adding a release added a way to lose the lock to someone else, so the
release is compare-and-delete on a per-acquisition token, never a bare
`DEL`. A run whose work outruns the 3600s TTL no longer owns the key —
by then it may have expired and been re-taken — and deleting it there
would hand a SUCCESSOR a duplicate detection, which is worse than the
bug being fixed. `cache_delete_if` runs the compare and the delete as
one server-side step; GET-then-DEL from the client would leave exactly
the window it is meant to close.
`test_a_late_release_cannot_take_a_successor_s_lock` expires the key
mid-run, lets a second run take it, and fails if the first run's
`finally` removes it.

## Scope

Both arches are covered: `ContradictionEngine` is a facade that
delegates to these same two functions, so the flag makes no difference.
`cache_delete_if` is new; like its neighbours it is total (a missing
Redis or a failed EVAL returns False rather than raising), which is what
keeps the never-raises contract the Pub/Sub consumers depend on to ack.
`test_cache_delete_if_is_total` pins that, since the release runs inside
a `finally`, and a second test pins that a non-matching value is not
deleted and that the compare+delete is a single round trip.

## Tests

`tests/test_h06_contradiction_lock.py`, 14 tests. All of them fail on
`origin/main` with the source reverted, but that number overstates the
signal: several fail only because the symbols they reference do not
exist there, not on behaviour.

The evidence that they discriminate is separate, and stronger — each of
the six designs rejected along the way was actually applied, and in
every case exactly the one test guarding it failed while the rest
stayed green:

| rejected design | test that caught it |
|---|---|
| release on success (`finally`, unconditional) | `test_a_completed_run_keeps_its_lock` |
| mark the run concluded once, early | `..._throws_mid_detection` |
| key on the caller's `content` parameter | `..._not_the_caller_copy` |
| release with a bare `DEL`, no ownership | `..._successor_s_lock` |
| let a null content reach the fingerprint | `..._still_gets_a_usable_key` |
| treat an empty row content as a missing one | `..._is_a_real_value_not_a_missing_one` |

Locks are modelled with an in-memory SETNX / compare-and-delete store
rather than by patching the `_acquire_*` helpers, so the assertions run
against the real key derivation and the real ownership check — the two
things that changed.

`tests/test_a4_14_back_channel_idempotency.py` is updated for the new
two-argument helpers, and its Path C skip test's docstring corrected:
that path does now fetch the row before the lock.

