### PR TITLE
refactor(plugin): collapse the plugin id to one constant and pin both ends

### DIFF
--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -1,7 +1,8 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { writeFileSync, readFileSync, mkdtempSync, mkdirSync, rmSync } from "fs";
-import { join } from "path";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import { tmpdir } from "os";
 import {
   autoFixAllowlist,
@@ -11,8 +12,35 @@ import {
   isMemclawFullyConfigured,
   isMemorySlotClaimed,
   shouldRunAutoFix,
+  PLUGIN_ID,
 } from "./config.js";
 import { getPluginDir } from "./paths.js";
+
+describe("PLUGIN_ID", () => {
+  // The id lives in two files that are read by different consumers:
+  // openclaw.plugin.json, which OpenClaw's LOADER reads, and config.ts, which
+  // writes the four id-keyed fields in the USER's openclaw.json. Renaming one
+  // and not the other type-checks and leaves every other test in this suite
+  // green, while producing a plugin that writes entries.<new> into a config
+  // OpenClaw still keys as <old> — memory slot never claimed, keystone
+  // injection silently dead. Nothing else in the build compares the two.
+  test("matches the id in openclaw.plugin.json", () => {
+    const manifestPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "openclaw.plugin.json",
+    );
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    assert.equal(
+      PLUGIN_ID,
+      manifest.id,
+      `config.ts PLUGIN_ID ("${PLUGIN_ID}") and openclaw.plugin.json id ` +
+        `("${manifest.id}") must be identical — OpenClaw reads the manifest, ` +
+        `this module writes the user's config, and a mismatch means the memory ` +
+        `slot is never claimed and keystone injection stops with nothing failing.`,
+    );
+  });
+});
 
 // Minimal "happy-path" config scaffold — every predicate true. Individual
 // tests selectively break one field at a time.

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -11,6 +11,25 @@ import { logError } from "./logger.js";
 
 export { getPluginDir, getOpenClawConfigPath };
 
+/**
+ * This plugin's id, as OpenClaw knows it.
+ *
+ * It is NOT a display name and it is not ours to change unilaterally. The same
+ * string appears in ``openclaw.plugin.json`` — which is what OpenClaw's loader
+ * actually reads — and keys four separate places in the USER's
+ * ``~/.openclaw/openclaw.json``: ``plugins.allow``, ``plugins.entries.<id>``,
+ * ``plugins.slots.memory`` and ``plugins.slots.contextEngine``.
+ *
+ * Every one of those used to spell the id inline, eleven times in this file.
+ * That is what made a partial rename possible: renaming the eleven while
+ * leaving the manifest alone type-checks, tests green, and produces a plugin
+ * writing ``entries.<new>`` into a config OpenClaw still keys as ``<old>`` — so
+ * the memory slot is never claimed and keystone injection silently dies. One
+ * declaration means a rename is one edit, and ``config.test.ts`` asserts this
+ * value still equals the manifest's so the two cannot drift apart again.
+ */
+export const PLUGIN_ID = "memclaw";  // legacy-name-ok: the id keys every existing on-disk install
+
 export function getPluginSrcPath(): string {
   return join(getPluginDir(), "src", "index.ts");
 }
@@ -52,11 +71,11 @@ export function isMemclawAllowed(config: Record<string, any>): boolean {
   // plugin including `openai`. Customer-reported on a fresh 2.8.1
   // install: "Unknown model: openai/gpt-5.5" 2 minutes after install.
   if (!Array.isArray(allow) || allow.length === 0) return true;
-  return allow.includes("memclaw");
+  return allow.includes(PLUGIN_ID);
 }
 
 export function isMemclawEnabled(config: Record<string, any>): boolean {
-  return !!config?.plugins?.entries?.memclaw?.enabled;
+  return !!config?.plugins?.entries?.[PLUGIN_ID]?.enabled;
 }
 
 export function isMemclawPathLoaded(config: Record<string, any>): boolean {
@@ -71,7 +90,7 @@ export function isMemclawPathLoaded(config: Record<string, any>): boolean {
  * which case `register()` runs but memory-runtime methods are never called.
  */
 export function isMemorySlotClaimed(config: Record<string, any>): boolean {
-  return config?.plugins?.slots?.memory === "memclaw";
+  return config?.plugins?.slots?.memory === PLUGIN_ID;
 }
 
 /**
@@ -87,7 +106,7 @@ export function isMemorySlotClaimed(config: Record<string, any>): boolean {
  * ``dist/registry-DFFgCbcm.js:241 resolveContextEngine``.
  */
 export function isContextEngineSlotClaimed(config: Record<string, any>): boolean {
-  return config?.plugins?.slots?.contextEngine === "memclaw";
+  return config?.plugins?.slots?.contextEngine === PLUGIN_ID;
 }
 
 export function isMemclawFullyConfigured(config: Record<string, any>): boolean {
@@ -136,9 +155,9 @@ export function autoFixAllowlist(options?: {
   if (
     Array.isArray(config?.plugins?.allow) &&
     config.plugins.allow.length > 0 &&
-    !config.plugins.allow.includes("memclaw")
+    !config.plugins.allow.includes(PLUGIN_ID)
   ) {
-    config.plugins.allow.push("memclaw");
+    config.plugins.allow.push(PLUGIN_ID);
     changes.push("plugins.allow");
   }
 
@@ -146,7 +165,7 @@ export function autoFixAllowlist(options?: {
   if (!isMemclawEnabled(config)) {
     if (!config.plugins) config.plugins = {};
     if (!config.plugins.entries) config.plugins.entries = {};
-    config.plugins.entries.memclaw = { enabled: true };
+    config.plugins.entries[PLUGIN_ID] = { enabled: true };
     changes.push("plugins.entries");
   }
 
@@ -163,7 +182,7 @@ export function autoFixAllowlist(options?: {
   // 4. Claim the exclusive memory slot for memclaw
   if (!config.plugins) config.plugins = {};
   if (!config.plugins.slots) config.plugins.slots = {};
-  if (config.plugins.slots.memory !== "memclaw") {
+  if (config.plugins.slots.memory !== PLUGIN_ID) {
     const previousSlot = config.plugins.slots.memory;
     if (previousSlot && !options?.forceSlotOverride) {
       console.warn(
@@ -172,7 +191,7 @@ export function autoFixAllowlist(options?: {
           `or set CAURA_AUTO_FIX_CONFIG=true to force.`,
       );
     } else {
-      config.plugins.slots.memory = "memclaw";
+      config.plugins.slots.memory = PLUGIN_ID;
       // Disable the previous memory plugin to avoid slot conflict
       if (previousSlot && config.plugins.entries?.[previousSlot]) {
         config.plugins.entries[previousSlot].enabled = false;
@@ -192,17 +211,17 @@ export function autoFixAllowlist(options?: {
   //     prompt. Mirrors step 4's forceSlotOverride handling so an
   //     operator who deliberately set a different engine doesn't get
   //     silently stomped.
-  if (config.plugins.slots.contextEngine !== "memclaw") {
+  if (config.plugins.slots.contextEngine !== PLUGIN_ID) {
     const previousCe = config.plugins.slots.contextEngine;
     if (previousCe && !options?.forceSlotOverride) {
       console.warn(
         `[caura] plugins.slots.contextEngine already set to "${previousCe}" — ` +
           `skipping auto-override. Run "openclaw gateway memclaw.allowlist.fix" ` +
           `or set CAURA_AUTO_FIX_CONFIG=true to force. ` +
-          `Note: keystone rules will NOT inject without contextEngine="memclaw".`,
+          `Note: keystone rules will NOT inject without contextEngine="${PLUGIN_ID}".`,
       );
     } else {
-      config.plugins.slots.contextEngine = "memclaw";
+      config.plugins.slots.contextEngine = PLUGIN_ID;
       // Disable the previous contextEngine plugin to avoid slot conflict.
       // Without this, two plugins are both ``enabled`` and both
       // declared a contextEngine — OpenClaw's resolveContextEngine

--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -165,6 +165,22 @@ SENTINELS: tuple[Sentinel, ...] = (
         kind=LITERAL,
         breaks="every installed plugin is orphaned — the id keys the on-disk install",
     ),
+    # The other end of the same id. The manifest above is what OpenClaw's loader
+    # reads; this constant is what writes the four id-keyed fields in the USER's
+    # openclaw.json. Pinning only the manifest was worse than pinning neither:
+    # the gate went green on a change that renamed the plugin side alone, which
+    # is the half that produces a config OpenClaw cannot match.
+    Sentinel(
+        path="plugin/src/config.ts",
+        text='PLUGIN_ID = "memclaw"',  # legacy-name-ok: pinned floor string
+        kind=LITERAL,
+        breaks=(
+            "the id this plugin writes into plugins.allow, plugins.entries.<id> "
+            "and both plugins.slots entries of the user's openclaw.json — rename "
+            "it without the manifest and the loader never matches what we wrote, "
+            "so the memory slot is never claimed and keystone injection stops"
+        ),
+    ),
     Sentinel(
         path="core-api/src/core_api/routes/plugin.py",
         text=".openclaw/plugins/memclaw",  # legacy-name-ok: pinned floor string


### PR DESCRIPTION
The plugin id was spelled inline **eleven times** in `config.ts`. That's what made a *partial* rename possible — and the partial rename is the dangerous one.

## The failure this removes

The id keys four fields in the **user's** `~/.openclaw/openclaw.json` — `plugins.allow`, `plugins.entries.<id>`, `plugins.slots.memory`, `plugins.slots.contextEngine` — and the same string is in `openclaw.plugin.json`, which is what OpenClaw's **loader** reads.

Rename the eleven and leave the manifest alone: it type-checks, the whole suite stays green, and the plugin writes `entries.<new>` into a config OpenClaw still keys as `<old>`. The memory slot is never claimed, and per the docstring on `isContextEngineSlotClaimed`, keystone injection silently dies.

**Only the manifest was pinned** — so the sentinel went green on exactly that half. That made the gate *worse than no gate*, because it looked covered.

## What changed

- `config.ts` declares `export const PLUGIN_ID = "memclaw"` once; all eleven sites reference it, including the two property accesses (now `entries?.[PLUGIN_ID]`) and the operator-facing warning that quotes the slot value.
- `config.test.ts` asserts `PLUGIN_ID` equals `openclaw.plugin.json`'s `id`. **This is the only thing in the build that compares them.**
- The sentinel pins `PLUGIN_ID = "memclaw"` next to the manifest entry it belongs with (35 total), so neither end can move alone.

Two comments keep the old literal deliberately: both narrate a historical bug where the code created `["memclaw"]` from an empty allowlist. They describe what a *past version* wrote, so they're only accurate in the old spelling.

## The new test fails without its fix — both directions

| simulated change | sentinel | suite |
|---|---|---|
| rename the **plugin** side only | exit 1 | new test **fails** |
| rename the **manifest** side only | exit 1 | new test **fails**, and `fail 1` — it is the **only** test of 42 that catches manifest drift |
| restored | exit 0 | 42 pass, 0 fail |

The second row is the point: nothing else in the suite notices, which is why this drift class survived until now.

## Side effect

Collapsing eleven literals into one removes **12 old-brand lines** (`-12 net`) without touching behaviour.

## Verification

| check | result |
|---|---|
| `do_not_touch_sentinel.py` | exit 0, all 35 survive |
| `legacy_name_ratchet.py --base origin/main` | exit 0, no new lines, -12 net, 2 exemptions (both pinned strings) |
| `cd plugin && npm run build` (tsc) | exit 0 |
| `cd plugin && npm test` | **415 tests, 415 pass, 0 fail** (was 414; +1 is the new test) |
| `npm run check:version` | ok |
| `tests/test_do_not_touch_sentinel.py` | 89 passed |
| `ruff check` | clean |
| generated files | no `dist/`, `version.ts` or lockfile drift |

The sentinel entry is placed beside the existing manifest-id entry rather than appended, both because that's its natural home and to avoid a tail conflict with #939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)