### PR TITLE
chore(plugin): rename the MEMCLAW_* constants and [memclaw] prefix — the env keys stay

### DIFF
--- a/clients/python/src/caura_client/interviewer/cli.py
+++ b/clients/python/src/caura_client/interviewer/cli.py
@@ -1,9 +1,9 @@
 """memclaw-interviewer CLI — run / status / hook.
 
 Config precedence: flags > env > defaults. Env vars:
-  MEMCLAW_API_KEY (required)      MEMCLAW_TENANT_ID (required)
-  MEMCLAW_BASE_URL                MEMCLAW_AGENT_ID (default user@host)
-  MEMCLAW_FLEET_ID                MEMCLAW_INTERVIEWER_PROJECTS (comma-sep globs)
+  CAURA_API_KEY (required)      CAURA_TENANT_ID (required)
+  CAURA_BASE_URL                CAURA_AGENT_ID (default user@host)
+  CAURA_FLEET_ID                CAURA_INTERVIEWER_PROJECTS (comma-sep globs)
 
 Exit codes: 0 success / nothing to do; 1 every attempted file failed;
 2 configuration or authorization error. ``hook`` ALWAYS exits 0 — a
@@ -165,7 +165,7 @@ def _deny_guidance(args: argparse.Namespace) -> str:
     lines = [
         "No project allowlist configured - refusing to harvest by default.",
         "Agent transcripts can contain sensitive work across ALL projects;",
-        "opt in explicitly with --projects <glob...>, MEMCLAW_INTERVIEWER_PROJECTS,",
+        "opt in explicitly with --projects <glob...>, CAURA_INTERVIEWER_PROJECTS,",
         "or --all-projects.",
         "",
         "Discovered project dirs:",
@@ -496,7 +496,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     args = parser.parse_args(argv)
     # argparse's choices= only validates values passed on the command line,
     # NOT a default sourced from os.environ — so a bad
-    # MEMCLAW_INTERVIEWER_HARNESS (wrong case "Cursor", a typo) would slip
+    # CAURA_INTERVIEWER_HARNESS (wrong case "Cursor", a typo) would slip
     # through and silently fall back to Claude Code behavior. Fail loudly —
     # but ONLY for run/status: parser.error() exits 2, and `hook` both
     # ignores --harness (it infers from path shape) and must ALWAYS exit 0.

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -156,7 +156,7 @@ def _validate_production_settings(app_settings) -> None:  # type: ignore[no-unty
         raise RuntimeError("ADMIN_API_KEY must be set for production")
     if not app_settings.gateway_shared_secret and not app_settings.memclaw_api_key:
         # What production actually requires is A PERIMETER — not specifically the
-        # gateway one. ``MEMCLAW_API_KEY`` is the other way to have one: when it
+        # gateway one. ``CAURA_API_KEY`` is the other way to have one: when it
         # is set, auth.py's "Path 2" either authenticates the request against
         # that key or raises 401 for everything else, so "Path 4" below it is
         # UNREACHABLE and there is no header-trust surface left to protect. That

--- a/plugin/e2e/interviewer-wet-capture.sh
+++ b/plugin/e2e/interviewer-wet-capture.sh
@@ -8,22 +8,22 @@
 # cron runs where possible, schema-introspecting inserts for edge
 # shapes). No appendInterviewEvent calls anywhere in this file.
 #
-# Expects: plugin/ cwd with dist/ built; backend up on MEMCLAW_API_URL;
+# Expects: plugin/ cwd with dist/ built; backend up on CAURA_API_URL;
 # a real ~/.openclaw created by the installed OpenClaw (legacy layout
 # phase A; run again post-upgrade for phase B). TASK_DB points at the
 # discovered task DB for insert helpers.
 set -u
 set -o pipefail
 
-: "${MEMCLAW_API_URL:=http://localhost:8000}"
-: "${MEMCLAW_API_KEY:?set MEMCLAW_API_KEY (admin key)}"
-: "${MEMCLAW_TENANT_ID:=t-wet-capture}"
-: "${MEMCLAW_FLEET_ID:=wet-fleet}"
-: "${MEMCLAW_NODE_NAME:=wet-node-capture}"
+: "${CAURA_API_URL:=http://localhost:8000}"
+: "${CAURA_API_KEY:?set CAURA_API_KEY (admin key)}"
+: "${CAURA_TENANT_ID:=t-wet-capture}"
+: "${CAURA_FLEET_ID:=wet-fleet}"
+: "${CAURA_NODE_NAME:=wet-node-capture}"
 : "${TASK_DB:=$HOME/.openclaw/tasks/runs.sqlite}"
-export MEMCLAW_API_URL MEMCLAW_API_KEY MEMCLAW_TENANT_ID MEMCLAW_FLEET_ID MEMCLAW_NODE_NAME
-export MEMCLAW_INTERVIEWER=true
-unset MEMCLAW_INTERVIEWER_TASKS MEMCLAW_TASK_DB_PATH || true
+export CAURA_API_URL CAURA_API_KEY CAURA_TENANT_ID CAURA_FLEET_ID CAURA_NODE_NAME
+export CAURA_INTERVIEWER=true
+unset CAURA_INTERVIEWER_TASKS CAURA_TASK_DB_PATH || true
 
 H() { node e2e/interviewer-wet.mjs "$@" | tail -1; }
 PASS=0; FAIL=0
@@ -75,12 +75,12 @@ need '.result.synced_tasks' 1 "$R" "terminal event synced on transition"
 W=$(echo "$R" | jq -r '.result.watermark // empty')
 
 say "D1 observability: task capture disabled is a distinct note"
-R=$(MEMCLAW_INTERVIEWER_TASKS=false H tick $((W + 1)))
+R=$(CAURA_INTERVIEWER_TASKS=false H tick $((W + 1)))
 need '.result.synced_tasks' 0 "$R" "no sync when disabled"
-need '.result.task_trail' "task capture disabled (MEMCLAW_INTERVIEWER_TASKS=false)" "$R" "disabled note"
+need '.result.task_trail' "task capture disabled (CAURA_INTERVIEWER_TASKS=false)" "$R" "disabled note"
 
-say "D2 observability: broken MEMCLAW_TASK_DB_PATH names the path"
-R=$(MEMCLAW_TASK_DB_PATH=/nonexistent/tasks.sqlite H tick $((W + 1)))
+say "D2 observability: broken CAURA_TASK_DB_PATH names the path"
+R=$(CAURA_TASK_DB_PATH=/nonexistent/tasks.sqlite H tick $((W + 1)))
 need '.result.synced_tasks' 0 "$R" "no sync on broken override"
 need '.result.task_trail | contains("/nonexistent/tasks.sqlite")' true "$R" "note names the misconfigured path"
 

--- a/plugin/e2e/interviewer-wet.mjs
+++ b/plugin/e2e/interviewer-wet.mjs
@@ -8,15 +8,15 @@
  * Each subcommand prints a single JSON line on stdout for the
  * orchestrating shell script (interviewer-wet.sh) to assert on.
  *
- * Required env (set by the orchestrator): MEMCLAW_API_URL,
- * MEMCLAW_API_KEY (admin), MEMCLAW_TENANT_ID, MEMCLAW_FLEET_ID,
- * MEMCLAW_NODE_NAME, MEMCLAW_INTERVIEWER=true.
+ * Required env (set by the orchestrator): CAURA_API_URL,
+ * CAURA_API_KEY (admin), CAURA_TENANT_ID, CAURA_FLEET_ID,
+ * CAURA_NODE_NAME, CAURA_INTERVIEWER=true.
  */
 
-const API = process.env.MEMCLAW_API_URL || "http://localhost:8000";
-const KEY = process.env.MEMCLAW_API_KEY || "";
-const TENANT = process.env.MEMCLAW_TENANT_ID || "";
-const NODE_NAME = process.env.MEMCLAW_NODE_NAME || "";
+const API = process.env.CAURA_API_URL || "http://localhost:8000";
+const KEY = process.env.CAURA_API_KEY || "";
+const TENANT = process.env.CAURA_TENANT_ID || "";
+const NODE_NAME = process.env.CAURA_NODE_NAME || "";
 
 function out(obj) {
   console.log(JSON.stringify(obj));

--- a/plugin/e2e/interviewer-wet.sh
+++ b/plugin/e2e/interviewer-wet.sh
@@ -4,20 +4,20 @@
 # Runs the crash/idempotency matrix against a live backend using the
 # real plugin modules (see interviewer-wet.mjs). Expects to run from the
 # plugin/ directory with dist/ built and the backend up on
-# $MEMCLAW_API_URL. Exits non-zero on the first failed assertion.
+# $CAURA_API_URL. Exits non-zero on the first failed assertion.
 set -u
 # pipefail so H()'s `node ... | tail -1` propagates node's exit code —
 # without it the P0 `|| exit` guards never fire (tail always exits 0) and
 # a dead backend surfaces as confusing downstream assertion mismatches.
 set -o pipefail
 
-: "${MEMCLAW_API_URL:=http://localhost:8000}"
-: "${MEMCLAW_API_KEY:?set MEMCLAW_API_KEY (admin key)}"
-: "${MEMCLAW_TENANT_ID:=t-wet}"
-: "${MEMCLAW_FLEET_ID:=wet-fleet}"
-: "${MEMCLAW_NODE_NAME:=wet-node-1}"
-export MEMCLAW_API_URL MEMCLAW_API_KEY MEMCLAW_TENANT_ID MEMCLAW_FLEET_ID MEMCLAW_NODE_NAME
-export MEMCLAW_INTERVIEWER=true
+: "${CAURA_API_URL:=http://localhost:8000}"
+: "${CAURA_API_KEY:?set CAURA_API_KEY (admin key)}"
+: "${CAURA_TENANT_ID:=t-wet}"
+: "${CAURA_FLEET_ID:=wet-fleet}"
+: "${CAURA_NODE_NAME:=wet-node-1}"
+export CAURA_API_URL CAURA_API_KEY CAURA_TENANT_ID CAURA_FLEET_ID CAURA_NODE_NAME
+export CAURA_INTERVIEWER=true
 
 # The plugin modules log progress lines to stdout; the harness's JSON is
 # always the LAST line — capture just that.

--- a/plugin/src/agent-auth.ts
+++ b/plugin/src/agent-auth.ts
@@ -16,7 +16,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, chmodSync } from "fs";
-import { MEMCLAW_API_URL, MEMCLAW_API_KEY, MEMCLAW_API_PREFIX } from "./env.js";
+import { CAURA_API_URL, CAURA_API_KEY, CAURA_API_PREFIX } from "./env.js";
 import { getSecretsPath } from "./paths.js";
 import { logError } from "./logger.js";
 
@@ -25,7 +25,7 @@ import { logError } from "./logger.js";
 const SECRETS_PATH = getSecretsPath();
 
 // Skip agent auth when no tenant key or running in standalone/OSS mode
-const AGENT_AUTH_ENABLED = Boolean(MEMCLAW_API_KEY);
+const AGENT_AUTH_ENABLED = Boolean(CAURA_API_KEY);
 
 // --- In-memory cache ---
 
@@ -67,12 +67,12 @@ async function provisionAgentKey(
   agentId: string,
 ): Promise<{ raw_key: string; key_prefix: string } | null> {
   try {
-    const url = new URL(`${MEMCLAW_API_PREFIX}/admin/agent-keys/provision`, MEMCLAW_API_URL);
+    const url = new URL(`${CAURA_API_PREFIX}/admin/agent-keys/provision`, CAURA_API_URL);
     const res = await fetch(url.toString(), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-API-Key": MEMCLAW_API_KEY,
+        "X-API-Key": CAURA_API_KEY,
       },
       body: JSON.stringify({ agent_id: agentId }),
       signal: AbortSignal.timeout(10_000),

--- a/plugin/src/bootstrap-memoization.test.ts
+++ b/plugin/src/bootstrap-memoization.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the process-level bootstrap memoization (CAURA-000).
  *
- * Pins the contract that ``MemClawContextEngine.bootstrap()`` runs the
+ * Pins the contract that ``CauraContextEngine.bootstrap()`` runs the
  * smoke test (write → search → delete) AT MOST ONCE per Node process,
  * regardless of how many engine instances OpenClaw constructs. The
  * customer's goodclaw window logged 390 ``ContextEngine bootstrap``
@@ -18,11 +18,11 @@ import assert from "node:assert/strict";
 
 // Set required env before importing the module so resolveTenantId
 // short-circuits without hitting the network.
-process.env.MEMCLAW_API_KEY = "mc_test_key_for_bootstrap_memo";
-process.env.MEMCLAW_API_URL = "http://localhost:8000";
-process.env.MEMCLAW_TENANT_ID = "t_test";
+process.env.CAURA_API_KEY = "mc_test_key_for_bootstrap_memo";
+process.env.CAURA_API_URL = "http://localhost:8000";
+process.env.CAURA_TENANT_ID = "t_test";
 
-const { MemClawContextEngine, _resetBootstrapForTests } = await import(
+const { CauraContextEngine, _resetBootstrapForTests } = await import(
   "./context-engine.js"
 );
 
@@ -115,7 +115,7 @@ function countSmokeWrites(): number {
   ).length;
 }
 
-describe("MemClawContextEngine — process-level bootstrap memoization (CAURA-000)", () => {
+describe("CauraContextEngine — process-level bootstrap memoization (CAURA-000)", () => {
   beforeEach(() => {
     originalFetch = globalThis.fetch;
     calls = [];
@@ -131,8 +131,8 @@ describe("MemClawContextEngine — process-level bootstrap memoization (CAURA-00
   });
 
   test("two engine instances share one smoke test (the headline fix)", async () => {
-    const engine1 = new MemClawContextEngine({ sessionId: "session-a" });
-    const engine2 = new MemClawContextEngine({ sessionId: "session-b" });
+    const engine1 = new CauraContextEngine({ sessionId: "session-a" });
+    const engine2 = new CauraContextEngine({ sessionId: "session-b" });
 
     await engine1.bootstrap();
     await engine2.bootstrap();
@@ -154,7 +154,7 @@ describe("MemClawContextEngine — process-level bootstrap memoization (CAURA-00
     // race-trigger N smoke writes here.
     const engines = Array.from(
       { length: 10 },
-      (_, i) => new MemClawContextEngine({ sessionId: `session-${i}` }),
+      (_, i) => new CauraContextEngine({ sessionId: `session-${i}` }),
     );
     await Promise.all(engines.map((e) => e.bootstrap()));
 
@@ -166,15 +166,15 @@ describe("MemClawContextEngine — process-level bootstrap memoization (CAURA-00
   });
 
   test("after success, subsequent bootstrap() calls are instant no-ops", async () => {
-    const engine = new MemClawContextEngine({ sessionId: "session-a" });
+    const engine = new CauraContextEngine({ sessionId: "session-a" });
     await engine.bootstrap();
     const callsAfterFirst = calls.length;
 
     // Bootstrap again on the same engine + on fresh engines — none should
     // trigger new fetches.
     await engine.bootstrap();
-    await new MemClawContextEngine({ sessionId: "session-b" }).bootstrap();
-    await new MemClawContextEngine({ sessionId: "session-c" }).bootstrap();
+    await new CauraContextEngine({ sessionId: "session-b" }).bootstrap();
+    await new CauraContextEngine({ sessionId: "session-c" }).bootstrap();
 
     assert.equal(
       calls.length,
@@ -202,7 +202,7 @@ describe("MemClawContextEngine — process-level bootstrap memoization (CAURA-00
       return new Response("{}", { status: 200 });
     }) as typeof fetch;
 
-    const engine = new MemClawContextEngine({ sessionId: "sick-backend" });
+    const engine = new CauraContextEngine({ sessionId: "sick-backend" });
     // MUST NOT throw — the smoke is internal-best-effort, lifecycle hooks
     // continue regardless. (Customer ground truth: their 2 SMOKE TEST
     // ERROR log lines on 06-07 13:14/13:22 did NOT prevent subsequent
@@ -211,7 +211,7 @@ describe("MemClawContextEngine — process-level bootstrap memoization (CAURA-00
     // And the memoization holds — second engine doesn't re-fail and
     // re-log; one error per process, not per engine.
     const callsAfterFirst = calls.length;
-    await new MemClawContextEngine({ sessionId: "subsequent" }).bootstrap();
+    await new CauraContextEngine({ sessionId: "subsequent" }).bootstrap();
     assert.equal(
       calls.length,
       callsAfterFirst,

--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -8,8 +8,8 @@ import {
   autoFixAllowlist,
   ensureExtraSkillDirs,
   isContextEngineSlotClaimed,
-  isMemclawAllowed,
-  isMemclawFullyConfigured,
+  isCauraAllowed,
+  isCauraFullyConfigured,
   isMemorySlotClaimed,
   shouldRunAutoFix,
   PLUGIN_ID,
@@ -74,12 +74,12 @@ describe("isMemorySlotClaimed", () => {
   });
 });
 
-describe("isMemclawFullyConfigured", () => {
+describe("isCauraFullyConfigured", () => {
   // Paints the Fleet UI dashboard via heartbeat.setup_status.fully_configured.
   // Each test below corresponds to one of the four conditions that must hold.
 
   test("true on happy-path config", () => {
-    assert.equal(isMemclawFullyConfigured(happyConfig()), true);
+    assert.equal(isCauraFullyConfigured(happyConfig()), true);
   });
 
   test("false when memclaw is not in a restrictive allowlist", () => {
@@ -91,25 +91,25 @@ describe("isMemclawFullyConfigured", () => {
     // "not allowlisted" case.
     const c = happyConfig();
     (c as any).plugins.allow = ["some-other-plugin"];
-    assert.equal(isMemclawFullyConfigured(c), false);
+    assert.equal(isCauraFullyConfigured(c), false);
   });
 
   test("false when memclaw is disabled", () => {
     const c = happyConfig();
     (c as any).plugins.entries.memclaw.enabled = false;
-    assert.equal(isMemclawFullyConfigured(c), false);
+    assert.equal(isCauraFullyConfigured(c), false);
   });
 
   test("false when plugin path is not loaded", () => {
     const c = happyConfig();
     (c as any).plugins.load.paths = [];
-    assert.equal(isMemclawFullyConfigured(c), false);
+    assert.equal(isCauraFullyConfigured(c), false);
   });
 
   test("false when memory slot is not claimed", () => {
     const c = happyConfig();
     (c as any).plugins.slots.memory = "memory-core";
-    assert.equal(isMemclawFullyConfigured(c), false);
+    assert.equal(isCauraFullyConfigured(c), false);
   });
 });
 
@@ -143,8 +143,8 @@ describe("isContextEngineSlotClaimed (CAURA-000 — keystone-injection gate)", (
   });
 });
 
-describe("isMemclawFullyConfigured — contextEngine slot is now required", () => {
-  // Pre-fix happyConfig() didn't include contextEngine and isMemclawFullyConfigured
+describe("isCauraFullyConfigured — contextEngine slot is now required", () => {
+  // Pre-fix happyConfig() didn't include contextEngine and isCauraFullyConfigured
   // returned true anyway. That hid the WhatsApp keystone-injection regression
   // because Fleet UI's "fully configured" badge was green while assemble()
   // silently never ran. Adding the slot to the predicate surfaces the gap.
@@ -152,13 +152,13 @@ describe("isMemclawFullyConfigured — contextEngine slot is now required", () =
   test("false when contextEngine slot is missing", () => {
     const c = happyConfig();
     delete (c as any).plugins.slots.contextEngine;
-    assert.equal(isMemclawFullyConfigured(c), false);
+    assert.equal(isCauraFullyConfigured(c), false);
   });
 
   test("false when contextEngine slot is held by another plugin", () => {
     const c = happyConfig();
     (c as any).plugins.slots.contextEngine = "legacy";
-    assert.equal(isMemclawFullyConfigured(c), false);
+    assert.equal(isCauraFullyConfigured(c), false);
   });
 });
 
@@ -173,11 +173,11 @@ describe("shouldRunAutoFix — allowlist drift gate", () => {
     contextEngineSlotClaimed: true,
   };
 
-  test("MEMCLAW_AUTO_FIX_CONFIG=true always runs (explicit force)", () => {
+  test("CAURA_AUTO_FIX_CONFIG=true always runs (explicit force)", () => {
     assert.equal(shouldRunAutoFix({ ...clean, autoFixEnv: "true" }), true);
   });
 
-  test("MEMCLAW_AUTO_FIX_CONFIG=false never runs, even with drift", () => {
+  test("CAURA_AUTO_FIX_CONFIG=false never runs, even with drift", () => {
     assert.equal(
       shouldRunAutoFix({
         autoFixEnv: "false",
@@ -210,7 +210,7 @@ describe("shouldRunAutoFix — allowlist drift gate", () => {
 });
 
 
-// ---- isMemclawAllowed — permissive allowlist semantics (CAURA-000) ----
+// ---- isCauraAllowed — permissive allowlist semantics (CAURA-000) ----
 //
 // OpenClaw 2026.6.x treats `plugins.allow` as a STRICT allowlist only when
 // it is BOTH present AND non-empty. A missing or empty array means "no
@@ -220,34 +220,34 @@ describe("shouldRunAutoFix — allowlist drift gate", () => {
 // permissive config into a restrictive one and locking out built-ins
 // like the bundled `openai` provider plugin.
 
-describe("isMemclawAllowed — permissive when allow is missing or empty (CAURA-000)", () => {
+describe("isCauraAllowed — permissive when allow is missing or empty (CAURA-000)", () => {
   test("true when plugins.allow is missing entirely (permissive default)", () => {
     const c: any = { plugins: { entries: {}, load: {}, slots: {} } };
-    assert.equal(isMemclawAllowed(c), true);
+    assert.equal(isCauraAllowed(c), true);
   });
 
   test("true when plugins.allow is an empty array (permissive)", () => {
     const c: any = { plugins: { allow: [], entries: {}, load: {}, slots: {} } };
-    assert.equal(isMemclawAllowed(c), true);
+    assert.equal(isCauraAllowed(c), true);
   });
 
   test("true when plugins.allow is non-empty AND includes memclaw", () => {
     const c: any = {
       plugins: { allow: ["memclaw", "browser"], entries: {}, load: {}, slots: {} },
     };
-    assert.equal(isMemclawAllowed(c), true);
+    assert.equal(isCauraAllowed(c), true);
   });
 
   test("false when plugins.allow is non-empty AND excludes memclaw (the only real 'not allowed' case)", () => {
     const c: any = {
       plugins: { allow: ["browser"], entries: {}, load: {}, slots: {} },
     };
-    assert.equal(isMemclawAllowed(c), false);
+    assert.equal(isCauraAllowed(c), false);
   });
 
   test("true when plugins object is completely missing (no allowlist to speak of)", () => {
     const c: any = {};
-    assert.equal(isMemclawAllowed(c), true);
+    assert.equal(isCauraAllowed(c), true);
   });
 });
 

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -5,7 +5,7 @@
 import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join, resolve } from "path";
 import { homedir } from "os";
-import { MEMCLAW_TOOLS } from "./tools.js";
+import { CAURA_TOOLS } from "./tools.js";
 import { getPluginDir, getOpenClawConfigPath } from "./paths.js";
 import { logError } from "./logger.js";
 
@@ -49,7 +49,7 @@ export function readOpenClawConfig(): Record<string, unknown> | null {
 // that varies by version and cannot be statically typed here.
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export function isMemclawAllowed(config: Record<string, any>): boolean {
+export function isCauraAllowed(config: Record<string, any>): boolean {
   const allow = config?.plugins?.allow;
   // CAURA-000: `plugins.allow` in OpenClaw 2026.6.x is a STRICT
   // allowlist only when it is BOTH present AND non-empty. The runtime
@@ -74,11 +74,11 @@ export function isMemclawAllowed(config: Record<string, any>): boolean {
   return allow.includes(PLUGIN_ID);
 }
 
-export function isMemclawEnabled(config: Record<string, any>): boolean {
+export function isCauraEnabled(config: Record<string, any>): boolean {
   return !!config?.plugins?.entries?.[PLUGIN_ID]?.enabled;
 }
 
-export function isMemclawPathLoaded(config: Record<string, any>): boolean {
+export function isCauraPathLoaded(config: Record<string, any>): boolean {
   const paths = config?.plugins?.load?.paths;
   const pluginDir = getPluginDir();
   return Array.isArray(paths) && paths.includes(pluginDir);
@@ -109,11 +109,11 @@ export function isContextEngineSlotClaimed(config: Record<string, any>): boolean
   return config?.plugins?.slots?.contextEngine === PLUGIN_ID;
 }
 
-export function isMemclawFullyConfigured(config: Record<string, any>): boolean {
+export function isCauraFullyConfigured(config: Record<string, any>): boolean {
   return (
-    isMemclawAllowed(config) &&
-    isMemclawEnabled(config) &&
-    isMemclawPathLoaded(config) &&
+    isCauraAllowed(config) &&
+    isCauraEnabled(config) &&
+    isCauraPathLoaded(config) &&
     isMemorySlotClaimed(config) &&
     isContextEngineSlotClaimed(config)
   );
@@ -145,7 +145,7 @@ export function autoFixAllowlist(options?: {
   //    into a restrictive one that locked out every other plugin
   //    (the customer's "openai disabled after 2.8.1 install"
   //    symptom). The runtime gate treats missing/empty allow as
-  //    "no restriction" — see `isMemclawAllowed` docstring for the
+  //    "no restriction" — see `isCauraAllowed` docstring for the
   //    OpenClaw-side gate evidence.
   //
   //    So the fix is: leave a missing/empty allowlist alone; only
@@ -162,7 +162,7 @@ export function autoFixAllowlist(options?: {
   }
 
   // 2. Ensure memclaw is enabled in plugins.entries
-  if (!isMemclawEnabled(config)) {
+  if (!isCauraEnabled(config)) {
     if (!config.plugins) config.plugins = {};
     if (!config.plugins.entries) config.plugins.entries = {};
     config.plugins.entries[PLUGIN_ID] = { enabled: true };
@@ -170,7 +170,7 @@ export function autoFixAllowlist(options?: {
   }
 
   // 3. Ensure plugin path is in plugins.load.paths
-  if (!isMemclawPathLoaded(config)) {
+  if (!isCauraPathLoaded(config)) {
     if (!config.plugins) config.plugins = {};
     if (!config.plugins.load) config.plugins.load = {};
     if (!Array.isArray(config.plugins.load.paths))
@@ -244,7 +244,7 @@ export function autoFixAllowlist(options?: {
   // 5. Ensure tools are in tools.alsoAllow
   if (!config.tools) config.tools = {};
   if (!Array.isArray(config.tools.alsoAllow)) config.tools.alsoAllow = [];
-  for (const t of MEMCLAW_TOOLS) {
+  for (const t of CAURA_TOOLS) {
     if (!config.tools.alsoAllow.includes(t)) {
       config.tools.alsoAllow.push(t);
       changes.push(t);
@@ -253,7 +253,7 @@ export function autoFixAllowlist(options?: {
 
   // 6. Remove stale pre-v1.0 tool names that no longer match any registered tool
   const staleRemoved: string[] = [];
-  const currentToolSet = new Set<string>(MEMCLAW_TOOLS);
+  const currentToolSet = new Set<string>(CAURA_TOOLS);
   config.tools.alsoAllow = config.tools.alsoAllow.filter((entry: string) => {
     if (entry.startsWith("memclaw_") && !currentToolSet.has(entry)) {
       staleRemoved.push(entry);
@@ -282,8 +282,8 @@ export function autoFixAllowlist(options?: {
 
 export function getMissingTools(config: Record<string, any>): string[] {
   const alsoAllow = config?.tools?.alsoAllow;
-  if (!Array.isArray(alsoAllow)) return [...MEMCLAW_TOOLS];
-  return MEMCLAW_TOOLS.filter((t) => !alsoAllow.includes(t));
+  if (!Array.isArray(alsoAllow)) return [...CAURA_TOOLS];
+  return CAURA_TOOLS.filter((t) => !alsoAllow.includes(t));
 }
 
 /**
@@ -291,7 +291,7 @@ export function getMissingTools(config: Record<string, any>): string[] {
  *
  * Pure so it can be unit-tested. The original gate ran auto-fix exactly
  * once (guarded by the ``.allowlist-applied`` flag file), which meant a
- * plugin upgrade that ADDED a tool to ``MEMCLAW_TOOLS`` (e.g.
+ * plugin upgrade that ADDED a tool to ``CAURA_TOOLS`` (e.g.
  * ``caura_keystones``) never got that tool into ``tools.alsoAllow`` on
  * an existing install — so a later OpenClaw ``tools.profile`` (which only
  * grants core tools + ``alsoAllow``) silently stripped it. We now also
@@ -299,8 +299,8 @@ export function getMissingTools(config: Record<string, any>): string[] {
  * slot. ``autoFixAllowlist`` is idempotent (writes only on change) so a
  * clean install with the flag present still no-ops.
  *
- *   - ``MEMCLAW_AUTO_FIX_CONFIG=true``  → always run (explicit force).
- *   - ``MEMCLAW_AUTO_FIX_CONFIG=false`` → never run (explicit opt-out).
+ *   - ``CAURA_AUTO_FIX_CONFIG=true``  → always run (explicit force).
+ *   - ``CAURA_AUTO_FIX_CONFIG=false`` → never run (explicit opt-out).
  *   - unset → run on first registration (no flag) OR when drift exists.
  */
 export function shouldRunAutoFix(params: {

--- a/plugin/src/context-engine.internal.ts
+++ b/plugin/src/context-engine.internal.ts
@@ -12,14 +12,14 @@
  * the session-key consistency tests guard against.
  */
 
-import { MEMCLAW_TENANT_ID } from "./env.js";
+import { CAURA_TENANT_ID } from "./env.js";
 import { resolveAgentId } from "./resolve-agent.js";
 
 export function getTenantPrefix(
   config: Record<string, unknown> | undefined | null,
 ): string {
   // Optional chaining — config may be missing entirely (CAURA-000).
-  return ((config?.tenantId as string) || MEMCLAW_TENANT_ID || "default");
+  return ((config?.tenantId as string) || CAURA_TENANT_ID || "default");
 }
 
 export function getSessionKey(

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -7,16 +7,16 @@
  * OpenClaw runtime via ``openclaw-sdk-bridge``).
  *
  * Security:
- * - afterTurn enabled by default; opt out with MEMCLAW_AUTO_WRITE_TURNS=false
+ * - afterTurn enabled by default; opt out with CAURA_AUTO_WRITE_TURNS=false
  * - Recall timeout enforced via AbortController
  */
 
 import { createHash } from "crypto";
 import { apiCall, parseSearchItems } from "./transport.js";
 import {
-  MEMCLAW_FLEET_ID,
-  MEMCLAW_TENANT_ID,
-  MEMCLAW_AUTO_WRITE_TURNS,
+  CAURA_FLEET_ID,
+  CAURA_TENANT_ID,
+  CAURA_AUTO_WRITE_TURNS,
   ensureTenantId,
   RECALL_CACHE_TTL_MS,
   RECALL_TIMEOUT_MS,
@@ -30,13 +30,13 @@ import {
   RECALL_MACHINE_PATTERNS,
   RECALL_GATE_MODE,
   RECALL_CROSS_AGENT,
-  MEMCLAW_INTERVIEWER,
+  CAURA_INTERVIEWER,
   type RecallPolicy,
   readEnv,
 } from "./env.js";
 import { appendInterviewEvent } from "./interview-buffer.js";
-import { memclawPromptSectionText } from "./prompt-section.js";
-import { MEMCLAW_TOOLS } from "./tools.js";
+import { cauraPromptSectionText } from "./prompt-section.js";
+import { CAURA_TOOLS } from "./tools.js";
 import { resolveAgentId, resolveAgentIdQuiet } from "./resolve-agent.js";
 import { getTenantPrefix, getSessionKey } from "./context-engine.internal.js";
 import { logError, logErrorCritical } from "./logger.js";
@@ -485,7 +485,7 @@ const recallCache = new Map<string, { text: string; ts: number }>();
 
 // --- ContextEngine class ---
 
-export class MemClawContextEngine {
+export class CauraContextEngine {
   private config: Record<string, unknown>;
 
   /**
@@ -556,7 +556,7 @@ export class MemClawContextEngine {
     const bootAgentId = resolveAgentIdQuiet(this.config);
     console.log(
       `[caura] ContextEngine bootstrap: agent=${bootAgentId}, ` +
-        `fleet=${MEMCLAW_FLEET_ID || "(unset)"}, ` +
+        `fleet=${CAURA_FLEET_ID || "(unset)"}, ` +
         `config keys=${Object.keys(this.config || {}).join(",") || "(empty)"}`,
     );
 
@@ -648,7 +648,7 @@ export class MemClawContextEngine {
     // on-disk buffer the interview_request handler reads. Fire-and-forget —
     // the write chain inside the buffer preserves ordering, and a disk
     // error must never break the turn.
-    if (MEMCLAW_INTERVIEWER) {
+    if (CAURA_INTERVIEWER) {
       const bufContent =
         typeof message.content === "string"
           ? message.content
@@ -693,7 +693,7 @@ export class MemClawContextEngine {
         await apiCall("POST", "/memories", {
           tenant_id: tid,
           agent_id: agentId,
-          fleet_id: MEMCLAW_FLEET_ID || undefined,
+          fleet_id: CAURA_FLEET_ID || undefined,
           content: truncated,
           memory_type: "episode",
           tags: ["auto-ingest", "user-message"],
@@ -821,14 +821,14 @@ export class MemClawContextEngine {
       params as unknown as Record<string, unknown>,
       this.config,
     );
-    const fleetId = MEMCLAW_FLEET_ID || undefined;
+    const fleetId = CAURA_FLEET_ID || undefined;
 
     // --- Section 1: Education (always emitted; cheap, static) ---
-    const educationText = memclawPromptSectionText(new Set(MEMCLAW_TOOLS));
+    const educationText = cauraPromptSectionText(new Set(CAURA_TOOLS));
     const identityBlock =
       `\n**Your identity**: agent_id=\`${agentId}\`` +
       (fleetId ? `, fleet_id=\`${fleetId}\`` : "") +
-      (MEMCLAW_TENANT_ID ? `, tenant_id=\`${MEMCLAW_TENANT_ID}\`` : "") +
+      (CAURA_TENANT_ID ? `, tenant_id=\`${CAURA_TENANT_ID}\`` : "") +
       "\n";
     const operatorPrompt = readEnv(["CAURA_EDUCATION_PROMPT", "MEMCLAW_EDUCATION_PROMPT"]) || "";  // legacy-name-ok: rule 3 dual-read alias
     const operatorBlock = operatorPrompt
@@ -1123,7 +1123,7 @@ export class MemClawContextEngine {
         await apiCall("POST", "/memories", {
           tenant_id: tid,
           agent_id: agentId,
-          fleet_id: MEMCLAW_FLEET_ID || undefined,
+          fleet_id: CAURA_FLEET_ID || undefined,
           content: summary,
           memory_type: "episode",
           tags: ["auto-compaction"],
@@ -1289,9 +1289,9 @@ export class MemClawContextEngine {
     };
   }
 
-  /** afterTurn — auto-write turn summary. Enabled by default; opt out with MEMCLAW_AUTO_WRITE_TURNS=false. */
+  /** afterTurn — auto-write turn summary. Enabled by default; opt out with CAURA_AUTO_WRITE_TURNS=false. */
   async afterTurn(context: AfterTurnContext): Promise<void> {
-    if (!MEMCLAW_AUTO_WRITE_TURNS) return;
+    if (!CAURA_AUTO_WRITE_TURNS) return;
 
     const lastAssistant = context?.messages
       ?.filter((m) => m.role === "assistant")
@@ -1317,7 +1317,7 @@ export class MemClawContextEngine {
       await apiCall("POST", "/memories", {
         tenant_id: tid,
         agent_id: agentId,
-        fleet_id: MEMCLAW_FLEET_ID || undefined,
+        fleet_id: CAURA_FLEET_ID || undefined,
         content: turnSummary,
         memory_type: "episode",
         tags: ["auto-turn-summary"],
@@ -1384,3 +1384,6 @@ export class MemClawContextEngine {
   async onSubagentEnded(_context: unknown): Promise<void> {}
 }
 
+// The pre-rename class name is public API — dist/ is consumed outside this repo.
+export const MemClawContextEngine = CauraContextEngine;  // legacy-name-ok: rule 3 exported API alias
+export type MemClawContextEngine = CauraContextEngine;  // legacy-name-ok: rule 3 exported API alias

--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -11,7 +11,7 @@ import {
   discoverAgentWorkspaces,
   cleanupStaleHeartbeatEducation,
 } from "./educate.js";
-import { MEMCLAW_TOOLS } from "./tools.js";
+import { CAURA_TOOLS } from "./tools.js";
 import { MEMORY_TYPES, STATUSES } from "./tool-definitions.js";
 
 // Resolve the shared SKILL.md that ships with the plugin. Tests run from
@@ -1268,8 +1268,8 @@ describe("buildToolsMd", () => {
   test("quick-matrix header uses dynamic tool count", () => {
     const tools = buildToolsMd();
     assert.ok(
-      tools.includes(`### Quick matrix · ${MEMCLAW_TOOLS.length} tools`),
-      `quick matrix header missing dynamic tool count (expected "### Quick matrix · ${MEMCLAW_TOOLS.length} tools")`,
+      tools.includes(`### Quick matrix · ${CAURA_TOOLS.length} tools`),
+      `quick matrix header missing dynamic tool count (expected "### Quick matrix · ${CAURA_TOOLS.length} tools")`,
     );
   });
 

--- a/plugin/src/educate.ts
+++ b/plugin/src/educate.ts
@@ -23,7 +23,7 @@ import { join, basename, resolve } from "path";
 import { createHash } from "crypto";
 import { isContainedPath, assertPromptLength } from "./validation.js";
 import { getOpenClawBaseDir } from "./paths.js";
-import { MEMCLAW_TOOLS } from "./tools.js";
+import { CAURA_TOOLS } from "./tools.js";
 import { logError } from "./logger.js";
 
 /**
@@ -350,7 +350,7 @@ filesystem for it) before your first call in a session.
 
 \`agent_id\` is resolved by your runtime — never fabricate.
 
-### Quick matrix · ${MEMCLAW_TOOLS.length} tools
+### Quick matrix · ${CAURA_TOOLS.length} tools
 
 | Tool | Purpose | Returns |
 |------|---------|---------|

--- a/plugin/src/env.test.ts
+++ b/plugin/src/env.test.ts
@@ -10,9 +10,9 @@ import assert from "node:assert/strict";
 
 // Set API key before importing env.ts so resolveTenantId won't early-exit.
 // Must be MEMCLAW_*-prefixed — env.ts only loads those from .env.
-process.env.MEMCLAW_API_KEY = "mc_test_key_for_env_tests";
+process.env.CAURA_API_KEY = "mc_test_key_for_env_tests";
 // Clear tenant id so resolveTenantId actually attempts a fetch.
-delete process.env.MEMCLAW_TENANT_ID;
+delete process.env.CAURA_TENANT_ID;
 
 const { resolveTenantId, readEnv, isPluginEnvKey, hasPluginEnvPrefix } = await import("./env.js");
 
@@ -152,7 +152,7 @@ describe("resolveTenantId — network failure handling", () => {
 //
 // We don't pin defaults via runtime import because other test files in
 // this suite override env vars at their module-load time (e.g.
-// ``keystones.test.ts:26`` sets ``MEMCLAW_KEYSTONES_TOKEN_CAP=120``),
+// ``keystones.test.ts:26`` sets ``CAURA_KEYSTONES_TOKEN_CAP=120``),
 // and ``node --test`` shares process env across files — so any
 // runtime read could see a polluted value. Reading the source TS
 // file's literal value is robust to that, and also documents the
@@ -160,7 +160,7 @@ describe("resolveTenantId — network failure handling", () => {
 // without intent.
 
 describe("env.ts default-value source pins", () => {
-  test("MEMCLAW_KEYSTONES_TOKEN_CAP default literal is 1500 (CAURA-000)", async () => {
+  test("CAURA_KEYSTONES_TOKEN_CAP default literal is 1500 (CAURA-000)", async () => {
     const { readFile } = await import("node:fs/promises");
     const { fileURLToPath } = await import("node:url");
     const { dirname, join } = await import("node:path");
@@ -178,12 +178,12 @@ describe("env.ts default-value source pins", () => {
     const match = envSrc.match(re);
     assert.ok(
       match,
-      "could not locate MEMCLAW_KEYSTONES_TOKEN_CAP _readIntEnv call in env.ts",
+      "could not locate CAURA_KEYSTONES_TOKEN_CAP _readIntEnv call in env.ts",
     );
     assert.equal(
       match![1],
       "1500",
-      "MEMCLAW_KEYSTONES_TOKEN_CAP default must be 1500 — bumped from 500 " +
+      "CAURA_KEYSTONES_TOKEN_CAP default must be 1500 — bumped from 500 " +
         "after CAURA-000 customer with 16 rules saw 4 dropped at every turn. " +
         "If you intend to change it, also update the doc comment in env.ts " +
         "and review the keystones formatter's truncation behavior in " +

--- a/plugin/src/env.ts
+++ b/plugin/src/env.ts
@@ -81,7 +81,7 @@ export function readEnv(names: readonly string[]): string | undefined {
   return sawBlank ? "" : undefined;
 }
 
-export const MEMCLAW_API_URL =
+export const CAURA_API_URL =
   readEnv(["CAURA_API_URL", "MEMCLAW_API_URL"]) || "http://localhost:8000";  // legacy-name-ok: rule 3 dual-read alias
 
 /**
@@ -91,22 +91,22 @@ export const MEMCLAW_API_URL =
  * The transport layer auto-prepends this to relative paths. Raw fetch
  * sites use it via template literal.
  */
-export const MEMCLAW_API_PREFIX = readEnv(["CAURA_API_PREFIX", "MEMCLAW_API_PREFIX"]) || "/api/v1";  // legacy-name-ok: rule 3 dual-read alias
-export const MEMCLAW_API_KEY = readEnv(["CAURA_API_KEY", "MEMCLAW_API_KEY"]) || "";  // legacy-name-ok: rule 3 dual-read alias
-export const MEMCLAW_FLEET_ID = readEnv(["CAURA_FLEET_ID", "MEMCLAW_FLEET_ID"]) || "";  // legacy-name-ok: rule 3 dual-read alias
-export let MEMCLAW_TENANT_ID = readEnv(["CAURA_TENANT_ID", "MEMCLAW_TENANT_ID"]) || "";  // legacy-name-ok: rule 3 dual-read alias
-export const MEMCLAW_NODE_NAME = readEnv(["CAURA_NODE_NAME", "MEMCLAW_NODE_NAME"]) || "";  // legacy-name-ok: rule 3 dual-read alias
-export const MEMCLAW_AGENT_ID = readEnv(["CAURA_AGENT_ID", "MEMCLAW_AGENT_ID"]) || "";  // legacy-name-ok: rule 3 dual-read alias
+export const CAURA_API_PREFIX = readEnv(["CAURA_API_PREFIX", "MEMCLAW_API_PREFIX"]) || "/api/v1";  // legacy-name-ok: rule 3 dual-read alias
+export const CAURA_API_KEY = readEnv(["CAURA_API_KEY", "MEMCLAW_API_KEY"]) || "";  // legacy-name-ok: rule 3 dual-read alias
+export const CAURA_FLEET_ID = readEnv(["CAURA_FLEET_ID", "MEMCLAW_FLEET_ID"]) || "";  // legacy-name-ok: rule 3 dual-read alias
+export let CAURA_TENANT_ID = readEnv(["CAURA_TENANT_ID", "MEMCLAW_TENANT_ID"]) || "";  // legacy-name-ok: rule 3 dual-read alias
+export const CAURA_NODE_NAME = readEnv(["CAURA_NODE_NAME", "MEMCLAW_NODE_NAME"]) || "";  // legacy-name-ok: rule 3 dual-read alias
+export const CAURA_AGENT_ID = readEnv(["CAURA_AGENT_ID", "MEMCLAW_AGENT_ID"]) || "";  // legacy-name-ok: rule 3 dual-read alias
 // Default to true — auto-writing turn summaries is the core fix for the
 // "100% dark matter" problem (memories written but never recalled).
-// Users can opt out with MEMCLAW_AUTO_WRITE_TURNS=false.
-export const MEMCLAW_AUTO_WRITE_TURNS =
+// Users can opt out with CAURA_AUTO_WRITE_TURNS=false.
+export const CAURA_AUTO_WRITE_TURNS =
   readEnv(["CAURA_AUTO_WRITE_TURNS", "MEMCLAW_AUTO_WRITE_TURNS"]) !== "false";  // legacy-name-ok: rule 3 dual-read alias
 
 // HMAC signature enforcement on incoming fleet commands. Default is
 // **opt-in** because the OSS server doesn't sign commands at all (the
 // signing infra is reserved for enterprise gateways that proxy commands
-// through a signing layer). Setting MEMCLAW_API_KEY for tenant auth
+// through a signing layer). Setting CAURA_API_KEY for tenant auth
 // shouldn't auto-trigger strict signature requirements that the server
 // can't satisfy — that would silently break educate / deploy /
 // install_skill / uninstall_skill on every OSS install with auth on.
@@ -116,7 +116,7 @@ export const MEMCLAW_AUTO_WRITE_TURNS =
 // DOES carry a signature is still verified end-to-end (so a tampered
 // signature still fails). When **true**: missing-or-invalid signatures
 // fail closed (the original strict behavior).
-export const MEMCLAW_REQUIRE_SIGNED_COMMANDS =
+export const CAURA_REQUIRE_SIGNED_COMMANDS =
   readEnv(["CAURA_REQUIRE_SIGNED_COMMANDS", "MEMCLAW_REQUIRE_SIGNED_COMMANDS"]) === "true";  // legacy-name-ok: rule 3 dual-read alias
 
 // Interviewer Phase 1 opt-in. Default OFF: enabling starts writing the
@@ -125,7 +125,7 @@ export const MEMCLAW_REQUIRE_SIGNED_COMMANDS =
 // privacy change an operator must choose, mirroring the server-side
 // per-tenant ``interviewer.enabled`` flag. Both must be on for the
 // feature to function end-to-end.
-export const MEMCLAW_INTERVIEWER = readEnv(["CAURA_INTERVIEWER", "MEMCLAW_INTERVIEWER"]) === "true";  // legacy-name-ok: rule 3 dual-read alias
+export const CAURA_INTERVIEWER = readEnv(["CAURA_INTERVIEWER", "MEMCLAW_INTERVIEWER"]) === "true";  // legacy-name-ok: rule 3 dual-read alias
 
 // Interviewer Phase 1.5 (issue #654): mirror OpenClaw's ``task_runs``
 // SQLite trail into the interview buffer at interview time, so task /
@@ -133,16 +133,16 @@ export const MEMCLAW_INTERVIEWER = readEnv(["CAURA_INTERVIEWER", "MEMCLAW_INTERV
 // Default ON whenever the interviewer itself is on — this is the fix
 // for the empty-interview gap, not a separate feature. ``"false"`` is
 // the escape hatch if a node's task DB misbehaves.
-export const MEMCLAW_INTERVIEWER_TASKS = readEnv(["CAURA_INTERVIEWER_TASKS", "MEMCLAW_INTERVIEWER_TASKS"]) !== "false";  // legacy-name-ok: rule 3 dual-read alias
+export const CAURA_INTERVIEWER_TASKS = readEnv(["CAURA_INTERVIEWER_TASKS", "MEMCLAW_INTERVIEWER_TASKS"]) !== "false";  // legacy-name-ok: rule 3 dual-read alias
 
 // Operator override for the task_runs database location. Normally
 // discovered (legacy <base>/tasks/runs.sqlite, else a shallow scan for
 // a task_runs table — the >= 2026.6 consolidated state DB has no stable
 // filename); set this when a deployment relocates OpenClaw state.
-export const MEMCLAW_TASK_DB_PATH = readEnv(["CAURA_TASK_DB_PATH", "MEMCLAW_TASK_DB_PATH"]) || "";  // legacy-name-ok: rule 3 dual-read alias
+export const CAURA_TASK_DB_PATH = readEnv(["CAURA_TASK_DB_PATH", "MEMCLAW_TASK_DB_PATH"]) || "";  // legacy-name-ok: rule 3 dual-read alias
 
 // Warn at import time if API key is set but URL is HTTP
-warnIfInsecureUrl(MEMCLAW_API_URL, MEMCLAW_API_KEY);
+warnIfInsecureUrl(CAURA_API_URL, CAURA_API_KEY);
 
 // --- Tenant resolution ---
 
@@ -166,8 +166,8 @@ warnIfInsecureUrl(MEMCLAW_API_URL, MEMCLAW_API_KEY);
 const TENANT_RESOLVE_TIMEOUT_MS = 10_000;
 
 export async function resolveTenantId(): Promise<string> {
-  if (MEMCLAW_TENANT_ID) return MEMCLAW_TENANT_ID;
-  if (!MEMCLAW_API_KEY) return "";
+  if (CAURA_TENANT_ID) return CAURA_TENANT_ID;
+  if (!CAURA_API_KEY) return "";
 
   const MAX_RETRIES = 3;
   const BASE_DELAY_MS = 2000;
@@ -175,11 +175,11 @@ export async function resolveTenantId(): Promise<string> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       const res = await fetch(
-        new URL(`${MEMCLAW_API_PREFIX}/auth/verify`, MEMCLAW_API_URL).toString(),
+        new URL(`${CAURA_API_PREFIX}/auth/verify`, CAURA_API_URL).toString(),
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ key: MEMCLAW_API_KEY }),
+          body: JSON.stringify({ key: CAURA_API_KEY }),
           // Bound per-attempt wall-clock; see TENANT_RESOLVE_TIMEOUT_MS
           // docstring above for why this is critical to liveness.
           signal: AbortSignal.timeout(TENANT_RESOLVE_TIMEOUT_MS),
@@ -188,7 +188,7 @@ export async function resolveTenantId(): Promise<string> {
       if (res.ok) {
         const data = (await res.json()) as Record<string, unknown>;
         if (data.tenant_id && typeof data.tenant_id === "string") {
-          MEMCLAW_TENANT_ID = data.tenant_id;
+          CAURA_TENANT_ID = data.tenant_id;
           return data.tenant_id;
         }
         console.warn(
@@ -218,10 +218,10 @@ export async function resolveTenantId(): Promise<string> {
       // backend is unreachable now, it'll be unreachable 14s from now too.
       // Short-circuit with one clear line instead of four noisy retries.
       // This is the common OSS/standalone case: API key set but no backend
-      // running (or MEMCLAW_API_URL points at something unreachable).
+      // running (or CAURA_API_URL points at something unreachable).
       if (e instanceof TypeError) {
         console.warn(
-          `[memclaw] tenant_id resolution skipped: ${msg} (backend at ${MEMCLAW_API_URL} unreachable; set MEMCLAW_TENANT_ID in .env to run in standalone mode)`,
+          `[caura] tenant_id resolution skipped: ${msg} (backend at ${CAURA_API_URL} unreachable; set CAURA_TENANT_ID in .env to run in standalone mode)`,
         );
         break;
       }
@@ -240,7 +240,7 @@ export async function resolveTenantId(): Promise<string> {
         e instanceof Error &&
         (e.name === "TimeoutError" || e.name === "AbortError");
       const reason = isTimeout
-        ? `timed out after ${TENANT_RESOLVE_TIMEOUT_MS}ms (backend at ${MEMCLAW_API_URL} accepted the connection but did not respond)`
+        ? `timed out after ${TENANT_RESOLVE_TIMEOUT_MS}ms (backend at ${CAURA_API_URL} accepted the connection but did not respond)`
         : msg;
       if (attempt < MAX_RETRIES) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt);
@@ -261,7 +261,7 @@ export async function resolveTenantId(): Promise<string> {
 let _tenantPromise: Promise<string> | null = null;
 
 export async function ensureTenantId(): Promise<string> {
-  if (MEMCLAW_TENANT_ID) return MEMCLAW_TENANT_ID;
+  if (CAURA_TENANT_ID) return CAURA_TENANT_ID;
   if (!_tenantPromise) {
     _tenantPromise = resolveTenantId();
   }
@@ -269,7 +269,7 @@ export async function ensureTenantId(): Promise<string> {
   if (!tid) {
     _tenantPromise = null;
     throw new Error(
-      "MemClaw: Failed to resolve tenant_id from API key. Set MEMCLAW_TENANT_ID in .env.",
+      "Caura: Failed to resolve tenant_id from API key. Set CAURA_TENANT_ID in .env.",
     );
   }
   return tid;
@@ -282,9 +282,9 @@ let toolDescriptions: Record<string, string> = {};
 export async function fetchToolDescriptions(): Promise<void> {
   try {
     const headers: Record<string, string> = {};
-    if (MEMCLAW_API_KEY) headers["X-API-Key"] = MEMCLAW_API_KEY;
+    if (CAURA_API_KEY) headers["X-API-Key"] = CAURA_API_KEY;
     const res = await fetch(
-      new URL(`${MEMCLAW_API_PREFIX}/tool-descriptions`, MEMCLAW_API_URL).toString(),
+      new URL(`${CAURA_API_PREFIX}/tool-descriptions`, CAURA_API_URL).toString(),
       // Bound the fetch — same rationale as resolveTenantId. Less
       // critical here (cold path, called at registration not per-turn)
       // but a hung registration still blocks plugin load.
@@ -352,10 +352,10 @@ export const INTERVIEW_TASK_SIDECAR_RETENTION_MS = 8 * 24 * 60 * 60_000;
 // The ContextEngine fetches keystones from ``/memclaw/keystones`` and
 // prepends them to every system prompt. Operators get three knobs:
 //
-// - ``MEMCLAW_KEYSTONES_ENABLED`` (default ``"true"``) — kill switch so
+// - ``CAURA_KEYSTONES_ENABLED`` (default ``"true"``) — kill switch so
 //   ops can disable the auto-inject without redeploying if something
 //   misfires. Set to ``"false"`` to turn it off.
-// - ``MEMCLAW_KEYSTONES_TOKEN_CAP`` (default 1500 tokens, ~6000 chars)
+// - ``CAURA_KEYSTONES_TOKEN_CAP`` (default 1500 tokens, ~6000 chars)
 //   — hard ceiling on the injected block. Lowest-weight rules are
 //   dropped first when the cap is hit so a runaway rule set can't crowd
 //   out recall or the operator prompt. The default of 1500 comfortably
@@ -364,7 +364,7 @@ export const INTERVIEW_TASK_SIDECAR_RETENTION_MS = 8 * 24 * 60 * 60_000;
 //   rule sets can raise it further, and operators on small-context
 //   models can lower it. Previously 500 — bumped after a customer
 //   with 16 rules saw 4 dropped at every turn (CAURA-000).
-// - ``MEMCLAW_KEYSTONES_CACHE_TTL_MS`` (default 5 minutes) — per-identity
+// - ``CAURA_KEYSTONES_CACHE_TTL_MS`` (default 5 minutes) — per-identity
 //   cache TTL. ``caura_keystones_set`` invocations bust the cache for
 //   the current session so a freshly authored rule takes effect on the
 //   next turn.
@@ -397,16 +397,16 @@ function _readIntEnv(names: readonly string[], defaultValue: number, min: number
   if (!Number.isFinite(n) || n < min) return defaultValue;
   return n;
 }
-export const MEMCLAW_KEYSTONES_ENABLED: boolean = _readBoolEnv(
+export const CAURA_KEYSTONES_ENABLED: boolean = _readBoolEnv(
   ["CAURA_KEYSTONES_ENABLED", "MEMCLAW_KEYSTONES_ENABLED"],  // legacy-name-ok: rule 3 dual-read alias
   true,
 );
-export const MEMCLAW_KEYSTONES_TOKEN_CAP: number = _readIntEnv(
+export const CAURA_KEYSTONES_TOKEN_CAP: number = _readIntEnv(
   ["CAURA_KEYSTONES_TOKEN_CAP", "MEMCLAW_KEYSTONES_TOKEN_CAP"],  // legacy-name-ok: rule 3 dual-read alias
   1500,
   1,
 );
-export const MEMCLAW_KEYSTONES_CACHE_TTL_MS: number = _readIntEnv(
+export const CAURA_KEYSTONES_CACHE_TTL_MS: number = _readIntEnv(
   ["CAURA_KEYSTONES_CACHE_TTL_MS", "MEMCLAW_KEYSTONES_CACHE_TTL_MS"],  // legacy-name-ok: rule 3 dual-read alias
   300_000,
   1_000,
@@ -487,7 +487,7 @@ function _readDenySessions(): readonly string[] {
 // information-seeking question — recalling on it just injects noise. The set
 // is DEPLOYMENT-TUNABLE (a term that's noise here may be real business content
 // elsewhere, e.g. "health check" for an ops product), so operators can
-// override the whole list via MEMCLAW_RECALL_MACHINE_PATTERNS (comma-separated
+// override the whole list via CAURA_RECALL_MACHINE_PATTERNS (comma-separated
 // regex sources). Defaults are seeded from observed eToro automation traffic.
 const DEFAULT_MACHINE_PATTERNS = [
   "heartbeat",
@@ -528,7 +528,7 @@ export const RECALL_TRIGGER_KEYWORDS: readonly string[] = _readTriggerKeywords()
 export const RECALL_DENY_SESSIONS: readonly string[] = _readDenySessions();
 export const RECALL_MACHINE_PATTERNS: readonly RegExp[] = _readMachinePatterns();
 
-// Noise-skip gate rollout mode (MEMCLAW_RECALL_GATE):
+// Noise-skip gate rollout mode (CAURA_RECALL_GATE):
 //   "off"    (default) — new noise-skip rules (machine / agent-name /
 //              mention-only / subagent-context / 3rd-party-instruction) are
 //              NOT applied. Merge is behavior-neutral; opt-in required.

--- a/plugin/src/health.ts
+++ b/plugin/src/health.ts
@@ -2,7 +2,7 @@
  * Caura backend-reachability tracker.
  *
  * Process-wide state that remembers whether the Caura server (configured via
- * MEMCLAW_API_URL) is currently reachable from this plugin. Fed by:
+ * CAURA_API_URL) is currently reachable from this plugin. Fed by:
  *   - `markReachable()` — called after any successful `apiCall` via the
  *     transport helpers, or by the heartbeat's periodic health probe.
  *   - `markUnreachable(reason)` — called when an `apiCall` throws a

--- a/plugin/src/heartbeat.test.ts
+++ b/plugin/src/heartbeat.test.ts
@@ -73,21 +73,21 @@ describe("deploy cooldown lifecycle", () => {
   });
 
   test("failureCooldownHours honours env override", () => {
-    const prev = process.env.MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS;
+    const prev = process.env.CAURA_DEPLOY_FAILURE_COOLDOWN_HOURS;
     try {
-      process.env.MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS = "6";
+      process.env.CAURA_DEPLOY_FAILURE_COOLDOWN_HOURS = "6";
       assert.equal(__DEPLOY_INTERNALS__.failureCooldownHours(), 6);
-      process.env.MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS = "";
+      process.env.CAURA_DEPLOY_FAILURE_COOLDOWN_HOURS = "";
       assert.equal(__DEPLOY_INTERNALS__.failureCooldownHours(), 24);
-      process.env.MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS = "garbage";
+      process.env.CAURA_DEPLOY_FAILURE_COOLDOWN_HOURS = "garbage";
       assert.equal(__DEPLOY_INTERNALS__.failureCooldownHours(), 24);
-      process.env.MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS = "0";
+      process.env.CAURA_DEPLOY_FAILURE_COOLDOWN_HOURS = "0";
       assert.equal(__DEPLOY_INTERNALS__.failureCooldownHours(), 24);
     } finally {
       if (prev === undefined) {
-        delete process.env.MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS;
+        delete process.env.CAURA_DEPLOY_FAILURE_COOLDOWN_HOURS;
       } else {
-        process.env.MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS = prev;
+        process.env.CAURA_DEPLOY_FAILURE_COOLDOWN_HOURS = prev;
       }
     }
   });
@@ -178,9 +178,9 @@ describe("deploy post-restart verification", () => {
 
 describe("processCommand — restart-after-POST ordering (CAURA-000)", () => {
   // Required env so transport.ts / sendHeartbeat machinery imports cleanly.
-  process.env.MEMCLAW_API_KEY = "mc_test_key_for_processcommand_tests";
-  process.env.MEMCLAW_API_URL = "http://localhost:8000";
-  process.env.MEMCLAW_TENANT_ID = "t_test";
+  process.env.CAURA_API_KEY = "mc_test_key_for_processcommand_tests";
+  process.env.CAURA_API_URL = "http://localhost:8000";
+  process.env.CAURA_TENANT_ID = "t_test";
 
   let originalFetch: typeof fetch;
   let order: string[];

--- a/plugin/src/heartbeat.ts
+++ b/plugin/src/heartbeat.ts
@@ -24,15 +24,15 @@ import { getOpenClawBaseDir } from "./paths.js";
 
 import { apiCall } from "./transport.js";
 import {
-  MEMCLAW_API_URL,
-  MEMCLAW_API_PREFIX,
-  MEMCLAW_API_KEY,
-  MEMCLAW_TENANT_ID,
-  MEMCLAW_NODE_NAME,
-  MEMCLAW_FLEET_ID,
-  MEMCLAW_REQUIRE_SIGNED_COMMANDS,
-  MEMCLAW_INTERVIEWER,
-  MEMCLAW_INTERVIEWER_TASKS,
+  CAURA_API_URL,
+  CAURA_API_PREFIX,
+  CAURA_API_KEY,
+  CAURA_TENANT_ID,
+  CAURA_NODE_NAME,
+  CAURA_FLEET_ID,
+  CAURA_REQUIRE_SIGNED_COMMANDS,
+  CAURA_INTERVIEWER,
+  CAURA_INTERVIEWER_TASKS,
   INTERVIEW_SUBMIT_MAX_EVENTS,
   INTERVIEW_SUBMIT_TIMEOUT_MS,
   BUILD_TIMEOUT_MS,
@@ -44,12 +44,12 @@ import { readInterviewEvents, pruneInterviewBuffer } from "./interview-buffer.js
 import { syncTaskTrail } from "./task-trail.js";
 import { resolveAgentIdQuiet } from "./resolve-agent.js";
 import { PLUGIN_VERSION } from "./version.js";
-import { MEMCLAW_TOOLS } from "./tools.js";
+import { CAURA_TOOLS } from "./tools.js";
 import {
   getPluginDir,
   getMissingTools,
   readOpenClawConfig,
-  isMemclawFullyConfigured,
+  isCauraFullyConfigured,
 } from "./config.js";
 import { getReachability, markReachable, markUnreachable } from "./health.js";
 import { deployPlugin } from "./deploy.js";
@@ -70,12 +70,12 @@ import { getInstallId } from "./install-id.js";
 import { getDisplayName } from "./identity.js";
 import { reconcileSkills, type ReconcileSummary } from "./reconcile-skills.js";
 
-// Test seam: MEMCLAW_INTERVIEWER is captured at env.js import time, so
+// Test seam: CAURA_INTERVIEWER is captured at env.js import time, so
 // tests can't flip it via process.env after module load. Production
 // always reads the env-derived constant.
 let _interviewerEnabledOverride: boolean | undefined;
 function interviewerEnabled(): boolean {
-  return _interviewerEnabledOverride ?? MEMCLAW_INTERVIEWER;
+  return _interviewerEnabledOverride ?? CAURA_INTERVIEWER;
 }
 
 let heartbeatCount = 0;
@@ -91,7 +91,7 @@ let postRestartCheckDone = false;
 // rolled back, prebuild failed silently and version.ts wasn't updated,
 // the gateway never restarted, etc.), we record a failure into
 // ``.deploy-cooldown.json`` and refuse further deploys for that
-// version for ``MEMCLAW_DEPLOY_FAILURE_COOLDOWN_HOURS``.
+// version for ``CAURA_DEPLOY_FAILURE_COOLDOWN_HOURS``.
 //
 // The plugin also surfaces ``deploy_blocked_until`` in its heartbeat
 // payload so the backend's auto-upgrade trigger can skip queueing
@@ -372,7 +372,7 @@ function cleanupStaleBackups(): void {
 export async function sendHeartbeat(): Promise<void> {
   cleanupStaleBackups();
   verifyDeployPostRestart();
-  if (!MEMCLAW_TENANT_ID || !MEMCLAW_NODE_NAME) return;
+  if (!CAURA_TENANT_ID || !CAURA_NODE_NAME) return;
 
   // Skill reconciler — converge plugin/skills/ with the catalog before
   // anything else. Failures are non-fatal (best-effort distribution).
@@ -553,14 +553,14 @@ export async function sendHeartbeat(): Promise<void> {
     const reach = getReachability();
 
     // Single source of truth for "fully configured" — see
-    // plugin/src/config.ts::isMemclawFullyConfigured. Checks that memclaw is
+    // plugin/src/config.ts::isCauraFullyConfigured. Checks that the plugin is
     // allowlisted, enabled, on the load path, and holds the exclusive memory
     // slot. `backend_reachable` below surfaces runtime health separately.
     setupStatus = {
       plugin_loaded: true,
-      tools_registered: MEMCLAW_TOOLS.length,
+      tools_registered: CAURA_TOOLS.length,
       tools_allowed: toolsAllowed,
-      fully_configured: config ? isMemclawFullyConfigured(config) : false,
+      fully_configured: config ? isCauraFullyConfigured(config) : false,
       agents_educated: educated,
       shared_skill_present: sharedSkillPresent,
       backend_reachable: reach.state,
@@ -579,9 +579,9 @@ export async function sendHeartbeat(): Promise<void> {
   const deploy_blocked_until = cooldown.blocked_until || undefined;
 
   const body: Record<string, unknown> = {
-    tenant_id: MEMCLAW_TENANT_ID,
-    node_name: MEMCLAW_NODE_NAME,
-    fleet_id: MEMCLAW_FLEET_ID || undefined,
+    tenant_id: CAURA_TENANT_ID,
+    node_name: CAURA_NODE_NAME,
+    fleet_id: CAURA_FLEET_ID || undefined,
     hostname: hostname(),
     ip: ipAddress,
     openclaw_version: openclawVersion,
@@ -590,7 +590,7 @@ export async function sendHeartbeat(): Promise<void> {
     plugin_hash: pluginHash,
     install_id: installId,
     agents,
-    tools: MEMCLAW_TOOLS,
+    tools: CAURA_TOOLS,
     metadata: setupStatus ? { setup_status: setupStatus } : undefined,
     // CAURA-444: rolling counters reset on plugin restart. Backend
     // stores latest snapshot per node; aggregated via the existing
@@ -630,10 +630,10 @@ export async function sendHeartbeat(): Promise<void> {
   // benign reasons (new tenant, throttled embeddings) and is NOT treated as
   // unreachable — only genuine network-class throws are.
   heartbeatCount++;
-  if (heartbeatCount % 10 === 0 && MEMCLAW_TENANT_ID) {
+  if (heartbeatCount % 10 === 0 && CAURA_TENANT_ID) {
     try {
       (await apiCall("POST", "/search", {
-        tenant_id: MEMCLAW_TENANT_ID,
+        tenant_id: CAURA_TENANT_ID,
         query: "health check",
         top_k: 1,
       })) as Record<string, any>;
@@ -655,8 +655,8 @@ async function processCommand(cmd: {
   // Verify command signature (HMAC-SHA256)
   const sigResult = verifyCommandSignature(
     cmd,
-    MEMCLAW_API_KEY,
-    MEMCLAW_REQUIRE_SIGNED_COMMANDS,
+    CAURA_API_KEY,
+    CAURA_REQUIRE_SIGNED_COMMANDS,
   );
   if (!sigResult.valid) {
     console.warn(
@@ -706,7 +706,7 @@ async function processCommand(cmd: {
       const targetVersion = (payload.target_version as string | undefined) ?? undefined;
       let sourceCode = source;
 
-      if (!sourceCode && MEMCLAW_API_URL) {
+      if (!sourceCode && CAURA_API_URL) {
         // Fetch the canonical file list from /plugin-manifest. Falls
         // back to a built-in default array when the backend doesn't
         // expose the endpoint yet (back-compat with pre-CAURA-444
@@ -746,8 +746,8 @@ async function processCommand(cmd: {
         let manifestVersion: string | undefined;
         try {
           const mUrl = new URL(
-            `${MEMCLAW_API_PREFIX}/plugin-manifest`,
-            MEMCLAW_API_URL,
+            `${CAURA_API_PREFIX}/plugin-manifest`,
+            CAURA_API_URL,
           ).toString();
           // ``X-API-Key`` is required for the enterprise gateway's auth
           // subrequest on ``/api/v1/*``. Without it, the manifest fetch
@@ -759,7 +759,7 @@ async function processCommand(cmd: {
           // gateway; the bootstrap-router alias path is the
           // unauthenticated route for fresh installs.
           const mHeaders: Record<string, string> = {};
-          if (MEMCLAW_API_KEY) mHeaders["X-API-Key"] = MEMCLAW_API_KEY;
+          if (CAURA_API_KEY) mHeaders["X-API-Key"] = CAURA_API_KEY;
           const mRes = await fetch(mUrl, {
             headers: mHeaders,
             signal: AbortSignal.timeout(10_000),
@@ -904,8 +904,8 @@ async function processCommand(cmd: {
             const fetchTimeout = setTimeout(() => fetchController.abort(), 30_000);
             try {
               const url = new URL(
-                `${MEMCLAW_API_PREFIX}/plugin-source?file=${encodeURIComponent(name)}`,
-                MEMCLAW_API_URL,
+                `${CAURA_API_PREFIX}/plugin-source?file=${encodeURIComponent(name)}`,
+                CAURA_API_URL,
               ).toString();
               const res = await fetch(url, { signal: fetchController.signal });
               if (res.ok) {
@@ -1136,9 +1136,9 @@ async function processCommand(cmd: {
         // syncTaskTrail never throws; a degraded sync (db missing/locked)
         // is reported via ``task_trail`` so operators can tell "idle"
         // from "not captured" instead of a silent no-op.
-        const taskSync = MEMCLAW_INTERVIEWER_TASKS
+        const taskSync = CAURA_INTERVIEWER_TASKS
           ? await syncTaskTrail()
-          : { synced: 0, note: "task capture disabled (MEMCLAW_INTERVIEWER_TASKS=false)" };
+          : { synced: 0, note: "task capture disabled (CAURA_INTERVIEWER_TASKS=false)" };
         const events = await readInterviewEvents(sinceSeq, INTERVIEW_SUBMIT_MAX_EVENTS);
         if (events.length === 0) {
           // Nothing new since the cursor: done, nothing submitted. The
@@ -1159,7 +1159,7 @@ async function processCommand(cmd: {
           const agentId = resolveAgentIdQuiet();
           const resp = (await apiCall("POST", "/interview/submit", {
             tenant_id: tenantId,
-            fleet_id: MEMCLAW_FLEET_ID || undefined,
+            fleet_id: CAURA_FLEET_ID || undefined,
             node_id: nodeId,
             agent_id: agentId,
             command_id: cmd.id,
@@ -1203,7 +1203,7 @@ async function processCommand(cmd: {
       result = {
         ok: true,
         pong: true,
-        node_name: MEMCLAW_NODE_NAME,
+        node_name: CAURA_NODE_NAME,
         plugin_version: PLUGIN_VERSION,
         uptime_ms: Math.floor(process.uptime() * 1000),
         timestamp: new Date().toISOString(),

--- a/plugin/src/identity.test.ts
+++ b/plugin/src/identity.test.ts
@@ -75,7 +75,7 @@ describe("getDisplayName", () => {
     assert.ok(out.length >= "main".length);
   });
 
-  test("MEMCLAW_DISPLAY_NAME_OVERRIDE wins verbatim", () => {
+  test("CAURA_DISPLAY_NAME_OVERRIDE wins verbatim", () => {
     // Operator-supplied label takes precedence over hostname-derived
     // default. The trim is intentional — env-var values often have
     // accidental whitespace; an empty / whitespace-only override

--- a/plugin/src/identity.ts
+++ b/plugin/src/identity.ts
@@ -12,7 +12,7 @@
  * stable so historical attribution is preserved.
  *
  * Resolution order:
- *   1. ``MEMCLAW_DISPLAY_NAME_OVERRIDE`` env var — operator's literal
+ *   1. ``CAURA_DISPLAY_NAME_OVERRIDE`` env var — operator's literal
  *      override, used verbatim. Lets users pick a pseudonymous or
  *      branded label, or pin a stable name when their hostname flaps.
  *   2. ``${shortHostname}-${baseName}`` — shortHostname is the first
@@ -69,7 +69,7 @@ export function sanitizeHostname(raw: string): string {
  * Resolution: env-var override → ``${shortHostname}-${baseName}`` →
  * ``baseName``. The hostname source and override env can be passed
  * for tests; production callers omit them and the OS hostname /
- * ``process.env.MEMCLAW_DISPLAY_NAME_OVERRIDE`` are used.
+ * ``process.env.CAURA_DISPLAY_NAME_OVERRIDE`` are used.
  */
 export function getDisplayName(
   baseName: string,

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -2,7 +2,7 @@
  * Caura OpenClaw Plugin — registration glue.
  *
  * Registers Caura tools (set + order derived from plugin/tools.json
- * via MEMCLAW_TOOLS), gateway methods, prompt section, memory runtime,
+ * via CAURA_TOOLS), gateway methods, prompt section, memory runtime,
  * context engine, and heartbeat loop.
  *
  * All implementation is in separate modules for maintainability:
@@ -15,7 +15,7 @@
  * - deploy.ts       — plugin deployment logic
  * - heartbeat.ts    — heartbeat loop + command processing
  * - educate.ts      — agent education (HEARTBEAT.md writes)
- * - context-engine.ts — MemClawContextEngine lifecycle
+ * - context-engine.ts — CauraContextEngine lifecycle
  * - resolve-agent.ts  — agent identity resolution
  */
 
@@ -25,11 +25,11 @@ import { createHash } from "crypto";
 import { getOpenClawBaseDir, getPluginEnvPath } from "./paths.js";
 
 import {
-  MEMCLAW_API_URL,
-  MEMCLAW_API_KEY,
-  MEMCLAW_FLEET_ID,
-  MEMCLAW_TENANT_ID,
-  MEMCLAW_NODE_NAME,
+  CAURA_API_URL,
+  CAURA_API_KEY,
+  CAURA_FLEET_ID,
+  CAURA_TENANT_ID,
+  CAURA_NODE_NAME,
   ensureTenantId,
   fetchToolDescriptions,
   HEARTBEAT_INTERVAL_MS,
@@ -41,10 +41,10 @@ import {
 import { apiCall, parseSearchItems } from "./transport.js";
 import { PLUGIN_VERSION } from "./version.js";
 import {
-  memclawPromptSectionBuilder,
-  memclawPromptSectionText,
+  cauraPromptSectionBuilder,
+  cauraPromptSectionText,
 } from "./prompt-section.js";
-import { MEMCLAW_TOOLS } from "./tools.js";
+import { CAURA_TOOLS } from "./tools.js";
 import {
   autoFixAllowlist,
   readOpenClawConfig,
@@ -52,10 +52,10 @@ import {
   getPluginDir,
   getPluginSrcPath,
   getMissingTools,
-  isMemclawAllowed,
-  isMemclawEnabled,
-  isMemclawPathLoaded,
-  isMemclawFullyConfigured,
+  isCauraAllowed,
+  isCauraEnabled,
+  isCauraPathLoaded,
+  isCauraFullyConfigured,
   isContextEngineSlotClaimed,
   shouldRunAutoFix,
 } from "./config.js";
@@ -68,7 +68,7 @@ import {
   buildToolsMd,
   buildAgentsMd,
 } from "./educate.js";
-import { MemClawContextEngine } from "./context-engine.js";
+import { CauraContextEngine } from "./context-engine.js";
 import {
   getReachability,
   markReachable,
@@ -148,12 +148,12 @@ const memclawPlugin = {
       sideEffectsBootstrapped = true;
       ensureTenantId()
         .then((tid) => {
-          if (tid && MEMCLAW_NODE_NAME) {
+          if (tid && CAURA_NODE_NAME) {
             setTimeout(() => {
               sendHeartbeat();
               setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS);
             }, HEARTBEAT_INITIAL_DELAY_MS);
-          } else if (tid && !MEMCLAW_NODE_NAME) {
+          } else if (tid && !CAURA_NODE_NAME) {
             console.warn("[caura] Heartbeat disabled — CAURA_NODE_NAME not set.");
           }
         })
@@ -179,9 +179,9 @@ const memclawPlugin = {
     }
 
     // Register tools from the SoT (plugin/tools.json), in the order
-    // declared by MEMCLAW_TOOLS. The factory pulls name/description from
+    // declared by CAURA_TOOLS. The factory pulls name/description from
     // tools.json; drift between the two sets throws at import time.
-    for (const name of MEMCLAW_TOOLS) {
+    for (const name of CAURA_TOOLS) {
       api.registerTool(createToolFromSpec(name), { names: [name] });
     }
 
@@ -195,16 +195,16 @@ const memclawPlugin = {
         version: PLUGIN_VERSION,
         status: "loaded",
         description: memclawPlugin.description,
-        apiUrl: MEMCLAW_API_URL,
-        fleetId: MEMCLAW_FLEET_ID || null,
-        apiKeyHint: MEMCLAW_API_KEY ? MEMCLAW_API_KEY.slice(0, 6) + "..." : null,
-        tools: MEMCLAW_TOOLS,
-        allowlisted: config ? isMemclawAllowed(config as any) : null,
-        enabled: config ? isMemclawEnabled(config as any) : null,
-        pathLoaded: config ? isMemclawPathLoaded(config as any) : null,
-        fullyConfigured: config ? isMemclawFullyConfigured(config as any) : null,
+        apiUrl: CAURA_API_URL,
+        fleetId: CAURA_FLEET_ID || null,
+        apiKeyHint: CAURA_API_KEY ? CAURA_API_KEY.slice(0, 6) + "..." : null,
+        tools: CAURA_TOOLS,
+        allowlisted: config ? isCauraAllowed(config as any) : null,
+        enabled: config ? isCauraEnabled(config as any) : null,
+        pathLoaded: config ? isCauraPathLoaded(config as any) : null,
+        fullyConfigured: config ? isCauraFullyConfigured(config as any) : null,
         toolsAllowed: config
-          ? MEMCLAW_TOOLS.every(
+          ? CAURA_TOOLS.every(
               (t) =>
                 Array.isArray((config as any)?.tools?.alsoAllow) &&
                 (config as any).tools.alsoAllow.includes(t),
@@ -222,10 +222,10 @@ const memclawPlugin = {
       const allow = (config as any)?.plugins?.allow;
       respond({
         ok: true,
-        allowed: isMemclawAllowed(config as any),
-        enabled: isMemclawEnabled(config as any),
-        pathLoaded: isMemclawPathLoaded(config as any),
-        fullyConfigured: isMemclawFullyConfigured(config as any),
+        allowed: isCauraAllowed(config as any),
+        enabled: isCauraEnabled(config as any),
+        pathLoaded: isCauraPathLoaded(config as any),
+        fullyConfigured: isCauraFullyConfigured(config as any),
         allowList: Array.isArray(allow) ? allow : [],
         path: getOpenClawConfigPath(),
       });
@@ -252,7 +252,7 @@ const memclawPlugin = {
     // Gateway methods are already gated by OpenClaw operator auth, but we add
     // a token check as defense-in-depth (consistent with heartbeat HMAC model).
     api.registerGatewayMethod("memclaw.deploy", ({ respond, params }: any) => {
-      if (MEMCLAW_API_KEY && params?.token !== MEMCLAW_API_KEY) {
+      if (CAURA_API_KEY && params?.token !== CAURA_API_KEY) {
         respond({ ok: false, error: "invalid or missing token" });
         return;
       }
@@ -374,7 +374,7 @@ const memclawPlugin = {
 
     try {
       if (typeof api.registerMemoryPromptSection === "function") {
-        api.registerMemoryPromptSection(memclawPromptSectionBuilder);
+        api.registerMemoryPromptSection(cauraPromptSectionBuilder);
         promptSectionRegistered = true;
       }
     } catch (e: unknown) {
@@ -384,9 +384,9 @@ const memclawPlugin = {
     if (!promptSectionRegistered) {
       try {
         if (typeof api.on === "function") {
-          const fallbackToolSet = new Set(MEMCLAW_TOOLS);
+          const fallbackToolSet = new Set(CAURA_TOOLS);
           api.on("before_prompt_build", async (_event: unknown, _ctx: unknown) => {
-            const text = memclawPromptSectionText(fallbackToolSet);
+            const text = cauraPromptSectionText(fallbackToolSet);
             if (!text) return {};
             return { prependSystemContext: text };
           });
@@ -400,14 +400,14 @@ const memclawPlugin = {
     // Auto-fix allowlist on first registration — claims memory slot, ensures
     // v1.0 tool names are in tools.alsoAllow, and removes stale pre-v1.0 names.
     // Gated by .allowlist-applied flag file (same pattern as .educated above).
-    // Opt-out: MEMCLAW_AUTO_FIX_CONFIG=false skips auto-fix.
-    // Force re-run: MEMCLAW_AUTO_FIX_CONFIG=true ignores the flag file.
+    // Opt-out: CAURA_AUTO_FIX_CONFIG=false skips auto-fix.
+    // Force re-run: CAURA_AUTO_FIX_CONFIG=true ignores the flag file.
     const allowlistFlagPath = join(getPluginDir(), ".allowlist-applied");
     const autoFixEnv = readEnv(["CAURA_AUTO_FIX_CONFIG", "MEMCLAW_AUTO_FIX_CONFIG"]);  // legacy-name-ok: rule 3 dual-read alias
     const flagExists = existsSync(allowlistFlagPath);
     // Read config once to detect drift so auto-fix re-runs even when the
     // one-time flag is already present: a plugin upgrade that ADDS a tool
-    // to MEMCLAW_TOOLS (e.g. caura_keystones) would otherwise never land
+    // to CAURA_TOOLS (e.g. caura_keystones) would otherwise never land
     // in tools.alsoAllow on an existing install, and a later OpenClaw
     // tools.profile (core tools + alsoAllow only) silently strips it.
     // autoFixAllowlist is idempotent (writes only on change), so a clean
@@ -418,7 +418,7 @@ const memclawPlugin = {
       flagExists,
       missingToolCount: preFixConfig
         ? getMissingTools(preFixConfig).length
-        : MEMCLAW_TOOLS.length,
+        : CAURA_TOOLS.length,
       contextEngineSlotClaimed: preFixConfig
         ? isContextEngineSlotClaimed(preFixConfig)
         : false,
@@ -432,7 +432,7 @@ const memclawPlugin = {
         } else if (changed) {
           console.log(
             `[caura] Config auto-fixed: ${changes.join(", ")}. ` +
-            `Restart OpenClaw to activate all ${MEMCLAW_TOOLS.length} tools.`,
+            `Restart OpenClaw to activate all ${CAURA_TOOLS.length} tools.`,
           );
         }
         writeFileSync(
@@ -466,7 +466,7 @@ const memclawPlugin = {
           const missing = getMissingTools(config);
           if (missing.length > 0) {
             console.warn(
-              `[memclaw] WARNING: ${missing.length} of ${MEMCLAW_TOOLS.length} tools not in tools.alsoAllow — ` +
+              `[caura] WARNING: ${missing.length} of ${CAURA_TOOLS.length} tools not in tools.alsoAllow — ` +
               `agents cannot use: ${missing.join(", ")}`,
             );
             console.warn(
@@ -481,7 +481,7 @@ const memclawPlugin = {
               `OpenClaw will fall back to the default "legacy" context engine.`,
             );
             console.warn(
-              `[memclaw] Fix: set plugins.slots.contextEngine to "memclaw" in ~/.openclaw/openclaw.json, ` +
+              `[caura] Fix: set plugins.slots.contextEngine to "memclaw" in ~/.openclaw/openclaw.json, ` +  // legacy-name-ok: "memclaw" is the kept plugin id the user must type
               `or run "openclaw gateway memclaw.allowlist.fix" / set CAURA_AUTO_FIX_CONFIG=true`, // legacy-name-ok: gateway command is namespaced by the frozen plugin id
             );
           }
@@ -622,7 +622,7 @@ const memclawPlugin = {
             // `{manager: null, error}` shape is OpenClaw's typed unreachability
             // channel; the caller surfaces it as a "memory unavailable"
             // result to the model instead of treating empty as success.
-            if (!MEMCLAW_API_URL) {
+            if (!CAURA_API_URL) {
               return {
                 manager: null,
                 error: "Caura plugin unconfigured: CAURA_API_URL not set",
@@ -672,7 +672,7 @@ const memclawPlugin = {
                 const base = {
                   provider: "memclaw",
                   backend: "memclaw-api" as const,
-                  apiUrl: MEMCLAW_API_URL,
+                  apiUrl: CAURA_API_URL,
                 };
                 if (hs.state === "unreachable") {
                   return {
@@ -750,9 +750,9 @@ const memclawPlugin = {
     try {
       if (typeof api.registerContextEngine === "function") {
         api.registerContextEngine("memclaw", (config: Record<string, unknown> | undefined | null) => {
-          return new MemClawContextEngine(config);
+          return new CauraContextEngine(config);
         });
-        console.log("[memclaw] ContextEngine 'memclaw' registered");
+        console.log("[caura] ContextEngine 'memclaw' registered");  // legacy-name-ok: names the kept engine id (info.id)
       }
     } catch (e: unknown) {
       logError("registerContextEngine failed", e);
@@ -773,7 +773,7 @@ const memclawPlugin = {
           ? process.versions.node
           : "unknown";
       console.log(
-        `[memclaw] BOOT: plugin v${PLUGIN_VERSION}, ${MEMCLAW_TOOLS.length} tools registered, node ${nodeVersion}`,
+        `[caura] BOOT: plugin v${PLUGIN_VERSION}, ${CAURA_TOOLS.length} tools registered, node ${nodeVersion}`,
       );
     } catch (e: unknown) {
       // Diagnostic line must never block registration — swallow any

--- a/plugin/src/interview-command.test.ts
+++ b/plugin/src/interview-command.test.ts
@@ -20,9 +20,9 @@ import { tmpdir } from "os";
 // Pattern matches ``keystones.test.ts`` / ``transport.test.ts``: env is
 // fixed BEFORE the dynamic import so env.js captures it (its exports are
 // bound at module-evaluation time — a static import would evaluate first).
-process.env.MEMCLAW_API_KEY = "mc_test_interview";
-process.env.MEMCLAW_API_URL = "http://localhost:8000";
-process.env.MEMCLAW_TENANT_ID = "t-test";
+process.env.CAURA_API_KEY = "mc_test_interview";
+process.env.CAURA_API_URL = "http://localhost:8000";
+process.env.CAURA_TENANT_ID = "t-test";
 
 const { __DEPLOY_INTERNALS__ } = await import("./heartbeat.js");
 const { __TASK_TRAIL_INTERNALS__ } = await import("./task-trail.js");

--- a/plugin/src/keystones.test.ts
+++ b/plugin/src/keystones.test.ts
@@ -15,15 +15,15 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 
-process.env.MEMCLAW_API_KEY = "mc_test_keystones";
-process.env.MEMCLAW_API_URL = "http://localhost:8000";
-process.env.MEMCLAW_TENANT_ID = "t_keystones_test";
+process.env.CAURA_API_KEY = "mc_test_keystones";
+process.env.CAURA_API_URL = "http://localhost:8000";
+process.env.CAURA_TENANT_ID = "t_keystones_test";
 // Default-on; specific tests flip the flag and re-import the module.
-process.env.MEMCLAW_KEYSTONES_ENABLED = "true";
+process.env.CAURA_KEYSTONES_ENABLED = "true";
 // Cap fits the header (~190 chars) plus a single short rule (~30 chars)
 // + footer (~20 chars). Anything beyond rule #1 (in weight DESC order)
 // must be dropped — that's what the truncation test asserts.
-process.env.MEMCLAW_KEYSTONES_TOKEN_CAP = "120"; // ~480 chars
+process.env.CAURA_KEYSTONES_TOKEN_CAP = "120"; // ~480 chars
 
 const keystones = await import("./keystones.js");
 const { formatKeystones, fetchKeystonesBlock, invalidateKeystoneCache } = keystones;
@@ -179,7 +179,7 @@ describe("fetchKeystonesBlock", () => {
     const url = new URL(ks[0].url);
     assert.equal(url.searchParams.get("agent_id"), null);
     assert.equal(url.searchParams.get("fleet_id"), null);
-    assert.equal(url.searchParams.get("tenant_id"), process.env.MEMCLAW_TENANT_ID);
+    assert.equal(url.searchParams.get("tenant_id"), process.env.CAURA_TENANT_ID);
   });
 
   test("fail-open on network error — returns '' and does not throw", async () => {
@@ -219,10 +219,10 @@ describe("fetchKeystonesBlock", () => {
   });
 });
 
-// NB: ``MEMCLAW_KEYSTONES_ENABLED`` is captured at module-load time in
+// NB: ``CAURA_KEYSTONES_ENABLED`` is captured at module-load time in
 // ``env.ts`` (see ``_readBoolEnv``), so toggling the env var inside a
 // running test would no-op against the already-imported boolean. The
 // kill-switch path is covered indirectly by the env-test suite, which
 // exercises ``_readBoolEnv`` with both literal values. Re-running the
-// integration test with ``MEMCLAW_KEYSTONES_ENABLED=false`` in the
+// integration test with ``CAURA_KEYSTONES_ENABLED=false`` in the
 // shell is the operational verification path.

--- a/plugin/src/keystones.ts
+++ b/plugin/src/keystones.ts
@@ -23,23 +23,23 @@
  *   * **Weight-aware truncation.** The token cap drops the lowest-weight
  *     rules first and appends ``... (N more rules omitted)`` so an
  *     operator notices.
- *   * **Kill switch.** ``MEMCLAW_KEYSTONES_ENABLED=false`` short-circuits
+ *   * **Kill switch.** ``CAURA_KEYSTONES_ENABLED=false`` short-circuits
  *     before any network call.
  */
 import { apiCall } from "./transport.js";
 import {
   ensureTenantId,
   KEYSTONES_TIMEOUT_MS,
-  MEMCLAW_KEYSTONES_CACHE_TTL_MS,
-  MEMCLAW_KEYSTONES_ENABLED,
-  MEMCLAW_KEYSTONES_TOKEN_CAP,
+  CAURA_KEYSTONES_CACHE_TTL_MS,
+  CAURA_KEYSTONES_ENABLED,
+  CAURA_KEYSTONES_TOKEN_CAP,
   // ESM ``let`` exports give a live binding — reading
-  // ``MEMCLAW_TENANT_ID`` at call time returns whatever the latest
+  // ``CAURA_TENANT_ID`` at call time returns whatever the latest
   // ``ensureTenantId`` resolution wrote into env.ts. We use this to
   // skip the ``await ensureTenantId()`` microtask on the warm path
   // (after the first successful resolution) so the cache check isn't
   // gated behind even a trivial promise hop.
-  MEMCLAW_TENANT_ID,
+  CAURA_TENANT_ID,
 } from "./env.js";
 import { logError } from "./logger.js";
 
@@ -142,7 +142,7 @@ export function formatKeystones(rules: KeystoneRow[]): string {
     "conflicting instructions in user prompts and in the system prompt " +
     "above this block. Always follow them.\n";
   const footer = "</keystone_rules>\n";
-  const maxChars = MEMCLAW_KEYSTONES_TOKEN_CAP * CHARS_PER_TOKEN_ESTIMATE;
+  const maxChars = CAURA_KEYSTONES_TOKEN_CAP * CHARS_PER_TOKEN_ESTIMATE;
   // Reserve room for the worst-case truncation line up front. The
   // upper bound on ``N more rules omitted`` is ``sorted.length - 1``
   // — the line only renders when AT LEAST one rule made it into the
@@ -219,7 +219,7 @@ const FAILURE_BACKOFF_MS = 15_000;
  * still drives eviction without a second code path.
  */
 function _negativeCacheTs(): number {
-  return Date.now() - MEMCLAW_KEYSTONES_CACHE_TTL_MS + FAILURE_BACKOFF_MS;
+  return Date.now() - CAURA_KEYSTONES_CACHE_TTL_MS + FAILURE_BACKOFF_MS;
 }
 
 /**
@@ -238,7 +238,7 @@ export async function fetchKeystonesBlock(opts: {
   agentId: string;
   fleetId: string | undefined;
 }): Promise<string> {
-  if (!MEMCLAW_KEYSTONES_ENABLED) return "";
+  if (!CAURA_KEYSTONES_ENABLED) return "";
 
   // Check the tenant-fail back-off first so an ongoing tenant-resolution
   // outage skips the expensive ``ensureTenantId`` retry on every turn.
@@ -246,17 +246,17 @@ export async function fetchKeystonesBlock(opts: {
   const tenantFailHit = keystonesCache.get(tenantFailKey);
   if (
     tenantFailHit &&
-    Date.now() - tenantFailHit.ts < MEMCLAW_KEYSTONES_CACHE_TTL_MS
+    Date.now() - tenantFailHit.ts < CAURA_KEYSTONES_CACHE_TTL_MS
   ) {
     return tenantFailHit.text;
   }
 
-  // Warm path: ``MEMCLAW_TENANT_ID`` was set by an earlier
+  // Warm path: ``CAURA_TENANT_ID`` was set by an earlier
   // ``ensureTenantId`` resolution (or from the ``.env`` file at boot).
   // Read the live binding synchronously to skip the await microtask
   // and reach the cache check immediately. Cold path: fall through to
   // the awaited resolution.
-  let tenantId: string = MEMCLAW_TENANT_ID;
+  let tenantId: string = CAURA_TENANT_ID;
   if (!tenantId) {
     try {
       tenantId = await ensureTenantId();
@@ -275,14 +275,14 @@ export async function fetchKeystonesBlock(opts: {
 
   const cacheKey = _cacheKey(tenantId, opts.fleetId, opts.agentId);
   const cached = keystonesCache.get(cacheKey);
-  if (cached && Date.now() - cached.ts < MEMCLAW_KEYSTONES_CACHE_TTL_MS) {
+  if (cached && Date.now() - cached.ts < CAURA_KEYSTONES_CACHE_TTL_MS) {
     return cached.text;
   }
   // Best-effort eviction of stale entries on cache miss — keeps the Map
   // bounded under steady-state churn without a separate sweeper.
   const now = Date.now();
   for (const [k, v] of keystonesCache) {
-    if (now - v.ts > MEMCLAW_KEYSTONES_CACHE_TTL_MS) keystonesCache.delete(k);
+    if (now - v.ts > CAURA_KEYSTONES_CACHE_TTL_MS) keystonesCache.delete(k);
   }
 
   // Collapse concurrent misses onto a single in-flight request. Without

--- a/plugin/src/openclaw-sdk-bridge.ts
+++ b/plugin/src/openclaw-sdk-bridge.ts
@@ -99,7 +99,7 @@ export interface OpenClawSdkSurface {
  *     we don't recognize (custom symlink farm, vendored tree). The
  *     operator's next step is to check where openclaw lives.
  *
- * Callers (currently just ``MemClawContextEngine.compact()``) branch
+ * Callers (currently just ``CauraContextEngine.compact()``) branch
  * on ``pkgRoot`` to emit a remediation-specific log message instead
  * of a generic "not discoverable" hint that sends operators hunting
  * for a missing install when the real cause is a present-but-broken

--- a/plugin/src/prompt-section.ts
+++ b/plugin/src/prompt-section.ts
@@ -21,10 +21,10 @@
  * first Caura call to pick up the operating contract.
  */
 
-import { MEMCLAW_TOOLS } from "./tools.js";
+import { CAURA_TOOLS } from "./tools.js";
 
 function buildRecallLines(availableTools: Set<string>): string[] {
-  const present = MEMCLAW_TOOLS.filter((t) => availableTools.has(t));
+  const present = CAURA_TOOLS.filter((t) => availableTools.has(t));
   if (present.length === 0) return [];
 
   const lines: string[] = [];
@@ -55,7 +55,7 @@ function buildRecallLines(availableTools: Set<string>): string[] {
  * Signature matches OpenClaw's expected:
  *   ({ availableTools: Set<string>, citationsMode?: string }) => string[]
  */
-export function memclawPromptSectionBuilder(params: {
+export function cauraPromptSectionBuilder(params: {
   availableTools: Set<string>;
   citationsMode?: string;
 }): string[] {
@@ -66,7 +66,7 @@ export function memclawPromptSectionBuilder(params: {
  * Flatten the prompt section into a single string for use as
  * `prependSystemContext` in the before_prompt_build fallback path.
  */
-export function memclawPromptSectionText(
+export function cauraPromptSectionText(
   availableTools: Set<string>,
 ): string {
   return buildRecallLines(availableTools).join("\n");

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -28,9 +28,9 @@ import { tmpdir } from "os";
 
 // Set env BEFORE importing reconcile-skills.js — module reads from
 // process.env at import time via env.ts.
-process.env.MEMCLAW_API_KEY = "mc_test_key_for_reconcile_tests";
-process.env.MEMCLAW_API_URL = "http://localhost:8000";
-process.env.MEMCLAW_TENANT_ID = "t_test";
+process.env.CAURA_API_KEY = "mc_test_key_for_reconcile_tests";
+process.env.CAURA_API_URL = "http://localhost:8000";
+process.env.CAURA_TENANT_ID = "t_test";
 
 // Redirect HOME so getPluginDir() returns a tmpdir instead of a real
 // ~/.openclaw — keeps the test from touching the dev's plugin install.
@@ -367,11 +367,11 @@ describe("reconcileSkills", () => {
 
 describe("resolveSkillTargets (config plumbing)", () => {
   afterEach(() => {
-    delete process.env.MEMCLAW_SKILL_TARGETS;
+    delete process.env.CAURA_SKILL_TARGETS;
   });
 
   test("default (unset): single owned target = the plugin skills dir", () => {
-    delete process.env.MEMCLAW_SKILL_TARGETS;
+    delete process.env.CAURA_SKILL_TARGETS;
     const targets = resolveSkillTargets();
     assert.equal(targets.length, 1);
     assert.equal(targets[0].dir, SKILLS_ROOT);
@@ -379,7 +379,7 @@ describe("resolveSkillTargets (config plumbing)", () => {
   });
 
   test("valid JSON appends extra targets (owned + additive)", () => {
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([
       { dir: "/tmp/wt-a", mode: "additive" },
       { dir: "/tmp/wt-b", mode: "owned" },
     ]);
@@ -392,14 +392,14 @@ describe("resolveSkillTargets (config plumbing)", () => {
   });
 
   test("register defaults to false; owned default dir is never register:true", () => {
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([{ dir: "/tmp/wt-a", mode: "additive" }]);
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([{ dir: "/tmp/wt-a", mode: "additive" }]);
     const targets = resolveSkillTargets();
     assert.equal(targets[0].register, false, "owned default dir is never registered");
     assert.equal(targets[1].register, false, "register omitted → false");
   });
 
   test("register: true is parsed per entry", () => {
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([
       { dir: "/tmp/wt-a", mode: "additive", register: true },
       { dir: "/tmp/wt-b", mode: "additive", register: false },
       { dir: "/tmp/wt-c", mode: "additive", register: "yes" }, // non-true → false
@@ -412,19 +412,19 @@ describe("resolveSkillTargets (config plumbing)", () => {
   });
 
   test("invalid JSON → fail safe to owned-only", () => {
-    process.env.MEMCLAW_SKILL_TARGETS = "{not valid json";
+    process.env.CAURA_SKILL_TARGETS = "{not valid json";
     const targets = resolveSkillTargets();
     assert.equal(targets.length, 1);
     assert.equal(targets[0].mode, "owned");
   });
 
   test("non-array JSON → owned-only", () => {
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify({ dir: "/tmp/x", mode: "owned" });
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify({ dir: "/tmp/x", mode: "owned" });
     assert.equal(resolveSkillTargets().length, 1);
   });
 
   test("malformed entries skipped (missing dir / invalid mode)", () => {
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([
       { mode: "owned" }, // missing dir
       { dir: "/tmp/x", mode: "weird" }, // invalid mode
       { dir: "/tmp/ok", mode: "additive" }, // valid
@@ -435,12 +435,12 @@ describe("resolveSkillTargets (config plumbing)", () => {
   });
 
   test("an entry duplicating the owned dir is dropped", () => {
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([{ dir: SKILLS_ROOT, mode: "owned" }]);
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([{ dir: SKILLS_ROOT, mode: "owned" }]);
     assert.equal(resolveSkillTargets().length, 1);
   });
 
   test("too-shallow target dirs (/, /tmp) are skipped — owned-mode rmSync guard", () => {
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([
       { dir: "/", mode: "owned" }, // 0 segments
       { dir: "/tmp", mode: "owned" }, // 1 segment
       { dir: "/tmp/skills-ok", mode: "additive" }, // 2 segments → kept
@@ -468,7 +468,7 @@ describe("reconcileSkills — configured targets", () => {
 
   afterEach(() => {
     restoreFetch();
-    delete process.env.MEMCLAW_SKILL_TARGETS;
+    delete process.env.CAURA_SKILL_TARGETS;
     if (existsSync(OPENCLAW_JSON)) rmSync(OPENCLAW_JSON, { force: true });
   });
 
@@ -495,7 +495,7 @@ describe("reconcileSkills — configured targets", () => {
     writeFileSync(ext(slug, OWNED_MARKER), "x", "utf-8");
   };
   const useAdditive = () => {
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([{ dir: EXTERNAL, mode: "additive" }]);
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([{ dir: EXTERNAL, mode: "additive" }]);
   };
 
   test("additive: writes a catalog skill into the dir, stamps the ownership marker", async () => {
@@ -620,7 +620,7 @@ describe("reconcileSkills — configured targets", () => {
 
   test("an extra owned target is reconciled alongside the default", async () => {
     plantOnDisk("memclaw");
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([{ dir: EXTRA_OWNED, mode: "owned" }]);
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([{ dir: EXTRA_OWNED, mode: "owned" }]);
     mockCatalog = [
       { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# deploy\n" } },
     ];
@@ -684,7 +684,7 @@ describe("reconcileSkills — configured targets", () => {
   test("register: an additive target with register:true is added to skills.load.extraDirs", async () => {
     plantOnDisk("memclaw");
     writeOpenClawJson({ tools: {} }); // vanilla config, no skills block yet
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([
       { dir: EXTERNAL, mode: "additive", register: true },
     ]);
     mockCatalog = [
@@ -718,7 +718,7 @@ describe("reconcileSkills — configured targets", () => {
     plantOnDisk("memclaw");
     // No openclaw.json written → ensureExtraSkillDirs fails closed.
     if (existsSync(OPENCLAW_JSON)) rmSync(OPENCLAW_JSON, { force: true });
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([
       { dir: EXTERNAL, mode: "additive", register: true },
     ]);
     mockCatalog = [
@@ -735,7 +735,7 @@ describe("reconcileSkills — configured targets", () => {
   test("register: idempotent — re-running does not duplicate the entry", async () => {
     plantOnDisk("memclaw");
     writeOpenClawJson({ skills: { load: { extraDirs: [EXTERNAL] } } }); // already present
-    process.env.MEMCLAW_SKILL_TARGETS = JSON.stringify([
+    process.env.CAURA_SKILL_TARGETS = JSON.stringify([
       { dir: EXTERNAL, mode: "additive", register: true },
     ]);
     mockCatalog = [];

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -9,7 +9,7 @@
  *
  * Targets: by default the reconciler converges the plugin's own skills
  * dir (``getPluginDir()/skills``) in ``owned`` mode. Additional targets
- * can be configured via ``MEMCLAW_SKILL_TARGETS`` (see
+ * can be configured via ``CAURA_SKILL_TARGETS`` (see
  * {@link resolveSkillTargets}). Two modes:
  *   - ``owned`` ({@link reconcileOwnedDir}): the dir is fully
  *     Caura-managed; any on-disk skill not in the catalog is pruned
@@ -55,7 +55,7 @@ import {
 import { join, resolve } from "path";
 
 import { apiCall } from "./transport.js";
-import { MEMCLAW_TENANT_ID, MEMCLAW_FLEET_ID, readEnv } from "./env.js";  // legacy-name-ok: rule 3 dual-read alias
+import { CAURA_TENANT_ID, CAURA_FLEET_ID, readEnv } from "./env.js";
 import { getPluginDir, ensureExtraSkillDirs } from "./config.js";
 import { logError } from "./logger.js";
 
@@ -83,7 +83,7 @@ const OWNED_MARKER_BODY =
   "Do not edit by hand — it is overwritten/removed to match the catalog.\n";
 
 /** True if ``skillDir`` carries the Caura ownership marker. */
-function isMemclawOwned(skillDir: string): boolean {
+function isCauraOwned(skillDir: string): boolean {
   return existsSync(join(skillDir, OWNED_MARKER));
 }
 
@@ -173,7 +173,7 @@ function ownedSkillsDir(): string {
  * Resolve the target dirs to reconcile this tick.
  *
  * Always includes the plugin's owned dir (``owned`` mode). Additional
- * targets come from the ``MEMCLAW_SKILL_TARGETS`` env var — a JSON array
+ * targets come from the ``CAURA_SKILL_TARGETS`` env var — a JSON array
  * of ``{ dir, mode }``. Read at call time (``env.ts`` has already loaded
  * ``.env`` into ``process.env`` at import). The parse fails safe: invalid
  * JSON, a non-array value, or a malformed entry is logged and ignored so
@@ -198,29 +198,29 @@ export function resolveSkillTargets(): SkillTarget[] {
   try {
     parsed = JSON.parse(raw);
   } catch (e: unknown) {
-    logError("resolveSkillTargets: MEMCLAW_SKILL_TARGETS is not valid JSON; ignoring", e);
+    logError("resolveSkillTargets: CAURA_SKILL_TARGETS is not valid JSON; ignoring", e);
     return targets;
   }
   if (!Array.isArray(parsed)) {
-    console.warn("[memclaw] MEMCLAW_SKILL_TARGETS must be a JSON array; ignoring");
+    console.warn("[caura] CAURA_SKILL_TARGETS must be a JSON array; ignoring");
     return targets;
   }
 
   const seen = new Set<string>([ownedDir]);
   for (const entry of parsed) {
     if (!entry || typeof entry !== "object") {
-      console.warn("[memclaw] MEMCLAW_SKILL_TARGETS: skipping non-object entry");
+      console.warn("[caura] CAURA_SKILL_TARGETS: skipping non-object entry");
       continue;
     }
     const dir = (entry as { dir?: unknown }).dir;
     const mode = (entry as { mode?: unknown }).mode;
     const register = (entry as { register?: unknown }).register === true;
     if (typeof dir !== "string" || !dir.trim()) {
-      console.warn("[memclaw] MEMCLAW_SKILL_TARGETS: entry missing string 'dir'; skipping");
+      console.warn("[caura] CAURA_SKILL_TARGETS: entry missing string 'dir'; skipping");
       continue;
     }
     if (mode !== "owned" && mode !== "additive") {
-      console.warn(`[memclaw] MEMCLAW_SKILL_TARGETS: entry ${dir} has invalid mode ${String(mode)}; skipping`);
+      console.warn(`[caura] CAURA_SKILL_TARGETS: entry ${dir} has invalid mode ${String(mode)}; skipping`);
       continue;
     }
     const normalized = resolve(dir);
@@ -230,7 +230,7 @@ export function resolveSkillTargets(): SkillTarget[] {
     const parts = normalized.split("/").filter(Boolean);
     if (parts.length < 2) {
       console.warn(
-        `[memclaw] MEMCLAW_SKILL_TARGETS: entry dir ${normalized} is too shallow; skipping`,
+        `[caura] CAURA_SKILL_TARGETS: entry dir ${normalized} is too shallow; skipping`,
       );
       continue;
     }
@@ -413,7 +413,7 @@ function reconcileAdditiveDir(
     // "memclaw" dir (no marker) is the client's, not ours — ignore it
     // rather than misreport it as a Caura-protected skill. An OWNED
     // protected dir still survives via the protected check below.
-    if (!isMemclawOwned(join(skillsRoot, slug))) continue; // foreign — leave alone
+    if (!isCauraOwned(join(skillsRoot, slug))) continue; // foreign — leave alone
     if (PROTECTED_SKILLS.has(slug)) {
       result.protected.push(slug);
       continue;
@@ -435,7 +435,7 @@ function reconcileAdditiveDir(
   // of a desired slug is never "ours" and is reported as a collision.)
   const installedSet = new Set<string>(
     [...onDisk].filter(
-      (s) => desired.has(s) && isMemclawOwned(join(skillsRoot, s)),
+      (s) => desired.has(s) && isCauraOwned(join(skillsRoot, s)),
     ),
   );
 
@@ -451,7 +451,7 @@ function reconcileAdditiveDir(
     // non-recursive ``mkdirSync`` below provides the actual atomic guard
     // via EEXIST.
     const dirExistsNow = existsSync(skillDir);
-    if (dirExistsNow && !isMemclawOwned(skillDir)) {
+    if (dirExistsNow && !isCauraOwned(skillDir)) {
       result.collisions.push(slug);
       console.warn(
         `[caura] additive: ${slug} is occupied by an unowned skill in ` +
@@ -483,7 +483,7 @@ function reconcileAdditiveDir(
         if ((mkdirErr as NodeJS.ErrnoException).code !== "EEXIST") throw mkdirErr;
         // Dir raced into existence after our existsSync check — re-verify
         // ownership before touching it; a foreign winner is a collision.
-        if (!isMemclawOwned(skillDir)) {
+        if (!isCauraOwned(skillDir)) {
           result.collisions.push(slug);
           console.warn(
             `[caura] additive: ${slug} collision (post-existsSync race in ${skillsRoot}); skipping`,
@@ -531,7 +531,7 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
     registeredDirs: [],
   };
 
-  if (!MEMCLAW_TENANT_ID) {
+  if (!CAURA_TENANT_ID) {
     // No tenant resolved — heartbeat already short-circuits in this
     // case, but the reconciler is called independently in tests.
     return summary;
@@ -549,8 +549,8 @@ export async function reconcileSkills(): Promise<ReconcileSummary> {
       "POST",
       "/skills/installable",
       {
-        tenant_id: MEMCLAW_TENANT_ID,
-        fleet_id: MEMCLAW_FLEET_ID || undefined,
+        tenant_id: CAURA_TENANT_ID,
+        fleet_id: CAURA_FLEET_ID || undefined,
         limit: 1000,
       },
     )) as { documents?: CatalogDoc[] } | CatalogDoc[];

--- a/plugin/src/resolve-agent.test.ts
+++ b/plugin/src/resolve-agent.test.ts
@@ -17,7 +17,7 @@ import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 
 // Clear any inherited test pollution so the fallback path actually runs.
-delete process.env.MEMCLAW_AGENT_ID;
+delete process.env.CAURA_AGENT_ID;
 
 const { resolveAgentId, resolveAgentIdQuiet } = await import(
   "./resolve-agent.js"

--- a/plugin/src/resolve-agent.ts
+++ b/plugin/src/resolve-agent.ts
@@ -5,7 +5,7 @@
  *   1. Explicit field from caller (context.agentId, config.agentId)
  *   2. Session key parsing — "agent:AGENT_NAME:CHANNEL:TARGET"
  *   3. Config agent name (config.agentName, config.agent?.name)
- *   4. MEMCLAW_AGENT_ID env var
+ *   4. CAURA_AGENT_ID env var
  *   5. ``main-${installId}`` — install-disambiguated default so two
  *      OpenClaw installs sharing one tenant don't merge their memories
  *      into a single ``(tenant_id, agent_id="main")`` row. Pre-Task6
@@ -13,7 +13,7 @@
  *      with worse semantics.
  */
 
-import { MEMCLAW_AGENT_ID } from "./env.js";
+import { CAURA_AGENT_ID } from "./env.js";
 import { getInstallId } from "./install-id.js";
 
 function resolveAgentIdInner(
@@ -41,13 +41,13 @@ function resolveAgentIdInner(
       return src.agentName as string;
   }
 
-  if (MEMCLAW_AGENT_ID) {
+  if (CAURA_AGENT_ID) {
     if (!quiet) {
       console.warn(
         "[caura] Agent ID resolved from the CAURA_AGENT_ID (legacy: MEMCLAW_AGENT_ID) env var — consider passing agent_id explicitly", // legacy-name-ok: taught as legacy alias
       );
     }
-    return MEMCLAW_AGENT_ID;
+    return CAURA_AGENT_ID;
   }
 
   // Per-install fallback. Was ``"unknown-agent"`` pre-Task6 — every

--- a/plugin/src/runtime-contract.test.ts
+++ b/plugin/src/runtime-contract.test.ts
@@ -472,15 +472,15 @@ describe("MemoryFlushPlan resolver — negative-timestamp guard (review 2026-05-
 // in unit tests, the catch guarantees we never surface ``messages:
 // undefined`` to OpenClaw.
 
-import { MemClawContextEngine } from "./context-engine.js";
+import { CauraContextEngine } from "./context-engine.js";
 
 describe("ContextEngine.assemble contract (OpenClaw AssembleResult)", () => {
-  function makeEngine(): MemClawContextEngine {
+  function makeEngine(): CauraContextEngine {
     // Tenant-less config — bootstrap's educate POST will fail-fast
-    // against MEMCLAW_API_URL, but assemble's own try/catch swallows
+    // against CAURA_API_URL, but assemble's own try/catch swallows
     // it so the test still exercises the return shape. We're testing
     // the contract surface, not the bootstrap success path.
-    return new MemClawContextEngine({});
+    return new CauraContextEngine({});
   }
 
   test("returns AssembleResult shape with `messages` and `estimatedTokens` (skip-recall path)", async () => {
@@ -606,8 +606,8 @@ describe("ContextEngine.assemble contract (OpenClaw AssembleResult)", () => {
 // the structural assertions above; this is intentional.
 
 describe("ContextEngine.assemble agent-id resolution (v2.8.1)", () => {
-  function makeEngine(): MemClawContextEngine {
-    return new MemClawContextEngine({});
+  function makeEngine(): CauraContextEngine {
+    return new CauraContextEngine({});
   }
 
   test("resolves agent_id from params.sessionKey 'agent:NAME:...' format", async () => {
@@ -652,7 +652,7 @@ describe("ContextEngine.assemble agent-id resolution (v2.8.1)", () => {
       tokenBudget: 4000,
     });
     // Either "main-<12-hex>" (install-default) OR whatever
-    // MEMCLAW_AGENT_ID env var is set to. Don't pin the exact
+    // CAURA_AGENT_ID env var is set to. Don't pin the exact
     // value; just assert the contract still produces SOMETHING.
     assert.match(
       result.systemPromptAddition ?? "",
@@ -796,7 +796,7 @@ describe("ContextEngine session-key consistency (ingest ↔ assemble)", () => {
 //      cleanly, so future turns get full keystones + recall instead
 //      of silent degradation.
 
-describe("MemClawContextEngine.constructor — undefined-config tolerance (v2.6.5)", () => {
+describe("CauraContextEngine.constructor — undefined-config tolerance (v2.6.5)", () => {
   test("constructed with undefined: assemble does NOT throw and does NOT take the safe-fallback path", async () => {
     // Pass undefined where the type-system expects a config object —
     // exactly the shape that triggered the dbaclaw production
@@ -804,7 +804,7 @@ describe("MemClawContextEngine.constructor — undefined-config tolerance (v2.6.
     // surface ``[caura] assemble: unexpected error (returning safe
     // fallback)`` in the log; with it, the inner code completes and
     // we get the normal AssembleResult.
-    const engine = new MemClawContextEngine(
+    const engine = new CauraContextEngine(
       undefined as unknown as Record<string, unknown>,
     );
     const result = await engine.assemble({
@@ -833,7 +833,7 @@ describe("MemClawContextEngine.constructor — undefined-config tolerance (v2.6.
   });
 
   test("constructed with null: same tolerance (defense-in-depth)", async () => {
-    const engine = new MemClawContextEngine(
+    const engine = new CauraContextEngine(
       null as unknown as Record<string, unknown>,
     );
     const result = await engine.assemble({
@@ -892,13 +892,13 @@ describe("MemClawContextEngine.constructor — undefined-config tolerance (v2.6.
 // the wet test on the GCE VM exercises the success path against a
 // real openclaw install.
 
-// MemClawContextEngine already imported above for the assemble-contract
+// CauraContextEngine already imported above for the assemble-contract
 // block. Import only what's new for the compaction-bridge contract.
 import { _resetSdkBridgeCache, getOpenClawSdk } from "./openclaw-sdk-bridge.js";
 
 describe("ContextEngine.info compaction-ownership (v2.6.4)", () => {
   test("info.ownsCompaction === true (we own compaction by delegating to SDK)", () => {
-    const engine = new MemClawContextEngine({});
+    const engine = new CauraContextEngine({});
     assert.equal(
       engine.info.ownsCompaction,
       true,
@@ -909,7 +909,7 @@ describe("ContextEngine.info compaction-ownership (v2.6.4)", () => {
   });
 
   test("info.id === 'memclaw' (slot resolver depends on this)", () => {
-    const engine = new MemClawContextEngine({});
+    const engine = new CauraContextEngine({});
     assert.equal(engine.info.id, "memclaw");
   });
 });
@@ -951,7 +951,7 @@ describe("openclaw-sdk-bridge resolver", () => {
 describe("ContextEngine.compact contract (delegation + persistence)", () => {
   test("returns a CompactResult-shaped object (not undefined)", async () => {
     _resetSdkBridgeCache();
-    const engine = new MemClawContextEngine({});
+    const engine = new CauraContextEngine({});
     // In the test runtime, the bridge returns null, so compact() takes
     // the structured-fallback path. We must still get the v2.6.4 shape
     // — not a regression to v2.6.3's `undefined`.
@@ -981,7 +981,7 @@ describe("ContextEngine.compact contract (delegation + persistence)", () => {
 
   test("compact() with no summary returns the fallback without throwing", async () => {
     _resetSdkBridgeCache();
-    const engine = new MemClawContextEngine({});
+    const engine = new CauraContextEngine({});
     const result = await engine.compact({ sessionId: "test-session" });
     assert.equal(result.ok, false);
     assert.equal(result.compacted, false);
@@ -997,7 +997,7 @@ describe("ContextEngine.compact contract (delegation + persistence)", () => {
     // ``pi-embedded-X0afS0ip.js:2447``) ALWAYS provides both
     // fields, so this guard never fires on the happy path.
     _resetSdkBridgeCache();
-    const engine = new MemClawContextEngine({});
+    const engine = new CauraContextEngine({});
     const result = await engine.compact({ sessionFile: "/tmp/test.jsonl" }); // no sessionId
     assert.equal(result.ok, false);
     assert.equal(result.compacted, false);
@@ -1010,7 +1010,7 @@ describe("ContextEngine.compact contract (delegation + persistence)", () => {
 
   test("compact() with missing sessionFile skips SDK delegation entirely (defensive guard)", async () => {
     _resetSdkBridgeCache();
-    const engine = new MemClawContextEngine({});
+    const engine = new CauraContextEngine({});
     const result = await engine.compact({ sessionId: "test-id" }); // no sessionFile
     assert.equal(result.ok, false);
     assert.equal(result.compacted, false);
@@ -1018,13 +1018,13 @@ describe("ContextEngine.compact contract (delegation + persistence)", () => {
   });
 
   test("compact() with a summary attempts MemClaw persist but does not throw on failure", async () => {
-    // Persistence target is unconfigured (no MEMCLAW_API_KEY in test env),
+    // Persistence target is unconfigured (no CAURA_API_KEY in test env),
     // so the POST /memories call fails. compact() must catch that and still
     // return a CompactResult. This is the production-safety contract:
     // compaction must NEVER break a turn just because the memory write
     // failed.
     _resetSdkBridgeCache();
-    const engine = new MemClawContextEngine({});
+    const engine = new CauraContextEngine({});
     const result = await engine.compact({
       summary: "synthetic compaction summary for the contract test",
       sessionId: "test-session",

--- a/plugin/src/task-trail.test.ts
+++ b/plugin/src/task-trail.test.ts
@@ -140,7 +140,7 @@ describe("task-trail sync", () => {
     assert.equal(events.length, 0);
   });
 
-  test("MEMCLAW_TASK_DB_PATH override: valid path is exclusive, broken path is named in the note", async () => {
+  test("CAURA_TASK_DB_PATH override: valid path is exclusive, broken path is named in the note", async () => {
     // Valid override: used exclusively, even though a legacy DB also exists.
     makeDb(legacyDbPath);
     insertRow(legacyDbPath, { task_id: "t-legacy" });
@@ -158,7 +158,7 @@ describe("task-trail sync", () => {
       __TASK_TRAIL_INTERNALS__.setTaskDbPathForTests(join(tmp, "does-not-exist.sqlite"));
       const broken = await syncTaskTrail();
       assert.equal(broken.synced, 0);
-      assert.match(broken.note ?? "", /MEMCLAW_TASK_DB_PATH=.*does-not-exist\.sqlite/);
+      assert.match(broken.note ?? "", /CAURA_TASK_DB_PATH=.*does-not-exist\.sqlite/);
     } finally {
       __TASK_TRAIL_INTERNALS__.setTaskDbPathForTests(undefined);
     }

--- a/plugin/src/task-trail.ts
+++ b/plugin/src/task-trail.ts
@@ -41,7 +41,7 @@ import { getOpenClawBaseDir, getPluginDir } from "./paths.js";
 import {
   INTERVIEW_TASK_SYNC_MAX_PER_TICK,
   INTERVIEW_TASK_SIDECAR_RETENTION_MS,
-  MEMCLAW_TASK_DB_PATH,
+  CAURA_TASK_DB_PATH,
 } from "./env.js";
 
 // ---------------------------------------------------------------------------
@@ -131,7 +131,7 @@ export const __TASK_TRAIL_INTERNALS__ = {
 };
 
 function taskDbPathOverride(): string {
-  return _taskDbPathOverride ?? MEMCLAW_TASK_DB_PATH;
+  return _taskDbPathOverride ?? CAURA_TASK_DB_PATH;
 }
 
 function baseDir(): string {
@@ -229,7 +229,7 @@ function hasTaskRunsTable(db: SqliteDb): boolean {
  * multi-source safe (rows migrated into the new DB de-dup as already
  * seen), and the shallow scan is a trivial hourly readdir.
  *
- * ``MEMCLAW_TASK_DB_PATH`` remains an exclusive operator override.
+ * ``CAURA_TASK_DB_PATH`` remains an exclusive operator override.
  */
 function discoverTaskDbs(sqlite: SqliteModule): string[] {
   const tryPath = (p: string): boolean => {
@@ -407,7 +407,7 @@ export async function syncTaskTrail(): Promise<TaskSyncResult> {
       // sends the operator hunting in the wrong place.
       const overridePath = taskDbPathOverride();
       const note = overridePath
-        ? `task-db-unavailable: MEMCLAW_TASK_DB_PATH=${overridePath} has no task_runs table`
+        ? `task-db-unavailable: CAURA_TASK_DB_PATH=${overridePath} has no task_runs table`
         : "task-db-unavailable: no task_runs database found";
       return { synced: 0, note };
     }

--- a/plugin/src/tool-definitions.test.ts
+++ b/plugin/src/tool-definitions.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the Caura plugin tool surface.
  *
- * Guards the contract between `plugin/tools.json` (SoT), `MEMCLAW_TOOLS`
+ * Guards the contract between `plugin/tools.json` (SoT), `CAURA_TOOLS`
  * (registration order), `PARAM_SCHEMAS` (runtime input validation), and
  * `ENDPOINT_DISPATCH` (HTTP routing).
  */
@@ -10,11 +10,11 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { MEMCLAW_TOOLS } from "./tools.js";
+import { CAURA_TOOLS } from "./tools.js";
 import { createToolFromSpec } from "./tool-definitions.js";
 import { TOOL_SPECS, TOOL_SPECS_BY_NAME, getSpec } from "./tool-specs.js";
 import { buildToolsMd } from "./educate.js";
-import { memclawPromptSectionText } from "./prompt-section.js";
+import { cauraPromptSectionText } from "./prompt-section.js";
 
 describe("tool-specs loader", () => {
   test("loads a non-empty ordered spec list from tools.json", () => {
@@ -46,9 +46,9 @@ describe("tool-specs loader", () => {
   });
 });
 
-describe("MEMCLAW_TOOLS surface", () => {
+describe("CAURA_TOOLS surface", () => {
   test("is the expected list of plugin tools", () => {
-    assert.deepEqual([...MEMCLAW_TOOLS], [
+    assert.deepEqual([...CAURA_TOOLS], [
       "caura_recall",
       "caura_write",
       "caura_manage",
@@ -68,31 +68,31 @@ describe("MEMCLAW_TOOLS surface", () => {
   });
 
   test("every listed tool is plugin_exposed in tools.json", () => {
-    for (const name of MEMCLAW_TOOLS) {
+    for (const name of CAURA_TOOLS) {
       const spec = TOOL_SPECS_BY_NAME[name];
       assert.ok(spec, `${name} missing from tools.json`);
       assert.equal(spec.plugin_exposed, true);
     }
   });
 
-  test("every plugin_exposed tool in tools.json is listed in MEMCLAW_TOOLS", () => {
+  test("every plugin_exposed tool in tools.json is listed in CAURA_TOOLS", () => {
     const exposed = TOOL_SPECS.filter((s) => s.plugin_exposed).map((s) => s.name);
     for (const name of exposed) {
       assert.ok(
-        (MEMCLAW_TOOLS as readonly string[]).includes(name),
-        `${name} is plugin_exposed in tools.json but absent from MEMCLAW_TOOLS`,
+        (CAURA_TOOLS as readonly string[]).includes(name),
+        `${name} is plugin_exposed in tools.json but absent from CAURA_TOOLS`,
       );
     }
   });
 
-  test("STM and placeholder tools are NOT in MEMCLAW_TOOLS", () => {
+  test("STM and placeholder tools are NOT in CAURA_TOOLS", () => {
     for (const hidden of [
       "memclaw_notes_read",
       "memclaw_bulletin_read",
       "memclaw_promote",
     ]) {
       assert.ok(
-        !(MEMCLAW_TOOLS as readonly string[]).includes(hidden),
+        !(CAURA_TOOLS as readonly string[]).includes(hidden),
         `${hidden} should not be plugin-exposed`,
       );
     }
@@ -101,7 +101,7 @@ describe("MEMCLAW_TOOLS surface", () => {
 
 describe("createToolFromSpec factory", () => {
   test("produces a valid AgentTool for every listed name", () => {
-    for (const name of MEMCLAW_TOOLS) {
+    for (const name of CAURA_TOOLS) {
       const tool = createToolFromSpec(name);
       assert.equal(tool.name, name);
       assert.ok(tool.label.startsWith("Caura "), `${name}: label`);
@@ -183,10 +183,10 @@ describe("createToolFromSpec factory", () => {
     }
   });
 
-  test("openclaw.plugin.json contracts.tools matches MEMCLAW_TOOLS exactly", () => {
+  test("openclaw.plugin.json contracts.tools matches CAURA_TOOLS exactly", () => {
     // OpenClaw runtime requires plugins to declare ``contracts.tools``
     // before it accepts ``api.registerTool`` calls. The list MUST match
-    // ``MEMCLAW_TOOLS`` — drift here means OpenClaw silently rejects
+    // ``CAURA_TOOLS`` — drift here means OpenClaw silently rejects
     // tool registration at boot ("plugin must declare contracts.tools
     // before registering agent tools" in the gateway log) and every
     // agent loses access to the tool.
@@ -200,8 +200,8 @@ describe("createToolFromSpec factory", () => {
     assert.ok(Array.isArray(declared), "manifest must declare contracts.tools");
     assert.deepEqual(
       [...declared].sort(),
-      [...MEMCLAW_TOOLS].sort(),
-      "contracts.tools in openclaw.plugin.json must match MEMCLAW_TOOLS",
+      [...CAURA_TOOLS].sort(),
+      "contracts.tools in openclaw.plugin.json must match CAURA_TOOLS",
     );
   });
 
@@ -222,7 +222,7 @@ describe("drift checks across tool surface artefacts", () => {
   // asserts presence by name (not a signature card). Without it, adding a
   // tool (e.g. caura_stats in #64) silently leaves SKILL.md a version
   // behind and agents see the wrong tool surface.
-  test("SKILL.md names every tool in MEMCLAW_TOOLS", () => {
+  test("SKILL.md names every tool in CAURA_TOOLS", () => {
     const skillPath = join(
       import.meta.dirname,
       "..",
@@ -231,7 +231,7 @@ describe("drift checks across tool surface artefacts", () => {
       "SKILL.md",
     );
     const skill = readFileSync(skillPath, "utf-8");
-    for (const name of MEMCLAW_TOOLS) {
+    for (const name of CAURA_TOOLS) {
       assert.ok(
         skill.includes(name),
         `SKILL.md does not mention ${name}`,
@@ -272,9 +272,9 @@ describe("drift checks across tool surface artefacts", () => {
 
   // TOOLS.md (per-workspace bootstrap) is built from buildToolsMd() and
   // injected into every turn. It must mention every exposed tool by name.
-  test("buildToolsMd output mentions every tool in MEMCLAW_TOOLS", () => {
+  test("buildToolsMd output mentions every tool in CAURA_TOOLS", () => {
     const md = buildToolsMd();
-    for (const name of MEMCLAW_TOOLS) {
+    for (const name of CAURA_TOOLS) {
       assert.ok(
         md.includes("`" + name + "`"),
         `buildToolsMd output missing ${name}`,
@@ -284,18 +284,18 @@ describe("drift checks across tool surface artefacts", () => {
 
   // PARAM_SCHEMAS / ENDPOINT_DISPATCH are not exported, but
   // createToolFromSpec throws when either is missing — iterating
-  // MEMCLAW_TOOLS via the factory covers the "MEMCLAW_TOOLS ⊆ {schemas,
+  // CAURA_TOOLS via the factory covers the "CAURA_TOOLS ⊆ {schemas,
   // dispatch}" direction (already in the createToolFromSpec test
   // above). The reverse direction — extra entries in either map that
-  // are NOT in MEMCLAW_TOOLS — is guarded indirectly: any extra entry
+  // are NOT in CAURA_TOOLS — is guarded indirectly: any extra entry
   // would still need a tools.json spec to be reachable, and the
   // existing "every plugin_exposed tool in tools.json is listed in
-  // MEMCLAW_TOOLS" test catches that.
-  test("MEMCLAW_TOOLS == plugin-exposed tools in tools.json (set equality)", () => {
+  // CAURA_TOOLS" test catches that.
+  test("CAURA_TOOLS == plugin-exposed tools in tools.json (set equality)", () => {
     const exposed = new Set(
       TOOL_SPECS.filter((s) => s.plugin_exposed).map((s) => s.name),
     );
-    const listed = new Set(MEMCLAW_TOOLS);
+    const listed = new Set(CAURA_TOOLS);
     assert.deepEqual(listed, exposed);
   });
 
@@ -304,7 +304,7 @@ describe("drift checks across tool surface artefacts", () => {
   // (per-turn), AGENTS.md (per-turn), and SKILL.md (on-demand).
   // Regression guard against the pre-C3 verbose form.
   describe("prompt-section.ts (per-turn system-prompt fragment)", () => {
-    const tools = memclawPromptSectionText(new Set(MEMCLAW_TOOLS));
+    const tools = cauraPromptSectionText(new Set(CAURA_TOOLS));
 
     test("includes header, identity, and pointer to the memclaw skill (by name)", () => {
       assert.ok(tools.includes("## Caura Memory"), "missing header");
@@ -332,7 +332,7 @@ describe("drift checks across tool surface artefacts", () => {
     });
 
     test("lists all currently-available MemClaw tools by name", () => {
-      for (const name of MEMCLAW_TOOLS) {
+      for (const name of CAURA_TOOLS) {
         assert.ok(
           tools.includes(name),
           `prompt-section must list ${name} in available-tools cue`,
@@ -381,7 +381,7 @@ describe("drift checks across tool surface artefacts", () => {
     });
 
     test("emits nothing when no MemClaw tools are available", () => {
-      const empty = memclawPromptSectionText(new Set());
+      const empty = cauraPromptSectionText(new Set());
       assert.equal(empty, "", "must emit empty string when no tools available");
     });
   });

--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -22,8 +22,8 @@
 import { randomUUID } from "crypto";
 import { apiCall, textResult } from "./transport.js";
 import {
-  MEMCLAW_FLEET_ID,
-  MEMCLAW_AGENT_ID,
+  CAURA_FLEET_ID,
+  CAURA_AGENT_ID,
   ensureTenantId,
   getToolDescription,
 } from "./env.js";
@@ -82,7 +82,7 @@ async function enrichBody(
 ): Promise<Record<string, unknown>> {
   const body = { ...params };
   if (!body.tenant_id) body.tenant_id = await ensureTenantId();
-  if (!body.agent_id && MEMCLAW_AGENT_ID) body.agent_id = MEMCLAW_AGENT_ID;
+  if (!body.agent_id && CAURA_AGENT_ID) body.agent_id = CAURA_AGENT_ID;
   // The configured fleet below is a DEFAULT, for callers that did not say
   // which fleet they meant — so it must not override a caller that asked to
   // span every fleet. Three cases deliberately keep it: an omitted ``scope``
@@ -91,7 +91,7 @@ async function enrichBody(
   // ask for), and a caller-supplied ``fleet_id`` — this withholds a default,
   // it never strips a value.
   if (opts.fleetIsReadFilterOnly && body.scope === "all") return body;
-  if (!body.fleet_id && MEMCLAW_FLEET_ID) body.fleet_id = MEMCLAW_FLEET_ID;
+  if (!body.fleet_id && CAURA_FLEET_ID) body.fleet_id = CAURA_FLEET_ID;
   return body;
 }
 
@@ -388,7 +388,7 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
     const body = await enrichBody(params);
     // Write-scoped identity default: never send an empty agent_id, which on the
     // gateway path collapses onto the reserved "main" default. enrichBody set it
-    // from MEMCLAW_AGENT_ID if present; otherwise fall back to a stable
+    // from CAURA_AGENT_ID if present; otherwise fall back to a stable
     // install-scoped id (mirrors resolve-agent.ts step 5). Scoped to writes so
     // read visibility scoping is unchanged.
     if (!body.agent_id) body.agent_id = `main-${getInstallId()}`;

--- a/plugin/src/tools.ts
+++ b/plugin/src/tools.ts
@@ -18,7 +18,7 @@
  */
 import { TOOL_SPECS } from "./tool-specs.js";
 
-export const MEMCLAW_TOOLS = [
+export const CAURA_TOOLS = [
   "caura_recall",
   "caura_write",
   "caura_manage",
@@ -37,7 +37,7 @@ export const MEMCLAW_TOOLS = [
 const exposedInSpec = new Set(
   TOOL_SPECS.filter((t) => t.plugin_exposed).map((t) => t.name),
 );
-const listed = new Set<string>(MEMCLAW_TOOLS);
+const listed = new Set<string>(CAURA_TOOLS);
 
 const missingFromList = [...exposedInSpec].filter((t) => !listed.has(t));
 const extraInList = [...listed].filter((t) => !exposedInSpec.has(t));
@@ -46,12 +46,12 @@ if (missingFromList.length || extraInList.length) {
   const parts: string[] = [];
   if (missingFromList.length) {
     parts.push(
-      `exposed in tools.json but missing from MEMCLAW_TOOLS: ${missingFromList.join(", ")}`,
+      `exposed in tools.json but missing from CAURA_TOOLS: ${missingFromList.join(", ")}`,
     );
   }
   if (extraInList.length) {
     parts.push(
-      `listed in MEMCLAW_TOOLS but not plugin_exposed in tools.json: ${extraInList.join(", ")}`,
+      `listed in CAURA_TOOLS but not plugin_exposed in tools.json: ${extraInList.join(", ")}`,
     );
   }
   throw new Error(`[caura] Tool-surface drift — ${parts.join("; ")}`);

--- a/plugin/src/transport.test.ts
+++ b/plugin/src/transport.test.ts
@@ -2,15 +2,15 @@
  * Tests for apiCall in transport.ts.
  *
  * Guards the API-prefix consolidation: all resource paths must be
- * auto-prepended with MEMCLAW_API_PREFIX, and absolute "/api/..." paths
+ * auto-prepended with CAURA_API_PREFIX, and absolute "/api/..." paths
  * must be rejected so regressions surface at test time.
  */
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 
-process.env.MEMCLAW_API_KEY = "mc_test_key_for_transport_tests";
-process.env.MEMCLAW_API_URL = "http://localhost:8000";
-process.env.MEMCLAW_TENANT_ID = "t_test";
+process.env.CAURA_API_KEY = "mc_test_key_for_transport_tests";
+process.env.CAURA_API_URL = "http://localhost:8000";
+process.env.CAURA_TENANT_ID = "t_test";
 
 const { apiCall, parseSearchItems } = await import("./transport.js");
 
@@ -32,7 +32,7 @@ function installOkFetch(): void {
   }) as typeof fetch;
 }
 
-describe("apiCall — MEMCLAW_API_PREFIX handling", () => {
+describe("apiCall — CAURA_API_PREFIX handling", () => {
   beforeEach(() => {
     originalFetch = globalThis.fetch;
     calls = [];
@@ -43,13 +43,13 @@ describe("apiCall — MEMCLAW_API_PREFIX handling", () => {
     globalThis.fetch = originalFetch;
   });
 
-  test("prepends MEMCLAW_API_PREFIX to resource paths", async () => {
+  test("prepends CAURA_API_PREFIX to resource paths", async () => {
     await apiCall("POST", "/search", { q: "x" });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].url, "http://localhost:8000/api/v1/search");
   });
 
-  test("rejects paths starting with MEMCLAW_API_PREFIX", async () => {
+  test("rejects paths starting with CAURA_API_PREFIX", async () => {
     await assert.rejects(
       () => apiCall("POST", "/api/v1/search", {}),
       /apiCall path must be a resource path/,

--- a/plugin/src/transport.ts
+++ b/plugin/src/transport.ts
@@ -7,7 +7,7 @@
  * - HTTPS enforced by default
  */
 
-import { MEMCLAW_API_PREFIX, MEMCLAW_API_URL, MEMCLAW_API_KEY } from "./env.js";
+import { CAURA_API_PREFIX, CAURA_API_URL, CAURA_API_KEY } from "./env.js";
 import { resolveAgentKey, evictAgentKey } from "./agent-auth.js";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -27,13 +27,13 @@ export async function apiCall(
   // Reject prefixed paths early so accidental full-path regressions are loud
   // during tsc/tests rather than silently 404'ing at runtime.
   const normalized = path.startsWith("/") ? path : `/${path}`;
-  if (normalized.startsWith(MEMCLAW_API_PREFIX + "/") || normalized === MEMCLAW_API_PREFIX) {
+  if (normalized.startsWith(CAURA_API_PREFIX + "/") || normalized === CAURA_API_PREFIX) {
     throw new Error(
       `[caura] apiCall path must be a resource path (e.g. "/evolve/report"); ` +
-      `got "${path}". MEMCLAW_API_PREFIX ("${MEMCLAW_API_PREFIX}") is applied automatically.`,
+      `got "${path}". CAURA_API_PREFIX ("${CAURA_API_PREFIX}") is applied automatically.`,
     );
   }
-  const url = new URL(`${MEMCLAW_API_PREFIX}${normalized}`, MEMCLAW_API_URL);
+  const url = new URL(`${CAURA_API_PREFIX}${normalized}`, CAURA_API_URL);
   if (query) {
     for (const [k, v] of Object.entries(query)) {
       url.searchParams.set(k, v);
@@ -42,7 +42,7 @@ export async function apiCall(
 
   // Resolve agent-scoped credential, or fall back to the tenant-scoped key
   const effectiveAgentId = agentId || (body?.agent_id as string) || (query?.agent_id as string);
-  let effectiveKey = MEMCLAW_API_KEY;
+  let effectiveKey = CAURA_API_KEY;
   if (effectiveAgentId) {
     const agentKey = await resolveAgentKey(effectiveAgentId);
     if (agentKey) effectiveKey = agentKey;
@@ -76,7 +76,7 @@ export async function apiCall(
 
     if (!res.ok) {
       // 401 with agent key → evict and retry once with tenant key
-      if (res.status === 401 && effectiveKey !== MEMCLAW_API_KEY && effectiveAgentId) {
+      if (res.status === 401 && effectiveKey !== CAURA_API_KEY && effectiveAgentId) {
         evictAgentKey(effectiveAgentId);
         console.warn(`[caura] Agent key rejected for '${effectiveAgentId}', retrying with tenant key`);
         // Forward extraHeaders so the retry reuses the same per-attempt

--- a/plugin/src/validation.ts
+++ b/plugin/src/validation.ts
@@ -70,7 +70,7 @@ let _unsignedWarned = false;
  *
  * The OSS server doesn't sign commands — signing is reserved for
  * enterprise gateways that proxy commands through a signing layer.
- * Defaulting to "fail closed when MEMCLAW_API_KEY is set" (the prior
+ * Defaulting to "fail closed when CAURA_API_KEY is set" (the prior
  * behavior) silently broke every fleet command (educate / deploy /
  * install_skill / uninstall_skill) on every OSS install with auth on,
  * because the secret used for tenant auth is not a command-signing
@@ -115,7 +115,7 @@ export function verifyCommandSignature(
     }
     // Permissive (default): server-side command-signing is opt-in
     // infra; reject only when the operator has explicitly demanded it
-    // via MEMCLAW_REQUIRE_SIGNED_COMMANDS=true. Warn once so the gap
+    // via CAURA_REQUIRE_SIGNED_COMMANDS=true. Warn once so the gap
     // is visible without flooding logs every 60s heartbeat.
     if (!_unsignedWarned) {
       console.warn(

--- a/scripts/gateway_integration_test.py
+++ b/scripts/gateway_integration_test.py
@@ -301,13 +301,13 @@ class GatewayIntegrationTest:
             content = env_path.read_text()
             self.check(
                 "Plugin .env: has API_URL",
-                "MEMCLAW_API_URL=" in content,
-                "MEMCLAW_API_URL",
+                "CAURA_API_URL=" in content,
+                "CAURA_API_URL",
             )
             self.check(
                 "Plugin .env: has API_KEY",
-                "MEMCLAW_API_KEY=" in content,
-                "MEMCLAW_API_KEY",
+                "CAURA_API_KEY=" in content,
+                "CAURA_API_KEY",
             )
 
     def test_openclaw_config_allowlist(self):
@@ -412,7 +412,7 @@ class GatewayIntegrationTest:
 
         self.check(
             "Gateway log: plugin loaded",
-            "[memclaw]" in log_content,
+            "[caura]" in log_content,
             "searched journalctl + log files",
         )
 
@@ -1071,7 +1071,7 @@ def main():
     parser.add_argument(
         "--node-name",
         required=True,
-        help="Node name (must match the gateway's MEMCLAW_NODE_NAME)",
+        help="Node name (must match the gateway's CAURA_NODE_NAME)",
     )
     parser.add_argument("--fleet-id", default="", help="Fleet ID")
     parser.add_argument(

--- a/scripts/wet_test_triple_emission.py
+++ b/scripts/wet_test_triple_emission.py
@@ -38,7 +38,7 @@ Keys you (the operator) need
 ============================
 * No LLM keys required — triple emission is purely deterministic and
   the contradiction path under test is the *non-LLM* one.
-* ``--api-key`` only needed if your core-api has ``MEMCLAW_API_KEY`` set
+* ``--api-key`` only needed if your core-api has ``CAURA_API_KEY`` set
   (network-exposed deployments). Local docker-compose dev does not.
 """
 

--- a/tests/test_org_role_plumb.py
+++ b/tests/test_org_role_plumb.py
@@ -11,7 +11,7 @@ Pins:
 - the allowlist — values outside the org-membership model are dropped
   (a smuggled third role must never reach ``== "admin"`` gates),
 - absent header → ``org_role is None`` (pre-rollout gateways),
-- the MEMCLAW_API_KEY path (Path 2) ignores the header — API-key
+- the CAURA_API_KEY path (Path 2) ignores the header — API-key
   callers must NOT gain inbox-action rights from a spoofable header,
 - end-to-end: a gateway-shaped request opens the Skills Inbox admin
   gate with the role and is 403'd without it.

--- a/tests/test_production_startup_guards.py
+++ b/tests/test_production_startup_guards.py
@@ -72,7 +72,7 @@ def test_empty_strings_count_as_unset():
 def test_memclaw_api_key_alone_is_an_acceptable_perimeter():
     """The network-exposed OSS pattern, and why the guard is not gateway-specific.
 
-    When ``MEMCLAW_API_KEY`` is set, auth.py's Path 2 either authenticates the
+    When ``CAURA_API_KEY`` is set, auth.py's Path 2 either authenticates the
     request against that key or 401s everything else — so Path 4's header-trust
     surface is UNREACHABLE and there is nothing left to protect. Such a
     deployment legitimately sets ENVIRONMENT=production for JSON logging and


### PR DESCRIPTION
The W5 identifier sweep plus the W4 set-site flip, landed together because the ratchet proved they cannot land apart: renaming only two constants left sibling `MEMCLAW_*` tokens on every touched line — mixed lines that would need editing twice.

**−402 lines net.** The largest single cut of the programme so far.

## What changed

- Every exported `MEMCLAW_*` constant in `plugin/src` → `CAURA_*`. These are **TypeScript identifiers** — the env keys the plugin reads are untouched: every `readEnv(["CAURA_X", "MEMCLAW_X"])` list is byte-identical, markers intact (verified: zero unmarked quoted `MEMCLAW_` strings before the sweep, zero after).
- `isMemclaw*` → `isCaura*`, `memclawPromptSection*` → `caura*`, `MemClawContextEngine` → `CauraContextEngine` **with the old name kept as an exported const+type alias** — `dist/` is consumed outside this repo, so the pre-rename class name is public API.
- `[memclaw]` → `[caura]` on every log line, **including the matcher** at `scripts/gateway_integration_test.py` that greps gateway logs for it — prefix and assertion in the same commit, per the one-cluster rule.
- Tests/e2e now **set** `CAURA_*`; the alias-pinning tests that deliberately set `MEMCLAW_*` keep doing so.
- Teaching prose (cli.py docstring, comments, script banners) teaches `CAURA_*`.

## Untouched, deliberately

On-disk sentinel strings: `educate.ts` matchers, `.memclaw-owned`, the engine `info.id`, gateway RPC method names, every quoted legacy env key. Two new exemptions name the **kept plugin id** a user must literally type into `openclaw.json` (`index.ts:484`, `:755`).

## Verification

- `tsc` clean
- Full 19-file plugin suite: **336 pass / 74 fail** vs **335/75 on untouched `origin/main`** measured in the same shell — one net gain, no regressions (the 74 are the known Windows path fixtures)
- `bash -n` / `node --check` / `ast.parse` clean on every touched script
- Ratchet: `No new lines. 402 removed by this change (-402 net).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)