### PR TITLE
feat(llm): attribute the per-call token log to its service label

### DIFF
--- a/common/llm/call_context.py
+++ b/common/llm/call_context.py
@@ -1,0 +1,28 @@
+"""Ambient label for the LLM call currently in flight (E4-prep).
+
+The per-call token log (E3, ``common/llm/providers/openai.py``) is the
+cost-attribution surface — but the provider is invoked through ``call_fn``
+closures built by ``call_with_fallback`` and never sees the caller's
+``service_label``. Threading a parameter through every provider method,
+protocol, and test double would touch dozens of signatures for one log
+field; a ``ContextVar`` instead rides the await chain from the retry
+layer down to the provider with no call-site changes.
+
+Set/reset by ``common.llm.retry.call_with_retry`` (which every production
+LLM call goes through, primary and fallback tiers alike), read at log
+time by the provider. A call that bypasses the retry layer (unit tests,
+one-off scripts) logs the empty default, rendered as ``service=-``.
+
+Lives in its own module so both ``retry`` and the providers can import it
+without creating a cycle.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+# The retry layer stores its per-tier label here, e.g.
+# ``"contradiction_batch-primary"`` / ``"contradiction_batch-fallback"`` —
+# the tier suffix is kept deliberately so a cost regression can be
+# attributed not just to a service but to its fallback tier misfiring.
+llm_call_label: ContextVar[str] = ContextVar("llm_call_label", default="")

--- a/common/llm/providers/openai.py
+++ b/common/llm/providers/openai.py
@@ -22,6 +22,7 @@ import time
 import httpx
 import openai
 
+from common.llm.call_context import llm_call_label
 from common.llm.constants import (
     LLM_PROVIDER_MAX_RETRIES,
     OPENAI_CHAT_BASE_URL,
@@ -252,12 +253,13 @@ class OpenAILLMProvider:
         tokens_in, tokens_out, tokens_reasoning = _usage_tokens(response)
         logger.info(
             "OpenAI-compatible complete_json (%s) took %dms "
-            "tokens_in=%d tokens_out=%d tokens_reasoning=%d",
+            "tokens_in=%d tokens_out=%d tokens_reasoning=%d service=%s",
             self._model,
             llm_ms,
             tokens_in,
             tokens_out,
             tokens_reasoning,
+            llm_call_label.get() or "-",
         )
         content = response.choices[0].message.content
         if not content:
@@ -286,11 +288,12 @@ class OpenAILLMProvider:
         tokens_in, tokens_out, tokens_reasoning = _usage_tokens(response)
         logger.info(
             "OpenAI-compatible complete_text (%s) took %dms "
-            "tokens_in=%d tokens_out=%d tokens_reasoning=%d",
+            "tokens_in=%d tokens_out=%d tokens_reasoning=%d service=%s",
             self._model,
             llm_ms,
             tokens_in,
             tokens_out,
             tokens_reasoning,
+            llm_call_label.get() or "-",
         )
         return response.choices[0].message.content or ""

--- a/common/llm/retry.py
+++ b/common/llm/retry.py
@@ -24,6 +24,7 @@ from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import Any, TypeVar
 
+from common.llm.call_context import llm_call_label
 from common.llm.constants import (
     LLM_MAX_RETRY_AFTER_S,
     LLM_RETRY_ATTEMPTS,
@@ -99,6 +100,39 @@ def retry_after_seconds(exc: BaseException) -> float | None:
 
 
 async def call_with_retry(
+    coro_fn: Callable[[], Coroutine[Any, Any, T]],
+    label: str,
+    max_attempts: int = LLM_RETRY_ATTEMPTS,
+    base_delay: float = LLM_RETRY_DELAY_S,
+    timeout: float | None = None,
+    non_retryable: tuple[type[BaseException], ...] = (),
+    budget_s: float | None = None,
+) -> T:
+    """Call *coro_fn* with retry and linear backoff — see
+    :func:`_call_with_retry_impl` for the full parameter contract.
+
+    This thin wrapper additionally publishes *label* as the ambient
+    :data:`common.llm.call_context.llm_call_label` for the duration of the
+    call (E4-prep), so the provider's per-call token log can attribute
+    cost to its service without any signature changes. Reset in
+    ``finally`` — the label must not leak into a sibling task's log lines.
+    """
+    _label_token = llm_call_label.set(label)
+    try:
+        return await _call_with_retry_impl(
+            coro_fn,
+            label,
+            max_attempts=max_attempts,
+            base_delay=base_delay,
+            timeout=timeout,
+            non_retryable=non_retryable,
+            budget_s=budget_s,
+        )
+    finally:
+        llm_call_label.reset(_label_token)
+
+
+async def _call_with_retry_impl(
     coro_fn: Callable[[], Coroutine[Any, Any, T]],
     label: str,
     max_attempts: int = LLM_RETRY_ATTEMPTS,

--- a/tests/test_llm_service_label_in_token_log.py
+++ b/tests/test_llm_service_label_in_token_log.py
@@ -1,0 +1,113 @@
+"""E4-prep — the per-call token log carries the service label.
+
+The E3 token log made per-call cost visible; attributing it to a SERVICE
+(judge vs enrichment vs dedup) still required correlating adjacent log
+lines. The retry layer now publishes its per-tier label through
+``common.llm.call_context.llm_call_label`` (a ContextVar riding the await
+chain), and the OpenAI provider renders it as ``service=<label>`` on the
+same log line — making a per-service token aggregation a one-regex
+log-based metric.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _response() -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content='{"ok": true}'))]
+    )
+
+
+async def test_direct_provider_call_logs_placeholder(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Outside the retry layer there is no ambient label — the field is
+    still present (stable log shape for the metric regex) as ``service=-``."""
+    from common.llm.providers.openai import OpenAILLMProvider
+
+    provider = OpenAILLMProvider(api_key="sk-test", model="gpt-test")
+    with (
+        caplog.at_level(logging.INFO, logger="common.llm.providers.openai"),
+        patch.object(
+            provider._client.chat.completions,
+            "create",
+            AsyncMock(return_value=_response()),
+        ),
+    ):
+        await provider.complete_json("test prompt")
+
+    assert "service=-" in caplog.text
+
+
+async def test_label_flows_from_call_with_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``call_with_fallback(service_label=...)`` reaches the provider's
+    token log line, tier-suffixed, with zero call-site plumbing."""
+    from common.llm.providers.openai import OpenAILLMProvider
+    from common.llm.retry import call_with_fallback
+
+    provider = OpenAILLMProvider(api_key="sk-test", model="gpt-test")
+    with (
+        caplog.at_level(logging.INFO, logger="common.llm.providers.openai"),
+        patch.object(
+            provider._client.chat.completions,
+            "create",
+            AsyncMock(return_value=_response()),
+        ),
+    ):
+        result = await call_with_fallback(
+            primary_provider_name="openai",
+            call_fn=lambda llm: llm.complete_json("test prompt"),
+            fake_fn=lambda: {},
+            provider_factory=lambda *a, **k: provider,
+            service_label="contradiction_batch",
+        )
+
+    assert result == {"ok": True}
+    assert "service=contradiction_batch-primary" in caplog.text
+
+
+async def test_label_resets_after_the_call(caplog: pytest.LogCaptureFixture) -> None:
+    """The ContextVar must not leak: a later unlabeled call in the same
+    task logs the placeholder again, not the previous service's label."""
+    from common.llm.call_context import llm_call_label
+    from common.llm.providers.openai import OpenAILLMProvider
+    from common.llm.retry import call_with_retry
+
+    provider = OpenAILLMProvider(api_key="sk-test", model="gpt-test")
+    with patch.object(
+        provider._client.chat.completions, "create", AsyncMock(return_value=_response())
+    ):
+        await call_with_retry(
+            lambda: provider.complete_json("p"), label="dedup-primary"
+        )
+        assert llm_call_label.get() == ""
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="common.llm.providers.openai"):
+            await provider.complete_json("p")
+
+    assert "service=dedup-primary" not in caplog.text
+    assert "service=-" in caplog.text
+
+
+async def test_label_resets_even_when_the_call_raises() -> None:
+    from common.llm.call_context import llm_call_label
+    from common.llm.retry import call_with_retry
+
+    async def _boom() -> dict:
+        raise RuntimeError("provider down")
+
+    with pytest.raises(RuntimeError):
+        await call_with_retry(_boom, label="enrich-primary", max_attempts=1)
+
+    assert llm_call_label.get() == ""


### PR DESCRIPTION
## Why

Follow-up to #940 (E3), prep for E4's dollar verification. The token log made per-call cost visible, but attributing a line to its **service** (contradiction judge vs enrichment vs dedup vs recall) still required correlating adjacent log lines or clustering by prompt size. The cost-baseline window Erni is about to run needs cleanly attributed data from day one.

## What

- `call_with_retry` publishes its per-tier label (e.g. `contradiction_batch-primary` / `-fallback`) through a new `ContextVar` in `common/llm/call_context.py` — set on entry, reset in `finally` so it never leaks into a sibling task's lines.
- `OpenAILLMProvider.complete_json`/`complete_text` render it on the existing token line: `... tokens_in=N tokens_out=N tokens_reasoning=N service=<label>`.
- Zero call-site, protocol, or provider-signature changes (a parameter would have touched dozens of signatures and every test double). Calls outside the retry layer log `service=-`, keeping the log shape stable for a regex-extracted log-based metric.
- The tier suffix is kept deliberately: a cost regression can then be attributed not just to a service but to a misfiring fallback tier.

## Tests

4 new tests: direct call logs placeholder; label flows end-to-end through `call_with_fallback`; label resets after the call (no leak into subsequent unlabeled calls); reset holds when the call raises. Full suite: 5,046 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)