### PR TITLE
fix(governance): the auto-chunk branch must apply the verdict it computes

### DIFF
--- a/core-api/src/core_api/pipeline/compositions/write.py
+++ b/core-api/src/core_api/pipeline/compositions/write.py
@@ -38,6 +38,24 @@ def build_enrichment_pipeline() -> Pipeline:
     )
 
 
+def build_auto_chunk_governance_pipeline() -> Pipeline:
+    """The LLM verdict gate for the auto-chunk branch (#852).
+
+    ``GovernanceDecision`` cannot simply be appended to
+    ``build_enrichment_pipeline``: that composition is shared with the
+    extract-only branch (``persist=False``), which writes nothing and returns a
+    preview of content the caller already holds. Rejecting there would refuse a
+    request that leaks nothing. So the step is applied only on the branch that
+    goes on to persist.
+
+    A composition rather than a bare ``GovernanceDecision().execute(ctx)`` call
+    so that "which write paths enforce the LLM verdict?" stays answerable by
+    reading this module — the question that got the wrong answer when the
+    auto-chunk branch was written.
+    """
+    return Pipeline("write_auto_chunk_governance", [GovernanceDecision()])
+
+
 def build_persist_pipeline() -> Pipeline:
     """Only for persist=True, non-chunked memories."""
     return Pipeline(

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -150,6 +150,32 @@ def _auto_chunk_request_id() -> str:
     return f"auto-chunk:{uuid4()}"
 
 
+# The LLM governance verdict, as ``MergeEnrichmentFields`` / the enrichment
+# worker record it on the parent's metadata.
+_GOVERNANCE_SIGNAL_KEYS = ("contains_pii", "pii_types", "business_relevance")
+
+
+def _inherit_governance_signals(child_meta: dict, parent_meta: dict) -> None:
+    """Copy the parent's governance verdict onto a row derived from its content.
+
+    Derived rows — atomic facts (#808), auto-chunk children (#852) — are built
+    out of the parent's text, so a finding about that content is a finding about
+    them. Without the copy a child reads as clean to every later consumer (an
+    audit query, any future remediation pass) while being made of the flagged
+    text.
+
+    Only ever called on rows the policy allowed to live: a ``drop`` verdict
+    stops both fan-outs before they reach their children.
+
+    Shared by the two fan-outs rather than repeated, because that repetition is
+    exactly the shape #847 is about — the first of the pair got this in #808 and
+    the second did not.
+    """
+    for key in _GOVERNANCE_SIGNAL_KEYS:
+        if key in parent_meta:
+            child_meta[key] = parent_meta[key]
+
+
 async def _live_duplicate_hashes(
     sc,
     *,
@@ -692,7 +718,36 @@ async def _create_memory_pipeline(data: MemoryCreate) -> MemoryOut:
 
 async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> MemoryOut:
     """Auto-chunking branch using pipeline context enrichment results."""
+    from core_api.pipeline.compositions.write import (
+        build_auto_chunk_governance_pipeline,
+        build_persist_pipeline,
+    )
     from core_api.services.ingest_service import _chunk_content
+
+    # #852: apply the LLM's free-form verdict, which this branch had computed
+    # and then discarded. It belongs HERE rather than at the one call site so
+    # that the enforcement travels with the function that does the writing.
+    #
+    # First statement in the function, ahead of the chunking call, for two
+    # reasons: a rejected write should not pay for the chunking LLM round-trip,
+    # and a policy that could not be applied must not be followed by rows it
+    # might have forbidden.
+    #
+    # The step mutates in place — ``fields["metadata"]`` for the PII flag,
+    # ``data.visibility`` for a ``keep_private`` downgrade — and both the parent
+    # payload and every child payload below read those. That is what makes the
+    # downgrade cascade rather than needing to be threaded through by hand, and
+    # it is why this runs before either payload is built.
+    governance = await build_auto_chunk_governance_pipeline().run(ctx)
+    if governance.failed:
+        # Not optional, and not merely tidy: the runner CATCHES a non-HTTP
+        # exception and returns ``failed`` instead of raising. Without this
+        # check a governance step that blew up would return here as an ordinary
+        # ``None`` result and the write would proceed ungoverned — the exact
+        # defect this function is being fixed for, reintroduced one level up.
+        # (An ``HTTPException`` — the 422 a ``drop`` policy raises — is
+        # re-raised by the runner and never reaches this line.)
+        raise HTTPException(status_code=500, detail="Memory governance pipeline failed unexpectedly")
 
     sc = get_storage_client()
     fields = ctx.data["memory_fields"]
@@ -812,6 +867,14 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
         child_payloads = []
         for fact, child_embedding in zip(facts, child_embeddings):
             child_ch = _content_hash(data.tenant_id, data.fleet_id, fact["content"])
+            child_meta = {
+                "parent_memory_id": str(parent_id),
+                "source": "auto_chunk",
+            }
+            # Read off ``parent_metadata``, the dict actually written to the
+            # parent row, so the children cannot end up labelled differently
+            # from the row they were cut out of.
+            _inherit_governance_signals(child_meta, parent_metadata)
             child_payloads.append(
                 {
                     "tenant_id": data.tenant_id,
@@ -823,10 +886,7 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
                     "weight": fields["weight"],
                     "source_uri": data.source_uri,
                     "run_id": data.run_id,
-                    "metadata_": {
-                        "parent_memory_id": str(parent_id),
-                        "source": "auto_chunk",
-                    },
+                    "metadata_": child_meta,
                     "content_hash": child_ch,
                     "client_request_id": _auto_chunk_request_id(),
                     "expires_at": data.expires_at.isoformat() if data.expires_at else None,
@@ -863,9 +923,12 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
 
         return _dict_to_memory_out(parent)
 
-    # Chunking produced 0-1 facts: fall through to persist pipeline
-    from core_api.pipeline.compositions.write import build_persist_pipeline
-
+    # Chunking produced 0-1 facts: fall through to persist pipeline. Governed
+    # by the gate at the top of this function — ``build_persist_pipeline`` has
+    # no ``GovernanceDecision`` of its own, and the fast-mode fan-out in
+    # ``ScheduleBackgroundTasks`` (which is what would otherwise request
+    # post-write remediation) is keyed on a ``resolved_write_mode`` this branch
+    # never sets.
     persist_pipeline = build_persist_pipeline()
     persist_result = await persist_pipeline.run(ctx)
     if persist_result.failed:
@@ -3032,17 +3095,10 @@ async def _enrich_memory_background(
                     "source": "atomic_fact_fanout",
                     "retrieval_hint": fact.retrieval_hint or "",
                 }
-                # #808: carry the parent's verdict onto the derived rows. They
-                # are extracted from the parent's content, so the LLM's finding
-                # about that content is a finding about them. Without it a
-                # child reads as clean to every later consumer — an audit
-                # query, or any future remediation pass — while being made of
-                # the text that was flagged. A DROP never reaches here (the
-                # early return above), so this only ever labels rows the policy
-                # allowed to live.
-                for _signal in ("contains_pii", "pii_types", "business_relevance"):
-                    if _signal in meta:
-                        child_meta[_signal] = meta[_signal]
+                # #808: carry the parent's verdict onto the derived rows. A DROP
+                # never reaches here — the early return above — so this only
+                # ever labels rows the policy allowed to live.
+                _inherit_governance_signals(child_meta, meta)
                 if child_embedding is None:
                     # ``embedding_pending`` is public API, not bookkeeping:
                     # ``MemoryOut.metadata`` documents it, agents are told to

--- a/tests/test_child_dedup_minting_paths.py
+++ b/tests/test_child_dedup_minting_paths.py
@@ -27,6 +27,7 @@ import pytest
 
 from core_api.services import memory_service
 from core_api.services.memory_enrichment import AtomicFact
+from core_api.services.organization_settings import ResolvedConfig
 
 # No ``asyncio`` mark: ``pytest.ini`` sets ``asyncio_mode = auto``, and applying
 # it module-wide here warns on every sync test in the file.
@@ -35,6 +36,20 @@ pytestmark = [pytest.mark.unit]
 TENANT = "t-child-dedup"
 FLEET = "f1"
 AGENT = "a"
+
+
+def _tenant_config() -> ResolvedConfig:
+    """The real resolver, not a ``SimpleNamespace`` with the two attributes the
+    handler happened to read when these tests were written.
+
+    ``_handle_auto_chunk_from_ctx`` now also runs ``GovernanceDecision`` (#852),
+    which reads ``governance_pii`` / ``governance_non_business``; a stand-in
+    missing them raised ``AttributeError`` inside the step. Using the real class
+    means the next attribute the handler starts reading resolves to its actual
+    default instead of failing here. Governance is left unconfigured, so the new
+    step SKIPs and these dedup tests observe what they always did.
+    """
+    return ResolvedConfig({"entity_extraction": {"enabled": False}})
 
 
 def _fact(content: str) -> dict:
@@ -317,7 +332,7 @@ async def _run_auto_chunk(chunks: list[str], live: dict[str, dict]) -> list[dict
             "embedding": [0.0],
             "t0": 0.0,
         },
-        tenant_config=SimpleNamespace(entity_extraction_enabled=False),
+        tenant_config=_tenant_config(),
     )
 
     async def _chunks(_content, _x, _cfg):
@@ -396,7 +411,7 @@ async def test_the_parent_child_count_is_the_number_of_children_that_exist() -> 
             "embedding": [0.0],
             "t0": 0.0,
         },
-        tenant_config=SimpleNamespace(entity_extraction_enabled=False),
+        tenant_config=_tenant_config(),
     )
 
     async def _chunks(_content, _x, _cfg):
@@ -474,7 +489,7 @@ async def test_a_dropped_child_is_never_embedded() -> None:
             "embedding": [0.0],
             "t0": 0.0,
         },
-        tenant_config=SimpleNamespace(entity_extraction_enabled=False),
+        tenant_config=_tenant_config(),
     )
 
     async def _chunks(_content, _x, _cfg):

--- a/tests/test_h852_governed_auto_chunk.py
+++ b/tests/test_h852_governed_auto_chunk.py
@@ -1,0 +1,446 @@
+"""The auto-chunk branch must APPLY the LLM governance verdict, not just compute it.
+
+``create_memory`` routes content over ``CHUNKING_THRESHOLD_CHARS`` to
+``_handle_auto_chunk_from_ctx``. That branch runs ``build_enrichment_pipeline``,
+which ends in ``MergeEnrichmentFields`` — so ``contains_pii`` / ``pii_types`` /
+``business_relevance`` are all sitting in ``fields["metadata"]`` before the first
+row is written. Nothing then acted on them: ``GovernanceDecision`` lives only in
+``build_strong_write_pipeline``, and the post-write remediation is reached from
+the enrichment and bulk paths, none of which this branch takes (#852).
+
+The concrete losses, each pinned below:
+
+* ``pii.action="drop"`` / ``non_business.disposition="drop"`` — the row and every
+  chunk child persisted anyway;
+* ``keep_private`` — the parent kept its original visibility, and so did the
+  children cut out of it;
+* ``flag`` / ``mask`` — the row was marked (``MergeEnrichmentFields`` does that
+  much) but no governance audit row was ever written, so the enforcement action
+  left no record;
+* the children carried no verdict at all — ``metadata_`` was exactly
+  ``{parent_memory_id, source}``, the same shape #808 fixed for atomic facts.
+
+The deterministic gate is NOT part of this: ``GovernanceScanContent`` sits in
+``build_enrichment_pipeline`` after ``LoadTenantConfig``, so regex/Luhn/entropy
+PII was already masked or rejected here. What was lost is the free-form
+judgement, the same thing H-18 (#806) was about on the other two entry points.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from common.enrichment.schema import EnrichmentResult
+from core_api.pipeline.compositions import write as compositions
+from core_api.pipeline.steps.write import GovernanceDecision
+from core_api.schemas import MemoryCreate
+from core_api.services import memory_service
+from core_api.services.organization_settings import ResolvedConfig
+
+pytestmark = [pytest.mark.unit]
+
+TENANT = "t-h852"
+FLEET = "f1"
+AGENT = "a"
+
+
+def _parent_row() -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "tenant_id": TENANT,
+        "fleet_id": FLEET,
+        "agent_id": AGENT,
+        "memory_type": "fact",
+        "title": "t",
+        "content": "body",
+        "weight": 0.5,
+        "status": "active",
+        "visibility": "scope_team",
+        "recall_count": 0,
+        "created_at": datetime(2026, 8, 21, tzinfo=UTC),
+        "metadata_": {},
+        "embedding": None,
+        "deleted_at": None,
+    }
+
+
+def _config(*, pii: dict | None = None, non_business: dict | None = None) -> ResolvedConfig:
+    """A real ``ResolvedConfig`` — the enum/default resolution is part of what a
+    governance test should exercise, and a stand-in object drifts from it."""
+    governance: dict = {}
+    if pii is not None:
+        governance["pii"] = pii
+    if non_business is not None:
+        governance["non_business"] = non_business
+    return ResolvedConfig(
+        {"governance": governance, "entity_extraction": {"enabled": False}}
+    )
+
+
+class _Run:
+    """What one drive of the handler produced."""
+
+    def __init__(self) -> None:
+        self.parent: dict | None = None
+        self.parent_id: str = ""
+        self.children: list[dict] = []
+        self.audits: list[str] = []
+        self.chunked = False
+        self.error: HTTPException | None = None
+
+
+async def _run_auto_chunk(
+    *,
+    config: ResolvedConfig,
+    chunks: tuple[str, ...] = ("chunk one", "chunk two"),
+    enrichment: EnrichmentResult | None = None,
+    audit_raises: bool = False,
+) -> _Run:
+    """Drive ``_handle_auto_chunk_from_ctx`` and capture what reached storage.
+
+    ``enrichment=None`` means the LLM did not run at all (provider off / failed),
+    which is also when ``MergeEnrichmentFields`` writes none of the three verdict
+    keys — so the context is built to match rather than being set independently.
+
+    Every ``EnrichmentResult`` a caller passes needs ``llm_ms`` set: the gate
+    treats ``llm_ms == 0`` as "no live model judged this write" and takes no
+    destructive action, so a test that left it at zero would pass against a
+    completely unwired gate.
+    """
+    run = _Run()
+
+    parent_row = _parent_row()
+    run.parent_id = parent_row["id"]
+    sc = AsyncMock(name="storage_client")
+    sc.create_memory = AsyncMock(return_value=parent_row)
+    sc.create_memories = AsyncMock(return_value=[])
+    sc.bulk_find_by_content_hashes = AsyncMock(return_value={})
+
+    data = MemoryCreate(
+        tenant_id=TENANT,
+        fleet_id=FLEET,
+        agent_id=AGENT,
+        content="a body long enough to be worth chunking " * 60,
+    )
+    ctx = SimpleNamespace(
+        data={
+            # ``GovernanceDecision`` reads the request off the context, exactly
+            # as ``_create_memory_pipeline`` populates it.
+            "input": data,
+            "memory_fields": {
+                "memory_type": "fact",
+                "title": "t",
+                "weight": 0.5,
+                "status": "active",
+                # What ``MergeEnrichmentFields`` leaves behind for this verdict.
+                "metadata": _merged_metadata(enrichment),
+            },
+            "enrichment": enrichment,
+            "embedding": [0.0],
+            "t0": 0.0,
+        },
+        tenant_config=config,
+    )
+
+    async def _chunk_content(_content, _x, _cfg):
+        run.chunked = True
+        return [{"content": c, "suggested_type": "fact"} for c in chunks]
+
+    async def _embeddings(texts, _cfg, background=False):
+        return [[0.0] for _ in texts]
+
+    async def _audit(**kwargs):
+        if audit_raises:
+            raise RuntimeError("audit backend unavailable")
+        run.audits.append(kwargs["action"])
+
+    with (
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(memory_service, "get_embeddings_batch", new=_embeddings),
+        patch("core_api.services.ingest_service._chunk_content", new=_chunk_content),
+        # Patched where ``GovernanceDecision`` resolves it, not where it is
+        # defined — the step imports the name at module level.
+        patch(
+            "core_api.pipeline.steps.write.governance_decision.emit_governance_audit",
+            new=_audit,
+        ),
+    ):
+        try:
+            await memory_service._handle_auto_chunk_from_ctx(data, ctx)
+        except HTTPException as exc:
+            run.error = exc
+
+    if sc.create_memory.await_args_list:
+        run.parent = sc.create_memory.await_args_list[0].args[0]
+    if sc.create_memories.await_args_list:
+        run.children = sc.create_memories.await_args_list[0].args[0]
+    return run
+
+
+def _merged_metadata(enrichment: EnrichmentResult | None) -> dict:
+    """The governance-relevant subset of what ``MergeEnrichmentFields`` writes.
+
+    Reproduced rather than imported because the point of the fix is what happens
+    to these three keys AFTER that step has run — the handler receives them
+    already merged. Note that the step writes them for any enrichment result at
+    all: they describe the content, and are recorded whether or not a governance
+    policy is configured to act on them.
+    """
+    if enrichment is None:
+        return {}
+    metadata: dict = {"business_relevance": enrichment.business_relevance}
+    if enrichment.contains_pii:
+        metadata["contains_pii"] = True
+        if enrichment.pii_types:
+            metadata["pii_types"] = enrichment.pii_types
+    return metadata
+
+
+def _business() -> EnrichmentResult:
+    return EnrichmentResult(llm_ms=5)
+
+
+def _pii() -> EnrichmentResult:
+    return EnrichmentResult(contains_pii=True, pii_types=["health"], llm_ms=5)
+
+
+def _personal() -> EnrichmentResult:
+    return EnrichmentResult(business_relevance="personal", llm_ms=5)
+
+
+# ── drop: nothing may be written ─────────────────────────────────────────────
+
+
+async def test_a_pii_drop_verdict_refuses_the_auto_chunk_write() -> None:
+    run = await _run_auto_chunk(
+        config=_config(pii={"enabled": True, "action": "drop"}), enrichment=_pii()
+    )
+
+    assert run.error is not None and run.error.status_code == 422
+    assert run.parent is None, "the parent persisted despite a drop verdict"
+    assert run.children == [], "chunk children persisted despite a drop verdict"
+    assert "pii_drop" in run.audits
+
+
+async def test_a_personal_drop_verdict_refuses_the_auto_chunk_write() -> None:
+    run = await _run_auto_chunk(
+        config=_config(non_business={"enabled": True, "disposition": "drop"}),
+        enrichment=_personal(),
+    )
+
+    assert run.error is not None and run.error.status_code == 422
+    assert run.parent is None
+    assert run.children == []
+    assert "nonbusiness_drop" in run.audits
+
+
+async def test_a_drop_verdict_costs_no_chunking_call() -> None:
+    """The gate is ahead of ``_chunk_content``, not merely ahead of the insert.
+
+    Chunking is an LLM round-trip. Refusing the write after paying for it would
+    still be correct, but the fail-safe ordering that makes the refusal reliable
+    — decide before deriving anything — comes for free with the cheaper one.
+    """
+    run = await _run_auto_chunk(
+        config=_config(pii={"enabled": True, "action": "drop"}), enrichment=_pii()
+    )
+
+    assert run.chunked is False
+
+
+async def test_the_single_fact_fall_through_is_governed_too() -> None:
+    """Chunking that yields 0-1 facts falls through to ``build_persist_pipeline``,
+    which has no ``GovernanceDecision`` of its own. Placing the gate inside the
+    ``len(facts) > 1`` branch would leave that sub-path exactly as it was."""
+    run = await _run_auto_chunk(
+        config=_config(pii={"enabled": True, "action": "drop"}),
+        chunks=("just the one",),
+        enrichment=_pii(),
+    )
+
+    # The audit is what makes this specific: a gate moved into the multi-fact
+    # branch leaves a single-fact run with no governance action at all, which no
+    # assertion about the raised status code alone would distinguish from the
+    # fall-through failing for some unrelated reason.
+    assert run.audits == ["pii_drop"]
+    assert run.error is not None and run.error.status_code == 422
+    assert run.parent is None
+
+
+# ── keep_private: the downgrade must reach the children ──────────────────────
+
+
+async def test_keep_private_downgrades_the_parent() -> None:
+    run = await _run_auto_chunk(
+        config=_config(non_business={"enabled": True, "disposition": "keep_private"}),
+        enrichment=_personal(),
+    )
+
+    assert run.error is None
+    assert run.parent is not None
+    assert run.parent["visibility"] == "scope_agent"
+
+
+async def test_keep_private_cascades_to_the_children() -> None:
+    """The children are cut out of the parent's text. Leaving them at the
+    original visibility re-publishes exactly the content the policy just made
+    private — #808's finding on the other fan-out, and the same here."""
+    run = await _run_auto_chunk(
+        config=_config(non_business={"enabled": True, "disposition": "keep_private"}),
+        enrichment=_personal(),
+    )
+
+    assert len(run.children) == 2
+    assert {c["visibility"] for c in run.children} == {"scope_agent"}
+
+
+# ── flag: the row is marked, the children inherit, the action is recorded ────
+
+
+async def test_the_children_carry_the_parents_governance_verdict() -> None:
+    run = await _run_auto_chunk(
+        config=_config(pii={"enabled": True, "action": "flag"}), enrichment=_pii()
+    )
+
+    assert len(run.children) == 2
+    for child in run.children:
+        meta = child["metadata_"]
+        assert meta["contains_pii"] is True
+        assert meta["pii_types"] == ["health"]
+        assert meta["business_relevance"] == "business"
+        # The verdict is added to the provenance keys, not in place of them.
+        assert meta["source"] == "auto_chunk"
+        assert meta["parent_memory_id"] == run.parent_id
+
+
+async def test_a_flagged_write_is_audited() -> None:
+    """``MergeEnrichmentFields`` already set ``contains_pii`` on the row, so the
+    metadata alone cannot tell whether the gate ran. The audit row can: before
+    this fix no governance action was recorded for an auto-chunk write at all."""
+    run = await _run_auto_chunk(
+        config=_config(pii={"enabled": True, "action": "flag"}), enrichment=_pii()
+    )
+
+    assert run.audits == ["pii_flag"]
+    assert run.parent is not None
+    assert run.parent["metadata_"]["contains_pii"] is True
+
+
+# ── failure and over-application guards ──────────────────────────────────────
+
+
+async def test_a_failed_governance_step_refuses_the_write() -> None:
+    """The runner CATCHES a non-``HTTPException`` and reports ``failed`` rather
+    than raising, so the handler has to check. Without the check an audit
+    backend outage would quietly downgrade an enforced policy to no policy —
+    which is the defect being fixed, one level up."""
+    run = await _run_auto_chunk(
+        config=_config(pii={"enabled": True, "action": "flag"}),
+        enrichment=_pii(),
+        audit_raises=True,
+    )
+
+    assert run.error is not None and run.error.status_code == 500
+    assert run.parent is None
+    assert run.children == []
+
+
+async def test_an_uncertain_llm_signal_takes_no_destructive_action() -> None:
+    """``llm_ms == 0`` means no live model judged this write. The deterministic
+    scan is the fail-closed backstop; the free-form gate records the uncertainty
+    and lets the write through rather than dropping on an absent signal."""
+    run = await _run_auto_chunk(
+        config=_config(pii={"enabled": True, "action": "drop"}),
+        enrichment=EnrichmentResult(contains_pii=True, pii_types=["health"], llm_ms=0),
+    )
+
+    assert run.error is None
+    assert run.parent is not None
+    assert run.parent["metadata_"]["governance_llm_uncertain"] is True
+    assert run.audits == []
+
+
+async def test_business_content_is_written_unchanged() -> None:
+    """Over-application guard: an enabled policy with nothing to act on must
+    leave the write exactly as it was."""
+    run = await _run_auto_chunk(
+        config=_config(
+            pii={"enabled": True, "action": "drop"},
+            non_business={"enabled": True, "disposition": "drop"},
+        ),
+        enrichment=_business(),
+    )
+
+    assert run.error is None
+    assert run.parent is not None
+    assert run.parent["visibility"] == "scope_team"
+    assert len(run.children) == 2
+    assert run.audits == []
+
+
+async def test_governance_disabled_enforces_nothing() -> None:
+    """With no policy configured the step SKIPs: a flagged verdict costs the
+    write nothing — no rejection, no downgrade, no audit row.
+
+    The children still inherit the three labels, and that is not the gate
+    firing: ``MergeEnrichmentFields`` records them for any enrichment result
+    because they describe the content, and the children are made of that
+    content. Enforcement is what governance adds, not the labelling.
+    """
+    run = await _run_auto_chunk(config=_config(), enrichment=_pii())
+
+    assert run.error is None
+    assert run.audits == []
+    assert run.parent is not None
+    assert run.parent["visibility"] == "scope_team"
+    assert len(run.children) == 2
+    assert all(c["metadata_"]["contains_pii"] is True for c in run.children)
+
+
+async def test_the_inheritance_does_not_invent_a_verdict() -> None:
+    """Over-application guard on the copy itself: a parent with no verdict keys
+    (the LLM did not run) yields children with the two provenance keys and
+    nothing else."""
+    run = await _run_auto_chunk(
+        config=_config(pii={"enabled": True, "action": "drop"}), enrichment=None
+    )
+
+    assert run.error is None
+    assert len(run.children) == 2
+    for child in run.children:
+        assert set(child["metadata_"]) == {"parent_memory_id", "source"}
+
+
+def test_only_the_persisting_compositions_apply_the_llm_verdict() -> None:
+    """Pins WHERE the step may live, which is the whole design question here.
+
+    ``build_enrichment_pipeline`` is shared with the extract-only branch
+    (``persist=False``), which writes nothing and returns a preview of content
+    the caller already holds — a 422 there refuses a request that leaks nothing.
+    So the step goes on the auto-chunk composition instead. Asserting the exact
+    set rather than "auto-chunk has it" also catches the reverse mistake of
+    dropping it from strong mode.
+    """
+    builders = {
+        name: getattr(compositions, name)
+        for name in dir(compositions)
+        if name.startswith("build_") and name.endswith("_pipeline")
+    }
+    assert len(builders) >= 6, f"composition set shrank unexpectedly: {sorted(builders)}"
+
+    applies = {
+        name
+        for name, build in builders.items()
+        if any(isinstance(step, GovernanceDecision) for step in build()._steps)
+    }
+    assert applies == {
+        "build_strong_write_pipeline",
+        "build_auto_chunk_governance_pipeline",
+    }


### PR DESCRIPTION
Fixes #852.

## The bug

The auto-chunk branch runs `build_enrichment_pipeline`, which ends in `MergeEnrichmentFields` — so `contains_pii`, `pii_types` and `business_relevance` are sitting in `fields["metadata"]` before the first row is written, and `parent_metadata` copies them onto the parent. Nothing then acted on them: `GovernanceDecision` lives only in `build_strong_write_pipeline`, and `remediate_after_enrichment` is reached from the two enrichment paths and the bulk path, none of which this branch takes.

Four distinct losses, not one:

| policy | what happened |
|---|---|
| `pii.action="drop"` / `non_business.disposition="drop"` | parent **and** every chunk child persisted |
| `keep_private` | parent kept its visibility, and so did the children cut out of its text |
| `flag` / `mask` | row was marked (`MergeEnrichmentFields` does that much) but **no audit row** was written |
| any | children carried no verdict at all — `metadata_` was exactly `{parent_memory_id, source}` |

That last row is the shape #808 just fixed for atomic facts, on the other fan-out.

The deterministic gate is unaffected — `GovernanceScanContent` sits in `build_enrichment_pipeline` after `LoadTenantConfig`, so pattern-detectable PII was already masked or rejected here. What was lost is the free-form judgement, same as H-18 (#806) on a third entry point.

## The fix: decide before deriving

`GovernanceDecision` runs as the **first statement** of `_handle_auto_chunk_from_ctx`, ahead of the chunking call. Ahead, not merely before the insert: chunking is an LLM round-trip a rejected write shouldn't pay for, and deciding before anything is derived is the fail-safe order.

Three things fall out of that placement, and all three are deliberate:

- **The `keep_private` downgrade cascades for free.** The step mutates `data.visibility` in place, and both the parent payload and every child payload read `data.visibility or "scope_team"`. Nothing has to be threaded through by hand — but it only works if the step runs before either payload is built.
- **The 0-1-fact fall-through is covered.** That sub-path hands the same context to `build_persist_pipeline`, which has no `GovernanceDecision` of its own, on a branch that never sets the `resolved_write_mode` that `ScheduleBackgroundTasks` keys post-write remediation on.
- **A `drop` costs no chunking call.**

It's a composition (`build_auto_chunk_governance_pipeline`), not a bare `GovernanceDecision().execute(ctx)`, so that *"which write paths enforce the LLM verdict?"* stays answerable by reading `compositions/write.py`. That's the question that got the wrong answer when this branch was written; a test now pins the exact set of compositions carrying the step.

It is **not** appended to `build_enrichment_pipeline` — that composition is shared with the extract-only branch (`persist=False`), which writes nothing and returns a preview of content the caller already holds. A 422 there would refuse a request that leaks nothing.

### Why the `governance.failed` check matters

The runner re-raises `HTTPException` (the 422 a `drop` raises) but **catches everything else** and returns `failed`. Without the explicit check, a governance step that blew up — an audit backend outage is the realistic one — returns as an ordinary result and the write proceeds ungoverned: the exact defect being fixed, one level up. Not theoretical: it fired during development against a stale test fake (below).

### Children inherit the verdict, via a shared helper

`_inherit_governance_signals` replaces the inline loop #808 added for atomic facts and is now called from both fan-outs. Shared rather than repeated, because that repetition is the shape #847 is about — this is the second of the pair, and it didn't get in #808 what the first one did.

## A stale test fake, surfaced by the new check

`test_child_dedup_minting_paths.py` built `tenant_config` as a `SimpleNamespace` carrying the two attributes the handler happened to read when those tests were written. `GovernanceDecision` reads `governance_pii`/`governance_non_business`, so it raised `AttributeError` inside the step — which the new check correctly turned into a refused write rather than an ungoverned one. Replaced with the real `ResolvedConfig`; governance left unconfigured, so the step SKIPs and those dedup tests observe exactly what they always did.

## Tests

`tests/test_h852_governed_auto_chunk.py`, 14 tests. A plain revert gives no signal (the file imports `build_auto_chunk_governance_pipeline`, so on `main` it fails at collection, not on behaviour). Each rejected or pre-fix design was applied to the **fixed** tree instead, and in every case exactly the intended tests failed:

| simulated design | caught by |
|---|---|
| no gate at all (the pre-fix branch) | 9 of the 14 |
| children inherit nothing | `..._carry_the_parents_governance_verdict`, `..._disabled_enforces_nothing` |
| gate inside the `len(facts) > 1` branch | `..._costs_no_chunking_call`, `..._fall_through_is_governed_too` |
| `governance.failed` ignored | `..._failed_governance_step_refuses_the_write` |
| step appended to the shared enrichment pipeline | `..._only_the_persisting_compositions_apply_the_llm_verdict` |
| inherit unconditionally rather than by presence | `..._does_not_invent_a_verdict` |

Four of the fourteen guard against over-applying the fix: an enabled policy with nothing to act on writes unchanged; a disabled policy enforces nothing; an uncertain LLM signal (`llm_ms == 0`) records the uncertainty and lets the write through; a parent with no verdict keys yields children with only their provenance keys.

## Scope, and two things deliberately not in here

**Inline deployments.** In a deferred deployment `ParallelEmbedEnrich` skips the LLM on this branch, so there is no verdict to apply — the gate records `governance_llm_uncertain` and the write proceeds. Same scope as #808.

**`_create_memory_legacy` — filed as #855.** Its auto-chunk branch has the same gap, but so does the rest of it: no `GovernanceScanContent`, no `GovernanceDecision`, no `BusinessPersonalPregate`, and `remediate_after_enrichment` never called. It is ungoverned end to end rather than leaking one verdict, and it is unreachable (`_USE_PIPELINE_WRITE` is a hardcoded `True`; the lever exists to cut a hotfix build). Wiring a whole governance stack into a deprecated path is a different change from applying a verdict on a live one.

**Deferred auto-chunk parents are never enriched at all — filed as #856.** Noticed while establishing the deployment-mode scope above, and orthogonal to governance.

## Gates

`ruff check` + `ruff format --check` on `core-api/src/` clean and run separately; `mypy` clean; broker OpenAPI baseline up to date (8 operations, no contract change — no route or parameter is touched).

### Full suite, and one flake worth naming

| run | result |
|---|---|
| `origin/main` (70a357f7) ×2 | 4731 passed, 0 failed |
| this branch | 4743 passed, **2 failed** |
| this branch, rerun | 4745 passed, 0 failed |
| this branch, new test file ignored | 4731 passed, 0 failed |

4731 + 14 = 4745, so the counts line up.

The one run with failures hit `test_api_interview.py::test_schedule_queues_once_then_respects_pending_and_dueness` and `test_interview_async_submit.py::test_schedule_sweep_processes_pending_jobs`. They did not reproduce, and they are not reachable from this change:

- `interview_service.py` writes memories only through `create_memories_bulk` (line 553). Nothing in the interview path calls `create_memory`, so nothing reaches `_handle_auto_chunk_from_ctx` or the new composition.
- The first of the two sorts *before* `test_h852_governed_auto_chunk.py` in collection order, so the new file cannot have polluted it.
- The observed shape — `jobs_processed >= 1` passing while `jobs_done == 0` — is the outcome `process_pending_interview_jobs` itself documents for a race: *"a concurrent run claimed the job between the sweep's fetch and our claim"*, counted as `jobs_skipped`.

Reporting it rather than rounding to "green": one run in three did fail, and the reason it did is load-sensitivity in a shared module-level `synthesis_sem`, not this diff.
