### PR TITLE
feat(search): wire diagnostic mode end-to-end, expose ranking score + factors

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -915,6 +915,27 @@
             ],
             "title": "Scope"
           },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "score_parts": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScoreParts"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "similarity": {
             "anyOf": [
               {
@@ -1301,6 +1322,165 @@
         "title": "PaginatedMemoryResponse",
         "type": "object"
       },
+      "ScoreParts": {
+        "description": "D12 — per-factor breakdown of the ranking composite ``MemoryOut.score``.\n\nEvery factor mirrors a column the scored-search SQL already computes and\nreturns per row; this model only surfaces them. All fields are nullable:\nFTS-only rows have no ``vec_sim``, entity-lookup short-circuit rows have no\nFTS rank, and successor-injected rows were never scored at all.",
+        "properties": {
+          "entity_boost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Boost"
+          },
+          "freshness": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Freshness"
+          },
+          "fts_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fts Score"
+          },
+          "recall_boost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Boost"
+          },
+          "status_penalty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Penalty"
+          },
+          "temporal_boost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Temporal Boost"
+          },
+          "vec_sim": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vec Sim"
+          }
+        },
+        "title": "ScoreParts",
+        "type": "object"
+      },
+      "SearchDiagnostic": {
+        "description": "D12 — retrieval trace returned when ``SearchRequest.diagnostic`` is true.\n\nAnswers \"why did each result appear (and what got cut)\": the full widened\ncandidate set with per-row score factors and exclusion reasons, the applied\nknobs, and the strategy the classifier picked. Requesting it does NOT change\nthe ``items`` a caller gets back, and a diagnostic call never bumps\n``recall_count`` — it is inspection, not use.",
+        "properties": {
+          "all_candidates": {
+            "default": [],
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "All Candidates",
+            "type": "array"
+          },
+          "candidates_considered": {
+            "default": 0,
+            "title": "Candidates Considered",
+            "type": "integer"
+          },
+          "excluded_below_min_similarity": {
+            "default": 0,
+            "title": "Excluded Below Min Similarity",
+            "type": "integer"
+          },
+          "excluded_by_top_k_trim": {
+            "default": 0,
+            "title": "Excluded By Top K Trim",
+            "type": "integer"
+          },
+          "min_similarity_applied": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Similarity Applied"
+          },
+          "retrieval_strategy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retrieval Strategy"
+          },
+          "returned": {
+            "default": 0,
+            "title": "Returned",
+            "type": "integer"
+          },
+          "search_params": {
+            "additionalProperties": true,
+            "default": {},
+            "title": "Search Params",
+            "type": "object"
+          },
+          "top_k_requested": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top K Requested"
+          }
+        },
+        "title": "SearchDiagnostic",
+        "type": "object"
+      },
       "SearchRequest": {
         "properties": {
           "diagnostic": {
@@ -1343,6 +1523,20 @@
               }
             ],
             "description": "Filter results to a single memory type. Valid values: fact, episode, decision, preference, task, semantic, intention, plan, commitment, action, outcome, cancellation, rule, insight."
+          },
+          "min_similarity": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-request similarity floor (0.0-1.0) applied to the raw cosine; overrides the agent/tenant search-profile value for this call.",
+            "title": "Min Similarity"
           },
           "query": {
             "maxLength": 5000,
@@ -1397,6 +1591,16 @@
       "SearchResponse": {
         "description": "Envelope for search results — matches PaginatedMemoryResponse shape.",
         "properties": {
+          "diagnostic": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SearchDiagnostic"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/MemoryOut"

--- a/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
+++ b/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
@@ -54,7 +54,16 @@ class ExecuteScoredSearch:
         top_k = sp["top_k"]
         if diagnostic:
             data["diagnostic_original_top_k"] = top_k
-            top_k = max(top_k, 50)
+            # D12 — diagnostic must not change what the caller gets back:
+            # ``final_top_k`` is set so PostFilterResults trims the RESULTS to
+            # the requested size exactly as a normal call would, while the
+            # widened fetch below feeds the trace with the full candidate set
+            # (captured pre-trim in PostFilterResults). Before this, the
+            # diagnostic branch skipped ``final_top_k`` — an untrimmed 50-row
+            # response whose extra rows would also each get a recall_count
+            # bump (TrackRecalls now skips diagnostic calls entirely).
+            data["final_top_k"] = top_k
+            top_k = max(top_k * SEARCH_OVERFETCH_FACTOR, 50)
         else:
             # Overfetch so PostFilterResults has headroom to drop low-vec_sim rows
             # without starving the final result set. Final trim happens in PostFilterResults.
@@ -77,11 +86,11 @@ class ExecuteScoredSearch:
         # storage route's required-key check be the one place that rejects.
         #
         # The diagnostic branch's widening to 50 was defeated by the same
-        # shadowing and is restored — but note that mode is half-wired:
-        # ``SearchRequest.diagnostic`` is never read by a route and nothing writes
-        # ``diagnostic_results``, so no caller reaches it. Whoever reconnects it
-        # should know the branch skips ``final_top_k``, so PostFilterResults does
-        # not trim and TrackRecalls would bump ``recall_count`` for all 50 rows.
+        # shadowing and is restored. D12 wired the mode end-to-end: /search and
+        # /recall forward ``SearchRequest.diagnostic``, PostFilterResults writes
+        # ``diagnostic_results``/``diagnostic_counts``, the branch above sets
+        # ``final_top_k`` so results stay identical, and TrackRecalls skips
+        # diagnostic calls.
         search_data: dict = {
             "tenant_id": data["tenant_id"],
             "query": data["query"],

--- a/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
+++ b/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
@@ -8,11 +8,35 @@ from types import SimpleNamespace
 from core_api.clients.storage_client import get_storage_client
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
+from core_api.schemas import ScoreParts
 from core_api.services.memory_service import _memory_to_out
 
 logger = logging.getLogger(__name__)
 
 MAX_SUCCESSOR_LOOKUPS = 10
+
+_SCORE_FACTORS = (
+    "vec_sim",
+    "fts_score",
+    "freshness",
+    "entity_boost",
+    "recall_boost",
+    "temporal_boost",
+    "status_penalty",
+)
+
+
+def _score_parts(row) -> ScoreParts | None:
+    """Build the D12 factor breakdown from a scored row; None when unscored.
+
+    A row with every factor None (successor-injected rows, hand-built test
+    rows) yields None rather than an all-null object, so unscored contexts
+    keep the field absent instead of noisy.
+    """
+    values = {k: getattr(row, k, None) for k in _SCORE_FACTORS}
+    if all(v is None for v in values.values()):
+        return None
+    return ScoreParts(**{k: (round(float(v), 4) if v is not None else None) for k, v in values.items()})
 
 
 class LoadAndSerialize:
@@ -95,6 +119,12 @@ class LoadAndSerialize:
                 # already ordered by ``score`` upstream). None for FTS-only hits,
                 # which have no vector similarity.
                 similarity=(round(float(row.vec_sim), 4) if row.vec_sim is not None else None),
+                # D12 — the composite that ordered this row, and its factors.
+                # The storage SQL has always computed these per row; this is the
+                # first place they survive serialization. None end-to-end for
+                # successor-injected rows, which were never scored.
+                score=(round(float(row.score), 4) if row.score is not None else None),
+                score_parts=_score_parts(row),
             )
             for row in rows
         ]

--- a/core-api/src/core_api/pipeline/steps/search/post_filter_results.py
+++ b/core-api/src/core_api/pipeline/steps/search/post_filter_results.py
@@ -35,12 +35,66 @@ class PostFilterResults:
             or row.vec_sim is None
             or float(row.vec_sim) >= min_similarity
         ]
+        below_floor = len(ctx.data["raw_rows"]) - len(filtered)
         # Trim to the user-requested top_k (storage returned top_k * overfetch_factor)
         final_top_k = ctx.data.get("final_top_k")
         if final_top_k is not None:
             filtered = trim_reserving_fts_only(filtered, final_top_k, _is_fts_only)
         ctx.data["filtered_rows"] = filtered
+
+        # D12 — diagnostic trace: capture the FULL widened candidate set with
+        # per-row score factors and the reason each cut row was cut, before the
+        # trimmed rows are forgotten. Written here (not in a separate step)
+        # because this is the one place that knows both the floor and the trim.
+        if ctx.data.get("diagnostic"):
+            kept_ids = {id(row) for row in filtered}
+            passed_floor_ids = set()
+            for row in ctx.data["raw_rows"]:
+                if (
+                    (not getattr(row, "has_embedding", True))
+                    or row.vec_sim is None
+                    or float(row.vec_sim) >= min_similarity
+                ):
+                    passed_floor_ids.add(id(row))
+            candidates = []
+            for row in ctx.data["raw_rows"]:
+                m = row.Memory
+                excluded = None
+                if id(row) not in passed_floor_ids:
+                    excluded = "below_min_similarity"
+                elif id(row) not in kept_ids:
+                    excluded = "trimmed_by_top_k"
+                candidates.append(
+                    {
+                        "id": str(getattr(m, "id", None)),
+                        "title": getattr(m, "title", None),
+                        "memory_type": getattr(m, "memory_type", None),
+                        "status": getattr(m, "status", None),
+                        "score": _f(getattr(row, "score", None)),
+                        "vec_sim": _f(getattr(row, "vec_sim", None)),
+                        "fts_score": _f(getattr(row, "fts_score", None)),
+                        "freshness": _f(getattr(row, "freshness", None)),
+                        "entity_boost": _f(getattr(row, "entity_boost", None)),
+                        "recall_boost": _f(getattr(row, "recall_boost", None)),
+                        "temporal_boost": _f(getattr(row, "temporal_boost", None)),
+                        "status_penalty": _f(getattr(row, "status_penalty", None)),
+                        "has_embedding": bool(getattr(row, "has_embedding", True)),
+                        "excluded": excluded,
+                    }
+                )
+            ctx.data["diagnostic_results"] = candidates
+            ctx.data["diagnostic_counts"] = {
+                "candidates_considered": len(ctx.data["raw_rows"]),
+                "returned": len(filtered),
+                "excluded_below_min_similarity": below_floor,
+                "excluded_by_top_k_trim": len(ctx.data["raw_rows"]) - below_floor - len(filtered),
+            }
         return None
+
+
+def _f(v) -> float | None:
+    """Round a score factor for the diagnostic trace; None passes through."""
+    return round(float(v), 4) if v is not None else None
 
 
 def _is_fts_only(row) -> bool:

--- a/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
+++ b/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
@@ -24,4 +24,12 @@ class ResolveSearchProfile:
             top_k=ctx.data["top_k"],
             tenant_config=ctx.tenant_config,
         )
+        # D12 — a per-request ``min_similarity`` (SearchRequest field) outranks
+        # the whole resolution ladder for this one call: request → agent
+        # profile → tenant default → constant. Applied here, after resolution,
+        # so PostFilterResults and the diagnostic trace both see the value the
+        # gate will actually use.
+        override = ctx.data.get("min_similarity_override")
+        if override is not None:
+            ctx.data["search_params"]["min_similarity"] = float(override)
         return None

--- a/core-api/src/core_api/pipeline/steps/search/track_recalls.py
+++ b/core-api/src/core_api/pipeline/steps/search/track_recalls.py
@@ -55,6 +55,13 @@ class TrackRecalls:
         # unchanged either way; only the counter bump is skipped. (Gap A26.)
         if not ctx.data.get("caller_agent_id"):
             return None
+        # D12 — a diagnostic call is inspection, not use: the caller is asking
+        # "why does ranking look like this", and letting that bump
+        # ``recall_count`` would distort the very signal being inspected (the
+        # A26/A48 class of feedback loop). This also makes ``diagnostic=true``
+        # the supported dry-run recall: same results, no reinforcement.
+        if ctx.data.get("diagnostic"):
+            return None
         memory_ids = [row.Memory.id for row in ctx.data["filtered_rows"]]
         if memory_ids:
             track_task(_track_recalls_background(memory_ids))

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -54,6 +54,7 @@ from core_api.schemas import (
     PaginatedMemoryResponse,
     RedistributeRequest,
     RedistributeResponse,
+    SearchDiagnostic,
     SearchRequest,
     SearchResponse,
     STMWriteResponse,
@@ -1722,6 +1723,10 @@ async def _search_inner(
     t_start = time.perf_counter()
     success = True
     results: list = []
+    # D12 — the pipeline fills this when ``body.diagnostic`` is set; it feeds
+    # the typed ``SearchResponse.diagnostic`` block below. Results themselves
+    # are unchanged by diagnostic mode, and no recall_count is bumped.
+    diagnostic_ctx: dict = {}
     try:
         config = await resolve_config(body.tenant_id)
         # Widen the read predicate when the caller authenticated with
@@ -1746,6 +1751,9 @@ async def _search_inner(
             tenant_config=config,
             search_profile=_agent.get("search_profile") if _agent else None,
             readable_tenant_ids=auth.readable_tenant_ids if auth.is_cross_tenant_read else None,
+            diagnostic=body.diagnostic,
+            diagnostic_ctx=diagnostic_ctx if body.diagnostic else None,
+            min_similarity=body.min_similarity,
         )
     except HTTPException:
         # Auth / tenant errors raised downstream are expected outcomes,
@@ -1767,7 +1775,26 @@ async def _search_inner(
                     "error": not success,
                 },
             )
-    return SearchResponse(items=results)
+    if not body.diagnostic:
+        return SearchResponse(items=results)
+    counts = diagnostic_ctx.get("counts", {}) or {}
+    return SearchResponse(
+        items=results,
+        diagnostic=SearchDiagnostic(
+            retrieval_strategy=diagnostic_ctx.get("retrieval_strategy"),
+            top_k_requested=diagnostic_ctx.get("diagnostic_original_top_k"),
+            min_similarity_applied=diagnostic_ctx.get("min_similarity_applied"),
+            candidates_considered=counts.get("candidates_considered", 0),
+            returned=counts.get("returned", len(results)),
+            excluded_below_min_similarity=counts.get("excluded_below_min_similarity", 0),
+            excluded_by_top_k_trim=counts.get("excluded_by_top_k_trim", 0),
+            search_params={
+                k: (float(v) if isinstance(v, (int, float)) else v)
+                for k, v in (diagnostic_ctx.get("search_params", {}) or {}).items()
+            },
+            all_candidates=diagnostic_ctx.get("all_candidates", []) or [],
+        ),
+    )
 
 
 @router.post("/ingest/preview")
@@ -1962,6 +1989,12 @@ async def recall_endpoint(
 
     t0 = time.perf_counter()
 
+    # D12 — same wiring as /search: the pipeline fills the ctx when
+    # ``body.diagnostic`` is set, and ``summarize_memories`` folds it into the
+    # response's ``diagnostic`` block (the recall-flavoured shape, which also
+    # carries the prompt/model/provider fields).
+    diagnostic_ctx: dict = {}
+
     # ── Phase 1: DB-bound — config + search ──────────────────────
     config = await resolve_config(body.tenant_id)
     memories = await search_memories(
@@ -1979,6 +2012,9 @@ async def recall_endpoint(
         entity_retrieval=config.entity_retrieval,
         tenant_config=config,
         readable_tenant_ids=auth.readable_tenant_ids if auth.is_cross_tenant_read else None,
+        diagnostic=body.diagnostic,
+        diagnostic_ctx=diagnostic_ctx if body.diagnostic else None,
+        min_similarity=body.min_similarity,
     )
 
     # Release the pooled DB connection before the LLM round-trip.
@@ -1991,6 +2027,8 @@ async def recall_endpoint(
         body.query,
         config,
         valid_at=body.valid_at,
+        diagnostic=body.diagnostic,
+        diagnostic_ctx=diagnostic_ctx,
         top_k=body.top_k,
         t0=t0,
     )

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -276,6 +276,24 @@ class UsageSummary(BaseModel):
     writes_remaining: int | None = None
 
 
+class ScoreParts(BaseModel):
+    """D12 — per-factor breakdown of the ranking composite ``MemoryOut.score``.
+
+    Every factor mirrors a column the scored-search SQL already computes and
+    returns per row; this model only surfaces them. All fields are nullable:
+    FTS-only rows have no ``vec_sim``, entity-lookup short-circuit rows have no
+    FTS rank, and successor-injected rows were never scored at all.
+    """
+
+    vec_sim: float | None = None
+    fts_score: float | None = None
+    freshness: float | None = None
+    entity_boost: float | None = None
+    recall_boost: float | None = None
+    temporal_boost: float | None = None
+    status_penalty: float | None = None
+
+
 class MemoryOut(BaseModel):
     id: UUID
     tenant_id: str
@@ -318,6 +336,15 @@ class MemoryOut(BaseModel):
     expires_at: datetime | None
     entity_links: list[EntityLinkOut] = []
     similarity: float | None = None
+    # D12 — the multiplicative ranking composite (similarity * freshness *
+    # entity/recall/temporal boosts * status_penalty) that actually ordered
+    # this row, plus its factors. ``similarity`` above stays the raw 0..1
+    # cosine (the ``min_similarity``-comparable value); ``score`` routinely
+    # exceeds 1.0 and is for explaining rank, not for threshold gating.
+    # Populated only on scored-search hits; None on list/get reads and on
+    # successor-injected rows, which were never scored.
+    score: float | None = None
+    score_parts: ScoreParts | None = None
     # RDF triple
     subject_entity_id: UUID | None = None
     predicate: str | None = None
@@ -445,10 +472,37 @@ class PaginatedMemoryResponse(BaseModel):
     next_cursor: str | None = None
 
 
+class SearchDiagnostic(BaseModel):
+    """D12 — retrieval trace returned when ``SearchRequest.diagnostic`` is true.
+
+    Answers "why did each result appear (and what got cut)": the full widened
+    candidate set with per-row score factors and exclusion reasons, the applied
+    knobs, and the strategy the classifier picked. Requesting it does NOT change
+    the ``items`` a caller gets back, and a diagnostic call never bumps
+    ``recall_count`` — it is inspection, not use.
+    """
+
+    retrieval_strategy: str | None = None
+    top_k_requested: int | None = None
+    min_similarity_applied: float | None = None
+    candidates_considered: int = 0
+    returned: int = 0
+    excluded_below_min_similarity: int = 0
+    excluded_by_top_k_trim: int = 0
+    # The resolved knob set the scoring SQL ran with (profile → tenant → constant,
+    # after any per-request ``min_similarity`` override).
+    search_params: dict = {}
+    # One entry per widened candidate: id/title/type/status + score + factors +
+    # ``excluded`` (None | "below_min_similarity" | "trimmed_by_top_k").
+    all_candidates: list[dict] = []
+
+
 class SearchResponse(BaseModel):
     """Envelope for search results — matches PaginatedMemoryResponse shape."""
 
     items: list[MemoryOut]
+    # D12 — present only when the request set ``diagnostic=true``.
+    diagnostic: SearchDiagnostic | None = None
 
 
 class SearchRequest(BaseModel):
@@ -468,6 +522,23 @@ class SearchRequest(BaseModel):
         le=MAX_SEARCH_TOP_K,
         description=f"Maximum results to return (1-{MAX_SEARCH_TOP_K}, default {DEFAULT_SEARCH_TOP_K}).",
     )
+    # D12 — per-request cosine floor. Overrides the resolved profile/tenant
+    # default for THIS call only (request beats profile beats tenant beats
+    # constant). Gates on the raw ``vec_sim`` — the same value returned in
+    # ``MemoryOut.similarity`` — never on the boosted composite ``score``.
+    # FTS-only rows (no embedding yet) bypass the floor by contract.
+    min_similarity: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Per-request similarity floor (0.0-1.0) applied to the raw cosine; "
+            "overrides the agent/tenant search-profile value for this call."
+        ),
+    )
+    # D12 — when true, the response carries a ``diagnostic`` retrieval trace
+    # (full candidate set, score factors, exclusion reasons, applied knobs).
+    # Results are unchanged and no recall_count is bumped on a diagnostic call.
     diagnostic: bool = False
 
 

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -88,6 +88,7 @@ from core_api.schemas import (
     MemoryCreate,
     MemoryOut,
     MemoryUpdate,
+    ScoreParts,
 )
 from core_api.search_trim import trim_reserving_fts_only
 from core_api.services.entity_extraction_worker import process_entity_extraction
@@ -483,6 +484,8 @@ def _memory_to_out(
     entity_links: list[EntityLinkOut] | None = None,
     similarity: float | None = None,
     contradictions: list[ContradictionInfo] | None = None,
+    score: float | None = None,
+    score_parts: ScoreParts | None = None,
 ) -> MemoryOut:
     # See ``_dict_to_memory_out`` for the falsy-``{}`` trap.
     if isinstance(memory, dict):
@@ -507,6 +510,8 @@ def _memory_to_out(
         expires_at=_mem_attr(memory, "expires_at"),
         entity_links=entity_links or [],
         similarity=similarity,
+        score=score,
+        score_parts=score_parts,
         subject_entity_id=_mem_attr(memory, "subject_entity_id"),
         predicate=_mem_attr(memory, "predicate"),
         object_value=_mem_attr(memory, "object_value"),
@@ -4310,6 +4315,7 @@ async def search_memories(
     diagnostic_ctx: dict | None = None,
     readable_tenant_ids: list[str] | None = None,
     source: str = "search",
+    min_similarity: float | None = None,
 ) -> list[MemoryOut]:
     # Diagnostic mode requires the pipeline path for score introspection
     if _USE_PIPELINE_SEARCH or diagnostic:
@@ -4332,6 +4338,7 @@ async def search_memories(
             diagnostic_ctx=diagnostic_ctx,
             readable_tenant_ids=readable_tenant_ids,
             source=source,
+            min_similarity=min_similarity,
         )
     logger.warning("legacy search path invoked; this path is deprecated and scheduled for removal")
     return await _search_memories_legacy(
@@ -4349,6 +4356,7 @@ async def search_memories(
         entity_retrieval=entity_retrieval,
         tenant_config=tenant_config,
         search_profile=search_profile,
+        min_similarity=min_similarity,
     )
 
 
@@ -4371,6 +4379,7 @@ async def _search_memories_pipeline(
     diagnostic_ctx: dict | None = None,
     readable_tenant_ids: list[str] | None = None,
     source: str = "search",
+    min_similarity: float | None = None,
 ) -> list[MemoryOut]:
     """Pipeline-based search_memories -- same logic, decomposed into timed steps."""
     from core_api.pipeline.compositions.search import build_search_pipeline
@@ -4396,6 +4405,9 @@ async def _search_memories_pipeline(
             "tenant_config": tenant_config,
             "search_profile": search_profile,
             "diagnostic": diagnostic,
+            # D12 — per-request cosine floor; ResolveSearchProfile applies it
+            # OVER the resolved profile (request beats profile beats tenant).
+            "min_similarity_override": min_similarity,
             "readable_tenant_ids": readable_tenant_ids,
             "source": source,
         },
@@ -4424,6 +4436,11 @@ async def _search_memories_pipeline(
             ctx.data["retrieval_plan"].strategy.value if ctx.data.get("retrieval_plan") else None
         )
         diagnostic_ctx["diagnostic_original_top_k"] = ctx.data.get("diagnostic_original_top_k")
+        # D12 — exclusion tallies written by PostFilterResults, and the floor
+        # the gate actually used (post-override), so callers can see both.
+        diagnostic_ctx["counts"] = ctx.data.get("diagnostic_counts", {})
+        sp_applied = ctx.data.get("search_params") or {}
+        diagnostic_ctx["min_similarity_applied"] = sp_applied.get("min_similarity")
 
     return ctx.data["results"]
 
@@ -4452,6 +4469,7 @@ async def _search_memories_legacy(
     entity_retrieval: bool = True,
     tenant_config=None,
     search_profile: dict | None = None,
+    min_similarity: float | None = None,
 ) -> list[MemoryOut]:
     """Legacy search -- uses scored_search storage API endpoint."""
     sc = get_storage_client()
@@ -4459,7 +4477,9 @@ async def _search_memories_legacy(
     # Same resolver the pipeline step uses — see ``resolve_search_params``.
     sp = resolve_search_params(search_profile, query=query, top_k=top_k, tenant_config=tenant_config)
     _top_k = sp["top_k"]
-    _min_similarity = sp["min_similarity"]
+    # D12 — per-request floor beats the resolved profile, same precedence as
+    # ResolveSearchProfile applies on the pipeline path.
+    _min_similarity = min_similarity if min_similarity is not None else sp["min_similarity"]
 
     # Temporal hint
     temporal_window = _extract_temporal_hint(query)

--- a/core-api/src/core_api/services/recall_service.py
+++ b/core-api/src/core_api/services/recall_service.py
@@ -264,6 +264,7 @@ async def recall(
     valid_at: datetime | None = None,
     diagnostic: bool = False,
     readable_tenant_ids: list[str] | None = None,
+    min_similarity: float | None = None,
 ) -> dict:
     """Search memories and synthesize a context summary.
 
@@ -304,6 +305,7 @@ async def recall(
         diagnostic=diagnostic,
         diagnostic_ctx=diagnostic_ctx if diagnostic else None,
         readable_tenant_ids=readable_tenant_ids,
+        min_similarity=min_similarity,
     )
     return await summarize_memories(
         memories,

--- a/tests/test_d12_search_diagnostics.py
+++ b/tests/test_d12_search_diagnostics.py
@@ -1,0 +1,217 @@
+"""D12 — search diagnostics wired end-to-end.
+
+Covers the pieces this change added:
+
+- ``ResolveSearchProfile`` honours a per-request ``min_similarity`` override
+  (request beats profile beats tenant beats constant).
+- ``PostFilterResults`` captures the full candidate trace + exclusion tallies
+  when ``diagnostic`` is set, without changing the returned rows.
+- ``TrackRecalls`` never bumps ``recall_count`` on a diagnostic call —
+  inspection must not reinforce the signal being inspected.
+- ``LoadAndSerialize`` surfaces the ranking composite (``score``) and its
+  factor breakdown (``score_parts``) on scored hits, and omits them on
+  unscored rows.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search import track_recalls as tr
+from core_api.pipeline.steps.search.load_and_serialize import LoadAndSerialize, _score_parts
+from core_api.pipeline.steps.search.post_filter_results import PostFilterResults
+from core_api.pipeline.steps.search.resolve_search_profile import ResolveSearchProfile
+
+
+def _scored_row(vec_sim, score=1.0, status="active", has_embedding=True, **factors):
+    return SimpleNamespace(
+        Memory=SimpleNamespace(
+            id=uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            agent_display_name=None,
+            memory_type="fact",
+            title="row",
+            content="c",
+            weight=0.5,
+            source_uri=None,
+            run_id=None,
+            metadata_=None,
+            created_at="2026-08-25T00:00:00Z",
+            expires_at=None,
+            subject_entity_id=None,
+            predicate=None,
+            object_value=None,
+            ts_valid_start=None,
+            ts_valid_end=None,
+            status=status,
+            visibility="scope_fleet",
+            recall_count=0,
+            last_recalled_at=None,
+            supersedes_id=None,
+        ),
+        score=score,
+        similarity=None,
+        vec_sim=vec_sim,
+        fts_score=factors.get("fts_score"),
+        freshness=factors.get("freshness"),
+        entity_boost=factors.get("entity_boost"),
+        recall_boost=factors.get("recall_boost"),
+        temporal_boost=factors.get("temporal_boost"),
+        status_penalty=factors.get("status_penalty"),
+        has_embedding=has_embedding,
+        entity_links=[],
+    )
+
+
+# --- ResolveSearchProfile: request-level min_similarity override --------------
+
+
+async def test_min_similarity_override_beats_profile():
+    ctx = PipelineContext(
+        data={
+            "query": "q",
+            "top_k": 5,
+            "search_profile": {"min_similarity": 0.5},
+            "min_similarity_override": 0.9,
+        },
+        tenant_config=None,
+    )
+    await ResolveSearchProfile().execute(ctx)
+    assert ctx.data["search_params"]["min_similarity"] == 0.9
+
+
+async def test_profile_min_similarity_kept_without_override():
+    ctx = PipelineContext(
+        data={
+            "query": "q",
+            "top_k": 5,
+            "search_profile": {"min_similarity": 0.5},
+            "min_similarity_override": None,
+        },
+        tenant_config=None,
+    )
+    await ResolveSearchProfile().execute(ctx)
+    assert ctx.data["search_params"]["min_similarity"] == 0.5
+
+
+# --- PostFilterResults: diagnostic trace --------------------------------------
+
+
+async def test_diagnostic_capture_reasons_and_counts():
+    rows = [
+        _scored_row(0.9, score=1.2),  # kept
+        _scored_row(0.8, score=1.1),  # kept
+        _scored_row(0.7, score=1.0),  # trimmed by top_k
+        _scored_row(0.1, score=0.2),  # below floor
+    ]
+    ctx = PipelineContext(
+        data={
+            "search_params": {"min_similarity": 0.3},
+            "raw_rows": rows,
+            "final_top_k": 2,
+            "diagnostic": True,
+        }
+    )
+    await PostFilterResults().execute(ctx)
+
+    assert len(ctx.data["filtered_rows"]) == 2  # results identical to a normal call
+    trace = ctx.data["diagnostic_results"]
+    assert [c["excluded"] for c in trace] == [
+        None,
+        None,
+        "trimmed_by_top_k",
+        "below_min_similarity",
+    ]
+    # score factors survive into the trace
+    assert trace[0]["score"] == 1.2 and trace[0]["vec_sim"] == 0.9
+    counts = ctx.data["diagnostic_counts"]
+    assert counts == {
+        "candidates_considered": 4,
+        "returned": 2,
+        "excluded_below_min_similarity": 1,
+        "excluded_by_top_k_trim": 1,
+    }
+
+
+async def test_no_diagnostic_keys_on_normal_call():
+    ctx = PipelineContext(
+        data={
+            "search_params": {"min_similarity": 0.3},
+            "raw_rows": [_scored_row(0.9)],
+            "final_top_k": 5,
+            "diagnostic": False,
+        }
+    )
+    await PostFilterResults().execute(ctx)
+    assert "diagnostic_results" not in ctx.data
+    assert "diagnostic_counts" not in ctx.data
+
+
+# --- TrackRecalls: diagnostic never reinforces --------------------------------
+
+
+async def test_track_recalls_skips_diagnostic(monkeypatch):
+    calls = []
+    monkeypatch.setattr(tr, "track_task", lambda c: (calls.append(c), c.close()))
+    ctx = PipelineContext(
+        data={
+            "caller_agent_id": "brandclaw",
+            "diagnostic": True,
+            "filtered_rows": [SimpleNamespace(Memory=SimpleNamespace(id=uuid4()))],
+        }
+    )
+    await tr.TrackRecalls().execute(ctx)
+    assert calls == []  # diagnostic is inspection, not use
+
+
+async def test_track_recalls_still_counts_normal(monkeypatch):
+    calls = []
+    monkeypatch.setattr(tr, "track_task", lambda c: (calls.append(c), c.close()))
+    ctx = PipelineContext(
+        data={
+            "caller_agent_id": "brandclaw",
+            "diagnostic": False,
+            "filtered_rows": [SimpleNamespace(Memory=SimpleNamespace(id=uuid4()))],
+        }
+    )
+    await tr.TrackRecalls().execute(ctx)
+    assert len(calls) == 1
+
+
+# --- LoadAndSerialize: score + score_parts on the wire -------------------------
+
+
+async def test_serialize_exposes_score_and_parts():
+    row = _scored_row(
+        0.87,
+        score=1.4321,
+        fts_score=0.2,
+        freshness=0.9,
+        status_penalty=1.0,
+    )
+    ctx = PipelineContext(data={"filtered_rows": [row], "tenant_id": "t1"})
+    await LoadAndSerialize().execute(ctx)
+    out = ctx.data["results"][0]
+    assert out.similarity == 0.87
+    assert out.score == 1.4321
+    assert out.score_parts is not None
+    assert out.score_parts.vec_sim == 0.87
+    assert out.score_parts.fts_score == 0.2
+    assert out.score_parts.freshness == 0.9
+    assert out.score_parts.status_penalty == 1.0
+    assert out.score_parts.entity_boost is None
+
+
+def test_score_parts_none_when_unscored():
+    unscored = SimpleNamespace(
+        vec_sim=None,
+        fts_score=None,
+        freshness=None,
+        entity_boost=None,
+        recall_boost=None,
+        temporal_boost=None,
+        status_penalty=None,
+    )
+    assert _score_parts(unscored) is None


### PR DESCRIPTION
## What

Closes canonical **D12** (register MEM-01; MemoryImpact C6/C8): `SearchRequest.diagnostic` was accepted and dead — no route forwarded it, nothing wrote `diagnostic_results`, and the one built-in retrieval-debugging affordance was a no-op. The ranking composite that actually orders results was computed by the storage SQL on every query and then dropped at serialization.

- **`/search` + `/recall` forward `diagnostic`**. `/search` returns a typed `SearchDiagnostic`: full widened candidate set with per-row score factors and exclusion reasons (`below_min_similarity` / `trimmed_by_top_k`), the applied knob set, retrieval strategy, and coherent tallies. `/recall` folds the same data into its existing recall-flavoured diagnostic block.
- **`MemoryOut.score` + `MemoryOut.score_parts`** — the multiplicative composite and its factors (vec_sim, fts_score, freshness, entity_boost, recall_boost, temporal_boost, status_penalty). `similarity` stays the raw cosine.
- **`SearchRequest.min_similarity`** — per-request cosine floor; precedence request → agent profile → tenant default → constant, applied on pipeline and legacy paths.
- **Diagnostic changes nothing else**: the diagnostic branch now sets `final_top_k` so items are identical to a normal call, and `TrackRecalls` skips diagnostic calls — inspection must not reinforce the signal being inspected (A26/A48 class). This doubles as the dry-run recall the MemoryImpact study asked for.

All additive — no existing field or behavior changes for callers not sending the new fields.

## Testing

- `ruff check` / `ruff format --check` / `mypy src/` clean; full suite **5152 passed** incl. 8 new unit tests (`tests/test_d12_search_diagnostics.py`).
- Local-stack e2e wet test (fresh images, real OpenAI embeddings): **17/17 checks** — seeded memories, score/score_parts on hits, diagnostic trace correctness (considered=4 / returned=1 / below_floor=3), identical items with/without diagnostic, min_similarity=0.99 exclusion + 422 on >1.0, 3×diagnostic → recall_count unchanged, 1×normal → +1, /recall diagnostic block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)