### PR TITLE
perf(llm): log per-call token usage and add contradiction-judge reasoning-effort control

### DIFF
--- a/common/llm/protocols.py
+++ b/common/llm/protocols.py
@@ -33,6 +33,7 @@ class LLMProvider(Protocol):
         temperature: float = 0.0,
         seed: int | None = None,
         response_schema: dict | None = None,
+        reasoning_effort: str | None = None,
     ) -> dict:
         """Send a prompt and return a parsed JSON dict.
 
@@ -41,11 +42,20 @@ class LLMProvider(Protocol):
         ``response_format``, Vertex ``response_mime_type``, or prompt
         engineering for APIs without native JSON mode).
 
+        ``reasoning_effort`` (E3): reasoning-token budget hint for
+        reasoning-class models. Valid values are MODEL-SPECIFIC (e.g.
+        gpt-5.4 family: ``"none"`` / ``"low"`` / ``"medium"`` /
+        ``"high"`` / ``"xhigh"``); an unsupported value is a 400 on
+        every call. ``None`` means "do not send the parameter" —
+        required for non-reasoning models, which reject it. Providers
+        without an equivalent knob accept-and-ignore.
+
         Parameters that are not supported by a provider (e.g.,
-        ``temperature``, ``seed``, ``response_schema``) MUST be
-        accepted-and-ignored, never rejected: a ``TypeError`` here is
-        swallowed by the ``call_with_fallback`` retry loop and surfaces
-        as a silent degradation to the fake/regex fallback (audit C1).
+        ``temperature``, ``seed``, ``response_schema``,
+        ``reasoning_effort``) MUST be accepted-and-ignored, never
+        rejected: a ``TypeError`` here is swallowed by the
+        ``call_with_fallback`` retry loop and surfaces as a silent
+        degradation to the fake/regex fallback (audit C1).
         """
         ...
 

--- a/common/llm/providers/fake.py
+++ b/common/llm/providers/fake.py
@@ -35,9 +35,11 @@ class FakeLLMProvider:
         temperature: float = 0.0,
         seed: int | None = None,
         response_schema: dict | None = None,
+        reasoning_effort: str | None = None,
     ) -> dict:
-        """Return an empty JSON object (``seed`` / ``response_schema``
-        accepted-and-ignored, matching the provider contract)."""
+        """Return an empty JSON object (``seed`` / ``response_schema`` /
+        ``reasoning_effort`` accepted-and-ignored, matching the provider
+        contract)."""
         return {}
 
     async def complete_text(

--- a/common/llm/providers/gemini.py
+++ b/common/llm/providers/gemini.py
@@ -129,10 +129,12 @@ class GeminiLLMProvider:
         temperature: float = 0.0,
         seed: int | None = None,
         response_schema: dict | None = None,
+        reasoning_effort: str | None = None,
     ) -> dict:
         """Async wrapper around the synchronous Gemini JSON completion.
 
-        ``seed`` / ``response_schema`` are accepted-and-ignored (OpenAI
+        ``seed`` / ``response_schema`` / ``reasoning_effort`` are
+        accepted-and-ignored (OpenAI
         structured-output kwargs). Rejecting them made every
         ``complete_json(..., seed=..., response_schema=...)`` caller —
         notably entity extraction — raise ``TypeError``, exhaust its

--- a/common/llm/providers/openai.py
+++ b/common/llm/providers/openai.py
@@ -51,6 +51,35 @@ class OpenAIResponseShapeError(ProviderResponseShapeError):
         return (type(self), (self.args[1], self.args[2]))
 
 
+def _usage_tokens(response) -> tuple[int, int, int]:
+    """``(prompt, completion, reasoning)`` token counts from a chat response.
+
+    E3 — OpenAI bills tokens, not calls, so per-call cost has to be visible
+    in the logs to make a spend fix verifiable in dollars. ``reasoning``
+    (inside ``completion_tokens_details``, gpt-5-family reasoning models
+    only) is broken out because it is billed as output while never
+    appearing in the visible content — it is the invisible majority of the
+    contradiction judge's spend. Every field is optional on OpenAI-
+    compatible endpoints, so absence degrades to 0 rather than raising.
+    """
+
+    def _int(value: object) -> int:
+        # Coerce defensively: OpenAI-compatible endpoints return None or
+        # omit fields, and unit-test stubs return non-numeric attributes.
+        try:
+            return int(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 0
+
+    usage = getattr(response, "usage", None)
+    details = getattr(usage, "completion_tokens_details", None)
+    return (
+        _int(getattr(usage, "prompt_tokens", 0)),
+        _int(getattr(usage, "completion_tokens", 0)),
+        _int(getattr(details, "reasoning_tokens", 0)),
+    )
+
+
 class OpenAILLMProvider:
     """LLM provider using the OpenAI chat completions API.
 
@@ -152,6 +181,7 @@ class OpenAILLMProvider:
         temperature: float = 0.0,
         seed: int | None = None,
         response_schema: dict | None = None,
+        reasoning_effort: str | None = None,
     ) -> dict:
         """Send a prompt and return a parsed JSON dict.
 
@@ -175,6 +205,17 @@ class OpenAILLMProvider:
         mode requirements (additionalProperties=false everywhere); the
         client-side Pydantic parse is the real guardrail. Passing
         ``None`` preserves today's shape-less behaviour.
+
+        ``reasoning_effort`` (E3): forwarded to the chat completions API
+        only when set, so callers doing bounded classification work (the
+        contradiction judge) can bound hidden reasoning-token spend —
+        billed as output, invisible in the content. Valid values are
+        MODEL-SPECIFIC (gpt-5.4 family, wet-tested: ``"none"`` /
+        ``"low"`` / ``"medium"`` / ``"high"`` / ``"xhigh"``); an
+        unsupported value is a 400 on every call. ``None`` (the default)
+        omits the parameter entirely, because non-reasoning models
+        reject it with a 400. Sending it also drops ``temperature`` —
+        see the inline note at the call.
         """
         t0 = time.perf_counter()
         if response_schema is not None:
@@ -196,12 +237,27 @@ class OpenAILLMProvider:
         }
         if seed is not None:
             create_kwargs["seed"] = seed
+        if reasoning_effort is not None:
+            create_kwargs["reasoning_effort"] = reasoning_effort
+            # Wet-tested against gpt-5.4-nano: sending reasoning_effort
+            # switches the model into reasoning mode, which rejects any
+            # non-default temperature with a 400 ("only the default (1)
+            # value is supported") — and call_with_fallback would swallow
+            # that into the abstain fallback, silently disabling the
+            # judge. Temperature is a no-op in reasoning mode anyway, so
+            # drop it rather than fail the call.
+            create_kwargs.pop("temperature", None)
         response = await self._client.chat.completions.create(**create_kwargs)
         llm_ms = int((time.perf_counter() - t0) * 1000)
+        tokens_in, tokens_out, tokens_reasoning = _usage_tokens(response)
         logger.info(
-            "OpenAI-compatible complete_json (%s) took %dms",
+            "OpenAI-compatible complete_json (%s) took %dms "
+            "tokens_in=%d tokens_out=%d tokens_reasoning=%d",
             self._model,
             llm_ms,
+            tokens_in,
+            tokens_out,
+            tokens_reasoning,
         )
         content = response.choices[0].message.content
         if not content:
@@ -227,9 +283,14 @@ class OpenAILLMProvider:
             max_completion_tokens=max_tokens,
         )
         llm_ms = int((time.perf_counter() - t0) * 1000)
+        tokens_in, tokens_out, tokens_reasoning = _usage_tokens(response)
         logger.info(
-            "OpenAI-compatible complete_text (%s) took %dms",
+            "OpenAI-compatible complete_text (%s) took %dms "
+            "tokens_in=%d tokens_out=%d tokens_reasoning=%d",
             self._model,
             llm_ms,
+            tokens_in,
+            tokens_out,
+            tokens_reasoning,
         )
         return response.choices[0].message.content or ""

--- a/common/llm/providers/vertex.py
+++ b/common/llm/providers/vertex.py
@@ -167,10 +167,12 @@ class VertexLLMProvider:
         temperature: float = 0.0,
         seed: int | None = None,
         response_schema: dict | None = None,
+        reasoning_effort: str | None = None,
     ) -> dict:
         """Async wrapper around synchronous Vertex AI JSON completion.
 
-        ``seed`` / ``response_schema`` are accepted-and-ignored (OpenAI
+        ``seed`` / ``response_schema`` / ``reasoning_effort`` are
+        accepted-and-ignored (OpenAI
         structured-output kwargs) — see ``GeminiProvider.complete_json``
         for why rejecting them silently broke entity extraction (C1).
         """

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -109,6 +109,19 @@ class Settings(BaseSettings):
     gemini_api_key: str | None = None
     entity_extraction_provider: str = "openai"  # none | fake | openai | anthropic | openrouter | gemini
     entity_extraction_model: str = "gpt-5.4-nano"
+    # E3 — reasoning-effort for the contradiction judge's LLM calls.
+    # Valid values are MODEL-SPECIFIC (gpt-5.4 family, wet-tested:
+    # "none" | "low" | "medium" | "high" | "xhigh"; some models take
+    # "minimal" instead of "none") — verify against the configured
+    # entity_extraction_model before setting, because an unsupported
+    # value 400s on every call and call_with_fallback silently degrades
+    # the judge to abstention. The judge is bounded classification work,
+    # so a low tier bounds hidden reasoning-token spend (billed as
+    # output) without changing which candidates are considered; use the
+    # per-call tokens_reasoning log field to compare tiers in dollars.
+    # None (the default) sends no parameter at all — REQUIRED for
+    # non-reasoning models, which reject the parameter outright.
+    contradiction_reasoning_effort: str | None = None
     # Default for the ``search.entity_retrieval`` org setting: query-time entity
     # lookup + graph search. A tenant override wins; this is the fleet-wide
     # fallback so an operator can disable entity/graph reads on a whole box

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1092,6 +1092,21 @@ def _judge_contradiction(raw) -> tuple[bool, float]:
 # ---------------------------------------------------------------------------
 
 
+def _judge_effort_kwargs() -> dict:
+    """``complete_json`` kwargs for every contradiction-judge call (E3).
+
+    The judge is the dominant OpenAI spend (up to 20 candidates per write,
+    ~80% of the bill in OUTPUT tokens — mostly hidden reasoning tokens on
+    gpt-5-family models). ``contradiction_reasoning_effort`` caps that
+    per-call reasoning budget. Returned as a kwargs dict, EMPTY when
+    unset, rather than passing ``reasoning_effort=None`` positionally:
+    an unset knob must not change the wire request, and test doubles that
+    predate the parameter keep working without it.
+    """
+    effort = settings.contradiction_reasoning_effort
+    return {"reasoning_effort": effort} if effort else {}
+
+
 async def _llm_contradiction_check(
     new_content: str,
     old_content: str,
@@ -1117,7 +1132,7 @@ async def _llm_contradiction_check(
     prompt = CONTRADICTION_PROMPT.format(new_content=new_content[:500], old_content=old_content[:500])
 
     async def _do_check(llm) -> tuple[bool, float]:
-        raw = await llm.complete_json(prompt)
+        raw = await llm.complete_json(prompt, **_judge_effort_kwargs())
         return _judge_contradiction(raw)
 
     return await call_with_fallback(
@@ -1219,7 +1234,7 @@ async def _llm_contradiction_check_batch(
         return out
 
     async def _do_check(llm) -> list[dict]:
-        raw = await llm.complete_json(prompt)
+        raw = await llm.complete_json(prompt, **_judge_effort_kwargs())
         return _align(raw)
 
     return await call_with_fallback(
@@ -1633,7 +1648,7 @@ async def _llm_entity_aware_contradiction_check(
     )
 
     async def _do_check(llm) -> tuple[bool, float]:
-        raw = await llm.complete_json(prompt)
+        raw = await llm.complete_json(prompt, **_judge_effort_kwargs())
         return _judge_contradiction(raw)
 
     return await call_with_fallback(
@@ -1757,7 +1772,7 @@ async def _llm_entity_aware_contradiction_check_batch(
         return out
 
     async def _do_check(llm) -> list[dict]:
-        raw = await llm.complete_json(prompt)
+        raw = await llm.complete_json(prompt, **_judge_effort_kwargs())
         return _align(raw)
 
     return await call_with_fallback(

--- a/tests/test_e3_judge_token_cost.py
+++ b/tests/test_e3_judge_token_cost.py
@@ -1,0 +1,269 @@
+"""E3 — contradiction-judge LLM cost: token-usage logging + reasoning effort.
+
+Aug-2026 finding: ~80% of prod OpenAI spend was OUTPUT tokens on the
+contradiction judge, and on gpt-5-family reasoning models those are
+dominated by hidden reasoning tokens — invisible in the logs (only
+``llm_ms`` was recorded) and unaffected by the A61 call batching, which
+is why the bill never moved. Two changes are pinned here:
+
+1. **``complete_json``/``complete_text`` log ``response.usage``** —
+   ``tokens_in`` / ``tokens_out`` / ``tokens_reasoning`` — so a spend fix
+   is verifiable in dollars, not call counts.
+2. **``complete_json`` accepts and forwards ``reasoning_effort``**, and
+   every contradiction-judge call site passes
+   ``settings.contradiction_reasoning_effort`` through
+   ``_judge_effort_kwargs()`` — EMPTY kwargs when unset, so the wire
+   request (and any non-reasoning model) is untouched by default.
+
+Deliberately NOT changed (decision 2026-08-24): the 20-candidate
+``/similar-candidates`` default stays — contradiction recall is already
+the weak spot, and cutting candidates trades recall for cost.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _response(
+    content: str = '{"ok": true}', usage: object | None = None
+) -> SimpleNamespace:
+    """A chat-completions response stub. Built on SimpleNamespace, not
+    MagicMock, so an absent ``usage`` is genuinely absent (getattr → None)
+    rather than auto-created."""
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+    if usage is not None:
+        resp.usage = usage
+    return resp
+
+
+def _usage(
+    prompt: int, completion: int, reasoning: int | None = None
+) -> SimpleNamespace:
+    details = (
+        SimpleNamespace(reasoning_tokens=reasoning) if reasoning is not None else None
+    )
+    return SimpleNamespace(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        completion_tokens_details=details,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1 — reasoning_effort forwarding through OpenAILLMProvider.complete_json
+# ---------------------------------------------------------------------------
+
+
+async def test_complete_json_forwards_reasoning_effort_when_provided() -> None:
+    from common.llm.providers.openai import OpenAILLMProvider
+
+    provider = OpenAILLMProvider(api_key="sk-test", model="gpt-test")
+    mock_create = AsyncMock(return_value=_response())
+    with patch.object(provider._client.chat.completions, "create", mock_create):
+        await provider.complete_json("test prompt", reasoning_effort="low")
+
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs.get("reasoning_effort") == "low", (
+        f"Expected reasoning_effort='low' forwarded to OpenAI client, got kwargs={list(kwargs.keys())}"
+    )
+    # Wet-tested against gpt-5.4-nano: reasoning mode 400s on any
+    # non-default temperature, so the two must never travel together.
+    assert "temperature" not in kwargs, (
+        "temperature must be dropped when reasoning_effort is sent — reasoning "
+        "models reject non-default values with a 400"
+    )
+
+
+async def test_complete_json_omits_reasoning_effort_when_none() -> None:
+    """Non-reasoning models reject the parameter with a 400, and
+    ``call_with_fallback`` would read that as a provider outage — so an
+    unset knob must not appear in the request at all."""
+    from common.llm.providers.openai import OpenAILLMProvider
+
+    provider = OpenAILLMProvider(api_key="sk-test", model="gpt-test")
+    mock_create = AsyncMock(return_value=_response())
+    with patch.object(provider._client.chat.completions, "create", mock_create):
+        await provider.complete_json("test prompt")
+
+    assert "reasoning_effort" not in mock_create.call_args.kwargs
+    # ...and the temperature-drop is scoped to reasoning mode only: the
+    # deterministic default (0.0) still travels on ordinary calls.
+    assert mock_create.call_args.kwargs.get("temperature") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 2 — token-usage logging
+# ---------------------------------------------------------------------------
+
+
+async def test_complete_json_logs_token_usage(caplog: pytest.LogCaptureFixture) -> None:
+    from common.llm.providers.openai import OpenAILLMProvider
+
+    provider = OpenAILLMProvider(api_key="sk-test", model="gpt-test")
+    mock_create = AsyncMock(
+        return_value=_response(usage=_usage(120, 950, reasoning=900))
+    )
+    with (
+        caplog.at_level(logging.INFO, logger="common.llm.providers.openai"),
+        patch.object(provider._client.chat.completions, "create", mock_create),
+    ):
+        await provider.complete_json("test prompt")
+
+    assert "tokens_in=120 tokens_out=950 tokens_reasoning=900" in caplog.text
+
+
+async def test_complete_text_logs_token_usage(caplog: pytest.LogCaptureFixture) -> None:
+    from common.llm.providers.openai import OpenAILLMProvider
+
+    provider = OpenAILLMProvider(api_key="sk-test", model="gpt-test")
+    mock_create = AsyncMock(
+        return_value=_response(content="plain text", usage=_usage(10, 20))
+    )
+    with (
+        caplog.at_level(logging.INFO, logger="common.llm.providers.openai"),
+        patch.object(provider._client.chat.completions, "create", mock_create),
+    ):
+        await provider.complete_text("test prompt")
+
+    assert "tokens_in=10 tokens_out=20 tokens_reasoning=0" in caplog.text
+
+
+async def test_complete_json_tolerates_missing_usage(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """OpenAI-compatible endpoints (OpenRouter, self-hosted) may omit
+    ``usage`` entirely; the call must succeed and log zeros."""
+    from common.llm.providers.openai import OpenAILLMProvider
+
+    provider = OpenAILLMProvider(api_key="sk-test", model="gpt-test")
+    mock_create = AsyncMock(return_value=_response())  # no usage attr at all
+    with (
+        caplog.at_level(logging.INFO, logger="common.llm.providers.openai"),
+        patch.object(provider._client.chat.completions, "create", mock_create),
+    ):
+        result = await provider.complete_json("test prompt")
+
+    assert result == {"ok": True}
+    assert "tokens_in=0 tokens_out=0 tokens_reasoning=0" in caplog.text
+
+
+async def test_usage_tokens_tolerates_non_numeric_stub() -> None:
+    """A stub response with non-numeric fields (the shape older tests
+    use) must degrade to real ints, never leak a non-int into ``%d`` log
+    formatting or raise. (A bare MagicMock coerces via ``__int__`` — the
+    interesting case is an attribute int() genuinely rejects.)"""
+    from common.llm.providers.openai import _usage_tokens
+
+    assert all(type(v) is int for v in _usage_tokens(MagicMock()))
+    stub = SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens="not-a-number",
+            completion_tokens=None,
+            completion_tokens_details=None,
+        )
+    )
+    assert _usage_tokens(stub) == (0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# 3 — the judge passes settings.contradiction_reasoning_effort through
+# ---------------------------------------------------------------------------
+
+
+async def test_judge_effort_kwargs_empty_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core_api.config import settings
+    from core_api.services.contradiction_detector import _judge_effort_kwargs
+
+    monkeypatch.setattr(settings, "contradiction_reasoning_effort", None)
+    assert _judge_effort_kwargs() == {}
+
+
+async def test_judge_effort_kwargs_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core_api.config import settings
+    from core_api.services.contradiction_detector import _judge_effort_kwargs
+
+    monkeypatch.setattr(settings, "contradiction_reasoning_effort", "minimal")
+    assert _judge_effort_kwargs() == {"reasoning_effort": "minimal"}
+
+
+async def test_batch_judge_forwards_effort_to_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end through ``call_with_fallback``: the batched judge's
+    ``complete_json`` call carries the configured effort."""
+    from core_api.config import settings
+    from core_api.services.contradiction_detector import _llm_contradiction_check_batch
+
+    monkeypatch.setattr(settings, "contradiction_reasoning_effort", "low")
+    monkeypatch.setattr(settings, "entity_extraction_provider", "openai")
+
+    seen_kwargs: dict = {}
+
+    class _StubProvider:
+        provider_name = "openai"
+        model = "gpt-test"
+
+        async def complete_json(self, prompt: str, **kwargs) -> dict:
+            seen_kwargs.update(kwargs)
+            return {"0": {"same_subject": False, "contradicts": False}}
+
+    with patch("common.llm.registry.get_llm_provider", return_value=_StubProvider()):
+        judged = await _llm_contradiction_check_batch(
+            "new statement",
+            [
+                {"id": "c0", "content": "old statement"},
+                {"id": "c1", "content": "other"},
+            ],
+            tenant_config=None,
+        )
+
+    assert seen_kwargs.get("reasoning_effort") == "low"
+    assert len(judged) == 2
+
+
+async def test_batch_judge_omits_effort_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the knob unset the judge must not pass the kwarg at all —
+    test doubles and providers predating the parameter keep working."""
+    from core_api.config import settings
+    from core_api.services.contradiction_detector import _llm_contradiction_check_batch
+
+    monkeypatch.setattr(settings, "contradiction_reasoning_effort", None)
+    monkeypatch.setattr(settings, "entity_extraction_provider", "openai")
+
+    class _LegacyProvider:
+        provider_name = "openai"
+        model = "gpt-test"
+
+        # Deliberately NO **kwargs: passing reasoning_effort here raises
+        # TypeError, which call_with_fallback would swallow into the
+        # fake fallback (audit C1) — this pins that we never send it unset.
+        async def complete_json(self, prompt: str) -> dict:
+            return {"0": {"same_subject": False, "contradicts": False}}
+
+    with patch("common.llm.registry.get_llm_provider", return_value=_LegacyProvider()):
+        judged = await _llm_contradiction_check_batch(
+            "new statement",
+            [
+                {"id": "c0", "content": "old statement"},
+                {"id": "c1", "content": "other"},
+            ],
+            tenant_config=None,
+        )
+
+    assert judged == [
+        {"same_subject": False, "contradicts": False},
+        {"contradicts": False},
+    ]


### PR DESCRIPTION
## Why

Aug-2026 prod OpenAI spend ($1,155 on core-api+worker) is ~80% **output** tokens. The A61 call batching (#770/#771) cut daily request count ~5x but the bill barely moved — OpenAI bills tokens, not calls, and the only per-call cost signal in our logs was `llm_ms`. Tracked as **E3** on the shared task checklist.

## What

Two changes, deliberately **without** touching the 20-candidate `/similar-candidates` default (contradiction recall is already the weak spot; cutting candidates trades recall for cost — decision 2026-08-24):

1. **Token-usage logging** — `OpenAILLMProvider.complete_json`/`complete_text` now log `tokens_in` / `tokens_out` / `tokens_reasoning` from `response.usage` on every call, so a spend fix is verifiable in dollars instead of call counts. `tokens_reasoning` (from `completion_tokens_details`) is broken out because reasoning models bill it as output while it never appears in the visible content. Defensive against OpenAI-compatible endpoints that omit `usage`.

2. **`CONTRADICTION_REASONING_EFFORT` knob (default: unset)** — `complete_json` accepts `reasoning_effort` (protocol-wide, accept-and-ignore on fake/gemini/vertex), forwarded only when set. All four contradiction-judge call sites pass the setting through `_judge_effort_kwargs()` — empty kwargs when unset, so the wire request and pre-existing test doubles are untouched by default.

## Wet test (local enterprise stack, real gpt-5.4-nano)

Full rebuild + e2e on 5 contradicting memory pairs, which caught two things unit tests couldn't:

- **Reasoning mode rejects `temperature=0.0`** (400: only default 1 supported) → the provider now drops `temperature` whenever `reasoning_effort` is sent. Without this the judge silently degraded to abstention via the fallback chain.
- **Valid effort values are model-specific** — gpt-5.4-nano takes `none|low|medium|high|xhigh` (no `minimal`). Documented on the setting; an unsupported value 400s every call and abstains.

Verified end-to-end: token fields present on every LLM log line; `effort=low` → judge verdicts still correct (verdict=True 0.90 on planted contradictions), `tokens_reasoning=37–117` per judge call; `effort=none` → correct verdicts, zero reasoning tokens; unset → byte-identical behavior to main.

**Operational note:** on this local workload the *default* (unset) mode already showed `tokens_reasoning=0`, so the right prod move is: deploy the logging first, read the prod `tokens_reasoning` distribution, then decide the knob value from data.

`ruff` / `mypy` / 5028 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)