### PR TITLE
chore(sentinel): retire the observability logger-name pin

### DIFF
--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -188,12 +188,6 @@ SENTINELS: tuple[Sentinel, ...] = (
         breaks="the generated installer writes to a path no installed plugin reads",
     ),
     Sentinel(
-        path="core-storage-api/src/core_storage_api/observability.py",
-        text="memclaw.observability",  # legacy-name-ok: pinned floor string
-        kind=LITERAL,
-        breaks="the logger name changes and every log-based filter keyed to it goes quiet",
-    ),
-    Sentinel(
         path="core-api/src/core_api/services/organization_settings.py",
         text="memclaw.auto_upgrade_enabled",  # legacy-name-ok: pinned floor string
         kind=LITERAL,


### PR DESCRIPTION
Removes one entry from `scripts/do_not_touch_sentinel.py`. **No rename in this PR** — see
*What this PR is not* below.

## The entry's justification is false

```
Sentinel(
    path="core-storage-api/src/core_storage_api/observability.py",
    text="memclaw.observability",
    breaks="the logger name changes and every log-based filter keyed to it goes quiet",
)
```

Re-measured **2026-08-25**. Every place a "log-based filter" could live is empty:

| surface | state | how it was measured |
| --- | --- | --- |
| Datadog log-type monitors | **0 of 18** — all `query` / `trace-analytics` / `synthetics` / `event-v2` | full monitor listing; offset 18 returns empty, so the list is complete |
| GCP log-based metrics | **0** | `gcloud logging metrics list` → empty |
| GCP log sinks | **2**, both built-in (`_Required`, `_Default`), filtering on `LOG_ID()` only | `gcloud logging sinks list` |
| GCP log-match alert policies | **2 of 6 exist** — but neither is keyed to a logger name | Monitoring API `alertPolicies`, cross-checked against `caura-enterprise/terraform/datadog-gcp/gcp_alerts.tf` |
| Datadog log pipelines · index exclusion filters · log-based custom metrics | `0 active, 0 disabled` · 1 index, `*`, zero exclusions · none | **hand-checked in the Datadog UI on 25 Aug**; see *limits* below |

### The one surface that is not empty, and why it does not save the entry

Two `conditionMatchedLog` alert policies do exist:

- `Prod embedding degraded / gate timeout` — `gcp_alerts.tf:40`
- `caura-ops memory backend unreachable` — `gcp_alerts.tf:169`

Both match on **`jsonPayload.message` text**, neither references a logger field, and
neither targets `core-storage-api` at all — they watch `prod-*-core-api` / `-core-worker`
and `caura-ops-api` / `-worker`. The strings they match on are separately pinned by the
sentinel entries directly above this one, which stay.

The logger name **is** live and queryable — `@logger:memclaw.observability` returns ~50k
records over two days across `core-storage-reader` / `-writer`. The attribute exists.
What does not exist is anything keyed to it.

## Why removing a pin is the safe direction here

The sentinel's whole power is that people believe the list. An entry asserting a
dependency nobody can locate teaches readers that the list contains unchecked claims —
and the cost of that lands on the entries that really are load-bearing. A list that is
shorter and entirely true is a stronger gate than one that is longer and partly
aspirational.

## Limits of this audit — stated deliberately

- **Facets and saved views were not checked.** They break a human's filtering workflow,
  not an alert. That is why this is still the right call, and why whoever does the rename
  should mention them in the release note.
- The three Datadog surfaces in the last table row could not be re-verified from this
  environment (no MCP tool exposes pipelines, exclusion filters or log-based metrics, and
  no API key is available here). They rest on the 25 Aug hand-check. The four rows above
  them were re-measured independently for this PR.

## What this PR is not

**The logger is not renamed.** `observability.py:26` still reads
`logging.getLogger("memclaw.observability")`, and `tests/test_observability.py` still
pins it in five places. That is ordinary debt for a later sweep; bundling it here would
make neither change reviewable.

## Gates

- `do_not_touch_sentinel.py` → `All 34 protected strings survive.` (was 35)
- `legacy_name_ratchet.py --base origin/main` → `No new lines.`, with the expected
  *"1 exempt line(s) removed by this change"* report. The alias it flags is the pin's own
  copy of the string; the original at `observability.py:26` is untouched.
- `pytest tests/test_do_not_touch_sentinel.py tests/test_sentinel_scanner.py` → 153 passed.
  No test hardcodes the entry count.