### PR TITLE
docs(plugin): an omitted scope is not scope='agent' on caura_list/caura_stats

### DIFF
--- a/plugin/src/tool-definitions.test.ts
+++ b/plugin/src/tool-definitions.test.ts
@@ -154,6 +154,35 @@ describe("createToolFromSpec factory", () => {
     assert.ok(list.properties.include_deleted);
   });
 
+  // ``GET /memories`` and ``GET /memories/stats`` declare ``scope`` as an
+  // OPT-IN query param (``Query(default=None)``), and an omitted one is a
+  // different request from ``scope='agent'``: it skips the trust ladder and
+  // takes its author filter from ``written_by ?? agent_id``. So neither may
+  // declare a schema default — a client honouring it would start sending
+  // 'agent', which adds the trust-1 gate and turns an agent-less install's
+  // tenant-wide team/org read into a 400. Nor may the description call any
+  // value "the default", which is what it used to claim.
+  //
+  // ``caura_insights`` / ``caura_evolve`` are deliberately not covered: their
+  // ``scope`` travels in a JSON body whose Pydantic model really does
+  // ``Field(default="agent")``, so calling 'agent' the default is true there.
+  test("caura_list / caura_stats declare no default for scope", () => {
+    for (const name of ["caura_list", "caura_stats"]) {
+      const schema = createToolFromSpec(name).parameters as any;
+      const scope = schema.properties.scope;
+      assert.ok(scope, `${name}: scope property missing`);
+      assert.deepEqual(scope.enum, ["agent", "fleet", "all"], `${name}: scope enum`);
+      assert.ok(
+        !("default" in scope),
+        `${name}: scope must not declare a schema default — an omitted scope is not scope='agent'`,
+      );
+      assert.ok(
+        !/\(default/.test(scope.description),
+        `${name}: scope description must not call a value "the default": ${scope.description}`,
+      );
+    }
+  });
+
   test("openclaw.plugin.json contracts.tools matches MEMCLAW_TOOLS exactly", () => {
     // OpenClaw runtime requires plugins to declare ``contracts.tools``
     // before it accepts ``api.registerTool`` calls. The list MUST match

--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -243,9 +243,20 @@ const PARAM_SCHEMAS: Record<string, Record<string, unknown>> = {
     required: [],
     properties: {
       agent_id: { type: "string", description: "Caller agent ID (trust + visibility scoping)" },
-      scope: { type: "string", enum: ["agent", "fleet", "all"], description: "'agent' (default) = your memories only (trust ≥ 1). 'fleet'/'all' = cross-agent (trust ≥ 2)." },
+      // Deliberately NO schema ``default``. ``GET /memories`` declares
+      // ``scope`` as an opt-in query param (``Query(default=None)``), and an
+      // omitted one skips the trust ladder and takes its author filter from
+      // ``written_by ?? agent_id``. Declaring 'agent' here would make a
+      // schema-honouring client start sending it, which adds the trust-1 gate
+      // and, on an install with no agent id, turns a working tenant-wide
+      // team/org read into a 400 ("scope='agent' requires an agent identity").
+      // The two requests are near-identical once an agent id is configured,
+      // but they are not the same request — so the description says what
+      // omitting does instead of calling either one the default.
+      // ``caura_stats`` below has the same shape.
+      scope: { type: "string", enum: ["agent", "fleet", "all"], description: "Optional. Omitted: filtered by agent_id if one is set, with no trust gate — not the same request as 'agent'. 'agent' = your memories only (trust ≥ 1). 'fleet'/'all' = cross-agent (trust ≥ 2)." },
       fleet_id: { type: "string", description: "Restrict to a fleet" },
-      written_by: { type: "string", description: "Filter by author agent_id (ignored when scope='agent')" },
+      written_by: { type: "string", description: "Filter by author agent_id. With scope='agent' it must be omitted or match your own agent_id — a different author is rejected, not ignored." },
       memory_type: MEMORY_TYPE_SCHEMA,
       status: STATUS_SCHEMA,
       weight_min: { type: "number" },
@@ -320,7 +331,8 @@ const PARAM_SCHEMAS: Record<string, Record<string, unknown>> = {
     type: "object",
     required: [],
     properties: {
-      scope: { type: "string", enum: ["agent", "fleet", "all"], description: "'agent' (default, trust ≥ 1) | 'fleet'/'all' (trust ≥ 2)" },
+      // No schema ``default`` — see the note on ``caura_list.scope`` above.
+      scope: { type: "string", enum: ["agent", "fleet", "all"], description: "Optional. Omitted: aggregated over agent_id if one is set, with no trust gate — not the same request as 'agent'. 'agent' = only memories visible to you (trust ≥ 1). 'fleet'/'all' = cross-agent (trust ≥ 2)." },
       agent_id: { type: "string", description: "Caller agent ID" },
       fleet_id: { type: "string", description: "Restrict aggregate to a fleet" },
       memory_type: MEMORY_TYPE_SCHEMA,


### PR DESCRIPTION
Follows #904. Both `caura_list` and `caura_stats` described `'agent'` as the default value of `scope`. On these two tools it is not.

## Why it is wrong on exactly these two

`GET /memories` and `GET /memories/stats` declare `scope` as an **opt-in query param** (`Query(default=None)`), and the route consults the trust ladder only when the caller supplied one:

```python
author_filter = written_by if written_by is not None else agent_id
if scope is not None:
    author_filter, fleet_id = await _resolve_scoped_read(...)
```

So omitting `scope` takes the author filter from `written_by ?? agent_id` (list) or aggregates over `agent_id` (stats), and skips `_resolve_scoped_read` entirely. Since the plugin already fills in `agent_id` from the configured identity, the two are near-identical in the common case — but they are different requests. `scope='agent'`:

- adds the trust-1 gate (`require_trust`), which omitting skips altogether;
- resolves the author from the **authenticated credential** (`auth.agent_id or agent_id`) rather than the query param;
- **400s outright** when no agent identity is available, where omitting it serves a tenant-wide team/org read.

The fix says what omitting actually does, rather than adding a schema `default` to make the old wording true — that would be a behaviour change, since a client honouring the default would start sending `'agent'`.

## Deliberately not changed

| surface | `scope` default | verdict |
|---|---|---|
| plugin `caura_list` / `caura_stats` | none — opt-in query param | **fixed here** |
| plugin `caura_insights` / `caura_evolve` | `Field(default="agent")` in the request body model | correct as written |
| MCP `caura_list` (`mcp_server.py`) | real Python default `= "agent"` | correct as written |

That asymmetry is the whole finding: the claim is true wherever `scope` has a binding default, and false on the two query-param routes where it does not.

**Out of lane, same inaccuracy, reported not fixed** — these are the SoT registry copies, not `plugin/src`:
- `plugin/tools.json` (tool-level description mirroring the server registry)
- `core-api/src/core_api/tools/caura_list.py` and `caura_stats.py`

All three still read "scope='agent' (default) lists your memories at trust ≥ 1". Worth a follow-up by whoever owns the registry, since the plugin's param description and the server's tool description now disagree.

## Also corrected

`caura_list.written_by` claimed it was "ignored when `scope='agent'`". It is **rejected**, not ignored — `_resolve_scoped_read` 400s on a `written_by` naming anyone but the caller. Found reading the line directly below the one above.

## Test

`caura_list / caura_stats declare no default for scope` pins the behavioural half rather than the prose: neither may carry a schema `default` (a client honouring it changes what goes on the wire), and neither description may call a value "the default" again. Both halves confirmed load-bearing by breaking them — re-adding `default: "agent"` fails the first assertion, restoring the old wording fails the second.

Gates: 414/414 plugin tests, `tsc` clean, ratchet "No new lines", sentinel "All 23 protected strings survive". No behaviour change — schema descriptions and one new assertion only.