### PR TITLE
docs: fix four old-brand references that name things which do not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,7 +1192,7 @@ Anything not listed above is internal and may change in any release without a ma
 
 - Python module layout (`core_api.middleware.*`, `core_api.providers.*`, `core_api.pipeline.*`, `core_api.services.*`, `common/*`)
 - Database schema, table names, migration paths
-- Gateway-injected HTTP headers (`X-Memclaw-Gateway`, `X-Tenant-ID`, `X-Agent-ID`, `X-Org-Read-Only`)
+- Gateway-injected HTTP headers (`X-Gateway-Secret`, `X-Tenant-ID`, `X-Agent-ID`, `X-Org-Read-Only`)
 - Most `/api/v1/admin/*` and all `/api/v1/testing/*` routes (the documented exception is `POST /admin/agent-keys/provision`, which is part of the stable identity-bootstrap surface — see the Agents row above)
 - The `core-storage-api` microservice (internal, not user-facing)
 - The plugin's TypeScript module structure

--- a/docs/operator-forge-cron.md
+++ b/docs/operator-forge-cron.md
@@ -42,7 +42,7 @@ http_target:
   oidc_token:
     service_account_email: <core-operations-sa>@<project>.iam.gserviceaccount.com
   headers:
-    X-Memclaw-Admin-Token: ${MEMCLAW_ADMIN_TOKEN}   # see core-api/auth.enforce_admin
+    X-API-Key: ${ADMIN_API_KEY}   # the admin key — see core-api/auth.enforce_admin
 ```
 
 ### Kubernetes CronJob (alternative)
@@ -67,9 +67,10 @@ spec:
                 - |
                   curl -fsS \
                     -X POST \
-                    -H "X-Memclaw-Admin-Token: $MEMCLAW_ADMIN_TOKEN" \
+                    -H "X-API-Key: $ADMIN_API_KEY" \
                     "$CORE_API_BASE_URL/admin/lifecycle/fanout/forge-distill"
               envFrom:
+                # whichever secret you use, it must expose ADMIN_API_KEY
                 - secretRef: { name: memclaw-admin }
           restartPolicy: OnFailure
 ```

--- a/docs/plugin-upgrade.md
+++ b/docs/plugin-upgrade.md
@@ -58,11 +58,24 @@ When upgrading an existing install, read its current `.env` first and pass the v
 
 ```bash
 ENV=$HOME/.openclaw/plugins/memclaw/.env
-URL=$(grep    '^MEMCLAW_API_URL='    "$ENV" | cut -d= -f2-)
-KEY=$(grep    '^MEMCLAW_API_KEY='    "$ENV" | cut -d= -f2-)
-FLEET=$(grep  '^MEMCLAW_FLEET_ID='   "$ENV" | cut -d= -f2-)
-TENANT=$(grep '^MEMCLAW_TENANT_ID='  "$ENV" | cut -d= -f2-)
-NODE=$(grep   '^MEMCLAW_NODE_NAME='  "$ENV" | cut -d= -f2-)
+
+# Read one setting, accepting either prefix: the installer writes CAURA_* into
+# new installs, older installs kept the pre-rename prefix, and a re-deploy
+# preserves whichever the file already had. First NON-EMPTY wins — a key can be
+# present but blank in a hand-edited .env, and blank here silently re-installs
+# the node with no identity at all.
+read_env() {
+  for _p in CAURA MEMCLAW; do  # legacy-name-ok: dual-prefix read, both are live
+    _v=$(grep -m1 "^${_p}_$1=" "$ENV" | cut -d= -f2-)
+    if [ -n "$_v" ]; then printf '%s\n' "$_v"; return; fi
+  done
+}
+
+URL=$(read_env API_URL)
+KEY=$(read_env API_KEY)
+FLEET=$(read_env FLEET_ID)
+TENANT=$(read_env TENANT_ID)
+NODE=$(read_env NODE_NAME)
 
 curl -ks -X POST "$URL/api/v1/install-plugin" \
   -H "Content-Type: application/json" \

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -229,7 +229,7 @@ MEMCLAW_NODE_NAME=my-gateway                                 # friendly name sho
 # MEMCLAW_AUTO_FIX_CONFIG=false                              # set true to auto-fix openclaw.json on startup
 ```
 
-The plugin loads this `.env` file automatically (only `MEMCLAW_*` keys are read). If you use systemd, also add the vars to a drop-in file (`.env` values don't override existing process env).
+The plugin loads this `.env` file automatically. Both `CAURA_*` and `MEMCLAW_*` keys are read — and only those, so a `.env` cannot set `PATH` or `NODE_OPTIONS`. The installer writes `CAURA_*` into new installs; the older names above keep working unchanged. If you use systemd, also add the vars to a drop-in file (`.env` values don't override existing process env). <!-- legacy-name-ok: rule 3 dual-read alias -->
 
 **Configure OpenClaw** — edit `~/.openclaw/openclaw.json`:
 


### PR DESCRIPTION
Lane 3 (Phase 5.4 first slice): the docs that are actually served — `static/docs/`, `README.md`, `docs/`.

**The rule applied:** fix prose that is factually **wrong**; defer prose that is merely **incomplete**. ~110 old-brand occurrences examined across 26 files; **4 were wrong**, in 4 files. The rest name something that genuinely still answers to that name and are left for 5.4's wholesale rewrite.

### Fixed

| File | Was | Why it's wrong |
|---|---|---|
| `docs/plugin-upgrade.md` | `grep '^MEMCLAW_API_URL='` ×5 | Since #895 the installer writes a `.env` of only `CAURA_*`. On any current install all five greps return empty and the re-install POSTs blank identity — silently wiping the per-node identity the section exists to preserve. |
| `static/docs/integration-guide.md` | "only `MEMCLAW_*` keys are read" | False since #886 — `isPluginEnvKey` is `/^(?:CAURA\|MEMCLAW)_[A-Z_]+$/`. Reads as a contradiction next to the all-`CAURA_*` `.env` the installer just wrote. |
| `docs/operator-forge-cron.md` | `X-Memclaw-Admin-Token: ${MEMCLAW_ADMIN_TOKEN}` ×2 | Neither header nor variable exists anywhere in the tree. `enforce_admin` tests `is_admin` off the credential from `X-API-Key`. Both examples 401 on every tick. |
| `README.md` | `X-Memclaw-Gateway` | Has never existed in the codebase in any spelling since the initial public release. Real one is `X-Gateway-Secret`. |

The last one is **replaced, not renamed** — minting `X-Caura-Gateway` would move the phantom rather than remove it. The `plugin-upgrade` fix accepts **both** prefixes rather than swapping one for the other, because `deploy.ts` preserves whichever a node's `.env` already had, so both are live in the field. It takes the first **non-empty**, not the first defined: a hand-edited `.env` can carry a present-but-blank key (the §09 empty-string trap), and blank is exactly the failure this snippet cannot afford.

### Verification

The snippet was extracted **verbatim from the rendered doc** and run against fixtures:

```
new-install.env  (CAURA_* only, as the installer writes)  OLD=[]              NEW=[mc_realkey]
legacy.env       (MEMCLAW_* only, pre-rename)             OLD=[mc_legacykey]  NEW=[mc_legacykey]
halffilled.env   (CAURA_ blank + real MEMCLAW_)           NEW=[mc_theonlyrealkey]
```

Empty under the old form, correct under the new, no regression on a pre-rename `.env`. Also `bash -n` clean, and both YAML examples still parse.

Gates: ratchet **no new lines, −9 net** (two dual-read lines carry `legacy-name-ok`); sentinel **all 23 protected strings survive**.

### Deliberately deferred

Every one still names something real, verified against the tree — not skipped for time:

- **`MEMCLAW_*` env family** (guide `.env` block, README table, `MEMCLAW_VERSION`, `MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS`, `MEMCLAW_INTERVIEWER`, `MEMCLAW_SKILL_TARGETS`, `MEMCLAW_API_KEY`) — all confirmed dual-read; incomplete, and 5.4's to rewrite.
- **Plugin id `memclaw`** — `index.ts:131`, `context-engine.ts:505`. So `plugins.allow`/`entries`/`slots`, `openclaw plugins enable memclaw` are all correct.
- **Gateway RPC `memclaw.status|deploy|educate|allowlist.*`** — all registered in `index.ts`.
- **`[memclaw]` log prefix** — still what the plugin emits.
- **`~/.openclaw/plugins/memclaw`, `~/.claude/skills/memclaw/`, `.memclaw-owned`** — real paths (`paths.ts`, `plugin.py:731/739`, `OWNED_MARKER`). Floor-class: changing them breaks live installs.
- **`/api/v1/memclaw/keystones`** — the live endpoint path.
- **`memclaw.auto_upgrade_enabled`** — real settings key (`organization_settings.py:580`).
- **GHCR `caura-memclaw-core-api` / `-core-storage-api`** — match `docker-compose.yml` exactly. Phase 6, gated on 1.7.
- **`POSTGRES_USER`/`_DB` = `memclaw`, `pg_dump -U memclaw`** — sentinel-protected floor.
- **`memclawd` / `memclaw` CLI / `memclawctl`** — real binaries and harnesses.
- **`memclaw.<domain>.<verb>` events** (`component-registry.yaml`, `operator-forge-cron.md:15`) — real topics, and Lane 5's to flip. Out of this lane.
- **`docs/performance.md:15,72` blog links** — re-probed today: `/blog/memclaw-benchmarks` **and** `/blog/caura-benchmarks` both return 200. The link works, so it is incomplete, not wrong. (`BENCHMARKS.md:165` is the third hit in that unowned item and sits outside this lane.)
- **`memclaw-client` package / `memclaw-interviewer` CLI** (README:584-585) — `pyproject.toml` keeps `memclaw-interviewer` as a permanent console script and ships a `memclaw_client` import shim. Stale wording, not false. Flagged below.
- **`docs/live-memory-pitch/*`, `beacon-…-2026-07-26.md`, `docs/plans/`** — dated internal planning and incident records. Historical, not instructions.

### Worth a second pair of eyes

`README.md:585` says the interviewer CLI is "shipped in the `memclaw-client` package", but the distribution is now `caura-client`; `memclaw-client` on PyPI is frozen at its pre-rename release. The console script and import shim both survive, so nothing is strictly false — but a reader who runs `pip install memclaw-client` gets a frozen build, not the current one. Left alone as 5.4 scope rather than widened here.

Boundaries respected: no edits to `plugin/src` (Lane 4), `common/events/` (Lane 5), `scripts/` or `.github/`. Read-only there to verify what the docs claim.
