### PR TITLE
chore(clients): 1.0.1 — ship the H-01 recall fix to the registries

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "caura-client"
-version = "1.0.0"
+version = "1.0.1"
 description = "Official Python client for Caura (formerly MemClaw; the memclaw_client import and MemClaw class remain permanent aliases) — governed shared memory for AI agent fleets (multi-agent, multi-tenant, MCP-native)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/clients/python/src/caura_client/__init__.py
+++ b/clients/python/src/caura_client/__init__.py
@@ -34,4 +34,4 @@ __all__ = [
     "DEFAULT_BASE_URL",
 ]
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caura/memclaw-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Official TypeScript/JavaScript client for Caura (formerly MemClaw) \u2014 governed shared memory for AI agent fleets (multi-agent, multi-tenant, MCP-native).",
   "license": "Apache-2.0",
   "author": "Caura <hello@caura.ai>",


### PR DESCRIPTION
The #835 fix is merged but unpublished — PyPI/npm still serve 1.0.0, whose `recall()` returns empty memories for every SDK user (Python and TS). Version bump to 1.0.1 on both clients; the `caura` metapackage and `memclaw-client` shim need no change (`>=1.0.0` resolves forward).

Publish plan after merge: `uv build && uv publish` in clients/python (needs a fresh PyPI token or Trusted Publishing — the Aug 17 token was to be revoked), `npm publish` in clients/typescript (OTP).

Handover follow-up: this closes the gap between §04 'all ten highs merged' and what users actually install.

@erni-a green-and-ready per house rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBz7XjfFPBfdz3sQSNLBbB