### PR TITLE
docs: the interviewer CLI ships in caura-client, not memclaw-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,8 +581,8 @@ settings.
 - **How activity is captured.** Two families, one submit protocol:
   - **Plugin-buffer** — the OpenClaw plugin keeps a durable node-local buffer
     and submits windows (add `MEMCLAW_INTERVIEWER=true` to the plugin env).
-  - **Disk-parser** — the `memclaw-interviewer` CLI (shipped in the
-    `memclaw-client` package) reads a harness's on-disk transcript read-only
+  - **Disk-parser** — the `caura-interviewer` CLI (shipped in the
+    `caura-client` package) reads a harness's on-disk transcript read-only
     and submits windows. Ships for **Claude Code** (`~/.claude/projects`) and
     **Cursor** (`~/.cursor/…/agent-transcripts`) today; **Hermes** and others
     are planned.


### PR DESCRIPTION
Follow-up to #905. That PR deferred this line as "stale wording, not false" and flagged it for a second look. **That call was wrong** — measured, it is false, so here is the fix.

### What I actually checked

`memclaw-client` is not an alias of `caura-client`. They are two distributions:

| PyPI project | Latest | Releases |
|---|---|---|
| `caura-client` | **1.0.1** | 1.0.0, 1.0.1 |
| `memclaw-client` | **0.5.0** | 0.2.0 … 0.5.0 |

Then I opened the 0.5.0 wheel rather than trusting the version gap:

- **no `entry_points.txt` at all** — it declares zero console scripts
- **no interviewer module** — nothing matching `interviewer` in the archive

So `pip install memclaw-client` gives you neither `caura-interviewer` nor `memclaw-interviewer`, and none of the disk-parser code the paragraph goes on to describe. It also sits below the H-01 wire-key fix that shipped in 1.0.1, so a reader who followed this line landed on a client whose `recall()` returned empty.

### The change

Two words on one line pair. The passage now names the primary console script alongside the primary package — `caura-client` declares `caura-interviewer`, and keeps `memclaw-interviewer` as a permanent alias so pre-rename cron entries keep working. I did not restate that locally because the README banner already covers it document-wide: *"the old `memclaw_*` names, packages, env vars and URLs keep working unchanged."*

Ratchet: **no new lines, −2 net**. Sentinel: **all 23 protected strings survive**.

### Why #905 got it wrong

Worth recording, because it is a repeatable trap. #905 reasoned from the repo — `pyproject.toml` keeps a `memclaw-interviewer` console script and `clients/python/src/` carries a `memclaw_client` import shim — and concluded the old name still worked. Both facts are true, and both are about **`caura-client`'s own contents**. Neither says anything about what the separately-published `memclaw-client` distribution contains. The tree cannot answer a question about a registry; only the registry can. Same shape as the "merged is not shipped" lesson, one level further out.
