### PR TITLE
ci(mypy): put common/ under the type gate, and fix what it was hiding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,37 @@ jobs:
         # along, nothing ever ran it.
         run: cd core-worker && uv run mypy src/
 
+      - name: Run mypy (common/)
+        # common/ was type-checked by NOTHING before this step. Each mypy step
+        # above ``cd``s into one service and checks that service's own src/, so
+        # no invocation's path ever resolved to common/ — while 40 files under
+        # core-api/src alone import it. Those imports were not caught either:
+        # ``ignore_missing_imports = true`` (every service sets it) plus a
+        # ``mypy_path`` of just that service's src/ means an unresolved
+        # ``common.*`` import degrades to Any in silence rather than failing.
+        # ``cd core-api && mypy src/`` reported 199 files and none of them were
+        # common/'s 94.
+        #
+        # Nor did the hook cover it: .pre-commit-config.yaml deliberately runs no
+        # mypy, deferring to "CI is the authoritative type-check" — which pointed
+        # at a check that did not include this directory.
+        #
+        # What it was hiding: 12 errors in 7 files, all fixed in the commit that
+        # added this step. Two were ``# type: ignore[...]`` comments naming an
+        # error code mypy does not report here (``arg-type`` for an overload
+        # failure, ``import-untyped`` for a namespace-package attribute), so they
+        # suppressed nothing — nobody could have known, because nothing ever ran
+        # mypy over these files to say so.
+        #
+        # ``--config-file`` is required, not stylistic: common/ has no
+        # pyproject.toml and the repo root has no [tool.mypy], and mypy resolves
+        # config from the CWD rather than walking up from the files it checks
+        # (ruff does walk up, which is why common/ruff.toml needs no flag). Drop
+        # the flag and this runs at mypy's bare defaults, which reports 17 —
+        # the 12 plus 5 missing-stub errors for optional deps — so the failure
+        # mode is a noisier gate, not an absent one. See common/mypy.ini.
+        run: uv run mypy --config-file common/mypy.ini common/
+
       - name: Enable pgvector extension
         run: PGPASSWORD=changeme psql -h localhost -U memclaw -d memclaw -c "CREATE EXTENSION IF NOT EXISTS vector;"
 

--- a/common/embedding/_service.py
+++ b/common/embedding/_service.py
@@ -23,7 +23,7 @@ from common.embedding.constants import (
     EMBEDDING_RETRY_ATTEMPTS,
     EMBEDDING_RETRY_DELAY_S,
 )
-from common.embedding.protocols import InstructionAwareEmbedder
+from common.embedding.protocols import EmbeddingProvider, InstructionAwareEmbedder
 
 logger = logging.getLogger(__name__)
 
@@ -791,7 +791,7 @@ async def _run_with_retry(
 async def _resolve_provider_or_degrade(
     tenant_config: object | None,
     context: str,
-) -> object | None:
+) -> EmbeddingProvider | None:
     """Resolve the embedding provider, mapping a misconfiguration
     ``ValueError`` from the registry to the same ``None`` degradation
     contract the rest of this module documents.
@@ -936,14 +936,21 @@ async def get_query_embedding(
     # not implement ``embed_query`` and the isinstance check returns
     # False — they fall through to :meth:`embed` and silently ignore
     # *instruction*.
-    is_instruction_aware = isinstance(provider, InstructionAwareEmbedder)
+    #
+    # Bound to the narrowed provider rather than to a bare bool: the isinstance
+    # still runs exactly once here, but a ``bool`` would not carry the narrowing
+    # into the closure below, and ``embed_query`` is deliberately absent from
+    # ``EmbeddingProvider`` — so a bool leaves that call unverifiable.
+    instruction_aware = (
+        provider if isinstance(provider, InstructionAwareEmbedder) else None
+    )
 
     async def _call() -> list[float]:
         # Inner ``def`` rather than a ``lambda`` so the closure captures
         # *provider* / *text* / *instruction* with explicit ``await``
         # ergonomics; ruff E731 disapproves of ``make_call = lambda:``.
-        if is_instruction_aware:
-            return await provider.embed_query(text, instruction)
+        if instruction_aware is not None:
+            return await instruction_aware.embed_query(text, instruction)
         return await provider.embed(text)
 
     return await _run_with_retry(

--- a/common/embedding/providers/local.py
+++ b/common/embedding/providers/local.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 from common.constants import VECTOR_DIM
 
@@ -20,7 +21,13 @@ class LocalEmbedding:
 
     def __init__(self, model_name: str = "BAAI/bge-base-en-v1.5") -> None:
         self._model_name = model_name
-        self._model = None
+        # ``SentenceTransformer`` is imported inside ``_ensure_model`` to keep
+        # sentence-transformers optional (see the module docstring), so there is
+        # no importable type to name here and ``Any`` is the honest annotation.
+        # Stated rather than left implicit: from the bare ``None`` sentinel mypy
+        # infers the attribute's type as ``None``, which made both
+        # ``self._model.encode`` calls below errors against ``None``.
+        self._model: Any = None
         self._load_lock = asyncio.Lock()
 
     @property

--- a/common/enrichment/service.py
+++ b/common/enrichment/service.py
@@ -118,11 +118,12 @@ def _validate_enrichment(raw: dict, llm_ms: int) -> EnrichmentResult:
     parsed_ts: dict[str, datetime | None] = {}
     for ts_field in ("ts_valid_start", "ts_valid_end"):
         val = raw.get(ts_field)
-        if val and isinstance(val, str):
-            parsed_ts[ts_field] = _parse_temporal(val)
-        else:
-            parsed_ts[ts_field] = None
-        raw[ts_field] = parsed_ts[ts_field].isoformat() if parsed_ts[ts_field] else None
+        parsed = _parse_temporal(val) if val and isinstance(val, str) else None
+        parsed_ts[ts_field] = parsed
+        # Via the local, not a repeated ``parsed_ts[ts_field]`` subscript: the
+        # guard and the use were two separate index expressions, which mypy does
+        # not narrow against each other.
+        raw[ts_field] = parsed.isoformat() if parsed else None
     # Ensure end > start; drop invalid end
     start, end = parsed_ts["ts_valid_start"], parsed_ts["ts_valid_end"]
     if start and end and end <= start:
@@ -210,11 +211,11 @@ def fake_enrich(content: str) -> EnrichmentResult:
     if any(
         kw in lower for kw in ("decided", "chose", "going with", "approved", "we will")
     ):
-        mt, w = "decision", 0.85
+        mt, w = MemoryType.DECISION, 0.85
     elif any(
         kw in lower for kw in ("prefers", "likes", "always wants", "rather", "favorite")
     ):
-        mt, w = "preference", 0.70
+        mt, w = MemoryType.PREFERENCE, 0.70
     elif any(
         kw in lower
         for kw in (
@@ -237,28 +238,28 @@ def fake_enrich(content: str) -> EnrichmentResult:
             "mandatory",
         )
     ):
-        mt, w = "rule", 0.85
+        mt, w = MemoryType.RULE, 0.85
     elif any(
         kw in lower
         for kw in ("deployed", "happened", "launched", "met with", "incident")
     ):
-        mt, w = "episode", 0.65
+        mt, w = MemoryType.EPISODE, 0.65
     elif any(kw in lower for kw in ("task", "todo", "assigned", "need to", "must")):
-        mt, w, st = "task", 0.70, "pending"
+        mt, w, st = MemoryType.TASK, 0.70, "pending"
     elif any(kw in lower for kw in ("plan", "steps", "roadmap", "strategy")):
-        mt, w, st = "plan", 0.75, "pending"
+        mt, w, st = MemoryType.PLAN, 0.75, "pending"
     elif any(kw in lower for kw in ("commit", "promise", "guarantee", "agreed to")):
-        mt, w, st = "commitment", 0.80, "pending"
+        mt, w, st = MemoryType.COMMITMENT, 0.80, "pending"
     elif any(kw in lower for kw in ("cancelled", "abandoned", "stopped", "withdrew")):
-        mt, w = "cancellation", 0.65
+        mt, w = MemoryType.CANCELLATION, 0.65
     elif any(kw in lower for kw in ("result", "outcome", "achieved", "completed")):
-        mt, w, st = "outcome", 0.70, "confirmed"
+        mt, w, st = MemoryType.OUTCOME, 0.70, "confirmed"
     elif any(kw in lower for kw in ("intend", "aim", "goal", "want to")):
-        mt, w = "intention", 0.65
+        mt, w = MemoryType.INTENTION, 0.65
     elif any(kw in lower for kw in ("did", "executed", "performed", "ran")):
-        mt, w = "action", 0.65
+        mt, w = MemoryType.ACTION, 0.65
     else:
-        mt, w = "fact", 0.70
+        mt, w = MemoryType.FACT, 0.70
 
     words = content.split()
     title = " ".join(words[:10]) + ("..." if len(words) > 10 else "")

--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -258,7 +258,12 @@ class PubSubEventBus(EventBus):
     @staticmethod
     def _ensure_pubsub_sdk() -> Any:
         try:
-            from google.cloud import pubsub_v1  # type: ignore[import-untyped]
+            # ``attr-defined``, not ``import-untyped``: ``google.cloud`` is a
+            # namespace package, so with google-cloud-pubsub installed (as CI
+            # has it, via the storage-api ``pubsub`` extra) mypy resolves the
+            # parent and rejects the submodule as a missing attribute. The
+            # absent case is already covered by ignore_missing_imports.
+            from google.cloud import pubsub_v1  # type: ignore[attr-defined]
 
             return pubsub_v1
         except ImportError as exc:

--- a/common/llm/providers/openai.py
+++ b/common/llm/providers/openai.py
@@ -67,8 +67,13 @@ def _usage_tokens(response) -> tuple[int, int, int]:
     def _int(value: object) -> int:
         # Coerce defensively: OpenAI-compatible endpoints return None or
         # omit fields, and unit-test stubs return non-numeric attributes.
+        # The ignore code is ``call-overload``, not ``arg-type``: ``int`` is
+        # overloaded, so passing ``object`` fails overload resolution rather
+        # than a single argument's type. It read ``arg-type`` until common/
+        # entered the mypy gate, which is the first thing that ran mypy here
+        # and reported the mismatch.
         try:
-            return int(value)  # type: ignore[arg-type]
+            return int(value)  # type: ignore[call-overload]
         except (TypeError, ValueError):
             return 0
 

--- a/common/mypy.ini
+++ b/common/mypy.ini
@@ -1,0 +1,48 @@
+# mypy contract for common/ — pinned deliberately, and SHARED VERBATIM between
+# caura (OSS) and caura-enterprise. Sibling of common/ruff.toml; same directory,
+# same reason.
+#
+# WHY THIS FILE EXISTS: common/ has no pyproject.toml of its own (it is
+# PYTHONPATH-mounted, not pip-installed) and neither repo has a root
+# [tool.mypy]. Unlike ruff, mypy resolves config from the CWD only — it does not
+# walk up from the files being checked — so a repo-root ``mypy common/`` gets
+# mypy's bare CLI defaults, which are NOT the settings every service applies to
+# its own src/. Two differences, both measured on the tree that added this file:
+#
+#   * ignore_missing_imports is off by default, so common/'s optional and
+#     unstubbed imports (sentence_transformers, ddtrace, google.cloud, jose)
+#     report as missing-stub errors instead of degrading to Any: 5 such errors
+#     in OSS and 3 in enterprise, none of them a finding. That noise is what
+#     makes a defaults-based gate unlandable, and silencing it per-line would
+#     have meant eight ignores for a setting the services already agree on.
+#   * check_untyped_defs is off by default, so the bodies of unannotated
+#     functions go unchecked — a gate weaker than the one each service's src/
+#     already gets, which is the opposite of the point.
+#
+# Pass it explicitly: ``mypy --config-file common/mypy.ini common/``. There is no
+# per-directory discovery to rely on, so a step that forgets the flag silently
+# checks at defaults rather than failing — see the CI steps in both repos.
+#
+# WHY IT IS BYTE-IDENTICAL ACROSS REPOS: enterprise vendors common/ and its
+# scripts/vendored_files_manifest.json classifies this file ``identical``, so
+# check_vendored_drift.py fails on any divergence. Edit it in OSS; the re-vendor
+# bot mirrors it downstream. As with common/ruff.toml, ``python_version`` is the
+# LOWER bound of the two trees (py312 in OSS, py313 in enterprise) so the shared
+# config never assumes a version OSS does not run.
+#
+# The settings below are exactly the [tool.mypy] block that all four OSS services
+# and all six enterprise platform services already carry, verbatim and with
+# nothing added. That is deliberate: common/ is checked on the same terms as the
+# src/ trees that import it, so moving code between them does not change how it
+# is type-checked. mypy_path is the one service setting omitted — it points at
+# each service's own src/, and common/ resolves from the repo root without it.
+
+[mypy]
+python_version = 3.12
+explicit_package_bases = True
+warn_return_any = False
+warn_unused_ignores = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+check_untyped_defs = True
+ignore_missing_imports = True

--- a/common/ranking/providers/local.py
+++ b/common/ranking/providers/local.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 from common.ranking.constants import RANK_MAX_LENGTH, RANK_MODEL
 from common.ranking.errors import PermanentRankError
@@ -33,7 +34,15 @@ class LocalCrossEncoderRanker:
     ) -> None:
         self._model_name = model_name
         self._max_length = max_length
-        self._model = None
+        # ``CrossEncoder`` is imported inside ``_ensure_model`` to keep
+        # sentence-transformers optional (see the module docstring), so there is
+        # no importable type to name here and ``Any`` is the honest annotation.
+        # It has to be stated: from the bare ``None`` sentinel mypy infers the
+        # attribute's type as ``None`` itself, which made ``self._model.predict``
+        # below an error against ``None`` rather than against the model, and made
+        # the executor call in ``_ensure_model`` infer its result type as
+        # ``None`` too.
+        self._model: Any = None
         self._load_lock = asyncio.Lock()
 
     @property

--- a/common/ranking/providers/remote.py
+++ b/common/ranking/providers/remote.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 import logging
+from typing import cast
 
 import httpx
 
@@ -284,4 +285,12 @@ class RemoteRanker:
                 failures[0],
             )
 
-        return [score for chunk_scores in results for score in chunk_scores]
+        # ``failures`` is empty here, so every element is a ``list[float]`` —
+        # but that follows from the raise above, which mypy cannot carry back
+        # into ``results``. Re-testing each element would imply the exception
+        # case is still reachable; the cast says it is not.
+        return [
+            score
+            for chunk_scores in cast("list[list[float]]", results)
+            for score in chunk_scores
+        ]


### PR DESCRIPTION
## The gap

`common/` is type-checked by **nothing** on `origin/main`.

CI runs mypy four times (ci.yml:233, :236, :242, :248). Each one `cd`s into a
single service and checks that service's own `src/`, so no invocation's path
ever resolves to `common/`. Lint does cover it — `ruff check common/` at :167 —
so the directory looks gated at a glance.

The service runs don't cover it transitively either. 40 files under
`core-api/src` import `common`, but every service sets
`ignore_missing_imports = true` with a `mypy_path` of just its own `src/`, so
`common/` sits outside the search path and each `common.*` import degrades to
`Any` in silence. Measured: `cd core-api && mypy src/` reports **199 source
files** and none of them are `common/`'s 94.

Nor does the hook. `.pre-commit-config.yaml:23-27` deliberately runs no mypy and
defers to CI as *"the authoritative type-check"* — a deferral pointing at a
check that did not include this directory.

## What it was hiding

**12 errors in 7 files**, measured on `origin/main` before anything changed.
All 12 are fixed here; `common/` is clean at the new gate.

Two are worth calling out on their own. `# type: ignore[arg-type]` in
`llm/providers/openai.py` and `# type: ignore[import-untyped]` in
`events/pubsub.py` both name error codes mypy does **not** report at those lines
(an overload failure, and a namespace-package attribute). Neither suppressed
anything. Nobody could have known — nothing had ever run mypy over these files
to say so.

The other ten are declared types too narrow or too loose to verify the code
around them:

| file | was | fix |
|---|---|---|
| `ranking/providers/local.py`, `embedding/providers/local.py` | `self._model = None` unannotated → mypy infers the attribute's type as `None`, so every `.predict`/`.encode` errors against `None` (and in the ranking case the inference flows backwards into the model-loading lambda) | annotate `Any` — what a lazily-imported optional dep can honestly claim |
| `embedding/_service.py` | resolver returned `object \| None` though the registry it calls already returns `EmbeddingProvider`; 3 call sites couldn't see `embed` | narrow to the protocol; the `InstructionAwareEmbedder` dispatch now binds the narrowed provider instead of a bool, so `embed_query` is checked rather than assumed |
| `ranking/providers/remote.py`, `enrichment/service.py` | guards mypy can't follow — a raise on a separately-built failure list; a dict subscript used as both guard and value | narrow at the binding |
| `enrichment/service.py` | heuristic classifier passed bare strings for `memory_type` | use the `MemoryType` members, so the 13th branch someone adds is checked rather than trusted |

No `# type: ignore` is added without a reason on the line, and no existing check
is loosened. The `memory_type` literals were all valid members already — that
one buys future checking, not a bug fix.

## Why `common/mypy.ini`

Sibling of `common/ruff.toml`, and it exists for the same reason that file does:
`common/` has no `pyproject.toml` and neither repo has a root `[tool.mypy]`.
Unlike ruff, **mypy resolves config from the CWD rather than walking up from the
files it checks**, so `--config-file` is required rather than stylistic. Drop the
flag and the step runs at mypy's bare defaults and reports 17 — the 12 plus 5
missing-stub errors for optional deps — so the failure mode is a noisier gate,
not an absent one.

Its settings are the `[tool.mypy]` block all four services already carry,
verbatim and with nothing added, so `common/` is checked on the same terms as the
`src/` trees that import it. `python_version` is py312 — the lower bound of the
two trees — for the reason `common/ruff.toml` pins `target-version` the same way.

## Cross-repo and cross-lane notes

- **`caura-enterprise` gets the same gate in its own PR.** There, `common/`
  measured **clean (0 errors, 33 files)**, so it is a CI-step change only. That
  copy of `common/mypy.ini` will be classified `identical` in
  `vendored_files_manifest.json`, and `check_vendored_drift.py` fails an
  `identical` entry that is missing upstream — **so this PR must land first.**
  (The reverse direction is safe: the gate's unclassified-file check iterates the
  enterprise tree, so an OSS-only new file cannot wedge enterprise CI.)
- **Lane P is mid-cutover in `common/events/`.** This touches
  `events/pubsub.py` — one comment line at :261, correcting that ignore code.
  Lane P's hunks on that file are at ~48/126/156/439/497, so there is no textual
  overlap, but flagging it rather than letting it surface in a merge.
- Only 10 files are vendored into enterprise (4 `identical`, 6 `manual` =
  `events/*`). `events/pubsub.py` is `manual` policy and already divergent
  between the trees, so this change does not need a matching enterprise edit.

## Verification

Run from the repo root with CI's own env (`uv pip install -e` all four services):

- `mypy --config-file common/mypy.ini common/` → clean (94 files); was 12 errors
- `ruff check common/` → clean
- `ruff format --check --isolated common/{__init__,structlog_config,serve}.py` → clean
- all four service mypy steps → unchanged, clean (199 / 83 / 5 / 11 files)
- `pytest tests/` filtered to enrich/embed/rank/pubsub/event/llm → 888 passed, 1 skipped
- the 7 test files exercising `fake_enrich` → 138 passed
- `actionlint` → same one pre-existing finding as `origin/main`, none added
- `ruff check` and `ruff format` run separately and scoped; `ruff format` was not
  run over `common/`