### PR TITLE
fix(usage): bill recalls against the recall counter, flag-gated

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -354,6 +354,13 @@ class Settings(BaseSettings):
     paddle_business_monthly_price_id: str | None = None
     paddle_business_annual_price_id: str | None = None
     use_stm: bool = False
+    # D13 — meter /recall and MCP caura_recall against the "recall" counter
+    # instead of "search". Off by default because the recalls counter feeds
+    # plan enforcement (`_is_over_plan_limits` → x-org-read-only → 403 on
+    # write routes): flipping this makes the per-plan recall cap computable
+    # for the first time, so enabling it is a deliberate billing decision,
+    # not a deploy side effect. Off = the historical (miscounted) behavior.
+    meter_recall_as_recall: bool = False
     stm_backend: str = "memory"  # memory | redis
     stm_notes_ttl: int = 86400  # 24h
     stm_bulletin_ttl: int = 172800  # 48h

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -94,6 +94,7 @@ from core_api.services.recall_service import summarize_memories
 from core_api.services.trust_service import parse_trust_error
 from core_api.services.trust_service import require_trust as _require_trust
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
+from core_api.services.usage_service import recall_operation
 from core_api.trust_utils import effective_keystone_min_trust, keystone_min_trust
 
 logger = logging.getLogger(__name__)
@@ -749,7 +750,8 @@ async def caura_recall(
         # the agent lookup + write quota pin to the HOME tenant, while the READ
         # (search + audit) widens via ``readable_tenant_ids`` exactly as before.
         sc = get_storage_client()
-        await check_and_increment(tenant_id, "search")
+        # D13 — same fix as REST /recall: bill the recall counter (flag-gated).
+        await check_and_increment(tenant_id, recall_operation())
         config = await resolve_config(tenant_id)
         # Agent profile + fleet-scope signals are HOME-tenant only — never
         # widened by the readable set.

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -94,7 +94,11 @@ from core_api.services.memory_service import (
 )
 from core_api.services.tenants import list_active_tenant_ids
 from core_api.services.trust_service import parse_trust_error, require_trust
-from core_api.services.usage_service import bulk_check_and_increment, check_and_increment
+from core_api.services.usage_service import (
+    bulk_check_and_increment,
+    check_and_increment,
+    recall_operation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1981,7 +1985,10 @@ async def recall_endpoint(
                 body.fleet_ids = [_agent["fleet_id"]]
             if body.fleet_ids and len(body.fleet_ids) == 1:
                 await enforce_fleet_read(body.tenant_id, body.filter_agent_id, body.fleet_ids[0])
-        await check_and_increment(body.tenant_id, "search")
+        # D13 — a recall is a recall, not a search: plans meter them separately
+        # and the recalls counter never moved because this site (and the MCP
+        # twin) billed "search". Flag-gated; see ``recall_operation``.
+        await check_and_increment(body.tenant_id, recall_operation())
 
     from core_api.services.memory_service import search_memories
     from core_api.services.organization_settings import resolve_config

--- a/core-api/src/core_api/services/usage_service.py
+++ b/core-api/src/core_api/services/usage_service.py
@@ -116,6 +116,22 @@ async def _meter(tenant_id: str, operation: OperationType, count: int) -> UsageC
     return result if result is not None else _allowed(operation)
 
 
+def recall_operation() -> OperationType:
+    """D13 — which counter a recall (search + LLM brief) bills against.
+
+    Plans have carried separate ``searches`` / ``recalls`` limits since the
+    initial schema, and the platform hook maps ``"recall"`` to the ``recalls``
+    counter — but every recall call site passed ``"search"``, so the recalls
+    counter never moved and the per-plan recall cap could never fire
+    (canonical D13). The correct operation is gated behind
+    ``settings.meter_recall_as_recall`` (default off) because the recalls
+    counter feeds over-plan enforcement; see the setting's comment.
+    """
+    from core_api.config import settings
+
+    return "recall" if settings.meter_recall_as_recall else "search"
+
+
 async def check_and_increment(
     tenant_id: str,
     operation: OperationType,

--- a/tests/test_d13_recall_metering.py
+++ b/tests/test_d13_recall_metering.py
@@ -1,0 +1,72 @@
+"""D13 — recall operations bill the recall counter (flag-gated).
+
+Plans have always defined separate ``searches`` / ``recalls`` limits and the
+platform hook maps ``"recall"`` → the recalls counter, but both recall call
+sites (REST /recall and MCP caura_recall) passed ``"search"`` — so the recalls
+counter never moved and the per-plan recall cap could never fire.
+
+The correct literal is gated behind ``settings.meter_recall_as_recall``
+(default OFF) because the recalls counter feeds over-plan enforcement
+(x-org-read-only → 403 on write routes); enabling it is a billing decision.
+"""
+
+from core_api.config import settings
+from core_api.services import usage_service
+from core_api.services.usage_service import recall_operation
+
+
+def test_default_is_off_and_preserves_search_billing(monkeypatch):
+    monkeypatch.setattr(settings, "meter_recall_as_recall", False)
+    assert recall_operation() == "search"
+
+
+def test_flag_on_bills_recall(monkeypatch):
+    monkeypatch.setattr(settings, "meter_recall_as_recall", True)
+    assert recall_operation() == "recall"
+
+
+def test_default_setting_value_is_off():
+    # The deploy-time zero-impact guarantee: a rebuilt image with no env
+    # change must bill exactly as before.
+    assert settings.model_fields["meter_recall_as_recall"].default is False
+
+
+async def test_operation_reaches_the_usage_hook(monkeypatch):
+    """End-to-end through check_and_increment: the hook sees the gated literal."""
+    seen = {}
+
+    async def fake_hook(*, tenant_id, operation, count):
+        seen["operation"] = operation
+        return None
+
+    class Hooks:
+        usage_meter = staticmethod(fake_hook)
+
+    monkeypatch.setattr(usage_service, "get_hooks", lambda: Hooks)
+    monkeypatch.setattr(settings, "meter_recall_as_recall", True)
+    await usage_service.check_and_increment("t1", recall_operation())
+    assert seen["operation"] == "recall"
+
+    monkeypatch.setattr(settings, "meter_recall_as_recall", False)
+    await usage_service.check_and_increment("t1", recall_operation())
+    assert seen["operation"] == "search"
+
+
+def test_no_bare_search_literal_left_on_recall_sites():
+    """Regression guard: the two recall call sites must use recall_operation().
+
+    A grep-style assertion so a revert to the hardcoded literal cannot slip
+    back in silently — the exact failure mode that kept the recalls counter
+    at zero from the initial schema until D13.
+    """
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "core-api" / "src" / "core_api"
+    recall_route = (root / "routes" / "memories.py").read_text()
+    # the /recall endpoint body sits between its decorator and the next route
+    recall_section = recall_route.split('@router.post("/recall")')[1].split("@router.post")[0]
+    assert 'check_and_increment(body.tenant_id, recall_operation())' in recall_section
+    assert 'check_and_increment(body.tenant_id, "search")' not in recall_section
+
+    mcp = (root / "mcp_server.py").read_text()
+    assert "check_and_increment(tenant_id, recall_operation())" in mcp


### PR DESCRIPTION
## What

Closes canonical **D13** (register MEM-21/N1, found in the 2026-08 AX-audit verification pass): plans have carried separate `searches`/`recalls` limits since the initial schema and the platform hook maps `"recall"` → the recalls counter — but both recall call sites (REST `/recall`, MCP `caura_recall`) passed `"search"`. The recalls counter never moved and the per-plan recall cap could never fire.

- Both call sites now bill via `recall_operation()`.
- **Flag-gated, default OFF** (`METER_RECALL_AS_RECALL`): the recalls counter feeds over-plan enforcement (`_is_over_plan_limits` → `x-org-read-only` → 403 on write routes), so making the cap computable for the first time is a deliberate billing decision, not a deploy side effect. With the flag off, billing is byte-identical to before.
- Regression-guard test asserts the bare `"search"` literal cannot silently return to either recall site.

## Testing

- `ruff` / `mypy` clean; full suite **5157 passed** incl. 5 new tests (`tests/test_d13_recall_metering.py`).
- Local-stack e2e wet test against `tenant_usage_counters`:
  - flag OFF: 5 recalls + 2 searches → all billed `search`, zero `recall` rows (legacy behavior preserved exactly);
  - flag ON: 3 recalls + 1 search → `recall = 3`, `search +1` — the recalls counter moved for the first time.

## Rollout note

Enabling the flag on hosted should be coordinated with billing: free-tier tenants recalling >500/mo would become over-plan at the next evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)