### PR TITLE
fix(plugin): conform prepareSubagentSpawn to OpenClaw's rollback contract

### DIFF
--- a/plugin/src/context-engine.test.ts
+++ b/plugin/src/context-engine.test.ts
@@ -13,8 +13,67 @@ import {
   shouldRecall,
   getRecallMetrics,
   isDuplicateMemoryError,
+  // Aliased so the test bodies below carry no brand and survive the rename
+  // untouched — the class rename lands with its exported alias in its own
+  // slice, and only this line will need to change.
+  MemClawContextEngine as ContextEngine,  // legacy-name-ok: references the class as currently named
   type ShouldRecallInput,
 } from "./context-engine.js";
+
+describe("prepareSubagentSpawn — OpenClaw's rollback contract", () => {
+  // OpenClaw's contract is `Promise<SubagentSpawnPreparation | undefined>` with
+  // `SubagentSpawnPreparation = { rollback: () => void | Promise<void> }`, and it
+  // consumes the result as `await preparation?.rollback()` inside a best-effort
+  // try/catch.
+  //
+  // That makes a truthy return WITHOUT a callable rollback the worst possible
+  // shape: the optional chain does not short-circuit, the TypeError is swallowed
+  // by the catch, and OpenClaw reports cleanup failure on every failed spawn.
+  // Returning `undefined` is fine; returning a real handle is fine; returning a
+  // bare object is not. Nothing else in the build checks this — the plugin has no
+  // `openclaw` dependency, so tsc cannot see the contract at all.
+  const spawnParams = {
+    parentSessionKey: "agent:alice:cli:local",
+    childSessionKey: "agent:alice:cli:child",
+    contextMode: "isolated" as const,
+  };
+
+  test("survives OpenClaw's `await preparation?.rollback()` call", async () => {
+    const engine = new ContextEngine({ sessionId: "subagent-contract" });
+    const preparation = await engine.prepareSubagentSpawn(spawnParams);
+
+    // Byte-for-byte what subagent-spawn-context.ts does on spawn failure.
+    // NOTE the single `?.`: OpenClaw writes `preparation?.rollback()`, not
+    // `preparation?.rollback?.()`. Adding the second one here would make this
+    // test pass against the very bug it exists to catch, because it would
+    // short-circuit on the missing method instead of throwing on it.
+    let threw = false;
+    try {
+      await (preparation as { rollback: () => unknown } | undefined)?.rollback();
+    } catch {
+      threw = true;
+    }
+    assert.equal(
+      threw,
+      false,
+      "OpenClaw invokes preparation?.rollback() on spawn failure — a truthy " +
+        "return without a callable rollback throws into its best-effort catch " +
+        "and makes cleanup report failure every time",
+    );
+  });
+
+  test("returns undefined, or a preparation whose rollback is callable", async () => {
+    const engine = new ContextEngine({ sessionId: "subagent-contract-2" });
+    const preparation = await engine.prepareSubagentSpawn(spawnParams);
+    if (preparation !== undefined) {
+      assert.equal(
+        typeof (preparation as { rollback?: unknown }).rollback,
+        "function",
+        "a truthy preparation MUST carry a callable rollback",
+      );
+    }
+  });
+});
 
 const DEFAULT_KEYWORDS = [
   "memclaw",

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -1332,13 +1332,53 @@ export class MemClawContextEngine {
     }
   }
 
-  async prepareSubagentSpawn(
-    context: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    return {
-      memclawAgentId: resolveAgentId(context, this.config),
-      memclawFleetId: MEMCLAW_FLEET_ID,
-    };
+  /**
+   * Nothing is prepared here, so there is nothing to roll back.
+   *
+   * OpenClaw's contract (``src/context-engine/types.ts``) is
+   * ``Promise<SubagentSpawnPreparation | undefined>``, where the preparation is
+   * ``{ rollback: () => void | Promise<void> }`` — a handle it invokes if the
+   * spawn fails after preparation succeeded.
+   *
+   * This previously returned two identity fields instead, and both problems
+   * with that were invisible to every gate we have:
+   *
+   * 1. The object was truthy but carried no ``rollback``. OpenClaw calls
+   *    ``await preparation?.rollback()`` inside a best-effort ``try/catch``, so
+   *    the optional chain did NOT short-circuit, the resulting TypeError was
+   *    swallowed, and its cleanup helper reported failure on every failed spawn
+   *    rather than "nothing to undo".
+   * 2. Nothing read either field — not this repo, not OpenClaw, no test. They
+   *    were computed and dropped. And the agent id could never resolve from
+   *    what OpenClaw passes: the params carry ``parentSessionKey`` /
+   *    ``childSessionKey``, while the resolver looks for a bare ``sessionKey``,
+   *    so every spawn fell through to the install default and emitted the loud
+   *    "could not resolve agent ID" warning that ``resolveAgentIdQuiet``'s
+   *    docstring calls a real bug. It was: we were reading the wrong key.
+   *
+   * ``undefined`` is the honest answer. The optional chain short-circuits and
+   * the rollback path becomes a correct no-op.
+   *
+   * If subagent identity propagation is ever actually wanted, this return value
+   * is not the channel for it — OpenClaw never reads it. The parent's identity
+   * is available, but as ``parentSessionKey``.
+   *
+   * The parameter is typed to OpenClaw's real shape rather than
+   * ``Record<string, unknown>`` so the next reader can see what arrives. ``tsc``
+   * cannot check that for us: the plugin has no ``openclaw`` dependency and
+   * reaches the SDK at runtime (see ``openclaw-sdk-bridge.ts``).
+   */
+  async prepareSubagentSpawn(_params: {
+    parentSessionKey: string;
+    childSessionKey: string;
+    contextMode?: "isolated" | "fork";
+    parentSessionId?: string;
+    parentSessionFile?: string;
+    childSessionId?: string;
+    childSessionFile?: string;
+    ttlMs?: number;
+  }): Promise<undefined> {
+    return undefined;
   }
 
   async onSubagentEnded(_context: unknown): Promise<void> {}


### PR DESCRIPTION
The hook returned two identity fields where OpenClaw expects a rollback handle. Neither problem could fail a build, and one of them was emitting a warning in production that we had already documented as meaning "real bug".

OpenClaw's contract — `src/context-engine/types.ts:513` and `:202` in the public `openclaw/openclaw`:

```ts
prepareSubagentSpawn?(params: {
  parentSessionKey: string; childSessionKey: string;
  contextMode?: "isolated" | "fork"; ...
}): Promise<SubagentSpawnPreparation | undefined>;

export type SubagentSpawnPreparation = { rollback: () => void | Promise<void> };
```

## What was wrong

**1. Wrong return shape.** OpenClaw consumes the result at `subagent-spawn-context.ts:173`:

```ts
try { await preparation?.rollback(); return true; }
catch { /* Best-effort cleanup only. */ return false; }
```

Our object was **truthy with no `rollback`**, so the optional chain did *not* short-circuit: the call threw a TypeError, the catch swallowed it, and cleanup reported failure on every failed spawn instead of "nothing to undo". A bare object is the worst of the three possible returns — worse than `undefined`, worse than a real handle.

**2. Wrong input assumption — and this one was live.** OpenClaw passes spawn params (`parentSessionKey`, `childSessionKey`, `contextMode`, …), which we handed straight to `resolveAgentId`. That resolver scans its sources for a bare `sessionKey` — never `parentSessionKey` — and the engine's `this.config` is the factory config with no per-call session info. So resolution fell through on **every subagent spawn** to the install default and emitted the loud `"Could not resolve agent ID"` warning.

Per the docstring on `resolveAgentIdQuiet`, a fall-through on this exact path *"is a real bug (it means OpenClaw's per-call context did not carry an agent identity)"*. It did carry one — in `parentSessionKey` — and we read the wrong key.

**3. Neither field had a consumer.** No reference anywhere in this repo, no test, and zero hits searching `openclaw/openclaw`. Computed and dropped.

## The fix

Return `undefined`. The optional chain short-circuits and the rollback path becomes a correct no-op. The dead identity computation goes with it, which also removes the spurious per-spawn warning.

**Identity propagation is deliberately not restored here.** This return value isn't a channel OpenClaw reads, so plumbing it properly is a feature with a design question attached, not a bug fix. The docstring records where the parent identity actually lives if that's wanted later.

The parameter is typed to OpenClaw's real shape so the next reader can see what arrives. `tsc` cannot check it — the plugin has no `openclaw` dependency and reaches the SDK at runtime via `openclaw-sdk-bridge.ts`.

## The tests fail without the fix

| | result |
|---|---|
| both new tests against the **old** implementation | **fail 2** |
| with the fix | pass — 417 total, 0 fail |

The first test reproduces OpenClaw's call byte-for-byte, and its comment warns about a trap I nearly shipped: written as `preparation?.rollback?.()` it would short-circuit on the *missing method* and pass against the very bug it exists to catch. **The single `?.` is load-bearing.**

## Verification

| check | result |
|---|---|
| `cd plugin && npm run build` (tsc) | exit 0 |
| `cd plugin && npm test` | **417 tests, 417 pass, 0 fail** (was 414; +2 new, +1 from #941) |
| `npm run check:version` | ok |
| `do_not_touch_sentinel.py` | exit 0, all 35 survive |
| `legacy_name_ratchet.py --base origin/main` | exit 0, no new lines, **-2 net**, 1 exemption |
| generated files | no `dist/`, `version.ts` or lockfile drift |

The one exemption is the class import, aliased (`MemClawContextEngine as ContextEngine`) so the test bodies carry no brand and survive the pending rename untouched — only that line will change when the identifier slice lands.

## Related

Found while auditing `plugin/` for rebrand anchors (#936, #939, #941). The audit also established that these two keys are **not** a cross-repo contract, which is what unblocks renaming them in the identifier sweep.

Separate, not fixed here: `context-engine.ts`'s `info.id = "memclaw"` is a **third** end of the plugin id — `slots.contextEngine` is matched against it — and #941's `PLUGIN_ID` doesn't cover it. Worth a follow-up making it reference `PLUGIN_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)