### PR TITLE
feat(api): structured errors, safe deletes, and client alias packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,18 @@ jobs:
         # type-check gate in CI.
         run: cd plugin && npm ci && npm run build
 
+      - name: Run plugin tests (node:test)
+        # The plugin had 423 tests and CI ran NONE of them. The step above
+        # proves it compiles; nothing proved it behaves. `client-typescript-ci.yml`
+        # is path-scoped to clients/typescript, so its `npm test` never touched
+        # /plugin — which is how the caura_tune identity bug (F5) reached a
+        # release: `tool-definitions.ts` shipped a literal "unknown-agent"
+        # fallback that a two-line test would have caught.
+        #
+        # `npm ci` is not repeated — the build step above installed into the
+        # same workspace, and `npm test` re-runs tsc itself via `pretest`.
+        run: cd plugin && npm test
+
       - name: Install uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5.4.2
         with:
@@ -226,6 +238,24 @@ jobs:
           fi
           if grep -nE "[f]?'Error(:| \()" core-api/src/core_api/mcp_server.py | grep -vE '^[0-9]+:\s*#'; then
             echo "::error::Raw-string MCP error return found (single-quote). Use _error_response(code, message) instead — see tests/test_mcp_iserror_propagation.py."
+            exit 1
+          fi
+
+      - name: Guard against stringified exception details (C29)
+        # ``HTTPException.detail`` is sometimes ``{code, message, details}`` now
+        # (``common.duplicate_memory.core_api_detail``). ``str()`` on that shape
+        # renders a Python dict repr — braces, quotes and all — straight into a
+        # message a model reads, and neither git nor mypy sees anything wrong:
+        # the types line up, the tests that assert on prose still pass, and the
+        # damage only shows in what the caller is told.
+        #
+        # This is aimed at the merge window specifically. Work already in flight
+        # was written when every detail was a string, so a rebase can
+        # reintroduce ``str(e.detail)`` with no conflict marker to warn anyone.
+        # ``_detail_text`` / ``_detail_code`` handle both shapes.
+        run: |
+          if grep -nE 'str\((e|exc)\.detail\)' core-api/src/core_api/mcp_server.py | grep -vE '^[0-9]+:\s*#'; then
+            echo "::error::Stringified exception detail found. Details may be structured — use _detail_text(...) / _detail_code(...) instead."
             exit 1
           fi
 

--- a/.github/workflows/publish-npm-sdk.yml
+++ b/.github/workflows/publish-npm-sdk.yml
@@ -1,0 +1,138 @@
+name: Publish the @caura/sdk alias
+
+# Publishes `clients/npm-sdk` — `@caura/sdk`, an alias that re-exports the
+# canonical package `@caura/client`, which in turn re-exports the implementation.
+#
+# WHY THIS PACKAGE EXISTS, AND WHY IT IS NOT URGENT. AI search assistants
+# instruct `npm install @caura/sdk`. Unlike the PyPI half of the same problem
+# (`caura-sdk`, which any third party could have claimed), a SCOPED npm name is
+# only publishable by members of the scope — so this was never a supply-chain
+# hole, only a 404 on an install line we did not write. Recorded because the
+# original finding rated both halves the same and they are not the same.
+#
+# GATES. This workflow keeps every gate from `publish-npm-metapackage.yml`
+# — credential present, tag agrees with package.json, dependencies already on
+# the registry, publish, verify the registry actually serves it — but not that
+# file's full commentary. READ THAT FILE for why each gate exists; every one of
+# them is there because it failed in production first. The two are deliberate
+# duplicates for now: consolidating them into a reusable `workflow_call` is the
+# right end state but touches the release path for `@caura/client`, so it is
+# filed separately rather than bundled into a publish that has to work today.
+#
+# One-time setup by a maintainer:
+#   1. `NPM_TOKEN` repository secret — an npm automation token with publish
+#      rights to the `@caura` SCOPE. Reusing the token from
+#      `publish-npm-client.yml` satisfies this.
+#
+# Release: bump the version in clients/npm-sdk/package.json, then push a tag
+# `caura-sdk-npm-v<version>` (or run this workflow manually).
+
+on:
+  push:
+    tags:
+      - "caura-sdk-npm-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      # `contents: read` is not redundant — declaring a permissions block sets
+      # every unlisted scope to `none`, which would leave `actions/checkout`
+      # unable to read the repo.
+      contents: read
+      id-token: write # npm provenance
+    defaults:
+      run:
+        working-directory: clients/npm-sdk
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: The publish credential must exist
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -z "${NPM_TOKEN}" ]]; then
+            echo "::error::NPM_TOKEN repository secret is not set. Add an npm automation token with publish rights to the @caura scope; nothing here can publish without it."
+            exit 1
+          fi
+
+      - name: The tag must agree with package.json
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#caura-sdk-npm-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::tag ${GITHUB_REF_NAME} says ${TAG_VERSION} but package.json says ${PKG_VERSION}"
+            exit 1
+          fi
+          echo "publishing $(node -p "require('./package.json').name")@${PKG_VERSION}"
+
+      # npm does not resolve dependencies at publish time: publishing against a
+      # version that is not on the registry SUCCEEDS and produces a package that
+      # fails for the first person who installs it.
+      - name: Every dependency must already be on the registry
+        run: |
+          node -p "Object.entries(require('./package.json').dependencies || {}).map(([n, r]) => n + '@' + r).join('\n')" \
+            > /tmp/deps.txt
+          while read -r SPEC; do
+            [[ -z "$SPEC" ]] && continue
+            RESOLVED=""
+            for attempt in 1 2 3 4 5; do
+              # `|| true` is load-bearing: steps run under `bash -eo pipefail`,
+              # so an unresolvable spec would abort the step on attempt 1 and
+              # the retry would be decorative. The type check matters too —
+              # npm prints its E404 as valid JSON on stdout under `--json`, so
+              # a successful parse proves nothing about existence.
+              RESOLVED=$(npm view "$SPEC" version --json 2>/dev/null | node -e '
+                let s = "";
+                process.stdin.on("data", d => s += d).on("end", () => {
+                  try {
+                    const j = JSON.parse(s);
+                    const a = Array.isArray(j) ? j : [j];
+                    const last = a[a.length - 1];
+                    console.log(typeof last === "string" ? last : "");
+                  } catch { console.log(""); }
+                });' || true)
+              [[ -n "$RESOLVED" ]] && break
+              echo "attempt ${attempt}: ${SPEC} not visible yet, waiting"
+              sleep 10
+            done
+            if [[ -z "$RESOLVED" ]]; then
+              echo "::error::${SPEC} is not on the registry. Publish it first (publish-npm-client.yml) — npm would accept this package anyway and it would be uninstallable."
+              exit 1
+            fi
+            echo "${SPEC} -> ${RESOLVED}"
+          done < /tmp/deps.txt
+
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # A green publish step is not evidence the registry serves it.
+      - name: The registry must serve what we just published
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          for attempt in 1 2 3 4 5; do
+            SERVED=$(npm view "${PKG_NAME}@${PKG_VERSION}" version --json 2>/dev/null | node -e '
+              let s = "";
+              process.stdin.on("data", d => s += d).on("end", () => {
+                try {
+                  const j = JSON.parse(s);
+                  const a = Array.isArray(j) ? j : [j];
+                  const last = a[a.length - 1];
+                  console.log(typeof last === "string" ? last : "");
+                } catch { console.log(""); }
+              });' || true)
+            [[ -n "$SERVED" ]] && { echo "registry serves ${PKG_NAME}@${SERVED}"; exit 0; }
+            echo "attempt ${attempt}: not served yet, waiting"
+            sleep 10
+          done
+          echo "::error::${PKG_NAME}@${PKG_VERSION} is not being served after publish."
+          exit 1

--- a/.github/workflows/publish-python-metapackage.yml
+++ b/.github/workflows/publish-python-metapackage.yml
@@ -1,0 +1,52 @@
+name: Publish the caura metapackage to PyPI
+
+# Publishes `clients/caura-meta` — the bare `caura` name, a metapackage that
+# installs and re-exports `caura-client`. Trusted publishing (OIDC), no token.
+#
+# WHY THIS WORKFLOW EXISTS. `caura` 1.0.0 was published by hand on 2026-08-17
+# and had no workflow, so the one package whose whole job is to make
+# `pip install caura` resolve was also the one nobody could ship a fix to
+# without remembering a manual twine invocation. Every other client artifact in
+# this repo publishes from CI; this closes the gap.
+#
+# NAMED FOR WHAT IT PUBLISHES — see the same note in `publish-python-sdk.yml`.
+#
+# One-time setup by a maintainer:
+#   1. `caura` ALREADY EXISTS on PyPI, so this is not a pending publisher. Add
+#      it under Manage → the `caura` project → Publishing → Add a new publisher:
+#      repo `caura-ai/caura`, workflow `publish-python-metapackage.yml`,
+#      environment `pypi`.
+#   2. The GitHub environment `pypi` already exists for
+#      `publish-python-client.yml`; this workflow reuses it.
+#
+# Release: bump the version in clients/caura-meta/pyproject.toml, then push a
+# tag `caura-meta-v<version>` (or run this workflow manually). The tag prefix is
+# `caura-meta-` rather than `caura-` so it cannot collide with a future bare
+# `caura-v*` release tag for the repo itself.
+
+on:
+  push:
+    tags:
+      - "caura-meta-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # required for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Build
+        run: |
+          pip install build
+          python -m build
+        working-directory: clients/caura-meta
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: clients/caura-meta/dist/

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -1,0 +1,55 @@
+name: Publish caura-sdk to PyPI
+
+# Publishes `clients/caura-sdk-meta` — `caura-sdk`, a metapackage that installs
+# and re-exports `caura-client`. Trusted publishing (OIDC), no token.
+#
+# WHY THIS PACKAGE EXISTS. AI search assistants confidently instruct
+# `pip install caura-sdk`. Until 2026-08-24 nobody owned that name, so the
+# instruction pointed at a slot any third party could fill — install guidance we
+# did not write, resolving to code we did not publish. The name is now claimed
+# and made to work.
+#
+# NAMED FOR WHAT IT PUBLISHES. There are three Python publish workflows here:
+# `publish-python-client.yml` ships the IMPLEMENTATION (`clients/python`),
+# `publish-python-metapackage.yml` ships the bare `caura` name, and this one
+# ships `caura-sdk`. Directory and package name disagree by design — the
+# directory carries the `-meta` suffix so it does not read as the real client.
+#
+# One-time setup by a maintainer (done 2026-08-24):
+#   1. On PyPI, add a PENDING Trusted Publisher: project `caura-sdk`,
+#      repo `caura-ai/caura`, workflow `publish-python-sdk.yml`,
+#      environment `pypi`. A pending publisher reserves the name immediately —
+#      the project does not need to exist first, and the first run of this
+#      workflow creates it.
+#   2. The GitHub environment `pypi` already exists for
+#      `publish-python-client.yml`; this workflow reuses it.
+#
+# Release: bump the version in clients/caura-sdk-meta/pyproject.toml, then push
+# a tag `caura-sdk-v<version>` (or run this workflow manually).
+
+on:
+  push:
+    tags:
+      - "caura-sdk-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # required for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Build
+        run: |
+          pip install build
+          python -m build
+        working-directory: clients/caura-sdk-meta
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: clients/caura-sdk-meta/dist/

--- a/clients/caura-sdk-meta/README.md
+++ b/clients/caura-sdk-meta/README.md
@@ -1,0 +1,18 @@
+# caura-sdk
+
+Metapackage for [`caura-client`](https://pypi.org/project/caura-client/), the
+official Python client for [Caura](https://caura.ai) — governed shared memory
+for AI agent fleets.
+
+```bash
+pip install caura-sdk
+```
+
+```python
+from caura_sdk import Caura
+```
+
+`caura-sdk`, [`caura`](https://pypi.org/project/caura/) and
+[`caura-client`](https://pypi.org/project/caura-client/) all install the same
+client. `caura-client` is the canonical name; the other two exist so that
+install instructions pointing at them resolve instead of 404ing.

--- a/clients/caura-sdk-meta/pyproject.toml
+++ b/clients/caura-sdk-meta/pyproject.toml
@@ -1,0 +1,34 @@
+# Metapackage holding the `caura-sdk` name on PyPI. Not a stub: it installs the
+# real client and re-exports it, so `pip install caura-sdk` +
+# `from caura_sdk import Caura` genuinely work.
+#
+# Why this name exists at all: AI search assistants confidently instruct
+# `pip install caura-sdk`, a name we did not own. An unowned name that install
+# instructions already point at is a supply-chain hole, so the name is claimed
+# and made to work rather than left open.
+#
+# The import package is `caura_sdk`, NOT `caura`. Two distributions that both
+# ship a top-level `caura/` would collide on disk and `pip install caura
+# caura-sdk` would leave whichever installed last. `tests/test_client_metapackages.py`
+# pins that invariant.
+[build-system]
+requires = ["setuptools>=75"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "caura-sdk"
+version = "1.0.0"
+description = "Caura — governed shared memory for AI agent fleets. Metapackage for caura-client."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Caura", email = "hello@caura.ai" }]
+dependencies = ["caura-client>=1.0.0"]
+
+[project.urls]
+Homepage = "https://caura.ai"
+Documentation = "https://caura.ai/docs"
+Repository = "https://github.com/caura-ai/caura"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/clients/caura-sdk-meta/src/caura_sdk/__init__.py
+++ b/clients/caura-sdk-meta/src/caura_sdk/__init__.py
@@ -1,0 +1,4 @@
+"""Metapackage: re-exports the official client. See ``caura_client``."""
+
+from caura_client import *  # noqa: F401,F403
+from caura_client import __all__, __version__  # noqa: F401

--- a/clients/npm-sdk/README.md
+++ b/clients/npm-sdk/README.md
@@ -1,0 +1,18 @@
+# @caura/sdk
+
+Alias for [`@caura/client`](https://www.npmjs.com/package/@caura/client), the
+official TypeScript client for [Caura](https://caura.ai) — governed shared
+memory for AI agent fleets.
+
+```bash
+npm install @caura/sdk
+```
+
+```ts
+import { Caura } from '@caura/sdk';
+```
+
+`@caura/client` is the canonical name. This alias exists so that install
+instructions pointing at `@caura/sdk` resolve instead of 404ing, and it depends
+on the canonical package rather than re-exporting the implementation directly —
+so there is one place to change if the implementation is ever renamed.

--- a/clients/npm-sdk/index.d.ts
+++ b/clients/npm-sdk/index.d.ts
@@ -1,0 +1,1 @@
+export * from '@caura/client';

--- a/clients/npm-sdk/index.js
+++ b/clients/npm-sdk/index.js
@@ -1,0 +1,1 @@
+export * from '@caura/client';

--- a/clients/npm-sdk/package.json
+++ b/clients/npm-sdk/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@caura/sdk",
+  "version": "1.0.0",
+  "description": "Caura — governed shared memory for AI agent fleets. Alias for @caura/client.",
+  "license": "Apache-2.0",
+  "author": "Caura <hello@caura.ai>",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "files": ["index.js", "index.d.ts", "README.md"],
+  "dependencies": {
+    "@caura/client": "^1.0.0"
+  },
+  "homepage": "https://caura.ai",
+  "repository": { "type": "git", "url": "git+https://github.com/caura-ai/caura.git", "directory": "clients/npm-sdk" },
+  "keywords": ["caura", "agent-memory", "ai-agents", "mcp", "multi-agent"]
+}

--- a/common/duplicate_memory.py
+++ b/common/duplicate_memory.py
@@ -1,0 +1,88 @@
+"""Wire shape for the "this content already exists" 409, shared by both services.
+
+Why this module exists. The winning row's id used to travel as English. Storage
+built the sentence ``Duplicate memory exists: <uuid>``, core-api lifted it out
+of storage's JSON verbatim, raised it as its own 409 detail, and the MCP server
+regex-parsed the uuid back out at the far end (``_DUPLICATE_DETAIL_RE``). A
+uuid was serialised into prose, shipped across two service boundaries, and
+recovered with a regular expression — by us, against our own API, which is the
+clearest possible evidence that the contract was wrong. Anything a client
+needed that the sentence did not happen to mention was simply unavailable, and
+one thing it never mentioned was whether the row it names is still active.
+
+The messages here are byte-identical to the ones they replace, deliberately.
+They are what a human reads, what four test modules assert on, and what any
+customer who parsed them already depends on; the structured fields are added
+ALONGSIDE rather than instead. That also lets the two services deploy in either
+order — an old core-api reading a new storage response still finds ``detail``
+where it expects it, and a new core-api reading an old storage response finds
+no structured fields and falls back to the prose.
+
+Pure data: no framework imports, so both services and their tests can use it.
+"""
+
+from __future__ import annotations
+
+DUPLICATE_MEMORY_CODE = "DUPLICATE_MEMORY"
+
+# Why the write was refused. Distinguishing these is most of the point: an
+# exact-hash duplicate means "use this row instead", a semantic one means "a
+# judge decided these say the same thing", and the third means "the row that
+# beat you has since been deleted, so try again" — three different next moves
+# that the single word "duplicate" collapsed into one.
+REASON_EXACT = "exact_content_hash"
+REASON_SEMANTIC = "semantic_similarity"
+REASON_RACE_NOT_LIVE = "winner_no_longer_live"
+
+# The prose forms. Kept as functions rather than format strings at each call
+# site so a future wording change cannot drift between the producers, and so
+# the regex fallback in mcp_server has exactly one thing to stay in step with.
+NOT_LIVE_MESSAGE = "Duplicate memory exists but is no longer live; retry the write"
+
+
+def exact_message(existing_id: object) -> str:
+    return f"Duplicate memory exists: {existing_id}"
+
+
+def near_message(existing_id: object) -> str:
+    return f"Near-duplicate memory exists: {existing_id}"
+
+
+def duplicate_fields(
+    *,
+    reason: str,
+    existing_id: object = None,
+    existing_status: str | None = None,
+    similarity: float | None = None,
+) -> dict:
+    """The structured half: everything the sentence could not carry.
+
+    ``existing_status`` is the field the prose never had. A duplicate of an
+    archived or conflicted row is not the same situation as a duplicate of an
+    active one, and a caller told only "duplicate" cannot tell which it got.
+    Omitted keys are left out entirely rather than sent as null, so a consumer
+    can distinguish "not applicable" from "unknown".
+    """
+    fields: dict = {"reason": reason}
+    if existing_id is not None:
+        fields["existing_id"] = str(existing_id)
+    if existing_status is not None:
+        fields["existing_status"] = existing_status
+    if similarity is not None:
+        fields["similarity"] = round(float(similarity), 4)
+    return fields
+
+
+def core_api_detail(message: str, **fields: object) -> dict:
+    """The ``{code, message, details}`` detail core-api's handler expands.
+
+    ``app.http_exception_handler`` recognises this shape and emits the
+    canonical envelope while keeping top-level ``detail`` as the plain message
+    string — so this adds a field for new clients without moving one for old
+    ones.
+    """
+    return {
+        "code": DUPLICATE_MEMORY_CODE,
+        "message": message,
+        "details": dict(fields),
+    }

--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -350,6 +350,42 @@
         "title": "BulkMemoryResponse",
         "type": "object"
       },
+      "CauraError": {
+        "description": "Canonical error envelope. ``detail`` is the human-readable message and is retained for backwards compatibility; ``error.code`` is the stable machine-readable identifier and is what clients should branch on.",
+        "properties": {
+          "detail": {
+            "description": "Human-readable message.",
+            "type": "string"
+          },
+          "error": {
+            "properties": {
+              "code": {
+                "description": "Stable UPPER_SNAKE identifier. Derived from the status code unless the raiser supplied a specific one — e.g. READ_ONLY_CREDENTIAL vs PLAN_LIMIT_READ_ONLY, which are both 403 and need different responses from the caller.",
+                "type": "string"
+              },
+              "details": {
+                "additionalProperties": true,
+                "description": "Optional structured context, e.g. remediation or existing_id.",
+                "type": "object"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail",
+          "error"
+        ],
+        "title": "CauraError",
+        "type": "object"
+      },
       "ContradictionInfo": {
         "description": "Summary of a contradiction detected on write.\n\n``old_memory_id`` always refers to the **pre-existing candidate**\n(never to ``new_memory``), regardless of which row ended up being\nthe older one in the supersession chain. The ``direction`` field\ndisambiguates the two cases:\n\n  - ``\"canonical\"`` — the candidate is older than ``new_memory``;\n    the candidate became outdated/conflicted, ``new_memory``\n    carries ``supersedes_id`` pointing at it. (Historical behaviour.)\n  - ``\"flipped\"`` — the candidate is newer than ``new_memory``;\n    ``new_memory`` is the row that became outdated/conflicted, and\n    the candidate now carries ``supersedes_id`` pointing back at\n    ``new_memory``. This branch was previously unreachable\n    (CAURA-125; gap A6) and is now exercised by deferred-embedding\n    races and ``created_at`` ties.",
         "properties": {
@@ -1481,6 +1517,26 @@
               }
             },
             "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authentication failed or was not supplied."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authenticated, but not permitted to perform this operation."
           }
         },
         "summary": "Health",
@@ -1817,6 +1873,26 @@
             },
             "description": "Successful Response"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authentication failed or was not supplied."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authenticated, but not permitted to perform this operation."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -1908,6 +1984,26 @@
             },
             "description": "Multi-Status"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authentication failed or was not supplied."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authenticated, but not permitted to perform this operation."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -1974,6 +2070,26 @@
           "204": {
             "description": "Successful Response"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authentication failed or was not supplied."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authenticated, but not permitted to perform this operation."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -2029,6 +2145,26 @@
               }
             },
             "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authentication failed or was not supplied."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authenticated, but not permitted to perform this operation."
           },
           "422": {
             "content": {
@@ -2131,6 +2267,26 @@
             },
             "description": "Successful Response"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authentication failed or was not supplied."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authenticated, but not permitted to perform this operation."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -2177,6 +2333,26 @@
             },
             "description": "Successful Response"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authentication failed or was not supplied."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authenticated, but not permitted to perform this operation."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -2210,6 +2386,26 @@
               }
             },
             "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authentication failed or was not supplied."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CauraError"
+                }
+              }
+            },
+            "description": "Authenticated, but not permitted to perform this operation."
           }
         },
         "summary": "Version",

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -534,12 +534,33 @@ async def lifespan(app):
         executor.shutdown(wait=False)
 
 
+# CAP-01 / F6. Tag-level labelling for capabilities whose REST surface is not
+# what its presence in this spec implies. Only STM qualifies today: it is
+# advertised here, gated on a server setting hosted tenants cannot reach, and
+# has no REST write route at all. The per-operation text lives in
+# ``routes/stm.py``; this is what a reader sees in the docs sidebar before
+# they open an operation.
+OPENAPI_TAGS = [
+    {
+        "name": "stm",
+        "description": (
+            "**Plugin-only — not available over hosted REST.** Short-term "
+            "memory is served by the OpenClaw plugin. These operations are "
+            "gated on the server-side `USE_STM` setting, which is off in the "
+            "hosted deployment and is not per-tenant, and there is no REST "
+            "write route for STM at all. Use `/memories` and `/search` for "
+            "durable memory."
+        ),
+    },
+]
+
 app = FastAPI(
     title="Caura",
     version=VERSION,
     docs_url="/api/docs",
     redoc_url="/api/redoc",
     openapi_url="/api/openapi.json",
+    openapi_tags=OPENAPI_TAGS,
     lifespan=lifespan,
 )
 

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -8,6 +8,7 @@ import httpx
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.types import ASGIApp as ASGIApplication
@@ -563,6 +564,96 @@ app = FastAPI(
     openapi_tags=OPENAPI_TAGS,
     lifespan=lifespan,
 )
+
+
+# ── Error responses in the spec (C32 / API-05) ────────────────────────────
+#
+# Before this, 422 was the ONLY documented error response on the whole surface.
+# Every other failure — every 401, every 403 — was absent from the spec, so a
+# generated client had no type for the body it will certainly receive, and an
+# agent reading the spec offline could reasonably conclude those statuses do not
+# occur. They occur constantly: authentication and authorization are checked on
+# essentially every route.
+#
+# Injected once over the generated schema rather than declared per route.
+# ``responses={401: ..., 403: ...}`` on ~91 path operations is the same fact
+# written ninety-one times, and the copy that gets forgotten is the one that
+# matters. Existing per-route declarations win — this only fills gaps.
+_ERROR_ENVELOPE_REF = "CauraError"
+
+_ERROR_ENVELOPE_SCHEMA: dict = {
+    "type": "object",
+    "title": "CauraError",
+    "description": (
+        "Canonical error envelope. ``detail`` is the human-readable message and "
+        "is retained for backwards compatibility; ``error.code`` is the stable "
+        "machine-readable identifier and is what clients should branch on."
+    ),
+    "properties": {
+        "detail": {"type": "string", "description": "Human-readable message."},
+        "error": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": (
+                        "Stable UPPER_SNAKE identifier. Derived from the status "
+                        "code unless the raiser supplied a specific one — e.g. "
+                        "READ_ONLY_CREDENTIAL vs PLAN_LIMIT_READ_ONLY, which are "
+                        "both 403 and need different responses from the caller."
+                    ),
+                },
+                "message": {"type": "string"},
+                "details": {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "description": "Optional structured context, e.g. remediation or existing_id.",
+                },
+            },
+            "required": ["code", "message"],
+        },
+    },
+    "required": ["detail", "error"],
+}
+
+# Status → description, for the statuses every authenticated route can return.
+_INJECTED_ERROR_RESPONSES: dict[str, str] = {
+    "401": "Authentication failed or was not supplied.",
+    "403": "Authenticated, but not permitted to perform this operation.",
+}
+
+
+def _openapi_with_error_responses() -> dict:
+    """Generate the spec, then document the errors every route can return."""
+    if app.openapi_schema:
+        return app.openapi_schema
+    schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        routes=app.routes,
+        tags=OPENAPI_TAGS,
+    )
+    schema.setdefault("components", {}).setdefault("schemas", {})[_ERROR_ENVELOPE_REF] = (
+        _ERROR_ENVELOPE_SCHEMA
+    )
+    ref = {"$ref": f"#/components/schemas/{_ERROR_ENVELOPE_REF}"}
+    for path_item in schema.get("paths", {}).values():
+        for method, operation in path_item.items():
+            if method not in {"get", "put", "post", "delete", "patch"}:
+                continue
+            responses = operation.setdefault("responses", {})
+            for status, description in _INJECTED_ERROR_RESPONSES.items():
+                if status in responses:
+                    continue  # a route that documented its own says it better
+                responses[status] = {
+                    "description": description,
+                    "content": {"application/json": {"schema": ref}},
+                }
+    app.openapi_schema = schema
+    return schema
+
+
+app.openapi = _openapi_with_error_responses  # type: ignore[method-assign]
 
 # slowapi reads limiter + handler from app.state; decorators in
 # middleware/rate_limit.py consult this at request time.

--- a/core-api/src/core_api/auth.py
+++ b/core-api/src/core_api/auth.py
@@ -5,8 +5,10 @@ import logging
 from fastapi import HTTPException, Request, Security
 from fastapi.security import APIKeyHeader
 
+from core_api import errors
 from core_api.config import settings
 from core_api.constants import API_KEY_HEADER
+from core_api.errors import coded_detail
 from core_api.suppression import is_tenant_suppressed
 from core_api.tenant_context import set_current_tenant, set_readable_tenants
 
@@ -160,11 +162,27 @@ class AuthContext:
         the write target, not here.
         """
         if self.is_demo:
-            raise HTTPException(status_code=403, detail="Demo sandbox is read-only.")
+            raise HTTPException(
+                status_code=403,
+                detail=coded_detail(
+                    errors.AUTH_DEMO_SANDBOX,
+                    "Demo sandbox is read-only.",
+                    remediation="Use a real tenant credential to write.",
+                ),
+            )
         if self.capabilities is not None and "write" not in self.capabilities:
             raise HTTPException(
                 status_code=403,
-                detail="This API key is read-only and cannot perform write operations.",
+                detail=coded_detail(
+                    errors.AUTH_READ_ONLY_KEY,
+                    "This API key is read-only and cannot perform write operations.",
+                    remediation=(
+                        "This is a property of the CREDENTIAL, not of the endpoint or "
+                        "of tenant keys in general — mint a key with the 'write' "
+                        "capability (Settings → Organization → API Credentials) and "
+                        "retry the same call."
+                    ),
+                ),
             )
 
     def enforce_usage_limits(self) -> None:
@@ -177,23 +195,39 @@ class AuthContext:
         if self.is_read_only:
             raise HTTPException(
                 status_code=403,
-                detail=(
+                detail=coded_detail(
+                    errors.AUTH_PLAN_LIMIT,
                     "Organization is in read-only mode: usage exceeds plan limits. "
-                    "Upgrade your plan or delete data to restore write access."
+                    "Upgrade your plan or delete data to restore write access.",
+                    remediation="Deletes stay permitted so you can get back under the limit.",
                 ),
             )
 
     def enforce_admin(self) -> None:
         """Raise 403 unless the caller is the system super admin."""
         if not self.is_admin:
-            raise HTTPException(status_code=403, detail="Admin access required")
+            raise HTTPException(
+                status_code=403,
+                detail=coded_detail(
+                    errors.AUTH_ADMIN_REQUIRED,
+                    "Admin access required",
+                    remediation="This endpoint needs the system admin key; a tenant or agent credential cannot reach it.",
+                ),
+            )
 
     def enforce_org_admin(self) -> None:
         """Raise 403 unless the caller is an org admin (or super admin)."""
         if self.is_admin:
             return
         if self.org_role != "admin":
-            raise HTTPException(status_code=403, detail="Org admin access required")
+            raise HTTPException(
+                status_code=403,
+                detail=coded_detail(
+                    errors.AUTH_ORG_ADMIN_REQUIRED,
+                    "Org admin access required",
+                    remediation="Your credential is authenticated but its org role is not 'admin'.",
+                ),
+            )
 
     def enforce_not_agent_credential(self, action: str = "perform this action") -> None:
         """Raise 403 if the caller is an agent-scoped credential.
@@ -212,7 +246,11 @@ class AuthContext:
         if self.agent_id:
             raise HTTPException(
                 status_code=403,
-                detail=f"Agent-scoped credentials cannot {action}; use an admin credential.",
+                detail=coded_detail(
+                    errors.AUTH_AGENT_CREDENTIAL_FORBIDDEN,
+                    f"Agent-scoped credentials cannot {action}; use an admin credential.",
+                    action=action,
+                ),
             )
 
     def enforce_tenant(self, requested_tenant: str) -> None:
@@ -222,7 +260,12 @@ class AuthContext:
         if self.tenant_id != requested_tenant:
             raise HTTPException(
                 status_code=403,
-                detail=f"API key is not authorized for tenant '{requested_tenant}'",
+                detail=coded_detail(
+                    errors.AUTH_TENANT_MISMATCH,
+                    f"API key is not authorized for tenant '{requested_tenant}'",
+                    requested_tenant=requested_tenant,
+                    remediation="The credential is valid; it is bound to a different tenant.",
+                ),
             )
 
     def enforce_readable_tenant(self, requested_tenant: str) -> None:
@@ -237,7 +280,11 @@ class AuthContext:
         if requested_tenant not in self.readable_tenant_ids:
             raise HTTPException(
                 status_code=403,
-                detail=f"API key is not authorized to read tenant '{requested_tenant}'",
+                detail=coded_detail(
+                    errors.AUTH_TENANT_NOT_READABLE,
+                    f"API key is not authorized to read tenant '{requested_tenant}'",
+                    requested_tenant=requested_tenant,
+                ),
             )
 
     def enforce_cross_tenant_read(self) -> None:
@@ -258,7 +305,10 @@ class AuthContext:
         if not self.is_cross_tenant_read:
             raise HTTPException(
                 status_code=403,
-                detail="Cross-tenant read privileges are required for this report.",
+                detail=coded_detail(
+                    errors.AUTH_CROSS_TENANT_REQUIRED,
+                    "Cross-tenant read privileges are required for this report.",
+                ),
             )
 
     def enforce_write_scope(self) -> None:
@@ -274,7 +324,14 @@ class AuthContext:
         if "write" not in self.capabilities:
             raise HTTPException(
                 status_code=403,
-                detail="This API key is read-only and cannot perform write operations.",
+                detail=coded_detail(
+                    errors.AUTH_READ_ONLY_KEY,
+                    "This API key is read-only and cannot perform write operations.",
+                    remediation=(
+                        "A property of the credential, not of the endpoint — mint a key "
+                        "with the 'write' capability and retry."
+                    ),
+                ),
             )
 
 
@@ -303,7 +360,13 @@ async def _block_if_suppressed(tenant_id: str | None) -> None:
     if await is_tenant_suppressed(tenant_id):
         raise HTTPException(
             status_code=403,
-            detail="Organization is suspended; access denied.",
+            # Deliberately says nothing more. The generic wording is the point —
+            # see this function's docstring — so the code carries the machine
+            # signal without the message leaking org lifecycle state.
+            detail=coded_detail(
+                errors.AUTH_ORG_SUSPENDED,
+                "Organization is suspended; access denied.",
+            ),
         )
 
 
@@ -406,9 +469,19 @@ async def get_auth_context(
         if not key:
             raise HTTPException(
                 status_code=401,
-                detail="Missing API key. Include X-API-Key header.",
+                detail=coded_detail(
+                    errors.AUTH_MISSING_API_KEY,
+                    "Missing API key. Include X-API-Key header.",
+                ),
             )
-        raise HTTPException(status_code=401, detail="Invalid API key.")
+        raise HTTPException(
+            status_code=401,
+            detail=coded_detail(
+                errors.AUTH_INVALID_API_KEY,
+                "Invalid API key.",
+                remediation="The key was sent but did not match. Check for a truncated paste or a rotated key.",
+            ),
+        )
 
     # ── Path 3: Standalone mode (no key required) ──
     if settings.is_standalone:
@@ -434,7 +507,11 @@ async def get_auth_context(
         if gw_secret and not hmac.compare_digest(request.headers.get("x-gateway-secret") or "", gw_secret):
             raise HTTPException(
                 status_code=401,
-                detail="Direct access to this service is not permitted.",
+                detail=coded_detail(
+                    errors.AUTH_GATEWAY_ONLY,
+                    "Direct access to this service is not permitted.",
+                    remediation="Route the request through the public gateway host.",
+                ),
             )
         await _block_if_suppressed(tenant_id)
         # Cross-tenant credentials carry a list of readable tenants via
@@ -497,5 +574,8 @@ async def get_auth_context(
     # Unscoped access without authentication is not allowed.
     raise HTTPException(
         status_code=401,
-        detail="Missing API key or X-Tenant-ID header.",
+        detail=coded_detail(
+            errors.AUTH_MISSING_TENANT_CONTEXT,
+            "Missing API key or X-Tenant-ID header.",
+        ),
     )

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -35,7 +35,16 @@ class DuplicateMemoryError(Exception):
     ``CheckExactDuplicate``: that gate answers the duplicate it can see before
     the write, this answers the race it cannot, and callers should not have to
     tell the two apart.
+
+    ``fields`` carries storage's structured half (C29) — the winning id as data
+    rather than as a substring, plus its status and the reason. Empty when
+    talking to a storage that predates the structured body, which is why every
+    consumer must treat it as optional.
     """
+
+    def __init__(self, detail: str, fields: dict | None = None) -> None:
+        super().__init__(detail)
+        self.fields: dict = fields or {}
 
 
 def _storage_detail(response: httpx.Response) -> str:
@@ -50,6 +59,28 @@ def _storage_detail(response: httpx.Response) -> str:
     except (ValueError, AttributeError):
         return _DUPLICATE_FALLBACK_DETAIL
     return detail if isinstance(detail, str) and detail else _DUPLICATE_FALLBACK_DETAIL
+
+
+def _storage_duplicate_fields(response: httpx.Response) -> dict:
+    """The structured half of storage's 409, or ``{}`` from an older storage.
+
+    C29. Storage now sends ``reason`` / ``existing_id`` / ``existing_status``
+    beside ``detail`` instead of only naming the winning row inside an English
+    sentence. Returning ``{}`` rather than raising is what lets the two services
+    deploy in either order: against a storage that predates this, the caller
+    still gets the prose and simply has no fields to forward.
+
+    Same defensiveness as ``_storage_detail`` and for the same reason — this
+    runs on an error path, so a non-JSON body must not turn a clean 409 into a
+    JSONDecodeError raised from inside an exception handler.
+    """
+    try:
+        body = response.json()
+    except (ValueError, AttributeError):
+        return {}
+    if not isinstance(body, dict):
+        return {}
+    return {k: body[k] for k in ("reason", "existing_id", "existing_status") if k in body}
 
 
 def _reject_reserved_write_id(agent_id: str | None) -> None:
@@ -490,7 +521,9 @@ class CoreStorageClient:
             # own an HTTP contract translate it; see ``WriteMemoryRow``.
             if exc.response.status_code != 409:
                 raise
-            raise DuplicateMemoryError(_storage_detail(exc.response)) from exc
+            raise DuplicateMemoryError(
+                _storage_detail(exc.response), _storage_duplicate_fields(exc.response)
+            ) from exc
 
     async def create_memories(self, data: list[dict]) -> list[dict]:
         """Bulk-insert memories with per-attempt idempotency (CAURA-602).
@@ -527,7 +560,9 @@ class CoreStorageClient:
             # batch was written, unlike the per-item outcomes a success returns.
             if exc.response.status_code != 409:
                 raise
-            raise DuplicateMemoryError(_storage_detail(exc.response)) from exc
+            raise DuplicateMemoryError(
+                _storage_detail(exc.response), _storage_duplicate_fields(exc.response)
+            ) from exc
 
     async def get_memory(self, memory_id: str, *, read: bool = True) -> dict | None:
         """Fetch one memory by id.

--- a/core-api/src/core_api/errors.py
+++ b/core-api/src/core_api/errors.py
@@ -68,3 +68,49 @@ def make_error_payload(
     if details:
         payload["error"]["details"] = details
     return payload
+
+
+# ── Codes for the auth boundary (C32 / API-05) ────────────────────────────
+#
+# Why these exist at all. ``code_for_status`` maps every 403 to ``FORBIDDEN``
+# and every 401 to ``UNAUTHORIZED``, so the eight distinct reasons a request can
+# be refused at this boundary arrived at the caller as one word. An agent that
+# gets FORBIDDEN on a write cannot tell "this key is read-only" from "your org
+# is over its plan limit" from "this action needs an admin" — and the only move
+# left is to guess. One did: an agent was refused a write with a tenant key and
+# concluded that tenant keys cannot write, which is false, and then stopped
+# trying. A wrong general rule learned from a specific refusal is worse than no
+# answer, because the agent stops asking.
+#
+# Each code names one reason and each message says what would work instead.
+# ``MISSING_AGENT_ID`` in ``mcp_server`` is the shape being copied: what
+# happened, why, and the concrete way out.
+AUTH_READ_ONLY_KEY = "READ_ONLY_CREDENTIAL"
+AUTH_DEMO_SANDBOX = "DEMO_SANDBOX_READ_ONLY"
+AUTH_PLAN_LIMIT = "PLAN_LIMIT_READ_ONLY"
+AUTH_ADMIN_REQUIRED = "ADMIN_REQUIRED"
+AUTH_ORG_ADMIN_REQUIRED = "ORG_ADMIN_REQUIRED"
+AUTH_MISSING_API_KEY = "MISSING_API_KEY"
+AUTH_INVALID_API_KEY = "INVALID_API_KEY"
+AUTH_MISSING_TENANT_CONTEXT = "MISSING_TENANT_CONTEXT"
+AUTH_GATEWAY_ONLY = "GATEWAY_ONLY"
+AUTH_AGENT_CREDENTIAL_FORBIDDEN = "AGENT_CREDENTIAL_FORBIDDEN"
+AUTH_TENANT_MISMATCH = "TENANT_MISMATCH"
+AUTH_TENANT_NOT_READABLE = "TENANT_NOT_READABLE"
+AUTH_CROSS_TENANT_REQUIRED = "CROSS_TENANT_READ_REQUIRED"
+AUTH_ORG_SUSPENDED = "ORGANIZATION_SUSPENDED"
+
+
+def coded_detail(code: str, message: str, **details: object) -> dict:
+    """An ``HTTPException`` detail that keeps its own error code.
+
+    ``app.http_exception_handler`` recognises this shape and emits
+    ``{"detail": message, "error": {"code", "message", "details"}}`` — so the
+    top-level ``detail`` a client already reads is unchanged and stays a plain
+    string, while the code and any structured context ride alongside.
+
+    Use this instead of a bare string wherever the caller's next action depends
+    on WHICH refusal this is. A bare string is not wrong, it is just
+    indistinguishable: it collapses into the status-derived code above.
+    """
+    return {"code": code, "message": message, "details": dict(details)}

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -25,6 +25,7 @@ from mcp.types import CallToolResult, TextContent
 from pydantic import Field, ValidationError
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from common import duplicate_memory
 from common.enrichment.constants import SERVER_RESERVED_MEMORY_TYPES
 from core_api.agent_ids import DEFAULT_AGENT_ID, effective_write_agent_id
 from core_api.auth import get_admin_key
@@ -412,15 +413,60 @@ def _refuse_reserved_memory_type(memory_type: str | None, *, index: int | None =
     return _error_response("INVALID_ARGUMENTS", detail)
 
 
+# C29 legacy path. Every duplicate 409 in this repo now carries its fields as
+# data, so this regex is only reachable while a deploy is mid-flight — a core-api
+# on this version talking to a storage that predates the structured body, which
+# still answers with the sentence and nothing else. Kept for exactly that window
+# rather than deleted, and deliberately anchored to the one message form
+# ``common.duplicate_memory.exact_message`` produces, so it cannot start matching
+# something else if the wording moves.
 _DUPLICATE_DETAIL_RE = re.compile(r"^Duplicate memory exists:\s*(?P<id>[0-9a-fA-F-]{36})\s*$")
 
 
-def _extract_duplicate_id(detail: str) -> str | None:
-    """Parse the duplicate-memory exception detail. Returns the existing
-    memory id, or None if the format doesn't match (semantic-duplicate
-    hits use a different prefix and stay opaque to callers)."""
-    m = _DUPLICATE_DETAIL_RE.match(detail or "")
-    return m.group("id") if m else None
+def _detail_text(detail: object) -> str:
+    """The human message, whichever shape the detail arrived in.
+
+    Details are now sometimes ``{"code", "message", "details"}`` (the shape
+    ``app.http_exception_handler`` expands into the canonical envelope). Passing
+    one of those to ``str()`` renders a Python dict repr — braces, quotes and
+    all — straight into a message a model reads, so every site that used to
+    stringify a detail goes through here instead.
+    """
+    if isinstance(detail, dict) and isinstance(detail.get("message"), str):
+        return detail["message"]
+    return str(detail)
+
+
+def _detail_code(detail: object, status_code: int) -> str:
+    """The error code the raiser chose, or the one its status implies.
+
+    A structured detail names its own code; anything else still derives one
+    from the status, exactly as before.
+    """
+    if isinstance(detail, dict) and isinstance(detail.get("code"), str):
+        return detail["code"]
+    return code_for_status(status_code)
+
+
+def _duplicate_info(detail: object) -> dict | None:
+    """What the 409 says about the row that already holds this content.
+
+    Returns ``None`` when the detail is not a duplicate answer at all.
+    Structured first — that is the whole point of C29, and it is also the only
+    path that can report ``existing_status`` or tell an exact hit from a
+    semantic one. The regex is the mid-deploy fallback described above, and it
+    can only ever recover the id.
+    """
+    if isinstance(detail, dict) and detail.get("code") == duplicate_memory.DUPLICATE_MEMORY_CODE:
+        fields = detail.get("details")
+        return dict(fields) if isinstance(fields, dict) else {}
+    m = _DUPLICATE_DETAIL_RE.match(_detail_text(detail))
+    if m:
+        return {
+            "existing_id": m.group("id"),
+            "reason": duplicate_memory.REASON_EXACT,
+        }
+    return None
 
 
 def _check_auth() -> CallToolResult | None:
@@ -747,7 +793,9 @@ async def caura_recall(
         return _with_latency(json.dumps(payload, indent=2, default=str), t0)
     except HTTPException as e:
         logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+        return _with_latency(
+            _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+        )
     except httpx.HTTPStatusError as e:
         # sc.get_agent() / enforce_fleet_read() are storage HTTP calls now —
         # surface a storage 4xx/5xx as the canonical envelope, not a raw raise.
@@ -968,20 +1016,34 @@ async def caura_write(
             # an error. Semantic-duplicate hits still surface as errors —
             # the caller wrote new content that we suppressed, which is a
             # semantically distinct outcome.
-            if e.status_code == 409 and (existing_id := _extract_duplicate_id(str(e.detail))):
+            dup = _duplicate_info(e.detail) if e.status_code == 409 else None
+            # Only an exact-hash hit is a retry no-op. A semantic hit means the
+            # caller wrote NEW content that we suppressed — a different outcome
+            # that must keep surfacing as an error. That distinction used to be
+            # made by the regex simply failing to match the near-duplicate
+            # wording, i.e. by accident; it is now explicit.
+            if dup is not None and dup.get("reason") == duplicate_memory.REASON_EXACT:
                 payload = {
                     "status": "duplicate",
-                    "existing_id": existing_id,
+                    "existing_id": dup.get("existing_id"),
                     "agent_id": agent_id,
                 }
+                # New in C29: which state the surviving row is in. A duplicate of
+                # an archived row is not the no-op a duplicate of a live row is,
+                # and the caller could not previously tell.
+                if dup.get("existing_status"):
+                    payload["existing_status"] = dup["existing_status"]
                 logger.info(
-                    "caura_write: idempotent duplicate hit existing=%s agent=%s",
-                    existing_id,
+                    "caura_write: idempotent duplicate hit existing=%s status=%s agent=%s",
+                    dup.get("existing_id"),
+                    dup.get("existing_status"),
                     agent_id,
                 )
                 return _with_latency(json.dumps(payload), t0)
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+            return _with_latency(
+                _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+            )
 
 
 async def caura_manage(
@@ -1303,7 +1365,9 @@ async def caura_manage(
             return _with_latency(f"Memory {memory_id} deleted.", t0)
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+            return _with_latency(
+                _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+            )
         except httpx.HTTPStatusError as e:
             # storage_client raises on non-2xx — surface the upstream status +
             # detail in the canonical envelope (parity with sibling tools).
@@ -1332,7 +1396,9 @@ async def caura_entity_get(
     try:
         result = await get_entity(uid, _get_tenant(), caller_agent_id=_get_agent_id())
     except HTTPException as e:
-        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+        return _with_latency(
+            _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+        )
     except httpx.HTTPStatusError as e:
         return _storage_error_envelope(e, t0)
     except Exception as e:
@@ -1394,7 +1460,9 @@ async def caura_tune(
         return _with_latency(json.dumps({"agent_id": agent_id, "search_profile": current}, indent=2), t0)
     except HTTPException as e:
         logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+        return _with_latency(
+            _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+        )
     except httpx.HTTPStatusError as e:
         return _storage_error_envelope(e, t0)
 
@@ -2188,7 +2256,9 @@ async def caura_doc(
             )
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+            return _with_latency(
+                _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+            )
         except httpx.HTTPStatusError as e:
             return _storage_error_envelope(e, t0)
         except Exception as e:
@@ -2406,7 +2476,9 @@ async def caura_list(
             )
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
-            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+            return _with_latency(
+                _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+            )
         except httpx.HTTPStatusError as e:
             return _storage_error_envelope(e, t0)
         except Exception as e:
@@ -2706,7 +2778,9 @@ async def caura_insights(
         }
         return _with_latency(json.dumps(result, indent=2, default=str), t0)
     except HTTPException as e:
-        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+        return _with_latency(
+            _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+        )
     except Exception as e:
         logger.exception("Unhandled error in caura_insights")
         return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
@@ -2876,7 +2950,9 @@ async def caura_evolve(
             )
         return _with_latency(json.dumps(result, indent=2, default=str), t0)
     except HTTPException as e:
-        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+        return _with_latency(
+            _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+        )
     except Exception as e:
         logger.exception("Unhandled error in caura_evolve")
         return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)
@@ -2943,7 +3019,9 @@ async def caura_keystones(
             agent_id=agent_id_effective if fleet_id else None,
         )
     except HTTPException as e:
-        return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+        return _with_latency(
+            _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+        )
     except httpx.HTTPStatusError as e:
         # storage_client raises this on non-2xx — surface the upstream
         # status + detail so a 4xx from storage doesn't surface as a 500.
@@ -3318,7 +3396,9 @@ async def caura_keystones_set(
                 t0,
             )
         except HTTPException as e:
-            return _with_latency(_error_response(code_for_status(e.status_code), str(e.detail)), t0)
+            return _with_latency(
+                _error_response(_detail_code(e.detail, e.status_code), _detail_text(e.detail)), t0
+            )
         except Exception as e:
             logger.exception("Unhandled error in caura_keystones_set")
             return _with_latency(_error_response("INTERNAL_ERROR", str(e)), t0)

--- a/core-api/src/core_api/pipeline/steps/write/check_exact_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/check_exact_duplicate.py
@@ -8,6 +8,7 @@ import time
 
 from fastapi import HTTPException
 
+from common import duplicate_memory
 from core_api.clients.storage_client import get_storage_client
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
@@ -38,8 +39,19 @@ class CheckExactDuplicate:
             (time.perf_counter() - dedup_t0) * 1000
         )
         if dup:
+            # The message is unchanged; the fields beside it are the point (C29).
+            # ``status`` in particular was never expressible in the sentence, and
+            # "you duplicated an archived row" needs a different response from
+            # "you duplicated a live one".
             raise HTTPException(
                 status_code=409,
-                detail=f"Duplicate memory exists: {dup['id']}",
+                detail=duplicate_memory.core_api_detail(
+                    duplicate_memory.exact_message(dup["id"]),
+                    **duplicate_memory.duplicate_fields(
+                        reason=duplicate_memory.REASON_EXACT,
+                        existing_id=dup["id"],
+                        existing_status=dup.get("status"),
+                    ),
+                ),
             )
         return None

--- a/core-api/src/core_api/pipeline/steps/write/check_semantic_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/check_semantic_duplicate.py
@@ -28,6 +28,7 @@ import time
 
 from fastapi import HTTPException
 
+from common import duplicate_memory
 from common.constants import (
     SEMANTIC_DEDUP_AUTO_THRESHOLD,
     SEMANTIC_DEDUP_JUDGE_THRESHOLD,
@@ -163,7 +164,15 @@ class CheckSemanticDuplicate:
             )
             raise HTTPException(
                 status_code=409,
-                detail=f"Near-duplicate memory exists: {candidate_id}",
+                detail=duplicate_memory.core_api_detail(
+                    duplicate_memory.near_message(candidate_id),
+                    **duplicate_memory.duplicate_fields(
+                        reason=duplicate_memory.REASON_SEMANTIC,
+                        existing_id=candidate_id,
+                        existing_status=(sem_dup_dict.get("status") if sem_dup_dict else None),
+                        similarity=similarity,
+                    ),
+                ),
             )
 
         # A1 #17 — subject preflight. If both rows carry a non-NULL
@@ -207,7 +216,15 @@ class CheckSemanticDuplicate:
             )
             raise HTTPException(
                 status_code=409,
-                detail=f"Near-duplicate memory exists: {candidate_id}",
+                detail=duplicate_memory.core_api_detail(
+                    duplicate_memory.near_message(candidate_id),
+                    **duplicate_memory.duplicate_fields(
+                        reason=duplicate_memory.REASON_SEMANTIC,
+                        existing_id=candidate_id,
+                        existing_status=(sem_dup_dict.get("status") if sem_dup_dict else None),
+                        similarity=similarity,
+                    ),
+                ),
             )
 
         # Low-confidence "is duplicate" → write accepted, but the

--- a/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
+++ b/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
@@ -7,6 +7,7 @@ import time
 
 from fastapi import HTTPException
 
+from common import duplicate_memory
 from core_api.clients.storage_client import DuplicateMemoryError, get_storage_client
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
@@ -100,7 +101,10 @@ class WriteMemoryRow:
             #
             # Nothing has been committed by THIS request at this point, so unlike
             # everything below, raising here is correct rather than a strand.
-            raise HTTPException(status_code=409, detail=str(exc)) from exc
+            raise HTTPException(
+                status_code=409,
+                detail=duplicate_memory.core_api_detail(str(exc), **exc.fields),
+            ) from exc
         timings["storage_ms"] = round((time.perf_counter() - storage_t0) * 1000)
 
         # H-05: the row above is COMMITTED, so everything after it degrades rather

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -594,6 +594,14 @@ async def delete_all_memories(
     agent_id: str | None = Query(default=None),
     memory_type: str | None = Query(default=None),
     status: str | None = Query(default=None),
+    confirm_scope: str | None = Query(
+        default=None,
+        description=(
+            "Required, with the value 'tenant', when this call would delete an "
+            "entire tenant corpus — i.e. no fleet_id and no other narrowing "
+            "filter. Ignored otherwise."
+        ),
+    ),
     auth: AuthContext = Depends(get_auth_context),
     body: dict | None = Body(default=None),
 ):
@@ -607,6 +615,26 @@ async def delete_all_memories(
       harness, tagging rows with ``metadata.load_test_run_id``) clean
       up by tag in one round-trip instead of paginated enumerate +
       per-row delete. All entries combine with AND.
+
+    **Blast radius.** With no ``fleet_id`` and no other narrowing filter this
+    deletes EVERY memory the tenant has. That is a supported operation — it is
+    the dashboard's "reset workspace" — but it was reachable by omission: leave
+    one query parameter off a fleet-scoped call and the same request wipes the
+    tenant, with nothing in the request to distinguish the two intents. Agent
+    credentials have been gated at trust >= 3 since the BFLA fix below; tenant
+    and user credentials were not gated at all.
+
+    So the unbounded case now requires ``confirm_scope=tenant`` (SAFE-03 /
+    C28). Every narrowed call is unaffected: pass a ``fleet_id``, ``agent_id``,
+    ``memory_type``, ``status``, ``exclude_ids`` or ``metadata_filter`` and
+    nothing changes. This deliberately does not widen C13 — the trust ladder is
+    untouched, and the confirmation is a statement of intent, not a permission.
+
+    **Recovery.** Deletes here are SOFT: rows are marked deleted, not removed,
+    and stay readable with ``include_deleted=true``. There is no self-serve
+    restore endpoint today (API-08), so undoing a mistaken tenant-wide delete
+    is an operator task against the store. Treat the confirmation as the last
+    cheap step before an expensive one.
     """
     auth.enforce_read_only()
     auth.enforce_tenant(tenant_id)
@@ -619,6 +647,32 @@ async def delete_all_memories(
         await enforce_delete(tenant_id, auth.agent_id)
     exclude_ids = (body or {}).get("exclude_ids", [])
     metadata_filter = (body or {}).get("metadata_filter") or {}
+    # SAFE-03 / C28. "Unbounded" means every narrowing input is absent, so the
+    # filter set degenerates to the tenant alone. Listed explicitly rather than
+    # inferred, because a new filter parameter added later must be a deliberate
+    # entry here: forgetting it would silently classify a narrowed call as
+    # unbounded (annoying), while inferring from ``locals()`` would silently do
+    # the reverse the day someone adds a non-filter parameter (dangerous).
+    is_tenant_wide = not any((fleet_id, agent_id, memory_type, status, exclude_ids, metadata_filter))
+    if is_tenant_wide and confirm_scope != "tenant":
+        logger.warning(
+            "Refused unconfirmed tenant-wide delete",
+            extra={
+                "tenant_id": tenant_id,
+                "principal_agent_id": auth.agent_id,
+                "confirm_scope": confirm_scope,
+            },
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This request would soft-delete every memory in the tenant. "
+                "No fleet_id and no other narrowing filter was supplied. "
+                "Pass confirm_scope=tenant to proceed, or narrow the request "
+                "with fleet_id / agent_id / memory_type / status / exclude_ids "
+                "/ metadata_filter."
+            ),
+        )
     if metadata_filter:
         # Validation stays in core-api so the exact 400 messages are preserved;
         # the storage endpoint builds the JSONB predicate via SQLAlchemy bound
@@ -672,6 +726,10 @@ async def delete_all_memories(
             "memory_type": memory_type,
             "status_filter": status,
             "metadata_filter": metadata_filter or None,
+            # Without this the audit row for a tenant wipe is shaped exactly
+            # like the row for a narrow delete that happened to match a lot.
+            "tenant_wide": is_tenant_wide,
+            "confirm_scope": confirm_scope,
         },
     )
 

--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -618,7 +618,19 @@ echo ""
 
 class InstallPluginRequest(BaseModel):
     fleet_id: str = ""
-    api_url: str = "http://localhost:8000"
+    # F4/AX-03. Was ``"http://localhost:8000"``. That default is correct for
+    # exactly one caller — someone running the API on their own machine — and
+    # wrong for every hosted install, which is who the published one-liner is
+    # for: ``curl https://caura.ai/api/v1/install-plugin | bash`` produced a
+    # script pointing at the installing machine's own port 8000, so the
+    # documented cloud install could not work unless the reader knew to append
+    # ``?api_url=`` that no published copy of the command mentions.
+    #
+    # ``None`` means "not supplied", and the host that just served this script
+    # is by definition a reachable API host. That is what the SKILL installer
+    # below already does via ``_derive_api_url_from_request`` — this endpoint
+    # simply never adopted it.
+    api_url: str | None = None
     api_key: str = ""
     node_name: str = ""
 
@@ -627,7 +639,14 @@ class InstallPluginRequest(BaseModel):
 async def install_plugin_script(
     request: Request,
     fleet_id: str = Query(default=""),
-    api_url: str = Query(default="http://localhost:8000"),
+    api_url: str | None = Query(
+        default=None,
+        description=(
+            "Override the API URL baked into the generated script. Auto-derived "
+            "from the request Host (and X-Forwarded-Proto) when omitted — so "
+            "``curl https://caura.ai/api/v1/install-plugin | bash`` just works."
+        ),
+    ),
     node_name: str = Query(default=""),
 ):
     """Generate a bash install script for first-time plugin setup on an OpenClaw gateway."""
@@ -635,7 +654,7 @@ async def install_plugin_script(
     tenant_id = _resolve_tenant_id()
 
     script = _generate_install_script(
-        api_url=api_url,
+        api_url=api_url or _derive_api_url_from_request(request),
         api_key=api_key,
         fleet_id=fleet_id,
         tenant_id=tenant_id,
@@ -654,7 +673,7 @@ async def install_plugin_script_post(
     tenant_id = _resolve_tenant_id()
 
     script = _generate_install_script(
-        api_url=body.api_url,
+        api_url=body.api_url or _derive_api_url_from_request(request),
         api_key=api_key,
         fleet_id=body.fleet_id,
         tenant_id=tenant_id,

--- a/core-api/src/core_api/routes/stm.py
+++ b/core-api/src/core_api/routes/stm.py
@@ -17,6 +17,39 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["stm"])
 
+# CAP-01 / F6 — surface honesty for STM.
+#
+# STM is advertised here and reachable nowhere. Three facts, all verified
+# against a running stack:
+#
+#   1. There is no REST WRITE route. POST /stm/notes and POST /stm/bulletin
+#      do not exist, so a caller who reads these docs and tries to put
+#      anything into short-term memory gets a bare 405 with no explanation.
+#      Writing is plugin-only.
+#   2. Every read, delete and promote below is gated on ``USE_STM``, which is
+#      off by default and is not tenant-toggleable — the setting appears
+#      nowhere in the hosted deployment, so a hosted customer cannot turn it
+#      on at any price.
+#   3. The gate's own message used to say "Set USE_STM=true to enable
+#      short-term memory", which is advice the reader it reaches cannot act
+#      on. Telling someone to flip a switch they cannot reach is worse than
+#      saying nothing.
+#
+# This block LABELS that. It does not enable STM, add the missing write
+# routes, or change any status code — STM stays dead by standing decision, and
+# A25 stays closed. The register's wording is the whole scope: label it, don't
+# build it.
+_PLUGIN_ONLY = (
+    "**Plugin-only — not available over hosted REST.** Short-term memory is "
+    "served by the OpenClaw plugin, not by this API. This operation is gated "
+    "on the server-side `USE_STM` setting, which is off in the hosted "
+    "deployment and cannot be enabled per tenant; it returns 422 there. "
+    "There is also no REST write route for STM (`POST /stm/notes` and "
+    "`POST /stm/bulletin` return 405), so nothing can be put into short-term "
+    "memory over REST even where reads are enabled. Self-hosted operators who "
+    "set `USE_STM=true` get the read, clear and promote operations only."
+)
+
 
 def _reject_reserved_memory_type(memory_type: str | None) -> None:
     """Twin of ``memories._reject_reserved_memory_type``, for the promote door.
@@ -36,10 +69,27 @@ def _reject_reserved_memory_type(memory_type: str | None) -> None:
 
 
 def _check_stm_enabled() -> None:
+    """Reject with a message the reader can actually act on.
+
+    The status stays 422 deliberately. It is arguably the wrong class — the
+    caller's arguments are fine, the capability is absent — but the code that
+    rides on it (``INVALID_ARGUMENTS``, derived from the status by
+    ``errors.STATUS_TO_CODE``) is part of the wire contract, and re-classing it
+    belongs with the error-design work in API-05 rather than here. What is in
+    scope is the message, which told hosted callers to set a variable they have
+    no way to reach.
+    """
     if not settings.use_stm:
         raise HTTPException(
             status_code=422,
-            detail="STM is not enabled. Set USE_STM=true to enable short-term memory.",
+            detail=(
+                "Short-term memory is not available on this deployment. STM is "
+                "plugin-only: it is served by the OpenClaw plugin, and the hosted "
+                "REST API cannot enable it (USE_STM is a server setting, not a "
+                "per-tenant one). Self-hosted operators can set USE_STM=true; "
+                "hosted callers should use the durable memory endpoints "
+                "(/memories, /search) instead."
+            ),
         )
 
 
@@ -54,7 +104,7 @@ def _require_tenant(auth: AuthContext) -> str:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/stm/notes")
+@router.get("/stm/notes", description=_PLUGIN_ONLY)
 async def get_notes(
     auth: AuthContext = Depends(get_auth_context),
     agent_id: str = Query(...),
@@ -85,7 +135,7 @@ async def get_notes(
     }
 
 
-@router.delete("/stm/notes")
+@router.delete("/stm/notes", description=_PLUGIN_ONLY)
 async def clear_notes(
     auth: AuthContext = Depends(get_auth_context),
     agent_id: str = Query(...),
@@ -111,7 +161,7 @@ async def clear_notes(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/stm/bulletin")
+@router.get("/stm/bulletin", description=_PLUGIN_ONLY)
 async def get_bulletin(
     auth: AuthContext = Depends(get_auth_context),
     fleet_id: str = Query(...),
@@ -130,7 +180,7 @@ async def get_bulletin(
     }
 
 
-@router.delete("/stm/bulletin")
+@router.delete("/stm/bulletin", description=_PLUGIN_ONLY)
 async def clear_bulletin(
     auth: AuthContext = Depends(get_auth_context),
     fleet_id: str = Query(...),
@@ -157,7 +207,7 @@ class PromoteRequest(BaseModel):
     visibility: str | None = None
 
 
-@router.post("/stm/promote")
+@router.post("/stm/promote", description=_PLUGIN_ONLY)
 async def promote_stm(
     body: PromoteRequest,
     auth: AuthContext = Depends(get_auth_context),

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -12,6 +12,7 @@ from uuid import UUID, uuid4
 from fastapi import HTTPException
 from sqlalchemy.exc import SQLAlchemyError
 
+from common import duplicate_memory
 from core_api.clients.storage_client import DuplicateMemoryError, get_storage_client
 from core_api.config import settings
 from core_api.middleware.per_tenant_concurrency import per_tenant_slot, per_tenant_storage_slot
@@ -385,7 +386,13 @@ async def _create_memory_or_409(payload: dict) -> dict:
     try:
         return await get_storage_client().create_memory(payload)
     except DuplicateMemoryError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        # ``exc.fields`` is storage's structured half, and is empty when talking
+        # to a storage that predates it — so this forwards what it has rather
+        # than asserting the fields are there.
+        raise HTTPException(
+            status_code=409,
+            detail=duplicate_memory.core_api_detail(str(exc), **exc.fields),
+        ) from exc
 
 
 async def _find_semantic_duplicate(
@@ -1332,7 +1339,14 @@ async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:
     if dup:
         raise HTTPException(
             status_code=409,
-            detail=f"Duplicate memory exists: {dup.get('id')}",
+            detail=duplicate_memory.core_api_detail(
+                duplicate_memory.exact_message(dup.get("id")),
+                **duplicate_memory.duplicate_fields(
+                    reason=duplicate_memory.REASON_EXACT,
+                    existing_id=dup.get("id"),
+                    existing_status=dup.get("status"),
+                ),
+            ),
         )
 
     # Semantic dedup: catch near-duplicates (same meaning, different phrasing)
@@ -1349,7 +1363,14 @@ async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:
         if sem_dup:
             raise HTTPException(
                 status_code=409,
-                detail=f"Near-duplicate memory exists: {sem_dup.get('id')}",
+                detail=duplicate_memory.core_api_detail(
+                    duplicate_memory.near_message(sem_dup.get("id")),
+                    **duplicate_memory.duplicate_fields(
+                        reason=duplicate_memory.REASON_SEMANTIC,
+                        existing_id=sem_dup.get("id"),
+                        existing_status=sem_dup.get("status"),
+                    ),
+                ),
             )
 
     if embedding is None:
@@ -2030,7 +2051,10 @@ async def create_memories_bulk(
                 # resolved every duplicate it could see, through
                 # ``existing_hashes`` and ``seen_hashes``. A retry re-runs those
                 # against the now-committed winner and succeeds.
-                raise HTTPException(status_code=409, detail=str(exc)) from exc
+                raise HTTPException(
+                    status_code=409,
+                    detail=duplicate_memory.core_api_detail(str(exc), **exc.fields),
+                ) from exc
 
         # Map each storage result back to its source item via
         # ``client_request_id``. Postgres ``RETURNING`` order is
@@ -3470,7 +3494,17 @@ async def update_memory(
             exclude_id=str(memory_id),
         )
         if dup:
-            raise HTTPException(status_code=409, detail=f"Duplicate memory exists: {dup.get('id')}")
+            raise HTTPException(
+                status_code=409,
+                detail=duplicate_memory.core_api_detail(
+                    duplicate_memory.exact_message(dup.get("id")),
+                    **duplicate_memory.duplicate_fields(
+                        reason=duplicate_memory.REASON_EXACT,
+                        existing_id=dup.get("id"),
+                        existing_status=dup.get("status"),
+                    ),
+                ),
+            )
 
         # Semantic dedup on content change (exclude self; skip when new embedding is None)
         if tenant_config.semantic_dedup_enabled and new_embedding is not None:
@@ -3483,7 +3517,14 @@ async def update_memory(
             if sem_dup:
                 raise HTTPException(
                     status_code=409,
-                    detail=f"Near-duplicate memory exists: {sem_dup.get('id')}",
+                    detail=duplicate_memory.core_api_detail(
+                        duplicate_memory.near_message(sem_dup.get("id")),
+                        **duplicate_memory.duplicate_fields(
+                            reason=duplicate_memory.REASON_SEMANTIC,
+                            existing_id=sem_dup.get("id"),
+                            existing_status=sem_dup.get("status"),
+                        ),
+                    ),
                 )
 
         changes["content"] = {"old": mem.get("content", "")[:200], "new": data.content[:200]}

--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse
 
 from common.structlog_config import configure_logging
 from core_storage_api.config import settings
+from core_storage_api.services.postgres_service import DuplicateContentHashError
 
 # Must run before any other module-level import emits a log record —
 # database.init and the routers below pull in SQLAlchemy, httpx, etc., all
@@ -87,6 +88,26 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
         redirect_slashes=False,
     )
+
+    @app.exception_handler(DuplicateContentHashError)
+    async def _duplicate_content_hash_handler(
+        request: Request, exc: DuplicateContentHashError
+    ) -> JSONResponse:
+        # C29. Both memory-insert routes used to catch this and re-raise it as
+        # ``HTTPException(409, detail=str(exc))``. That could only ever send one
+        # string, which is why the winning row's id travelled as English and
+        # core-api's MCP server ended up regex-parsing it back out.
+        #
+        # ``detail`` is byte-identical to what those routes sent, so an older
+        # core-api reading this response is unaffected; the structured fields
+        # sit BESIDE it for anyone who wants the id without a regular
+        # expression. Registered for the dedicated subclass only — a bare
+        # ``ValueError`` handler would relabel genuine server faults as client
+        # errors, which is exactly what the routes were careful to avoid.
+        return JSONResponse(
+            status_code=409,
+            content={"detail": str(exc), **exc.fields},
+        )
 
     @app.exception_handler(json.JSONDecodeError)
     async def _malformed_json_handler(request: Request, exc: json.JSONDecodeError) -> JSONResponse:

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -19,7 +19,6 @@ from core_storage_api.routers._validation import _require, _require_dict
 from core_storage_api.schemas import MEMORY_FIELDS, MEMORY_LIST_FIELDS, orm_to_dict
 from core_storage_api.services.postgres_service import (
     BulkValidationError,
-    DuplicateContentHashError,
     PostgresService,
 )
 
@@ -85,20 +84,12 @@ def _validate_pg_regex(value: str | None, field: str) -> None:
 async def create_memory(request: Request) -> dict:
     body: dict = await request.json()
     _parse_datetimes(body)
-    try:
-        memory = await _svc.memory_add(body)
-    except DuplicateContentHashError as exc:
-        # Migration 040's unique index rejected the insert. 409, not 500: the
-        # dedup contract already promises this code — ``CheckExactDuplicate``
-        # raises it upstream when the duplicate is visible before the write, and
-        # this is the same answer for the race it cannot see. The detail carries
-        # the winning row's id, so a caller can use the row it should have got.
-        #
-        # Catches the dedicated subclass, NOT bare ``ValueError``, for the reason
-        # spelled out on ``BulkValidationError`` below: the try spans a call that
-        # opens a session, so a broad catch would relabel a server fault as a
-        # client error.
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    # ``DuplicateContentHashError`` (migration 040's unique index) is handled
+    # app-wide so its 409 body can carry structured fields beside the message —
+    # see ``app._duplicate_content_hash_handler``. Nothing else here is caught:
+    # this call opens a session, and a broad catch would relabel a server fault
+    # as a client error.
+    memory = await _svc.memory_add(body)
     return orm_to_dict(memory, MEMORY_FIELDS)
 
 
@@ -120,13 +111,6 @@ async def create_memories_bulk(request: Request) -> list[dict]:
         _parse_datetimes(item)
     try:
         return await _svc.memory_add_all(body)
-    except DuplicateContentHashError as exc:
-        # Migration 040's constraint aborted the batch. 409 for the same reason
-        # the single-row route gives it: the content is already stored, and
-        # nothing here was written. Listed BEFORE ``BulkValidationError`` only
-        # for readability — the two are siblings under ``ValueError``, neither is
-        # a subclass of the other, so the order does not affect which one runs.
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except BulkValidationError as exc:
         # Malformed batch (an item missing ``client_request_id``, or mixed
         # ``tenant_id`` / ``fleet_id``). Unwrapped it escaped as a 500 — a

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -44,6 +44,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import load_only
 
+from common import duplicate_memory
 from common.constants import (
     CONTRADICTION_CANDIDATE_MAX,
     CONTRADICTION_SIMILARITY_THRESHOLD,
@@ -552,7 +553,17 @@ class DuplicateContentHashError(ValueError):
 
     Subclasses ``ValueError`` so the 409 convention the entities routes already
     use (``except ValueError -> HTTPException(409)``) keeps working unchanged.
+
+    Carries the structured half of the answer alongside the message (C29). The
+    message stays exactly what it was — ``str(exc)`` is what the router used to
+    send and what core-api still reads when it is talking to an older storage —
+    while ``fields`` holds what the sentence could not: which row won, what
+    state that row is in, and why the write was refused.
     """
+
+    def __init__(self, message: str, fields: dict | None = None) -> None:
+        super().__init__(message)
+        self.fields: dict = fields or {}
 
 
 def _content_hash_fleet_scope(fleet_id: str | None):
@@ -689,10 +700,10 @@ class PostgresService:
             # manager" — which would turn every duplicate insert into the 500
             # this handler exists to prevent. The lookup below therefore opens a
             # fresh session of its own.
-            raise DuplicateContentHashError(await self._describe_content_hash_winner(data)) from exc
+            raise await self._describe_content_hash_winner(data) from exc
 
-    async def _describe_content_hash_winner(self, data: dict) -> str:
-        """Message naming the row that already holds this content.
+    async def _describe_content_hash_winner(self, data: dict) -> DuplicateContentHashError:
+        """The 409 naming the row that already holds this content.
 
         Re-SELECTed rather than omitted, and it is the whole reason this raises a
         message instead of a bare flag: ``CheckExactDuplicate``'s 409 says
@@ -710,7 +721,10 @@ class PostgresService:
         ``memory_find_by_content_hash`` returns — a 409 pointing at a different
         row than the lookup would give is worse than no id at all.
         """
-        stmt = select(Memory.id).where(
+        # ``status`` rides along because the prose form could not carry it, and
+        # "you duplicated an archived row" is a different situation from "you
+        # duplicated a live one" — see ``common.duplicate_memory``.
+        stmt = select(Memory.id, Memory.status).where(
             Memory.tenant_id == data["tenant_id"],
             Memory.content_hash == data.get("content_hash"),
             Memory.agent_id == data["agent_id"],
@@ -723,14 +737,24 @@ class PostgresService:
         async with get_session() as session:
             winner = (
                 await session.execute(stmt.order_by(Memory.created_at.asc(), Memory.id.asc()).limit(1))
-            ).scalar_one_or_none()
+            ).first()
         if winner is None:
             # The winner was soft-deleted between the conflict and this read, so
             # the content is free again. Reported honestly rather than retried
             # here: a retry inside the failed transaction's handler is a loop
             # waiting to happen, and the caller's own retry will now succeed.
-            return "Duplicate memory exists but is no longer live; retry the write"
-        return f"Duplicate memory exists: {winner}"
+            return DuplicateContentHashError(
+                duplicate_memory.NOT_LIVE_MESSAGE,
+                duplicate_memory.duplicate_fields(reason=duplicate_memory.REASON_RACE_NOT_LIVE),
+            )
+        return DuplicateContentHashError(
+            duplicate_memory.exact_message(winner.id),
+            duplicate_memory.duplicate_fields(
+                reason=duplicate_memory.REASON_EXACT,
+                existing_id=winner.id,
+                existing_status=winner.status,
+            ),
+        )
 
     async def memory_add_all(self, items: list[dict]) -> list[dict]:
         """Insert with per-attempt idempotency (CAURA-602).
@@ -853,7 +877,13 @@ class PostgresService:
                 )
                 raise DuplicateContentHashError(
                     "bulk insert rejected: an item's content already exists for "
-                    "this agent; nothing in this batch was written"
+                    "this agent; nothing in this batch was written",
+                    # No id: the constraint aborts the batch without telling us
+                    # WHICH item lost, and re-deriving it would mean re-running
+                    # the whole batch's hashes against the table. The reason is
+                    # still worth sending — it is the difference between "retry
+                    # this batch" and "your payload was malformed".
+                    duplicate_memory.duplicate_fields(reason=duplicate_memory.REASON_EXACT),
                 ) from exc
             inserted: dict[str, UUID] = {row.client_request_id: row.id for row in result.all()}
 

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -16,7 +16,7 @@
     "pretest": "bash ../scripts/gen-version.sh",
     "build": "tsc",
     "dev": "bash ../scripts/gen-version.sh && tsc --watch",
-    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/interview-buffer.test.js dist/interview-command.test.js dist/task-trail.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js dist/fleet-scope.test.js",
+    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/tool-identity.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/interview-buffer.test.js dist/interview-command.test.js dist/task-trail.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js dist/fleet-scope.test.js",
     "check:version": "bash -c 'V=$(node -p \"require(\\\"./package.json\\\").version\"); grep -qF \"PLUGIN_VERSION = \\\"$V\\\"\" src/version.ts || (echo \"version.ts out of sync with package.json ($V): run bash ../scripts/gen-version.sh\" >&2 && exit 1) && echo \"check:version ok: $V\"'"
   },
   "devDependencies": {

--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -28,8 +28,8 @@ import {
   getToolDescription,
 } from "./env.js";
 import { assertSafePathSegment } from "./validation.js";
+import { resolveAgentIdQuiet } from "./resolve-agent.js";
 import { getSpec } from "./tool-specs.js";
-import { getInstallId } from "./install-id.js";
 
 interface ToolResult {
   content: Array<{ type: string; text: string }>;
@@ -74,6 +74,25 @@ interface EnrichOptions {
    * under. Withholding it there relocates a write instead of widening a read.
    */
   fleetIsReadFilterOnly?: boolean;
+
+  /**
+   * Set on the tools that SEND ``agent_id`` to the server, so identity is
+   * resolved once here instead of each dispatch inventing its own fallback.
+   *
+   * Three of them did invent one, and they disagreed: ``caura_write`` fell
+   * back to ``main-${installId}`` (correct — it mirrors ``resolve-agent.ts``
+   * step 5), while ``caura_manage`` op=update and ``caura_tune`` fell back to
+   * the literal ``"unknown-agent"``. That literal is not an identity: tune
+   * PATCHes ``/agents/unknown-agent/tune`` and 404s, and update passes it as
+   * the ``agent_id`` query param where the server feeds it to trust and fleet
+   * enforcement (``routes/memories.py``: ``auth.agent_id or agent_id``) — so
+   * it does not fail loudly there, it authorizes as the wrong principal.
+   *
+   * Deliberately opt-in rather than applied to every call. Reads do not send
+   * ``agent_id`` today, and adding one would narrow their visibility scoping —
+   * a silent behaviour change dressed up as a bug fix.
+   */
+  resolveIdentity?: boolean;
 }
 
 async function enrichBody(
@@ -82,7 +101,15 @@ async function enrichBody(
 ): Promise<Record<string, unknown>> {
   const body = { ...params };
   if (!body.tenant_id) body.tenant_id = await ensureTenantId();
-  if (!body.agent_id && CAURA_AGENT_ID) body.agent_id = CAURA_AGENT_ID;
+  // ``resolveAgentIdQuiet`` covers the env var too (its step 4), so the
+  // identity-bearing branch subsumes the plain one rather than racing it.
+  // Quiet, not loud: the install-scoped default IS the design for a tool call,
+  // which carries no session context to resolve a richer identity from. The
+  // loud variant is for the per-turn paths, where a fall-through is a real bug.
+  if (!body.agent_id) {
+    if (opts.resolveIdentity) body.agent_id = resolveAgentIdQuiet(params);
+    else if (CAURA_AGENT_ID) body.agent_id = CAURA_AGENT_ID;
+  }
   // The configured fleet below is a DEFAULT, for callers that did not say
   // which fleet they meant — so it must not override a caller that asked to
   // span every fleet. Three cases deliberately keep it: an omitted ``scope``
@@ -385,13 +412,10 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
 
   caura_write: async (params, signal) => {
     const isBatch = Array.isArray(params.items);
-    const body = await enrichBody(params);
-    // Write-scoped identity default: never send an empty agent_id, which on the
-    // gateway path collapses onto the reserved "main" default. enrichBody set it
-    // from CAURA_AGENT_ID if present; otherwise fall back to a stable
-    // install-scoped id (mirrors resolve-agent.ts step 5). Scoped to writes so
-    // read visibility scoping is unchanged.
-    if (!body.agent_id) body.agent_id = `main-${getInstallId()}`;
+    // Never send an empty agent_id: on the gateway path it collapses onto the
+    // reserved "main" default. ``resolveIdentity`` supplies the install-scoped
+    // id this dispatch used to build inline.
+    const body = await enrichBody(params, { resolveIdentity: true });
     if (isBatch) {
       // POST /memories/bulk requires a per-attempt idempotency token via
       // the `X-Bulk-Attempt-Id` header (CAURA-602). The server derives each
@@ -410,7 +434,8 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
   },
 
   caura_manage: async (params, signal) => {
-    const enriched = await enrichBody(params);
+    // op=update sends ``agent_id`` as a query param; the other ops ignore it.
+    const enriched = await enrichBody(params, { resolveIdentity: true });
     const op = enriched.op as string;
     const memory_id = enriched.memory_id as string;
     assertSafePathSegment(memory_id, "memory_id");
@@ -432,7 +457,7 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
       return apiCall("DELETE", `/memories/${id}`, undefined, { tenant_id }, signal);
     }
     // op === "update"
-    const agent_id = (enriched.agent_id as string) || "unknown-agent";
+    const agent_id = enriched.agent_id as string;
     const updateFields: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(enriched)) {
       if (v === undefined) continue;
@@ -535,9 +560,9 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
   },
 
   caura_tune: async (params, signal) => {
-    const enriched = await enrichBody(params);
+    const enriched = await enrichBody(params, { resolveIdentity: true });
     const tenant_id = enriched.tenant_id as string;
-    const agent_id = (enriched.agent_id as string) || "unknown-agent";
+    const agent_id = enriched.agent_id as string;
     assertSafePathSegment(agent_id, "agent_id");
     const body = { ...enriched };
     delete body.agent_id;

--- a/plugin/src/tool-identity.test.ts
+++ b/plugin/src/tool-identity.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Identity wiring for the tools that send ``agent_id`` (SAFE-04B / F5).
+ *
+ * Three dispatches used to invent their own fallback and disagree.
+ * ``caura_write`` fell back to ``main-${installId}``; ``caura_manage``
+ * op=update and ``caura_tune`` fell back to the literal ``"unknown-agent"``.
+ *
+ * The literal is not an identity, and the two tools carrying it fail
+ * differently, which is why only one of them was noticed:
+ *
+ *   - ``caura_tune`` PATCHes ``/agents/unknown-agent/tune`` and 404s. Loud.
+ *   - ``caura_manage`` op=update sends it as the ``agent_id`` QUERY PARAM,
+ *     where ``routes/memories.py`` resolves ``auth.agent_id or agent_id`` and
+ *     feeds the result to trust and fleet enforcement. With no gateway agent
+ *     header that literal becomes the authorizing principal. Silent.
+ *
+ * These assert on the request the server would actually receive, so a
+ * regression in either the resolver or a dispatch's own wiring is caught.
+ */
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+
+// Env is read into module constants at import time, so it must be set before
+// the dynamic imports below. No CAURA_AGENT_ID: that is the case under test.
+process.env.CAURA_API_URL = "http://identity.test";
+process.env.CAURA_API_KEY = "test-key";
+process.env.CAURA_TENANT_ID = "t-identity";
+delete process.env.CAURA_AGENT_ID;
+delete process.env.MEMCLAW_AGENT_ID; // legacy-name-ok: the dual-read alias must be cleared too
+
+const { createToolFromSpec } = await import("./tool-definitions.js");
+const { resolveAgentIdQuiet } = await import("./resolve-agent.js");
+
+/** The identity every one of these tools must converge on. */
+const EXPECTED_AGENT_ID = resolveAgentIdQuiet({});
+
+interface Captured {
+  url: URL;
+  method: string;
+  body: Record<string, unknown> | undefined;
+}
+
+let captured: Captured[] = [];
+let realFetch: typeof globalThis.fetch;
+
+before(() => {
+  realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    captured.push({
+      url: new URL(String(input)),
+      method: init?.method ?? "GET",
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+});
+
+after(() => {
+  globalThis.fetch = realFetch;
+});
+
+/**
+ * The operation request, not the credential lookup.
+ *
+ * ``apiCall`` resolves an agent-scoped API key before issuing the call
+ * whenever an ``agent_id`` is in play, so an identity-bearing tool makes two
+ * requests and the operation is always the last. Asserting on a fixed count
+ * would make these tests fail the day a tool grows another round-trip, which
+ * is not what they are guarding.
+ */
+async function run(tool: string, params: Record<string, unknown>): Promise<Captured> {
+  captured = [];
+  await createToolFromSpec(tool).execute("test-call", params, undefined as never);
+  assert.ok(captured.length >= 1, `${tool} made no request`);
+  return captured[captured.length - 1];
+}
+
+describe("agent identity is resolved, never invented", () => {
+  test("the resolved default is a real install-scoped id", () => {
+    assert.match(EXPECTED_AGENT_ID, /^main-.+/);
+    assert.notEqual(EXPECTED_AGENT_ID, "unknown-agent");
+  });
+
+  test("caura_tune targets the resolved agent, not a placeholder path", async () => {
+    const req = await run("caura_tune", { weight_delta: 0.1, memory_id: "m-1" });
+    assert.equal(
+      req.url.pathname,
+      `/api/v1/agents/${encodeURIComponent(EXPECTED_AGENT_ID)}/tune`,
+    );
+    assert.doesNotMatch(req.url.pathname, /unknown-agent/);
+  });
+
+  test("caura_manage op=update authorizes as the resolved agent", async () => {
+    const req = await run("caura_manage", {
+      op: "update",
+      memory_id: "11111111-1111-4111-8111-111111111111",
+      content: "updated",
+    });
+    assert.equal(req.method, "PATCH");
+    assert.equal(req.url.searchParams.get("agent_id"), EXPECTED_AGENT_ID);
+    assert.notEqual(req.url.searchParams.get("agent_id"), "unknown-agent");
+  });
+
+  test("caura_write sends the same identity as the other two", async () => {
+    const req = await run("caura_write", { content: "hello" });
+    assert.equal(req.body?.agent_id, EXPECTED_AGENT_ID);
+  });
+
+  test("an explicit agent_id always wins over the default", async () => {
+    const req = await run("caura_tune", {
+      agent_id: "explicit-agent",
+      weight_delta: 0.1,
+      memory_id: "m-1",
+    });
+    assert.equal(req.url.pathname, "/api/v1/agents/explicit-agent/tune");
+  });
+
+  test("reads still send no agent_id — identity resolution must not narrow scope", async () => {
+    const req = await run("caura_recall", { query: "anything" });
+    assert.equal(req.body?.agent_id, undefined);
+    assert.equal(req.url.searchParams.get("agent_id"), null);
+  });
+});

--- a/tests/test_auth_context.py
+++ b/tests/test_auth_context.py
@@ -3,6 +3,16 @@
 from __future__ import annotations
 
 import pytest
+
+from core_api import errors
+
+# C32 / API-05: ``detail`` on an auth refusal is now
+# ``{"code", "message", "details"}`` so the eight distinct reasons this boundary
+# can refuse a request stop collapsing into the single status-derived
+# ``FORBIDDEN``. The human message is unchanged and lives under ``["message"]``;
+# these assertions follow it there, and additionally pin the code — which is the
+# part a caller is now expected to branch on.
+
 from fastapi import HTTPException
 
 from core_api.auth import AuthContext
@@ -18,7 +28,8 @@ def test_enforce_read_only_blocks_demo():
     with pytest.raises(HTTPException) as exc_info:
         ctx.enforce_read_only()
     assert exc_info.value.status_code == 403
-    assert "demo" in exc_info.value.detail.lower()
+    assert "demo" in exc_info.value.detail["message"].lower()
+    assert exc_info.value.detail["code"] == errors.AUTH_DEMO_SANDBOX
 
 
 def test_enforce_usage_limits_allows_normal_org():
@@ -31,8 +42,9 @@ def test_enforce_usage_limits_blocks_read_only_org():
     with pytest.raises(HTTPException) as exc_info:
         ctx.enforce_usage_limits()
     assert exc_info.value.status_code == 403
-    assert "read-only" in exc_info.value.detail.lower()
-    assert "upgrade" in exc_info.value.detail.lower()
+    assert "read-only" in exc_info.value.detail["message"].lower()
+    assert "upgrade" in exc_info.value.detail["message"].lower()
+    assert exc_info.value.detail["code"] == errors.AUTH_PLAN_LIMIT
 
 
 def test_read_only_is_independent_of_demo():
@@ -122,7 +134,8 @@ def test_enforce_write_scope_blocks_read_only_scopes():
     with pytest.raises(HTTPException) as exc_info:
         ctx.enforce_write_scope()
     assert exc_info.value.status_code == 403
-    assert "read-only" in exc_info.value.detail.lower()
+    assert "read-only" in exc_info.value.detail["message"].lower()
+    assert exc_info.value.detail["code"] == errors.AUTH_READ_ONLY_KEY
 
 
 # ── enforce_read_only also enforces scope (composite gate) ───────────
@@ -140,7 +153,8 @@ def test_enforce_read_only_blocks_scope_restricted_keys():
     with pytest.raises(HTTPException) as exc_info:
         ctx.enforce_read_only()
     assert exc_info.value.status_code == 403
-    assert "read-only" in exc_info.value.detail.lower()
+    assert "read-only" in exc_info.value.detail["message"].lower()
+    assert exc_info.value.detail["code"] == errors.AUTH_READ_ONLY_KEY
 
 
 def test_enforce_read_only_passes_when_write_in_scopes():

--- a/tests/test_c28_confirm_scope_tenant_delete.py
+++ b/tests/test_c28_confirm_scope_tenant_delete.py
@@ -1,0 +1,126 @@
+"""``DELETE /memories`` must not wipe a tenant by omission — SAFE-03 / C28.
+
+The endpoint deletes every memory matching its filters. With no ``fleet_id``
+and no other narrowing filter, "matching" means the whole tenant — and that
+case was reachable by leaving one query parameter off an otherwise ordinary
+fleet-scoped call. Nothing in the request distinguished "clear this fleet" from
+"clear everything", so the two could not be told apart by a gate, a log, or an
+audit row.
+
+Agent credentials have been gated at trust >= 3 since the BFLA fix. Tenant and
+user credentials were not gated at all, by design — it is the dashboard's
+"reset workspace". The fix is therefore a statement of intent rather than a
+permission: the unbounded call requires ``confirm_scope=tenant``, and every
+narrowed call is untouched.
+
+That last property is most of what these tests are for. A safety gate that also
+breaks ordinary filtered deletes would be reverted within a day, so each
+narrowing input is checked independently.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.conftest import get_test_auth
+
+pytestmark = pytest.mark.integration
+
+
+def _tenant() -> tuple[str, dict]:
+    return get_test_auth(f"t-c28-{uuid.uuid4().hex[:8]}")
+
+
+async def test_unbounded_delete_is_refused_without_confirmation(client) -> None:
+    tenant_id, headers = _tenant()
+    resp = await client.delete(f"/api/v1/memories?tenant_id={tenant_id}", headers=headers)
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    # The message has to name the parameter and the way out, or the caller's
+    # next move is to guess.
+    assert "confirm_scope=tenant" in detail
+    assert "every memory" in detail.lower()
+
+
+async def test_unbounded_delete_proceeds_when_confirmed(client) -> None:
+    tenant_id, headers = _tenant()
+    resp = await client.delete(
+        f"/api/v1/memories?tenant_id={tenant_id}&confirm_scope=tenant", headers=headers
+    )
+    assert resp.status_code == 204, resp.text
+
+
+async def test_a_wrong_confirmation_value_is_not_a_confirmation(client) -> None:
+    """``confirm_scope=true`` is the plausible guess, and it must not work."""
+    tenant_id, headers = _tenant()
+    resp = await client.delete(
+        f"/api/v1/memories?tenant_id={tenant_id}&confirm_scope=true", headers=headers
+    )
+    assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.parametrize(
+    "narrowing",
+    [
+        "fleet_id=f-c28",
+        "agent_id=a-c28",
+        "memory_type=fact",
+        "status=active",
+    ],
+)
+async def test_any_narrowing_filter_keeps_the_old_behaviour(client, narrowing: str) -> None:
+    """Each filter is checked on its own: one missing from the guard's list
+    would silently reclassify a narrowed delete as a tenant wipe."""
+    tenant_id, headers = _tenant()
+    resp = await client.delete(
+        f"/api/v1/memories?tenant_id={tenant_id}&{narrowing}", headers=headers
+    )
+    assert resp.status_code == 204, f"{narrowing} was refused: {resp.text}"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"exclude_ids": ["11111111-1111-4111-8111-111111111111"]},
+        {"metadata_filter": {"load_test_run_id": "r-1"}},
+    ],
+)
+async def test_body_side_narrowing_also_counts(client, body: dict) -> None:
+    """``exclude_ids`` and ``metadata_filter`` arrive in the body, not the
+    query — the guard reads both, and the load-test harness depends on the
+    second one still working unconfirmed."""
+    tenant_id, headers = _tenant()
+    resp = await client.request(
+        "DELETE",
+        f"/api/v1/memories?tenant_id={tenant_id}",
+        json=body,
+        headers=headers,
+    )
+    assert resp.status_code == 204, resp.text
+
+
+async def test_a_refused_call_deletes_nothing(client) -> None:
+    """The guard must run before the delete, not alongside it.
+
+    A gate that returns 400 *after* issuing the soft-delete would pass every
+    other test in this file — the status code is right, the message is right —
+    while doing exactly the damage it exists to prevent. So this writes a row,
+    gets refused, and checks the row survived.
+    """
+    tenant_id, headers = get_test_auth(f"t-c28-{uuid.uuid4().hex[:8]}")
+    written = await client.post(
+        "/api/v1/memories",
+        json={"tenant_id": tenant_id, "content": "c28 survivor", "agent_id": "a-c28"},
+        headers=headers,
+    )
+    assert written.status_code == 201, written.text
+    memory_id = written.json()["id"]
+
+    refused = await client.delete(f"/api/v1/memories?tenant_id={tenant_id}", headers=headers)
+    assert refused.status_code == 400, refused.text
+
+    after = await client.get(f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}", headers=headers)
+    assert after.status_code == 200, "the refused delete removed the row anyway"
+    assert after.json()["status"] != "deleted"

--- a/tests/test_c29_structured_duplicate_409.py
+++ b/tests/test_c29_structured_duplicate_409.py
@@ -1,0 +1,183 @@
+"""A duplicate 409 answers in fields, not in a sentence — API-06 / C29.
+
+The winning row's id used to travel as English. Storage built
+``Duplicate memory exists: <uuid>``, core-api lifted that string out of
+storage's JSON and re-raised it as its own detail, and the MCP server
+regex-parsed the uuid back out at the far end. A uuid was serialised into
+prose, shipped across two service boundaries, and recovered with a regular
+expression — by us, against our own API.
+
+Two properties matter and both are pinned here:
+
+* the structured fields exist, including ``existing_status``, which the
+  sentence could never carry; and
+* the sentence is UNCHANGED, because four other test modules and any customer
+  who parsed it depend on it, and because byte-identical prose is what lets the
+  two services deploy in either order.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from common import duplicate_memory
+from tests.conftest import get_test_auth
+
+
+@pytest.mark.integration
+async def test_exact_duplicate_answers_with_fields_and_keeps_the_sentence(client) -> None:
+    tenant_id, headers = get_test_auth(f"t-c29-{uuid.uuid4().hex[:8]}")
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": "a-c29",
+        "content": f"c29 exact duplicate probe {uuid.uuid4().hex}",
+    }
+    first = await client.post("/api/v1/memories", json=body, headers=headers)
+    assert first.status_code == 201, first.text
+    existing_id = first.json()["id"]
+
+    second = await client.post("/api/v1/memories", json=body, headers=headers)
+    assert second.status_code == 409, second.text
+    payload = second.json()
+
+    # The structured half — what C29 adds.
+    assert payload["error"]["code"] == duplicate_memory.DUPLICATE_MEMORY_CODE
+    details = payload["error"]["details"]
+    assert details["existing_id"] == existing_id
+    assert details["reason"] == duplicate_memory.REASON_EXACT
+    # Never expressible in the sentence: a duplicate of an archived row is not
+    # the same situation as a duplicate of a live one.
+    assert "existing_status" in details
+
+    # The prose half — unchanged, byte for byte.
+    assert payload["detail"] == duplicate_memory.exact_message(existing_id)
+
+
+@pytest.mark.unit
+def test_the_messages_are_byte_identical_to_what_they_replaced() -> None:
+    """If these drift, the mid-deploy regex fallback and four other test
+    modules break at the same time — so they are pinned as literals here
+    rather than derived from the module under test."""
+    mid = "0d1e2f34-5678-4abc-8def-0123456789ab"
+    assert duplicate_memory.exact_message(mid) == f"Duplicate memory exists: {mid}"
+    assert duplicate_memory.near_message(mid) == f"Near-duplicate memory exists: {mid}"
+    assert (
+        duplicate_memory.NOT_LIVE_MESSAGE
+        == "Duplicate memory exists but is no longer live; retry the write"
+    )
+
+
+@pytest.mark.unit
+def test_absent_fields_are_omitted_not_nulled() -> None:
+    """A consumer must be able to tell 'not applicable' from 'unknown'."""
+    fields = duplicate_memory.duplicate_fields(reason=duplicate_memory.REASON_EXACT)
+    assert fields == {"reason": duplicate_memory.REASON_EXACT}
+    assert "existing_id" not in fields
+    assert "existing_status" not in fields
+
+
+@pytest.mark.unit
+def test_mcp_reads_the_structured_form_including_status() -> None:
+    from core_api.mcp_server import _duplicate_info
+
+    detail = duplicate_memory.core_api_detail(
+        duplicate_memory.exact_message("abc"),
+        **duplicate_memory.duplicate_fields(
+            reason=duplicate_memory.REASON_EXACT,
+            existing_id="abc",
+            existing_status="archived",
+        ),
+    )
+    info = _duplicate_info(detail)
+    assert info == {
+        "reason": duplicate_memory.REASON_EXACT,
+        "existing_id": "abc",
+        "existing_status": "archived",
+    }
+
+
+@pytest.mark.unit
+def test_mcp_still_understands_an_older_storage_talking_prose() -> None:
+    """The mid-deploy window: a new core-api against a storage that predates
+    the structured body still recovers the id, and says which reason it is."""
+    from core_api.mcp_server import _duplicate_info
+
+    mid = "0d1e2f34-5678-4abc-8def-0123456789ab"
+    info = _duplicate_info(duplicate_memory.exact_message(mid))
+    assert info == {"existing_id": mid, "reason": duplicate_memory.REASON_EXACT}
+
+
+@pytest.mark.unit
+def test_a_semantic_hit_is_not_treated_as_a_retry_no_op() -> None:
+    """A near-duplicate means the caller wrote NEW content that we suppressed.
+    That used to be distinguished only by the regex failing to match the other
+    wording — i.e. by accident."""
+    from core_api.mcp_server import _duplicate_info
+
+    info = _duplicate_info(
+        duplicate_memory.core_api_detail(
+            duplicate_memory.near_message("abc"),
+            **duplicate_memory.duplicate_fields(
+                reason=duplicate_memory.REASON_SEMANTIC, existing_id="abc", similarity=0.97
+            ),
+        )
+    )
+    assert info is not None
+    assert info["reason"] == duplicate_memory.REASON_SEMANTIC
+    assert info["similarity"] == 0.97
+
+
+@pytest.mark.unit
+def test_a_non_duplicate_detail_is_not_mistaken_for_one() -> None:
+    from core_api.mcp_server import _duplicate_info
+
+    assert _duplicate_info("tenant_id required") is None
+    assert _duplicate_info({"code": "INVALID_ARGUMENTS", "message": "nope"}) is None
+
+
+@pytest.mark.unit
+def test_structured_details_never_reach_a_model_as_a_dict_repr() -> None:
+    """``str()`` on the new detail shape renders braces and quotes into a
+    message a model reads. Twelve MCP sites used to do exactly that."""
+    from core_api.mcp_server import _detail_code, _detail_text
+
+    detail = duplicate_memory.core_api_detail("Duplicate memory exists: abc")
+    assert _detail_text(detail) == "Duplicate memory exists: abc"
+    assert "{" not in _detail_text(detail)
+    assert _detail_text("plain string") == "plain string"
+    # The raiser's own code wins over the status-derived one.
+    assert _detail_code(detail, 409) == duplicate_memory.DUPLICATE_MEMORY_CODE
+    assert _detail_code("plain string", 409) == "CONFLICT"
+
+
+@pytest.mark.unit
+def test_an_older_storage_response_yields_no_fields_rather_than_an_error() -> None:
+    """Deploy-order independence: core-api must tolerate a storage that only
+    sends ``detail``."""
+    import httpx
+
+    from core_api.clients.storage_client import _storage_detail, _storage_duplicate_fields
+
+    old = httpx.Response(409, json={"detail": "Duplicate memory exists: abc"})
+    assert _storage_duplicate_fields(old) == {}
+    assert _storage_detail(old) == "Duplicate memory exists: abc"
+
+    new = httpx.Response(
+        409,
+        json={
+            "detail": "Duplicate memory exists: abc",
+            "reason": duplicate_memory.REASON_EXACT,
+            "existing_id": "abc",
+            "existing_status": "active",
+        },
+    )
+    assert _storage_duplicate_fields(new) == {
+        "reason": duplicate_memory.REASON_EXACT,
+        "existing_id": "abc",
+        "existing_status": "active",
+    }
+
+    # Error paths must not raise from inside an exception handler.
+    assert _storage_duplicate_fields(httpx.Response(409, text="<html>502</html>")) == {}

--- a/tests/test_c32_coded_auth_errors.py
+++ b/tests/test_c32_coded_auth_errors.py
@@ -1,0 +1,142 @@
+"""Refusals must say WHICH refusal they are — C32 / API-05.
+
+``code_for_status`` maps every 403 to ``FORBIDDEN`` and every 401 to
+``UNAUTHORIZED``. The auth boundary has eight distinct reasons to refuse a
+request, and all of them arrived at the caller as one of those two words. An
+agent that gets FORBIDDEN on a write cannot tell "this credential is read-only"
+from "your org is over its plan limit" from "this needs an admin", so the only
+move left is to guess.
+
+One did. An agent was refused a write with a tenant key and concluded that
+tenant keys cannot write — false, and it stopped trying. That is the failure mode these
+tests exist for: not a missing error, a *misleading* one. A wrong general rule
+learned from a specific refusal is worse than no answer.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from core_api import errors
+from core_api.auth import AuthContext
+
+pytestmark = pytest.mark.unit
+
+
+def _refusal(fn) -> tuple[int, dict]:
+    with pytest.raises(HTTPException) as caught:
+        fn()
+    return caught.value.status_code, caught.value.detail
+
+
+def test_two_different_403s_are_distinguishable() -> None:
+    """The whole point. Same status, same shape, different machine-readable code."""
+    _, read_only = _refusal(AuthContext(tenant_id="t", capabilities=set()).enforce_read_only)
+    _, over_limit = _refusal(
+        AuthContext(tenant_id="t", is_read_only=True).enforce_usage_limits
+    )
+    _, needs_admin = _refusal(AuthContext(tenant_id="t", is_admin=False).enforce_admin)
+
+    codes = {read_only["code"], over_limit["code"], needs_admin["code"]}
+    assert codes == {
+        errors.AUTH_READ_ONLY_KEY,
+        errors.AUTH_PLAN_LIMIT,
+        errors.AUTH_ADMIN_REQUIRED,
+    }
+    assert len(codes) == 3, "three reasons collapsed into fewer codes"
+
+
+def test_the_read_only_refusal_cannot_teach_the_false_general_rule() -> None:
+    """The exact reported failure: refused a write, concluded tenant keys cannot write.
+
+    The remediation has to say the limit is a property of the CREDENTIAL, or the
+    reader is entitled to the wrong inference.
+    """
+    _, detail = _refusal(AuthContext(tenant_id="t", capabilities=set()).enforce_read_only)
+    assert detail["code"] == errors.AUTH_READ_ONLY_KEY
+    remediation = detail["details"]["remediation"].lower()
+    assert "credential" in remediation
+    assert "retry" in remediation
+
+
+def test_the_human_message_is_unchanged() -> None:
+    """Back-compat: ``detail`` stays the string clients already read.
+
+    ``app.http_exception_handler`` flattens the structured detail back to this
+    message at the top level, so nothing that logged or displayed it moves.
+    """
+    _, detail = _refusal(AuthContext(tenant_id="t", is_admin=False).enforce_admin)
+    assert detail["message"] == "Admin access required"
+
+
+def test_tenant_mismatch_reports_which_tenant_was_refused() -> None:
+    ctx = AuthContext(tenant_id="mine", is_admin=False)
+    _, detail = _refusal(lambda: ctx.enforce_tenant("theirs"))
+    assert detail["code"] == errors.AUTH_TENANT_MISMATCH
+    assert detail["details"]["requested_tenant"] == "theirs"
+    # The credential is valid — saying so prevents "my key is broken".
+    assert "different tenant" in detail["details"]["remediation"]
+
+
+async def test_the_suppression_refusal_stays_deliberately_vague(monkeypatch) -> None:
+    """Not every message should improve.
+
+    The org-suspended 403 is generic on purpose: naming the lifecycle state
+    leaks it to a partner whose key was provisioned under that org. So the CODE
+    carries the machine signal while the MESSAGE stays exactly as opaque as it
+    was — a case where adding remediation would be the bug.
+    """
+    from core_api import auth
+
+    monkeypatch.setattr(auth, "is_tenant_suppressed", lambda _tenant: _true())
+
+    with pytest.raises(HTTPException) as caught:
+        await auth._block_if_suppressed("t-suppressed")
+
+    detail = caught.value.detail
+    assert caught.value.status_code == 403
+    assert detail["code"] == errors.AUTH_ORG_SUSPENDED
+    assert detail["message"] == "Organization is suspended; access denied."
+    # No lifecycle vocabulary, and nothing added under details either.
+    leaked = ("soft-delete", "deleted", "lifecycle", "suspended org")
+    assert not any(word in str(detail["details"]).lower() for word in leaked)
+
+
+async def _true() -> bool:
+    return True
+
+
+def test_every_auth_code_is_unique() -> None:
+    """Two reasons sharing a code is the bug this whole item is about,
+    reintroduced one level down."""
+    codes = [v for k, v in vars(errors).items() if k.startswith("AUTH_") and isinstance(v, str)]
+    assert len(codes) == len(set(codes)), sorted(codes)
+    assert all(c.isupper() for c in codes), codes
+
+
+def test_the_spec_documents_the_errors_every_route_can_return() -> None:
+    """422 used to be the only documented error response on the entire surface,
+    so a generated client had no type for a body it will certainly receive."""
+    from core_api.app import app
+
+    schema = app.openapi()
+    assert "CauraError" in schema["components"]["schemas"]
+
+    operations = [
+        (path, method, op)
+        for path, item in schema["paths"].items()
+        for method, op in item.items()
+        if method in {"get", "post", "put", "patch", "delete"}
+    ]
+    assert operations
+    missing = [
+        f"{m.upper()} {p}"
+        for p, m, op in operations
+        if not {"401", "403"} <= set(op.get("responses", {}))
+    ]
+    assert not missing, missing[:5]
+
+    ref = {"$ref": "#/components/schemas/CauraError"}
+    _, _, sample = operations[0]
+    assert sample["responses"]["403"]["content"]["application/json"]["schema"] == ref

--- a/tests/test_client_metapackages.py
+++ b/tests/test_client_metapackages.py
@@ -1,0 +1,144 @@
+"""Invariants for the client metapackages under ``clients/``.
+
+Three distributions on PyPI (``caura``, ``caura-sdk``, ``caura-client``) and
+three on npm (``@caura/client``, ``@caura/sdk``, and the implementation they
+re-export) install the same client. The aliases exist because install instructions in the
+wild — much of it AI-generated — point at names we did not choose, and a name
+that 404s is either a dead instruction or, on PyPI where anyone may claim an
+unused name, an open door.
+
+That shape has two failure modes with no natural symptom, and this module pins
+both:
+
+* **Two distributions shipping the same import package.** ``caura`` ships
+  ``src/caura/``. If ``caura-sdk`` shipped ``src/caura/`` too, both would
+  install to the same path and ``pip install caura caura-sdk`` would leave
+  whichever landed last — no warning from pip, no error at import.
+
+* **A package with no way to publish it.** ``caura`` 1.0.0 was published by
+  hand and had no workflow for its first week, so the one artifact whose whole
+  job is making ``pip install caura`` resolve was also the one nobody could
+  ship a fix to. Every metapackage here must have a workflow that builds *its*
+  directory.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLIENTS = REPO_ROOT / "clients"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# Directory → the distribution it publishes. The implementation package is
+# listed alongside the metapackages because the uniqueness check below is only
+# meaningful across the whole set.
+PY_DISTS = {
+    "python": "caura-client",
+    "caura-meta": "caura",
+    "caura-sdk-meta": "caura-sdk",
+}
+
+NPM_DISTS = {
+    "typescript": "@caura/memclaw-client",  # legacy-name-ok: pins the immutable published implementation name
+    "npm-client": "@caura/client",
+    "npm-sdk": "@caura/sdk",
+}
+
+# Each alias re-exports the package it declares as a dependency. They differ on
+# purpose: ``@caura/client`` wraps the implementation, and ``@caura/sdk`` wraps
+# ``@caura/client`` rather than reaching past it — so a future rename of the
+# implementation is a one-package change, not a two-package change.
+NPM_REEXPORT_TARGET = {
+    "npm-client": NPM_DISTS["typescript"],
+    "npm-sdk": "@caura/client",
+}
+
+# Metapackages only — the implementation is excluded, since it is the thing
+# they all depend on.
+PY_METAPACKAGES = ("caura-meta", "caura-sdk-meta")
+NPM_METAPACKAGES = ("npm-client", "npm-sdk")
+
+
+def _pyproject(directory: str) -> dict:
+    return tomllib.loads((CLIENTS / directory / "pyproject.toml").read_text())
+
+
+def _package_json(directory: str) -> dict:
+    return json.loads((CLIENTS / directory / "package.json").read_text())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("directory,expected_name", sorted(PY_DISTS.items()))
+def test_python_distribution_names_are_stable(
+    directory: str, expected_name: str
+) -> None:
+    """A renamed distribution silently stops publishing to the name people install."""
+    assert _pyproject(directory)["project"]["name"] == expected_name
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("directory", PY_METAPACKAGES)
+def test_python_metapackages_depend_on_the_real_client(directory: str) -> None:
+    """A metapackage that installs nothing is a stub — the thing we said these are not."""
+    deps = _pyproject(directory)["project"]["dependencies"]
+    assert any(d.startswith("caura-client") for d in deps), deps
+
+
+@pytest.mark.unit
+def test_python_import_packages_do_not_collide() -> None:
+    """Two distributions shipping one import package overwrite each other on install."""
+    owners: dict[str, str] = {}
+    for directory, dist in sorted(PY_DISTS.items()):
+        for module in sorted(
+            p.name for p in (CLIENTS / directory / "src").iterdir() if p.is_dir()
+        ):
+            assert module not in owners, (
+                f"import package {module!r} is shipped by both {owners[module]!r} "
+                f"and {dist!r}; installing both leaves whichever pip wrote last"
+            )
+            owners[module] = dist
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("directory,expected_name", sorted(NPM_DISTS.items()))
+def test_npm_package_names_are_stable(directory: str, expected_name: str) -> None:
+    assert _package_json(directory)["name"] == expected_name
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("directory", NPM_METAPACKAGES)
+def test_npm_metapackages_reexport_what_they_depend_on(directory: str) -> None:
+    """The alias must re-export, not just depend — `import { Caura }` has to work.
+
+    Declaring the dependency and re-exporting a *different* package installs
+    cleanly and then fails to resolve at import time, so the two are pinned
+    together rather than separately.
+    """
+    pkg = _package_json(directory)
+    target = NPM_REEXPORT_TARGET[directory]
+    assert target in pkg["dependencies"], pkg["dependencies"]
+    for entry in ("index.js", "index.d.ts"):
+        assert f"export * from '{target}';" in (CLIENTS / directory / entry).read_text()
+        # A file missing from `files` is absent from the published tarball —
+        # the package installs and then fails to resolve its own main.
+        assert entry in pkg["files"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "directory", sorted({*PY_DISTS, *NPM_DISTS} - {"typescript", "python"})
+)
+def test_every_metapackage_has_a_publish_workflow(directory: str) -> None:
+    """`caura` shipped for a week with no workflow. Nothing else does that."""
+    needle = f"clients/{directory}"
+    matches = [
+        wf.name
+        for wf in sorted(WORKFLOWS.glob("publish-*.yml"))
+        if needle in wf.read_text()
+    ]
+    assert matches, f"no publish workflow builds {needle}"

--- a/tests/test_duplicate_insert_conflict_409.py
+++ b/tests/test_duplicate_insert_conflict_409.py
@@ -21,6 +21,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+
+from common import duplicate_memory
 from fastapi import HTTPException
 
 from core_api.clients.storage_client import (
@@ -124,6 +126,13 @@ async def test_every_other_status_propagates_unchanged(status) -> None:
 
 @pytest.mark.asyncio
 async def test_the_helper_maps_the_duplicate_to_409_with_the_id() -> None:
+    """The message-only case, which is also the older-storage case (C29).
+
+    ``DuplicateMemoryError`` carries structured fields now, but a storage that
+    predates them sends only the sentence — as constructed here. The helper must
+    still produce a 409 that names the winning row, with an empty ``details``
+    rather than a failure, or the two services could not deploy independently.
+    """
     sc = MagicMock()
     sc.create_memory = AsyncMock(
         side_effect=DuplicateMemoryError(f"Duplicate memory exists: {WINNER}")
@@ -134,7 +143,38 @@ async def test_the_helper_maps_the_duplicate_to_409_with_the_id() -> None:
             await memory_service._create_memory_or_409({"tenant_id": "t"})
 
     assert caught.value.status_code == 409
-    assert WINNER in caught.value.detail
+    # ``detail`` is the structured shape now; the id lives in the message, and
+    # ``app.http_exception_handler`` is what flattens it back to a plain string
+    # for the top-level ``detail`` field clients read.
+    assert WINNER in caught.value.detail["message"]
+    assert caught.value.detail["code"] == duplicate_memory.DUPLICATE_MEMORY_CODE
+    assert caught.value.detail["details"] == {}
+
+
+@pytest.mark.asyncio
+async def test_the_helper_forwards_storage_structured_fields() -> None:
+    """The current-storage case: the id arrives as data and is passed through
+    rather than being re-derived from the sentence."""
+    sc = MagicMock()
+    sc.create_memory = AsyncMock(
+        side_effect=DuplicateMemoryError(
+            f"Duplicate memory exists: {WINNER}",
+            {
+                "reason": duplicate_memory.REASON_EXACT,
+                "existing_id": WINNER,
+                "existing_status": "active",
+            },
+        )
+    )
+
+    with patch.object(memory_service, "get_storage_client", lambda: sc):
+        with pytest.raises(HTTPException) as caught:
+            await memory_service._create_memory_or_409({"tenant_id": "t"})
+
+    details = caught.value.detail["details"]
+    assert details["existing_id"] == WINNER
+    assert details["existing_status"] == "active"
+    assert details["reason"] == duplicate_memory.REASON_EXACT
 
 
 @pytest.mark.asyncio

--- a/tests/test_embedding_coverage_admin.py
+++ b/tests/test_embedding_coverage_admin.py
@@ -88,10 +88,21 @@ async def test_aggregate_agrees_with_per_tenant_endpoint(client, monkeypatch):
 
 async def test_aggregate_is_worst_first(client):
     """Ordering is the contract the per-tenant log cap relies on — it drops the
-    tail, so the tail must be the tenants nobody would act on."""
+    tail, so the tail must be the tenants nobody would act on.
+
+    Asserted on ``stale + missing``, which is what the query actually orders by
+    (``memory_embedding_coverage_by_tenant``: ``.order_by((stale + missing).desc())``,
+    documented there as "a stale row is actively wrong, a missing one is merely
+    absent, so stale leads"). This previously asserted ``missing`` alone, which
+    is a DIFFERENT invariant and only coincides while every tenant has zero
+    stale rows: a tenant with (stale=3, missing=0) correctly sorts above one
+    with (stale=0, missing=2), and the old assertion read that as [0, 2] and
+    failed. It surfaced as an intermittent failure that depended on whether
+    anything earlier in the session happened to leave a stale row behind.
+    """
     aggregate = await get_storage_client().get_embedding_coverage_all()
-    missing = [r["missing_embeddings"] for r in aggregate["tenants"]]
-    assert missing == sorted(missing, reverse=True), missing
+    worst_first = [r["stale_embeddings"] + r["missing_embeddings"] for r in aggregate["tenants"]]
+    assert worst_first == sorted(worst_first, reverse=True), aggregate["tenants"]
 
 
 async def test_admin_route_rejects_non_admin():

--- a/tests/test_f4_installer_api_url_default.py
+++ b/tests/test_f4_installer_api_url_default.py
@@ -1,0 +1,84 @@
+"""The published install one-liner must work as published — F4 / AX-03.
+
+``curl https://caura.ai/api/v1/install-plugin | bash`` is the documented cloud
+install. It could not work: the generated script hardcoded
+``CAURA_API_URL=http://localhost:8000`` unless the caller appended an
+``?api_url=`` that no published copy of the command mentions. So the script
+installed a plugin pointed at port 8000 on the installing machine — the one
+place the API certainly is not — and the failure surfaced later as a heartbeat
+that never arrived, not as an install error.
+
+The sibling ``/install-skill`` endpoint already derived the URL from the
+request. These tests pin that ``/install-plugin`` does the same, and that the
+proxy case works, since in production the app never sees the public host on
+``request.url`` — only in ``X-Forwarded-*``.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+CLOUD_HEADERS = {"x-forwarded-proto": "https", "x-forwarded-host": "caura.ai"}
+
+
+def assignment(url: str) -> str:
+    """The exact line the script carries.
+
+    Built with ``shlex.quote`` like the generator, which only adds quotes when
+    the value needs them — so a hand-written literal matches for one URL and
+    silently not for another.
+    """
+    return f"CAURA_API_URL={shlex.quote(url)}"
+
+
+async def test_the_published_cloud_one_liner_produces_a_cloud_url(client) -> None:
+    """The exact shape of the documented command: no api_url, behind a proxy."""
+    resp = await client.get("/api/v1/install-plugin", headers=CLOUD_HEADERS)
+    assert resp.status_code == 200, resp.text
+    script = resp.text
+    assert assignment("https://caura.ai") in script, script[:400]
+    # The specific regression: a cloud install must never be told to talk to
+    # the installing machine's own port 8000. Asserted on the ASSIGNMENT, not on
+    # the string anywhere — the script legitimately mentions localhost in a
+    # comment about OSS installs, and a blanket check would fail on prose.
+    assert assignment("http://localhost:8000") not in script
+
+
+async def test_the_post_variant_derives_it_too(client) -> None:
+    """POST is the preferred form (no secrets in the URL) and had the same default."""
+    resp = await client.post("/api/v1/install-plugin", json={}, headers=CLOUD_HEADERS)
+    assert resp.status_code == 200, resp.text
+    assert assignment("https://caura.ai") in resp.text
+    assert assignment("http://localhost:8000") not in resp.text
+
+
+@pytest.mark.parametrize("method", ["get", "post"])
+async def test_an_explicit_api_url_still_wins(client, method: str) -> None:
+    """Deriving is a default, not an override — the escape hatch that made the
+    cloud install possible at all must keep working."""
+    override = "https://caura.example.internal"
+    if method == "get":
+        resp = await client.get(
+            f"/api/v1/install-plugin?api_url={override}", headers=CLOUD_HEADERS
+        )
+    else:
+        resp = await client.post(
+            "/api/v1/install-plugin", json={"api_url": override}, headers=CLOUD_HEADERS
+        )
+    assert resp.status_code == 200, resp.text
+    assert assignment(override) in resp.text
+
+
+async def test_a_self_hosted_install_still_points_at_itself(client) -> None:
+    """The old default was right for exactly one caller — someone running the
+    API locally. Deriving from the request keeps that caller working, which is
+    why this is a fix rather than a trade."""
+    resp = await client.get(
+        "/api/v1/install-plugin", headers={"host": "localhost:8000"}
+    )
+    assert resp.status_code == 200, resp.text
+    assert assignment("http://localhost:8000") in resp.text

--- a/tests/test_f6_stm_labelled_plugin_only.py
+++ b/tests/test_f6_stm_labelled_plugin_only.py
@@ -1,0 +1,89 @@
+"""STM is advertised over REST and reachable nowhere — CAP-01 / F6.
+
+Three facts, each verified against a running stack before this was written:
+
+* ``POST /stm/notes`` and ``POST /stm/bulletin`` do not exist. There is no REST
+  write route for short-term memory at all, so a caller who follows the docs
+  gets a bare 405.
+* Every read, delete and promote is gated on ``USE_STM``, which is off in the
+  hosted deployment and is a server setting rather than a per-tenant one — so
+  a hosted customer cannot enable it at any price.
+* The gate's message used to read "Set USE_STM=true to enable short-term
+  memory": instructions the reader it reaches cannot follow.
+
+STM stays dead by standing decision. These tests pin the LABELLING, and one of
+them pins the other half — that nobody quietly adds the missing write routes
+and turns a documentation fix into a feature. A25 is not reopened by any of
+this.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_api.app import app
+
+STM_PATHS = ("/api/v1/stm/notes", "/api/v1/stm/bulletin", "/api/v1/stm/promote")
+
+# Phrases that make the constraint findable by someone reading the spec rather
+# than the source. Matching on meaning-bearing substrings rather than the exact
+# sentence, so wording can improve without breaking the test.
+REQUIRED_SIGNALS = ("plugin-only", "hosted")
+
+
+@pytest.mark.unit
+def test_every_advertised_stm_operation_is_labelled() -> None:
+    schema = app.openapi()
+    operations = [
+        (path, method, op)
+        for path, item in schema["paths"].items()
+        if path.startswith("/api/v1/stm/")
+        for method, op in item.items()
+    ]
+    assert operations, "no STM operations in the schema — did the routes move?"
+    for path, method, op in operations:
+        description = (op.get("description") or "").lower()
+        assert description, f"{method.upper()} {path} is advertised with no description"
+        for signal in REQUIRED_SIGNALS:
+            assert signal in description, (
+                f"{method.upper()} {path} does not tell the reader it is {signal}; "
+                "an operation nobody can call must say so where it is advertised"
+            )
+
+
+@pytest.mark.unit
+def test_the_stm_tag_carries_the_same_warning() -> None:
+    """The sidebar is what a reader sees before opening any single operation."""
+    tags = {t["name"]: t.get("description", "") for t in app.openapi().get("tags", [])}
+    assert "stm" in tags, "the stm tag has no metadata"
+    for signal in REQUIRED_SIGNALS:
+        assert signal in tags["stm"].lower()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", ["/api/v1/stm/notes", "/api/v1/stm/bulletin"])
+def test_stm_has_no_rest_write_route(path: str) -> None:
+    """The 'don't build it' half.
+
+    CAP-01 is a labelling task precisely because the tempting fix for a 405 is
+    to add the route. If someone does, this fails and the decision gets made
+    deliberately instead of in a pull request about documentation.
+    """
+    item = app.openapi()["paths"].get(path, {})
+    assert "post" not in item, (
+        f"{path} grew a POST route. STM is plugin-only by standing decision — "
+        "adding a REST write path is a product decision, not a docs fix."
+    )
+
+
+@pytest.mark.unit
+async def test_the_disabled_gate_does_not_give_unfollowable_advice(client) -> None:
+    """A hosted caller cannot set USE_STM, so it must not be the only remedy offered."""
+    response = await client.get(
+        "/api/v1/stm/notes", params={"tenant_id": "t-f6", "agent_id": "a-f6"}
+    )
+    assert response.status_code == 422
+    detail = response.json()["detail"].lower()
+    assert "plugin-only" in detail
+    # It must point somewhere the reader can actually go.
+    assert "/memories" in detail or "/search" in detail

--- a/tests/test_suppression_boundary.py
+++ b/tests/test_suppression_boundary.py
@@ -10,6 +10,16 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import pytest
+
+from core_api import errors
+
+# C32 / API-05: ``detail`` on an auth refusal is now
+# ``{"code", "message", "details"}`` so the eight distinct reasons this boundary
+# can refuse a request stop collapsing into the single status-derived
+# ``FORBIDDEN``. The human message is unchanged and lives under ``["message"]``;
+# these assertions follow it there, and additionally pin the code — which is the
+# part a caller is now expected to branch on.
+
 from fastapi import HTTPException
 
 from core_api import suppression
@@ -130,7 +140,8 @@ async def test_block_if_suppressed_raises_403_when_suppressed(
     # Detail wording is intentionally generic — avoids leaking the
     # specific lifecycle state to a partner whose key was provisioned
     # under that org.
-    assert "suspended" in exc.value.detail.lower()
+    assert "suspended" in exc.value.detail["message"].lower()
+    assert exc.value.detail["code"] == errors.AUTH_ORG_SUSPENDED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Nine independent fixes to the API's error contract, the plugin's identity
resolution, the hosted install path, and the published client packages. Each is
one typed commit; none changes a request contract.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [x] Other: CI coverage, one unrelated test-assertion fix

The only behaviour change is that an unbounded `DELETE /memories` (no
`fleet_id` and no other narrowing filter) now requires `confirm_scope=tenant`.
That request deletes an entire tenant corpus and was reachable by omission.
Every narrowed delete is unaffected, and no caller in this repo or the
dashboard uses the unbounded form.

## How Has This Been Tested?

Against a from-scratch Postgres and an isolated Docker stack
(`docker compose -p caura-ax`, own network, volumes and ports).

```
tests/                          5082 passed, 3 skipped, 1 xfailed
core-storage-api/tests/          154 passed
core-operations / core-worker     50 / 72 passed
plugin (node:test)               423 passed
ruff + ruff format + mypy        clean, both services
legacy-name ratchet              no new lines (2 justified exemptions)
do-not-touch sentinel            35/35 protected strings survive
MCP raw-string guard             clean
broker OpenAPI baseline          regenerated; oasdiff (pinned image) reports
                                 "No breaking changes to report"
```

Behaviour-critical changes were mutation-tested: the old code was restored and
the new tests confirmed to fail. That covers the plugin identity fix, the
installer default, and the metapackage import-collision guard.

`@caura/client@1.0.0` and `@caura/sdk@1.0.0` are published and verified by a
clean-room `npm install` resolving through to the implementation. `caura-sdk`
on PyPI is reserved via a pending trusted publisher and ships from CI on a tag.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes (7 new test modules)
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally
- [x] I have updated relevant documentation (OpenAPI descriptions, endpoint docstrings)
- [ ] CHANGELOG.md - N/A, release-please generates it from Conventional Commits

## Additional Notes

**Merge strategy.** The nine commits are individually typed so the changelog
gets `feat` and `fix` entries separately. A squash-merge collapses them into
one subject; a merge commit preserves the split.

**One merge hazard worth naming.** `HTTPException.detail` is now sometimes
`{code, message, details}`. Branches written before this that call
`str(e.detail)` will silently render a Python dict repr into a caller-facing
message, with no merge conflict to warn anyone. The new CI guard fails on that
pattern in `mcp_server.py`; `_detail_text` / `_detail_code` handle both shapes.

**Scope, called out rather than quietly narrowed.** Roughly 69 raise sites pass
bare detail strings. This converts the 13 at the auth boundary, where the
indistinguishability actually misleads callers - every 403 currently arrives as
`FORBIDDEN` regardless of whether the credential is read-only, the org is over
its plan limit, or the endpoint needs an admin. The remainder are validation
errors whose messages are already unambiguous, and `coded_detail` is the
pattern for converting them incrementally.

**Two follow-ups found while verifying this branch**, not fixed here:

- `docker-compose.yml` parameterizes every host port, which makes an isolated
  stack look fully supported, but the app config only honours `DATABASE_URL`.
  Host-side tooling pointed at an isolated stack with `POSTGRES_*` silently
  connects to 5432 instead.
- `plugin/package.json` enumerates its test files by name in the `test` script,
  so a newly added test file never runs until someone remembers to list it.
