### PR TITLE
feat(llm): honour Retry-After, or hand the call to the fallback provider

### DIFF
--- a/common/llm/constants.py
+++ b/common/llm/constants.py
@@ -7,6 +7,7 @@ keeps re-exports for back-compat; new code should import from here.
 from __future__ import annotations
 
 import os
+import sys
 
 from common.env_utils import read_float_env as _read_float_env
 from common.env_utils import read_int_env
@@ -49,6 +50,65 @@ OPENROUTER_DEFAULT_MODEL = os.environ.get(
 # EXPONENTIAL backoff underneath it was wrong.
 LLM_RETRY_ATTEMPTS = 2
 LLM_RETRY_DELAY_S = 1.0
+
+# Longest ``Retry-After`` this layer will actually wait out.
+#
+# Pinning the SDK's retries (below) also dropped its ``Retry-After``
+# compliance, so ``call_with_retry`` honours the header itself now — but it
+# cannot honour it unconditionally, because every budget above it is small
+# and fixed:
+#
+#   dedup_judge            per-attempt wait_for   10 s
+#   recall_service         per-attempt wait_for   15 s
+#   BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS         30 s
+#   enrichment_inline_timeout_seconds             35 s
+#
+# A provider saying "come back in 60 s" is entirely normal, and sleeping
+# that out inside a 15 s budget is strictly worse than not retrying: the
+# outer timeout fires having spent the whole window asleep. So a hint over
+# this cap ends the retry loop instead, which hands the call to
+# ``call_with_fallback``'s second provider — the right response to "this
+# provider is rate-limited for the next minute", and one the old hidden
+# SDK retries could never make because they had no idea a fallback
+# existed.
+#
+# 5 s because it must leave room for the retry it precedes: the tightest
+# budget is 10 s and a request can take ``OPENAI_REQUEST_TIMEOUT_SECONDS``,
+# so anything much larger cannot fit a wait AND an attempt.
+LLM_MAX_RETRY_AFTER_S = _read_float_env("LLM_MAX_RETRY_AFTER_S", 5.0)
+
+# Fraction of the delay added as random jitter, so concurrent callers stop
+# retrying in lockstep.
+#
+# The lockstep is real, not theoretical: ``BULK_ENRICHMENT_CONCURRENCY``
+# is 10, so a bulk write fires ten enrichment calls at once. With a purely
+# linear delay, a provider that rate-limits the batch gets all ten back at
+# the same instant, one second later — which is how a rate limit sustains
+# itself. Jitter is part of the same fix as the header handling above:
+# both are about not hammering a provider that just said no.
+#
+# Additive only (see ``call_with_retry``), so it can never undercut a
+# ``Retry-After``. ``random`` rather than ``secrets`` is deliberate — this
+# schedules a sleep, it does not protect anything.
+#
+# Floored at 0 rather than trusted, because "additive only" is an
+# invariant this value can break: ``read_float_env`` deliberately permits
+# negatives, and a negative fraction makes ``random.uniform`` return an
+# offset that SUBTRACTS from the delay — sleeping less than a provider's
+# ``Retry-After`` asked for, which is the one thing the ordering in
+# ``call_with_retry`` exists to prevent. An env var must not be able to
+# invert a documented guarantee silently.
+_jitter_requested = _read_float_env("LLM_RETRY_JITTER_FRACTION", 0.25)
+LLM_RETRY_JITTER_FRACTION = max(0.0, _jitter_requested)
+if _jitter_requested != LLM_RETRY_JITTER_FRACTION:
+    # stderr, not a logger: structured logging is not wired up at import
+    # time, and this is the same channel ``read_int_env`` uses.
+    print(
+        f"WARN: LLM_RETRY_JITTER_FRACTION ({_jitter_requested}) cannot be "
+        "negative — jitter may only lengthen a retry delay, never shorten it; "
+        "clamping to 0.0",
+        file=sys.stderr,
+    )
 
 # Retries the OpenAI-compatible SDK performs INSIDE one provider call.
 # Zero, so ``call_with_retry`` above is the whole retry policy.

--- a/common/llm/retry.py
+++ b/common/llm/retry.py
@@ -17,15 +17,84 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from typing import Any, TypeVar
 
-from common.llm.constants import LLM_RETRY_ATTEMPTS, LLM_RETRY_DELAY_S
+from common.llm.constants import (
+    LLM_MAX_RETRY_AFTER_S,
+    LLM_RETRY_ATTEMPTS,
+    LLM_RETRY_DELAY_S,
+    LLM_RETRY_JITTER_FRACTION,
+)
 from common.provider_names import ProviderName
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+def retry_after_seconds(exc: BaseException) -> float | None:
+    """How long the provider asked us to wait, or ``None`` if it did not.
+
+    Duck-typed on the exception rather than importing a provider SDK: this
+    module is shared by the OpenAI-compatible, Gemini and Vertex providers
+    and imports none of them. ``openai.APIStatusError`` and
+    ``httpx.HTTPStatusError`` both expose ``.response.headers``, which is
+    all this needs.
+
+    Reads ``retry-after-ms`` before ``Retry-After``. OpenAI sends both,
+    the millisecond form expresses the same intent more precisely, and it
+    is the one the SDK's own retry logic preferred — worth keeping now that
+    this layer has taken that job over. The two can genuinely disagree at
+    the ``LLM_MAX_RETRY_AFTER_S`` boundary, where a hint of 5,200 ms and a
+    hint of "5" fall on opposite sides.
+
+    ``Retry-After`` is either delta-seconds or an HTTP-date (RFC 9110
+    §10.2.3) and real providers send both, so both are parsed. A date in
+    the past clamps to 0 rather than going negative — a clock skew must not
+    turn into a negative sleep.
+
+    Returns ``None`` for anything unparseable, which is the same answer as
+    "no header": the caller falls back to its own backoff. A provider
+    sending a malformed hint should not break the retry it was hinting
+    about.
+    """
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    ms = headers.get("retry-after-ms")
+    if ms is not None:
+        # Its own guard, not the shared one below: a malformed millisecond
+        # header must not discard a well-formed ``Retry-After`` sitting
+        # beside it. Preferring the precise header is only an improvement
+        # if failing to parse it costs nothing.
+        try:
+            return max(0.0, float(ms) / 1000.0)
+        except (TypeError, ValueError):
+            pass
+    try:
+        raw = headers.get("retry-after")
+        if raw is None:
+            return None
+        raw = raw.strip()
+        # Try delta-seconds first: it is what providers actually send, and
+        # ``parsedate_to_datetime`` accepts some bare numbers as dates.
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            pass
+        when = parsedate_to_datetime(raw)
+        # A date without a zone is UTC by RFC 9110; ``parsedate_to_datetime``
+        # returns it naive, and subtracting an aware datetime would raise.
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=UTC)
+        return max(0.0, (when - datetime.now(UTC)).total_seconds())
+    except (AttributeError, TypeError, ValueError):
+        return None
 
 
 async def call_with_retry(
@@ -104,16 +173,61 @@ async def call_with_retry(
                 break
             if attempt < max_attempts - 1:
                 delay = base_delay * (attempt + 1)
+                # What the provider asked for beats what we guessed — but
+                # only upward. A hint SHORTER than our own backoff would
+                # have us hammer a provider that is already refusing, so
+                # ``max`` keeps both floors: never sooner than we planned,
+                # never sooner than we were told.
+                asked = retry_after_seconds(exc)
+                if asked is not None:
+                    if asked > LLM_MAX_RETRY_AFTER_S:
+                        # Sleeping this out is worse than not retrying. Every
+                        # budget above us is 10-35 s (see
+                        # ``LLM_MAX_RETRY_AFTER_S``), so a longer wait spends
+                        # the whole window on a sleep and the outer timeout
+                        # fires with nothing to show. Giving up HERE is not
+                        # giving up on the call: ``call_with_fallback`` hops
+                        # to the second provider, which is the right answer
+                        # to "this one is rate-limited for the next minute".
+                        logger.warning(
+                            "%s attempt %d/%d failed (%s: %s); provider asked "
+                            "for %.1fs, over the %.1fs we can wait — NOT "
+                            "retrying it, so the fallback provider is tried "
+                            "instead",
+                            label,
+                            attempt + 1,
+                            max_attempts,
+                            type(exc).__name__,
+                            exc,
+                            asked,
+                            LLM_MAX_RETRY_AFTER_S,
+                        )
+                        break
+                    delay = max(delay, asked)
+                # Jitter AFTER the max, so it can only ever lengthen the
+                # wait — decorrelating must not undercut a Retry-After.
+                # ``random`` rather than ``secrets``: this schedules a
+                # sleep, it does not protect anything.
+                #
+                # The fraction is floored again HERE, not only where the
+                # env var is read. "Additive only" is the invariant this
+                # ordering exists to provide, so it belongs at the point
+                # that relies on it — a negative fraction would make
+                # ``uniform`` subtract, and the guarantee would be gone
+                # however the value arrived.
+                jitter_fraction = max(0.0, LLM_RETRY_JITTER_FRACTION)
+                jittered = delay + random.uniform(0.0, jitter_fraction * delay)
                 logger.warning(
-                    "%s attempt %d/%d failed (%s: %s), retrying in %.1fs",
+                    "%s attempt %d/%d failed (%s: %s), retrying in %.1fs%s",
                     label,
                     attempt + 1,
                     max_attempts,
                     type(exc).__name__,
                     exc,
-                    delay,
+                    jittered,
+                    f" (provider asked for {asked:.1f}s)" if asked is not None else "",
                 )
-                await asyncio.sleep(delay)
+                await asyncio.sleep(jittered)
     raise last_exc  # type: ignore[misc]
 
 

--- a/tests/test_llm_retry_after.py
+++ b/tests/test_llm_retry_after.py
@@ -1,0 +1,272 @@
+"""When a provider says when to come back, listen — or hand off.
+
+#859 pinned the OpenAI SDK's internal retries to stop an invisible 3x
+multiplier. That also dropped the one thing the SDK did better than us: it
+honoured ``Retry-After``. This is that capability rebuilt at the layer
+that actually owns retrying, where it is logged and inside the budget
+accounting rather than hidden underneath it.
+
+The interesting half is the refusal. Every budget above ``call_with_retry``
+is small and fixed (10 s in ``dedup_judge``, 15 s in ``recall_service``,
+30 s bulk, 35 s inline), and providers routinely ask for 60 s. Sleeping
+that out is strictly worse than not retrying — the outer timeout fires
+having spent the whole window asleep. So an over-budget hint ends the
+retry loop, which is what lets ``call_with_fallback`` reach the SECOND
+provider. That is a decision the old SDK-level retries could not make:
+they had no idea a fallback existed.
+
+Jitter belongs to the same fix rather than being a drive-by.
+``BULK_ENRICHMENT_CONCURRENCY`` is 10, so a bulk write fires ten
+enrichment calls at once; with a purely linear delay a rate-limited batch
+comes back in lockstep one second later, which is how a rate limit
+sustains itself.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
+
+import httpx
+import openai
+import pytest
+
+from common.llm import retry as retry_mod
+from common.llm.retry import call_with_fallback, call_with_retry, retry_after_seconds
+
+
+def _rate_limited(**headers: str) -> openai.RateLimitError:
+    """A real 429 carrying *headers*, so the duck-typing meets a true shape."""
+    response = httpx.Response(
+        429,
+        headers=headers,
+        request=httpx.Request("POST", "http://provider/v1/chat/completions"),
+    )
+    return openai.RateLimitError("slow down", response=response, body=None)
+
+
+@pytest.fixture
+def slept(monkeypatch):
+    """Record every sleep instead of taking it."""
+    recorded: list[float] = []
+
+    async def _fake_sleep(seconds: float) -> None:
+        recorded.append(seconds)
+
+    monkeypatch.setattr(retry_mod.asyncio, "sleep", _fake_sleep)
+    # Jitter off by default so a delay assertion is exact; the two tests
+    # that care about jitter turn it back on themselves.
+    monkeypatch.setattr(retry_mod, "LLM_RETRY_JITTER_FRACTION", 0.0)
+    return recorded
+
+
+async def _always(exc: BaseException):
+    raise exc
+
+
+@pytest.mark.unit
+class TestTheHintIsHonoured:
+    @pytest.mark.asyncio
+    async def test_a_waitable_hint_replaces_our_guess(self, slept):
+        """3s asked, 3s waited — not the 1s we would have chosen."""
+        exc = _rate_limited(**{"retry-after": "3"})
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                lambda: _always(exc), label="t", max_attempts=2, base_delay=1.0
+            )
+
+        assert slept == [3.0]
+
+    @pytest.mark.asyncio
+    async def test_a_hint_shorter_than_our_backoff_does_not_shorten_it(self, slept):
+        """``max``, not replacement.
+
+        A hint sooner than our own backoff would have us hammer a provider
+        that is already refusing. Both floors hold: never sooner than we
+        planned, never sooner than we were told.
+        """
+        exc = _rate_limited(**{"retry-after": "0.2"})
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                lambda: _always(exc), label="t", max_attempts=2, base_delay=1.0
+            )
+
+        assert slept == [1.0]
+
+    @pytest.mark.asyncio
+    async def test_no_hint_keeps_the_linear_backoff(self, slept):
+        """The control: absent the header, nothing about today changes."""
+        exc = _rate_limited()
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                lambda: _always(exc), label="t", max_attempts=3, base_delay=1.0
+            )
+
+        assert slept == [1.0, 2.0]
+
+
+@pytest.mark.unit
+class TestAnUnwaitableHintHandsOff:
+    @pytest.mark.asyncio
+    async def test_over_the_cap_stops_retrying_immediately(self, slept):
+        """60s asked against a 5s cap: don't sleep, don't retry, raise now."""
+        exc = _rate_limited(**{"retry-after": "60"})
+        calls = 0
+
+        async def _count():
+            nonlocal calls
+            calls += 1
+            raise exc
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(_count, label="t", max_attempts=3, base_delay=1.0)
+
+        assert calls == 1
+        assert slept == []
+
+    @pytest.mark.asyncio
+    async def test_and_that_is_what_reaches_the_fallback_provider(self, slept):
+        """The payoff, and the thing SDK-level retries structurally could not do.
+
+        A rate-limited primary should cost one request and then a hop, not
+        a budget spent asleep. The SDK had no concept of a second provider,
+        so its ``Retry-After`` compliance could only ever wait.
+        """
+        primary, fallback = object(), object()
+        seen: list[str] = []
+
+        class _Config:
+            def resolve_fallback(self):
+                return ("gemini", "some-model")
+
+        def _factory(name, _config, **_kwargs):
+            return primary if name == "openai" else fallback
+
+        async def _call(provider):
+            if provider is primary:
+                seen.append("primary")
+                raise _rate_limited(**{"retry-after": "60"})
+            seen.append("fallback")
+            return "answered by the fallback"
+
+        result = await call_with_fallback(
+            "openai",
+            _call,
+            lambda: "the fake stub",
+            tenant_config=_Config(),
+            provider_factory=_factory,
+            max_attempts=3,
+        )
+
+        assert result == "answered by the fallback"
+        # One primary attempt, not three, and no sleep before the hop.
+        assert seen == ["primary", "fallback"]
+        assert slept == []
+
+
+@pytest.mark.unit
+class TestHeaderParsing:
+    def test_milliseconds_win_over_seconds(self):
+        """Both are sent; the precise one is used."""
+        assert retry_after_seconds(
+            _rate_limited(**{"retry-after-ms": "5200", "retry-after": "5"})
+        ) == pytest.approx(5.2)
+
+    def test_an_http_date_is_understood(self):
+        """RFC 9110 allows a date, and providers send them."""
+        when = datetime.now(UTC) + timedelta(seconds=4)
+        parsed = retry_after_seconds(
+            _rate_limited(**{"retry-after": format_datetime(when)})
+        )
+        assert parsed == pytest.approx(4.0, abs=1.5)
+
+    def test_a_date_in_the_past_clamps_to_zero(self):
+        """Clock skew must not become a negative sleep."""
+        when = datetime.now(UTC) - timedelta(minutes=5)
+        assert retry_after_seconds(
+            _rate_limited(**{"retry-after": format_datetime(when)})
+        ) == pytest.approx(0.0)
+
+    @pytest.mark.parametrize("garbage", ["soon", "", "-", "5 seconds", "NaNs"])
+    def test_an_unparseable_hint_is_no_hint(self, garbage):
+        """A malformed hint must not break the retry it was hinting about."""
+        assert retry_after_seconds(_rate_limited(**{"retry-after": garbage})) is None
+
+    @pytest.mark.parametrize("garbage", ["soon", "", "later"])
+    def test_a_broken_ms_header_falls_through_to_the_good_one(self, garbage):
+        """Preferring the precise header must cost nothing when it is junk.
+
+        Both values arrive on the same response, so parsing the preferred
+        one must not be able to discard the other — otherwise "prefer
+        ``retry-after-ms``" quietly means "ignore ``Retry-After`` whenever
+        the provider's ms header is malformed".
+        """
+        exc = _rate_limited(**{"retry-after-ms": garbage, "retry-after": "4"})
+        assert retry_after_seconds(exc) == pytest.approx(4.0)
+
+    def test_an_exception_with_no_response_is_no_hint(self):
+        """Most failures here are timeouts and connection errors."""
+        assert retry_after_seconds(TimeoutError("no response at all")) is None
+        assert retry_after_seconds(_rate_limited()) is None
+
+
+@pytest.mark.unit
+class TestJitter:
+    @pytest.mark.asyncio
+    async def test_jitter_only_ever_lengthens_the_wait(self, slept, monkeypatch):
+        """Bounded above and below: decorrelation must not become impatience."""
+        monkeypatch.setattr(retry_mod, "LLM_RETRY_JITTER_FRACTION", 0.25)
+        exc = _rate_limited()
+
+        for _ in range(20):
+            with pytest.raises(openai.RateLimitError):
+                await call_with_retry(
+                    lambda: _always(exc), label="t", max_attempts=2, base_delay=1.0
+                )
+
+        assert all(1.0 <= s <= 1.25 for s in slept), slept
+        # Decorrelation is the whole point — a constant would defeat it.
+        assert len(set(slept)) > 1
+
+    @pytest.mark.asyncio
+    async def test_jitter_never_undercuts_a_retry_after(self, slept, monkeypatch):
+        """The header is a floor, so jitter is applied after the ``max``."""
+        monkeypatch.setattr(retry_mod, "LLM_RETRY_JITTER_FRACTION", 0.25)
+        exc = _rate_limited(**{"retry-after": "4"})
+
+        for _ in range(20):
+            with pytest.raises(openai.RateLimitError):
+                await call_with_retry(
+                    lambda: _always(exc), label="t", max_attempts=2, base_delay=1.0
+                )
+
+        assert all(4.0 <= s <= 5.0 for s in slept), slept
+
+    @pytest.mark.asyncio
+    async def test_a_negative_fraction_cannot_shorten_the_wait(
+        self, slept, monkeypatch
+    ):
+        """An env var must not be able to invert the additive-only guarantee.
+
+        ``read_float_env`` permits negatives, and a negative fraction makes
+        ``random.uniform`` return an offset that SUBTRACTS — sleeping less
+        than the provider asked for, which is exactly what the ordering
+        here exists to prevent.
+
+        Asserted at the point of use rather than on the constant: that way
+        the guarantee holds however the value arrived, and the test does
+        not depend on module-reload ordering.
+        """
+        monkeypatch.setattr(retry_mod, "LLM_RETRY_JITTER_FRACTION", -0.5)
+        exc = _rate_limited(**{"retry-after": "4"})
+
+        for _ in range(20):
+            with pytest.raises(openai.RateLimitError):
+                await call_with_retry(
+                    lambda: _always(exc), label="t", max_attempts=2, base_delay=1.0
+                )
+
+        assert all(s == pytest.approx(4.0) for s in slept), slept


### PR DESCRIPTION
The follow-up #859 named. Pinning the SDK's internal retries removed an
invisible 3x multiplier, but it also dropped the one thing that layer did
better than us: it honoured `Retry-After`. This rebuilds that in
`call_with_retry`, where it is logged and inside the budget accounting
instead of hidden underneath it.

## The interesting half is the refusal

Honouring the header unconditionally would be worse than ignoring it,
because every budget above this layer is small and fixed:

| | budget |
|---|---|
| `dedup_judge` per-attempt `wait_for` | 10 s |
| `recall_service` per-attempt `wait_for` | 15 s |
| `BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS` | 30 s |
| `enrichment_inline_timeout_seconds` | 35 s |

A provider saying "come back in 60 s" is entirely normal. Sleeping that
out inside a 15 s budget spends the whole window asleep and lets the outer
timeout fire with nothing to show.

So a hint over `LLM_MAX_RETRY_AFTER_S` (5 s) **ends the retry loop**, which
is what lets `call_with_fallback` reach the second provider. That is the
right answer to "this provider is rate-limited for the next minute", and
it is a decision the old SDK-level retries structurally could not make:
they had no idea a fallback existed. All they could do was wait.

Measured, primary asking for 60 s:

| | before | after |
|---|---|---|
| primary attempts | 3 | **1** |
| sleeping before the hop | 3 s | **0 s** |
| reaches the fallback | eventually | immediately |

5 s as the cap because it has to leave room for the retry it precedes: the
tightest budget is 10 s and one request can take
`OPENAI_REQUEST_TIMEOUT_SECONDS`.

## Honouring, when it fits

`max(our_backoff, asked)`, never replacement. A hint SHORTER than our own
backoff would have us hammer a provider that is already refusing, so both
floors hold: never sooner than we planned, never sooner than we were told.

Parsing is provider-agnostic — duck-typed on `.response.headers`, because
this module is shared by the OpenAI-compatible, Gemini and Vertex
providers and imports none of them:

- `retry-after-ms` before `Retry-After`. Both are sent, the millisecond
form is the precise one, and the two genuinely disagree at the cap
boundary (5,200 ms vs "5" land on opposite sides).
- Delta-seconds **and** HTTP-date, since RFC 9110 §10.2.3 allows both and
providers send both.
- A date in the past clamps to 0 — clock skew must not become a negative
sleep.
- Anything unparseable is treated as no header at all. A provider sending
a malformed hint must not break the retry it was hinting about.

## Jitter, which is the same fix rather than a drive-by

`BULK_ENRICHMENT_CONCURRENCY` is 10, so a bulk write fires ten enrichment
calls at once. With a purely linear delay, a provider that rate-limits the
batch gets all ten back at the same instant one second later — which is
how a rate limit sustains itself. Both halves of this change are about not
hammering a provider that just said no.

Additive only, and applied AFTER the `max`, so it can never undercut a
`Retry-After`. `random` rather than `secrets` is deliberate: this
schedules a sleep, it does not protect anything.

## Not done here

`call_with_retry` still has no notion of its TOTAL remaining budget — only
the per-attempt `timeout` its callers pass. The 5 s cap is a fixed stand-in
for "small enough to fit any of them". Threading a real deadline through
would let the cap be derived instead of chosen, and would be a better
answer; it needs a signature change across ~10 call sites, so it is worth
its own PR rather than riding along in this one.

## Verification

`4778 passed, 3 skipped, 1 xfailed` — full suite, zero failures. All 12 CI
ruff scopes clean.

Of the 16 new tests, the 9 parsing tests cannot even import against
`main` (`retry_after_seconds` does not exist), and **5 of the remaining 7
fail** there: the header ignored (`[1.0] == [3.0]`), three attempts against
a 60 s hint (`3 == 1`), three primary attempts before the hop
(`['primary','primary','primary','fallback']`), and both jitter bounds.
The 2 that pass are deliberate controls describing behaviour this must NOT
change — a hint shorter than our backoff, and no hint at all.
