### PR TITLE
test(interview): mint tenants the end-of-run sweep can actually see

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,13 @@ TEST_DB_URL = os.environ.get(
 # tenant without taking a fixture argument. None of them relies on cross-test
 # sharing, so they could each mint their own; threading a tenant through those
 # helpers is the follow-up that would let this go away.
-TENANT_ID = f"test-tenant-{uuid.uuid4().hex[:8]}"
+# The prefix the end-of-run sweep matches on, and the only place it is written.
+# The two sides that must agree — every minter here and the DELETE in
+# ``_setup_schema`` — were previously coupled by a note in a docstring, which is
+# what #858 cost: a file minting its own prefix leaked every row it ever wrote.
+SWEEP_TENANT_PREFIX = "test-tenant-"
+
+TENANT_ID = f"{SWEEP_TENANT_PREFIX}{uuid.uuid4().hex[:8]}"
 FLEET_ID = "test-fleet"
 AGENT_ID = "test-agent"
 
@@ -101,6 +107,24 @@ def get_admin_headers() -> dict:
 def uid() -> str:
     """Short unique suffix — for distinct content (409s) and distinct tenant ids."""
     return uuid.uuid4().hex[:8]
+
+
+def new_tenant_id() -> str:
+    """A tenant id unique to one test AND visible to the end-of-run sweep.
+
+    The prefix is not cosmetic: ``_setup_schema`` cleans with
+    ``tenant_id LIKE 'test-tenant-%'``, so a tenant minted with any other prefix
+    is never reclaimed and its committed rows outlive the run. That is how #858
+    happened — two interview files minted ``t-`` tenants, their job documents
+    accumulated across every local run, and a cross-tenant sweep endpoint under
+    test started reading other runs' residue.
+
+    Defined here rather than repeated at call sites so the prefix and the DELETE
+    that depends on it stay in one file. The ``tenant_id`` fixture is the same
+    value for tests that can take a fixture; this is for the ones that mint
+    several per test.
+    """
+    return f"{SWEEP_TENANT_PREFIX}{uid()}"
 
 
 # ---------------------------------------------------------------------------
@@ -170,7 +194,8 @@ async def _setup_schema(_engine):
         ):
             try:
                 await conn.execute(
-                    text(f"DELETE FROM {table} WHERE tenant_id LIKE 'test-tenant-%'")
+                    text(f"DELETE FROM {table} WHERE tenant_id LIKE :prefix"),
+                    {"prefix": f"{SWEEP_TENANT_PREFIX}%"},
                 )
             except Exception:
                 # Best-effort, and the ONLY thing that ever removes rows written
@@ -186,8 +211,9 @@ async def _setup_schema(_engine):
             await conn.execute(
                 text(
                     "DELETE FROM memory_entity_links WHERE memory_id IN "
-                    "(SELECT id FROM memories WHERE tenant_id LIKE 'test-tenant-%')"
-                )
+                    "(SELECT id FROM memories WHERE tenant_id LIKE :prefix)"
+                ),
+                {"prefix": f"{SWEEP_TENANT_PREFIX}%"},
             )
         except Exception:
             pass
@@ -304,9 +330,10 @@ def tenant_id():
     reason, or failing only when the run order changed. Nothing removes those rows
     mid-run; see the sweep in ``_setup_schema`` for why.
 
-    Keep the ``test-tenant-`` prefix: that sweep matches on it.
+    Keep the ``test-tenant-`` prefix: that sweep matches on it — see
+    :func:`new_tenant_id`, which owns it.
     """
-    return f"test-tenant-{uid()}"
+    return new_tenant_id()
 
 
 @pytest.fixture

--- a/tests/test_api_interview.py
+++ b/tests/test_api_interview.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 import core_api.services.interview_service as interview_service
-from tests.conftest import get_test_auth, uid
+from tests.conftest import get_test_auth, new_tenant_id, uid
 
 
 # ── helpers ──
@@ -100,7 +100,7 @@ def canned_llm(monkeypatch):
 
 
 async def test_submit_rejected_when_interviewer_disabled(client):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     resp = await client.post(
         "/api/v1/interview/submit",
         json=_payload(tenant_id, f"node-{uid()}", f"agent-{uid()}"),
@@ -111,7 +111,7 @@ async def test_submit_rejected_when_interviewer_disabled(client):
 
 
 async def test_submit_rejects_reversed_cursor(client):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     resp = await client.post(
         "/api/v1/interview/submit",
@@ -124,7 +124,7 @@ async def test_submit_rejects_reversed_cursor(client):
 
 
 async def test_submit_rejects_events_outside_window(client):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     resp = await client.post(
         "/api/v1/interview/submit",
@@ -143,7 +143,7 @@ async def test_submit_rejects_events_outside_window(client):
 
 
 async def test_submit_rejects_unsorted_events(client):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     events = _events(3)
     events[0], events[2] = events[2], events[0]
@@ -162,7 +162,7 @@ async def test_submit_rejects_unsorted_events(client):
 async def test_submit_happy_path_writes_typed_memories_and_watermark(
     client, canned_llm
 ):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
 
@@ -198,7 +198,7 @@ async def test_submit_happy_path_writes_typed_memories_and_watermark(
 
 
 async def test_submit_retry_is_idempotent(client, canned_llm):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     payload = _payload(tenant_id, node_id, agent_id)
@@ -221,7 +221,7 @@ async def test_submit_retry_is_idempotent(client, canned_llm):
 
 
 async def test_watermark_is_forward_only(client, canned_llm):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
 
@@ -352,7 +352,7 @@ async def test_schedule_queues_once_then_respects_pending_and_dueness(
 ):
     from tests.conftest import get_admin_headers
 
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     await _seed_live_node(client, tenant_id, headers, f"node-{uid()}")
 
@@ -406,7 +406,7 @@ async def test_schedule_next_window_resumes_from_watermark(
 ):
     from tests.conftest import get_admin_headers
 
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     await _seed_live_node(client, tenant_id, headers, f"node-{uid()}")
 
@@ -446,7 +446,7 @@ async def test_schedule_survives_per_node_storage_failure(client, monkeypatch):
     """One node's storage failure must not abort the whole schedule run."""
     from tests.conftest import get_admin_headers
 
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     await _seed_live_node(client, tenant_id, headers, f"node-{uid()}")
 
@@ -484,7 +484,7 @@ def test_mask_events_preserves_absent_optional_fields():
 
 
 async def test_submit_rejects_duplicate_seqs(client):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     events = _events(3)
     events[1]["seq"] = events[0]["seq"]  # duplicate
@@ -502,7 +502,7 @@ async def test_submit_rejects_oversized_event_content(client):
     is a 422, never a silent truncation of the LLM prompt."""
     from core_api.constants import INTERVIEW_EVENT_MAX_CHARS
 
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     events = _events(1)
     events[0]["content"] = "x" * (INTERVIEW_EVENT_MAX_CHARS + 1)
@@ -536,7 +536,7 @@ async def test_submit_times_out_with_504_and_unconsumed_window(client, monkeypat
 
     import core_api.routes.interview as interview_route
 
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
 
     async def _slow_interview(**kwargs):

--- a/tests/test_interview_async_submit.py
+++ b/tests/test_interview_async_submit.py
@@ -24,7 +24,7 @@ from core_api.services.interview_service import (
     process_interview_job,
     process_pending_interview_jobs,
 )
-from tests.conftest import get_admin_headers, get_test_auth, uid
+from tests.conftest import get_admin_headers, get_test_auth, new_tenant_id, uid
 from tests.test_api_interview import (
     _CANNED_REPORT,
     _enable_interviewer,
@@ -115,7 +115,7 @@ def _enqueue_kwargs(tenant_id: str, node_id: str, agent_id: str, **kw) -> dict:
 async def test_async_submit_accepts_with_watermark_and_masked_job(
     client, canned_llm, async_submit
 ):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     events = _events()
@@ -150,7 +150,7 @@ async def test_async_submit_accepts_with_watermark_and_masked_job(
 
 
 async def test_processing_writes_typed_memories_and_marks_done(client, canned_llm, async_submit):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
 
@@ -184,7 +184,7 @@ async def test_processing_writes_typed_memories_and_marks_done(client, canned_ll
 
 
 async def test_resubmit_same_window_is_idempotent(client, canned_llm, async_submit):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     payload = _payload(tenant_id, node_id, agent_id)
@@ -218,7 +218,7 @@ async def test_resubmit_same_window_is_idempotent(client, canned_llm, async_subm
 
 
 async def test_enqueue_over_processing_job_does_not_downgrade(client, canned_llm):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -239,7 +239,7 @@ async def test_enqueue_over_processing_job_does_not_downgrade(client, canned_llm
 
 
 async def test_duplicate_enqueue_preserves_attempts(client, monkeypatch):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -270,7 +270,7 @@ async def test_enqueue_prior_read_failure_raises_and_leaves_done_job_untouched(
     submit would lose the window, see the round-5 test below) and must
     NOT upsert (writing "pending" over a "done" job would re-open the
     consumed window and reset the retry budget) (#667)."""
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -305,7 +305,7 @@ async def test_first_submit_prior_read_failure_500s_without_advancing_watermark(
     the plugin prunes its buffer and the window is permanently lost. The
     enqueue must raise → route 500s → the plugin keeps the window and
     resubmits next tick."""
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = interview_job_doc_id(node_id, 0, 10)
@@ -357,7 +357,7 @@ async def test_first_submit_prior_read_failure_500s_without_advancing_watermark(
 
 
 async def test_failed_synthesis_returns_to_pending_then_retry_succeeds(client, monkeypatch):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -386,7 +386,7 @@ async def test_failed_synthesis_returns_to_pending_then_retry_succeeds(client, m
 
 
 async def test_job_attempts_exhaustion_parks_as_failed_permanent(client, monkeypatch):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -415,7 +415,7 @@ async def test_concurrent_processors_increment_attempts_from_fresh_base(client, 
     a job exceed interview_job_max_attempts (#667). Simulated by doctoring
     the second run's top-level fetch to return the pre-increment snapshot
     while _set_state's fresh re-fetch sees the real doc."""
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -460,7 +460,7 @@ async def test_pending_reset_retry_survives_one_write_failure(client, monkeypatc
     """Synthesis fails AND the first pending-reset upsert fails: the reset's
     extra best-effort attempt must still land the job in "pending" — a job
     left in "processing" waits on the (slower) stale sweep."""
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -498,7 +498,7 @@ async def test_pending_reset_does_not_overwrite_concurrent_done(client, monkeypa
     this run was in flight (flipping the doc to "done"): the finally
     pending-reset must detect the terminal status and back off — writing
     "pending" over it would re-open a consumed window (#667)."""
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -534,7 +534,7 @@ async def test_pending_reset_guard_uses_the_merge_base_fetch(client, monkeypatch
     fetch happens after the synthesis failure — pinning the collapsed
     single fetch-write gap (a reintroduced pre-check would make it two,
     re-opening the gap between check and merge base)."""
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -594,7 +594,7 @@ async def test_direct_processor_skips_processing_unless_stale_and_allowed(client
     process_interview_job call skips it, flag or not, while it is FRESH;
     only allow_stale_processing=True on a STALE doc (the sweep's reclaim
     path) reprocesses it (#667)."""
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -625,7 +625,7 @@ async def test_direct_processor_skips_processing_unless_stale_and_allowed(client
 
 
 async def test_done_job_is_a_noop_for_the_processor(client, canned_llm):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     doc_id = await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -640,7 +640,7 @@ async def test_done_job_is_a_noop_for_the_processor(client, canned_llm):
 
 
 async def test_schedule_sweep_processes_pending_jobs(client, canned_llm, async_submit, monkeypatch):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
 
@@ -674,7 +674,7 @@ async def test_sweep_recovers_stale_processing_but_not_fresh(client, canned_llm)
     """A job stranded in "processing" past the staleness cutoff (its task
     hard-crashed mid-run) is re-swept and completed; a fresh "processing"
     job (a live concurrent run) is left alone."""
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     now = datetime.now(UTC)
 
@@ -713,9 +713,9 @@ async def test_sweep_bounded_concurrency_completes_all_jobs(client, canned_llm, 
     (7 pending jobs across 2 tenants > INTERVIEW_SWEEP_CONCURRENCY=5)
     completes every job with the same summary semantics as the old
     sequential drain, while never exceeding the bound in flight."""
-    tenant_a, headers_a = get_test_auth(f"t-{uid()}")
+    tenant_a, headers_a = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_a, headers_a)
-    tenant_b, headers_b = get_test_auth(f"t-{uid()}")
+    tenant_b, headers_b = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_b, headers_b)
 
     seeded: list[tuple[str, str]] = []
@@ -753,7 +753,7 @@ async def test_sweep_bounded_concurrency_completes_all_jobs(client, canned_llm, 
 
 
 async def test_process_pending_jobs_returns_counts_summary(client, canned_llm):
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
     await enqueue_interview_job(**_enqueue_kwargs(tenant_id, node_id, agent_id))
@@ -777,7 +777,7 @@ async def test_process_pending_jobs_returns_counts_summary(client, canned_llm):
 
 async def test_flag_off_runs_legacy_inline_path(client, canned_llm, monkeypatch):
     monkeypatch.setattr(interview_route.app_settings, "interview_async_submit", False)
-    tenant_id, headers = get_test_auth(f"t-{uid()}")
+    tenant_id, headers = get_test_auth(new_tenant_id())
     await _enable_interviewer(client, tenant_id, headers)
     node_id, agent_id = f"node-{uid()}", f"agent-{uid()}"
 

--- a/tests/test_tenant_sweep_coupling.py
+++ b/tests/test_tenant_sweep_coupling.py
@@ -1,0 +1,96 @@
+"""The tenant prefix a test mints and the prefix the sweep deletes must agree.
+
+Nothing removes rows written through the service layer mid-run — most tests here
+write via a storage client that commits on its own connection, so the per-test
+session rollback never sees them. The only thing that ever reclaims them is the
+end-of-run ``DELETE ... WHERE tenant_id LIKE 'test-tenant-%'`` in
+``_setup_schema``.
+
+That made the prefix load-bearing while leaving it a convention in a docstring,
+and #858 is what it cost: two interview files minted ``t-`` tenants, so every job
+document they ever wrote survived every run. A local database reached 300 of them
+across 228 tenants, and because the endpoint under test sweeps *across* tenants,
+it began reading other runs' residue — failing in a way that looks nothing like
+accumulated state, which is the same trap the conftest comment already describes
+for keystones.
+
+These tests pin the coupling itself rather than any one call site.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+
+import pytest
+
+from tests import conftest
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_the_minted_prefix_is_the_one_the_sweep_deletes() -> None:
+    assert conftest.new_tenant_id().startswith(conftest.SWEEP_TENANT_PREFIX)
+
+
+def test_the_tenant_id_fixture_mints_a_sweepable_id() -> None:
+    """The fixture and the plain function are two doors to the same decision;
+    a test taking the fixture must not get a tenant the sweep cannot see."""
+    fn = conftest.tenant_id.__wrapped__ if hasattr(conftest.tenant_id, "__wrapped__") else None
+    assert fn is not None, "tenant_id is expected to be a pytest fixture wrapping a function"
+    assert fn().startswith(conftest.SWEEP_TENANT_PREFIX)
+
+
+def test_the_sweep_has_no_hardcoded_prefix_left() -> None:
+    """The constant only helps while both sides actually use it.
+
+    A literal creeping back into either the DELETE or the minter re-opens exactly
+    the gap #858 came through, and it would read as harmless in review.
+
+    Parsed rather than grepped, so that only *code* is checked: docstrings and
+    comments here explain the prefix and quote it, which is the opposite of a
+    problem, and a plain text search would fail on the documentation this change
+    adds.
+    """
+    tree = ast.parse(inspect.getsource(conftest))
+
+    docstrings = {
+        id(node.body[0].value)
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.body
+        and isinstance(node.body[0], ast.Expr)
+        and isinstance(node.body[0].value, ast.Constant)
+        and isinstance(node.body[0].value.value, str)
+    }
+    literals = [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstrings
+        and conftest.SWEEP_TENANT_PREFIX in node.value
+    ]
+
+    assert literals == [conftest.SWEEP_TENANT_PREFIX], (
+        "the prefix should appear in code exactly once, as the SWEEP_TENANT_PREFIX "
+        f"definition; found {literals}"
+    )
+
+
+def test_every_swept_statement_binds_the_prefix() -> None:
+    """Each ``DELETE`` in the sweep must be parameterised on the constant.
+
+    Counted rather than inspected one by one: a table added to the sweep list
+    with its own inline pattern is the realistic regression, and it would leave
+    that table leaking silently while the others stayed clean.
+    """
+    source = inspect.getsource(conftest)
+    deletes = re.findall(r"DELETE FROM", source)
+    bindings = re.findall(r"LIKE :prefix", source)
+
+    assert len(deletes) == len(bindings), (
+        f"{len(deletes)} DELETE statement(s) but {len(bindings)} bound to the prefix — "
+        "one of them is not using SWEEP_TENANT_PREFIX"
+    )


### PR DESCRIPTION
Fixes #858.

## Not a race — accumulated state, and my original diagnosis was wrong

I filed #858 as a job-claim race on the shared `synthesis_sem`, inferred from the code because it would not reproduce. It reproduced today — **deterministically, and in isolation**, which the report explicitly said it did not do. That difference is the answer.

`tests/conftest.py` cleans up with `DELETE FROM {table} WHERE tenant_id LIKE 'test-tenant-%'`, and `documents` is in its table list. The two interview files minted tenants as `get_test_auth(f"t-{uid()}")` — a prefix that `LIKE` does not match. So every interview job either file had ever written was still there:

```
interview_jobs   done              286
                 failed_permanent   12
                 processing          2   <- reclaimed by the sweep on every run

tenants with interview jobs:    228
matched by the conftest sweep:    0
```

The endpoint under test is **cross-tenant**: `process_pending_interview_jobs` loops over every tenant taking pending and stale-`processing` jobs. Those two stuck rows qualified on every run, from tenants no test knew about — so `jobs_processed >= 1` passed on residue while `jobs_done`, which counts only rows reaching `committed`, stayed 0. That is exactly the `1 processed / 0 done` shape observed.

CI provisions a fresh Postgres per run, which is why CI stayed green while a local database degraded from "1 in 3" to "every time" over a day of running the suite.

## The fix

34 call sites now use a new `conftest.new_tenant_id()`, and the prefix moves into `SWEEP_TENANT_PREFIX` — used by every minter (`TENANT_ID`, the `tenant_id` fixture, `new_tenant_id`) and by the `DELETE`s, which are parameterised on it instead of repeating the literal.

The prefix was load-bearing while documented as a convention in a docstring. This sweep is the only thing that ever removes rows written through the service layer, because most tests write via a storage client that commits on its own connection where the per-test rollback never reaches. One constant is what makes the two sides agree by construction rather than by everyone remembering.

## Verified by what stops accumulating

Not "the test is green" — it was green in isolation this morning too:

| | before | after |
|---|---|---|
| 3 consecutive runs of the two tests | fails | **3× pass** |
| `interview_jobs` + `interview_watermarks` left behind | ~100 per run, forever | **0** |
| full interview suites (47 tests) | — | pass, leaving 0 rows |
| full suite | 1 failed | **4815 passed, 0 failed** |

## Tests

`tests/test_tenant_sweep_coupling.py`, 4 tests pinning the coupling rather than any call site. Each confirmed to fail against the way it can break:

| simulated break | caught by |
|---|---|
| a minter hardcodes its own prefix | the minter + fixture tests |
| a `DELETE` hardcodes the pattern | the no-literal + binding tests |
| a table added to the sweep with an inline pattern | `..._binds_the_prefix` |
| the fixture diverges from the plain function | `..._fixture_mints_a_sweepable_id` |

Two notes worth keeping:

- The no-literal test **parses rather than greps**, so only code counts. Docstrings and comments here quote the prefix while explaining it, which is the opposite of a problem — written as a grep first, it failed on this change's own documentation.
- The third case is the realistic regression: a table appended to the sweep list with its own inline pattern would leak silently while every other table stayed clean.

## Scope

The interview files only. The same mismatch affects at least `test_reports.py`, `test_security_tenant_isolation.py` and others — **12,714 rows across seven tables were unswept on the measured database, of which 0 matched**. Filed as #865 with the numbers and three options; converting the rest, or making the sweep prefix-agnostic, is a decision about the fixture rather than a flake fix and wants taking as one change.

This PR's guard protects the conftest's internal coupling. It deliberately does not guard call sites — such a check would be red today, for the reason in #865.
