### PR TITLE
fix(events): refuse to publish a flipped family into a name nothing binds

### DIFF
--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -48,7 +48,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from common.events.base import Event, EventBus, EventHandler
-from common.events.topics import publish_name, subscribe_names
+from common.events.topics import publish_name, subscribe_names, unbound_publish_topics
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +157,28 @@ class PubSubEventBus(EventBus):
         # project, eliminating cross-env message fan-out. See _topic_name().
         self._topic_prefix = topic_prefix
         self._dual_subscribe = dual_subscribe
+        # Refuse to exist in the one combination that fails silently: publishing
+        # a flipped family under its renamed name while binding only the current
+        # one. See ``unbound_publish_topics`` for why the check compares the two
+        # names instead of asking whether ``FLIPPED_FAMILIES`` is empty.
+        #
+        # At construction, not at ``start()``: publishing does not require
+        # ``start()`` (a publish-only process never calls it), so a check there
+        # would leave exactly the write side of the hazard unguarded. Raising
+        # here also means a misconfigured process dies before it can report
+        # itself ready. This is the loud direction of a fault that otherwise has
+        # no signal, so a hard failure is the point rather than a side effect.
+        if unbound := unbound_publish_topics(dual=dual_subscribe):
+            raise ValueError(
+                f"dual_subscribe is off, but {len(unbound)} topic(s) would be "
+                f"published under a name this bus does not bind: {sorted(unbound)}. "
+                "Nothing would be delivered and nothing would raise. Either those "
+                "families were flipped before this environment could bind their "
+                "twins, or this environment's twin subscriptions exist and its "
+                "configuration has not caught up — the two halves are set "
+                "independently, which is what lets them disagree. Resolve which "
+                "one is wrong; do not start a publisher in this state."
+            )
         self._max_messages = max_messages
         self._pull_timeout = pull_timeout
         self._error_backoff = error_backoff

--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -172,20 +172,24 @@ def family(topic: str) -> str:
 FLIPPED_FAMILIES: frozenset[str] = frozenset()
 
 
-def known_families() -> frozenset[str]:
-    """Every family the topics declared in this module actually use.
+def all_topics() -> tuple[str, ...]:
+    """Every topic declared in this module.
 
     Derived by walking the enums rather than listed, so it cannot drift from
     them, and so the same code yields the right answer in each repo despite the
-    two copies declaring different families.
+    two copies declaring different topics.
     """
-    return frozenset(
-        f
+    return tuple(
+        str(member)
         for attr in vars(Topics).values()
         if isinstance(attr, type) and issubclass(attr, enum.StrEnum)
         for member in attr
-        if (f := family(member))
     )
+
+
+def known_families() -> frozenset[str]:
+    """Every family the topics declared in this module actually use."""
+    return frozenset(f for topic in all_topics() if (f := family(topic)))
 
 
 # A family named here that does not exist would be a SILENT no-op: publish_name
@@ -245,3 +249,36 @@ def subscribe_names(topic: str, *, dual: bool) -> tuple[str, ...]:
         return (current,)
     new = renamed(current)
     return (current,) if new == current else (current, new)
+
+
+def unbound_publish_topics(*, dual: bool) -> tuple[str, ...]:
+    """Topics this module would publish under a name no subscriber of them binds.
+
+    The one combination in this cutover that fails with no signal at all. A
+    flipped family publishes under its renamed name; a subscriber running with
+    ``dual=False`` binds only the current one. The message lands on a topic
+    nothing is pulling — no exception, no ``NotFound``, a green readiness probe,
+    and zero delivered. Every other ordering mistake here is loud: binding a twin
+    that was never provisioned is a permanent ``NotFound`` that reds the health
+    endpoint, and naming a family that does not exist raises at import.
+
+    Asking the two functions directly, rather than testing ``FLIPPED_FAMILIES``
+    for emptiness, is what makes this exact instead of approximate. Non-empty
+    ``FLIPPED_FAMILIES`` is only a PROXY for the hazard, and it over-fires in a
+    state this cutover really passes through: once a family's enum members have
+    themselves been renamed (the contract step), ``renamed`` is the identity for
+    them, so ``publish_name`` and ``subscribe_names(dual=False)`` agree and
+    ``dual=False`` is not merely safe but correct — there is no twin left to
+    bind. A guard keyed on emptiness would refuse to start those processes, and
+    ``dual=False`` is the DEFAULT, so it would take out precisely the standalone
+    and on-prem deployments that never run the Terraform the flag is gated on.
+    Comparing the names cannot make that mistake: agreement is agreement however
+    it arose.
+
+    Returns the offending topics rather than a bool so a caller can name them.
+    """
+    return tuple(
+        topic
+        for topic in all_topics()
+        if publish_name(topic) not in subscribe_names(topic, dual=dual)
+    )

--- a/tests/test_events/test_topic_rename_cutover.py
+++ b/tests/test_events/test_topic_rename_cutover.py
@@ -376,3 +376,117 @@ async def test_dual_subscribe_flag_reads_anything_but_an_explicit_yes_as_off(
         assert bus._dual_subscribe is expected
     finally:
         await reset_event_bus_for_testing()
+
+
+# ── the guard: refuse to publish where nothing is bound (#913) ───────────────
+#
+# The combination the rest of this module documents as the one that fails with
+# no signal at all — a flipped family publishing under its renamed name while
+# the subscriber binds only the current one — is now refused at construction
+# instead of merely being described. These tests pin the refusal AND its
+# boundaries, because a guard that over-fires here would take out the default
+# configuration rather than the broken one.
+
+
+def test_unbound_publish_topics_is_empty_in_the_shipped_state() -> None:
+    """Nothing flipped: no topic publishes anywhere unbound, either way.
+
+    The byte-identical-behaviour property. If this fails, merging this guard
+    stopped being a runtime no-op.
+    """
+    assert topics_mod.FLIPPED_FAMILIES == frozenset()
+    assert topics_mod.unbound_publish_topics(dual=False) == ()
+    assert topics_mod.unbound_publish_topics(dual=True) == ()
+
+
+def test_unbound_publish_topics_names_a_flipped_family_when_dual_is_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flipped + dual off is the hazard, and it is reported per topic."""
+    monkeypatch.setattr(topics_mod, "FLIPPED_FAMILIES", frozenset({"memory"}))
+    unbound = topics_mod.unbound_publish_topics(dual=False)
+    assert unbound, "a flipped family with dual off must be reported"
+    assert all(topics_mod.family(t) == "memory" for t in unbound)
+    # Every reported topic really would go nowhere: the name it publishes under
+    # is absent from the names a dual=False subscriber binds.
+    for topic in unbound:
+        assert topics_mod.publish_name(topic) not in topics_mod.subscribe_names(
+            topic, dual=False
+        )
+    # A family that has NOT flipped is not swept up in the report.
+    assert not any(topics_mod.family(t) == "audit" for t in unbound)
+
+
+def test_dual_subscribe_makes_a_flipped_family_bound_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same flip with dual on is exactly what step 2 bought."""
+    monkeypatch.setattr(topics_mod, "FLIPPED_FAMILIES", frozenset({"memory"}))
+    assert topics_mod.unbound_publish_topics(dual=True) == ()
+
+
+def test_pubsub_bus_refuses_to_construct_when_a_flip_has_nothing_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard itself: the bus will not exist in the silent-failure state.
+
+    At construction rather than ``start()`` — a publish-only process never calls
+    ``start()``, so a check there would leave the write side unguarded, which is
+    the side that does the losing.
+    """
+    monkeypatch.setattr(topics_mod, "FLIPPED_FAMILIES", frozenset({"memory"}))
+    with pytest.raises(ValueError, match="does not bind"):
+        PubSubEventBus(project_id="proj", subscription_prefix="test")
+
+
+def test_pubsub_bus_constructs_when_the_flip_is_matched_by_dual_subscribe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard is about the MISMATCH, not about having flipped anything."""
+    monkeypatch.setattr(topics_mod, "FLIPPED_FAMILIES", frozenset({"memory"}))
+    b = PubSubEventBus(
+        project_id="proj", subscription_prefix="test", dual_subscribe=True
+    )
+    assert b._dual_subscribe is True
+
+
+def test_the_guard_does_not_fire_once_a_family_is_fully_contracted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The false positive an emptiness check would cause — the reason this guard
+    compares names instead of testing ``FLIPPED_FAMILIES`` for emptiness.
+
+    After the contract step a family's enum members ARE the renamed names.
+    ``renamed`` is idempotent, so ``publish_name`` and
+    ``subscribe_names(dual=False)`` agree and there is no twin left to bind:
+    ``dual=False`` is not merely tolerable there, it is correct. A guard keyed on
+    "is FLIPPED_FAMILIES non-empty" would refuse to start those processes — and
+    ``dual=False`` is the DEFAULT, so it would take out precisely the standalone
+    and on-prem deployments that never run the Terraform the flag is gated on.
+
+    Simulated by declaring a topic whose name already carries the new prefix,
+    which is what the contract step leaves behind.
+    """
+    contracted = topics_mod.RENAMED_PREFIX + "memory.embedded"
+    assert topics_mod.renamed(contracted) == contracted, "precondition: idempotent"
+    monkeypatch.setattr(topics_mod, "all_topics", lambda: (contracted,))
+    monkeypatch.setattr(topics_mod, "FLIPPED_FAMILIES", frozenset({"memory"}))
+
+    # Non-empty FLIPPED_FAMILIES, dual off — and yet nothing is unbound.
+    assert topics_mod.FLIPPED_FAMILIES
+    assert topics_mod.unbound_publish_topics(dual=False) == ()
+    PubSubEventBus(project_id="proj", subscription_prefix="test")
+
+
+def test_inprocess_bus_can_never_reach_the_guarded_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Why the in-process backend needs no guard: it binds both, always.
+
+    ``InProcessEventBus.subscribe`` calls ``subscribe_names(..., dual=True)``
+    unconditionally, so the mismatch this guard catches is unreachable there for
+    any value of ``FLIPPED_FAMILIES``.
+    """
+    for flipped in (frozenset(), frozenset({"memory"}), topics_mod.known_families()):
+        monkeypatch.setattr(topics_mod, "FLIPPED_FAMILIES", flipped)
+        assert topics_mod.unbound_publish_topics(dual=True) == ()


### PR DESCRIPTION
Closes #913.

Every other ordering mistake in this rename is loud. Binding a twin that was never provisioned is a permanent `NotFound` that halts the pull loop and reds the readiness probe; naming a family that does not exist raises at import. One combination has no signal at all — a flipped family publishes under its renamed name while a `dual=False` subscriber binds only the current one, so the message lands on a topic nothing is pulling. No exception, green health, zero delivered.

`test_a_flipped_family_reaches_nobody_without_the_dual_binding` already proved it. Nothing prevented it. `PubSubEventBus` now refuses to construct in that state.

## The condition is NOT "is FLIPPED_FAMILIES empty"

#913 proposed keying the guard on a non-empty `FLIPPED_FAMILIES`, on the premise that combined with `dual=False` it is never intentional. I was asked to re-derive that premise rather than take it. **It has one exception, and it is a state this cutover really passes through.**

After the contract step a family's enum members **are** the renamed names. `renamed` is idempotent, so for those topics `publish_name` and `subscribe_names(dual=False)` agree — there is no twin left to bind, and `dual=False` is not merely tolerable but *correct*. Measured:

| topic | `publish_name` | `subscribe_names(dual=False)` | mismatch? |
|---|---|---|---|
| mid-flip (`<brand>.pipeline.…`) | `caura.pipeline.…` | `('<brand>.pipeline.…',)` | **yes** — the hazard |
| contracted (`caura.pipeline.…`) | `caura.pipeline.…` | `('caura.pipeline.…',)` | no — safe and correct |

An emptiness check refuses to start the second row. And `dual=False` is the **default**, so it would take out precisely the standalone and on-prem deployments that never run the Terraform the flag is gated on — converting a silent failure into an outage, in the population least able to diagnose it.

So the guard asks the two functions instead: `unbound_publish_topics(dual=...)` returns the topics whose publish name is absent from their own subscribe set. It fires exactly when a publish would go nowhere, cannot false-positive on an already-renamed family, and needs no premise about intent — agreement is agreement however it arose.

**Both implementations pass the "refuses to construct" test.** Only `test_the_guard_does_not_fire_once_a_family_is_fully_contracted` separates them — I verified by implementing the guard as originally proposed and confirming that test, and only that test, fails.

## At construction, not at `start()`

A publish-only process never calls `start()`, so a check there would leave the write side unguarded — and the write side is the side that loses the messages.

## Live context, corrected

The brief I picked this up from said Deploy Infrastructure had failed three consecutive times, latest 01:33 after the merge, leaving the twins declared but not created. **That reading has expired, and it conflated two branches.** Re-measured from the run history:

- The four failures on `pubsub-caura-topic-twins` (00:56, 01:04, 01:16, 01:24) were all **pre-merge**, on the PR branch.
- The 01:33 failure was on `add-datadog-dbm-collector` — unrelated Datadog work.
- ent#1242 merged 01:28, and the two post-merge `dev` runs (01:45:25, 01:45:33) both **succeeded**.

So the expand step appears to have applied. I am deliberately not asserting the twins exist: that is a claim about a deploy in a specific environment, and the entire argument of this PR is that it must be confirmed per running service rather than inferred from a green branch run. The guard does not depend on the answer either way.

## Scope

The guard only. `FLIPPED_FAMILIES` is untouched and still empty, so this is a **runtime no-op in every environment today** — with nothing flipped, no topic publishes anywhere unbound under either flag value (`test_unbound_publish_topics_is_empty_in_the_shipped_state`). Steps 3–6 remain Lane 5's. **No environment configuration is changed or recommended here** — in particular this PR does not set, or tell anyone to set, `EVENT_BUS_DUAL_SUBSCRIBE`.

The in-process backend needs no guard: `subscribe` binds `subscribe_names(..., dual=True)` unconditionally, so the mismatch is unreachable there for any value of `FLIPPED_FAMILIES` — asserted across the empty, partial and all-families cases.

`common/` is vendored to enterprise, so the guard reaches that tree on the next re-vendor rather than needing a parallel change.

## Tests

Seven new tests in `test_topic_rename_cutover.py`. Verified load-bearing by breaking what each guards:

- Removing the guard entirely → `test_pubsub_bus_refuses_to_construct_when_a_flip_has_nothing_bound` fails, alone.
- Implementing it as the issue proposed → `test_the_guard_does_not_fire_once_a_family_is_fully_contracted` fails, alone.

Gates: full suite **5001 passed**, 3 skipped, 1 xfailed, 0 failed. `ruff check common/` clean (CI's exact invocation — no `--config`, per that file's own warning; `ruff format` deliberately NOT run over `common/`). mypy core-api clean, 199 files. Ratchet "No new lines", sentinel "All 23 protected strings survive", `gen_events_manifest.py --check` up to date. Rebased on `f310d432`.

Note the pre-commit ruff hooks are scoped `^(core-api|core-storage-api)/src/` and so do not cover `common/` or `tests/`; `ruff check common/` under `common/ruff.toml` is the gate that applies to this diff, and CI runs it as its own step.