### PR TITLE
test(retry): stop a faked `asyncio.sleep` escaping the module under test

### DIFF
--- a/tests/_scoped_module.py
+++ b/tests/_scoped_module.py
@@ -1,0 +1,56 @@
+"""Fake a stdlib function for ONE importer instead of for the process.
+
+``monkeypatch.setattr(some_module.asyncio, "sleep", fake)`` does not patch
+``some_module``'s sleep. ``some_module.asyncio`` IS the one ``asyncio``
+module object, so that line replaces ``asyncio.sleep`` for every importer
+alive — the code under test, every other module, and every task already
+running. The same is true of ``patch("pkg.mod.asyncio.sleep", ...)``: the
+dotted string resolves the same shared object.
+
+That is how caura#863's CI failure happened. ``test_llm_retry_after``
+recorded sleeps into a list and asserted the list was ``[1.0, 2.0]``; it
+got ``[0.7359102269208245, 1.0, 2.0]``, and the test's own captured log
+named the intruder::
+
+    WARNING common.http_retry storage_client.POST /memories/similar-candidates:
+            ConnectError on attempt 3/5, retrying in 0.74s
+
+A post-commit ``detect_contradictions_async`` task, left running by an
+earlier test, retrying a storage-api that does not exist in CI. Its third
+backoff came due while the recorder was installed, so an unrelated task's
+sleep was reported as the retry loop's.
+
+Patching the module REFERENCE instead of the module CONTENTS is the whole
+fix: give the importer under test its own copy, and nobody else's sleep
+can reach the recorder::
+
+    monkeypatch.setattr(mod, "asyncio", scoped(asyncio, sleep=fake))
+    patch.object(mod, "asyncio", scoped(asyncio, sleep=fake))
+
+A real ``ModuleType`` carrying a shallow copy of the original namespace,
+rather than a stub or a forwarding proxy: everything the importer reaches
+for keeps working whether or not this file anticipated it. ``retry.py``
+uses ``asyncio.wait_for`` beside its ``sleep``, and ``memory_service`` uses
+nine asyncio names; an explicit stub would have to list them and would
+break — silently, in the wait_for case — the next time one was added.
+
+The copy is a snapshot. That is fine for stdlib modules, and wrong for a
+module whose attributes a test rebinds later; use ``monkeypatch`` directly
+for those.
+"""
+
+from __future__ import annotations
+
+import types
+
+
+def scoped(real: types.ModuleType, **overrides: object) -> types.ModuleType:
+    """A private copy of *real* with *overrides* applied.
+
+    Assign it over the importing module's own reference, so the override is
+    visible to that importer and to nothing else.
+    """
+    clone = types.ModuleType(real.__name__)
+    clone.__dict__.update(real.__dict__)
+    clone.__dict__.update(overrides)
+    return clone

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -19,6 +19,7 @@ cases for the publish path.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -29,6 +30,7 @@ from core_api.constants import VECTOR_DIM
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.steps.write.parallel_embed_enrich import ParallelEmbedEnrich
 from core_api.schemas import MemoryCreate
+from tests._scoped_module import scoped
 
 pytestmark = pytest.mark.asyncio
 
@@ -211,7 +213,7 @@ async def test_reembed_skips_initial_sleep_when_flag_off() -> None:
             new=AsyncMock(return_value=[0.1] * VECTOR_DIM),
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
-        patch("core_api.services.memory_service.asyncio.sleep", new=_fake_sleep),
+        patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_fake_sleep)),
         patch.object(memory_service, "track_task"),
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -250,7 +252,7 @@ async def test_reembed_sleeps_on_failure_path_when_flag_on() -> None:
             new=AsyncMock(return_value=[0.1] * VECTOR_DIM),
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
-        patch("core_api.services.memory_service.asyncio.sleep", new=_fake_sleep),
+        patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_fake_sleep)),
         patch.object(memory_service, "track_task"),
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -295,7 +297,7 @@ async def test_reembed_schedules_contradiction_after_success() -> None:
             new=AsyncMock(return_value=[0.1] * VECTOR_DIM),
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
-        patch("core_api.services.memory_service.asyncio.sleep", new=_noop_sleep),
+        patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_noop_sleep)),
         patch.object(memory_service, "track_task"),
         patch.object(
             memory_service,
@@ -350,7 +352,7 @@ async def test_reembed_race_guard_fires_with_flag_on_too() -> None:
             new=AsyncMock(return_value=[0.1] * VECTOR_DIM),
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
-        patch("core_api.services.memory_service.asyncio.sleep", new=_noop_sleep),
+        patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_noop_sleep)),
         patch.object(memory_service, "track_task"),
         patch.object(
             memory_service,
@@ -417,7 +419,7 @@ async def test_reembed_respects_existing_embedding_from_enrich_race() -> None:
             new=AsyncMock(return_value=[0.1] * VECTOR_DIM),
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
-        patch("core_api.services.memory_service.asyncio.sleep", new=_noop_sleep),
+        patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_noop_sleep)),
         patch(
             "core_api.services.contradiction_detector.detect_contradictions_async",
             new=_fake_detect,
@@ -636,7 +638,7 @@ async def test_reembed_is_failure_fallback_triggers_backoff() -> None:
             new=AsyncMock(return_value=[0.1] * VECTOR_DIM),
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
-        patch("core_api.services.memory_service.asyncio.sleep", new=_fake_sleep),
+        patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_fake_sleep)),
         patch.object(memory_service, "track_task"),
         patch(
             "core_api.services.organization_settings.resolve_config",

--- a/tests/test_embedding_retry.py
+++ b/tests/test_embedding_retry.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from common.embedding import _service as embedding_service
 from core_api.constants import (
     EMBEDDING_REEMBED_BATCH_SIZE,
     EMBEDDING_REEMBED_DELAY_S,
@@ -21,6 +22,7 @@ from core_api.constants import (
     EMBEDDING_RETRY_DELAY_S,
     VECTOR_DIM,
 )
+from tests._scoped_module import scoped
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +74,7 @@ async def test_retry_exhaustion_returns_none():
             "common.embedding._service.get_embedding_provider",
             return_value=mock_provider,
         ),
-        patch("common.embedding._service.asyncio.sleep", new_callable=AsyncMock),
+        patch.object(embedding_service, "asyncio", scoped(asyncio, sleep=AsyncMock())),
     ):
         result = await get_embedding("hello world", background=False)
 
@@ -99,7 +101,7 @@ async def test_success_on_second_attempt():
             "common.embedding._service.get_embedding_provider",
             return_value=mock_provider,
         ),
-        patch("common.embedding._service.asyncio.sleep", new_callable=AsyncMock),
+        patch.object(embedding_service, "asyncio", scoped(asyncio, sleep=AsyncMock())),
     ):
         result = await get_embedding("hello world", background=False)
 

--- a/tests/test_llm_retry_after.py
+++ b/tests/test_llm_retry_after.py
@@ -24,6 +24,7 @@ sustains itself.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
 
@@ -33,6 +34,7 @@ import pytest
 
 from common.llm import retry as retry_mod
 from common.llm.retry import call_with_fallback, call_with_retry, retry_after_seconds
+from tests._scoped_module import scoped
 
 
 def _rate_limited(**headers: str) -> openai.RateLimitError:
@@ -47,13 +49,19 @@ def _rate_limited(**headers: str) -> openai.RateLimitError:
 
 @pytest.fixture
 def slept(monkeypatch):
-    """Record every sleep instead of taking it."""
+    """Record every sleep ``call_with_retry`` takes, instead of taking it.
+
+    Scoped to ``retry_mod``'s own view of ``asyncio``. Patching
+    ``retry_mod.asyncio.sleep`` would patch the shared module and record
+    every task in the process — see ``tests/_scoped_module`` for the CI
+    failure that cost.
+    """
     recorded: list[float] = []
 
     async def _fake_sleep(seconds: float) -> None:
         recorded.append(seconds)
 
-    monkeypatch.setattr(retry_mod.asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(retry_mod, "asyncio", scoped(asyncio, sleep=_fake_sleep))
     # Jitter off by default so a delay assertion is exact; the two tests
     # that care about jitter turn it back on themselves.
     monkeypatch.setattr(retry_mod, "LLM_RETRY_JITTER_FRACTION", 0.0)
@@ -62,6 +70,57 @@ def slept(monkeypatch):
 
 async def _always(exc: BaseException):
     raise exc
+
+
+@pytest.mark.unit
+class TestTheRecorderRecordsOnlyUs:
+    """Every delay assertion below is only worth what this class pins.
+
+    caura#863 failed here with ``[0.7359102269208245, 1.0, 2.0]``: a
+    leaked background task retrying ``/memories/similar-candidates``
+    reached its third backoff inside this fixture's window, and the
+    recorder took the credit. Nothing in the suite said the recorder was
+    supposed to be ours alone, so nothing caught it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_sleep_taken_elsewhere_is_not_recorded(self, slept):
+        """This module is not ``common.llm.retry``, so its sleeps are its own."""
+        await asyncio.sleep(0)
+
+        assert slept == []
+
+    @pytest.mark.asyncio
+    async def test_a_sleep_taken_elsewhere_still_really_happens(self, slept):
+        """Scoping must not silence the rest of the process either.
+
+        A globally faked ``sleep`` does not merely mis-attribute: it turns
+        every other task's backoff into a no-op, so a leaked retry loop
+        spins through its remaining attempts at once. Whatever else is
+        running must be left alone, not sped up.
+        """
+        started = asyncio.get_running_loop().time()
+        await asyncio.sleep(0.05)
+
+        assert asyncio.get_running_loop().time() - started >= 0.05
+
+    @pytest.mark.asyncio
+    async def test_the_retry_loop_is_still_recorded(self, slept):
+        """The inverse, and the one that keeps the rest of the file honest.
+
+        A fixture scoped to the WRONG module records nothing at all, and
+        every ``assert slept == [...]`` here would then be asserting on an
+        empty list that no code path can fill.
+        """
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                lambda: _always(_rate_limited()),
+                label="t",
+                max_attempts=2,
+                base_delay=1.0,
+            )
+
+        assert slept == [1.0]
 
 
 @pytest.mark.unit

--- a/tests/test_llm_retry_budget.py
+++ b/tests/test_llm_retry_budget.py
@@ -28,6 +28,7 @@ that is the common case and the controls here cover it.
 from __future__ import annotations
 
 import asyncio
+import time
 
 import httpx
 import openai
@@ -35,6 +36,7 @@ import pytest
 
 from common.llm import retry as retry_mod
 from common.llm.retry import call_with_fallback, call_with_retry
+from tests._scoped_module import scoped
 
 
 def _rate_limited(**headers: str) -> openai.RateLimitError:
@@ -71,10 +73,60 @@ def clock(monkeypatch):
             self.now += seconds
 
     c = _Clock()
-    monkeypatch.setattr(retry_mod.time, "monotonic", c.monotonic)
-    monkeypatch.setattr(retry_mod.asyncio, "sleep", c.sleep)
+    # Both scoped to ``retry_mod``'s own view — see ``tests/_scoped_module``.
+    # Patching the shared modules would hand this clock to the whole process:
+    # every ``time.monotonic()`` anywhere would return 1000-and-change, and
+    # any other task's sleep would ADVANCE the clock these budget assertions
+    # are computed from. That is worse than the mis-attribution that caught
+    # ``test_llm_retry_after`` in caura#863 — a stray 0.74s here does not add
+    # a list entry, it silently spends 0.74s of the budget under test.
+    monkeypatch.setattr(retry_mod, "time", scoped(time, monotonic=c.monotonic))
+    monkeypatch.setattr(retry_mod, "asyncio", scoped(asyncio, sleep=c.sleep))
     monkeypatch.setattr(retry_mod, "LLM_RETRY_JITTER_FRACTION", 0.0)
     return c
+
+
+@pytest.mark.unit
+class TestTheClockIsOursAlone:
+    """Every budget assertion in this file is arithmetic on ``clock.now``.
+
+    A clock the rest of the process can move is not a clock. caura#863
+    showed a leaked background task reaching ``asyncio.sleep`` inside a
+    sibling fixture's window; the same intrusion here would have spent
+    part of the budget under test, and the test would have failed — or
+    quietly passed — for a reason found nowhere in its own code.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_sleep_taken_elsewhere_does_not_spend_the_budget(self, clock):
+        before = clock.now
+
+        await asyncio.sleep(0)
+
+        assert clock.now == before
+        assert clock.slept == []
+
+    def test_the_real_clock_still_runs_for_everybody_else(self, clock):
+        """The fake is 1000-and-change; real monotonic time is not."""
+        assert time.monotonic() != clock.now
+
+    @pytest.mark.asyncio
+    async def test_the_retry_loop_does_still_move_it(self, clock):
+        """The inverse: scoped to the wrong module, this file tests nothing."""
+
+        async def _always():
+            raise _rate_limited()
+
+        with pytest.raises(openai.RateLimitError):
+            await call_with_retry(
+                _always,
+                label="t",
+                max_attempts=2,
+                base_delay=1.0,
+                budget_s=30.0,
+            )
+
+        assert clock.slept == [1.0]
 
 
 @pytest.mark.unit

--- a/tests/test_p4_1_llm_fallback.py
+++ b/tests/test_p4_1_llm_fallback.py
@@ -10,16 +10,19 @@ Unit tests validate:
   - "fake" and "none" short-circuit without calling LLM
 """
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from common.llm import retry as retry_mod
 from core_api.constants import (
     LLM_FALLBACK_MODEL_OPENAI,
     LLM_RETRY_ATTEMPTS,
     LLM_RETRY_DELAY_S,
 )
+from tests._scoped_module import scoped
 
 
 # ---------------------------------------------------------------------------
@@ -159,7 +162,7 @@ class TestCallWithRetry:
             side_effect=[RuntimeError("fail")] * (LLM_RETRY_ATTEMPTS - 1)
             + [MemoryEnrichment()],
         )
-        with patch("common.llm.retry.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(retry_mod, "asyncio", scoped(asyncio, sleep=AsyncMock())):
             result = await _call_with_retry(fn, "test")
         assert isinstance(result, MemoryEnrichment)
         assert fn.call_count == LLM_RETRY_ATTEMPTS
@@ -169,7 +172,7 @@ class TestCallWithRetry:
         from core_api.services.memory_enrichment import _call_with_retry
 
         fn = AsyncMock(side_effect=RuntimeError("permanent"))
-        with patch("common.llm.retry.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(retry_mod, "asyncio", scoped(asyncio, sleep=AsyncMock())):
             with pytest.raises(RuntimeError, match="permanent"):
                 await _call_with_retry(fn, "test")
         assert fn.call_count == LLM_RETRY_ATTEMPTS
@@ -196,7 +199,7 @@ class TestCallExtractWithRetry:
         from core_api.services.entity_extraction import _call_extract_with_retry
 
         fn = AsyncMock(side_effect=RuntimeError("permanent"))
-        with patch("common.llm.retry.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(retry_mod, "asyncio", scoped(asyncio, sleep=AsyncMock())):
             with pytest.raises(RuntimeError, match="permanent"):
                 await _call_extract_with_retry(fn, "test")
         assert fn.call_count == LLM_RETRY_ATTEMPTS
@@ -646,7 +649,7 @@ class TestCallWithFallbackMaxAttempts:
             calls += 1
             raise RuntimeError("slow/hung")
 
-        with patch("common.llm.retry.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(retry_mod, "asyncio", scoped(asyncio, sleep=AsyncMock())):
             result = await call_with_fallback(
                 primary_provider_name="openai",
                 call_fn=call_fn,
@@ -671,7 +674,7 @@ class TestCallWithFallbackMaxAttempts:
             calls += 1
             raise RuntimeError("transient")
 
-        with patch("common.llm.retry.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(retry_mod, "asyncio", scoped(asyncio, sleep=AsyncMock())):
             result = await call_with_fallback(
                 primary_provider_name="openai",
                 call_fn=call_fn,


### PR DESCRIPTION
test(retry): stop a faked `asyncio.sleep` escaping the module under test

caura#863's CI run failed in `test_no_hint_keeps_the_linear_backoff` with

    assert [0.7359102269208245, 1.0, 2.0] == [1.0, 2.0]

on a PR that touches a shell script, a workflow job and CONTRIBUTING.md.
The test's own captured log names the intruder, so this needed no
guessing:

    WARNING common.http_retry storage_client.POST /memories/similar-candidates:
            ConnectError on attempt 3/5, retrying in 0.74s

That is a `detect_contradictions_async` background call, left running by
an earlier test, retrying a storage-api that does not exist in CI. Its
third backoff came due while the recorder was installed and was reported
as the LLM retry loop's own sleep. It logged before both `llm.retry`
lines, which is why the stray value is at index 0.

## The defect

    monkeypatch.setattr(retry_mod.asyncio, "sleep", fake)

does not patch `retry_mod`'s sleep. `retry_mod.asyncio` IS the one
`asyncio` module object, so that line replaces `asyncio.sleep` for every
importer alive — the code under test, every other module, and every task
already running. `patch("pkg.mod.asyncio.sleep", ...)` resolves the same
shared object. Five test files did this, twelve sites.

Two distinct costs, and the second is the one that has no assertion
watching it:

* **Mis-attribution.** Any task that sleeps during the window lands in
  the recorder. That is this failure.
* **Silencing.** Everyone else's backoff becomes a no-op, so a leaked
  retry loop spins through its remaining attempts at once instead of
  waiting. Nothing anywhere asserts that it did not.

`test_llm_retry_budget` had it worst. It fakes `time.monotonic` the same
way, which hands its fake clock to the whole process, and its fake sleep
ADVANCES that clock. A stray 0.74s there does not add a list entry — it
silently spends 0.74s of the budget the assertions are computing on.

## The fix

Patch the module REFERENCE, not the module CONTENTS: give the importer
under test a private copy of `asyncio` and leave the shared one alone.

    monkeypatch.setattr(mod, "asyncio", scoped(asyncio, sleep=fake))

`tests/_scoped_module.scoped` returns a real `ModuleType` holding a
shallow copy of the original namespace. A copy rather than a stub or a
forwarding proxy because the importers reach for more than `sleep`:
`retry.py` also uses `asyncio.wait_for`, and `memory_service` uses nine
asyncio names. An explicit stub would have to list them, and would break
— silently, in the `wait_for` case — the next time one was added.
Removing the namespace copy in a simulation fails 12 existing tests, so
that property is already covered by tests that exist for other reasons.

## Tests

Six, in the two files whose assertions the recorder feeds. Each pair
pins the property in both directions, because the two ways of getting
this wrong fail in opposite manners:

| test | fails without the fix |
|---|---|
| `..._sleep_taken_elsewhere_is_not_recorded` | yes — records `[0]` |
| `..._sleep_taken_elsewhere_still_really_happens` | yes — returns instantly |
| `..._a_sleep_elsewhere_does_not_spend_the_budget` | yes — clock moves |
| `..._the_real_clock_still_runs_for_everybody_else` | yes — 1000-and-change |
| `..._the_retry_loop_is_still_recorded` | vacuity guard |
| `..._the_retry_loop_does_still_move_it` | vacuity guard |

The last two do not fail against the old code, deliberately. They fail
against the realistic MIS-fix: a fixture scoped to the wrong module
records nothing at all, and every `assert slept == [...]` in both files
would then be asserting on a list no code path can fill. Simulated —
scoping the fixture at `common.http_retry` instead — and the suite takes
its sleeps for real and hangs, so the mis-scope is loud rather than
silent.

## What this does NOT fix

The leaked task itself. `detect_contradictions_async` is a post-commit
fire-and-forget call that outlives the test that started it and spends
~3s retrying an endpoint that is not there; it appears in the warnings
summary as `coroutine 'detect_contradictions_async' was never awaited`.
Filed separately — deciding what the fixture should do about background
tasks is not a flake fix.

Worth recording why it surfaced on #863 in particular. `pytest.ini` sets
`asyncio_default_test_loop_scope = session`, so nothing runs the loop
during a sync test; a block of them accumulates a leaked task's expired
timers and the next async test drains them all at once. #863 added 24
sync subprocess tests, ~1.1s, immediately before this file in
alphabetical order. It did not create the bug — it moved the timing that
exposes it, which is also why the re-run went green.

Root `tests/` is the only Python tree in the repo `ruff check` does not
cover, so none of this was lintable. Left alone here; noted.

Signed-off-by: eldad-caura <eldad@caura.ai>
