### PR TITLE
ci(review): count conftest and shared test helpers as source, not just say so

### DIFF
--- a/.github/workflows/claude_code_review.yml
+++ b/.github/workflows/claude_code_review.yml
@@ -266,8 +266,20 @@ jobs:
           # Paginated for the same reason as the count above, and here the failure is worse than
           # a dead cap: unpaginated, a pull request whose first 30 files are all docs would be
           # skipped as "no source files" even with source changes on page two.
+          #
+          # `conftest.py` and `tests/_*.py` count as SOURCE here, which is the other half of the
+          # carve-out #872 made to REVIEW_PROMPT. Telling the reviewer to review them achieved
+          # nothing on its own: a change confined to those files still counted zero here, so the
+          # job skipped and the prompt was never read. #866 was exactly that, and #872 itself was
+          # too — a lone workflow `.yml` is config, so the PR fixing the exclusion was not
+          # reviewed either. They earn it: they are the highest-fan-in files in the suite
+          # (`tests/_scoped_module.py` is imported by five test files), and a defect in one is a
+          # defect in everything that imports it.
+          #
+          # The expression is pinned by tests/test_review_source_filter.py, which extracts THIS
+          # line from THIS file and runs it — a copy in a test would only prove the copy works.
           SRC_FILES=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
-            --jq '[.[] | select(.filename | (startswith("tests/") or startswith("test_") or test("^(Dockerfile|helm/|docs/|.*\\.(md|toml|lock|ya?ml)$)")) | not)] | length' \
+            --jq '[.[] | select(.filename | if (test("(^|/)conftest\\.py$") or test("^tests/_[^/]*\\.py$")) then true else ((startswith("tests/") or startswith("test_") or test("^(Dockerfile|helm/|docs/|.*\\.(md|toml|lock|ya?ml)$)")) | not) end)] | length' \
             | awk '{s+=$1} END {print s+0}')
           if [[ "$SRC_FILES" -eq 0 ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/tests/test_review_source_filter.py
+++ b/tests/test_review_source_filter.py
@@ -1,0 +1,131 @@
+"""What `pre-checks` counts as "source" decides whether a review happens at all.
+
+`claude_code_review.yml` skips the whole review job when a pull request
+changes no source files. #872 told the reviewer to review ``conftest.py``
+and ``tests/_*.py``, but that instruction lives in ``REVIEW_PROMPT``, which
+is only read once the job runs — and a change confined to those files still
+counted zero source files, so the job skipped and the prompt was never
+reached. #866 was that case, and #872 itself was too: a lone workflow
+``.yml`` is config, so the pull request removing the exclusion was not
+reviewed either.
+
+The expression is extracted from the workflow and executed here rather than
+restated. A copy would pin the copy: the two would drift, this file would
+stay green, and the thing that decides whether code gets reviewed would go
+back to being unverified. Extraction also means a reformat of that line
+fails loudly here instead of silently unpinning it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github/workflows/claude_code_review.yml"
+
+# The `SRC_FILES=` assignment, then the single-quoted argument to `--jq` that
+# follows it. Anchored on the variable name because the same file runs several
+# `gh api --jq` calls and only this one decides the skip.
+_FILTER_RE = re.compile(r"SRC_FILES=.*?--jq\s+'(?P<expr>[^']*)'", re.DOTALL)
+
+
+def _source_filter() -> str:
+    match = _FILTER_RE.search(WORKFLOW.read_text())
+    assert match is not None, (
+        f"could not find the SRC_FILES --jq expression in {WORKFLOW}. If that step was "
+        "reworded, update this regex — do not delete the test: the expression decides "
+        "whether any pull request gets reviewed."
+    )
+    return match.group("expr")
+
+
+def _counts_as_source(*filenames: str) -> int:
+    """Run the workflow's own filter over *filenames*, as the GitHub API shapes them."""
+    payload = json.dumps([{"filename": f} for f in filenames])
+    result = subprocess.run(
+        ["jq", _source_filter()],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return int(result.stdout.strip())
+
+
+pytestmark = [
+    pytestmark,
+    pytest.mark.skipif(shutil.which("jq") is None, reason="jq is not installed"),
+]
+
+
+class TestTheSharedTestFilesCountAsSource:
+    """The regression #872 aimed at and did not reach."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/conftest.py",
+            "tests/pipeline/conftest.py",
+            "tests/_scoped_module.py",
+            "tests/_mcp_test_helpers.py",
+        ],
+    )
+    def test_a_shared_helper_alone_is_enough_to_trigger_a_review(self, path: str) -> None:
+        assert _counts_as_source(path) == 1, (
+            f"{path} counts as zero source files, so a pull request touching only it "
+            "skips review entirely — regardless of what REVIEW_PROMPT says"
+        )
+
+
+class TestOrdinaryTestsAndDocsStillDoNot:
+    """The carve-out must not become 'review everything'.
+
+    Widening it far enough to catch the helpers would spend a review run on
+    every docs typo, which is the cost the exclusion exists to avoid.
+    """
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/test_llm_retry_after.py",
+            "tests/pipeline/test_write_pipeline.py",
+            "test_toplevel.py",
+            "docs/runbooks/pubsub.md",
+            "README.md",
+            "pyproject.toml",
+            "core-api/uv.lock",
+            "Dockerfile",
+            "helm/values.yaml",
+            ".github/workflows/ci.yml",
+        ],
+    )
+    def test_it_does_not_count_as_source(self, path: str) -> None:
+        assert _counts_as_source(path) == 0
+
+
+class TestTheCountIsACount:
+    def test_real_source_still_counts(self) -> None:
+        assert _counts_as_source("core-api/src/core_api/services/memory_service.py") == 1
+
+    def test_a_mixed_pull_request_counts_only_the_source(self) -> None:
+        """The skip is `-eq 0`, so what matters is that the total is not zero —
+        but a wrong count here would also mean a wrong `MAX_FILES` intuition."""
+        assert (
+            _counts_as_source(
+                "docs/x.md",
+                "tests/test_foo.py",
+                "core-api/src/core_api/main.py",
+                "tests/conftest.py",
+            )
+            == 2
+        )
+
+    def test_an_empty_pull_request_is_zero(self) -> None:
+        assert _counts_as_source() == 0


### PR DESCRIPTION
ci(review): count conftest and shared test helpers as source, not just say so

#872 told the reviewer to review `conftest.py` and `tests/_*.py`. That
instruction lives in `REVIEW_PROMPT`, which is only read once the review
job runs — and whether it runs is decided earlier, by `pre-checks`
condition 6:

    SRC_FILES=$(gh api ... --jq '[.[] | select(.filename |
      (startswith("tests/") or ...) | not)] | length')
    if [[ "$SRC_FILES" -eq 0 ]]; then skip

Both carved-out patterns start with `tests/`, so a pull request confined
to them still counted zero source files, the job skipped, and the new
prompt was never reached. The half that shipped covers a real case — a PR
touching source AND `conftest.py` no longer has the conftest part ignored
— but the case it was written for stayed open.

This is the other half: those two patterns now count as source.

## Why they earn it

`tests/conftest.py` is the highest-fan-in file in the suite, and
`tests/_scoped_module.py` is imported by five test files. A defect in
either is a defect in everything downstream, which is the argument for
reviewing source in the first place. The exclusion exists so a docs typo
does not spend a review; it was never meant to cover the files most
capable of breaking the suite silently.

Three of this month's PRs demonstrate the gap, and the third is the one
worth stating plainly:

  #866  tests/conftest.py only          -> skipped
  #868  five test files + a new helper  -> skipped
  #872  one workflow .yml               -> skipped

**The pull request removing the exclusion was not reviewed, for the reason
it existed to fix.** A `.yml` is config, so it too counted zero.

Not widened further. Ordinary `test_*.py`, docs, lockfiles, Dockerfile,
helm and other workflow YAML still count zero, which is what keeps a
one-word README change from costing a review run.

## The test runs the workflow's own expression

`tests/test_review_source_filter.py` extracts the `--jq` argument from
`claude_code_review.yml` and executes it against fixture file lists. It
does not restate it.

That is the whole point. A copy pins the copy: the two drift, the test
stays green, and the expression deciding whether any code gets reviewed
goes back to being unverified — which is how this gap survived in the
first place. Extraction also means rewording that step fails loudly here,
with a message saying to fix the regex rather than delete the test.

17 tests. Five fail against the merged state — the four shared-helper
paths and the mixed-count case — and were confirmed to do so by reverting
the workflow hunk and re-running. The other twelve pass either way by
design: they are the do-not-over-widen side, and a carve-out broad enough
to catch the helpers by accident would break them.

`jq` is preinstalled on GitHub runners; the module skips if it is absent
locally rather than failing.

## Consequence to expect

Every conftest-touching pull request now spends a review run, including
trivial ones. That is the intended trade and it is worth naming, since it
is a real cost per PR rather than a one-off.

Signed-off-by: eldad-caura <eldad@caura.ai>
