### PR TITLE
fix(images): stamp the current brand in the published image description

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -147,7 +147,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.push_latest == 'true' }}
           labels: |
             org.opencontainers.image.title=caura-memclaw-${{ matrix.name }}
-            org.opencontainers.image.description=MemClaw ${{ matrix.name }} — fleet memory for AI agents
+            org.opencontainers.image.description=Caura ${{ matrix.name }} — fleet memory for AI agents
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.licenses=Apache-2.0
 


### PR DESCRIPTION
## What

`.github/workflows/publish-docker.yml` stamps every public OSS image with:

```
org.opencontainers.image.description=MemClaw ${{ matrix.name }} — fleet memory for AI agents
```

This changes `MemClaw` → `Caura`. That label is the one-line summary registry UIs and image
scanners display.

## What this deliberately does NOT change

The neighbouring line, two above the published image name:

```
images: ghcr.io/${{ github.repository_owner }}/caura-memclaw-${{ matrix.name }}
...
org.opencontainers.image.title=caura-memclaw-${{ matrix.name }}
```

`image.title` has to keep the old spelling — it mirrors the actual published repository name. The
image name is floor (renaming it strands every existing `:v1` / `:v1.0` / `:v1.0.0` pin documented
in the README), so the title label must stay in step with it. Changing the title alone would make
the label disagree with the image it is attached to, which is worse than the stale brand.

## Checks

```
scripts/legacy_name_ratchet.py --base origin/main   No new lines. 1 removed by this change (-1 net).
scripts/do_not_touch_sentinel.py                    All 23 protected strings survive.
actionlint .github/workflows/publish-docker.yml     clean
```

## Provenance

Found by a Lane D sweep for old-brand **values** rather than identifiers — the gates count
identifiers, so a brand-neutral key holding an old-brand value scores as fully migrated forever.
Classified **inert**: registry metadata, no build or runtime effect. Full classified inventory in
`LANE-REPORT-agent11-2026-08-24.md`.