### PR TITLE
fix(gates): correct a stale summary and two latent bugs in the shared checks

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -7,9 +7,12 @@ redirect somebody has to keep forever and spends a rename option that was alread
 paid for. The programme runs for weeks with ordinary feature work alongside it,
 so the rule needs a gate rather than a reviewer's attention.
 
-What it does: counts the lines carrying the legacy name per file, in the tree being
-built and in the base tree, and fails on any file that went **up**. Decreases are
-the point of the programme and are reported as progress.
+What it does: compares the legacy-name lines per file, by TEXT, between the tree
+being built and the base tree, and fails a file that carries text the repo did
+not have before. Not a count comparison — a flat or falling count can still hide
+newly minted text, and a risen one can be nothing but a move. See "Why the count
+is not the check" below. Decreases are the point of the programme and are
+reported as progress.
 
 Why per file rather than a repo total: a total hides an addition behind an
 unrelated deletion elsewhere in the same PR, while a per-file count keeps a

--- a/tests/test_do_not_touch_sentinel.py
+++ b/tests/test_do_not_touch_sentinel.py
@@ -252,7 +252,17 @@ def test_every_listed_string_is_actually_load_bearing(
     assert _check(sentinel, scrubbed) is not None
 
 
-_COMMENT_STARTS = ("#", "//", "*", "--")
+_COMMENT_STARTS = ("#", "//", "*")
+# SQL's marker needs its trailing space to tell ``-- a note`` from a command-line
+# flag. Without it a pinned ``--update-labels=…`` reads as a comment and the
+# guard fails the very entry it exists to protect. No OSS entry starts with a
+# dash today; the enterprise copy has several, and found this.
+_SQL_COMMENT = "-- "
+
+
+def _is_comment_only(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith(_COMMENT_STARTS) or stripped.startswith(_SQL_COMMENT)
 
 
 @pytest.mark.parametrize(
@@ -278,7 +288,7 @@ def test_no_literal_can_be_satisfied_by_a_comment_alone(sentinel: Sentinel) -> N
     in_comment = [
         line.strip()
         for line in lines
-        if sentinel.text in line and line.strip().startswith(_COMMENT_STARTS)
+        if sentinel.text in line and _is_comment_only(line)
     ]
 
     assert not in_comment, (
@@ -320,5 +330,7 @@ def test_a_removal_names_the_file_and_what_breaks(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert sentinel.path in result.stdout
-    assert sentinel.text in result.stdout
+    # repr, because that is how the report prints it — a pinned string containing
+    # a backslash (a terraform filter, say) never appears verbatim in the output.
+    assert repr(sentinel.text) in result.stdout
     assert sentinel.breaks in result.stdout


### PR DESCRIPTION
Three small corrections, all the same kind: prose or a helper asserting something the code does not do. **All three were found by porting these files to `caura-enterprise`**, whose content exercises paths the OSS tree does not — which is itself the useful result here.

## 1. The ratchet's summary described the pre-#885 algorithm

Flagged by the review on [installer#11](https://github.com/caura-ai/caura-onprem-installer/pull/11). The "What it does" paragraph still said the gate *"fails on any file that went **up**"* — which the same docstring then spends two paragraphs contradicting under "Why the count is not the check".

It compares text, not counts: a flat or falling count can hide newly minted text, and a risen one can be nothing but a move. The summary now says so and points at the section for the rest.

## 2. The sentinel's comment guard treated a bare `--` as a comment marker

`test_no_literal_can_be_satisfied_by_a_comment_alone` refuses any entry whose pinned text appears on a comment-only line. Its prefix list included `"--"` for SQL — but SQL's marker needs its **trailing space** to be distinguishable from a command-line flag.

So a pinned `--update-labels=dd-monitor=true` reads as a comment, and the guard fails the very entry it exists to protect:

```
AssertionError: promote-to-prod.yml mentions 'update-labels=dd-monitor=true' in a
comment, so deleting the code that uses it would still pass:
['--update-labels=dd-monitor=true \\', ...]
```

Every one of those is a functional shell continuation line. **No OSS entry starts with a dash today**, which is why this sat unnoticed; the enterprise list has four.

## 3. The sentinel's report test asserted raw text where the report prints `repr()`

`_check`'s failure report prints `{s.text!r}`, so a pinned string containing a backslash never appears verbatim in stdout. The enterprise list pins a terraform `filter = "resource.type=\"cloud_run_revision\" AND …"`, and the test failed against a report that was working correctly.

Same reason it went unnoticed: no OSS entry contains a backslash yet.

## Why this is worth its own PR

None of it changes what passes or fails **today**. But two of the three would have failed the enterprise sentinel on its first run for reasons that have nothing to do with that repo — a gate red for a bug in its own test is exactly the thing that teaches people to skip gates, which is the failure mode this programme is already fighting after #1218 merged past a red ratchet.

Fixing them here rather than in the enterprise copy also keeps the three copies convergent: they are currently byte-identical, and I would rather not start the divergence with a bug fix.

## Checks

100 tests pass. `No new lines.` / `All 22 protected strings survive.`

## Propagation

Goes to `caura-onprem-installer` and `caura-enterprise` with the rest. [installer#11](https://github.com/caura-ai/caura-onprem-installer/pull/11) is still open and will carry it; the enterprise sentinel (0.3b) is being written against this version now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)