### PR TITLE
ci(release): give `caura` on npm a publish path, and stop trusting the tick

### DIFF
--- a/.github/workflows/publish-npm-caura.yml
+++ b/.github/workflows/publish-npm-caura.yml
@@ -1,0 +1,175 @@
+name: Publish caura to npm
+
+# Publishes `clients/npm-caura` — the bare `caura` name on npm, a thin
+# re-export of the scoped TypeScript client.
+#
+# WHY THIS EXISTS AS ITS OWN WORKFLOW. The package had none, so the name was
+# never claimed: `npm install caura` 404s today while `README.md` and
+# `clients/npm-caura/README.md` both instruct people to run it. That is worse
+# than an unshipped package — it is a live instruction pointing at a slot
+# anyone can take, and whoever takes it inherits the traffic and the two
+# README citations.
+#
+# The precedent is ours. The old brand's bare name is third-party-held on BOTH
+# registries — npm by `deshrajdry`, PyPI by `emanuilo` — and one of the two
+# describes itself as a memory layer for OpenClaw. Installing either by that
+# name fetches foreign code today. Both were lost by not claiming them and
+# neither is recoverable; `caura` on npm is the equivalent door still open.
+#
+# ORDERING. This package depends on the scoped client at `^1.0.0`, so that
+# package must exist on the registry at a matching version first — it does
+# (1.0.0, and 1.0.1 once `publish-npm-client.yml` runs). npm does not verify
+# dependencies at publish time, so publishing this against a missing version
+# would succeed and produce a package nobody can install.
+#
+# One-time setup by a maintainer:
+#   1. Add an `NPM_TOKEN` repository secret — an npm automation token with
+#      publish rights. Automation tokens are exempt from 2FA/OTP prompts by
+#      design; an OTP is never entered in CI.
+#   2. Nothing else. The name is unscoped, so no npm org is required.
+#
+# Release: push a tag `caura-npm-v<version>` matching the version in
+# clients/npm-caura/package.json, or run this workflow manually.
+
+on:
+  push:
+    tags:
+      - "caura-npm-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      # Both, and `contents: read` is not redundant: declaring a permissions
+      # block sets every scope NOT listed to `none`, so naming only id-token
+      # leaves `contents: none` and `actions/checkout` authenticating with a
+      # token that cannot read the repo.
+      contents: read
+      id-token: write # npm provenance
+    defaults:
+      run:
+        working-directory: clients/npm-caura
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      # Checked explicitly because the failure it prevents is a confusing one.
+      # Without the secret, `npm publish` authenticates as nobody and fails
+      # with a 401 or ENEEDAUTH that reads like an npm-side problem rather
+      # than a missing repository secret. This has already cost a debugging
+      # round once.
+      - name: The publish credential must exist
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -z "${NPM_TOKEN}" ]]; then
+            echo "::error::NPM_TOKEN repository secret is not set. Add an npm automation token with publish rights; nothing here can publish without it."
+            exit 1
+          fi
+
+      # A tag that disagrees with package.json does not fail — it publishes
+      # whatever package.json says, under a tag claiming otherwise. The
+      # release then looks done and the registry serves a different version.
+      - name: The tag must agree with package.json
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#caura-npm-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::tag ${GITHUB_REF_NAME} says ${TAG_VERSION} but package.json says ${PKG_VERSION}"
+            exit 1
+          fi
+          echo "publishing $(node -p "require('./package.json').name")@${PKG_VERSION}"
+
+      # The ORDERING note in the header is the one risk here with no natural
+      # symptom: npm does not resolve dependencies at publish time, so
+      # publishing this against a client version that is not on the registry
+      # SUCCEEDS, and produces a package that fails for the first person who
+      # installs it. Every other risk named in this file has a check; this one
+      # was described and left to the operator, which is the shape of comment
+      # that goes stale and is worth even less than no comment.
+      #
+      # Every dependency is checked, not just the one that exists today, so
+      # adding a second cannot quietly skip it.
+      - name: Every dependency must already be on the registry
+        run: |
+          node -p "Object.entries(require('./package.json').dependencies || {}).map(([n, r]) => n + '@' + r).join('\n')" \
+            > /tmp/deps.txt
+          # Retried on the same schedule as the post-publish check below, and
+          # for the same reason: the expected release order is client then
+          # metapackage, minutes apart, so this lookup runs exactly when the
+          # dependency is newest and least likely to have propagated. A single
+          # attempt would turn npm's own CDN lag into a failed release.
+          while read -r SPEC; do
+            [[ -z "$SPEC" ]] && continue
+            RESOLVED=""
+            for attempt in 1 2 3 4 5; do
+              # `--json`, not the human-readable form. `npm view <spec> <field>`
+              # prints `pkg@ver 'ver'` per match, which parses correctly today
+              # but is presentation output with no stability contract; `--json`
+              # is a string for one match and an array for several, and both
+              # are contractual. Same reason the collaborators lookup below
+              # uses it.
+              #
+              # `|| true` is load-bearing, not defensive noise. Actions runs
+              # steps under `bash -eo pipefail`, so an unresolvable spec makes
+              # `npm view` exit non-zero, pipefail propagates it, and `set -e`
+              # aborts the whole step on attempt 1 — silently, before the
+              # diagnostic below ever prints. That is the exact case this loop
+              # exists for, so without this the retry is decorative.
+              RESOLVED=$(npm view "$SPEC" version --json 2>/dev/null | node -e '
+                let s = "";
+                process.stdin.on("data", d => s += d).on("end", () => {
+                  try {
+                    const j = JSON.parse(s);
+                    const a = Array.isArray(j) ? j : [j];
+                    const last = a[a.length - 1];
+                    // A string, or nothing. npm prints its E404 as VALID JSON
+                    // on stdout when --json is set — an object with an "error"
+                    // key — so JSON.parse succeeding proves nothing about
+                    // whether the package exists. Without this type check that
+                    // error object itself becomes a non-empty RESOLVED, and a
+                    // missing dependency silently PASSES the gate. Verified:
+                    // it did exactly that before the check was added.
+                    console.log(typeof last === "string" ? last : "");
+                  } catch { console.log(""); }
+                });' || true)
+              [[ -n "$RESOLVED" ]] && break
+              echo "attempt ${attempt}: ${SPEC} not visible yet, waiting"
+              sleep 10
+            done
+            if [[ -z "$RESOLVED" ]]; then
+              echo "::error::${SPEC} is not on the registry. Publish it first (publish-npm-client.yml) — npm would accept this package anyway and it would be uninstallable."
+              exit 1
+            fi
+            echo "${SPEC} -> ${RESOLVED}"
+          done < /tmp/deps.txt
+
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # A green publish step is not evidence the registry serves it. Today
+      # `#870` merged a version bump, every check passed, and both registries
+      # went on serving the old build because no tag had been pushed — the
+      # tick meant "nothing went wrong", not "it shipped". Ask the registry.
+      - name: The registry must actually serve it
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          for attempt in 1 2 3 4 5; do
+            PUBLISHED=$(npm view "${PKG_NAME}@${PKG_VERSION}" version 2>/dev/null || true)
+            if [[ "$PUBLISHED" == "$PKG_VERSION" ]]; then
+              echo "registry serves ${PKG_NAME}@${PUBLISHED}"
+              exit 0
+            fi
+            echo "attempt ${attempt}: registry does not serve ${PKG_VERSION} yet, waiting"
+            sleep 10
+          done
+          echo "::error::published without error but the registry does not serve ${PKG_NAME}@${PKG_VERSION}"
+          exit 1

--- a/.github/workflows/publish-npm-client.yml
+++ b/.github/workflows/publish-npm-client.yml
@@ -1,25 +1,47 @@
-name: Publish @caura/memclaw-client to npm
+name: Publish the TypeScript client to npm
 
-# Publishes the TypeScript client SDK to npm.
+# Publishes `clients/typescript` to npm.
+#
+# THIS WORKFLOW HAS NEVER RUN. No tag matching either pattern below has ever
+# existed; the 1.0.0 on the registry was uploaded by hand on 2026-08-17. Treat
+# the first real run as unproven, and check the registry afterwards rather than
+# the green tick.
 #
 # One-time setup by a maintainer:
 #   1. Ensure the @caura npm org/scope exists and the publisher has access.
-#   2. Add an `NPM_TOKEN` repository secret (automation token with publish rights),
-#      OR configure npm trusted publishing for the package.
+#   2. Add an `NPM_TOKEN` repository secret — an npm automation token with
+#      publish rights. Automation tokens are exempt from 2FA/OTP prompts by
+#      design; an OTP is never entered in CI. As of 2026-08-23 this secret does
+#      NOT exist, so this workflow cannot publish.
 #
 # Release: bump the version in clients/typescript/package.json, then push a tag
-# `memclaw-client-ts-v<version>` (or run this workflow manually).
+# `caura-client-ts-v<version>` (or run this workflow manually).
+#
+# The legacy tag pattern below still triggers, and stays: rule 3 of the rename
+# programme keeps old names working rather than replacing them, and a tag
+# pattern is exactly the kind of thing sitting in someone's runbook. New
+# releases should use the caura-named tag, because rule 7 is "mint nothing new
+# carrying the old brand" and a release under the old pattern mints one.
+#
+# The package name is read from package.json throughout rather than written
+# out, so the rename lands in one place and these steps keep working.
 
 on:
   push:
     tags:
-      - "memclaw-client-ts-v*"
+      - "caura-client-ts-v*"
+      - "memclaw-client-ts-v*" # legacy-name-ok: rule 3 keeps the published tag pattern working
   workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      # Both, and `contents: read` is not redundant: declaring a permissions
+      # block sets every scope NOT listed to `none`, so naming only id-token
+      # leaves `contents: none` and `actions/checkout` authenticating with a
+      # token that cannot read the repo.
+      contents: read
       id-token: write # npm provenance
     defaults:
       run:
@@ -30,9 +52,60 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+
+      # Checked explicitly because the failure it prevents is a confusing one.
+      # Without the secret, `npm publish` authenticates as nobody and fails
+      # with a 401 or ENEEDAUTH that reads like an npm-side problem rather
+      # than a missing repository secret.
+      - name: The publish credential must exist
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -z "${NPM_TOKEN}" ]]; then
+            echo "::error::NPM_TOKEN repository secret is not set. Add an npm automation token with publish rights; nothing here can publish without it."
+            exit 1
+          fi
+
       - name: Install + build
         run: npm install
+
+      # A tag that disagrees with package.json does not fail — it publishes
+      # whatever package.json says, under a tag claiming otherwise. The release
+      # then looks done while the registry serves a different version. Both
+      # prefixes are stripped so the check works on either tag.
+      - name: The tag must agree with package.json
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#caura-client-ts-v}"
+          TAG_VERSION="${TAG_VERSION#memclaw-client-ts-v}" # legacy-name-ok: strips the tag pattern kept above
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::tag ${GITHUB_REF_NAME} says ${TAG_VERSION} but package.json says ${PKG_VERSION}"
+            exit 1
+          fi
+          echo "publishing $(node -p "require('./package.json').name")@${PKG_VERSION}"
+
       - name: Publish
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # A green publish step is not evidence the registry serves it. #870
+      # merged a version bump, every check passed, and both registries went on
+      # serving the old build because no tag had been pushed — the tick meant
+      # "nothing went wrong", not "it shipped". Ask the registry.
+      - name: The registry must actually serve it
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          for attempt in 1 2 3 4 5; do
+            PUBLISHED=$(npm view "${PKG_NAME}@${PKG_VERSION}" version 2>/dev/null || true)
+            if [[ "$PUBLISHED" == "$PKG_VERSION" ]]; then
+              echo "registry serves ${PKG_NAME}@${PUBLISHED}"
+              exit 0
+            fi
+            echo "attempt ${attempt}: registry does not serve ${PKG_VERSION} yet, waiting"
+            sleep 10
+          done
+          echo "::error::published without error but the registry does not serve ${PKG_NAME}@${PKG_VERSION}"
+          exit 1

--- a/.github/workflows/verify-npm-credential.yml
+++ b/.github/workflows/verify-npm-credential.yml
@@ -1,0 +1,132 @@
+name: Verify the npm credential
+
+# Answers "is NPM_TOKEN the right token?" WITHOUT publishing anything.
+#
+# Manual only. Read-only: `npm whoami` and `npm access` make no changes, and
+# no `npm publish` runs here in any form.
+#
+# WHY THIS IS NOT AN IDLE QUESTION. The broker package in the `@caura-ai`
+# scope and the client package in the `@caura` scope were published by two
+# DIFFERENT npm accounts — `caura-ai-admin` and `caura` respectively, per the
+# registry's own maintainer field.
+#
+# So a token minted for one is not automatically good for the other. A token
+# belonging to `caura-ai-admin` publishes the broker fine and gets a 403 on
+# the `@caura` scope unless that account is also a member with publish rights.
+# The failure surfaces only at the publish step, after a tag has been pushed,
+# and the two halves of a release can then disagree: the unscoped `caura` name
+# is unclaimed, so ANY valid account can take it, while the scoped client needs
+# the right one. Claiming the bare name under one account while the scoped
+# package lives under another is a mess to unpick afterwards, and npm does not
+# let you simply move it.
+#
+# Nothing here gates a release. It exists so the answer is known before a tag
+# is pushed rather than discovered by a half-finished one.
+#
+# Run: Actions -> Verify the npm credential -> Run workflow.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Which account does the token belong to
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -z "${NODE_AUTH_TOKEN}" ]]; then
+            echo "::error::NPM_TOKEN is not set."
+            exit 1
+          fi
+          # The identity is the whole question, so a failure here is fatal
+          # rather than advisory: no answer means the token is invalid or
+          # expired, which is itself the finding.
+          WHO=$(npm whoami 2>&1) || {
+            echo "::error::npm whoami failed — the token is invalid or expired: ${WHO}"
+            exit 1
+          }
+          echo "token authenticates as: ${WHO}"
+          echo "NPM_USER=${WHO}" >> "$GITHUB_ENV"
+
+      # `npm access` output and flags have moved between npm majors, so an
+      # unparseable answer here means "could not determine", never "no
+      # access" — reporting uncertainty as a refusal would be worse than
+      # saying nothing. A DEFINITE negative does fail the job, because that
+      # is the answer worth stopping for.
+      - name: Can it publish what the release needs
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "── every package this token can reach ──"
+          npm access list packages 2>&1 | head -50 || echo "  (could not list; npm access varies by CLI version)"
+          echo
+          echo "── publish rights on the two packages this release needs ──"
+          # Names read from the manifests rather than written out, so this
+          # cannot drift from what the publish workflows actually ship.
+          CLIENT_PKG=$(node -p "require('./clients/typescript/package.json').name")
+          META_PKG=$(node -p "require('./clients/npm-caura/package.json').name")
+          BLOCKED=0
+          for PKG in "$CLIENT_PKG" "$META_PKG"; do
+            # An unpublished name has no collaborator list and cannot have
+            # one. That is not a failure: an unclaimed name is publishable by
+            # any valid account, which is exactly what this repo is trying to
+            # do with the unscoped name.
+            if ! npm view "$PKG" version >/dev/null 2>&1; then
+              printf "  %-26s not published yet — any valid account may claim it\n" "$PKG"
+              continue
+            fi
+            # `collaborators`, not `get status`: status reports whether a
+            # package is public or restricted, which says nothing about who
+            # may publish it. Permission is the entire question here.
+            RAW=$(npm access list collaborators "$PKG" --json 2>/dev/null || true)
+            PERM=$(printf '%s' "$RAW" | node -e '
+              let s = "";
+              process.stdin.on("data", d => s += d).on("end", () => {
+                try { console.log(JSON.parse(s)[process.argv[1]] || "NONE"); }
+                catch { console.log("UNKNOWN"); }
+              });' "$NPM_USER" 2>/dev/null || echo UNKNOWN)
+            case "$PERM" in
+              read-write)
+                printf "  %-26s read-write — can publish\n" "$PKG" ;;
+              read-only)
+                printf "  %-26s read-only — CANNOT publish\n" "$PKG"; BLOCKED=1 ;;
+              NONE)
+                printf "  %-26s %s is not a collaborator — CANNOT publish\n" "$PKG" "$NPM_USER"; BLOCKED=1 ;;
+              *)
+                printf "  %-26s (could not determine)\n" "$PKG" ;;
+            esac
+          done
+          echo "BLOCKED=${BLOCKED}" >> "$GITHUB_ENV"
+
+      - name: The verdict
+        run: |
+          echo "Authenticated as: ${NPM_USER}"
+          echo
+          if [[ "${BLOCKED}" == "1" ]]; then
+            echo "::error::This token cannot publish everything the release needs."
+            echo "The dangerous part is that it would not fail cleanly. The unscoped"
+            echo "name is unclaimed, so ANY valid account can take it — so a release"
+            echo "attempted with this token can 403 on the scoped client while still"
+            echo "claiming the bare name, leaving the two packages under two different"
+            echo "owners. npm has no self-service way to move a package between"
+            echo "owners; undoing it means going through npm support."
+            echo
+            echo "Use a token from an account with publish rights on the @caura scope,"
+            echo "with 'All packages' selected rather than named packages — the"
+            echo "unscoped name does not exist yet, so it cannot appear in a"
+            echo "selected-packages list."
+            exit 1
+          fi
+          echo "No blocker found. Note this proves publish RIGHTS, not that a"
+          echo "publish will succeed — a version already on the registry, or a"
+          echo "token expiring between now and the tag, would still fail."


### PR DESCRIPTION
ci(release): give `caura` on npm a publish path, and stop trusting the tick

Two problems, one cause. `clients/npm-caura` has never had a publish
workflow, so the bare `caura` name on npm has never been claimed —
`npm install caura` returns 404 while `README.md:377` and
`clients/npm-caura/README.md:9` both instruct people to run it. And the
TypeScript client's workflow has never run at all: no matching tag has
ever existed, and the 1.0.0 on the registry was uploaded by hand on
2026-08-17.

Neither can publish today regardless: there is no `NPM_TOKEN` secret.
That still needs a maintainer. Everything else is here.

## Why the name matters more than an unshipped package

A documented install command pointing at an unclaimed slot is the worst of
the three states, because whoever claims it inherits the traffic and the
two README citations.

The precedent is ours: the old brand's bare name is third-party-held on
BOTH registries — npm by `deshrajdry`, PyPI by `emanuilo` — and one of the
two describes itself as a memory layer for OpenClaw. Installing either by
that name fetches foreign code today. Both were lost by not claiming them
and neither is recoverable. The rename programme lists registry names
under "unaffected by all scenarios" precisely because they are one-way
doors, and it is about to spend six to eight weeks making this name far
more visible.

## Three guards, each for a failure that already happened

**The credential must exist.** Without the secret, `npm publish`
authenticates as nobody and fails with a 401/ENEEDAUTH that reads like an
npm-side problem. That already cost a debugging round, and the handover it
came through recorded the blocker as "npm OTP" — which does not apply,
since CI publishes with an automation token, exempt from OTP by design.

**The tag must agree with package.json.** A mismatch does not fail: npm
publishes whatever package.json says, under a tag claiming otherwise, and
the release looks done while the registry serves a different version.

**The registry must actually serve it.** This is the one worth having.
#870 merged a version bump to 1.0.1, every check went green, and both
registries carried on serving 1.0.0 — because the publish is tag-triggered
and no tag was pushed. The tick meant "nothing went wrong", not "it
shipped". So the last step asks the registry, with a short retry for
propagation, and fails if the version is not being served.

## Verified locally, because these workflows are unproven

Neither has a successful run to point at, so the parts that could be
exercised without publishing were:

* Built `clients/typescript`, packed both dists, installed them into a
  scratch project, and imported the metapackage. `import { Caura } from
  "caura"` resolves, `Caura` is a class, and `MemClaw === Caura` still
  holds — rule 3's alias survives the re-export, which `export *` would
  silently drop for a default export.
* Confirmed the packed 1.0.1 contains the H-01 fix: the built
  `dist/index.js` reads `data?.memories ?? data?.items`, not the invented
  `supporting_memories` key still live on the registry.
* Exercised the tag/version guard both ways, and both tag prefixes, so the
  legacy pattern still strips correctly.
* `actionlint` clean, which covers shellcheck on the `run:` blocks.

## Names

The old `memclaw-client-ts-v*` tag still triggers — rule 3, and a tag
pattern is exactly what sits in someone's runbook — but new releases use
`caura-client-ts-v*`, because rule 7 is "mint nothing new carrying the old
brand" and every release under the old pattern mints one. The two lines
that must carry the legacy literal are marked `legacy-name-ok:` with their
reason; the rest was reworded, and two of those rewordings improve the
code: the package name is now read from package.json instead of written
out, so the eventual rename lands in one place.

Net effect on the ratchet: **-3 lines**.

## Not in this change

`publish-python-client.yml` needs the same treatment and one correction
that matters: its setup note still says to create a PyPI project named
`memclaw-client`, while `clients/python/pyproject.toml` now builds
`caura-client`. PyPI Trusted Publishers are per-project, so an entry
registered against the old name will not authorise the new one — the
Python half will likely fail for that reason. Separate change, since this
one was scoped to npm.

`clients/caura-meta` and `clients/memclaw-client-shim` also have no
publish workflow; both exist on PyPI only because someone uploaded them by
hand.

Refs #873

Signed-off-by: eldad-caura <eldad@caura.ai>
