### PR TITLE
docs(contributing): keep the old brand out of commit subjects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,6 +230,35 @@ python3 scripts/legacy_name_ratchet.py --report
 python3 scripts/legacy_name_ratchet.py --base origin/main
 ```
 
+### Keep the old brand out of the commit subject
+
+`release-please` builds `CHANGELOG.md` from merged commit subjects. A subject
+naming the old brand puts that text into a file that had none, so the ratchet
+fails **the release pull request** — not yours, days later, for whoever opens
+the release to debug.
+
+This bites hardest on rebrand work, where naming what you renamed is the natural
+way to describe the change. Describe it without:
+
+| | |
+|---|---|
+| ✗ | `fix(api): the OpenAPI titles four services publish still said <old brand>` |
+| ✓ | `fix(api): the OpenAPI titles four services publish used the previous brand name` |
+
+The changelog entry links the pull request, which carries the detail the subject
+drops.
+
+Only the subject reaches the changelog, so the body is free — put the old name
+there if it helps a reader. And only the changelog-visible types are affected:
+`test`, `build`, `ci` and `chore` are hidden from `CHANGELOG.md` (see the table
+above), so a subject under those cannot reach it.
+
+**This is not fixable after merge.** The subject is immutable, so the only
+remedy is hand-editing the generated entry on the release pull request — and
+`release-please` force-pushes that branch on every merge to `main`, so the edit
+is lost if anything lands before the release goes in. Getting the subject right
+costs nothing; getting it wrong costs a race.
+
 ## Questions
 
 For questions that aren't bug reports, use


### PR DESCRIPTION
Docs-only. Adds one subsection to the existing naming section in `CONTRIBUTING.md`.

## The problem it prevents

`release-please` builds `CHANGELOG.md` from merged commit subjects. A subject naming the old brand writes that text into a file that had none, and the ratchet fails **the release pull request** — not the one that caused it, days later, for whoever opens the release to debug.

#898 hit exactly this. Four rebrand PRs described their own work by naming what they renamed:

> `fix(api): the OpenAPI titles four services publish still said <old brand>`

Accurate, and unfixable after merge — subjects are immutable, so the remedy was hand-editing four generated entries on the release branch. `release-please` force-pushes that branch on every merge to `main`, so the edit survived only because nothing landed in the window. With several lanes shipping, that window is not reliable.

**The rebrand work generates the subjects that break the release.** Without a convention this recurs every cycle, and gets likelier the more the sweep succeeds.

## What it says

Describe the change without naming the old brand; the changelog entry links the PR, which carries the detail the subject drops.

It also states what is **not** affected, because the rule reads broader than it is:

- **Only the subject reaches the changelog** — the body is free, and often the right place for the old name
- **Only changelog-visible types matter** — `test`, `build`, `ci` and `chore` are hidden from `CHANGELOG.md` per the table already in this file

## Two placement notes

**In the naming section, not the commit-message section.** It is a rule about the old brand that happens to bite through commit subjects, and the person reading the ratchet's rules is the one who needs it.

**The example uses a placeholder, not the literal**, so this file stays at zero old-brand lines and needs no `legacy-name-ok`. That is the rule applied to itself: a mention gets reworded, a contract gets the marker. Using the marker for prose quietly widens the exemption surface.

## Gates

- `Legacy-name ratchet` — no new lines, no new exemptions
- `Do-not-touch sentinel` — green, 35 strings