### PR TITLE
docs: the two things the README still gets wrong after #877 and #878

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Get up and running in minutes — no infrastructure, automatic updates, usage an
 
 The fastest path is Docker Compose — one command brings up Postgres + pgvector + Redis + the API.
 
-> **Prefer not to use Docker?** Skip to [Manual deployment (Python + Postgres)](#manual-deployment) below for the bare-Python path.
+> **Prefer not to use Docker?** Skip to [Manual deployment (without Docker)](#manual-deployment-without-docker) below for the bare-Python path.
 >
 > **No cloud API key, no external calls?** v2.0+ supports a self-hosted local embedder (`BAAI/bge-m3` via HuggingFace TEI) — see [`docs/local-embedder.md`](docs/local-embedder.md). The setup below walks through the OpenAI default; the local-embedder doc walks through the alternative.
 
@@ -374,8 +374,7 @@ await mc.write("Q3 revenue target is $4M, set on 2026-04-15.");
 console.log((await mc.recall("Q3 revenue target")).summary);
 ```
 
-`MemClaw` remains a permanent alias of `Caura`, and `npm install caura`
-works too (a re-export of this package).
+`MemClaw` remains a permanent alias of `Caura`.
 
 See [`clients/typescript/`](clients/typescript/) for the full client.
 


### PR DESCRIPTION
docs: the two things the README still gets wrong after #877 and #878

#877 fixed the broken `cd caura-memclaw` in both quickstarts and #878 found
the same line in three sibling files. Checking whether anything else in the
README is still false — by resolving every command, link and anchor rather
than by counting brand strings — turns up two.

## `npm install caura` does not work

> `MemClaw` remains a permanent alias of `Caura`, and `npm install caura`
> works too (a re-export of this package).

The bare `caura` name on npm is **HTTP 404**. `clients/npm-caura/` exists in
this repo, is not private, and has no publish workflow, so it has never been
published. The README has been telling people to run a command that fails.

The first half is true — `MemClaw` is exported as an alias of `Caura` in
`clients/typescript/src/index.ts`, and the published 1.0.1 still carries it —
so only the second half is removed. It goes back when the name is actually
claimed; caura#873 tracks that, and caura#875 adds the publish path.

Not touching `clients/npm-caura/README.md`, which says the same thing: that
is the package's own README and ships inside it, where the instruction is
correct the moment it is published.

## A link to a heading that does not exist

`#manual-deployment` has never matched. The heading is
`### Manual deployment (without Docker)`, which anchors to
`#manual-deployment-without-docker`. The link text was also wrong — it
promised "(Python + Postgres)" against a section titled "(without Docker)" —
so both halves now match the target.

## What was checked and is fine

* Every `git clone` / `cd` pair — correct as of #877.
* `pip install caura-client` and `npm install @caura/memclaw-client` — both
  resolve 200, and both now serve 1.0.1 with the H-01 fix.
* The two remaining `caura-memclaw` strings, at lines 708–709. Those are the
  real GHCR image names: `publish-docker.yml:127` builds
  `ghcr.io/<owner>/caura-memclaw-<service>`. Correct today, and renaming them
  is the sunset programme's Wave 3d, not a docs fix.
* Internal anchors: 6/7 resolved before, 7/7 after.
* Every relative link resolves to a file that exists.

Signed-off-by: eldad-caura <eldad@caura.ai>
