### PR TITLE
fix(sentinel): a file the gate cannot read exits 2, not a traceback

### DIFF
--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -364,7 +364,14 @@ def main() -> int:
         return 1
 
     root = Path(args.root).resolve()
-    failures = [(s, why) for s in SENTINELS if (why := _check(s, root)) is not None]
+    try:
+        failures = [(s, why) for s in SENTINELS if (why := _check(s, root)) is not None]
+    except RuntimeError as exc:
+        # A file this gate cannot read is a gate that did not run, which is not
+        # the same as a gate that found something — and a traceback reads as
+        # neither. Exit 2 says it could not run; exit 1 always means it ran.
+        print(exc, file=sys.stderr)
+        return 2
 
     if not failures:
         print(f"All {len(SENTINELS)} protected strings survive.")

--- a/tests/test_do_not_touch_sentinel.py
+++ b/tests/test_do_not_touch_sentinel.py
@@ -26,6 +26,7 @@ SCRIPT = REPO_ROOT / "scripts" / "do_not_touch_sentinel.py"
 
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
+import do_not_touch_sentinel as sentinel_module
 from do_not_touch_sentinel import (
     LITERAL,
     LOG_MESSAGE,
@@ -295,6 +296,29 @@ def test_no_literal_can_be_satisfied_by_a_comment_alone(sentinel: Sentinel) -> N
         f"{sentinel.path} mentions {sentinel.text!r} in a comment, so deleting the "
         f"code that uses it would still pass: {in_comment}"
     )
+
+
+def test_main_turns_an_unreadable_file_into_exit_two(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A file the gate cannot read means the gate did not run — which is not the
+    same as the gate finding something, and a traceback reads as neither. Exit 2
+    says it could not run; exit 1 always means it ran and something is missing.
+
+    Driven through a substituted list rather than the real one, so the case is
+    identical in every copy of this file: only a LOG_MESSAGE entry reaches the
+    parser, and not every repo's list has one.
+    """
+    root = _root(tmp_path, "a.py", "def broken(:\n")
+    monkeypatch.setattr(
+        sentinel_module,
+        "SENTINELS",
+        (Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"),),
+    )
+    monkeypatch.setattr(sys, "argv", ["do_not_touch_sentinel.py", "--root", str(root)])
+
+    assert sentinel_module.main() == 2
+    assert "does not parse" in capsys.readouterr().err
 
 
 def test_the_list_is_not_empty() -> None:


### PR DESCRIPTION
Found reviewing the enterprise port ([enterprise#1228](https://github.com/caura-ai/caura-enterprise/pull/1228)).

`_log_calls` raises `RuntimeError` when a pinned Python file will not parse — deliberately, so an unreadable file is a failed gate rather than a silent skip. But `main()` called `_check` inside a list comprehension with nothing catching it, so the gate crashed with a traceback and Python's default **exit 1**.

**Exit 1 is not free here.** In this script it means the gate *ran* and something load-bearing is missing — the loudest signal it has. A gate that could not run must never be mistaken for a gate that failed you. `main()` now catches it and exits **2**, the same distinction the ratchet already draws for an unresolvable `--base`.

## On the test

Driven through `main()` with a **substituted list** rather than the real one. Only a `LOG_MESSAGE` entry reaches the parser, and not every repo's list has one — the enterprise list has none — so driving it off the real `SENTINELS` would pass vacuously in exactly the copies where this was found. The substituted form makes the case identical in all three copies, which is the property that keeps them diffable.

Confirmed failing with the guard removed.

## Checks

61 tests pass. `All 22 protected strings survive.` / `No new lines.`

Propagates to `caura-onprem-installer` and `caura-enterprise`; the enterprise copy already carries it in #1228, noted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)