### PR TITLE
fix(governance): a dropped memory must not leave its children behind

### DIFF
--- a/core-api/src/core_api/consumer.py
+++ b/core-api/src/core_api/consumer.py
@@ -104,7 +104,7 @@ async def handle_memory_enriched(event: Event) -> None:
     # counterpart to the synchronous GovernanceDecision step. ``resolve_config``
     # tolerates a None session (cache-first; cold-miss opens its own).
     gov_cfg = await resolve_config(payload.tenant_id)
-    if await remediate_after_enrichment(memory, gov_cfg):
+    if (await remediate_after_enrichment(memory, gov_cfg)).dropped:
         # Row was dropped by policy — skip contradiction detection on it.
         logger.info(
             "memory-enriched: row dropped by governance policy; ack",

--- a/core-api/src/core_api/services/governance_remediation.py
+++ b/core-api/src/core_api/services/governance_remediation.py
@@ -16,6 +16,7 @@ eventually-consistent here (≈ enrichment-deferral latency).
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from core_api.clients.storage_client import get_storage_client
@@ -33,17 +34,34 @@ from core_api.services.governance_gate import (
 logger = logging.getLogger(__name__)
 
 
-async def remediate_after_enrichment(memory: dict, cfg: Any) -> bool:
+@dataclass(frozen=True)
+class RemediationOutcome:
+    """What remediation did to the row — enough for a caller to follow it.
+
+    ``dropped`` alone was sufficient while the only caller had nothing left to
+    do afterwards. A caller that goes on to create rows DERIVED from this one
+    needs the rest: ``keep_private`` downgrades the row's visibility, and a
+    derived row that keeps the pre-downgrade visibility re-publishes exactly
+    the content the policy just made private (#808).
+    """
+
+    dropped: bool = False
+    visibility: str | None = None
+    """The row's new visibility when remediation changed it; ``None`` when it
+    was left alone."""
+
+
+async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutcome:
     """Apply LLM-signal governance to a fast-mode row after enrichment landed.
 
-    Returns ``True`` if the row was dropped (the caller should then stop further
-    processing of it). No-op + ``False`` when governance is disabled or the
-    signals are clean.
+    Returns what was done. A caller that only needs "should I stop?" reads
+    ``.dropped``; one that creates derived rows must also honour
+    ``.visibility``. No-op when governance is disabled or the signals are clean.
     """
     pii_cfg = cfg.governance_pii
     nb_cfg = cfg.governance_non_business
     if not pii_cfg.enabled and not nb_cfg.enabled:
-        return False
+        return RemediationOutcome()
 
     md = memory.get("metadata_") or memory.get("metadata") or {}
     content = memory.get("content") or ""
@@ -54,7 +72,7 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> bool:
         # A malformed enriched-event payload without an id would otherwise
         # soft-delete "None" and stamp resource_id="None" on every audit row.
         logger.warning("governance: remediate_after_enrichment called with memory missing 'id'; skipping")
-        return False
+        return RemediationOutcome()
     memory_id = str(raw_id)
     sc = get_storage_client()
 
@@ -78,7 +96,7 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> bool:
             )
             await sc.soft_delete_memory(memory_id)
             logger.info("governance: dropped fast-mode memory %s (pii)", memory_id)
-            return True
+            return RemediationOutcome(dropped=True)
         # mask/flag: the LLM gives no offsets to redact a free-form span, and in
         # fast mode the row is already persisted — so a "mask"-configured tenant
         # can only be flagged here. Keep the action truthful (flag), but record
@@ -113,7 +131,7 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> bool:
             )
             await sc.soft_delete_memory(memory_id)
             logger.info("governance: dropped fast-mode memory %s (non-business)", memory_id)
-            return True
+            return RemediationOutcome(dropped=True)
         if nb_cfg.disposition == "keep_private":
             await sc.update_memory(memory_id, tenant_id, {"visibility": "scope_agent"})
             await emit_governance_audit(
@@ -123,4 +141,7 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> bool:
                 detail=nonbusiness_audit_detail(ACTION_NB_KEEP_PRIVATE, content, "fast"),
                 resource_id=memory_id,
             )
-    return False
+            # Reported so a caller creating derived rows can carry the
+            # downgrade to them instead of publishing the same content wider.
+            return RemediationOutcome(visibility="scope_agent")
+    return RemediationOutcome()

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2269,61 +2269,55 @@ async def _schedule_enrich_or_inline(
         # ``reference_datetime`` is still not forwarded — the inline path
         # resolves relative dates against the enrichment call's own clock, and
         # that is a separate concern.
-        enriched_row = await _enrich_memory_background(
+        await _enrich_memory_background(
             memory_id,
             content,
             tenant_id,
             fleet_id,
             agent_id,
             agent_provided_fields=agent_provided_fields,
+            governance_config=tenant_config,
+            run_governance_remediation=run_governance_remediation,
         )
-        # H-18: apply the LLM governance verdict on the INLINE path too.
+        # H-18 governance (the LLM verdict) is applied INSIDE
+        # ``_enrich_memory_background``, not here.
         #
-        # Fast mode always defers enrichment, so ``GovernanceDecision`` cannot
-        # run in its pipeline; the fast path is governed by post-write
-        # remediation instead. But that remediation lived ONLY in
-        # ``consumer.py``, which runs when the WORKER PATCHes enrichment back.
-        # An inline deployment — the DEFAULT — never publishes, so no consumer
-        # ever fired and the verdict computed just above was discarded. This is
-        # the inline counterpart of that call; both now converge on
-        # ``remediate_after_enrichment``.
+        # It ran here originally, and #808 is why it moved: by the time this
+        # function regained control, the atomic-fact fan-out had already
+        # written a child memory per claim extracted from the parent's
+        # content. A DROP then removed the parent and left the children — same
+        # text, no governance metadata, no audit trail. Governance has to
+        # happen before anything derived from the row exists, and only the
+        # enrichment function knows where that boundary is.
         #
-        # Gated on the caller rather than applied unconditionally, because
-        # strong mode already enforces the same policy synchronously via
-        # ``GovernanceDecision`` and would double-apply — duplicate audit rows
-        # and a second drop on a row policy already acted on. Its call site
-        # cannot reach this branch today (``not settings.inline_enrichment``
-        # guards it), so the flag is defence against that guard being relaxed.
+        # ``run_governance_remediation`` is still the caller's to set, for the
+        # original reason: strong mode already enforces the same policy
+        # synchronously via ``GovernanceDecision`` and would double-apply —
+        # duplicate audit rows and a second drop on a row policy already acted
+        # on. Only the caller knows the resolved write mode, and that is what
+        # decides whether the synchronous step ran. Its call site cannot reach
+        # this branch today (``not settings.inline_enrichment`` guards it), so
+        # the flag is defence against that guard being relaxed.
         #
         # ⚠ The default is OFF, which means a new caller that reaches this
         # branch without passing the flag silently skips governance — the exact
         # shape of H-18. If you add a third call site, it MUST pass
         # ``run_governance_remediation=True`` unless it has already applied
-        # ``GovernanceDecision`` synchronously for the same write. Deriving it
-        # here instead is not possible today: only the caller knows the resolved
-        # write mode, and that is what decides whether the synchronous step ran.
+        # ``GovernanceDecision`` synchronously for the same write.
         #
-        # ``enriched_row`` is ``None`` exactly when no verdict was produced.
+        # ``tenant_config`` is forwarded as ``governance_config``: it is the
+        # snapshot the pipeline resolved for this write, while
+        # ``_enrich_memory_background`` re-resolves its own to decide whether to
+        # enrich at all. With a 5-minute TTL cache they are the same object in
+        # practice; if an org toggles governance in the window between pipeline
+        # start and enrichment completing, the enrich decision and the policy
+        # decision can come from different snapshots. Deliberate — the write
+        # stays governed by the config it started under, not one that changed
+        # underneath it.
         #
-        # ``tenant_config`` is the snapshot the pipeline resolved for this write,
-        # while ``_enrich_memory_background`` re-resolves its own to decide
-        # whether to enrich at all. With a 5-minute TTL cache they are the same
-        # object in practice; if an org toggles governance in the window between
-        # pipeline start and enrichment completing, the enrich decision and the
-        # policy decision can come from different snapshots. Deliberate — using
-        # the pipeline's snapshot keeps the whole write governed by the config it
-        # started under, rather than one that changed underneath it.
-        #
-        # Deliberately unguarded, matching ``consumer.py`` on the deferred path.
-        # This is the last statement of the task — extraction and Path A are
-        # scheduled as their own ``track_task`` calls, not chained behind it — so
-        # a failure here cannot cascade, and the enclosing ``tracked_task``
-        # records it as a ``BackgroundTaskLog`` row. Swallowing it locally would
-        # only downgrade an unenforced governance policy to a bare log line.
-        if run_governance_remediation and enriched_row is not None:
-            from core_api.services.governance_remediation import remediate_after_enrichment
-
-            await remediate_after_enrichment(enriched_row, tenant_config)
+        # The return value is deliberately discarded. It used to be the
+        # governance hook; it is diagnostics only now, and treating it as one
+        # again would re-apply a policy that has already run.
     else:
         await publish_memory_enrich_request(
             memory_id=memory_id,
@@ -2699,6 +2693,8 @@ async def _enrich_memory_background(
     agent_id: str,
     *,
     agent_provided_fields: list[str] | None = None,
+    governance_config: object | None = None,
+    run_governance_remediation: bool = False,
 ) -> dict | None:
     """Background task: run LLM enrichment on a fast-path memory, then patch the row.
 
@@ -2706,9 +2702,20 @@ async def _enrich_memory_background(
     as sub-tasks.
 
     Returns the enriched row as governance needs to see it — ``id``, ``content``,
-    ``tenant_id``, ``agent_id`` and the merged ``metadata_`` — or ``None`` when no
-    LLM verdict was produced (enrichment disabled, the call failed, or the row
-    went away). See the assembly site below for why it is not re-read.
+    ``tenant_id``, ``agent_id`` and the merged ``metadata_`` — or ``None`` when
+    there is no live governed row to describe: enrichment disabled, the call
+    failed, the row went away, or governance DROPPED it. See the assembly site
+    below for why it is not re-read.
+
+    Non-``None`` therefore means "this row exists and has been governed", which
+    is the reading a caller is most likely to assume. Returning the pre-drop
+    snapshot instead would hand the next caller a dict for a row that had just
+    been soft-deleted. The value is diagnostics only — the sole caller discards
+    it — and it is NOT a governance hook; remediation runs inside this function.
+
+    ``governance_config`` is REQUIRED when ``run_governance_remediation`` is set,
+    and passing the flag without it raises rather than crashing downstream on an
+    attribute of ``None``.
 
     ``agent_provided_fields`` names the enrichment columns the caller set
     EXPLICITLY at write time (computed by ``_agent_provided_enrichment_fields``
@@ -2731,6 +2738,16 @@ async def _enrich_memory_background(
     from core_api.services.memory_enrichment import enrich_memory
     from core_api.services.organization_settings import resolve_config
     from core_api.services.task_tracker import tracked_task
+
+    if run_governance_remediation and governance_config is None:
+        # Programming error, raised before any work: the two parameters are
+        # independent, and ``remediate_after_enrichment`` dereferences
+        # ``cfg.governance_pii`` immediately. Without this a call site that set
+        # the flag but forgot the config would fail safe (no derived rows) but
+        # opaquely, as an AttributeError on ``None`` from two modules away —
+        # and the caller-side ⚠ note about adding a third call site is exactly
+        # the scenario in which that happens.
+        raise ValueError("run_governance_remediation=True requires governance_config")
 
     try:
         tenant_config = await resolve_config(tenant_id)
@@ -2858,6 +2875,43 @@ async def _enrich_memory_background(
             "metadata_": meta,
         }
 
+    except (TimeoutError, ValueError, RuntimeError, SQLAlchemyError, OpenAIError, GoogleAPIError):
+        logger.exception("Background enrichment error for memory %s", memory_id)
+        return governed_row
+
+    # ── Govern, between enriching and deriving ────────────────────────────────
+    #
+    # #808: the verdict is applied HERE, before anything derived from this row
+    # exists. It used to run in the CALLER, after this function returned — by
+    # which time the atomic-fact fan-out below had already written a child
+    # memory per claim extracted from this same content. On a DROP the parent
+    # was then soft-deleted and the children survived it: same text, no
+    # governance metadata, no audit row tying them to the drop. A policy that
+    # says this row must not exist must not first spawn rows derived from it.
+    # The early return also skips the entity extraction scheduled at the end —
+    # entities mined out of dropped content are the same leak in another table.
+    #
+    # Deliberately OUTSIDE both ``try`` blocks, and that is why this function
+    # has two of them. The enclosing ``tracked_task`` turns an exception here
+    # into a ``BackgroundTaskLog`` row; letting the enrichment handler catch it
+    # would downgrade an unenforced governance policy to a log line among
+    # ordinary enrichment errors — the property
+    # ``test_remediation_failure_surfaces_to_the_task_tracker`` pins. Raising
+    # also skips the fan-out, which is the fail-safe order: a policy that could
+    # not be applied must not be followed by rows it might have forbidden.
+    effective_visibility: str | None = None
+    if run_governance_remediation and governed_row is not None:
+        from core_api.services.governance_remediation import remediate_after_enrichment
+
+        outcome = await remediate_after_enrichment(governed_row, governance_config)
+        if outcome.dropped:
+            # ``None``: the row no longer exists, and the return value's whole
+            # meaning is "here is the live governed row".
+            return None
+        effective_visibility = outcome.visibility
+
+    # ── Derive: rows and links built out of the governed content ──────────────
+    try:
         memory_type = patch.get("memory_type") or mem.get("memory_type")
 
         # Hint-based re-embed removed (CAURA-222): the hot path embeds raw
@@ -2880,7 +2934,13 @@ async def _enrich_memory_background(
         atomic_facts = getattr(enrichment, "atomic_facts", None) or []
         if len(atomic_facts) >= 1:
             parent_ts_start = mem.get("ts_valid_start")
-            parent_visibility = mem.get("visibility") or "scope_team"
+            # ``effective_visibility`` when remediation downgraded the parent:
+            # ``mem`` was read before the PATCH and still holds the pre-policy
+            # value, so reading it here would hand the children the visibility
+            # keep_private just took away (#808). Not re-fetched — the row read
+            # can route to a replica, which is the H-02 shape the governed_row
+            # assembly above documents.
+            parent_visibility = effective_visibility or mem.get("visibility") or "scope_team"
             parent_weight = patch.get("weight") or mem.get("weight") or 0.5
             fanout_created = 0
             fanout_unembedded = 0
@@ -2952,6 +3012,17 @@ async def _enrich_memory_background(
                     "source": "atomic_fact_fanout",
                     "retrieval_hint": fact.retrieval_hint or "",
                 }
+                # #808: carry the parent's verdict onto the derived rows. They
+                # are extracted from the parent's content, so the LLM's finding
+                # about that content is a finding about them. Without it a
+                # child reads as clean to every later consumer — an audit
+                # query, or any future remediation pass — while being made of
+                # the text that was flagged. A DROP never reaches here (the
+                # early return above), so this only ever labels rows the policy
+                # allowed to live.
+                for _signal in ("contains_pii", "pii_types", "business_relevance"):
+                    if _signal in meta:
+                        child_meta[_signal] = meta[_signal]
                 if child_embedding is None:
                     # ``embedding_pending`` is public API, not bookkeeping:
                     # ``MemoryOut.metadata`` documents it, agents are told to
@@ -3137,7 +3208,10 @@ async def _enrich_memory_background(
         # respective worker PATCHes land.
         logger.info("Background enrichment succeeded for memory %s", memory_id)
     except (TimeoutError, ValueError, RuntimeError, SQLAlchemyError, OpenAIError, GoogleAPIError):
-        logger.exception("Background enrichment error for memory %s", memory_id)
+        # Distinct from the enrichment handler above so the two phases are
+        # tellable apart in logs: by this point the row is enriched AND
+        # governed, and only the derived rows failed.
+        logger.exception("Background enrichment fan-out error for memory %s", memory_id)
 
     return governed_row
 

--- a/tests/test_governance_remediation.py
+++ b/tests/test_governance_remediation.py
@@ -64,8 +64,8 @@ def _mem(**kw) -> dict:
 
 
 async def test_disabled_is_noop(emitted, storage):
-    dropped = await governance_remediation.remediate_after_enrichment(_mem(), _cfg())
-    assert dropped is False
+    outcome = await governance_remediation.remediate_after_enrichment(_mem(), _cfg())
+    assert outcome.dropped is False
     assert emitted == []
     assert storage == []
 
@@ -75,8 +75,8 @@ async def test_missing_id_skips_without_side_effects(emitted, storage):
     # literal "None" or stamp resource_id="None" on an audit row.
     cfg = _cfg(pii={"enabled": True, "action": "drop"})
     mem = _mem(id=None, metadata={"contains_pii": True})
-    dropped = await governance_remediation.remediate_after_enrichment(mem, cfg)
-    assert dropped is False
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+    assert outcome.dropped is False
     assert storage == []
     assert emitted == []
 
@@ -84,8 +84,8 @@ async def test_missing_id_skips_without_side_effects(emitted, storage):
 async def test_pii_drop_soft_deletes_and_audits(emitted, storage):
     cfg = _cfg(pii={"enabled": True, "action": "drop"})
     mem = _mem(metadata={"contains_pii": True, "pii_types": ["health"]})
-    dropped = await governance_remediation.remediate_after_enrichment(mem, cfg)
-    assert dropped is True
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+    assert outcome.dropped is True
     assert ("soft_delete", "m1") in storage
     assert any(c["action"] == "pii_drop" for c in emitted)
 
@@ -95,8 +95,8 @@ async def test_pii_mask_config_flags_but_records_intent(emitted, storage):
     # but stays distinguishable from a genuine flag policy in the audit.
     cfg = _cfg(pii={"enabled": True, "action": "mask"})
     mem = _mem(metadata={"contains_pii": True, "pii_types": ["health"]})
-    dropped = await governance_remediation.remediate_after_enrichment(mem, cfg)
-    assert dropped is False
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+    assert outcome.dropped is False
     assert storage == []  # nothing redacted/dropped
     flag = next(c for c in emitted if c["action"] == "pii_flag")
     assert flag["detail"]["configured_action"] == "pii_mask"
@@ -113,8 +113,8 @@ async def test_pii_flag_config_records_no_configured_action(emitted, storage):
 async def test_nonbusiness_keep_private_updates_visibility(emitted, storage):
     cfg = _cfg(nb={"enabled": True, "disposition": "keep_private"})
     mem = _mem(metadata={"business_relevance": "personal"})
-    dropped = await governance_remediation.remediate_after_enrichment(mem, cfg)
-    assert dropped is False
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+    assert outcome.dropped is False
     assert ("update", "m1", "t1", {"visibility": "scope_agent"}) in storage
     assert any(c["action"] == "nonbusiness_keep_private" for c in emitted)
 
@@ -122,8 +122,8 @@ async def test_nonbusiness_keep_private_updates_visibility(emitted, storage):
 async def test_nonbusiness_drop_soft_deletes(emitted, storage):
     cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
     mem = _mem(metadata={"business_relevance": "personal"})
-    dropped = await governance_remediation.remediate_after_enrichment(mem, cfg)
-    assert dropped is True
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+    assert outcome.dropped is True
     assert ("soft_delete", "m1") in storage
     assert any(c["action"] == "nonbusiness_drop" for c in emitted)
 
@@ -131,8 +131,8 @@ async def test_nonbusiness_drop_soft_deletes(emitted, storage):
 async def test_business_content_is_noop(emitted, storage):
     cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
     mem = _mem(metadata={"business_relevance": "business"})
-    dropped = await governance_remediation.remediate_after_enrichment(mem, cfg)
-    assert dropped is False
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+    assert outcome.dropped is False
     assert storage == []
     assert emitted == []
 
@@ -171,8 +171,8 @@ async def test_drop_audits_before_soft_delete(
     monkeypatch.setattr(governance_remediation, "emit_governance_audit", _audit)
     monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
 
-    dropped = await governance_remediation.remediate_after_enrichment(
+    outcome = await governance_remediation.remediate_after_enrichment(
         _mem(metadata=metadata), _cfg(**cfg_kwargs)
     )
-    assert dropped is True
+    assert outcome.dropped is True
     assert order == [f"audit:{drop_action}", "soft_delete"]

--- a/tests/test_h808_governed_fanout.py
+++ b/tests/test_h808_governed_fanout.py
@@ -1,0 +1,413 @@
+"""Derived rows must not outlive the governance verdict on their source (#808).
+
+``_enrich_memory_background`` fans the enricher's ``atomic_facts`` out into a
+child memory per claim, each one made of text lifted from the parent. The LLM
+governance verdict was applied by the CALLER, after this function returned — by
+which time every child already existed. With ``governance_pii.action = "drop"``
+the parent was soft-deleted and the children survived it: same content, no
+governance metadata, and no audit row tying them to the drop.
+
+``keep_private`` had the matching hole: the parent was downgraded to
+``scope_agent`` while the children kept the visibility read off the parent row
+BEFORE remediation ran, so the content the policy had just made private was
+re-published at the original scope.
+
+Inline deployments only — core-worker does not implement the fan-out
+(``_ENRICHMENT_UNROUTED_FIELDS`` lists ``atomic_facts`` as deliberately
+unrouted), so a deferred deployment has no children to leak. The deterministic
+pre-write gate still covers regex/Luhn/entropy-detectable PII in both modes;
+this is specifically the LLM's free-form judgement.
+
+The fix moves remediation inside the enrichment function, ahead of anything
+derived from the row. These tests pin all three consequences of that ordering:
+no children on a drop, no entity extraction on a drop, and the downgrade
+carried to the children on keep_private.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core_api.services import memory_service
+from core_api.services.governance_remediation import RemediationOutcome
+from core_api.services.memory_enrichment import AtomicFact
+
+pytestmark = [pytest.mark.unit]
+
+TENANT = "t-h808"
+FLEET = "f1"
+AGENT = "a"
+
+
+def _cfg(*, entity_extraction: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        enrichment_enabled=True,
+        enrichment_provider="fake",
+        entity_extraction_enabled=entity_extraction,
+    )
+
+
+def _parent_row(visibility: str = "scope_team") -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "memory_type": "fact",
+        "status": "active",
+        "weight": 0.5,
+        "ts_valid_start": None,
+        "ts_valid_end": None,
+        "metadata_": {},
+        "deleted_at": None,
+        "fleet_id": FLEET,
+        "embedding": None,
+        "content": "body",
+        "visibility": visibility,
+    }
+
+
+def _enrichment(facts: list[AtomicFact], *, contains_pii: bool = False, personal: bool = False):
+    return SimpleNamespace(
+        memory_type="fact",
+        weight=0.5,
+        status="active",
+        title="t",
+        summary="",
+        tags=[],
+        llm_ms=1,
+        contains_pii=contains_pii,
+        pii_types=["email"] if contains_pii else [],
+        business_relevance="personal" if personal else "business",
+        retrieval_hint="",
+        ts_valid_start=None,
+        ts_valid_end=None,
+        atomic_facts=facts,
+    )
+
+
+async def _run(
+    *,
+    facts: list[AtomicFact],
+    outcome: RemediationOutcome | Exception = RemediationOutcome(),
+    run_governance: bool = True,
+    entity_extraction: bool = False,
+    contains_pii: bool = False,
+    personal: bool = False,
+    parent_visibility: str = "scope_team",
+    _created_sink: list | None = None,
+    _return_sink: list | None = None,
+):
+    """Drive one ``_enrich_memory_background`` with a stubbed verdict.
+
+    Returns ``(children, calls)`` where ``calls`` records the ORDER of the
+    governance call against the child writes — the ordering is the fix, so it
+    has to be observable rather than inferred from the end state.
+    """
+    sc = AsyncMock(name="storage_client")
+    sc.get_memory = AsyncMock(return_value=_parent_row(parent_visibility))
+    sc.update_memory = AsyncMock(return_value=None)
+    sc.update_memory_status = AsyncMock(return_value=None)
+    sc.bulk_find_by_content_hashes = AsyncMock(return_value={})
+
+    calls: list[str] = []
+
+    async def _create(payload):
+        calls.append("create_child")
+        if _created_sink is not None:
+            _created_sink.append(payload)
+        return {"id": str(uuid.uuid4())}
+
+    sc.create_memory = AsyncMock(side_effect=_create)
+
+    async def _remediate(_row, _cfg_arg):
+        calls.append("remediate")
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    async def _embed(_content, tenant_config=None, **_kw):
+        return [0.0]
+
+    def _stub_tracked_task(coro, *_a, **_k):
+        coro.close()
+        return None
+
+    scheduled: list[str] = []
+
+    def _stub_track_task(task, *_a, **_k):
+        scheduled.append("task")
+        return None
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock(side_effect=_stub_track_task)),
+        patch.object(memory_service, "tracked_task", new=_stub_tracked_task),
+        patch.object(memory_service, "get_embedding", new=_embed),
+        patch(
+            "core_api.services.memory_enrichment.enrich_memory",
+            new=AsyncMock(return_value=_enrichment(facts, contains_pii=contains_pii, personal=personal)),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(return_value=_cfg(entity_extraction=entity_extraction)),
+        ),
+        patch(
+            "core_api.services.governance_remediation.remediate_after_enrichment",
+            new=_remediate,
+        ),
+    ):
+        _returned = await memory_service._enrich_memory_background(
+            uuid.uuid4(),
+            "body",
+            TENANT,
+            FLEET,
+            AGENT,
+            governance_config=_cfg(entity_extraction=entity_extraction),
+            run_governance_remediation=run_governance,
+        )
+    if _return_sink is not None:
+        _return_sink.append(_returned)
+
+    children = [c.args[0] for c in sc.create_memory.await_args_list]
+    return children, calls, scheduled
+
+
+async def _run_returning(**kwargs):
+    """``_run`` but yielding what the function returned rather than its effects."""
+    box: list = []
+    kwargs["_return_sink"] = box
+    await _run(**kwargs)
+    return box[0]
+
+
+# ---------------------------------------------------------------------------
+# A dropped parent must not have spawned anything
+# ---------------------------------------------------------------------------
+
+
+async def test_a_dropped_parent_creates_no_children():
+    """The issue in one assertion.
+
+    Pre-fix the two children were already written by the time the caller
+    applied the verdict, so the drop removed the parent and left them behind.
+    """
+    children, calls, _ = await _run(
+        facts=[AtomicFact(content="alpha fact"), AtomicFact(content="beta fact")],
+        outcome=RemediationOutcome(dropped=True),
+        contains_pii=True,
+    )
+
+    assert children == [], "a policy that says this row must not exist spawned derived rows"
+    assert calls == ["remediate"], "governance must run before, not after, the fan-out"
+
+
+async def test_a_dropped_parent_schedules_no_entity_extraction():
+    """Entities mined out of dropped content are the same leak in another table."""
+    _, _, scheduled = await _run(
+        facts=[AtomicFact(content="alpha fact"), AtomicFact(content="beta fact")],
+        outcome=RemediationOutcome(dropped=True),
+        entity_extraction=True,
+        contains_pii=True,
+    )
+
+    assert scheduled == [], "entity extraction ran on content the policy dropped"
+
+
+async def test_a_remediation_failure_propagates_and_stops_the_fanout():
+    """Two properties at once, and they pull against each other.
+
+    The failure must PROPAGATE — the enclosing ``tracked_task`` turns it into a
+    ``BackgroundTaskLog`` row, and swallowing it would downgrade an unenforced
+    governance policy to a log line (the property
+    ``test_remediation_failure_surfaces_to_the_task_tracker`` has pinned since
+    H-18). Catching it inside the enrichment handler would have been the easy
+    way to keep the fan-out from running, and would have broken that.
+
+    And it must be FAIL-SAFE: a policy that could not be applied must not be
+    followed by rows it might have forbidden. Raising achieves both, which is
+    why the governance step sits between the two ``try`` blocks rather than
+    inside either.
+    """
+    with pytest.raises(RuntimeError, match="audit sink unreachable"):
+        await _run(
+            facts=[AtomicFact(content="alpha fact")],
+            outcome=RuntimeError("audit sink unreachable"),
+            entity_extraction=True,
+        )
+
+
+async def test_no_child_survives_a_remediation_failure():
+    """The fail-safe half of the above, observed rather than inferred."""
+    created: list[dict] = []
+
+    try:
+        await _run(
+            facts=[AtomicFact(content="alpha fact")],
+            outcome=RuntimeError("audit sink unreachable"),
+            entity_extraction=True,
+            _created_sink=created,
+        )
+    except RuntimeError:
+        pass
+
+    assert created == []
+
+
+async def test_a_dropped_parent_is_reported_as_gone():
+    """``None`` means "no live governed row" — including after a drop.
+
+    Returning the pre-drop snapshot would hand the next caller a dict for a row
+    that had just been soft-deleted, and ``is not None`` is the reading a
+    caller is most likely to assume means "still there".
+    """
+    result = await _run_returning(
+        facts=[AtomicFact(content="alpha fact")],
+        outcome=RemediationOutcome(dropped=True),
+        contains_pii=True,
+    )
+    assert result is None
+
+
+async def test_the_flag_without_a_config_fails_loudly_and_early():
+    """The two parameters are independent, and remediation dereferences the
+    config immediately. A call site that sets the flag but forgets the config
+    must say so, not surface an AttributeError on ``None`` from two modules
+    away — the caller-side "if you add a third call site" warning describes
+    exactly when that would happen."""
+    with pytest.raises(ValueError, match="requires governance_config"):
+        _returned = await memory_service._enrich_memory_background(
+            uuid.uuid4(),
+            "body",
+            TENANT,
+            FLEET,
+            AGENT,
+            run_governance_remediation=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# keep_private has to reach the children too
+# ---------------------------------------------------------------------------
+
+
+async def test_keep_private_cascades_to_the_children():
+    """Pre-fix the children were written with the parent's PRE-downgrade
+    visibility, re-publishing at ``scope_team`` exactly the content the policy
+    had just restricted to ``scope_agent``."""
+    children, _, _ = await _run(
+        facts=[AtomicFact(content="alpha fact"), AtomicFact(content="beta fact")],
+        outcome=RemediationOutcome(visibility="scope_agent"),
+        personal=True,
+    )
+
+    assert len(children) == 2
+    assert {c["visibility"] for c in children} == {"scope_agent"}
+
+
+async def test_an_untouched_parent_still_passes_its_own_visibility_down():
+    """The guard against over-applying the cascade: with no remediation action,
+    children keep inheriting the parent's visibility as they always did."""
+    children, _, _ = await _run(
+        facts=[AtomicFact(content="alpha fact")],
+        outcome=RemediationOutcome(),
+        parent_visibility="scope_org",
+    )
+
+    assert [c["visibility"] for c in children] == ["scope_org"]
+
+
+# ---------------------------------------------------------------------------
+# Surviving children must not read as clean
+# ---------------------------------------------------------------------------
+
+
+async def test_children_carry_the_parents_governance_verdict():
+    """A flagged (not dropped) parent's children are made of the flagged text.
+
+    Pre-fix ``child_meta`` was ``{parent_memory_id, source, retrieval_hint}``
+    only, so a child read as clean to an audit query while being made of the
+    content the LLM flagged.
+    """
+    children, _, _ = await _run(
+        facts=[AtomicFact(content="alpha fact")],
+        outcome=RemediationOutcome(),  # flag, not drop
+        contains_pii=True,
+        personal=True,
+    )
+
+    assert len(children) == 1
+    meta = children[0]["metadata_"]
+    assert meta["contains_pii"] is True
+    assert meta["pii_types"] == ["email"]
+    assert meta["business_relevance"] == "personal"
+    # The existing keys must survive alongside them.
+    assert meta["source"] == "atomic_fact_fanout"
+    assert "parent_memory_id" in meta
+
+
+# ---------------------------------------------------------------------------
+# The flag still gates it, and the caller must not apply it twice
+# ---------------------------------------------------------------------------
+
+
+async def test_the_flag_off_leaves_the_path_untouched():
+    """Strong mode already applied ``GovernanceDecision`` synchronously; a second
+    application would duplicate audit rows and re-drop a row policy already
+    acted on. With the flag off, remediation must not be called at all."""
+    children, calls, _ = await _run(
+        facts=[AtomicFact(content="alpha fact")],
+        outcome=RemediationOutcome(dropped=True),  # would kill the fan-out if consulted
+        run_governance=False,
+        contains_pii=True,
+    )
+
+    assert "remediate" not in calls
+    assert len(children) == 1
+
+
+async def test_the_scheduler_does_not_apply_the_verdict_a_second_time():
+    """Remediation moved out of ``_schedule_enrich_or_inline`` and into the
+    enrichment function. If the old call were left behind, a drop would be
+    audited and soft-deleted twice for one write."""
+    seen: list[str] = []
+
+    async def _remediate(_row, _cfg_arg):
+        seen.append("remediate")
+        return RemediationOutcome()
+
+    async def _fake_enrich(*_a, **kwargs):
+        # Stand in for the real function; report the flag it was handed so the
+        # test also proves the caller still forwards it.
+        seen.append(f"enrich(run={kwargs.get('run_governance_remediation')})")
+        return {"id": "x"}
+
+    with (
+        patch.object(memory_service, "_enrich_memory_background", new=_fake_enrich),
+        patch(
+            "core_api.services.governance_remediation.remediate_after_enrichment",
+            new=_remediate,
+        ),
+        # inline_enrichment is a derived PROPERTY on Settings (no setter),
+        # so it is patched on the class — same idiom as
+        # test_governance_inline_fast_remediation.
+        patch.object(
+            type(memory_service.settings),
+            "inline_enrichment",
+            property(lambda self: True),
+        ),
+    ):
+        await memory_service._schedule_enrich_or_inline(
+            uuid.uuid4(),
+            "body",
+            TENANT,
+            FLEET,
+            AGENT,
+            _cfg(),
+            run_governance_remediation=True,
+        )
+
+    assert seen == ["enrich(run=True)"], (
+        "the scheduler must forward the flag and NOT apply remediation itself"
+    )


### PR DESCRIPTION
Fixes #808.

## The bug

`_enrich_memory_background` fans the enricher's `atomic_facts` out into
a child memory per claim, each one made of text lifted from the parent.
The LLM governance verdict was applied by the CALLER, after that
function returned — by which time every child already existed.

With `governance_pii.action = "drop"` and `contains_pii: true`, the
parent was soft-deleted and the children survived it: same content, no
governance metadata, and no audit row tying them to the drop. The audit
log records one deletion; the tenant's data still holds the text.

`keep_private` had the matching hole. The parent was downgraded to
`scope_agent`, but `parent_visibility` is read off the row fetched at
the top of the function, before remediation touched it — so the
children were written at the ORIGINAL visibility, re-publishing exactly
the content the policy had just made private.

Inline deployments only: core-worker does not implement the fan-out
(`_ENRICHMENT_UNROUTED_FIELDS` lists `atomic_facts` as deliberately
unrouted), so a deferred deployment has no children to leak. The
deterministic pre-write gate still covers pattern-detectable PII in
both modes — this is the LLM's free-form judgement.

## The fix: enrich, then govern, then derive

Remediation moves out of `_schedule_enrich_or_inline` and into
`_enrich_memory_background`, immediately after the enrichment PATCH and
before anything derived from the row exists. On a drop it returns,
which also skips the entity extraction scheduled at the end —
entities mined out of dropped content are the same leak in another
table.

`remediate_after_enrichment` now returns a `RemediationOutcome` rather
than a bare bool, because a caller that goes on to create derived rows
needs more than "should I stop?": `keep_private` reports the new
visibility so the children inherit the downgrade instead of the value
`mem` still holds. Not re-read from storage — `get_memory` can route to
the read replica, the H-02 shape the `governed_row` assembly directly
above already documents.

Surviving children now carry the parent's `contains_pii` / `pii_types` /
`business_relevance`. They are extracted from the parent's content, so a
finding about that content is a finding about them; without it a child
reads as clean to an audit query while being made of the flagged text. A
drop never reaches this code, so it only ever labels rows the policy
allowed to live.

## Why the function now has two `try` blocks

The governance step sits BETWEEN them, deliberately, and that is the
only reason for the split.

H-18 established that a governance failure must propagate: the
enclosing `tracked_task` turns it into a `BackgroundTaskLog` row, and
swallowing it "would only downgrade an unenforced governance policy to
a bare log line".
`test_remediation_failure_surfaces_to_the_task_tracker` pins it.

`RuntimeError` is in the exception tuple `_enrich_memory_background`
catches, so simply moving the call inside that `try` would have
silently broken this — the easy way to stop the fan-out on failure is
also the way that loses the failure. Raising past both blocks keeps the
property AND gives the fail-safe ordering: a policy that could not be
applied is not followed by rows it might have forbidden.

The second block's handler logs "fan-out error" rather than
"enrichment error" so the two phases stay tellable apart.

## Not included

`_handle_auto_chunk_from_ctx` has the same class of gap and is filed
separately as #852: the auto-chunk branch computes the verdict
(`MergeEnrichmentFields` writes it into the metadata it persists) and
then never applies it, to the parent or the children, because it never
reaches `_schedule_enrich_or_inline` and `build_enrichment_pipeline`
carries no `GovernanceDecision`. It is a different enforcement point —
that path has the verdict PRE-persist — and bundling two enforcement
designs into one PR is what #847 is about.

## Tests

`tests/test_h808_governed_fanout.py`, 11 tests. A plain revert gives no
signal here: the file imports `RemediationOutcome`, so on `main` it
fails at collection rather than on behaviour. Each pre-fix behaviour was
therefore applied to the fixed tree instead, and in every case exactly
the intended tests failed:

| simulated pre-fix behaviour | tests that caught it |
|---|---|
| verdict does not stop the derivation | `..._creates_no_children`, `..._schedules_no_entity_extraction` |
| `keep_private` does not cascade | `..._cascades_to_the_children` |
| children carry no verdict | `..._carry_the_parents_governance_verdict` |
| governance failure swallowed | both failure tests **and** H-18's `test_remediation_failure_surfaces_to_the_task_tracker` |
| drop returns the pre-drop snapshot | `..._is_reported_as_gone` |
| no guard on the flag/config pair | `..._fails_loudly_and_early` |

The "governance failure swallowed" row is the useful one: tripping H-18's
own pre-existing test confirms that property is genuinely preserved by the
two-block structure, rather than passing by accident.

Two of the eleven guard against over-applying the fix — an untouched parent
still passes its own visibility down, and with
`run_governance_remediation=False` (strong mode, already governed
synchronously) remediation is not called at all.

`test_governance_remediation.py` is updated for the new return type, and
`consumer.py` reads `.dropped`.

## Review round

Two Lows, both applied. A drop now returns `None` rather than the
pre-drop snapshot — `is not None` is the reading a caller will assume
means "still there", and handing back a dict for a row that was just
soft-deleted invites it. And `run_governance_remediation=True` without
`governance_config` now raises up front instead of failing opaquely on
an attribute of `None` two modules away: the parameters are
independent, and the caller-side "if you add a third call site" warning
describes exactly the circumstance in which they would be set
inconsistently.

