### PR TITLE
fix(embedding): a full backend must be told once, not six times

### DIFF
--- a/common/embedding/__init__.py
+++ b/common/embedding/__init__.py
@@ -25,6 +25,11 @@ Public surface:
   backend, is what stopped an embed. A ``TimeoutError`` subclass, so
   existing handlers are unaffected; catch it only to tell saturation apart
   from provider failure.
+* :class:`EmbeddingBackendBusy` — the same distinction for the SHARED
+  backend: raised on a 429, meaning capacity ran out across every calling
+  instance rather than in this process. Not a ``TimeoutError`` (the
+  refusal is immediate). Catch it to tell aggregate saturation apart from
+  a provider fault; the concurrency cap is per process and cannot see it.
 * :func:`init_platform_embedding` / :func:`get_platform_embedding` —
   platform-tier singleton, initialised once at service startup from
   ``PLATFORM_EMBEDDING_*`` env vars.
@@ -51,6 +56,7 @@ from common.embedding._platform import (
 )
 from common.embedding._registry import get_embedding_provider
 from common.embedding._service import (
+    EmbeddingBackendBusy,
     EmbeddingGateTimeout,
     call_embedding_gated,
     get_embedding,
@@ -65,6 +71,7 @@ from common.embedding.providers.fake import (
 )
 
 __all__ = [
+    "EmbeddingBackendBusy",
     "EmbeddingGateTimeout",
     "EmbeddingProvider",
     "FakeEmbeddingProvider",

--- a/common/embedding/_service.py
+++ b/common/embedding/_service.py
@@ -270,6 +270,54 @@ class EmbeddingGateTimeout(TimeoutError):
     """
 
 
+class EmbeddingBackendBusy(Exception):
+    """The backend refused the call because it is at capacity (HTTP 429).
+
+    The same class of signal as :class:`EmbeddingGateTimeout`, one layer
+    out: our gate says "this PROCESS is at its cap", a 429 says "the
+    SHARED backend is". Both are capacity, neither is a fault, and
+    retrying either deepens it.
+
+    Worth naming separately because a 429 is the only evidence any single
+    process can ever have about aggregate demand. The concurrency cap is
+    per process, so ``cap x instances`` is what actually arrives at the
+    backend and no instance can observe that number — but a 429 can only
+    happen once the other instances have taken the capacity, so it
+    reports the aggregate directly. It is the signal an aggregate cap
+    would have to be built on, which is why it must not be swallowed into
+    the generic provider-failure path (where it was: a 429 counted
+    against the degraded-provider streak, and was retried).
+
+    Deliberately NOT a ``TimeoutError`` subclass, unlike its sibling. A
+    gate timeout is one — we really did wait — and existing handlers were
+    already written for that. A refusal is immediate, and callers that
+    special-case timeouts should not silently inherit this.
+    """
+
+
+def _is_backend_busy(exc: BaseException) -> bool:
+    """Whether *exc* is the backend declining for capacity (HTTP 429).
+
+    Duck-typed on the status code rather than importing the provider SDK:
+    this is the service layer, it is shared by every provider, and it has
+    no ``openai`` import today. ``openai.APIStatusError`` exposes
+    ``status_code`` directly and ``httpx.HTTPStatusError`` exposes it via
+    ``.response``, so both shapes are covered without either dependency.
+
+    Only 429 counts, and the narrowness is the point. Cloud Run returns
+    429 for "no instance available" and TEI returns it when its queue is
+    full, so a 429 unambiguously means "at capacity, try later". A 503 is
+    the ambiguous one — it is equally what a genuine outage looks like —
+    and classifying it as capacity would suppress the degraded-provider
+    ERROR during a real one. A 503 therefore stays a provider failure:
+    retried, counted, and loud.
+    """
+    code = getattr(exc, "status_code", None)
+    if code is None:
+        code = getattr(getattr(exc, "response", None), "status_code", None)
+    return code == 429
+
+
 def _concurrency_gate() -> asyncio.Semaphore:
     """The process-wide cap on concurrent provider calls.
 
@@ -392,7 +440,45 @@ async def call_embedding_gated[T](
                 f"embedding gate timeout after {EMBEDDING_GATE_TIMEOUT_SECONDS:.1f}s "
                 f"(background={background})"
             ) from exc
-        return await make_call()
+        # Classify the backend's answer HERE, at the one choke point every
+        # embed passes through, rather than at each call site. Same
+        # reasoning as putting the gate here (see the note above on
+        # ``call_embedding_gated`` being the single entry): a caller that
+        # forgets the classification would silently fall back to treating
+        # saturation as a fault, which is the bug being fixed, and there
+        # is no way to notice from the call site.
+        try:
+            return await make_call()
+        except Exception as exc:
+            if not _is_backend_busy(exc):
+                raise
+            # WARNING, not debug: unlike our own gate saturating, this
+            # says the shared backend ran out, which is the only
+            # aggregate-demand signal that exists (see
+            # ``EmbeddingBackendBusy``). It has never fired in prod — TEI
+            # served 345,802 requests in the 7 days to 2026-08-21 with
+            # zero 429s — so if it starts, that is new information and
+            # should be visible without turning debug on.
+            #
+            # The provider's own text is carried rather than left to the
+            # exception chain. This has never fired, so the first time it
+            # does the operator's question is "was that really a 429, or
+            # did the classifier catch something else" — and the answer
+            # has to be in the line that alerts, not in a traceback a
+            # level up. Not ``exc_info``: a genuine capacity event fires
+            # this per refused call, and the gate-timeout precedent is
+            # 1,915 in one hour.
+            logger.warning(
+                "Embedding backend refused at capacity (429, background=%s, "
+                "per-process cap=%d) — the shared backend is full, not faulty; "
+                "not retrying. Backend said: %s",
+                background,
+                EMBEDDING_MAX_CONCURRENCY,
+                exc,
+            )
+            raise EmbeddingBackendBusy(
+                f"embedding backend at capacity (background={background})"
+            ) from exc
 
 
 def is_blank_text(text: str) -> bool:
@@ -423,14 +509,26 @@ async def get_embeddings_batch(
 ) -> list[list[float]]:
     """Generate embeddings for multiple texts in a single API call.
 
-    Raises on any provider-side error. Bulk callers
-    (``memory_service.create_memories_bulk``,
-    ``_reembed_batch_via_provider``) already wrap this in
-    ``try: ... except Exception:`` and fall back to per-item retries,
-    so any exception type is acceptable here — what matters is that
-    the failure stats counter increments so the registry-level
-    degraded-provider trip-wire fires consistently with the single-embed
-    paths (``get_embedding`` / ``get_query_embedding``).
+    Raises on any provider-side error. Both bulk callers wrap this in
+    ``try: ... except Exception:``, so any exception type is acceptable
+    here — what matters is that the failure stats counter increments so
+    the registry-level degraded-provider trip-wire fires consistently
+    with the single-embed paths (``get_embedding`` /
+    ``get_query_embedding``).
+
+    What they do with the exception differs, and it is worth being exact
+    because an earlier version of this docstring credited both with a
+    per-item retry:
+
+    * ``_reembed_batch_via_provider`` DOES fan the batch out per item,
+      through the inline/deferred router — so in deferred mode a rejected
+      batch becomes N durable EMBED_REQUESTED messages that drain at
+      core-worker's sequential rate. That is the demand smoothing, and it
+      is why a 429 here needs no special caller handling.
+    * ``create_memories_bulk`` does NOT. Inline it re-raises (504 on a
+      timeout); otherwise it logs and leaves ``embedding=NULL`` for the
+      backfill sweep to collect. Durable either way, but there is no
+      second attempt in this request.
 
     A failed ``embed_batch`` also advances a bulk-only failure streak that
     single-embed successes cannot reset — see ``record_failure`` for why
@@ -539,11 +637,13 @@ async def get_embeddings_batch(
                 result = await call_embedding_gated(
                     lambda: provider.embed_batch(texts), background=background
                 )
-    except EmbeddingGateTimeout:
+    except (EmbeddingGateTimeout, EmbeddingBackendBusy):
         # Excluded from the bulk streak for the same reason the retry path
-        # excludes it: the streak drives "Embedding service degraded
-        # [<backend>]", and our own queue is not evidence about the backend's
-        # health. Still raised — the caller has no vector either way.
+        # excludes both: the streak drives "Embedding service degraded
+        # [<backend>]", and neither our own queue nor a backend correctly
+        # shedding load is evidence about that backend's health. Still raised —
+        # the caller has no vector either way, and raising is what routes the
+        # batch to the durable per-item path described above.
         raise
     except BaseException:
         await _stats_for(scope, label).record_failure(bulk_batch_size=len(texts))
@@ -615,6 +715,43 @@ async def _run_with_retry(
             logger.warning(
                 "%s gave up at the concurrency gate on attempt %d/%d — not "
                 "retrying; retrying saturation deepens it%s",
+                context,
+                attempt,
+                EMBEDDING_RETRY_ATTEMPTS,
+                " (an earlier attempt failed for a provider reason; counting that)"
+                if last_exc is not None
+                else "",
+            )
+            if last_exc is not None:
+                await stats.record_failure()
+            return None
+        # A 429 gets the identical treatment, for the identical reason one
+        # layer out: the backend told us it is full, so a retry adds load
+        # to the thing that is full. The only difference is that this one
+        # DID reach the backend, so it cost a round trip — which is an
+        # argument for retrying it less, not more.
+        #
+        # Not counted against the degraded streak either: that streak
+        # drives "Embedding service degraded [<backend>]", and a backend
+        # correctly shedding load is healthy. Counting it would page an
+        # operator toward a service that is behaving exactly as intended,
+        # which is what the 2026-08-18 window looked like from the logs.
+        # ``last_exc`` carries the same meaning as above — a genuine
+        # earlier failure in this call must still be recorded.
+        #
+        # The message says what THIS layer did and stops there. It must not
+        # claim the work is deferred: whether a ``None`` becomes durable
+        # work is the caller's property, not ours. A write's ``None``
+        # persists as ``embedding=NULL`` for the backfill sweep and a
+        # batch's fans out to EMBED_REQUESTED, but a query embed has no
+        # queue behind it at all — the search just fails with a 503. An
+        # operator reading "the work defers instead" during a search
+        # outage would be told recovery was in hand when it was not, in
+        # exactly the incident this classification exists to make legible.
+        except EmbeddingBackendBusy:
+            logger.warning(
+                "%s stopped at a busy backend on attempt %d/%d — not retrying;"
+                " a refusal is capacity, and retrying it deepens the shortage%s",
                 context,
                 attempt,
                 EMBEDDING_RETRY_ATTEMPTS,

--- a/common/embedding/constants.py
+++ b/common/embedding/constants.py
@@ -43,8 +43,16 @@ OPENAI_REQUEST_TIMEOUT_SECONDS: float = float(
 )
 
 # Retry budget for the high-level ``get_embedding`` call. Two attempts
-# is enough to ride out a single slow / 429 round-trip without
-# meaningfully extending the hot-path tail.
+# is enough to ride out a single slow round-trip without meaningfully
+# extending the hot-path tail.
+#
+# This is the WHOLE retry budget, which it previously was not: the OpenAI
+# SDK retries internally too (``DEFAULT_MAX_RETRIES = 2``, i.e. three
+# HTTP requests per call), and nothing pinned it, so one logical embed
+# could reach the backend six times. See
+# ``EMBEDDING_PROVIDER_MAX_RETRIES``, which now holds it at zero so this
+# number means what it says. A 429 is no longer retried at any layer —
+# see ``EmbeddingBackendBusy``.
 EMBEDDING_RETRY_ATTEMPTS: int = int(os.environ.get("EMBEDDING_RETRY_ATTEMPTS", "2"))
 EMBEDDING_RETRY_DELAY_S: float = float(os.environ.get("EMBEDDING_RETRY_DELAY_S", "1.0"))
 
@@ -118,11 +126,49 @@ EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS: float | None = read_float_env(
     "EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS", None
 )
 
+# Retries the OpenAI SDK performs INSIDE one provider call. Zero, so this
+# module's retry policy is the only one there is.
+#
+# Left unset, the SDK applies ``DEFAULT_MAX_RETRIES = 2`` — three HTTP
+# requests per call, on 429/408/409/5xx and connection errors — beneath a
+# service layer that then retries ``EMBEDDING_RETRY_ATTEMPTS`` times of
+# its own. One logical embed could reach the backend six times, and the
+# multiplication was invisible: the retries happen below the gate, so
+# they occupy no slot, emit no log line, and count as one call in every
+# stat we keep.
+#
+# Two concrete harms, not just tidiness:
+#
+#  1. It inverts the response to saturation. A 429 means the shared
+#     backend is already full, and the honest reply is to stop; instead
+#     each layer retried, so the reply was 6x the load at the exact
+#     moment capacity ran out. Same shape as retrying a gate timeout,
+#     which ``EmbeddingGateTimeout`` exists to prevent one layer up.
+#  2. It breaks the timeout arithmetic that other budgets are derived
+#     from. ``OPENAI_REQUEST_TIMEOUT_SECONDS`` is per REQUEST, so three
+#     of them is 75 s inside a call the caller believes is capped at 25 s
+#     — and ``BULK_STRONG_EMBED_TIMEOUT_SECONDS`` (8 s) was sized against
+#     the 25 s figure.
+#
+# Nothing is lost by zeroing it: ``_run_with_retry`` still retries genuine
+# provider errors, and it does so holding a gate slot, with the attempt
+# counted and logged. Env-tunable purely so an incident can restore the
+# old behaviour without a deploy.
+#
+# ``minimum=0`` because 0 is the intended value here and
+# ``read_int_env``'s usual floor of 1 would reject it — the value would
+# arrive by FALLING BACK rather than by being accepted. That warns on a
+# correct manifest, and would silently substitute a different value if
+# the default were ever changed. Garbage input is still caught.
+EMBEDDING_PROVIDER_MAX_RETRIES: int = read_int_env(
+    "EMBEDDING_PROVIDER_MAX_RETRIES", 0, minimum=0
+)
+
 
 # ── Client-side concurrency cap (backpressure) ───────────────────────
 #
-# The embedding backend is finite and can be much smaller than the
-# fleet calling it: prod's TEI service serves
+# The embedding backend is finite and can be much smaller than the set
+# of services calling it: prod's TEI service serves
 # ``maxScale x containerConcurrency`` requests at once, while core-api
 # scales to many instances that each hold a large httpx pool. Aggregate
 # demand can therefore oversubscribe the backend by orders of magnitude.
@@ -139,12 +185,46 @@ EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS: float | None = read_float_env(
 # a cheap in-process semaphore instead of holding a connection until it
 # times out.
 #
-# Be honest about the bound: this is PER PROCESS, so the fleet-wide total
-# is this value x instance count. At the default 16 x minScale 10 that is
-# still ~8x TEI's capacity, and far more at maxScale — so this reduces
-# thrash AMPLITUDE, it does not restore a capacity invariant. Raising TEI
-# maxScale/containerConcurrency is the actual capacity fix; set this
-# explicitly per deployment with the arithmetic written down.
+# Be honest about the bound: this is PER PROCESS, so the deployment-wide
+# total is this value x instance count, and nothing coordinates it.
+# Measured prod, 2026-08-21:
+#
+#   core-api      minScale 10, maxScale 200, cap 16  -> 160 in flight at
+#                 the scale prod actually runs (instance count observed
+#                 between 9 and 12 across a week), 3,200 at the ceiling
+#   core-worker   minScale 2, maxScale 20, ONE embed in flight per
+#                 instance because the Pub/Sub pull loop drains a batch
+#                 sequentially -> 2 now, 20 at the ceiling
+#   TEI (supply)  minScale 2, maxScale 3, containerConcurrency 10
+#                 -> 20 warm, 30 absolute
+#
+# So ~8x oversubscribed at the scale prod runs at, and ~107x at the
+# configured ceiling.
+#
+# DO NOT "fix" that by dividing this cap by the instance count. Fair
+# shares (30 / 10 = 3) would optimise for a coincident burst that has
+# never been observed, at the cost of the case that is observed
+# constantly: in the 7 days to 2026-08-21 TEI served 345,802 requests
+# with ZERO 5xx and ZERO 429 — every non-2xx was one of the 270
+# blank-input 413s — while OUR gate rejected work it would have served
+# (1,915 gate timeouts on 08-17 alone, TEI sitting at roughly half of a
+# single instance's container concurrency). Demand is bursty and not
+# coincident across instances, so a generous per-process cap plus a hard
+# aggregate signal beats a small per-process cap. Raising this from 8 to
+# 16 was the 2026-08-21 change, and it was in that direction on purpose.
+#
+# What bounds the aggregate is therefore NOT this number. It is the
+# backend's own 429 at ``maxScale``, which is the one signal carrying
+# cross-instance information: it can only fire when the OTHER instances
+# have taken the capacity. The requirement is that we neither amplify it
+# nor mistake it for an outage — see ``EmbeddingBackendBusy`` and
+# ``EMBEDDING_PROVIDER_MAX_RETRIES``. Rejected work lands on the durable
+# EMBED_REQUESTED path and drains at core-worker's sequential rate, which
+# is the demand smoothing; no shared token bucket is needed for it.
+#
+# Note for anyone reaching for the supply side first: TEI cannot be
+# grown. L4 GPUs are unavailable in us-central1 and the 3 -> 8 quota
+# request was DENIED, not deferred. maxScale 3 is a hard ceiling.
 EMBEDDING_MAX_CONCURRENCY: int = read_int_env("EMBEDDING_MAX_CONCURRENCY", 16)
 
 # Slots of the cap above that only INTERACTIVE embeds may occupy.

--- a/common/embedding/providers/openai.py
+++ b/common/embedding/providers/openai.py
@@ -15,6 +15,7 @@ from common.embedding.constants import (
     EMBEDDING_HTTPX_MAX_CONNECTIONS,
     EMBEDDING_HTTPX_MAX_KEEPALIVE_CONNECTIONS,
     EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS,
+    EMBEDDING_PROVIDER_MAX_RETRIES,
     EMBEDDING_REMOTE_MAX_BATCH,
     OPENAI_EMBEDDING_MODEL,
     OPENAI_REQUEST_TIMEOUT_SECONDS,
@@ -113,8 +114,15 @@ class OpenAIEmbeddingProvider:
         # ``OpenAILLMProvider``: the SDK's default httpx pool (100 max
         # / 20 keepalive) saturates under storm load and queues other
         # tenants' embed calls at the pool layer.
+        #
+        # ``max_retries`` is pinned rather than left at the SDK's default
+        # 2, which would put a silent 3x multiplier under every retry the
+        # service layer already performs — and under the per-request
+        # timeout that the bulk budgets are derived from. See
+        # ``EMBEDDING_PROVIDER_MAX_RETRIES``.
         client_kwargs: dict = {
             "api_key": api_key,
+            "max_retries": EMBEDDING_PROVIDER_MAX_RETRIES,
             "timeout": httpx.Timeout(
                 connect=EMBEDDING_HTTPX_CONNECT_TIMEOUT_SECONDS,
                 # read AND write keep the full request budget — the bare float

--- a/common/env_utils.py
+++ b/common/env_utils.py
@@ -16,7 +16,7 @@ import sys
 from typing import overload
 
 
-def read_int_env(name: str, default: int) -> int:
+def read_int_env(name: str, default: int, *, minimum: int = 1) -> int:
     """Read ``name`` from the environment, parse as int, fall back on bad input.
 
     Falls back to ``default`` and writes a warning to stderr in three
@@ -25,12 +25,20 @@ def read_int_env(name: str, default: int) -> int:
     1. Env value is not a valid integer literal (``"200abc"``,
        ``"25s"``, etc.) — would raise ``ValueError`` from bare
        ``int(...)`` and crash module import.
-    2. Env value is non-positive (``"0"``, ``"-1"``) — ``int(...)``
-       accepts these but downstream consumers (``httpx.Limits``,
-       semaphore-style caps) interpret 0 / negative as "block forever"
-       or silently degrade.
+    2. Env value is below ``minimum`` — ``int(...)`` accepts ``"0"`` and
+       ``"-1"`` but most consumers here (``httpx.Limits``,
+       semaphore-style caps) read 0 / negative as "block forever" or
+       silently degrade, so the floor defaults to 1.
     3. ``TypeError`` from a non-string env value (defensive; shouldn't
        happen in practice but cheap to guard).
+
+    *minimum* exists because that floor is not universal: a retry budget
+    or a reserved-slot count has 0 as a legitimate, and sometimes
+    intended, value. Without it, a knob whose default is 0 cannot be set
+    to 0 — the value lands by falling back rather than by being accepted,
+    which warns on a correct configuration AND, worse, would silently
+    substitute a NEW default if one were ever chosen. Keyword-only, and
+    defaulting to the historical 1, so every existing caller is unchanged.
 
     Module-level callers can't use a logger because structured logging
     isn't wired up yet at import time — stderr is the only universal
@@ -47,9 +55,9 @@ def read_int_env(name: str, default: int) -> int:
             file=sys.stderr,
         )
         return default
-    if value < 1:
+    if value < minimum:
         print(
-            f"WARN: {name}={raw!r} must be >= 1; falling back to {default}",
+            f"WARN: {name}={raw!r} must be >= {minimum}; falling back to {default}",
             file=sys.stderr,
         )
         return default

--- a/core-worker/src/core_worker/consumer.py
+++ b/core-worker/src/core_worker/consumer.py
@@ -179,11 +179,19 @@ async def handle_embed_request(event: Event) -> None:
     # worker throughput — that spends a shared backend to speed up work no
     # one is waiting for.
     #
-    # A gate timeout raises ``TimeoutError``, which propagates and nacks
-    # rather than acking the message embedding-less. Saturation is
-    # transient, so redelivery with Pub/Sub backoff (and the DLQ behind it)
-    # is the right answer for a queue consumer — unlike core-api, which
-    # degrades to ``None`` because an HTTP caller is waiting on it.
+    # Both saturation classes propagate from here and nack rather than
+    # acking the message embedding-less: ``EmbeddingGateTimeout`` (this
+    # process is at its cap) and ``EmbeddingBackendBusy`` (the shared
+    # backend is, HTTP 429). Neither is caught, and that is the intended
+    # handling — saturation is transient, so redelivery with Pub/Sub
+    # backoff, and the DLQ behind it, is the right answer for a queue
+    # consumer. Unlike core-api, which degrades to ``None`` because an
+    # HTTP caller is waiting on it.
+    #
+    # That nack is also what makes the queue the demand-smoothing
+    # mechanism rather than just a transport: a refused embed comes back
+    # later at Pub/Sub's pace instead of being retried into a backend that
+    # just said it was full.
     if embedding is None:
         embedding = await call_embedding_gated(lambda: provider.embed(request.content), background=True)
 

--- a/tests/test_backend_backpressure_is_capacity.py
+++ b/tests/test_backend_backpressure_is_capacity.py
@@ -1,0 +1,243 @@
+"""A backend at capacity is capacity, and one embed is one request.
+
+Two faults, one root: nothing in the stack could tell "the shared backend
+is full" apart from "the backend is broken".
+
+  1. A 429 was retried. It is the ONE signal a single process can have
+     about aggregate demand — the concurrency cap is per process, so
+     ``cap x instances`` is what reaches the backend and no instance can
+     observe that number, but a 429 can only fire once the other
+     instances have taken the capacity. Retrying it answers "you are
+     full" with more load.
+  2. It was retried more times than anyone wrote down. The OpenAI SDK
+     applies ``DEFAULT_MAX_RETRIES = 2`` beneath a service layer that
+     retries ``EMBEDDING_RETRY_ATTEMPTS`` times, so one logical embed
+     could reach the backend six times — invisibly, because SDK retries
+     happen below the gate: no slot, no log line, one call in every stat.
+
+Both were latent rather than firing: TEI served 345,802 requests in the 7
+days to 2026-08-21 with zero 429s and zero 5xx. The tests below are the
+line that keeps them latent, and that keeps the 429 usable as the
+aggregate-demand signal an aggregate cap would have to be built on.
+
+The narrowness is deliberate and is tested in both directions: 429 is
+capacity, 503 is a fault. A 503 is equally what a real outage looks like,
+so classifying it as capacity would silence the degraded-provider ERROR
+during one.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import openai
+import pytest
+
+from common.embedding import _service as svc
+from common.embedding.constants import EMBEDDING_PROVIDER_MAX_RETRIES
+from common.embedding.providers.openai import OpenAIEmbeddingProvider
+
+
+def _status_error(code: int) -> Exception:
+    """A real SDK error for *code*, not a stand-in.
+
+    Constructed from the actual ``openai`` types so the duck-typed
+    classifier is checked against the shape it will meet in production
+    rather than against a local mock that happens to agree with it.
+    """
+    response = httpx.Response(
+        code, request=httpx.Request("POST", "http://tei/v1/embeddings")
+    )
+    cls = openai.RateLimitError if code == 429 else openai.APIStatusError
+    return cls("backend said no", response=response, body=None)
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    """A provider whose every call raises, with the call count visible."""
+    prov = MagicMock()
+    prov.provider_name = "spy"
+    prov.model = "spy-model"
+    prov.embed = AsyncMock()
+    prov.embed_batch = AsyncMock()
+
+    async def _resolve(_tenant_config, _context):
+        return prov
+
+    monkeypatch.setattr(svc, "_resolve_provider_or_degrade", _resolve)
+    monkeypatch.setattr(svc, "get_embedding_provider", lambda *_a, **_k: prov)
+    # The retry path sleeps ``delay x attempt`` between attempts; the
+    # control tests below deliberately exhaust the budget.
+    monkeypatch.setattr(svc, "EMBEDDING_RETRY_DELAY_S", 0.0)
+    return prov
+
+
+@pytest.fixture
+def stats(monkeypatch):
+    """Intercept the shared stats object the degraded-provider ERROR reads."""
+    s = svc._EmbeddingStats(label="spy")
+    monkeypatch.setattr(svc, "_stats_for", lambda *_a, **_k: s)
+    return s
+
+
+@pytest.mark.unit
+class TestBusyBackendIsNotRetried:
+    @pytest.mark.asyncio
+    async def test_429_costs_exactly_one_request(self, provider, stats):
+        """The whole point: one refusal, one round trip.
+
+        Before this change the same call reached the backend twice here,
+        and up to six times in a deployed process — the SDK's own two
+        retries multiply each of these attempts.
+        """
+        provider.embed.side_effect = _status_error(429)
+
+        assert await svc.get_embedding("hello", background=True) is None
+
+        assert provider.embed.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_the_interactive_path_also_stops_at_one(self, provider, stats):
+        """The query path is the one with nothing behind it.
+
+        A write's ``None`` persists as ``embedding=NULL`` for the backfill
+        and a batch's fans out to EMBED_REQUESTED, so both recover on
+        their own. A query embed has no queue at all — the search just
+        fails with a 503. It still must not retry into a full backend, and
+        the shared log line must not tell an operator the work was
+        deferred when for this caller nothing is.
+        """
+        provider.embed.side_effect = _status_error(429)
+
+        assert await svc.get_query_embedding("hello") is None
+
+        assert provider.embed.await_count == 1
+        assert stats.failures == 0
+
+    @pytest.mark.asyncio
+    async def test_429_does_not_blame_the_backend(self, provider, stats):
+        """A backend shedding load correctly must not read as degraded.
+
+        The streak drives "Embedding service degraded [<backend>]", which
+        points an operator at the service. During a 429 that service is
+        doing exactly what it should.
+        """
+        provider.embed.side_effect = _status_error(429)
+
+        for _ in range(5):
+            assert await svc.get_embedding("hello", background=True) is None
+
+        assert stats.consecutive_failures == 0
+        assert stats.failures == 0
+
+    @pytest.mark.asyncio
+    async def test_an_earlier_real_failure_still_counts(self, provider, stats):
+        """A genuine fault before the 429 must survive it.
+
+        A backend both erroring and full is what an outage looks like,
+        and returning early must not discard the evidence — the same
+        mixed case ``EmbeddingGateTimeout`` handles.
+
+        Passes with or without the new arm, deliberately: before it, the
+        429 was itself counted as the failure, so the number came out
+        right for the wrong reason. It is here to pin that the early
+        return did not silently drop it — the exact regression the same
+        fix introduced when it was made one layer up.
+        """
+        provider.embed.side_effect = [_status_error(500), _status_error(429)]
+
+        assert await svc.get_embedding("hello", background=True) is None
+
+        assert provider.embed.await_count == 2
+        assert stats.failures == 1
+
+
+@pytest.mark.unit
+class TestOnlyA429CountsAsCapacity:
+    @pytest.mark.asyncio
+    async def test_500_is_still_retried_and_counted(self, provider, stats):
+        """The control. Without it, "not retried" could just mean broken."""
+        provider.embed.side_effect = _status_error(500)
+
+        assert await svc.get_embedding("hello", background=True) is None
+
+        assert provider.embed.await_count == svc.EMBEDDING_RETRY_ATTEMPTS
+        assert stats.failures == 1
+
+    @pytest.mark.asyncio
+    async def test_503_is_a_fault_not_capacity(self, provider, stats):
+        """A 503 is ambiguous, so it keeps the loud treatment.
+
+        Cloud Run returns 429 for "no instance available" and TEI returns
+        it when its queue is full — both unambiguously "later". A 503 is
+        equally a real outage, and misreading one as capacity would
+        suppress the signal that names it.
+        """
+        provider.embed.side_effect = _status_error(503)
+
+        assert await svc.get_embedding("hello", background=True) is None
+
+        assert provider.embed.await_count == svc.EMBEDDING_RETRY_ATTEMPTS
+        assert stats.failures == 1
+
+    def test_classifier_reads_both_exception_shapes(self):
+        """``status_code`` sits in two places across the two libraries.
+
+        ``openai.APIStatusError`` exposes it directly; ``httpx`` puts it
+        on ``.response``. The classifier is duck-typed to avoid importing
+        a provider SDK into the service layer, so both are checked here
+        rather than assumed.
+        """
+        request = httpx.Request("POST", "http://tei/v1/embeddings")
+        assert svc._is_backend_busy(_status_error(429))
+        assert svc._is_backend_busy(
+            httpx.HTTPStatusError(
+                "busy", request=request, response=httpx.Response(429, request=request)
+            )
+        )
+        assert not svc._is_backend_busy(_status_error(503))
+        assert not svc._is_backend_busy(ValueError("nothing to do with HTTP"))
+
+
+@pytest.mark.unit
+class TestBatchPath:
+    @pytest.mark.asyncio
+    async def test_429_raises_without_advancing_the_bulk_streak(self, provider, stats):
+        """Raising is what routes the batch to its durable per-item path.
+
+        ``_reembed_batch_via_provider`` fans a failed batch out through
+        the inline/deferred router, so in deferred mode a refused batch
+        becomes N EMBED_REQUESTED messages that drain at core-worker's
+        sequential rate. That IS the demand smoothing — so the exception
+        must reach the caller, while still not counting against the
+        bulk-failure streak.
+        """
+        provider.embed_batch.side_effect = _status_error(429)
+
+        with pytest.raises(svc.EmbeddingBackendBusy):
+            await svc.get_embeddings_batch(["a", "b"], background=True)
+
+        assert provider.embed_batch.await_count == 1
+        assert stats.failures == 0
+        assert stats.consecutive_bulk_failures == 0
+
+
+@pytest.mark.unit
+class TestSdkRetriesArePinned:
+    @pytest.mark.asyncio
+    async def test_client_does_not_retry_underneath_us(self):
+        """Guard the multiplier, not just today's behaviour.
+
+        This is a library default, so it comes back on its own the moment
+        the constructor stops passing the value — an upgrade, a refactor,
+        a copied kwargs dict. Nothing else in the stack can see it: SDK
+        retries take no gate slot and emit no log.
+        """
+        provider = OpenAIEmbeddingProvider(api_key="test-key")
+        try:
+            assert provider._client.max_retries == EMBEDDING_PROVIDER_MAX_RETRIES
+            assert provider._client.max_retries == 0, (
+                "one logical embed must be one request; the SDK's default 2 puts "
+                "a silent 3x under every service-layer retry"
+            )
+        finally:
+            await provider.aclose()

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -61,6 +61,45 @@ def test_one_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
     assert read_int_env("CAURA_TEST_KEY", 42) == 1
 
 
+def test_minimum_zero_accepts_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Not every knob has 1 as its floor, and the difference is not cosmetic.
+
+    ``EMBEDDING_PROVIDER_MAX_RETRIES`` defaults to 0 on purpose. Under the
+    fixed floor of 1, setting it to 0 warned about a correct value AND
+    took the fallback path — so if the default were ever changed, an
+    explicit 0 would silently become the new default instead of 0.
+    """
+    monkeypatch.setenv("CAURA_TEST_KEY", "0")
+    assert read_int_env("CAURA_TEST_KEY", 0, minimum=0) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_minimum_zero_still_rejects_negative(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Lowering the floor lowers it to exactly the value asked for."""
+    monkeypatch.setenv("CAURA_TEST_KEY", "-1")
+    assert read_int_env("CAURA_TEST_KEY", 7, minimum=0) == 7
+    assert ">= 0" in capsys.readouterr().err
+
+
+def test_minimum_zero_still_rejects_garbage(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The floor is the only thing that moves; the parse guard stays."""
+    monkeypatch.setenv("CAURA_TEST_KEY", "none")
+    assert read_int_env("CAURA_TEST_KEY", 3, minimum=0) == 3
+    assert "not a valid int" in capsys.readouterr().err
+
+
+def test_minimum_defaults_to_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every pre-existing caller must be unaffected by the new parameter."""
+    monkeypatch.setenv("CAURA_TEST_KEY", "0")
+    assert read_int_env("CAURA_TEST_KEY", 42) == 42
+
+
 def test_whitespace_around_int_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
     """``int("  100  ")`` succeeds in Python — the env var would parse and
     return 100, not the default. This documents that surrounding


### PR DESCRIPTION
Groundwork for bounding embedding demand across instances, which is the
last open item of this workstream. The concurrency cap is per process, so
`cap x instances` is what actually reaches the backend and no instance can
observe that number. Measuring it first changed what the fix should be.

## The arithmetic, prod, 2026-08-21

| | scaling | concurrency | in flight |
|---|---|---|---|
| core-api | minScale 10, maxScale 200 | cap **16** | **160** at the scale it runs, 3,200 at the ceiling |
| core-worker | minScale 2, maxScale 20 | 1/instance (the pull loop drains sequentially) | **2** now, 20 at the ceiling |
| **TEI (supply)** | minScale 2, **maxScale 3** | containerConcurrency 10 | **20 warm, 30 absolute** |

**~8x oversubscribed at the scale prod runs at; ~107x at the configured
ceiling.** Instance count was observed between 9 and 12 across a week, so
the ceiling figure describes a state prod has never entered.

## Why this is not a token bucket, and not fair shares

**Nothing has ever pushed back.** In the 7 days to 2026-08-21 TEI served
**345,802 requests with zero 5xx and zero 429** — every non-2xx was one
of the 270 blank-input 413s that #851 fixed.

Meanwhile *our* gate rejected work that backend would have served: 1,915
gate timeouts on 08-17 alone, with TEI sitting at roughly half of a single
instance's container concurrency. Raising the cap 8 -> 16 was the
2026-08-21 change and it was in that direction on purpose.

So fair shares (30 / 10 = **3**) would optimise for a coincident burst
that has never happened, at the cost of the case that happens
constantly. Demand is bursty and not coincident across instances, and a
generous per-process cap plus a hard aggregate signal beats a small
per-process cap. A shared Redis bucket buys a coordination dependency in
the hot path to enforce a limit nothing is reaching.

**What bounds the aggregate is the backend's own 429.** It is the only
signal carrying cross-instance information — it can only fire once the
*other* instances have taken the capacity. Rejected work already lands on
the durable EMBED_REQUESTED path and drains at core-worker's sequential
rate, which is the demand smoothing. Two things had to be true for that
to work, and neither was.

## Fault 1 — a 429 was a provider failure

It was retried (answering "you are full" with more load) and counted
against the streak behind `Embedding service degraded [<backend>]`,
pointing an operator at a service behaving exactly as intended. Same
class as #850, one layer out: our gate says *this process* is at its cap,
a 429 says *the shared backend* is.

`EmbeddingBackendBusy` now names it, raised at `call_embedding_gated` —
the one choke point every embed passes through since #848 — so no call
site can forget the classification.

Narrow on purpose: **429 only**. Cloud Run returns it for "no instance
available" and TEI when its queue is full, both unambiguously "later". A
503 is equally what a real outage looks like, so it stays a fault:
retried, counted, loud.

## Fault 2 — one embed was up to six requests

`AsyncOpenAI` was constructed without `max_retries`, so the SDK applied
its default of 2 (three HTTP requests per call) *beneath* a service layer
already retrying `EMBEDDING_RETRY_ATTEMPTS` times.

The multiplication was invisible: SDK retries happen below the gate, so
they take no slot, emit no log line, and count as one call in every stat
we keep. Two concrete harms beyond tidiness:

1. It inverted the response to saturation — 6x the load at the exact
moment capacity ran out.
2. It broke the timeout arithmetic other budgets derive from.
`OPENAI_REQUEST_TIMEOUT_SECONDS` is per *request*, so three is 75 s
inside a call believed capped at 25 s — and
`BULK_STRONG_EMBED_TIMEOUT_SECONDS` (8 s) was sized against the 25 s
figure.

`EMBEDDING_PROVIDER_MAX_RETRIES=0` pins it. Nothing is lost: genuine
provider errors are still retried, now holding a gate slot with the
attempt counted and logged.

**These ship together deliberately.** Without the pin, "not retried"
would be false — the SDK would have already sent the 429 three times
before this layer saw it.

## Also corrected

- `get_embeddings_batch`'s docstring credited **both** bulk callers with a
per-item retry. Only `_reembed_batch_via_provider` has one;
`create_memories_bulk` re-raises inline or leaves `embedding=NULL` for the
backfill. Durable either way, but there is no second attempt in that
request.
- The cap's own comment pointed at "raising TEI maxScale/containerConcurrency"
as the real fix. It is not available: L4 GPUs are unavailable in
us-central1 and the 3 -> 8 quota request was **denied**, not deferred.
- "fleet" as a word for a set of Cloud Run services.

## What this does not do

It is not a hard aggregate cap. Demand is still `cap x instances` with no
coordination; what changes is that the backend can now say no and be
believed. A real ceiling means routing the remaining synchronous
non-interactive embeds through core-worker — an API-contract change for
`POST /documents`, and not justified by anything measured here.

## Verification

`4739 passed, 3 skipped, 1 xfailed` — full suite, zero failures. All 12
CI ruff scopes clean.

**5 of the 8 new tests fail against unfixed source** (429 retried, streak
advanced, classifier absent, batch streak advanced, `max_retries == 2`).
The other 3 are controls that must pass both ways: a 500 is still retried
and counted, a 503 is still a fault, and an earlier genuine failure in the
same call is still recorded — the regression the same fix introduced when
it was made one layer up in #850.
