### PR TITLE
fix(ci): pin the plugin's self-migration anchors in the do-not-touch sentinel

### DIFF
--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -266,6 +266,88 @@ SENTINELS: tuple[Sentinel, ...] = (
         kind=LITERAL,
         breaks="the migration stops naming the topic it documents, before Phase 2 renames it",
     ),
+    # -- Plugin self-migration anchors. -----------------------------------------
+    #
+    # A category the entries above do not cover. Everything else here is pinned
+    # for a consumer in another repo or another company's config — Datadog, npm,
+    # a crontab, a customer's .env. These are pinned because the consumer is the
+    # plugin's OWN PREVIOUS OUTPUT, already sitting in end users' TOOLS.md,
+    # AGENTS.md and .env files, written by versions 0.98.5 and 1.x.
+    #
+    # That makes them invisible twice over. The ratchet is directional, so
+    # renaming one lowers the file's count and reads as progress. And a reviewer
+    # seeing a legacy heading prefix in a diff sees brand prose, because it IS
+    # brand prose — it just happens to be brand prose that a regex on a user's
+    # disk has to keep matching.
+    #
+    # Every text below is anchored to its code form rather than to the bare
+    # string, for the reason the CRON_MARKER entry gives above: LITERAL is a
+    # substring test over the whole file, and educate.ts discusses each of these
+    # in its own comments as well as using it. Pinning the bare phrase would be
+    # satisfied by the commentary alone, on exactly the tree where the code that
+    # matters is gone. Verified: each text below appears only on code lines.
+    Sentinel(
+        path="plugin/src/educate.ts",
+        text="const tag = `memclaw:${marker}`;",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks=(
+            "the fence tag written into every install's TOOLS.md/AGENTS.md as an "
+            "HTML comment also builds the regex that finds that block again — "
+            "rename it and the next run appends a second block instead of "
+            "updating the first, in every existing install at once"
+        ),
+    ),
+    Sentinel(
+        path="plugin/src/educate.ts",
+        text='"## MemClaw —",',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks=(
+            "the legacyHeadingPrefix that finds pre-fence sections this plugin "
+            "itself emitted (1.x and 0.98.5) — rename it and those sections are "
+            "never replaced, so users keep a stale duplicate forever"
+        ),
+    ),
+    Sentinel(
+        path="plugin/src/educate.ts",
+        text='.memclaw-bak"',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks=(
+            "the one-shot backup is written only when the path does not already "
+            "exist — rename it and the guard stops seeing the backup already on "
+            "disk, overwriting the hand-edits it was created to preserve"
+        ),
+    ),
+    Sentinel(
+        path="plugin/src/educate.ts",
+        # Regex syntax, so this form cannot occur in prose about the phrase.
+        text="You have been connected to MemClaw[^\\n]*?always include your agent_id",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks=(
+            "the pre-C1 blurb stops being stripped and accumulates alongside "
+            "the current one on every subsequent run"
+        ),
+    ),
+    Sentinel(
+        path="plugin/src/educate.ts",
+        text='includes("MemClaw — Tools Available")',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="phantom plugin-written files under workspaces/ stop being collected",
+    ),
+    # Diagnostic rather than a data contract, and pinned anyway: breaking these
+    # does not corrupt anything, it makes every existing install report itself as
+    # not-installed, which is the shape of bug that gets chased for a week.
+    Sentinel(
+        path="plugin/src/heartbeat.ts",
+        text='"HEARTBEAT.md"), "utf-8").includes("memclaw")',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="heartbeat reports heartbeat_md=false for every install written before the rename",
+    ),
+    Sentinel(
+        path="plugin/src/heartbeat.ts",
+        text='"TOOLS.md"), "utf-8").toLowerCase().includes("memclaw")',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks="heartbeat reports tools_md=false for every install written before the rename",
+    ),
 )
 
 


### PR DESCRIPTION
Adds 7 sentinel entries, **23 → 30**. All are old-brand strings in `plugin/src` that are matched against content **earlier plugin versions already wrote to end users'** `TOOLS.md`, `AGENTS.md` and `.env` files. They are migration anchors, not brand prose — and today nothing stops a sweep from renaming them.

Found while scoping the Phase 1.3 `plugin/` sweep, which is why they're being pinned *before* that sweep rather than after it.

## Why neither existing gate catches this

Demonstrated on this branch, with only the two plugin files swept (`perl -pi -e 's/memclaw/caura/gi'`) and the sentinel at its old 23 entries:

```
legacy_name_ratchet.py --base origin/main
  exit 0 — "No new lines. 83 removed by this change (-83 net)."

do_not_touch_sentinel.py
  exit 0 — "All 23 protected strings survive."
```

**Green on both required contexts, for a change that breaks every existing install.** The ratchet is directional by design, so a deletion reads as progress; the sentinel simply didn't list these. With this patch the same sweep fails:

```
exit 1 — "This change removes 7 string(s) that something depends on."
```

## What breaks, worst first

| site | consequence |
|---|---|
| `educate.ts:570` fence tag | Written into every install's `TOOLS.md`/`AGENTS.md`, and **the same string builds the regex that finds that block on the next run**. Rename → the next run appends a *second* block instead of updating the first, everywhere at once. |
| `educate.ts:695` `legacyHeadingPrefix` | Finds pre-fence sections this plugin emitted in 1.x and 0.98.5. Rename → they are never replaced, so users keep a stale duplicate forever. |
| `educate.ts:698,723` one-shot backup path | Written only when it does not already exist. Rename → the guard stops seeing the backup on disk and overwrites the hand-edits it exists to preserve. |
| `educate.ts:189` pre-C1 blurb regex | Stops stripping, so the old blurb accumulates alongside the new one on every run. |
| `educate.ts:220` orphan detection | Phantom plugin-written files under `workspaces/` stop being collected. |
| `heartbeat.ts:506,509,544` install telemetry | Diagnostic rather than a data contract, pinned anyway: breaking it makes every pre-rename install report itself as *not installed*. |

## Each text is anchored to its code form, not the bare phrase

`LITERAL` is a substring test over the whole file, and `educate.ts` discusses every one of these in its own comments as well as using it. Pinning the bare phrase would be satisfied by **the commentary alone**, on exactly the tree where the code that matters is gone — the trap the existing `CRON_MARKER` entry already documents at length.

Verified per entry that the pinned text occurs **only on code lines, never on a comment line**.

The 7 new lines carry `legacy-name-ok: pinned floor string`, matching the file's existing convention. Three prose lines in my first draft tripped the ratchet by minting the brand outside a pinned string; those are reworded rather than marked, so the marker keeps meaning "this is a pinned floor string" and nothing else.

## A note for whoever sweeps `plugin/` next

`plugin/src/educate.test.ts` (97 old-brand lines — the largest single file in `plugin/`) is mostly **legacy-content fixtures**: `"## MemClaw — Tools Available"`, `"auto-added by MemClaw plugin"`, `"You have been connected to MemClaw …"`. Renaming those leaves the suite **green while testing nothing**, which is worse than a red build. Not pinned here — a sentinel entry per fixture would be unmaintainable — so flagging it instead.

## Verification

| check | result |
|---|---|
| `do_not_touch_sentinel.py` | exit 0, all 30 survive |
| `do_not_touch_sentinel.py` on a swept tree | **exit 1, catches all 7** |
| `legacy_name_ratchet.py --base origin/main` | exit 0, no new lines, 7 exemptions (all pinned floor strings) |
| `tests/test_do_not_touch_sentinel.py` | 79 passed |
| `ruff check` + `format --check --isolated` | clean |

The count assertion in the sentinel's own test uses `len(SENTINELS)`, so it moves with the list rather than pinning 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)