### PR TITLE
ci: accept either spelling of the agents key, so the rename is an admin flip

### DIFF
--- a/.github/scripts/claude_pr_capture.sh
+++ b/.github/scripts/claude_pr_capture.sh
@@ -11,7 +11,7 @@
 # shared pipeline and keeps its own copy. See the workflow header. The fleet is shared even
 # though the code is not: notes written here are recalled by the other six repos and vice versa.
 #
-# DARK AND SILENT without MEMCLAW_AGENTS_KEY. That is the state to expect at the moment this
+# DARK AND SILENT without CAURA_AGENTS_KEY. That is the state to expect at the moment this
 # lands: the org secret has `private` visibility, which a PUBLIC repo cannot read, so until a
 # repo-level secret exists this exits immediately having done nothing.
 #
@@ -29,8 +29,9 @@
 #   ANTHROPIC_API_KEY Anthropic API key
 #   GH_TOKEN          token with issues:read and pull-requests:read
 # Optional env:
-#   MEMCLAW_AGENTS_KEY   internal-agents tenant key (empty => dark no-op)
-#   MEMCLAW_API_URL      default https://caura.ai
+#   CAURA_AGENTS_KEY     internal-agents tenant key (empty => dark no-op)
+#   CAURA_API_URL        default https://caura.ai
+# Both also accept their pre-rename MEMCLAW_* spelling.  # legacy-name-ok: rule 3 dual-read alias
 #   CODE_REVIEW_FLEET_ID default code-review
 #   MODEL                default claude-sonnet-5
 #   MAX_BUDGET_USD       per-invocation ceiling (default 2.00)
@@ -46,8 +47,15 @@ MAX_THREAD_CHARS=60000
 # from here would be the only one no per-reviewer filter could account for.
 REVIEWER="claude"
 
-if [ -z "${MEMCLAW_AGENTS_KEY:-}" ]; then
-  echo "::notice::Declined-finding capture is dark (no MEMCLAW_AGENTS_KEY) — skipping"
+# Either spelling: the workflow passes CAURA_AGENTS_KEY (itself resolved from
+# whichever secret exists), but a manual run may still export the old name.
+# ``:-`` treats blank as unset, so this is first NON-EMPTY, not first defined —
+# an unfilled CAURA_AGENTS_KEY= must not shadow a working old one and take the
+# capture dark without saying so.
+AGENTS_KEY="${CAURA_AGENTS_KEY:-${MEMCLAW_AGENTS_KEY:-}}"  # legacy-name-ok: rule 3 dual-read alias
+
+if [ -z "$AGENTS_KEY" ]; then
+  echo "::notice::Declined-finding capture is dark (no CAURA_AGENTS_KEY) — skipping"
   exit 0
 fi
 
@@ -236,7 +244,7 @@ if [ -z "$NOTES" ]; then
   exit 0
 fi
 
-CAURA_URL="${MEMCLAW_API_URL:-https://caura.ai}"
+CAURA_URL="${CAURA_API_URL:-${MEMCLAW_API_URL:-https://caura.ai}}"  # legacy-name-ok: rule 3 dual-read alias
 CR_FLEET="${CODE_REVIEW_FLEET_ID:-code-review}"
 SAVED=0
 while IFS= read -r NOTE; do
@@ -259,7 +267,7 @@ while IFS= read -r NOTE; do
     continue
   }
   RESP=$(curl -sS --max-time 20 "${CAURA_URL%/}/mcp" \
-    -H "X-API-Key: ${MEMCLAW_AGENTS_KEY}" \
+    -H "X-API-Key: ${AGENTS_KEY}" \
     -H "Content-Type: application/json" -H "Accept: application/json" \
     -d "$REQ") || { echo "::warning::MemClaw unreachable — note dropped"; continue; }
   if printf '%s' "$RESP" | jq -e 'has("result") and (.error | not)' >/dev/null 2>&1; then

--- a/.github/scripts/claude_pr_review.sh
+++ b/.github/scripts/claude_pr_review.sh
@@ -61,7 +61,7 @@ fi
 # findings a maintainer has already judged wrong — here and in the six repos on the org's shared
 # pipeline, which write into the same fleet.
 #
-# DARK AND SILENT without MEMCLAW_AGENTS_KEY: returns immediately, and the review is
+# DARK AND SILENT without CAURA_AGENTS_KEY: returns immediately, and the review is
 # byte-for-byte what it would be without the feature. That matters more here than elsewhere —
 # this repo is PUBLIC, and the org secret is `private` visibility, so it cannot read it. Until a
 # repo-level secret exists this is a no-op by design, not a misconfiguration.
@@ -72,8 +72,12 @@ fi
 recall_review_guidance() {
   local diff="$1"
   GUIDANCE_SECTION=""
-  [ -n "${MEMCLAW_AGENTS_KEY:-}" ] || return 0
-  local memclaw_url="${MEMCLAW_API_URL:-https://caura.ai}"
+  # Either spelling, first NON-EMPTY (``:-`` treats blank as unset): the workflow
+  # passes CAURA_AGENTS_KEY, resolved from whichever secret exists, but a manual
+  # run may still export the pre-rename name.
+  local agents_key="${CAURA_AGENTS_KEY:-${MEMCLAW_AGENTS_KEY:-}}"  # legacy-name-ok: rule 3 dual-read alias
+  [ -n "$agents_key" ] || return 0
+  local caura_url="${CAURA_API_URL:-${MEMCLAW_API_URL:-https://caura.ai}}"  # legacy-name-ok: rule 3 dual-read alias
   local fleet="${CODE_REVIEW_FLEET_ID:-code-review}"
   # Query built from the changed paths so recall is relevant to THIS diff. The sanitiser keeps
   # only path characters, so a crafted filename cannot inject into the query, and caps length.
@@ -93,8 +97,8 @@ recall_review_guidance() {
   # -S so a failure (bad key, DNS, TLS) reaches the workflow log and warns — distinct from the
   # "no memories" no-op. Best-effort either way: the review proceeds without guidance.
   local resp
-  resp=$(curl -sS --max-time 20 "${memclaw_url%/}/mcp" \
-    -H "X-API-Key: ${MEMCLAW_AGENTS_KEY}" \
+  resp=$(curl -sS --max-time 20 "${caura_url%/}/mcp" \
+    -H "X-API-Key: ${agents_key}" \
     -H "Content-Type: application/json" -H "Accept: application/json" \
     -d "$req") || { echo "::warning::memclaw recall failed — reviewing without learned guidance"; return 0; }
   local guidance

--- a/.github/workflows/claude_code_review.yml
+++ b/.github/workflows/claude_code_review.yml
@@ -114,7 +114,7 @@ on:
   issue_comment:
     types: [created]
   # Manual backfill for claude-capture, mirroring the shared pipeline's caller. Two uses: it makes
-  # capture verifiable the moment MEMCLAW_AGENTS_KEY is added — the on-merge path cannot be tested
+  # capture verifiable the moment CAURA_AGENTS_KEY is added — the on-merge path cannot be tested
   # on demand, since it needs a real merge that happens to carry a declined finding — and it can
   # extract declines from pull requests that merged BEFORE capture existed here.
   #
@@ -360,7 +360,7 @@ jobs:
           # is unreadable — which is TODAY, because the org secret is `private` visibility and
           # this repo is public — and recall is then a silent no-op leaving the review
           # byte-for-byte unchanged. Adding a repo-level secret turns it on with no code change.
-          MEMCLAW_AGENTS_KEY: ${{ secrets.MEMCLAW_AGENTS_KEY }}
+          CAURA_AGENTS_KEY: ${{ secrets.CAURA_AGENTS_KEY || secrets.MEMCLAW_AGENTS_KEY }}  # legacy-name-ok: rule 3 dual-read alias
         run: bash .github/scripts/claude_pr_review.sh
 
   # Runs on @claude comment — only for public org members (MEMBER or OWNER).
@@ -468,7 +468,7 @@ jobs:
           # is unreadable — which is TODAY, because the org secret is `private` visibility and
           # this repo is public — and recall is then a silent no-op leaving the review
           # byte-for-byte unchanged. Adding a repo-level secret turns it on with no code change.
-          MEMCLAW_AGENTS_KEY: ${{ secrets.MEMCLAW_AGENTS_KEY }}
+          CAURA_AGENTS_KEY: ${{ secrets.CAURA_AGENTS_KEY || secrets.MEMCLAW_AGENTS_KEY }}  # legacy-name-ok: rule 3 dual-read alias
         run: bash .github/scripts/claude_pr_review.sh
 
   # Runs on MERGE, and only on merge: extracts findings a maintainer DECLINED into the shared
@@ -479,7 +479,7 @@ jobs:
   # accepted judgement, and capturing declines from an abandoned branch would teach the reviewer
   # from a decision nobody stood behind.
   #
-  # Dark and silent without MEMCLAW_AGENTS_KEY, which is the state on the day this lands — the
+  # Dark and silent without CAURA_AGENTS_KEY, which is the state on the day this lands — the
   # org secret is `private` visibility and this repo is public, so it reads as ''. The job still
   # runs and exits 0 having logged that it was dark, which is the diagnosable outcome.
   # Only this job answers a workflow_dispatch. pre-checks is gated on `pull_request` and
@@ -516,5 +516,5 @@ jobs:
           # pull_request supplies the number; on workflow_dispatch that context is absent and the
           # input takes over. Ordered this way so a merge never reads a stale dispatch input.
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-          MEMCLAW_AGENTS_KEY: ${{ secrets.MEMCLAW_AGENTS_KEY }}
+          CAURA_AGENTS_KEY: ${{ secrets.CAURA_AGENTS_KEY || secrets.MEMCLAW_AGENTS_KEY }}  # legacy-name-ok: rule 3 dual-read alias
         run: bash .github/scripts/claude_pr_capture.sh


### PR DESCRIPTION
The `.github` half of 5.4. **It cannot be a rename**, and the tests half is almost entirely a no-op — both for reasons worth reading before the next repo does this.

### Why .github is a dual-accept, not a rename

`MEMCLAW_AGENTS_KEY` is a **live repository secret** — created 2026-08-10, confirmed with `gh secret list`. Rewriting the reference to `secrets.CAURA_AGENTS_KEY` resolves to `''` until an admin creates that secret, and **both scripts are built to go dark and silent on an empty key**. So the obvious rename would have switched off declined-finding capture and learned-guidance recall with nothing red anywhere — the exact silent-degradation shape this programme keeps re-learning.

So the workflow resolves from either secret and exports the new name:

```yaml
CAURA_AGENTS_KEY: ${{ secrets.CAURA_AGENTS_KEY || secrets.MEMCLAW_AGENTS_KEY }}
```

An unset secret is falsy, so **behaviour today is byte-identical** — the existing secret still wins. Adding `CAURA_AGENTS_KEY` flips it with no code change, and deleting the old one afterwards is then safe. **The remaining secret rename is an admin action; this PR makes it a no-risk flip instead of a coupled change.**

The scripts read new-with-old-fallback via `${CAURA_X:-${MEMCLAW_X:-}}` — first **non-empty**, since `:-` treats blank as unset, so an unfilled `CAURA_AGENTS_KEY=` cannot shadow a working old key and take capture dark.

**Exercised all five states** rather than reasoning about them:

```
  unset + unset           -> []        (goes dark)
  new-only                -> [newkey]
  old-only                -> [oldkey]
  blank-new + working-old -> [oldkey]  <- must not go dark
  both                    -> [newkey]
```

`actionlint` clean, both scripts pass `bash -n`, workflow parses as YAML.

### Why the tests half is (correctly) empty

5.4 says "rewrite every doc, installer heredoc, workflow and **test** to teach `CAURA_*`". Taken literally on tests, that **destroys the coverage that proves the old names still work**. `tests/test_env_dual_read.py` says so in its own docstring: *"a test that only proves the new name works would pass just as well after someone deleted the fallback."* Per file:

| File | Why it stays |
|---|---|
| `tests/test_env_dual_read.py` | **Is** the dual-read guard; both names are the assertion. Already marked `legacy-name-ok`. |
| `tests/conftest.py:51` | Scrubs `MEMCLAW_API_KEY` **and** `CAURA_API_KEY` from the env so a dev's real key can't leak into tests. Dropping the old name re-opens that leak. |
| `tests/test_migration_012_safety_gate.py`, `tests/test_api_status.py` | These are the **old-name arm** of two-directional coverage. Flipping them to `CAURA_*` leaves nothing proving the old name opts in. |
| `clients/python/tests/test_interviewer_cursor.py` | Same — the old-name arm for `INTERVIEWER_HARNESS`. |
| `tests/test_agent_identity_guard.py`, `tests/test_preflight_012.py` | Assert **source text** (`agent_identity.py`'s error, migration 012's pre-flight). Source changes first, test follows; both sources are outside this lane. |
| `tests/test_plugin_source_manifest.py` | Refers to `MEMCLAW_TOOLS`, a `plugin/src` identifier — not an env var, and Agent 4's lane. |
| `plugin/src/*.test.ts` | `env.test.ts` is the plugin's dual-read guard and pins the *exclusions* too. Agent 4's lane. |

### Also deliberately untouched

- **`ci.yml`'s `POSTGRES_DB` / `POSTGRES_USER` / `pg_isready -U memclaw`** — floor strings. The sentinel pins that family, and CI's service credentials must keep matching the compose defaults that customers' volumes were created with.
- **Issue templates** ("MemClaw version") — product-name prose, which is the W1 punch list / Phase 1.3, not the 5.4 env family.

### One finding for whoever does the core-storage-api half

`scripts/do_not_touch_sentinel.py:256` pins `os.environ.get("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS"` as a **floor string**. So 5.4's instruction to rewrite `012_vector_dim_1024.py`'s pre-flight text collides with the sentinel unless that row moves in the same commit. Ordering trap, not a blocker — but it will fail the gate if hit blind.

Also: `scripts/repro_contradictions_*.py` read `MEMCLAW_API_URL` / `_API_KEY` / `_TENANT_ID` through a **bare** `_env()` with no fallback, so `CAURA_*` genuinely does not work there. Real gap, in `scripts/`, outside this lane.

Ratchet: **no new lines, −17 net**, 8 exempt lines. Sentinel: **23/23**.
