### PR TITLE
chore: rename the old brand out of plugin comment prose

### DIFF
--- a/plugin/src/agent-auth.ts
+++ b/plugin/src/agent-auth.ts
@@ -1,5 +1,5 @@
 /**
- * Agent authentication broker for MemClaw plugin.
+ * Agent authentication broker for Caura plugin.
  *
  * Auto-provisions agent-scoped credentials using the tenant-scoped key
  * as a bootstrap credential. Both kinds share the `mc_` prefix on the

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -317,7 +317,7 @@ function canonicalDir(p: string): string {
  * ``openclaw.json`` — OpenClaw's documented, watched load path for extra
  * skill directories (``docs/tools/skills-config.md``; consumed by
  * ``src/skills/runtime/refresh.ts``). This is how a reconciled *additive*
- * target dir (one MemClaw doesn't own and can't publish as a plugin skill)
+ * target dir (one Caura doesn't own and can't publish as a plugin skill)
  * actually reaches agents.
  *
  * Append-only and idempotent: existing entries are preserved, a dir already

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -1050,7 +1050,7 @@ export class MemClawContextEngine {
    *
    *   1. **Persist** any pre-computed summary (passed in by OpenClaw
    *      when its compaction pipeline ran the summarization step
-   *      before invoking us) as a MemClaw episode memory tagged
+   *      before invoking us) as a Caura episode memory tagged
    *      ``auto-compaction``. This is the long-standing
    *      observability side-effect — surviving summaries get
    *      recallable later via ``caura_recall``.
@@ -1107,7 +1107,7 @@ export class MemClawContextEngine {
   async compact(
     context: CompactContext,
   ): Promise<{ ok: boolean; compacted: boolean; reason?: string; result?: unknown }> {
-    // 1. Persist OpenClaw's summary into MemClaw as an episode
+    // 1. Persist OpenClaw's summary into Caura as an episode
     // memory. This runs regardless of whether the delegation
     // succeeds below — even on a degraded environment the summary
     // is worth keeping if we can. Failure here is logged and

--- a/plugin/src/env.ts
+++ b/plugin/src/env.ts
@@ -1,5 +1,5 @@
 /**
- * Environment configuration and tenant resolution for MemClaw plugin.
+ * Environment configuration and tenant resolution for Caura plugin.
  *
  * Security fixes:
  * - .env parse errors are logged (no silent swallow)
@@ -85,7 +85,7 @@ export const MEMCLAW_API_URL =
   readEnv(["CAURA_API_URL", "MEMCLAW_API_URL"]) || "http://localhost:8000";  // legacy-name-ok: rule 3 dual-read alias
 
 /**
- * Prefix for all MemClaw REST routes. Single source of truth for API
+ * Prefix for all Caura REST routes. Single source of truth for API
  * versioning — bump to "/api/v2" here when the backend ships a new version.
  *
  * The transport layer auto-prepends this to relative paths. Raw fetch
@@ -417,7 +417,7 @@ export const KEYSTONES_TIMEOUT_MS = 5_000;
 //
 // The OpenClaw runtime calls our context engine on every prompt assembly
 // (heartbeats, tool follow-ups, no-reply lurk turns, trivial pings — all
-// of them). Without gating, every call hits the MemClaw backend with a
+// of them). Without gating, every call hits the Caura backend with a
 // `/search` regardless of whether the turn would benefit from LTM. These
 // knobs let operators tune when recall fires.
 

--- a/plugin/src/health.ts
+++ b/plugin/src/health.ts
@@ -1,7 +1,7 @@
 /**
- * MemClaw backend-reachability tracker.
+ * Caura backend-reachability tracker.
  *
- * Process-wide state that remembers whether the MemClaw server (configured via
+ * Process-wide state that remembers whether the Caura server (configured via
  * MEMCLAW_API_URL) is currently reachable from this plugin. Fed by:
  *   - `markReachable()` — called after any successful `apiCall` via the
  *     transport helpers, or by the heartbeat's periodic health probe.

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,7 +1,7 @@
 /**
- * MemClaw OpenClaw Plugin — registration glue.
+ * Caura OpenClaw Plugin — registration glue.
  *
- * Registers MemClaw tools (set + order derived from plugin/tools.json
+ * Registers Caura tools (set + order derived from plugin/tools.json
  * via MEMCLAW_TOOLS), gateway methods, prompt section, memory runtime,
  * context engine, and heartbeat loop.
  *
@@ -512,7 +512,7 @@ const memclawPlugin = {
     //
     // relativePath is the workspace-relative scratch file the
     // compaction sub-agent has append-only write access to during the
-    // flush turn. MemClaw's server-side persistence is orthogonal — the
+    // flush turn. Caura's server-side persistence is orthogonal — the
     // sub-agent still calls caura_write to capture salient
     // context, but it ALSO needs the file to exist because that's the
     // only filesystem write surface OpenClaw exposes to it. Mirror
@@ -652,7 +652,7 @@ const memclawPlugin = {
               async search(query: string, opts?: { limit?: number }) {
                 return searchMemories(query, opts?.limit ?? 5);
               },
-              // readFile is not a MemClaw concept — memories are fetched by
+              // readFile is not a Caura concept — memories are fetched by
               // id, not by path. Return an empty MemoryReadResult-shaped
               // value (type-conformant) rather than `null` (type violation
               // that OpenClaw silently coerces).
@@ -732,13 +732,13 @@ const memclawPlugin = {
                 return getReachability().state !== "unreachable";
               },
               async close() {
-                // no-op — MemClaw manages connections server-side
+                // no-op — Caura manages connections server-side
               },
             };
             return { manager, error: null };
           },
           async closeAllMemorySearchManagers() {
-            // no-op — MemClaw manages connections server-side
+            // no-op — Caura manages connections server-side
           },
         });
       }

--- a/plugin/src/prompt-section.ts
+++ b/plugin/src/prompt-section.ts
@@ -1,5 +1,5 @@
 /**
- * MemClaw Memory Prompt Section Builder
+ * Caura Memory Prompt Section Builder
  *
  * Produces the system-prompt fragment that is injected on every turn
  * via the OpenClaw memory-prompt-section API. Two consumers:
@@ -16,9 +16,9 @@
  * non-negotiable identity reminder, and a pointer to SKILL.md.
  *
  * On hosts that do NOT bootstrap-inject TOOLS.md / AGENTS.md, this
- * fragment is the agent's only direct prompt-time signal that MemClaw
+ * fragment is the agent's only direct prompt-time signal that Caura
  * exists; the agent is still expected to read SKILL.md before its
- * first MemClaw call to pick up the operating contract.
+ * first Caura call to pick up the operating contract.
  */
 
 import { MEMCLAW_TOOLS } from "./tools.js";

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -600,7 +600,7 @@ describe("reconcileSkills — configured targets", () => {
     const summary = await reconcileSkills();
 
     // Ownership gates first: the foreign dir is left untouched AND is not
-    // misreported as a MemClaw-protected skill.
+    // misreported as a Caura-protected skill.
     assert.equal(readFileSync(ext("memclaw", "SKILL.md"), "utf-8"), "# client's own thing named memclaw\n");
     assert.ok(!summary.removed.includes("memclaw"), "foreign protected-name dir not removed");
     assert.ok(!summary.protected.includes("memclaw"), "foreign dir not reported as protected");

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -12,10 +12,10 @@
  * can be configured via ``MEMCLAW_SKILL_TARGETS`` (see
  * {@link resolveSkillTargets}). Two modes:
  *   - ``owned`` ({@link reconcileOwnedDir}): the dir is fully
- *     MemClaw-managed; any on-disk skill not in the catalog is pruned
+ *     Caura-managed; any on-disk skill not in the catalog is pruned
  *     (except {@link PROTECTED_SKILLS}).
  *   - ``additive`` ({@link reconcileAdditiveDir}): a shared/foreign dir.
- *     MemClaw only ever touches entries it wrote, tracked per-skill via
+ *     Caura only ever touches entries it wrote, tracked per-skill via
  *     the {@link OWNED_MARKER} sentinel — foreign skills are never
  *     overwritten (collisions are skipped) or removed.
  * With no config, the single default ``owned`` target makes behaviour
@@ -68,7 +68,7 @@ import { logError } from "./logger.js";
 export const PROTECTED_SKILLS: ReadonlySet<string> = new Set(["memclaw"]);
 
 // Per-skill ownership marker for ``additive`` (shared/foreign) target
-// dirs. MemClaw writes this sentinel inside every skill dir it creates
+// dirs. Caura writes this sentinel inside every skill dir it creates
 // there, and only ever updates/removes a ``<slug>`` that carries it — so
 // a skill it doesn't own is never touched. The marker lives INSIDE the
 // skill dir (``<dir>/<slug>/.memclaw-owned``); OpenClaw's loader reads
@@ -79,10 +79,10 @@ export const PROTECTED_SKILLS: ReadonlySet<string> = new Set(["memclaw"]);
 // "delete it".
 export const OWNED_MARKER = ".memclaw-owned";
 const OWNED_MARKER_BODY =
-  "This skill directory is managed by the MemClaw plugin reconciler.\n" +
+  "This skill directory is managed by the Caura plugin reconciler.\n" +
   "Do not edit by hand — it is overwritten/removed to match the catalog.\n";
 
-/** True if ``skillDir`` carries the MemClaw ownership marker. */
+/** True if ``skillDir`` carries the Caura ownership marker. */
 function isMemclawOwned(skillDir: string): boolean {
   return existsSync(join(skillDir, OWNED_MARKER));
 }
@@ -121,7 +121,7 @@ export interface ReconcileSummary {
   // For the default single-target case this is one entry mirroring the
   // top-level arrays.
   targets: TargetReconcileResult[];
-  // Target dirs MemClaw ensured are present in OpenClaw's
+  // Target dirs Caura ensured are present in OpenClaw's
   // ``skills.load.extraDirs`` this tick (the ``register: true`` opt-in).
   // Standing truth — the full set we manage, sorted — not a delta. Empty
   // unless a configured target opts into registration.
@@ -142,9 +142,9 @@ export interface TargetReconcileResult {
 /**
  * How aggressively the reconciler may prune a target dir.
  *
- * - ``owned``: the dir is fully MemClaw-managed — every on-disk entry
+ * - ``owned``: the dir is fully Caura-managed — every on-disk entry
  *   not in the catalog is deleted (except {@link PROTECTED_SKILLS}).
- * - ``additive``: a shared/foreign dir — MemClaw only ever touches
+ * - ``additive``: a shared/foreign dir — Caura only ever touches
  *   entries it wrote, tracked by a per-skill {@link OWNED_MARKER}. A
  *   foreign occupant of a desired slug is a collision (skipped, never
  *   clobbered); unowned entries are never pruned.
@@ -249,7 +249,7 @@ interface DirReconcileResult {
   installed: string[];
   /**
    * Desired skills NOT materialised because the slug is already occupied
-   * by a foreign (non-MemClaw-owned) entry in an ``additive`` dir. Always
+   * by a foreign (non-Caura-owned) entry in an ``additive`` dir. Always
    * empty for ``owned`` dirs (which fully own their contents).
    */
   collisions: string[];
@@ -371,19 +371,19 @@ function reconcileOwnedDir(
 /**
  * Reconcile ONE ``additive`` (shared / foreign) target dir.
  *
- * Unlike {@link reconcileOwnedDir}, MemClaw does NOT own this dir, so it
+ * Unlike {@link reconcileOwnedDir}, Caura does NOT own this dir, so it
  * must never touch an entry it didn't write. Safety is enforced by the
  * per-skill {@link OWNED_MARKER}:
  *
  *  - **write**: a desired slug is written only when its dir is absent
- *    (new → stamp the marker) or already MemClaw-owned (update in place).
+ *    (new → stamp the marker) or already Caura-owned (update in place).
  *    A slug occupied by an UNOWNED dir is a collision → skipped, never
  *    overwritten.
  *  - **remove**: an on-disk slug not in the catalog is removed only when
  *    it carries the marker; unowned (foreign) entries are left untouched.
  *
  * Consequence: an empty catalog (or a misconfigured tenant returning an
- * empty installable set) prunes only MemClaw-owned entries here —
+ * empty installable set) prunes only Caura-owned entries here —
  * foreign skills survive. Never throws.
  */
 function reconcileAdditiveDir(
@@ -404,14 +404,14 @@ function reconcileAdditiveDir(
   const onDisk = readDirSlugs(skillsRoot, "reconcileAdditiveDir");
   if (!onDisk) return result;
 
-  // Removals first — but ONLY for MemClaw-owned (marker-bearing) orphans.
+  // Removals first — but ONLY for Caura-owned (marker-bearing) orphans.
   // Anything without the marker is foreign and is never touched.
   for (const slug of onDisk) {
     if (desired.has(slug)) continue;
     // Ownership gates everything in an additive dir: a foreign slug is left
     // alone even if its name collides with a PROTECTED one. A foreign
     // "memclaw" dir (no marker) is the client's, not ours — ignore it
-    // rather than misreport it as a MemClaw-protected skill. An OWNED
+    // rather than misreport it as a Caura-protected skill. An OWNED
     // protected dir still survives via the protected check below.
     if (!isMemclawOwned(join(skillsRoot, slug))) continue; // foreign — leave alone
     if (PROTECTED_SKILLS.has(slug)) {
@@ -428,7 +428,7 @@ function reconcileAdditiveDir(
   }
 
   // Track CONFIRMED on-disk state for ``installed``. Pre-seed with skills
-  // already on disk, MemClaw-owned, AND catalog-active this tick — mirrors
+  // already on disk, Caura-owned, AND catalog-active this tick — mirrors
   // reconcileOwnedDir so a transient read/write I/O failure doesn't drop a
   // physically-present skill from the installed report. (Unlike the owned
   // dir we additionally require the ownership marker — a foreign occupant

--- a/plugin/src/runtime-contract.test.ts
+++ b/plugin/src/runtime-contract.test.ts
@@ -243,7 +243,7 @@ describe("memory-runtime contract (OpenClaw MemoryPluginRuntime)", () => {
     assert.equal(r, r); // non-null
     assert.equal(typeof r.text, "string");
     assert.equal(typeof r.path, "string");
-    // MemClaw does not back readFile with content; empty text is the honest
+    // Caura does not back readFile with content; empty text is the honest
     // answer. What matters is the SHAPE, not the content.
   });
 });
@@ -875,7 +875,7 @@ describe("MemClawContextEngine.constructor — undefined-config tolerance (v2.6.
 //      return would break compaction silently again).
 //   2. ``compact()`` returns a structured ``CompactResult`` shape
 //      regardless of whether the SDK is discoverable.
-//   3. ``compact()`` still persists the summary into MemClaw as a
+//   3. ``compact()`` still persists the summary into Caura as a
 //      side effect (existing behavior preserved).
 //   4. The bridge's resolver cache works — second call doesn't
 //      repeat the filesystem walk.

--- a/plugin/src/tool-definitions.test.ts
+++ b/plugin/src/tool-definitions.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the MemClaw plugin tool surface.
+ * Tests for the Caura plugin tool surface.
  *
  * Guards the contract between `plugin/tools.json` (SoT), `MEMCLAW_TOOLS`
  * (registration order), `PARAM_SCHEMAS` (runtime input validation), and

--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -1,5 +1,5 @@
 /**
- * MemClaw tool definitions — current surface (10 tools).
+ * Caura tool definitions — current surface (10 tools).
  *
  * One `createToolFromSpec(name)` factory wires together three sources:
  *

--- a/plugin/src/tool-specs.ts
+++ b/plugin/src/tool-specs.ts
@@ -1,6 +1,6 @@
 /**
  * Typed loader for `plugin/tools.json` — the single source of truth for
- * MemClaw MCP tool metadata, exported from core-api by
+ * Caura MCP tool metadata, exported from core-api by
  * `scripts/export_tool_specs.py` and kept in sync via CI.
  *
  * This module reads the file at runtime (not at compile time) because

--- a/plugin/src/tools.ts
+++ b/plugin/src/tools.ts
@@ -1,10 +1,10 @@
 /**
- * Ordered list of MemClaw tool names exposed via the OpenClaw plugin.
+ * Ordered list of Caura tool names exposed via the OpenClaw plugin.
  *
  * The *set* is derived from `plugin/tools.json` (SoT): every entry with
  * `plugin_exposed: true`. The *order* is hand-maintained here because
  * it is observable — it drives registration order, the "Available
- * MemClaw tools: …" line in the prompt section, and any downstream UI
+ * tools: …" line in the prompt section, and any downstream UI
  * that renders tools in discovery order.
  *
  * Current surface: 11 tools — LTM (write/recall/list/manage), doc,

--- a/plugin/src/validation.ts
+++ b/plugin/src/validation.ts
@@ -1,5 +1,5 @@
 /**
- * Validation helpers for MemClaw plugin security.
+ * Validation helpers for Caura plugin security.
  *
  * Covers: UUID format, HTTPS enforcement, path containment,
  * HMAC command signature verification, and prompt length caps.

--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -348,6 +348,21 @@ SENTINELS: tuple[Sentinel, ...] = (
         kind=LITERAL,
         breaks="heartbeat reports tools_md=false for every install written before the rename",
     ),
+    # Same category as the six above, found one PR later while rebranding the
+    # prose in this very file — which is exactly why it is being pinned here:
+    # the surrounding comments now say Caura, so the next reader has one more
+    # reason to think the marker should follow them. It must not.
+    Sentinel(
+        path="plugin/src/reconcile-skills.ts",
+        text='OWNED_MARKER = ".memclaw-owned"',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks=(
+            "the per-skill ownership marker already written into every managed "
+            "skill dir on disk — the ownership check gates all pruning on it, so "
+            "a rename makes every existing dir read as foreign and orphans stop "
+            "being collected, permanently and silently"
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
Phase 1.3, **slice 3** — comment and docstring prose in `plugin/src`. 42 lines across 15 files, plus one new sentinel entry. No identifiers, no wire values, no logic.

**Measured: -42 net old-brand lines, no new lines.**

## Only 42 of `plugin/`'s 796 non-exempt lines are safe prose

The exclusions are the interesting part:

| excluded | why |
|---|---|
| **`educate.ts` + `educate.test.ts`** — skipped entirely | The legacy migration surface. Its comments **quote the old headings verbatim** (`"## MemClaw —"`, `auto-added by MemClaw plugin`, the pre-C1 blurb), so rebranding them makes the comments describe strings that don't exist. #936 pinned the seven anchors; the comments *about* them aren't pinned and must keep the old spelling to stay true. |
| `educate.test.ts` fixtures | Legacy **content**, not prose. Renaming leaves the suite green while testing nothing. |
| `heartbeat.ts:492,527` | Comments describing the `.includes("memclaw")` checks — renaming makes them describe a search the code doesn't perform. |
| `config.ts` allowlist comments | "ensure memclaw is in `plugins.allow`" names the plugin id, which is protected. |
| `context-engine.ts:2`, `context-engine.internal.ts:2` | Deferred so `"MemClaw ContextEngine"` moves **with** the class it names rather than drifting from it. |
| 72 wire lines + 18 identifier lines | `MEMCLAW_*` constants, `memclaw://` URIs, `/api/v1/memclaw` routes, `skills/memclaw` paths; identifiers are their own slice. |

## One sentinel entry added (30 → 31)

`reconcile-skills.ts:80` — `OWNED_MARKER = ".memclaw-owned"`. **Same category as the six pinned by #936, and missed there.** It's written into every managed skill dir on users' disks, and `isMemclawOwned()` gates *all* pruning on it:

```ts
if (!isMemclawOwned(join(skillsRoot, slug))) continue; // foreign — leave alone
```

Rename it and every existing dir reads as foreign, so orphans stop being collected — permanently and silently.

Pinned in **this** PR rather than a follow-up because this PR rebrands the prose immediately around it: those comments now say Caura, which gives the next reader one more reason to think the marker should follow them. Flagging that as a deliberate scope addition.

Verified the same way as #936 — sentinel catches the rename (**exit 1**), ratchet passes it (**exit 0**).

## Three judgement calls worth a look

**`OWNED_MARKER_BODY`** text is rebranded. It's written to users' disks but **never read back or compared** (only `existsSync` on the path — grepped both uses), so it's inert. Existing on-disk markers keep the old body harmlessly.

**`isMemclawOwned()` keeps its name** this slice while its docstring now says Caura. That inconsistency is deliberate and resolves in the identifier slice — renaming the function here would mean touching its call sites and tests, which belongs with the rest of the identifier work.

**`tools.ts:7`** described an `"Available MemClaw tools: …"` prompt line — but `prompt-section.ts:34` emits `"Available tools: "` with no brand at all. The comment was **already stale**; corrected to match what's actually emitted rather than rebranding a string that doesn't exist.

## Verification

| check | result |
|---|---|
| `do_not_touch_sentinel.py` | exit 0, all 31 survive |
| sentinel on a renamed marker | **exit 1**, names it |
| `legacy_name_ratchet.py --base origin/main` | exit 0, no new lines, -42 net, 1 exemption (the pinned string) |
| `cd plugin && npm ci && npm run build` (tsc) | exit 0 |
| `cd plugin && npm test` | **414 tests, 414 pass, 0 fail** |
| generated files | no `dist/`, `version.ts` or lockfile drift |

CI type-checks and builds `plugin/` but does not run its test suite, so the 414 above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)