### PR TITLE
fix(mcp): stop the identity surface misdescribing itself

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -130,6 +130,28 @@ _ADMIN = "__admin__"
 _NO_AUTH = "__no_auth__"
 _DEFAULT_AGENT_ID = DEFAULT_AGENT_ID
 
+# The most consequential parameter on the tool surface: it decides which agent
+# a write is attributed to, and which rows an agent-scoped read can see. All
+# ten tools documented it as "Caller agent." - two words - while defaulting to
+# a value the hosted gateway path actively REFUSES
+# (``_refuse_default_agent_on_gateway``). So the schema advertised a default
+# that cannot be used where most callers run, and said nothing about what to
+# send instead. An agent reading the tool list had no way to learn that.
+#
+# The DEFAULT itself is deliberately unchanged. "mcp-agent" is a legitimate
+# standalone identity by design (see ``core_api.agent_ids``); removing it would
+# break every single-tenant caller and change the schema for all of them. What
+# changes is that the schema now tells the truth about when it applies.
+#
+# Kept deliberately short. tools/list is re-sent on every agent session, so
+# this text is paid ten times per call; the first draft was three times this
+# length and pushed the surface 498 tokens over the ceiling in
+# tests/test_mcp_token_budget.py. +117 is the price of the three facts that
+# matter: what it attributes, what it filters, and that hosted needs a real one.
+_AGENT_ID_DESC = (
+    "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one."
+)
+
 
 def _error_response(code: str, message: str, **details) -> str:
     """Return the canonical MCP error envelope as a JSON string.
@@ -371,9 +393,12 @@ def _refuse_default_agent_on_gateway(agent_id: str) -> str | None:
         return None
     return _error_response(
         "MISSING_AGENT_ID",
-        "Writes via the gateway with a tenant-scoped credential must specify "
-        "an agent_id explicitly; the reserved default "
-        f"'{_DEFAULT_AGENT_ID}' is not accepted on this path. Either pass "
+        "This call reached the gateway with a tenant-scoped credential, which "
+        "carries no agent identity, so agent_id must be supplied explicitly; "
+        f"the reserved default '{_DEFAULT_AGENT_ID}' is not accepted on this "
+        "path. This applies to reads as well as writes: agent-scoped reads "
+        "filter by agent_id, so a defaulted value would quietly query one "
+        "shared identity's rows rather than yours. Either pass "
         "agent_id=<your-agent-name> or provision an agent-scoped credential "
         "(POST /api/v1/admin/agent-keys/provision, or via the dashboard at "
         "Settings → Organization → API Credentials with kind=agent_key) — "
@@ -663,7 +688,7 @@ def _storage_error_envelope(e: httpx.HTTPStatusError, t0: float) -> str | CallTo
 
 async def caura_recall(
     query: Annotated[str, Field(description="NL query.")],
-    agent_id: Annotated[str, Field(description="Caller agent.")] = "mcp-agent",
+    agent_id: Annotated[str, Field(description=_AGENT_ID_DESC)] = DEFAULT_AGENT_ID,
     filter_agent_id: Annotated[str | None, Field(description="Filter by author.")] = None,
     memory_type: Annotated[str | None, Field(description="Filter by type.")] = None,
     status: Annotated[str | None, Field(description="Filter by status.")] = None,
@@ -807,7 +832,7 @@ async def caura_write(
     items: Annotated[
         list[dict] | None, Field(description="Batch of objects, ≤100; each needs 'content'.")
     ] = None,
-    agent_id: Annotated[str, Field(description="Caller agent.")] = "mcp-agent",
+    agent_id: Annotated[str, Field(description=_AGENT_ID_DESC)] = DEFAULT_AGENT_ID,
     fleet_id: Annotated[str | None, Field(description="Fleet scope.")] = None,
     visibility: Annotated[str | None, Field(description="scope_team|scope_org|scope_agent.")] = None,
     memory_type: Annotated[str | None, Field(description="Type (single only).")] = None,
@@ -1060,7 +1085,7 @@ async def caura_manage(
     title: Annotated[str | None, Field(description="op=update.")] = None,
     metadata: Annotated[dict | None, Field(description="op=update.")] = None,
     source_uri: Annotated[str | None, Field(description="op=update.")] = None,
-    agent_id: Annotated[str, Field(description="Caller agent.")] = "mcp-agent",
+    agent_id: Annotated[str, Field(description=_AGENT_ID_DESC)] = DEFAULT_AGENT_ID,
 ) -> str:
     """Per-memory lifecycle: read | update | transition | delete | bulk_delete | lineage.
 
@@ -1409,7 +1434,7 @@ async def caura_entity_get(
 
 
 async def caura_tune(
-    agent_id: Annotated[str, Field(description="Caller agent.")] = "mcp-agent",
+    agent_id: Annotated[str, Field(description=_AGENT_ID_DESC)] = DEFAULT_AGENT_ID,
     top_k: Annotated[int | None, Field(description="1-20.")] = None,
     min_similarity: Annotated[float | None, Field(description="0.1-0.9.")] = None,
     fts_weight: Annotated[float | None, Field(description="0=semantic, 1=keyword.")] = None,
@@ -1612,7 +1637,7 @@ async def caura_doc(
     order: Annotated[str, Field(description="op=query: asc|desc.")] = "asc",
     limit: Annotated[int, Field(description="op=query.")] = 20,
     offset: Annotated[int, Field(description="op=query.")] = 0,
-    agent_id: Annotated[str, Field(description="Caller agent.")] = "mcp-agent",
+    agent_id: Annotated[str, Field(description=_AGENT_ID_DESC)] = DEFAULT_AGENT_ID,
     fleet_id: Annotated[
         str | None,
         Field(description="op=write; optional scoping filter for op=list_collections|search."),
@@ -2267,7 +2292,7 @@ async def caura_doc(
 
 
 async def caura_list(
-    agent_id: Annotated[str, Field(description="Caller agent.")] = "mcp-agent",
+    agent_id: Annotated[str, Field(description=_AGENT_ID_DESC)] = DEFAULT_AGENT_ID,
     scope: Annotated[
         str,
         Field(
@@ -2497,7 +2522,7 @@ async def caura_stats(
         str | None,
         Field(description="Filter by fleet. When scope='fleet' and omitted, defaults to your home fleet."),
     ] = None,
-    agent_id: Annotated[str, Field(description="Caller agent.")] = "mcp-agent",
+    agent_id: Annotated[str, Field(description=_AGENT_ID_DESC)] = DEFAULT_AGENT_ID,
     memory_type: Annotated[str | None, Field(description="Filter by type.")] = None,
     status: Annotated[str | None, Field(description="Filter by status.")] = None,
     include_deleted: Annotated[
@@ -2627,7 +2652,7 @@ async def caura_insights(
     ],
     scope: Annotated[str, Field(description="agent|fleet|all.")] = "agent",
     fleet_id: Annotated[str | None, Field(description="Required when scope='fleet'.")] = None,
-    agent_id: Annotated[str, Field(description="Caller agent.")] = "mcp-agent",
+    agent_id: Annotated[str, Field(description=_AGENT_ID_DESC)] = DEFAULT_AGENT_ID,
 ) -> str:
     """Analyze the memory store for patterns, contradictions, stale knowledge,
     or unexpected clusters; persist findings as ``insight`` memories.
@@ -2794,7 +2819,7 @@ async def caura_evolve(
         Field(description="Memory UUIDs that influenced the action."),
     ] = None,
     scope: Annotated[str, Field(description="agent|fleet|all.")] = "agent",
-    agent_id: Annotated[str, Field(description="Caller agent.")] = "mcp-agent",
+    agent_id: Annotated[str, Field(description=_AGENT_ID_DESC)] = DEFAULT_AGENT_ID,
     fleet_id: Annotated[str | None, Field(description="Required when scope='fleet'.")] = None,
 ) -> str:
     """Record a real-world outcome against the memories that influenced the
@@ -2984,7 +3009,7 @@ async def caura_evolve(
 
 
 async def caura_keystones(
-    agent_id: Annotated[str, Field(description="Caller agent.")] = "mcp-agent",
+    agent_id: Annotated[str, Field(description=_AGENT_ID_DESC)] = DEFAULT_AGENT_ID,
     fleet_id: Annotated[
         str | None,
         Field(description="Scope filter; supply to include fleet- and agent-scoped rules."),

--- a/plugin/tools.json
+++ b/plugin/tools.json
@@ -123,7 +123,7 @@
       },
       {
         "default": "mcp-agent",
-        "description": "Caller agent.",
+        "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
         "name": "agent_id",
         "required": false,
         "type": "str"
@@ -205,7 +205,7 @@
       },
       {
         "default": "mcp-agent",
-        "description": "Caller agent.",
+        "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
         "name": "agent_id",
         "required": false,
         "type": "str"
@@ -250,7 +250,7 @@
       },
       {
         "default": "mcp-agent",
-        "description": "Caller agent.",
+        "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
         "name": "agent_id",
         "required": false,
         "type": "str"
@@ -270,7 +270,7 @@
     "params": [
       {
         "default": "mcp-agent",
-        "description": "Caller agent.",
+        "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
         "name": "agent_id",
         "required": false,
         "type": "str"
@@ -393,7 +393,7 @@
     "params": [
       {
         "default": "mcp-agent",
-        "description": "Caller agent.",
+        "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
         "name": "agent_id",
         "required": false,
         "type": "str"
@@ -614,7 +614,7 @@
       },
       {
         "default": "mcp-agent",
-        "description": "Caller agent.",
+        "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
         "name": "agent_id",
         "required": false,
         "type": "str"
@@ -638,7 +638,7 @@
       },
       {
         "default": "mcp-agent",
-        "description": "Caller agent.",
+        "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
         "name": "agent_id",
         "required": false,
         "type": "str"
@@ -712,7 +712,7 @@
       },
       {
         "default": "mcp-agent",
-        "description": "Caller agent.",
+        "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
         "name": "agent_id",
         "required": false,
         "type": "str"
@@ -751,7 +751,7 @@
     "params": [
       {
         "default": "mcp-agent",
-        "description": "Caller agent.",
+        "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
         "name": "agent_id",
         "required": false,
         "type": "str"
@@ -850,7 +850,7 @@
       },
       {
         "default": "mcp-agent",
-        "description": "Caller agent.",
+        "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
         "name": "agent_id",
         "required": false,
         "type": "str"

--- a/tests/fixtures/tools_list_baseline_v1.json
+++ b/tests/fixtures/tools_list_baseline_v1.json
@@ -97,7 +97,7 @@
         },
         "agent_id": {
           "default": "mcp-agent",
-          "description": "Caller agent.",
+          "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
           "title": "Agent Id",
           "type": "string"
         },
@@ -210,7 +210,7 @@
         },
         "agent_id": {
           "default": "mcp-agent",
-          "description": "Caller agent.",
+          "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
           "title": "Agent Id",
           "type": "string"
         },
@@ -273,7 +273,7 @@
         },
         "agent_id": {
           "default": "mcp-agent",
-          "description": "Caller agent.",
+          "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
           "title": "Agent Id",
           "type": "string"
         }
@@ -298,7 +298,7 @@
       "properties": {
         "agent_id": {
           "default": "mcp-agent",
-          "description": "Caller agent.",
+          "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
           "title": "Agent Id",
           "type": "string"
         },
@@ -454,7 +454,7 @@
       "properties": {
         "agent_id": {
           "default": "mcp-agent",
-          "description": "Caller agent.",
+          "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
           "title": "Agent Id",
           "type": "string"
         },
@@ -742,7 +742,7 @@
         },
         "agent_id": {
           "default": "mcp-agent",
-          "description": "Caller agent.",
+          "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
           "title": "Agent Id",
           "type": "string"
         }
@@ -772,7 +772,7 @@
         },
         "agent_id": {
           "default": "mcp-agent",
-          "description": "Caller agent.",
+          "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
           "title": "Agent Id",
           "type": "string"
         },
@@ -883,7 +883,7 @@
         },
         "agent_id": {
           "default": "mcp-agent",
-          "description": "Caller agent.",
+          "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
           "title": "Agent Id",
           "type": "string"
         },
@@ -937,7 +937,7 @@
       "properties": {
         "agent_id": {
           "default": "mcp-agent",
-          "description": "Caller agent.",
+          "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
           "title": "Agent Id",
           "type": "string"
         },
@@ -1106,7 +1106,7 @@
         },
         "agent_id": {
           "default": "mcp-agent",
-          "description": "Caller agent.",
+          "description": "Agent this call is attributed to; agent-scoped reads filter by it. Hosted callers must pass a real one.",
           "title": "Agent Id",
           "type": "string"
         },

--- a/tests/test_f1_mcp_identity_surface.py
+++ b/tests/test_f1_mcp_identity_surface.py
@@ -1,0 +1,140 @@
+"""What the MCP tool surface tells a caller about its own identity - F1 / SAFE-04A.
+
+``agent_id`` decides which agent a write is attributed to and which rows an
+agent-scoped read can see. All ten tools that accept it documented it as
+"Caller agent." while defaulting to ``mcp-agent`` - a value the hosted gateway
+path actively refuses. The schema therefore advertised a default that cannot be
+used where most callers run, and offered no hint of what to send instead.
+
+The default is deliberately kept: ``mcp-agent`` is a legitimate standalone
+identity (see ``core_api.agent_ids``), and dropping it would break every
+single-tenant caller and change the schema for all of them. Only the
+description changes, and these tests pin both halves of that - the text now
+says something useful, AND the default did not move.
+
+The guard's message is the second half. It fires on eleven tools, seven of them
+reads, while opening with "Writes via the gateway ..." - a sentence that is
+simply false on a read, and the same class of error that teaches an agent a
+wrong general rule.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from contextlib import contextmanager
+import typing
+
+import pytest
+
+from core_api import mcp_server
+from core_api.agent_ids import DEFAULT_AGENT_ID
+
+pytestmark = pytest.mark.unit
+
+# Tools whose signature exposes agent_id to the client.
+AGENT_ID_TOOLS = [
+    "caura_recall", "caura_write", "caura_manage", "caura_tune", "caura_doc",
+    "caura_list", "caura_stats", "caura_insights", "caura_evolve", "caura_keystones",
+]
+
+
+def _agent_id_field(tool_name: str):
+    fn = getattr(mcp_server, tool_name)
+    hints = typing.get_type_hints(fn, include_extras=True)
+    annotated = hints["agent_id"]
+    return typing.get_args(annotated)[1]
+
+
+def _default(tool_name: str):
+    return inspect.signature(getattr(mcp_server, tool_name)).parameters["agent_id"].default
+
+
+@pytest.mark.parametrize("tool", AGENT_ID_TOOLS)
+def test_the_schema_explains_what_agent_id_decides(tool: str) -> None:
+    description = (_agent_id_field(tool).description or "").lower()
+    assert description != "caller agent."
+    # It governs two different things and the old text implied neither.
+    assert "attributed" in description
+    assert "read" in description
+
+
+@pytest.mark.parametrize("tool", AGENT_ID_TOOLS)
+def test_the_schema_warns_that_the_default_is_refused_when_hosted(tool: str) -> None:
+    """The concrete trap: the advertised default cannot be used on the gateway.
+
+    Asserted on meaning rather than exact wording, because this text is paid on
+    every agent call and will be re-tightened whenever the token ceiling bites.
+    """
+    description = (_agent_id_field(tool).description or "").lower()
+    assert "hosted" in description
+    assert "real one" in description or "real value" in description
+
+
+@pytest.mark.parametrize("tool", AGENT_ID_TOOLS)
+def test_the_default_itself_did_not_move(tool: str) -> None:
+    """Standalone depends on it. This is a documentation fix, not a contract change."""
+    assert _default(tool) == DEFAULT_AGENT_ID == "mcp-agent"
+
+
+@contextmanager
+def gateway_without_agent_identity():
+    """The tenant-key-through-the-gateway case the guard exists for.
+
+    ``_via_gateway_var`` is a ContextVar, so it is set and reset rather than
+    monkeypatched - attributes cannot be assigned on one.
+    """
+    token = mcp_server._via_gateway_var.set(True)
+    agent_token = mcp_server._agent_id_var.set(None)
+    try:
+        yield
+    finally:
+        mcp_server._via_gateway_var.reset(token)
+        mcp_server._agent_id_var.reset(agent_token)
+
+
+def test_the_gateway_guard_does_not_call_every_call_a_write() -> None:
+    """Seven of the eleven guarded tools are reads."""
+    with gateway_without_agent_identity():
+        envelope = mcp_server._refuse_default_agent_on_gateway(DEFAULT_AGENT_ID)
+    assert envelope is not None
+    message = json.loads(envelope)["error"]["message"]
+
+    assert not message.startswith("Writes")
+    # It must say why a read is affected too, or a reader reasonably concludes
+    # reads are exempt and goes hunting the wrong problem.
+    assert "read" in message.lower()
+    # And it must still name the way out - the part that already worked.
+    assert "agent_id=<your-agent-name>" in message
+    assert "agent-scoped credential" in message
+
+
+def test_the_guard_still_lets_legitimate_callers_through() -> None:
+    """Three ways to be legitimate: off-gateway, identity already resolved, or
+    a real id supplied. Widening the message must not widen the refusal."""
+    # Off the gateway entirely - standalone, where mcp-agent is by design.
+    assert mcp_server._refuse_default_agent_on_gateway(DEFAULT_AGENT_ID) is None
+
+    with gateway_without_agent_identity():
+        # A real id supplied by the caller.
+        assert mcp_server._refuse_default_agent_on_gateway("a-real-agent") is None
+
+    # Gateway injected an identity (agent-scoped credential).
+    token = mcp_server._via_gateway_var.set(True)
+    agent_token = mcp_server._agent_id_var.set("resolved-agent")
+    try:
+        assert mcp_server._refuse_default_agent_on_gateway(DEFAULT_AGENT_ID) is None
+    finally:
+        mcp_server._via_gateway_var.reset(token)
+        mcp_server._agent_id_var.reset(agent_token)
+
+
+def test_the_error_code_is_unchanged() -> None:
+    """MISSING_AGENT_ID is the documented contract and A14/A29 closed against it."""
+    token = mcp_server._via_gateway_var.set(True)
+    try:
+        envelope = mcp_server._refuse_default_agent_on_gateway(DEFAULT_AGENT_ID)
+    finally:
+        mcp_server._via_gateway_var.reset(token)
+    assert envelope is not None
+    assert json.loads(envelope)["error"]["code"] == "MISSING_AGENT_ID"


### PR DESCRIPTION
## Summary

`agent_id` decides which agent a write is attributed to and which rows an
agent-scoped read can see. Two things about how the MCP surface describes it
were wrong, and both taught callers something false.

**The schema advertised an unusable default.** All ten tools that accept
`agent_id` described it as `"Caller agent."` while defaulting to `"mcp-agent"`,
a value the hosted gateway path actively refuses. So the schema named a default
that cannot be used where most callers run, and offered no hint of what to send
instead. The default itself is unchanged - `mcp-agent` is a legitimate
standalone identity by design, and dropping it would break every single-tenant
caller and change the schema for all of them. A test pins that it did not move.

**The guard called every call a write.** Its message opened
`"Writes via the gateway ... must specify an agent_id"`, but it fires on eleven
tools and seven are reads (`caura_recall`, `caura_doc`, `caura_list`,
`caura_stats`, `caura_insights`, `caura_evolve`, `caura_keystones`). On a read
that sentence is simply false. It now names the real condition and explains why
reads are affected, since agent-scoped reads filter by `agent_id`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (tool schema text)
- [ ] Refactor / internal cleanup
- [ ] Other

No behaviour change: the default, the guard's trigger conditions, and the
`MISSING_AGENT_ID` code are all untouched. Only what the surface *says*.

## How Has This Been Tested?

```
tests/                     5128 passed, 3 skipped, 1 xfailed
plugin (node:test)          423 passed
ruff + format + mypy       clean
legacy-name ratchet        no new lines
do-not-touch sentinel      35/35
tools/list token budget    5178 of 5200 ceiling
```

Mutation-tested: with the old description and message restored, 21 of the 33
new assertions fail and the remaining 12 - the behavioural guard tests and the
"default did not move" checks - correctly stay green.

The export drift gate (`test_tools_export_in_sync.py`) was confirmed to fail
before regenerating `plugin/tools.json` and pass after, so the regeneration is
verified rather than assumed.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally
- [x] I have updated relevant documentation (the tool schema is the documentation here)
- [ ] CHANGELOG.md - N/A, release-please generates it from Conventional Commits

## Additional Notes

**Description length was constrained, not chosen.** `tools/list` is re-sent on
every agent session and this text is paid ten times per call. The first draft
was three times longer and pushed the surface to 5698 tokens, 498 over the
ceiling in `test_mcp_token_budget.py`. The shipped wording costs +117 for the
three facts that matter - what it attributes, what it filters, and that hosted
needs a real one - against a +155 precedent already recorded beside that
constant for the same kind of clarification. Five candidate wordings were
measured; this one leaves 22 tokens of headroom rather than the 2 the next
shortest would have left.

**One part of this item is deliberately not addressed.** The remaining
complaint is that three logical 4xx in a row disable a client's entire toolset.
Every refusal is currently `CallToolResult(isError=True)`, and that is a
deliberate decision defended by `tests/test_mcp_iserror_propagation.py` plus a
CI guard, so that clients doing `if not result.isError: succeed()` cannot read
a refusal as success. Making refusals look non-fatal pushes directly against
that guarantee, and under the MCP spec a refusal genuinely is a tool error - so
a client's circuit breaker counting them as transport failures is arguably
client-side. Both positions are defensible; this needs a decision, not a patch,
so it is left open rather than resolved unilaterally.
