### PR TITLE
docs: teach CAURA_INTERVIEWER in the interviewer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ settings.
   with the trail's real event timestamps preserved.
 - **How activity is captured.** Two families, one submit protocol:
   - **Plugin-buffer** — the OpenClaw plugin keeps a durable node-local buffer
-    and submits windows (add `MEMCLAW_INTERVIEWER=true` to the plugin env).
+    and submits windows (add `CAURA_INTERVIEWER=true` to the plugin env).
   - **Disk-parser** — the `caura-interviewer` CLI (shipped in the
     `caura-client` package) reads a harness's on-disk transcript read-only
     and submits windows. Ships for **Claude Code** (`~/.claude/projects`) and


### PR DESCRIPTION
Follow-up to #907, which moved the disk-parser bullet to the caura names and left the plugin-buffer bullet directly above it still teaching `MEMCLAW_INTERVIEWER` — two adjacent lines in the same list disagreeing about which name to use.

### Verified, not assumed

Two things both have to hold for `CAURA_INTERVIEWER` to work, and they live in different places:

- **It has to be loaded from the plugin `.env` at all.** `isPluginEnvKey` is `/^(?:CAURA|MEMCLAW)_[A-Z_]+$/` (`plugin/src/env.ts:22`). Ran the shipped regex against the real keys:

  ```
  CAURA_INTERVIEWER    loaded from .env
  MEMCLAW_INTERVIEWER  loaded from .env
  PATH                 rejected
  NODE_OPTIONS         rejected
  ```

- **It has to be read.** `env.ts:128` — `readEnv(["CAURA_INTERVIEWER", "MEMCLAW_INTERVIEWER"])`.

Worth separating those, because the first one is the failure that bit #886: a reader-side dual-read is a no-op if the `.env` key filter drops the new prefix before it ever reaches `process.env`.

### Scope

One line. This changes **what the docs teach**, not what the plugin reads — `MEMCLAW_INTERVIEWER` keeps working, and the README banner already states that document-wide, so the local text does not repeat it.

Deliberately **not** included: the wider `MEMCLAW_*` env table further down the README, and the `.env` block in `static/docs/integration-guide.md`. Those remain Phase 5.4's to rewrite wholesale.

Ratchet: **no new lines, −1 net**. Sentinel: **all 23 protected strings survive**.
