### PR TITLE
fix(ratchet): the gate cannot be run on a non-UTF-8 workstation

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -125,7 +125,21 @@ def _git(args: list[str]) -> str:
     :func:`main` refuses to pass when BOTH trees come back empty.
     """
     # check=False deliberately: the return code is the signal here, not an error.
-    proc = subprocess.run(args, capture_output=True, text=True, check=False)
+    #
+    # The encoding is pinned rather than left to the locale. ``text=True`` alone
+    # decodes with ``locale.getpreferredencoding()``, which is UTF-8 on the CI
+    # runner but a legacy codepage on a Windows workstation — cp1255, cp1251,
+    # cp1252, whatever the machine is set to. The tree has non-ASCII bytes in it
+    # (em dashes in prose, accented names in fixtures), so on those machines the
+    # decode raises UnicodeDecodeError inside subprocess's reader thread and the
+    # script dies before it prints anything. It is not a gate failure — the gate
+    # simply cannot be run locally, which is where you want to run it first.
+    # ``errors="replace"`` keeps an undecodable byte from being fatal: this
+    # counts occurrences of an ASCII name, so a mangled character elsewhere on
+    # the line changes nothing about the match.
+    proc = subprocess.run(
+        args, capture_output=True, text=True, check=False, encoding="utf-8", errors="replace"
+    )
     if proc.returncode == 0:
         return proc.stdout
     if proc.returncode == 1:


### PR DESCRIPTION
`subprocess.run(..., text=True)` decodes with `locale.getpreferredencoding()`. On the CI runner that is UTF-8, so the job is green. On a Windows workstation it is whatever legacy codepage the machine is set to — cp1255, cp1251, cp1252.

The tree contains non-ASCII bytes (em dashes throughout the prose, accented names in fixtures), so on those machines the decode raises inside subprocess's reader thread and the script dies before printing anything:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 68951
AttributeError: 'NoneType' object has no attribute 'split'
```

This is not a gate failure. It means **the gate cannot be run locally** — which is exactly where you want to run it, before pushing, rather than discovering a rule 7 violation from a red check.

## The fix

Pin `encoding="utf-8"` so a local run decodes the same bytes CI does. `errors="replace"` keeps an undecodable byte non-fatal: the script counts occurrences of an ASCII name, so a mangled character elsewhere on the line cannot change whether a match is found or which file it is attributed to.

## Verification

- `scripts/legacy_name_ratchet.py --report` on this repo from a cp1255 machine: previously crashed, now prints `2400 lines across 278 files`
- `tests/test_legacy_name_ratchet.py`: **39 passed**

One test fails on Windows, `test_a_path_containing_a_colon_is_attributed_correctly` — NTFS reserves `:`, so `git add 'we:ird.py'` returns 128 and the fixture cannot be created. It fails identically against the unmodified script, so it is pre-existing and unrelated. Worth a `skipif` on `os.name == "nt"` at some point, but not smuggled into this PR.

`caura-enterprise/scripts/legacy_name_ratchet.py` has the same line and needs the same fix; sent separately since the two copies have diverged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)