### PR TITLE
docs: the same broken cd in the setup docs #877 fixes in the README

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -15,7 +15,7 @@ You need these on your machine:
 ```bash
 # 1. Clone
 git clone https://github.com/caura-ai/caura.git
-cd caura-memclaw
+cd caura
 
 # 2. Start everything (PostgreSQL + pgvector, Redis, Caura API)
 docker compose up -d
@@ -37,7 +37,7 @@ You need a PostgreSQL 16+ instance with pgvector extension installed.
 ```bash
 # 1. Clone
 git clone https://github.com/caura-ai/caura.git
-cd caura-memclaw
+cd caura
 
 # 2. Create virtual environment
 python -m venv venv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ up, the expected workflow, and how we review changes.
 
 ```bash
 git clone https://github.com/caura-ai/caura.git
-cd caura-memclaw
+cd caura
 uv venv .venv
 source .venv/bin/activate
 uv pip install -e "core-api/[dev]" -e "core-storage-api/[dev]"

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -200,7 +200,7 @@ On a machine with `node` (v18+) and `npm`:
 
 ```bash
 git clone https://github.com/caura-ai/caura.git
-cd caura-memclaw/plugin
+cd caura/plugin
 npm install
 npm run build            # emits plugin/dist/
 ```


### PR DESCRIPTION
**Companion to #877** — same root cause, different files. #774 updated every `git clone` URL to `caura.git` but missed the `cd caura-memclaw` line beneath each one; #877 fixes the README's two quickstart blocks (plus three more README breaks), this PR fixes the remaining four sites so no copy-paste setup block in the repo dies at step 2:

- `AGENT-INSTALL.md:18` and `:40`
- `CONTRIBUTING.md:29`
- `static/docs/integration-guide.md:203` (`cd caura-memclaw/plugin` → `cd caura/plugin`)

README changes were dropped from this branch in favor of #877 (first, and more complete there) — no conflict between the two; they can merge in either order.

Gate: `legacy_name_ratchet.py` → **No new lines. 4 removed by this change (-4 net).**

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129mDPbfSxqBrCLs5dDpcGv