### PR TITLE
docs(sunset): write down the writer side of rule 3

### DIFF
--- a/docs/plans/rebrand-sunset-plan.md
+++ b/docs/plans/rebrand-sunset-plan.md
@@ -26,6 +26,29 @@ These are the durable part of the plan. Every gate in CI traces to one of them.
 | 6 | **One coupled cluster at a time** | `{core-api, core-worker, platform-admin-api}` move together; vendored files move together; all DSN consumers move together. |
 | 7 | **Mint nothing under the old name** | A new repo, topic, package or service under the legacy brand kills a redirect that already works. This is the one the ratchet enforces automatically. |
 
+### The writer side of rule 3
+
+Rule 3 is stated read-side, and the corollary is not: **the moment you make a
+consumer dual-read, every writer that pins the old spelling into something that
+consumer later reads becomes a hazard** — a child process environment, a
+generated config, an installed service unit. The consumer now *prefers* the new
+name, so an ambient new-name value from anywhere else outranks the old-name
+value the writer deliberately set. This has already shipped once, as a daemon
+and the CLI that started it silently on different state directories.
+
+- **Pin both spellings.** Find every writer that feeds a dual-reading consumer
+  and have it set both, in the same change that makes the consumer dual-read.
+  Whether that works is a language question: Go's `os/exec` keeps the **last**
+  duplicate key, so appending overrides. Verify your language's rule instead of
+  assuming it.
+- **Precedence is first NON-EMPTY, never first-defined.** Every consumer in
+  this fleet reads `""` as "use the default", so first-defined would relocate a
+  state directory or drop a cloud origin with nothing red anywhere.
+- **The smell:** clearing the *new*-name variable in a test for hermeticity
+  during an alias wave. Production has no `t.Setenv`. If a test needs that
+  line, check whether the writer it stands in for is still pinning one
+  spelling — that clear will mask the live gap for as long as it is there.
+
 ---
 
 ## What is *not* frozen
@@ -105,6 +128,11 @@ contract, not for convenience.
    installed clients and air-gapped image tarballs all do.
 4. **Would deleting it lower a count while breaking a behaviour?** That combination
    passes CI green. It is the failure mode this plan is built around.
+5. **Are you making a consumer read both spellings?** Then find that consumer's
+   writers in the same PR and pin both — see
+   [The writer side of rule 3](#the-writer-side-of-rule-3). Neither gate can see
+   this one: the writer already carries the old name, so nothing is minted and
+   nothing is deleted.
 
 ---
 


### PR DESCRIPTION
Rule 3 (\"old names stay readable forever\") is stated **read-side only**. The corollary
nobody wrote down: **when you make a consumer dual-read, every writer that pins the old
spelling into something that consumer later reads becomes a hazard** — a child process
environment, a generated config, an installed service unit. The consumer now *prefers*
the new name, so an ambient new-name value from anywhere else outranks the old-name value
the writer deliberately set.

This is a real bug, not a hypothetical one. In `caura-daemon`, `daemon.Spawn` pinned only
the old spelling into the child. The child inherits the parent environment and prefers
the new name, so an ambient new-name home directory outranked the state root the CLI had
just resolved — **daemon and CLI on different state directories, silently.** An ambient
daemon-mode flag that wasn't `1` was worse: the child never entered daemon mode at all.

`caura-onprem-installer/install.sh:296-303` **documents this exact hazard** for its
`sudo -E` handoff and solved it in #17–#22 — *\"the child, reading the new name first,
would take the stale one.\"* That knowledge existed and did not reach the next lane. This
PR is the fix for that.

## What's here

A `### The writer side of rule 3` subsection after the rules table, and a fifth item on
the **Before you change an old-brand string** checklist. Three things and no more, since
this file earns its place by being read:

1. **The rule** — find every writer that pins the old spelling into a child env, config
   file or service unit, and pin **both**. With the language-specific caveat that decides
   whether it works: Go's `os/exec` keeps the **last** duplicate key, so appending
   overrides. Verified empirically rather than assumed.
2. **Precedence is first NON-EMPTY, never first-defined** — every consumer in this fleet
   reads `\"\"` as \"use the default\", so first-defined relocates a state directory or drops
   a cloud origin with nothing red. Matches #886/#895.
3. **The smell** — clearing the *new*-name variable in a test for hermeticity during an
   alias wave. In the daemon that clear masked the live bug for a full review cycle.

The checklist item states why neither gate catches this class: the writer already carries
the old name, so nothing is minted and nothing is deleted.

## Consistency

The added text is **byte-identical** to the same change against
`caura-enterprise:docs/rebrand-sunset-plan.md` (opened separately, since they are separate
repos). The two files are near-identical by design.

## Gates

Worded around the old-brand literals — \"the old spelling\", never the name — so **no new
`legacy-name-ok` markers were needed**.

- `scripts/legacy_name_ratchet.py --base origin/main` → `No new lines.`
- `scripts/do_not_touch_sentinel.py` → `All 35 protected strings survive.`

Docs-only. No behaviour change.