### PR TITLE
fix(mcp): stop _with_latency corrupting non-dict JSON payloads

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -666,6 +666,16 @@ def _with_latency(result: str, t0: float) -> str | CallToolResult:
             if isinstance(data.get("error"), dict):
                 return _as_error_result(payload)
             return payload
+        # C24 — valid JSON that is NOT a dict (``_serialize``'s list branch,
+        # or a bare scalar) must go back UNCHANGED. The old fall-through
+        # appended the plain-text ``_latency_ms`` line after the JSON,
+        # producing ``[...]\n\n_latency_ms: N`` — trailing junk that strict
+        # parsers reject (the likely source of the field-reported "invalid
+        # JSON" sighting; REST serialization cannot emit it). An array can't
+        # carry the stamp without changing its shape, and no client ever
+        # successfully parsed the stamped form anyway — so valid JSON wins
+        # over the telemetry line here. Prose payloads below keep the suffix.
+        return result
     except (json.JSONDecodeError, ValueError):
         pass
     return result + f"\n\n_latency_ms: {ms}"

--- a/tests/test_c24_latency_json_integrity.py
+++ b/tests/test_c24_latency_json_integrity.py
@@ -1,0 +1,64 @@
+"""C24 — ``_with_latency`` must never corrupt a JSON payload.
+
+The old fall-through appended a plain-text ``_latency_ms`` line after ANY
+non-dict result. For ``_serialize``'s list branch that produced
+``[...]\\n\\n_latency_ms: N`` — a JSON document with trailing junk that
+strict parsers reject. Dict payloads carry the stamp inside the object;
+valid-but-non-dict JSON now returns unchanged; only non-JSON prose keeps
+the trailing text line (it was never parseable as JSON to begin with).
+"""
+
+import json
+import time
+
+import pytest
+
+from core_api.mcp_server import _with_latency
+
+pytestmark = pytest.mark.unit
+
+
+def _t0():
+    return time.perf_counter()
+
+
+def test_dict_payload_gets_inline_stamp_and_stays_valid_json():
+    out = _with_latency(json.dumps({"items": [1, 2]}), _t0())
+    data = json.loads(out)  # strict parse must succeed
+    assert data["items"] == [1, 2]
+    assert isinstance(data["_latency_ms"], int)
+
+
+def test_array_payload_returns_unchanged_valid_json():
+    payload = json.dumps([{"id": "a"}, {"id": "b"}], indent=2)
+    out = _with_latency(payload, _t0())
+    assert out == payload  # byte-identical: no stamp, no trailing junk
+    assert json.loads(out) == [{"id": "a"}, {"id": "b"}]
+
+
+def test_array_payload_has_no_trailing_latency_line():
+    out = _with_latency(json.dumps([1, 2, 3]), _t0())
+    assert "_latency_ms" not in out
+
+
+def test_scalar_json_payload_returns_unchanged():
+    out = _with_latency("42", _t0())
+    assert out == "42"
+
+
+def test_prose_payload_keeps_latency_suffix():
+    out = _with_latency("plain text summary", _t0())
+    assert out.startswith("plain text summary")
+    assert "_latency_ms:" in out
+
+
+def test_error_envelope_still_promoted_to_iserror():
+    from mcp.types import CallToolResult
+
+    payload = json.dumps({"error": {"code": "FORBIDDEN", "message": "no"}})
+    out = _with_latency(payload, _t0())
+    assert isinstance(out, CallToolResult)
+    assert out.isError is True
+    body = json.loads(out.content[0].text)
+    assert body["error"]["code"] == "FORBIDDEN"
+    assert "_latency_ms" in body


### PR DESCRIPTION
## What

Closes canonical **C24** (register API-01/N4, from the AX-audit verification pass). `_with_latency` stamped dict payloads inline but appended a plain-text `_latency_ms` line after any other result — for `_serialize`'s list branch that produced `[...]` + trailing junk, which strict JSON parsers reject. This is the likely real source of the field-reported "invalid JSON from /search" (REST serialization is stock FastAPI end-to-end and cannot emit unescaped output; the sighting matches the MCP surface).

Fix: valid-but-non-dict JSON (arrays, bare scalars) returns **unchanged** — an array can't carry the stamp without breaking its shape, and no client ever successfully parsed the stamped form. Dict payloads keep the inline stamp, error envelopes keep the `isError` promotion (regression-guarded), non-JSON prose keeps the suffix.

## Testing

- 6 new unit tests (`tests/test_c24_latency_json_integrity.py`): strict-parse guarantees per payload class, byte-identical array pass-through, isError promotion intact. Full root suite **5186 passed**; ruff/mypy clean.
- Wet: verified against the **shipped container image** (docker-exec into the rebuilt core-api): array untouched + strictly parseable, dict stamped inline, prose suffixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)