### PR TITLE
fix(ratchet): name the line the change added, and group repeated exemptions

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -104,6 +104,12 @@ EXEMPT_RE = re.compile(
 )
 
 
+# Above this many lines sharing one reason, the list is collapsed to a count.
+# Four is where a homogeneous block stops being read line by line; below it the
+# individual lines are still the more useful form.
+_EXEMPTION_GROUP_AT = 4
+
+
 def _git(args: list[str]) -> str:
     """git, with ``grep``'s no-match exit treated as an empty result.
 
@@ -168,6 +174,41 @@ def _grep(tree: str | None, pathspec: str = ":/") -> list[tuple[str, str, str, b
             path = path[len(prefix) :]
         out.append((path, lineno, text, bool(EXEMPT_RE.search(text))))
     return out
+
+
+def _added_lines(base: str, path: str) -> set[int]:
+    """Line numbers this change actually added to ``path``, per git's own diff.
+
+    Used for the failure report only, never for the decision. The decision
+    compares text because a per-line diff calls every move an addition — but the
+    report has the opposite problem, and needs exactly what the diff knows.
+
+    Without it the report spends a text-keyed budget in file order, which assumes
+    the first occurrence of a text is the new one. Line order says nothing about
+    that. A file holding an untouched line and a new line with identical text
+    gets the untouched one named, and the real addition is never printed — the
+    reader is sent to a line that has not changed, for a gate whose whole output
+    is "here is the line you added".
+
+    Empty on any failure, and the caller falls back to naming every occurrence of
+    the minted text: too many lines is a nuisance, none is a dead end.
+    """
+    try:
+        out = _git(["git", "diff", "-U0", base, "--", _literal(path)])
+    except RuntimeError:
+        return set()
+
+    added: set[int] = set()
+    lineno = 0
+    for line in out.splitlines():
+        if line.startswith("@@"):
+            # ``@@ -a,b +c,d @@`` — c is where the added run starts.
+            match = re.search(r"\+(\d+)", line)
+            lineno = int(match.group(1)) if match else 0
+        elif line.startswith("+") and not line.startswith("+++"):
+            added.add(lineno)
+            lineno += 1
+    return added
 
 
 def _literal(path: str) -> str:
@@ -386,10 +427,36 @@ def _report_new_exemptions(before: Counter[str], after: Counter[str]) -> None:
     print(
         "compat alias, a redirect or a pinned wire format, and not headroom for a new name:"
     )
+
+    # Grouped by reason, because the wall is the failure mode. A dual-read wave
+    # exempts dozens of lines carrying one identical reason, and at that length
+    # the list stops being read — which costs exactly the thing it is for, since
+    # the swap this report exists to expose shows up as the ONE reason that does
+    # not match its neighbours. Collapsing the repeats is what makes the odd one
+    # visible instead of burying it on line forty.
+    by_reason: dict[str, list[tuple[str, str, str]]] = {}
     for path in sorted(added):
         for _, lineno, text, exempt in _grep(None, pathspec=_literal(path)):
-            if exempt:
-                print(f"  {path}:{lineno}: {text.strip()[:100]}")
+            if not exempt:
+                continue
+            stripped = text.strip()
+            match = EXEMPT_RE.search(stripped)
+            tail = stripped[match.end() :].lstrip(": ") if match else ""
+            by_reason.setdefault(tail.strip() or "(no reason given)", []).append(
+                (path, lineno, stripped)
+            )
+
+    for reason, lines in sorted(by_reason.items(), key=lambda kv: (-len(kv[1]), kv[0])):
+        if len(lines) <= _EXEMPTION_GROUP_AT:
+            for path, lineno, stripped in lines:
+                print(f"  {path}:{lineno}: {stripped[:100]}")
+            continue
+        files = sorted({path for path, _, _ in lines})
+        shown = ", ".join(files[:4]) + (
+            f" (+{len(files) - 4} more)" if len(files) > 4 else ""
+        )
+        print(f"  {len(lines)}x  {reason[:80]}")
+        print(f"      in {len(files)} file(s): {shown}")
     print()
 
 
@@ -487,16 +554,36 @@ def main() -> int:
         else:
             note = ", count fell — the text is new"
         print(f"  {path}  ({before} -> {after}{note})")
-        # Only the minted lines, and only as many of each as were minted. A file
-        # can hold three copies of a text that moved in twice and was added once;
-        # printing all three sends the reader to "fix" two lines that are not why
-        # this failed. The budget is consumed as lines are printed.
-        budget = Counter(minted)
-        for _, lineno, text, exempt in _grep(None, pathspec=_literal(path)):
-            stripped = text.strip()
-            if not exempt and budget[stripped] > 0:
-                budget[stripped] -= 1
-                print(f"      {lineno}: {stripped[:110]}")
+        # Lines carrying minted text AND actually added by this change. Both
+        # halves are needed. Without the text filter the report names every
+        # branded line in the file; without the diff it names the first line
+        # holding the text, which in a file that already had one is a line
+        # nobody touched.
+        added = _added_lines(args.base, path)
+        candidates = [
+            (lineno, text.strip())
+            for _, lineno, text, exempt in _grep(None, pathspec=_literal(path))
+            if not exempt and text.strip() in minted
+        ]
+        shown = [(n, t) for n, t in candidates if int(n) in added]
+        # Falling back to every occurrence rather than to silence: if the diff
+        # could not be read, too many lines is a nuisance and none is a dead end.
+        shown = shown or candidates
+        for lineno, stripped in shown:
+            print(f"      {lineno}: {stripped[:110]}")
+
+        # When a change adds several identical lines and only some are minted,
+        # every one of them is a line this change added and they cannot be told
+        # apart — that is what identical means. Naming one would be a guess
+        # dressed as a finding, so all are printed and the split is stated.
+        for text, new in sorted(minted.items()):
+            here = sum(1 for _, t in shown if t == text)
+            if here > new:
+                print(
+                    f"      ^ {here} added lines share this text; {new} new, "
+                    f"{here - new} moved in from elsewhere — identical, so which is which"
+                    " cannot be told apart"
+                )
     print(
         f"\nRule 7 of the sunset plan: mint nothing new named '{LEGACY_NAME}'. Every one adds a\n"
         "redirect to keep forever and spends a rename option. Use the Caura name instead.\n\n"

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -303,13 +303,17 @@ def test_a_move_does_not_launder_an_addition_beside_it(repo: Path) -> None:
     assert "URL" not in offenders
 
 
-def test_only_the_minted_copies_of_a_repeated_line_are_named(repo: Path) -> None:
-    """A file can hold more copies of a text than were actually minted.
+def test_identical_added_lines_are_all_named_with_the_split_stated(repo: Path) -> None:
+    """A file can gain more copies of a text than were minted.
 
-    Two identical lines move in and a third is added. All three read the same, so
-    a membership test on the minted set prints all three and sends the reader to
-    "fix" two lines that were already in the tree. Only the count separates them,
-    so the report spends a budget rather than testing membership.
+    Two identical lines move in and a third is added. All three are lines this
+    change added, and they are byte-identical, so which one is the mint cannot be
+    determined — naming one would be a guess dressed as a finding. All three are
+    printed and the split is stated instead.
+
+    An earlier version spent a text-keyed budget and named whichever occurrence
+    came first in the file. That is worse than imprecise: where the file ALREADY
+    held the text it names a line nobody touched, which the next test pins.
     """
     # Base holds two copies: the fixture's existing.py, plus a second file.
     _stage(repo, "second.py", f'URL = "https://{LEGACY}.net"\n')
@@ -325,7 +329,10 @@ def test_only_the_minted_copies_of_a_repeated_line_are_named(repo: Path) -> None
 
     assert result.returncode == 1
     assert "(0 -> 3)" in offenders
-    assert offenders.count("URL = ") == 1
+    # All three are lines this change added, so all three are named...
+    assert offenders.count('URL = "https://') == 3
+    # ...and the report says how many of them are actually new.
+    assert "3 added lines share this text; 1 new, 2 moved in" in offenders
 
 
 def test_one_deletion_pays_for_only_one_of_two_destinations(repo: Path) -> None:
@@ -350,6 +357,35 @@ def test_one_deletion_pays_for_only_one_of_two_destinations(repo: Path) -> None:
     assert offenders.count("(0 -> 1)") == 1
     # And the other is named as the move it is, not silently dropped.
     assert "treated as moved rather than added" in result.stdout
+
+
+def test_the_line_named_is_one_the_change_added(repo: Path) -> None:
+    """The report must never point at a line nobody touched.
+
+    ``existing.py`` already carries the text on line 1 and keeps it. The change
+    appends an identical line further down. Both hold the same text, so a
+    text-keyed budget spent in file order names line 1 — a line that did not
+    change — and never prints the one that did. For a gate whose entire output is
+    "here is the line you added", sending the reader to an untouched line is
+    worse than saying nothing: they go looking for a mistake that is not there.
+
+    Which physical line the change added is the one question the text cannot
+    answer and git's diff can, so the report asks git.
+    """
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"\n'
+        + "filler = 1\n" * 5
+        + f'URL = "https://{LEGACY}.net"\n',
+    )
+
+    result = _run(repo)
+    offenders = result.stdout.split("adds the legacy name in", 1)[1]
+
+    assert result.returncode == 1
+    assert "      7: " in offenders  # the appended line
+    assert "      1: " not in offenders  # the untouched one
 
 
 def test_an_excused_move_is_always_named(repo: Path) -> None:
@@ -443,6 +479,45 @@ def test_a_newly_exempted_line_is_always_named(repo: Path) -> None:
     assert "1 line(s) newly exempted" in result.stdout
     assert "existing.py:1" in result.stdout
     assert "gateway mirror" in result.stdout
+
+
+def test_many_exemptions_sharing_a_reason_are_grouped(repo: Path) -> None:
+    """The wall is the failure mode, and Phase 5 builds walls.
+
+    A dual-read wave exempts dozens of lines carrying one identical reason. At
+    that length the list stops being read, which costs the report the thing it is
+    for: the swap it exposes shows up as the ONE reason that does not match its
+    neighbours. Collapsing repeats is what keeps the odd one visible.
+    """
+    body = "".join(
+        f'A{i} = "{LEGACY}_x"  # legacy-name-ok: rule 3 dual-read alias\n'
+        for i in range(6)
+    )
+    _stage(repo, "many.py", body)
+
+    out = _run(repo).stdout
+
+    assert "6x  rule 3 dual-read alias" in out
+    assert "in 1 file(s): many.py" in out
+    # Collapsed, not listed line by line.
+    assert out.count("A0 = ") == 0
+
+
+def test_an_odd_reason_out_survives_the_grouping(repo: Path) -> None:
+    """The whole point of grouping: the one that differs is still printed in full,
+    where a reader scanning past forty identical lines would have missed it."""
+    body = "".join(
+        f'A{i} = "{LEGACY}_x"  # legacy-name-ok: rule 3 dual-read alias\n'
+        for i in range(6)
+    )
+    body += f'SNUCK = "{LEGACY}-new"  # legacy-name-ok: headroom, honestly\n'
+    _stage(repo, "many.py", body)
+
+    out = _run(repo).stdout
+
+    assert "6x  rule 3 dual-read alias" in out
+    assert "headroom, honestly" in out
+    assert "SNUCK" in out
 
 
 def test_the_exempt_and_add_swap_is_caught(repo: Path) -> None:


### PR DESCRIPTION
Two report fixes on top of #885. Neither changes what passes or fails. Both change whether the output can be trusted — which, for a gate whose entire product is a diagnostic, is the same class of defect as a wrong verdict.

## 1. The failure report could name a line nobody touched

Found by the review on [installer#11](https://github.com/caura-ai/caura-onprem-installer/pull/11), and it is a regression I introduced in #885.

Spending a text-keyed budget in file order assumes the first occurrence of a text is the new one. **Line order says nothing about that.** A file that already holds the text on line 3 and gains an identical line on line 14:

```
  f.py  (1 -> 2)
      3: T = "memclaw-thing"     <- unchanged line, named
                                 <- line 14, the actual addition, never printed
```

The reader is sent to a line that did not change, hunting a mistake that is not there, by a gate whose whole output is "here is the line you added". Worse than imprecise — before #885 the report printed every matching line in the file, so the real one was at least *among* the output.

**Which physical line a change added is the one question the text cannot answer and git's diff can**, so the report now asks git:

```
  f.py  (1 -> 2)
      14: T = "memclaw-thing"
```

The **decision** still compares text and must: a per-line diff calls every move an addition, which is exactly what #885 fixed. The report has the opposite problem and needs the opposite tool. `_added_lines()` is used for reporting only, returns empty on any failure, and the caller falls back to naming every occurrence of the minted text — too many lines is a nuisance, none is a dead end.

Where several identical lines were **all** added and only some are minted, all are printed and the split is stated:

```
      1: URL = "https://memclaw.net"
      2: URL = "https://memclaw.net"
      3: URL = "https://memclaw.net"
      ^ 3 added lines share this text; 1 new, 2 moved in from elsewhere — identical, so which is which cannot be told apart
```

That replaces `test_only_the_minted_copies_of_a_repeated_line_are_named`, which I added two rounds ago to satisfy an earlier finding. It was asking for false precision: all three are lines the change added, they are byte-identical, and naming one is a guess dressed as a finding.

## 2. The exemption report became unreadable at exactly the size that matters

Reported by Agent 5 from a live Phase 5 PR, and worth acting on rather than filing.

A dual-read wave exempts dozens of lines carrying one identical reason — their PR has **58 markers**, and 5.3 and 5.4 make that worse, not better. At that length the list stops being read, which costs the report the thing it exists for: the exempt-and-add swap it guards against shows up as the **one reason that does not match its neighbours**.

Repeats past four are now collapsed:

```
  6x  rule 3 dual-read alias
      in 1 file(s): many.py
  many.py:7: SNUCK = "memclaw-new"  # legacy-name-ok: headroom, honestly
```

**Grouping cannot hide the hole it guards** — a laundered line carries a reason that does not match the group, so collapsing the group is precisely what surfaces it. Pinned both ways: `test_many_exemptions_sharing_a_reason_are_grouped` and `test_an_odd_reason_out_survives_the_grouping`.

## Tests

40, up from 37. Both new behaviours confirmed failing against the pre-fix reporting.

Gates green: `No new lines.` / `All 22 protected strings survive.`

## Propagation

This goes to `caura-enterprise` and `caura-onprem-installer` once it lands, same as #885 — all three copies are now byte-identical, so it is a straight copy with an AST check rather than a semantic port. [installer#11](https://github.com/caura-ai/caura-onprem-installer/pull/11) is still open and will carry this before it merges; the enterprise copy (#1225, merged) needs a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)