### PR TITLE
ci(review): review a draft PR when it is marked ready

### DIFF
--- a/.github/workflows/claude_code_review.yml
+++ b/.github/workflows/claude_code_review.yml
@@ -48,7 +48,9 @@
 #     policy is "drafts get opt-in review, not automatic review" — which is
 #     deliberate (drafts are unfinished; each review costs real budget), and
 #     is the intended way to request one. It is not discoverable from the
-#     skip message, which is why it is written down here.
+#     skip message, which is why it is written down here. It stops being a
+#     draft when it is marked ready, and ``ready_for_review`` reviews it
+#     then — see the note on the trigger list.
 #   * The ``MAX_FILES`` cap is likewise bypassed on the comment path, so an
 #     "@claude" comment can review a PR of any size. Left as-is on purpose:
 #     it is a useful escape hatch for a large but genuinely reviewable PR.
@@ -100,7 +102,15 @@ on:
     branches: [main, dev]
     # `closed` feeds claude-capture ONLY (merged PRs). pre-checks excludes it, which is
     # what stops a merge triggering a fresh review.
-    types: [opened, reopened, synchronize, closed]
+    #
+    # `ready_for_review` reviews a draft at the moment it stops being one. Without it a
+    # draft-first PR is never reviewed automatically at all: `opened` hits the draft skip
+    # by design, the promotion fires an event nobody listens for, and the next push fires
+    # `synchronize`, which is skipped deliberately. This does not weaken the drafts-are-
+    # opt-in policy described above — it applies exactly when the PR is no longer a draft,
+    # and `pull_request.draft` is already false by the time the event fires, so the draft
+    # skip in pre-checks is untouched.
+    types: [opened, reopened, synchronize, closed, ready_for_review]
   issue_comment:
     types: [created]
   # Manual backfill for claude-capture, mirroring the shared pipeline's caller. Two uses: it makes


### PR DESCRIPTION
## What

One word in the trigger list: `ready_for_review` added to `on.pull_request.types`.

## Why

A PR opened as a **draft is never reviewed automatically at all**:

| event | what happens | why |
|---|---|---|
| `opened` (as draft) | skipped | `pre-checks` draft skip, deliberate |
| marked ready → `ready_for_review` | **nothing fires** | not in the trigger list |
| next push → `synchronize` | skipped | `pre-checks` synchronize skip, deliberate |

Each skip is individually correct; together they leave no automatic path to a review. The only route is a manual `@claude` comment, which relies on someone remembering.

## This does not change the drafts-are-opt-in policy

The header documents that policy deliberately — "drafts are unfinished; each review costs real budget". That reasoning is about the *draft state*, and it is preserved exactly: `ready_for_review` fires when the PR **stops** being a draft.

Verified against the gates that read the event payload:

- the synchronize skip tests `github.event.action == 'synchronize'` → no match
- the draft skip tests `github.event.pull_request.draft` → already `false` when the event fires
- `claude-capture` is gated on `github.event.action == 'closed'` → unaffected
- `claude-retrigger` is gated on `issue_comment` → unaffected

No gate changes. The two header comments that described the old behaviour are updated in the same commit so they do not go stale.

## Scope — the gap is org-wide and cannot be fixed centrally

Measured on `origin/main` today. A reusable workflow **cannot declare its own triggers**, so every caller carries its own `on:` block and each needs its own one-line PR — moving the shared pipeline's `v1` tag delivers nothing here:

| repo | `types:` today | status |
|---|---|---|
| `caura` (OSS) | `[opened, reopened, synchronize, closed]` | this PR |
| `caura-onprem-installer` | `[opened, reopened, synchronize]` | [installer#8](https://github.com/caura-ai/caura-onprem-installer/pull/8) |
| `.github` `self-review.yml` + caller template | `[opened, reopened, synchronize, closed]` | separate PR |
| `caura-enterprise` | `[opened, reopened, synchronize, closed]` | still open |
| `caura-ops`, `caura-daemon`, `caura-test-automation` | `[opened, reopened, synchronize, closed]` | still open |

## Testing

`actionlint .github/workflows/claude_code_review.yml` clean. The change is inert until a draft is promoted and cannot affect any currently-working path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)