### PR TITLE
ci(sentinel): pin the interviewer's cron marker

### DIFF
--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -202,6 +202,30 @@ SENTINELS: tuple[Sentinel, ...] = (
         kind=LITERAL,
         breaks="the interviewer stops finding config customers already have on disk",
     ),
+    # The whole assignment, not the marker value alone — and this one is a
+    # judgement call the comment-only guard below CANNOT make for us.
+    #
+    # That guard asks whether the pinned text appears on a line that starts with
+    # a comment character. This value *is* comment-shaped (it starts with ``#``),
+    # but the line defining it starts with ``CRON_MARKER``, so the guard sees
+    # nothing and every candidate form passes it. Pinning the bare value would
+    # therefore be accepted while being satisfiable by anyone who later writes a
+    # single line of commentary quoting the marker — and commentary quoting it is
+    # likelier here than usual, precisely because it reads as a comment already.
+    #
+    # Anchoring to the assignment also fails if the value survives only in prose
+    # after the constant is deleted. It costs a false red on a rename that keeps
+    # the value, which is behaviour-preserving; that trade is deliberate, because
+    # a false red is loud and a gate that quietly stopped protecting is not.
+    Sentinel(
+        path="clients/python/src/caura_client/interviewer/installer.py",
+        text='CRON_MARKER = "# memclaw-interviewer (managed)"',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks=(
+            "uninstall stops finding crontab entries customers already have, "
+            "and re-install duplicates them instead of replacing"
+        ),
+    ),
     Sentinel(
         path=".github/workflows/publish-python-client.yml",
         text="memclaw-client-v*",  # legacy-name-ok: pinned floor string


### PR DESCRIPTION
`CRON_MARKER` is floor-class in the same way as the two strings already pinned
in that package, and it was the only one of the three left unprotected.

`clients/python/src/caura_client/interviewer/installer.py:33` defines it, `:116`
writes it into the cron line, `:125` filters the user's crontab on it to find
the managed entry. Change it and:

- `uninstall` can no longer find an entry that is already installed — it is
  orphaned in the user's crontab permanently
- a re-install **duplicates** the entry rather than replacing it

Neither failure raises. The install reports success either way, which is what
puts this on the list rather than in a test.

### The pin form is a judgement the guard cannot make

Pinned as the whole assignment, `CRON_MARKER = "# memclaw-interviewer (managed)"`.

I expected `test_no_literal_can_be_satisfied_by_a_comment_alone` to reject the
bare value and tell me the answer. **It doesn't, and that's worth recording.**
The guard asks whether the pinned text appears on a line whose stripped form
starts with a comment character. This value *is* comment-shaped — it starts with
`#` — but the line defining it starts with `CRON_MARKER`, so the guard sees
nothing. Measured, all three candidates pass it:

| form | occurrences | guard rejects |
|---|---|---|
| bare value | 1 | no |
| quoted value | 1 | no |
| whole assignment | 1 | no |

So the bare form would have been *accepted* while remaining satisfiable by one
later line of commentary quoting the marker — likelier here than usual,
precisely because the text already reads as a comment. The guard detects
comment-reachability **in the current tree**, not pins that one new line could
make reachable. Stating that as a known blind spot is more useful than assuming
an automated check covers it.

### Verified in both directions

Not just that it passes:

1. **marker value changed** (a rename sweep — the real risk) → fails, with the
   `breaks=` reason attached
2. **constant deleted, value left in a docstring** → fails

(2) is the case the quoted-value-only form would have **passed**, which is what
decided the form.

### The tradeoff, stated

Anchoring to the assignment costs a false red if someone renames the constant
while keeping the value, which is behaviour-preserving. That's deliberate: a
false red is loud and cheap, and a gate that quietly stopped protecting is
neither.

Found while shipping #895 (Phase 5.2), which deliberately left this marker alone
for exactly this reason. Rebased onto #893, which touched the same file.

### One process note, since it now has three instances

`origin/main` moved under me twice while landing 5.1 and 5.2, and because a diff
is taken against the *current* tip, another session's **additions render as my
deletions**. The second instance looked like I had gutted 24 lines from
`tests/test_do_not_touch_sentinel.py`, including `test_main_turns_an_unreadable_file_into_exit_two`.
A rebase clears it every time, but with five sessions landing into one repo,
"this diff shows me deleting someone else's gate" has become a routine artifact
rather than an alarm — and a reviewer skimming could plausibly approve the
reverse. Worth a `git fetch && git diff origin/main -- scripts/ .github/` before
trusting a local green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)