### PR TITLE
ci(review): the credential check must not print private package names

### DIFF
--- a/.github/workflows/verify-npm-credential.yml
+++ b/.github/workflows/verify-npm-credential.yml
@@ -67,8 +67,28 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "── every package this token can reach ──"
-          npm access list packages 2>&1 | head -50 || echo "  (could not list; npm access varies by CLI version)"
+          # COUNT ONLY, deliberately. `npm access list packages` names every
+          # package the token can reach, private ones included, and this
+          # repository is PUBLIC — its workflow logs are world-readable. Printing
+          # that list would disclose the existence and names of private packages
+          # to anyone who opens the run. The count still answers the question the
+          # list was there for ("is this a broad token or a narrow one?") without
+          # naming anything, and the per-package check below names only the two
+          # packages this release publishes, both public.
+          # Captured first, then piped from the variable — NOT
+          # `npm ... | node ... || echo unknown`. Under `-eo pipefail` a
+          # non-zero npm exit makes the whole pipeline non-zero even though
+          # node succeeded and already printed its own fallback, so the
+          # trailing `||` fires too and REACHABLE ends up holding BOTH lines.
+          # Same trap as the dependency check in publish-npm-caura.yml.
+          RAW_PKGS=$(npm access list packages --json 2>/dev/null || true)
+          REACHABLE=$(printf '%s' "$RAW_PKGS" | node -e '
+            let s = "";
+            process.stdin.on("data", d => s += d).on("end", () => {
+              try { console.log(Object.keys(JSON.parse(s)).length); }
+              catch { console.log("unknown"); }
+            });' || echo unknown)
+          echo "── this token can reach ${REACHABLE} package(s) (names withheld: public log) ──"
           echo
           echo "── publish rights on the two packages this release needs ──"
           # Names read from the manifests rather than written out, so this


### PR DESCRIPTION
ci(review): the credential check must not print private package names

`verify-npm-credential.yml` ran

    npm access list packages 2>&1 | head -50

which names every package the token can reach, private ones included.
`caura-ai/caura` is a PUBLIC repository, so its workflow logs are
world-readable: the first run of this workflow would have disclosed the
existence and names of any private npm package that token can see, to
anyone who opened the run.

Nothing has leaked — the workflow is `workflow_dispatch` only and has
never been run. It merged in #875 minutes ago and this lands before the
first dispatch.

Replaced with a count. The list was there to answer one question — "is
this a broad token or a narrow one?" — and a count answers it without
naming anything. The per-package check below it is unaffected and names
only the two packages this release publishes, both public.

Worth noting how it got here: five review rounds on #875 read this file,
three of them found real defects in it, and none flagged this. Every
round was reading for correctness — does the check answer the question it
claims to — and this is not a correctness bug. The output is accurate. It
is a disclosure bug, and it only exists because of a property of the
repository rather than of the code, which is exactly the kind of thing a
diff-scoped read does not surface.

Signed-off-by: eldad-caura <eldad@caura.ai>
