### PR TITLE
fix(entities): make the entities read path work — search filters + relations

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1371,12 +1371,18 @@ class CoreStorageClient:
         self,
         tenant_id: str,
         fleet_id: str | None = None,
+        entity_type: str | None = None,
+        search: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[dict]:
         params: dict[str, Any] = {"tenant_id": tenant_id, "limit": limit, "offset": offset}
         if fleet_id is not None:
             params["fleet_id"] = fleet_id
+        if entity_type is not None:
+            params["entity_type"] = entity_type
+        if search is not None:
+            params["search"] = search
         return await self._get_list("/entities", **params)
 
     async def count_memories_per_entity(
@@ -1393,8 +1399,11 @@ class CoreStorageClient:
     async def get_entity_with_linked_memories(self, entity_id: str) -> dict | None:
         return await self._get(f"/entities/{entity_id}/with-memories")
 
-    async def get_outgoing_relations(self, entity_id: str) -> list[dict]:
-        return await self._get_list(f"/entities/{entity_id}/relations")
+    async def get_outgoing_relations(self, entity_id: str, tenant_id: str | None = None) -> list[dict]:
+        params: dict[str, Any] = {}
+        if tenant_id is not None:
+            params["tenant_id"] = tenant_id
+        return await self._get_list(f"/entities/{entity_id}/relations", **params)
 
     async def find_relation(
         self,

--- a/core-api/src/core_api/routes/entities.py
+++ b/core-api/src/core_api/routes/entities.py
@@ -41,7 +41,17 @@ async def list_entities(
     """
     auth.enforce_readable_tenant(tenant_id)
     sc = get_storage_client()
-    entities = await sc.list_entities(tenant_id, fleet_id=fleet_id, limit=limit)
+    # C22 — ``search`` and ``entity_type`` were declared on this route since
+    # day one but never forwarded, so ``GET /entities?search=foo`` silently
+    # returned the unfiltered list. The storage service always supported both
+    # (entity_list: ilike on canonical_name, equality on entity_type).
+    entities = await sc.list_entities(
+        tenant_id,
+        fleet_id=fleet_id,
+        entity_type=entity_type,
+        search=search,
+        limit=limit,
+    )
 
     # Count linked memories per entity
     eids = [e.get("id", "") for e in entities]

--- a/core-api/src/core_api/services/entity_service.py
+++ b/core-api/src/core_api/services/entity_service.py
@@ -204,13 +204,43 @@ async def get_entity(entity_id: UUID, tenant_id: str, caller_agent_id: str | Non
             )
         )
 
-    # Outgoing relations. Same scope contract as the linked memories above:
-    # without it, relations were emitted straight from the raw entity, so an
-    # agent credential could enumerate relation edges and evidence_memory_ids
-    # pointing at memories it cannot read (scope side-door, audit S5). A
-    # relation is visible iff its evidence memory is readable by the caller
-    # (relations with no evidence carry no memory-derived content and stay).
-    relations_raw = entity.get("relations", [])
+    # Outgoing relations. C23 — since v1.0.0 this read
+    # ``entity.get("relations", [])`` off the with-memories payload, which has
+    # NEVER carried a relations key (ENTITY_FIELDS has none), so relations were
+    # structurally always ``[]`` on REST and MCP alike while /graph showed the
+    # edges — the read-surface inconsistency two field reports hit. Fetch them
+    # from the storage endpoint built for exactly this (and until now unused).
+    # Failure degrades to ``[]`` — the pre-C23 behavior — rather than failing
+    # the whole entity read; same resilience contract as find_successors.
+    #
+    # Scope contract (audit S5 / C14), unchanged and now operating on real
+    # rows: an agent credential must not enumerate relation edges or
+    # evidence_memory_ids pointing at memories it cannot read. A relation is
+    # visible iff its evidence memory is readable by the caller (relations
+    # with no evidence carry no memory-derived content and stay).
+    try:
+        relation_rows = await sc.get_outgoing_relations(str(entity_id), tenant_id=tenant_id)
+    except Exception:
+        logger.warning(
+            "get_outgoing_relations failed for entity %s; returning entity without relations",
+            entity_id,
+            exc_info=True,
+        )
+        relation_rows = []
+    relations_raw = []
+    for row in relation_rows:
+        rel = row.get("relation", {}) or {}
+        target = row.get("target", {}) or {}
+        relations_raw.append(
+            {
+                "id": rel.get("id"),
+                "relation_type": rel.get("relation_type"),
+                "to_entity_id": rel.get("to_entity_id"),
+                "to_entity_name": target.get("canonical_name"),
+                "weight": rel.get("weight"),
+                "evidence_memory_id": rel.get("evidence_memory_id"),
+            }
+        )
     if caller_agent_id and relations_raw:
         from core_api.services.agent_service import memory_access_allowed_for_agent
 

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -66,10 +66,21 @@ async def create_entity(request: Request) -> dict:
 async def list_entities(
     tenant_id: str,
     fleet_id: str | None = None,
+    entity_type: str | None = None,
+    search: str | None = None,
     limit: int = 100,
     offset: int = 0,
 ) -> list[dict]:
-    entities = await _svc.entity_list(tenant_id, fleet_id=fleet_id, limit=limit, offset=offset)
+    # C22 — accept and forward the filters entity_list has always supported;
+    # core-api declared them publicly but this hop dropped them.
+    entities = await _svc.entity_list(
+        tenant_id,
+        fleet_id=fleet_id,
+        entity_type=entity_type,
+        search=search,
+        limit=limit,
+        offset=offset,
+    )
     return [orm_to_dict(e, ENTITY_FIELDS) for e in entities]
 
 

--- a/tests/test_c22_c23_entities_read.py
+++ b/tests/test_c22_c23_entities_read.py
@@ -1,0 +1,172 @@
+"""C22 + C23 — the entities read path actually works.
+
+C22: ``GET /entities`` declared ``search`` and ``entity_type`` since day one
+but never forwarded them — core-api called the storage client without them
+and the storage router didn't accept them, so ``?search=foo`` silently
+returned the unfiltered list (the storage service supported both all along).
+
+C23: ``get_entity`` read ``entity.get("relations", [])`` off the
+with-memories payload, which has never carried a relations key — relations
+were structurally ``[]`` on REST and MCP since v1.0.0 while /graph showed the
+edges. They now come from the (previously unused) relations endpoint, and the
+S5/C14 scope filter finally operates on real rows
+(see test_entity_relations_scope.py for the scope behavior itself).
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+# --- C22: filters forwarded through every hop ---------------------------------
+
+
+async def test_storage_client_sends_filters():
+    from core_api.clients.storage_client import CoreStorageClient
+
+    sc = CoreStorageClient()
+    seen = {}
+
+    async def fake_get_list(path, **params):
+        seen["path"] = path
+        seen["params"] = params
+        return []
+
+    sc._get_list = fake_get_list  # type: ignore[method-assign]
+    await sc.list_entities("t1", fleet_id="f1", entity_type="person", search="astra", limit=7)
+    assert seen["path"] == "/entities"
+    assert seen["params"] == {
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "entity_type": "person",
+        "search": "astra",
+        "limit": 7,
+        "offset": 0,
+    }
+
+
+async def test_storage_client_omits_absent_filters():
+    from core_api.clients.storage_client import CoreStorageClient
+
+    sc = CoreStorageClient()
+    seen = {}
+
+    async def fake_get_list(path, **params):
+        seen["params"] = params
+        return []
+
+    sc._get_list = fake_get_list  # type: ignore[method-assign]
+    await sc.list_entities("t1")
+    assert "search" not in seen["params"] and "entity_type" not in seen["params"]
+
+
+def test_route_forwards_filters_to_client():
+    """Grep-guard: the route must pass search/entity_type into list_entities —
+    the exact one-hop drop that made entity search non-functional (N2)."""
+    import pathlib
+
+    src = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "core-api/src/core_api/routes/entities.py"
+    ).read_text()
+    call = src.split("await sc.list_entities(")[1].split(")")[0]
+    assert "entity_type=entity_type" in call
+    assert "search=search" in call
+
+
+def test_storage_router_accepts_and_forwards_filters():
+    import inspect
+
+    from core_storage_api.routers import entities as storage_entities
+
+    sig = inspect.signature(storage_entities.list_entities)
+    assert "search" in sig.parameters and "entity_type" in sig.parameters
+    src = inspect.getsource(storage_entities.list_entities)
+    assert "entity_type=entity_type" in src and "search=search" in src
+
+
+# --- C23: relations come from the relations endpoint ---------------------------
+
+
+def _entity_payload():
+    return {
+        "entity": {
+            "id": str(uuid.uuid4()),
+            "tenant_id": "t",
+            "fleet_id": None,
+            "entity_type": "system",
+            "canonical_name": "Astra SSO",
+            "attributes": {},
+        },
+        "linked_memories": [],
+    }
+
+
+async def test_get_entity_returns_relations_from_endpoint(monkeypatch):
+    from core_api.services import entity_service
+
+    to_id = str(uuid.uuid4())
+    rel_id = str(uuid.uuid4())
+    sc = MagicMock()
+    sc.get_entity_with_linked_memories = AsyncMock(return_value=_entity_payload())
+    sc.get_outgoing_relations = AsyncMock(
+        return_value=[
+            {
+                "relation": {
+                    "id": rel_id,
+                    "relation_type": "authenticates",
+                    "to_entity_id": to_id,
+                    "weight": 0.9,
+                    "evidence_memory_id": None,
+                },
+                "target": {"canonical_name": "Webhook Service"},
+            }
+        ]
+    )
+    monkeypatch.setattr(entity_service, "get_storage_client", lambda: sc)
+
+    out = await entity_service.get_entity(uuid.uuid4(), "t", caller_agent_id=None)
+    assert len(out.relations) == 1
+    r = out.relations[0]
+    assert r.relation_type == "authenticates"
+    assert str(r.to_entity_id) == to_id
+    assert r.to_entity_name == "Webhook Service"
+    assert r.weight == 0.9
+    # tenant scoping is passed through to the storage endpoint
+    sc.get_outgoing_relations.assert_awaited_once()
+    _, kwargs = sc.get_outgoing_relations.await_args
+    assert kwargs.get("tenant_id") == "t"
+
+
+async def test_get_entity_degrades_to_empty_relations_on_endpoint_failure(monkeypatch):
+    """Relations-endpoint failure must not fail the whole entity read —
+    degrade to the pre-C23 behavior ([]) instead."""
+    from core_api.services import entity_service
+
+    sc = MagicMock()
+    sc.get_entity_with_linked_memories = AsyncMock(return_value=_entity_payload())
+    sc.get_outgoing_relations = AsyncMock(side_effect=RuntimeError("storage down"))
+    monkeypatch.setattr(entity_service, "get_storage_client", lambda: sc)
+
+    out = await entity_service.get_entity(uuid.uuid4(), "t", caller_agent_id=None)
+    assert out is not None
+    assert out.relations == []
+
+
+async def test_get_entity_ignores_legacy_entity_relations_key(monkeypatch):
+    """A with-memories payload that (hypothetically) carried a relations key
+    must not double-count: the endpoint is the single source of truth."""
+    from core_api.services import entity_service
+
+    payload = _entity_payload()
+    payload["entity"]["relations"] = [{"id": "ghost", "relation_type": "ghost"}]
+    sc = MagicMock()
+    sc.get_entity_with_linked_memories = AsyncMock(return_value=payload)
+    sc.get_outgoing_relations = AsyncMock(return_value=[])
+    monkeypatch.setattr(entity_service, "get_storage_client", lambda: sc)
+
+    out = await entity_service.get_entity(uuid.uuid4(), "t", caller_agent_id=None)
+    assert out.relations == []

--- a/tests/test_entity_relations_scope.py
+++ b/tests/test_entity_relations_scope.py
@@ -68,10 +68,29 @@ def fake_storage(monkeypatch):
                     "entity_type": "person",
                     "canonical_name": "X",
                     "attributes": {},
-                    "relations": relations,
+                    # C23: with-memories NEVER carried relations; get_entity now
+                    # fetches them from the relations endpoint below. Kept absent
+                    # here to mirror the real payload.
                 },
                 "linked_memories": linked,
             }
+        )
+        # C23 — relations arrive as {"relation": ..., "target": ...} rows from
+        # GET /entities/{id}/relations; adapt the flat test dicts.
+        sc.get_outgoing_relations = AsyncMock(
+            return_value=[
+                {
+                    "relation": {
+                        "id": r["id"],
+                        "relation_type": r["relation_type"],
+                        "to_entity_id": r["to_entity_id"],
+                        "weight": r["weight"],
+                        "evidence_memory_id": r["evidence_memory_id"],
+                    },
+                    "target": {"canonical_name": r["to_entity_name"]},
+                }
+                for r in relations
+            ]
         )
         sc.bulk_get_memories = AsyncMock(return_value=bulk_rows or [])
         from core_api.services import entity_service


### PR DESCRIPTION
## What

Closes canonical **C22 + C23** (register MEM-12/N2+N3) — the two structural bugs behind "trivial to populate, impossible to use well" from the SupportHive v2 and Capability Review field reports.

**C22 — entity search was non-functional.** `GET /entities` declared `search` and `entity_type` since day one but never forwarded them: core-api dropped both on the storage-client call and the storage router didn't accept them, so `?search=foo` silently returned the unfiltered list — while the storage service (`entity_list`) supported both filters all along. Now forwarded through every hop.

**C23 — relations were structurally `[]` since v1.0.0.** `get_entity` read `entity.get('relations', [])` off the with-memories payload, which has never carried a relations key — so REST and MCP showed no relations while /graph showed the edges. Relations now come from the (previously unused) `GET /entities/{id}/relations` storage endpoint, tenant-scoped, and the S5/C14 evidence-visibility filter finally operates on real rows. Endpoint failure degrades to `[]` rather than failing the entity read.

## Testing

- `ruff`/`mypy`/format clean on both services; root suite **5164 passed** (7 new tests in `tests/test_c22_c23_entities_read.py`, incl. grep-guards on both formerly-dropped hops); storage suite 154 passed; S5 scope tests updated to feed relations from the new source and still pass.
- Local-stack e2e wet test on a clean tenant, fresh images: **11/11** — every filter combination (search hit/miss, entity_type, combined AND, fleet_id unchanged), `entity_get` returning real relations with correct fields, a freshly-upserted relation immediately visible (the exact WR-5 repro), and /graph agreeing with entity_get on edge count.
- Dirty-tenant run also exercised: filters behave correctly against 84k pre-existing entities (and surfaced an unrelated pre-existing /graph 500 on full-graph serialization at that scale — known graph-blowup class, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)