### PR TITLE
fix(plugin): caura_list scope='all' spans fleets instead of narrowing to one

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -16,7 +16,7 @@
     "pretest": "bash ../scripts/gen-version.sh",
     "build": "tsc",
     "dev": "bash ../scripts/gen-version.sh && tsc --watch",
-    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/interview-buffer.test.js dist/interview-command.test.js dist/task-trail.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js",
+    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/interview-buffer.test.js dist/interview-command.test.js dist/task-trail.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js dist/fleet-scope.test.js",
     "check:version": "bash -c 'V=$(node -p \"require(\\\"./package.json\\\").version\"); grep -qF \"PLUGIN_VERSION = \\\"$V\\\"\" src/version.ts || (echo \"version.ts out of sync with package.json ($V): run bash ../scripts/gen-version.sh\" >&2 && exit 1) && echo \"check:version ok: $V\"'"
   },
   "devDependencies": {

--- a/plugin/src/fleet-scope.test.ts
+++ b/plugin/src/fleet-scope.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The configured-fleet default is a DEFAULT, not an override.
+ *
+ * ``enrichBody`` fills in ``fleet_id`` from ``CAURA_FLEET_ID`` whenever the
+ * caller omits it, so ordinary calls are fleet-scoped without every agent
+ * having to say so. But ``scope: 'all'`` is a caller explicitly asking to span
+ * every fleet, and on the two read-enumeration surfaces the server applies
+ * ``fleet_id`` as an unconditional row filter — ``memory_list_by_filters`` and
+ * ``memory_stats_breakdown`` both do ``if fleet_id: Memory.fleet_id ==
+ * fleet_id`` OUTSIDE any scope branch, and ``resolve_read_fleet_gate`` passes
+ * ``fleet_id`` straight through for ``scope='all'``. Defaulting it in there
+ * turns a tenant-wide read into a single-fleet one, and because the filter is a
+ * strict equality it also drops every fleet-less (``fleet_id IS NULL``) row.
+ * Nothing in the response says the result was narrowed.
+ *
+ * These tests assert on the QUERY STRING the plugin actually puts on the wire.
+ * Asserting that the tool "returns results" would pass either way — the
+ * narrowed call succeeds, it just answers with less.
+ *
+ * The env vars are read at ``env.ts`` import time, so they are set before the
+ * dynamic import below (same pattern as ``env.test.ts``).
+ */
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+const CONFIGURED_FLEET = "fleet-from-env";
+
+// A pinned tenant keeps ``ensureTenantId`` from reaching for the network.
+process.env.CAURA_TENANT_ID = "tenant-fleet-scope-test";
+process.env.CAURA_FLEET_ID = CONFIGURED_FLEET;
+delete process.env.CAURA_API_KEY;
+
+const { createToolFromSpec } = await import("./tool-definitions.js");
+
+/** The endpoint each tool under test dispatches to. */
+const ENDPOINTS: Record<string, string> = {
+  caura_list: "/memories",
+  caura_stats: "/memories/stats",
+  caura_insights: "/insights/generate",
+  caura_evolve: "/evolve/report",
+};
+
+let originalFetch: typeof fetch;
+
+/**
+ * Run one tool call against a stubbed transport and return the request it made
+ * to the tool's own endpoint.
+ *
+ * Matching on the endpoint rather than taking the only request keeps the test
+ * hermetic against an ambient API key, which would switch on ``agent-auth``
+ * and add a provisioning call. Asserting that exactly one MATCHING request
+ * happened is what stops an assertion from passing over a request that was
+ * never made.
+ */
+async function callAndCaptureRequest(
+  toolName: string,
+  params: Record<string, unknown>,
+): Promise<{ query: URLSearchParams; body: Record<string, unknown> }> {
+  const matched: { url: URL; rawBody?: string }[] = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    if (url.pathname.endsWith(ENDPOINTS[toolName])) {
+      matched.push({ url, rawBody: init?.body as string | undefined });
+    }
+    return new Response(JSON.stringify({ items: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  await createToolFromSpec(toolName).execute("test-call", params);
+
+  assert.equal(
+    matched.length,
+    1,
+    `${toolName} should hit ${ENDPOINTS[toolName]} exactly once, hit it ${matched.length}x`,
+  );
+  const { url, rawBody } = matched[0];
+  return {
+    query: url.searchParams,
+    body: rawBody ? JSON.parse(rawBody) : {},
+  };
+}
+
+describe("configured-fleet default vs an explicit scope", () => {
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // THE regression. Without the fix this request carries
+  // ``fleet_id=fleet-from-env`` and the tenant-wide read silently comes back
+  // narrowed to one fleet.
+  test("caura_list scope='all' does not inherit the configured fleet", async () => {
+    const { query } = await callAndCaptureRequest("caura_list", { scope: "all" });
+    assert.equal(query.get("scope"), "all");
+    assert.equal(
+      query.get("fleet_id"),
+      null,
+      "scope='all' asked to span fleets; a fleet_id here narrows it back to one",
+    );
+  });
+
+  // Same defect, same server code path (``_resolve_scoped_read`` is shared by
+  // GET /memories and GET /memories/stats), so a count can't disagree with the
+  // listing it summarises.
+  test("caura_stats scope='all' does not inherit the configured fleet", async () => {
+    const { query } = await callAndCaptureRequest("caura_stats", { scope: "all" });
+    assert.equal(query.get("scope"), "all");
+    assert.equal(query.get("fleet_id"), null);
+  });
+
+  // The other half of the contract: the default must SURVIVE for every caller
+  // that did not ask to span fleets. Omitting ``scope`` is not the same request
+  // as ``scope: 'all'`` — this is the distinction the fix turns on.
+  test("caura_list keeps the configured fleet when scope is omitted", async () => {
+    const { query } = await callAndCaptureRequest("caura_list", {});
+    assert.equal(query.get("scope"), null);
+    assert.equal(query.get("fleet_id"), CONFIGURED_FLEET);
+  });
+
+  test("caura_list keeps the configured fleet for scope='agent' and 'fleet'", async () => {
+    for (const scope of ["agent", "fleet"]) {
+      const { query } = await callAndCaptureRequest("caura_list", { scope });
+      assert.equal(query.get("scope"), scope);
+      assert.equal(
+        query.get("fleet_id"),
+        CONFIGURED_FLEET,
+        `scope='${scope}' is a fleet-scoped read; the default belongs here`,
+      );
+    }
+  });
+
+  test("caura_stats keeps the configured fleet when scope is omitted", async () => {
+    const { query } = await callAndCaptureRequest("caura_stats", {});
+    assert.equal(query.get("fleet_id"), CONFIGURED_FLEET);
+  });
+
+  // A caller-supplied fleet_id is never touched: the fix withholds a default,
+  // it does not strip a value. ``scope='all'`` with an explicit fleet is a
+  // legitimate cross-fleet read of ONE named fleet.
+  test("an explicit fleet_id survives scope='all'", async () => {
+    const { query } = await callAndCaptureRequest("caura_list", {
+      scope: "all",
+      fleet_id: "fleet-named-by-caller",
+    });
+    assert.equal(query.get("fleet_id"), "fleet-named-by-caller");
+  });
+
+  // ``caura_insights`` and ``caura_evolve`` also take scope='all', and they are
+  // deliberately NOT part of the fix: their ``fleet_id`` is not merely a read
+  // filter. Server-side both branch on ``scope`` and ignore ``fleet_id``
+  // entirely under 'all' (``_insights_scope_filters`` /
+  // ``evolve_service._filter_by_scope``), so there is no read to widen — while
+  // both PERSIST with it (``BulkMemoryCreate(fleet_id=...)`` for insight
+  // findings, ``_persist_rule`` for evolve outcomes, plus insights'
+  // ``supersede_priors`` key). Withholding it there would relocate a write and
+  // strand the priors it was supposed to supersede.
+  test("caura_insights and caura_evolve keep the configured fleet at scope='all'", async () => {
+    const insights = await callAndCaptureRequest("caura_insights", {
+      focus: "patterns",
+      scope: "all",
+    });
+    assert.equal(insights.body.fleet_id, CONFIGURED_FLEET);
+
+    const evolve = await callAndCaptureRequest("caura_evolve", {
+      outcome: "test outcome",
+      outcome_type: "success",
+      scope: "all",
+    });
+    assert.equal(evolve.body.fleet_id, CONFIGURED_FLEET);
+  });
+});

--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -50,12 +50,47 @@ export interface AgentTool {
 
 // --- Helpers ---
 
+interface EnrichOptions {
+  /**
+   * Set on the tools whose ``fleet_id`` is *only* a read filter, so an
+   * explicit ``scope: "all"`` is honoured instead of being narrowed back to
+   * the configured fleet.
+   *
+   * ``caura_list`` and ``caura_stats`` are the two. Server-side they apply
+   * ``fleet_id`` as a row filter OUTSIDE any scope branch
+   * (``memory_list_by_filters`` / ``memory_stats_breakdown``:
+   * ``if fleet_id: Memory.fleet_id == fleet_id``), and their shared ladder
+   * ``resolve_read_fleet_gate`` passes it through untouched for 'all'. So a
+   * defaulted ``fleet_id`` turns a tenant-wide read into a single-fleet one —
+   * and being a strict equality it drops fleet-less (``NULL``) rows too, with
+   * nothing in the response to signal it.
+   *
+   * NOT set on ``caura_insights`` / ``caura_evolve``, which also take
+   * ``scope: "all"``. Their reads branch on ``scope`` and ignore ``fleet_id``
+   * entirely under 'all' (``_insights_scope_filters`` /
+   * ``evolve_service._filter_by_scope``), so there is no read to widen — and
+   * for them ``fleet_id`` doubles as a WRITE target: the fleet persisted
+   * findings and outcome rules land in, and the key insights supersedes priors
+   * under. Withholding it there relocates a write instead of widening a read.
+   */
+  fleetIsReadFilterOnly?: boolean;
+}
+
 async function enrichBody(
   params: Record<string, unknown>,
+  opts: EnrichOptions = {},
 ): Promise<Record<string, unknown>> {
   const body = { ...params };
   if (!body.tenant_id) body.tenant_id = await ensureTenantId();
   if (!body.agent_id && MEMCLAW_AGENT_ID) body.agent_id = MEMCLAW_AGENT_ID;
+  // The configured fleet below is a DEFAULT, for callers that did not say
+  // which fleet they meant — so it must not override a caller that asked to
+  // span every fleet. Three cases deliberately keep it: an omitted ``scope``
+  // (that default is what makes ordinary calls fleet-scoped in the first
+  // place), ``scope='agent'`` / ``'fleet'`` (a fleet-scoped read is what they
+  // ask for), and a caller-supplied ``fleet_id`` — this withholds a default,
+  // it never strips a value.
+  if (opts.fleetIsReadFilterOnly && body.scope === "all") return body;
   if (!body.fleet_id && MEMCLAW_FLEET_ID) body.fleet_id = MEMCLAW_FLEET_ID;
   return body;
 }
@@ -464,7 +499,7 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
   },
 
   caura_list: async (params, signal) => {
-    const enriched = await enrichBody(params);
+    const enriched = await enrichBody(params, { fleetIsReadFilterOnly: true });
     const query: Record<string, string> = {};
     for (const [k, v] of Object.entries(enriched)) {
       if (v === undefined || v === null) continue;
@@ -517,7 +552,7 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
   },
 
   caura_stats: async (params, signal) => {
-    const enriched = await enrichBody(params);
+    const enriched = await enrichBody(params, { fleetIsReadFilterOnly: true });
     const query: Record<string, string> = {};
     for (const [k, v] of Object.entries(enriched)) {
       if (v === undefined || v === null) continue;


### PR DESCRIPTION
`enrichBody` in `plugin/src/tool-definitions.ts` fills in `fleet_id` from the configured fleet whenever the caller omits it. That default is deliberate — it is what makes ordinary calls fleet-scoped without every agent having to say so. But `scope: 'all'` is a caller explicitly asking to span every fleet, and the default was overriding it.

#886 gave this code path `CAURA_FLEET_ID` for free and deliberately did not touch the narrowing, because fixing it is behavioural and #886 was additive-only. This is that fix.

## The defect

On the two read-enumeration tools the server applies `fleet_id` as a row filter **outside any scope branch** — `memory_list_by_filters` and `memory_stats_breakdown` both do `if fleet_id: Memory.fleet_id == fleet_id` — while their shared ladder `resolve_read_fleet_gate` passes `fleet_id` through untouched for `'all'`.

So a tenant-wide read came back narrowed to a single fleet. Because the filter is a strict equality it also dropped every fleet-less (`fleet_id IS NULL`) row. Nothing in the response said so: the call succeeded and simply answered with less.

## Behaviour matrix, measured on both sides

With a configured fleet `F` and no caller-supplied `fleet_id`. Only the two bold cells move.

| tool | `scope` | before | after |
|---|---|---|---|
| `caura_list` | omitted | `fleet_id=F` | `fleet_id=F` |
| `caura_list` | `'agent'` | `fleet_id=F` | `fleet_id=F` |
| `caura_list` | `'fleet'` | `fleet_id=F` | `fleet_id=F` |
| `caura_list` | `'all'` | **`fleet_id=F`** | **omitted** |
| `caura_stats` | omitted | `fleet_id=F` | `fleet_id=F` |
| `caura_stats` | `'agent'` | `fleet_id=F` | `fleet_id=F` |
| `caura_stats` | `'fleet'` | `fleet_id=F` | `fleet_id=F` |
| `caura_stats` | `'all'` | **`fleet_id=F`** | **omitted** |
| `caura_insights` | any | `fleet_id=F` | `fleet_id=F` |
| `caura_evolve` | any | `fleet_id=F` | `fleet_id=F` |

A caller-supplied `fleet_id` is byte-identical in every row, at every scope: this withholds a default, it does not strip a value.

Two deliberate non-changes worth naming:

- **`scope='agent'` keeps the default.** It also narrows — an agent listing its own memories misses ones it wrote in another fleet, and all fleet-less ones. But `'agent'` does not contradict a fleet-scoped default the way `'all'` does, so it is left as-is rather than folded into a bug fix.
- **`scope='fleet'` keeps the default.** When `F` is the caller's home fleet this is exactly the pin `resolve_read_fleet_gate` would apply anyway; when it is not, the server raises the bar to trust 2, which is the correct gate for a cross-fleet read.

## Why only two of the four tools that accept scope='all'

`caura_insights` and `caura_evolve` deliberately do **not** opt in:

1. Their reads branch on `scope` and ignore `fleet_id` entirely under `'all'` (`_insights_scope_filters`, `evolve_service._filter_by_scope`), so there is no read to widen.
2. Their `fleet_id` doubles as a **write target** — the fleet persisted findings and outcome rules land in, and the key insights supersedes priors under. Withholding it there would relocate a write and strand the priors it was meant to supersede.

I nearly widened the fix to `caura_insights` on the grounds that it looked like the same shape; the `BulkMemoryCreate(fleet_id=...)` in `insights_service` is why that would have been wrong.

## Did any caller depend on the narrowing?

No.

- No in-repo caller: `caura_list` / `caura_stats` are agent-facing tools with no internal call site in `plugin/src`.
- `scripts/trust_matrix_e2e.py` is the only script exercising `scope='all'`, and it drives core-api directly over HTTP with an `X-API-Key` — the plugin is not in its path.
- The server-side MCP `caura_list` has no environment-driven fleet injection at all, so there is no sibling copy of this defect left unowned.

## Tests

`plugin/src/fleet-scope.test.ts` asserts on the **query string actually put on the wire**. An assertion that the tool "returns results" would pass either way, since the narrowed call succeeds — that is the trap this bug sets for its own test.

- The two `scope='all'` tests **fail without the fix**, with `'fleet-from-env'` where `null` is expected.
- The five guard tests were verified load-bearing by breaking what they guard: removing the default outright fails all five; applying the fix without the per-tool opt-in fails exactly the insights/evolve one and nothing else.

It needs its own file because the env vars are read at `env.ts` import time, so they must be set before the module is imported.

Gates: 413/413 plugin tests, `tsc` clean, legacy-name ratchet "No new lines", sentinel "All 23 protected strings survive". `env.ts` and the env-reading paths are untouched.