### PR TITLE
fix(events): refuse a FLIPPED_FAMILIES entry that names no real family

### DIFF
--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -172,6 +172,43 @@ def family(topic: str) -> str:
 FLIPPED_FAMILIES: frozenset[str] = frozenset()
 
 
+def known_families() -> frozenset[str]:
+    """Every family the topics declared in this module actually use.
+
+    Derived by walking the enums rather than listed, so it cannot drift from
+    them, and so the same code yields the right answer in each repo despite the
+    two copies declaring different families.
+    """
+    return frozenset(
+        f
+        for attr in vars(Topics).values()
+        if isinstance(attr, type) and issubclass(attr, enum.StrEnum)
+        for member in attr
+        if (f := family(member))
+    )
+
+
+# A family named here that does not exist would be a SILENT no-op: publish_name
+# would go on returning the outgoing name for every topic, so the flip would
+# look done, move nothing, and leave the twin subscriptions idle with no error
+# anywhere to say so. That is the same shape as every other failure in this
+# cutover — quiet, and only visible if you already suspected it — so it is
+# checked at the point of definition rather than left to a reviewer's eye.
+#
+# Raising here is a deliberate choice about blast radius. This set is a literal
+# in this file, so the only way to trip it is editing that literal, and the
+# import runs in every test that touches the bus — a typo cannot get past CI,
+# let alone reach a deploy. The cost of being wrong is an ImportError in front
+# of the person who made the typo; the cost of NOT checking is a step 4 that
+# reports success and moves no traffic.
+if unknown_families := FLIPPED_FAMILIES - known_families():
+    raise ValueError(
+        f"FLIPPED_FAMILIES names {sorted(unknown_families)}, which match no topic "
+        f"family declared here (known: {sorted(known_families())}). A family that "
+        "does not exist flips nothing and reports no error — fix the spelling."
+    )
+
+
 def publish_name(topic: str) -> str:
     """The single name to publish ``topic`` under.
 

--- a/tests/test_events/test_topic_rename_cutover.py
+++ b/tests/test_events/test_topic_rename_cutover.py
@@ -24,6 +24,7 @@ opposite ones and a missing twin fails differently in each.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -107,6 +108,47 @@ def test_no_family_is_flipped_yet() -> None:
     cutover has not started, instead of somewhere that reads like a broken test.
     """
     assert topics_mod.FLIPPED_FAMILIES == frozenset()
+
+
+def test_known_families_are_derived_from_the_enums() -> None:
+    """The set a flip is validated against comes from the topics themselves."""
+    assert topics_mod.known_families() == {
+        "memory",
+        "audit",
+        "pipeline",
+        "lifecycle",
+        "org",
+    }
+
+
+def test_a_misspelled_flipped_family_is_refused() -> None:
+    """A typo must not be a silent no-op.
+
+    ``publish_name`` looks the family up by string, so ``"audi"`` would simply
+    never match: every topic keeps its outgoing name, the flip reports success,
+    no traffic moves, and the twin subscriptions sit idle with nothing anywhere
+    saying why.
+
+    The guard runs at import, so this re-executes the real module source with
+    the literal edited — the same edit a fat-fingered flip would make — rather
+    than re-implementing the check and asserting the copy raises.
+    """
+    original = Path(topics_mod.__file__).read_text(encoding="utf-8")
+    target = "FLIPPED_FAMILIES: frozenset[str] = frozenset()"
+    assert target in original, "the literal moved; this test is no longer editing it"
+    source = original.replace(target, f'{target[:-11]}frozenset({{"audi"}})')
+    assert source != original
+
+    with pytest.raises(ValueError, match="match no topic family"):
+        exec(  # noqa: S102 — executing our own module source, with one literal edited
+            compile(source, topics_mod.__file__, "exec"),
+            {"__name__": "_topics_under_test"},
+        )
+
+
+def test_the_real_module_passes_its_own_guard() -> None:
+    """Counterpart, so the test above cannot pass because the guard is unreachable."""
+    assert topics_mod.FLIPPED_FAMILIES - topics_mod.known_families() == frozenset()
 
 
 def test_publish_name_is_the_identity_while_nothing_is_flipped() -> None:


### PR DESCRIPTION
Follow-up to [#911](https://github.com/caura-ai/caura/pull/911) (step 2 of the Pub/Sub rename), from a review suggestion on the enterprise copy ([caura-enterprise#1246](https://github.com/caura-ai/caura-enterprise/pull/1246)).

## The problem

`publish_name()` looks the family up by string:

```python
return renamed(topic) if family(topic) in FLIPPED_FAMILIES else str(topic)
```

So a typo is a **silent no-op**. `"audi"` for `"audit"` matches nothing: every topic keeps its outgoing name, the flip reports success, no traffic moves, and the twin subscriptions sit idle with no error anywhere to say why.

That matters more than a normal typo would, because this string *is* the mechanism for the step the whole wave is heading toward — publishers get flipped one family at a time, and each of those steps is exactly one edit to this set. It is also the same fail-quiet shape as the other hazards in this cutover: the missing broadcast attach binding, the blank dual-subscribe flag, the dropped boolean. Nothing goes red; you only find it if you already suspected.

## The fix

`known_families()` derives the valid set by **walking the enums** rather than listing it, so it cannot drift from them — and the same code gives the right answer in both repos despite the two copies declaring different families (`lifecycle` and `org` here, `security` and `fleet` in enterprise).

The check **raises at the point of definition** rather than deferring to a test. That is a deliberate call about blast radius: the set is a literal in this file, so the only way to trip it is editing that literal, and the import runs in every test that touches the bus — a typo cannot get past CI, let alone reach a deploy. The cost of being wrong is an `ImportError` in front of the person who made the typo; the cost of not checking is a flip that reports success and moves nothing.

## The test

It **re-executes the real module source with the literal edited** — the same edit a fat-fingered flip would make — rather than re-implementing the check and asserting the copy raises, which would pass whether or not the guard existed. It also asserts the literal is still present *before* editing it, so it cannot go vacuous if the constant is ever moved or renamed.

Confirmed to fail with the guard removed. A companion test asserts the real module passes its own guard, so the first cannot pass because the guard is simply unreachable.

## Verification

- Events suite: **106 passed**, up from 103. The 12 failures are pre-existing in this local env (`No module named 'google'`) and identical on `origin/main`.
- `ruff check common/` and the isolated format check, run separately. Manifest not stale. Legacy-name ratchet: `No new lines.`

The block is **byte-identical** to the one landing in [caura-enterprise#1248](https://github.com/caura-ai/caura-enterprise/pull/1248) — `common/events/*` is `manual` vendor policy, so these two files only stay in step by hand.
