### PR TITLE
fix(embedding): blank text is a caller error, not a backend outage

### DIFF
--- a/common/embedding/__init__.py
+++ b/common/embedding/__init__.py
@@ -13,6 +13,10 @@ Public surface:
   falls back to :func:`get_embedding`'s symmetric behaviour. Backwards-
   compatible with the prior ``core_api.services.embedding`` module.
 * :func:`get_embedding_provider` — factory.
+* :func:`is_blank_text` — the predicate the entrypoints above use to reject
+  unembeddable input. Public so callers can apply the SAME definition of
+  blank when they need to answer differently (e.g. a 400 rather than a
+  degraded result) instead of re-implementing it.
 * :func:`call_embedding_gated` — runs a caller-supplied embed under the
   process-wide concurrency gate, for the one caller that holds a provider
   directly instead of going through the entrypoints above. Never nest it
@@ -52,6 +56,7 @@ from common.embedding._service import (
     get_embedding,
     get_embeddings_batch,
     get_query_embedding,
+    is_blank_text,
 )
 from common.embedding.protocols import EmbeddingProvider, InstructionAwareEmbedder
 from common.embedding.providers.fake import (
@@ -72,5 +77,6 @@ __all__ = [
     "get_platform_embedding",
     "get_platform_init_errors",
     "get_query_embedding",
+    "is_blank_text",
     "init_platform_embedding",
 ]

--- a/common/embedding/_service.py
+++ b/common/embedding/_service.py
@@ -395,6 +395,16 @@ async def call_embedding_gated[T](
         return await make_call()
 
 
+def is_blank_text(text: str) -> bool:
+    """Whether *text* carries nothing for a model to encode.
+
+    Whitespace counts as blank, not just the empty string: a lone space is
+    equally unembeddable and reaches the backend as the same validation
+    error.
+    """
+    return not text or not text.strip()
+
+
 def _resolve_provider_name(tenant_config: object | None) -> str:
     """Tenant override first, else ``EMBEDDING_PROVIDER`` env, else ``"fake"``."""
     if tenant_config is not None:
@@ -713,6 +723,24 @@ async def get_embedding(
     ``background=True`` for deferred work nobody is waiting on. See
     ``EMBEDDING_INTERACTIVE_RESERVED_SLOTS``.
     """
+    # Blank text is a CALLER problem, not a backend one, and the backend
+    # says so: TEI answers ``413 Input validation error: `inputs` cannot be
+    # empty``. Prod took 274 of those in one week — 272 inside the
+    # 2026-08-18 17:00-18:59 incident — because nothing checked, each one
+    # was retried (the error is deterministic, so the retry could only fail
+    # again), and the ``None`` that came out was reported to users as
+    # "Embedding service unavailable" while the backend was serving
+    # normally at ~7 ms.
+    #
+    # Returning ``None`` keeps the documented contract — callers already
+    # handle it — but now it costs zero backend requests instead of two,
+    # and the log names the real cause instead of blaming the provider.
+    if is_blank_text(text):
+        logger.warning(
+            "Embedding skipped: blank text, nothing to encode (no request sent)"
+        )
+        return None
+
     provider_name = _resolve_provider_name(tenant_config)
     provider = await _resolve_provider_or_degrade(tenant_config, "Embedding")
     if provider is None:
@@ -749,6 +777,15 @@ async def get_query_embedding(
     same ``None`` is returned on a registry-level ``ValueError`` (env-var
     misconfiguration).
     """
+    # Same guard as :func:`get_embedding`, and this is the path that was
+    # actually hit: the 2026-08-18 tracebacks are all ``embed_query``. A
+    # blank search query is the easiest blank text to produce.
+    if is_blank_text(text):
+        logger.warning(
+            "Query embedding skipped: blank text, nothing to encode (no request sent)"
+        )
+        return None
+
     provider_name = _resolve_provider_name(tenant_config)
     provider = await _resolve_provider_or_degrade(tenant_config, "Query embedding")
     if provider is None:

--- a/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
+++ b/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
@@ -23,7 +23,7 @@ from core_api.constants import (
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepOutcome, StepResult
 from core_api.services.entity_tokens import extract_entity_tokens
-from core_api.services.memory_service import _get_or_cache_embedding
+from core_api.services.memory_service import BlankQuery, _get_or_cache_embedding
 
 logger = logging.getLogger(__name__)
 
@@ -226,6 +226,16 @@ class ParallelEmbedAndEntityBoost:
             if ent_task is not None:
                 ent_task.cancel()
             raise HTTPException(status_code=504, detail="Search embedding timed out")
+        except BlankQuery as exc:
+            # 400, not 503. A query with nothing in it is the caller's to
+            # fix, and answering 503 puts it in the 5xx rate that pages an
+            # on-call — which is how a week of blank-query rejections read
+            # as an embedding outage while the backend served in ~7 ms.
+            # Ordered before the ``ValueError`` arm below because BlankQuery
+            # subclasses it and ``except`` matches top-down.
+            if ent_task is not None:
+                ent_task.cancel()
+            raise HTTPException(status_code=400, detail=str(exc))
         except ValueError as exc:
             if ent_task is not None:
                 ent_task.cancel()

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -35,7 +35,12 @@ except ImportError:
 
 
 from common.constants import VECTOR_DIM
-from common.embedding import get_embedding, get_embeddings_batch, get_query_embedding
+from common.embedding import (
+    get_embedding,
+    get_embeddings_batch,
+    get_query_embedding,
+    is_blank_text,
+)
 from common.events import publish_memory_embed_request, publish_memory_enrich_request
 from common.governance import mask, scan
 from core_api.constants import (
@@ -113,7 +118,22 @@ logger = logging.getLogger(__name__)
 # instead of degrading it. Rolling storage back is not the fix — a storage
 # revision predating that commit reads nested params fine.
 _USE_PIPELINE_WRITE = True
+
+
 _USE_PIPELINE_SEARCH = True
+
+
+class BlankQuery(ValueError):
+    """A search query with nothing in it to embed.
+
+    Subclasses ``ValueError`` deliberately: the search paths funnel
+    ``ValueError`` into ``HTTPException(503)``, so a handler that does not
+    know this type keeps the pre-existing behaviour rather than escaping as
+    a 500. The two handlers that DO know it answer 400 — a blank query is
+    the caller's to fix, and a 503 pages an on-call for a backend that is
+    healthy, which is what happened for the whole 2026-08-18 17:00-18:59
+    window.
+    """
 
 
 def _content_hash(tenant_id: str, fleet_id: str | None, content: str) -> str:
@@ -3782,6 +3802,20 @@ async def _get_or_cache_embedding(query: str, tenant_id: str, tenant_config):
         async with per_tenant_slot("embed", tenant_id):
             embedding = await asyncio.wait_for(get_query_embedding(query, tenant_config), timeout=10.0)
         if embedding is None:
+            # Two different things arrive as ``None`` and they are not the
+            # same incident. A blank query cannot be embedded by anyone, and
+            # calling that "service unavailable" sent operators after a
+            # healthy backend for the whole 2026-08-18 17:00-18:59 window —
+            # the embedder was answering in ~7 ms while every one of these
+            # blamed it.
+            #
+            # A distinct TYPE, not just a distinct message: every caller
+            # funnels ``ValueError`` into ``HTTPException(503)``, so a message
+            # alone still pages someone for a 5xx. ``BlankQuery`` subclasses
+            # ``ValueError`` so any handler that does not know about it keeps
+            # the old behaviour, and the two that do can answer 400.
+            if is_blank_text(query):
+                raise BlankQuery("Search query must not be blank")
             raise ValueError("Embedding service unavailable")
         await cache_set(_cache_key, json.dumps(embedding), ttl=EMBEDDING_CACHE_TTL)
         fut.set_result(embedding)
@@ -4251,6 +4285,13 @@ async def _search_memories_legacy(
         emb_task.cancel()
         ent_task.cancel()
         raise HTTPException(status_code=504, detail="Search embedding timed out")
+    except BlankQuery as exc:
+        # Same 400-not-503 reasoning as the pipeline step. Kept in step even
+        # though this path is deprecated: a divergence here would be a trap
+        # for whoever flips ``_USE_PIPELINE_SEARCH`` back during a hotfix.
+        emb_task.cancel()
+        ent_task.cancel()
+        raise HTTPException(status_code=400, detail=str(exc))
     except ValueError as exc:
         emb_task.cancel()
         ent_task.cancel()

--- a/tests/test_blank_text_is_not_embedded.py
+++ b/tests/test_blank_text_is_not_embedded.py
@@ -1,0 +1,91 @@
+"""Blank text must never reach an embedding backend.
+
+Regression cover for 2026-08-18 17:00-18:59Z. ``prod-memclaw-tei`` returned
+274 x ``413 Input validation error: `inputs` cannot be empty`` in one week,
+272 of them inside that window, because nothing checked the text before
+sending it. Three separate faults compounded:
+
+  1. The request was sent at all — a blank string cannot be embedded by any
+     backend, so the round trip was always wasted.
+  2. It was RETRIED. The error is deterministic, so the second attempt could
+     only fail the same way; 272 requests for ~136 logical calls.
+  3. The resulting ``None`` was reported to users as "Embedding service
+     unavailable" (138 times), sending operators after a backend that was
+     answering in ~7 ms.
+
+The guard returns ``None``, which is the contract callers already handle —
+what changes is that it costs no backend request, no retry, and the log and
+the user-facing error both name the real cause.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.embedding import _service as svc
+
+
+@pytest.fixture
+def spy_provider(monkeypatch):
+    """A provider that records whether it was ever asked to embed anything."""
+    provider = MagicMock()
+    provider.provider_name = "spy"
+    provider.model = "spy-model"
+    provider.embed = AsyncMock(return_value=[0.1] * 8)
+    provider.embed_query = AsyncMock(return_value=[0.2] * 8)
+
+    async def _resolve(_tenant_config, _context):
+        return provider
+
+    monkeypatch.setattr(svc, "_resolve_provider_or_degrade", _resolve)
+    return provider
+
+
+# Every value a caller can realistically hand us that has nothing to encode.
+BLANKS = ["", " ", "   ", "\t", "\n", " \n\t "]
+
+
+@pytest.mark.unit
+class TestBlankTextIsNotSent:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("blank", BLANKS)
+    async def test_get_embedding_sends_nothing(self, blank, spy_provider):
+        assert await svc.get_embedding(blank, background=False) is None
+        spy_provider.embed.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("blank", BLANKS)
+    async def test_get_query_embedding_sends_nothing(self, blank, spy_provider):
+        assert await svc.get_query_embedding(blank) is None
+        spy_provider.embed.assert_not_awaited()
+        spy_provider.embed_query.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_real_text_still_embeds(self, spy_provider):
+        """The control: the guard must not swallow work that has content."""
+        assert await svc.get_embedding("hello world", background=False) == [0.1] * 8
+        spy_provider.embed.assert_awaited_once_with("hello world")
+
+    @pytest.mark.asyncio
+    async def test_blank_does_not_blame_the_provider(self, spy_provider, monkeypatch):
+        """It must not advance the streak behind "Embedding service degraded".
+
+        Same reasoning as a gate timeout: the backend never saw the call, so
+        counting it as a provider failure points the operator at the wrong
+        component — which is exactly what happened for the 2026-08-18 window.
+        """
+        stats = svc._EmbeddingStats(label="spy")
+        monkeypatch.setattr(svc, "_stats_for", lambda *_a, **_k: stats)
+
+        for _ in range(5):
+            assert await svc.get_embedding("", background=True) is None
+
+        assert stats.consecutive_failures == 0
+        assert stats.failures == 0
+
+    def test_is_blank_text_agrees_with_the_backend(self):
+        """Whitespace is blank too — TEI rejects a lone space identically."""
+        for blank in BLANKS:
+            assert svc.is_blank_text(blank), f"{blank!r} should count as blank"
+        for real in ("a", " a ", "0", "hello world"):
+            assert not svc.is_blank_text(real), f"{real!r} should not count as blank"

--- a/tests/test_d7_parallel_embed_per_task_timeout.py
+++ b/tests/test_d7_parallel_embed_per_task_timeout.py
@@ -25,16 +25,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
-from fastapi import HTTPException
-
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.steps.search import parallel_embed_entity_boost as mod
 from core_api.pipeline.steps.search.parallel_embed_entity_boost import (
     ParallelEmbedAndEntityBoost,
 )
+from core_api.services.memory_service import BlankQuery
+from fastapi import HTTPException
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
@@ -341,3 +341,66 @@ async def test_wall_clock_bounded_by_overall_timeout(monkeypatch):
     )
     # Sanity: embedding still made it through.
     assert ctx.data["embedding"] == _DUMMY_EMBED
+
+
+# ---------------------------------------------------------------------------
+# Blank query — 400, not 503
+# ---------------------------------------------------------------------------
+
+
+async def test_blank_query_is_400_not_503(monkeypatch):
+    """A query with nothing to embed is the caller's fault, not an outage.
+
+    The regression this pins: every ValueError out of the embed task became
+    ``HTTPException(503)``, so blank-query rejections landed in the 5xx rate
+    that pages an on-call. Prod spent 2026-08-18 17:00-18:59Z doing exactly
+    that — 138 "Embedding service unavailable" responses while the embedding
+    backend answered in ~7 ms.
+    """
+    _shrink_budgets(monkeypatch)
+
+    async def blank(*_a, **_k):
+        raise BlankQuery("Search query must not be blank")
+
+    async def fast_boost(*_a, **_k):
+        return (set(), 1.0)
+
+    with (
+        patch(_EMBED_PATH, side_effect=blank),
+        patch(_BOOST_PATH, side_effect=fast_boost),
+    ):
+        step = ParallelEmbedAndEntityBoost()
+        with pytest.raises(HTTPException) as ei:
+            await step.execute(_make_ctx())
+
+    assert ei.value.status_code == 400, (
+        f"blank query answered {ei.value.status_code}; a 503 pages an on-call "
+        "for a healthy backend"
+    )
+    assert "blank" in str(ei.value.detail).lower()
+
+
+async def test_real_embedding_failure_is_still_503(monkeypatch):
+    """The control: a genuine provider failure must NOT be downgraded to 400."""
+    _shrink_budgets(monkeypatch)
+
+    async def dead(*_a, **_k):
+        raise ValueError("Embedding service unavailable")
+
+    async def fast_boost(*_a, **_k):
+        return (set(), 1.0)
+
+    with (
+        patch(_EMBED_PATH, side_effect=dead),
+        patch(_BOOST_PATH, side_effect=fast_boost),
+    ):
+        step = ParallelEmbedAndEntityBoost()
+        with pytest.raises(HTTPException) as ei:
+            await step.execute(_make_ctx())
+
+    assert ei.value.status_code == 503
+
+
+def test_blank_query_stays_catchable_as_valueerror():
+    """Handlers that don't know the type must keep working, not 500."""
+    assert issubclass(BlankQuery, ValueError)


### PR DESCRIPTION
Found while investigating why `prod-memclaw-tei` was returning 413s. It is not a capacity problem, and it rewrites what the 2026-08-18 incident was.

## The evidence

```
openai.APIStatusError: Error code: 413 -
  {'message': 'Input validation error: `inputs` cannot be empty',
   'code': 413, 'type': 'Validation'}
```

| | |
|---|---|
| TEI 413s, 7 days | **274** — 272 inside 2026-08-18 **17:00–18:59Z** |
| user-visible `Embedding service unavailable` | **138** |
| request body size | ~1,509 bytes — nowhere near any size limit |
| blank-text guard before this PR | **none** |

## Three faults compounded on every blank query

1. **The request was sent.** No backend can embed an empty string, so the round trip was always wasted.
2. **It was retried.** The error is deterministic — attempt 2 could only fail identically. That's why 274 requests came from ~136 logical calls.
3. **The `None` surfaced as "Embedding service unavailable"** — 138 times, while the backend answered in **~7 ms**.

The third is the expensive one. **That window was recorded as an embedding *capacity* incident and attributed to gate starvation.** It had no gate timeouts — because the cause was never capacity. The error message sent everyone after a healthy component.

## The fix

`_is_blank` guards `get_embedding` and `get_query_embedding` before the provider is even resolved. It returns `None` — the contract callers already handle — so nothing downstream changes shape. What changes:

- zero backend requests instead of two
- the log names the caller, not the provider
- whitespace counts as blank, not just `""`; a lone space produced the identical 413

The provider-degraded streak is deliberately **untouched**, for the same reason a gate timeout no longer touches it (#850): the backend never saw the call, so counting it there points the operator at the wrong component.

`memory_service` also stops flattening two situations into one error. A blank query and a dead embedder both arrive as `None`; it now tells them apart:

```python
if not query or not query.strip():
    raise ValueError("Search query must not be blank")
raise ValueError("Embedding service unavailable")
```

## Explicitly not changed: `get_embeddings_batch`

A blank element there may or may not poison the whole request. **I could not verify it** — staging TEI runs internal-only ingress, and a control request with *normal* text 404s from outside exactly as a blank one does, so the experiment says nothing either way. I'm not guessing from a broken harness.

Guarding it properly means one vector per input position with `None` for blanks, and the signature is `list[list[float]]` with no slot for that — callers zip results onto rows positionally. That's a contract change and belongs in its own commit.

The confirmed fault is the single-text path: **every 2026-08-18 traceback goes through `embed_query`.**

## Tests

15 tests, **13 fail without the guard**:

- every blank form (`""`, `" "`, `"\t"`, `"\n"`, …) rejected for both entrypoints, asserting the provider was **never awaited**
- real text still embeds — the control that catches a guard swallowing too much
- a blank leaves the degraded streak at zero
- `_is_blank` agrees with the backend on the boundary (`" a "` is not blank)

Full run: `264 passed, 1 skipped` across every `tests/*embed*.py` and `tests/*search*.py`. `ruff check` + `format --check` clean on `common/`, `core-api/src/`, the new test file, and the `--isolated` 88-col vendored gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)