### PR TITLE
feat(llm): give the retry loop a deadline it can actually enforce

### DIFF
--- a/common/llm/retry.py
+++ b/common/llm/retry.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import time
 from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
@@ -104,6 +105,7 @@ async def call_with_retry(
     base_delay: float = LLM_RETRY_DELAY_S,
     timeout: float | None = None,
     non_retryable: tuple[type[BaseException], ...] = (),
+    budget_s: float | None = None,
 ) -> T:
     """Call *coro_fn* with retry and linear backoff.
 
@@ -119,6 +121,30 @@ async def call_with_retry(
         Base delay in seconds; actual delay = ``base_delay * attempt_number``.
     timeout:
         Optional per-attempt timeout in seconds.
+    budget_s:
+        Optional wall-clock budget for this whole call — every attempt plus
+        every delay between them. PER PROVIDER, exactly like *timeout*:
+        ``call_with_fallback`` forwards the same value to the primary and to
+        the fallback, so two providers means two budgets.
+
+        Given one, three things stop being guesses. Each attempt's timeout
+        becomes ``min(timeout, remaining)`` so an attempt cannot overrun the
+        budget; the loop stops once the budget is spent instead of starting
+        an attempt with no time to finish; and the cap on a ``Retry-After``
+        is DERIVED from what is left rather than read from
+        ``LLM_MAX_RETRY_AFTER_S``, which exists precisely because callers
+        without a declared budget give this layer nothing to reason from.
+
+        Why it matters more than tidiness: without it the worst case is
+        enforced by parameter VALUES rather than by structure. ``recall``
+        documents "one primary attempt (15s), then one fallback attempt
+        (15s) ... worst case ~30s" — a guarantee that holds only while
+        ``max_attempts`` stays 1, and that silently doubles if anyone
+        restores the default. A budget makes the same promise hold whatever
+        the attempt count is.
+
+        Omitting it keeps the previous behaviour exactly, which is right for
+        the callers that have no deadline of their own to declare.
     non_retryable:
         Exception types that must NOT be retried within this provider — the
         first occurrence raises immediately. Empty by default, so every
@@ -149,12 +175,60 @@ async def call_with_retry(
     """
     if max_attempts <= 0:
         raise ValueError(f"max_attempts must be >= 1, got {max_attempts}")
+    if budget_s is not None and budget_s <= 0:
+        # Same reasoning as the guard above: a caller asking for a
+        # zero-length budget has misconfigured something, and silently
+        # running one unbounded attempt would hide it behind exactly the
+        # overrun the budget was meant to prevent.
+        raise ValueError(f"budget_s must be > 0, got {budget_s}")
+    # ``monotonic``, not ``time()``: a deadline must not move because NTP
+    # stepped the wall clock mid-retry.
+    deadline = None if budget_s is None else time.monotonic() + budget_s
     last_exc: BaseException | None = None
     for attempt in range(max_attempts):
+        remaining = None if deadline is None else deadline - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            # Checked BEFORE ``coro_fn()`` so no coroutine is created that
+            # never gets awaited. Reachable without any sleep: an attempt
+            # that runs to its own timeout can exhaust the budget by itself.
+            logger.warning(
+                "%s giving up before attempt %d/%d — the %.1fs budget is spent",
+                label,
+                attempt + 1,
+                max_attempts,
+                budget_s,
+            )
+            # This is the ONLY break that can be reached with nothing caught
+            # yet — the other two are inside the ``except`` below, where
+            # ``last_exc`` is always set. On the first iteration it would
+            # leave the ``raise`` at the end of this function executing
+            # ``raise None``, which Python reports as "exceptions must derive
+            # from BaseException": a confusing type error standing in for a
+            # perfectly clear condition.
+            #
+            # Only synthesised when there is nothing to report. If an earlier
+            # attempt failed for a real reason, THAT exception is the useful
+            # one and running out of time afterwards must not overwrite it —
+            # same precedence the retry paths below apply.
+            if last_exc is None:
+                last_exc = TimeoutError(
+                    f"{label}: the {budget_s:.1f}s budget was spent before any "
+                    "attempt could start"
+                )
+            break
         try:
             coro = coro_fn()
-            if timeout is not None:
-                return await asyncio.wait_for(coro, timeout=timeout)
+            # The budget binds each attempt too, not just the loop. Without
+            # this an attempt could start with 2 s left and run for its full
+            # ``timeout``, so the budget would be advisory — enforced only by
+            # whoever cancels us from outside.
+            attempt_timeout = timeout
+            if remaining is not None:
+                attempt_timeout = (
+                    remaining if timeout is None else min(timeout, remaining)
+                )
+            if attempt_timeout is not None:
+                return await asyncio.wait_for(coro, timeout=attempt_timeout)
             return await coro
         except Exception as exc:
             last_exc = exc
@@ -180,18 +254,34 @@ async def call_with_retry(
                 # never sooner than we were told.
                 asked = retry_after_seconds(exc)
                 if asked is not None:
-                    if asked > LLM_MAX_RETRY_AFTER_S:
-                        # Sleeping this out is worse than not retrying. Every
-                        # budget above us is 10-35 s (see
-                        # ``LLM_MAX_RETRY_AFTER_S``), so a longer wait spends
-                        # the whole window on a sleep and the outer timeout
-                        # fires with nothing to show. Giving up HERE is not
-                        # giving up on the call: ``call_with_fallback`` hops
-                        # to the second provider, which is the right answer
-                        # to "this one is rate-limited for the next minute".
+                    # Derived when there is a budget to derive from, and only
+                    # then falling back to the fixed constant. Half of what
+                    # is left, so honouring a wait always leaves at least as
+                    # much time again for the attempt it precedes — waiting
+                    # out a hint and then having no time to use it is the
+                    # same wasted request as not waiting at all.
+                    #
+                    # This can exceed ``LLM_MAX_RETRY_AFTER_S``, deliberately.
+                    # That constant is the answer for callers that declared
+                    # nothing; a caller that declares 60 s has said it can
+                    # afford to wait, and second-guessing it would make the
+                    # budget decorative.
+                    now = time.monotonic()
+                    cap = (
+                        LLM_MAX_RETRY_AFTER_S
+                        if deadline is None
+                        else max(0.0, (deadline - now) / 2)
+                    )
+                    if asked > cap:
+                        # Sleeping this out is worse than not retrying: the
+                        # wait spends the window and the outer timeout fires
+                        # with nothing to show. Giving up HERE is not giving
+                        # up on the call — ``call_with_fallback`` hops to the
+                        # second provider, which is the right answer to "this
+                        # one is rate-limited for the next minute".
                         logger.warning(
                             "%s attempt %d/%d failed (%s: %s); provider asked "
-                            "for %.1fs, over the %.1fs we can wait — NOT "
+                            "for %.1fs, over the %.1fs we can wait (%s) — NOT "
                             "retrying it, so the fallback provider is tried "
                             "instead",
                             label,
@@ -200,7 +290,10 @@ async def call_with_retry(
                             type(exc).__name__,
                             exc,
                             asked,
-                            LLM_MAX_RETRY_AFTER_S,
+                            cap,
+                            "half the remaining budget"
+                            if deadline is not None
+                            else "no budget declared, so the fixed cap",
                         )
                         break
                     delay = max(delay, asked)
@@ -217,6 +310,25 @@ async def call_with_retry(
                 # however the value arrived.
                 jitter_fraction = max(0.0, LLM_RETRY_JITTER_FRACTION)
                 jittered = delay + random.uniform(0.0, jitter_fraction * delay)
+                # The plain linear delay needs the same check the Retry-After
+                # path gets from its cap: a 2 s backoff with 1 s left is a
+                # sleep that guarantees the next attempt has nothing. Only
+                # the loop-top check would catch that, and only AFTER
+                # sleeping the budget away for no reason.
+                if deadline is not None and time.monotonic() + jittered >= deadline:
+                    logger.warning(
+                        "%s attempt %d/%d failed (%s: %s); a %.1fs wait would "
+                        "spend the rest of the %.1fs budget — NOT retrying it, "
+                        "so the fallback provider is tried instead",
+                        label,
+                        attempt + 1,
+                        max_attempts,
+                        type(exc).__name__,
+                        exc,
+                        jittered,
+                        budget_s,
+                    )
+                    break
                 logger.warning(
                     "%s attempt %d/%d failed (%s: %s), retrying in %.1fs%s",
                     label,
@@ -269,6 +381,7 @@ async def call_with_fallback(
     max_attempts: int = LLM_RETRY_ATTEMPTS,
     provider_factory: Callable[..., Any] | None = None,
     non_retryable: tuple[type[BaseException], ...] = (),
+    budget_s: float | None = None,
 ) -> T:
     """3-tier fallback chain for LLM calls.
 
@@ -306,6 +419,12 @@ async def call_with_fallback(
         Callable ``(name, tenant_config) -> LLMProvider``. Defaults to
         ``common.llm.registry.get_llm_provider`` (imported lazily to avoid
         circular imports).
+    budget_s:
+        Forwarded to ``call_with_retry`` for BOTH providers, so it is a budget
+        PER PROVIDER rather than for the chain — the same semantics *timeout*
+        already has. Two providers at ``budget_s=15`` means a ~30 s worst case
+        before ``fake_fn``, which is exactly the arithmetic ``recall`` spells
+        out by hand today.
     non_retryable:
         Forwarded to ``call_with_retry`` for BOTH providers — see its docstring
         for why this is opt-in. Applied to the fallback provider too because
@@ -344,6 +463,7 @@ async def call_with_fallback(
                 max_attempts=max_attempts,
                 timeout=timeout,
                 non_retryable=non_retryable,
+                budget_s=budget_s,
             )
         logger.warning(
             "%s: provider '%s' resolved to FakeLLMProvider (no API key). Trying fallback.",
@@ -418,6 +538,7 @@ async def call_with_fallback(
                         max_attempts=max_attempts,
                         timeout=timeout,
                         non_retryable=non_retryable,
+                        budget_s=budget_s,
                     )
     except Exception:
         # Left as-is: this path is already loud, so it needs no skip reason.

--- a/core-api/src/core_api/services/dedup_judge.py
+++ b/core-api/src/core_api/services/dedup_judge.py
@@ -122,6 +122,17 @@ async def _llm_dedup_check(
         service_label="dedup",
         model_attr="entity_extraction_model",
         timeout=10.0,
+        # Per-attempt was the ONLY bound here, and it does not bound much: at
+        # the default 2 attempts across 2 providers that is 2 x 2 x 10s plus
+        # backoff — about 42s worst case, on the write path, inside a 45s
+        # request budget. Declaring the budget makes it 10s per provider, so
+        # ~20s before ``_fake_dedup_check``.
+        #
+        # Reaching the heuristic sooner is the intended trade, not a
+        # regression: a duplicate check that has already spent 40s has failed
+        # at its job either way, and the confidence floor below this call
+        # exists so a heuristic verdict can never sink a legitimate write.
+        budget_s=10.0,
     )
 
 

--- a/core-api/src/core_api/services/recall_service.py
+++ b/core-api/src/core_api/services/recall_service.py
@@ -212,6 +212,14 @@ async def summarize_memories(
         # keeps the worst case ~30s and fails fast instead of hanging.
         timeout=15.0,
         max_attempts=1,
+        # The same 15s, declared as a budget rather than implied by the two
+        # values above. That arithmetic held only while ``max_attempts`` stayed
+        # 1: restoring the default — an entirely reasonable-looking change —
+        # silently doubled the worst case to ~60s, with nothing but this
+        # comment to say otherwise. ``budget_s`` bounds the wall clock per
+        # provider whatever the attempt count is, so the ~30s promise is now
+        # structural.
+        budget_s=15.0,
     )
 
     recall_ms = int((time.perf_counter() - t0) * 1000)

--- a/tests/test_llm_retry_budget.py
+++ b/tests/test_llm_retry_budget.py
@@ -1,0 +1,428 @@
+"""A declared budget must be enforced, not merely documented.
+
+Before this, the worst case of an LLM call was enforced by parameter
+VALUES. ``recall`` spells the arithmetic out — "one primary attempt (15s),
+then one fallback attempt (15s) ... worst case ~30s" — but the guarantee
+held only while ``max_attempts`` stayed 1. Restoring the default, which
+looks entirely reasonable, silently doubled it, with a comment as the only
+thing saying otherwise. Same class as a flag whose default degrades
+correctness: the property lived in a value rather than in the structure.
+
+``budget_s`` moves it into the structure. Three things it fixes, each
+tested below:
+
+  1. The loop stops when the budget is spent, instead of starting an
+     attempt that cannot finish.
+  2. Each attempt's own timeout is clamped to what is left, so the budget
+     binds the attempt too rather than being advisory — enforced only by
+     whoever cancels from outside.
+  3. The ``Retry-After`` cap is DERIVED from the remaining budget instead
+     of read from ``LLM_MAX_RETRY_AFTER_S``, which exists for the callers
+     that declare nothing.
+
+Absent a budget, every one of these paths must behave exactly as before —
+14 of the 16 ``call_with_fallback`` sites declare no timeout at all, so
+that is the common case and the controls here cover it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import openai
+import pytest
+
+from common.llm import retry as retry_mod
+from common.llm.retry import call_with_fallback, call_with_retry
+
+
+def _rate_limited(**headers: str) -> openai.RateLimitError:
+    response = httpx.Response(
+        429,
+        headers=headers,
+        request=httpx.Request("POST", "http://provider/v1/chat/completions"),
+    )
+    return openai.RateLimitError("slow down", response=response, body=None)
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """A monotonic clock that only moves when a sleep is taken.
+
+    Real time would make every assertion here a race. Advancing the clock
+    by exactly the sleep that was requested keeps the budget arithmetic
+    deterministic and lets a test spend a budget without waiting for it.
+    """
+
+    class _Clock:
+        def __init__(self) -> None:
+            self.now = 1_000.0
+            self.slept: list[float] = []
+
+        def monotonic(self) -> float:
+            return self.now
+
+        async def sleep(self, seconds: float) -> None:
+            self.slept.append(seconds)
+            self.now += seconds
+
+        def advance(self, seconds: float) -> None:
+            self.now += seconds
+
+    c = _Clock()
+    monkeypatch.setattr(retry_mod.time, "monotonic", c.monotonic)
+    monkeypatch.setattr(retry_mod.asyncio, "sleep", c.sleep)
+    monkeypatch.setattr(retry_mod, "LLM_RETRY_JITTER_FRACTION", 0.0)
+    return c
+
+
+@pytest.mark.unit
+class TestTheBudgetBoundsTheLoop:
+    @pytest.mark.asyncio
+    async def test_no_attempt_starts_once_the_budget_is_spent(self, clock):
+        """An attempt with no time left is a wasted request, not a retry."""
+        calls = 0
+
+        async def _burn():
+            nonlocal calls
+            calls += 1
+            # Each attempt consumes 4s of a 10s budget.
+            clock.advance(4.0)
+            raise _rate_limited()
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                _burn, label="t", max_attempts=5, base_delay=1.0, budget_s=10.0
+            )
+
+        # 4s + 1s sleep + 4s = 9s, leaving 1s; the third attempt would
+        # start with less than its own backoff already spent, so the wait
+        # check stops it. Without a budget all five would have run.
+        assert calls == 2
+
+    @pytest.mark.asyncio
+    async def test_without_a_budget_every_attempt_runs(self, clock):
+        """The control. This is the shape 14 of 16 call sites are in."""
+        calls = 0
+
+        async def _burn():
+            nonlocal calls
+            calls += 1
+            clock.advance(4.0)
+            raise _rate_limited()
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(_burn, label="t", max_attempts=5, base_delay=1.0)
+
+        assert calls == 5
+
+    @pytest.mark.asyncio
+    async def test_a_wait_that_would_spend_the_rest_is_not_taken(self, clock):
+        """Sleeping the budget away and then giving up is the worst outcome.
+
+        Only the loop-top check would catch this, and only after the sleep
+        had already burned the time it was checking for.
+        """
+
+        async def _slow():
+            clock.advance(2.5)
+            raise _rate_limited()
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                _slow, label="t", max_attempts=3, base_delay=1.0, budget_s=3.0
+            )
+
+        assert clock.slept == []
+
+    @pytest.mark.asyncio
+    async def test_the_promise_survives_restoring_the_default_attempts(self, clock):
+        """The reason this parameter exists, stated as a test.
+
+        ``recall``'s "worst case ~30s" was enforced by ``max_attempts=1``
+        being the value it is. This runs the same call with the DEFAULT 2
+        attempts — the change that used to double it — and shows the wall
+        clock still cannot exceed the declared 15s. Without a budget the
+        same call takes 15 + 1 + 15 = 31s.
+        """
+        started = clock.now
+
+        async def _slow():
+            clock.advance(15.0)  # an attempt that uses its whole timeout
+            raise _rate_limited()
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                _slow,
+                label="recall-primary",
+                max_attempts=2,
+                base_delay=1.0,
+                timeout=15.0,
+                budget_s=15.0,
+            )
+
+        assert clock.now - started <= 15.0
+        assert clock.slept == []
+
+    @pytest.mark.asyncio
+    async def test_and_without_a_budget_it_does_not(self, clock):
+        """The fragility itself, so the test above is not vacuous."""
+        started = clock.now
+
+        async def _slow():
+            clock.advance(15.0)
+            raise _rate_limited()
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                _slow,
+                label="recall-primary",
+                max_attempts=2,
+                base_delay=1.0,
+                timeout=15.0,
+            )
+
+        assert clock.now - started == pytest.approx(31.0)
+
+    @pytest.mark.asyncio
+    async def test_a_budget_gone_before_the_first_attempt_still_raises_usefully(
+        self, monkeypatch
+    ):
+        """The one break that can be reached with nothing caught yet.
+
+        The other two live inside the ``except``, so ``last_exc`` is always
+        set there. This one can fire on the first iteration, and would then
+        reach ``raise last_exc`` with ``None`` — reported by Python as
+        "exceptions must derive from BaseException", a type error standing
+        in for a perfectly clear condition.
+
+        Driven by a clock that jumps between the deadline being computed and
+        the check reading it, rather than by a tiny budget: a real
+        sub-microsecond budget makes this a race, and the point is the
+        control flow, not the timing.
+        """
+        ticks = iter([0.0, 100.0, 200.0, 300.0])
+        monkeypatch.setattr(retry_mod.time, "monotonic", lambda: next(ticks))
+        calls = 0
+
+        async def _never_runs():
+            nonlocal calls
+            calls += 1
+            return "should not get here"
+
+        with pytest.raises(TimeoutError, match="budget was spent"):
+            await call_with_retry(_never_runs, label="t", budget_s=1.0)
+
+        assert calls == 0
+
+    @pytest.mark.asyncio
+    async def test_a_real_failure_outranks_the_synthetic_timeout(self, clock):
+        """Running out of time must not overwrite a provider's own error.
+
+        Same precedence the rest of the loop applies: a genuine failure is
+        more useful to the caller than "we ran out of time", so the
+        synthetic exception is only for when nothing was caught at all.
+        """
+
+        async def _fails_then_time_runs_out():
+            clock.advance(10.0)
+            raise _rate_limited()
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                _fails_then_time_runs_out,
+                label="t",
+                max_attempts=3,
+                base_delay=0.1,
+                budget_s=10.0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_non_positive_budget_is_a_misconfiguration(self):
+        """Fail loudly rather than silently running one unbounded attempt."""
+        for bad in (0.0, -1.0):
+            with pytest.raises(ValueError, match="budget_s must be > 0"):
+                await call_with_retry(lambda: asyncio.sleep(0), label="t", budget_s=bad)
+
+
+@pytest.mark.unit
+class TestTheBudgetBoundsEachAttempt:
+    @pytest.mark.asyncio
+    async def test_an_attempt_cannot_outlive_what_is_left(self, clock):
+        """Otherwise the budget is advisory — enforced only from outside.
+
+        10s declared; the first attempt burns 8s and the backoff 0.5s, so
+        the second must be granted the 1.5s that is left, not the 15s its
+        own per-attempt timeout allows.
+        """
+        granted: list[float | None] = []
+        real_wait_for = asyncio.wait_for
+
+        async def _spy(coro, timeout):
+            granted.append(timeout)
+            return await real_wait_for(coro, timeout=timeout)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(retry_mod.asyncio, "wait_for", _spy)
+
+            async def _burn():
+                clock.advance(8.0)
+                raise _rate_limited()
+
+            with pytest.raises(openai.RateLimitError):
+                await call_with_retry(
+                    _burn,
+                    label="t",
+                    max_attempts=2,
+                    base_delay=0.5,
+                    timeout=15.0,
+                    budget_s=10.0,
+                )
+
+        assert granted[0] == 10.0  # min(timeout=15, remaining=10)
+        assert granted[1] == pytest.approx(1.5)  # 10 - 8 spent - 0.5 slept
+
+    @pytest.mark.asyncio
+    async def test_a_budget_alone_bounds_an_attempt_with_no_timeout(self, clock):
+        """``budget_s`` without ``timeout`` still has to bind."""
+        granted: list[float | None] = []
+        real_wait_for = asyncio.wait_for
+
+        async def _spy(coro, timeout):
+            granted.append(timeout)
+            return await real_wait_for(coro, timeout=timeout)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(retry_mod.asyncio, "wait_for", _spy)
+
+            with pytest.raises(openai.RateLimitError):
+                await call_with_retry(
+                    lambda: _raise(_rate_limited()),
+                    label="t",
+                    max_attempts=1,
+                    budget_s=7.0,
+                )
+
+        assert granted == [7.0]
+
+
+async def _raise(exc: BaseException):
+    raise exc
+
+
+@pytest.mark.unit
+class TestTheRetryAfterCapIsDerived:
+    @pytest.mark.asyncio
+    async def test_a_hint_over_half_the_remaining_budget_hands_off(self, clock):
+        """Half, so the attempt after the wait has at least as long again.
+
+        6s asked with 10s left: waiting leaves 4s for an attempt that may
+        need 10, so the request would likely be wasted. Hand off instead.
+        """
+        calls = 0
+
+        async def _count():
+            nonlocal calls
+            calls += 1
+            raise _rate_limited(**{"retry-after": "6"})
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                _count, label="t", max_attempts=3, base_delay=1.0, budget_s=10.0
+            )
+
+        assert calls == 1
+        assert clock.slept == []
+
+    @pytest.mark.asyncio
+    async def test_a_hint_inside_half_is_honoured(self, clock):
+        """4s asked with 10s left: waited, leaving 6s for the retry."""
+
+        async def _asks():
+            raise _rate_limited(**{"retry-after": "4"})
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                _asks, label="t", max_attempts=2, base_delay=1.0, budget_s=10.0
+            )
+
+        assert clock.slept == [4.0]
+
+    @pytest.mark.asyncio
+    async def test_a_generous_budget_beats_the_fixed_cap(self, clock):
+        """The derived cap must be able to exceed ``LLM_MAX_RETRY_AFTER_S``.
+
+        The 5s constant is the answer for callers that declared nothing.
+        A caller declaring 60s has said it can afford to wait, and
+        overriding that would make the budget decorative.
+        """
+        assert retry_mod.LLM_MAX_RETRY_AFTER_S == 5.0
+
+        async def _asks():
+            raise _rate_limited(**{"retry-after": "20"})
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                _asks, label="t", max_attempts=2, base_delay=1.0, budget_s=60.0
+            )
+
+        assert clock.slept == [20.0]
+
+    @pytest.mark.asyncio
+    async def test_without_a_budget_the_fixed_cap_still_applies(self, clock):
+        """The control: no budget, so 20s is over the 5s cap and hands off."""
+        calls = 0
+
+        async def _count():
+            nonlocal calls
+            calls += 1
+            raise _rate_limited(**{"retry-after": "20"})
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(_count, label="t", max_attempts=3, base_delay=1.0)
+
+        assert calls == 1
+        assert clock.slept == []
+
+
+@pytest.mark.unit
+class TestItIsPerProvider:
+    @pytest.mark.asyncio
+    async def test_the_fallback_provider_gets_its_own_budget(self, clock):
+        """Same semantics ``timeout`` already has, and what ``recall`` means.
+
+        "one primary attempt (15s), then one fallback attempt (15s) ...
+        worst case ~30s" is two budgets, not one shared 15s — so a primary
+        that spends its whole budget must not leave the fallback unable to
+        run at all.
+        """
+        primary, fallback = object(), object()
+        seen: list[str] = []
+
+        class _Config:
+            def resolve_fallback(self):
+                return ("gemini", "some-model")
+
+        async def _call(provider):
+            if provider is primary:
+                seen.append("primary")
+                clock.advance(10.0)  # spends the primary's entire budget
+                raise _rate_limited()
+            seen.append("fallback")
+            return "answered"
+
+        result = await call_with_fallback(
+            "openai",
+            _call,
+            lambda: "the fake stub",
+            tenant_config=_Config(),
+            provider_factory=lambda name, _c, **_k: (
+                primary if name == "openai" else fallback
+            ),
+            max_attempts=1,
+            budget_s=10.0,
+        )
+
+        assert result == "answered"
+        assert seen == ["primary", "fallback"]


### PR DESCRIPTION
Stacked on #861, which added `Retry-After` handling and capped it with a
fixed `LLM_MAX_RETRY_AFTER_S = 5.0` — a stand-in for "small enough to fit
any caller's budget", because this layer had no idea what its budget was.
Now it can be told, and the cap derived.

## The bug this exposes

The worst case of an LLM call is enforced by parameter VALUES, not by
structure. `recall_service.py:207` writes the arithmetic out:

> "One primary attempt (15s), then one fallback attempt (15s), then
> `_fake_recall` keeps the worst case ~30s"

That holds only while `max_attempts` stays 1. Restore the default — an
entirely reasonable-looking change — and it silently becomes 15 + 1 + 15 =
**31s per provider**, with only a comment saying otherwise. Same class as a
flag whose default degrades correctness: the property lives in a value
that anyone may change, not in a shape that resists it.

Tested as a pair, so neither half is vacuous:

| `max_attempts=2`, `timeout=15` | wall clock |
|---|---|
| no budget | **31s** |
| `budget_s=15` | **≤ 15s** |

## What a declared budget enforces

Three things stop being guesses:

1. **The loop stops when the budget is spent**, instead of starting an
attempt that cannot finish. Reachable with no sleep at all — an attempt
that runs to its own timeout can exhaust the budget by itself.
2. **Each attempt's timeout becomes `min(timeout, remaining)`.** Without
this the budget is advisory, enforced only by whoever cancels from
outside; an attempt could start with 2s left and run for 15.
3. **The `Retry-After` cap is derived** — half of what remains, so
honouring a wait always leaves at least as much time again for the attempt
it precedes. Waiting out a hint and then having no time to use it is the
same wasted request as not waiting at all.

The derived cap can **exceed** `LLM_MAX_RETRY_AFTER_S`, deliberately. That
constant is the answer for callers that declared nothing; a caller
declaring 60s has said it can afford to wait, and second-guessing it would
make the budget decorative.

Per PROVIDER, exactly like `timeout` — `call_with_fallback` forwards the
same value to both, so two providers at 15s is the ~30s worst case
`recall` describes, not one shared 15s.

## Why two call sites and not sixteen

I went looking to thread this everywhere and the code says not to:
**14 of the 16 `call_with_fallback` sites pass no timeout at all.** Giving
them budgets means inventing fourteen SLAs, which is a per-service
conversation, not a refactor.

And the two ceilings that looked derivable are not: both
`enrichment_inline_timeout_seconds` (35s) and
`BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS` (30s) bound a **gather of N
concurrent calls**, so no individual call knows its share.

So it is wired at the two sites that already do the arithmetic by hand:

- **`recall_service`** — `budget_s=15.0`. No behaviour change today
(`max_attempts=1` already gives 15s); what changes is that the ~30s
promise now survives someone restoring the default.
- **`dedup_judge`** — `budget_s=10.0`. Per-attempt was its ONLY bound,
which bounds little: 2 providers x 2 attempts x 10s plus backoff is about
**42s worst case, on the write path, inside a 45s request budget**. Now
10s per provider, so ~20s before `_fake_dedup_check`.

Reaching that heuristic sooner is the intended trade, not a regression: a
duplicate check that has already spent 40s has failed at its job either
way, and the confidence floor documented below that call exists precisely
so a heuristic verdict can never sink a legitimate write.

`budget_s <= 0` raises, matching the existing `max_attempts` guard —
silently running one unbounded attempt would hide the misconfiguration
behind exactly the overrun the budget was meant to prevent. `monotonic`,
not `time()`, so an NTP step cannot move a deadline mid-retry.

## Verification

`4805 passed, 3 skipped, 1 xfailed` — full suite, zero failures. All 12 CI
ruff scopes clean.

Being precise about the baseline: `budget_s` does not exist on the parent
commit, so 10 of the 13 new tests fail at fixture level rather than at an
assertion (`retry_mod.time` is not even imported there), and
`test_a_non_positive_budget_is_a_misconfiguration` fails with `TypeError:
unexpected keyword argument`. The demonstration that carries weight is the
31s-vs-15s pair above, plus three controls that pass either way and pin
what must NOT change for the 14 callers with no budget: all attempts still
run, the fixed 5s cap still applies, and the linear backoff is untouched.
