### PR TITLE
fix(sentinel): the log message is the first argument, not any of them

### DIFF
--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -85,11 +85,12 @@ class Sentinel:
 
 # ── the list ─────────────────────────────────────────────────────────────────
 #
-# Every entry carries ``legacy-name-ok`` because this file is itself scanned by
-# the ratchet, and the reason is the same one every time: the line exists to pin
-# a string rule 3 keeps readable forever. Excluding the file from the ratchet
-# instead would leave a hole in that scan, which is the trade its author already
-# refused once for the same reason.
+# Entries whose pinned text contains the old brand carry ``legacy-name-ok``,
+# because this file is itself scanned by the ratchet, and the reason is the same
+# every time: the line exists to pin a string rule 3 keeps readable forever.
+# Entries pinning brand-free text need no marker and correctly have none — the
+# ratchet never sees them. Excluding this file from the ratchet instead would
+# leave a hole in that scan, which is the trade its author already refused once.
 
 SENTINELS: tuple[Sentinel, ...] = (
     # -- Matched by a live production Datadog monitor. Carries no brand. -------
@@ -273,9 +274,11 @@ def _static_text(node: ast.expr) -> str | None:
 def _log_calls(source: str, path: str) -> list[tuple[str | None, str]]:
     """``(level, message)`` for every logging call — level ``None`` if unknowable.
 
-    Positional args only, and every one of them: ``logger.log`` takes the level
-    first, so keying on argument position would miss the message while keying on
-    "any string argument" costs nothing.
+    One argument per call, by position: index 0, or index 1 for ``logger.log``
+    where the level takes the first slot. Reading every positional argument
+    instead — which this did until a %-substitution value was found able to
+    satisfy a check for a message that had been renamed — is the wider net that
+    catches the wrong fish.
     """
     try:
         tree = ast.parse(source)
@@ -292,8 +295,14 @@ def _log_calls(source: str, path: str) -> list[tuple[str | None, str]]:
         ):
             continue
         level = node.func.attr if node.func.attr in _LEVEL_RANK else None
-        for arg in node.args:
-            text = _static_text(arg)
+        # The message is the first positional argument — except for
+        # ``logger.log(level, msg)``, where the level takes that slot. Reading
+        # every argument instead would let a %-substitution VALUE satisfy the
+        # check for a call whose message text had changed, which is the exact
+        # false pass this kind exists to prevent.
+        index = 1 if node.func.attr == "log" else 0
+        if len(node.args) > index:
+            text = _static_text(node.args[index])
             if text:
                 out.append((level, text))
     return out
@@ -312,6 +321,13 @@ def _check(sentinel: Sentinel, root: Path) -> str | None:
 
     if sentinel.kind == LITERAL:
         return None if sentinel.text in source else "the string is gone"
+
+    if sentinel.kind != LOG_MESSAGE:
+        # Not defensive padding: a mistyped kind would otherwise fall through to
+        # the log-message path and quietly check the wrong thing, on an entry
+        # whose author believed they had written a literal one. A gate running
+        # the wrong check is worse than one that refuses to run.
+        raise RuntimeError(f"unknown kind {sentinel.kind!r} on {sentinel.path}")
 
     emitting = [
         (level, text)

--- a/tests/test_do_not_touch_sentinel.py
+++ b/tests/test_do_not_touch_sentinel.py
@@ -199,6 +199,23 @@ def test_exception_counts_as_error(tmp_path: Path) -> None:
     assert _check(sentinel, root) is None
 
 
+def test_a_format_argument_does_not_count_as_the_message(tmp_path: Path) -> None:
+    """The message is the first positional argument, not any of them.
+
+    Reading every argument lets a %-substitution VALUE satisfy the check for a
+    call whose message text has changed — a false pass on exactly the regression
+    this kind exists to catch, and the harder one to notice because the phrase
+    really is still in the file.
+    """
+    root = _root(
+        tmp_path, "a.py", 'logger.error("Widget renamed: %s", "Widget degraded")\n'
+    )
+
+    result = _check(Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"), root)
+
+    assert result == "it survives only in prose — no logging call emits it any more"
+
+
 def test_a_phrase_in_a_non_logging_call_does_not_count(tmp_path: Path) -> None:
     """Otherwise any string anywhere satisfies the strictest kind in the list."""
     root = _root(tmp_path, "a.py", 'print("Widget degraded")\n')
@@ -216,6 +233,19 @@ def test_a_file_that_does_not_parse_fails_loudly(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeError, match="does not parse"):
         _check(Sentinel("a.py", "Widget degraded", LOG_MESSAGE, "x"), root)
+
+
+def test_an_unknown_kind_refuses_to_run(tmp_path: Path) -> None:
+    """A mistyped kind must not fall through to the log-message path.
+
+    It would quietly run the wrong check on an entry whose author believed they
+    had written a literal one — and pass or fail for reasons unrelated to what
+    they pinned. A gate running the wrong check is worse than one that refuses.
+    """
+    root = _root(tmp_path, "a.py", 'KEY = "keep-me"\n')
+
+    with pytest.raises(RuntimeError, match="unknown kind"):
+        _check(Sentinel("a.py", "keep-me", "litteral", "x"), root)
 
 
 # ── the real list ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Found reviewing the enterprise port ([enterprise#1228](https://github.com/caura-ai/caura-enterprise/pull/1228)).

`_log_calls` treated **every** positional string argument as candidate message text, so a `%`-substitution *value* could satisfy a `LOG_MESSAGE` entry for a call whose message had changed:

```python
logger.error("Widget renamed: %s", "Widget degraded")
```

still reported `Widget degraded` as emitted. That is a false pass on exactly the regression this kind exists to catch — and the harder one to notice, because the phrase really *is* still in the file, so grepping confirms the wrong answer.

**It matters most here.** The three entries this guards are the embedding phrases matched by the CRITICAL Datadog policy at `gcp_alerts.tf:40`. A rename that moved one of those phrases from the format string into an argument would have passed the gate and killed the alert.

## Why not simply "the first argument"

The obvious fix breaks `logger.log(level, msg)`, where the level takes the first slot — a case added deliberately two rounds ago, with its own test. So it is the first argument, except for `.log`, where it is the second:

```python
index = 1 if node.func.attr == "log" else 0
```

Both cases still pinned: `test_the_level_first_logging_form_is_read_too` and the new `test_a_format_argument_does_not_count_as_the_message`, the latter confirmed failing against the read-every-argument version.

## Note on where this was found

The enterprise list has **no** `LOG_MESSAGE` entries — the monitored log lines are emitted by other repos; enterprise holds the monitors that read them. So the port could not have hit this bug, and the reviewer found it by reading the mechanism rather than by running it. Fixed here first because this is the copy where the kind is actually load-bearing.

## Checks

62 tests pass. `All 22 protected strings survive.` / `No new lines.`

Propagates to the installer; enterprise already carries it in #1228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)