### PR TITLE
fix(ci): pin the plugin's .env gate and install root in the sentinel

### DIFF
--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -363,6 +363,58 @@ SENTINELS: tuple[Sentinel, ...] = (
             "being collected, permanently and silently"
         ),
     ),
+    # -- The plugin's own .env gate and install root. ----------------------------
+    #
+    # These three outrank everything above them in blast radius, and they were
+    # the last to be pinned, for a reason worth writing down: all three sit on
+    # lines that already carried an exemption marker.
+    #
+    # The marker and this list do different jobs. The marker tells the ratchet
+    # "this old-brand text is deliberate, stop failing the build". It says
+    # nothing about DELETING the line, and a sweep that deletes it lowers the
+    # file's count, which the ratchet reads as progress. So the three lines with
+    # the largest consequence in the whole plugin were annotated in a way that
+    # looks like protection and is not. An exemption is a statement of intent;
+    # only an entry here is a guard.
+    #
+    # If a future dual-read alias is added anywhere, it wants both.
+    Sentinel(
+        path="plugin/src/env.ts",
+        text="/^(?:CAURA|MEMCLAW)_[A-Z_]+$/",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks=(
+            "the gate deciding which .env keys may reach process.env — drop the "
+            "legacy alternative and every existing install silently stops loading "
+            "its api key, tenant, agent and fleet id, then starts up behaving "
+            "like a fresh install with nothing configured"
+        ),
+    ),
+    # Anchored through ``.test(key)`` deliberately. The bare prefix pattern is a
+    # SUBSTRING of the stricter regex two functions above, so pinning it alone
+    # would still pass on a tree where this function had been deleted and only
+    # the stricter one survived — a pin satisfied by the wrong line.
+    Sentinel(
+        path="plugin/src/env.ts",
+        text="/^(?:CAURA|MEMCLAW)_/.test(key)",  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks=(
+            "deploy.ts filters the operator's existing .env through this and then "
+            "writes the survivors back as the WHOLE file — drop the legacy "
+            "alternative and the next redeploy ERASES every legacy-prefixed key "
+            "from a file the plugin explicitly does not own the contents of"
+        ),
+    ),
+    Sentinel(
+        path="plugin/src/paths.ts",
+        text='join(getOpenClawBaseDir(), "plugins", "memclaw")',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks=(
+            "the install root on every user's disk — the .env, install.json, "
+            "dist/ and shared-skill paths all derive from it. The server's copy "
+            "of this same path is pinned separately, so renaming one side alone "
+            "leaves a server writing where the plugin no longer reads"
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
Adds 3 entries, **31 → 34**. These outrank everything already on the list by blast radius, and they were the last to be pinned — for a reason worth recording.

## The marker is not a guard

All three sit on lines that **already carried `legacy-name-ok`**.

That marker tells the *ratchet* "this old-brand text is deliberate, stop failing the build." It says nothing about **deleting** the line — and a deletion lowers the file's count, which the ratchet reads as *progress*. So the three lines with the largest consequence in the entire plugin were annotated in a way that **looks like protection and isn't**.

An exemption states intent; only a sentinel entry guards. A dual-read alias wants both. That's arguably a policy point beyond this PR.

## What they are

**`env.ts:36` — `hasPluginEnvPrefix` — CRITICAL, and it destroys customer data rather than merely breaking things.**

`deploy.ts` filters the operator's existing `.env` through this predicate, then writes the survivors back as the *whole file*:

```ts
// deploy.ts:62 — read existing
if (hasPluginEnvPrefix(k)) existing.set(k, v);
// deploy.ts:77 — write back, whole file
writeFileSync(envPath, lines.join("\n") + "\n", "utf-8");
```

Drop the legacy alternative and the next redeploy **erases** every legacy-prefixed key from a file whose own docstring calls it *"a file we do not own the contents of."* Fires on any redeploy that changes at least one env key.

**`env.ts:22` — `isPluginEnvKey`.** The gate deciding which `.env` keys may reach `process.env`. Drop the legacy alternative and every existing install silently stops loading its api key, tenant, agent and fleet id — then starts up behaving like a fresh install with nothing configured.

**`paths.ts:11` — the install root.** `.env`, `install.json`, `dist/` and the shared-skill path all derive from it. The **server's** copy of this same path is already pinned (`core-api/.../routes/plugin.py`); the plugin's own resolution was not — so a one-sided rename leaves a server writing where the plugin no longer reads, with nothing red on either side.

## One anchoring subtlety

The bare prefix pattern in `hasPluginEnvPrefix` is a **substring** of the stricter regex in `isPluginEnvKey` two functions above. Pinning it alone would still pass on a tree where `hasPluginEnvPrefix` had been deleted and only the stricter form survived — a pin satisfied by the wrong line. It's anchored through `.test(key)`, which the stricter line does not contain.

## Proven independently, not just in aggregate

| simulated change | result |
|---|---|
| drop legacy branch from `isPluginEnvKey` only | exit 1, catches **1** (its own) |
| drop legacy branch from `hasPluginEnvPrefix` only | exit 1, catches **1** (its own) |
| rename the install root only | exit 1, catches **1** (its own) |
| naive `s/memclaw/caura/gi` over both files | exit 1, catches **3** |
| restored | exit 0 |

The second row is the one that matters — it confirms the two `env.ts` pins don't subsume each other.

## Verification

| check | result |
|---|---|
| `do_not_touch_sentinel.py` | exit 0, all 34 survive |
| `legacy_name_ratchet.py --base origin/main` | exit 0, no new lines, 3 exemptions (all pinned floor strings) |
| `tests/test_do_not_touch_sentinel.py` | 87 passed |
| `ruff check` + `format --check --isolated` | clean |

## Not in this PR

From the same audit, deliberately held back:

- **The eleven plugin-id sites in `config.ts`** (`plugins.allow`, `entries.<id>.enabled`, `slots.memory`, `slots.contextEngine`). Eleven entries is the wrong shape — these want a single shared `PLUGIN_ID` constant pinned once, which also removes the manifest/config drift class. That's a refactor, so it gets its own PR. Note the current manifest-only pin gives *false* coverage: a sweep renaming all eleven config sites while leaving `openclaw.plugin.json` alone goes green.
- **`context-engine.ts:1339-40`** — `prepareSubagentSpawn` returns `{ memclawAgentId, memclawFleetId }`. No consumer exists anywhere in this repo and no test pins them, so the consumer is OpenClaw's contract in `openclaw/openclaw` — unverifiable from here, and a blocker on any identifier sweep, which would rename them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)