### PR TITLE
refactor(events): keep the FLIPPED_FAMILIES check out of the module namespace

### DIFF
--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -201,12 +201,23 @@ def known_families() -> frozenset[str]:
 # let alone reach a deploy. The cost of being wrong is an ImportError in front
 # of the person who made the typo; the cost of NOT checking is a step 4 that
 # reports success and moves no traffic.
-if unknown_families := FLIPPED_FAMILIES - known_families():
-    raise ValueError(
-        f"FLIPPED_FAMILIES names {sorted(unknown_families)}, which match no topic "
-        f"family declared here (known: {sorted(known_families())}). A family that "
-        "does not exist flips nothing and reports no error — fix the spelling."
-    )
+def _validate_flipped_families() -> None:
+    """Raise if FLIPPED_FAMILIES names a family that does not exist.
+
+    A function rather than a bare module-level check so nothing is left behind in
+    the module namespace once it has run, and so ``known_families()`` is
+    evaluated once for both the comparison and the message.
+    """
+    known = known_families()
+    if unknown := FLIPPED_FAMILIES - known:
+        raise ValueError(
+            f"FLIPPED_FAMILIES names {sorted(unknown)}, which match no topic "
+            f"family declared here (known: {sorted(known)}). A family that does "
+            "not exist flips nothing and reports no error — fix the spelling."
+        )
+
+
+_validate_flipped_families()
 
 
 def publish_name(topic: str) -> str:


### PR DESCRIPTION
Two Low findings from the enterprise copy's review of the same block ([caura-enterprise#1248](https://github.com/caura-ai/caura-enterprise/pull/1248)), applied here so the two stay in step. [#914](https://github.com/caura-ai/caura/pull/914) merged before they could be folded into it.

## What was wrong

The check landed as a bare module-level statement:

```python
if unknown_families := FLIPPED_FAMILIES - known_families():
    raise ValueError(
        f"... {sorted(unknown_families)} ... (known: {sorted(known_families())}) ..."
    )
```

- **The walrus leaks.** `unknown_families` survives import as an empty `frozenset`, becoming unintended public surface on the module. (Claude)
- **`known_families()` is called twice** on the error path — once for the comparison, again for the message. (Gemini)

Both are the same six lines, and a private `_validate_flipped_families()` closes both: nothing survives the call, and the derived set is computed once. Verified directly — `[n for n in vars(topics) if "unknown" in n]` is now empty.

## What deliberately did not change

The check still runs **at import**, rather than moving into a test, which was the other option offered. The set is a literal in this file, so the only way to trip it is editing that literal, and the import runs in every test that touches the bus — a typo cannot get past CI, let alone reach a deploy. Deferring to a test would leave a hotfix path that skips it, and what is being guarded against is a publisher flip that reports success and moves no traffic.

Behaviour is otherwise unchanged; the error message text is preserved, so the existing test still matches on it.

## Verification

- 32 tests in the rename module, full events suite unchanged otherwise.
- The guard test was **re-confirmed to fail with `_validate_flipped_families()` removed**, so the refactor did not quietly make it unreachable.
- `ruff check common/` clean.

## Why this is a separate PR

`common/events/*` is **`manual`** vendor policy in the enterprise repo's `vendored_files_manifest.json` — the re-vendor bot only syncs `identical`-policy files and never touches these. So nothing re-syncs the two copies on its own, and a fix applied to one side stays on that side until someone carries it across by hand. This is that hand-carry: the block is byte-identical to #1248 again as of this commit.