### PR TITLE
feat(env): read CAURA_* everywhere the old names are read

### DIFF
--- a/clients/python/src/caura_client/interviewer/cli.py
+++ b/clients/python/src/caura_client/interviewer/cli.py
@@ -48,6 +48,23 @@ def _default_agent_id() -> str:
     return f"cc-{getpass.getuser()}@{socket.gethostname()}"
 
 
+def _read_env(*names: str, default: str = "") -> str:
+    """First alias carrying a value, new names before old ones.
+
+    A blank alias never shadows a working one, but a lone ``X=`` still means
+    "empty" rather than falling back to ``default`` — which is what
+    ``os.environ.get(name, default)`` did before the aliases existed.
+    """
+    saw_blank = False
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+        if value is not None:
+            saw_blank = True
+    return "" if saw_blank else default
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="memclaw-interviewer",
@@ -56,11 +73,17 @@ def _build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     def common(p: argparse.ArgumentParser) -> None:
-        p.add_argument("--base-url", default=os.environ.get("MEMCLAW_BASE_URL", DEFAULT_BASE_URL))
-        p.add_argument("--api-key", default=os.environ.get("MEMCLAW_API_KEY", ""))
-        p.add_argument("--tenant-id", default=os.environ.get("MEMCLAW_TENANT_ID", ""))
-        p.add_argument("--agent-id", default=os.environ.get("MEMCLAW_AGENT_ID", "") or _default_agent_id())
-        p.add_argument("--fleet-id", default=os.environ.get("MEMCLAW_FLEET_ID", "") or None)
+        p.add_argument(
+            "--base-url",
+            default=_read_env("CAURA_BASE_URL", "MEMCLAW_BASE_URL", default=DEFAULT_BASE_URL),  # legacy-name-ok: rule 3 dual-read alias
+        )
+        p.add_argument("--api-key", default=_read_env("CAURA_API_KEY", "MEMCLAW_API_KEY"))  # legacy-name-ok: rule 3 dual-read alias
+        p.add_argument("--tenant-id", default=_read_env("CAURA_TENANT_ID", "MEMCLAW_TENANT_ID"))  # legacy-name-ok: rule 3 dual-read alias
+        p.add_argument(
+            "--agent-id",
+            default=_read_env("CAURA_AGENT_ID", "MEMCLAW_AGENT_ID") or _default_agent_id(),  # legacy-name-ok: rule 3 dual-read alias
+        )
+        p.add_argument("--fleet-id", default=_read_env("CAURA_FLEET_ID", "MEMCLAW_FLEET_ID") or None)  # legacy-name-ok: rule 3 dual-read alias
         p.add_argument(
             "--projects",
             nargs="+",
@@ -71,7 +94,11 @@ def _build_parser() -> argparse.ArgumentParser:
         p.add_argument(
             "--harness",
             choices=(HARNESS_CLAUDE_CODE, HARNESS_CURSOR),
-            default=os.environ.get("MEMCLAW_INTERVIEWER_HARNESS", HARNESS_CLAUDE_CODE),
+            default=_read_env(
+                "CAURA_INTERVIEWER_HARNESS",
+                "MEMCLAW_INTERVIEWER_HARNESS",  # legacy-name-ok: rule 3 dual-read alias
+                default=HARNESS_CLAUDE_CODE,
+            ),
             help="which agent's transcripts to harvest (default: claude-code; env MEMCLAW_INTERVIEWER_HARNESS)",
         )
         p.add_argument(
@@ -121,7 +148,7 @@ def _projects_root(args: argparse.Namespace) -> Path:
 def _resolve_allowlist(args: argparse.Namespace) -> list[str]:
     if args.projects is not None:
         return list(args.projects)
-    env = os.environ.get("MEMCLAW_INTERVIEWER_PROJECTS", "")
+    env = _read_env("CAURA_INTERVIEWER_PROJECTS", "MEMCLAW_INTERVIEWER_PROJECTS")  # legacy-name-ok: rule 3 dual-read alias
     return [g.strip() for g in env.split(",") if g.strip()]
 
 

--- a/clients/python/tests/test_interviewer_env_dual_read.py
+++ b/clients/python/tests/test_interviewer_env_dual_read.py
@@ -1,0 +1,97 @@
+"""Phase 5.1: the interviewer CLI reads both env spellings.
+
+Rule 3 makes the old names permanent, so every case is asserted in both
+directions — asserting only the new name would pass after someone deleted the
+fallback and stranded every crontab an older installer wrote.
+
+Old names are confined to the constants below so the ratchet has one marked
+line per name rather than one per assertion.
+"""
+
+import pytest
+
+from caura_client.interviewer.cli import _build_parser, _read_env, _resolve_allowlist
+
+OLD_PREFIX = "MEMCLAW_"  # legacy-name-ok: rule 3 — the alias prefix under test
+NEW_PREFIX = "CAURA_"
+
+ALIASED = [
+    ("api_key", "API_KEY", "k-value"),
+    ("tenant_id", "TENANT_ID", "t-value"),
+    ("agent_id", "AGENT_ID", "a-value"),
+    ("fleet_id", "FLEET_ID", "f-value"),
+    ("base_url", "BASE_URL", "https://example.invalid"),
+]
+
+
+SUFFIXES = [suffix for _, suffix, _ in ALIASED] + ["INTERVIEWER_PROJECTS", "INTERVIEWER_HARNESS"]
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for suffix in SUFFIXES:
+        monkeypatch.delenv(NEW_PREFIX + suffix, raising=False)
+        monkeypatch.delenv(OLD_PREFIX + suffix, raising=False)
+    return monkeypatch
+
+
+def _parse(argv):
+    return _build_parser().parse_args(argv)
+
+
+@pytest.mark.parametrize(("dest", "suffix", "value"), ALIASED)
+def test_old_name_still_read(clean_env, dest, suffix, value):
+    clean_env.setenv(OLD_PREFIX + suffix, value)
+    assert getattr(_parse(["status"]), dest) == value
+
+
+@pytest.mark.parametrize(("dest", "suffix", "value"), ALIASED)
+def test_new_name_read(clean_env, dest, suffix, value):
+    clean_env.setenv(NEW_PREFIX + suffix, value)
+    assert getattr(_parse(["status"]), dest) == value
+
+
+@pytest.mark.parametrize(("dest", "suffix", "value"), ALIASED)
+def test_new_name_wins_when_both_are_set(clean_env, dest, suffix, value):
+    clean_env.setenv(NEW_PREFIX + suffix, value)
+    clean_env.setenv(OLD_PREFIX + suffix, "old-" + value)
+    assert getattr(_parse(["status"]), dest) == value
+
+
+@pytest.mark.parametrize(("dest", "suffix", "value"), ALIASED)
+def test_blank_new_name_does_not_shadow_the_old_one(clean_env, dest, suffix, value):
+    clean_env.setenv(NEW_PREFIX + suffix, "")
+    clean_env.setenv(OLD_PREFIX + suffix, value)
+    assert getattr(_parse(["status"]), dest) == value
+
+
+def test_harness_reads_either_name(clean_env):
+    clean_env.setenv(OLD_PREFIX + "INTERVIEWER_HARNESS", "cursor")
+    assert _parse(["status"]).harness == "cursor"
+    clean_env.setenv(NEW_PREFIX + "INTERVIEWER_HARNESS", "claude-code")
+    assert _parse(["status"]).harness == "claude-code"
+
+
+def test_allowlist_reads_either_name(clean_env):
+    clean_env.setenv(OLD_PREFIX + "INTERVIEWER_PROJECTS", "a/*, b/*")
+    args = _parse(["status"])
+    assert _resolve_allowlist(args) == ["a/*", "b/*"]
+    clean_env.setenv(NEW_PREFIX + "INTERVIEWER_PROJECTS", "c/*")
+    assert _resolve_allowlist(args) == ["c/*"]
+
+
+def test_explicit_flag_still_beats_both_env_names(clean_env):
+    clean_env.setenv(NEW_PREFIX + "API_KEY", "from-new-env")
+    clean_env.setenv(OLD_PREFIX + "API_KEY", "from-old-env")
+    assert _parse(["status", "--api-key", "from-flag"]).api_key == "from-flag"
+
+
+class TestReadEnv:
+    def test_default_applies_only_when_nothing_is_set(self):
+        assert _read_env("CAURA_ABSENT_NEW", "CAURA_ABSENT_OLD", default="fallback") == "fallback"
+
+    def test_blank_only_alias_is_honoured(self, monkeypatch):
+        # ``KEY=`` in a sourced env file is how an operator blanks a value, and
+        # that has to keep meaning "empty" rather than falling back to default.
+        monkeypatch.setenv("CAURA_BLANK_PROBE", "")
+        assert _read_env("CAURA_BLANK_PROBE", default="fallback") == ""

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -26,7 +26,19 @@ class Settings(BaseSettings):
     # ``db_pool_*`` settings + ``database_url`` were removed with the engine.
     api_key: str | None = None  # legacy, deprecated
     admin_api_key: str | None = None
-    memclaw_api_key: str | None = None  # Optional: when set, all non-admin requests must present this key
+    # Optional: when set, all non-admin requests must present this key. Both
+    # spellings are accepted as INPUTS; ``_prefer_the_new_api_key_name`` below
+    # collapses them onto the second field, the only one downstream code reads —
+    # the first is None whenever the operator set the old name.
+    #
+    # Deliberately NOT ``AliasChoices``: that resolves to the first alias that is
+    # DEFINED, and the empty string counts. A deploy template carrying an
+    # unfilled ``CAURA_API_KEY=`` next to a working old name would resolve to
+    # ``""``, and auth.py's ``if mclaw_key:`` would skip the whole Path-2
+    # perimeter without a word. For a secret, blank and unset mean the same
+    # thing, so first-NON-EMPTY is the only safe rule.
+    caura_api_key: str | None = None
+    memclaw_api_key: str | None = None  # legacy-name-ok: rule 3 dual-read alias
     # Perimeter secret shared with the enterprise gateway. When set, the
     # header-trust auth path (X-Tenant-ID) additionally requires a matching
     # ``X-Gateway-Secret`` header — so a caller who reaches core-api directly
@@ -355,6 +367,16 @@ class Settings(BaseSettings):
     security_audit_alert_score_below: float | None = None
     security_audit_alert_critical_findings_min: int | None = None
     security_audit_alert_score_drop_delta: float | None = None
+
+    @model_validator(mode="after")
+    def _prefer_the_new_api_key_name(self) -> "Settings":
+        """Collapse the two accepted spellings onto the field auth.py reads.
+
+        First non-empty wins, new name first — so the old spelling keeps working
+        forever and a blank new one can never shadow it.
+        """
+        self.memclaw_api_key = self.caura_api_key or self.memclaw_api_key  # legacy-name-ok: rule 3 alias
+        return self
 
     @field_validator("log_level", mode="before")
     @classmethod

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -73,7 +73,8 @@ def _resolve_version() -> str:
 
     Precedence (most to least authoritative):
 
-    1. ``MEMCLAW_VERSION`` env — explicit deploy/ad-hoc override.
+    1. ``CAURA_VERSION`` env, or its legacy alias below — explicit deploy /
+       ad-hoc override. The new name wins when both are set.
     2. ``VERSION`` file baked into the image at build time from
        ``pyproject.toml`` (see ``core-api/Dockerfile``). Deterministic and
        independent of installed-package metadata — the prod Dockerfile
@@ -83,7 +84,7 @@ def _resolve_version() -> str:
     3. Installed package metadata — editable dev installs (``pip install -e``).
     4. ``"dev"`` — source-only checkout with none of the above.
     """
-    env = os.environ.get("MEMCLAW_VERSION")
+    env = os.environ.get("CAURA_VERSION") or os.environ.get("MEMCLAW_VERSION")  # legacy-name-ok: alias
     if env and env.strip():
         return env.strip()
     # constants.py → core_api → src → core-api → repo root (image: /app).

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/012_vector_dim_1024.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/012_vector_dim_1024.py
@@ -129,7 +129,10 @@ def upgrade() -> None:
 
     from sqlalchemy import text as _sql_text
 
-    _opt_in = os.environ.get("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", "").lower() == "true"
+    _opt_in = (
+        os.environ.get("CAURA_RUN_DESTRUCTIVE_MIGRATIONS", "")
+        or os.environ.get("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", "")  # legacy-name-ok: rule 3 dual-read alias
+    ).lower() == "true"
     if not _opt_in:
         bind = op.get_bind()
         # Count rows that would be destroyed. Single round-trip; cast

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,9 +60,16 @@ services:
     # on pull failure; an unreachable registry hard-fails ``up`` only
     # when no local image is cached.
     #
-    # Pin a specific version with ``MEMCLAW_VERSION=v1.2.3`` in your
-    # ``.env``; defaults to ``latest`` for the most recent stable.
-    image: ghcr.io/caura-ai/caura-memclaw-core-storage-api:${MEMCLAW_VERSION:-latest}
+    # Pin a specific version with ``CAURA_VERSION=v1.2.3`` in your ``.env``
+    # (``MEMCLAW_VERSION`` is still read); defaults to ``latest``.  # legacy-name-ok: rule 3 dual-read alias
+    #
+    # The nested default is deliberate and needs Compose v2, which README.md
+    # already requires. Compose v2 resolves a ``${...}`` inside a default
+    # recursively — verified for all four combinations of the two names, and
+    # pinned by ``tests/test_env_dual_read.py`` so the fallback cannot be
+    # dropped silently. Do not flatten it to a single name: dropping the old
+    # one strands every install that pins with it today.
+    image: ghcr.io/caura-ai/caura-memclaw-core-storage-api:${CAURA_VERSION:-${MEMCLAW_VERSION:-latest}}  # legacy-name-ok: rule 3 dual-read alias
     pull_policy: missing
     build:
       context: .
@@ -94,7 +101,7 @@ services:
   core-api:
     # Same pull-on-first-up + ``pull_policy: missing`` pattern as
     # core-storage-api above. See its block for the full rationale.
-    image: ghcr.io/caura-ai/caura-memclaw-core-api:${MEMCLAW_VERSION:-latest}
+    image: ghcr.io/caura-ai/caura-memclaw-core-api:${CAURA_VERSION:-${MEMCLAW_VERSION:-latest}}  # legacy-name-ok: rule 3 dual-read alias
     pull_policy: missing
     build:
       context: .

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -11,9 +11,13 @@
   "configSchema": {
     "type": "object",
     "properties": {
-      "MEMCLAW_AGENT_ID": {
+      "CAURA_AGENT_ID": {
         "type": "string",
         "description": "Optional but recommended: a stable, human-readable identity for THIS install (e.g. \"webclaw\", \"vm-01\"); surfaces as the agent_id on writes. If unset, the plugin uses a stable per-install id (main-<install_id>) so installs don't collide."
+      },
+      "MEMCLAW_AGENT_ID": {
+        "type": "string",
+        "description": "Accepted forever as an alias for CAURA_AGENT_ID; the new name wins when both are set."
       }
     },
     "required": []

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -32,6 +32,7 @@ import {
   RECALL_CROSS_AGENT,
   MEMCLAW_INTERVIEWER,
   type RecallPolicy,
+  readEnv,
 } from "./env.js";
 import { appendInterviewEvent } from "./interview-buffer.js";
 import { memclawPromptSectionText } from "./prompt-section.js";
@@ -829,7 +830,7 @@ export class MemClawContextEngine {
       (fleetId ? `, fleet_id=\`${fleetId}\`` : "") +
       (MEMCLAW_TENANT_ID ? `, tenant_id=\`${MEMCLAW_TENANT_ID}\`` : "") +
       "\n";
-    const operatorPrompt = process.env.MEMCLAW_EDUCATION_PROMPT || "";
+    const operatorPrompt = readEnv(["CAURA_EDUCATION_PROMPT", "MEMCLAW_EDUCATION_PROMPT"]) || "";  // legacy-name-ok: rule 3 dual-read alias
     const operatorBlock = operatorPrompt
       ? `\n## Operator Instructions\n${operatorPrompt}\n`
       : "";

--- a/plugin/src/deploy.ts
+++ b/plugin/src/deploy.ts
@@ -3,7 +3,9 @@
  *
  * Security controls:
  * - Size validation on source code (MAX_SOURCE_SIZE)
- * - Only MEMCLAW_* env vars accepted (key filtering)
+ * - Only the plugin's own env-var prefixes accepted, via
+ *   ``hasPluginEnvPrefix`` (key filtering) — a remote deploy command cannot
+ *   write an arbitrary key into the plugin's ``.env``
  * - Backup and restore on build failure
  *
  * Note: caller authentication (HMAC or token) is handled upstream —
@@ -14,7 +16,7 @@ import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 import { execSync } from "child_process";
 import { getPluginDir, getPluginSrcPath } from "./config.js";
-import { BUILD_TIMEOUT_MS, MAX_SOURCE_SIZE } from "./env.js";
+import { BUILD_TIMEOUT_MS, MAX_SOURCE_SIZE, hasPluginEnvPrefix } from "./env.js";
 import { logError } from "./logger.js";
 
 export async function deployPlugin(
@@ -57,13 +59,13 @@ export async function deployPlugin(
           if (eq < 1) continue;
           const k = trimmed.slice(0, eq).trim();
           const v = trimmed.slice(eq + 1).trim();
-          if (/^MEMCLAW_/.test(k)) existing.set(k, v);
+          if (hasPluginEnvPrefix(k)) existing.set(k, v);
         }
       }
 
       // Merge provided keys over existing
       for (const [key, val] of Object.entries(envVars)) {
-        if (/^MEMCLAW_/.test(key) && typeof val === "string") {
+        if (hasPluginEnvPrefix(key) && typeof val === "string") {
           existing.set(key, val.replace(/[\r\n]/g, ""));
           envChanges.push(key);
         }

--- a/plugin/src/env.test.ts
+++ b/plugin/src/env.test.ts
@@ -14,7 +14,7 @@ process.env.MEMCLAW_API_KEY = "mc_test_key_for_env_tests";
 // Clear tenant id so resolveTenantId actually attempts a fetch.
 delete process.env.MEMCLAW_TENANT_ID;
 
-const { resolveTenantId } = await import("./env.js");
+const { resolveTenantId, readEnv, isPluginEnvKey, hasPluginEnvPrefix } = await import("./env.js");
 
 interface MockCall {
   url: string;
@@ -171,7 +171,10 @@ describe("env.ts default-value source pins", () => {
     const envSrc = await readFile(join(here, "..", "src", "env.ts"), "utf8");
     // Match the exact ``_readIntEnv`` call site to avoid colliding with
     // doc-comment occurrences of the number 1500.
-    const re = /_readIntEnv\(\s*"MEMCLAW_KEYSTONES_TOKEN_CAP"\s*,\s*(\d+)\s*,/;
+    // Tolerates the ratchet's ``legacy-name-ok`` comment between the alias
+    // array and the default, which is where it has to sit.
+    const re =
+      /_readIntEnv\(\s*\[[^\]]*"MEMCLAW_KEYSTONES_TOKEN_CAP"[^\]]*\]\s*,(?:\s*\/\/[^\n]*)?\s*(\d+)\s*,/;  // legacy-name-ok: rule 3 dual-read alias
     const match = envSrc.match(re);
     assert.ok(
       match,
@@ -186,5 +189,133 @@ describe("env.ts default-value source pins", () => {
         "and review the keystones formatter's truncation behavior in " +
         "keystones.test.ts.",
     );
+  });
+});
+
+// --- Environment dual-read (Phase 5.1) ---
+
+describe("isPluginEnvKey — .env allow-list", () => {
+  test("accepts both prefixes", () => {
+    assert.ok(isPluginEnvKey("CAURA_API_KEY"), "CAURA_* must not be dropped");
+    assert.ok(isPluginEnvKey("MEMCLAW_API_KEY"), "old prefix keeps working"); // legacy-name-ok: rule 3 — pins that the old prefix is still accepted
+  });
+
+  test("is stricter than hasPluginEnvPrefix, deliberately", () => {
+    // deploy.ts filters with the loose form because it PRESERVES an operator's
+    // existing .env keys across a redeploy; using the strict form there would
+    // silently delete anything it rejects from a file we don't own.
+    for (const key of ["CAURA_API_KEY2", "MEMCLAW_API_KEY2", "CAURA_lower"]) { // legacy-name-ok: rule 3 — an old-prefixed key must survive a redeploy
+      assert.equal(hasPluginEnvPrefix(key), true, `${key} must survive a redeploy`);
+      assert.equal(isPluginEnvKey(key), false, `${key} must not reach process.env`);
+    }
+  });
+
+  test("hasPluginEnvPrefix still refuses foreign keys", () => {
+    for (const key of ["PATH", "NODE_OPTIONS", "CAURAX_API_KEY", "XCAURA_API_KEY"]) {
+      assert.equal(hasPluginEnvPrefix(key), false, `${key} is not ours to carry`);
+    }
+  });
+
+  test("still refuses everything else", () => {
+    for (const key of [
+      "PATH",
+      "NODE_OPTIONS",
+      "LD_PRELOAD",
+      "CAURA",
+      "CAURAX_API_KEY",
+      "XCAURA_API_KEY",
+      "caura_api_key",
+      "CAURA_api_key",
+      "CAURA_API-KEY",
+      " CAURA_API_KEY",
+    ]) {
+      assert.equal(isPluginEnvKey(key), false, `${key} must not be settable from .env`);
+    }
+  });
+});
+
+describe("readEnv call sites — alias pairs stay in step", () => {
+  test("every pair is the same suffix under both prefixes", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join } = await import("node:path");
+    const here = dirname(fileURLToPath(import.meta.url));
+    // Source-scraped for the same reason as the default pin above: the risk is a
+    // typo in a literal, which no runtime test can see. A mismatched suffix
+    // type-checks, passes any test that only sets the new name, and strands the
+    // old one forever — the one thing rule 3 forbids.
+    const { readdir } = await import("node:fs/promises");
+    const srcDir = join(here, "..", "src");
+    // Globbed, not listed: a new module with a dual-read call site would be
+    // silently unchecked by a hardcoded list, and the floor below cannot catch
+    // that because a new file only ever adds pairs.
+    const files = (await readdir(srcDir)).filter(
+      (f) => f.endsWith(".ts") && !f.endsWith(".test.ts"),
+    );
+    // Covers the wrapper helpers too — those are the multi-line call sites,
+    // where a mismatched suffix is hardest to spot by eye.
+    const callSite =
+      /(?:readEnv|_readBoolEnv|_readIntEnv)\(\s*\[\s*"([A-Z_]+)"\s*,\s*"([A-Z_]+)"\s*,?\s*\]/gs;
+    let pairs = 0;
+    for (const file of files) {
+      const src = await readFile(join(srcDir, file), "utf8");
+      for (const [, newName, oldName] of src.matchAll(callSite)) {
+        pairs++;
+        assert.ok(
+          newName.startsWith("CAURA_"),
+          `${file}: first alias must be the new name, got ${newName}`,
+        );
+        assert.equal(
+          oldName,
+          `MEMCLAW_${newName.slice("CAURA_".length)}`, // legacy-name-ok: rule 3 — asserts the old alias tracks the new one
+          `${file}: ${newName} is paired with ${oldName}, which is a different variable — the old name would never be read`,
+        );
+      }
+    }
+    assert.ok(pairs >= 28, `expected every dual-read call site to be scanned, found ${pairs}`);
+  });
+});
+
+describe("readEnv — new/old env-name dual-read", () => {
+  const NEW = "CAURA_TEST_DUAL_READ";
+  const OLD = "MEMCLAW_TEST_DUAL_READ"; // legacy-name-ok: rule 3 — the old alias this suite pins
+  const aliases = [NEW, OLD];
+
+  afterEach(() => {
+    delete process.env[NEW];
+    delete process.env[OLD];
+  });
+
+  test("new name wins when both are set", () => {
+    process.env[NEW] = "new-value";
+    process.env[OLD] = "old-value";
+    assert.equal(readEnv(aliases), "new-value");
+  });
+
+  test("old name is still read when the new one is absent", () => {
+    process.env[OLD] = "old-value";
+    assert.equal(readEnv(aliases), "old-value");
+  });
+
+  test("new name is read when the old one is absent", () => {
+    process.env[NEW] = "new-value";
+    assert.equal(readEnv(aliases), "new-value");
+  });
+
+  test("a blank new name does not shadow a working old one", () => {
+    // The regression this guards: a single "first defined wins" pass would
+    // return "" here and strand an install that only sets the old name.
+    process.env[NEW] = "";
+    process.env[OLD] = "old-value";
+    assert.equal(readEnv(aliases), "old-value");
+  });
+
+  test("a blank value is honoured when it is the only alias set", () => {
+    process.env[NEW] = "";
+    assert.equal(readEnv(aliases), "", "KEY= must still mean 'set to empty'");
+  });
+
+  test("undefined when no alias is set", () => {
+    assert.equal(readEnv(aliases), undefined);
   });
 });

--- a/plugin/src/env.ts
+++ b/plugin/src/env.ts
@@ -7,13 +7,38 @@
  */
 
 import { readFileSync, existsSync } from "fs";
-import { join } from "path";
-import { homedir } from "os";
+import { getPluginEnvPath } from "./paths.js";
 import { warnIfInsecureUrl } from "./validation.js";
+
+/**
+ * Keys a plugin ``.env`` file may inject into ``process.env``. Fully anchored
+ * on purpose — without the bound a ``.env`` could hijack PATH, NODE_OPTIONS,
+ * etc. This is the security boundary; keep it strict.
+ *
+ * Both prefixes are accepted so a ``CAURA_*`` line is not silently dropped;
+ * the old prefix keeps working forever.
+ */
+export function isPluginEnvKey(key: string): boolean {
+  return /^(?:CAURA|MEMCLAW)_[A-Z_]+$/.test(key);  // legacy-name-ok: rule 3 dual-read alias
+}
+
+/**
+ * Whether a key belongs to the plugin's ``.env`` at all — deliberately looser
+ * than ``isPluginEnvKey``: it answers "is this ours to carry", not "may this
+ * reach process.env".
+ *
+ * Kept permissive because ``deploy.ts`` uses it to PRESERVE an operator's
+ * existing keys across a redeploy. Tightening it here would quietly delete
+ * anything the strict form rejects (``CAURA_FOO2``, lowercase) from a file we
+ * do not own the contents of.
+ */
+export function hasPluginEnvPrefix(key: string): boolean {
+  return /^(?:CAURA|MEMCLAW)_/.test(key);  // legacy-name-ok: rule 3 dual-read alias
+}
 
 // --- Load .env file from plugin directory ---
 try {
-  const envPath = join(homedir(), ".openclaw", "plugins", "memclaw", ".env");
+  const envPath = getPluginEnvPath();
   if (existsSync(envPath)) {
     for (const line of readFileSync(envPath, "utf-8").split("\n")) {
       const trimmed = line.trim();
@@ -29,8 +54,7 @@ try {
       ) {
         val = val.slice(1, -1);
       }
-      // Only set MEMCLAW_* vars — prevent .env from hijacking PATH, NODE_OPTIONS, etc.
-      if (!/^MEMCLAW_[A-Z_]+$/.test(key)) continue;
+      if (!isPluginEnvKey(key)) continue;
       process.env[key] = val;
     }
   }
@@ -39,8 +63,26 @@ try {
   console.warn("[memclaw] Failed to parse .env file:", msg);
 }
 
+/**
+ * Read the first alias that carries a value. Aliases are listed new name
+ * first, so ``CAURA_X`` wins when both are set.
+ *
+ * A blank alias never shadows a working one, but a lone ``CAURA_X=`` still
+ * resolves to ``""`` rather than "unset" — the distinction only matters to
+ * ``_readBoolEnv`` below, where ``""`` means off and unset means the default.
+ */
+export function readEnv(names: readonly string[]): string | undefined {
+  let sawBlank = false;
+  for (const name of names) {
+    const value = process.env[name];
+    if (value) return value;
+    if (value !== undefined) sawBlank = true;
+  }
+  return sawBlank ? "" : undefined;
+}
+
 export const MEMCLAW_API_URL =
-  process.env.MEMCLAW_API_URL || "http://localhost:8000";
+  readEnv(["CAURA_API_URL", "MEMCLAW_API_URL"]) || "http://localhost:8000";  // legacy-name-ok: rule 3 dual-read alias
 
 /**
  * Prefix for all MemClaw REST routes. Single source of truth for API
@@ -49,17 +91,17 @@ export const MEMCLAW_API_URL =
  * The transport layer auto-prepends this to relative paths. Raw fetch
  * sites use it via template literal.
  */
-export const MEMCLAW_API_PREFIX = process.env.MEMCLAW_API_PREFIX || "/api/v1";
-export const MEMCLAW_API_KEY = process.env.MEMCLAW_API_KEY || "";
-export const MEMCLAW_FLEET_ID = process.env.MEMCLAW_FLEET_ID || "";
-export let MEMCLAW_TENANT_ID = process.env.MEMCLAW_TENANT_ID || "";
-export const MEMCLAW_NODE_NAME = process.env.MEMCLAW_NODE_NAME || "";
-export const MEMCLAW_AGENT_ID = process.env.MEMCLAW_AGENT_ID || "";
+export const MEMCLAW_API_PREFIX = readEnv(["CAURA_API_PREFIX", "MEMCLAW_API_PREFIX"]) || "/api/v1";  // legacy-name-ok: rule 3 dual-read alias
+export const MEMCLAW_API_KEY = readEnv(["CAURA_API_KEY", "MEMCLAW_API_KEY"]) || "";  // legacy-name-ok: rule 3 dual-read alias
+export const MEMCLAW_FLEET_ID = readEnv(["CAURA_FLEET_ID", "MEMCLAW_FLEET_ID"]) || "";  // legacy-name-ok: rule 3 dual-read alias
+export let MEMCLAW_TENANT_ID = readEnv(["CAURA_TENANT_ID", "MEMCLAW_TENANT_ID"]) || "";  // legacy-name-ok: rule 3 dual-read alias
+export const MEMCLAW_NODE_NAME = readEnv(["CAURA_NODE_NAME", "MEMCLAW_NODE_NAME"]) || "";  // legacy-name-ok: rule 3 dual-read alias
+export const MEMCLAW_AGENT_ID = readEnv(["CAURA_AGENT_ID", "MEMCLAW_AGENT_ID"]) || "";  // legacy-name-ok: rule 3 dual-read alias
 // Default to true — auto-writing turn summaries is the core fix for the
 // "100% dark matter" problem (memories written but never recalled).
 // Users can opt out with MEMCLAW_AUTO_WRITE_TURNS=false.
 export const MEMCLAW_AUTO_WRITE_TURNS =
-  process.env.MEMCLAW_AUTO_WRITE_TURNS !== "false";
+  readEnv(["CAURA_AUTO_WRITE_TURNS", "MEMCLAW_AUTO_WRITE_TURNS"]) !== "false";  // legacy-name-ok: rule 3 dual-read alias
 
 // HMAC signature enforcement on incoming fleet commands. Default is
 // **opt-in** because the OSS server doesn't sign commands at all (the
@@ -75,7 +117,7 @@ export const MEMCLAW_AUTO_WRITE_TURNS =
 // signature still fails). When **true**: missing-or-invalid signatures
 // fail closed (the original strict behavior).
 export const MEMCLAW_REQUIRE_SIGNED_COMMANDS =
-  process.env.MEMCLAW_REQUIRE_SIGNED_COMMANDS === "true";
+  readEnv(["CAURA_REQUIRE_SIGNED_COMMANDS", "MEMCLAW_REQUIRE_SIGNED_COMMANDS"]) === "true";  // legacy-name-ok: rule 3 dual-read alias
 
 // Interviewer Phase 1 opt-in. Default OFF: enabling starts writing the
 // node's conversation events to the durable on-disk interview buffer
@@ -83,7 +125,7 @@ export const MEMCLAW_REQUIRE_SIGNED_COMMANDS =
 // privacy change an operator must choose, mirroring the server-side
 // per-tenant ``interviewer.enabled`` flag. Both must be on for the
 // feature to function end-to-end.
-export const MEMCLAW_INTERVIEWER = process.env.MEMCLAW_INTERVIEWER === "true";
+export const MEMCLAW_INTERVIEWER = readEnv(["CAURA_INTERVIEWER", "MEMCLAW_INTERVIEWER"]) === "true";  // legacy-name-ok: rule 3 dual-read alias
 
 // Interviewer Phase 1.5 (issue #654): mirror OpenClaw's ``task_runs``
 // SQLite trail into the interview buffer at interview time, so task /
@@ -91,13 +133,13 @@ export const MEMCLAW_INTERVIEWER = process.env.MEMCLAW_INTERVIEWER === "true";
 // Default ON whenever the interviewer itself is on — this is the fix
 // for the empty-interview gap, not a separate feature. ``"false"`` is
 // the escape hatch if a node's task DB misbehaves.
-export const MEMCLAW_INTERVIEWER_TASKS = process.env.MEMCLAW_INTERVIEWER_TASKS !== "false";
+export const MEMCLAW_INTERVIEWER_TASKS = readEnv(["CAURA_INTERVIEWER_TASKS", "MEMCLAW_INTERVIEWER_TASKS"]) !== "false";  // legacy-name-ok: rule 3 dual-read alias
 
 // Operator override for the task_runs database location. Normally
 // discovered (legacy <base>/tasks/runs.sqlite, else a shallow scan for
 // a task_runs table — the >= 2026.6 consolidated state DB has no stable
 // filename); set this when a deployment relocates OpenClaw state.
-export const MEMCLAW_TASK_DB_PATH = process.env.MEMCLAW_TASK_DB_PATH || "";
+export const MEMCLAW_TASK_DB_PATH = readEnv(["CAURA_TASK_DB_PATH", "MEMCLAW_TASK_DB_PATH"]) || "";  // legacy-name-ok: rule 3 dual-read alias
 
 // Warn at import time if API key is set but URL is HTTP
 warnIfInsecureUrl(MEMCLAW_API_URL, MEMCLAW_API_KEY);
@@ -326,8 +368,8 @@ export const INTERVIEW_TASK_SIDECAR_RETENTION_MS = 8 * 24 * 60 * 60_000;
 //   cache TTL. ``caura_keystones_set`` invocations bust the cache for
 //   the current session so a freshly authored rule takes effect on the
 //   next turn.
-function _readBoolEnv(name: string, defaultValue: boolean): boolean {
-  const v = process.env[name];
+function _readBoolEnv(names: readonly string[], defaultValue: boolean): boolean {
+  const v = readEnv(names);
   if (v === undefined) return defaultValue;
   // Treat the standard set of "off" idioms as off: ``"false"``, ``"0"``,
   // the empty string, ``"no"``, ``"off"``, and ``"disabled"``. The last
@@ -348,24 +390,24 @@ function _readBoolEnv(name: string, defaultValue: boolean): boolean {
     lower !== "disabled"
   );
 }
-function _readIntEnv(name: string, defaultValue: number, min: number): number {
-  const raw = process.env[name];
+function _readIntEnv(names: readonly string[], defaultValue: number, min: number): number {
+  const raw = readEnv(names);
   if (!raw) return defaultValue;
   const n = parseInt(raw, 10);
   if (!Number.isFinite(n) || n < min) return defaultValue;
   return n;
 }
 export const MEMCLAW_KEYSTONES_ENABLED: boolean = _readBoolEnv(
-  "MEMCLAW_KEYSTONES_ENABLED",
+  ["CAURA_KEYSTONES_ENABLED", "MEMCLAW_KEYSTONES_ENABLED"],  // legacy-name-ok: rule 3 dual-read alias
   true,
 );
 export const MEMCLAW_KEYSTONES_TOKEN_CAP: number = _readIntEnv(
-  "MEMCLAW_KEYSTONES_TOKEN_CAP",
+  ["CAURA_KEYSTONES_TOKEN_CAP", "MEMCLAW_KEYSTONES_TOKEN_CAP"],  // legacy-name-ok: rule 3 dual-read alias
   1500,
   1,
 );
 export const MEMCLAW_KEYSTONES_CACHE_TTL_MS: number = _readIntEnv(
-  "MEMCLAW_KEYSTONES_CACHE_TTL_MS",
+  ["CAURA_KEYSTONES_CACHE_TTL_MS", "MEMCLAW_KEYSTONES_CACHE_TTL_MS"],  // legacy-name-ok: rule 3 dual-read alias
   300_000,
   1_000,
 );
@@ -389,15 +431,15 @@ const _validPolicies: ReadonlySet<RecallPolicy> = new Set([
 ]);
 
 function _readPolicy(): RecallPolicy {
-  if (process.env.MEMCLAW_RECALL_FORCE === "true") return "always";
-  const raw = (process.env.MEMCLAW_RECALL_POLICY || "auto").toLowerCase();
+  if (readEnv(["CAURA_RECALL_FORCE", "MEMCLAW_RECALL_FORCE"]) === "true") return "always";  // legacy-name-ok: rule 3 dual-read alias
+  const raw = (readEnv(["CAURA_RECALL_POLICY", "MEMCLAW_RECALL_POLICY"]) || "auto").toLowerCase();  // legacy-name-ok: rule 3 dual-read alias
   return _validPolicies.has(raw as RecallPolicy)
     ? (raw as RecallPolicy)
     : "auto";
 }
 
 function _readMinPromptChars(): number {
-  const raw = parseInt(process.env.MEMCLAW_RECALL_MIN_PROMPT_CHARS || "", 10);
+  const raw = parseInt(readEnv(["CAURA_RECALL_MIN_PROMPT_CHARS", "MEMCLAW_RECALL_MIN_PROMPT_CHARS"]) || "", 10);  // legacy-name-ok: rule 3 dual-read alias
   return Number.isFinite(raw) && raw >= 0 ? raw : 14;
 }
 
@@ -422,7 +464,7 @@ const DEFAULT_TRIGGER_KEYWORDS = [
 ] as const;
 
 function _readTriggerKeywords(): readonly string[] {
-  const raw = process.env.MEMCLAW_RECALL_TRIGGER_KEYWORDS;
+  const raw = readEnv(["CAURA_RECALL_TRIGGER_KEYWORDS", "MEMCLAW_RECALL_TRIGGER_KEYWORDS"]);  // legacy-name-ok: rule 3 dual-read alias
   if (!raw) return DEFAULT_TRIGGER_KEYWORDS;
   const tokens = raw
     .split(",")
@@ -432,7 +474,7 @@ function _readTriggerKeywords(): readonly string[] {
 }
 
 function _readDenySessions(): readonly string[] {
-  const raw = process.env.MEMCLAW_RECALL_DENY_SESSIONS;
+  const raw = readEnv(["CAURA_RECALL_DENY_SESSIONS", "MEMCLAW_RECALL_DENY_SESSIONS"]);  // legacy-name-ok: rule 3 dual-read alias
   if (!raw) return [];
   return raw
     .split(",")
@@ -465,7 +507,7 @@ const DEFAULT_MACHINE_PATTERNS = [
 ] as const;
 
 function _readMachinePatterns(): readonly RegExp[] {
-  const raw = process.env.MEMCLAW_RECALL_MACHINE_PATTERNS;
+  const raw = readEnv(["CAURA_RECALL_MACHINE_PATTERNS", "MEMCLAW_RECALL_MACHINE_PATTERNS"]);  // legacy-name-ok: rule 3 dual-read alias
   const sources = raw
     ? raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0)
     : [...DEFAULT_MACHINE_PATTERNS];
@@ -497,7 +539,7 @@ export const RECALL_MACHINE_PATTERNS: readonly RegExp[] = _readMachinePatterns()
 // deployment until an operator opts in (cross-customer safety not yet validated).
 export type RecallGateMode = "off" | "shadow" | "on";
 function _readGateMode(): RecallGateMode {
-  const raw = (process.env.MEMCLAW_RECALL_GATE || "off").toLowerCase();
+  const raw = (readEnv(["CAURA_RECALL_GATE", "MEMCLAW_RECALL_GATE"]) || "off").toLowerCase();  // legacy-name-ok: rule 3 dual-read alias
   return raw === "shadow" || raw === "on" ? raw : "off";
 }
 export const RECALL_GATE_MODE: RecallGateMode = _readGateMode();
@@ -506,4 +548,4 @@ export const RECALL_GATE_MODE: RecallGateMode = _readGateMode();
 // the server-side fleet/trust scope). Default false — this changes read
 // isolation and must ship alongside the freshness cap (A43), else a
 // future-dated hub memory dominates cross-agent results. Opt-in.
-export const RECALL_CROSS_AGENT: boolean = _readBoolEnv("MEMCLAW_RECALL_CROSS_AGENT", false);
+export const RECALL_CROSS_AGENT: boolean = _readBoolEnv(["CAURA_RECALL_CROSS_AGENT", "MEMCLAW_RECALL_CROSS_AGENT"], false);  // legacy-name-ok: rule 3 dual-read alias

--- a/plugin/src/heartbeat.ts
+++ b/plugin/src/heartbeat.ts
@@ -38,6 +38,7 @@ import {
   BUILD_TIMEOUT_MS,
   MAX_SOURCE_SIZE,
   ensureTenantId,
+  readEnv,
 } from "./env.js";
 import { readInterviewEvents, pruneInterviewBuffer } from "./interview-buffer.js";
 import { syncTaskTrail } from "./task-trail.js";
@@ -101,7 +102,7 @@ const DEPLOY_COOLDOWN_FILE = ".deploy-cooldown.json";
 
 function _failureCooldownHours(): number {
   const raw = parseInt(
-    process.env.MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS || "",
+    readEnv(["CAURA_DEPLOY_FAILURE_COOLDOWN_HOURS", "MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS"]) || "",  // legacy-name-ok: rule 3 dual-read alias
     10,
   );
   return Number.isFinite(raw) && raw > 0 ? raw : 24;

--- a/plugin/src/identity.ts
+++ b/plugin/src/identity.ts
@@ -28,6 +28,7 @@
  */
 
 import { hostname } from "os";
+import { readEnv } from "./env.js";
 
 /**
  * Normalise a hostname to a friendly suffix:
@@ -78,7 +79,7 @@ export function getDisplayName(
   const ov =
     override !== undefined
       ? override
-      : process.env.MEMCLAW_DISPLAY_NAME_OVERRIDE;
+      : readEnv(["CAURA_DISPLAY_NAME_OVERRIDE", "MEMCLAW_DISPLAY_NAME_OVERRIDE"]);  // legacy-name-ok: rule 3 dual-read alias
   if (ov && ov.trim()) return ov.trim();
   const h = sanitizeHostname(host !== undefined ? host : hostname());
   if (!h) return baseName;

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -35,6 +35,8 @@ import {
   HEARTBEAT_INTERVAL_MS,
   HEARTBEAT_INITIAL_DELAY_MS,
   MAX_SOURCE_SIZE,
+  readEnv,
+  hasPluginEnvPrefix,
 } from "./env.js";
 import { apiCall, parseSearchItems } from "./transport.js";
 import { PLUGIN_VERSION } from "./version.js";
@@ -310,11 +312,14 @@ const memclawPlugin = {
           const content = readFileSync(envPath, "utf-8");
           const env = result.currentEnv as Record<string, string>;
           for (const line of content.split("\n")) {
-            const match = line.match(/^(MEMCLAW_\w+)=(.*)$/);
-            if (match) {
-              const key = match[1];
-              env[key] = key.includes("KEY") ? match[2].slice(0, 6) + "..." : match[2];
-            }
+            // Trim before testing, like the loader does — otherwise an indented
+            // line reads as foreign here while env.ts loads it fine.
+            const eq = line.indexOf("=");
+            if (eq < 1) continue;
+            const key = line.slice(0, eq).trim();
+            if (!hasPluginEnvPrefix(key)) continue;
+            const val = line.slice(eq + 1).trim();
+            env[key] = key.includes("KEY") ? val.slice(0, 6) + "..." : val;
           }
         }
       } catch (e: unknown) {
@@ -398,7 +403,7 @@ const memclawPlugin = {
     // Opt-out: MEMCLAW_AUTO_FIX_CONFIG=false skips auto-fix.
     // Force re-run: MEMCLAW_AUTO_FIX_CONFIG=true ignores the flag file.
     const allowlistFlagPath = join(getPluginDir(), ".allowlist-applied");
-    const autoFixEnv = process.env.MEMCLAW_AUTO_FIX_CONFIG;
+    const autoFixEnv = readEnv(["CAURA_AUTO_FIX_CONFIG", "MEMCLAW_AUTO_FIX_CONFIG"]);  // legacy-name-ok: rule 3 dual-read alias
     const flagExists = existsSync(allowlistFlagPath);
     // Read config once to detect drift so auto-fix re-runs even when the
     // one-time flag is already present: a plugin upgrade that ADDS a tool

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -55,7 +55,7 @@ import {
 import { join, resolve } from "path";
 
 import { apiCall } from "./transport.js";
-import { MEMCLAW_TENANT_ID, MEMCLAW_FLEET_ID } from "./env.js";
+import { MEMCLAW_TENANT_ID, MEMCLAW_FLEET_ID, readEnv } from "./env.js";  // legacy-name-ok: rule 3 dual-read alias
 import { getPluginDir, ensureExtraSkillDirs } from "./config.js";
 import { logError } from "./logger.js";
 
@@ -191,7 +191,7 @@ export function resolveSkillTargets(): SkillTarget[] {
   // as an extraDir.
   const targets: SkillTarget[] = [{ dir: ownedDir, mode: "owned", register: false }];
 
-  const raw = process.env.MEMCLAW_SKILL_TARGETS;
+  const raw = readEnv(["CAURA_SKILL_TARGETS", "MEMCLAW_SKILL_TARGETS"]);  // legacy-name-ok: rule 3 dual-read alias
   if (!raw || !raw.trim()) return targets;
 
   let parsed: unknown;

--- a/tests/test_env_dual_read.py
+++ b/tests/test_env_dual_read.py
@@ -1,0 +1,119 @@
+"""Phase 5.1: every server-side env read accepts the new name and the old one.
+
+Rule 3 makes the old spellings permanent, so each case here is asserted in both
+directions — a test that only proves the new name works would pass just as well
+after someone deleted the fallback.
+
+Each line that has to spell the old name carries its own ``legacy-name-ok``
+marker, and they are kept to a minimum: two env-name constants plus the one
+helper that touches the settings field.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from core_api import constants
+from core_api.config import Settings
+
+OLD_API_KEY_ENV = "MEMCLAW_API_KEY"  # legacy-name-ok: rule 3 — the alias under test
+OLD_VERSION_ENV = "MEMCLAW_VERSION"  # legacy-name-ok: rule 3 — the alias under test
+NEW_API_KEY_ENV = "CAURA_API_KEY"
+NEW_VERSION_ENV = "CAURA_VERSION"
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for name in (NEW_API_KEY_ENV, OLD_API_KEY_ENV, NEW_VERSION_ENV, OLD_VERSION_ENV):
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def _resolved_api_key(**overrides):
+    """The api-key setting, whichever spelling supplied it."""
+    return Settings(**overrides).memclaw_api_key  # legacy-name-ok: rule 3 — field the aliases feed
+
+
+class TestApiKeyResolution:
+    def test_old_name_still_resolves(self, clean_env):
+        clean_env.setenv(OLD_API_KEY_ENV, "old-key")
+        assert _resolved_api_key() == "old-key"
+
+    def test_new_name_resolves(self, clean_env):
+        clean_env.setenv(NEW_API_KEY_ENV, "new-key")
+        assert _resolved_api_key() == "new-key"
+
+    def test_new_name_wins_when_both_are_set(self, clean_env):
+        clean_env.setenv(NEW_API_KEY_ENV, "new-key")
+        clean_env.setenv(OLD_API_KEY_ENV, "old-key")
+        assert _resolved_api_key() == "new-key"
+
+    def test_unset_stays_none(self, clean_env):
+        assert _resolved_api_key() is None
+
+    def test_blank_new_name_does_not_disable_the_perimeter(self, clean_env):
+        # The regression this guards, and why it is not cosmetic: auth.py gates
+        # Path 2 on ``if mclaw_key:``, so resolving to "" here silently drops the
+        # API-key perimeter on a deploy whose template carries a blank new name
+        # next to a working old one. ``AliasChoices`` resolves it exactly that
+        # way, which is why this field does not use it.
+        clean_env.setenv(NEW_API_KEY_ENV, "")
+        clean_env.setenv(OLD_API_KEY_ENV, "real-key")
+        assert _resolved_api_key() == "real-key"
+
+    def test_field_name_construction_still_works(self, clean_env):
+        assert _resolved_api_key(memclaw_api_key="kw") == "kw"  # legacy-name-ok: rule 3 — field-name path
+
+
+class TestVersionResolution:
+    def test_old_name_still_resolves(self, clean_env):
+        clean_env.setenv(OLD_VERSION_ENV, "1.2.3-old")
+        assert constants._resolve_version() == "1.2.3-old"
+
+    def test_new_name_resolves(self, clean_env):
+        clean_env.setenv(NEW_VERSION_ENV, "1.2.3-new")
+        assert constants._resolve_version() == "1.2.3-new"
+
+    def test_new_name_wins_when_both_are_set(self, clean_env):
+        clean_env.setenv(NEW_VERSION_ENV, "1.2.3-new")
+        clean_env.setenv(OLD_VERSION_ENV, "1.2.3-old")
+        assert constants._resolve_version() == "1.2.3-new"
+
+    def test_blank_new_name_does_not_shadow_the_old_one(self, clean_env):
+        # The regression this guards: an operator who blanks the new name in a
+        # deploy template must not lose a working old one.
+        clean_env.setenv(NEW_VERSION_ENV, "")
+        clean_env.setenv(OLD_VERSION_ENV, "1.2.3-old")
+        assert constants._resolve_version() == "1.2.3-old"
+
+
+class TestComposeImageTags:
+    """The compose image tag reads the same pair, one process removed.
+
+    Compose interpolates in its own process, so no dual-read in this codebase
+    reaches it — the fallback has to live in the YAML. Asserted here because
+    nothing else can: flattening it to one name would either strand installs
+    that pin with the old name today, or silently serve ``latest`` to an
+    operator who followed the new docs.
+    """
+
+    def test_both_names_are_read_in_the_right_order(self):
+        compose = (Path(__file__).resolve().parents[1] / "docker-compose.yml").read_text()
+        # First-party images only. Third-party ones (pgvector, redis, TEI) carry
+        # their own upstream tags and have nothing to do with our version pin.
+        # The trailing group absorbs the ratchet's ``legacy-name-ok`` comment.
+        refs = re.findall(
+            r"^\s*image:\s*(ghcr\.io/caura-ai/\S+?)(?:\s+#.*)?$", compose, re.MULTILINE
+        )
+        assert refs, "found no first-party image references to check"
+        # Split at the tag separator, not the first colon — the tag itself
+        # contains colons once it interpolates.
+        tags = [ref[ref.index(":", ref.rindex("/")) + 1 :] for ref in refs]
+        expected = "${" + NEW_VERSION_ENV + ":-${" + OLD_VERSION_ENV + ":-latest}}"
+        for tag in tags:
+            assert tag == expected, (
+                f"image tag {tag!r} must interpolate {NEW_VERSION_ENV} with "
+                f"{OLD_VERSION_ENV} as its fallback, so an operator pinning with "
+                "either name gets the pin rather than 'latest'"
+            )


### PR DESCRIPTION
Phase 5.1 of the rebrand (work order item 5.1): every environment **reader**
accepts the new `CAURA_*` name and the old `MEMCLAW_*` one. Purely additive —
old spellings keep working forever, per rule 3.

**Writers are deliberately not in this PR.** The generated installers still
emit the old names; that is item 5.2, which the work order says must land only
after this is deployed.

### The gating defect

`plugin/src/env.ts` filtered the plugin `.env` through `/^MEMCLAW_[A-Z_]+$/`,
so every `CAURA_*` key was dropped before it reached `process.env`. Until that
changed, the new names would have been accepted everywhere and read nowhere —
the rest of the lane would look done while doing nothing. It is now the
exported, unit-tested `isPluginEnvKey`.

That predicate is load-bearing for a **security** reason, not a cosmetic one:
its prefix bound is what stops a plugin `.env` setting `PATH` or
`NODE_OPTIONS`. Tests pin the exclusions, not just the inclusions.

### Two things worth reviewer attention

**1. core-api deliberately does NOT use `AliasChoices`.** The work order
specified it; it is unsafe here. `AliasChoices` resolves to the first alias
that is *defined*, and the empty string counts:

```
CAURA_API_KEY=""  +  MEMCLAW_API_KEY="real-key"   ->   ""
```

`auth.py:376` gates the whole Path-2 perimeter on `if mclaw_key:`, so that
resolves to falsey and **the API-key perimeter drops silently**. The startup
guard at `app.py:157` only catches it when `gateway_shared_secret` is also
unset, so a deploy with a gateway secret boots clean and quietly loses a
perimeter. The trigger is mundane — a deploy template that has started listing
new names with an unfilled `CAURA_API_KEY=`, which is exactly what 5.4 will
cause people to write. Replaced with two plain fields collapsed by a model
validator, giving first-**non-empty**; for a secret, blank and unset mean the
same thing. Pinned by `test_blank_new_name_does_not_disable_the_perimeter`.

**2. `deploy.ts` keeps a looser filter on purpose.** `hasPluginEnvPrefix` is a
bare prefix test because `deploy.ts` uses it to *preserve* an operator's
existing `.env` keys across a redeploy. Reusing the strict predicate there
would have silently deleted anything it rejects (`MEMCLAW_API_KEY2`,
lowercase) from a file we do not own the contents of. The strict/loose split
is intentional and tested.

### Aliases are listed in full, not derived

Every call site spells both names. A `readEnv("RECALL_GATE")` form that built
them from a suffix was rejected: it makes the old names ungreppable, and
grepping for the old brand is how this programme is tracked.

The cost of that choice is 28 hand-written pairs, where a suffix typo
type-checks, passes any test that only sets the new name, and strands the old
name permanently. So a source-scraped guard asserts all 28 share a suffix. It
globs `plugin/src` rather than listing files, and covers the `_readBoolEnv` /
`_readIntEnv` call sites — those are the multi-line ones, where a typo is
hardest to eyeball, and one of them gates cross-agent read isolation.

### Scope note

`docker-compose.yml` interpolates the image tag in a *different process*, so a
code-level dual-read cannot reach it. Without its own nested default an
operator following 5.4-updated docs would set `CAURA_VERSION` and silently get
`:latest`, while core-api reported the pinned version. Verified all three
cases resolve (`CAURA_VERSION`, `MEMCLAW_VERSION`, neither).

`plugin/openclaw.plugin.json` declares both names in `configSchema` — the
plugin's registration object carries an empty schema, so the manifest is the
real contract with the OpenClaw host.

### Verification

- 406 plugin tests, 139 client tests, 56 core-api tests — all pass
- `ruff check` and `ruff format --check` clean at CI's exact scopes
- **Every new test confirmed failing without its fix** (2 TS, 4 core-api, 12
  client), including the planted-typo check on the alias-pair guard
- Ratchet: **-4 net, no unexempted additions**; 10 exemptions, each a compat
  alias or a test pinning an old name
- Sentinel (#884): all 22 protected strings survive

### Out of scope, flagged not fixed

- `tool-definitions.ts` `enrichBody` now honours `CAURA_FLEET_ID` for free, but
  the `caura_list {scope:'all'}` narrowing is a *behavioural* bug (it injects
  `fleet_id` whenever the caller omits it). Fixing that is not additive.
- The three `.env` line parsers (`env.ts`, `deploy.ts`, `index.ts`) still
  differ on quote-stripping. Unifying them would change `deploy.ts` behaviour,
  so it wants its own PR.
- Observed once and not reproduced in 5 runs: `validation.test.ts`
  "tampered signature fails closed" flaked. `verifyCommandSignature` checks
  timestamp freshness *before* the HMAC, so a slow run can return
  `expired_timestamp` where the test expects `invalid_signature`. Untouched by
  this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)