### PR TITLE
fix(llm): one attempt must be one request

### DIFF
--- a/common/llm/constants.py
+++ b/common/llm/constants.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 
 from common.env_utils import read_float_env as _read_float_env
+from common.env_utils import read_int_env
 
 # ── Provider model defaults ──────────────────────────────────────────
 
@@ -41,8 +42,67 @@ OPENROUTER_DEFAULT_MODEL = os.environ.get(
 # provider (configured via ``call_with_fallback``). Linear backoff
 # rather than exponential because the LLM call is already slow (1-3s)
 # and a multi-second backoff would push the request past timeout.
+#
+# This is the ONLY retry layer, which it previously was not — see
+# ``LLM_PROVIDER_MAX_RETRIES``. Worth reading the two together: the
+# reason for linear backoff above is the same reason a second, hidden,
+# EXPONENTIAL backoff underneath it was wrong.
 LLM_RETRY_ATTEMPTS = 2
 LLM_RETRY_DELAY_S = 1.0
+
+# Retries the OpenAI-compatible SDK performs INSIDE one provider call.
+# Zero, so ``call_with_retry`` above is the whole retry policy.
+#
+# Left unset, the SDK applies ``DEFAULT_MAX_RETRIES = 2`` — three HTTP
+# requests per call, on 429/408/409/5xx and connection errors. Nothing
+# pinned it, so the real request count was the PRODUCT of every layer:
+#
+#   call_with_fallback (2 providers)
+#     x call_with_retry (LLM_RETRY_ATTEMPTS = 2)
+#       x the SDK (3 requests)
+#   = up to 12 HTTP requests for one logical LLM call, where the code
+#     reads as 4.
+#
+# Invisible at every level that could have caught it: SDK retries emit no
+# log line, so ``call_with_retry``'s "attempt 1/2 failed" covered up to
+# three real requests, and the two are indistinguishable in any provider
+# dashboard or spend report.
+#
+# Three concrete harms, not tidiness:
+#
+#  1. It overrode callers that had explicitly opted OUT of retrying.
+#     ``recall_service`` passes ``max_attempts=1`` precisely to fail fast
+#     to the fallback provider rather than retry a slow primary — and
+#     then got three tries anyway, with exponential backoff, inside a
+#     15 s budget.
+#  2. It broke the timeout arithmetic that the inline and bulk ceilings
+#     were derived from. ``OPENAI_REQUEST_TIMEOUT_SECONDS`` is per
+#     REQUEST, so one "attempt" is up to 75 s — over
+#     ``enrichment_inline_timeout_seconds`` (35 s) and
+#     ``BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS`` (30 s) on the FIRST
+#     attempt, when both were sized believing an attempt was one request.
+#  3. Its backoff contradicts the documented policy directly. The comment
+#     above chose linear delay because "a multi-second backoff would push
+#     the request past timeout" — while the SDK was applying exactly that
+#     underneath, inside the budget the choice was protecting.
+#
+# Accepted cost, stated plainly: the SDK honours ``Retry-After`` and
+# jitters its backoff, and ``call_with_retry`` does neither. That matters
+# more here than on the embedding side, because this client serves three
+# HOSTED APIs with real per-org rate limits (OpenAI, Anthropic,
+# OpenRouter) rather than a self-hosted backend. It is still the right
+# trade today: callers wrap each attempt in ``asyncio.wait_for`` at 10-15 s,
+# which cancels a respectful ``Retry-After`` wait long before it
+# completes, so the compliance was mostly theoretical. The real fix is to
+# teach ``call_with_retry`` about ``Retry-After`` — where it is visible
+# and inside the budget accounting — not to keep a second retry layer
+# that no caller can see.
+#
+# ``minimum=0`` because 0 is the intended value and ``read_int_env``'s
+# usual floor of 1 would make it arrive by FALLING BACK rather than by
+# being accepted. Env-tunable purely so an incident can restore the old
+# behaviour without a deploy.
+LLM_PROVIDER_MAX_RETRIES = read_int_env("LLM_PROVIDER_MAX_RETRIES", 0, minimum=0)
 
 # Fallback model for OpenAI-compatible providers when the tenant's
 # configured model is not set — env-overridable so on-call can swap to
@@ -55,6 +115,11 @@ LLM_FALLBACK_MODEL_OPENAI = os.environ.get("LLM_FALLBACK_MODEL_OPENAI", "gpt-5.4
 # enough that a single hung upstream call eats the whole enrichment
 # budget silently. 25s gives the provider room to respond while still
 # leaving budget for one retry under the inline ceiling.
+#
+# That last clause only holds now that ``LLM_PROVIDER_MAX_RETRIES`` is
+# pinned. This value is per REQUEST, and the SDK's own default made one
+# ATTEMPT up to three of them — 75 s, past the 35 s inline ceiling on the
+# first attempt, so the budget for a retry never existed.
 OPENAI_REQUEST_TIMEOUT_SECONDS = _read_float_env("OPENAI_REQUEST_TIMEOUT_SECONDS", 25.0)
 
 
@@ -88,7 +153,6 @@ PREGATE_CLASSIFIER_TIMEOUT_SECONDS = _read_float_env(
 # upstream provider's per-IP cap is hit) without a redeploy.
 from common.env_utils import (  # noqa: E402 — intentional late import, see module docstring
     clamp_keepalive,
-    read_int_env,
 )
 
 OPENAI_HTTPX_MAX_CONNECTIONS = read_int_env("OPENAI_HTTPX_MAX_CONNECTIONS", 200)

--- a/common/llm/providers/openai.py
+++ b/common/llm/providers/openai.py
@@ -23,6 +23,7 @@ import httpx
 import openai
 
 from common.llm.constants import (
+    LLM_PROVIDER_MAX_RETRIES,
     OPENAI_CHAT_BASE_URL,
     OPENAI_HTTPX_CONNECT_TIMEOUT_SECONDS,
     OPENAI_HTTPX_MAX_CONNECTIONS,
@@ -92,9 +93,15 @@ class OpenAILLMProvider:
         # tenant's traffic queueing at the pool layer. Sizing the pool
         # 2x the worst-case fan-out keeps headroom; values are env-
         # tunable for incident-time adjustment.
+        #
+        # ``max_retries`` is pinned rather than left at the SDK's default
+        # 2, which put a silent 3x multiplier under ``call_with_retry``
+        # AND under the per-request timeout that the inline and bulk
+        # ceilings are derived from. See ``LLM_PROVIDER_MAX_RETRIES``.
         self._client = openai.AsyncOpenAI(
             api_key=api_key,
             base_url=base_url,
+            max_retries=LLM_PROVIDER_MAX_RETRIES,
             timeout=httpx.Timeout(
                 connect=OPENAI_HTTPX_CONNECT_TIMEOUT_SECONDS,
                 # read AND write keep the full request budget — the bare

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -76,13 +76,20 @@ class Settings(BaseSettings):
     # (typical p95 ~6-12s, plus 2 retries x 1s linear backoff) without
     # breaching the 45s outer request budget. Must stay below
     # ``request_timeout_seconds`` so this fires first.
+    #
+    # That derivation counts ONE request per attempt, which only became
+    # true with ``LLM_PROVIDER_MAX_RETRIES``: the SDK's own default of 2
+    # made an attempt up to three requests, each with the per-request
+    # budget below, plus its own exponential backoff — so the worst case
+    # exceeded this ceiling on the first attempt rather than the third.
     enrichment_inline_timeout_seconds: float = 35.0
     # Per-call timeout passed to the AsyncOpenAI client (covers both LLM
     # enrichment and embedding providers). Without an explicit value the
     # SDK rides httpx's default — long enough that a single hung upstream
     # call eats the whole enrichment budget silently. 25s gives the
     # provider room to respond while still leaving budget for one retry
-    # under the inline ceiling.
+    # under the inline ceiling. Per REQUEST, not per attempt — see
+    # ``LLM_PROVIDER_MAX_RETRIES`` for why that distinction mattered.
     openai_request_timeout_seconds: float = 25.0
     openai_api_key: str | None = None
     anthropic_api_key: str | None = None

--- a/tests/test_llm_provider_sdk_retries.py
+++ b/tests/test_llm_provider_sdk_retries.py
@@ -1,0 +1,144 @@
+"""One LLM attempt must be one HTTP request.
+
+``openai.AsyncOpenAI`` defaults to ``max_retries=2`` — three requests per
+call — and the LLM path stacks two retry layers of its own on top:
+``call_with_fallback`` tries two providers, each through
+``call_with_retry`` at ``LLM_RETRY_ATTEMPTS``. Unpinned, the real count
+was the product: up to 12 requests where the code reads as 4.
+
+It could not be caught at any layer above. SDK retries emit no log line,
+so ``call_with_retry``'s "attempt 1/2 failed" covered up to three real
+requests, and every stat and dashboard counted one.
+
+These tests assert at the HTTP boundary for that exact reason. Mocking
+the provider would prove nothing — the multiplier lives *below* it, which
+is what made it invisible in the first place.
+
+Two consequences are pinned here rather than just the constant:
+
+  1. ``max_attempts=1`` means one request. ``recall_service`` passes it to
+     fail fast to the fallback provider instead of retrying a slow
+     primary; the SDK was overriding that with three tries and
+     exponential backoff inside a 15 s budget.
+  2. The retry budget is a sum, not a product. ``LLM_RETRY_ATTEMPTS``
+     attempts is ``LLM_RETRY_ATTEMPTS`` requests.
+"""
+
+from __future__ import annotations
+
+import httpx
+import openai
+import pytest
+
+from common.llm.constants import LLM_PROVIDER_MAX_RETRIES, LLM_RETRY_ATTEMPTS
+from common.llm.providers.openai import OpenAILLMProvider
+from common.llm.retry import call_with_retry
+
+
+def _counting_provider(calls: list[str]) -> OpenAILLMProvider:
+    """A real provider whose only stub is the socket underneath it.
+
+    The provider is built by its own constructor — that is the thing under
+    test, since ``max_retries`` is what the constructor passes — and only
+    the transport at the very bottom is swapped. Patching
+    ``httpx.AsyncClient`` instead would be global (the module does ``import
+    httpx``, so there is no module-local name to patch) and breaks the
+    SDK's own ``isinstance(http_client, httpx.AsyncClient)`` check.
+
+    Every request answers 429. That status is the one that matters: it is
+    retryable to the SDK, so an unpinned client walks its whole ladder,
+    where a 400 would exit on the first response and hide the defect.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        return httpx.Response(429, json={"error": {"message": "slow down"}})
+
+    provider = OpenAILLMProvider(api_key="test-key", model="test-model")
+    provider._client._client._transport = httpx.MockTransport(_handler)
+    return provider
+
+
+@pytest.fixture
+def count_requests():
+    """Collects one entry per HTTP request the SDK actually issues."""
+    return []
+
+
+@pytest.mark.unit
+class TestOneAttemptIsOneRequest:
+    @pytest.mark.asyncio
+    async def test_a_single_call_issues_a_single_request(self, count_requests):
+        provider = _counting_provider(count_requests)
+        try:
+            with pytest.raises(openai.RateLimitError):
+                await provider.complete_text("hello")
+        finally:
+            await provider.aclose()
+
+        assert len(count_requests) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_one_means_one_request(self, count_requests):
+        """The opt-out has to actually opt out.
+
+        ``recall_service`` sets ``max_attempts=1`` on a latency-sensitive
+        read path specifically so a slow primary is abandoned for the
+        fallback provider rather than retried. Three hidden tries with
+        exponential backoff is the opposite of what it asked for, inside
+        a budget chosen to make the fast failure possible.
+        """
+        provider = _counting_provider(count_requests)
+        try:
+            with pytest.raises(openai.RateLimitError):
+                await call_with_retry(
+                    lambda: provider.complete_text("hello"),
+                    label="test-single-attempt",
+                    max_attempts=1,
+                )
+        finally:
+            await provider.aclose()
+
+        assert len(count_requests) == 1
+
+    @pytest.mark.asyncio
+    async def test_the_retry_budget_is_a_sum_not_a_product(
+        self, count_requests, monkeypatch
+    ):
+        """N attempts must cost N requests, not N x 3."""
+        monkeypatch.setattr("common.llm.retry.LLM_RETRY_DELAY_S", 0.0)
+        provider = _counting_provider(count_requests)
+        try:
+            with pytest.raises(openai.RateLimitError):
+                await call_with_retry(
+                    lambda: provider.complete_text("hello"),
+                    label="test-full-budget",
+                    max_attempts=LLM_RETRY_ATTEMPTS,
+                    base_delay=0.0,
+                )
+        finally:
+            await provider.aclose()
+
+        assert len(count_requests) == LLM_RETRY_ATTEMPTS
+
+
+@pytest.mark.unit
+class TestTheKnobIsPinned:
+    @pytest.mark.asyncio
+    async def test_client_carries_the_pinned_value(self):
+        """Guard the library default, which returns on its own.
+
+        It comes back the moment the constructor stops passing the value —
+        an SDK upgrade, a refactor, a copied kwargs dict — and nothing
+        downstream can see it happen.
+        """
+        provider = OpenAILLMProvider(api_key="test-key", model="test-model")
+        try:
+            assert provider._client.max_retries == LLM_PROVIDER_MAX_RETRIES
+            assert provider._client.max_retries == 0, (
+                "one attempt must be one request; the SDK's default 2 puts a "
+                "silent 3x under call_with_retry and under the per-request "
+                "timeout the inline/bulk ceilings are derived from"
+            )
+        finally:
+            await provider.aclose()


### PR DESCRIPTION
Follow-up to #854, which found the same unpinned `max_retries` on the
embedding client. The question worth answering first was whether that
conclusion transfers, because the LLM path has a real retry policy of its
own and pinning to 0 would be wrong if it did not. It does — and the
evidence here is stronger.

## The LLM path retries twice, in two nested layers

`common/llm/retry.py` is deliberate: `call_with_retry` takes
`LLM_RETRY_ATTEMPTS` attempts with linear backoff, and
`call_with_fallback` runs it **twice** — once for the primary provider,
once for the tenant-resolved fallback. So the real request count was the
product of three layers:

```
call_with_fallback     2 providers
  x call_with_retry    LLM_RETRY_ATTEMPTS = 2
    x the SDK          DEFAULT_MAX_RETRIES = 2  ->  3 requests
  = up to 12 HTTP requests for one logical call, where the code reads as 4
```

Invisible at every layer that could have caught it. SDK retries emit no
log line, so this — from the test run against the unpinned client —

```
common.llm.retry: test-full-budget attempt 1/2 failed (RateLimitError: 429)
```

is **one** logged attempt covering **three** real requests. Every stat,
dashboard and spend report counted it as one.

## Three harms, and the first is the one that decides it

**1. It overrode callers that had explicitly opted out of retrying.**
`recall_service.py:214` passes `max_attempts=1` — documented in
`call_with_fallback` as "pass 1 on latency-sensitive read paths (e.g.
recall) to fail fast to the fallback provider instead of retrying a
slow/hung primary". It got three tries anyway, with exponential backoff,
inside a 15 s budget chosen to make the fast failure possible. Measured:

| | requests |
|---|---|
| `max_attempts=1`, before | **3** |
| `max_attempts=1`, after | **1** |
| `LLM_RETRY_ATTEMPTS=2`, before | **6** |
| `LLM_RETRY_ATTEMPTS=2`, after | **2** |

**2. It broke ceilings whose derivation was written down.**
`config.py:76` sizes the inline cap as "35s leaves headroom for
nano-class LLM tail latency (typical p95 ~6-12s, plus 2 retries x 1s
linear backoff)". That counts one request per attempt. At three requests
of `openai_request_timeout_seconds` (25 s) each, one attempt is up to 75 s
— over the 35 s ceiling, and over `BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS`
(30 s), on the **first** attempt rather than the third.

**3. Its backoff contradicted the stated policy.** `constants.py:41`
chose linear delay because "a multi-second backoff would push the request
past timeout" — while the SDK applied exactly that underneath, inside the
budget that choice was protecting.

## The cost, stated rather than glossed

The SDK honours `Retry-After` and jitters; `call_with_retry` does neither.
That matters more here than for embedding, because this one client class
serves three **hosted** APIs with real per-org rate limits (OpenAI,
Anthropic, OpenRouter) rather than a self-hosted backend.

It is still the right trade. Callers wrap each attempt in
`asyncio.wait_for` at 10-15 s (`dedup_judge`, `recall_service`), which
cancels a respectful `Retry-After` wait long before it completes — so the
compliance was mostly theoretical, while the multiplier was not. The real
fix is teaching `call_with_retry` about `Retry-After`, where it is visible
and inside the budget accounting, not keeping a second retry layer no
caller can see. Worth a follow-up.

## Scope

Only `OpenAILLMProvider` needed it. Checked the rest: `gemini.py` uses
`genai.Client` and `vertex.py` uses `GenerativeModel` (different SDKs,
their own policies — not touched here), `fake.py` makes no calls.

`LLM_PROVIDER_MAX_RETRIES` uses the keyword-only `minimum=0` that #854
added to `read_int_env`, so an explicit `0` in a manifest is *accepted*
rather than arriving via the fallback path.

## Verification

`4762 passed, 3 skipped, 1 xfailed` — full suite, zero failures. All 12
CI ruff scopes clean.

**All 4 new tests fail against the unpinned client** (3, 3, 6 and
`max_retries == 2` against expected 1, 1, 2 and 0). They assert at the
HTTP boundary via a `MockTransport`, answering 429 — the status the SDK
considers retryable — because the multiplier lives *below* the provider,
which is exactly what made it invisible. Mocking the provider would have
proved nothing.
