### PR TITLE
refactor(scripts): one alias rule for the repro harnesses, not six copies

### DIFF
--- a/scripts/_env_compat.py
+++ b/scripts/_env_compat.py
@@ -1,0 +1,49 @@
+"""Env lookup shared by the standalone repro/wet-test harnesses.
+
+Every name these scripts read was renamed by the Caura rebrand, and rule 3
+makes the pre-rename spelling permanent — so each read has to try both. That
+rule lives here once rather than in each script, which is the difference
+between closing the legacy window later as one edit and remembering six.
+
+Private, underscore-prefixed module, imported by sibling scripts through the
+``sys.path`` prologue they already use for ``_locomo_bench`` and
+``_f3_wet_test_observer``: ``scripts/`` deliberately has no ``__init__.py``,
+because these are harnesses you run by path, not an importable package.
+
+The three entry points differ only in what they do when nothing is set:
+
+    env_any       -> ``None``            (the value is optional)
+    env_required  -> exits 2 with a message
+    env_default   -> the supplied default
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def env_any(name: str) -> str | None:
+    """First non-empty of ``name`` and its pre-rename spelling.
+
+    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
+    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value. That is
+    the same first-non-empty rule the plugin's ``readEnv`` and core-api's
+    settings use, and it is the reason neither uses ``AliasChoices``.
+    """
+    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
+    return os.environ.get(name) or os.environ.get(legacy)
+
+
+def env_required(name: str) -> str:
+    """``env_any``, exiting 2 when neither spelling carries a value."""
+    val = env_any(name)
+    if not val:
+        print(f"ERROR: ${name} must be set", file=sys.stderr)
+        sys.exit(2)
+    return val
+
+
+def env_default(name: str, default: str = "") -> str:
+    """``env_any`` falling back to ``default``."""
+    return env_any(name) or default

--- a/scripts/repro_contradictions_collision.py
+++ b/scripts/repro_contradictions_collision.py
@@ -47,23 +47,9 @@ import uuid
 
 import httpx
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-def _env_any(name: str) -> str | None:
-    """First non-empty of ``name`` and its pre-rename spelling.
-
-    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
-    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
-    """
-    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
-    return os.environ.get(name) or os.environ.get(legacy)
-
-
-def _env(name: str) -> str:
-    val = _env_any(name)
-    if not val:
-        print(f"ERROR: ${name} must be set", file=sys.stderr)
-        sys.exit(2)
-    return val
+from _env_compat import env_required as _env  # noqa: E402  (path shim above must run first)
 
 
 def _detected(target_id: str, resp: dict) -> bool:

--- a/scripts/repro_contradictions_diagnostic.py
+++ b/scripts/repro_contradictions_diagnostic.py
@@ -34,23 +34,9 @@ import uuid
 
 import httpx
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-def _env_any(name: str) -> str | None:
-    """First non-empty of ``name`` and its pre-rename spelling.
-
-    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
-    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
-    """
-    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
-    return os.environ.get(name) or os.environ.get(legacy)
-
-
-def _env(name: str) -> str:
-    val = _env_any(name)
-    if not val:
-        print(f"ERROR: ${name} must be set", file=sys.stderr)
-        sys.exit(2)
-    return val
+from _env_compat import env_any as _env_any, env_required as _env  # noqa: E402  (path shim above must run first)
 
 
 def _ts() -> str:

--- a/scripts/repro_contradictions_not_detected.py
+++ b/scripts/repro_contradictions_not_detected.py
@@ -43,23 +43,9 @@ import uuid
 
 import httpx
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-def _env_any(name: str) -> str | None:
-    """First non-empty of ``name`` and its pre-rename spelling.
-
-    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
-    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
-    """
-    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
-    return os.environ.get(name) or os.environ.get(legacy)
-
-
-def _env(name: str) -> str:
-    val = _env_any(name)
-    if not val:
-        print(f"ERROR: ${name} must be set", file=sys.stderr)
-        sys.exit(2)
-    return val
+from _env_compat import env_any as _env_any, env_required as _env  # noqa: E402  (path shim above must run first)
 
 
 def main() -> int:

--- a/scripts/repro_contradictions_proper_noun.py
+++ b/scripts/repro_contradictions_proper_noun.py
@@ -52,6 +52,10 @@ import uuid
 
 import httpx
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _env_compat import env_any as _env_any, env_required as _env  # noqa: E402  (path shim above must run first)
+
 # Synthesised proper-noun stems. Mixed-case + no digits + no hyphens →
 # guaranteed NOT to match _IDENTIFIER_TOKEN, exercising the gap.
 _STEMS = (
@@ -72,24 +76,6 @@ def _mint_proper_noun() -> str:
     stem = random.choice(_STEMS)
     tail = "".join(random.choices(string.ascii_lowercase, k=6))
     return f"Project {stem}{tail.capitalize()}"
-
-
-def _env_any(name: str) -> str | None:
-    """First non-empty of ``name`` and its pre-rename spelling.
-
-    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
-    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
-    """
-    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
-    return os.environ.get(name) or os.environ.get(legacy)
-
-
-def _env(name: str) -> str:
-    val = _env_any(name)
-    if not val:
-        print(f"ERROR: ${name} must be set", file=sys.stderr)
-        sys.exit(2)
-    return val
 
 
 def _detected(target_id: str, resp: dict) -> bool:

--- a/scripts/repro_contradictions_race.py
+++ b/scripts/repro_contradictions_race.py
@@ -63,6 +63,10 @@ import uuid
 
 import httpx
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _env_compat import env_required as _env  # noqa: E402  (path shim above must run first)
+
 _STEMS = (
     "Lumenwave",
     "Trident",
@@ -81,24 +85,6 @@ def _mint_proper_noun() -> str:
     stem = random.choice(_STEMS)
     tail = "".join(random.choices(string.ascii_lowercase, k=6))
     return f"Project {stem}{tail.capitalize()}"
-
-
-def _env_any(name: str) -> str | None:
-    """First non-empty of ``name`` and its pre-rename spelling.
-
-    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
-    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
-    """
-    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
-    return os.environ.get(name) or os.environ.get(legacy)
-
-
-def _env(name: str) -> str:
-    val = _env_any(name)
-    if not val:
-        print(f"ERROR: ${name} must be set", file=sys.stderr)
-        sys.exit(2)
-    return val
 
 
 def _detected(target_id: str, resp: dict) -> bool:

--- a/scripts/repro_contradictions_with_entity_links.py
+++ b/scripts/repro_contradictions_with_entity_links.py
@@ -23,20 +23,15 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 import time
 import uuid
 
 import httpx
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-def _env(name: str, default: str = "") -> str:
-    """First non-empty of ``name`` and its pre-rename spelling.
-
-    ``or`` rather than a defined-check on purpose: blank counts as unset, so an
-    exported-but-empty ``CAURA_*`` cannot shadow a working legacy value.
-    """
-    legacy = name.replace("CAURA_", "MEMCLAW_", 1)  # legacy-name-ok: rule 3 dual-read alias
-    return os.environ.get(name) or os.environ.get(legacy) or default
+from _env_compat import env_default as _env  # noqa: E402  (path shim above must run first)
 
 
 BASE = _env("CAURA_API_URL", "http://localhost:8000").rstrip("/")


### PR DESCRIPTION
Follow-up to #916, **applying the review suggestion I argued against on that PR.** My counter-argument is [in the record there](https://github.com/caura-ai/caura/pull/916#issuecomment-5389559926) and I'll leave it standing — but on reflection it weighed the wrong two things against each other.

I compared boilerplate cost against tidiness. The reviewer's actual point was **drift**: closing the legacy-fallback window is a planned Phase 7 step, so six copies means six chances to miss one. The import cost is paid once, at review time. The drift cost is paid later, by whoever is mid-sweep. That's the trade, and it goes the other way.

### What changed

`scripts/_env_compat.py` holds the alias rule once, in the three shapes callers actually need:

| | when nothing is set |
|---|---|
| `env_any` | `None` — the value is optional |
| `env_required` | exits 2 with a message |
| `env_default` | the supplied default |

The scripts import it through the same `sys.path` prologue they already use for `_locomo_bench` and `_f3_wet_test_observer`, so this follows the directory's existing convention rather than inventing one. (`scripts/` has no `__init__.py` deliberately — these are harnesses you run by path.)

**The marker count is the measure.** Six exempt lines become one:

```
$ grep -rln "legacy-name-ok: rule 3 dual-read alias" scripts/
scripts/_env_compat.py
```

So the ratchet's own exemption report is now the enumeration of where the fallback lives — which is a better answer to the drift concern than the grep I offered on #916, because it can't drift at all.

### One thing my own check caught

`collision.py` and `race.py` import **only** `env_required` — their tenant read is required, so pulling in `env_any` as well would have been an unused import. Found by an AST pass, not by a gate: `scripts/` isn't ruff-gated, so F401 would not have failed CI.

### Verified after the move

From a working directory **outside the repo**, so the path prologue is genuinely exercised rather than accidentally satisfied by `cwd`:

- all six import cleanly
- all six answer `--help` (the real entry path)
- **30 assertions** across new-only, old-only, both, blank-new-beside-a-working-old, and nothing-set

The last case is stricter than before: through `env_required` it now asserts `exit(2)` rather than a `None` return. My first harness run tripped over exactly that and died with `ERROR: $CAURA_API_URL must be set` — the harness was wrong, not the code, and fixing it turned that case into a real assertion.

Ratchet: **no new lines**, one exempt line. Sentinel: **23/23**. Net −26 lines.
