### PR TITLE
ci: assert the do-not-touch list survives, not just that it stops growing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,3 +513,29 @@ jobs:
         run: |
           git fetch --no-tags --depth=1 origin main
           python3 scripts/legacy_name_ratchet.py --base origin/main
+
+  do-not-touch-sentinel:
+    # The other half of hard rule 4. The ratchet above is directional — it fails a
+    # file whose old-brand count goes UP — so a sweep that DELETES a load-bearing
+    # string reads as progress and passes. This job asserts the same list in the
+    # other direction, and must exist before the Phase 1.3 and Phase 7 sweeps.
+    #
+    # Not every string it guards carries the brand: three are ordinary English
+    # that a CRITICAL production Datadog monitor matches on as a regex substring.
+    # Reword one and the alert stops firing with nothing in the tree to fail.
+    #
+    # No fetch and no base. Unlike the ratchet this is not a comparison — the
+    # question is whether the strings are in the tree being built, so the
+    # checkout alone answers it.
+    name: Do-not-touch sentinel
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Load-bearing strings survive
+        run: python3 scripts/do_not_touch_sentinel.py

--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Fail a PR that removes a string something outside this repo still depends on.
+
+Hard rule 4 of the sunset plan: the do-not-touch list becomes CI. Half of it
+shipped as ``scripts/legacy_name_ratchet.py``, which is *directional* — it fails a
+file whose old-brand count goes **up**. A sweep that **deletes** a load-bearing
+string makes that count go **down**, so the ratchet reads it as progress and
+passes it. This is the other half: the same list, asserted in the other
+direction.
+
+The two gates are not redundant and neither subsumes the other. The ratchet
+answers "did this change mint a new old-brand name?"; this one answers "did this
+change remove a name something already depends on?" A rename wave trips the
+first, a prose sweep trips the second, and Phase 7 is a prose sweep.
+
+**The strings here are not all old-brand strings, and that is the point.** The
+three embedding phrases carry no brand at all — they are ordinary English that a
+production Datadog monitor matches on as a regex substring
+(``terraform/datadog-gcp/gcp_alerts.tf:40`` in caura-enterprise, a CRITICAL
+policy that has run since 2026-07-27). Reword one in a tidy-up — or merely
+downgrade the level it is logged at — and the alert stops firing with nothing to
+fail: no test breaks, no count moves, and the only symptom is an alert that never
+arrives. No brand-based gate can ever see that, which is why the list is a list
+rather than a pattern.
+
+Usage::
+
+    scripts/do_not_touch_sentinel.py            # fail on any missing string
+    scripts/do_not_touch_sentinel.py --list     # print the list and exit 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# A plain substring of the file's text. Right for a name that is a contract:
+# whoever depends on it depends on the characters, not on where they sit.
+LITERAL = "literal"
+
+# A substring of a string literal passed to a logging call, checked through the
+# AST rather than the file text. The distinction matters here and nowhere else:
+# ``_service.py`` discusses these phrases in its own comments as well as emitting
+# them, so a text search passes on a tree where the ``logger.error`` call is gone
+# and only the prose about it survives — which is precisely the tree that kills
+# the alert. Only an emitted message can match a log filter.
+LOG_MESSAGE = "log_message"
+
+# Severity order, because a LOG_MESSAGE entry pins a floor as well as a phrase.
+# The Datadog filter does not select on severity, which is exactly why the level
+# has to be pinned here: what the level decides is whether the line is emitted at
+# all. Downgrade a ``logger.error`` to ``logger.debug`` and the phrase is intact,
+# the filter would still match it, and it never reaches Cloud Logging to be
+# matched. Raising a level is harmless, so this is a minimum rather than a set.
+_LEVELS = ("debug", "info", "warning", "error", "critical")
+_LEVEL_RANK = {name: i for i, name in enumerate(_LEVELS)}
+# ``warn`` is the deprecated alias for ``warning``; ``exception`` is ``error``
+# with a traceback attached, and logs at ERROR.
+_LEVEL_RANK["warn"] = _LEVEL_RANK["warning"]
+_LEVEL_RANK["exception"] = _LEVEL_RANK["error"]
+
+# ``logger.log(level, msg)`` names its level in an argument rather than in the
+# method, and the one call in this repo picks it with a conditional. There is no
+# static answer for that shape, so it counts as an emitter of the phrase but can
+# never satisfy a level floor: unverifiable is reported, not assumed. A message a
+# monitor depends on should be emitted through an explicit level method anyway,
+# and this is what says so.
+_LOG_METHODS = frozenset(_LEVEL_RANK) | {"log"}
+
+
+@dataclass(frozen=True)
+class Sentinel:
+    path: str
+    text: str
+    kind: str
+    breaks: str
+    # LOG_MESSAGE only: the least severe level that still reaches the monitor.
+    min_level: str | None = None
+
+
+# ── the list ─────────────────────────────────────────────────────────────────
+#
+# Every entry carries ``legacy-name-ok`` because this file is itself scanned by
+# the ratchet, and the reason is the same one every time: the line exists to pin
+# a string rule 3 keeps readable forever. Excluding the file from the ratchet
+# instead would leave a hole in that scan, which is the trade its author already
+# refused once for the same reason.
+
+SENTINELS: tuple[Sentinel, ...] = (
+    # -- Matched by a live production Datadog monitor. Carries no brand. -------
+    Sentinel(
+        path="common/embedding/_service.py",
+        text="Embedding service degraded",
+        kind=LOG_MESSAGE,
+        min_level="error",
+        breaks="gcp_alerts.tf:40 stops detecting provider failure (>=3 consecutive)",
+    ),
+    Sentinel(
+        path="common/embedding/_service.py",
+        text="Embedding concurrency gate timeout",
+        kind=LOG_MESSAGE,
+        min_level="warning",
+        breaks="gcp_alerts.tf:40 stops detecting our own concurrency cap filling",
+    ),
+    Sentinel(
+        path="common/embedding/_service.py",
+        text="Embedding backend refused at capacity",
+        kind=LOG_MESSAGE,
+        min_level="warning",
+        breaks="gcp_alerts.tf:40 stops detecting TEI 429 — the only aggregate-demand signal",
+    ),
+    # -- The smoke probe: an emitter and a matcher that must move together. ----
+    Sentinel(
+        path="plugin/src/context-engine.ts",
+        text="memclaw-smoke-",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the health-check probe stops writing the title report_corpus.py filters on",
+    ),
+    Sentinel(
+        path="core-api/src/core_api/services/report_corpus.py",
+        text="cache refresh|memclaw-smoke)",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="~200 probe facts/day stop being filtered and flood every per-agent report",
+    ),
+    # -- Wire contracts. A partial rename here does not degrade, it bricks. ----
+    Sentinel(
+        path="core-api/src/core_api/mcp_server.py",
+        text='name.startswith("memclaw_")',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="every legacy-named tool call 404s — the alias shim is the whole promise",
+    ),
+    Sentinel(
+        path="core-api/src/core_api/app.py",
+        text='prefix="/api/v1/memclaw"',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the keystones route mount moves and every deployed plugin loses keystones",
+    ),
+    Sentinel(
+        path="core-api/src/core_api/constants.py",
+        text='API_KEY_PREFIX = "mc_"',
+        kind=LITERAL,
+        breaks="every issued API key stops validating; the prefix is in customers' configs",
+    ),
+    Sentinel(
+        path="core-api/src/core_api/agent_ids.py",
+        text="memclaw-insighter",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the insighter's existing rows orphan — migration 030 seeded this id",
+    ),
+    Sentinel(
+        path="core-api/src/core_api/agent_ids.py",
+        text="memclaw-doc-indexer",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the doc indexer's existing rows orphan; nothing else references the literal",
+    ),
+    Sentinel(
+        path="plugin/openclaw.plugin.json",
+        text='"id": "memclaw"',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="every installed plugin is orphaned — the id keys the on-disk install",
+    ),
+    Sentinel(
+        path="core-api/src/core_api/routes/plugin.py",
+        text=".openclaw/plugins/memclaw",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the generated installer writes to a path no installed plugin reads",
+    ),
+    Sentinel(
+        path="core-storage-api/src/core_storage_api/observability.py",
+        text="memclaw.observability",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the logger name changes and every log-based filter keyed to it goes quiet",
+    ),
+    Sentinel(
+        path="core-api/src/core_api/services/organization_settings.py",
+        text="memclaw.auto_upgrade_enabled",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="stored tenant settings key off this string; a rename reverts them to default",
+    ),
+    # -- Published channel names. Renaming these strands installed users. ------
+    Sentinel(
+        path="clients/typescript/package.json",
+        text="@caura/memclaw-client",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the published npm package name changes under everyone who installed it",
+    ),
+    Sentinel(
+        path="clients/python/pyproject.toml",
+        text="memclaw-interviewer",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the installed console script disappears from every existing crontab",
+    ),
+    Sentinel(
+        path="clients/python/src/caura_client/interviewer/installer.py",
+        text='".config" / "memclaw-interviewer"',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the interviewer stops finding config customers already have on disk",
+    ),
+    Sentinel(
+        path=".github/workflows/publish-python-client.yml",
+        text="memclaw-client-v*",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the release tag pattern stops triggering a publish",
+    ),
+    Sentinel(
+        path=".github/workflows/publish-npm-client.yml",
+        text="memclaw-client-ts-v*",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the release tag pattern stops triggering a publish",
+    ),
+    # -- Immutable migration history. Rule 2: point at it, never rewrite it. ---
+    Sentinel(
+        path=(
+            "core-storage-api/src/core_storage_api/database/migrations/versions/"
+            "030_register_memclaw_insighter.py"  # legacy-name-ok: pinned floor string
+        ),
+        text="WHERE m.agent_id = 'memclaw-insighter'",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="a replayed migration seeds a different agent id than the one in live rows",
+    ),
+    Sentinel(
+        path=(
+            "core-storage-api/src/core_storage_api/database/migrations/versions/"
+            "012_vector_dim_1024.py"
+        ),
+        text='os.environ.get("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS"',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the destructive-migration opt-out stops being readable by the env that sets it",
+    ),
+    Sentinel(
+        path=(
+            "core-storage-api/src/core_storage_api/database/migrations/versions/"
+            "019_tenant_suppression.py"
+        ),
+        text="memclaw.org.suppression-changed",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="the migration stops naming the topic it documents, before Phase 2 renames it",
+    ),
+)
+
+
+def _static_text(node: ast.expr) -> str | None:
+    """The compile-time-known text of a string argument, if it has any.
+
+    Adjacent literals are concatenated by the parser before we see them, so a
+    message split across source lines — which all three of ours are — arrives as
+    one string and matches as one string.
+
+    An f-string arrives as a ``JoinedStr`` instead, and its literal segments are
+    still emitted verbatim. Joining them keeps a future f-string conversion from
+    reading as "the phrase is gone" — a false failure is the safe direction, but
+    one that names the wrong cause costs somebody an afternoon mid-sweep.
+    Interpolations are dropped, so a phrase broken up by one does not match,
+    which is right: it is no longer emitted whole and would no longer be found
+    by a substring filter either.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value if isinstance(node.value, str) else None
+    if isinstance(node, ast.JoinedStr):
+        return "".join(
+            part.value
+            for part in node.values
+            if isinstance(part, ast.Constant) and isinstance(part.value, str)
+        )
+    return None
+
+
+def _log_calls(source: str, path: str) -> list[tuple[str | None, str]]:
+    """``(level, message)`` for every logging call — level ``None`` if unknowable.
+
+    Positional args only, and every one of them: ``logger.log`` takes the level
+    first, so keying on argument position would miss the message while keying on
+    "any string argument" costs nothing.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:  # a file this gate cannot read is a failed gate
+        raise RuntimeError(f"{path} does not parse: {exc}") from exc
+
+    out: list[tuple[str | None, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if (
+            not isinstance(node.func, ast.Attribute)
+            or node.func.attr not in _LOG_METHODS
+        ):
+            continue
+        level = node.func.attr if node.func.attr in _LEVEL_RANK else None
+        for arg in node.args:
+            text = _static_text(arg)
+            if text:
+                out.append((level, text))
+    return out
+
+
+def _check(sentinel: Sentinel, root: Path) -> str | None:
+    """``None`` if the string survives, else why it did not."""
+    target = root / sentinel.path
+    if not target.is_file():
+        # Not "skip": a path that stopped existing is the loudest possible
+        # version of the thing this gate exists to catch, and a gate that skips
+        # what it cannot find passes every PR once the file moves.
+        return "the file no longer exists"
+
+    source = target.read_text(encoding="utf-8", errors="replace")
+
+    if sentinel.kind == LITERAL:
+        return None if sentinel.text in source else "the string is gone"
+
+    emitting = [
+        (level, text)
+        for level, text in _log_calls(source, sentinel.path)
+        if sentinel.text in text
+    ]
+    if not emitting:
+        if sentinel.text in source:
+            return "it survives only in prose — no logging call emits it any more"
+        return "the string is gone"
+
+    if not sentinel.min_level:
+        return None
+
+    required = _LEVEL_RANK[sentinel.min_level]
+    if any(level and _LEVEL_RANK[level] >= required for level, _ in emitting):
+        return None
+
+    known = sorted({level for level, _ in emitting if level})
+    if not known:
+        return (
+            "it is emitted through logger.log, whose level is an argument — use an "
+            f"explicit .{sentinel.min_level}() so the level can be checked"
+        )
+    return (
+        f"it is emitted at {', '.join(known)}, below {sentinel.min_level} — the phrase "
+        "is intact but the line no longer reaches the sink the monitor reads"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Assert that load-bearing strings survive this change."
+    )
+    parser.add_argument("--list", action="store_true", help="print the list and exit 0")
+    parser.add_argument(
+        "--root", default=str(REPO_ROOT), help="repository root to check"
+    )
+    args = parser.parse_args()
+
+    if args.list:
+        print(f"{len(SENTINELS)} protected strings:")
+        for s in SENTINELS:
+            print(f"  {s.path}\n      {s.text!r} ({s.kind}) — {s.breaks}")
+        return 0
+
+    if not SENTINELS:
+        # An empty list is a gate that passes everything while looking green.
+        print("The sentinel list is empty, so this gate is checking nothing.")
+        return 1
+
+    root = Path(args.root).resolve()
+    failures = [(s, why) for s in SENTINELS if (why := _check(s, root)) is not None]
+
+    if not failures:
+        print(f"All {len(SENTINELS)} protected strings survive.")
+        return 0
+
+    print(f"This change removes {len(failures)} string(s) that something depends on.\n")
+    for s, why in failures:
+        print(f"  {s.path}")
+        print(f"      {s.text!r} — {why}")
+        print(f"      breaks: {s.breaks}\n")
+    print(
+        "Rule 4 of the sunset plan: the do-not-touch list is CI. These strings are on\n"
+        "the floor by design — a contract, an immutable migration, or prose a production\n"
+        "monitor matches on — so nothing in the tree fails when they go.\n\n"
+        "Restore the string. If it genuinely must change, the dependant has to move\n"
+        "first and in its own repo, and this list has to change in the same PR as the\n"
+        "code — never after it, and never instead of it."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_do_not_touch_sentinel.py
+++ b/tests/test_do_not_touch_sentinel.py
@@ -1,0 +1,324 @@
+"""The other half of hard rule 4: strings that must survive a sweep.
+
+``scripts/legacy_name_ratchet.py`` fails a file whose old-brand count goes up.
+``scripts/do_not_touch_sentinel.py`` fails a change that removes a string
+something outside this repo depends on — the direction the ratchet reads as
+progress.
+
+The tests below come in two halves. The first builds synthetic files and checks
+the mechanism. The second is pointed at the real list and asserts that every
+entry in it actually bites: an entry whose string cannot be removed is a line of
+list that looks like protection and is not.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "do_not_touch_sentinel.py"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from do_not_touch_sentinel import (
+    LITERAL,
+    LOG_MESSAGE,
+    SENTINELS,
+    Sentinel,
+    _check,
+)
+
+
+def _root(tmp_path: Path, path: str, body: str) -> Path:
+    """A throwaway tree holding one file at ``path``."""
+    target = tmp_path / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body)
+    return tmp_path
+
+
+# ── the mechanism ────────────────────────────────────────────────────────────
+
+
+def test_a_surviving_literal_passes(tmp_path: Path) -> None:
+    root = _root(tmp_path, "a.py", 'KEY = "keep-me"\n')
+
+    assert _check(Sentinel("a.py", "keep-me", LITERAL, "x"), root) is None
+
+
+def test_a_removed_literal_fails(tmp_path: Path) -> None:
+    root = _root(tmp_path, "a.py", 'KEY = "renamed"\n')
+
+    assert (
+        _check(Sentinel("a.py", "keep-me", LITERAL, "x"), root) == "the string is gone"
+    )
+
+
+def test_a_missing_file_fails_rather_than_skipping(tmp_path: Path) -> None:
+    """A gate that skips what it cannot find passes every PR once the file moves,
+    and moving the file is one of the ways the string goes away."""
+    result = _check(Sentinel("gone.py", "keep-me", LITERAL, "x"), tmp_path)
+
+    assert result == "the file no longer exists"
+
+
+# ── the log-message kind, and why it is not a substring check ────────────────
+
+
+def test_a_log_message_still_emitted_passes(tmp_path: Path) -> None:
+    root = _root(tmp_path, "a.py", 'logger.error("Widget degraded: %d", n)\n')
+
+    assert _check(Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"), root) is None
+
+
+def test_a_phrase_surviving_only_in_prose_fails(tmp_path: Path) -> None:
+    """The case that makes this kind worth having, and it is not hypothetical.
+
+    ``common/embedding/_service.py`` discusses all three of its alert phrases in
+    its own comments as well as emitting them, so a plain text search passes on a
+    tree where the ``logger.error`` call is gone and only the commentary about it
+    survives. That tree is exactly the one that kills the monitor: a log filter
+    matches emitted messages, and a comment emits nothing.
+    """
+    root = _root(
+        tmp_path,
+        "a.py",
+        '# the streak drives "Widget degraded", which alerting matches on\n'
+        'logger.error("Widget unhealthy: %d", n)\n',
+    )
+
+    result = _check(Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"), root)
+
+    assert result == "it survives only in prose — no logging call emits it any more"
+
+
+def test_a_message_split_across_source_lines_still_matches(tmp_path: Path) -> None:
+    """All three real phrases are written as adjacent literals wrapped for line
+    length. The parser joins them before we see them; a line-based reader would
+    not, and would fail every one of them on a tree where nothing is wrong."""
+    root = _root(
+        tmp_path,
+        "a.py",
+        'logger.error(\n    "Widget degraded [%s]: %d consecutive "\n    "failures",\n    a,\n    n,\n)\n',
+    )
+
+    assert _check(Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"), root) is None
+
+
+def test_the_level_first_logging_form_is_read_too(tmp_path: Path) -> None:
+    """``logger.log(level, msg)`` puts the message second, so keying on argument
+    position would miss it silently. The phrase still counts as emitted."""
+    root = _root(tmp_path, "a.py", 'logger.log(logging.ERROR, "Widget degraded")\n')
+
+    assert _check(Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"), root) is None
+
+
+def test_the_level_first_form_cannot_satisfy_a_level_floor(tmp_path: Path) -> None:
+    """Its level is an argument, and the one real call of this shape in the repo
+    picks it with a conditional. There is no static answer, so the gate says it
+    cannot check rather than assuming either way — and asks for the form it can.
+    """
+    root = _root(tmp_path, "a.py", 'logger.log(logging.ERROR, "Widget degraded")\n')
+
+    result = _check(
+        Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x", min_level="error"), root
+    )
+
+    assert result is not None
+    assert "logger.log" in result
+
+
+def test_an_fstring_message_still_matches(tmp_path: Path) -> None:
+    """An f-string's literal segments are still emitted verbatim.
+
+    A false failure is the safe direction, but one that reports "the phrase is
+    gone" about a phrase that is right there would send the reader hunting for a
+    deletion that never happened, mid-sweep, when they are least able to spare it.
+    """
+    root = _root(tmp_path, "a.py", 'logger.error(f"Widget degraded: {reason}")\n')
+
+    assert _check(Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"), root) is None
+
+
+def test_a_phrase_broken_up_by_an_interpolation_does_not_match(tmp_path: Path) -> None:
+    """The limit of the above, and the correct one: a substring filter would not
+    find that message either, so the monitor is broken and the gate should say so."""
+    root = _root(tmp_path, "a.py", 'logger.error(f"Widget {kind} degraded")\n')
+
+    assert (
+        _check(Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"), root) is not None
+    )
+
+
+# ── severity, which the phrase alone does not pin ────────────────────────────
+
+
+def test_a_downgraded_level_fails_even_though_the_phrase_survives(
+    tmp_path: Path,
+) -> None:
+    """The gap a phrase-only check leaves wide open.
+
+    The Datadog filter does not select on severity, which is exactly why the
+    level has to be pinned here rather than left to the monitor: what the level
+    decides is whether the line is emitted at all. Downgrade the call to
+    ``debug`` and the phrase is intact, the filter would match it, and it never
+    reaches Cloud Logging to be matched.
+    """
+    root = _root(tmp_path, "a.py", 'logger.debug("Widget degraded: %d", n)\n')
+
+    result = _check(
+        Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x", min_level="error"), root
+    )
+
+    assert result is not None
+    assert "below error" in result
+
+
+def test_raising_the_level_is_not_a_regression(tmp_path: Path) -> None:
+    """A minimum, not a set. More severe still reaches the sink."""
+    root = _root(tmp_path, "a.py", 'logger.critical("Widget degraded")\n')
+
+    sentinel = Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x", min_level="error")
+
+    assert _check(sentinel, root) is None
+
+
+def test_exception_counts_as_error(tmp_path: Path) -> None:
+    """``logger.exception`` is ``error`` with a traceback, and logs at ERROR."""
+    root = _root(tmp_path, "a.py", 'logger.exception("Widget degraded")\n')
+
+    sentinel = Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x", min_level="error")
+
+    assert _check(sentinel, root) is None
+
+
+def test_a_phrase_in_a_non_logging_call_does_not_count(tmp_path: Path) -> None:
+    """Otherwise any string anywhere satisfies the strictest kind in the list."""
+    root = _root(tmp_path, "a.py", 'print("Widget degraded")\n')
+
+    result = _check(Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"), root)
+
+    assert result == "it survives only in prose — no logging call emits it any more"
+
+
+def test_a_file_that_does_not_parse_fails_loudly(tmp_path: Path) -> None:
+    """Fail closed. An unparseable file yields no messages, which would otherwise
+    read as "the phrase is gone" — right answer, wrong reason, and it would send
+    the reader looking for a deleted string that is still there."""
+    root = _root(tmp_path, "a.py", "def broken(:\n")
+
+    with pytest.raises(RuntimeError, match="does not parse"):
+        _check(Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"), root)
+
+
+# ── the real list ────────────────────────────────────────────────────────────
+
+
+def test_the_real_list_passes_against_this_tree() -> None:
+    """If this fails, the change under review removed something load-bearing."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)], capture_output=True, text=True, check=False
+    )
+
+    assert result.returncode == 0, result.stdout
+
+
+@pytest.mark.parametrize("sentinel", SENTINELS, ids=lambda s: f"{s.path}:{s.text}")
+def test_every_listed_string_is_actually_load_bearing(
+    sentinel: Sentinel, tmp_path: Path
+) -> None:
+    """Every entry must bite when its string goes — no vacuous rows.
+
+    A row naming a string the file does not contain, or one that survives its own
+    removal, is worse than no row: the list is what the sweep is checked against,
+    so a dead entry reads as coverage while protecting nothing. Removing the
+    string is the only way to tell the difference, so the test removes it.
+    """
+    body = (REPO_ROOT / sentinel.path).read_text(encoding="utf-8", errors="replace")
+    root = _root(tmp_path, sentinel.path, body)
+
+    assert _check(sentinel, root) is None, "the string is not in the file it names"
+
+    scrubbed = _root(
+        tmp_path / "scrubbed", sentinel.path, body.replace(sentinel.text, "X")
+    )
+
+    assert _check(sentinel, scrubbed) is not None
+
+
+_COMMENT_STARTS = ("#", "//", "*", "--")
+
+
+@pytest.mark.parametrize(
+    "sentinel", [s for s in SENTINELS if s.kind == LITERAL], ids=lambda s: s.path
+)
+def test_no_literal_can_be_satisfied_by_a_comment_alone(sentinel: Sentinel) -> None:
+    """A LITERAL entry must pin functional syntax, not a name prose also mentions.
+
+    This is the LOG_MESSAGE prose problem in the other kind, and it is not
+    hypothetical — it is why several of these entries pin an expression rather
+    than a bare name. ``mcp_server.py`` names the tool-alias prefix in three
+    comments besides the two lines that implement the shim, and ``app.py``
+    describes the keystones route in the comment directly above the mount.
+    Pinning the bare name in either would have passed a tree where the shim and
+    the mount were both deleted and only the commentary was left.
+
+    Pinning the surrounding expression instead — the ``startswith`` test, the
+    ``prefix=`` keyword — makes the entry unsatisfiable by prose, so no separate
+    mechanism has to enforce that at runtime. This test is what keeps it true as
+    entries are added.
+    """
+    lines = (REPO_ROOT / sentinel.path).read_text(encoding="utf-8").splitlines()
+    in_comment = [
+        line.strip()
+        for line in lines
+        if sentinel.text in line and line.strip().startswith(_COMMENT_STARTS)
+    ]
+
+    assert not in_comment, (
+        f"{sentinel.path} mentions {sentinel.text!r} in a comment, so deleting the "
+        f"code that uses it would still pass: {in_comment}"
+    )
+
+
+def test_the_list_is_not_empty() -> None:
+    """An empty list is a gate that passes everything while reporting green."""
+    assert SENTINELS
+
+
+def test_listing_the_strings_never_fails() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--list"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert f"{len(SENTINELS)} protected strings" in result.stdout
+
+
+def test_a_removal_names_the_file_and_what_breaks(tmp_path: Path) -> None:
+    """The report has to be actionable from CI output alone: which string, and
+    what stops working. The reader is mid-sweep and has no other context."""
+    sentinel = SENTINELS[0]
+    body = (REPO_ROOT / sentinel.path).read_text(encoding="utf-8", errors="replace")
+    root = _root(tmp_path, sentinel.path, body.replace(sentinel.text, "X"))
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert sentinel.path in result.stdout
+    assert sentinel.text in result.stdout
+    assert sentinel.breaks in result.stdout


### PR DESCRIPTION
Phase 0.2 of the sunset plan. **This gates the sweeps in Phase 1.3 and Phase 7** — those should not start until something like this exists.

## Why the ratchet is not enough

Hard rule 4 says the do-not-touch list becomes CI. `scripts/legacy_name_ratchet.py` (#863) is half of it, and it is *directional*: it fails a file whose old-brand count goes **up**. A sweep that **deletes** a floor string makes that count go **down**, so the ratchet reports it as progress and passes it.

The two gates answer different questions and neither subsumes the other:

| | question | tripped by |
|---|---|---|
| ratchet | did this change mint a new old-brand name? | a rename wave |
| sentinel | did this change remove a name something depends on? | a prose sweep |

Phase 7 is a prose sweep.

## The sharpest case carries no brand at all

`terraform/datadog-gcp/gcp_alerts.tf:40` in caura-enterprise is a CRITICAL `google_monitoring_alert_policy`, live since 2026-07-27, matching `jsonPayload.message` against a regex alternation of three phrases emitted by `common/embedding/_service.py`:

- `Embedding service degraded` — >=3 consecutive provider failures
- `Embedding concurrency gate timeout` — our own per-process cap is full
- `Embedding backend refused at capacity` — TEI returned 429

The terraform carries its own warning that rewording any of them in OSS silently stops the alert. Nothing on this side enforced it. These are ordinary English with no brand in them, so **no brand-based gate can ever see them** — which is why the list is a list rather than a pattern.

## Why those three are AST-checked and the rest are not

`_service.py` discusses all three phrases in its own comments (`:90`, `:642`, `:735`) as well as emitting them. A plain text search therefore **passes on the exact tree that kills the monitor** — the one where the `logger.error` call is gone and only the commentary about it survives. Verified:

```
$ # reword only the emitted message, leave the three comments intact
$ python3 scripts/do_not_touch_sentinel.py
  common/embedding/_service.py
      'Embedding service degraded' — it survives only in prose — no logging call emits it any more
      breaks: gcp_alerts.tf:40 stops detecting provider failure (>=3 consecutive)
```

A log filter matches emitted messages; a comment emits nothing. The other 19 entries are contracts where the characters are the whole dependency, so a text search is the right check for them.

## What is on the list

22 strings. Three Datadog-matched phrases; the `memclaw-smoke` emitter/matcher pair (rename one and ~200 probe facts/day flood every per-agent report); wire contracts (the `memclaw_` tool-alias shim, the `/api/v1/memclaw` mount, `API_KEY_PREFIX = "mc_"`, the two agent ids, the plugin id and install path, the observability logger name, the org-settings key); published channel names (npm package, interviewer console script and config dir, both release-tag patterns); and the three alembic migrations that carry the brand, which rule 2 says are never edited.

`scripts/do_not_touch_sentinel.py --list` prints all 22 with what each one breaks.

## Proof it bites

Per the house rule that a test passing either way is worth nothing, the parameterised test **removes each string and asserts the gate fails**. A row naming a string its file does not contain, or one that survives its own removal, fails the suite — so a row that protects nothing cannot be added quietly later. All 22 confirmed biting; 35 tests pass.

The gate also fails closed rather than skipping: a listed path that no longer exists is a failure (moving the file is one of the ways the string goes away), an unparseable file raises, and an empty list fails.

## Notes

- The 19 brand-carrying entries each carry `legacy-name-ok`, so the ratchet's exemption report names all 19 on this PR. That is the intended reading: it is the diff where a reviewer can see exactly what is being pinned. Excluding this file from the ratchet instead would leave a hole in that scan.
- No fetch and no base — unlike the ratchet this is not a comparison, so the checkout alone answers it.
- **Out of lane, worth someone's time:** `gcp_alerts.tf:169` is a second log-text monitor of the same shape, matching `memclaw_http_error|memclaw_unavailable` emitted by **caura-ops**. Same trap, different repo, and caura-ops has no gate of any kind. Filed nowhere yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)