### PR TITLE
chore: drop .dockerignore entries for a directory that does not exist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,8 +4,6 @@ __pycache__
 .env
 .env.*
 node_modules
-memclaw/node_modules
-memclaw/.next
 *.egg-info
 # Bare globs only match the context root — add a recursive form so a stray
 # nested build artifact (e.g. core-api/src/core_api.egg-info from a local


### PR DESCRIPTION
Latent-config item from the contextual residue sweep: `.dockerignore:7–8` ignores `memclaw/node_modules` and `memclaw/.next` — no `memclaw/` directory exists at the repo root, and rule 7 guarantees one never will. A no-op today, but ghost ignore entries are exactly the kind of thing that confuses the next build debug.

Ratchet: **No new lines. 2 removed by this change (-2 net).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129mDPbfSxqBrCLs5dDpcGv