### PR TITLE
fix(scripts): the contradiction repros could not read a CAURA_* environment

### DIFF
--- a/scripts/repro_contradictions_collision.py
+++ b/scripts/repro_contradictions_collision.py
@@ -29,9 +29,9 @@ The verdict logic inspects the entity_links after the writes settle
 and reports which arm fired.
 
 Usage:
-    export MEMCLAW_API_URL=https://caura.ai
-    export MEMCLAW_API_KEY=mc_...
-    export MEMCLAW_TENANT_ID=rantaig-...
+    export CAURA_API_URL=https://caura.ai
+    export CAURA_API_KEY=mc_...
+    export CAURA_TENANT_ID=rantaig-...
     python scripts/repro_contradictions_collision.py
 """
 
@@ -48,8 +48,18 @@ import uuid
 import httpx
 
 
+def _env_any(name: str) -> str | None:
+    """First non-empty of ``name`` and its pre-rename spelling.
+
+    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
+    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
+    """
+    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
+    return os.environ.get(name) or os.environ.get(legacy)
+
+
 def _env(name: str) -> str:
-    val = os.environ.get(name)
+    val = _env_any(name)
     if not val:
         print(f"ERROR: ${name} must be set", file=sys.stderr)
         sys.exit(2)
@@ -85,9 +95,9 @@ def main() -> int:
     ap.add_argument("--verbose", "-v", action="store_true")
     args = ap.parse_args()
 
-    base = _env("MEMCLAW_API_URL").rstrip("/")
-    key = _env("MEMCLAW_API_KEY")
-    tenant = _env("MEMCLAW_TENANT_ID")
+    base = _env("CAURA_API_URL").rstrip("/")
+    key = _env("CAURA_API_KEY")
+    tenant = _env("CAURA_TENANT_ID")
 
     # Generate two distinguishable contexts that share a common given
     # name. Use a uniqued suffix to avoid polluting prior runs.

--- a/scripts/repro_contradictions_diagnostic.py
+++ b/scripts/repro_contradictions_diagnostic.py
@@ -35,8 +35,18 @@ import uuid
 import httpx
 
 
+def _env_any(name: str) -> str | None:
+    """First non-empty of ``name`` and its pre-rename spelling.
+
+    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
+    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
+    """
+    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
+    return os.environ.get(name) or os.environ.get(legacy)
+
+
 def _env(name: str) -> str:
-    val = os.environ.get(name)
+    val = _env_any(name)
     if not val:
         print(f"ERROR: ${name} must be set", file=sys.stderr)
         sys.exit(2)
@@ -55,9 +65,9 @@ def main() -> int:
     ap.add_argument("--probe", choices=("all", "a", "b", "c"), default="all")
     args = ap.parse_args()
 
-    base = _env("MEMCLAW_API_URL").rstrip("/")
-    key = _env("MEMCLAW_API_KEY")
-    tenant = os.environ.get("MEMCLAW_TENANT_ID")
+    base = _env("CAURA_API_URL").rstrip("/")
+    key = _env("CAURA_API_KEY")
+    tenant = _env_any("CAURA_TENANT_ID")
 
     token = f"TOKEN-{uuid.uuid4().hex[:8].upper()}"
     agent = f"diag-contradictions-{uuid.uuid4().hex[:6]}"

--- a/scripts/repro_contradictions_not_detected.py
+++ b/scripts/repro_contradictions_not_detected.py
@@ -24,8 +24,8 @@ prints a structured diagnostic dump showing exactly what the server
 reported.
 
 Usage:
-    export MEMCLAW_API_URL=https://caura.ai
-    export MEMCLAW_API_KEY=mc_...
+    export CAURA_API_URL=https://caura.ai
+    export CAURA_API_KEY=mc_...
     python scripts/repro_contradictions_not_detected.py
 
     # Adjust settle time if your env's detection is slow
@@ -44,8 +44,18 @@ import uuid
 import httpx
 
 
+def _env_any(name: str) -> str | None:
+    """First non-empty of ``name`` and its pre-rename spelling.
+
+    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
+    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
+    """
+    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
+    return os.environ.get(name) or os.environ.get(legacy)
+
+
 def _env(name: str) -> str:
-    val = os.environ.get(name)
+    val = _env_any(name)
     if not val:
         print(f"ERROR: ${name} must be set", file=sys.stderr)
         sys.exit(2)
@@ -67,9 +77,9 @@ def main() -> int:
     )
     args = ap.parse_args()
 
-    base = _env("MEMCLAW_API_URL").rstrip("/")
-    key = _env("MEMCLAW_API_KEY")
-    tenant = os.environ.get("MEMCLAW_TENANT_ID")  # optional — server may infer from key
+    base = _env("CAURA_API_URL").rstrip("/")
+    key = _env("CAURA_API_KEY")
+    tenant = _env_any("CAURA_TENANT_ID")  # optional — server may infer from key
 
     token = args.token or f"TOKEN-{uuid.uuid4().hex[:8].upper()}"
     agent = f"repro-contradictions-{uuid.uuid4().hex[:6]}"
@@ -125,7 +135,7 @@ def main() -> int:
     # parameter; without it, validation 422s and the response
     # decoder silently returns ``{"detail": [...]}``). Use the
     # tenant id returned on the write so this works even when
-    # ``MEMCLAW_TENANT_ID`` is unset.
+    # ``CAURA_TENANT_ID`` is unset.
     print("\n[4/4] Re-fetching memories + contradictions endpoints\n")
     qp = {"tenant_id": tenant or mem_a.get("tenant_id")}
     a_now = client.get(f"/api/v1/memories/{mem_a['id']}", params=qp).json()

--- a/scripts/repro_contradictions_proper_noun.py
+++ b/scripts/repro_contradictions_proper_noun.py
@@ -28,8 +28,8 @@ This script probes that exact gap with two arms:
   If both succeed → S1 is closed; move to S2 (enrichment-lag race).
 
 Usage:
-    export MEMCLAW_API_URL=https://caura.ai
-    export MEMCLAW_API_KEY=mc_...
+    export CAURA_API_URL=https://caura.ai
+    export CAURA_API_KEY=mc_...
     python scripts/repro_contradictions_proper_noun.py
 
     # tweak settle time
@@ -74,8 +74,18 @@ def _mint_proper_noun() -> str:
     return f"Project {stem}{tail.capitalize()}"
 
 
+def _env_any(name: str) -> str | None:
+    """First non-empty of ``name`` and its pre-rename spelling.
+
+    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
+    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
+    """
+    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
+    return os.environ.get(name) or os.environ.get(legacy)
+
+
 def _env(name: str) -> str:
-    val = os.environ.get(name)
+    val = _env_any(name)
     if not val:
         print(f"ERROR: ${name} must be set", file=sys.stderr)
         sys.exit(2)
@@ -198,9 +208,9 @@ def main() -> int:
     )
     args = ap.parse_args()
 
-    base = _env("MEMCLAW_API_URL").rstrip("/")
-    key = _env("MEMCLAW_API_KEY")
-    tenant = os.environ.get("MEMCLAW_TENANT_ID")
+    base = _env("CAURA_API_URL").rstrip("/")
+    key = _env("CAURA_API_KEY")
+    tenant = _env_any("CAURA_TENANT_ID")
 
     agent = f"repro-proper-noun-{uuid.uuid4().hex[:6]}"
     common = {

--- a/scripts/repro_contradictions_race.py
+++ b/scripts/repro_contradictions_race.py
@@ -41,9 +41,9 @@ Method:
   on entity extraction).
 
 Usage:
-    export MEMCLAW_API_URL=https://caura.ai
-    export MEMCLAW_API_KEY=mc_...
-    export MEMCLAW_TENANT_ID=ran-test
+    export CAURA_API_URL=https://caura.ai
+    export CAURA_API_KEY=mc_...
+    export CAURA_TENANT_ID=ran-test
     python scripts/repro_contradictions_race.py
 
     # poll longer if your env is slow
@@ -83,8 +83,18 @@ def _mint_proper_noun() -> str:
     return f"Project {stem}{tail.capitalize()}"
 
 
+def _env_any(name: str) -> str | None:
+    """First non-empty of ``name`` and its pre-rename spelling.
+
+    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
+    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
+    """
+    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
+    return os.environ.get(name) or os.environ.get(legacy)
+
+
 def _env(name: str) -> str:
-    val = os.environ.get(name)
+    val = _env_any(name)
     if not val:
         print(f"ERROR: ${name} must be set", file=sys.stderr)
         sys.exit(2)
@@ -225,9 +235,9 @@ def main() -> int:
     ap.add_argument("--verbose", "-v", action="store_true")
     args = ap.parse_args()
 
-    base = _env("MEMCLAW_API_URL").rstrip("/")
-    key = _env("MEMCLAW_API_KEY")
-    tenant = _env("MEMCLAW_TENANT_ID")
+    base = _env("CAURA_API_URL").rstrip("/")
+    key = _env("CAURA_API_KEY")
+    tenant = _env("CAURA_TENANT_ID")
 
     agent = f"repro-race-{uuid.uuid4().hex[:6]}"
     common = {

--- a/scripts/repro_contradictions_with_entity_links.py
+++ b/scripts/repro_contradictions_with_entity_links.py
@@ -28,8 +28,19 @@ import uuid
 
 import httpx
 
-BASE = os.environ.get("MEMCLAW_API_URL", "http://localhost:8000").rstrip("/")
-TENANT = os.environ.get("MEMCLAW_TENANT_ID", "default")  # standalone default
+
+def _env(name: str, default: str = "") -> str:
+    """First non-empty of ``name`` and its pre-rename spelling.
+
+    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
+    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
+    """
+    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
+    return os.environ.get(name) or os.environ.get(legacy) or default
+
+
+BASE = _env("CAURA_API_URL", "http://localhost:8000").rstrip("/")
+TENANT = _env("CAURA_TENANT_ID", "default")  # standalone default
 
 
 def main() -> int:
@@ -37,7 +48,7 @@ def main() -> int:
     ap.add_argument("--wait", type=int, default=5)
     args = ap.parse_args()
 
-    key = os.environ.get("MEMCLAW_API_KEY", "")
+    key = _env("CAURA_API_KEY")
     headers = {"Content-Type": "application/json"}
     if key:
         headers["X-API-Key"] = key


### PR DESCRIPTION
Closes the gap flagged in #915. **Unlike the rest of 5.4, this one was genuinely broken** — not stale teaching.

### The bug

All six contradiction repro harnesses resolved config through a bare lookup with no alias:

```python
base = _env("MEMCLAW_API_URL")   # os.environ.get(name), no fallback
```

So an operator who followed the renamed docs and exported `CAURA_API_URL` got:

```
ERROR: $MEMCLAW_API_URL must be set     → exit 2
```

**Confirmed against the pre-change file, not assumed** — loaded both versions side by side with only `CAURA_API_URL` set:

```
operator exports CAURA_API_URL only:
  BEFORE: exit(2) — 'ERROR: $MEMCLAW_API_URL must be set'
  AFTER : https://caura.ai
```

### The fix

Five of the six shared an identical `_env` that exits on a missing value; three of those *also* read an optional tenant id inline. Rather than duplicate the alias rule twice per file, the lookup is one helper and `_env` is the required-wrapper over it:

| | |
|---|---|
| `_env_any(name)` | first non-empty of `name` and its pre-rename spelling |
| `_env(name)` | the same, exiting 2 when neither is set |

`with_entity_links.py` has no `_env` at all — three inline reads with defaults — so it gets the same helper in default-bearing form.

`or` rather than a defined-check throughout, so blank counts as unset and an exported-but-empty `CAURA_*` cannot shadow a working legacy value. Same first-non-empty rule as `env.ts`'s `readEnv` and core-api's config.

### Verified

Every helper, all six files, five states each — **30 assertions, all passing**:

```
new only                -> NEW    OK
old only (legacy)       -> OLD    OK
blank new + old         -> OLD    OK     <- the one that matters
both set                -> NEW    OK
neither                 -> None   OK
```

Plus `py_compile` on all six after every edit.

### One thing worth recording

The mechanical pass through this family **made `with_entity_links.py` worse before it made it better.** Renaming the literals there without adding a fallback would have dropped legacy support entirely — that file was the one with no helper to fix, so the rename landed but the alias didn't. Caught on the diff read, not by a gate: the ratchet counts old names and this *removed* one, so it read as progress.

That is the same asymmetry the do-not-touch sentinel exists for, one category out — a sweep that deletes a working fallback lowers the count and looks like progress. Worth a thought for whoever sweeps the remaining families.

Also: the docstrings deliberately don't spell the old prefix. The mapping sits on the line below, which carries the marker — keeping the exemption off the line a `--help` reader sees.

Ratchet: **no new lines, −29 net**, six exempt lines. Sentinel: **23/23**. `scripts/` is not ruff-gated in CI (checked), so formatting was done by hand — including a two-blank-line fix after the new import block.
