### PR TITLE
fix(forge): the distill cron never ran, and the dry-run CLI never used an LLM

### DIFF
--- a/core-api/src/core_api/services/forge/cron_handler.py
+++ b/core-api/src/core_api/services/forge/cron_handler.py
@@ -31,6 +31,7 @@ attribute failures to the right tenant.
 from __future__ import annotations
 
 import logging
+import os
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -200,11 +201,17 @@ async def _wire_llm_fn() -> LlmFn:
     # Lazy import — ``common.llm`` pulls in vertex/openai SDKs that
     # we don't want loading at core-api startup just for the cron
     # adapter wiring.
+    #
+    # Every name here is one ``common.llm`` actually exports. It used to ask for
+    # ``LLMRequest``, which has never existed in that module, so the import below
+    # always raised and the ``except`` clause below always ran — meaning this
+    # function raised RuntimeError on every tick and the distill cron could not
+    # run at all. Worse, the message blamed a missing provider chain, so the
+    # symptom read as a deployment problem rather than as a wrong import.
     try:
-        from common.llm import (  # type: ignore[import-not-found]
-            LLMRequest,
-            call_with_fallback,
-        )
+        from common.llm import LLMProvider, call_with_fallback
+        from common.llm.retry import deliberate_fake_provider
+        from common.provider_names import ProviderName
     except ImportError as exc:
         raise RuntimeError(
             "forge_cron: common.llm not importable — the production "
@@ -213,10 +220,50 @@ async def _wire_llm_fn() -> LlmFn:
             "dry-run); see scripts/forge_dry_run.py."
         ) from exc
 
+    # Same selector the enrichment write path uses. Forge has no provider
+    # setting of its own, and ``call_with_fallback`` resolves per-tenant model
+    # overrides against ``enrichment_model`` by default, so borrowing the
+    # enrichment provider keeps the two halves of one write pipeline on the same
+    # provider. A dedicated ``FORGE_PROVIDER`` would be a new config surface and
+    # belongs in its own change, not in a repair.
+    provider_name = os.environ.get("ENTITY_EXTRACTION_PROVIDER", ProviderName.OPENAI)
+
+    def _refuse_fake() -> str:
+        """``call_with_fallback``'s last resort, which this caller must not take.
+
+        This tick PERSISTS what the LLM returns, as skill candidates that
+        promote into ``staged``. ``deliberate_fake_provider`` documents the line
+        that matters for persisting callers: a configured ``fake`` provider is an
+        operator asking for a stub, while a real provider whose every attempt
+        failed is an outage — and an outage is not a request for made-up output.
+        Neither case may write placeholder skills here, so both raise; the
+        distinction is kept in the message because the two want different
+        operator responses. Same posture as ``contradiction_detector``, which
+        abstains rather than guessing a verdict.
+        """
+        if deliberate_fake_provider(provider_name):
+            raise RuntimeError(
+                "forge_cron: ENTITY_EXTRACTION_PROVIDER is 'fake'. The fake-LLM "
+                "fallback is intentionally CLI-only (see scripts/forge_dry_run.py) "
+                "— the cron will not mint placeholder skill candidates."
+            )
+        raise RuntimeError(
+            "forge_cron: every configured LLM provider failed for "
+            f"'{provider_name}'. Refusing to persist placeholder skill candidates."
+        )
+
     async def _llm_fn(prompt: str) -> str:
-        request = LLMRequest(messages=[{"role": "user", "content": prompt}])
-        response = await call_with_fallback(request, expecting="json")
-        return response.text
+        async def _call(llm: LLMProvider) -> str:
+            # ``complete_text``, not ``complete_json``: ``LlmFn``'s contract is
+            # raw text, which ``parse_distill_response`` parses downstream.
+            return await llm.complete_text(prompt)
+
+        return await call_with_fallback(
+            primary_provider_name=provider_name,
+            call_fn=_call,
+            fake_fn=_refuse_fake,
+            service_label="forge_cron",
+        )
 
     return _llm_fn
 
@@ -268,9 +315,12 @@ async def run_forge_cron_tick(
     candidate_writer = _make_candidate_writer()
     status_checker = _make_status_checker()
 
-    # ``run_forge_distill`` keeps a (now-vestigial) first positional arg for
-    # CLI / test-call-site compatibility; it no longer touches the DB —
-    # ``build_session_traces`` + the injected fetchers route through storage.
+    # ``run_forge_distill`` is keyword-only — it takes NO positional arg. It no
+    # longer touches the DB either; ``build_session_traces`` + the injected
+    # fetchers route through storage. This comment used to say the vestigial
+    # first positional was kept "for CLI / test-call-site compatibility", which
+    # stopped being true when the parameter was removed, and the CLI kept
+    # passing a session positionally on the strength of it.
     forge_result = await run_forge_distill(
         tenant_id=tenant_id,
         fleet_id=fleet_id,

--- a/scripts/forge_dry_run.py
+++ b/scripts/forge_dry_run.py
@@ -34,6 +34,7 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import sys
 from datetime import datetime, timedelta, timezone
 
@@ -108,11 +109,16 @@ async def _wire_llm_fn():
     # the heavy DB/LLM deps. ImportError is the explicit fallback
     # signal: ``common.llm`` not installed (e.g. a packaging variant
     # without the LLM provider chain).
+    #
+    # Every name here is one ``common.llm`` actually exports. It used to ask for
+    # ``LLMRequest``, which has never existed in that module, so this import
+    # always raised and the ``except`` below always ran: the CLI has never once
+    # used a real LLM, and it said so in a warning that blamed a packaging
+    # variant rather than a wrong import. The fake fallback is a real feature
+    # here — the point is that it was reached unconditionally.
     try:
-        from common.llm import (  # type: ignore[import-not-found]
-            LLMRequest,
-            call_with_fallback,
-        )
+        from common.llm import LLMProvider, call_with_fallback
+        from common.provider_names import ProviderName
     except ImportError:
         logger.warning(
             "forge_dry_run: common.llm not importable; falling back to "
@@ -122,13 +128,28 @@ async def _wire_llm_fn():
         )
         return _fake_llm_fn
 
+    # Same selector the enrichment write path uses; see the matching comment in
+    # ``core_api.services.forge.cron_handler._wire_llm_fn``. Setting it to
+    # ``fake`` is the supported way to force placeholder output on a machine
+    # that DOES have provider keys configured.
+    provider_name = os.environ.get("ENTITY_EXTRACTION_PROVIDER", ProviderName.OPENAI)
+
     async def llm_fn(prompt: str) -> str:
-        # Tenant-resolution and provider chain are handled inside
-        # call_with_fallback. We pass the prompt as a single user
-        # message; the prompt itself carries the system framing.
-        request = LLMRequest(messages=[{"role": "user", "content": prompt}])
-        response = await call_with_fallback(request, expecting="json")
-        return response.text
+        async def _call(llm: LLMProvider) -> str:
+            # ``complete_text``, not ``complete_json``: ``LlmFn``'s contract is
+            # raw text, which ``parse_distill_response`` parses downstream.
+            return await llm.complete_text(prompt)
+
+        # ``fake_fn`` is the documented promise of this CLI — placeholder output
+        # rather than a failed run when no provider answers. That is the
+        # opposite of the cron's posture, which refuses to persist a stub; the
+        # difference is deliberate and is why the two do not share this wiring.
+        return await call_with_fallback(
+            primary_provider_name=provider_name,
+            call_fn=_call,
+            fake_fn=_fake_distill_json,
+            service_label="forge_dry_run",
+        )
 
     return llm_fn
 
@@ -140,12 +161,24 @@ _FAKE_LLM_COUNTER = {"n": 0}
 
 
 async def _fake_llm_fn(_prompt: str) -> str:
-    """Deterministic placeholder LLM. Returns a valid JSON response
-    that ``parse_distill_response`` will accept. Used when
-    ``common.llm`` is not importable (no LLM provider chain
-    available) so an operator can still smoke the
-    extraction → cluster → fingerprint → write pipeline without
-    needing API keys."""
+    """Deterministic placeholder LLM, as an ``LlmFn``.
+
+    Kept as the async shape ``run_forge_distill`` expects, for the path where
+    ``common.llm`` is not importable at all. When the provider chain IS
+    importable, the same payload is reached through ``call_with_fallback``'s
+    ``fake_fn`` seam, which requires a synchronous callable — hence the split.
+    """
+    return _fake_distill_json()
+
+
+def _fake_distill_json() -> str:
+    """The placeholder payload itself: a valid JSON response that
+    ``parse_distill_response`` will accept, so an operator can smoke the
+    extraction → cluster → fingerprint → write pipeline without API keys.
+
+    Synchronous because ``call_with_fallback`` types ``fake_fn`` as
+    ``Callable[[], T]`` and calls it without awaiting.
+    """
     _FAKE_LLM_COUNTER["n"] += 1
     n = _FAKE_LLM_COUNTER["n"]
     payload = {
@@ -306,8 +339,12 @@ async def _run(args: argparse.Namespace) -> int:
             max_writes_per_run=args.max_writes_per_run,
         )
 
+        # No positional argument: ``run_forge_distill`` is keyword-only and takes
+        # none. The session used to be its first parameter; when that was removed
+        # this call site was not updated, so every real invocation died on
+        # ``TypeError: too many positional arguments``. ``db`` is still needed —
+        # the wiring helpers above close over it — just not here.
         result = await run_forge_distill(
-            db,
             tenant_id=args.tenant,
             fleet_id=args.fleet,
             window_start=window_start,

--- a/tests/test_forge_cron_tick.py
+++ b/tests/test_forge_cron_tick.py
@@ -376,11 +376,28 @@ class TestRunForgeCronTick:
             # The real production path will hit the same branch when
             # the LLM provider chain is uninstalled.
             with pytest.raises(RuntimeError, match="common.llm not importable"):
-                # Force the import by deleting the cached module first.
+                # ``patch.dict`` alone, and the alone is the point: a
+                # ``sys.modules`` entry of None makes ``import`` raise
+                # ImportError, which is the branch under test, and patch.dict
+                # restores the real module on exit.
+                #
+                # There used to be a ``sys.modules.pop("common.llm", None)``
+                # here, OUTSIDE the patch.dict, to "force the import by
+                # deleting the cached module first". It was both unnecessary
+                # and unrestored: popping before patch.dict takes its snapshot
+                # means the snapshot records "absent", so the real module never
+                # came back and every later test in the session saw a
+                # ``common.llm`` it had to re-import. That re-import rebinds the
+                # package without rebinding its ``retry`` submodule attribute,
+                # so an unrelated
+                # ``monkeypatch.setattr("common.llm.retry.LLM_RETRY_DELAY_S", …)``
+                # in tests/test_llm_provider_sdk_retries.py failed with
+                # "'module' object at common.llm.retry has no attribute
+                # 'retry'". It only started firing once _wire_llm_fn was fixed
+                # to import successfully — before that its import always raised,
+                # so nothing downstream ever completed the re-import.
                 import sys
 
-                sys.modules.pop("common.llm", None)
-                # Replace common with a stub missing ``llm``.
                 with patch.dict(sys.modules, {"common.llm": None}):
                     await _wire_llm_fn()
 

--- a/tests/test_forge_distill.py
+++ b/tests/test_forge_distill.py
@@ -387,6 +387,41 @@ class TestForgeDryRunFakeLLMFallback:
             assert key in parsed, f"fake-LLM missing required key: {key}"
 
     @pytest.mark.asyncio
+    async def test_wire_llm_fn_does_not_degrade_when_chain_importable(self):
+        """The fallback must be a fallback, not the only path.
+
+        ``_wire_llm_fn`` selects between the real provider chain and the
+        placeholder stub by catching ImportError. It asked ``common.llm`` for
+        ``LLMRequest``, a name that module has never exported, so the import
+        always raised and the CLI silently ran in FAKE-LLM mode on every
+        invocation — while logging a warning that blamed a packaging variant
+        rather than a wrong import. Nothing caught it for the file's whole
+        lifetime because the sibling tests here exercise ``_fake_llm_fn``
+        directly and deliberately skip the branch selection.
+
+        Asserting the negative is the point: with ``common.llm`` importable,
+        whatever comes back must NOT be the stub. Returns the callable without
+        calling it, so this stays hermetic — no provider is constructed and no
+        network is touched.
+        """
+        import importlib.util
+        import pathlib
+
+        pytest.importorskip("common.llm")
+
+        script_path = pathlib.Path("scripts/forge_dry_run.py")
+        spec = importlib.util.spec_from_file_location("forge_dry_run_3", script_path)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        llm_fn = await mod._wire_llm_fn()
+        assert llm_fn is not mod._fake_llm_fn, (
+            "_wire_llm_fn fell back to the fake stub even though common.llm "
+            "imports — the real-provider branch is unreachable again"
+        )
+
+    @pytest.mark.asyncio
     async def test_fake_llm_each_call_distinct_slug(self):
         # Two calls must yield distinct slugs so a multi-cluster run
         # doesn't collide on doc_id.
@@ -410,6 +445,52 @@ class TestForgeDryRunFakeLLMFallback:
         from core_api.services.forge.distill_prompt import _SLUG_RE
         assert _SLUG_RE.fullmatch(slug1)
         assert _SLUG_RE.fullmatch(slug2)
+
+
+@pytest.mark.unit
+class TestForgeCronLlmWiring:
+    """``cron_handler._wire_llm_fn`` is the production path, and it carried the
+    same wrong import as the CLI — asking ``common.llm`` for ``LLMRequest``,
+    which that module has never exported. Its ``except ImportError`` turns the
+    failure into ``RuntimeError``, so every tick died at the wiring step and the
+    distill cron could not run at all, while the message blamed a missing
+    provider chain rather than the import.
+
+    It was invisible to the type gate as well: ``core_api.services.forge.*`` is
+    deliberately opted IN to mypy (``ignore_errors = false``), but ``common/``
+    sits outside core-api's ``mypy_path``, so every ``common.*`` symbol resolves
+    to ``Any`` and neither the missing name nor the wrong call signature could be
+    reported. These two asserts are what stands in for that until the service
+    runs can see ``common/``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_wire_llm_fn_resolves(self):
+        """Wiring must succeed — not raise — when the provider chain imports."""
+        pytest.importorskip("common.llm")
+        from core_api.services.forge.cron_handler import _wire_llm_fn
+
+        llm_fn = await _wire_llm_fn()
+        assert callable(llm_fn)
+
+    @pytest.mark.asyncio
+    async def test_cron_refuses_to_persist_a_stub(self, monkeypatch):
+        """The cron must never mint placeholder skills.
+
+        ``call_with_fallback`` always has a ``fake_fn`` last resort, and this
+        tick PERSISTS what it returns as skill candidates. So the cron's
+        ``fake_fn`` raises in both of the contexts ``deliberate_fake_provider``
+        distinguishes — a deliberately-configured ``fake`` provider and a real
+        provider whose attempts all failed. Verified through the deliberate-fake
+        route because it needs no outage to reproduce.
+        """
+        pytest.importorskip("common.llm")
+        from core_api.services.forge.cron_handler import _wire_llm_fn
+
+        monkeypatch.setenv("ENTITY_EXTRACTION_PROVIDER", "fake")
+        llm_fn = await _wire_llm_fn()
+        with pytest.raises(RuntimeError, match="will not mint placeholder"):
+            await llm_fn("any prompt")
 
 
 # ── Clustering ────────────────────────────────────────────────────


### PR DESCRIPTION
> **Production impact, and it is the headline.** The forge distill cron has never been able to run a tick. Started as a dev-script repair (spun out of caura#948); the same broken wiring turned out to be in the production cron handler, so both are fixed here — one bug, one fix, two call sites.

## The bug

Both `cron_handler._wire_llm_fn` and `scripts/forge_dry_run.py::_wire_llm_fn` did:

```python
from common.llm import LLMRequest, call_with_fallback   # LLMRequest does not exist
```

`LLMRequest` has never been exported by `common.llm` and is defined nowhere under `common/`. So the import **always** raised `ImportError`, and each file's `except` clause always ran:

| | what the `except` does | consequence |
|---|---|---|
| **`cron_handler.py`** (production) | `raise RuntimeError("forge_cron: common.llm not importable — the production cron requires a configured LLM provider chain")` | **every tick dies at the wiring step.** The distill cron cannot run at all, and the error blames a missing deployment dependency rather than a wrong import — so the symptom points away from the cause |
| **`forge_dry_run.py`** (CLI) | `return _fake_llm_fn` | **the CLI has never once used a real LLM.** It degraded silently on every invocation, logging a warning about "a packaging variant without the LLM provider chain" |

The fake fallback is a real, documented feature of the CLI. The bug is that it was reached *unconditionally* — which is precisely what kept this invisible.

Both then called `call_with_fallback(request, expecting="json")`, matching no signature it has ever had — the real one is `(primary_provider_name, call_fn, fake_fn, tenant_config=None, *, service_label="", ...)` with no `expecting` parameter. Dead code in the CLI; unreachable in the cron.

**Third defect, CLI only:** `run_forge_distill(db, ...)` passed a session positionally to a keyword-only function → `TypeError: too many positional arguments` on every real invocation. Verified: `inspect.signature(run_forge_distill)` has **zero** positional parameters. A comment in `cron_handler` still described a "now-vestigial first positional arg … kept for CLI / test-call-site compatibility" — which is what the CLI was relying on. Corrected, because a stale comment asserting a parameter exists is how this survived.

## The fix

Rewired both against the real API, following the shape `common/enrichment/service.py:347` already uses: `call_fn` receives the resolved provider and calls `complete_text` (`LlmFn`'s contract is raw text, which `parse_distill_response` parses downstream).

Provider comes from `ENTITY_EXTRACTION_PROVIDER`. Forge has no provider setting of its own, and `call_with_fallback` already resolves per-tenant model overrides against `enrichment_model`, so borrowing the enrichment selector keeps both halves of one write pipeline on one provider. A dedicated `FORGE_PROVIDER` would be new config surface and belongs in its own change, not a repair.

**The two differ deliberately on `fake_fn`**, which `call_with_fallback` always has:

- **CLI → returns the placeholder.** That is its documented promise.
- **Cron → raises.** The tick *persists* what comes back, as skill candidates that promote into `staged`. `deliberate_fake_provider` (`retry.py:380`) documents exactly this line for persisting callers: a configured `fake` provider is an operator asking for a stub; a real provider whose attempts all failed is an outage; *an outage is not a request for made-up output*. Neither may write placeholder skills, so both raise and only the message differs — the two want different operator responses. Same posture as `contradiction_detector`, which abstains rather than guess a verdict.

## Why nothing caught any of it

`scripts/` is covered by neither `ruff check` nor mypy in `ci.yml`. **The cron is worse, because it looks covered:** `core_api.services.forge.*` is deliberately opted *into* the type gate (`ignore_errors = false`), and `cd core-api && mypy src/` still reports `Success: no issues found in 199 source files`.

`common/` sits outside core-api's `mypy_path`, so every `common.*` symbol resolves to `Any` — neither the missing name nor the wrong call signature is reportable. Put the repo root on the path and that same unmodified file reports all three:

```
cron_handler.py:204: error: Module "common.llm" has no attribute "LLMRequest"  [attr-defined]
cron_handler.py:218: error: Unexpected keyword argument "expecting" for "call_with_fallback"  [call-arg]
cron_handler.py:218: error: Need type annotation for "response"  [var-annotated]
```

caura#948 gated `common/` itself. **This is the same gap one layer out — the services still cannot see what they import** — and closing it is its own piece of work, not something to bolt onto a repair. Sizing, measured: OSS root `scripts/` has 45 errors in 8 files, root `tests/` has 487 in 100 files.

## Verification

- **Three regression tests, each confirmed to fail without this commit** (reverted the two source files, re-ran, watched them fail with the production `RuntimeError` verbatim, restored): the CLI's wiring must not return the stub when `common.llm` imports; the cron's wiring must resolve rather than raise; the cron must refuse to emit a stub. The existing tests here exercised `_fake_llm_fn` directly and *deliberately skipped the branch selection* — the exact line the bug lived on.
- Behavioural, end-to-end with `ENTITY_EXTRACTION_PROVIDER=fake`: the CLI's real wiring routes through `call_with_fallback` → `fake_fn` and yields JSON `parse_distill_response` accepts with every required key; the cron raises instead. `_fake_llm_fn` stays awaitable and slug-distinct, so its existing tests are untouched.
- `tests/test_forge_distill.py` → **79 passed**; forge/cron/skill/distill/promote across `tests/` → **420 passed**.
- All four gated mypy runs clean (199 / 83 / 5 / 11). `ruff check` + `ruff format --check core-api/src/` clean, run separately. `common/` gate from #948 still clean.
- No new lint anywhere: pre-existing findings in `scripts/forge_dry_run.py` (EXE001, G201, and a RUF100 `# noqa` that suppresses nothing) and in `tests/test_forge_distill.py` are left alone — unrelated to this repair, and neither path is lint-gated. Counts verified identical to `origin/main`.
- `core-api/uv.lock` untouched. Rebased onto `main` at `3cc6ea8d`; none of the four intervening commits touch these files.

## One judgement call worth flagging

I did **not** narrow the `except ImportError` further. With only real names imported it now fires solely for a genuinely absent package, which is what it was written for. Guarding against a *future* rename would need a runtime `getattr` dance that duplicates what the type checker should do — the durable fix is making `common/` visible to the service mypy runs, above.