### PR TITLE
fix(apm): stop Pub/Sub pull timeouts from reporting as error spans

### DIFF
--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -47,6 +47,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from common.events import trace_filters
 from common.events.base import Event, EventBus, EventHandler
 from common.events.topics import publish_name, subscribe_names, unbound_publish_topics
 
@@ -569,6 +570,24 @@ class PubSubEventBus(EventBus):
         # gRPC channel. publish() handles the off-loop construction
         # lazily on the first call (see ``_ensure_publisher``).
         if topic_count > 0:
+            # Inside this branch, not at the top of start(): the spans this
+            # corrects come from the pull loop, so a publisher-only bus can
+            # never produce one and shouldn't pay for the filter — and
+            # registering it calls tracer.configure(), which recreates the
+            # trace writer.
+            #
+            # Registered here rather than at import for the same reason.
+            # Idempotent, never raises, and a no-op when ddtrace isn't
+            # installed. See trace_filters for the measurement that motivated
+            # it. Logged either way so "pull spans are still showing as errors"
+            # is one grep from the answer instead of a guess about whether the
+            # filter ever loaded. The negative branch doesn't name a cause:
+            # False means ddtrace is absent OR registration failed, and
+            # install() warns about the latter itself.
+            if trace_filters.install():
+                logger.debug("Pub/Sub pull-timeout span filter registered")
+            else:
+                logger.debug("Pub/Sub pull-timeout span filter not registered")
             loop = asyncio.get_running_loop()
             # Snapshot the stop generation BEFORE the shielded await.
             # A clean ``stop()`` resets both ``_stopped`` and

--- a/common/events/trace_filters.py
+++ b/common/events/trace_filters.py
@@ -1,0 +1,152 @@
+"""APM span corrections for Pub/Sub's pull loop.
+
+``PubSubEventBus._pull_loop`` calls ``subscriber.pull(timeout=...)``. When no
+message arrives inside that window, gRPC returns ``DEADLINE_EXCEEDED`` and the
+pull loop treats it as the non-event it is::
+
+    except gexc.DeadlineExceeded:
+        # No messages in the pull window; loop back and try again.
+        continue
+
+ddtrace's gRPC integration, however, wraps the call and marks the span failed
+on any non-OK status before that ``except`` ever runs
+(``contrib/internal/grpc/client_interceptor.py``: ``if response_code !=
+grpc.StatusCode.OK`` -> ``span.error = 1``, with no per-status configuration to
+opt out of). An idle subscriber therefore manufactures error spans at one per
+empty window, forever.
+
+Measured over 24h before this existed: 51,568 such spans from core-api in
+staging alone, against 617 in prod — an idle deployment is far noisier than a
+busy one, because a pull that returns messages succeeds. In prod this resource
+was still the single largest source of error spans (1,223 of ~3,163).
+
+This clears ``span.error`` for that exact case and nothing else. The span is
+kept, not dropped: a pull that fails for a real reason (NotFound,
+PermissionDenied) still arrives as an error, and the timing of poll waits stays
+visible. ``StatusCode.CANCELLED`` — a pull interrupted by shutdown — is also
+left alone, since it says something true about the process.
+
+User trace processors run before the writer (``SpanAggregator.on_span_finish``
+chains ``user_processors`` ahead of sampling and the writer), so the payload the
+Agent receives — and computes APM stats from — already has ``error: 0``. That is
+what makes this fix the error-rate metric and any monitor on it, not just what
+Error Tracking displays.
+
+The ``error.*`` tags are deliberately left in place. ddtrace 4.x offers no
+public way to remove a tag: ``set_tag(k, None)`` stores the *string* ``"None"``,
+and the only thing that really removes one is ``Span._remove_attribute``, a
+private method on a native-backed span. Since ``span.error`` is what the above
+keys on, keeping the tags costs nothing and leaves the timeouts queryable on
+purpose (``@error.type:StatusCode.DEADLINE_EXCEEDED``) rather than merely
+absent.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ddtrace is an optional dependency — only the `datadog` extra installs it.
+# Guarded exactly like common/structlog_config.py so installs without it keep
+# importing this module. Top-level (not deferred) so the names are patchable in
+# tests.
+try:
+    from ddtrace.constants import ERROR_TYPE as _ERROR_TYPE
+    from ddtrace.trace import TraceFilter as _TraceFilter
+    from ddtrace.trace import tracer as _dd_tracer
+except ImportError:  # pragma: no cover - exercised only in non-datadog installs
+    _ERROR_TYPE = "error.type"
+    _TraceFilter = object  # type: ignore[assignment,misc]
+    _dd_tracer = None  # type: ignore[assignment]
+
+# The gRPC method the pull loop calls. Matched exactly rather than by prefix so
+# a future Pub/Sub call that genuinely fails is never swept up.
+PULL_RESOURCE = "/google.pubsub.v1.Subscriber/Pull"
+
+# Substring, not equality: ddtrace records this as the stringified enum
+# (``StatusCode.DEADLINE_EXCEEDED``), and that repr is not something to depend
+# on staying byte-identical across grpc/ddtrace versions.
+_DEADLINE_EXCEEDED = "DEADLINE_EXCEEDED"
+
+# Guard so repeated start() calls in one process don't re-register. See
+# install() for why re-registering would be actively harmful rather than merely
+# redundant.
+_installed = False
+
+
+class PubSubPullDeadlineFilter(_TraceFilter):  # type: ignore[misc,valid-type]
+    """Clear ``span.error`` on Pub/Sub pull spans that only timed out."""
+
+    def process_trace(self, trace: list[Any]) -> list[Any]:
+        # Runs on every trace this process flushes, so the tests are ordered
+        # cheapest-first: an int attribute, then a string compare, and only
+        # then the tag lookup (a call into ddtrace's native span).
+        for span in trace:
+            if not span.error:
+                continue
+            if span.resource != PULL_RESOURCE:
+                continue
+            error_type = span.get_tag(_ERROR_TYPE) or ""
+            if _DEADLINE_EXCEEDED in error_type:
+                span.error = 0
+        # Always return the trace — returning None would drop it entirely.
+        return trace
+
+
+def install() -> bool:
+    """Register the filter with the global tracer. Idempotent.
+
+    Returns True when the filter is registered, False when it isn't — either
+    because ddtrace is absent or because registration failed. Never raises:
+    this is a reporting correction, and nothing here is worth failing a
+    service's startup over.
+    """
+    global _installed
+
+    if _dd_tracer is None:
+        return False
+    if _installed:
+        return True
+
+    # configure(trace_processors=...) REPLACES the user-processor list rather
+    # than appending to it (Tracer.configure -> _recreate ->
+    # SpanAggregator.reset(user_processors=...)), so a bare call here would
+    # silently evict any processor registered before us — no error, no warning,
+    # tracing just quietly stops doing whatever that one did. `common/` is
+    # shared by every service here, so "nobody else registers one today" is a
+    # fact with a short shelf life.
+    #
+    # Read what's already registered and pass it back through, making this
+    # additive. Any future processor should be added the same way; if a second
+    # one appears, hoist this read-append-configure into a shared helper rather
+    # than repeating it.
+    #
+    # The aggregator is private, hence the getattr: if ddtrace renames it on
+    # upgrade we fall back to replace-the-list behaviour instead of raising
+    # during service startup. The whole block is wrapped for the same reason —
+    # configure() is public but not immune, and a signature change across a
+    # major ddtrace bump would otherwise raise straight out of
+    # PubSubEventBus.start() and take the service down at boot. Trading correct
+    # error rates for a service that starts is not a trade worth making.
+    try:
+        aggregator = getattr(_dd_tracer, "_span_aggregator", None)
+        existing = list(getattr(aggregator, "user_processors", None) or [])
+        _dd_tracer.configure(trace_processors=[*existing, PubSubPullDeadlineFilter()])
+    except Exception:
+        # Broad on purpose — every failure mode here is one we'd rather absorb
+        # than raise, and enumerating ddtrace's internal exception types would
+        # be a guess that rots on upgrade. Warning, not debug: the symptom
+        # (Pub/Sub pull timeouts still counted as errors) is confusing enough
+        # that it needs to name itself in the logs.
+        logger.warning(
+            "Failed to register the Pub/Sub pull-timeout span filter; empty "
+            "pull windows will keep reporting as errors in APM",
+            exc_info=True,
+        )
+        # _installed deliberately left False so a later start() retries.
+        return False
+
+    _installed = True
+    return True

--- a/tests/test_pubsub_trace_filters.py
+++ b/tests/test_pubsub_trace_filters.py
@@ -1,0 +1,318 @@
+"""The Pub/Sub pull-timeout span filter must clear exactly that case.
+
+Regression cover for the finding described in ``common/events/trace_filters``:
+an idle subscriber's empty pull windows were arriving in APM as error spans,
+drowning real failures — 51,568 of them from core-api in staging in 24h. The
+risk in fixing it is over-reach — a filter that clears too much hides genuine
+outages — so most of what follows pins down what must *stay* an error.
+
+These tests deliberately do NOT require ddtrace. CI installs only each
+service's ``[dev]`` extra, never ``datadog``, so a module-level
+``importorskip("ddtrace")`` would skip this file in the one environment that
+gates merges — shipping the filter with no coverage at all. The filter only
+ever touches ``.error``, ``.resource`` and ``.get_tag()``, so a stub span
+covers it, and ``_FIDELITY`` below pins the stub to the real Span shape
+whenever the extra happens to be installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from common.events import trace_filters
+from common.events.pubsub import PubSubEventBus
+from common.events.trace_filters import (
+    PULL_RESOURCE,
+    PubSubPullDeadlineFilter,
+)
+
+# The key ddtrace records the gRPC status under. Equal to
+# ``ddtrace.constants.ERROR_TYPE``; asserted in test_stub_matches_a_real_span.
+ERROR_TYPE = "error.type"
+
+
+class _StubSpan:
+    """The subset of ddtrace's Span that the filter actually uses."""
+
+    def __init__(
+        self, resource: str, *, error: int, error_type: str | None = None
+    ) -> None:
+        self.resource = resource
+        self.error = error
+        self._tags: dict[str, str] = {}
+        if error_type is not None:
+            self._tags[ERROR_TYPE] = error_type
+
+    def get_tag(self, key: str) -> str | None:
+        return self._tags.get(key)
+
+
+def _span(resource: str, *, error: int, error_type: str | None = None) -> _StubSpan:
+    return _StubSpan(resource, error=error, error_type=error_type)
+
+
+def test_clears_error_on_pull_deadline() -> None:
+    span = _span(PULL_RESOURCE, error=1, error_type="StatusCode.DEADLINE_EXCEEDED")
+
+    out = PubSubPullDeadlineFilter().process_trace([span])
+
+    assert span.error == 0, "an empty pull window is not an error"
+    # The span itself must survive: dropping it would also hide the real
+    # failures this resource can produce, and lose poll timing.
+    assert out is not None and span in out
+
+
+def test_returns_trace_rather_than_dropping_it() -> None:
+    """Returning None from process_trace discards the whole trace."""
+    span = _span(PULL_RESOURCE, error=1, error_type="StatusCode.DEADLINE_EXCEEDED")
+    other = _span("/some.other.Service/Call", error=0)
+
+    out = PubSubPullDeadlineFilter().process_trace([span, other])
+
+    assert out == [span, other]
+
+
+@pytest.mark.parametrize(
+    ("resource", "error_type", "why"),
+    [
+        (
+            PULL_RESOURCE,
+            "StatusCode.PERMISSION_DENIED",
+            "a pull that is genuinely forbidden must stay an error",
+        ),
+        (
+            PULL_RESOURCE,
+            "StatusCode.NOT_FOUND",
+            "a missing subscription halts the loop and must stay an error",
+        ),
+        (
+            PULL_RESOURCE,
+            "StatusCode.CANCELLED",
+            # Observed for real alongside the timeouts: a pull interrupted by
+            # shutdown. It says something true about the process, so it is not
+            # this filter's business.
+            "a cancelled pull is not a timeout and must stay an error",
+        ),
+        (
+            "/google.pubsub.v1.Publisher/Publish",
+            "StatusCode.DEADLINE_EXCEEDED",
+            "a publish timeout loses an event and must stay an error",
+        ),
+        (
+            "/google.pubsub.v1.Subscriber/StreamingPull",
+            "StatusCode.DEADLINE_EXCEEDED",
+            "only the exact resource the pull loop calls is corrected",
+        ),
+    ],
+)
+def test_leaves_other_errors_alone(resource: str, error_type: str, why: str) -> None:
+    span = _span(resource, error=1, error_type=error_type)
+
+    PubSubPullDeadlineFilter().process_trace([span])
+
+    assert span.error == 1, why
+
+
+def test_ignores_spans_that_are_not_errors() -> None:
+    """A successful pull must not be touched, so nothing can be masked."""
+    span = _span(PULL_RESOURCE, error=0)
+
+    PubSubPullDeadlineFilter().process_trace([span])
+
+    assert span.error == 0
+
+
+def test_survives_a_missing_error_type_tag() -> None:
+    """An error span with no error.type must not raise inside the filter.
+
+    ddtrace wraps each processor in its own try/except, so a raise here would
+    not lose traces — it would log.error on every single flush and silently
+    stop correcting anything. Quiet-but-broken, which is the worse failure.
+    """
+    span = _span(PULL_RESOURCE, error=1)  # error set, tag absent
+
+    PubSubPullDeadlineFilter().process_trace([span])
+
+    assert span.error == 1, "no error.type means no evidence it was a timeout"
+
+
+def test_stub_matches_a_real_span() -> None:
+    """Guard against _StubSpan drifting from the thing it stands in for.
+
+    Skipped in CI, which installs no `datadog` extra — the point is to catch
+    drift locally or in a datadog-enabled build, so the stub-based tests above
+    stay trustworthy.
+    """
+    pytest.importorskip("ddtrace", reason="only the `datadog` extra installs it")
+
+    from ddtrace.constants import ERROR_TYPE as REAL_ERROR_TYPE
+    from ddtrace.trace import tracer
+
+    assert REAL_ERROR_TYPE == ERROR_TYPE, "the tag key the stub uses has moved"
+
+    real = tracer.start_span("grpc")
+    real.resource = PULL_RESOURCE
+    real.error = 1
+    real.set_tag(REAL_ERROR_TYPE, "StatusCode.DEADLINE_EXCEEDED")
+
+    PubSubPullDeadlineFilter().process_trace([real])
+
+    assert real.error == 0, "the filter must behave the same on a real Span"
+
+
+class _FakeAggregator:
+    def __init__(self, user_processors: list[object]) -> None:
+        self.user_processors = user_processors
+
+
+class _RecordingTracer:
+    """Stands in for the global tracer so no test mutates real tracing.
+
+    Models the one private attribute install() reads —
+    ``_span_aggregator.user_processors`` — so the pass-through below is
+    exercised against the real shape rather than a convenient one.
+    """
+
+    def __init__(self, already_registered: list[object] | None = None) -> None:
+        self.calls: list[list[object]] = []
+        self._span_aggregator = _FakeAggregator(already_registered or [])
+
+    def configure(self, trace_processors: list[object]) -> None:
+        self.calls.append(trace_processors)
+        self._span_aggregator.user_processors = trace_processors
+
+
+def _install_with(monkeypatch: pytest.MonkeyPatch, tracer_double: object) -> None:
+    monkeypatch.setattr(trace_filters, "_dd_tracer", tracer_double)
+    # Module-level, so it survives between tests and would leak the state of
+    # whichever ran first; monkeypatch restores it either way.
+    monkeypatch.setattr(trace_filters, "_installed", False)
+
+
+@pytest.fixture
+def fake_tracer(monkeypatch: pytest.MonkeyPatch) -> _RecordingTracer:
+    tracer_double = _RecordingTracer()
+    _install_with(monkeypatch, tracer_double)
+    return tracer_double
+
+
+def test_install_registers_the_filter(fake_tracer: _RecordingTracer) -> None:
+    assert trace_filters.install() is True
+
+    assert len(fake_tracer.calls) == 1
+    (registered,) = fake_tracer.calls[0]
+    assert isinstance(registered, PubSubPullDeadlineFilter)
+
+
+def test_install_keeps_processors_registered_before_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """configure() replaces the processor list, so install() must re-pass it.
+
+    Without this, registering our filter silently evicts anyone else's
+    processor — no error, no warning, their filtering just stops. `common/` is
+    shared by every service, so this needs to hold by construction.
+    """
+    someone_elses = object()
+    tracer_double = _RecordingTracer(already_registered=[someone_elses])
+    _install_with(monkeypatch, tracer_double)
+
+    assert trace_filters.install() is True
+
+    (registered,) = tracer_double.calls
+    assert someone_elses in registered, "an existing processor must survive"
+    assert any(isinstance(p, PubSubPullDeadlineFilter) for p in registered)
+    assert len(registered) == 2
+
+
+def test_install_survives_a_renamed_private_aggregator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pass-through reads a private attribute; an upgrade may rename it.
+
+    Degrading to replace-the-list behaviour is acceptable. Raising during
+    service startup, because APM internals moved, is not.
+    """
+
+    class _NoAggregator:
+        def __init__(self) -> None:
+            self.calls: list[list[object]] = []
+
+        def configure(self, trace_processors: list[object]) -> None:
+            self.calls.append(trace_processors)
+
+    tracer_double = _NoAggregator()
+    _install_with(monkeypatch, tracer_double)
+
+    assert trace_filters.install() is True
+    (registered,) = tracer_double.calls
+    assert any(isinstance(p, PubSubPullDeadlineFilter) for p in registered)
+
+
+def test_install_is_idempotent(fake_tracer: _RecordingTracer) -> None:
+    """A second configure() would evict any other processor registered since.
+
+    Every service constructs its own bus, and a process with two of them calls
+    start() twice — so this guard is load-bearing, not hypothetical.
+    """
+    assert trace_filters.install() is True
+    assert trace_filters.install() is True
+
+    assert len(fake_tracer.calls) == 1, "configure() must be called exactly once"
+
+
+def test_install_reports_false_without_ddtrace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The no-datadog-extra path: nothing to register."""
+    monkeypatch.setattr(trace_filters, "_dd_tracer", None)
+    monkeypatch.setattr(trace_filters, "_installed", False)
+
+    assert trace_filters.install() is False
+
+
+def test_install_absorbs_a_configure_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A broken configure() must not propagate out of PubSubEventBus.start().
+
+    install() runs during service startup. Correct APM error rates are not
+    worth trading a service that boots for, so a ddtrace incompatibility has
+    to degrade rather than raise.
+    """
+
+    class _BrokenTracer:
+        def configure(self, trace_processors: list[object]) -> None:
+            raise TypeError("configure() got an unexpected keyword argument")
+
+    _install_with(monkeypatch, _BrokenTracer())
+
+    with caplog.at_level("WARNING"):
+        assert trace_filters.install() is False
+
+    assert "Failed to register" in caplog.text, "a silent failure is unusable"
+    # Left False so a later start() can retry rather than being locked out by
+    # one bad attempt.
+    assert trace_filters._installed is False
+
+
+async def test_publisher_only_bus_does_not_register_the_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No subscribers means no pull loop, so no pull spans to correct.
+
+    Registration is not free — it calls tracer.configure(), which recreates
+    the trace writer — and the comment at the call site claims this gating,
+    so it needs to actually hold.
+    """
+    calls: list[bool] = []
+    monkeypatch.setattr(trace_filters, "install", lambda: calls.append(True) or True)
+    monkeypatch.setattr(
+        PubSubEventBus, "_ensure_pubsub_sdk", staticmethod(lambda: object())
+    )
+
+    bus = PubSubEventBus(project_id="proj", subscription_prefix="test")
+    await bus.start()  # publisher-only: subscribe() never called
+
+    assert bus._started is True, "the bus must still start"
+    assert calls == [], "a publisher-only bus has no pull loop to correct"


### PR DESCRIPTION
Ports the fix already merged as [caura-enterprise #1287](https://github.com/caura-ai/caura-enterprise/pull/1287) to this repo's copy of `common/events/pubsub.py` — which turns out to be where nearly all of the volume actually comes from.

## Problem

An idle Pub/Sub subscriber emits **one error span per empty pull window**, forever.

`PubSubEventBus._pull_loop` calls `subscriber.pull(timeout=...)` and already treats `DEADLINE_EXCEEDED` as the non-event it is:

```python
except gexc.DeadlineExceeded:
    # No messages in the pull window; loop back and try again.
    continue
```

ddtrace's gRPC integration marks the span failed on *any* non-OK status before that `except` ever runs — `contrib/internal/grpc/client_interceptor.py`, `if response_code != grpc.StatusCode.OK` → `span.error = 1` — with no per-status config to opt out. So the application handles the timeout correctly and APM records a failure anyway.

**Measured over 24h**, `@error.type:StatusCode.DEADLINE_EXCEEDED` on `/google.pubsub.v1.Subscriber/Pull`:

| service | env | spans |
|---|---|---|
| core-api | staging | 51,568 |
| core-api | prod | 617 |
| core-worker | prod / staging | 99 / 90 |

An idle deployment is far noisier than a busy one — a pull that returns messages succeeds — which is why staging dwarfs prod. Even so, in prod this was the single largest source of error spans (1,223 of ~3,163), so error rate and any monitor on it were reporting mostly poll timeouts.

## Fix

A trace processor that clears `span.error` for that exact resource + status, and nothing else.

- **Fixes the metric, not just the display.** `SpanAggregator.on_span_finish` chains `user_processors` ahead of sampling and the writer, so the payload the Agent computes APM stats from already carries `error: 0`.
- **The span is kept, not dropped.** A pull that fails for a real reason still arrives as an error, and poll timing stays visible. `error.*` tags are left in place so the timeouts stay queryable on purpose (`@error.type:StatusCode.DEADLINE_EXCEEDED`) rather than merely absent.
- **`StatusCode.CANCELLED` is deliberately untouched** — a pull interrupted by shutdown, which I observed for real alongside the timeouts. It says something true about the process.
- **Registration is additive.** `configure(trace_processors=...)` replaces the user-processor list rather than appending, so a bare call would silently evict any processor registered before us. `install()` reads what's registered and passes it back through.
- **`install()` never raises.** Both the private-aggregator read and the `configure()` call are guarded — a signature change across a major ddtrace bump would otherwise propagate out of `PubSubEventBus.start()` and fail service boot. Correct error rates aren't worth trading a service that starts.
- **Registered inside `start()`'s `topic_count > 0` branch** — the spans come from the pull loop, so a publisher-only bus can't produce one and shouldn't pay for registration (which recreates the trace writer).

There is no gRPC status→error config knob in ddtrace 4.x (nothing like `DD_TRACE_HTTP_SERVER_ERROR_STATUSES` for gRPC; `config.grpc` carries no error-status field), so a user trace processor is the only supported altitude.

## Tests deliberately do not require ddtrace

Worth calling out, because it differs from the enterprise version. CI installs only each service's `[dev]` extra, never `datadog` — so a module-level `pytest.importorskip("ddtrace")` would skip the whole file in the one environment that gates merges, shipping this with no coverage at all.

The filter only touches `.error`, `.resource` and `.get_tag()`, so a stub span covers it. One additional test pins the stub to the real `Span` shape (and asserts `ddtrace.constants.ERROR_TYPE == "error.type"`) whenever the extra happens to be installed — skipped in CI by design, so stub drift gets caught locally rather than never.

16 tests plus that fidelity check: the clear; the trace returned rather than dropped; five must-stay-an-error cases (`PERMISSION_DENIED`, `NOT_FOUND`, `CANCELLED`, Publish timeout, `StreamingPull`); a missing `error.type` tag; `install()`'s idempotency guard; an already-registered processor surviving; a renamed private aggregator; an absorbed `configure()` failure; and a publisher-only bus not registering at all. **Each was confirmed to fail without its fix.**

## Verification

- `16 passed, 1 skipped` for the new file, run in a venv **without** ddtrace — i.e. the CI configuration
- `5075 passed, 4 skipped, 1 xfailed` for the full repo-root suite
- `ruff check common/` clean; `ruff format --check` clean; `mypy --config-file common/mypy.ini common/` reports only two pre-existing `dateutil` stub errors in `common/enrichment/service.py`, none in the new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)