### PR TITLE
chore: rename the old brand out of benchmark and harness script prose

### DIFF
--- a/scripts/benchmark_nano_vs_flash.py
+++ b/scripts/benchmark_nano_vs_flash.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Quick benchmark: GPT-5.4-nano vs Gemini 3.1 Flash Lite.
 
-Measures latency, output quality, and token throughput on MemClaw-relevant tasks:
+Measures latency, output quality, and token throughput on Caura-relevant tasks:
   1. Memory classification (type + title from content)
   2. Entity extraction
   3. Summarization / recall synthesis
@@ -34,7 +34,7 @@ PRICING = {
     "gemini": {"input": 0.025, "output": 0.15, "label": "Gemini 3.1 Flash Lite"},
 }
 
-# ── Prompts (MemClaw-relevant tasks) ──
+# ── Prompts (Caura-relevant tasks) ──
 
 TASKS = [
     {
@@ -119,7 +119,7 @@ async def call_gemini(client: httpx.AsyncClient, prompt: str) -> tuple[str, floa
 
 async def benchmark():
     print()
-    print("  GPT-5.4-nano vs Gemini 3.1 Flash Lite — MemClaw Task Benchmark")
+    print("  GPT-5.4-nano vs Gemini 3.1 Flash Lite — Caura Task Benchmark")
     print("  " + "=" * 62)
     print(f"  Runs per task: {RUNS}")
     print()

--- a/scripts/benchmark_openai_models.py
+++ b/scripts/benchmark_openai_models.py
@@ -1,4 +1,4 @@
-"""Benchmark OpenAI LLMs for MemClaw enrichment + entity extraction tasks.
+"""Benchmark OpenAI LLMs for Caura enrichment + entity extraction tasks.
 
 Tests speed, cost, and output quality across all available OpenAI models.
 Requires OPENAI_API_KEY env var (or .env file).
@@ -29,7 +29,7 @@ EMBEDDING_MODELS: list[tuple[str, float, int]] = [
     ("text-embedding-3-large", 0.13, 3072),
 ]
 
-VECTOR_DIM = 768  # MemClaw's configured dimension
+VECTOR_DIM = 768  # Caura's configured dimension
 
 # ── LLM models to benchmark ─────────────────────────────────────────────────
 # (model_id, input_price_per_1M, output_price_per_1M)
@@ -52,7 +52,7 @@ MODELS: list[tuple[str, float, float]] = [
     ("o4-mini",        1.10,   4.40),
 ]
 
-# ── Test prompts (same ones MemClaw actually sends) ──────────────────────────
+# ── Test prompts (same ones Caura actually sends) ────────────────────────────
 ENRICHMENT_PROMPT = """\
 You are a memory classifier for a business agent memory system.
 
@@ -730,11 +730,11 @@ def print_embedding_report(summaries: list[EmbeddingSummary]):
             print(f"  Both models have equal similarity accuracy ({sim_s*100:.0f}%)")
 
     print(f"\n  Current model: text-embedding-3-small (${EMBEDDING_MODELS[0][1]}/1M)")
-    print(f"  MemClaw vector dimension: {VECTOR_DIM}")
+    print(f"  Caura vector dimension: {VECTOR_DIM}")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Benchmark OpenAI LLMs + Embeddings for MemClaw")
+    parser = argparse.ArgumentParser(description="Benchmark OpenAI LLMs + Embeddings for Caura")
     parser.add_argument("--rounds", type=int, default=1, help="Number of rounds per model (default: 1)")
     parser.add_argument("--models", nargs="*", help="Specific LLM model IDs to test (default: all)")
     parser.add_argument("--embeddings-only", action="store_true", help="Only run embedding benchmark")
@@ -757,7 +757,7 @@ def main():
                     print(f"WARNING: Unknown model '{name}', add pricing to MODELS dict. Skipping.")
 
         if models:
-            print(f"MemClaw OpenAI LLM Benchmark")
+            print(f"Caura OpenAI LLM Benchmark")
             print(f"Models: {len(models)} | Samples: {len(TEST_SAMPLES)} | Rounds: {args.rounds}")
             print(f"Tasks per sample: 2 (enrichment + entity extraction)")
             print(f"Total API calls: {len(models) * len(TEST_SAMPLES) * 2 * args.rounds}")

--- a/scripts/export_tool_specs.py
+++ b/scripts/export_tool_specs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Dump the SoT `REGISTRY` to `plugin/tools.json` for consumption by the TS plugin.
 
-Run from the memclaw repo root:
+Run from the caura repo root:
 
     PYTHONPATH=core-api/src:core-storage-api/src:. python scripts/export_tool_specs.py
 

--- a/scripts/forge_dry_run.py
+++ b/scripts/forge_dry_run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """``memclawctl forge dry-run`` — Phase 1 manual harness (SF-106).
 
-Invokes the Forge resident pipeline against a live MemClaw deployment
+Invokes the Forge resident pipeline against a live Caura deployment
 for one tenant + fleet and reports the run summary. Candidates always
 land with ``status='candidate'`` and are NEVER promoted; the operator
 runs this to:
@@ -19,7 +19,7 @@ Usage::
         --fleet  <fleet_id> \\
         --window-days 14
 
-The script reads MemClaw connection params from the standard env
+The script reads Caura connection params from the standard env
 (``DATABASE_URL``, ``OPENAI_API_KEY``) — see ``core_api.config``.
 
 This is NOT a production-grade scheduler. The real Forge run flows


### PR DESCRIPTION
Phase 1.3, **slice 2** — prose in the standalone `scripts/` harnesses: benchmark headers, docstrings, and one stale repo-root reference. No logic, no wire values, no exemptions needed.

**Measured: -12 net old-brand lines, no new lines.**

## Scoped deliberately narrow

The rest of `scripts/` is load-bearing and stays:

- `caura-memclaw-enterprise-*-1` — docker-compose container names
- Postgres user/database defaults (`memclaw`)
- `staging-memclaw-core-storage-writer` — a live Cloud Run service
- `memclaw-local-dev` skill, `memclawctl` CLI
- `memclaw.lifecycle.forge-distill-requested` — Agent 5's topic migration

`export_tool_specs.py` said *"run from the memclaw repo root"* — the repo is `caura` now, so that line was stale as well as old-branded.

`benchmark_openai_models.py:55` carries a box-drawing rule; re-padded to hold its original 79-char width after the shorter name.

## Verification

- `do_not_touch_sentinel.py` → exit 0, all 23 protected strings survive
- `legacy_name_ratchet.py --base origin/main` → exit 0, -12 net, **zero exemptions**
- `ruff check` on the four touched files is **byte-identical before and after** (27 pre-existing findings, none introduced; `scripts/` is not a CI ruff scope — verified by re-running against a stashed tree)
- `tests/test_forge_distill.py` + `test_tools_export_in_sync.py` + `test_mcp_token_budget.py` → **79 passed**. `test_forge_distill.py` execs `forge_dry_run.py` as a module; it asserts on `_fake_llm_fn`'s output, not on the docstring text I edited.

## Note on the remaining lane

While scoping this I found that `plugin/` — the largest remaining block — is **not** safely sweepable yet. `educate.ts` and `heartbeat.ts` match on old-brand content already written to users' disks (`"## MemClaw —"` heading prefix, `content.includes("MemClaw — Tools Available")`, the `You have been connected to MemClaw…` regex, the `memclaw:tools` fence tag, `.memclaw-bak` backups). None of those are among the sentinel's 23, and the ratchet reports their deletion as *progress*. Raising that separately before sweeping `plugin/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)