### PR TITLE
fix(ratchet): git chooses which files the exemption report examines, not the tally

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -198,7 +198,30 @@ def _grep(tree: str | None, pathspec: str = ":/") -> list[tuple[str, str, str, b
     return out
 
 
-def _added_lines(base: str, path: str) -> set[int]:
+def _changed_paths(base: str) -> set[str] | None:
+    """Every path this change touched, per git. ``None`` if the diff failed.
+
+    What selects the files the exemption report talks about. The exempt tally
+    cannot do it: a change that removes one exemption and adds another in the
+    same file is net zero, so a rise-based filter never looks at that file and
+    the new exemption is never printed — the one thing the report exists to stop
+    happening quietly. Asking git which files moved has no such blind spot.
+
+    ``None`` rather than an empty set on failure, because the two mean opposite
+    things to the caller: "could not tell" must fall back to the old tally-based
+    selection, while "nothing changed" must select nothing.
+    """
+    try:
+        return {
+            line
+            for line in _git(["git", "diff", "--name-only", base]).splitlines()
+            if line
+        }
+    except RuntimeError:
+        return None
+
+
+def _added_lines(base: str, path: str) -> set[int] | None:
     """Line numbers this change actually added to ``path``, per git's own diff.
 
     Used for the failure report only, never for the decision. The decision
@@ -212,13 +235,21 @@ def _added_lines(base: str, path: str) -> set[int]:
     reader is sent to a line that has not changed, for a gate whose whole output
     is "here is the line you added".
 
-    Empty on any failure, and the caller falls back to naming every occurrence of
+    ``None`` on failure, and the caller falls back to naming every occurrence of
     the minted text: too many lines is a nuisance, none is a dead end.
+
+    ``None`` rather than an empty set, because once the exemption report selects
+    files by what git says changed rather than by a risen tally, an empty result
+    is a real and common answer — a file this change only DELETED from adds no
+    lines, and every exempt line it still holds predates the change. Collapsing
+    that into the failure case would reprint the whole pile for exactly the files
+    that deserve none of it, which is the bug #894 fixed, reintroduced through
+    the back door.
     """
     try:
         out = _git(["git", "diff", "-U0", base, "--", _literal(path)])
     except RuntimeError:
-        return set()
+        return None
 
     added: set[int] = set()
     lineno = 0
@@ -441,8 +472,7 @@ def _report_new_exemptions(
     unrelated work — should never be made quietly even when it is legitimate.
 
     Which is why the list is filtered to the lines this change actually wrote,
-    rather than every exempt line the file happens to hold. A file's exempt count
-    is what selects it; the diff is what selects the lines. Re-greping and
+    rather than every exempt line the file happens to hold. Re-greping and
     printing all of them puts a file's whole accumulated pile under a header
     counting one, sends the reader to lines that are not in the diff, and reads
     as self-contradictory — which invites distrusting the total rather than the
@@ -450,9 +480,28 @@ def _report_new_exemptions(
     so every later PR touching those files would reprint them. A reader who
     learns the list is mostly noise stops reading it, and that is the failure
     this report exists to prevent.
+
+    **Git decides both halves.** It selects the lines, and it also selects the
+    files. Selecting files by a risen exempt tally leaves a hole: remove one
+    exemption and add another in the same file and the tally is flat, so the file
+    is never examined and the new exemption is never printed. The gate still
+    catches the dangerous form of that — un-marking a line raises the non-exempt
+    count and :func:`_minted` charges the text — but a brand-new reason nobody is
+    pointed at is precisely what this report exists to prevent, and during a
+    dual-read wave a one-for-one swap inside a file already full of exemptions is
+    unremarkable in a diff.
+
+    The tally is kept only as the fallback for when git cannot answer, since a
+    selection that is too narrow beats one that is arbitrary.
     """
-    added = {p: n - before.get(p, 0) for p, n in after.items() if n > before.get(p, 0)}
-    if not added:
+    # Files git says this change touched, narrowed to those that hold an exempt
+    # line at all. The union with the risen-tally set is belt and braces: when
+    # ``changed`` is available it already contains every risen file, and when it
+    # is ``None`` the tally is all there is.
+    changed = _changed_paths(base)
+    risen = {p for p, n in after.items() if n > before.get(p, 0)}
+    paths = risen if changed is None else {p for p in after if p in changed} | risen
+    if not paths:
         return
 
     # Grouped by reason, because the wall is the failure mode. A dual-read wave
@@ -464,34 +513,36 @@ def _report_new_exemptions(
     by_reason: dict[str, list[tuple[str, str, str]]] = {}
     shown_total = 0
     unfiltered: list[str] = []
-    for path in sorted(added):
+    for path in sorted(paths):
         here = [
             (lineno, text.strip())
             for _, lineno, text, exempt in _grep(None, pathspec=_literal(path))
             if exempt
         ]
-        # The same pair the offender report below uses, for the same reason: the
-        # text-or-count comparison decides WHICH FILE to talk about, and git's own
-        # diff decides which of its lines the change is responsible for. An
-        # existing line that gains a marker is a rewrite, so git calls it added
-        # and it stays in — which matters, because that is the headroom move.
+        if not here:
+            continue
+        # git decides which of the file's lines this change is responsible for.
+        # An existing line that gains a marker is a rewrite, so git calls it
+        # added and it stays in — which matters, because that is the headroom
+        # move this report exists to expose.
         touched = _added_lines(base, path)
-        picked = [(n, t) for n, t in here if int(n) in touched]
-        if not picked:
-            # Falling back to every exempt line in the file rather than to
-            # silence, on the same trade as below: too many lines is a nuisance
-            # and none is a dead end. Named out loud, though, because unlike
-            # below this report puts a number on its own list.
-            #
-            # Reported as what was observed, not as a cause. An unreadable diff
-            # is the likely one — ``_added_lines`` returns empty on any git
-            # failure — but a diff that read fine and simply did not intersect
-            # this file's exempt lines lands here identically, and nothing at
-            # this point can tell the two apart. Naming the cause would be a
-            # guess printed as a finding, which is the habit this whole report
-            # exists to discourage.
+        if touched is None:
+            # Diff unreadable. Falling back to every exempt line in the file
+            # rather than to silence, on the same trade the offender report
+            # makes below: too many lines is a nuisance and none is a dead end.
+            # Named out loud, though, because unlike below this report puts a
+            # number on its own list.
             picked = here
             unfiltered.append(path)
+        else:
+            picked = [(n, t) for n, t in here if int(n) in touched]
+        # Empty is now a real answer rather than a failure — a file this change
+        # only deleted from, or touched somewhere other than its exempt lines,
+        # adds nothing and every marker it holds predates the change. Printing
+        # them would be #894 reintroduced through the file-selection door, which
+        # is the specific risk of selecting on the diff rather than the tally.
+        if not picked:
+            continue
         shown_total += len(picked)
         for lineno, stripped in picked:
             match = EXEMPT_RE.search(stripped)
@@ -500,9 +551,15 @@ def _report_new_exemptions(
                 (path, lineno, stripped)
             )
 
-    print(
-        f"{shown_total} exempt line(s) written by this change in {len(added)} file(s) —"
-    )
+    # Nothing survived the per-line filter: every candidate file holds only
+    # exemptions that predate this change. Silence is right — the previous
+    # version could not reach here, because a risen tally guaranteed something
+    # to print.
+    if not by_reason:
+        return
+
+    listed = len({path for lines in by_reason.values() for path, _, _ in lines})
+    print(f"{shown_total} exempt line(s) written by this change in {listed} file(s) —")
     print("check each is a compat alias, a redirect or a pinned wire format, and not")
     print("headroom for a new name:")
     if unfiltered:
@@ -510,7 +567,7 @@ def _report_new_exemptions(
             f" (+{len(unfiltered) - 4} more)" if len(unfiltered) > 4 else ""
         )
         print(
-            f"  (no diff line matched in {len(unfiltered)} file(s): {named} — every "
+            f"  (diff unreadable for {len(unfiltered)} file(s): {named} — every "
             "exempt line they hold is listed, so some may predate this change)"
         )
 
@@ -633,9 +690,19 @@ def main() -> int:
             for _, lineno, text, exempt in _grep(None, pathspec=_literal(path))
             if not exempt and text.strip() in minted
         ]
-        shown = [(n, t) for n, t in candidates if int(n) in added]
+        shown = (
+            candidates
+            if added is None
+            else [(n, t) for n, t in candidates if int(n) in added]
+        )
         # Falling back to every occurrence rather than to silence: if the diff
         # could not be read, too many lines is a nuisance and none is a dead end.
+        #
+        # The ``or candidates`` also covers an empty-but-successful diff. Unlike
+        # the exemption report, silence is NOT right here: this branch only runs
+        # for a file that minted text the repo never had, so something was added
+        # and an empty intersection means the two disagree. Naming every
+        # occurrence keeps a real offender on screen.
         shown = shown or candidates
         for lineno, stripped in shown:
             print(f"      {lineno}: {stripped[:110]}")

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -552,6 +552,70 @@ def test_an_edited_exemption_is_listed_though_it_is_not_newly_exempt(
     assert "pre-existing alias one" not in out
 
 
+def test_a_net_zero_swap_of_exemptions_is_still_reported(repo: Path) -> None:
+    """The hole a risen-tally selection leaves, and why git picks the files now.
+
+    Drop one exemption and add another in the same file and the tally is flat, so
+    a rise-based filter never examines the file and the new reason is never
+    printed. The gate still catches the dangerous form — un-marking a line raises
+    the non-exempt count and the text gets charged — but a brand-new reason
+    nobody is pointed at is the exact thing this report exists to prevent, and in
+    a file already full of exemptions the swap is unremarkable in a diff.
+    """
+    body = _with_two_aliases_already(repo)
+    _stage(
+        repo,
+        "aliases.py",
+        # "alias two" loses its marker and "alias three" arrives with one:
+        # exempt 2 -> 2, flat.
+        body.replace("  # legacy-name-ok: pre-existing alias two", "")
+        + f'C = "{LEGACY}-three"  # legacy-name-ok: brand new alias three\n',
+    )
+
+    out = _run(repo).stdout
+
+    assert "brand new alias three" in out
+    assert "1 exempt line(s) written by this change in 1 file(s)" in out
+    # Still only the written one — widening the file selection must not widen
+    # the line list back out to the whole pile.
+    assert "pre-existing alias one" not in out
+
+
+def test_a_touched_file_whose_exemptions_are_all_old_says_nothing(repo: Path) -> None:
+    """The cost of letting git choose the files, and the guard against paying it.
+
+    Selecting on the diff means every touched file that happens to hold a marker
+    becomes a candidate — including ones where the change went nowhere near it.
+    If an empty per-line result fell back to "print them all", #894 would be back
+    through the file-selection door, and worse: it would fire on files whose
+    exempt count never moved at all.
+    """
+    body = _with_two_aliases_already(repo)
+    _stage(repo, "aliases.py", body + "UNRELATED = 1\n")
+
+    result = _run(repo)
+
+    assert result.returncode == 0
+    assert "exempt line(s) written by this change" not in result.stdout
+    assert "pre-existing alias" not in result.stdout
+
+
+def test_a_file_only_deleted_from_reports_no_exemptions(repo: Path) -> None:
+    """A deletion adds no lines, so there is nothing for this report to name.
+
+    Distinct from the case above because `_added_lines` returns an empty set here
+    rather than a set that simply misses — which is why it has to be able to say
+    "empty" separately from "I could not read the diff".
+    """
+    body = _with_two_aliases_already(repo)
+    _stage(repo, "aliases.py", body.splitlines(keepends=True)[0])
+
+    result = _run(repo)
+
+    assert result.returncode == 0
+    assert "exempt line(s) written by this change" not in result.stdout
+
+
 def test_many_exemptions_sharing_a_reason_are_grouped(repo: Path) -> None:
     """The wall is the failure mode, and Phase 5 builds walls.
 


### PR DESCRIPTION
Closes #900. Follows #899, which fixed the other half — that one narrowed the
LINES; this narrows what selects the FILES.

`_report_new_exemptions` examined only files whose exempt count ROSE. Remove one
exemption and add another in the same file and the count is flat, so the file
was never looked at and the new reason was never printed.

The gate still caught the dangerous form: un-marking a line raises the
non-exempt count and `_minted` charges the text. What was lost is review
visibility — a PR could land a brand-new `legacy-name-ok` reason that nobody is
pointed at, provided it dropped an unrelated one in the same file. In a Phase 5
file already carrying dozens of exemptions, a one-for-one swap is unremarkable
in a diff, and "an exemption should never be made quietly" is the entire reason
this report exists.

## The fix

`_changed_paths()` asks git which files moved; candidates are those intersected
with the files that hold an exempt line at all. The risen-tally set is kept only
as the fallback for when git cannot answer, because a selection that is too
narrow beats one that is arbitrary.

## Widening the file set forced a real change to `_added_lines`

It returned an empty set both when the diff failed and when the diff was fine.
That was survivable while only risen-tally files were examined, because such a
file always had something added. Now every touched file holding a marker is a
candidate, including ones the change only DELETED from, or touched nowhere near
their exempt lines — and for those, empty is the correct answer.

So it returns `None` for "could not read" and an empty set for "added nothing",
and the caller treats them oppositely: `None` lists everything (the documented
nuisance-over-dead-end trade), empty prints nothing. Collapsing them would have
been #894 reintroduced through the file-selection door, and worse — it would have
fired on files whose exempt count never moved at all.

A side effect worth having: the fallback note can go back to saying "diff
unreadable", because that branch is now only reachable when the diff genuinely
failed. #899 had to hedge the wording precisely because the two cases were
indistinguishable.

## Verified

- the issue's scenario, both versions: the new reason is invisible before, named
  after
- 45 tests pass. **`test_a_net_zero_swap_of_exemptions_is_still_reported` fails
  against `main`** — that is the bug
- the other two new tests pass either way, because they guard the NEW
  mechanism's failure mode rather than reproducing the old bug. Both were
  confirmed by breaking the property they guard — reverting `if not picked:
  continue` to `picked = here` fails exactly those two and nothing else
- `ruff check` / `ruff format --check` clean; ratchet and sentinel green on this
  change

## The cost, measured rather than asserted

Selecting on the diff means one `git grep` and one `git diff` per touched file
that holds an exemption. On a synthetic dual-read-shaped repo — 80 files, 12
exemptions each, all 80 touched without altering a single exemption, which is
the worst case — the run goes **0.06s -> 1.46s**.

Acceptable: the gate's own two full-tree scans dominate a real run, and CI's job
takes seconds. Stated because it scales linearly with touched-files-holding-
exemptions, so a 500-file Phase 5.4 PR would be several seconds more.

Two ways to buy it back if that ever matters, neither taken here because
1.4s does not justify the churn: have `Scan` retain line numbers, which removes
every per-path `_grep` (both reports re-grep only to recover the number `scan()`
already read and discarded); or replace the per-path `git diff` with one
whole-repo `-U0` parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: eldad-caura <eldad@caura.ai>