### PR TITLE
CAURA-718 fix(doc): render the whole doc payload into the minted memory

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -178,10 +178,13 @@ MAX_QUERY_LENGTH = 5000
 # ``memories.content`` directly). Docs themselves are only searchable via their
 # ``data["summary"]`` embedding, and ``caura_recall`` never returns documents.
 #
-# The memory content is the doc body VERBATIM, so the cutoff is simply the
-# memory schema ceiling: mint whenever the body fits in a memory at all.
-# Over-cutoff bodies are SKIPPED rather than truncated — a truncated body reads
-# as complete and would produce confidently wrong downstream conclusions.
+# The memory content is the whole ``data`` payload rendered as text (CAURA-717),
+# so the cutoff is simply the memory schema ceiling: mint whenever the RENDER
+# fits in a memory at all. Note the render is slightly longer than any one field
+# — ``key: `` labels and blank-line separators — so a doc can be under the cap
+# on its body and over it once rendered. Over-cutoff payloads are SKIPPED rather
+# than truncated: a truncated payload reads as complete and would produce
+# confidently wrong downstream conclusions.
 DOC_MEMORY_MAX_CHARS = MAX_CONTENT_LENGTH
 
 # NOTE: there is deliberately no ``DOC_MEMORY_TYPE``. Doc-derived memories pass

--- a/core-api/src/core_api/services/doc_indexing.py
+++ b/core-api/src/core_api/services/doc_indexing.py
@@ -19,18 +19,22 @@ Embed-source contract (``resolve_embed_source``):
   path).
 
 Doc-memory contract (``resolve_doc_memory``):
-- A doc write also mints a memory carrying the document body verbatim,
-  because the two stores are not cross-searched: ``caura_recall``
-  never returns documents, and only ``data["summary"]`` is embedded on
-  the document row. The minted memory is what makes the *body*
-  reachable by meaning.
+- A doc write also mints a memory carrying the document's data, because
+  the two stores are not cross-searched: ``caura_recall`` never returns
+  documents, and only ``data["summary"]`` is embedded on the document
+  row. The minted memory is what makes the *content* reachable by
+  meaning.
+- CAURA-717: the memory carries the WHOLE ``data`` payload rendered as
+  text, ``summary`` first — not one guessed field. See the note above
+  ``_render_doc_data`` for why guessing could not be made correct.
 - Independent of the embed rule: a doc with no ``summary`` is stored
   unindexed (invisible to ``op=search``) yet still mints a memory, so
-  recall can reach the body even when doc-search cannot.
+  recall can reach the content even when doc-search cannot.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime
@@ -41,11 +45,23 @@ logger = logging.getLogger(__name__)
 
 SKILLS_COLLECTION = "skills"
 
-# Field names checked, in order, for the document body. ``content`` is the
-# convention advertised in the ``caura_doc`` tool description ("The full body
-# lives wherever the caller puts it (e.g. data['content'])"); ``body`` is
-# accepted as the obvious synonym.
-_BODY_FIELDS: tuple[str, ...] = ("content", "body")
+# CAURA-717: there is deliberately no list of "body" field names any more.
+#
+# The previous rule looked for ``data["content"]`` then ``data["body"]`` and
+# skipped the mint when neither was present. That was a guess against a store
+# with NO schema: ``documents.data`` is free-form JSONB (``data: dict``, no
+# required keys — even ``{}`` is a legal document), and the tool description
+# says the body "lives wherever the caller puts it (e.g. data['content'])",
+# offering ``content`` as an EXAMPLE rather than a contract.
+#
+# In production at eToro the only organic doc feed writes
+# ``{url, date, title, source, summary, platform, decisions, action_items,
+# participants, duration_minutes}`` — no ``content``, no ``body``. Every write
+# returned 200 and silently minted nothing, so the feature could never fire for
+# the one feed that had real content. Guessing field names cannot be made
+# correct, only longer.
+#
+# The whole ``data`` payload is rendered instead — see ``_render_doc_data``.
 
 
 class InvalidDocIndexingError(ValueError):
@@ -86,10 +102,10 @@ def resolve_embed_source(collection: str, data: dict) -> str | None:
 class DocMemorySpec:
     """The memory to mint for one document write.
 
-    ``content`` is the document body VERBATIM — no prefix, no wrapper, no
-    summary header. Whitespace and markdown structure are preserved exactly as
-    the caller stored them, so the memory is a faithful copy of the doc rather
-    than a rendering of it.
+    ``content`` is the whole ``data`` payload rendered as text with ``summary``
+    first. Lossless — every non-empty field is included, and string values pass
+    through unmodified — but NOT byte-identical to any single field, because no
+    single field reliably holds the body (see ``_render_doc_data``).
     """
 
     content: str
@@ -97,13 +113,79 @@ class DocMemorySpec:
     metadata: dict
 
 
-def _resolve_body(data: dict) -> str | None:
-    """First non-empty string among ``_BODY_FIELDS``, else ``None``."""
-    for field in _BODY_FIELDS:
-        value = data.get(field)
-        if isinstance(value, str) and value.strip():
-            return value
-    return None
+def _render_value(value: object) -> str:
+    """One field's value as text. Strings pass through untouched."""
+    if isinstance(value, str):
+        return value
+    # Lists / dicts / scalars: compact JSON keeps nested structure readable and
+    # parseable without exploding into many lines. ``ensure_ascii=False`` so
+    # non-ASCII content (names, non-English text) stays legible instead of
+    # becoming \\uXXXX escapes — this text is read by an embedder and an LLM.
+    # ``default=str`` so an unexpected non-serialisable value degrades to its
+    # repr rather than raising, since this must never fail the doc write.
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def _is_empty(value: object) -> bool:
+    """True for values that carry no information and should not be rendered.
+
+    Empty fields are noise in an embedding and waste the 500-char prefix budget
+    that ``caura_insights`` reads.
+
+    Whitespace-only strings count as empty — ``"   \\n\\t"`` is not caught by
+    ``value == ""`` and would otherwise render as a bare ``key:`` followed by
+    blanks. This matches how ``summary`` is already tested (``summary.strip()``).
+
+    Falsy-but-real values are deliberately NOT empty: ``0`` and ``False`` are
+    meaningful field values (``duration_minutes: 0``, ``archived: false``), so
+    this must not collapse into a plain truthiness check.
+    """
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    return value == [] or value == {}
+
+
+def _render_doc_data(data: dict) -> str:
+    """Render the whole document payload as text, ``summary`` first.
+
+    Why summary first
+    -----------------
+    Downstream consumers read only a PREFIX of memory content: ``caura_insights``
+    truncates to 500 chars (``sanitize_content``'s default). A raw
+    ``json.dumps(data)`` spends that budget on whichever keys happen to come
+    first — for eToro's meeting docs that is ``url`` / ``date`` / ``title`` /
+    ``source``, roughly 250 chars of metadata, pushing the substance
+    (``decisions``, ``action_items``) past the cut. Emitting ``summary`` first
+    puts the most information-dense field inside every consumer's window.
+
+    With no ``summary`` the remaining fields render in the caller's own
+    insertion order — nothing is reordered or dropped, so the memory still
+    carries the entire document, just without a guaranteed-useful prefix.
+
+    Why ``key: value`` lines rather than JSON
+    ----------------------------------------
+    This text is embedded and fed to LLMs. Braces, brackets and quotes are
+    tokens that carry no meaning for either, so they are pure cost. ``summary``
+    is emitted as bare prose (no ``summary:`` label) so the prefix reads
+    naturally to both.
+    """
+    parts: list[str] = []
+
+    summary = data.get("summary")
+    summary_emitted = isinstance(summary, str) and bool(summary.strip())
+    if summary_emitted:
+        parts.append(summary.strip())  # type: ignore[union-attr]
+
+    for key, value in data.items():
+        if key == "summary" and summary_emitted:
+            continue  # already emitted as the bare prose prefix
+        if _is_empty(value):
+            continue
+        parts.append(f"{key}: {_render_value(value)}")
+
+    return "\n\n".join(parts)
 
 
 def resolve_doc_memory(
@@ -119,6 +201,10 @@ def resolve_doc_memory(
     raises — an undecidable input is a skip, because failing here must not fail
     the document write that triggered it.
 
+    CAURA-717: the content is the WHOLE ``data`` payload rendered as text with
+    ``summary`` first, not one guessed field, so there is no body-field
+    requirement — a document mints whenever it carries any usable data.
+
     Skips when:
       * ``collection == "skills"`` — skills have their own discovery path
         (``op=search collection=skills``) plus a staged -> active approval
@@ -126,23 +212,31 @@ def resolve_doc_memory(
         recallable, routing around that lifecycle.
       * ``collection`` starts with ``_`` — system-managed (e.g. ``_keystones``);
         storage rejects public writes to these anyway.
-      * no non-empty body — nothing to carry. This is also what keeps bulk
-        structured records (``{"plan": "business", "seats": 40}``) from minting
-        memories: they have no body field.
-      * body longer than ``DOC_MEMORY_MAX_CHARS`` — would not fit in a memory.
-        Skipped rather than truncated: a truncated body reads as complete.
+      * the render is empty — ``data`` is ``{}`` or holds only empty values.
+      * the render is longer than ``DOC_MEMORY_MAX_CHARS`` — would not fit in a
+        memory. Skipped rather than truncated: a truncated payload reads as
+        complete and yields confidently wrong conclusions downstream.
 
-    ``data["summary"]`` is deliberately NOT required. It gates *doc* indexing
-    (``resolve_embed_source``), not memory minting — a summary-less doc is
-    invisible to ``op=search`` but its body is still worth recalling. When a
-    summary is present it is carried in metadata for provenance.
+    ``data["summary"]`` is NOT required. It gates *doc* indexing
+    (``resolve_embed_source``), not minting — a summary-less doc is invisible to
+    ``op=search`` but its content is still worth recalling; it just renders
+    without the guaranteed-useful prefix. When present it is also copied to
+    metadata for provenance.
 
-    Every skip is logged, because all four look identical from the outside — a
-    document with no memory gives an operator no clue which rule fired, or
-    whether the mint threw instead. Levels are deliberately split: the size skip
-    is INFO (rare, surprising, and the operator probably wants the body indexed),
-    the rest are DEBUG (routine and high-volume — every bulk structured record
-    hits the no-body branch, and logging those at INFO would be pure noise).
+    Two consequences of not guessing, both accepted:
+      * bulk structured records (``{"plan": "business", "seats": 40}``) now mint,
+        where the old body-field rule excluded them as a side effect. A sync that
+        writes many small documents therefore produces one memory per document.
+      * server-written collections are unaffected: ``ingest-sources``,
+        ``interview_jobs`` and ``skills_rollback`` are written through
+        ``sc.upsert_document`` directly and never reach this code path, so no
+        ingested content is duplicated.
+
+    Every skip is logged — they look identical from the outside, so a document
+    with no memory otherwise gives an operator no clue which rule fired or
+    whether the mint threw. Levels are split deliberately: the size skip is INFO
+    (rare, surprising, and the operator probably wants that content recallable),
+    the rest DEBUG (routine and high-volume).
     """
     if collection == SKILLS_COLLECTION or collection.startswith("_"):
         logger.debug(
@@ -152,22 +246,20 @@ def resolve_doc_memory(
         )
         return None
 
-    body = _resolve_body(data)
-    if body is None:
+    body = _render_doc_data(data)
+    if not body.strip():
         logger.debug(
-            "doc_memory: no mint for %s/%s — no non-empty %s field",
+            "doc_memory: no mint for %s/%s — data rendered empty (no usable fields)",
             collection,
             doc_id,
-            " / ".join(f"data[{f!r}]" for f in _BODY_FIELDS),
         )
         return None
     if len(body) > DOC_MEMORY_MAX_CHARS:
-        # INFO: the doc IS stored and (with a summary) searchable, but its body
-        # is unreachable by recall. Skipped rather than truncated — a truncated
-        # body reads as complete and yields confidently wrong conclusions.
+        # INFO: the doc IS stored and (with a summary) searchable, but its
+        # content is unreachable by recall.
         logger.info(
-            "doc_memory: no mint for %s/%s — body is %d chars, over the %d limit "
-            "(document stored; body not recallable)",
+            "doc_memory: no mint for %s/%s — rendered content is %d chars, over the "
+            "%d limit (document stored; content not recallable)",
             collection,
             doc_id,
             len(body),

--- a/core-api/src/core_api/services/doc_memory.py
+++ b/core-api/src/core_api/services/doc_memory.py
@@ -6,8 +6,14 @@ The two stores are not cross-searched: ``caura_recall`` never returns
 documents, and a document row embeds only ``data["summary"]`` — never its body.
 So a document's *content* is unreachable by meaning; you can only find it if you
 already know its ``collection`` + ``doc_id``. Minting a memory that carries the
-body verbatim closes that gap for the paths that read ``memories.content``
+document's data closes that gap for the paths that read ``memories.content``
 directly (``caura_recall`` and the recall brief, neither of which truncates).
+
+CAURA-717: that memory carries the WHOLE ``data`` payload rendered as text with
+``summary`` first — not one guessed field. The previous rule required
+``data["content"]`` or ``data["body"]``, which no producer is obliged to use;
+eToro's only organic doc feed has neither, so every write returned 200 and
+silently minted nothing. See ``doc_indexing._render_doc_data``.
 
 Rewrite semantics come free from ``write_mode="fast"``
 -----------------------------------------------------

--- a/tests/test_doc_memory_spec.py
+++ b/tests/test_doc_memory_spec.py
@@ -5,12 +5,14 @@ Pure function, no I/O. This is the single source of truth shared by the MCP
 these tests pin the contract both surfaces depend on.
 
 Covers:
-- The four skip conditions (skills / system collection / no body / over cap).
-- Content is the doc body VERBATIM — byte-for-byte, whitespace and markdown
-  preserved. This is the whole point of the feature; a regression here silently
-  degrades every downstream consumer.
-- A doc with NO ``summary`` still mints (summary gates *doc* indexing, not
-  memory minting).
+- The skip conditions (skills / system collection / empty render / over cap).
+- CAURA-717: content is the WHOLE ``data`` payload rendered as text with
+  ``summary`` FIRST — not a guessed body field. Summary-first is load-bearing:
+  ``caura_insights`` reads only the first 500 chars, so whatever leads the render
+  is what the reflection pass actually sees.
+- The render is lossless: every non-empty field appears, string values unmodified.
+- A doc with NO ``summary`` still mints — it just renders without the
+  guaranteed-useful prefix.
 - The ``DOC_MEMORY_MAX_CHARS`` boundary: at the cap mints, one over skips —
   never raises, so the document write it hangs off can never fail on size.
 """
@@ -39,23 +41,111 @@ def _data(**extra) -> dict:
 def test_mints_spec_for_ordinary_doc():
     spec = resolve_doc_memory("runbooks", "pg-tuning", _data(content="body text"))
     assert isinstance(spec, DocMemorySpec)
-    assert spec.content == "body text"
+    assert "body text" in spec.content
     assert spec.source_uri == "memclaw-doc://runbooks/pg-tuning"
     assert spec.metadata["doc_collection"] == "runbooks"
     assert spec.metadata["doc_id"] == "pg-tuning"
 
 
-def test_content_is_byte_for_byte_verbatim():
-    """No prefix, no wrapper, no summary header, no whitespace normalisation.
+def test_summary_is_rendered_first_as_bare_prose():
+    """Load-bearing: insights truncates to 500 chars, so the summary must lead.
 
-    The memory is a faithful copy of the doc body, not a rendering of it.
+    Emitted WITHOUT a ``summary:`` label so the prefix reads as natural prose to
+    both the embedder and the LLM.
     """
-    body = "# Runbook\n\n## Vacuum\n\n  - run VACUUM ANALYZE nightly\n\n\ttabbed\n"
-    spec = resolve_doc_memory("runbooks", "pg", _data(content=body))
+    spec = resolve_doc_memory("runbooks", "pg", _data(content="body text"))
     assert spec is not None
-    assert spec.content == body
-    # Guard against a summary prefix creeping back in.
-    assert not spec.content.startswith(_data()["summary"])
+    assert spec.content.startswith(_data()["summary"])
+    assert not spec.content.startswith("summary:")
+
+
+def test_render_is_lossless_and_keeps_string_values_intact():
+    """Every non-empty field appears; string values are not reformatted."""
+    body = "# Runbook\n\n  - run VACUUM ANALYZE nightly\n\ttabbed\n"
+    spec = resolve_doc_memory(
+        "runbooks", "pg", _data(content=body, owner="dba-team", priority=2)
+    )
+    assert spec is not None
+    assert body in spec.content  # verbatim, whitespace preserved
+    assert "owner: dba-team" in spec.content
+    assert "priority: 2" in spec.content
+
+
+def test_non_string_values_render_as_compact_json():
+    spec = resolve_doc_memory(
+        "meetings", "m1", _data(decisions=["ship it", "revisit Q4"], attendees={"a": 1})
+    )
+    assert spec is not None
+    assert 'decisions: ["ship it", "revisit Q4"]' in spec.content
+    assert 'attendees: {"a": 1}' in spec.content
+
+
+def test_non_ascii_is_not_escaped():
+    """This text is read by an LLM and by humans — \\uXXXX escapes would be noise."""
+    spec = resolve_doc_memory("meetings", "m1", _data(participants=["Eyal", "ארקדי"]))
+    assert spec is not None
+    assert "ארקדי" in spec.content
+    assert "\\u" not in spec.content
+
+
+def test_empty_values_are_omitted_from_the_render():
+    """Empty fields waste embedding tokens and prefix budget."""
+    spec = resolve_doc_memory(
+        "notes", "n1", _data(content="body", blank="", nothing=None, empty=[], void={})
+    )
+    assert spec is not None
+    for key in ("blank:", "nothing:", "empty:", "void:"):
+        assert key not in spec.content
+
+
+@pytest.mark.parametrize("blank", ["   ", "\n", "\t", " \n\t "])
+def test_whitespace_only_strings_count_as_empty(blank):
+    """REGRESSION (CR): ``value == ""`` does not match ``"   "``, so a
+    whitespace-only field rendered as a bare ``key:`` followed by blanks —
+    exactly the noise the filter exists to remove."""
+    spec = resolve_doc_memory("notes", "n1", _data(content="body", ws=blank))
+    assert spec is not None
+    assert "ws:" not in spec.content
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [
+        ("duration_minutes", 0, "duration_minutes: 0"),
+        ("archived", False, "archived: false"),
+        ("score", 0.0, "score: 0.0"),
+    ],
+)
+def test_falsy_but_real_values_are_kept(key, value, expected):
+    """The empty check must not collapse into truthiness: ``0`` and ``False``
+    are meaningful field values, not absent ones."""
+    spec = resolve_doc_memory("notes", "n1", _data(**{key: value}))
+    assert spec is not None
+    assert expected in spec.content
+
+
+def test_etoro_meeting_shape_mints_and_leads_with_substance():
+    """REGRESSION (production, eToro): this exact shape has NO ``content`` or
+    ``body`` key, so the old body-field rule skipped it and the feature could
+    never fire for the only organic doc feed."""
+    doc = {
+        "url": "https://meet.example.com/rec/abc",
+        "date": "2026-08-20",
+        "title": "Product direction sync",
+        "source": "zoom",
+        "summary": "Team debated an SMB pivot toward organization-efficiency use cases.",
+        "platform": "zoom",
+        "decisions": ["pursue SMB segment"],
+        "action_items": [{"owner": "Eyal", "task": "draft brief"}],
+        "participants": ["Eyal", "Arkady"],
+        "duration_minutes": 45,
+    }
+    spec = resolve_doc_memory("meeting-summaries", "m1", doc)
+    assert spec is not None, "the eToro feed shape must mint"
+    assert spec.content.startswith(doc["summary"])
+    # The substance, not just the metadata, must survive into the memory.
+    assert "pursue SMB segment" in spec.content
+    assert "draft brief" in spec.content
 
 
 def test_summary_is_carried_in_metadata_not_content():
@@ -65,19 +155,13 @@ def test_summary_is_carried_in_metadata_not_content():
     assert "summary" not in spec.content
 
 
-def test_body_field_fallback():
-    """``data["body"]`` is accepted when ``data["content"]`` is absent."""
-    spec = resolve_doc_memory("notes", "n1", {"body": "via body field"})
-    assert spec is not None
-    assert spec.content == "via body field"
-
-
-def test_content_wins_over_body_when_both_present():
-    spec = resolve_doc_memory(
-        "notes", "n1", {"content": "primary", "body": "secondary"}
-    )
-    assert spec is not None
-    assert spec.content == "primary"
+def test_any_field_name_works_now():
+    """No field name is privileged any more — the whole payload is rendered, so a
+    doc using ``transcript`` / ``notes`` / anything else is no longer invisible."""
+    for key in ("transcript", "notes", "markdown", "raw_text", "whatever"):
+        spec = resolve_doc_memory("notes", "n1", {key: "the actual content"})
+        assert spec is not None, f"data[{key!r}] must still mint"
+        assert "the actual content" in spec.content
 
 
 def test_updated_at_is_stamped_when_supplied():
@@ -113,25 +197,37 @@ def test_skips_system_collections(collection):
 @pytest.mark.parametrize(
     "data",
     [
-        {"summary": "S"},  # no body key at all
-        {"summary": "S", "content": ""},  # empty
-        {"summary": "S", "content": "   \n\t "},  # whitespace only
-        {"summary": "S", "content": 42},  # non-string
-        {"summary": "S", "content": None},
-        {"plan": "business", "seats": 40},  # bulk structured record
+        {},  # empty payload
+        {"blank": ""},  # only empty values
+        {"nothing": None},
+        {"empty": [], "void": {}},
     ],
 )
-def test_skips_when_no_usable_body(data):
+def test_skips_only_when_the_render_is_empty(data):
+    """The only content-based skip left: nothing usable to render."""
     assert resolve_doc_memory("customers", "acme", data) is None
 
 
-def test_bulk_structured_record_is_the_blast_radius_limit():
-    """A structured record carries no body, so dropping the summary gate does
-    NOT turn every customer/config row into a memory."""
-    assert (
-        resolve_doc_memory("customers", "acme", {"plan": "business", "seats": 40})
-        is None
-    )
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"summary": "S"},  # summary alone is enough
+        {"summary": "S", "content": 42},  # non-string values still render
+        {"plan": "business", "seats": 40},  # bulk structured record
+    ],
+)
+def test_bodyless_docs_now_mint(data):
+    """CAURA-717 behaviour change: the old rule skipped anything without a
+    ``content``/``body`` key, which silently excluded eToro's entire doc feed.
+    Structured records now mint too — the accepted cost of not guessing."""
+    assert resolve_doc_memory("customers", "acme", data) is not None
+
+
+def test_structured_record_renders_its_fields():
+    spec = resolve_doc_memory("customers", "acme", {"plan": "business", "seats": 40})
+    assert spec is not None
+    assert "plan: business" in spec.content
+    assert "seats: 40" in spec.content
 
 
 # ── Summary is NOT required ───────────────────────────────────────────────────
@@ -145,7 +241,7 @@ def test_mints_without_summary():
     """
     spec = resolve_doc_memory("notes", "n1", {"content": "no summary here"})
     assert spec is not None
-    assert spec.content == "no summary here"
+    assert "no summary here" in spec.content
     assert "doc_summary" not in spec.metadata
 
 
@@ -159,17 +255,18 @@ def test_unusable_summary_still_mints(summary):
 # ── Size boundary ─────────────────────────────────────────────────────────────
 
 
-def test_body_at_exactly_the_cap_mints():
-    spec = resolve_doc_memory("notes", "n1", {"content": "y" * DOC_MEMORY_MAX_CHARS})
+def test_render_at_exactly_the_cap_mints():
+    """The cap applies to the RENDERED content, not to one field, so size it from
+    the render: ``"content: " + body`` is 9 chars longer than the body."""
+    body = "y" * (DOC_MEMORY_MAX_CHARS - len("content: "))
+    spec = resolve_doc_memory("notes", "n1", {"content": body})
     assert spec is not None
     assert len(spec.content) == DOC_MEMORY_MAX_CHARS
 
 
-def test_body_one_char_over_the_cap_skips():
-    assert (
-        resolve_doc_memory("notes", "n1", {"content": "y" * (DOC_MEMORY_MAX_CHARS + 1)})
-        is None
-    )
+def test_render_one_char_over_the_cap_skips():
+    body = "y" * (DOC_MEMORY_MAX_CHARS - len("content: ") + 1)
+    assert resolve_doc_memory("notes", "n1", {"content": body}) is None
 
 
 def test_oversized_body_skips_rather_than_truncating():
@@ -186,10 +283,21 @@ def test_cap_cannot_exceed_the_memory_schema_limit():
 
 
 def test_never_raises_on_hostile_input():
-    """The doc write is already committed by the time this runs, so an
-    undecidable input must be a skip — never an exception."""
-    for data in ({}, {"content": []}, {"content": {"a": 1}}, {"summary": object()}):
-        assert resolve_doc_memory("c", "d", data) is None  # type: ignore[arg-type]
+    """The doc write is already committed by the time this runs, so nothing here
+    may raise — an undecidable input either renders or skips, never throws.
+
+    ``object()`` is not JSON-serialisable; ``_render_value``'s ``default=str``
+    is what keeps it from blowing up.
+    """
+    for data in (
+        {},
+        {"content": []},
+        {"content": {"a": 1}},
+        {"summary": object()},
+        {"weird": object()},
+        {"nested": {"deep": [{"a": object()}]}},
+    ):
+        resolve_doc_memory("c", "d", data)  # type: ignore[arg-type]  # must not raise
 
 
 # ── Every skip is logged ──────────────────────────────────────────────────────
@@ -207,19 +315,20 @@ _LOGGER = "core_api.services.doc_indexing"
 def test_oversize_skip_logs_at_info(caplog):
     """INFO, not DEBUG: this is the surprising one. The doc is stored and
     searchable, but its body is silently unreachable by recall."""
+    # Sized from the RENDER, not the field: ``"content: " + body`` is 9 chars
+    # longer than the body, so the reported size is the rendered length.
+    body = "y" * (DOC_MEMORY_MAX_CHARS - len("content: ") + 1)
+    rendered_len = len("content: ") + len(body)
+    assert rendered_len == DOC_MEMORY_MAX_CHARS + 1
+
     with caplog.at_level(logging.DEBUG, logger=_LOGGER):
-        assert (
-            resolve_doc_memory(
-                "notes", "big", {"content": "y" * (DOC_MEMORY_MAX_CHARS + 1)}
-            )
-            is None
-        )
+        assert resolve_doc_memory("notes", "big", {"content": body}) is None
 
     recs = [r for r in caplog.records if r.name == _LOGGER]
     assert any(r.levelno == logging.INFO for r in recs)
     msg = " ".join(r.getMessage() for r in recs)
     assert "notes/big" in msg
-    assert str(DOC_MEMORY_MAX_CHARS + 1) in msg  # the actual size
+    assert str(rendered_len) in msg  # the actual rendered size
     assert str(DOC_MEMORY_MAX_CHARS) in msg  # the limit it exceeded
 
 
@@ -228,7 +337,7 @@ def test_oversize_skip_logs_at_info(caplog):
     [
         ("skills", {"content": "body"}),
         ("_keystones", {"content": "body"}),
-        ("customers", {"plan": "business"}),
+        ("customers", {}),  # empty render — the only content-based skip left
     ],
 )
 def test_routine_skips_log_at_debug_not_info(caplog, collection, data):

--- a/tests/test_doc_memory_sync.py
+++ b/tests/test_doc_memory_sync.py
@@ -10,7 +10,7 @@ Covers:
 - Identity resolution: the real doc writer wins; the service fallback is used
   only when the caller has no identity at all, and either way the agent is
   registered (else insights refuses to run for it).
-- The ``MemoryCreate`` payload: verbatim content, provenance ``source_uri``,
+- The ``MemoryCreate`` payload: spec content passed through unchanged, provenance ``source_uri``,
   ``scope_team``, and ``write_mode="fast"`` (load-bearing — it's what gives
   exact-dedup-without-semantic-reject on rewrites).
 - Which fields are shielded from enrichment: ``status`` is pinned ``active``
@@ -82,7 +82,7 @@ def patched(monkeypatch):
 
 async def test_creates_memory_with_expected_payload(patched):
     mem_id = await doc_memory.sync_doc_memory(
-        _spec("# H\n\nverbatim body"),
+        _spec("# H\n\nrendered body"),
         tenant_id="t1",
         fleet_id="f1",
         agent_id="agent-a",
@@ -90,7 +90,9 @@ async def test_creates_memory_with_expected_payload(patched):
 
     assert mem_id == "mem-1"
     (payload,) = patched.create_memory.call_args.args
-    assert payload.content == "# H\n\nverbatim body"  # verbatim
+    # ``sync_doc_memory`` passes the spec's content through unchanged — the
+    # render happens upstream in ``resolve_doc_memory``.
+    assert payload.content == "# H\n\nrendered body"
     assert payload.source_uri == "memclaw-doc://runbooks/pg-tuning"
     assert payload.tenant_id == "t1"
     assert payload.fleet_id == "f1"

--- a/tests/test_documents_rest_doc_memory.py
+++ b/tests/test_documents_rest_doc_memory.py
@@ -43,7 +43,7 @@ def test_both_surfaces_share_one_rule():
 
     assert mcp_spec == rest_spec
     assert mcp_spec is not None
-    assert mcp_spec.content == _BODY  # verbatim on both
+    assert _BODY in mcp_spec.content  # same render on both
 
 
 def test_rule_lives_in_one_module_only():
@@ -146,7 +146,7 @@ async def test_unindexed_branch_mints(rest_env):
     rest_env["sc"].upsert_document.assert_awaited_once()
     rest_env["spy"].assert_awaited_once()
     spec = rest_env["spy"].call_args.args[0]
-    assert spec.content == _BODY
+    assert _BODY in spec.content
     assert spec.source_uri == "memclaw-doc://runbooks/pg-tuning"
 
 
@@ -165,7 +165,7 @@ async def test_indexed_branch_mints(rest_env, monkeypatch):
 
     rest_env["sc"].upsert_document_xmax.assert_awaited_once()
     rest_env["spy"].assert_awaited_once()
-    assert rest_env["spy"].call_args.args[0].content == _BODY
+    assert _BODY in rest_env["spy"].call_args.args[0].content
 
 
 async def test_caller_agent_id_is_forwarded(rest_env):
@@ -178,12 +178,31 @@ async def test_caller_agent_id_is_forwarded(rest_env):
     assert rest_env["spy"].call_args.kwargs["agent_id"] == "agent-a"
 
 
-async def test_skips_mint_for_bodyless_doc(rest_env):
+async def test_bodyless_structured_record_now_mints(rest_env):
+    """CAURA-717: a record with no ``content``/``body`` key used to skip. It now
+    renders its fields instead — the change that unblocked eToro's doc feed."""
     mod = rest_env["module"]
 
     await mod.upsert_document.__wrapped__(
         request=AsyncMock(),
         body=_body(mod, collection="customers", data={"plan": "business", "seats": 40}),
+        auth=_auth(),
+        idempotency_key=None,
+    )
+
+    rest_env["spy"].assert_awaited_once()
+    content = rest_env["spy"].call_args.args[0].content
+    assert "plan: business" in content
+    assert "seats: 40" in content
+
+
+async def test_skips_mint_for_empty_payload(rest_env):
+    """The only content-based skip left: nothing usable to render."""
+    mod = rest_env["module"]
+
+    await mod.upsert_document.__wrapped__(
+        request=AsyncMock(),
+        body=_body(mod, collection="customers", data={}),
         auth=_auth(),
         idempotency_key=None,
     )

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -103,9 +103,7 @@ async def test_doc_read_missing_doc_id(mcp_env):
 
 async def test_doc_read_not_found(mcp_env, monkeypatch):
     stub_storage_client(monkeypatch, get_document=None)
-    out = await mcp_server.caura_doc(
-        op="read", collection="customers", doc_id="ghost"
-    )
+    out = await mcp_server.caura_doc(op="read", collection="customers", doc_id="ghost")
     assert "Not found: customers/ghost" in strip_latency(out)
 
 
@@ -155,9 +153,7 @@ async def test_doc_delete_not_found_envelope(mcp_env, monkeypatch):
 
 async def test_doc_delete_happy_path(mcp_env, monkeypatch):
     sc = stub_storage_client(monkeypatch, delete_document=True)
-    out = await mcp_server.caura_doc(
-        op="delete", collection="customers", doc_id="acme"
-    )
+    out = await mcp_server.caura_doc(op="delete", collection="customers", doc_id="acme")
     payload = parse_envelope(out)
     assert payload["ok"] is True
     assert payload["deleted"] is True
@@ -708,9 +704,7 @@ async def test_skill_query_scopes_to_active_when_no_status_when_flag_on(
     # sees live skills.
     _patch_flag(monkeypatch, True)
     sc = stub_storage_client(monkeypatch, query_documents=[])
-    await mcp_server.caura_doc(
-        op="query", collection="skills", where={"domain": "ops"}
-    )
+    await mcp_server.caura_doc(op="query", collection="skills", where={"domain": "ops"})
     sent = sc.query_documents.await_args.args[0]
     assert sent["where"]["status"] == "active"
     assert sent["where"]["domain"] == "ops"
@@ -769,9 +763,7 @@ async def test_skill_search_scoped_passes_active_status_when_flag_on(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
     sc = stub_storage_client(monkeypatch, search_documents_vector=[])
-    await mcp_server.caura_doc(
-        op="search", collection="skills", query="deploy eu-west"
-    )
+    await mcp_server.caura_doc(op="search", collection="skills", query="deploy eu-west")
     assert sc.search_documents_vector.await_args.args[0]["status"] == "active"
 
 
@@ -781,9 +773,7 @@ async def test_skill_search_scoped_no_status_when_flag_off(mcp_env, monkeypatch)
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
     sc = stub_storage_client(monkeypatch, search_documents_vector=[])
-    await mcp_server.caura_doc(
-        op="search", collection="skills", query="deploy eu-west"
-    )
+    await mcp_server.caura_doc(op="search", collection="skills", query="deploy eu-west")
     assert sc.search_documents_vector.await_args.args[0]["status"] is None
 
 
@@ -1008,9 +998,7 @@ async def test_skill_delete_hides_non_active_when_flag_on(mcp_env, monkeypatch):
     stub_storage_client(
         monkeypatch, delete_document=False
     )  # status guard matched nothing
-    out = await mcp_server.caura_doc(
-        op="delete", collection="skills", doc_id="forge/x"
-    )
+    out = await mcp_server.caura_doc(op="delete", collection="skills", doc_id="forge/x")
     payload = parse_envelope(out)  # must be valid JSON
     assert payload["error"] == "Document 'forge/x' not found in collection 'skills'"
 
@@ -1020,9 +1008,7 @@ async def test_skill_delete_allows_active_when_flag_on(mcp_env, monkeypatch):
     # deleted, storage returns True.
     _patch_flag(monkeypatch, True)
     stub_storage_client(monkeypatch, delete_document=True)
-    out = await mcp_server.caura_doc(
-        op="delete", collection="skills", doc_id="forge/x"
-    )
+    out = await mcp_server.caura_doc(op="delete", collection="skills", doc_id="forge/x")
     payload = parse_envelope(out)
     assert payload["deleted"] is True
 
@@ -1037,9 +1023,7 @@ async def test_skill_delete_fails_closed_on_settings_error(mcp_env, monkeypatch)
 
     monkeypatch.setattr(mcp_server, "_skills_factory_flag", _boom)
     sc = stub_storage_client(monkeypatch, delete_document=True)
-    out = await mcp_server.caura_doc(
-        op="delete", collection="skills", doc_id="forge/x"
-    )
+    out = await mcp_server.caura_doc(op="delete", collection="skills", doc_id="forge/x")
     payload = parse_envelope(out)
     assert payload["error"]["code"] == "INTERNAL_ERROR"
     # The DELETE must never have run.
@@ -1268,7 +1252,7 @@ async def test_doc_write_mints_memory_for_body_bearing_doc(
     assert parse_envelope(out)["ok"] is True
     spy_doc_memory.assert_awaited_once()
     spec = spy_doc_memory.call_args.args[0]
-    assert spec.content == "# Vacuum\n\nRun nightly."  # verbatim
+    assert "# Vacuum\n\nRun nightly." in spec.content  # rendered, body intact
     assert spec.source_uri == "memclaw-doc://runbooks/pg-tuning"
 
 
@@ -1290,8 +1274,8 @@ async def test_doc_write_mints_on_update_too(mcp_env, monkeypatch, spy_doc_memor
 @pytest.mark.parametrize(
     ("collection", "data"),
     [
-        ("customers", {"plan": "enterprise"}),  # no body
-        ("notes", {"content": ""}),  # empty body
+        ("customers", {}),  # empty payload — nothing to render
+        ("notes", {"content": ""}),  # only empty values
     ],
 )
 async def test_doc_write_skips_mint_per_shared_rule(


### PR DESCRIPTION
CAURA-704 minted the memory from ``data["content"]``, falling back to ``data["body"]``, and skipped the write when neither was present. In production at eToro that meant the feature could never fire.

Their only organic doc feed (``meeting-summaries``) writes ``{url, date, title, source, summary, platform, decisions, action_items, participants, duration_minutes}``. No ``content``. No ``body``. Every write returned 200, minted nothing, and logged the skip at DEBUG — so the feed looked healthy while the feature it was built for never ran once. Verified in prod: six docs written 2026-08-20, zero memories, all six "expected skip: no body".

The field guess was never defensible. ``documents.data`` has NO schema — it is free-form JSONB (``data: dict``, no required keys; even ``{}`` is a legal document), and the tool description says the body "lives wherever the caller puts it (e.g. data['content'])", offering ``content`` as an EXAMPLE rather than a contract. Nothing obliges a producer to use it and nothing validates it. A field-name list cannot be made correct, only longer.

So the memory now carries the WHOLE ``data`` payload rendered as text, with ``summary`` first. There is no body-field requirement: a document mints whenever it carries any usable data.

Why summary first, specifically: ``caura_insights`` truncates memory content to 500 chars (``sanitize_content``'s default), so whatever leads the render is what the reflection pass actually sees. A raw ``json.dumps(data)`` would spend ~250 of those chars on eToro's ``url``/``date``/``title``/``source`` and push ``decisions``/``action_items`` past the cut. Rendering summary-first puts the information-dense field inside every consumer's window — for their real doc shape the entire render is ~370 chars, so insights now sees the decisions and action items rather than the metadata.

Format is ``key: value`` lines rather than JSON because this text is embedded and fed to LLMs, for which braces and quotes are tokens that carry no meaning. ``summary`` is emitted as bare prose (no label) so the prefix reads naturally. String values pass through unmodified; lists/dicts become compact JSON with ``ensure_ascii=False`` so names and non-English text stay legible. ``default=str`` keeps a non-serialisable value from raising, since nothing here may fail the doc write. Empty values are dropped — they waste prefix budget.

Two accepted consequences, both deliberate:

- Bulk structured records (``{"plan": "business", "seats": 40}``) now mint, where the old rule excluded them as a side effect of requiring a body field. A sync writing many small documents therefore produces one memory per document. That is the cost of not guessing.
- "content is byte-identical to a field" becomes "lossless render of the record". Byte-fidelity was only ever a means to *don't truncate, don't paraphrase*, which the render preserves — every non-empty field is present and strings are untouched.

Server-written collections are unaffected: ``ingest-sources``, ``interview_jobs`` and ``skills_rollback`` are written through ``sc.upsert_document`` directly and never reach this code path, so no ingested content is duplicated. ``skills`` and ``_``-prefixed collections keep their skips — minting a skill body would route around the staged -> active approval lifecycle.

Reviewer note, untested in production: the memory content is what ``BusinessPersonalPregate`` classifies, and eToro runs ``non_business.disposition="drop"`` with ``pregate.enabled`` and ``fail_closed=true``. The render now also includes ``participants`` — real names — which pushes the classifier marginally toward "personal", and a drop is swallowed by ``safe_sync_doc_memory`` so the doc write still returns 200. Worth pushing one real meeting doc through the pregate before rollout; excluding ``participants`` from the render sidesteps it at the cost of losing who-was-there from recall.

Also fixes the size cap to measure the RENDER rather than one field — the ``key: `` labels and separators make the render slightly longer, so a doc can be under the cap on its body and over it once rendered.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
