### PR TITLE
chore: rename the old brand out of core-api and core-storage-api prose

### DIFF
--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "core-api"
 version = "2.30.0"
-description = "MemClaw Core API service"
+description = "Caura Core API service"
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [

--- a/core-api/src/core_api/auth.py
+++ b/core-api/src/core_api/auth.py
@@ -29,7 +29,7 @@ class AuthContext:
 
     OSS auth paths:
     1. Admin API key (ADMIN_API_KEY)      → is_admin=True, tenant_id=None
-    2. MemClaw API key (MEMCLAW_API_KEY)  → gates all non-admin access when set
+    2. Caura API key (CAURA_API_KEY)      → gates all non-admin access when set
     3. Standalone mode                     → tenant_id from config, org_role="admin"
     4. X-Tenant-ID header (enterprise)    → tenant_id from header
 
@@ -371,11 +371,11 @@ async def get_auth_context(
         set_current_tenant(None)  # Admin — RLS bypass
         return AuthContext(tenant_id=None, is_admin=True)
 
-    # ── Path 2: MEMCLAW_API_KEY gate (optional, for network-exposed OSS) ──
+    # ── Path 2: CAURA_API_KEY gate (optional, for network-exposed OSS) ──
     mclaw_key = settings.memclaw_api_key
     if mclaw_key:
         if key and hmac.compare_digest(key, mclaw_key):
-            # Valid memclaw key — resolve tenant from standalone or header
+            # Valid Caura key — resolve tenant from standalone or header
             if settings.is_standalone:
                 from core_api.standalone import get_standalone_tenant_id
 

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -1,4 +1,4 @@
-"""Centralised constants for the MemClaw API."""
+"""Centralised constants for the Caura API."""
 
 import importlib.metadata
 import os

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1,6 +1,6 @@
-"""MCP (Model Context Protocol) server for MemClaw.
+"""MCP (Model Context Protocol) server for Caura.
 
-Exposes MemClaw tools over Streamable HTTP so any MCP client
+Exposes Caura tools over Streamable HTTP so any MCP client
 (Claude Desktop, Claude Code, Cursor, etc.) can connect with just a URL + API key.
 
 Mounted onto the main FastAPI app at /mcp.

--- a/core-api/src/core_api/pipeline/steps/search/extract_temporal_hint.py
+++ b/core-api/src/core_api/pipeline/steps/search/extract_temporal_hint.py
@@ -33,7 +33,7 @@ class ExtractTemporalHint:
         ctx.data["date_range_filter"] = _extract_temporal_date_range(query, reference_dt)
         # DEBUG, not INFO: this fires once per search and echoes the raw query
         # text — mild PII (customer query content), and it surfaces verbatim in
-        # prod logs whenever ops searches memclaw with an error-alert signature
+        # prod logs whenever ops searches Caura with an error-alert signature
         # (the "temporal_hint: query='<error text>'" echo). The extracted
         # window/date_range are carried on ctx.data for any downstream logging.
         logger.debug(

--- a/core-api/src/core_api/providers/sqlite_backend.py
+++ b/core-api/src/core_api/providers/sqlite_backend.py
@@ -1,4 +1,4 @@
-"""SQLite storage backend for MemClaw.
+"""SQLite storage backend for Caura.
 
 A lightweight, file-based implementation of the ``StorageBackend`` protocol
 suitable for local development, on-premise single-node deployments, and

--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -63,7 +63,7 @@ _plugin_files = [
 #   periodically as OpenClaw evolves its plugin contract — e.g. the
 #   ``contracts.tools`` field became strictly enforced upstream on
 #   2026-05-01 (openclaw/openclaw@7641783d), and any user installing
-#   from a stale baked HEREDOC silently lost their entire MemClaw tool
+#   from a stale baked HEREDOC silently lost their entire Caura tool
 #   surface. Serving from disk keeps the manifest in lockstep with
 #   ``plugin/openclaw.plugin.json`` so the installer never falls behind.
 _plugin_root_files = {
@@ -74,7 +74,7 @@ _plugin_root_files = {
 
 # Direct-MCP skill adapter. Lives under the repo-root ``static/`` tree
 # rather than ``plugin/`` — it is NOT an OpenClaw plugin artifact; it is
-# served to Claude Code / Codex users who connect to MemClaw directly via
+# served to Claude Code / Codex users who connect to Caura directly via
 # MCP. Resolved from app.py's position: core-api/src/core_api/routes/ →
 # five ``.parent``s up land on the repo root.
 _skill_md_path = (
@@ -436,7 +436,7 @@ for _f in $SRC_FILES $ROOT_FILES; do
   esac
 done
 
-# 5. Fetch latest plugin source from MemClaw server
+# 5. Fetch latest plugin source from Caura server
 echo "[5/7] Fetching latest plugin source from $CAURA_API_URL..."
 for srcfile in $SRC_FILES; do
   curl $CURL_INSECURE -sf "$CAURA_API_URL/api/plugin-source?file=$srcfile" > "$PLUGIN_DIR/src/$srcfile" || {{
@@ -670,7 +670,10 @@ _VALID_SKILL_AGENTS = {"claude-code", "codex", "both"}
 # filesystem path and the generated script, so an arbitrary value must never
 # reach either. ``memclaw`` is the default (the operational manual); the
 # opt-in ``company-brain`` posture skill layers on top of it.
-_SKILL_LABELS = {"memclaw": "MemClaw", "company-brain": "Company Brain"}
+_SKILL_LABELS = {
+    "memclaw": "Caura",  # legacy-name-ok: wire — ?skill= param + on-disk dir
+    "company-brain": "Company Brain",
+}
 _VALID_SKILLS = frozenset(_SKILL_LABELS)
 _static_skills_dir = Path(__file__).resolve().parent.parent.parent.parent.parent / "static" / "skills"
 # Precomputed name → SKILL.md path map. Keys are the constant allowlist, so

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -2,7 +2,7 @@
 
 Daily/weekly governed activity report — "what each agent did" — backing the
 report → product-page → agent-self-report flow (an agent fetches its own report
-and surfaces it in its 1:1 with its owner, or in its group). MemClaw returns the
+and surfaces it in its 1:1 with its owner, or in its group). Caura returns the
 governed data; the agent's runtime does the messaging.
 
 Two-check governed read (order matters):
@@ -444,7 +444,7 @@ async def get_report(
         ][:_LEARNING_LIMIT]
 
         # Value highlights: the most-reused (all-time) durable knowledge authored
-        # in-window. NOTE: recall_count is a lifetime counter — MemClaw has no
+        # in-window. NOTE: recall_count is a lifetime counter — Caura has no
         # per-period recall log — so this is not "reused *this* period".
         value_highlights = [
             {

--- a/core-api/src/core_api/services/forge/distill_prompt.py
+++ b/core-api/src/core_api/services/forge/distill_prompt.py
@@ -127,7 +127,7 @@ class ClusterPromptInputs:
 
 
 _SYSTEM_PREAMBLE = """\
-You are Forge, an autonomous resident inside MemClaw's "live memory".
+You are Forge, an autonomous resident inside Caura's "live memory".
 Your job: turn a cluster of agent session-traces — all of which
 followed approximately the same procedure to the same outcome —
 into a single reusable SKILL candidate.

--- a/core-api/src/core_api/services/outcome_inference/__init__.py
+++ b/core-api/src/core_api/services/outcome_inference/__init__.py
@@ -2,7 +2,7 @@
 
 The lake produces a memory stream. This package mines that stream
 for passive outcome evidence — no ``caura_evolve`` call required.
-Each signal module reads existing MemClaw data (memories table
+Each signal module reads existing Caura data (memories table
 columns, recall counters, contradiction status, audit log) and
 emits :class:`SignalEvidence` events keyed by ``(tenant_id, run_id,
 agent_id)``. The session-trace builder (SF-102) consumes these

--- a/core-api/src/core_api/services/outcome_inference/external_hooks.py
+++ b/core-api/src/core_api/services/outcome_inference/external_hooks.py
@@ -5,14 +5,14 @@ within the window with a ``run_id`` matching the trace is a near-
 certain SUCCESS; a CI run that failed with the same ``run_id`` is
 a near-certain FAILURE. Plan §6 signal #6, weight 0.85.
 
-**MVP**: the OSS MemClaw deployment has no built-in hook to ingest
+**MVP**: the OSS Caura deployment has no built-in hook to ingest
 external events from git / GitHub / CI today. The extractor ships
 with the contract finalised but the body returns [] until an
 optional ``external_hooks`` table or webhook ingest is wired.
 
 The Phase-5 OpenClaw bridge integration is the natural place to
 ingest these — OpenClaw plugins surface workflow-completion events
-that already carry a ``run_id`` correlatable to MemClaw memory
+that already carry a ``run_id`` correlatable to Caura memory
 writes. When that lands, this extractor becomes a SELECT against
 the ingested-events table.
 

--- a/core-api/src/core_api/services/outcome_inference/repeat_recall.py
+++ b/core-api/src/core_api/services/outcome_inference/repeat_recall.py
@@ -4,7 +4,7 @@ When an agent issues the same (or near-same) recall query multiple
 times within a session, the first answer didn't land. Plan §6
 signal #3.
 
-**Data source gap (acknowledged)**: MemClaw does not currently
+**Data source gap (acknowledged)**: Caura does not currently
 persist a per-recall log keyed by (session, agent, query, ts) with
 the query string preserved. Two reasonable proxies are available
 today:

--- a/core-storage-api/pyproject.toml
+++ b/core-storage-api/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "core-storage-api"
 version = "2.30.0"
-description = "MemClaw Core Storage API — PostgreSQL CRUD service"
+description = "Caura Core Storage API — PostgreSQL CRUD service"
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/test_install_skill_endpoint.py
+++ b/tests/test_install_skill_endpoint.py
@@ -128,14 +128,14 @@ def test_codex_only_skips_claude_block():
 
 
 def test_default_skill_is_memclaw_and_unchanged():
-    """No ``?skill=`` → the installer is the original memclaw installer:
-    memclaw paths, the /skill/memclaw fetch URL, the 'MemClaw' title, and no
-    trace of company-brain. Guards the 'default load is unaffected' contract."""
+    """No ``?skill=`` → the installer is the original default one: the same
+    install paths, the same fetch URL, the 'Caura' title, and no trace of
+    company-brain. Guards the 'default load is unaffected' contract."""
     client = _client()
     resp = client.get("/api/v1/install-skill?agent=both")
     assert resp.status_code == 200
     script = resp.text
-    assert "=== MemClaw Skill Installer (direct-MCP) ===" in script
+    assert "=== Caura Skill Installer (direct-MCP) ===" in script
     assert "$HOME/.claude/skills/memclaw" in script
     assert "$HOME/.agents/skills/memclaw" in script
     assert "/api/v1/skill/memclaw" in script


### PR DESCRIPTION
Phase 1.3, **slice 1 of 6** — the internal share of the mass rewrite, scoped to the two Python backend trees. Comments, docstrings and package descriptions, plus one user-visible installer title.

## Measured

| scope | before | after |
|---|---|---|
| `core-api/` + `core-storage-api/` (non-exempt) | 135 | 114 |
| repo-wide (non-exempt) | 1456 | 1432 |

Ratchet: **-24 net, no new lines**, 1 exemption. Sentinel: **all 23 protected strings survive.**

## What was deliberately left alone

The remainder in these trees is the designed permanent floor, not missed work:

- **env vars** — `MEMCLAW_API_KEY`, `MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS`, `MEMCLAW_AGENT_ID`, … Operators set these; `config.py` already dual-reads `CAURA_*` as primary.
- **wire formats** — the `/api/v1/memclaw` mount, the `memclaw_*` tool prefix, the `memclaw-doc://` URI scheme, on-disk install paths, plugin ids.
- **Pub/Sub topics and schema names** — Agent 5 owns that migration; untouched here.
- **landed Alembic migrations** (012, 019, 030) — immutable history.
- **`memclawd` references** — a separate component, named by its own repo.
- **8 of the sentinel's 23 protected strings** live in these trees.

## Two notes for review

**1. `_SKILL_LABELS` carries the only exemption this change writes.** The display value becomes `"Caura"`; the KEY stays `"memclaw"` because it is both the `?skill=` query value and the `static/skills/<id>/` directory name (`_SKILL_FILES` builds the path from it, `_VALID_SKILLS` validates against it). The dict is exploded so the `legacy-name-ok` marker sits on the key's own line and stays under the 110-char limit.

**2. `distill_prompt._SYSTEM_PREAMBLE` is LLM-visible text.** The brand token is pure identity prose, but the same prompt asks the model to keep fingerprint wording (`goal_phrase`, `domain`, `step_skeleton`) stable across re-runs of a cluster. I judged the preamble brand token inert with respect to those output fields, but flagging it rather than assuming.

## Also

`auth.py` now documents `CAURA_API_KEY` rather than `MEMCLAW_API_KEY`, per #929. The attribute it annotates is still `settings.memclaw_api_key`, which holds the resolved value of either (`config.py:378`) — this teaches the preferred name without changing behaviour. Docstring arrow alignment preserved at column 42.

The installer-title test moves with the label it pins — a source change and its pinning assertion cannot land in separate slices without leaving CI red in between.

## Verification

- `scripts/do_not_touch_sentinel.py` → exit 0, all 23 survive
- `scripts/legacy_name_ratchet.py --base origin/main` → exit 0, -24 net
- `ruff check` / `format --check` / `format --check --isolated` at CI's exact scopes → all clean
- `pytest tests/test_install_skill_endpoint.py` → 16 passed; related files 127 passed
- 7 pre-existing `kreuzberg` PDF-ingest failures confirmed identical on a clean `origin/main` tree (module not installed locally) — unrelated to this change

Rebased onto `8688e363` after #931 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)