### PR TITLE
feat(installers): write CAURA_* into new installs

### DIFF
--- a/clients/python/src/caura_client/interviewer/cli.py
+++ b/clients/python/src/caura_client/interviewer/cli.py
@@ -403,15 +403,17 @@ def _cmd_install(args: argparse.Namespace) -> int:
         print(f"[interviewer] {exc}", file=sys.stderr)
         return 2
 
+    # New installs are written with the new names only. Existing env files keep
+    # their old names and keep working — every reader above accepts both.
     env = {
-        "MEMCLAW_BASE_URL": args.base_url,
-        "MEMCLAW_API_KEY": args.api_key,
-        "MEMCLAW_TENANT_ID": args.tenant_id,
-        "MEMCLAW_AGENT_ID": args.agent_id,
-        "MEMCLAW_FLEET_ID": args.fleet_id or "",
+        "CAURA_BASE_URL": args.base_url,
+        "CAURA_API_KEY": args.api_key,
+        "CAURA_TENANT_ID": args.tenant_id,
+        "CAURA_AGENT_ID": args.agent_id,
+        "CAURA_FLEET_ID": args.fleet_id or "",
     }
     if not args.all_projects:
-        env["MEMCLAW_INTERVIEWER_PROJECTS"] = ",".join(allow)
+        env["CAURA_INTERVIEWER_PROJECTS"] = ",".join(allow)
 
     env_file = installer.env_file_path()
     log_file = installer.log_file_path()

--- a/clients/python/src/caura_client/interviewer/installer.py
+++ b/clients/python/src/caura_client/interviewer/installer.py
@@ -35,12 +35,12 @@ CRON_MARKER = "# memclaw-interviewer (managed)"
 # Only the connection identity is persisted to the env file (0600). Non-secret
 # behavior flags (--harness, --all-projects) ride on the cron command instead.
 _ENV_KEYS = (
-    "MEMCLAW_BASE_URL",
-    "MEMCLAW_API_KEY",
-    "MEMCLAW_TENANT_ID",
-    "MEMCLAW_AGENT_ID",
-    "MEMCLAW_FLEET_ID",
-    "MEMCLAW_INTERVIEWER_PROJECTS",
+    "CAURA_BASE_URL",
+    "CAURA_API_KEY",
+    "CAURA_TENANT_ID",
+    "CAURA_AGENT_ID",
+    "CAURA_FLEET_ID",
+    "CAURA_INTERVIEWER_PROJECTS",
 )
 
 _INTERVAL_RE = re.compile(r"^(\d+)\s*([mh])$", re.IGNORECASE)

--- a/clients/python/tests/test_interviewer_installer.py
+++ b/clients/python/tests/test_interviewer_installer.py
@@ -87,21 +87,21 @@ def test_build_run_command_all_projects_flag(tmp_path):
 
 def test_render_env_file_only_set_keys_and_quotes():
     out = render_env_file({
-        "MEMCLAW_BASE_URL": "https://memclaw.corp.internal",
-        "MEMCLAW_API_KEY": "mc_secret",
-        "MEMCLAW_TENANT_ID": "t1",
-        "MEMCLAW_AGENT_ID": "",          # falsy → omitted
-        "MEMCLAW_INTERVIEWER_PROJECTS": "app-*,foo",
+        "CAURA_BASE_URL": "https://caura.corp.internal",
+        "CAURA_API_KEY": "mc_secret",
+        "CAURA_TENANT_ID": "t1",
+        "CAURA_AGENT_ID": "",          # falsy → omitted
+        "CAURA_INTERVIEWER_PROJECTS": "app-*,foo",
     })
-    assert "export MEMCLAW_BASE_URL='https://memclaw.corp.internal'" in out
-    assert "export MEMCLAW_API_KEY='mc_secret'" in out
-    assert "export MEMCLAW_INTERVIEWER_PROJECTS='app-*,foo'" in out
-    assert "MEMCLAW_AGENT_ID" not in out  # empty value not written
-    assert "MEMCLAW_FLEET_ID" not in out  # absent key not written
+    assert "export CAURA_BASE_URL='https://caura.corp.internal'" in out
+    assert "export CAURA_API_KEY='mc_secret'" in out
+    assert "export CAURA_INTERVIEWER_PROJECTS='app-*,foo'" in out
+    assert "CAURA_AGENT_ID" not in out  # empty value not written
+    assert "CAURA_FLEET_ID" not in out  # absent key not written
 
 
 def test_render_env_file_escapes_single_quotes():
-    out = render_env_file({"MEMCLAW_API_KEY": "a'b"})
+    out = render_env_file({"CAURA_API_KEY": "a'b"})
     assert r"'a'\''b'" in out
 
 
@@ -167,7 +167,7 @@ def test_install_writes_cron_and_env_then_uninstall_removes(monkeypatch, tmp_pat
 
     rc = main([
         "install", "--interval", "30m",
-        "--base-url", "https://memclaw.corp.internal",
+        "--base-url", "https://caura.corp.internal",
         "--api-key", "mc_k", "--tenant-id", "t1",
         "--projects", "app-*",
     ])
@@ -176,8 +176,8 @@ def test_install_writes_cron_and_env_then_uninstall_removes(monkeypatch, tmp_pat
     assert "*/30 * * * *" in cron.table
     assert "run --harness claude-code" in cron.table
     env_txt = (tmp_path / "cfg" / "env").read_text()
-    assert "export MEMCLAW_API_KEY='mc_k'" in env_txt
-    assert "export MEMCLAW_INTERVIEWER_PROJECTS='app-*'" in env_txt
+    assert "export CAURA_API_KEY='mc_k'" in env_txt
+    assert "export CAURA_INTERVIEWER_PROJECTS='app-*'" in env_txt
     assert stat.S_IMODE(os.stat(tmp_path / "cfg" / "env").st_mode) == 0o600
 
     # re-install (hourly) replaces, does not duplicate

--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -262,12 +262,12 @@ def _generate_install_script(
 set -euo pipefail
 
 # ── Shell-safe variable assignments ──
-MEMCLAW_API_URL={safe_api_url}
-MEMCLAW_API_KEY={safe_api_key}
-MEMCLAW_FLEET_ID={safe_fleet_id}
-MEMCLAW_TENANT_ID={safe_tenant_id}
-MEMCLAW_NODE_NAME={safe_node_name or '"$(hostname -s)"'}
-MEMCLAW_PLUGIN_VERSION={safe_version}
+CAURA_API_URL={safe_api_url}
+CAURA_API_KEY={safe_api_key}
+CAURA_FLEET_ID={safe_fleet_id}
+CAURA_TENANT_ID={safe_tenant_id}
+CAURA_NODE_NAME={safe_node_name or '"$(hostname -s)"'}
+CAURA_PLUGIN_VERSION={safe_version}
 
 echo "=== MemClaw Plugin Installer ==="
 echo ""
@@ -303,10 +303,10 @@ _version_compare() {{
 }}
 if [ -z "$INSTALLED_OPENCLAW_VERSION" ]; then
   echo "WARNING: openclaw CLI not found in PATH or returned no version."
-  echo "         Plugin v$MEMCLAW_PLUGIN_VERSION targets OpenClaw >= $MIN_OPENCLAW_VERSION."
+  echo "         Plugin v$CAURA_PLUGIN_VERSION targets OpenClaw >= $MIN_OPENCLAW_VERSION."
 elif [ "$(_version_compare "$INSTALLED_OPENCLAW_VERSION" "$MIN_OPENCLAW_VERSION")" = "lt" ]; then
   echo "WARNING: OpenClaw $INSTALLED_OPENCLAW_VERSION is older than the recommended"
-  echo "         minimum $MIN_OPENCLAW_VERSION for MemClaw plugin v$MEMCLAW_PLUGIN_VERSION."
+  echo "         minimum $MIN_OPENCLAW_VERSION for plugin v$CAURA_PLUGIN_VERSION."
   echo "         The recall-policy gate (assemble({{prompt}}) param) and"
   echo "         registerContextEngine slot landed in OpenClaw v$MIN_OPENCLAW_VERSION;"
   echo "         on older runtimes the plugin falls back to before_prompt_build but"
@@ -323,11 +323,11 @@ CONFIG_PATH="$HOME/.openclaw/openclaw.json"
 # When the on-prem uses self-signed TLS, the bootstrap fetches below
 # (plugin-source, tools.json, SKILL.md) hit certificate verification
 # errors before step 8 has a chance to install the trust anchor.
-# Switch to TOFU mode for the bootstrap curls when MEMCLAW_API_URL is
+# Switch to TOFU mode for the bootstrap curls when CAURA_API_URL is
 # HTTPS — same reasoning as `docker login` against a self-signed
 # registry. After install, NODE_EXTRA_CA_CERTS handles long-term
 # trust at runtime, so no -k anywhere outside this script.
-case "$MEMCLAW_API_URL" in
+case "$CAURA_API_URL" in
   https://*) CURL_INSECURE="-k" ;;
   *)         CURL_INSECURE="" ;;
 esac
@@ -341,7 +341,7 @@ echo "[2/7] Writing package.json..."
 cat > "$PLUGIN_DIR/package.json" << PACKAGE_EOF
 {{
   "name": "@caura/memclaw",
-  "version": "$MEMCLAW_PLUGIN_VERSION",
+  "version": "$CAURA_PLUGIN_VERSION",
   "description": "OpenClaw plugin for MemClaw central memory",
   "private": true,
   "type": "module",
@@ -387,16 +387,16 @@ TSCONFIG_EOF
 # ``keystones.ts`` 2026-05). Fall back to the hardcoded list with a warning
 # if ``python3`` isn't available (older minimal containers) or the
 # manifest endpoint is unreachable.
-echo "[4/7] Fetching plugin manifest from $MEMCLAW_API_URL..."
+echo "[4/7] Fetching plugin manifest from $CAURA_API_URL..."
 # Use ``/api/v1/plugin-manifest`` with X-API-Key rather than the
 # unversioned bootstrap alias: the enterprise nginx gateway only
 # allowlists a small set of unauthenticated bootstrap paths
 # (``/plugin-source``, ``/plugin-source-hash``, ``/install-plugin``), and
 # adding a new path there is an enterprise-repo change. The install
-# script always has ``MEMCLAW_API_KEY`` (required arg), so sending it
+# script always has ``CAURA_API_KEY`` (required arg), so sending it
 # satisfies the gateway's auth subrequest. OSS standalone (no gateway)
 # ignores the header and serves the same route — works in both.
-MANIFEST_JSON=$(curl $CURL_INSECURE -sf -H "X-API-Key: $MEMCLAW_API_KEY" "$MEMCLAW_API_URL/api/v1/plugin-manifest" || true)
+MANIFEST_JSON=$(curl $CURL_INSECURE -sf -H "X-API-Key: $CAURA_API_KEY" "$CAURA_API_URL/api/v1/plugin-manifest" || true)
 
 SRC_FILES=""
 ROOT_FILES=""
@@ -437,10 +437,10 @@ for _f in $SRC_FILES $ROOT_FILES; do
 done
 
 # 5. Fetch latest plugin source from MemClaw server
-echo "[5/7] Fetching latest plugin source from $MEMCLAW_API_URL..."
+echo "[5/7] Fetching latest plugin source from $CAURA_API_URL..."
 for srcfile in $SRC_FILES; do
-  curl $CURL_INSECURE -sf "$MEMCLAW_API_URL/api/plugin-source?file=$srcfile" > "$PLUGIN_DIR/src/$srcfile" || {{
-    echo "ERROR: Could not fetch $srcfile from $MEMCLAW_API_URL/api/plugin-source?file=$srcfile"
+  curl $CURL_INSECURE -sf "$CAURA_API_URL/api/plugin-source?file=$srcfile" > "$PLUGIN_DIR/src/$srcfile" || {{
+    echo "ERROR: Could not fetch $srcfile from $CAURA_API_URL/api/plugin-source?file=$srcfile"
     exit 1
   }}
 done
@@ -453,8 +453,8 @@ for rootfile in $ROOT_FILES; do
     echo "ERROR: Could not create directory $_parent_dir"
     exit 1
   }}
-  curl $CURL_INSECURE -sf "$MEMCLAW_API_URL/api/plugin-source?file=$rootfile" > "$PLUGIN_DIR/$rootfile" || {{
-    echo "ERROR: Could not fetch $rootfile from $MEMCLAW_API_URL/api/plugin-source?file=$rootfile"
+  curl $CURL_INSECURE -sf "$CAURA_API_URL/api/plugin-source?file=$rootfile" > "$PLUGIN_DIR/$rootfile" || {{
+    echo "ERROR: Could not fetch $rootfile from $CAURA_API_URL/api/plugin-source?file=$rootfile"
     exit 1
   }}
 done
@@ -463,16 +463,16 @@ echo "    Downloaded all plugin source files"
 # Generate version.ts (imported by index.ts)
 cat > "$PLUGIN_DIR/src/version.ts" << VERSION_EOF
 // Auto-generated by install script
-export const PLUGIN_VERSION = "$MEMCLAW_PLUGIN_VERSION";
+export const PLUGIN_VERSION = "$CAURA_PLUGIN_VERSION";
 VERSION_EOF
 
 # Write .env file (includes heartbeat config)
 cat > "$PLUGIN_DIR/.env" << ENV_EOF
-MEMCLAW_API_URL=$MEMCLAW_API_URL
-MEMCLAW_API_KEY=$MEMCLAW_API_KEY
-MEMCLAW_FLEET_ID=$MEMCLAW_FLEET_ID
-MEMCLAW_TENANT_ID=$MEMCLAW_TENANT_ID
-MEMCLAW_NODE_NAME=$MEMCLAW_NODE_NAME
+CAURA_API_URL=$CAURA_API_URL
+CAURA_API_KEY=$CAURA_API_KEY
+CAURA_FLEET_ID=$CAURA_FLEET_ID
+CAURA_TENANT_ID=$CAURA_TENANT_ID
+CAURA_NODE_NAME=$CAURA_NODE_NAME
 ENV_EOF
 chmod 600 "$PLUGIN_DIR/.env"
 
@@ -539,17 +539,17 @@ else
   echo "    WARNING: $CONFIG_PATH not found — you will need to configure allowlist manually"
 fi
 
-# 8. TLS trust bootstrap — only when MEMCLAW_API_URL is HTTPS.
+# 8. TLS trust bootstrap — only when CAURA_API_URL is HTTPS.
 # OSS / dev installs (http://localhost:8000) skip this entirely.
 # For an enterprise on-prem with a self-signed cert, the gateway exposes
 # the cert at /onprem-ca.pem; we curl it once with -k (TOFU — same trust
 # pattern as `docker login` to a self-signed registry), save it next to
 # the plugin, and write a systemd drop-in that exports
 # NODE_EXTRA_CA_CERTS so Node trusts it across openclaw-gateway restarts.
-case "$MEMCLAW_API_URL" in
+case "$CAURA_API_URL" in
   https://*)
-    echo "[8/8] Bootstrapping TLS trust for $MEMCLAW_API_URL"
-    if curl -ksSL "$MEMCLAW_API_URL/onprem-ca.pem" -o "$PLUGIN_DIR/onprem-ca.pem" \
+    echo "[8/8] Bootstrapping TLS trust for $CAURA_API_URL"
+    if curl -ksSL "$CAURA_API_URL/onprem-ca.pem" -o "$PLUGIN_DIR/onprem-ca.pem" \
         && [ -s "$PLUGIN_DIR/onprem-ca.pem" ] \
         && head -1 "$PLUGIN_DIR/onprem-ca.pem" | grep -q '^-----BEGIN CERTIFICATE-----$'; then
       chmod 0644 "$PLUGIN_DIR/onprem-ca.pem"
@@ -583,7 +583,7 @@ SDEOF
       echo "    Shell env → ~/.bashrc + ~/.zshrc (NODE_EXTRA_CA_CERTS for new shells)"
     else
       rm -f "$PLUGIN_DIR/onprem-ca.pem"
-      echo "    WARNING: could not fetch $MEMCLAW_API_URL/onprem-ca.pem."
+      echo "    WARNING: could not fetch $CAURA_API_URL/onprem-ca.pem."
       echo "    If your on-prem uses a publicly-trusted cert (Let's Encrypt or"
       echo "    a corporate CA already in the system trust store), this is fine."
       echo "    Otherwise plugin requests will fail TLS verification — either"
@@ -597,8 +597,8 @@ echo ""
 echo "=== Installation complete ==="
 echo ""
 echo "Plugin directory: $PLUGIN_DIR"
-echo "API URL:          $MEMCLAW_API_URL"
-echo "Fleet ID:         $MEMCLAW_FLEET_ID"
+echo "API URL:          $CAURA_API_URL"
+echo "Fleet ID:         $CAURA_FLEET_ID"
 echo "API Key:          {api_key_preview}"
 echo ""
 echo "Next: restart your OpenClaw gateway to activate the plugin."
@@ -719,12 +719,12 @@ def _generate_skill_install_script(
 
     # Only emit the ``-H X-API-Key: …`` flag when a key was supplied.
     # Otherwise the header becomes an empty string and curl rejects.
-    key_header = ' -H "X-API-Key: $MEMCLAW_API_KEY"' if api_key else ""
+    key_header = ' -H "X-API-Key: $CAURA_API_KEY"' if api_key else ""
     # ``skill`` is allowlisted by the caller, so interpolating it into the
     # path and URL is safe. For skill="memclaw" every line below is identical
     # to the original installer.
     label = _SKILL_LABELS[skill]
-    skill_url = f'"$MEMCLAW_API_URL/api/v1/skill/{skill}"'
+    skill_url = f'"$CAURA_API_URL/api/v1/skill/{skill}"'
     blocks = []
     if install_claude:
         blocks.append(
@@ -757,7 +757,7 @@ def _generate_skill_install_script(
             "# treat as sensitive; do not paste the rendered script into "
             "shared channels.\n"
         )
-        key_assign = f"MEMCLAW_API_KEY={safe_api_key}"
+        key_assign = f"CAURA_API_KEY={safe_api_key}"
     else:
         header_line = ""
         key_assign = ""
@@ -765,12 +765,12 @@ def _generate_skill_install_script(
     return f"""#!/usr/bin/env bash
 {header_line}set -euo pipefail
 
-MEMCLAW_API_URL={safe_api_url}
+CAURA_API_URL={safe_api_url}
 {key_assign}
 
 echo "=== {label} Skill Installer (direct-MCP) ==="
 echo ""
-echo "Fetching SKILL.md from $MEMCLAW_API_URL and installing to:"
+echo "Fetching SKILL.md from $CAURA_API_URL and installing to:"
 
 {install_blocks}
 
@@ -876,7 +876,7 @@ async def skill_by_name(skill: str):
 
 # Non-versioned aliases for the install bootstrap. The generated install
 # script (see ``_generate_install_script``) fetches plugin sources via
-# ``$MEMCLAW_API_URL/api/plugin-source`` (no ``v1`` segment) so the same
+# ``$CAURA_API_URL/api/plugin-source`` (no ``v1`` segment) so the same
 # script runs unchanged against both OSS and the enterprise gateway —
 # enterprise nginx whitelists ``/api/install-plugin`` and
 # ``/api/plugin-source`` as unauthenticated bootstrap paths and rewrites

--- a/scripts/wet-test-install.sh
+++ b/scripts/wet-test-install.sh
@@ -24,21 +24,21 @@ set -euo pipefail
 BRANCH="main"
 REPO="git@github.com:caura-ai/caura.git"
 PLUGIN_DIR="$HOME/.openclaw/plugins/memclaw"
-MEMCLAW_API_URL=""
-MEMCLAW_API_KEY=""
-MEMCLAW_FLEET_ID=""
-MEMCLAW_NODE_NAME=""
-MEMCLAW_TENANT_ID=""
+CAURA_API_URL=""
+CAURA_API_KEY=""
+CAURA_FLEET_ID=""
+CAURA_NODE_NAME=""
+CAURA_TENANT_ID=""
 SKIP_RESTART=""
 
 # ── Parse arguments ──
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --api-url)      MEMCLAW_API_URL="$2"; shift 2 ;;
-    --api-key)      MEMCLAW_API_KEY="$2"; shift 2 ;;
-    --fleet-id)     MEMCLAW_FLEET_ID="$2"; shift 2 ;;
-    --node-name)    MEMCLAW_NODE_NAME="$2"; shift 2 ;;
-    --tenant-id)    MEMCLAW_TENANT_ID="$2"; shift 2 ;;
+    --api-url)      CAURA_API_URL="$2"; shift 2 ;;
+    --api-key)      CAURA_API_KEY="$2"; shift 2 ;;
+    --fleet-id)     CAURA_FLEET_ID="$2"; shift 2 ;;
+    --node-name)    CAURA_NODE_NAME="$2"; shift 2 ;;
+    --tenant-id)    CAURA_TENANT_ID="$2"; shift 2 ;;
     --branch)       BRANCH="$2"; shift 2 ;;
     --repo)         REPO="$2"; shift 2 ;;
     --plugin-dir)   PLUGIN_DIR="$2"; shift 2 ;;
@@ -51,13 +51,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ── Validate required args ──
-if [[ -z "$MEMCLAW_API_URL" || -z "$MEMCLAW_API_KEY" ]]; then
+if [[ -z "$CAURA_API_URL" || -z "$CAURA_API_KEY" ]]; then
   echo "ERROR: --api-url and --api-key are required"
   exit 1
 fi
-if [[ -z "$MEMCLAW_NODE_NAME" ]]; then
-  MEMCLAW_NODE_NAME="$(hostname)"
-  echo "INFO: --node-name not set, using hostname: $MEMCLAW_NODE_NAME"
+if [[ -z "$CAURA_NODE_NAME" ]]; then
+  CAURA_NODE_NAME="$(hostname)"
+  echo "INFO: --node-name not set, using hostname: $CAURA_NODE_NAME"
 fi
 
 echo ""
@@ -66,9 +66,9 @@ echo "║  MemClaw Wet-Test Installer                     ║"
 echo "╚══════════════════════════════════════════════════╝"
 echo ""
 echo "  Branch:    $BRANCH"
-echo "  API URL:   $MEMCLAW_API_URL"
-echo "  Fleet ID:  ${MEMCLAW_FLEET_ID:-"(not set)"}"
-echo "  Node:      $MEMCLAW_NODE_NAME"
+echo "  API URL:   $CAURA_API_URL"
+echo "  Fleet ID:  ${CAURA_FLEET_ID:-"(not set)"}"
+echo "  Node:      $CAURA_NODE_NAME"
 echo "  Plugin:    $PLUGIN_DIR"
 echo ""
 
@@ -129,13 +129,13 @@ fi
 cat > "$ENV_FILE" << ENVEOF
 # MemClaw wet-test config — generated $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Branch: $BRANCH
-MEMCLAW_API_URL=$MEMCLAW_API_URL
-MEMCLAW_API_KEY=$MEMCLAW_API_KEY
-MEMCLAW_FLEET_ID=$MEMCLAW_FLEET_ID
-MEMCLAW_NODE_NAME=$MEMCLAW_NODE_NAME
-MEMCLAW_TENANT_ID=$MEMCLAW_TENANT_ID
-MEMCLAW_AUTO_WRITE_TURNS=true
-MEMCLAW_AUTO_FIX_CONFIG=true
+CAURA_API_URL=$CAURA_API_URL
+CAURA_API_KEY=$CAURA_API_KEY
+CAURA_FLEET_ID=$CAURA_FLEET_ID
+CAURA_NODE_NAME=$CAURA_NODE_NAME
+CAURA_TENANT_ID=$CAURA_TENANT_ID
+CAURA_AUTO_WRITE_TURNS=true
+CAURA_AUTO_FIX_CONFIG=true
 ENVEOF
 
 echo "    .env written"

--- a/tests/test_api_plugin.py
+++ b/tests/test_api_plugin.py
@@ -26,13 +26,13 @@ async def test_post_install_plugin_generates_script(client):
     assert resp.status_code == 200
     script = resp.text
     assert script.startswith("#!/usr/bin/env bash")
-    assert "MEMCLAW_API_URL=" in script
+    assert "CAURA_API_URL=" in script
     assert "memclaw.example.com" in script
-    assert "MEMCLAW_FLEET_ID=" in script
+    assert "CAURA_FLEET_ID=" in script
     assert "my-fleet" in script
-    assert "MEMCLAW_API_KEY=" in script
+    assert "CAURA_API_KEY=" in script
     assert "sk-test-key-1234" in script
-    assert "MEMCLAW_NODE_NAME=" in script
+    assert "CAURA_NODE_NAME=" in script
     assert "node-alpha" in script
 
 
@@ -112,8 +112,8 @@ async def test_script_contains_correct_env_vars(client):
     assert resp.status_code == 200
     script = resp.text
     # Check .env block contains all five vars
-    for var in ("MEMCLAW_API_URL", "MEMCLAW_API_KEY", "MEMCLAW_FLEET_ID",
-                "MEMCLAW_TENANT_ID", "MEMCLAW_NODE_NAME"):
+    for var in ("CAURA_API_URL", "CAURA_API_KEY", "CAURA_FLEET_ID",
+                "CAURA_TENANT_ID", "CAURA_NODE_NAME"):
         assert var in script, f"Missing {var} in script"
 
 
@@ -139,7 +139,7 @@ async def test_shell_injection_api_url(client):
     # should NOT appear unquoted
     assert "rm -rf" not in script or "'" in script
     # The raw semicolon should be inside a quoted string, not bare
-    assert "MEMCLAW_API_URL=" in script
+    assert "CAURA_API_URL=" in script
 
 
 async def test_shell_injection_fleet_id(client):
@@ -156,9 +156,9 @@ async def test_shell_injection_fleet_id(client):
     assert resp.status_code == 200
     script = resp.text
     # shlex.quote should wrap it — the $() should not be bare
-    assert "MEMCLAW_FLEET_ID=" in script
+    assert "CAURA_FLEET_ID=" in script
     # Ensure the command substitution is neutralised (inside single quotes)
-    line = [l for l in script.splitlines() if "MEMCLAW_FLEET_ID=" in l][0]
+    line = [l for l in script.splitlines() if "CAURA_FLEET_ID=" in l][0]
     # shlex.quote produces: '$(cat /etc/passwd)' (with outer single quotes)
     assert line.count("'") >= 2, "Fleet ID should be single-quoted"
 
@@ -213,7 +213,7 @@ async def test_legacy_install_plugin_alias(client):
     )
     assert resp.status_code == 200
     assert resp.text.startswith("#!/usr/bin/env bash")
-    assert "MEMCLAW_FLEET_ID=alias-fleet" in resp.text
+    assert "CAURA_FLEET_ID=alias-fleet" in resp.text
 
 
 async def test_install_script_uses_non_versioned_paths(client):

--- a/tests/test_env_write_new_names.py
+++ b/tests/test_env_write_new_names.py
@@ -1,0 +1,57 @@
+"""Phase 5.2: the generated installer writes the new env names, and only those.
+
+New installs get ``CAURA_*`` alone. That is safe because every reader accepts
+both spellings (5.1), so nothing we ship needs the old name in a file we are
+creating from scratch — and rule 7 says not to mint one.
+
+Existing installs are untouched: their ``.env`` keeps the old names and keeps
+working. This file pins the *new-file* contract, not a migration.
+"""
+
+import re
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+# The connection identity the installer persists. Suffixes only — each is
+# checked under both prefixes below.
+CONNECTION_KEYS = ("API_URL", "API_KEY", "FLEET_ID", "TENANT_ID", "NODE_NAME")
+
+
+def _env_block(script: str) -> str:
+    """The body of the ``.env`` heredoc the install script writes.
+
+    Scoped deliberately: the script still carries the old brand elsewhere — in
+    the plugin's on-disk install path, which is floor-class, and in product
+    prose — so a whole-script search would fail for reasons that have nothing
+    to do with the env contract.
+    """
+    match = re.search(r"cat > \"\$PLUGIN_DIR/\.env\" << ENV_EOF\n(.*?)\nENV_EOF", script, re.S)
+    assert match, "could not locate the .env heredoc in the generated install script"
+    return match.group(1)
+
+
+async def _script(client) -> str:
+    resp = await client.post(
+        "/api/v1/install-plugin",
+        json={"fleet_id": "f1", "api_key": "mc_testkey123456", "tenant_id": "t1"},
+    )
+    assert resp.status_code == 200
+    return resp.text
+
+
+async def test_env_block_writes_every_connection_key_under_the_new_name(client):
+    block = _env_block(await _script(client))
+    for suffix in CONNECTION_KEYS:
+        assert f"CAURA_{suffix}=" in block, f"CAURA_{suffix} must be written to a new .env"
+
+
+async def test_env_block_writes_no_old_names(client):
+    block = _env_block(await _script(client))
+    for suffix in CONNECTION_KEYS:
+        old = f"MEMCLAW_{suffix}="  # legacy-name-ok: rule 3 — asserts a NEW file does not mint it
+        assert old not in block, (
+            f"{old} must not appear in a newly written .env — readers accept both "
+            "spellings, so writing the old one only mints a name to carry forever"
+        )

--- a/tests/test_install_skill_endpoint.py
+++ b/tests/test_install_skill_endpoint.py
@@ -2,13 +2,13 @@
 
 Covers two fixes that landed together:
 
-1. Auto-derive ``MEMCLAW_API_URL`` from the request Host (and
+1. Auto-derive ``CAURA_API_URL`` from the request Host (and
    ``X-Forwarded-Proto`` when proxied) so ``curl
-   https://memclaw.dev/api/v1/install-skill | bash`` yields a script that
-   keeps fetching from memclaw.dev — not from ``http://localhost:8000``
+   https://caura.ai/api/v1/install-skill | bash`` yields a script that
+   keeps fetching from caura.ai — not from ``http://localhost:8000``
    which was the old default.
 2. Forward the caller's ``X-API-Key`` into the generated script so its
-   internal curls carry auth. Required on edge-gated deploys (memclaw.dev
+   internal curls carry auth. Required on edge-gated deploys (caura.ai
    nginx rejects unauthenticated calls on every path).
 """
 
@@ -36,7 +36,7 @@ def test_api_url_auto_derived_from_request_host():
     # TestClient default Host is ``testserver``; scheme is http.
     resp = client.get("/api/v1/install-skill?agent=claude-code")
     assert resp.status_code == 200
-    assert "MEMCLAW_API_URL=http://testserver" in resp.text
+    assert "CAURA_API_URL=http://testserver" in resp.text
     assert "http://localhost:8000" not in resp.text
 
 
@@ -45,30 +45,30 @@ def test_api_url_override_via_query_param():
     client = _client()
     resp = client.get("/api/v1/install-skill?api_url=https://explicit.example.com")
     assert resp.status_code == 200
-    assert "MEMCLAW_API_URL=https://explicit.example.com" in resp.text
+    assert "CAURA_API_URL=https://explicit.example.com" in resp.text
 
 
 def test_x_forwarded_proto_and_host_preferred_over_raw():
     """Behind a proxy, ``X-Forwarded-Proto`` / ``X-Forwarded-Host`` should
     be treated as authoritative — otherwise a user's script generated
-    against ``https://memclaw.dev`` would read as ``http://internal-ip``."""
+    against ``https://caura.ai`` would read as ``http://internal-ip``."""
     client = _client()
     resp = client.get(
         "/api/v1/install-skill?agent=both",
         headers={
             "X-Forwarded-Proto": "https",
-            "X-Forwarded-Host": "memclaw.dev",
+            "X-Forwarded-Host": "caura.ai",
         },
     )
     assert resp.status_code == 200
-    assert "MEMCLAW_API_URL=https://memclaw.dev" in resp.text
+    assert "CAURA_API_URL=https://caura.ai" in resp.text
     # The raw ``Host: testserver`` header must not leak through.
     assert "testserver" not in resp.text
 
 
 def test_api_key_header_forwarded_into_script():
     """Caller's ``X-API-Key`` is baked into the script, and the internal
-    curl calls carry ``-H "X-API-Key: $MEMCLAW_API_KEY"``."""
+    curl calls carry ``-H "X-API-Key: $CAURA_API_KEY"``."""
     client = _client()
     resp = client.get(
         "/api/v1/install-skill?agent=claude-code",
@@ -78,8 +78,8 @@ def test_api_key_header_forwarded_into_script():
     script = resp.text
     # ``shlex.quote`` only wraps when the value has special chars. An
     # ``mc_``-style key is shell-safe and emitted unquoted, which is fine.
-    assert "MEMCLAW_API_KEY=mc_test_key_abc123" in script
-    assert '-H "X-API-Key: $MEMCLAW_API_KEY"' in script
+    assert "CAURA_API_KEY=mc_test_key_abc123" in script
+    assert '-H "X-API-Key: $CAURA_API_KEY"' in script
 
 
 def test_no_api_key_header_means_no_key_in_script():
@@ -89,7 +89,7 @@ def test_no_api_key_header_means_no_key_in_script():
     resp = client.get("/api/v1/install-skill?agent=claude-code")
     assert resp.status_code == 200
     script = resp.text
-    assert "MEMCLAW_API_KEY=" not in script
+    assert "CAURA_API_KEY=" not in script
     assert "X-API-Key" not in script
 
 

--- a/tests/test_plugin_source_manifest.py
+++ b/tests/test_plugin_source_manifest.py
@@ -262,7 +262,7 @@ def test_plugin_manifest_version_matches_package_json():
     The two are read by different downstream surfaces:
       - ``package.json:version`` is what ``_plugin_version()`` (in
         ``core_api/routes/plugin.py``) returns; the heartbeat auto-upgrade
-        trigger and the install script's stamped ``MEMCLAW_PLUGIN_VERSION``
+        trigger and the install script's stamped ``CAURA_PLUGIN_VERSION``
         derive from this side.
       - ``openclaw.plugin.json:version`` is what OpenClaw reads when
         loading the plugin and what any plugin-info UI renders to operators.

--- a/tests/test_security_tenant_isolation.py
+++ b/tests/test_security_tenant_isolation.py
@@ -268,7 +268,7 @@ async def test_install_script_escapes_malicious_api_url(client):
     assert resp.status_code == 200
     script = resp.text
     # The malicious URL must be single-quoted by shlex.quote() — not bare
-    assert "MEMCLAW_API_URL='https://evil.com; rm -rf /'" in script
+    assert "CAURA_API_URL='https://evil.com; rm -rf /'" in script
     # Bare (unquoted) interpolation into curl must NOT appear
     assert 'curl -sf "https://evil.com; rm -rf /' not in script
     assert 'curl $CURL_INSECURE -sf "https://evil.com; rm -rf /' not in script
@@ -277,7 +277,7 @@ async def test_install_script_escapes_malicious_api_url(client):
     # TOFU (CAURA-000 install-plugin), so the var sits between ``curl``
     # and ``-sf`` — match the safe-variable usage rather than the exact
     # arg ordering.
-    assert '"$MEMCLAW_API_URL/api/plugin-source' in script
+    assert '"$CAURA_API_URL/api/plugin-source' in script
 
 
 @pytest.mark.integration
@@ -294,7 +294,7 @@ async def test_install_script_escapes_malicious_node_name(client):
     assert resp.status_code == 200
     script = resp.text
     # The raw $(whoami) should NOT appear unquoted
-    assert "MEMCLAW_NODE_NAME=$(whoami)" not in script
+    assert "CAURA_NODE_NAME=$(whoami)" not in script
     # It should be single-quoted
     assert "'$(whoami)'" in script
 


### PR DESCRIPTION
Phase 5.2 — the writer half of the env rename, and the follow-up to #886.

The server-generated installer and the interviewer installer now write the new
names into a **new** customer's `.env` file and crontab. **New names only, not
both:** every reader accepts either spelling since #886, so nothing we ship
needs the old name in a file we are creating from scratch, and rule 7 says not
to mint one.

**Existing installs are untouched.** Their `.env` keeps the old names and keeps
working. This changes what a *new* file contains — it is not a migration, and
nothing rewrites a file already on disk.

### Why this can land beside 5.1 rather than after a release

The work order's precondition is "5.1 deployed", which I initially read as
needing a published artifact first. It doesn't, and the reason is worth stating
because it is the thing that makes this PR safe:

| writer | its reader | ships as |
|---|---|---|
| `routes/plugin.py` | `plugin/src/env.ts` | one core-api deploy — the plugin is `"private": true`, never published to npm; the installer curls source from `/api/plugin-source`, which reads core-api's own filesystem |
| `interviewer/installer.py` | `interviewer/cli.py` | one `caura-client` wheel |

At both sites the reader ships in the **same unit** as the writer, so there is
no window where a new-name file meets an old-name reader. Ordering inside the
generated script confirms it: source is fetched at 441-460, the `.env` written
at 470-477, the build runs at 483 — one run.

The one residual, for completeness: the `deploy` command can push env vars to
an install still running older source, where a `CAURA_*` key hits the older
filter and is dropped. That is a silent no-op — existing values persist — and
it self-heals on the next source fetch. #886 already replaced that filter with
`hasPluginEnvPrefix`, which accepts both.

### The security tests needed care, not a rename

Two of them are **negative** assertions:

```python
assert "MEMCLAW_NODE_NAME=$(whoami)" not in script   # injection guard
assert "MEMCLAW_API_KEY=" not in script              # no key when none supplied
```

After renaming the shell variables these would pass **because the old name no
longer appears anywhere in the script**, proving nothing. A rename that quietly
turns an injection test into a tautology is worse than the rename. Both now
name the new variable, and I re-checked the node-name one by removing
`shlex.quote` from the generator and confirming it still fails on a real
injection regression.

`test_api_plugin.py:161` was a related trap — not an assert but a list
comprehension indexed `[0]`, so a missed rename would have surfaced as an
IndexError rather than a clean failure.

### Left alone deliberately

These look renameable and are not — each strands or orphans live installs:

- the plugin's on-disk path `~/.openclaw/plugins/memclaw` *(sentinel-pinned)*
- the interviewer's config dir `~/.config/memclaw-interviewer` *(sentinel-pinned)*
- `CRON_MARKER` — `merge_crontab` matches this literal, so changing it means
  `uninstall` can no longer find an installed entry and a re-install
  **duplicates** rather than replaces. Equally floor-class and **not currently
  sentinel-pinned** — worth adding.
- the shipped console-script name `memclaw-interviewer` *(pinned via
  `pyproject.toml`)*, the `~/.bashrc` CA marker, and the systemd drop-in
  filename

### Scope

`_ENV_KEYS` in `installer.py` is an **allowlist** filtered against the dict
`cli.py` builds, so those two had to flip in the same commit — a mismatch
produces an env file with no exports at all and a cron job that fails auth with
no clue why.

`scripts/wet-test-install.sh` writes to the same customer path, so it moves too
rather than being left to disagree with the real installer.

Two fixture hostnames (`memclaw.dev`, `memclaw.corp.internal`) and one prose
string were cleaned rather than exempted — they are arbitrary test data and
product naming, so marking them as "compat aliases" would have been a false
reason on a gate whose value depends on its reasons being true.

### Deferred to 5.4, unchanged

Operator-facing guidance that still names only the old spelling: `cli.py`
docstring and `--help`, the `agent_identity.py` error message that says "set
MEMCLAW_AGENT_ID", `012_vector_dim_1024.py`'s pre-flight text, `.env.example`,
`README.md`. All are incomplete rather than incorrect — the old name still
works everywhere it is named.

### Verification

- 106 core-api / 139 client / 101 gate-self-tests pass; `ruff check` +
  `format --check` clean at CI's scopes; `bash -n` on the harness
- the new "only new names" test confirmed failing when a belt-and-braces old
  name is planted in the `.env` heredoc
- the injection test confirmed failing when `shlex.quote` is removed
- Ratchet **-115 net, no new lines**; sentinel all 22 strings survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)