### PR TITLE
docs: four README references that point at things which do not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The fastest way to see Caura work. Standalone mode runs single-tenant with auth 
 
 ```bash
 git clone https://github.com/caura-ai/caura.git
-cd caura-memclaw
+cd caura
 cp .env.example .env && echo "IS_STANDALONE=true" >> .env   # single-tenant, no API key
 docker compose up -d                                        # Postgres + pgvector + Redis + API (~30s)
 
@@ -129,7 +129,7 @@ The fastest path is Docker Compose — one command brings up Postgres + pgvector
 
 ```bash
 git clone https://github.com/caura-ai/caura.git
-cd caura-memclaw
+cd caura
 cp .env.example .env
 ```
 
@@ -767,7 +767,7 @@ The **reader/writer split** is an opt-in topology for high-write-rate deploys th
 
 2. **Snapshot the database.** A `pg_dump` is the safest fallback. Replace
    `<container>` with the running PostgreSQL container name (typically
-   `caura-memclaw-db-1`):
+   `caura-db-1`):
    ```bash
    docker compose up -d db    # bring just the DB back
    docker exec <container> pg_dump -U memclaw memclaw > backup-pre-v2.sql
@@ -1043,7 +1043,7 @@ All configuration is via environment variables or `.env`. See `.env.example` for
 <summary>Project structure</summary>
 
 ```
-memclaw/
+caura/
 ├── core-api/                      # Main FastAPI service
 │   └── src/core_api/
 │       ├── app.py                 # FastAPI app, lifespan, middleware
@@ -1264,7 +1264,7 @@ Mem0 and Zep focus on memory for individual agents; accuracy benchmarks
 cluster all three tools in a narrow band. Caura is built for *fleets*:
 multiple agents across teams and vendors sharing one governed memory plane,
 with trust tiers, keystone policies, and cross-fleet permissions those
-tools don't address. See [How Caura compares](#how-memclaw-compares).
+tools don't address. See [How Caura compares](#how-caura-compares).
 
 **Does Caura work with Claude Desktop, Claude Code, Cursor, or Windsurf?**
 Yes — Caura is MCP-native. Paste a JSON config with a URL and API key


### PR DESCRIPTION
All four broke on the 2026-08-15 repo rename. None is a legacy name kept on purpose — they are wrong, not old.

| Line | Was | Now |
| --- | --- | --- |
| 61, 132 | `cd caura-memclaw` | `cd caura` |
| 770 | `caura-memclaw-db-1` | `caura-db-1` |
| 1046 | `memclaw/` (tree root) | `caura/` |
| 1267 | `#how-memclaw-compares` | `#how-caura-compares` |

**The quickstart is the one that matters.** Both `cd caura-memclaw` lines follow `git clone https://github.com/caura-ai/caura.git`, so the quickstart dies at its second line for every reader. It passes locally only where a `caura-memclaw -> caura` symlink survived the rename, which is why it has gone unnoticed since 08-15. The 2026-08-19 rebrand audit flagged it as "a functional break".

The others: compose derives its project name from the directory, so a fresh clone gets `caura-db-1` and the `pg_dump` step names a container that will not exist; the heading has read `## How Caura compares` (L415) since the rename, leaving the L1267 anchor dead.

## What this deliberately does not touch

The other 59 occurrences stay. `MEMCLAW_*` envs, the `memclaw` Postgres role and database, the plugin and skill id, the `memclaw-client` / `MemClaw` aliases, the `ghcr.io/caura-ai/caura-memclaw-*` image names (verified against `docker-compose.yml`) and the `/memclaw/` routes are live contracts under hard rule 3 — old names stay readable forever. They come out with the env dual-read and infra waves, not with a prose sweep.

Line 377's `npm install caura` claim is the fifth broken reference and is already fixed by #876; this branch leaves it alone to avoid the conflict.

## Ratchet

`scripts/legacy_name_ratchet.py` reports `No new lines. 4 removed by this change (-4 net).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)