### PR TITLE
fix(ratchet): report exempt lines this change removed

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -295,6 +295,7 @@ class Scan(NamedTuple):
     by_file: dict[str, Counter[str]]
     total: Counter[str]
     exempt: Counter[str]
+    exempt_text: Counter[str]
 
     def counts(self) -> Counter[str]:
         """Non-exempt lines per file — what the ratchet holds flat."""
@@ -306,14 +307,20 @@ def scan(tree: str | None) -> Scan:
     by_file: dict[str, Counter[str]] = {}
     total: Counter[str] = Counter()
     exempt: Counter[str] = Counter()
+    # Keyed by text, unlike ``exempt`` which tallies per file. Both are needed:
+    # the per-file tally selects which files the new-exemption report examines,
+    # while the removal report has to name the actual line, since "did this alias
+    # survive the rewording" cannot be answered from a count.
+    exempt_text: Counter[str] = Counter()
     for path, _, text, is_exempt in _grep(tree):
         if is_exempt:
             exempt[path] += 1
+            exempt_text[text.strip()] += 1
             continue
         stripped = text.strip()
         by_file.setdefault(path, Counter())[stripped] += 1
         total[stripped] += 1
-    return Scan(by_file, total, exempt)
+    return Scan(by_file, total, exempt, exempt_text)
 
 
 def _mint_budget(head_total: Counter[str], base_total: Counter[str]) -> Counter[str]:
@@ -445,6 +452,52 @@ def _report_excused_moves(
             print(f"  {path}: {'x' + str(n) + ' ' if n > 1 else ''}{text[:80]}")
             print(f"      was in: {origin}")
     print()
+
+
+def _report_removed_exemptions(before: Counter[str], after: Counter[str]) -> None:
+    """Name every exempt line this change removed. Reports; never fails.
+
+    The other half of :func:`_report_new_exemptions`, and the gap that let a
+    demonstrated data-loss change pass both required gates green.
+
+    ``legacy-name-ok`` means "the ratchet may ignore this line". It has never
+    meant "this line is protected", and nothing enforced the second reading —
+    but the marker looks like protection, so lines carrying it were treated as
+    handled. Deleting one *lowers* a file's non-exempt count, which the ratchet
+    reports as progress. A sweep over two plugin files removed a dual-read alias
+    that decides which ``.env`` keys survive a redeploy; ratchet and sentinel
+    both exited 0. Three of the aliases involved already carried this marker.
+
+    Why this reports rather than fails, which was measured rather than assumed:
+    across the last 400 commits, seven removed a marked line and **none** was a
+    genuine removal of protection. Every one reworded or consolidated markers
+    while keeping the alias — one collapsed six into one. A failing rule keyed on
+    text identity would have produced four false positives and no true ones, and
+    a rule keyed on per-file counts would have failed the consolidation too.
+    Nothing textual separates "consolidated the alias" from "deleted the alias";
+    that judgement is irreducibly human, so this hands a human the fact rather
+    than guessing.
+
+    **What to do when this fires.** Confirm the protection still exists in some
+    form. If the line was reworded or merged, nothing is wrong. If it is simply
+    gone, the dependant it existed for is now broken and nothing else in CI will
+    say so. Anything whose removal breaks an already-installed user belongs in
+    ``do_not_touch_sentinel.py``, which pins exact text and does fail — this
+    marker is not a substitute for that and never was.
+    """
+    removed = before - after
+    if not removed:
+        return
+
+    n = sum(removed.values())
+    print(
+        f"\n{n} exempt line(s) removed by this change. ``legacy-name-ok`` marks a line\n"
+        "the ratchet ignores, NOT a line that is protected — deleting one lowers the\n"
+        "count and reads as progress. Confirm each alias still exists in some form:"
+    )
+    for text, count in sorted(removed.items()):
+        suffix = f"  (x{count})" if count > 1 else ""
+        print(f"  {text.strip()[:100]}{suffix}")
 
 
 def _report_new_exemptions(
@@ -630,6 +683,7 @@ def main() -> int:
         return 1
 
     _report_new_exemptions(base_scan.exempt, head_scan.exempt, args.base)
+    _report_removed_exemptions(base_scan.exempt_text, head_scan.exempt_text)
 
     head_by_file, base_by_file = head_scan.by_file, base_scan.by_file
     budget = _mint_budget(head_scan.total, base_scan.total)

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -884,3 +884,86 @@ def test_report_mode_never_fails(repo: Path) -> None:
 
     assert result.returncode == 0
     assert "2 lines across 2 files" in result.stdout
+
+
+# ── removed exemptions: reported, never fatal ────────────────────────────────
+#
+# ``legacy-name-ok`` exempts a line from this gate. It has never protected the
+# line from being DELETED — and deleting one lowers the file's non-exempt count,
+# which this gate reads as progress. A sweep that removed a dual-read alias
+# deciding which ``.env`` keys survive a redeploy passed both required gates
+# green. These pin the report that makes that visible.
+
+
+def test_removing_an_exempt_line_is_reported(repo: Path) -> None:
+    """The gap that let a data-loss change through green.
+
+    Deleting a marked alias is indistinguishable from progress by count alone,
+    so the only defence is telling the reader it happened.
+    """
+    alias = f'LEGACY = "{LEGACY}"  # legacy-name-ok: dual-read alias\n'
+    (repo / "aliases.py").write_text(alias)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add alias")
+    _stage(repo, "aliases.py", "LEGACY = None\n")
+
+    result = _run(repo)
+
+    assert "exempt line(s) removed" in result.stdout
+    assert "dual-read alias" in result.stdout
+
+
+def test_removing_an_exempt_line_does_not_fail_the_gate(repo: Path) -> None:
+    """Reports rather than fails, and the reason is measured, not stylistic.
+
+    Across the last 400 commits of the real repo, seven removed a marked line
+    and none was a genuine removal of protection — every one reworded or
+    consolidated markers while keeping the alias. Failing here would have been
+    four false positives and no true ones, and false positives on a gate teach
+    people to stop reading it.
+    """
+    alias = f'LEGACY = "{LEGACY}"  # legacy-name-ok: dual-read alias\n'
+    (repo / "aliases.py").write_text(alias)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add alias")
+    _stage(repo, "aliases.py", "LEGACY = None\n")
+
+    assert _run(repo).returncode == 0
+
+
+def test_consolidating_exemptions_still_reports_the_removals(repo: Path) -> None:
+    """The commonest real shape: several markers collapse into one.
+
+    Net protection is unchanged, so this must not fail — but the removals are
+    still named, because "did the alias survive the rewording" is exactly the
+    question a human has to answer and a tool cannot.
+    """
+    (repo / "aliases.py").write_text(
+        f'A = "{LEGACY}"  # legacy-name-ok: alias one\n'
+        f'B = "{LEGACY}"  # legacy-name-ok: alias two\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add aliases")
+    _stage(
+        repo, "aliases.py", f'BOTH = "{LEGACY}"  # legacy-name-ok: one rule for both\n'
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0
+    assert "alias one" in result.stdout
+    assert "alias two" in result.stdout
+
+
+def test_an_untouched_exemption_is_not_reported(repo: Path) -> None:
+    """No report when nothing was removed — a section that prints on every run
+    is one people stop reading, which is the failure this exists to prevent."""
+    alias = f'LEGACY = "{LEGACY}"  # legacy-name-ok: dual-read alias\n'
+    (repo / "aliases.py").write_text(alias)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add alias")
+    _stage(repo, "clean.py", "VALUE = 2\n")
+
+    result = _run(repo)
+
+    assert "exempt line(s) removed" not in result.stdout


### PR DESCRIPTION
Closes the gap Lane B demonstrated: a change that destroys a dual-read alias passing both required gates green.

### The defect

`legacy-name-ok` means *"the ratchet may ignore this line"*. It has never meant *"this line is protected"* — but the marker **looks** like protection, so lines carrying it were treated as handled. Deleting one **lowers** the file's non-exempt count, which this gate reports as progress.

Lane B's demonstration on then-current `main`: a blanket rename over two plugin files removed the alias deciding which `.env` keys survive a redeploy. Ratchet `-83 net, no new lines`, exit 0. Sentinel exit 0. **All three of the aliases involved already carried the marker.** That redeploy path rewrites the operator's `.env` as a whole file, so the failure mode is data loss, green.

### Why this reports rather than fails

Measured, not assumed. Across the last 400 commits, **seven removed a marked line and none was a genuine removal of protection** — every one reworded or consolidated markers while keeping the alias:

```
-6/+1   "one alias rule for the repro harnesses"     (six markers → one)
-1/+3   "teach the CAURA_* env names, one surviving"  (net +2)
-1/+1   "the log message is the first argument"       (reworded in place)
```

A rule keyed on text identity would have produced **four false positives and zero true ones**. A rule keyed on per-file counts would have failed the consolidation too. Nothing textual separates "consolidated the alias" from "deleted the alias" — that judgement is irreducibly human, and a gate that cries wolf four times teaches people to stop reading it. So this hands a human the fact instead of guessing the verdict.

### Verified against the original demonstration

Same blanket rename, with this change in place:

```
1 exempt line(s) removed by this change. ``legacy-name-ok`` marks a line
the ratchet ignores, NOT a line that is protected — deleting one lowers the
count and reads as progress. Confirm each alias still exists in some form:
  readEnv(["CAURA_DEPLOY_FAILURE_COOLDOWN_HOURS", "MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS"])
No new lines. 83 removed by this change (-83 net).
```

The destroyed alias is named. The `-83 net` progress line is unchanged — both facts are now visible instead of only the flattering one.

### Implementation note

`Scan` gains `exempt_text` alongside `exempt`. The existing counter is keyed by **path**, which is what selects files for the new-exemption report; the removal report has to name the **line**, since "did this alias survive the rewording" cannot be answered from a count. Both come from the same single read per tree — the scan's "read a tree once" contract is preserved.

### Tests

Four added. Confirmed to fail without the fix rather than assumed: removing the call fails two of them (`2 failed, 47 passed`); restored, `49 passed`. The other two guard the false-positive direction — no report when nothing was removed, and no failure when markers are consolidated.

### What this does not change

Anything whose removal breaks an already-installed user still belongs in `do_not_touch_sentinel.py`, which pins exact text and **does** fail. This marker is not a substitute for that and never was — the report says so where it prints.