### PR TITLE
docs(llm): say why the Vertex and Gemini SDK imports are deferred, and enforce it

### DIFF
--- a/common/llm/providers/vertex.py
+++ b/common/llm/providers/vertex.py
@@ -7,6 +7,28 @@ the event loop.
 CAURA-333: ``VertexEmbeddingProvider`` was removed (broken — never passed
 ``output_dimensionality`` to the SDK, so writes failed against pgvector's
 1024-dim column). Only the LLM-side provider remains.
+
+⚠ THE SDK IMPORTS IN THIS MODULE ARE DEFERRED ON PURPOSE, against the
+repo's top-level-imports rule. Stated here because this file is cited as
+the precedent for the pattern (``gemini.py``: "same pattern as
+VertexLLMProvider with vertexai") and was the one copy that never said
+why — so it reads as an oversight and gets re-flagged.
+
+The reason is optional dependencies, not circular imports.
+``google-cloud-aiplatform`` is an EXTRA for core-worker
+(``vertex = [...]`` in its ``pyproject.toml``), and only a hard dependency
+for core-api. Hoisting these to module scope makes
+``common.llm.providers.vertex`` unimportable wherever the extra is absent
+— verified by blocking ``vertexai`` and ``google.cloud.aiplatform`` on the
+import path: the module still imports cleanly today and
+``VertexLLMProvider`` is still reachable, while a top-level import raises
+``ModuleNotFoundError``. Deferred, an install without Vertex fails only if
+it actually CALLS Vertex, which is what an optional provider should do.
+
+``_platform.py`` imports this module lazily too, inside a ``try``, for the
+same reason — and ``registry.py`` deliberately omits it from the top-level
+provider imports it does for fake/gemini/openai. All three are one
+decision; changing any of them alone breaks it.
 """
 
 from __future__ import annotations
@@ -74,6 +96,8 @@ class VertexLLMProvider:
         temperature: float = 0.0,
     ) -> dict:
         """Synchronous JSON completion via Vertex AI GenerativeModel."""
+        # Lazy on purpose — see the module docstring. NOT an oversight
+        # against the top-level-imports rule.
         from google.cloud import aiplatform
         from vertexai.generative_models import GenerationConfig, GenerativeModel
 
@@ -117,6 +141,7 @@ class VertexLLMProvider:
         max_tokens: int = 1000,
     ) -> str:
         """Synchronous text completion via Vertex AI GenerativeModel."""
+        # Lazy on purpose — see the module docstring.
         from google.cloud import aiplatform
         from vertexai.generative_models import GenerationConfig, GenerativeModel
 

--- a/tests/test_optional_provider_sdks_stay_optional.py
+++ b/tests/test_optional_provider_sdks_stay_optional.py
@@ -1,0 +1,109 @@
+"""A provider whose SDK is optional must still be importable without it.
+
+``vertex.py`` and ``gemini.py`` defer their SDK imports into methods,
+against this repo's top-level-imports rule. That is deliberate, and it is
+load-bearing rather than stylistic:
+
+* ``google-cloud-aiplatform`` is an EXTRA for core-worker
+  (``vertex = [...]``), and only a hard dependency for core-api.
+* ``google-genai`` does not appear in core-worker's ``pyproject.toml`` at
+  ALL — not required, not optional. core-worker never has it.
+
+So hoisting either import to module scope makes that provider module
+unimportable in core-worker, and ``common/llm/_platform.py`` imports
+``vertex`` inside a ``try`` on the strength of exactly this property.
+
+A comment cannot stop that hoist; this can. Without the test, the rule
+argues for the change and nothing argues back until something fails at
+deploy time in the one install that lacks the package.
+
+What SHOULD fail is calling the provider, not importing the module. An
+install without Vertex configured should never touch either.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+# (module under test, the class it must still expose, SDK roots to hide)
+CASES = [
+    pytest.param(
+        "common.llm.providers.vertex",
+        "VertexLLMProvider",
+        ("vertexai", "google.cloud.aiplatform"),
+        id="vertex-without-aiplatform",
+    ),
+    pytest.param(
+        "common.llm.providers.gemini",
+        "GeminiLLMProvider",
+        ("google.genai",),
+        id="gemini-without-genai",
+    ),
+]
+
+
+class _Blocked:
+    """Meta-path finder that makes chosen packages look uninstalled.
+
+    RAISING from ``find_spec`` is what makes this absence rather than a
+    redirect. Falling through instead (the implicit ``None`` below, the
+    finder protocol's "not mine") hands the name to the next finder on the
+    path, which resolves it from site-packages — where these packages DO
+    exist in the dev environment, so the test would prove nothing.
+    """
+
+    def __init__(self, roots: tuple[str, ...]) -> None:
+        self._roots = roots
+
+    def find_spec(self, name, path=None, target=None):
+        if any(name == r or name.startswith(r + ".") for r in self._roots):
+            raise ModuleNotFoundError(
+                f"No module named {name!r} (simulated: extra not installed)"
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("module_name", "class_name", "sdk_roots"), CASES)
+def test_module_imports_without_its_sdk(
+    module_name, class_name, sdk_roots, monkeypatch
+):
+    # Evict the target and the SDKs so the import genuinely re-executes;
+    # monkeypatch restores every entry it removed at teardown, so a later
+    # test importing these normally is unaffected.
+    for name in list(sys.modules):
+        if name == module_name or any(
+            name == r or name.startswith(r + ".") for r in sdk_roots
+        ):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setattr(sys, "meta_path", [_Blocked(sdk_roots), *sys.meta_path])
+
+    module = importlib.import_module(module_name)
+
+    assert hasattr(module, class_name), (
+        f"{module_name} imported but {class_name} is missing — the SDK import "
+        "must be inside the methods that use it, not at module scope"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("module_name", "class_name", "sdk_roots"), CASES)
+def test_the_blocker_would_actually_catch_a_hoist(
+    module_name, class_name, sdk_roots, monkeypatch
+):
+    """The control, so the test above cannot pass vacuously.
+
+    If the blocker did not really hide these packages, the assertion above
+    would hold no matter where the imports lived and the guard would be
+    decorative.
+    """
+    monkeypatch.setattr(sys, "meta_path", [_Blocked(sdk_roots), *sys.meta_path])
+
+    for root in sdk_roots:
+        for name in list(sys.modules):
+            if name == root or name.startswith(root + "."):
+                monkeypatch.delitem(sys.modules, name, raising=False)
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module(root)


### PR DESCRIPTION
I set out to hoist `vertex.py`'s function-level imports to module scope,
which is what the top-level-imports rule asks for. **That would have been a
regression**, so this documents and enforces the exception instead.

## Why hoisting breaks

The deferral is about optional dependencies, not circular imports:

* `google-cloud-aiplatform` is an **extra** for core-worker
  (`vertex = [...]` in its `pyproject.toml`), and only a hard dependency
  for core-api.
* `google-genai` appears **zero times** in core-worker's
  `pyproject.toml` — not required, not optional. core-worker never has it.

Verified rather than assumed, by blocking `vertexai` and
`google.cloud.aiplatform` on the import path:

```
A. import common.llm.providers.vertex  ->  OK (module loads without the SDK)
   class present: True
B. top-level SDK import -> ModuleNotFoundError: No module named 'vertexai'
   => hoisting makes vertex.py unimportable in a no-extra install
```

Deferred, an install without Vertex fails only if it actually CALLS Vertex
— which is what an optional provider should do. Hoisted, the module cannot
be imported at all, and `common/llm/_platform.py` imports it inside a `try`
on the strength of exactly that property.

## Why it read as an oversight

`gemini.py:45` already explains its own lazy import — and cites this file
as the precedent: *"same pattern as VertexLLMProvider with vertexai"*. So
the file everything else points at was the one copy that never said why.
That is the actual defect, and it is why I flagged it as a rule violation
in the first place.

`registry.py` also deliberately omits `vertex` from the top-level provider
imports it does for fake/gemini/openai. Those three placements are one
decision; changing any alone breaks it, which the module docstring now
says.

## A comment cannot stop the next hoist

`tests/test_optional_provider_sdks_stay_optional.py` pins the invariant for
both providers: with the SDK hidden behind a meta-path finder, each module
must still import and still expose its provider class.

Without it the rule argues for the change and nothing argues back until
something fails at deploy time in the one install that lacks the package.
Confirmed to bite: hoisting the import makes
`test_module_imports_without_its_sdk[vertex-without-aiplatform]` fail with
the simulated `ModuleNotFoundError`.

Each case carries a control asserting the blocker really does hide the
package — otherwise the guard would pass no matter where the imports lived.
Raising from `find_spec` rather than falling through is what makes it
absence and not a redirect; falling through would resolve from
site-packages, where these packages do exist in the dev environment.

## Verification

`4811 passed, 3 skipped, 1 xfailed` — full suite, zero failures. All 12 CI
ruff scopes clean. No behaviour change: comments, a docstring, and a new
test.
