### PR TITLE
test(plugin): make the signature-tamper test deterministic

### DIFF
--- a/plugin/src/validation.test.ts
+++ b/plugin/src/validation.test.ts
@@ -74,7 +74,15 @@ describe("verifyCommandSignature", () => {
 
   test("tampered signature fails closed regardless of mode", () => {
     const cmd = signedCommand();
-    const tampered = { ...cmd, signature: cmd.signature.replace(/.$/, "0") };
+    // Flip the last hex char to a DIFFERENT value. The old `.replace(/.$/, "0")`
+    // was a 1-in-16 flake: whenever the genuine signature already ended in "0"
+    // (timestamp-dependent), the "tampered" copy was byte-identical to the
+    // original and verification correctly returned true.
+    const tampered = {
+      ...cmd,
+      signature: cmd.signature.replace(/.$/, (c) => (c === "0" ? "1" : "0")),
+    };
+    assert.notEqual(tampered.signature, cmd.signature);
     assert.equal(verifyCommandSignature(tampered, KEY).valid, false);
     assert.equal(verifyCommandSignature(tampered, KEY).reason, "invalid_signature");
     assert.equal(verifyCommandSignature(tampered, KEY, true).valid, false);


### PR DESCRIPTION
Fixes the 1-in-16 flake in `verifyCommandSignature > tampered signature fails closed regardless of mode`: the tamper replaced the last hex char with a literal `"0"`, so whenever the genuine (timestamp-dependent) signature already ended in `0`, the "tampered" copy was byte-identical to the original — verification correctly returned true and the test failed. Verified empirically (7/200 sampled timestamps produce sig-ends-in-0) and first observed on #954's rebase run — the suite only started running in CI with #950.

Fix: flip the last char to a guaranteed-different value + assert the tampered signature differs from the original. Validation file passes 8/8; fixed tamper produced 0 identical copies across 3200 sampled timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)