### PR TITLE
docs: teach the CAURA_* env names, with one surviving alias table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,9 +42,9 @@ ENVIRONMENT=development
 # build from local source instead, run
 # ``docker compose up --build --no-pull``.
 #
-# MEMCLAW_VERSION is tag-only (it expands inline into ``image:`` for
+# CAURA_VERSION is tag-only (it expands inline into ``image:`` for
 # both core-api and core-storage-api). For *digest pinning* — strict
-# supply-chain reproducibility — a single MEMCLAW_VERSION is not
+# supply-chain reproducibility — a single CAURA_VERSION is not
 # enough: the two services have different images and therefore
 # different sha256 digests, so a shared digest would fail to pull on
 # whichever service it doesn't belong to. Pin per-service via a
@@ -52,7 +52,7 @@ ENVIRONMENT=development
 # own ``name:tag@sha256:<digest>``. Look up each service's digest with:
 #     docker buildx imagetools inspect ghcr.io/caura-ai/caura-memclaw-core-api:v1.2.3
 #     docker buildx imagetools inspect ghcr.io/caura-ai/caura-memclaw-core-storage-api:v1.2.3
-# MEMCLAW_VERSION=latest
+# CAURA_VERSION=latest
 
 # -- Database (PostgreSQL + pgvector) ----------------------------------------
 POSTGRES_HOST=127.0.0.1
@@ -69,7 +69,7 @@ POSTGRES_REQUIRE_SSL=false
 ADMIN_API_KEY=
 # Optional: when set, ALL non-admin requests must include this key via X-API-Key.
 # Useful when exposing the API to a network (not just localhost).
-MEMCLAW_API_KEY=
+CAURA_API_KEY=
 
 # -- Embedding provider -----------------------------------------------------
 # Options: openai | local | fake

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Anthropic, Gemini, and OpenRouter don't offer embedding APIs here — pair them 
 docker compose up -d
 ```
 
-By default this **pulls the multi-arch images from `ghcr.io`** (`linux/amd64` + `linux/arm64`) on first run — takes ~30 seconds. Subsequent `up` commands re-use the cached image (no registry round-trip, works offline). To pin a specific version, set `MEMCLAW_VERSION=v1.2.3` in your `.env`. To build from local source instead (e.g. when iterating on a fork), run `docker compose up --build --no-pull`.
+By default this **pulls the multi-arch images from `ghcr.io`** (`linux/amd64` + `linux/arm64`) on first run — takes ~30 seconds. Subsequent `up` commands re-use the cached image (no registry round-trip, works offline). To pin a specific version, set `CAURA_VERSION=v1.2.3` in your `.env`. To build from local source instead (e.g. when iterating on a fork), run `docker compose up --build --no-pull`.
 
 To upgrade to a newer image at the same tag (e.g. `:latest` after we cut a new release), run `docker compose pull && docker compose up -d`. Without an explicit `pull`, the local cache wins — there's no silent version drift.
 
@@ -292,7 +292,7 @@ Pass `X-API-Key: your-long-random-admin-key` and include `tenant_id` in request 
 
 **Shared gate** — for network-exposed OSS deployments:
 ```env
-MEMCLAW_API_KEY=your-shared-key
+CAURA_API_KEY=your-shared-key
 ```
 Clients send `X-API-Key: your-shared-key` plus `X-Tenant-ID: <tenant>`.
 
@@ -782,7 +782,7 @@ The **reader/writer split** is an opt-in topology for high-write-rate deploys th
    a populated DB:
    ```bash
    docker compose pull
-   MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS=true docker compose up -d
+   CAURA_RUN_DESTRUCTIVE_MIGRATIONS=true docker compose up -d
    ```
    The `core-storage-api` container will run `alembic upgrade head` on
    startup. The migration runs in seconds-to-minutes for typical OSS
@@ -832,10 +832,10 @@ The **reader/writer split** is an opt-in topology for high-write-rate deploys th
      so self-hosters on the stock stack should use the `core-storage-api`
      variant above, which works as documented.
 
-6. **Once stable, unset `MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS`** so subsequent
+6. **Once stable, unset `CAURA_RUN_DESTRUCTIVE_MIGRATIONS`** so subsequent
    `up` commands don't carry the opt-in:
    ```bash
-   unset MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS  # if exported in the shell
+   unset CAURA_RUN_DESTRUCTIVE_MIGRATIONS  # if exported in the shell
    # or remove the line from your .env file
    ```
 
@@ -852,7 +852,7 @@ explicitly downgrade:
 
 ```bash
 docker compose run --rm \
-  -e MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS=true \
+  -e CAURA_RUN_DESTRUCTIVE_MIGRATIONS=true \
   core-storage-api alembic downgrade 011
 ```
 
@@ -981,7 +981,7 @@ All routes are versioned under `/api/v1/`. Interactive Swagger docs at `/api/doc
 |---|---|
 | `X-Agent-ID` | Scopes the request to this agent |
 | `X-Org-Read-Only: true` | Read-only mode — creates/updates return 403 |
-| `X-Tenant-ID` | Tenant identity when using the shared `MEMCLAW_API_KEY` gate |
+| `X-Tenant-ID` | Tenant identity when using the shared `CAURA_API_KEY` gate |
 
 These headers are honored unconditionally — `core-api` must not be network-exposed without a gateway that strips them from untrusted callers.
 
@@ -1158,12 +1158,17 @@ Read by the OpenClaw plugin. The plugin's published name (`memclaw`) and these v
 
 | Var | Purpose |
 |---|---|
-| `MEMCLAW_API_URL` | Base URL of the core-api server. |
-| `MEMCLAW_API_KEY` | Tenant or admin API key sent in `X-API-Key`. |
-| `MEMCLAW_TENANT_ID` | Optional pre-resolved tenant id; bypasses lookup. |
-| `MEMCLAW_FLEET_ID` | Default fleet id for writes/heartbeat. |
-| `MEMCLAW_NODE_NAME` | Fleet node identifier reported on heartbeat. |
-| `MEMCLAW_AUTO_WRITE_TURNS` | Auto-write turn summaries (default `true`). |
+| `CAURA_API_URL` | Base URL of the core-api server. |
+| `CAURA_API_KEY` | Tenant or admin API key sent in `X-API-Key`. |
+| `CAURA_TENANT_ID` | Optional pre-resolved tenant id; bypasses lookup. |
+| `CAURA_FLEET_ID` | Default fleet id for writes/heartbeat. |
+| `CAURA_NODE_NAME` | Fleet node identifier reported on heartbeat. |
+| `CAURA_AUTO_WRITE_TURNS` | Auto-write turn summaries (default `true`). |
+
+**Legacy spellings.** Every `CAURA_*` variable in this document — the table above, the `CAURA_API_KEY` server gate, and `CAURA_VERSION` in compose — also answers to its pre-rename `MEMCLAW_*` name and will keep doing so: swap the prefix, and the rest of the name is unchanged (`CAURA_API_URL` ⇄ `MEMCLAW_API_URL`). Where both are set the first **non-empty** value wins — deliberately, rather than the first one *defined* — so an unfilled `CAURA_FOO=` in a deploy template cannot blank out a working `MEMCLAW_FOO`. <!-- legacy-name-ok: rule 3 dual-read alias — the one surviving alias table -->
+
+New installs are written with the `CAURA_*` names. Variables without the prefix
+(`ADMIN_API_KEY`, `POSTGRES_*`, `IS_STANDALONE`, …) never had a branded spelling.
 
 #### Server environment variables
 
@@ -1172,7 +1177,7 @@ These mirror the Configuration table above. See it for defaults.
 | Group | Vars |
 |---|---|
 | Database | `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_USE_IAM_AUTH`, `POSTGRES_REQUIRE_SSL` |
-| Auth | `ADMIN_API_KEY`, `MEMCLAW_API_KEY`, `IS_STANDALONE` |
+| Auth | `ADMIN_API_KEY`, `CAURA_API_KEY`, `IS_STANDALONE` |
 | Providers | `EMBEDDING_PROVIDER`, `ENTITY_EXTRACTION_PROVIDER`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `USE_LLM_FOR_MEMORY_CREATION` |
 | Runtime | `CORS_ORIGINS`, `ENVIRONMENT`, `SETTINGS_ENCRYPTION_KEY`, `REDIS_URL` |
 
@@ -1182,7 +1187,7 @@ These mirror the Configuration table above. See it for defaults.
 |---|---|---|
 | Standalone | `IS_STANDALONE=true` | Single-tenant self-host; auth bypassed. |
 | Multi-tenant admin | `ADMIN_API_KEY=…` | Operator key for multi-tenant deployments. |
-| Shared gate | `MEMCLAW_API_KEY=…` | Optional shared secret required on every non-admin request. |
+| Shared gate | `CAURA_API_KEY=…` | Optional shared secret required on every non-admin request. |
 
 See [AGENT-INSTALL.md](AGENT-INSTALL.md) for installation flows that exercise each mode.
 

--- a/docs/local-embedder.md
+++ b/docs/local-embedder.md
@@ -41,7 +41,7 @@ In another terminal, fire one write → search round-trip:
 > These examples assume `IS_STANDALONE=true` in `.env` (see the
 > [Auth modes](../README.md#self-hosted-open-source) section in README).
 > Replace `standalone` with your actual API key if you're using `ADMIN_API_KEY`
-> or `MEMCLAW_API_KEY` instead, and add `tenant_id` matching your setup.
+> or `CAURA_API_KEY` instead, and add `tenant_id` matching your setup.
 
 ```bash
 curl -fsS -X POST http://localhost:8000/api/v1/memories \

--- a/docs/mcp-skill-delivery.md
+++ b/docs/mcp-skill-delivery.md
@@ -188,7 +188,7 @@ opt-in below); it's empty unless a target opts in.
 By default the reconciler manages one **`owned`** dir — the plugin's own
 `skills/` — where it has full authority: anything on disk not in the
 catalog is pruned. Operators can add extra target dirs via the
-`MEMCLAW_SKILL_TARGETS` env var (JSON array of `{ dir, mode, register? }`):
+`CAURA_SKILL_TARGETS` env var (JSON array of `{ dir, mode, register? }`):
 
 - **`owned`** — fully Caura-managed (destructive prune). Use only for
   dirs Caura exclusively controls.

--- a/docs/plugin-upgrade.md
+++ b/docs/plugin-upgrade.md
@@ -35,10 +35,10 @@ The server's `/api/v1/install-plugin` endpoint returns a complete bash installer
 ### Minimal — fresh install or operator-driven re-install with explicit creds
 
 ```bash
-curl -ks -X POST "$MEMCLAW_API_URL/api/v1/install-plugin" \
+curl -ks -X POST "$CAURA_API_URL/api/v1/install-plugin" \
   -H "Content-Type: application/json" \
   -d '{
-    "api_url":   "https://your-memclaw-server",
+    "api_url":   "https://your-caura-server",
     "api_key":   "mc_…",
     "fleet_id":  "your-fleet",
     "tenant_id": "your-tenant",
@@ -108,7 +108,7 @@ For operators with many nodes (and SSH or OpenClaw-agent reach to all of them), 
 Identifying which nodes need re-install:
 
 ```bash
-curl -s "https://your-memclaw-server/api/v1/fleet/stats?tenant_id=$TENANT_ID&fleet_id=$FLEET_ID" \
+curl -s "https://your-caura-server/api/v1/fleet/stats?tenant_id=$TENANT_ID&fleet_id=$FLEET_ID" \
   -H "Authorization: Bearer $JWT" \
   | jq '.nodes[]
         | select((.plugin_version // "0") | split(".") | map(tonumber? // 0) | . < [2,6,0])
@@ -121,7 +121,7 @@ That returns the stale-plugin set the auto-deploy gate is currently skipping. Th
 
 | Resource | Auto-upgrade (heartbeat) | Manual install (with creds) | Manual install (default creds) |
 |---|---|---|---|
-| `.env` (`MEMCLAW_API_KEY` etc.) | Preserved + merged | Preserved (you pass them back) | Overwritten with defaults |
+| `.env` (`CAURA_API_KEY` etc.) | Preserved + merged | Preserved (you pass them back) | Overwritten with defaults |
 | `dist/*.js`, `src/*.ts` | Replaced | Replaced | Replaced |
 | `node_modules/` | Replaced | Replaced | Replaced |
 | `.agent-keys.json`, `.educated`, `.allowlist-applied` | Preserved | Preserved | Preserved |

--- a/docs/skills-inbox-api.md
+++ b/docs/skills-inbox-api.md
@@ -24,7 +24,7 @@ deliberate, explicit error rather than a silent 404).
 - **Scripts / CLI** authenticate with a Bearer JWT:
   `Authorization: Bearer <token>`.
 - **Self-hosted / standalone** deployments that hit core-api directly
-  use the `X-API-Key` header (admin key or `MEMCLAW_API_KEY`); in
+  use the `X-API-Key` header (admin key or `CAURA_API_KEY`); in
   standalone mode the resolved context is already `orgRole=admin`.
 
 **Authorization.** The five action endpoints

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -66,7 +66,7 @@ Add this to your MCP client configuration:
 {
   "mcpServers": {
     "caura": {
-      "url": "https://your-memclaw-instance.example.com/mcp",
+      "url": "https://your-caura-instance.example.com/mcp",
       "headers": {
         "X-API-Key": "mc_your_api_key_here"
       }
@@ -81,8 +81,8 @@ Add this to your MCP client configuration:
 |---|---|
 | Claude Desktop (macOS) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
 | Claude Desktop (Windows) | `%APPDATA%\Claude\claude_desktop_config.json` |
-| Claude Code | `~/.claude.json` (user scope) — preferred; register via `claude mcp add --scope user --transport http caura https://your-memclaw-instance.example.com/mcp --header "X-API-Key: mc_your_key"` |
-| Cursor | Settings -> MCP Servers -> Add Server (type: `sse`, URL: `https://your-memclaw-instance.example.com/mcp`) |
+| Claude Code | `~/.claude.json` (user scope) — preferred; register via `claude mcp add --scope user --transport http caura https://your-caura-instance.example.com/mcp --header "X-API-Key: mc_your_key"` |
+| Cursor | Settings -> MCP Servers -> Add Server (type: `sse`, URL: `https://your-caura-instance.example.com/mcp`) |
 
 > The Claude Code MCP-server registry lives in `~/.claude.json` — NOT `~/.claude/settings.json`. The latter's schema rejects an `mcpServers` block. Prefer the `claude mcp add` CLI over hand-editing so the correct file is written.
 
@@ -98,7 +98,7 @@ agent reads on-demand. Install it after the MCP config above:
 ```bash
 # Installs SKILL.md into ~/.claude/skills/memclaw/ (Claude Code)
 # and/or ~/.agents/skills/memclaw/ (Codex).
-curl -s "https://your-memclaw-instance.example.com/api/v1/install-skill" \
+curl -s "https://your-caura-instance.example.com/api/v1/install-skill" \
   -H "X-API-Key: mc_your_key" | bash
 ```
 
@@ -220,16 +220,16 @@ scp -r plugin/dist plugin/package.json plugin/openclaw.plugin.json \
 Add to `~/.openclaw/plugins/memclaw/.env`:
 
 ```bash
-MEMCLAW_API_URL=https://your-memclaw-instance.example.com   # your Caura API
-MEMCLAW_API_KEY=mc_your_key_here                             # tenant-scoped API key
-MEMCLAW_FLEET_ID=fleet-001                                   # identifies this fleet
-MEMCLAW_NODE_NAME=my-gateway                                 # friendly name shown in Fleet page
-# MEMCLAW_TENANT_ID=                                         # auto-resolved from API key
-# MEMCLAW_AUTO_WRITE_TURNS=true                              # default; set false to disable auto-write
-# MEMCLAW_AUTO_FIX_CONFIG=false                              # set true to auto-fix openclaw.json on startup
+CAURA_API_URL=https://your-caura-instance.example.com   # your Caura API
+CAURA_API_KEY=mc_your_key_here                          # tenant-scoped API key
+CAURA_FLEET_ID=fleet-001                                # identifies this fleet
+CAURA_NODE_NAME=my-gateway                              # friendly name shown in Fleet page
+# CAURA_TENANT_ID=                                      # auto-resolved from API key
+# CAURA_AUTO_WRITE_TURNS=true                           # default; set false to disable auto-write
+# CAURA_AUTO_FIX_CONFIG=false                           # set true to auto-fix openclaw.json on startup
 ```
 
-The plugin loads this `.env` file automatically. Both `CAURA_*` and `MEMCLAW_*` keys are read — and only those, so a `.env` cannot set `PATH` or `NODE_OPTIONS`. The installer writes `CAURA_*` into new installs; the older names above keep working unchanged. If you use systemd, also add the vars to a drop-in file (`.env` values don't override existing process env). <!-- legacy-name-ok: rule 3 dual-read alias -->
+The plugin loads this `.env` file automatically. Both `CAURA_*` and `MEMCLAW_*` keys are read — and only those, so a `.env` cannot set `PATH` or `NODE_OPTIONS`. The pre-rename `MEMCLAW_*` spelling of every name above keeps working; where both are set the first **non-empty** one wins, so a half-filled template cannot blank out a working value. If you use systemd, also add the vars to a drop-in file (`.env` values don't override existing process env). <!-- legacy-name-ok: rule 3 dual-read alias -->
 
 **Configure OpenClaw** — edit `~/.openclaw/openclaw.json`:
 
@@ -711,11 +711,11 @@ Content-hash rejects exact duplicates within a tenant+fleet scope (HTTP 409). Sa
 | Issue | Fix |
 |---|---|
 | Plugin tools don't appear | Ensure all three `plugins` keys are set in `openclaw.json`: `allow`, `entries`, and `load.paths`. Restart OpenClaw |
-| Tools not in agent sessions | Auto-fixed on first plugin load (adds v1.0 names, removes stale pre-v1.0 names). If it persists after restart, run `openclaw gateway memclaw.allowlist.fix` or check that `MEMCLAW_AUTO_FIX_CONFIG` is not set to `false` |
+| Tools not in agent sessions | Auto-fixed on first plugin load (adds v1.0 names, removes stale pre-v1.0 names). If it persists after restart, run `openclaw gateway memclaw.allowlist.fix` or check that `CAURA_AUTO_FIX_CONFIG` is not set to `false` <!-- legacy-name-ok: memclaw.allowlist.fix is the live gateway RPC method name --> |
 | Plugin allowed but not loading | Missing `plugins.entries.memclaw.enabled: true` or `plugins.load.paths` entry — the installer and Fix Configuration set both |
 | All config issues | Use the "Fix Configuration" button in Fleet Browser Plugin Manager to auto-fix all settings |
-| `ECONNREFUSED` | Check `MEMCLAW_API_URL`, ensure API is running |
-| 401 Unauthorized | Check `MEMCLAW_API_KEY` env var on gateway |
+| `ECONNREFUSED` | Check `CAURA_API_URL`, ensure API is running |
+| 401 Unauthorized | Check `CAURA_API_KEY` env var on gateway |
 | 403 Forbidden | Key used for wrong tenant, or agent trust level too low |
 | 409 Conflict | Duplicate content — safe to ignore |
 | Empty search results | Verify tenant_id, check fleet_id scope, write test memories |


### PR DESCRIPTION
**Phase 5.4 for this repo's docs.** Every place the documentation told a reader to set a `MEMCLAW_*` variable now teaches the `CAURA_*` spelling. This changes **what we teach, not what anything reads** — every old name keeps working.

### Verified each name against its reader first

A doc that teaches a name nothing accepts is worse than one teaching a stale name that works, so nothing was renamed on faith:

| Name taught | Reader | 
|---|---|
| `CAURA_API_URL` `_API_KEY` `_TENANT_ID` `_FLEET_ID` `_NODE_NAME` `_AUTO_WRITE_TURNS` | `plugin/src/env.ts:85-104`, via `readEnv` |
| `CAURA_AUTO_FIX_CONFIG` | `plugin/src/index.ts:406` — **not** env.ts |
| `CAURA_SKILL_TARGETS` | `plugin/src/reconcile-skills.ts:194` |
| `CAURA_RUN_DESTRUCTIVE_MIGRATIONS` | `012_vector_dim_1024.py:133` |
| `CAURA_VERSION` | `docker-compose.yml:72,104` |
| `CAURA_API_KEY` (server gate) | `core-api/config.py`, via `_prefer_the_new_api_key_name` |

**Two of those are not where you would look.** `AUTO_FIX_CONFIG` is read in `index.ts` and `SKILL_TARGETS` in `reconcile-skills.ts`, not in `env.ts` with the rest. Grepping `env.ts` alone — the obvious move — reports both as unsupported and leaves two names un-swept. Worth knowing for the repos still to do.

**Both readers resolve first NON-EMPTY, not first defined.** `readEnv` skips a blank alias; `config.py` deliberately avoids `AliasChoices` for the same reason. That is precisely what makes teaching the new name safe next to a deploy template still carrying the old one, and the alias note now says so.

### One surviving alias table

Per 5.4's "leave exactly one legacy-alias table per repo", the mapping now lives in a single place — the **Legacy spellings** note under the plugin env table — and nowhere else. It states the prefix swap, the first-non-empty rule, and that unprefixed vars (`ADMIN_API_KEY`, `POSTGRES_*`, …) never had a branded spelling. After this, exactly **two** `MEMCLAW_` mentions remain in the swept files, both deliberate alias statements.

### Scope notes, both worth a look

**`.env.example` is included, and it is outside this lane's stated docs scope.** The README section it pairs with now says `CAURA_VERSION`; shipping a template that writes `MEMCLAW_VERSION` next to it would manufacture exactly the doc-versus-artifact mismatch this lane has spent four PRs removing. `POSTGRES_USER`/`POSTGRES_DB` in that file are floor strings and are untouched. Revert that one file if you'd rather keep the lane boundary strict.

**5.4's stated dependency, `5.3`, is still open** — `caura-onprem-installer#17`, "accept the CAURA_* spelling of every name this installer reads". That gate is real but it is about the **installer's own** names in the **installer's** repo: teaching a customer to put `CAURA_*` in `install.conf` before the installer reads it would produce a broken install. Every name in *this* PR is read by *this* repo's code, verified above, so the OSS half is not gated on it. The ONPREM half of 5.4 still is.

### Gates

Ratchet **no new lines, −40 net**, three exempt lines (the two alias statements and one troubleshooting row that legitimately keeps `memclaw.allowlist.fix`, the live RPC method). Sentinel **23/23**.

The exemption markers are HTML comments. Checked that this is safe for the served guide: the customer path is the README's relative link, GitHub-rendered, where HTML comments are hidden — and `/static/docs/integration-guide.md` 404s publicly, so nobody reads it as raw text. Also confirmed the edited troubleshooting row still parses as a 2-cell table row against its 2-cell header.

### Not in scope

Product-name prose (`# Upgrading the memclaw plugin`), the plugin id and its RPC methods, install paths, the `[memclaw]` log prefix, the skills dir. All real names, none of them env vars. Prose renaming is Phase 1.3 / Phase 7, not 5.4.
