### PR TITLE
fix(ratchet): the exemption report lists only the lines the change wrote

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -138,7 +138,12 @@ def _git(args: list[str]) -> str:
     # counts occurrences of an ASCII name, so a mangled character elsewhere on
     # the line changes nothing about the match.
     proc = subprocess.run(
-        args, capture_output=True, text=True, check=False, encoding="utf-8", errors="replace"
+        args,
+        capture_output=True,
+        text=True,
+        check=False,
+        encoding="utf-8",
+        errors="replace",
     )
     if proc.returncode == 0:
         return proc.stdout
@@ -411,8 +416,10 @@ def _report_excused_moves(
     print()
 
 
-def _report_new_exemptions(before: Counter[str], after: Counter[str]) -> None:
-    """Name every line this change newly exempted, whether or not it fails.
+def _report_new_exemptions(
+    before: Counter[str], after: Counter[str], base: str
+) -> None:
+    """Name every exempt line this change wrote, whether or not it fails.
 
     The one thing a count-based ratchet cannot decide for itself, and the reason
     this report exists. Marking an existing line exempt lowers a file's
@@ -432,18 +439,21 @@ def _report_new_exemptions(before: Counter[str], after: Counter[str]) -> None:
     It is still printed, on the passing path as well. An exemption is the move
     that buys headroom, and a deliberate one — an alias landing in the same PR as
     unrelated work — should never be made quietly even when it is legitimate.
+
+    Which is why the list is filtered to the lines this change actually wrote,
+    rather than every exempt line the file happens to hold. A file's exempt count
+    is what selects it; the diff is what selects the lines. Re-greping and
+    printing all of them puts a file's whole accumulated pile under a header
+    counting one, sends the reader to lines that are not in the diff, and reads
+    as self-contradictory — which invites distrusting the total rather than the
+    list. Phase 5's dual-read wave is exactly the change that builds those piles,
+    so every later PR touching those files would reprint them. A reader who
+    learns the list is mostly noise stops reading it, and that is the failure
+    this report exists to prevent.
     """
     added = {p: n - before.get(p, 0) for p, n in after.items() if n > before.get(p, 0)}
     if not added:
         return
-
-    total = sum(added.values())
-    print(
-        f"{total} line(s) newly exempted in {len(added)} file(s) — check each one is a"
-    )
-    print(
-        "compat alias, a redirect or a pinned wire format, and not headroom for a new name:"
-    )
 
     # Grouped by reason, because the wall is the failure mode. A dual-read wave
     # exempts dozens of lines carrying one identical reason, and at that length
@@ -452,16 +462,57 @@ def _report_new_exemptions(before: Counter[str], after: Counter[str]) -> None:
     # not match its neighbours. Collapsing the repeats is what makes the odd one
     # visible instead of burying it on line forty.
     by_reason: dict[str, list[tuple[str, str, str]]] = {}
+    shown_total = 0
+    unfiltered: list[str] = []
     for path in sorted(added):
-        for _, lineno, text, exempt in _grep(None, pathspec=_literal(path)):
-            if not exempt:
-                continue
-            stripped = text.strip()
+        here = [
+            (lineno, text.strip())
+            for _, lineno, text, exempt in _grep(None, pathspec=_literal(path))
+            if exempt
+        ]
+        # The same pair the offender report below uses, for the same reason: the
+        # text-or-count comparison decides WHICH FILE to talk about, and git's own
+        # diff decides which of its lines the change is responsible for. An
+        # existing line that gains a marker is a rewrite, so git calls it added
+        # and it stays in — which matters, because that is the headroom move.
+        touched = _added_lines(base, path)
+        picked = [(n, t) for n, t in here if int(n) in touched]
+        if not picked:
+            # Falling back to every exempt line in the file rather than to
+            # silence, on the same trade as below: too many lines is a nuisance
+            # and none is a dead end. Named out loud, though, because unlike
+            # below this report puts a number on its own list.
+            #
+            # Reported as what was observed, not as a cause. An unreadable diff
+            # is the likely one — ``_added_lines`` returns empty on any git
+            # failure — but a diff that read fine and simply did not intersect
+            # this file's exempt lines lands here identically, and nothing at
+            # this point can tell the two apart. Naming the cause would be a
+            # guess printed as a finding, which is the habit this whole report
+            # exists to discourage.
+            picked = here
+            unfiltered.append(path)
+        shown_total += len(picked)
+        for lineno, stripped in picked:
             match = EXEMPT_RE.search(stripped)
             tail = stripped[match.end() :].lstrip(": ") if match else ""
             by_reason.setdefault(tail.strip() or "(no reason given)", []).append(
                 (path, lineno, stripped)
             )
+
+    print(
+        f"{shown_total} exempt line(s) written by this change in {len(added)} file(s) —"
+    )
+    print("check each is a compat alias, a redirect or a pinned wire format, and not")
+    print("headroom for a new name:")
+    if unfiltered:
+        named = ", ".join(unfiltered[:4]) + (
+            f" (+{len(unfiltered) - 4} more)" if len(unfiltered) > 4 else ""
+        )
+        print(
+            f"  (no diff line matched in {len(unfiltered)} file(s): {named} — every "
+            "exempt line they hold is listed, so some may predate this change)"
+        )
 
     for reason, lines in sorted(by_reason.items(), key=lambda kv: (-len(kv[1]), kv[0])):
         if len(lines) <= _EXEMPTION_GROUP_AT:
@@ -521,7 +572,7 @@ def main() -> int:
         )
         return 1
 
-    _report_new_exemptions(base_scan.exempt, head_scan.exempt)
+    _report_new_exemptions(base_scan.exempt, head_scan.exempt, args.base)
 
     head_by_file, base_by_file = head_scan.by_file, base_scan.by_file
     budget = _mint_budget(head_scan.total, base_scan.total)

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -476,9 +476,80 @@ def test_a_newly_exempted_line_is_always_named(repo: Path) -> None:
     result = _run(repo)
 
     assert result.returncode == 0
-    assert "1 line(s) newly exempted" in result.stdout
+    assert "1 exempt line(s) written by this change" in result.stdout
     assert "existing.py:1" in result.stdout
     assert "gateway mirror" in result.stdout
+
+
+def _with_two_aliases_already(repo: Path) -> str:
+    """Commit a file that already carries two exemptions, and return its body.
+
+    The realistic starting point for this report, and the one the grouping tests
+    do not cover: they build files from nothing, where every line is new and no
+    filter can be wrong.
+    """
+    body = (
+        f'A = "{LEGACY}-one"  # legacy-name-ok: pre-existing alias one\n'
+        f'B = "{LEGACY}-two"  # legacy-name-ok: pre-existing alias two\n'
+    )
+    (repo / "aliases.py").write_text(body)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "two aliases already here")
+    return body
+
+
+def test_only_the_exemptions_this_change_wrote_are_listed(repo: Path) -> None:
+    """The file's exempt count selects the FILE; git's diff selects the LINES.
+
+    Re-greping the file and printing everything it holds puts its whole
+    accumulated pile under a header counting one — three lines under a "1", two
+    of them not in the diff. Phase 5's dual-read wave is precisely what builds
+    those piles, so this is the case that would have degraded fastest: every
+    later PR touching such a file reprints the lot, and a reader who learns the
+    list is mostly noise stops reading it.
+    """
+    body = _with_two_aliases_already(repo)
+    _stage(
+        repo,
+        "aliases.py",
+        body + f'C = "{LEGACY}-three"  # legacy-name-ok: brand new alias three\n',
+    )
+
+    out = _run(repo).stdout
+
+    # The claim, asserted before the header wording so a later rephrasing of the
+    # message cannot be what this test is seen to be about.
+    assert "pre-existing alias one" not in out
+    assert "pre-existing alias two" not in out
+    assert "brand new alias three" in out
+    assert "1 exempt line(s) written by this change in 1 file(s)" in out
+
+
+def test_an_edited_exemption_is_listed_though_it_is_not_newly_exempt(
+    repo: Path,
+) -> None:
+    """Why the header counts lines written rather than the rise in the tally.
+
+    Rewriting an existing exemption's reason does not newly exempt anything, but
+    it is exactly how a true reason becomes a false one — so the line has to be
+    read. Git calls a rewritten line an addition, which is what puts it in scope,
+    and the header counts what is printed so the two can never disagree.
+    """
+    body = _with_two_aliases_already(repo)
+    _stage(
+        repo,
+        "aliases.py",
+        body.replace("pre-existing alias two", "actually a pinned wire format")
+        + f'C = "{LEGACY}-three"  # legacy-name-ok: brand new alias three\n',
+    )
+
+    out = _run(repo).stdout
+
+    # Exempt tally rose by one; two lines were written, and both are shown.
+    assert "2 exempt line(s) written by this change in 1 file(s)" in out
+    assert "actually a pinned wire format" in out
+    assert "brand new alias three" in out
+    assert "pre-existing alias one" not in out
 
 
 def test_many_exemptions_sharing_a_reason_are_grouped(repo: Path) -> None:
@@ -548,7 +619,7 @@ def test_the_exempt_and_add_swap_is_caught(repo: Path) -> None:
     result = _run(repo)
 
     assert result.returncode == 1
-    assert "newly exempted" in result.stdout
+    assert "exempt line(s) written by this change" in result.stdout
     assert "gateway mirror" in result.stdout
     offenders = result.stdout.split("adds the legacy name in", 1)[1]
     assert "SNUCK" in offenders


### PR DESCRIPTION
Closes #894.

`_report_new_exemptions` computed its per-file delta correctly, then re-greped
each file and printed EVERY exempt line it currently holds. In a file that
already had exemptions, the old ones were listed as if this change had added
them -- header says 1, list shows 3.

Not a gate bug: pass/fail was unaffected. It degraded the one report that
guards the ratchet's known hole.

## The fix is the pair the offender report already uses

The file's exempt count decides WHICH FILE to talk about; git's own diff decides
which of its lines the change is responsible for. That split already exists
twenty lines below, for the same reason, with the same fallback -- the offender
report filters `_grep` candidates through `_added_lines`. This makes the two
consistent rather than inventing a mechanism.

Picking git's diff over the per-`(path, text)` tally the issue sketched, because
the diff answers the harder case for free: two exempt lines with identical text,
one old and one new, are indistinguishable by text and trivially distinguished
by line number. It also keeps `Scan` unchanged.

An existing line that GAINS a marker is a rewrite, so git calls it an addition
and it stays in scope -- which matters, because that is precisely the headroom
move this report exists to expose.

## The header now counts what it prints

Renamed from "N line(s) newly exempted" to "N exempt line(s) written by this
change", because those are different quantities and the second is the one on
screen. Editing an existing exemption's REASON does not newly exempt anything,
but it is exactly how a true reason becomes a false one, so the line has to be
read. Counting the tally rise would have reintroduced a smaller version of the
same contradiction.

## One hunk in here is not mine, and is worth keeping

`ruff format` rewrapped the `subprocess.run(...)` arguments in `_git`. That line
was already unformatted on `main` -- **CI never format-checks `scripts/`**, only
`core-api/src`, `core-storage-api`, `core-operations`, `core-worker` and three
named files under `common/`. So the canonical copy of this gate had drifted from
the project's own formatter without anything noticing.

Keeping the rewrap rather than reverting it, because it removes a real tax:
caura-enterprise's copy is *already* formatted this way, so that one hunk is the
entire difference between the two files today, and every re-vendor has to
reformat around it. After this and the three port PRs land, all four copies are
byte-identical for the first time -- which is the property the whole
copy-don't-adapt model rests on.

## Verified

- the issue's reproduction, run against both versions: 3 lines before, 1 after
- 42 tests pass; **the two new tests fail against the unfixed script**, and the
  first assertion to trip is the substantive one (a pre-existing reason absent
  from the output), not the header wording
- two existing tests updated for the new header string -- assertion substance
  unchanged, only the literal
- `ruff check` and `ruff format --check` clean

## Not fixed here, and worth its own issue

Filed as #900: the report only fires for files whose exempt count ROSE, so a
change that removes one exemption and adds another in the same file is net zero
and the new one is never printed. The gate still catches the dangerous version
-- removing a marker raises the non-exempt count and `_minted` charges it -- but
the report is silent where it should not be. Opposite direction, and it changes
which files get scanned rather than which lines get printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: eldad-caura <eldad@caura.ai>## Review round 2: the fallback note no longer names a cause

It said `(a diff could not be read — ...)`. `_added_lines` returning empty is
the likely reason, but a diff that read fine and simply did not intersect the
file's exempt lines lands in the same branch, and nothing at that point can tell
them apart. Now reports the observation and names the files:
`(no diff line matched in N file(s): ... — every exempt line they hold is
listed, so some may predate this change)`.

I tested the rename case the review hypothesised. It does **not** reach the
fallback: with the pathspec limited to the new path git cannot pair the rename,
so all three lines report as added, the header says 3 for a delta of 3, and the
output is correct — every one of those lines *was* written to that path by the
change. The wording still needed fixing, because I can show that one candidate
cause behaves well, not that the set of causes is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: eldad-caura <eldad@caura.ai>